### PR TITLE
Make StructVector have the same layout as DataChunk (vector<Vector>)

### DIFF
--- a/.github/config/extensions/inet.cmake
+++ b/.github/config/extensions/inet.cmake
@@ -4,4 +4,5 @@ duckdb_extension_load(inet
     GIT_TAG fe7f60bb60245197680fb07ecd1629a1dc3d91c8
     INCLUDE_DIR src/include
     TEST_DIR test/sql
+    APPLY_PATCHES
     )

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/avro_reader.cpp b/src/avro_reader.cpp
-index 5317c43..197f899 100644
+index 5317c43..28d6a31 100644
 --- a/src/avro_reader.cpp
 +++ b/src/avro_reader.cpp
 @@ -1,3 +1,9 @@
@@ -12,3 +12,30 @@ index 5317c43..197f899 100644
  #include "avro_reader.hpp"
  #include "utf8proc_wrapper.hpp"
  #include "duckdb/storage/caching_file_system.hpp"
+@@ -254,7 +260,7 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
+ 				throw InvalidInputException(avro_strerror());
+ 			}
+ 			TransformValue(&child_value, avro_type.children[child_idx].second,
+-			               *StructVector::GetEntries(target)[child_idx], out_idx);
++			               StructVector::GetEntries(target)[child_idx], out_idx);
+ 		}
+ 		break;
+ 	}
+@@ -284,7 +290,7 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
+ 			// orrrrrrrrrrrrr
+ 			for (idx_t child_idx = 1; child_idx < StructVector::GetEntries(target).size(); child_idx++) {
+ 				if (child_idx != duckdb_child_index + 1) { // duckdb child index is bigger because of the tag
+-					FlatVector::SetNull(*StructVector::GetEntries(target)[child_idx], out_idx, true);
++					FlatVector::SetNull(StructVector::GetEntries(target)[child_idx], out_idx, true);
+ 				}
+ 			}
+ 
+@@ -391,7 +397,7 @@ void AvroReader::Read(DataChunk &output) {
+ 				continue; // to be filled in later
+ 			}
+ 			output.data[col_idx].Reference(
+-			    *StructVector::GetEntries(*read_vec)[column_indexes[col_idx].GetPrimaryIndex()]);
++			    StructVector::GetEntries(*read_vec)[column_indexes[col_idx].GetPrimaryIndex()]);
+ 		}
+ 	} else {
+ 		output.data[column_indexes[0].GetPrimaryIndex()].Reference(*read_vec);

--- a/.github/patches/extensions/ducklake/fix.patch
+++ b/.github/patches/extensions/ducklake/fix.patch
@@ -11,7 +11,7 @@ index f03ad464..e6fc959d 100644
  namespace duckdb {
  
 diff --git a/src/functions/ducklake_add_data_files.cpp b/src/functions/ducklake_add_data_files.cpp
-index d8b57c80..a980cd79 100644
+index d8b57c80..7a47c866 100644
 --- a/src/functions/ducklake_add_data_files.cpp
 +++ b/src/functions/ducklake_add_data_files.cpp
 @@ -1,3 +1,7 @@
@@ -30,6 +30,116 @@ index d8b57c80..a980cd79 100644
  
  namespace duckdb {
  
+@@ -228,7 +233,7 @@ FROM parquet_full_metadata(%s)
+ 		idx_t struct_idx = file_metadata_offset;
+ 
+ 		auto filename =
+-		    FlatVector::GetData<string_t>(*struct_children[0])[struct_idx].GetString(); // struct field: file_name
++		    FlatVector::GetData<string_t>(struct_children[0])[struct_idx].GetString(); // struct field: file_name
+ 
+ 		// Check if we've already processed this file (can happen with overlapping globs)
+ 		auto &file_metadata_ptr = parquet_files[filename];
+@@ -242,10 +247,10 @@ FROM parquet_full_metadata(%s)
+ 		auto &file = *file_metadata_ptr;
+ 		file.filename = filename;
+ 
+-		file.row_count = FlatVector::GetData<int64_t>(*struct_children[1])[struct_idx]; // struct field: num_rows
++		file.row_count = FlatVector::GetData<int64_t>(struct_children[1])[struct_idx]; // struct field: num_rows
+ 		file.file_size_bytes =
+-		    FlatVector::GetData<uint64_t>(*struct_children[2])[struct_idx]; // struct field: file_size_bytes
+-		file.footer_size = FlatVector::GetData<uint64_t>(*struct_children[3])[struct_idx]; // struct field: footer_size
++		    FlatVector::GetData<uint64_t>(struct_children[2])[struct_idx]; // struct field: file_size_bytes
++		file.footer_size = FlatVector::GetData<uint64_t>(struct_children[3])[struct_idx]; // struct field: footer_size
+ 
+ 		bool saw_root = false;
+ 		vector<idx_t> child_counts;
+@@ -256,14 +261,14 @@ FROM parquet_full_metadata(%s)
+ 		auto &schema_struct_children = StructVector::GetEntries(parquet_schema_list_entries);
+ 
+ 		// Extract child vectors
+-		auto &name_vec = *schema_struct_children[0];
+-		auto &type_vec = *schema_struct_children[1];
+-		auto &num_children_vec = *schema_struct_children[2];
+-		auto &converted_type_vec = *schema_struct_children[3];
+-		auto &scale_vec = *schema_struct_children[4];
+-		auto &precision_vec = *schema_struct_children[5];
+-		auto &field_id_vec = *schema_struct_children[6];
+-		auto &logical_type_vec = *schema_struct_children[7];
++		auto &name_vec = schema_struct_children[0];
++		auto &type_vec = schema_struct_children[1];
++		auto &num_children_vec = schema_struct_children[2];
++		auto &converted_type_vec = schema_struct_children[3];
++		auto &scale_vec = schema_struct_children[4];
++		auto &precision_vec = schema_struct_children[5];
++		auto &field_id_vec = schema_struct_children[6];
++		auto &logical_type_vec = schema_struct_children[7];
+ 
+ 		// Get data pointers
+ 		auto name_data = FlatVector::GetData<string_t>(name_vec);
+@@ -357,14 +362,14 @@ FROM parquet_full_metadata(%s)
+ 		DetermineMapping(file);
+ 
+ 		auto &metadata_struct_children = StructVector::GetEntries(parquet_metadata_list_entries);
+-		auto &column_id_vec = *metadata_struct_children[0];
+-		auto &stats_min_vec = *metadata_struct_children[1];
+-		auto &stats_max_vec = *metadata_struct_children[2];
+-		auto &stats_null_count_vec = *metadata_struct_children[3];
+-		auto &stats_num_values_vec = *metadata_struct_children[4];
+-		auto &total_compressed_size_vec = *metadata_struct_children[5];
+-		auto &geo_bbox_vec = *metadata_struct_children[6];
+-		auto &geo_types_vec = *metadata_struct_children[7];
++		auto &column_id_vec = metadata_struct_children[0];
++		auto &stats_min_vec = metadata_struct_children[1];
++		auto &stats_max_vec = metadata_struct_children[2];
++		auto &stats_null_count_vec = metadata_struct_children[3];
++		auto &stats_num_values_vec = metadata_struct_children[4];
++		auto &total_compressed_size_vec = metadata_struct_children[5];
++		auto &geo_bbox_vec = metadata_struct_children[6];
++		auto &geo_types_vec = metadata_struct_children[7];
+ 
+ 		auto column_id_data = FlatVector::GetData<int64_t>(column_id_vec);
+ 		auto stats_min_data = FlatVector::GetData<string_t>(stats_min_vec);
+@@ -436,23 +441,23 @@ FROM parquet_full_metadata(%s)
+ 			if (geo_bbox_validity.RowIsValid(metadata_idx) && stats.extra_stats) {
+ 				// Access geo_bbox struct fields directly
+ 				auto &bbox_struct_children = StructVector::GetEntries(geo_bbox_vec);
+-				auto bbox_xmin_data = FlatVector::GetData<double>(*bbox_struct_children[0]);
+-				auto bbox_xmax_data = FlatVector::GetData<double>(*bbox_struct_children[1]);
+-				auto bbox_ymin_data = FlatVector::GetData<double>(*bbox_struct_children[2]);
+-				auto bbox_ymax_data = FlatVector::GetData<double>(*bbox_struct_children[3]);
+-				auto bbox_zmin_data = FlatVector::GetData<double>(*bbox_struct_children[4]);
+-				auto bbox_zmax_data = FlatVector::GetData<double>(*bbox_struct_children[5]);
+-				auto bbox_mmin_data = FlatVector::GetData<double>(*bbox_struct_children[6]);
+-				auto bbox_mmax_data = FlatVector::GetData<double>(*bbox_struct_children[7]);
+-
+-				auto &bbox_xmin_validity = FlatVector::Validity(*bbox_struct_children[0]);
+-				auto &bbox_xmax_validity = FlatVector::Validity(*bbox_struct_children[1]);
+-				auto &bbox_ymin_validity = FlatVector::Validity(*bbox_struct_children[2]);
+-				auto &bbox_ymax_validity = FlatVector::Validity(*bbox_struct_children[3]);
+-				auto &bbox_zmin_validity = FlatVector::Validity(*bbox_struct_children[4]);
+-				auto &bbox_zmax_validity = FlatVector::Validity(*bbox_struct_children[5]);
+-				auto &bbox_mmin_validity = FlatVector::Validity(*bbox_struct_children[6]);
+-				auto &bbox_mmax_validity = FlatVector::Validity(*bbox_struct_children[7]);
++				auto bbox_xmin_data = FlatVector::GetData<double>(bbox_struct_children[0]);
++				auto bbox_xmax_data = FlatVector::GetData<double>(bbox_struct_children[1]);
++				auto bbox_ymin_data = FlatVector::GetData<double>(bbox_struct_children[2]);
++				auto bbox_ymax_data = FlatVector::GetData<double>(bbox_struct_children[3]);
++				auto bbox_zmin_data = FlatVector::GetData<double>(bbox_struct_children[4]);
++				auto bbox_zmax_data = FlatVector::GetData<double>(bbox_struct_children[5]);
++				auto bbox_mmin_data = FlatVector::GetData<double>(bbox_struct_children[6]);
++				auto bbox_mmax_data = FlatVector::GetData<double>(bbox_struct_children[7]);
++
++				auto &bbox_xmin_validity = FlatVector::Validity(bbox_struct_children[0]);
++				auto &bbox_xmax_validity = FlatVector::Validity(bbox_struct_children[1]);
++				auto &bbox_ymin_validity = FlatVector::Validity(bbox_struct_children[2]);
++				auto &bbox_ymax_validity = FlatVector::Validity(bbox_struct_children[3]);
++				auto &bbox_zmin_validity = FlatVector::Validity(bbox_struct_children[4]);
++				auto &bbox_zmax_validity = FlatVector::Validity(bbox_struct_children[5]);
++				auto &bbox_mmin_validity = FlatVector::Validity(bbox_struct_children[6]);
++				auto &bbox_mmax_validity = FlatVector::Validity(bbox_struct_children[7]);
+ 				auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+ 				if (bbox_xmin_validity.RowIsValid(metadata_idx))
+ 					geo_stats.xmin = bbox_xmin_data[metadata_idx];
 diff --git a/src/functions/ducklake_compaction_functions.cpp b/src/functions/ducklake_compaction_functions.cpp
 index 6c2ba53b..7b5456ad 100644
 --- a/src/functions/ducklake_compaction_functions.cpp
@@ -1109,7 +1219,7 @@ index 35b0518f..770ac8da 100644
  		if (snapshot_filter_min.IsValid()) {
  			auto min_constant = Value::BIGINT(NumericCast<int64_t>(snapshot_filter_min.GetIndex()));
 diff --git a/src/storage/ducklake_inline_data.cpp b/src/storage/ducklake_inline_data.cpp
-index 4fd2ecfb..fd87462d 100644
+index 4fd2ecfb..d88cec05 100644
 --- a/src/storage/ducklake_inline_data.cpp
 +++ b/src/storage/ducklake_inline_data.cpp
 @@ -1,3 +1,6 @@
@@ -1119,6 +1229,15 @@ index 4fd2ecfb..fd87462d 100644
  #include "storage/ducklake_inline_data.hpp"
  #include "storage/ducklake_stats.hpp"
  
+@@ -250,7 +253,7 @@ void UpdateStats(vector<DuckLakeBaseColumnStats> &stats, idx_t c, Vector &data,
+ 		case LogicalTypeId::STRUCT: {
+ 			auto &children = StructVector::GetEntries(data);
+ 			for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+-				UpdateStats(column_stats.children, child_idx, *children[child_idx], row_count,
++				UpdateStats(column_stats.children, child_idx, children[child_idx], row_count,
+ 				            field_id.GetChildByIndex(child_idx));
+ 			}
+ 			break;
 diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
 index 405a5acf..f45dfc18 100644
 --- a/src/storage/ducklake_inlined_data_reader.cpp

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -12,7 +12,7 @@ index 608c67af..9c6744a7 100644
  	auto http_headers = HTTPHeaders();
  	for (auto &header : aws_headers) {
 diff --git a/src/iceberg_functions/iceberg_avro_multi_file_reader.cpp b/src/iceberg_functions/iceberg_avro_multi_file_reader.cpp
-index 0212aa3f..78bf6d9d 100644
+index 0212aa3f..e1333d4f 100644
 --- a/src/iceberg_functions/iceberg_avro_multi_file_reader.cpp
 +++ b/src/iceberg_functions/iceberg_avro_multi_file_reader.cpp
 @@ -1,3 +1,5 @@
@@ -21,6 +21,15 @@ index 0212aa3f..78bf6d9d 100644
  #include "iceberg_avro_multi_file_reader.hpp"
  #include "iceberg_avro_multi_file_list.hpp"
  #include "duckdb/common/exception.hpp"
+@@ -467,7 +469,7 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
+ 	auto &data_file_column = output_chunk.data[4];
+ 	auto &data_struct_children = StructVector::GetEntries(data_file_column);
+ 
+-	auto &first_row_id_column = *data_struct_children[15];
++	auto &first_row_id_column = data_struct_children[15];
+ 
+ 	auto &first_row_id_validity = FlatVector::Validity(first_row_id_column);
+ 	auto first_row_id_data = FlatVector::GetData<int64_t>(first_row_id_column);
 diff --git a/src/iceberg_functions/iceberg_multi_file_list.cpp b/src/iceberg_functions/iceberg_multi_file_list.cpp
 index 02a3b3d3..3dbbc921 100644
 --- a/src/iceberg_functions/iceberg_multi_file_list.cpp
@@ -274,7 +283,7 @@ index 62b71d18..1d8a5e1f 100644
  	mutable mutex entry_lock;
  	mutable vector<IcebergManifestEntry> manifest_entries;
 diff --git a/src/manifest_list_reader.cpp b/src/manifest_list_reader.cpp
-index 68d290a8..b670dc45 100644
+index 68d290a8..987c8162 100644
 --- a/src/manifest_list_reader.cpp
 +++ b/src/manifest_list_reader.cpp
 @@ -1,3 +1,6 @@
@@ -284,8 +293,23 @@ index 68d290a8..b670dc45 100644
  #include "manifest_reader.hpp"
  #include "include/metadata/iceberg_manifest_list.hpp"
  
+@@ -62,10 +65,10 @@ idx_t ManifestListReader::ReadChunk(idx_t offset, idx_t count, vector<IcebergMan
+ 	auto &child_vectors = StructVector::GetEntries(field_summary_vec);
+ 
+ 	idx_t partition_index = 0;
+-	auto &contains_null = *child_vectors[partition_index++];
+-	auto &contains_nan = *child_vectors[partition_index++];
+-	auto &lower_bound = *child_vectors[partition_index++];
+-	auto &upper_bound = *child_vectors[partition_index++];
++	auto &contains_null = child_vectors[partition_index++];
++	auto &contains_nan = child_vectors[partition_index++];
++	auto &lower_bound = child_vectors[partition_index++];
++	auto &upper_bound = child_vectors[partition_index++];
+ 
+ 	optional_ptr<Vector> first_row_id;
+ 	if (iceberg_version >= 3) {
 diff --git a/src/manifest_reader.cpp b/src/manifest_reader.cpp
-index dba21c67..a7ad6cef 100644
+index dba21c67..acfabf08 100644
 --- a/src/manifest_reader.cpp
 +++ b/src/manifest_reader.cpp
 @@ -1,3 +1,6 @@
@@ -295,6 +319,92 @@ index dba21c67..a7ad6cef 100644
  #include "manifest_reader.hpp"
  
  namespace duckdb {
+@@ -32,8 +35,8 @@ idx_t ManifestReader::Read(idx_t count, vector<IcebergManifestEntry> &result) {
+ 
+ static unordered_map<int32_t, Value> GetBounds(Vector &bounds, idx_t index) {
+ 	auto &bounds_child = ListVector::GetEntry(bounds);
+-	auto keys = FlatVector::GetData<int32_t>(*StructVector::GetEntries(bounds_child)[0]);
+-	auto &values = *StructVector::GetEntries(bounds_child)[1];
++	auto keys = FlatVector::GetData<int32_t>(StructVector::GetEntries(bounds_child)[0]);
++	auto &values = StructVector::GetEntries(bounds_child)[1];
+ 	auto bounds_list = FlatVector::GetData<list_entry_t>(bounds);
+ 
+ 	unordered_map<int32_t, Value> parsed_bounds;
+@@ -53,8 +56,8 @@ static unordered_map<int32_t, Value> GetBounds(Vector &bounds, idx_t index) {
+ 
+ static unordered_map<int32_t, int64_t> GetCounts(Vector &counts, idx_t index) {
+ 	auto &counts_child = ListVector::GetEntry(counts);
+-	auto keys = FlatVector::GetData<int32_t>(*StructVector::GetEntries(counts_child)[0]);
+-	auto values = FlatVector::GetData<int64_t>(*StructVector::GetEntries(counts_child)[1]);
++	auto keys = FlatVector::GetData<int32_t>(StructVector::GetEntries(counts_child)[0]);
++	auto values = FlatVector::GetData<int64_t>(StructVector::GetEntries(counts_child)[1]);
+ 	auto counts_list = FlatVector::GetData<list_entry_t>(counts);
+ 
+ 	unordered_map<int32_t, int64_t> parsed_counts;
+@@ -113,35 +116,35 @@ idx_t ManifestReader::ReadChunk(idx_t offset, idx_t count, vector<IcebergManifes
+ 	auto &data_file_entries = StructVector::GetEntries(data_file);
+ 	optional_ptr<Vector> content;
+ 	if (iceberg_version >= 2) {
+-		content = *data_file_entries[entry_index++];
++		content = data_file_entries[entry_index++];
+ 	}
+-	auto &file_path = *data_file_entries[entry_index++];
+-	auto &file_format = *data_file_entries[entry_index++];
+-	auto &partition = *data_file_entries[entry_index++];
+-	auto &record_count = *data_file_entries[entry_index++];
+-	auto &file_size_in_bytes = *data_file_entries[entry_index++];
+-	auto &column_sizes = *data_file_entries[entry_index++];
+-	auto &value_counts = *data_file_entries[entry_index++];
+-	auto &null_value_counts = *data_file_entries[entry_index++];
+-	auto &nan_value_counts = *data_file_entries[entry_index++];
+-	auto &lower_bounds = *data_file_entries[entry_index++];
+-	auto &upper_bounds = *data_file_entries[entry_index++];
+-	auto &split_offsets = *data_file_entries[entry_index++];
+-	auto &equality_ids = *data_file_entries[entry_index++];
+-	auto &sort_order_id = *data_file_entries[entry_index++];
++	auto &file_path = data_file_entries[entry_index++];
++	auto &file_format = data_file_entries[entry_index++];
++	auto &partition = data_file_entries[entry_index++];
++	auto &record_count = data_file_entries[entry_index++];
++	auto &file_size_in_bytes = data_file_entries[entry_index++];
++	auto &column_sizes = data_file_entries[entry_index++];
++	auto &value_counts = data_file_entries[entry_index++];
++	auto &null_value_counts = data_file_entries[entry_index++];
++	auto &nan_value_counts = data_file_entries[entry_index++];
++	auto &lower_bounds = data_file_entries[entry_index++];
++	auto &upper_bounds = data_file_entries[entry_index++];
++	auto &split_offsets = data_file_entries[entry_index++];
++	auto &equality_ids = data_file_entries[entry_index++];
++	auto &sort_order_id = data_file_entries[entry_index++];
+ 	optional_ptr<Vector> first_row_id;
+ 	if (iceberg_version >= 3) {
+-		first_row_id = *data_file_entries[entry_index++];
++		first_row_id = data_file_entries[entry_index++];
+ 	}
+ 	optional_ptr<Vector> referenced_data_file;
+ 	if (iceberg_version >= 2) {
+-		referenced_data_file = *data_file_entries[entry_index++];
++		referenced_data_file = data_file_entries[entry_index++];
+ 	}
+ 	optional_ptr<Vector> content_offset;
+ 	optional_ptr<Vector> content_size_in_bytes;
+ 	if (iceberg_version >= 3) {
+-		content_offset = *data_file_entries[entry_index++];
+-		content_size_in_bytes = *data_file_entries[entry_index++];
++		content_offset = data_file_entries[entry_index++];
++		content_size_in_bytes = data_file_entries[entry_index++];
+ 	}
+ 
+ 	auto status_data = FlatVector::GetData<int32_t>(status);
+@@ -174,7 +177,7 @@ idx_t ManifestReader::ReadChunk(idx_t offset, idx_t count, vector<IcebergManifes
+ 		D_ASSERT(partition_children.size() == scan_info.partition_field_id_to_type.size());
+ 		idx_t child_index = 0;
+ 		for (auto &it : scan_info.partition_field_id_to_type) {
+-			partition_vectors.emplace_back(it.first, *partition_children[child_index++]);
++			partition_vectors.emplace_back(it.first, partition_children[child_index++]);
+ 		}
+ 	}
+ 
 diff --git a/src/storage/catalog/iceberg_schema_entry.cpp b/src/storage/catalog/iceberg_schema_entry.cpp
 index 88c7537c..c4e63923 100644
 --- a/src/storage/catalog/iceberg_schema_entry.cpp

--- a/.github/patches/extensions/inet/fix.patch
+++ b/.github/patches/extensions/inet/fix.patch
@@ -1,0 +1,17 @@
+diff --git a/src/inet_functions.cpp b/src/inet_functions.cpp
+index afa7446..2f0234a 100644
+--- a/src/inet_functions.cpp
++++ b/src/inet_functions.cpp
+@@ -49,9 +49,9 @@ bool INetFunctions::CastVarcharToINET(Vector &source, Vector &result,
+   source.ToUnifiedFormat(count, vdata);
+ 
+   auto &entries = StructVector::GetEntries(result);
+-  auto ip_type = FlatVector::GetData<uint8_t>(*entries[0]);
+-  auto address_data = FlatVector::GetData<hugeint_t>(*entries[1]);
+-  auto mask_data = FlatVector::GetData<uint16_t>(*entries[2]);
++  auto ip_type = FlatVector::GetData<uint8_t>(entries[0]);
++  auto address_data = FlatVector::GetData<hugeint_t>(entries[1]);
++  auto mask_data = FlatVector::GetData<uint16_t>(entries[2]);
+ 
+   auto input = UnifiedVectorFormat::GetData<string_t>(vdata);
+   bool success = true;

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/include/postgres_binary_writer.hpp b/src/include/postgres_binary_writer.hpp
-index fef2faf..5cae453 100644
+index fef2faf..cff8e8c 100644
 --- a/src/include/postgres_binary_writer.hpp
 +++ b/src/include/postgres_binary_writer.hpp
 @@ -11,6 +11,9 @@
@@ -12,6 +12,18 @@ index fef2faf..5cae453 100644
  #include "postgres_conversion.hpp"
  
  namespace duckdb {
+@@ -427,9 +430,9 @@ public:
+ 			WriteRawInteger<int32_t>(0);                     // data size (nop for now)
+ 			WriteRawInteger<uint32_t>(child_entries.size()); // column count
+ 			for (auto &child : child_entries) {
+-				auto value_oid = PostgresUtils::ToPostgresOid(child->GetType());
++				auto value_oid = PostgresUtils::ToPostgresOid(child.GetType());
+ 				WriteRawInteger<uint32_t>(value_oid); // value oid
+-				WriteValue(*child, r);
++				WriteValue(child, r);
+ 			}
+ 			auto end_position = stream.GetPosition();
+ 			// after writing all list elements update the field size
 diff --git a/src/include/postgres_filter_pushdown.hpp b/src/include/postgres_filter_pushdown.hpp
 index d3dc0b6..471bc4c 100644
 --- a/src/include/postgres_filter_pushdown.hpp
@@ -26,7 +38,7 @@ index d3dc0b6..471bc4c 100644
  #include "duckdb/planner/filter/constant_filter.hpp"
  
 diff --git a/src/postgres_binary_reader.cpp b/src/postgres_binary_reader.cpp
-index c7fd72e..6d0b0c6 100644
+index c7fd72e..7260477 100644
 --- a/src/postgres_binary_reader.cpp
 +++ b/src/postgres_binary_reader.cpp
 @@ -1,3 +1,6 @@
@@ -36,8 +48,28 @@ index c7fd72e..6d0b0c6 100644
  #include "postgres_binary_reader.hpp"
  #include "postgres_scanner.hpp"
  
+@@ -427,8 +430,8 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
+ 		auto &child_entries = StructVector::GetEntries(out_vec);
+ 		if (postgres_type.info == PostgresTypeAnnotation::GEOM_POINT) {
+ 			D_ASSERT(value_len == sizeof(double) * 2);
+-			FlatVector::GetData<double>(*child_entries[0])[output_offset] = ReadDouble();
+-			FlatVector::GetData<double>(*child_entries[1])[output_offset] = ReadDouble();
++			FlatVector::GetData<double>(child_entries[0])[output_offset] = ReadDouble();
++			FlatVector::GetData<double>(child_entries[1])[output_offset] = ReadDouble();
+ 			break;
+ 		}
+ 		auto entry_count = ReadInteger<uint32_t>();
+@@ -437,7 +440,7 @@ void PostgresBinaryReader::ReadValue(const LogicalType &type, const PostgresType
+ 			                        entry_count);
+ 		}
+ 		for (idx_t c = 0; c < entry_count; c++) {
+-			auto &child = *child_entries[c];
++			auto &child = child_entries[c];
+ 			auto value_oid = ReadInteger<uint32_t>();
+ 			ReadValue(child.GetType(), postgres_type.children[c], child, output_offset);
+ 		}
 diff --git a/src/postgres_copy_to.cpp b/src/postgres_copy_to.cpp
-index 72580a3..780758f 100644
+index 72580a3..2b2c910 100644
 --- a/src/postgres_copy_to.cpp
 +++ b/src/postgres_copy_to.cpp
 @@ -1,3 +1,6 @@
@@ -47,6 +79,15 @@ index 72580a3..780758f 100644
  #include "postgres_connection.hpp"
  #include "postgres_binary_writer.hpp"
  #include "postgres_text_writer.hpp"
+@@ -214,7 +217,7 @@ void CastStructToPostgres(ClientContext &context, Vector &input, Vector &varchar
+ 	vector<Vector> child_varchar_vectors;
+ 	for (idx_t c = 0; c < child_vectors.size(); c++) {
+ 		Vector child_varchar(LogicalType::VARCHAR, size);
+-		CastToPostgresVarchar(context, *child_vectors[c], child_varchar, size);
++		CastToPostgresVarchar(context, child_vectors[c], child_varchar, size);
+ 		child_varchar_vectors.push_back(std::move(child_varchar));
+ 	}
+ 
 diff --git a/src/postgres_filter_pushdown.cpp b/src/postgres_filter_pushdown.cpp
 index c2f981a..cabe77f 100644
 --- a/src/postgres_filter_pushdown.cpp
@@ -77,7 +118,7 @@ index c2f981a..cabe77f 100644
  
  		if (filter_text.empty()) {
 diff --git a/src/postgres_text_reader.cpp b/src/postgres_text_reader.cpp
-index 9a1bbed..096187f 100644
+index 9a1bbed..60c99d2 100644
 --- a/src/postgres_text_reader.cpp
 +++ b/src/postgres_text_reader.cpp
 @@ -1,3 +1,6 @@
@@ -87,6 +128,15 @@ index 9a1bbed..096187f 100644
  #include "postgres_text_reader.hpp"
  #include "postgres_scanner.hpp"
  #include "duckdb/common/types/blob.hpp"
+@@ -245,7 +248,7 @@ void PostgresTextReader::ConvertStruct(Vector &source, Vector &target, const Pos
+ 		ParsePostgresStruct(struct_parser, strings[i]);
+ 	}
+ 	for (idx_t c = 0; c < children.size(); c++) {
+-		ConvertVector(struct_parser.data.data[c], *children[c],
++		ConvertVector(struct_parser.data.data[c], children[c],
+ 		              c >= postgres_type.children.size() ? PostgresType() : postgres_type.children[c], count);
+ 	}
+ }
 diff --git a/src/storage/postgres_merge_into.cpp b/src/storage/postgres_merge_into.cpp
 index 03188d6..7bcab80 100644
 --- a/src/storage/postgres_merge_into.cpp

--- a/.github/patches/extensions/spatial/fix.patch
+++ b/.github/patches/extensions/spatial/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/spatial/index/rtree/rtree_index.cpp b/src/spatial/index/rtree/rtree_index.cpp
-index 239d546..290ab80 100644
+index 239d546..c16df2d 100644
 --- a/src/spatial/index/rtree/rtree_index.cpp
 +++ b/src/spatial/index/rtree/rtree_index.cpp
 @@ -1,3 +1,5 @@
@@ -8,6 +8,23 @@ index 239d546..290ab80 100644
  #include "spatial/index/rtree/rtree_index.hpp"
  
  #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+@@ -167,11 +169,11 @@ static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CA
+ 	const auto &box_validity = FlatVector::Validity(box_vec);
+ 	const auto &row_validity = FlatVector::Validity(rowid_vec);
+ 
+-	const auto &box_entries = StructVector::GetEntries(box_vec);
+-	const auto box_xmin_data = FlatVector::GetData<float>(*box_entries[0]);
+-	const auto box_ymin_data = FlatVector::GetData<float>(*box_entries[1]);
+-	const auto box_xmax_data = FlatVector::GetData<float>(*box_entries[2]);
+-	const auto box_ymax_data = FlatVector::GetData<float>(*box_entries[3]);
++	auto &box_entries = StructVector::GetEntries(box_vec);
++	const auto box_xmin_data = FlatVector::GetData<float>(box_entries[0]);
++	const auto box_ymin_data = FlatVector::GetData<float>(box_entries[1]);
++	const auto box_xmax_data = FlatVector::GetData<float>(box_entries[2]);
++	const auto box_ymax_data = FlatVector::GetData<float>(box_entries[3]);
+ 
+ 	const auto row_data = FlatVector::GetData<row_t>(rowid_vec);
+ 
 diff --git a/src/spatial/index/rtree/rtree_index_create_logical.cpp b/src/spatial/index/rtree/rtree_index_create_logical.cpp
 index 263d413..63d35f1 100644
 --- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -22,7 +39,7 @@ index 263d413..63d35f1 100644
  	// Visit the operator's expressions
  	LogicalOperatorVisitor::EnumerateExpressions(*this,
 diff --git a/src/spatial/index/rtree/rtree_index_create_physical.cpp b/src/spatial/index/rtree/rtree_index_create_physical.cpp
-index bc4134a..174b227 100644
+index bc4134a..b4d5601 100644
 --- a/src/spatial/index/rtree/rtree_index_create_physical.cpp
 +++ b/src/spatial/index/rtree/rtree_index_create_physical.cpp
 @@ -1,3 +1,5 @@
@@ -31,6 +48,24 @@ index bc4134a..174b227 100644
  #include "spatial/index/rtree/rtree_index_create_physical.hpp"
  #include "spatial/index/rtree/rtree_index.hpp"
  #include "spatial/index/rtree/rtree_node.hpp"
+@@ -102,12 +104,12 @@ SinkResultType PhysicalCreateRTreeIndex::Sink(ExecutionContext &context, DataChu
+ 	// TODO: Dont flatten chunk
+ 	chunk.Flatten();
+ 
+-	const auto &bbox_vecs = StructVector::GetEntries(chunk.data[0]);
++	auto &bbox_vecs = StructVector::GetEntries(chunk.data[0]);
+ 	const auto &rowid_data = FlatVector::GetData<row_t>(chunk.data[1]);
+-	const auto min_x_data = FlatVector::GetData<float>(*bbox_vecs[0]);
+-	const auto min_y_data = FlatVector::GetData<float>(*bbox_vecs[1]);
+-	const auto max_x_data = FlatVector::GetData<float>(*bbox_vecs[2]);
+-	const auto max_y_data = FlatVector::GetData<float>(*bbox_vecs[3]);
++	const auto min_x_data = FlatVector::GetData<float>(bbox_vecs[0]);
++	const auto min_y_data = FlatVector::GetData<float>(bbox_vecs[1]);
++	const auto max_x_data = FlatVector::GetData<float>(bbox_vecs[2]);
++	const auto max_y_data = FlatVector::GetData<float>(bbox_vecs[3]);
+ 
+ 	// Vectorized conversion from columnar to row-wise
+ 	RTreeEntry entries[STANDARD_VECTOR_SIZE];
 diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
 index 3b37ca8..fa54ae8 100644
 --- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -156,7 +191,7 @@ index 3b37ca8..fa54ae8 100644
  		new_filter->children.push_back(std::move(get_ptr));
  		new_filter->ResolveOperatorTypes();
 diff --git a/src/spatial/index/rtree/rtree_index_pragmas.cpp b/src/spatial/index/rtree/rtree_index_pragmas.cpp
-index a0e5397..0080dd9 100644
+index a0e5397..69a1578 100644
 --- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
 +++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
 @@ -1,3 +1,5 @@
@@ -165,8 +200,25 @@ index a0e5397..0080dd9 100644
  #include "spatial/spatial_types.hpp"
  #include "spatial/index/rtree/rtree_index.hpp"
  #include "spatial/index/rtree/rtree_module.hpp"
+@@ -203,11 +205,11 @@ static void RTreeIndexDumpExecute(ClientContext &context, TableFunctionInput &da
+ 	idx_t output_idx = 0;
+ 
+ 	const auto level_data = FlatVector::GetData<int32_t>(output.data[0]);
+-	const auto &bounds_vectors = StructVector::GetEntries(output.data[1]);
+-	const auto xmin_data = FlatVector::GetData<float>(*bounds_vectors[0]);
+-	const auto ymin_data = FlatVector::GetData<float>(*bounds_vectors[1]);
+-	const auto xmax_data = FlatVector::GetData<float>(*bounds_vectors[2]);
+-	const auto ymax_data = FlatVector::GetData<float>(*bounds_vectors[3]);
++	auto &bounds_vectors = StructVector::GetEntries(output.data[1]);
++	const auto xmin_data = FlatVector::GetData<float>(bounds_vectors[0]);
++	const auto ymin_data = FlatVector::GetData<float>(bounds_vectors[1]);
++	const auto xmax_data = FlatVector::GetData<float>(bounds_vectors[2]);
++	const auto ymax_data = FlatVector::GetData<float>(bounds_vectors[3]);
+ 	const auto rowid_data = FlatVector::GetData<row_t>(output.data[2]);
+ 
+ 	const auto &tree = *state.index.tree;
 diff --git a/src/spatial/modules/geos/geos_module.cpp b/src/spatial/modules/geos/geos_module.cpp
-index d111f0b..84f49f4 100644
+index d111f0b..fd5e3bb 100644
 --- a/src/spatial/modules/geos/geos_module.cpp
 +++ b/src/spatial/modules/geos/geos_module.cpp
 @@ -8,6 +8,7 @@
@@ -177,8 +229,919 @@ index d111f0b..84f49f4 100644
  #include "spatial/geometry/geometry_serialization.hpp"
  #include "spatial/geometry/sgl.hpp"
  
+@@ -304,11 +305,11 @@ struct ST_AsMVTGeom {
+ 		args.data[0].ToUnifiedFormat(args.size(), geom_format);
+ 		args.data[1].ToUnifiedFormat(args.size(), bbox_format);
+ 
+-		const auto &bbox_parts = StructVector::GetEntries(args.data[1]);
+-		bbox_parts[0]->ToUnifiedFormat(args.size(), minx_format);
+-		bbox_parts[1]->ToUnifiedFormat(args.size(), miny_format);
+-		bbox_parts[2]->ToUnifiedFormat(args.size(), maxx_format);
+-		bbox_parts[3]->ToUnifiedFormat(args.size(), maxy_format);
++		auto &bbox_parts = StructVector::GetEntries(args.data[1]);
++		bbox_parts[0].ToUnifiedFormat(args.size(), minx_format);
++		bbox_parts[1].ToUnifiedFormat(args.size(), miny_format);
++		bbox_parts[2].ToUnifiedFormat(args.size(), maxx_format);
++		bbox_parts[3].ToUnifiedFormat(args.size(), maxy_format);
+ 
+ 		const auto geom_data = UnifiedVectorFormat::GetData<string_t>(geom_format);
+ 		const auto minx_data = UnifiedVectorFormat::GetData<double>(minx_format);
+@@ -1653,8 +1654,8 @@ struct ST_MaximumInscribedCircle {
+ 		auto &lstate = LocalState::ResetAndGet(state);
+ 
+ 		auto &struct_vecs = StructVector::GetEntries(result);
+-		auto &center_vec = *struct_vecs[0];
+-		auto &nearest_vec = *struct_vecs[1];
++		auto &center_vec = struct_vecs[0];
++		auto &nearest_vec = struct_vecs[1];
+ 
+ 		using STRING_TYPE = PrimitiveType<string_t>;
+ 		using RESULT_TYPE = StructTypeTernary<string_t, string_t, double>;
+@@ -1681,8 +1682,8 @@ struct ST_MaximumInscribedCircle {
+ 		auto &lstate = LocalState::ResetAndGet(state);
+ 
+ 		auto &struct_vecs = StructVector::GetEntries(result);
+-		auto &center_vec = *struct_vecs[0];
+-		auto &nearest_vec = *struct_vecs[1];
++		auto &center_vec = struct_vecs[0];
++		auto &nearest_vec = struct_vecs[1];
+ 
+ 		using STRING_TYPE = PrimitiveType<string_t>;
+ 		using DOUBLE_TYPE = PrimitiveType<double>;
+@@ -2610,7 +2611,7 @@ struct ST_Union_Agg {
+ 
+ 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
+ 			const auto state_idx = state_format.sel->get_index(raw_idx);
+-			const auto &state = *state_ptr[state_idx];
++			auto &state = *state_ptr[state_idx];
+ 
+ 			// We can't steal the list, we need to clone and append all elements
+ 			auto &combined_state = *combined_ptr[raw_idx];
+@@ -2788,7 +2789,7 @@ struct GEOSCoverageAggFunction {
+ 
+ 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
+ 			const auto state_idx = state_format.sel->get_index(raw_idx);
+-			const auto &state = *state_ptr[state_idx];
++			auto &state = *state_ptr[state_idx];
+ 
+ 			// We can't steal the list, we need to clone and append all elements
+ 			auto &combined_state = *combined_ptr[raw_idx];
+diff --git a/src/spatial/modules/main/spatial_functions_cast.cpp b/src/spatial/modules/main/spatial_functions_cast.cpp
+index 72722cc..c64825a 100644
+--- a/src/spatial/modules/main/spatial_functions_cast.cpp
++++ b/src/spatial/modules/main/spatial_functions_cast.cpp
+@@ -245,15 +245,15 @@ struct PointCasts {
+ 	//------------------------------------------------------------------------------------------------------------------
+ 	static bool ToPoint2DCast(Vector &source, Vector &result, idx_t count, CastParameters &) {
+ 		auto &children = StructVector::GetEntries(source);
+-		const auto &x_child = children[0];
+-		const auto &y_child = children[1];
++		auto &x_child = children[0];
++		auto &y_child = children[1];
+ 
+-		const auto &result_children = StructVector::GetEntries(result);
+-		const auto &result_x_child = result_children[0];
+-		const auto &result_y_child = result_children[1];
++		auto &result_children = StructVector::GetEntries(result);
++		auto &result_x_child = result_children[0];
++		auto &result_y_child = result_children[1];
+ 
+-		result_x_child->Reference(*x_child);
+-		result_y_child->Reference(*y_child);
++		result_x_child.Reference(x_child);
++		result_y_child.Reference(y_child);
+ 
+ 		if (count == 1) {
+ 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+@@ -383,9 +383,9 @@ struct LinestringCasts {
+ 
+ 		auto &coord_vec = ListVector::GetEntry(source);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		const auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		const auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
+-		const auto z_data = HAS_Z ? FlatVector::GetData<double>(*coord_vec_children[2]) : nullptr;
++		const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
++		const auto z_data = HAS_Z ? FlatVector::GetData<double>(coord_vec_children[2]) : nullptr;
+ 
+ 		const auto coord_size = HAS_Z ? 3 : 2;
+ 
+@@ -457,11 +457,11 @@ struct LinestringCasts {
+ 			auto &coord_vec = ListVector::GetEntry(result);
+ 			auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 
+-			const auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-			const auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++			const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++			const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 			if (HAS_Z) {
+-				const auto z_data = FlatVector::GetData<double>(*coord_vec_children[2]);
++				const auto z_data = FlatVector::GetData<double>(coord_vec_children[2]);
+ 				for (idx_t i = 0; i < line_size; i++) {
+ 					const auto vertex = line.get_vertex_xyzm(i);
+ 					x_data[entry.offset + i] = vertex.x;
+@@ -501,8 +501,8 @@ struct LinestringCasts {
+ 	static bool ToLine2DCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+ 		auto &coord_src = ListVector::GetEntry(source);
+ 		auto &coord_src_children = StructVector::GetEntries(coord_src);
+-		const auto x_src = FlatVector::GetData<double>(*coord_src_children[0]);
+-		const auto y_src = FlatVector::GetData<double>(*coord_src_children[1]);
++		const auto x_src = FlatVector::GetData<double>(coord_src_children[0]);
++		const auto y_src = FlatVector::GetData<double>(coord_src_children[1]);
+ 
+ 		idx_t total_coords = 0;
+ 
+@@ -517,8 +517,8 @@ struct LinestringCasts {
+ 			auto &coord_dst = ListVector::GetEntry(result);
+ 			auto &coord_dst_children = StructVector::GetEntries(coord_dst);
+ 
+-			const auto x_dst = FlatVector::GetData<double>(*coord_dst_children[0]);
+-			const auto y_dst = FlatVector::GetData<double>(*coord_dst_children[1]);
++			const auto x_dst = FlatVector::GetData<double>(coord_dst_children[0]);
++			const auto y_dst = FlatVector::GetData<double>(coord_dst_children[1]);
+ 
+ 			for (idx_t i = 0; i < line.length; i++) {
+ 				x_dst[entry.offset + i] = x_src[line.offset + i];
+@@ -588,10 +588,10 @@ struct PolygonCasts {
+ 		auto &ring_vec = ListVector::GetEntry(source);
+ 		const auto ring_entries = ListVector::GetData(ring_vec);
+ 		const auto &coord_vec = ListVector::GetEntry(ring_vec);
+-		const auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		const auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		const auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
+-		const auto z_data = HAS_Z ? FlatVector::GetData<double>(*coord_vec_children[2]) : nullptr;
++		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
++		const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
++		const auto z_data = HAS_Z ? FlatVector::GetData<double>(coord_vec_children[2]) : nullptr;
+ 
+ 		const auto coord_size = HAS_Z ? 3 : 2;
+ 
+@@ -690,13 +690,13 @@ struct PolygonCasts {
+ 					const auto ring_entries = ListVector::GetData(ring_vec);
+ 					auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 					auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-					const auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-					const auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++					const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++					const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 					ring_entries[total_rings + ring_idx] = ring_entry;
+ 
+ 					if (HAS_Z) {
+-						const auto z_data = FlatVector::GetData<double>(*coord_vec_children[2]);
++						const auto z_data = FlatVector::GetData<double>(coord_vec_children[2]);
+ 						for (idx_t j = 0; j < ring_size; j++) {
+ 							const auto vertext = head->get_vertex_xyzm(j);
+ 							x_data[ring_entry.offset + j] = vertext.x;
+@@ -750,9 +750,9 @@ struct PolygonCasts {
+ 		auto &ring_src = ListVector::GetEntry(source);
+ 		const auto ring_entries_src = ListVector::GetData(ring_src);
+ 		const auto &coord_src = ListVector::GetEntry(ring_src);
+-		const auto &coord_src_children = StructVector::GetEntries(coord_src);
+-		const auto x_src = FlatVector::GetData<double>(*coord_src_children[0]);
+-		const auto y_src = FlatVector::GetData<double>(*coord_src_children[1]);
++		auto &coord_src_children = StructVector::GetEntries(coord_src);
++		const auto x_src = FlatVector::GetData<double>(coord_src_children[0]);
++		const auto y_src = FlatVector::GetData<double>(coord_src_children[1]);
+ 
+ 		idx_t total_rings = 0;
+ 		idx_t total_coords = 0;
+@@ -771,8 +771,8 @@ struct PolygonCasts {
+ 				const auto ring_entries_dst = ListVector::GetData(ring_dst);
+ 				auto &coord_dst = ListVector::GetEntry(ring_dst);
+ 				auto &coord_dst_children = StructVector::GetEntries(coord_dst);
+-				const auto x_dst = FlatVector::GetData<double>(*coord_dst_children[0]);
+-				const auto y_dst = FlatVector::GetData<double>(*coord_dst_children[1]);
++				const auto x_dst = FlatVector::GetData<double>(coord_dst_children[0]);
++				const auto y_dst = FlatVector::GetData<double>(coord_dst_children[1]);
+ 
+ 				ring_entries_dst[total_rings + i] = ring_entry_dst;
+ 
+@@ -969,8 +969,8 @@ void CoreVectorOperations::Point4DToVarchar(Vector &source, Vector &result, idx_
+ void CoreVectorOperations::LineString2DToVarchar(Vector &source, Vector &result, idx_t count) {
+ 	auto &inner = ListVector::GetEntry(source);
+ 	auto &children = StructVector::GetEntries(inner);
+-	auto x_data = FlatVector::GetData<double>(*children[0]);
+-	auto y_data = FlatVector::GetData<double>(*children[1]);
++	auto x_data = FlatVector::GetData<double>(children[0]);
++	auto y_data = FlatVector::GetData<double>(children[1]);
+ 
+ 	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](list_entry_t &line) {
+ 		auto offset = line.offset;
+@@ -998,9 +998,9 @@ void CoreVectorOperations::LineString2DToVarchar(Vector &source, Vector &result,
+ void CoreVectorOperations::LineString3DToVarchar(Vector &source, Vector &result, idx_t count) {
+ 	auto &inner = ListVector::GetEntry(source);
+ 	auto &children = StructVector::GetEntries(inner);
+-	auto x_data = FlatVector::GetData<double>(*children[0]);
+-	auto y_data = FlatVector::GetData<double>(*children[1]);
+-	auto z_data = FlatVector::GetData<double>(*children[2]);
++	auto x_data = FlatVector::GetData<double>(children[0]);
++	auto y_data = FlatVector::GetData<double>(children[1]);
++	auto z_data = FlatVector::GetData<double>(children[2]);
+ 
+ 	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](list_entry_t &line) {
+ 		auto offset = line.offset;
+@@ -1031,8 +1031,8 @@ void CoreVectorOperations::Polygon2DToVarchar(Vector &source, Vector &result, id
+ 	auto ring_entries = ListVector::GetData(ring_vector);
+ 	auto &point_vector = ListVector::GetEntry(ring_vector);
+ 	auto &point_children = StructVector::GetEntries(point_vector);
+-	auto x_data = FlatVector::GetData<double>(*point_children[0]);
+-	auto y_data = FlatVector::GetData<double>(*point_children[1]);
++	auto x_data = FlatVector::GetData<double>(point_children[0]);
++	auto y_data = FlatVector::GetData<double>(point_children[1]);
+ 
+ 	UnaryExecutor::Execute<list_entry_t, string_t>(poly_vector, result, count, [&](list_entry_t polygon_entry) {
+ 		auto offset = polygon_entry.offset;
+@@ -1073,9 +1073,9 @@ void CoreVectorOperations::Polygon3DToVarchar(Vector &source, Vector &result, id
+ 	auto ring_entries = ListVector::GetData(ring_vector);
+ 	auto &point_vector = ListVector::GetEntry(ring_vector);
+ 	auto &point_children = StructVector::GetEntries(point_vector);
+-	auto x_data = FlatVector::GetData<double>(*point_children[0]);
+-	auto y_data = FlatVector::GetData<double>(*point_children[1]);
+-	auto z_data = FlatVector::GetData<double>(*point_children[2]);
++	auto x_data = FlatVector::GetData<double>(point_children[0]);
++	auto y_data = FlatVector::GetData<double>(point_children[1]);
++	auto z_data = FlatVector::GetData<double>(point_children[2]);
+ 
+ 	UnaryExecutor::Execute<list_entry_t, string_t>(poly_vector, result, count, [&](list_entry_t polygon_entry) {
+ 		auto offset = polygon_entry.offset;
+diff --git a/src/spatial/modules/main/spatial_functions_scalar.cpp b/src/spatial/modules/main/spatial_functions_scalar.cpp
+index 750bd2e..b67d627 100644
+--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
++++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
+@@ -442,8 +442,8 @@ struct ST_Area {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		UnaryExecutor::Execute<list_entry_t, double>(input, result, count, [&](list_entry_t polygon) {
+ 			auto polygon_offset = polygon.offset;
+@@ -1394,12 +1394,12 @@ struct ST_Centroid {
+ 		auto line_vertex_entries = ListVector::GetData(input);
+ 		auto &line_vertex_vec = ListVector::GetEntry(input);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+-		auto line_x_data = FlatVector::GetData<double>(*line_vertex_vec_children[0]);
+-		auto line_y_vec = FlatVector::GetData<double>(*line_vertex_vec_children[1]);
++		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
++		auto line_y_vec = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+ 
+ 		auto &point_vertex_children = StructVector::GetEntries(result);
+-		auto point_x_data = FlatVector::GetData<double>(*point_vertex_children[0]);
+-		auto point_y_data = FlatVector::GetData<double>(*point_vertex_children[1]);
++		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
++		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+ 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
+ 
+ 			auto in_row_idx = format.sel->get_index(out_row_idx);
+@@ -1453,12 +1453,12 @@ struct ST_Centroid {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+-		auto x_data = FlatVector::GetData<double>(*vertex_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*vertex_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+ 
+ 		auto &centroid_children = StructVector::GetEntries(result);
+-		auto centroid_x_data = FlatVector::GetData<double>(*centroid_children[0]);
+-		auto centroid_y_data = FlatVector::GetData<double>(*centroid_children[1]);
++		auto centroid_x_data = FlatVector::GetData<double>(centroid_children[0]);
++		auto centroid_y_data = FlatVector::GetData<double>(centroid_children[1]);
+ 
+ 		for (idx_t in_row_idx = 0; in_row_idx < count; in_row_idx++) {
+ 			if (format.validity.RowIsValid(in_row_idx)) {
+@@ -1535,14 +1535,14 @@ struct ST_Centroid {
+ 		UnifiedVectorFormat format;
+ 		input.ToUnifiedFormat(count, format);
+ 		auto &box_children = StructVector::GetEntries(input);
+-		auto minx_data = FlatVector::GetData<T>(*box_children[0]);
+-		auto miny_data = FlatVector::GetData<T>(*box_children[1]);
+-		auto maxx_data = FlatVector::GetData<T>(*box_children[2]);
+-		auto maxy_data = FlatVector::GetData<T>(*box_children[3]);
++		auto minx_data = FlatVector::GetData<T>(box_children[0]);
++		auto miny_data = FlatVector::GetData<T>(box_children[1]);
++		auto maxx_data = FlatVector::GetData<T>(box_children[2]);
++		auto maxy_data = FlatVector::GetData<T>(box_children[3]);
+ 
+ 		auto &centroid_children = StructVector::GetEntries(result);
+-		auto centroid_x_data = FlatVector::GetData<double>(*centroid_children[0]);
+-		auto centroid_y_data = FlatVector::GetData<double>(*centroid_children[1]);
++		auto centroid_x_data = FlatVector::GetData<double>(centroid_children[0]);
++		auto centroid_y_data = FlatVector::GetData<double>(centroid_children[1]);
+ 
+ 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
+ 			auto in_row_idx = format.sel->get_index(out_row_idx);
+@@ -2012,8 +2012,8 @@ struct ST_Contains {
+ 
+ 		// Setup point vectors
+ 		auto &p_children = StructVector::GetEntries(in_point);
+-		auto p_x_data = FlatVector::GetData<double>(*p_children[0]);
+-		auto p_y_data = FlatVector::GetData<double>(*p_children[1]);
++		auto p_x_data = FlatVector::GetData<double>(p_children[0]);
++		auto p_y_data = FlatVector::GetData<double>(p_children[1]);
+ 
+ 		// Setup polygon vectors
+ 		auto polygon_entries = ListVector::GetData(in_polygon);
+@@ -2021,8 +2021,8 @@ struct ST_Contains {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_children[1]);
+ 
+ 		auto result_data = FlatVector::GetData<bool>(result);
+ 		for (idx_t polygon_idx = 0; polygon_idx < count; polygon_idx++) {
+@@ -2274,10 +2274,10 @@ struct ST_Azimuth {
+ 		auto &left_entries = StructVector::GetEntries(left);
+ 		auto &right_entries = StructVector::GetEntries(right);
+ 
+-		auto left_x = FlatVector::GetData<double>(*left_entries[0]);
+-		auto left_y = FlatVector::GetData<double>(*left_entries[1]);
+-		auto right_x = FlatVector::GetData<double>(*right_entries[0]);
+-		auto right_y = FlatVector::GetData<double>(*right_entries[1]);
++		auto left_x = FlatVector::GetData<double>(left_entries[0]);
++		auto left_y = FlatVector::GetData<double>(left_entries[1]);
++		auto right_x = FlatVector::GetData<double>(right_entries[0]);
++		auto right_y = FlatVector::GetData<double>(right_entries[1]);
+ 
+ 		auto &result_mask = FlatVector::Validity(result);
+ 
+@@ -2408,10 +2408,10 @@ struct ST_Distance {
+ 		auto &left_entries = StructVector::GetEntries(left);
+ 		auto &right_entries = StructVector::GetEntries(right);
+ 
+-		auto left_x = FlatVector::GetData<double>(*left_entries[0]);
+-		auto left_y = FlatVector::GetData<double>(*left_entries[1]);
+-		auto right_x = FlatVector::GetData<double>(*right_entries[0]);
+-		auto right_y = FlatVector::GetData<double>(*right_entries[1]);
++		auto left_x = FlatVector::GetData<double>(left_entries[0]);
++		auto left_y = FlatVector::GetData<double>(left_entries[1]);
++		auto right_x = FlatVector::GetData<double>(right_entries[0]);
++		auto right_y = FlatVector::GetData<double>(right_entries[1]);
+ 
+ 		auto out_data = FlatVector::GetData<double>(result);
+ 		for (idx_t i = 0; i < count; i++) {
+@@ -2433,8 +2433,8 @@ struct ST_Distance {
+ 		auto &p_children = StructVector::GetEntries(in_point);
+ 		auto &p_x = p_children[0];
+ 		auto &p_y = p_children[1];
+-		auto p_x_data = FlatVector::GetData<double>(*p_x);
+-		auto p_y_data = FlatVector::GetData<double>(*p_y);
++		auto p_x_data = FlatVector::GetData<double>(p_x);
++		auto p_y_data = FlatVector::GetData<double>(p_y);
+ 
+ 		// Set up the line vectors
+ 		in_line.Flatten(count);
+@@ -2443,8 +2443,8 @@ struct ST_Distance {
+ 		auto &children = StructVector::GetEntries(inner);
+ 		auto &x = children[0];
+ 		auto &y = children[1];
+-		auto x_data = FlatVector::GetData<double>(*x);
+-		auto y_data = FlatVector::GetData<double>(*y);
++		auto x_data = FlatVector::GetData<double>(x);
++		auto y_data = FlatVector::GetData<double>(y);
+ 		auto lines = ListVector::GetData(in_line);
+ 
+ 		auto result_data = FlatVector::GetData<double>(result);
+@@ -2904,11 +2904,11 @@ struct ST_Dump {
+ 			auto &result_path_vec = result_list_children[1];
+ 
+ 			// The child geometries must share the same properties as the parent geometry
+-			auto geom_data = FlatVector::GetData<string_t>(*result_geom_vec);
++			auto geom_data = FlatVector::GetData<string_t>(result_geom_vec);
+ 			for (idx_t i = 0; i < geom_length; i++) {
+ 				// Write the geometry
+ 				auto item_blob = std::get<0>(items[i]);
+-				geom_data[geom_offset + i] = lstate.Serialize(*result_geom_vec, *item_blob);
++				geom_data[geom_offset + i] = lstate.Serialize(result_geom_vec, *item_blob);
+ 
+ 				// Now write the paths
+ 				auto &path = std::get<1>(items[i]);
+@@ -2917,15 +2917,15 @@ struct ST_Dump {
+ 
+ 				total_path_count += path_length;
+ 
+-				ListVector::Reserve(*result_path_vec, total_path_count);
+-				ListVector::SetListSize(*result_path_vec, total_path_count);
++				ListVector::Reserve(result_path_vec, total_path_count);
++				ListVector::SetListSize(result_path_vec, total_path_count);
+ 
+-				auto path_entries = ListVector::GetData(*result_path_vec);
++				auto path_entries = ListVector::GetData(result_path_vec);
+ 
+ 				path_entries[geom_offset + i].offset = path_offset;
+ 				path_entries[geom_offset + i].length = path_length;
+ 
+-				auto &path_data_vec = ListVector::GetEntry(*result_path_vec);
++				auto &path_data_vec = ListVector::GetEntry(result_path_vec);
+ 				auto path_data = FlatVector::GetData<int32_t>(path_data_vec);
+ 
+ 				for (idx_t j = 0; j < path_length; j++) {
+@@ -3079,11 +3079,11 @@ struct ST_Extent {
+ 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
+ 		auto &lstate = LocalState::ResetAndGet(state);
+ 
+-		const auto &bbox_vec = StructVector::GetEntries(result);
+-		const auto min_x_data = FlatVector::GetData<double>(*bbox_vec[0]);
+-		const auto min_y_data = FlatVector::GetData<double>(*bbox_vec[1]);
+-		const auto max_x_data = FlatVector::GetData<double>(*bbox_vec[2]);
+-		const auto max_y_data = FlatVector::GetData<double>(*bbox_vec[3]);
++		auto &bbox_vec = StructVector::GetEntries(result);
++		const auto min_x_data = FlatVector::GetData<double>(bbox_vec[0]);
++		const auto min_y_data = FlatVector::GetData<double>(bbox_vec[1]);
++		const auto max_x_data = FlatVector::GetData<double>(bbox_vec[2]);
++		const auto max_y_data = FlatVector::GetData<double>(bbox_vec[3]);
+ 
+ 		UnifiedVectorFormat input_vdata;
+ 		args.data[0].ToUnifiedFormat(args.size(), input_vdata);
+@@ -3169,11 +3169,11 @@ struct ST_Extent_Approx {
+ 		const auto count = args.size();
+ 		auto &input = args.data[0];
+ 
+-		const auto &struct_vec = StructVector::GetEntries(result);
+-		const auto min_x_data = FlatVector::GetData<float>(*struct_vec[0]);
+-		const auto min_y_data = FlatVector::GetData<float>(*struct_vec[1]);
+-		const auto max_x_data = FlatVector::GetData<float>(*struct_vec[2]);
+-		const auto max_y_data = FlatVector::GetData<float>(*struct_vec[3]);
++		auto &struct_vec = StructVector::GetEntries(result);
++		const auto min_x_data = FlatVector::GetData<float>(struct_vec[0]);
++		const auto min_y_data = FlatVector::GetData<float>(struct_vec[1]);
++		const auto max_x_data = FlatVector::GetData<float>(struct_vec[2]);
++		const auto max_y_data = FlatVector::GetData<float>(struct_vec[3]);
+ 
+ 		UnifiedVectorFormat input_vdata;
+ 		input.ToUnifiedFormat(count, input_vdata);
+@@ -3258,12 +3258,12 @@ struct Op_IntersectApprox {
+         box.ToUnifiedFormat(count, box_vdata);
+ 
+         // Get the struct entries and convert them to unified format
+-        const auto &bbox_vec = StructVector::GetEntries(box);
++        auto &bbox_vec = StructVector::GetEntries(box);
+         UnifiedVectorFormat box_min_x_vdata, box_min_y_vdata, box_max_x_vdata, box_max_y_vdata;
+-        bbox_vec[0]->ToUnifiedFormat(count, box_min_x_vdata);
+-        bbox_vec[1]->ToUnifiedFormat(count, box_min_y_vdata);
+-        bbox_vec[2]->ToUnifiedFormat(count, box_max_x_vdata);
+-        bbox_vec[3]->ToUnifiedFormat(count, box_max_y_vdata);
++        bbox_vec[0].ToUnifiedFormat(count, box_min_x_vdata);
++        bbox_vec[1].ToUnifiedFormat(count, box_min_y_vdata);
++        bbox_vec[2].ToUnifiedFormat(count, box_max_x_vdata);
++        bbox_vec[3].ToUnifiedFormat(count, box_max_y_vdata);
+ 
+         const auto box_min_x_data = UnifiedVectorFormat::GetData<double>(box_min_x_vdata);
+         const auto box_min_y_data = UnifiedVectorFormat::GetData<double>(box_min_y_vdata);
+@@ -3405,8 +3405,8 @@ struct ST_ExteriorRing {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+-		auto poly_x_data = FlatVector::GetData<double>(*vertex_vec_children[0]);
+-		auto poly_y_data = FlatVector::GetData<double>(*vertex_vec_children[1]);
++		auto poly_x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
++		auto poly_y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+ 
+ 		auto count = args.size();
+ 		UnifiedVectorFormat poly_format;
+@@ -3433,8 +3433,8 @@ struct ST_ExteriorRing {
+ 
+ 		auto line_entries = ListVector::GetData(line_vec);
+ 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
+-		auto line_data_x = FlatVector::GetData<double>(*line_coord_vec[0]);
+-		auto line_data_y = FlatVector::GetData<double>(*line_coord_vec[1]);
++		auto line_data_x = FlatVector::GetData<double>(line_coord_vec[0]);
++		auto line_data_y = FlatVector::GetData<double>(line_coord_vec[1]);
+ 
+ 		// Now we can fill the result vector
+ 		idx_t line_data_offset = 0;
+@@ -3525,12 +3525,12 @@ struct ST_FlipCoordinates {
+ 		input.Flatten(count);
+ 
+ 		auto &coords_in = StructVector::GetEntries(input);
+-		auto x_data_in = FlatVector::GetData<double>(*coords_in[0]);
+-		auto y_data_in = FlatVector::GetData<double>(*coords_in[1]);
++		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
++		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+ 
+ 		auto &coords_out = StructVector::GetEntries(result);
+-		auto x_data_out = FlatVector::GetData<double>(*coords_out[0]);
+-		auto y_data_out = FlatVector::GetData<double>(*coords_out[1]);
++		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
++		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+ 
+ 		memcpy(x_data_out, y_data_in, count * sizeof(double));
+ 		memcpy(y_data_out, x_data_in, count * sizeof(double));
+@@ -3552,8 +3552,8 @@ struct ST_FlipCoordinates {
+ 
+ 		auto coord_vec_in = ListVector::GetEntry(input);
+ 		auto &coords_in = StructVector::GetEntries(coord_vec_in);
+-		auto x_data_in = FlatVector::GetData<double>(*coords_in[0]);
+-		auto y_data_in = FlatVector::GetData<double>(*coords_in[1]);
++		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
++		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+ 
+ 		auto coord_count = ListVector::GetListSize(input);
+ 		ListVector::Reserve(result, coord_count);
+@@ -3565,8 +3565,8 @@ struct ST_FlipCoordinates {
+ 
+ 		auto coord_vec_out = ListVector::GetEntry(result);
+ 		auto &coords_out = StructVector::GetEntries(coord_vec_out);
+-		auto x_data_out = FlatVector::GetData<double>(*coords_out[0]);
+-		auto y_data_out = FlatVector::GetData<double>(*coords_out[1]);
++		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
++		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+ 
+ 		memcpy(x_data_out, y_data_in, coord_count * sizeof(double));
+ 		memcpy(y_data_out, x_data_in, coord_count * sizeof(double));
+@@ -3591,8 +3591,8 @@ struct ST_FlipCoordinates {
+ 
+ 		auto coord_vec_in = ListVector::GetEntry(ring_vec_in);
+ 		auto &coords_in = StructVector::GetEntries(coord_vec_in);
+-		auto x_data_in = FlatVector::GetData<double>(*coords_in[0]);
+-		auto y_data_in = FlatVector::GetData<double>(*coords_in[1]);
++		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
++		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+ 
+ 		auto coord_count = ListVector::GetListSize(ring_vec_in);
+ 
+@@ -3612,8 +3612,8 @@ struct ST_FlipCoordinates {
+ 
+ 		auto coord_vec_out = ListVector::GetEntry(ring_vec_out);
+ 		auto &coords_out = StructVector::GetEntries(coord_vec_out);
+-		auto x_data_out = FlatVector::GetData<double>(*coords_out[0]);
+-		auto y_data_out = FlatVector::GetData<double>(*coords_out[1]);
++		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
++		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+ 
+ 		memcpy(x_data_out, y_data_in, coord_count * sizeof(double));
+ 		memcpy(y_data_out, x_data_in, coord_count * sizeof(double));
+@@ -3635,16 +3635,16 @@ struct ST_FlipCoordinates {
+ 		input.Flatten(count);
+ 
+ 		auto &children_in = StructVector::GetEntries(input);
+-		auto min_x_in = FlatVector::GetData<double>(*children_in[0]);
+-		auto min_y_in = FlatVector::GetData<double>(*children_in[1]);
+-		auto max_x_in = FlatVector::GetData<double>(*children_in[2]);
+-		auto max_y_in = FlatVector::GetData<double>(*children_in[3]);
++		auto min_x_in = FlatVector::GetData<double>(children_in[0]);
++		auto min_y_in = FlatVector::GetData<double>(children_in[1]);
++		auto max_x_in = FlatVector::GetData<double>(children_in[2]);
++		auto max_y_in = FlatVector::GetData<double>(children_in[3]);
+ 
+ 		auto &children_out = StructVector::GetEntries(result);
+-		auto min_x_out = FlatVector::GetData<double>(*children_out[0]);
+-		auto min_y_out = FlatVector::GetData<double>(*children_out[1]);
+-		auto max_x_out = FlatVector::GetData<double>(*children_out[2]);
+-		auto max_y_out = FlatVector::GetData<double>(*children_out[3]);
++		auto min_x_out = FlatVector::GetData<double>(children_out[0]);
++		auto min_y_out = FlatVector::GetData<double>(children_out[1]);
++		auto max_x_out = FlatVector::GetData<double>(children_out[2]);
++		auto max_y_out = FlatVector::GetData<double>(children_out[3]);
+ 
+ 		memcpy(min_x_out, min_y_in, count * sizeof(double));
+ 		memcpy(min_y_out, min_x_in, count * sizeof(double));
+@@ -4752,9 +4752,9 @@ struct ST_GeomFromWKB {
+ 
+ 		input.Flatten(count);
+ 
+-		const auto &point_children = StructVector::GetEntries(result);
+-		const auto x_data = FlatVector::GetData<double>(*point_children[0]);
+-		const auto y_data = FlatVector::GetData<double>(*point_children[1]);
++		auto &point_children = StructVector::GetEntries(result);
++		const auto x_data = FlatVector::GetData<double>(point_children[0]);
++		const auto y_data = FlatVector::GetData<double>(point_children[1]);
+ 
+ 		sgl::wkb_reader reader(alloc);
+ 		reader.set_allow_mixed_zm(true);
+@@ -4836,8 +4836,8 @@ struct ST_GeomFromWKB {
+ 			auto &children = StructVector::GetEntries(inner);
+ 			auto &x_child = children[0];
+ 			auto &y_child = children[1];
+-			auto x_data = FlatVector::GetData<double>(*x_child);
+-			auto y_data = FlatVector::GetData<double>(*y_child);
++			auto x_data = FlatVector::GetData<double>(x_child);
++			auto y_data = FlatVector::GetData<double>(y_child);
+ 
+ 			for (idx_t j = 0; j < line_size; j++) {
+ 				const auto vertex = geom.get_vertex_xy(j);
+@@ -4920,8 +4920,8 @@ struct ST_GeomFromWKB {
+ 					auto &children = StructVector::GetEntries(inner);
+ 					auto &x_child = children[0];
+ 					auto &y_child = children[1];
+-					auto x_data = FlatVector::GetData<double>(*x_child);
+-					auto y_data = FlatVector::GetData<double>(*y_child);
++					auto x_data = FlatVector::GetData<double>(x_child);
++					auto y_data = FlatVector::GetData<double>(y_child);
+ 
+ 					for (idx_t k = 0; k < point_count; k++) {
+ 						const auto vertex = ring->get_vertex_xy(k);
+@@ -6198,8 +6198,8 @@ struct ST_InteriorRingN {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+-		auto poly_x_data = FlatVector::GetData<double>(*vertex_vec_children[0]);
+-		auto poly_y_data = FlatVector::GetData<double>(*vertex_vec_children[1]);
++		auto poly_x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
++		auto poly_y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+ 
+ 		auto count = args.size();
+ 		UnifiedVectorFormat poly_format;
+@@ -6255,8 +6255,8 @@ struct ST_InteriorRingN {
+ 
+ 		auto line_entries = ListVector::GetData(line_vec);
+ 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
+-		auto line_data_x = FlatVector::GetData<double>(*line_coord_vec[0]);
+-		auto line_data_y = FlatVector::GetData<double>(*line_coord_vec[1]);
++		auto line_data_x = FlatVector::GetData<double>(line_coord_vec[0]);
++		auto line_data_y = FlatVector::GetData<double>(line_coord_vec[1]);
+ 
+ 		// Fill results
+ 		idx_t line_data_offset = 0;
+@@ -6719,8 +6719,8 @@ struct ST_Length {
+ 
+ 		auto &coord_vec = ListVector::GetEntry(line_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		UnaryExecutor::Execute<list_entry_t, double>(line_vec, result, count, [&](const list_entry_t &line) {
+ 			auto offset = line.offset;
+@@ -7242,11 +7242,11 @@ struct ST_MakeBox2D {
+ 	static void ExecuteBinary(DataChunk &args, ExpressionState &state, Vector &result) {
+ 		auto &lstate = LocalState::ResetAndGet(state);
+ 
+-		const auto &bbox_vec = StructVector::GetEntries(result);
+-		const auto min_x_data = FlatVector::GetData<double>(*bbox_vec[0]);
+-		const auto min_y_data = FlatVector::GetData<double>(*bbox_vec[1]);
+-		const auto max_x_data = FlatVector::GetData<double>(*bbox_vec[2]);
+-		const auto max_y_data = FlatVector::GetData<double>(*bbox_vec[3]);
++		auto &bbox_vec = StructVector::GetEntries(result);
++		const auto min_x_data = FlatVector::GetData<double>(bbox_vec[0]);
++		const auto min_y_data = FlatVector::GetData<double>(bbox_vec[1]);
++		const auto max_x_data = FlatVector::GetData<double>(bbox_vec[2]);
++		const auto max_y_data = FlatVector::GetData<double>(bbox_vec[3]);
+ 
+ 		UnifiedVectorFormat input_vdata1;
+ 		UnifiedVectorFormat input_vdata2;
+@@ -7721,8 +7721,8 @@ struct ST_Perimeter {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		UnaryExecutor::Execute<list_entry_t, double>(input, result, count, [&](list_entry_t polygon) {
+ 			auto polygon_offset = polygon.offset;
+@@ -7845,8 +7845,8 @@ struct ST_Point {
+ 		auto &x_child = children[0];
+ 		auto &y_child = children[1];
+ 
+-		x_child->Reference(x);
+-		y_child->Reference(y);
++		x_child.Reference(x);
++		y_child.Reference(y);
+ 
+ 		if (count == 1) {
+ 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+@@ -7873,9 +7873,9 @@ struct ST_Point {
+ 		auto &y_child = children[1];
+ 		auto &z_child = children[2];
+ 
+-		x_child->Reference(x);
+-		y_child->Reference(y);
+-		z_child->Reference(z);
++		x_child.Reference(x);
++		y_child.Reference(y);
++		z_child.Reference(z);
+ 
+ 		if (count == 1) {
+ 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+@@ -7905,10 +7905,10 @@ struct ST_Point {
+ 		auto &z_child = children[2];
+ 		auto &m_child = children[3];
+ 
+-		x_child->Reference(x);
+-		y_child->Reference(y);
+-		z_child->Reference(z);
+-		m_child->Reference(m);
++		x_child.Reference(x);
++		y_child.Reference(y);
++		z_child.Reference(z);
++		m_child.Reference(m);
+ 
+ 		if (count == 1) {
+ 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+@@ -8138,12 +8138,12 @@ struct ST_PointN {
+ 		auto line_vertex_entries = ListVector::GetData(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+-		auto line_x_data = FlatVector::GetData<double>(*line_vertex_vec_children[0]);
+-		auto line_y_data = FlatVector::GetData<double>(*line_vertex_vec_children[1]);
++		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
++		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+ 
+ 		auto &point_vertex_children = StructVector::GetEntries(result);
+-		auto point_x_data = FlatVector::GetData<double>(*point_vertex_children[0]);
+-		auto point_y_data = FlatVector::GetData<double>(*point_vertex_children[1]);
++		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
++		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+ 
+ 		auto index_data = FlatVector::GetData<int32_t>(index_vec);
+ 
+@@ -8436,8 +8436,8 @@ struct ST_RemoveRepeatedPoints {
+ 
+ 		auto in_line_entries = ListVector::GetData(input);
+ 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
+-		auto in_x_data = FlatVector::GetData<double>(*in_line_vertex_vec[0]);
+-		auto in_y_data = FlatVector::GetData<double>(*in_line_vertex_vec[1]);
++		auto in_x_data = FlatVector::GetData<double>(in_line_vertex_vec[0]);
++		auto in_y_data = FlatVector::GetData<double>(in_line_vertex_vec[1]);
+ 
+ 		auto out_line_entries = ListVector::GetData(result);
+ 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
+@@ -8458,8 +8458,8 @@ struct ST_RemoveRepeatedPoints {
+ 			if (in_length < 3) {
+ 
+ 				ListVector::Reserve(result, out_offset + in_length);
+-				auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-				auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 
+ 				// If the line has less than 3 points, we can't remove any points
+ 				// so we just copy the line
+@@ -8496,8 +8496,8 @@ struct ST_RemoveRepeatedPoints {
+ 			if (points_to_keep == 1) {
+ 				out_line_entries[out_row_idx] = list_entry_t {out_offset, 2};
+ 				ListVector::Reserve(result, out_offset + 2);
+-				auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-				auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 				out_x_data[out_offset] = in_x_data[in_offset];
+ 				out_y_data[out_offset] = in_y_data[in_offset];
+ 				out_x_data[out_offset + 1] = in_x_data[in_offset + in_length - 1];
+@@ -8511,8 +8511,8 @@ struct ST_RemoveRepeatedPoints {
+ 
+ 			// Second pass, copy the points we need to keep
+ 			ListVector::Reserve(result, out_offset + points_to_keep);
+-			auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-			auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++			auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++			auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 
+ 			// Copy the first point
+ 			out_x_data[out_offset] = in_x_data[in_offset];
+@@ -8558,8 +8558,8 @@ struct ST_RemoveRepeatedPoints {
+ 
+ 		auto in_line_entries = ListVector::GetData(input);
+ 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
+-		auto in_x_data = FlatVector::GetData<double>(*in_line_vertex_vec[0]);
+-		auto in_y_data = FlatVector::GetData<double>(*in_line_vertex_vec[1]);
++		auto in_x_data = FlatVector::GetData<double>(in_line_vertex_vec[0]);
++		auto in_y_data = FlatVector::GetData<double>(in_line_vertex_vec[1]);
+ 
+ 		auto out_line_entries = ListVector::GetData(result);
+ 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
+@@ -8584,8 +8584,8 @@ struct ST_RemoveRepeatedPoints {
+ 			if (in_length < 3) {
+ 
+ 				ListVector::Reserve(result, out_offset + in_length);
+-				auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-				auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 
+ 				// If the line has less than 3 points, we can't remove any points
+ 				// so we just copy the line
+@@ -8623,8 +8623,8 @@ struct ST_RemoveRepeatedPoints {
+ 			if (points_to_keep == 1) {
+ 				out_line_entries[out_row_idx] = list_entry_t {out_offset, 2};
+ 				ListVector::Reserve(result, out_offset + 2);
+-				auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-				auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 				out_x_data[out_offset] = in_x_data[in_offset];
+ 				out_y_data[out_offset] = in_y_data[in_offset];
+ 				out_x_data[out_offset + 1] = in_x_data[in_offset + in_length - 1];
+@@ -8638,8 +8638,8 @@ struct ST_RemoveRepeatedPoints {
+ 
+ 			// Second pass, copy the points we need to keep
+ 			ListVector::Reserve(result, out_offset + points_to_keep);
+-			auto out_x_data = FlatVector::GetData<double>(*out_line_vertex_vec[0]);
+-			auto out_y_data = FlatVector::GetData<double>(*out_line_vertex_vec[1]);
++			auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
++			auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+ 
+ 			// Copy the first point
+ 			out_x_data[out_offset] = in_x_data[in_offset];
+@@ -8767,12 +8767,12 @@ struct ST_StartPoint {
+ 		auto line_vertex_entries = ListVector::GetData(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+-		auto line_x_data = FlatVector::GetData<double>(*line_vertex_vec_children[0]);
+-		auto line_y_data = FlatVector::GetData<double>(*line_vertex_vec_children[1]);
++		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
++		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+ 
+ 		auto &point_vertex_children = StructVector::GetEntries(result);
+-		auto point_x_data = FlatVector::GetData<double>(*point_vertex_children[0]);
+-		auto point_y_data = FlatVector::GetData<double>(*point_vertex_children[1]);
++		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
++		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+ 
+ 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
+ 			auto in_row_idx = geom_format.sel->get_index(out_row_idx);
+@@ -8892,12 +8892,12 @@ struct ST_EndPoint {
+ 		auto line_vertex_entries = ListVector::GetData(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+-		auto line_x_data = FlatVector::GetData<double>(*line_vertex_vec_children[0]);
+-		auto line_y_data = FlatVector::GetData<double>(*line_vertex_vec_children[1]);
++		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
++		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+ 
+ 		auto &point_vertex_children = StructVector::GetEntries(result);
+-		auto point_x_data = FlatVector::GetData<double>(*point_vertex_children[0]);
+-		auto point_y_data = FlatVector::GetData<double>(*point_vertex_children[1]);
++		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
++		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+ 
+ 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
+ 			auto in_row_idx = geom_format.sel->get_index(out_row_idx);
+@@ -9075,7 +9075,7 @@ struct PointAccessFunctionBase {
+ 		auto &point = args.data[0];
+ 		auto &point_children = StructVector::GetEntries(point);
+ 		auto &n_child = point_children[OP::ORDINATE == VertexOrdinate::X ? 0 : 1];
+-		result.Reference(*n_child);
++		result.Reference(n_child);
+ 	}
+ 
+ 	static void Register(ExtensionLoader &loader) {
+@@ -9203,10 +9203,10 @@ struct VertexAggFunctionBase {
+ 
+ 		switch (OP::ORDINATE) {
+ 		case VertexOrdinate::X:
+-			result.Reference(*point_children[0]);
++			result.Reference(point_children[0]);
+ 			break;
+ 		case VertexOrdinate::Y:
+-			result.Reference(*point_children[1]);
++			result.Reference(point_children[1]);
+ 			break;
+ 		default:
+ 			D_ASSERT(false);
+@@ -9222,7 +9222,7 @@ struct VertexAggFunctionBase {
+ 		auto &line_coords_vec = StructVector::GetEntries(line_coords);
+ 
+ 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
+-		auto ordinate_data = FlatVector::GetData<double>(*line_coords_vec[axis]);
++		auto ordinate_data = FlatVector::GetData<double>(line_coords_vec[axis]);
+ 
+ 		UnaryExecutor::ExecuteWithNulls<list_entry_t, double>(
+ 		    line_vec, result, args.size(), [&](const list_entry_t &line, ValidityMask &mask, idx_t idx) {
+@@ -9259,7 +9259,7 @@ struct VertexAggFunctionBase {
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+ 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
+-		auto ordinate_data = FlatVector::GetData<double>(*vertex_vec_children[axis]);
++		auto ordinate_data = FlatVector::GetData<double>(vertex_vec_children[axis]);
+ 
+ 		UnaryExecutor::ExecuteWithNulls<list_entry_t, double>(
+ 		    input, result, count, [&](const list_entry_t &polygon, ValidityMask &mask, idx_t idx) {
+@@ -9298,16 +9298,16 @@ struct VertexAggFunctionBase {
+ 		switch (OP::ORDINATE) {
+ 		case VertexOrdinate::X:
+ 			if (AGG::MIN_NOT_MAX) {
+-				result.Reference(*box_vec[0]);
++				result.Reference(box_vec[0]);
+ 			} else {
+-				result.Reference(*box_vec[2]);
++				result.Reference(box_vec[2]);
+ 			}
+ 			break;
+ 		case VertexOrdinate::Y:
+ 			if (AGG::MIN_NOT_MAX) {
+-				result.Reference(*box_vec[1]);
++				result.Reference(box_vec[1]);
+ 			} else {
+-				result.Reference(*box_vec[3]);
++				result.Reference(box_vec[3]);
+ 			}
+ 			break;
+ 		default:
 diff --git a/src/spatial/modules/main/spatial_functions_table.cpp b/src/spatial/modules/main/spatial_functions_table.cpp
-index 8dd850a..b0b27fb 100644
+index 8dd850a..08af76b 100644
 --- a/src/spatial/modules/main/spatial_functions_table.cpp
 +++ b/src/spatial/modules/main/spatial_functions_table.cpp
 @@ -1,7 +1,10 @@
@@ -192,8 +1155,21 @@ index 8dd850a..b0b27fb 100644
  
  namespace duckdb {
  
+@@ -81,9 +84,9 @@ struct ST_GeneratePoints {
+ 		auto &bind_data = data_p.bind_data->Cast<GeneratePointsBindData>();
+ 		auto &state = data_p.global_state->Cast<GeneratePointsState>();
+ 
+-		const auto &point_vec = StructVector::GetEntries(output.data[0]);
+-		const auto &x_data = FlatVector::GetData<double>(*point_vec[0]);
+-		const auto &y_data = FlatVector::GetData<double>(*point_vec[1]);
++		auto &point_vec = StructVector::GetEntries(output.data[0]);
++		const auto &x_data = FlatVector::GetData<double>(point_vec[0]);
++		const auto &y_data = FlatVector::GetData<double>(point_vec[1]);
+ 
+ 		const auto chunk_size = MinValue<idx_t>(STANDARD_VECTOR_SIZE, bind_data.count - state.current_idx);
+ 		for (idx_t i = 0; i < chunk_size; i++) {
 diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
-index 6039454..0ec562b 100644
+index 6039454..a8e8744 100644
 --- a/src/spatial/modules/mvt/mvt_module.cpp
 +++ b/src/spatial/modules/mvt/mvt_module.cpp
 @@ -4,6 +4,7 @@
@@ -204,6 +1180,35 @@ index 6039454..0ec562b 100644
  #include "spatial/geometry/geometry_serialization.hpp"
  #include "spatial/geometry/sgl.hpp"
  #include "spatial/spatial_types.hpp"
+@@ -1017,7 +1018,7 @@ struct ST_AsMVT {
+ 	//------------------------------------------------------------------------------------------------------------------
+ 	static void Update(Vector inputs[], AggregateInputData &aggr, idx_t, Vector &state_vec, idx_t count) {
+ 		const auto &bdata = aggr.bind_data->Cast<BindData>();
+-		const auto &row_cols = StructVector::GetEntries(inputs[0]);
++		auto &row_cols = StructVector::GetEntries(inputs[0]);
+ 
+ 		UnifiedVectorFormat state_format;
+ 		UnifiedVectorFormat geom_format;
+@@ -1031,14 +1032,14 @@ struct ST_AsMVT {
+ 
+ 		for (idx_t col_idx = 0; col_idx < row_cols.size(); col_idx++) {
+ 			if (col_idx == bdata.geometry_column_idx) {
+-				row_cols[col_idx]->ToUnifiedFormat(count, geom_format);
++				row_cols[col_idx].ToUnifiedFormat(count, geom_format);
+ 			} else if (bdata.feature_id_column_idx.IsValid() && col_idx == bdata.feature_id_column_idx.GetIndex()) {
+-				row_cols[col_idx]->ToUnifiedFormat(count, fid_format);
+-				fid_type = row_cols[col_idx]->GetType();
++				row_cols[col_idx].ToUnifiedFormat(count, fid_format);
++				fid_type = row_cols[col_idx].GetType();
+ 			} else {
+ 				property_formats.emplace_back();
+-				row_cols[col_idx]->ToUnifiedFormat(count, property_formats.back());
+-				property_types.push_back(row_cols[col_idx]->GetType());
++				row_cols[col_idx].ToUnifiedFormat(count, property_formats.back());
++				property_types.push_back(row_cols[col_idx].GetType());
+ 			}
+ 		}
+ 
 diff --git a/src/spatial/modules/osm/osm_module.cpp b/src/spatial/modules/osm/osm_module.cpp
 index 26e4bc3..bc8bb83 100644
 --- a/src/spatial/modules/osm/osm_module.cpp
@@ -214,8 +1219,45 @@ index 26e4bc3..bc8bb83 100644
  #include "spatial/modules/osm/osm_module.hpp"
  
  #include "duckdb/function/replacement_scan.hpp"
+diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
+index 19c7e99..5d9b001 100644
+--- a/src/spatial/modules/proj/proj_module.cpp
++++ b/src/spatial/modules/proj/proj_module.cpp
+@@ -814,8 +814,8 @@ struct ST_Area_Spheroid {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		if (bdata.always_xy) {
+ 			std::swap(x_data, y_data);
+@@ -1008,8 +1008,8 @@ struct ST_Perimeter_Spheroid {
+ 		auto ring_entries = ListVector::GetData(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		if (bdata.always_xy) {
+ 			std::swap(x_data, y_data);
+@@ -1186,8 +1186,8 @@ struct ST_Length_Spheroid {
+ 
+ 		auto &coord_vec = ListVector::GetEntry(line_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+-		auto x_data = FlatVector::GetData<double>(*coord_vec_children[0]);
+-		auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
++		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
++		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+ 
+ 		if (bdata.always_xy) {
+ 			std::swap(x_data, y_data);
 diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
-index 57b34d0..4f36a55 100644
+index 57b34d0..6ceb429 100644
 --- a/src/spatial/modules/shapefile/shapefile_module.cpp
 +++ b/src/spatial/modules/shapefile/shapefile_module.cpp
 @@ -1,3 +1,5 @@
@@ -224,6 +1266,21 @@ index 57b34d0..4f36a55 100644
  #include "spatial/modules/shapefile/shapefile_module.hpp"
  #include "spatial/geometry/geometry_serialization.hpp"
  #include "spatial/geometry/sgl.hpp"
+@@ -1005,10 +1007,10 @@ struct Shapefile_Meta {
+ 		auto shape_type_data = FlatVector::GetData<uint8_t>(shape_type_vector);
+ 		auto &bounds_vector = output.data[2];
+ 		auto &bounds_vector_children = StructVector::GetEntries(bounds_vector);
+-		auto minx_data = FlatVector::GetData<double>(*bounds_vector_children[0]);
+-		auto miny_data = FlatVector::GetData<double>(*bounds_vector_children[1]);
+-		auto maxx_data = FlatVector::GetData<double>(*bounds_vector_children[2]);
+-		auto maxy_data = FlatVector::GetData<double>(*bounds_vector_children[3]);
++		auto minx_data = FlatVector::GetData<double>(bounds_vector_children[0]);
++		auto miny_data = FlatVector::GetData<double>(bounds_vector_children[1]);
++		auto maxx_data = FlatVector::GetData<double>(bounds_vector_children[2]);
++		auto maxy_data = FlatVector::GetData<double>(bounds_vector_children[3]);
+ 		auto record_count_vector = output.data[3];
+ 		auto record_count_data = FlatVector::GetData<int32_t>(record_count_vector);
+ 
 diff --git a/src/spatial/operators/spatial_join_logical.cpp b/src/spatial/operators/spatial_join_logical.cpp
 index 0e5c07c..48596c5 100644
 --- a/src/spatial/operators/spatial_join_logical.cpp
@@ -342,7 +1399,7 @@ index e46d5ad..f660a78 100644
  	spatial_join->has_estimated_cardinality = any_join.has_estimated_cardinality;
  	spatial_join->estimated_cardinality = any_join.estimated_cardinality;
 diff --git a/src/spatial/operators/spatial_join_physical.cpp b/src/spatial/operators/spatial_join_physical.cpp
-index 5738f83..2d86db9 100644
+index 5738f83..8dcb622 100644
 --- a/src/spatial/operators/spatial_join_physical.cpp
 +++ b/src/spatial/operators/spatial_join_physical.cpp
 @@ -1,3 +1,5 @@
@@ -383,6 +1440,40 @@ index 5738f83..2d86db9 100644
  	for (auto &rhs_col : right_projection_map_copy) {
  		auto &rhs_type = build_side_input_types[rhs_col];
  
+@@ -719,11 +707,11 @@ SinkFinalizeType PhysicalSpatialJoin::Finalize(Pipeline &pipeline, Event &event,
+ 
+ 		// Execute the bbox expression
+ 		bbox_executor.Execute(geom_chunk, bbox_chunk);
+-		const auto &entries = StructVector::GetEntries(bbox_chunk.data[0]);
+-		const auto xmin_data = FlatVector::GetData<float>(*entries[0]);
+-		const auto ymin_data = FlatVector::GetData<float>(*entries[1]);
+-		const auto xmax_data = FlatVector::GetData<float>(*entries[2]);
+-		const auto ymax_data = FlatVector::GetData<float>(*entries[3]);
++		auto &entries = StructVector::GetEntries(bbox_chunk.data[0]);
++		const auto xmin_data = FlatVector::GetData<float>(entries[0]);
++		const auto ymin_data = FlatVector::GetData<float>(entries[1]);
++		const auto xmax_data = FlatVector::GetData<float>(entries[2]);
++		const auto ymax_data = FlatVector::GetData<float>(entries[3]);
+ 
+ 		// Push the bounding boxes into the R-Tree
+ 		auto &validity = FlatVector::Validity(bbox_chunk.data[0]);
+@@ -928,11 +916,11 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
+ 			lstate.bbox_probe_executor.Execute(lstate.probe_side_key_chunk, lstate.probe_side_box_chunk);
+ 			lstate.probe_side_box_chunk.data[0].ToUnifiedFormat(input.size(), lstate.probe_side_box_vformat);
+ 
+-			const auto &entries = StructVector::GetEntries(lstate.probe_side_box_chunk.data[0]);
+-			entries[0]->ToUnifiedFormat(input.size(), lstate.probe_side_box_xmin_vformat);
+-			entries[1]->ToUnifiedFormat(input.size(), lstate.probe_side_box_ymin_vformat);
+-			entries[2]->ToUnifiedFormat(input.size(), lstate.probe_side_box_xmax_vformat);
+-			entries[3]->ToUnifiedFormat(input.size(), lstate.probe_side_box_ymax_vformat);
++			auto &entries = StructVector::GetEntries(lstate.probe_side_box_chunk.data[0]);
++			entries[0].ToUnifiedFormat(input.size(), lstate.probe_side_box_xmin_vformat);
++			entries[1].ToUnifiedFormat(input.size(), lstate.probe_side_box_ymin_vformat);
++			entries[2].ToUnifiedFormat(input.size(), lstate.probe_side_box_xmax_vformat);
++			entries[3].ToUnifiedFormat(input.size(), lstate.probe_side_box_ymax_vformat);
+ 
+ 			// Reference the columns that we actually care about
+ 			lstate.probe_side_row_chunk.ReferenceColumns(input, probe_side_output_columns);
 diff --git a/src/spatial/spatial_settings.cpp b/src/spatial/spatial_settings.cpp
 index dd2659d..656da67 100644
 --- a/src/spatial/spatial_settings.cpp

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2020,15 +2020,15 @@ struct StructDatePart {
 				ConstantVector::SetNull(result, false);
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
-					ConstantVector::SetNull(*child_entry, false);
+					ConstantVector::SetNull(child_entry, false);
 					const auto part_index = size_t(info.part_codes[col]);
 					if (owners[part_index] == col) {
 						if (IsBigintDatepart(info.part_codes[col])) {
 							bigint_values[part_index - size_t(DatePartSpecifier::BEGIN_BIGINT)] =
-							    ConstantVector::GetData<int64_t>(*child_entry);
+							    ConstantVector::GetData<int64_t>(child_entry);
 						} else {
 							double_values[part_index - size_t(DatePartSpecifier::BEGIN_DOUBLE)] =
-							    ConstantVector::GetData<double>(*child_entry);
+							    ConstantVector::GetData<double>(child_entry);
 						}
 					}
 				}
@@ -2037,7 +2037,7 @@ struct StructDatePart {
 					DatePart::StructOperator::Operation(bigint_values, double_values, tdata[0], 0, part_mask);
 				} else {
 					for (auto &child_entry : child_entries) {
-						ConstantVector::SetNull(*child_entry, true);
+						ConstantVector::SetNull(child_entry, true);
 					}
 				}
 			}
@@ -2058,8 +2058,8 @@ struct StructDatePart {
 			// Start with valid children
 			for (size_t col = 0; col < child_entries.size(); ++col) {
 				auto &child_entry = child_entries[col];
-				child_entry->SetVectorType(VectorType::FLAT_VECTOR);
-				auto &child_validity = FlatVector::Validity(*child_entry);
+				child_entry.SetVectorType(VectorType::FLAT_VECTOR);
+				auto &child_validity = FlatVector::Validity(child_entry);
 				if (child_validity.GetData()) {
 					child_validity.SetAllValid(count);
 				}
@@ -2069,10 +2069,10 @@ struct StructDatePart {
 				if (owners[part_index] == col) {
 					if (IsBigintDatepart(info.part_codes[col])) {
 						bigint_values[part_index - size_t(DatePartSpecifier::BEGIN_BIGINT)] =
-						    FlatVector::GetData<int64_t>(*child_entry);
+						    FlatVector::GetData<int64_t>(child_entry);
 					} else {
 						double_values[part_index - size_t(DatePartSpecifier::BEGIN_DOUBLE)] =
-						    FlatVector::GetData<double>(*child_entry);
+						    FlatVector::GetData<double>(child_entry);
 					}
 				}
 			}
@@ -2084,13 +2084,13 @@ struct StructDatePart {
 						DatePart::StructOperator::Operation(bigint_values, double_values, tdata[idx], i, part_mask);
 					} else {
 						for (auto &child_entry : child_entries) {
-							FlatVector::Validity(*child_entry).SetInvalid(i);
+							FlatVector::Validity(child_entry).SetInvalid(i);
 						}
 					}
 				} else {
 					res_valid.SetInvalid(i);
 					for (auto &child_entry : child_entries) {
-						FlatVector::Validity(*child_entry).SetInvalid(i);
+						FlatVector::Validity(child_entry).SetInvalid(i);
 					}
 				}
 			}
@@ -2101,7 +2101,7 @@ struct StructDatePart {
 			const auto part_index = size_t(info.part_codes[col]);
 			const auto owner = owners[part_index];
 			if (owner != col) {
-				child_entries[col]->Reference(*child_entries[owner]);
+				child_entries[col].Reference(child_entries[owner]);
 			}
 		}
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -57,9 +57,9 @@ void ExecuteStructMakeDate(DataChunk &input, ExpressionState &state, Vector &res
 
 	auto &children = StructVector::GetEntries(vec);
 	D_ASSERT(children.size() == 3);
-	auto &yyyy = *children[0];
-	auto &mm = *children[1];
-	auto &dd = *children[2];
+	auto &yyyy = children[0];
+	auto &mm = children[1];
+	auto &dd = children[2];
 
 	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(), FromDateCast<T>);
 }

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -194,7 +194,7 @@ bool StructFunction(DataChunk &args, Vector &result) {
 	for (idx_t member_idx = 0; member_idx < result_members.size(); member_idx++) {
 		// Same type for each column's member.
 		vector<LogicalType> types;
-		const auto member_type = result_members[member_idx]->GetType();
+		const auto member_type = result_members[member_idx].GetType();
 		for (idx_t col = 0; col < column_count; col++) {
 			types.push_back(member_type);
 		}
@@ -209,10 +209,10 @@ bool StructFunction(DataChunk &args, Vector &result) {
 				struct_vector.Flatten(args.size());
 			}
 			auto &struct_vector_members = StructVector::GetEntries(struct_vector);
-			chunk.data[col].Reference(*struct_vector_members[member_idx]);
+			chunk.data[col].Reference(struct_vector_members[member_idx]);
 		}
 
-		if (!PopulateChild(chunk, *result_members[member_idx])) {
+		if (!PopulateChild(chunk, result_members[member_idx])) {
 			return false;
 		}
 	}

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -21,12 +21,12 @@ static void StructInsertFunction(DataChunk &args, ExpressionState &state, Vector
 	// Assign the original child entries to the STRUCT.
 	for (idx_t i = 0; i < starting_child_entries.size(); i++) {
 		auto &starting_child = starting_child_entries[i];
-		result_child_entries[i]->Reference(*starting_child);
+		result_child_entries[i].Reference(starting_child);
 	}
 
 	// Assign the new children to the result vector.
 	for (idx_t i = 1; i < args.ColumnCount(); i++) {
-		result_child_entries[starting_child_entries.size() + i - 1]->Reference(args.data[i]);
+		result_child_entries[starting_child_entries.size() + i - 1].Reference(args.data[i]);
 	}
 
 	result.Verify(args.size());

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -36,11 +36,11 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 
 		if (update == new_entries.end()) {
 			// No update present, copy from source
-			result_child_entries[field_idx]->Reference(*starting_child);
+			result_child_entries[field_idx].Reference(starting_child);
 		} else {
 			// We found a replacement of the same name to update
 			auto arg_idx = update->second;
-			result_child_entries[field_idx]->Reference(args.data[arg_idx]);
+			result_child_entries[field_idx].Reference(args.data[arg_idx]);
 			is_new_field[arg_idx] = false;
 		}
 	}
@@ -48,7 +48,7 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 	// Assign the new (not updated) children to the end of the result vector.
 	for (idx_t arg_idx = 1, field_idx = starting_child_entries.size(); arg_idx < args.ColumnCount(); arg_idx++) {
 		if (is_new_field[arg_idx]) {
-			result_child_entries[field_idx++]->Reference(args.data[arg_idx]);
+			result_child_entries[field_idx++].Reference(args.data[arg_idx]);
 		}
 	}
 

--- a/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/extension/core_functions/scalar/struct/struct_values.cpp
@@ -25,7 +25,7 @@ static void StructValuesFunction(DataChunk &args, ExpressionState &state, Vector
 	// We would use result.Reference(input) also for this case,
 	// but that function asserts that the logical types are the same
 	for (idx_t i = 0; i < input_children.size(); i++) {
-		result_children[i]->Reference(*input_children[i]);
+		result_children[i].Reference(input_children[i]);
 	}
 
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -397,18 +397,18 @@ struct ICUDatePart : public ICUDateFunc {
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
 					if (is_finite) {
-						ConstantVector::SetNull(*child_entry, false);
+						ConstantVector::SetNull(child_entry, false);
 						if (IsBigintDatepart(info.part_codes[col])) {
-							auto pdata = ConstantVector::GetData<int64_t>(*child_entry);
+							auto pdata = ConstantVector::GetData<int64_t>(child_entry);
 							auto adapter = info.bigints[col];
 							pdata[0] = adapter(calendar, micros);
 						} else {
-							auto pdata = ConstantVector::GetData<double>(*child_entry);
+							auto pdata = ConstantVector::GetData<double>(child_entry);
 							auto adapter = info.doubles[col];
 							pdata[0] = adapter(calendar, micros);
 						}
 					} else {
-						ConstantVector::SetNull(*child_entry, true);
+						ConstantVector::SetNull(child_entry, true);
 					}
 				}
 			}
@@ -422,7 +422,7 @@ struct ICUDatePart : public ICUDateFunc {
 			result.SetVectorType(VectorType::FLAT_VECTOR);
 			auto &child_entries = StructVector::GetEntries(result);
 			for (auto &child_entry : child_entries) {
-				child_entry->SetVectorType(VectorType::FLAT_VECTOR);
+				child_entry.SetVectorType(VectorType::FLAT_VECTOR);
 			}
 
 			auto &res_valid = FlatVector::Validity(result);
@@ -435,24 +435,24 @@ struct ICUDatePart : public ICUDateFunc {
 					for (size_t col = 0; col < child_entries.size(); ++col) {
 						auto &child_entry = child_entries[col];
 						if (is_finite) {
-							FlatVector::Validity(*child_entry).SetValid(i);
+							FlatVector::Validity(child_entry).SetValid(i);
 							if (IsBigintDatepart(info.part_codes[col])) {
-								auto pdata = ConstantVector::GetData<int64_t>(*child_entry);
+								auto pdata = ConstantVector::GetData<int64_t>(child_entry);
 								auto adapter = info.bigints[col];
 								pdata[i] = adapter(calendar, micros);
 							} else {
-								auto pdata = ConstantVector::GetData<double>(*child_entry);
+								auto pdata = ConstantVector::GetData<double>(child_entry);
 								auto adapter = info.doubles[col];
 								pdata[i] = adapter(calendar, micros);
 							}
 						} else {
-							FlatVector::Validity(*child_entry).SetInvalid(i);
+							FlatVector::Validity(child_entry).SetInvalid(i);
 						}
 					}
 				} else {
 					res_valid.SetInvalid(i);
 					for (auto &child_entry : child_entries) {
-						FlatVector::Validity(*child_entry).SetInvalid(i);
+						FlatVector::Validity(child_entry).SetInvalid(i);
 					}
 				}
 			}

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -333,7 +333,7 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 	auto &entries = StructVector::GetEntries(value_v);
 	for (idx_t entry_i = 0; entry_i < entries.size(); entry_i++) {
 		auto &struct_key_v = *names.at(StructType::GetChildName(value_v.GetType(), entry_i));
-		auto &struct_val_v = *entries[entry_i];
+		auto &struct_val_v = entries[entry_i];
 		CreateKeyValuePairs(names, doc, vals, nested_vals, struct_key_v, struct_val_v, count);
 	}
 	// Whole struct can be NULL

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -514,13 +514,13 @@ static bool TransformObjectInternal(yyjson_val *objects[], yyjson_alc *alc, Vect
 		projected_indices.insert(actual_i);
 
 		child_names.push_back(StructType::GetChildName(result.GetType(), actual_i));
-		child_vectors.push_back(child_vs[actual_i].get());
+		child_vectors.push_back(&child_vs[actual_i]);
 	}
 
 	for (idx_t child_i = 0; child_i < child_vs.size(); child_i++) {
 		if (projected_indices.find(child_i) == projected_indices.end()) {
-			child_vs[child_i]->SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(*child_vs[child_i], true);
+			child_vs[child_i].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(child_vs[child_i], true);
 		}
 	}
 

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -885,9 +885,9 @@ void FullMetadataProcessor::PopulateMetadata(ParquetMetadataFileProcessor &proce
 
 	vector<reference<Vector>> vectors;
 	for (auto &entry : result_struct_entries) {
-		vectors.push_back(std::ref(*entry.get()));
-		entry->SetVectorType(VectorType::FLAT_VECTOR);
-		auto &validity = FlatVector::Validity(*entry);
+		vectors.push_back(std::ref(entry));
+		entry.SetVectorType(VectorType::FLAT_VECTOR);
+		auto &validity = FlatVector::Validity(entry);
 		validity.Initialize(count);
 	}
 	for (idx_t i = 0; i < count; i++) {

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -45,7 +45,7 @@ idx_t StructColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_
 	optional_idx read_count;
 	for (idx_t i = 0; i < child_readers.size(); i++) {
 		auto &child = child_readers[i];
-		auto &target_vector = *struct_entries[i];
+		auto &target_vector = struct_entries[i];
 		if (!child) {
 			// if we are not scanning this vector - set it to NULL
 			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/extension/parquet/reader/variant/variant_shredded_conversion.cpp
+++ b/extension/parquet/reader/variant/variant_shredded_conversion.cpp
@@ -430,7 +430,7 @@ vector<VariantValue> VariantShreddedConversion::ConvertShreddedObject(Vector &me
 	for (idx_t i = 0; i < fields.size(); i++) {
 		auto &field = fields[i];
 		auto &field_name = field.first;
-		auto &field_vec = *entries[i];
+		auto &field_vec = entries[i];
 
 		shredded_fields.emplace_back(field_name);
 		auto &shredded_field = shredded_fields.back();
@@ -543,9 +543,9 @@ vector<VariantValue> VariantShreddedConversion::Convert(Vector &metadata, Vector
 		auto &name = group_type_children[i].first;
 		auto &vec = group_entries[i];
 		if (name == "value") {
-			value = vec.get();
+			value = &vec;
 		} else if (name == "typed_value") {
-			typed_value = vec.get();
+			typed_value = &vec;
 		} else {
 			throw InvalidInputException("Variant group can only contain 'value'/'typed_value', not: %s", name);
 		}

--- a/extension/parquet/reader/variant_column_reader.cpp
+++ b/extension/parquet/reader/variant_column_reader.cpp
@@ -68,7 +68,7 @@ idx_t VariantColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data
 	Vector metadata_intermediate(LogicalType::BLOB, num_values);
 	Vector intermediate_group(GetIntermediateGroupType(typed_value_reader), num_values);
 	auto &group_entries = StructVector::GetEntries(intermediate_group);
-	auto &value_intermediate = *group_entries[0];
+	auto &value_intermediate = group_entries[0];
 
 	auto metadata_values =
 	    child_readers[metadata_reader_idx]->Read(num_values, define_out, repeat_out, metadata_intermediate);
@@ -84,7 +84,7 @@ idx_t VariantColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data
 
 	vector<VariantValue> intermediate;
 	if (typed_value_reader) {
-		auto typed_values = typed_value_reader->Read(num_values, define_out, repeat_out, *group_entries[1]);
+		auto typed_values = typed_value_reader->Read(num_values, define_out, repeat_out, group_entries[1]);
 		if (typed_values != value_values) {
 			throw InvalidInputException(
 			    "The shredded Variant column did not contain the same amount of values for 'typed_value' and 'value'");

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -46,7 +46,7 @@ void StructColumnWriter::Analyze(ColumnWriterState &state_p, ColumnWriterState *
 	for (idx_t child_idx = 0; child_idx < child_writers.size(); child_idx++) {
 		// Need to check again. It might be that just one child needs it but the rest not
 		if (child_writers[child_idx]->HasAnalyze()) {
-			child_writers[child_idx]->Analyze(*state.child_states[child_idx], &state_p, *child_vectors[child_idx],
+			child_writers[child_idx]->Analyze(*state.child_states[child_idx], &state_p, child_vectors[child_idx],
 			                                  count);
 		}
 	}
@@ -78,7 +78,7 @@ void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *
 	HandleDefineLevels(state_p, parent, validity, count, PARQUET_DEFINE_VALID, MaxDefine() - 1);
 	auto &child_vectors = StructVector::GetEntries(vector);
 	for (idx_t child_idx = 0; child_idx < child_writers.size(); child_idx++) {
-		child_writers[child_idx]->Prepare(*state.child_states[child_idx], &state_p, *child_vectors[child_idx], count,
+		child_writers[child_idx]->Prepare(*state.child_states[child_idx], &state_p, child_vectors[child_idx], count,
 		                                  vector_can_span_multiple_pages);
 	}
 }
@@ -94,7 +94,7 @@ void StructColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t
 	auto &state = state_p.Cast<StructColumnWriterState>();
 	auto &child_vectors = StructVector::GetEntries(vector);
 	for (idx_t child_idx = 0; child_idx < child_writers.size(); child_idx++) {
-		child_writers[child_idx]->Write(*state.child_states[child_idx], *child_vectors[child_idx], count);
+		child_writers[child_idx]->Write(*state.child_states[child_idx], child_vectors[child_idx], count);
 	}
 }
 

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -810,9 +810,9 @@ void ParquetVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varia
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		auto &name = child_types[i].first;
 		if (name == "value") {
-			value = child_vectors[i].get();
+			value = &child_vectors[i];
 		} else if (name == "typed_value") {
-			typed_value = child_vectors[i].get();
+			typed_value = &child_vectors[i];
 		}
 	}
 
@@ -865,7 +865,7 @@ static void ToParquetVariant(DataChunk &input, ExpressionState &state, Vector &r
 	UnifiedVariantVectorData variant(recursive_format);
 
 	auto &result_vectors = StructVector::GetEntries(result);
-	auto &metadata = *result_vectors[0];
+	auto &metadata = result_vectors[0];
 	CreateMetadata(variant, metadata, count);
 
 	ParquetVariantShredding shredding;

--- a/src/common/arrow/appender/struct_data.cpp
+++ b/src/common/arrow/appender/struct_data.cpp
@@ -26,7 +26,7 @@ void ArrowStructData::Append(ArrowAppendData &append_data, Vector &input, idx_t 
 	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
 		auto &child = children[child_idx];
 		auto &child_data = *append_data.child_data[child_idx];
-		child_data.append_vector(child_data, *child, from, to, size);
+		child_data.append_vector(child_data, child, from, to, size);
 	}
 	append_data.row_count += size;
 }

--- a/src/common/row_operations/row_matcher.cpp
+++ b/src/common/row_operations/row_matcher.cpp
@@ -144,7 +144,7 @@ static idx_t StructMatchEquality(Vector &lhs_vector, const TupleDataVectorFormat
 	D_ASSERT(rhs_struct_layout.ColumnCount() == lhs_struct_vectors.size());
 
 	for (idx_t struct_col_idx = 0; struct_col_idx < rhs_struct_layout.ColumnCount(); struct_col_idx++) {
-		auto &lhs_struct_vector = *lhs_struct_vectors[struct_col_idx];
+		auto &lhs_struct_vector = lhs_struct_vectors[struct_col_idx];
 		auto &lhs_struct_format = lhs_format.children[struct_col_idx];
 		const auto &child_function = child_functions[struct_col_idx];
 		match_count = child_function.function(lhs_struct_vector, lhs_struct_format, sel, match_count, rhs_struct_layout,

--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -112,7 +112,7 @@ void SortedRunScanState::TemplatedScan(const SortedRun &sorted_run, const Vector
 			if (opc.is_payload) {
 				break;
 			}
-			chunk.data[opc.output_col_idx].Reference(*decoded_key_entries[opc.layout_col_idx]);
+			chunk.data[opc.output_col_idx].Reference(decoded_key_entries[opc.layout_col_idx]);
 		}
 
 		gathered_payload = true;

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -828,9 +828,9 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 		ColumnDataMetaData child_meta_data(child_function, meta_data, child_index);
 
 		UnifiedVectorFormat child_data;
-		child_vectors[child_idx]->ToUnifiedFormat(copy_count, child_data);
+		child_vectors[child_idx].ToUnifiedFormat(copy_count, child_data);
 
-		child_function.function(child_meta_data, child_data, *child_vectors[child_idx], offset, copy_count);
+		child_function.function(child_meta_data, child_data, child_vectors[child_idx], offset, copy_count);
 	}
 }
 

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -228,8 +228,7 @@ idx_t ColumnDataCollectionSegment::ReadVector(ChunkManagementState &state, Vecto
 	} else if (internal_type == PhysicalType::STRUCT) {
 		auto &child_vectors = StructVector::GetEntries(result);
 		for (idx_t child_idx = 0; child_idx < child_vectors.size(); child_idx++) {
-			auto child_count =
-			    ReadVector(state, GetChildIndex(vdata.child_index, child_idx), child_vectors[child_idx]);
+			auto child_count = ReadVector(state, GetChildIndex(vdata.child_index, child_idx), child_vectors[child_idx]);
 			if (child_count != vcount) {
 				throw InternalException("Column Data Collection: mismatch in struct child sizes");
 			}

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -229,7 +229,7 @@ idx_t ColumnDataCollectionSegment::ReadVector(ChunkManagementState &state, Vecto
 		auto &child_vectors = StructVector::GetEntries(result);
 		for (idx_t child_idx = 0; child_idx < child_vectors.size(); child_idx++) {
 			auto child_count =
-			    ReadVector(state, GetChildIndex(vdata.child_index, child_idx), *child_vectors[child_idx]);
+			    ReadVector(state, GetChildIndex(vdata.child_index, child_idx), child_vectors[child_idx]);
 			if (child_count != vcount) {
 				throw InternalException("Column Data Collection: mismatch in struct child sizes");
 			}

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1221,11 +1221,11 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 	source_vec.Flatten(row_count);
 
 	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
-	const auto &vert_parts = StructVector::GetEntries(target_vec);
+	auto &vert_parts = StructVector::GetEntries(target_vec);
 	double *vert_data[V::WIDTH];
 
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1254,12 +1254,12 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
 
-	const auto &vert_parts = StructVector::GetEntries(source_vec);
+	auto &vert_parts = StructVector::GetEntries(source_vec);
 	const auto geom_data = FlatVector::GetData<string_t>(target_vec);
 	double *vert_data[V::WIDTH];
 
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1326,7 +1326,7 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(target_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	// Second pass, write out the linestrings
@@ -1369,11 +1369,11 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 	source_vec.Flatten(row_count);
 
 	const auto line_data = ListVector::GetData(source_vec);
-	const auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(source_vec));
+	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(source_vec));
 
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1463,7 +1463,7 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 	double *vert_data[V::WIDTH];
 
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1516,13 +1516,13 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 	source_vec.Flatten(row_count);
 
 	const auto poly_data = ListVector::GetData(source_vec);
-	const auto &ring_vec = ListVector::GetEntry(source_vec);
+	auto &ring_vec = ListVector::GetEntry(source_vec);
 	const auto ring_data = ListVector::GetData(ring_vec);
-	const auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(ring_vec));
+	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(ring_vec));
 
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1613,7 +1613,7 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(target_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	// Second pass, write out the multipoints
@@ -1658,11 +1658,11 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 	source_vec.Flatten(row_count);
 
 	const auto mult_data = ListVector::GetData(source_vec);
-	const auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(source_vec));
+	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(source_vec));
 
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1771,7 +1771,7 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(line_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	// Second pass, write out the multilinestrings
@@ -1828,12 +1828,12 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 	source_vec.Flatten(row_count);
 
 	const auto mult_data = ListVector::GetData(source_vec);
-	const auto line_vec = ListVector::GetEntry(source_vec);
+	auto &line_vec = ListVector::GetEntry(source_vec);
 	const auto line_data = ListVector::GetData(line_vec);
-	const auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(line_vec));
+	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(line_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1957,7 +1957,7 @@ static void ToMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_co
 	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(ring_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	// Second pass, write out the multipolygons
@@ -2022,14 +2022,14 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 	source_vec.Flatten(row_count);
 
 	const auto mult_data = ListVector::GetData(source_vec);
-	const auto &poly_vec = ListVector::GetEntry(source_vec);
+	auto &poly_vec = ListVector::GetEntry(source_vec);
 	const auto poly_data = ListVector::GetData(poly_vec);
-	const auto &ring_vec = ListVector::GetEntry(poly_vec);
+	auto &ring_vec = ListVector::GetEntry(poly_vec);
 	const auto ring_data = ListVector::GetData(ring_vec);
-	const auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(ring_vec));
+	auto &vert_parts = StructVector::GetEntries(ListVector::GetEntry(ring_vec));
 	double *vert_data[V::WIDTH];
 	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetData<double>(*vert_parts[i]);
+		vert_data[i] = FlatVector::GetData<double>(vert_parts[i]);
 	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -520,7 +520,7 @@ static void ReadDataFromStructSegment(const ListSegmentFunctions &functions, con
 	for (idx_t child_count = 0; child_count < children.size(); child_count++) {
 		auto struct_children_segment = Load<ListSegment *>(const_data_ptr_cast(struct_children + child_count));
 		auto &child_function = functions.child_functions[child_count];
-		child_function.read_data(child_function, struct_children_segment, *children[child_count], total_count);
+		child_function.read_data(child_function, struct_children_segment, children[child_count], total_count);
 	}
 }
 

--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -329,7 +329,7 @@ static inline void ToUnifiedFormatInternal(TupleDataVectorFormat &format, Vector
 		auto &entries = StructVector::GetEntries(vector);
 		D_ASSERT(format.children.size() == entries.size());
 		for (idx_t struct_col_idx = 0; struct_col_idx < entries.size(); struct_col_idx++) {
-			ToUnifiedFormatInternal(format.children[struct_col_idx], *entries[struct_col_idx], count);
+			ToUnifiedFormatInternal(format.children[struct_col_idx], entries[struct_col_idx], count);
 		}
 		break;
 	}

--- a/src/common/types/row/tuple_data_scatter_gather.cpp
+++ b/src/common/types/row/tuple_data_scatter_gather.cpp
@@ -217,7 +217,7 @@ void TupleDataCollection::ComputeHeapSizes(Vector &heap_sizes_v, const Vector &s
 		for (idx_t struct_col_idx = 0; struct_col_idx < struct_sources.size(); struct_col_idx++) {
 			const auto &struct_source = struct_sources[struct_col_idx];
 			auto &struct_format = source_format.children[struct_col_idx];
-			ComputeHeapSizes(heap_sizes_v, *struct_source, struct_format, append_sel, append_count);
+			ComputeHeapSizes(heap_sizes_v, struct_source, struct_format, append_sel, append_count);
 		}
 		break;
 	}
@@ -432,7 +432,7 @@ void TupleDataCollection::StructWithinCollectionComputeHeapSizes(Vector &heap_si
 	// Recurse
 	auto &struct_sources = StructVector::GetEntries(source_v);
 	for (idx_t struct_col_idx = 0; struct_col_idx < struct_sources.size(); struct_col_idx++) {
-		auto &struct_source = *struct_sources[struct_col_idx];
+		auto &struct_source = struct_sources[struct_col_idx];
 
 		auto &struct_format = source_format.children[struct_col_idx];
 		WithinCollectionComputeHeapSizes(heap_sizes_v, struct_source, struct_format, append_sel, append_count,
@@ -453,7 +453,7 @@ static void ApplySliceRecursive(const Vector &source_v, TupleDataVectorFormat &s
 		// We have to apply it to the child vectors too
 		auto &struct_sources = StructVector::GetEntries(source_v);
 		for (idx_t struct_col_idx = 0; struct_col_idx < struct_sources.size(); struct_col_idx++) {
-			auto &struct_source = *struct_sources[struct_col_idx];
+			auto &struct_source = struct_sources[struct_col_idx];
 			auto &struct_format = source_format.children[struct_col_idx];
 #ifdef D_ASSERT_IS_ENABLED
 			D_ASSERT(!struct_format.combined_list_data);
@@ -911,7 +911,7 @@ static void TupleDataStructScatter(const Vector &source, const TupleDataVectorFo
 
 	// Recurse through the struct children
 	for (idx_t struct_col_idx = 0; struct_col_idx < struct_layout.ColumnCount(); struct_col_idx++) {
-		auto &struct_source = *struct_sources[struct_col_idx];
+		auto &struct_source = struct_sources[struct_col_idx];
 		const auto &struct_source_format = source_format.children[struct_col_idx];
 		const auto &struct_scatter_function = child_functions[struct_col_idx];
 		struct_scatter_function.function(struct_source, struct_source_format, append_sel, append_count, struct_layout,
@@ -1132,7 +1132,7 @@ static void TupleDataStructWithinCollectionScatter(const Vector &source, const T
 	// Recurse through the children
 	auto &struct_sources = StructVector::GetEntries(source);
 	for (idx_t struct_col_idx = 0; struct_col_idx < struct_sources.size(); struct_col_idx++) {
-		auto &struct_source = *struct_sources[struct_col_idx];
+		auto &struct_source = struct_sources[struct_col_idx];
 		auto &struct_format = source_format.children[struct_col_idx];
 		const auto &struct_scatter_function = child_functions[struct_col_idx];
 		struct_scatter_function.function(struct_source, struct_format, append_sel, append_count, layout, row_locations,
@@ -1521,7 +1521,7 @@ static void TupleDataStructGather(const TupleDataLayout &layout, Vector &row_loc
 
 	// Recurse through the struct children
 	for (idx_t struct_col_idx = 0; struct_col_idx < struct_layout.ColumnCount(); struct_col_idx++) {
-		auto &struct_target = *struct_targets[struct_col_idx];
+		auto &struct_target = struct_targets[struct_col_idx];
 		const auto &struct_gather_function = child_functions[struct_col_idx];
 		struct_gather_function.function(struct_layout, struct_row_locations, struct_col_idx, scan_sel, scan_count,
 		                                struct_target, target_sel, dummy_vector,
@@ -1688,7 +1688,7 @@ static void TupleDataStructWithinCollectionGather(const TupleDataLayout &layout,
 	// Recurse
 	auto &struct_targets = StructVector::GetEntries(target);
 	for (idx_t struct_col_idx = 0; struct_col_idx < struct_targets.size(); struct_col_idx++) {
-		auto &struct_target = *struct_targets[struct_col_idx];
+		auto &struct_target = struct_targets[struct_col_idx];
 		const auto &struct_gather_function = child_functions[struct_col_idx];
 		struct_gather_function.function(layout, heap_locations, list_size_before, scan_sel, scan_count, struct_target,
 		                                target_sel, list_vector, struct_gather_function.child_functions);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -117,9 +117,7 @@ void Vector::Reference(const Value &value) {
 		auto &child_types = StructType::GetChildTypes(value.type());
 		auto &child_vectors = struct_buffer->GetChildren();
 		for (idx_t i = 0; i < child_types.size(); i++) {
-			auto vector =
-			    make_uniq<Vector>(value.IsNull() ? Value(child_types[i].second) : StructValue::GetChildren(value)[i]);
-			child_vectors.push_back(std::move(vector));
+			child_vectors.emplace_back(value.IsNull() ? Value(child_types[i].second) : StructValue::GetChildren(value)[i]);
 		}
 		auxiliary = shared_ptr<VectorBuffer>(struct_buffer.release());
 		if (value.IsNull()) {
@@ -212,7 +210,7 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto &other_entries = StructVector::GetEntries(other);
 		D_ASSERT(entries.size() == other_entries.size());
 		for (idx_t i = 0; i < entries.size(); i++) {
-			entries[i]->Slice(*other_entries[i], offset, end);
+			entries[i].Slice(other_entries[i], offset, end);
 		}
 		new_vector.validity.Slice(other.validity, offset, end - offset);
 		Reference(new_vector);
@@ -391,7 +389,7 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 		auto &vector_struct_buffer = auxiliary->Cast<VectorStructBuffer>();
 		auto &children = vector_struct_buffer.GetChildren();
 		for (auto &child : children) {
-			child->FindResizeInfos(resize_infos, multiplier);
+			child.FindResizeInfos(resize_infos, multiplier);
 		}
 		break;
 	}
@@ -534,7 +532,7 @@ void Vector::SetValue(idx_t index, const Value &val) {
 		if (val.IsNull()) {
 			for (size_t i = 0; i < children.size(); i++) {
 				auto &vec_child = children[i];
-				vec_child->SetValue(index, Value());
+				vec_child.SetValue(index, Value());
 			}
 		} else {
 			auto &val_children = StructValue::GetChildren(val);
@@ -542,7 +540,7 @@ void Vector::SetValue(idx_t index, const Value &val) {
 			for (size_t i = 0; i < children.size(); i++) {
 				auto &vec_child = children[i];
 				auto &struct_child = val_children[i];
-				vec_child->SetValue(index, struct_child);
+				vec_child.SetValue(index, struct_child);
 			}
 		}
 		break;
@@ -629,8 +627,8 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 			shredded_subtypes.push_back(make_pair("unshredded", unshredded.GetType()));
 			shredded_subtypes.push_back(make_pair("shredded", shredded.GetType()));
 			Vector new_shredded(LogicalType::STRUCT(std::move(shredded_subtypes)));
-			StructVector::GetEntries(new_shredded)[0]->Reference(sliced_unshredded);
-			StructVector::GetEntries(new_shredded)[1]->Reference(sliced_shredded);
+			StructVector::GetEntries(new_shredded)[0].Reference(sliced_unshredded);
+			StructVector::GetEntries(new_shredded)[1].Reference(sliced_shredded);
 
 			copy.Shred(new_shredded);
 			copy.Flatten(1);
@@ -819,7 +817,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		duckdb::vector<Value> children;
 		for (idx_t child_idx = 0; child_idx < child_entries.size(); child_idx++) {
 			auto &struct_child = child_entries[child_idx];
-			children.push_back(struct_child->GetValue(index_p));
+			children.push_back(struct_child.GetValue(index_p));
 		}
 
 		if (type.id() == LogicalTypeId::AGGREGATE_STATE) {
@@ -977,7 +975,7 @@ idx_t Vector::GetAllocationSize(idx_t cardinality) const {
 		} else {
 			auto &children = StructVector::GetEntries(*this);
 			for (auto &child : children) {
-				total_size += child->GetAllocationSize(cardinality);
+				total_size += child.GetAllocationSize(cardinality);
 			}
 		}
 		return total_size;
@@ -1152,10 +1150,9 @@ void Vector::FlattenConstant(idx_t count) {
 
 		auto &child_entries = StructVector::GetEntries(*this);
 		for (auto &child : child_entries) {
-			D_ASSERT(child->GetVectorType() == VectorType::CONSTANT_VECTOR);
-			auto vector = make_uniq<Vector>(*child);
-			vector->Flatten(count);
-			new_children.push_back(std::move(vector));
+			D_ASSERT(child.GetVectorType() == VectorType::CONSTANT_VECTOR);
+			new_children.emplace_back(child);
+			new_children.back().Flatten(count);
 		}
 		auxiliary = shared_ptr<VectorBuffer>(normalified_buffer.release());
 		break;
@@ -1173,7 +1170,7 @@ void Vector::Flatten(idx_t count) {
 		case PhysicalType::STRUCT: {
 			auto &entries = StructVector::GetEntries(*this);
 			for (auto &entry : entries) {
-				entry->Flatten(count);
+				entry.Flatten(count);
 			}
 			break;
 		}
@@ -1345,7 +1342,7 @@ void Vector::RecursiveToUnifiedFormat(Vector &input, idx_t count, RecursiveUnifi
 			data.children.emplace_back();
 		}
 		for (idx_t i = 0; i < children.size(); i++) {
-			Vector::RecursiveToUnifiedFormat(*children[i], count, data.children[i]);
+			Vector::RecursiveToUnifiedFormat(children[i], count, data.children[i]);
 		}
 	}
 }
@@ -1529,7 +1526,7 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 			// Serialize entries as a list
 			serializer.WriteList(103, "children", entries.size(), [&](Serializer::List &list, idx_t i) {
 				list.WriteObject(
-				    [&](Serializer &object) { entries[i]->Serialize(object, count, compressed_serialization); });
+				    [&](Serializer &object) { entries[i].Serialize(object, count, compressed_serialization); });
 			});
 			break;
 		}
@@ -1700,7 +1697,7 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 			auto &entries = StructVector::GetEntries(*this);
 			// Deserialize entries as a list
 			deserializer.ReadList(103, "children", [&](Deserializer::List &list, idx_t i) {
-				list.ReadObject([&](Deserializer &obj) { entries[i]->Deserialize(obj, count); });
+				list.ReadObject([&](Deserializer &obj) { entries[i].Deserialize(obj, count); });
 			});
 			break;
 		}
@@ -1750,7 +1747,7 @@ void Vector::SetVectorType(VectorType vector_type_p) {
 	if (vector_type == VectorType::CONSTANT_VECTOR && physical_type == PhysicalType::STRUCT) {
 		auto &entries = StructVector::GetEntries(*this);
 		for (auto &entry : entries) {
-			entry->SetVectorType(vector_type);
+			entry.SetVectorType(vector_type);
 		}
 	}
 }
@@ -1971,12 +1968,12 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 		auto &children = StructVector::GetEntries(*vector);
 		D_ASSERT(child_types.size() == children.size());
 		for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
-			D_ASSERT(children[child_idx]->GetType() == child_types[child_idx].second);
-			Vector::Verify(*children[child_idx], sel_p, count);
+			D_ASSERT(children[child_idx].GetType() == child_types[child_idx].second);
+			Vector::Verify(children[child_idx], sel_p, count);
 			if (vtype == VectorType::CONSTANT_VECTOR) {
-				D_ASSERT(children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR);
+				D_ASSERT(children[child_idx].GetVectorType() == VectorType::CONSTANT_VECTOR);
 				if (ConstantVector::IsNull(*vector)) {
-					D_ASSERT(ConstantVector::IsNull(*children[child_idx]));
+					D_ASSERT(ConstantVector::IsNull(children[child_idx]));
 				}
 			}
 			if (vtype != VectorType::FLAT_VECTOR) {
@@ -1985,19 +1982,19 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 			optional_ptr<ValidityMask> child_validity;
 			SelectionVector owned_child_sel;
 			const SelectionVector *child_sel = &owned_child_sel;
-			if (children[child_idx]->GetVectorType() == VectorType::FLAT_VECTOR) {
+			if (children[child_idx].GetVectorType() == VectorType::FLAT_VECTOR) {
 				child_sel = FlatVector::IncrementalSelectionVector();
-				child_validity = &FlatVector::Validity(*children[child_idx]);
-			} else if (children[child_idx]->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-				auto &child = DictionaryVector::Child(*children[child_idx]);
+				child_validity = &FlatVector::Validity(children[child_idx]);
+			} else if (children[child_idx].GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+				auto &child = DictionaryVector::Child(children[child_idx]);
 				if (child.GetVectorType() != VectorType::FLAT_VECTOR) {
 					continue;
 				}
 				child_validity = &FlatVector::Validity(child);
-				child_sel = &DictionaryVector::SelVector(*children[child_idx]);
-			} else if (children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				child_sel = &DictionaryVector::SelVector(children[child_idx]);
+			} else if (children[child_idx].GetVectorType() == VectorType::CONSTANT_VECTOR) {
 				child_sel = ConstantVector::ZeroSelectionVector(count, owned_child_sel);
-				child_validity = &ConstantVector::Validity(*children[child_idx]);
+				child_validity = &ConstantVector::Validity(children[child_idx]);
 			} else {
 				continue;
 			}
@@ -2123,7 +2120,7 @@ void Vector::DebugShuffleNestedVector(Vector &vector, idx_t count) {
 		auto &entries = StructVector::GetEntries(vector);
 		// recurse into child elements
 		for (auto &entry : entries) {
-			Vector::DebugShuffleNestedVector(*entry, count);
+			Vector::DebugShuffleNestedVector(entry, count);
 		}
 		break;
 	}
@@ -2214,7 +2211,7 @@ void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
 	if (internal_type == PhysicalType::STRUCT) {
 		auto &entries = StructVector::GetEntries(vector);
 		for (auto &entry : entries) {
-			FlatVector::SetNull(*entry, idx, is_null);
+			FlatVector::SetNull(entry, idx, is_null);
 		}
 		return;
 	}
@@ -2243,8 +2240,8 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 			// set all child entries to null as well
 			auto &entries = StructVector::GetEntries(vector);
 			for (auto &entry : entries) {
-				entry->SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(*entry, is_null);
+				entry.SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(entry, is_null);
 			}
 		} else if (internal_type == PhysicalType::ARRAY) {
 			auto &child = ArrayVector::GetEntry(vector);
@@ -2351,7 +2348,7 @@ void ConstantVector::Reference(Vector &vector, Vector &source, idx_t position, i
 		auto &source_entries = StructVector::GetEntries(source);
 		auto &target_entries = StructVector::GetEntries(vector);
 		for (idx_t i = 0; i < source_entries.size(); i++) {
-			ConstantVector::Reference(*target_entries[i], *source_entries[i], position, count);
+			ConstantVector::Reference(target_entries[i], source_entries[i], position, count);
 		}
 		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
 		vector.validity.Set(0, true);
@@ -2563,12 +2560,12 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 Vector &MapVector::GetKeys(Vector &vector) {
 	auto &entries = StructVector::GetEntries(ListVector::GetEntry(vector));
 	D_ASSERT(entries.size() == 2);
-	return *entries[0];
+	return entries[0];
 }
 Vector &MapVector::GetValues(Vector &vector) {
 	auto &entries = StructVector::GetEntries(ListVector::GetEntry(vector));
 	D_ASSERT(entries.size() == 2);
-	return *entries[1];
+	return entries[1];
 }
 
 const Vector &MapVector::GetKeys(const Vector &vector) {
@@ -2648,7 +2645,7 @@ void MapVector::EvalMapInvalidReason(MapInvalidReason reason) {
 //===--------------------------------------------------------------------===//
 // StructVector
 //===--------------------------------------------------------------------===//
-vector<unique_ptr<Vector>> &StructVector::GetEntries(Vector &vector) {
+vector<Vector> &StructVector::GetEntries(Vector &vector) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::STRUCT || vector.GetType().id() == LogicalTypeId::UNION ||
 	         vector.GetType().id() == LogicalTypeId::VARIANT ||
 	         vector.GetType().id() == LogicalTypeId::AGGREGATE_STATE);
@@ -2664,7 +2661,7 @@ vector<unique_ptr<Vector>> &StructVector::GetEntries(Vector &vector) {
 	return vector.auxiliary->Cast<VectorStructBuffer>().GetChildren();
 }
 
-const vector<unique_ptr<Vector>> &StructVector::GetEntries(const Vector &vector) {
+const vector<Vector> &StructVector::GetEntries(const Vector &vector) {
 	return GetEntries((Vector &)vector);
 }
 
@@ -2873,23 +2870,23 @@ void ListVector::GetConsecutiveChildSelVector(Vector &list, SelectionVector &sel
 const Vector &UnionVector::GetMember(const Vector &vector, idx_t member_index) {
 	D_ASSERT(member_index < UnionType::GetMemberCount(vector.GetType()));
 	auto &entries = StructVector::GetEntries(vector);
-	return *entries[member_index + 1]; // skip the "tag" entry
+	return entries[member_index + 1]; // skip the "tag" entry
 }
 
 Vector &UnionVector::GetMember(Vector &vector, idx_t member_index) {
 	D_ASSERT(member_index < UnionType::GetMemberCount(vector.GetType()));
 	auto &entries = StructVector::GetEntries(vector);
-	return *entries[member_index + 1]; // skip the "tag" entry
+	return entries[member_index + 1]; // skip the "tag" entry
 }
 
 const Vector &UnionVector::GetTags(const Vector &vector) {
 	// the tag vector is always the first struct child.
-	return *StructVector::GetEntries(vector)[0];
+	return StructVector::GetEntries(vector)[0];
 }
 
 Vector &UnionVector::GetTags(Vector &vector) {
 	// the tag vector is always the first struct child.
-	return *StructVector::GetEntries(vector)[0];
+	return StructVector::GetEntries(vector)[0];
 }
 
 void UnionVector::SetToMember(Vector &union_vector, union_tag_t tag, Vector &member_vector, idx_t count,
@@ -2951,7 +2948,7 @@ void UnionVector::SetToMember(Vector &union_vector, union_tag_t tag, Vector &mem
 
 bool UnionVector::TryGetTag(const Vector &vector, idx_t index, union_tag_t &result) {
 	// the tag vector is always the first struct child.
-	auto &tag_vector = *StructVector::GetEntries(vector)[0];
+	auto &tag_vector = StructVector::GetEntries(vector)[0];
 	if (tag_vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(tag_vector);
 		auto &dict_sel = DictionaryVector::SelVector(tag_vector);
@@ -3012,7 +3009,7 @@ UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector_p, idx_t count
 	auto &entries = StructVector::GetEntries(vector_p);
 	duckdb::vector<UnifiedVectorFormat> child_vdata(entries.size());
 	for (idx_t entry_idx = 0; entry_idx < entries.size(); entry_idx++) {
-		auto &child = *entries[entry_idx];
+		auto &child = entries[entry_idx];
 		child.ToUnifiedFormat(count, child_vdata[entry_idx]);
 	}
 
@@ -3094,67 +3091,67 @@ idx_t ArrayVector::GetTotalSize(const Vector &vector) {
 // VariantVector
 //===--------------------------------------------------------------------===//
 Vector &VariantVector::GetKeys(Vector &vec) {
-	return *StructVector::GetEntries(vec)[0];
+	return StructVector::GetEntries(vec)[0];
 }
 Vector &VariantVector::GetKeys(const Vector &vec) {
-	return *StructVector::GetEntries(vec)[0];
+	return StructVector::GetEntries(const_cast<Vector &>(vec))[0];
 }
 
 Vector &VariantVector::GetChildren(Vector &vec) {
-	return *StructVector::GetEntries(vec)[1];
+	return StructVector::GetEntries(vec)[1];
 }
 Vector &VariantVector::GetChildren(const Vector &vec) {
-	return *StructVector::GetEntries(vec)[1];
+	return StructVector::GetEntries(const_cast<Vector &>(vec))[1];
 }
 
 Vector &VariantVector::GetChildrenKeysIndex(Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
-	return *StructVector::GetEntries(children)[0];
+	return StructVector::GetEntries(children)[0];
 }
 Vector &VariantVector::GetChildrenKeysIndex(const Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
-	return *StructVector::GetEntries(children)[0];
+	return StructVector::GetEntries(children)[0];
 }
 
 Vector &VariantVector::GetChildrenValuesIndex(Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
-	return *StructVector::GetEntries(children)[1];
+	return StructVector::GetEntries(children)[1];
 }
 Vector &VariantVector::GetChildrenValuesIndex(const Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
-	return *StructVector::GetEntries(children)[1];
+	return StructVector::GetEntries(children)[1];
 }
 
 Vector &VariantVector::GetValues(Vector &vec) {
-	return *StructVector::GetEntries(vec)[2];
+	return StructVector::GetEntries(vec)[2];
 }
 Vector &VariantVector::GetValues(const Vector &vec) {
-	return *StructVector::GetEntries(vec)[2];
+	return StructVector::GetEntries(const_cast<Vector &>(vec))[2];
 }
 
 Vector &VariantVector::GetValuesTypeId(Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
-	return *StructVector::GetEntries(values)[0];
+	return StructVector::GetEntries(values)[0];
 }
 Vector &VariantVector::GetValuesTypeId(const Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
-	return *StructVector::GetEntries(values)[0];
+	return StructVector::GetEntries(values)[0];
 }
 
 Vector &VariantVector::GetValuesByteOffset(Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
-	return *StructVector::GetEntries(values)[1];
+	return StructVector::GetEntries(values)[1];
 }
 Vector &VariantVector::GetValuesByteOffset(const Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
-	return *StructVector::GetEntries(values)[1];
+	return StructVector::GetEntries(values)[1];
 }
 
 Vector &VariantVector::GetData(Vector &vec) {
-	return *StructVector::GetEntries(vec)[3];
+	return StructVector::GetEntries(vec)[3];
 }
 Vector &VariantVector::GetData(const Vector &vec) {
-	return *StructVector::GetEntries(vec)[3];
+	return StructVector::GetEntries(const_cast<Vector &>(vec))[3];
 }
 
 const UnifiedVectorFormat &UnifiedVariantVector::GetKeys(const RecursiveUnifiedVectorFormat &vec) {
@@ -3197,22 +3194,22 @@ const UnifiedVectorFormat &UnifiedVariantVector::GetData(const RecursiveUnifiedV
 
 const Vector &ShreddedVector::GetUnshreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return *StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 Vector &ShreddedVector::GetUnshreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return *StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 const Vector &ShreddedVector::GetShreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return *StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 Vector &ShreddedVector::GetShreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return *StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 void ShreddedVector::Unshred(Vector &vec, idx_t count) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -3094,22 +3094,23 @@ idx_t ArrayVector::GetTotalSize(const Vector &vector) {
 Vector &VariantVector::GetKeys(Vector &vec) {
 	return StructVector::GetEntries(vec)[0];
 }
-Vector &VariantVector::GetKeys(const Vector &vec) {
-	return StructVector::GetEntries(const_cast<Vector &>(vec))[0];
+const Vector &VariantVector::GetKeys(const Vector &vec) {
+	return StructVector::GetEntries(vec)[0];
 }
 
 Vector &VariantVector::GetChildren(Vector &vec) {
 	return StructVector::GetEntries(vec)[1];
 }
-Vector &VariantVector::GetChildren(const Vector &vec) {
-	return StructVector::GetEntries(const_cast<Vector &>(vec))[1];
+const Vector &VariantVector::GetChildren(const Vector &vec) {
+	return StructVector::GetEntries(vec)[1];
 }
 
 Vector &VariantVector::GetChildrenKeysIndex(Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
 	return StructVector::GetEntries(children)[0];
 }
-Vector &VariantVector::GetChildrenKeysIndex(const Vector &vec) {
+
+const Vector &VariantVector::GetChildrenKeysIndex(const Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
 	return StructVector::GetEntries(children)[0];
 }
@@ -3118,7 +3119,7 @@ Vector &VariantVector::GetChildrenValuesIndex(Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
 	return StructVector::GetEntries(children)[1];
 }
-Vector &VariantVector::GetChildrenValuesIndex(const Vector &vec) {
+const Vector &VariantVector::GetChildrenValuesIndex(const Vector &vec) {
 	auto &children = ListVector::GetEntry(GetChildren(vec));
 	return StructVector::GetEntries(children)[1];
 }
@@ -3126,15 +3127,15 @@ Vector &VariantVector::GetChildrenValuesIndex(const Vector &vec) {
 Vector &VariantVector::GetValues(Vector &vec) {
 	return StructVector::GetEntries(vec)[2];
 }
-Vector &VariantVector::GetValues(const Vector &vec) {
-	return StructVector::GetEntries(const_cast<Vector &>(vec))[2];
+const Vector &VariantVector::GetValues(const Vector &vec) {
+	return StructVector::GetEntries(vec)[2];
 }
 
 Vector &VariantVector::GetValuesTypeId(Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
 	return StructVector::GetEntries(values)[0];
 }
-Vector &VariantVector::GetValuesTypeId(const Vector &vec) {
+const Vector &VariantVector::GetValuesTypeId(const Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
 	return StructVector::GetEntries(values)[0];
 }
@@ -3143,7 +3144,7 @@ Vector &VariantVector::GetValuesByteOffset(Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
 	return StructVector::GetEntries(values)[1];
 }
-Vector &VariantVector::GetValuesByteOffset(const Vector &vec) {
+const Vector &VariantVector::GetValuesByteOffset(const Vector &vec) {
 	auto &values = ListVector::GetEntry(GetValues(vec));
 	return StructVector::GetEntries(values)[1];
 }
@@ -3151,8 +3152,8 @@ Vector &VariantVector::GetValuesByteOffset(const Vector &vec) {
 Vector &VariantVector::GetData(Vector &vec) {
 	return StructVector::GetEntries(vec)[3];
 }
-Vector &VariantVector::GetData(const Vector &vec) {
-	return StructVector::GetEntries(const_cast<Vector &>(vec))[3];
+const Vector &VariantVector::GetData(const Vector &vec) {
+	return StructVector::GetEntries(vec)[3];
 }
 
 const UnifiedVectorFormat &UnifiedVariantVector::GetKeys(const RecursiveUnifiedVectorFormat &vec) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -117,7 +117,8 @@ void Vector::Reference(const Value &value) {
 		auto &child_types = StructType::GetChildTypes(value.type());
 		auto &child_vectors = struct_buffer->GetChildren();
 		for (idx_t i = 0; i < child_types.size(); i++) {
-			child_vectors.emplace_back(value.IsNull() ? Value(child_types[i].second) : StructValue::GetChildren(value)[i]);
+			child_vectors.emplace_back(value.IsNull() ? Value(child_types[i].second)
+			                                          : StructValue::GetChildren(value)[i]);
 		}
 		auxiliary = shared_ptr<VectorBuffer>(struct_buffer.release());
 		if (value.IsNull()) {

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -51,8 +51,7 @@ VectorStructBuffer::VectorStructBuffer(const LogicalType &type, idx_t capacity)
     : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
 	auto &child_types = StructType::GetChildTypes(type);
 	for (auto &child_type : child_types) {
-		auto vector = make_uniq<Vector>(child_type.second, capacity);
-		children.push_back(std::move(vector));
+		children.emplace_back(child_type.second, capacity);
 	}
 }
 
@@ -60,8 +59,7 @@ VectorStructBuffer::VectorStructBuffer(Vector &other, const SelectionVector &sel
     : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
 	auto &other_vector = StructVector::GetEntries(other);
 	for (auto &child_vector : other_vector) {
-		auto vector = make_uniq<Vector>(*child_vector, sel, count);
-		children.push_back(std::move(vector));
+		children.emplace_back(child_vector, sel, count);
 	}
 }
 

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -92,7 +92,7 @@ public:
 			auto &children = result.auxiliary->Cast<VectorStructBuffer>().GetChildren();
 			for (idx_t i = 0; i < children.size(); i++) {
 				auto &child_cache = child_caches[i]->Cast<VectorCacheBuffer>();
-				child_cache.ResetFromCache(*children[i], child_caches[i]);
+				child_cache.ResetFromCache(children[i], child_caches[i]);
 			}
 			break;
 		}

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -545,11 +545,11 @@ idx_t DistinctSelectStruct(Vector &left, Vector &right, idx_t count, const Selec
 	idx_t match_count = 0;
 	for (idx_t col_no = 0; col_no < lchildren.size(); ++col_no) {
 		// Slice the children to maintain density
-		Vector lchild(*lchildren[col_no]);
+		Vector lchild(lchildren[col_no]);
 		lchild.Flatten(vcount);
 		lchild.Slice(slice_sel, count);
 
-		Vector rchild(*rchildren[col_no]);
+		Vector rchild(rchildren[col_no]);
 		rchild.Flatten(vcount);
 		rchild.Slice(slice_sel, count);
 

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -186,7 +186,7 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 		auto &target_children = StructVector::GetEntries(target);
 		D_ASSERT(source_children.size() == target_children.size());
 		for (idx_t i = 0; i < source_children.size(); i++) {
-			VectorOperations::Copy(*source_children[i], *target_children[i], sel_p, source_count, source_offset,
+			VectorOperations::Copy(source_children[i], target_children[i], sel_p, source_count, source_offset,
 			                       target_offset, copy_count);
 		}
 		break;

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -102,21 +102,21 @@ void StructLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, 
 	idx_t col_no = 0;
 	if (HAS_RSEL) {
 		if (FIRST_HASH) {
-			VectorOperations::Hash(*children[col_no++], hashes, *rsel, count);
+			VectorOperations::Hash(children[col_no++], hashes, *rsel, count);
 		} else {
-			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+			VectorOperations::CombineHash(hashes, children[col_no++], *rsel, count);
 		}
 		while (col_no < children.size()) {
-			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+			VectorOperations::CombineHash(hashes, children[col_no++], *rsel, count);
 		}
 	} else {
 		if (FIRST_HASH) {
-			VectorOperations::Hash(*children[col_no++], hashes, count);
+			VectorOperations::Hash(children[col_no++], hashes, count);
 		} else {
-			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+			VectorOperations::CombineHash(hashes, children[col_no++], count);
 		}
 		while (col_no < children.size()) {
-			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+			VectorOperations::CombineHash(hashes, children[col_no++], count);
 		}
 	}
 }

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -202,7 +202,7 @@ void ExpressionExecutor::FillSwitch(Vector &vector, Vector &result, const Select
 		ValidityFillLoop(vector, result, sel, count);
 		D_ASSERT(vector_entries.size() == result_entries.size());
 		for (idx_t i = 0; i < vector_entries.size(); i++) {
-			FillSwitch(*vector_entries[i], *result_entries[i], sel, count);
+			FillSwitch(vector_entries[i], result_entries[i], sel, count);
 		}
 		break;
 	}

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -91,7 +91,7 @@ static bool AggregateStateToStructReinterpret(Vector &source, Vector &result, id
 	D_ASSERT(source_entries.size() == result_entries.size());
 
 	for (idx_t i = 0; i < source_entries.size(); i++) {
-		result_entries[i]->Reference(*source_entries[i]);
+		result_entries[i].Reference(source_entries[i]);
 	}
 
 	source.Flatten(count);

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -225,7 +225,7 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 		if (!is_unnamed) {
 			child_names.insert({StructType::GetChildName(result.GetType(), child_idx), child_idx});
 		}
-		child_masks.emplace_back(FlatVector::Validity(*child_vectors[child_idx]));
+		child_masks.emplace_back(FlatVector::Validity(child_vectors[child_idx]));
 		child_masks[child_idx].get().SetAllInvalid(count);
 	}
 
@@ -254,8 +254,8 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 	D_ASSERT(cast_data.child_cast_info.size() == result_children.size());
 
 	for (idx_t child_idx = 0; child_idx < result_children.size(); child_idx++) {
-		auto &child_varchar_vector = *child_vectors[child_idx];
-		auto &result_child_vector = *result_children[child_idx];
+		auto &child_varchar_vector = child_vectors[child_idx];
+		auto &result_child_vector = result_children[child_idx];
 		auto &child_cast_info = cast_data.child_cast_info[child_idx];
 		CastParameters child_parameters(parameters, child_cast_info.cast_data, lstate.local_states[child_idx]);
 		if (!child_cast_info.function(child_varchar_vector, result_child_vector, count, child_parameters)) {

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -105,8 +105,8 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 		auto source_idx = cast_data.source_indexes[i];
 		auto target_idx = cast_data.target_indexes[i];
 
-		auto &source_vector = *source_vectors[source_idx];
-		auto &target_vector = *target_children[target_idx];
+		auto &source_vector = source_vectors[source_idx];
+		auto &target_vector = target_children[target_idx];
 
 		auto &child_cast_info = cast_data.child_cast_info[i];
 		CastParameters child_parameters(parameters, child_cast_info.cast_data, l_state.local_states[i]);
@@ -119,7 +119,7 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 	if (!cast_data.target_null_indexes.empty()) {
 		for (idx_t i = 0; i < cast_data.target_null_indexes.size(); i++) {
 			auto target_idx = cast_data.target_null_indexes[i];
-			auto &target_vector = *target_children[target_idx];
+			auto &target_vector = target_children[target_idx];
 
 			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
 			ConstantVector::SetNull(target_vector, true);
@@ -172,13 +172,13 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 			if (c > 0) {
 				string_length += SEP_LENGTH;
 			}
-			auto add_escapes = !base_children[c]->GetType().IsNested();
+			auto add_escapes = !base_children[c].GetType().IsNested();
 			auto string_length_func = add_escapes ? VectorCastHelpers::CalculateEscapedStringLength<false>
 			                                      : VectorCastHelpers::CalculateStringLength;
 
-			children[c]->Flatten(count);
-			auto &child_validity = FlatVector::Validity(*children[c]);
-			auto data = FlatVector::GetData<string_t>(*children[c]);
+			children[c].Flatten(count);
+			auto &child_validity = FlatVector::Validity(children[c]);
+			auto data = FlatVector::GetData<string_t>(children[c]);
 			auto &name = child_types[c].first;
 			if (!is_unnamed) {
 				string_length += VectorCastHelpers::CalculateEscapedStringLength<true>(name, key_needs_quotes[c]);
@@ -203,12 +203,12 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 				memcpy(dataptr + offset, ", ", SEP_LENGTH);
 				offset += SEP_LENGTH;
 			}
-			auto add_escapes = !base_children[c]->GetType().IsNested();
+			auto add_escapes = !base_children[c].GetType().IsNested();
 			auto write_string_func =
 			    add_escapes ? VectorCastHelpers::WriteEscapedString<false> : VectorCastHelpers::WriteString;
 
-			auto &child_validity = FlatVector::Validity(*children[c]);
-			auto data = FlatVector::GetData<string_t>(*children[c]);
+			auto &child_validity = FlatVector::Validity(children[c]);
+			auto data = FlatVector::GetData<string_t>(children[c]);
 			if (!is_unnamed) {
 				auto &name = child_types[c].first;
 				// "{<name>: <value>}"
@@ -318,7 +318,7 @@ static bool StructToMapCast(Vector &source, Vector &result, idx_t count, CastPar
 	bool values_converted = true;
 	auto &map_values = MapVector::GetValues(result);
 	for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
-		auto &source_field = *source_children[field_idx];
+		auto &source_field = source_children[field_idx];
 		Vector temp_converted(MapType::ValueType(result.GetType()), count);
 		CastParameters child_params(parameters, cast_data.value_casts[field_idx].cast_data,
 		                            local_state.value_states[field_idx]);

--- a/src/function/cast/union/from_struct.cpp
+++ b/src/function/cast/union/from_struct.cpp
@@ -56,8 +56,8 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 	auto &target_children = StructVector::GetEntries(result);
 
 	for (idx_t i = 0; i < source_children.size(); i++) {
-		auto &result_child_vector = *target_children[i];
-		auto &source_child_vector = *source_children[i];
+		auto &result_child_vector = target_children[i];
+		auto &source_child_vector = source_children[i];
 		CastParameters child_parameters(parameters, cast_data.child_cast_info[i].cast_data, lstate.local_states[i]);
 		auto converted =
 		    cast_data.child_cast_info[i].function(source_child_vector, result_child_vector, count, child_parameters);
@@ -72,11 +72,11 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 		ConstantVector::SetNull(result, ConstantVector::IsNull(source));
 
 		// if the tag is NULL, the union should be NULL
-		auto &tag_vec = *target_children[0];
+		auto &tag_vec = target_children[0];
 		ConstantVector::SetNull(result, ConstantVector::IsNull(tag_vec));
 	} else {
 		// if the tag is NULL, the union should be NULL
-		auto &tag_vec = *target_children[0];
+		auto &tag_vec = target_children[0];
 		UnifiedVectorFormat source_data, tag_data;
 		source.ToUnifiedFormat(count, source_data);
 		tag_vec.ToUnifiedFormat(count, tag_data);

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -428,7 +428,7 @@ static bool ConvertVariantToStruct(FromVariantConversionData &conversion_data, V
 			return false;
 		}
 		//! Now cast all the values we found to the target type
-		auto &child = *children[child_idx];
+		auto &child = children[child_idx];
 		if (!CastVariant(conversion_data, child, child_values_sel, offset, count, row)) {
 			return false;
 		}
@@ -699,9 +699,9 @@ static bool TryFromShreddedCast(Vector &variant_vec, Vector &result) {
 	if (ShreddedVector::IsFullyShredded(variant_vec) && shredded_vec.GetType().id() == LogicalTypeId::STRUCT) {
 		// it is! check if the type of the typed_value entry matches
 		auto &shredded_entries = StructVector::GetEntries(shredded_vec);
-		if (shredded_entries[1]->GetType() == result.GetType()) {
+		if (shredded_entries[1].GetType() == result.GetType()) {
 			// the typed_value matches - directly reference it
-			result.Reference(*shredded_entries[1]);
+			result.Reference(shredded_entries[1]);
 			return true;
 		}
 	}

--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -125,10 +125,10 @@ struct VariantLocalData : FunctionLocalState {
 		shredded_vector = make_uniq<Vector>(shredded_type, capacity);
 		auto &top_shredded = StructVector::GetEntries(*shredded_vector);
 		// NULL out everything in the unshredded part
-		auto &unshredded_child = *top_shredded[0];
+		auto &unshredded_child = top_shredded[0];
 		for (auto &unshredded_entry : StructVector::GetEntries(unshredded_child)) {
-			unshredded_entry->SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(*unshredded_entry, true);
+			unshredded_entry.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(unshredded_entry, true);
 		}
 		unshredded_child.SetVectorType(VectorType::CONSTANT_VECTOR);
 		ConstantVector::SetNull(unshredded_child, true);
@@ -174,7 +174,7 @@ static void ShreddedVectorReference(Vector &source, Vector &result, idx_t count)
 	if (source.GetType().id() == LogicalTypeId::STRUCT) {
 		// source is "{<children>}", target is "{typed value STRUCT(<children>)}"
 		// go into the "typed_value"
-		auto &typed_value = *StructVector::GetEntries(result)[0];
+		auto &typed_value = StructVector::GetEntries(result)[0];
 		// copy over the validity
 		// we need to flatten in order to reference the validity
 		if (source.GetVectorType() != VectorType::FLAT_VECTOR) {
@@ -186,7 +186,7 @@ static void ShreddedVectorReference(Vector &source, Vector &result, idx_t count)
 		auto &source_entries = StructVector::GetEntries(source);
 		auto &target_entries = StructVector::GetEntries(typed_value);
 		for (idx_t child_idx = 0; child_idx < source_entries.size(); child_idx++) {
-			ShreddedVectorReference(*source_entries[child_idx], *target_entries[child_idx], count);
+			ShreddedVectorReference(source_entries[child_idx], target_entries[child_idx], count);
 		}
 		return;
 	}
@@ -202,7 +202,7 @@ static bool TryToShreddedCast(Vector &source, Vector &result, idx_t count, CastP
 	auto &shredded_vector = local_data.GetShreddedVector(count);
 	// emit a shredded vector that references the source directly
 	auto &top_shredded = StructVector::GetEntries(shredded_vector);
-	auto &shredded_child = *top_shredded[1];
+	auto &shredded_child = top_shredded[1];
 	ShreddedVectorReference(source, shredded_child, count);
 	result.Shred(shredded_vector);
 	return true;
@@ -212,7 +212,7 @@ static void SetVectorConstant(Vector &vector) {
 	if (vector.GetType().InternalType() == PhysicalType::STRUCT) {
 		auto &entries = StructVector::GetEntries(vector);
 		for (auto &entry : entries) {
-			SetVectorConstant(*entry);
+			SetVectorConstant(entry);
 		}
 	}
 	vector.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -442,7 +442,7 @@ idx_t VectorStringToMap::CountPartsMap(const string_t &input) {
 }
 
 // ------- STRUCT SPLIT -------
-bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<Vector>> &varchar_vectors,
+bool VectorStringToStruct::SplitStruct(const string_t &input, vector<Vector> &varchar_vectors,
                                        idx_t &row_idx, string_map_t<idx_t> &child_names,
                                        vector<reference<ValidityMask>> &child_masks) {
 	const char *buf = input.GetData();
@@ -533,7 +533,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			if (pos == len) {
 				return false;
 			}
-			auto &child_vec = *varchar_vectors[child_idx];
+			auto &child_vec = varchar_vectors[child_idx];
 			auto string_data = FlatVector::GetData<string_t>(child_vec);
 			auto &child_mask = child_masks[child_idx].get();
 
@@ -576,7 +576,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			if (pos == len) {
 				return false;
 			}
-			auto &child_vec = *varchar_vectors[child_idx];
+			auto &child_vec = varchar_vectors[child_idx];
 			auto string_data = FlatVector::GetData<string_t>(child_vec);
 			auto &child_mask = child_masks[child_idx].get();
 

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -442,9 +442,8 @@ idx_t VectorStringToMap::CountPartsMap(const string_t &input) {
 }
 
 // ------- STRUCT SPLIT -------
-bool VectorStringToStruct::SplitStruct(const string_t &input, vector<Vector> &varchar_vectors,
-                                       idx_t &row_idx, string_map_t<idx_t> &child_names,
-                                       vector<reference<ValidityMask>> &child_masks) {
+bool VectorStringToStruct::SplitStruct(const string_t &input, vector<Vector> &varchar_vectors, idx_t &row_idx,
+                                       string_map_t<idx_t> &child_names, vector<reference<ValidityMask>> &child_masks) {
 	const char *buf = input.GetData();
 	idx_t len = input.GetSize();
 	idx_t pos = 0;

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -106,7 +106,7 @@ struct SortKeyVectorData {
 		case PhysicalType::STRUCT: {
 			auto &children = StructVector::GetEntries(input);
 			for (auto &child : children) {
-				child_data.push_back(make_uniq<SortKeyVectorData>(*child, size, child_modifiers));
+				child_data.push_back(make_uniq<SortKeyVectorData>(child, size, child_modifiers));
 			}
 			break;
 		}
@@ -983,7 +983,7 @@ void DecodeSortKeyStruct(DecodeSortKeyData decode_data_arr[], DecodeSortKeyVecto
 	auto &child_entries = StructVector::GetEntries(result);
 	for (idx_t c = 0; c < child_entries.size(); c++) {
 		auto &child_entry = child_entries[c];
-		DecodeSortKeyRecursive(decode_data_arr, vector_data.child_data[c], *child_entry, result_offset, count);
+		DecodeSortKeyRecursive(decode_data_arr, vector_data.child_data[c], child_entry, result_offset, count);
 	}
 }
 
@@ -1230,9 +1230,9 @@ static void DecodeSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 
 	// Loop through the columns
 	const auto &result_type = result.GetType();
-	const auto &child_vectors = StructVector::GetEntries(result);
+	auto &child_vectors = StructVector::GetEntries(result);
 	for (idx_t c = 0; c < StructType::GetChildCount(result_type); c++) {
-		auto &child_vector = *child_vectors[c];
+		auto &child_vector = child_vectors[c];
 		DecodeSortKeyVectorData sort_key_data(child_vector.GetType(), bind_data.modifiers[c]);
 		DecodeSortKeyRecursive(decode_data, sort_key_data, child_vector, 0, count);
 	}

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -118,7 +118,7 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 	for (idx_t child_idx = 0; child_idx < args_size; child_idx++) {
 		if (args.data[child_idx].GetType() != LogicalType::SQLNULL) {
 			struct_entries[child_idx].Slice(ListVector::GetEntry(args.data[child_idx]), selections[child_idx],
-			                                 result_size);
+			                                result_size);
 		}
 		struct_entries[child_idx].Flatten(result_size);
 		FlatVector::SetValidity((struct_entries[child_idx]), masks[child_idx]);

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -117,11 +117,11 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 	}
 	for (idx_t child_idx = 0; child_idx < args_size; child_idx++) {
 		if (args.data[child_idx].GetType() != LogicalType::SQLNULL) {
-			struct_entries[child_idx]->Slice(ListVector::GetEntry(args.data[child_idx]), selections[child_idx],
+			struct_entries[child_idx].Slice(ListVector::GetEntry(args.data[child_idx]), selections[child_idx],
 			                                 result_size);
 		}
-		struct_entries[child_idx]->Flatten(result_size);
-		FlatVector::SetValidity((*struct_entries[child_idx]), masks[child_idx]);
+		struct_entries[child_idx].Flatten(result_size);
+		FlatVector::SetValidity((struct_entries[child_idx]), masks[child_idx]);
 	}
 	result.SetVectorType(args.AllConstant() ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
 }

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -265,7 +265,7 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 	// Reference the 'input' StringBuffer, because we won't need to allocate new data
 	// for the result, all returned strings are substrings of the originals
 	for (auto &child_entry : child_entries) {
-		child_entry->SetAuxiliary(input.GetAuxiliary());
+		child_entry.SetAuxiliary(input.GetAuxiliary());
 	}
 
 	vector<RE2::Arg> argv(groupSize);
@@ -289,9 +289,9 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 			                                            UnsafeNumericCast<int>(groups.size()));
 			for (size_t col = 0; col < child_entries.size(); ++col) {
 				auto &child_entry = child_entries[col];
-				ConstantVector::SetNull(*child_entry, false);
+				ConstantVector::SetNull(child_entry, false);
 				auto &extracted = ws[col];
-				auto cdata = ConstantVector::GetData<string_t>(*child_entry);
+				auto cdata = ConstantVector::GetData<string_t>(child_entry);
 				cdata[0] = string_t(extracted.data(), UnsafeNumericCast<uint32_t>(match ? extracted.size() : 0));
 			}
 		}
@@ -308,7 +308,7 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 		// Start with valid children
 		for (size_t col = 0; col < child_entries.size(); ++col) {
 			auto &child_entry = child_entries[col];
-			child_entry->SetVectorType(VectorType::FLAT_VECTOR);
+			child_entry.SetVectorType(VectorType::FLAT_VECTOR);
 		}
 
 		for (idx_t i = 0; i < count; ++i) {
@@ -319,7 +319,7 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 				                                            UnsafeNumericCast<int>(groups.size()));
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
-					auto cdata = FlatVector::GetData<string_t>(*child_entry);
+					auto cdata = FlatVector::GetData<string_t>(child_entry);
 					auto &extracted = ws[col];
 					cdata[i] = string_t(extracted.data(), UnsafeNumericCast<uint32_t>(match ? extracted.size() : 0));
 				}

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -253,7 +253,7 @@ static inline bool ExtractAllStruct(duckdb_re2::StringPiece &input, duckdb_re2::
 
 static void ExtractStructAllSingleTuple(const string_t &string_val, duckdb_re2::RE2 &re,
                                         vector<duckdb_re2::StringPiece> &group_spans,
-                                        vector<unique_ptr<Vector>> &child_entries, Vector &result, idx_t row) {
+                                        vector<Vector> &child_entries, Vector &result, idx_t row) {
 	const idx_t group_count = child_entries.size();
 	auto list_entries = FlatVector::GetData<list_entry_t>(result);
 	idx_t current_list_size = ListVector::GetListSize(result);
@@ -268,7 +268,7 @@ static void ExtractStructAllSingleTuple(const string_t &string_val, duckdb_re2::
 		}
 		// Write each selected group
 		for (idx_t g = 0; g < group_count; g++) {
-			auto &child_vec = *child_entries[g];
+			auto &child_vec = child_entries[g];
 			child_vec.SetVectorType(VectorType::FLAT_VECTOR);
 			auto cdata = FlatVector::GetData<string_t>(child_vec);
 			auto &span = group_spans[g + 1];
@@ -312,8 +312,8 @@ void RegexpExtractAllStruct::Execute(DataChunk &args, ExpressionState &state, Ve
 
 	// Reference original string buffer for zero-copy substring assignment
 	for (auto &child : child_entries) {
-		child->SetAuxiliary(strings.GetAuxiliary());
-		child->SetVectorType(VectorType::FLAT_VECTOR);
+		child.SetAuxiliary(strings.GetAuxiliary());
+		child.SetVectorType(VectorType::FLAT_VECTOR);
 	}
 
 	UnifiedVectorFormat strings_data;

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -252,8 +252,8 @@ static inline bool ExtractAllStruct(duckdb_re2::StringPiece &input, duckdb_re2::
 }
 
 static void ExtractStructAllSingleTuple(const string_t &string_val, duckdb_re2::RE2 &re,
-                                        vector<duckdb_re2::StringPiece> &group_spans,
-                                        vector<Vector> &child_entries, Vector &result, idx_t row) {
+                                        vector<duckdb_re2::StringPiece> &group_spans, vector<Vector> &child_entries,
+                                        Vector &result, idx_t row) {
 	const idx_t group_count = child_entries.size();
 	auto list_entries = FlatVector::GetData<list_entry_t>(result);
 	idx_t current_list_size = ListVector::GetListSize(result);

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -62,7 +62,7 @@ void RemapChildVectors(const Vector &result, const vector<reference<Vector>> &in
 			reference<Vector> child_default = default_vector;
 			if (remap.default_index.IsValid()) {
 				auto &defaults = StructVector::GetEntries(default_vector);
-				child_default = *defaults[remap.default_index.GetIndex()];
+				child_default = defaults[remap.default_index.GetIndex()];
 			}
 			RemapNested(input_vector, child_default.get(), result_vectors[i], count, remap.child_remap_info);
 			continue;
@@ -70,7 +70,7 @@ void RemapChildVectors(const Vector &result, const vector<reference<Vector>> &in
 		// primitive type remap
 		if (remap.default_index.IsValid()) {
 			auto &defaults = StructVector::GetEntries(default_vector);
-			result_vectors[i].get().Reference(*defaults[remap.default_index.GetIndex()]);
+			result_vectors[i].get().Reference(defaults[remap.default_index.GetIndex()]);
 			if (result_vectors[i].get().GetVectorType() != VectorType::CONSTANT_VECTOR) {
 				throw InternalException("Default value in remap struct must be a constant");
 			}
@@ -224,12 +224,12 @@ void RemapStruct(Vector &input, Vector &default_vector, Vector &result, idx_t re
 	//! Build up the input for remapping the children of the struct
 	vector<reference<Vector>> input_vectors;
 	for (auto &child : input_child_vectors) {
-		input_vectors.emplace_back(*child);
+		input_vectors.emplace_back(child);
 	}
 
 	vector<reference<Vector>> result_vectors;
 	for (auto &child : result_child_vectors) {
-		result_vectors.emplace_back(*child);
+		result_vectors.emplace_back(child);
 	}
 
 	RemapChildVectors(result, input_vectors, result_vectors, remap_info, default_vector, has_top_level_null,

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -21,7 +21,7 @@ static void StructConcatFunction(DataChunk &args, ExpressionState &state, Vector
 	for (auto &arg : args.data) {
 		const auto &child_cols = StructVector::GetEntries(arg);
 		for (auto &child_col : child_cols) {
-			result_cols[offset++]->Reference(*child_col);
+			result_cols[offset++].Reference(child_col);
 		}
 	}
 	D_ASSERT(offset == result_cols.size());

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -10,7 +10,7 @@
 namespace duckdb {
 
 template <class T, class RETURN_TYPE, bool FIND_NULLS>
-static void TemplatedStructSearch(Vector &input_vector, vector<unique_ptr<Vector>> &members, Vector &target,
+static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members, Vector &target,
                                   const idx_t count, Vector &result) {
 	// If the return type is not a bool, return the position
 	const auto return_pos = std::is_same<RETURN_TYPE, int32_t>::value;
@@ -27,10 +27,10 @@ static void TemplatedStructSearch(Vector &input_vector, vector<unique_ptr<Vector
 	vector<const T *> member_datas;
 	vector<UnifiedVectorFormat> member_vectors;
 	idx_t total_matches = 0;
-	for (const auto &member : members) {
-		if (member->GetType().InternalType() == target_type.InternalType()) {
+	for (auto &member : members) {
+		if (member.GetType().InternalType() == target_type.InternalType()) {
 			UnifiedVectorFormat member_format;
-			member->ToUnifiedFormat(count, member_format);
+			member.ToUnifiedFormat(count, member_format);
 			member_datas.push_back(UnifiedVectorFormat::GetData<T>(member_format));
 			member_vectors.push_back(std::move(member_format));
 			total_matches++;
@@ -111,19 +111,18 @@ static void TemplatedStructSearch(Vector &input_vector, vector<unique_ptr<Vector
 }
 
 template <class RETURN_TYPE, bool FIND_NULLS>
-static void StructNestedOp(Vector &input_vector, vector<unique_ptr<Vector>> &members, Vector &target, const idx_t count,
+static void StructNestedOp(Vector &input_vector, vector<Vector> &members, Vector &target, const idx_t count,
                            Vector &result) {
 	const OrderModifiers order_modifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
 
 	// Set up sort keys for nested types.
 	const auto members_size = members.size();
-	vector<unique_ptr<Vector>> member_sort_key_vectors;
+	vector<Vector> member_sort_key_vectors;
 	for (idx_t i = 0; i < members_size; i++) {
 		Vector member_sort_key_vec(LogicalType::BLOB, count);
-		CreateSortKeyHelpers::CreateSortKeyWithValidity(*members[i], member_sort_key_vec, order_modifiers, count);
+		CreateSortKeyHelpers::CreateSortKeyWithValidity(members[i], member_sort_key_vec, order_modifiers, count);
 
-		auto member_sort_key_ptr = make_uniq<Vector>(member_sort_key_vec);
-		member_sort_key_vectors.push_back(std::move(member_sort_key_ptr));
+		member_sort_key_vectors.push_back(std::move(member_sort_key_vec));
 	}
 
 	Vector target_sort_key_vec(LogicalType::BLOB, count);
@@ -134,7 +133,7 @@ static void StructNestedOp(Vector &input_vector, vector<unique_ptr<Vector>> &mem
 }
 
 template <class RETURN_TYPE, bool FIND_NULLS>
-static void StructSearchOp(Vector &input_vector, vector<unique_ptr<Vector>> &members, Vector &target, const idx_t count,
+static void StructSearchOp(Vector &input_vector, vector<Vector> &members, Vector &target, const idx_t count,
                            Vector &result) {
 	const auto &target_type = target.GetType().InternalType();
 	switch (target_type) {

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -10,8 +10,8 @@
 namespace duckdb {
 
 template <class T, class RETURN_TYPE, bool FIND_NULLS>
-static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members, Vector &target,
-                                  const idx_t count, Vector &result) {
+static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members, Vector &target, const idx_t count,
+                                  Vector &result) {
 	// If the return type is not a bool, return the position
 	const auto return_pos = std::is_same<RETURN_TYPE, int32_t>::value;
 

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -22,7 +22,7 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 	auto &children = StructVector::GetEntries(vec);
 	D_ASSERT(info.index < children.size());
 	auto &struct_child = children[info.index];
-	result.Reference(*struct_child);
+	result.Reference(struct_child);
 	result.Verify(args.size());
 }
 

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -25,7 +25,7 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 			all_const = false;
 		}
 		// same holds for this
-		child_entries[i]->Reference(args.data[i]);
+		child_entries[i].Reference(args.data[i]);
 	}
 	result.SetVectorType(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
 	result.Verify(args.size());

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -143,7 +143,7 @@ struct LoadFieldOp {
 	template <class T>
 	static void Operation(idx_t root_stride, Vector &struct_vec, idx_t field_idx, const UnifiedVectorFormat &state_data,
 	                      idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
-		auto &child = *StructVector::GetEntries(struct_vec)[field_idx];
+		auto &child = StructVector::GetEntries(struct_vec)[field_idx];
 		auto child_data = FlatVector::GetData<T>(child);
 
 		for (idx_t row = 0; row < count; row++) {
@@ -161,7 +161,7 @@ struct LoadFieldOp {
 struct StoreFieldOp {
 	template <class T>
 	static void Operation(Vector &struct_vec, idx_t field_idx, idx_t count, data_ptr_t *sources, idx_t field_offset) {
-		auto &child = *StructVector::GetEntries(struct_vec)[field_idx];
+		auto &child = StructVector::GetEntries(struct_vec)[field_idx];
 		auto child_data = FlatVector::GetData<T>(child);
 
 		for (idx_t row = 0; row < count; row++) {
@@ -178,7 +178,7 @@ struct StoreFieldOp {
 template <>
 void StoreFieldOp::Operation<string_t>(Vector &struct_vec, idx_t field_idx, idx_t count, data_ptr_t *sources,
                                        idx_t field_offset) {
-	auto &child = *StructVector::GetEntries(struct_vec)[field_idx];
+	auto &child = StructVector::GetEntries(struct_vec)[field_idx];
 	auto child_data = FlatVector::GetData<string_t>(child);
 
 	for (idx_t row = 0; row < count; row++) {
@@ -193,10 +193,10 @@ struct CopyFromInputFieldOp {
 	template <class T>
 	static void Operation(Vector &input_vec, Vector &result_vec, idx_t field_idx, const SelectionVector &sel,
 	                      idx_t count, const UnifiedVectorFormat &input_data) {
-		auto &input_child = *StructVector::GetEntries(input_vec)[field_idx];
+		auto &input_child = StructVector::GetEntries(input_vec)[field_idx];
 		auto input_child_data = FlatVector::GetData<T>(input_child);
 
-		auto &result_child = *StructVector::GetEntries(result_vec)[field_idx];
+		auto &result_child = StructVector::GetEntries(result_vec)[field_idx];
 		auto result_child_data = FlatVector::GetData<T>(result_child);
 
 		for (idx_t i = 0; i < count; i++) {
@@ -212,7 +212,7 @@ struct LoadFieldForSelectedRowsOp {
 	static void Operation(const AggregateStateLayout &layout, Vector &struct_vec, idx_t field_idx,
 	                      const SelectionVector &sel, idx_t count, const UnifiedVectorFormat &state_data,
 	                      data_ptr_t base_ptr, idx_t field_offset) {
-		auto &child = *StructVector::GetEntries(struct_vec)[field_idx];
+		auto &child = StructVector::GetEntries(struct_vec)[field_idx];
 		auto child_data = FlatVector::GetData<T>(child);
 
 		for (idx_t i = 0; i < count; i++) {
@@ -228,7 +228,7 @@ struct StoreFieldForSelectedRowsOp {
 	template <class T>
 	static void Operation(const AggregateStateLayout &layout, Vector &result, idx_t field_idx,
 	                      const SelectionVector &sel, idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
-		auto &child = *StructVector::GetEntries(result)[field_idx];
+		auto &child = StructVector::GetEntries(result)[field_idx];
 		auto child_data = FlatVector::GetData<T>(child);
 
 		for (idx_t i = 0; i < count; i++) {
@@ -245,7 +245,7 @@ template <>
 void StoreFieldForSelectedRowsOp::Operation<string_t>(const AggregateStateLayout &layout, Vector &result,
                                                       idx_t field_idx, const SelectionVector &sel, idx_t count,
                                                       data_ptr_t base_ptr, idx_t field_offset) {
-	auto &child = *StructVector::GetEntries(result)[field_idx];
+	auto &child = StructVector::GetEntries(result)[field_idx];
 	auto child_data = FlatVector::GetData<string_t>(child);
 
 	for (idx_t i = 0; i < count; i++) {
@@ -285,7 +285,7 @@ void DeserializeStructFields(const AggregateStateLayout &layout, idx_t root_stri
 		if (field_type.id() == LogicalTypeId::STRUCT) {
 			auto child_layout = AggregateStateLayout(field_type, field_size);
 			auto &struct_entries = StructVector::GetEntries(struct_vec);
-			DeserializeStructFields(child_layout, root_stride, *struct_entries[field_idx], state_data, count,
+			DeserializeStructFields(child_layout, root_stride, struct_entries[field_idx], state_data, count,
 			                        dest_buffer + offset_in_state);
 		} else {
 			TemplateDispatch<LoadFieldOp>(physical, root_stride, struct_vec, field_idx, state_data, count, dest_buffer,
@@ -319,7 +319,7 @@ void SerializeStructFields(const AggregateStateLayout &layout, Vector &result, i
 			}
 
 			auto &struct_entries = StructVector::GetEntries(result);
-			SerializeStructFields(child_layout, *struct_entries.get(field_idx), count, child_ptrs);
+			SerializeStructFields(child_layout, struct_entries[field_idx], count, child_ptrs);
 		} else {
 			TemplateDispatch<StoreFieldOp>(physical, result, field_idx, count, addresses_ptrs, offset_in_state);
 		}

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -72,7 +72,7 @@ void ParseLogMessageFunction(DataChunk &args, ExpressionState &state, Vector &re
 		VectorOperations::DefaultCast(args.data[1], result, args.size(), true);
 	} else {
 		auto &struct_entries = StructVector::GetEntries(result);
-		struct_entries[0]->Reference(args.data[1]);
+		struct_entries[0].Reference(args.data[1]);
 	}
 }
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -114,14 +114,14 @@ static bool TryShreddedExtractRecursive(Vector &input, const vector<VariantPathC
 		Vector shredded_vector(shredded_type, count);
 		auto &top_shredded = StructVector::GetEntries(shredded_vector);
 		// NULL out everything in the unshredded part
-		auto &unshredded_child = *top_shredded[0];
+		auto &unshredded_child = top_shredded[0];
 		for (auto &unshredded_entry : StructVector::GetEntries(unshredded_child)) {
-			unshredded_entry->SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(*unshredded_entry, true);
+			unshredded_entry.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(unshredded_entry, true);
 		}
 		unshredded_child.SetVectorType(VectorType::CONSTANT_VECTOR);
 		ConstantVector::SetNull(unshredded_child, true);
-		auto &shredded_child = *top_shredded[1];
+		auto &shredded_child = top_shredded[1];
 		shredded_child.Reference(input);
 
 		result.Shred(shredded_vector);
@@ -134,7 +134,7 @@ static bool TryShreddedExtractRecursive(Vector &input, const vector<VariantPathC
 	}
 	// first entry is "typed_value"
 	auto &typed_entries = StructVector::GetEntries(input);
-	auto &typed_value = *typed_entries[0];
+	auto &typed_value = typed_entries[0];
 
 	// find the type in the struct type
 	auto &child_types = StructType::GetChildTypes(typed_value.GetType());
@@ -143,7 +143,7 @@ static bool TryShreddedExtractRecursive(Vector &input, const vector<VariantPathC
 		auto &entry = child_types[child_idx];
 		if (StringUtil::CIEquals(entry.first, component.key)) {
 			// key found - move onto next component
-			return TryShreddedExtractRecursive(*child_entries[child_idx], components, result, count, path_index + 1);
+			return TryShreddedExtractRecursive(child_entries[child_idx], components, result, count, path_index + 1);
 		}
 	}
 	// key not found - bail (FIXME: could we emit constant NULL here?)

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1164,7 +1164,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 		auto &child_entries = StructVector::GetEntries(vector);
 		auto &struct_validity_mask = FlatVector::Validity(vector);
 		for (idx_t child_idx = 0; child_idx < NumericCast<idx_t>(array.n_children); child_idx++) {
-			auto &child_entry = *child_entries[child_idx];
+			auto &child_entry = child_entries[child_idx];
 			auto &child_array = *array.children[child_idx];
 			auto &child_type = struct_info.GetChild(child_idx);
 			auto &child_state = array_state.GetChild(child_idx);

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -181,7 +181,7 @@ struct TestVectorSequence {
 		case PhysicalType::STRUCT: {
 			auto &child_entries = StructVector::GetEntries(result);
 			for (auto &child_entry : child_entries) {
-				GenerateVector(info, child_entry->GetType(), *child_entry);
+				GenerateVector(info, child_entry.GetType(), child_entry);
 			}
 			break;
 		}

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -196,7 +196,7 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 	child_result_sel.Initialize(count);
 
 	for (idx_t child_idx = 0; child_idx < shredded_types.size(); child_idx++) {
-		auto &child_vec = *shredded_fields[child_idx];
+		auto &child_vec = shredded_fields[child_idx];
 		D_ASSERT(child_vec.GetType() == shredded_types[child_idx].second);
 
 		//! Prepare the path component to perform the lookup for

--- a/src/function/window/window_collection.cpp
+++ b/src/function/window/window_collection.cpp
@@ -171,7 +171,7 @@ void WindowCollectionChunkScanner::ReferenceStructColumns(DataChunk &chunk, Vect
 	auto &entries = StructVector::GetEntries(vec);
 	D_ASSERT(width == entries.size());
 	for (column_t i = 0; i < entries.size(); ++i) {
-		entries[i]->Reference(chunk.data[begin + i]);
+		entries[i].Reference(chunk.data[begin + i]);
 	}
 }
 

--- a/src/include/duckdb/common/vector/struct_vector.hpp
+++ b/src/include/duckdb/common/vector/struct_vector.hpp
@@ -21,21 +21,21 @@ public:
 	~VectorStructBuffer() override;
 
 public:
-	const vector<unique_ptr<Vector>> &GetChildren() const {
+	const vector<Vector> &GetChildren() const {
 		return children;
 	}
-	vector<unique_ptr<Vector>> &GetChildren() {
+	vector<Vector> &GetChildren() {
 		return children;
 	}
 
 private:
 	//! child vectors used for nested data
-	vector<unique_ptr<Vector>> children;
+	vector<Vector> children;
 };
 
 struct StructVector {
-	DUCKDB_API static const vector<unique_ptr<Vector>> &GetEntries(const Vector &vector);
-	DUCKDB_API static vector<unique_ptr<Vector>> &GetEntries(Vector &vector);
+	DUCKDB_API static const vector<Vector> &GetEntries(const Vector &vector);
+	DUCKDB_API static vector<Vector> &GetEntries(Vector &vector);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/vector/variant_vector.hpp
+++ b/src/include/duckdb/common/vector/variant_vector.hpp
@@ -15,28 +15,28 @@ namespace duckdb {
 struct VariantVector {
 	//! Gets a reference to the 'keys' list (dictionary) of a Variant
 	DUCKDB_API static Vector &GetKeys(Vector &vec);
-	DUCKDB_API static Vector &GetKeys(const Vector &vec);
+	DUCKDB_API static const Vector &GetKeys(const Vector &vec);
 	//! Gets a reference to the 'children' list of a Variant
 	DUCKDB_API static Vector &GetChildren(Vector &vec);
-	DUCKDB_API static Vector &GetChildren(const Vector &vec);
+	DUCKDB_API static const Vector &GetChildren(const Vector &vec);
 	//! Gets a reference to the 'keys_index' inside the 'children' list of a Variant
 	DUCKDB_API static Vector &GetChildrenKeysIndex(Vector &vec);
-	DUCKDB_API static Vector &GetChildrenKeysIndex(const Vector &vec);
+	DUCKDB_API static const Vector &GetChildrenKeysIndex(const Vector &vec);
 	//! Gets a reference to the 'values_index' inside the 'children' list of a Variant
 	DUCKDB_API static Vector &GetChildrenValuesIndex(Vector &vec);
-	DUCKDB_API static Vector &GetChildrenValuesIndex(const Vector &vec);
+	DUCKDB_API static const Vector &GetChildrenValuesIndex(const Vector &vec);
 	//! Gets a reference to the 'values' list of a Variant
 	DUCKDB_API static Vector &GetValues(Vector &vec);
-	DUCKDB_API static Vector &GetValues(const Vector &vec);
+	DUCKDB_API static const Vector &GetValues(const Vector &vec);
 	//! Gets a reference to the 'type_id' inside the 'values' list of a Variant
 	DUCKDB_API static Vector &GetValuesTypeId(Vector &vec);
-	DUCKDB_API static Vector &GetValuesTypeId(const Vector &vec);
+	DUCKDB_API static const Vector &GetValuesTypeId(const Vector &vec);
 	//! Gets a reference to the 'byte_offset' inside the 'values' list of a Variant
 	DUCKDB_API static Vector &GetValuesByteOffset(Vector &vec);
-	DUCKDB_API static Vector &GetValuesByteOffset(const Vector &vec);
+	DUCKDB_API static const Vector &GetValuesByteOffset(const Vector &vec);
 	//! Gets a reference to the binary blob 'value', which encodes the data of the row
 	DUCKDB_API static Vector &GetData(Vector &vec);
-	DUCKDB_API static Vector &GetData(const Vector &vec);
+	DUCKDB_API static const Vector &GetData(const Vector &vec);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -63,7 +63,7 @@ struct StructTypeState {
 		input.ToUnifiedFormat(count, main_data);
 
 		for (idx_t i = 0; i < CHILD_COUNT; i++) {
-			entries[i]->ToUnifiedFormat(count, child_data[i]);
+			entries[i].ToUnifiedFormat(count, child_data[i]);
 		}
 	}
 };
@@ -88,7 +88,7 @@ struct StructTypeUnary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeUnary<A_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
+		auto a_data = FlatVector::GetData<A_TYPE>(entries[0]);
 		a_data[i] = value.a_val;
 	}
 };
@@ -119,8 +119,8 @@ struct StructTypeBinary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeBinary<A_TYPE, B_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
-		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
+		auto a_data = FlatVector::GetData<A_TYPE>(entries[0]);
+		auto b_data = FlatVector::GetData<B_TYPE>(entries[1]);
 		a_data[i] = value.a_val;
 		b_data[i] = value.b_val;
 	}
@@ -158,9 +158,9 @@ struct StructTypeTernary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
-		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
-		auto c_data = FlatVector::GetData<C_TYPE>(*entries[2]);
+		auto a_data = FlatVector::GetData<A_TYPE>(entries[0]);
+		auto b_data = FlatVector::GetData<B_TYPE>(entries[1]);
+		auto c_data = FlatVector::GetData<C_TYPE>(entries[2]);
 		a_data[i] = value.a_val;
 		b_data[i] = value.b_val;
 		c_data[i] = value.c_val;
@@ -205,10 +205,10 @@ struct StructTypeQuaternary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
-		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
-		auto c_data = FlatVector::GetData<C_TYPE>(*entries[2]);
-		auto d_data = FlatVector::GetData<D_TYPE>(*entries[3]);
+		auto a_data = FlatVector::GetData<A_TYPE>(entries[0]);
+		auto b_data = FlatVector::GetData<B_TYPE>(entries[1]);
+		auto c_data = FlatVector::GetData<C_TYPE>(entries[2]);
+		auto d_data = FlatVector::GetData<D_TYPE>(entries[3]);
 
 		a_data[i] = value.a_val;
 		b_data[i] = value.b_val;

--- a/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
@@ -81,7 +81,7 @@ bool ConvertStructToVariant(ToVariantSourceData &source, ToVariantGlobalResultDa
 	}
 
 	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
-		auto &child = *children[child_idx];
+		auto &child = children[child_idx];
 
 		if (sel.count != count) {
 			//! Some of the STRUCT rows are NULL entirely, we have to filter these rows out of the children

--- a/src/include/duckdb/function/cast/variant/union_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/union_to_variant.hpp
@@ -15,7 +15,7 @@ bool ConvertUnionToVariant(ToVariantSourceData &source, ToVariantGlobalResultDat
 
 	vector<ToVariantSourceData> member_data;
 	for (idx_t child_idx = 1; child_idx < children.size(); child_idx++) {
-		auto &child = *children[child_idx];
+		auto &child = children[child_idx];
 
 		//! Convert all the children, ignore nulls, only write the non-null values
 		//! UNION will have exactly 1 non-null value for each row
@@ -37,7 +37,7 @@ bool ConvertUnionToVariant(ToVariantSourceData &source, ToVariantGlobalResultDat
 	for (idx_t i = 0; i < count; i++) {
 		bool is_null = true;
 		for (idx_t child_idx = 1; child_idx < children.size() && is_null; child_idx++) {
-			auto &child = *children[child_idx];
+			auto &child = children[child_idx];
 			if (child.GetType().id() == LogicalTypeId::SQLNULL) {
 				continue;
 			}

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -280,7 +280,7 @@ struct VectorStringToArray {
 };
 
 struct VectorStringToStruct {
-	static bool SplitStruct(const string_t &input, vector<unique_ptr<Vector>> &varchar_vectors, idx_t &row_idx,
+	static bool SplitStruct(const string_t &input, vector<Vector> &varchar_vectors, idx_t &row_idx,
 	                        string_map_t<idx_t> &child_names, vector<reference<ValidityMask>> &child_masks);
 	static bool StringToNestedTypeCastLoop(const string_t *source_data, ValidityMask &source_mask, Vector &result,
 	                                       ValidityMask &result_mask, idx_t count, CastParameters &parameters,

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -225,7 +225,7 @@ duckdb_vector duckdb_struct_vector_get_child(duckdb_vector vector, idx_t index) 
 		return nullptr;
 	}
 	auto v = reinterpret_cast<duckdb::Vector *>(vector);
-	return reinterpret_cast<duckdb_vector>(duckdb::StructVector::GetEntries(*v)[index].get());
+	return reinterpret_cast<duckdb_vector>(&duckdb::StructVector::GetEntries(*v)[index]);
 }
 
 duckdb_vector duckdb_array_vector_get_child(duckdb_vector vector) {

--- a/src/storage/statistics/struct_stats.cpp
+++ b/src/storage/statistics/struct_stats.cpp
@@ -133,7 +133,7 @@ child_list_t<Value> StructStats::ToStruct(const BaseStatistics &stats) {
 void StructStats::Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count) {
 	auto &child_entries = StructVector::GetEntries(vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		stats.child_stats[i].Verify(*child_entries[i], sel, count, true);
+		stats.child_stats[i].Verify(child_entries[i], sel, count, true);
 	}
 }
 

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -556,8 +556,8 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 		// Apply the filter on the child vector
 		auto &child_vec = StructVector::GetEntries(vector)[struct_filter.child_idx];
 		UnifiedVectorFormat child_data;
-		child_vec->ToUnifiedFormat(scan_count, child_data);
-		return FilterSelection(sel, *child_vec, child_data, *struct_filter.child_filter, filter_state, scan_count,
+		child_vec.ToUnifiedFormat(scan_count, child_data);
+		return FilterSelection(sel, child_vec, child_data, *struct_filter.child_filter, filter_state, scan_count,
 		                       approved_tuple_count);
 	}
 	case TableFilterType::BLOOM_FILTER: {

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -123,7 +123,7 @@ static Vector &GetFieldVectorForScan(Vector &result, optional_idx field_index) {
 	}
 	auto index = field_index.GetIndex();
 	auto &children = StructVector::GetEntries(result);
-	return *children[index];
+	return children[index];
 }
 
 static void ScanChild(ColumnScanState &state, Vector &result, const std::function<idx_t(Vector &target)> &callback) {
@@ -225,7 +225,7 @@ void StructColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, V
 
 	auto &child_entries = StructVector::GetEntries(vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		sub_columns[i]->Append(StructStats::GetChildStats(stats, i), state.child_appends[i + 1], *child_entries[i],
+		sub_columns[i]->Append(StructStats::GetChildStats(stats, i), state.child_appends[i + 1], child_entries[i],
 		                       count);
 	}
 	this->count += count;
@@ -252,7 +252,7 @@ idx_t StructColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &resu
 	idx_t scan_count = validity->Fetch(state.child_states[0], row_id, result);
 	// fetch the sub-column states
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		sub_columns[i]->Fetch(state.child_states[i + 1], row_id, *child_entries[i]);
+		sub_columns[i]->Fetch(state.child_states[i + 1], row_id, child_entries[i]);
 	}
 	return scan_count;
 }
@@ -262,7 +262,7 @@ void StructColumnData::Update(TransactionData transaction, DataTable &data_table
 	validity->Update(transaction, data_table, column_index, update_vector, row_ids, update_count, row_group_start);
 	auto &child_entries = StructVector::GetEntries(update_vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		sub_columns[i]->Update(transaction, data_table, column_index, *child_entries[i], row_ids, update_count,
+		sub_columns[i]->Update(transaction, data_table, column_index, child_entries[i], row_ids, update_count,
 		                       row_group_start);
 	}
 }
@@ -332,7 +332,7 @@ void StructColumnData::FetchRow(TransactionData transaction, ColumnFetchState &s
 	auto &child_entries = StructVector::GetEntries(result);
 	// fetch the sub-column states
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		sub_columns[i]->FetchRow(transaction, state, storage_index, row_id, *child_entries[i], result_idx);
+		sub_columns[i]->FetchRow(transaction, state, storage_index, row_id, child_entries[i], result_idx);
 	}
 }
 

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -641,10 +641,10 @@ void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varian
 		auto &child_types = StructType::GetChildTypes(result_type);
 		D_ASSERT(child_types.size() == child_vectors.size());
 #endif
-		typed_value_ref = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
+		typed_value_ref = child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
 		if (child_vectors.size() > 1) {
 			D_ASSERT(child_vectors.size() == 2);
-			untyped_value_index = *child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
+			untyped_value_index = child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
 		}
 	}
 	auto &typed_value = typed_value_ref.get();
@@ -683,10 +683,10 @@ void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t co
 
 	//! First traverse the Variant to write the shredded values and collect the 'untyped_value_index'es
 	DuckDBVariantShredding shredding(count);
-	shredding.WriteVariantValues(variant, *child_vectors[1], nullptr, nullptr, nullptr, count);
+	shredding.WriteVariantValues(variant, child_vectors[1], nullptr, nullptr, nullptr, count);
 
 	//! Now we can write the unshredded values
-	auto &unshredded = *child_vectors[0];
+	auto &unshredded = child_vectors[0];
 	auto original_keys_size = ListVector::GetListSize(VariantVector::GetKeys(input));
 	auto original_children_size = ListVector::GetListSize(VariantVector::GetChildren(input));
 	auto original_values_size = ListVector::GetListSize(VariantVector::GetValues(input));

--- a/src/storage/table/variant/variant_unshredding.cpp
+++ b/src/storage/table/variant/variant_unshredding.cpp
@@ -92,7 +92,7 @@ static vector<VariantValue> UnshredTypedObject(UnifiedVariantVectorData &variant
 	vector<vector<VariantValue>> child_values(child_entries.size());
 	for (idx_t child_idx = 0; child_idx < child_entries.size(); child_idx++) {
 		auto &child_entry = child_entries[child_idx];
-		child_values[child_idx] = Unshred(variant, *child_entry, count, row_sel);
+		child_values[child_idx] = Unshred(variant, child_entry, count, row_sel);
 	}
 
 	//! Then compose the OBJECT value by combining all the children
@@ -204,10 +204,10 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
 		D_ASSERT(shredded.GetType().id() == LogicalTypeId::STRUCT);
 		auto &child_entries = StructVector::GetEntries(shredded);
 		D_ASSERT(child_entries.size() <= 2);
-		typed_value_ref = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
+		typed_value_ref = child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
 		if (child_vectors.size() > 1) {
 			D_ASSERT(child_vectors.size() == 2);
-			untyped_value_index = *child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
+			untyped_value_index = child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
 		}
 	}
 	auto &typed_value = typed_value_ref.get();
@@ -258,8 +258,8 @@ void VariantUtils::UnshredVariantData(Vector &input, Vector &output, idx_t count
 	auto &child_vectors = StructVector::GetEntries(input);
 	D_ASSERT(child_vectors.size() == 2);
 
-	auto &unshredded = *child_vectors[0];
-	auto &shredded = *child_vectors[1];
+	auto &unshredded = child_vectors[0];
+	auto &shredded = child_vectors[1];
 
 	RecursiveUnifiedVectorFormat recursive_format;
 	Vector::RecursiveToUnifiedFormat(unshredded, count, recursive_format);

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -247,7 +247,7 @@ idx_t VariantColumnData::ScanWithCallback(
 				D_ASSERT(list_child.GetType().id() == LogicalTypeId::STRUCT);
 				D_ASSERT(StructType::GetChildCount(list_child.GetType()) == 2);
 
-				auto &typed_value = *StructVector::GetEntries(list_child)[TYPED_VALUE_INDEX];
+				auto &typed_value = StructVector::GetEntries(list_child)[TYPED_VALUE_INDEX];
 				auto list_res = Vector(LogicalType::LIST(typed_value.GetType()));
 				ListVector::SetListSize(list_res, ListVector::GetListSize(result));
 				list_res.CopyBuffer(result);
@@ -263,8 +263,8 @@ idx_t VariantColumnData::ScanWithCallback(
 			auto unshredding_intermediate = CreateUnshreddingIntermediate(target_count);
 			auto &child_vectors = StructVector::GetEntries(unshredding_intermediate);
 
-			callback(*sub_columns[0], state.child_states[1], *child_vectors[0], target_count);
-			callback(*sub_columns[1], state.child_states[2], *child_vectors[1], target_count);
+			callback(*sub_columns[0], state.child_states[1], child_vectors[0], target_count);
+			callback(*sub_columns[1], state.child_states[2], child_vectors[1], target_count);
 			scan_count = callback(*validity, state.child_states[0], unshredding_intermediate, target_count);
 
 			intermediate.Shred(unshredding_intermediate);
@@ -309,8 +309,8 @@ idx_t VariantColumnData::ScanWithCallback(
 			auto intermediate = CreateUnshreddingIntermediate(target_count);
 			auto &child_vectors = StructVector::GetEntries(intermediate);
 
-			callback(*sub_columns[0], state.child_states[1], *child_vectors[0], target_count);
-			callback(*sub_columns[1], state.child_states[2], *child_vectors[1], target_count);
+			callback(*sub_columns[0], state.child_states[1], child_vectors[0], target_count);
+			callback(*sub_columns[1], state.child_states[2], child_vectors[1], target_count);
 			auto scan_count = callback(*validity, state.child_states[0], intermediate, target_count);
 
 			result.Shred(intermediate);
@@ -384,8 +384,8 @@ static void AppendShredded(Vector &input, Vector &append_vector, idx_t count, Va
 
 	//! Create the new column data for the shredded data
 	VariantColumnData::ShredVariantData(input, append_vector, count);
-	auto &unshredded_vector = *child_vectors[0];
-	auto &shredded_vector = *child_vectors[1];
+	auto &unshredded_vector = child_vectors[0];
+	auto &shredded_vector = child_vectors[1];
 
 	auto &unshredded = append_data.unshredded;
 	auto &shredded = append_data.shredded;
@@ -487,7 +487,7 @@ void VariantColumnData::FetchRow(TransactionData transaction, ColumnFetchState &
 		// fetch the sub-column states
 		StorageIndex empty(0);
 		for (idx_t i = 0; i < sub_columns.size(); i++) {
-			sub_columns[i]->FetchRow(transaction, state, empty, row_id, *child_vectors[i], result_idx);
+			sub_columns[i]->FetchRow(transaction, state, empty, row_id, child_vectors[i], result_idx);
 		}
 		if (result_idx) {
 			intermediate.SetValue(0, intermediate.GetValue(result_idx));

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -72,9 +72,9 @@ static inline void AddPointFunction(DataChunk &args, ExpressionState &state, Vec
 			auto &child_entry = child_entries[col];
 			auto &left_child_entry = left_child_entries[col];
 			auto &right_child_entry = right_child_entries[col];
-			auto pdata = ConstantVector::GetData<int32_t>(*child_entry);
-			auto left_pdata = ConstantVector::GetData<int32_t>(*left_child_entry);
-			auto right_pdata = ConstantVector::GetData<int32_t>(*right_child_entry);
+			auto pdata = ConstantVector::GetData<int32_t>(child_entry);
+			auto left_pdata = ConstantVector::GetData<int32_t>(left_child_entry);
+			auto right_pdata = ConstantVector::GetData<int32_t>(right_child_entry);
 			pdata[base_idx] = left_pdata[lhs_list_index] + right_pdata[rhs_list_index];
 		}
 	}
@@ -112,9 +112,9 @@ static inline void SubPointFunction(DataChunk &args, ExpressionState &state, Vec
 			auto &child_entry = child_entries[col];
 			auto &left_child_entry = left_child_entries[col];
 			auto &right_child_entry = right_child_entries[col];
-			auto pdata = ConstantVector::GetData<int32_t>(*child_entry);
-			auto left_pdata = ConstantVector::GetData<int32_t>(*left_child_entry);
-			auto right_pdata = ConstantVector::GetData<int32_t>(*right_child_entry);
+			auto pdata = ConstantVector::GetData<int32_t>(child_entry);
+			auto left_pdata = ConstantVector::GetData<int32_t>(left_child_entry);
+			auto right_pdata = ConstantVector::GetData<int32_t>(right_child_entry);
 			pdata[base_idx] = left_pdata[lhs_list_index] - right_pdata[rhs_list_index];
 		}
 	}

--- a/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
+++ b/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
@@ -279,9 +279,9 @@ void AttachWorker::append_internal(AttachTask &task, bool is_upsert) {
 		auto &col_struct = chunk.data[3];
 		auto &data_struct_entries = StructVector::GetEntries(col_struct);
 		auto &entry_ubigint = data_struct_entries[0];
-		auto data_struct_ubigint = FlatVector::GetData<uint64_t>(*entry_ubigint);
+		auto data_struct_ubigint = FlatVector::GetData<uint64_t>(entry_ubigint);
 		auto &entry_varchar = data_struct_entries[1];
-		auto data_struct_varchar = FlatVector::GetData<string_t>(*entry_varchar);
+		auto data_struct_varchar = FlatVector::GetData<string_t>(entry_varchar);
 
 		for (idx_t i = 0; i < task.ids.size(); i++) {
 			auto row_idx = task.ids[i];
@@ -289,7 +289,7 @@ void AttachWorker::append_internal(AttachTask &task, bool is_upsert) {
 			data_varchar[i] = StringVector::AddString(col_varchar, to_string(row_idx));
 			data_ts[i] = timestamp_t {static_cast<int64_t>(1000 * (row_idx))};
 			data_struct_ubigint[i] = row_idx;
-			data_struct_varchar[i] = StringVector::AddString(*entry_varchar, to_string(row_idx));
+			data_struct_varchar[i] = StringVector::AddString(entry_varchar, to_string(row_idx));
 		}
 
 		chunk.SetCardinality(task.ids.size());


### PR DESCRIPTION
Currently structs use `vector<unique_ptr<Vector>>`, while data chunks use `vector<Vector>`. They are both essentially the same - so them using different representations is inconsistent and can be annoying when trying to write generic code to operate over the two. This PR unifies them by making the struct vector use `vector<Vector>`