### PR TITLE
Use the parser to provide better annotations for the tokenizer

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -795,6 +795,15 @@ static unique_ptr<SQLTokenizeFunctionData> GenerateTokens(ClientContext &context
 	HighlightTokenizer tokenizer(sql);
 	tokenizer.TokenizeInput();
 
+	// use the parser to annotate any tokens
+	vector<MatcherSuggestion> suggestions;
+	ParseResultAllocator parse_allocator;
+	idx_t max_token_index = 0;
+	MatchState state(tokenizer.tokens, suggestions, parse_allocator, max_token_index);
+
+	auto peg_matcher = GetPEGMatcherCache(DBConfig::GetConfig(context)).GetMatcher();
+	peg_matcher->Root().Match(state);
+
 	return make_uniq<SQLTokenizeFunctionData>(tokenizer.tokens);
 }
 

--- a/extension/autocomplete/include/matcher.hpp
+++ b/extension/autocomplete/include/matcher.hpp
@@ -83,31 +83,6 @@ enum class MatchResultType { SUCCESS, FAIL };
 
 enum class SuggestionType { OPTIONAL, MANDATORY };
 
-enum class TokenType { KEYWORD, STRING_LITERAL, NUMBER_LITERAL, OPERATOR, IDENTIFIER, COMMENT, TERMINATOR, ERROR };
-
-inline string TokenTypeToString(TokenType type) {
-	switch (type) {
-	case TokenType::KEYWORD:
-		return "KEYWORD";
-	case TokenType::STRING_LITERAL:
-		return "STRING_LITERAL";
-	case TokenType::NUMBER_LITERAL:
-		return "NUMBER_LITERAL";
-	case TokenType::OPERATOR:
-		return "OPERATOR";
-	case TokenType::IDENTIFIER:
-		return "IDENTIFIER";
-	case TokenType::COMMENT:
-		return "COMMENT";
-	case TokenType::TERMINATOR:
-		return "TERMINATOR";
-	case TokenType::ERROR:
-		return "ERROR";
-	default:
-		return "UNKNOWN";
-	}
-}
-
 struct MatcherToken {
 	// NOLINTNEXTLINE: allow implicit conversion from text
 	MatcherToken(string text_p, idx_t offset_p, TokenType type_p, bool unterminated_p = false)

--- a/extension/autocomplete/include/transformer/parse_result.hpp
+++ b/extension/autocomplete/include/transformer/parse_result.hpp
@@ -12,6 +12,68 @@
 
 namespace duckdb {
 
+enum class TokenType {
+	INVALID,
+	KEYWORD,
+	STRING_LITERAL,
+	NUMBER_LITERAL,
+	OPERATOR,
+	IDENTIFIER,
+	COMMENT,
+	TERMINATOR,
+	CATALOG_NAME,
+	SCHEMA_NAME,
+	TABLE_NAME,
+	TYPE_NAME,
+	COLUMN_NAME,
+	SCALAR_FUNCTION,
+	TABLE_FUNCTION,
+	PRAGMA_FUNCTION,
+	SETTING_NAME,
+	ERROR
+};
+
+inline string TokenTypeToString(TokenType type) {
+	switch (type) {
+	case TokenType::KEYWORD:
+		return "KEYWORD";
+	case TokenType::STRING_LITERAL:
+		return "STRING_LITERAL";
+	case TokenType::NUMBER_LITERAL:
+		return "NUMBER_LITERAL";
+	case TokenType::OPERATOR:
+		return "OPERATOR";
+	case TokenType::IDENTIFIER:
+		return "IDENTIFIER";
+	case TokenType::COMMENT:
+		return "COMMENT";
+	case TokenType::TERMINATOR:
+		return "TERMINATOR";
+	case TokenType::ERROR:
+		return "ERROR";
+	case TokenType::CATALOG_NAME:
+		return "CATALOG_NAME";
+	case TokenType::SCHEMA_NAME:
+		return "SCHEMA_NAME";
+	case TokenType::TABLE_NAME:
+		return "TABLE_NAME";
+	case TokenType::TYPE_NAME:
+		return "TYPE_NAME";
+	case TokenType::COLUMN_NAME:
+		return "COLUMN_NAME";
+	case TokenType::SCALAR_FUNCTION:
+		return "SCALAR_FUNCTION";
+	case TokenType::TABLE_FUNCTION:
+		return "TABLE_FUNCTION";
+	case TokenType::PRAGMA_FUNCTION:
+		return "PRAGMA_FUNCTION";
+	case TokenType::SETTING_NAME:
+		return "SETTING_NAME";
+	default:
+		return "UNKNOWN";
+	}
+}
+
 class PEGTransformer; // Forward declaration
 
 enum class ParseResultType : uint8_t {

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -462,6 +462,7 @@ public:
 		if (!MatchIdentifier(state)) {
 			return MatchResultType::FAIL;
 		}
+		state.tokens[state.token_index - 1].type = GetTokenType();
 		return MatchResultType::SUCCESS;
 	}
 
@@ -487,6 +488,31 @@ public:
 			result_text = StringUtil::Replace(result_text, "''", "'");
 		}
 		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text, start_offset));
