### PR TITLE
Fix CLI getenv on attach statement

### DIFF
--- a/extension/autocomplete/grammar/statements/attach.gram
+++ b/extension/autocomplete/grammar/statements/attach.gram
@@ -1,6 +1,6 @@
 AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?
 
 Database <- 'DATABASE'
-DatabasePath <- StringLiteral
+DatabasePath <- Expression
 AttachAlias <- 'AS' ColId
 AttachOptions <- GenericCopyOptionList

--- a/extension/autocomplete/include/inlined_grammar.gram
+++ b/extension/autocomplete/include/inlined_grammar.gram
@@ -1618,7 +1618,7 @@ ForEachStatement <- 'FOR' 'EACH' 'STATEMENT'
 AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?
 
 Database <- 'DATABASE'
-DatabasePath <- StringLiteral
+DatabasePath <- Expression
 AttachAlias <- 'AS' ColId
 AttachOptions <- GenericCopyOptionList
 

--- a/extension/autocomplete/include/inlined_grammar.hpp
+++ b/extension/autocomplete/include/inlined_grammar.hpp
@@ -1451,7 +1451,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"ForEachStatement <- 'FOR' 'EACH' 'STATEMENT'\n"
 	"AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?\n"
 	"Database <- 'DATABASE'\n"
-	"DatabasePath <- StringLiteral\n"
+	"DatabasePath <- Expression\n"
 	"AttachAlias <- 'AS' ColId\n"
 	"AttachOptions <- GenericCopyOptionList\n"
 	"DetachStatement <- 'DETACH' Database? IfExists? CatalogName\n"

--- a/extension/autocomplete/include/transformer/peg_transformer.hpp
+++ b/extension/autocomplete/include/transformer/peg_transformer.hpp
@@ -376,7 +376,8 @@ private:
 	                                                                optional_ptr<ParseResult> parse_result);
 	static GenericCopyOption TransformGenericCopyOption(PEGTransformer &transformer,
 	                                                    optional_ptr<ParseResult> parse_result);
