### PR TITLE
Correctly deal with negative values in `GetPosixVersionTag`, and fix constant `NULL` struct scans after recent fix

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -702,9 +702,9 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 string GetPosixVersionTag(struct stat s) {
 	// dev/ino should be enough, but to guard against in-place writes we also add file size and modification time
 	uint64_t version_tag[4];
-	Store(NumericCast<uint64_t>(s.st_dev), data_ptr_cast(&version_tag[0]));
-	Store(NumericCast<uint64_t>(s.st_ino), data_ptr_cast(&version_tag[1]));
-	Store(NumericCast<uint64_t>(s.st_size), data_ptr_cast(&version_tag[2]));
+	Store(UnsafeNumericCast<uint64_t>(s.st_dev), data_ptr_cast(&version_tag[0]));
+	Store(UnsafeNumericCast<uint64_t>(s.st_ino), data_ptr_cast(&version_tag[1]));
+	Store(UnsafeNumericCast<uint64_t>(s.st_size), data_ptr_cast(&version_tag[2]));
 	Store(Timestamp::FromEpochSeconds(s.st_mtime).value, data_ptr_cast(&version_tag[3]));
 
 	return string(char_ptr_cast(version_tag), sizeof(uint64_t) * 4);

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -148,6 +148,13 @@ idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, Co
 	if (!state.storage_index.IsPushdownExtract()) {
 		// if we are scanning the entire struct we need to scan the validity
 		scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
+		if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			if (!ConstantVector::IsNull(result)) {
+				throw InternalException("StructColumnData::Scan returned a constant but not NULL vector ");
+			}
+			// constant NULL struct - we don't need to scan any children, everything is already NULL
+			return scan_count;
+		}
 	}
 	auto struct_children = GetStructChildren(state);
 	for (auto &child : struct_children) {


### PR DESCRIPTION
* `st_dev` can be negative on some platforms, use unsafe cast to wrap for the version tag. Despite the name this is defined behavior - the underflow just wraps - so for the purpose of a version tag this is perfectly acceptable.
* When scanning `all-NULL` struct values, we don't need to scan the children of the struct anymore. Add an early out. This is not just faster but also prevents an error later on (`unexpected constant vector`).

Both issues were found while merging v1.5 into main. No tests are added here since they are tested as part of that merge. 