### PR TITLE
Fix Parquet dictionary index bit widths

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -502,7 +502,8 @@ void ColumnReader::PrepareDataPage(PageHeader &page_hdr) {
 	if (HasRepeats()) {
 		uint32_t rep_length = is_v1 ? block->read<uint32_t>() : v2_header.repetition_levels_byte_length;
 		block->available(rep_length);
-		repeated_decoder = make_uniq<RleBpDecoder>(block->ptr, rep_length, RleBpDecoder::ComputeBitWidth(MaxRepeat()));
+		repeated_decoder =
+		    make_uniq<RleBpDecoder>(block->ptr, rep_length, RleBpDecoder::ComputeBitWidthFromMaxValue(MaxRepeat()));
 		block->inc(rep_length);
 	} else if (is_v2 && v2_header.repetition_levels_byte_length > 0) {
 		block->inc(v2_header.repetition_levels_byte_length);
@@ -511,7 +512,8 @@ void ColumnReader::PrepareDataPage(PageHeader &page_hdr) {
 	if (HasDefines()) {
 		uint32_t def_length = is_v1 ? block->read<uint32_t>() : v2_header.definition_levels_byte_length;
 		block->available(def_length);
-		defined_decoder = make_uniq<RleBpDecoder>(block->ptr, def_length, RleBpDecoder::ComputeBitWidth(MaxDefine()));
+		defined_decoder =
+		    make_uniq<RleBpDecoder>(block->ptr, def_length, RleBpDecoder::ComputeBitWidthFromMaxValue(MaxDefine()));
 		block->inc(def_length);
 	} else if (is_v2 && v2_header.definition_levels_byte_length > 0) {
 		block->inc(v2_header.definition_levels_byte_length);

--- a/extension/parquet/include/parquet_rle_bp_decoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_decoder.hpp
@@ -84,15 +84,27 @@ public:
 		D_ASSERT(values_skipped == batch_size);
 	}
 
-	static uint8_t ComputeBitWidth(idx_t val) {
-		if (val == 0) {
+	static uint8_t ComputeBitWidthFromMaxValue(idx_t max_value) {
+		if (max_value == 0) {
 			return 0;
 		}
 		uint8_t ret = 1;
-		while ((((idx_t)1u << (idx_t)ret) - 1) < val) {
+		while ((((idx_t)1u << (idx_t)ret) - 1) < max_value) {
 			ret++;
 		}
 		return ret;
+	}
+
+	static uint8_t ComputeBitWidthFromValueCount(idx_t value_count) {
+		if (value_count == 0) {
+			return 0;
+		}
+		if (value_count == 1) {
+			// A singleton dictionary only emits index 0. In theory that needs 0 bits, but the
+			// current writer still assumes dictionary bit widths are non-zero when it flushes pages.
+			return 1;
+		}
+		return ComputeBitWidthFromMaxValue(value_count - 1);
 	}
 
 private:

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -94,7 +94,8 @@ public:
 	    : encoding(encoding_p), dbp_initialized(false), dbp_encoder(total_value_count), dlba_initialized(false),
 	      dlba_encoder(total_value_count, total_string_size), bss_initialized(false),
 	      bss_encoder(total_value_count, sizeof(TGT)), dictionary(dictionary_p), dict_written_value(false),
-	      dict_bit_width(RleBpDecoder::ComputeBitWidth(dictionary.GetSize())), dict_encoder(dict_bit_width) {
+	      dict_bit_width(RleBpDecoder::ComputeBitWidthFromValueCount(dictionary.GetSize())),
+	      dict_encoder(dict_bit_width) {
 	}
 	duckdb_parquet::Encoding::type encoding;
 
@@ -257,7 +258,7 @@ public:
 				}
 			}
 		} else {
-			state.key_bit_width = RleBpDecoder::ComputeBitWidth(state.dictionary.GetSize());
+			state.key_bit_width = RleBpDecoder::ComputeBitWidthFromValueCount(state.dictionary.GetSize());
 		}
 	}
 

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -19,7 +19,7 @@ public:
 EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema,
                                    vector<string> schema_path_p)
     : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
-	bit_width = RleBpDecoder::ComputeBitWidth(EnumType::GetSize(Type()));
+	bit_width = RleBpDecoder::ComputeBitWidthFromValueCount(EnumType::GetSize(Type()));
 }
 
 unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -144,7 +144,7 @@ void PrimitiveColumnWriter::WriteLevels(Allocator &allocator, WriteStream &temp_
 	}
 
 	// write the levels using the RLE-BP encoding
-	const auto bit_width = RleBpDecoder::ComputeBitWidth((max_value));
+	const auto bit_width = RleBpDecoder::ComputeBitWidthFromMaxValue(max_value);
 	RleBpEncoder rle_encoder(bit_width);
 
 	// have to write to an intermediate stream first because we need to know the size

--- a/test/sql/copy/parquet/writer/parquet_dictionary_index_width.test
+++ b/test/sql/copy/parquet/writer/parquet_dictionary_index_width.test
@@ -1,0 +1,106 @@
+# name: test/sql/copy/parquet/writer/parquet_dictionary_index_width.test
+# description: Dictionary-encoded Parquet payloads should shrink when the number of distinct values crosses a bit-width boundary.
+# group: [writer]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+COPY (
+	SELECT CASE i % 5
+		WHEN 0 THEN 'A'
+		WHEN 1 THEN 'A'
+		WHEN 2 THEN 'A'
+		WHEN 3 THEN 'B'
+		ELSE 'B'
+	END AS s
+	FROM range(65536) t(i)
+) TO '__TEST_DIR__/dict-two-values.parquet' (FORMAT PARQUET, WRITE_BLOOM_FILTER FALSE);
+
+statement ok
+COPY (
+	SELECT CASE i % 5
+		WHEN 0 THEN 'A'
+		WHEN 1 THEN 'A'
+		WHEN 2 THEN 'A'
+		WHEN 3 THEN 'B'
+		ELSE 'C'
+	END AS s
+	FROM range(65536) t(i)
+) TO '__TEST_DIR__/dict-three-values.parquet' (FORMAT PARQUET, WRITE_BLOOM_FILTER FALSE);
+
+query II
+SELECT encodings, stats_distinct_count
+FROM parquet_metadata('__TEST_DIR__/dict-two-values.parquet');
+----
+PLAIN_DICTIONARY	2
+
+query II
+SELECT encodings, stats_distinct_count
+FROM parquet_metadata('__TEST_DIR__/dict-three-values.parquet');
+----
+PLAIN_DICTIONARY	3
+
+query I
+WITH two AS (
+	SELECT total_uncompressed_size AS sz
+	FROM parquet_metadata('__TEST_DIR__/dict-two-values.parquet')
+), three AS (
+	SELECT total_uncompressed_size AS sz
+	FROM parquet_metadata('__TEST_DIR__/dict-three-values.parquet')
+)
+SELECT CASE WHEN two.sz * 3 < three.sz * 2 THEN 1 ELSE 0 END
+FROM two, three;
+----
+1
+
+statement ok
+COPY (
+	SELECT CASE i % 5
+		WHEN 0 THEN 'A'
+		WHEN 1 THEN 'A'
+		WHEN 2 THEN 'A'
+		WHEN 3 THEN 'B'
+		ELSE 'B'
+	END AS s
+	FROM range(65536) t(i)
+) TO '__TEST_DIR__/dict-two-values-v2.parquet' (FORMAT PARQUET, PARQUET_VERSION v2, WRITE_BLOOM_FILTER FALSE);
+
+statement ok
+COPY (
+	SELECT CASE i % 5
+		WHEN 0 THEN 'A'
+		WHEN 1 THEN 'A'
+		WHEN 2 THEN 'A'
+		WHEN 3 THEN 'B'
+		ELSE 'C'
+	END AS s
+	FROM range(65536) t(i)
+) TO '__TEST_DIR__/dict-three-values-v2.parquet' (FORMAT PARQUET, PARQUET_VERSION v2, WRITE_BLOOM_FILTER FALSE);
+
+query II
+SELECT encodings, stats_distinct_count
+FROM parquet_metadata('__TEST_DIR__/dict-two-values-v2.parquet');
+----
+RLE_DICTIONARY	2
+
+query II
+SELECT encodings, stats_distinct_count
+FROM parquet_metadata('__TEST_DIR__/dict-three-values-v2.parquet');
+----
+RLE_DICTIONARY	3
+
+query I
+WITH two AS (
+	SELECT total_uncompressed_size AS sz
+	FROM parquet_metadata('__TEST_DIR__/dict-two-values-v2.parquet')
+), three AS (
+	SELECT total_uncompressed_size AS sz
+	FROM parquet_metadata('__TEST_DIR__/dict-three-values-v2.parquet')
+)
+SELECT CASE WHEN two.sz * 3 < three.sz * 2 THEN 1 ELSE 0 END
+FROM two, three;
+----
+1


### PR DESCRIPTION
Dictionary ids range from 0 to value_count - 1, but the Parquet writer was computing their bit width from value_count instead of the maximum dictionary id. That made power-of-two cardinalities one bit too wide in the generic dictionary and enum writer paths.

Split the helper into explicit max-value and value-count variants, use the correct semantics at each call site, and add a sqllogictest regression that covers both Parquet v1 and v2.

This helps with https://github.com/duckdb/duckdb/issues/3316