-	static string TransformDatabasePath(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
+	static unique_ptr<ParsedExpression> TransformDatabasePath(PEGTransformer &transformer,
+	                                                          optional_ptr<ParseResult> parse_result);
 
 	// analyze.gram
 	static unique_ptr<SQLStatement> TransformAnalyzeStatement(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_attach.cpp
+++ b/extension/autocomplete/transformer/transform_attach.cpp
@@ -28,7 +28,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAttachStatement(PEGTran
 		info->on_conflict = OnCreateConflict::ERROR_ON_CONFLICT;
 	}
 
-	info->path = transformer.Transform<string>(list_pr.Child<ListParseResult>(4));
+	info->parsed_path = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.Child<ListParseResult>(4));
 	transformer.TransformOptional<string>(list_pr, 5, info->name);
 	vector<GenericCopyOption> copy_options;
 	transformer.TransformOptional<vector<GenericCopyOption>>(list_pr, 6, copy_options);
@@ -134,10 +134,10 @@ GenericCopyOption PEGTransformerFactory::TransformGenericCopyOption(PEGTransform
 	return copy_option;
 }
 
-string PEGTransformerFactory::TransformDatabasePath(PEGTransformer &transformer,
-                                                    optional_ptr<ParseResult> parse_result) {
+unique_ptr<ParsedExpression> PEGTransformerFactory::TransformDatabasePath(PEGTransformer &transformer,
+                                                                          optional_ptr<ParseResult> parse_result) {
 	auto &list_pr = parse_result->Cast<ListParseResult>();
-	return transformer.Transform<string>(list_pr.Child<StringLiteralParseResult>(0));
+	return transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(0));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/attach_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/attach_info.hpp
@@ -28,6 +28,8 @@ public:
 	string name;
 	//! The path to the attached database
 	string path;
+	//! The path expression to the attached database
+	unique_ptr<ParsedExpression> parsed_path;
 	//! Set of (key, value) options
 	case_insensitive_map_t<unique_ptr<ParsedExpression>> parsed_options;
 	//! Set of bound (key, value) options

--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -8,6 +8,9 @@ unique_ptr<AttachInfo> AttachInfo::Copy() const {
 	auto result = make_uniq<AttachInfo>();
 	result->name = name;
 	result->path = path;
+	if (parsed_path) {
+		result->parsed_path = parsed_path->Copy();
+	}
 	result->options = options;
 	for (auto &entry : parsed_options) {
 		result->parsed_options[entry.first] = entry.second->Copy();
@@ -25,7 +28,11 @@ string AttachInfo::ToString() const {
 		result += " OR REPLACE";
 	}
 	result += " DATABASE ";
-	result += KeywordHelper::WriteQuoted(path, '\'');
+	if (parsed_path) {
+		result += parsed_path->ToString();
+	} else {
+		result += KeywordHelper::WriteQuoted(path, '\'');
+	}
 	if (!name.empty()) {
 		result += " AS " + KeywordHelper::WriteOptionallyQuoted(name);
 	}

--- a/src/planner/binder/statement/bind_attach.cpp
+++ b/src/planner/binder/statement/bind_attach.cpp
@@ -12,6 +12,18 @@ BoundStatement Binder::Bind(AttachStatement &stmt) {
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
 
+	// resolve the path expression if set by the parser
+	if (stmt.info->parsed_path) {
+		TableFunctionBinder path_binder(*this, context, "Attach", "Attach path");
+		auto bound_path = path_binder.Bind(stmt.info->parsed_path);
+		auto path_val = ExpressionExecutor::EvaluateScalar(context, *bound_path);
+		if (path_val.IsNull()) {
+			throw BinderException("ATTACH path expression must not evaluate to NULL");
+		}
+		stmt.info->path = path_val.ToString();
+		stmt.info->parsed_path.reset();
+	}
+
 	// bind the options
 	TableFunctionBinder option_binder(*this, context, "Attach", "Attach parameter");
 	unordered_map<string, Value> kv_options;

--- a/test/sql/attach/attach_issue_21491.test
+++ b/test/sql/attach/attach_issue_21491.test
@@ -1,0 +1,30 @@
+# name: test/sql/attach/attach_issue_21491.test
+# description: Issue #21491 - ATTACH expression support (PEG parser)
+# group: [attach]
+
+require autocomplete
+
+statement error
+ATTACH unknown_scalar('test.db') AS db;
+----
+syntax error at or near
+
+statement ok
+ATTACH ':memory:' AS memdb
+
+statement ok
+DETACH memdb
+
+statement ok
+call enable_peg_parser();
+
+statement error
+ATTACH unknown_scalar('test.db') AS db;
+----
+Scalar Function with name unknown_scalar does not exist!
+
+statement ok
+ATTACH lower(':MEMORY:') AS memdb
+
+statement ok
+DETACH memdb


### PR DESCRIPTION
This PR aims to fix this issue: https://github.com/duckdb/duckdb/issues/21491

My approach to this problem was extending the grammar to support paths from environment variables. The reasons behind my choice were:
1) It is common to have paths in environment variables
2) Resolution happens at parse time and thus we avoid complex error handling during query execution
3) Struct member path stays as a string in AttachInfo which leaves the all the remaining parts of the code-path untouched

Initially I tried to make the argument a_expr but I quickly realized that this change will introduce many conflicts in the parser and would require a lot of changes in the code to make it work. Also, I feel that it is also wrong semantically. The other option would be to parse it as a function call but I felt this was also a bit too broad and might have introduced other problems.

The downside of using ENV is that we introduce a new keyword but personally I do not think this is a big issue.

Files: src_backend_parser_gram.cpp, gram.hpp and kwlist.hpp were automatically generated bison (generate_grammar.py script)

Please let me know what you think!