### PR TITLE
Fix DELETE RETURNING for rows inserted in the same transaction

### DIFF
--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/storage/table/delete_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 
 namespace duckdb {
 
@@ -128,7 +129,6 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 	l_state.delete_chunk.SetCardinality(fetch_chunk);
 
 	// Append the deleted row IDs to the delete indexes.
-	// If we only delete local row IDs, then the delete_chunk is empty.
 	if (g_state.has_unique_indexes && l_state.delete_chunk.size() != 0) {
 		auto &local_storage = LocalStorage::Get(context.client, table.db);
 		auto storage = local_storage.GetStorage(table);

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -132,17 +132,7 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 	if (g_state.has_unique_indexes && l_state.delete_chunk.size() != 0) {
 		auto &local_storage = LocalStorage::Get(context.client, table.db);
 		auto storage = local_storage.GetStorage(table);
-		IndexAppendInfo index_append_info(IndexAppendMode::IGNORE_DUPLICATES, nullptr);
-		for (auto &index : storage->delete_indexes.Indexes()) {
-			if (!index.IsBound() || !index.IsUnique()) {
-				continue;
-			}
-			auto &bound_index = index.Cast<BoundIndex>();
-			auto error = bound_index.Append(l_state.delete_chunk, row_ids, index_append_info);
-			if (error.HasError()) {
-				throw InternalException("failed to update delete ART in physical delete: ", error.Message());
-			}
-		}
+		storage->AppendToDeleteIndexes(row_ids, l_state.delete_chunk);
 	}
 
 	auto deleted_count = table.Delete(*l_state.delete_state, context.client, row_ids, chunk.size());

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -182,7 +182,7 @@ public:
 	                const vector<StorageIndex> &bound_columns, Expression &cast_expr);
 
 	void MoveStorage(DataTable &old_dt, DataTable &new_dt);
-	void FetchChunk(DataTable &table, Vector &row_ids, idx_t count, const vector<StorageIndex> &col_ids,
+	void FetchChunk(DataTable &table, const Vector &row_ids, idx_t count, const vector<StorageIndex> &col_ids,
 	                DataChunk &chunk, ColumnFetchState &fetch_state);
 	//! Returns true, if the local storage contains the row id.
 	bool CanFetch(DataTable &table, const row_t row_id);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -29,6 +29,7 @@
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 
 namespace duckdb {
 
@@ -422,7 +423,76 @@ TableStorageInfo DataTable::GetStorageInfo() {
 //===--------------------------------------------------------------------===//
 void DataTable::Fetch(DuckTransaction &transaction, DataChunk &result, const vector<StorageIndex> &column_ids,
                       const Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state) {
+	D_ASSERT(row_identifiers.GetVectorType() == VectorType::FLAT_VECTOR);
+	auto row_ids = FlatVector::GetData<row_t>(row_identifiers);
+
+	// Quick scan to check for transaction-local row IDs (>= MAX_ROW_ID).
+	bool has_local = false;
+	for (idx_t i = 0; i < fetch_count; i++) {
+		if (row_ids[i] >= MAX_ROW_ID) {
+			has_local = true;
+			break;
+		}
+	}
+
+	if (!has_local) {
+		// All committed rows — fast path (common case).
+		row_groups->Fetch(transaction, result, column_ids, row_identifiers, fetch_count, state);
+		return;
+	}
+
+	// There are local rows. Classify all row IDs to determine the split.
+	auto &local_storage = transaction.GetLocalStorage();
+	SelectionVector committed_sel(fetch_count);
+	SelectionVector local_sel(fetch_count);
+	idx_t committed_count = 0;
+	idx_t local_count = 0;
+	for (idx_t i = 0; i < fetch_count; i++) {
+		if (row_ids[i] >= MAX_ROW_ID) {
+			local_sel.set_index(local_count++, i);
+		} else {
+			committed_sel.set_index(committed_count++, i);
+		}
+	}
+
+	if (committed_count == 0) {
+		// All local rows.
+		local_storage.FetchChunk(*this, row_identifiers, fetch_count, column_ids, result, state);
+		return;
+	}
+
+	// Mixed: some rows are committed, some are local.
+	// row_groups->Fetch silently skips local row IDs, packing committed rows at 0..committed_count-1.
 	row_groups->Fetch(transaction, result, column_ids, row_identifiers, fetch_count, state);
+	D_ASSERT(result.size() == committed_count);
+
+	// Fetch local rows into a separate chunk.
+	auto &allocator = Allocator::Get(local_storage.GetClientContext());
+	DataChunk local_chunk;
+	local_chunk.Initialize(allocator, result.GetTypes());
+	Vector local_row_ids(row_identifiers, local_sel, local_count);
+	local_row_ids.Flatten(local_count);
+	ColumnFetchState local_fetch_state;
+	local_storage.FetchChunk(*this, local_row_ids, local_count, column_ids, local_chunk, local_fetch_state);
+
+	// Append local rows after committed rows in the result.
+	for (idx_t col = 0; col < result.ColumnCount(); col++) {
+		VectorOperations::Copy(local_chunk.data[col], result.data[col], local_count, 0, committed_count);
+	}
+	result.SetCardinality(committed_count + local_count);
+
+	// Build inverse permutation to restore original row order.
+	// Current layout: [committed rows in relative order | local rows in relative order].
+	SelectionVector inv_perm(fetch_count);
+	for (idx_t i = 0; i < committed_count; i++) {
+		inv_perm.set_index(committed_sel.get_index(i), i);
+	}
+	for (idx_t j = 0; j < local_count; j++) {
+		inv_perm.set_index(local_sel.get_index(j), committed_count + j);
+	}
+	for (idx_t col = 0; col < result.ColumnCount(); col++) {
+		result.data[col].Slice(inv_perm, fetch_count);
+	}
 }
 
 void DataTable::FetchCommitted(DataChunk &result, const vector<StorageIndex> &column_ids, const Vector &row_identifiers,

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -695,7 +695,7 @@ void LocalStorage::ChangeType(DataTable &old_dt, DataTable &new_dt, idx_t change
 	table_manager.InsertEntry(new_dt, std::move(new_storage));
 }
 
-void LocalStorage::FetchChunk(DataTable &table, Vector &row_ids, idx_t count, const vector<StorageIndex> &col_ids,
+void LocalStorage::FetchChunk(DataTable &table, const Vector &row_ids, idx_t count, const vector<StorageIndex> &col_ids,
                               DataChunk &chunk, ColumnFetchState &fetch_state) {
 	auto storage = table_manager.GetStorage(table);
 	if (!storage) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -431,13 +431,37 @@ void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete
 		return;
 	}
 
+	// Only committed row IDs (< MAX_ROW_ID) belong in the delete indexes.
+	// Local row IDs (>= MAX_ROW_ID) live in transaction-local storage and are
+	// handled directly by LocalStorage::Delete.
+	row_ids.Flatten(delete_chunk.size());
+	auto flat_row_ids = FlatVector::GetData<row_t>(row_ids);
+	idx_t committed_count = 0;
+	SelectionVector committed_sel(delete_chunk.size());
+	for (idx_t i = 0; i < delete_chunk.size(); i++) {
+		if (flat_row_ids[i] < MAX_ROW_ID) {
+			committed_sel.set_index(committed_count++, i);
+		}
+	}
+
+	if (committed_count == 0) {
+		return;
+	}
+
+	DataChunk committed_chunk;
+	committed_chunk.Initialize(Allocator::DefaultAllocator(), delete_chunk.GetTypes());
+	committed_chunk.Slice(delete_chunk, committed_sel, committed_count);
+
+	Vector committed_row_ids(row_ids, committed_sel, committed_count);
+	committed_row_ids.Flatten(committed_count);
+
 	for (auto &index : delete_indexes.Indexes()) {
 		D_ASSERT(index.IsBound());
 		if (!index.IsUnique()) {
 			continue;
 		}
 		IndexAppendInfo index_append_info(IndexAppendMode::IGNORE_DUPLICATES, nullptr);
-		auto result = index.Cast<BoundIndex>().Append(delete_chunk, row_ids, index_append_info);
+		auto result = index.Cast<BoundIndex>().Append(committed_chunk, committed_row_ids, index_append_info);
 		if (result.HasError()) {
 			throw InternalException("unexpected constraint violation on delete ART: ", result.Message());
 		}

--- a/test/sql/returning/returning_delete_same_transaction.test
+++ b/test/sql/returning/returning_delete_same_transaction.test
@@ -1,0 +1,118 @@
+# name: test/sql/returning/returning_delete_same_transaction.test
+# description: Test DELETE RETURNING for rows inserted in the same transaction
+# group: [returning]
+
+# Basic case: INSERT + DELETE RETURNING in same explicit transaction
+statement ok
+CREATE TABLE t1 (id INT PRIMARY KEY, name TEXT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t1 VALUES (1, 'alice');
+
+query IT
+DELETE FROM t1 WHERE id = 1 RETURNING *;
+----
+1	alice
+
+statement ok
+COMMIT;
+
+# Without PRIMARY KEY
+statement ok
+CREATE TABLE t2 (id INT, name TEXT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t2 VALUES (1, 'alice');
+
+query IT
+DELETE FROM t2 WHERE id = 1 RETURNING *;
+----
+1	alice
+
+statement ok
+COMMIT;
+
+# Multiple rows inserted and deleted in same transaction
+statement ok
+CREATE TABLE t3 (id INT, name TEXT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t3 VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+query IT rowsort
+DELETE FROM t3 RETURNING *;
+----
+1	alice
+2	bob
+3	charlie
+
+statement ok
+COMMIT;
+
+# Mixed: pre-committed rows + transaction-local rows
+statement ok
+CREATE TABLE t4 (id INT PRIMARY KEY, name TEXT);
+
+statement ok
+INSERT INTO t4 VALUES (1, 'committed');
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t4 VALUES (2, 'local');
+
+query IT rowsort
+DELETE FROM t4 RETURNING *;
+----
+1	committed
+2	local
+
+statement ok
+COMMIT;
+
+# RETURNING specific columns
+statement ok
+CREATE TABLE t5 (id INT, name TEXT, value INT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t5 VALUES (1, 'alice', 100);
+
+query I
+DELETE FROM t5 WHERE id = 1 RETURNING id;
+----
+1
+
+statement ok
+COMMIT;
+
+# RETURNING with expression
+statement ok
+CREATE TABLE t6 (id INT, value INT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t6 VALUES (1, 10), (2, 20);
+
+query II rowsort
+DELETE FROM t6 RETURNING id, value * 2;
+----
+1	20
+2	40
+
+statement ok
+COMMIT;


### PR DESCRIPTION
`DELETE RETURNING` silently returned empty results for rows that were inserted in the same explicit transaction. The delete itself succeeded but the `RETURNING` clause missed rows in transaction-local storage.

The root cause is that table.Fetch() only reads from committed row groups, silently skipping row IDs >= MAX_ROW_ID which reside in transaction-local storage. This adds local storage awareness to the fetch path in PhysicalDelete::Sink, using LocalStorage::FetchChunk() for transaction-local rows.

Three code paths handle the cases:
- All committed: original table.Fetch() fast path (unchanged)
- All local: LocalStorage::FetchChunk()
- Mixed: fetch separately, concatenate via VectorOperations::Copy, restore order via zero-copy Vector::Slice

Fixes #21540 