### PR TITLE
Unify adding suffixes to path in `Path:: AddSuffixToPath` - fix temp directory split bug

### DIFF
--- a/src/common/path.cpp
+++ b/src/common/path.cpp
@@ -355,4 +355,20 @@ size_t Path::ParseUNCScheme(const string &input, Path &parsed) {
 }
 #endif
 
+string Path::AddSuffixToPath(const string &path, const string &suffix) {
+	// we append the ".wal" **before** a question mark in case of GET parameters
+	// but only if we are not in a windows long path (which starts with \\?\)
+	std::size_t question_mark_pos = std::string::npos;
+	if (!StringUtil::StartsWith(path, "\\\\?\\")) {
+		question_mark_pos = path.find('?');
+	}
+	auto result = path;
+	if (question_mark_pos != std::string::npos) {
+		result.insert(question_mark_pos, suffix);
+	} else {
+		result += suffix;
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/common/path.hpp
+++ b/src/include/duckdb/common/path.hpp
@@ -135,6 +135,8 @@ public:
 		return FromString(input).ToString();
 	}
 
+	static string AddSuffixToPath(const string &path, const string &suffix);
+
 private:
 	string scheme;
 	string authority;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/common/path.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -546,10 +547,8 @@ void DBConfig::SetDefaultTempDirectory() {
 		options.temporary_directory = string();
 	} else if (DBConfig::IsInMemoryDatabase(options.database_path.c_str())) {
 		options.temporary_directory = ".tmp";
-	} else if (StringUtil::Contains(options.database_path, "?")) {
-		options.temporary_directory = StringUtil::Split(options.database_path, "?")[0] + ".tmp";
 	} else {
-		options.temporary_directory = options.database_path + ".tmp";
+		options.temporary_directory = Path::AddSuffixToPath(options.database_path, ".tmp");
 	}
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "mbedtls_wrapper.hpp"
+#include "duckdb/common/path.hpp"
 
 namespace duckdb {
 using SHA256State = duckdb_mbedtls::MbedTlsWrapper::SHA256State;
@@ -285,19 +286,7 @@ unique_ptr<lock_guard<mutex>> StorageManager::GetWALLock() {
 }
 
 string StorageManager::GetWALPath(const string &suffix) {
-	// we append the ".wal" **before** a question mark in case of GET parameters
-	// but only if we are not in a windows long path (which starts with \\?\)
-	std::size_t question_mark_pos = std::string::npos;
-	if (!StringUtil::StartsWith(path, "\\\\?\\")) {
-		question_mark_pos = path.find('?');
-	}
-	auto result = path;
-	if (question_mark_pos != std::string::npos) {
-		result.insert(question_mark_pos, suffix);
-	} else {
-		result += suffix;
-	}
-	return result;
+	return Path::AddSuffixToPath(path, suffix);
 }
 
 string StorageManager::GetCheckpointWALPath() {

--- a/test/sql/storage/temp_directory/test_default_temp_directory.test
+++ b/test/sql/storage/temp_directory/test_default_temp_directory.test
@@ -1,0 +1,13 @@
+# name: test/sql/storage/temp_directory/test_default_temp_directory.test
+# group: [temp_directory]
+
+load __TEST_DIR__/test_default_temp_dir.db
+
+statement ok
+SET memory_limit='2MB';
+
+statement ok
+RESET temp_directory
+
+statement ok
+CREATE TEMPORARY TABLE t AS FROM range(1_000_000);


### PR DESCRIPTION
We add suffixes to a database path in two instances: the WAL (`.db.wal`) and the temporary directory (`.db.tmp`).

In both cases, we handle GET parameters (`?param=val`) by splitting on the question mark, so e.g. `file.db?param=value` becomes `file.db.wal?param=value`. However, when handling this question mark, care must be taken with Windows UNC paths that start with `\\?\`. The WAL code correctly handled these - but the temp directory code did not. This could lead to the temp directory path being set incorrectly.

This PR unifies these code paths and uses the correct handling for Windows UNC paths.