+	}
+
+	TokenType GetTokenType() const {
+		switch (suggestion_type) {
+		case SuggestionState::SUGGEST_CATALOG_NAME:
+			return TokenType::CATALOG_NAME;
+		case SuggestionState::SUGGEST_SCHEMA_NAME:
+			return TokenType::SCHEMA_NAME;
+		case SuggestionState::SUGGEST_TABLE_NAME:
+			return TokenType::TABLE_NAME;
+		case SuggestionState::SUGGEST_TYPE_NAME:
+			return TokenType::TYPE_NAME;
+		case SuggestionState::SUGGEST_COLUMN_NAME:
+			return TokenType::COLUMN_NAME;
+		case SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME:
+			return TokenType::SCALAR_FUNCTION;
+		case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
+			return TokenType::TABLE_FUNCTION;
+		case SuggestionState::SUGGEST_PRAGMA_NAME:
+			return TokenType::PRAGMA_FUNCTION;
+		case SuggestionState::SUGGEST_SETTING_NAME:
+			return TokenType::SETTING_NAME;
+		default:
+			return TokenType::IDENTIFIER;
+		}
 	}
 
 	bool SupportsStringLiteral() const {
@@ -602,6 +628,7 @@ public:
 		if (!MatchReservedIdentifier(state)) {
 			return MatchResultType::FAIL;
 		}
+		state.tokens[state.token_index - 1].type = GetTokenType();
 		return MatchResultType::SUCCESS;
 	}
 
@@ -656,6 +683,7 @@ public:
 		if (!MatchStringLiteral(state, string_info)) {
 			return MatchResultType::FAIL;
 		}
+		state.tokens[state.token_index - 1].type = TokenType::STRING_LITERAL;
 		return MatchResultType::SUCCESS;
 	}
 
@@ -728,6 +756,7 @@ public:
 		if (!MatchNumberLiteral(state)) {
 			return MatchResultType::FAIL;
 		}
+		state.tokens[state.token_index - 1].type = TokenType::NUMBER_LITERAL;
 		return MatchResultType::SUCCESS;
 	}
 

--- a/test/sql/function/tokenize/simple_tokenize.test
+++ b/test/sql/function/tokenize/simple_tokenize.test
@@ -10,13 +10,13 @@ query III
 select start, token_type, word from sql_tokenize($$select a$$);
 ----
 0	KEYWORD	select
-7	IDENTIFIER	a
+7	COLUMN_NAME	a
 
 query III
 select start, token_type, word from sql_tokenize($$select a;$$);
 ----
 0	KEYWORD	select
-7	IDENTIFIER	a
+7	COLUMN_NAME	a
 8	TERMINATOR	;
 
 query III
@@ -46,9 +46,9 @@ query III
 select start, token_type, word from sql_tokenize($$select "column name" from "Table";$$);
 ----
 0	KEYWORD	select
-7	IDENTIFIER	"column name"
+7	COLUMN_NAME	"column name"
 21	KEYWORD	from
-26	IDENTIFIER	"Table"
+26	TABLE_NAME	"Table"
 33	TERMINATOR	;
 
 query III
@@ -56,14 +56,14 @@ select start, token_type, word from sql_tokenize($$select (a + b) * 2, c;$$);
 ----
 0	KEYWORD	select
 7	OPERATOR	(
-8	IDENTIFIER	a
+8	COLUMN_NAME	a
 10	OPERATOR	+
-12	IDENTIFIER	b
+12	COLUMN_NAME	b
 13	OPERATOR	)
 15	OPERATOR	*
 17	NUMBER_LITERAL	2
 18	OPERATOR	,
-20	IDENTIFIER	c
+20	COLUMN_NAME	c
 21	TERMINATOR	;
 
 query III
@@ -84,7 +84,7 @@ select start, token_type, word from sql_tokenize($$select * fro$$);
 query III
 select start, token_type, word from sql_tokenize($$crea tab$$);
 ----
-0	IDENTIFIER	crea
+0	COLUMN_NAME	crea
 5	IDENTIFIER	tab
 
 query III
@@ -101,25 +101,44 @@ select start, token_type, word from sql_tokenize($$select 'O''Neil', "My ""Table
 0	KEYWORD	select
 7	STRING_LITERAL	'O''Neil'
 16	OPERATOR	,
-18	IDENTIFIER	"My ""Table"""
+18	COLUMN_NAME	"My ""Table"""
 32	TERMINATOR	;
 
 query III
 select start, token_type, word from sql_tokenize($$from ''hello world';$$);
 ----
 0	KEYWORD	from
-5	STRING_LITERAL	''
+5	TABLE_NAME	''
 7	IDENTIFIER	hello
 13	IDENTIFIER	world
 18	STRING_LITERAL	';
+
+# test keywords that can be used as other tokens
+query III
+select start, token_type, word from sql_tokenize($$select json::json from json$$);
+----
+0	KEYWORD	select
+7	COLUMN_NAME	json
+11	OPERATOR	::
+13	TYPE_NAME	json
+18	KEYWORD	from
+23	TABLE_NAME	json
+
+# also for partial queries
+query III
+select start, token_type, word from sql_tokenize($$select json::json from$$);
+----
+0	KEYWORD	select
+7	COLUMN_NAME	json
+11	OPERATOR	::
+13	TYPE_NAME	json
+18	KEYWORD	from
 
 query III 
 select start, token_type, word from sql_tokenize('from ''hello world''');
 ----
 0	KEYWORD	from
-5	STRING_LITERAL	'hello world'
-
-
+5	TABLE_NAME	'hello world'
 
 query III 
 select start, token_type, word from sql_tokenize('from ''hello world');


### PR DESCRIPTION
Currently we only use the tokenizer to generate token types. However, this can cause incorrect highlighting. Due to e.g. unreserved keywords existing keywords are not always keywords. A query like this is valid:

```sql
create table json(json json);
```

In this case `json` is a table name, column name and type name. 

By running the parser after tokenizing we can annotate tokens with their actual token types. We use `Match()` for this to also allow this to work on partial matches. 