### PR TITLE
Fix Bug: duckdb_client_context_get_config_option aborts on unknown setting names (debug builds)

### DIFF
--- a/src/main/capi/config_options-c.cpp
+++ b/src/main/capi/config_options-c.cpp
@@ -136,7 +136,14 @@ duckdb_value duckdb_client_context_get_config_option(duckdb_client_context conte
 	duckdb::Value *res_value = nullptr;
 
 	duckdb::Value result;
-	switch (ctx.TryGetCurrentSetting(option_name, result).GetScope()) {
+	auto lookup = ctx.TryGetCurrentSetting(option_name, result);
+	if (!lookup) {
+		if (out_scope) {
+			*out_scope = DUCKDB_CONFIG_OPTION_SCOPE_INVALID;
+		}
+		return nullptr;
+	}
+	switch (lookup.GetScope()) {
 	case duckdb::SettingScope::LOCAL:
 		// This is a bit messy, but "session" is presented as LOCAL on the "settings" side of the API.
 		res_value = new duckdb::Value(std::move(result));


### PR DESCRIPTION
Discovered while working on https://github.com/tomtom215/quack-rs
---

## Bug: `duckdb_client_context_get_config_option` aborts on unknown setting names (debug builds)

### Summary

Calling `duckdb_client_context_get_config_option` with a setting name that is not registered causes the process to abort via `D_ASSERT` in debug builds. The function is expected to return `nullptr` gracefully for unknown names, but instead crashes.

### Root cause

In `src/main/capi/config_options-c.cpp` the lookup result is chained directly into `.GetScope()` on a temporary:

```cpp
switch (ctx.TryGetCurrentSetting(option_name, result).GetScope()) {
```

When `option_name` is unknown, `TryGetCurrentSetting` returns a default-constructed `SettingLookupResult` with `scope = SettingScope::INVALID`. `GetScope()` in `setting_info.hpp` contains:

```cpp
SettingScope GetScope() {
    D_ASSERT(scope != SettingScope::INVALID);  // fires
    return scope;
}
```

In debug builds (`NDEBUG` absent) this assertion fires and the process receives `SIGABRT`. In release builds (`NDEBUG` defined) the assert is a no-op and the `default:` branch handles it correctly — so the bug is silent in production but crashes during development and CI.

### Fix

Store the lookup result before switching on it and return early if the lookup failed:

```cpp
auto lookup = ctx.TryGetCurrentSetting(option_name, result);
if (!lookup) {
    if (out_scope) {
        *out_scope = DUCKDB_CONFIG_OPTION_SCOPE_INVALID;
    }
    return nullptr;
}
switch (lookup.GetScope()) {
```

This uses the existing `SettingLookupResult::operator bool()` which returns `false` when `scope == INVALID`, consistent with how the result is checked elsewhere in the codebase.

### Minimal C reproducer

```c
#include "duckdb.h"

int main(void) {
    duckdb_database db;
    duckdb_connection con;
    duckdb_client_context ctx;

    duckdb_open(NULL, &db);
    duckdb_connect(db, &con);
    duckdb_connection_get_client_context(con, &ctx);

    // Debug build: SIGABRT via D_ASSERT inside GetScope()
    // Release build: correctly returns NULL
    duckdb_config_option_scope scope;
    duckdb_value val = duckdb_client_context_get_config_option(ctx, "nonexistent_option", &scope);

    duckdb_destroy_client_context(&ctx);
    duckdb_disconnect(&con);
    duckdb_close(&db);
    return 0;
}
```