### PR TITLE
[v1.5-variegata] Fix #21514: ASOF join empty right

### DIFF
--- a/src/optimizer/empty_result_pullup.cpp
+++ b/src/optimizer/empty_result_pullup.cpp
@@ -8,9 +8,9 @@ namespace duckdb {
 
 unique_ptr<LogicalOperator> EmptyResultPullup::PullUpEmptyJoinChildren(unique_ptr<LogicalOperator> op) {
 	JoinType join_type = JoinType::INVALID;
-	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op->type == LogicalOperatorType::LOGICAL_ANY_JOIN ||
-	         op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN || op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN ||
-	         op->type == LogicalOperatorType::LOGICAL_EXCEPT);
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT);
 	switch (op->type) {
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
 	case LogicalOperatorType::LOGICAL_ASOF_JOIN:

--- a/src/optimizer/empty_result_pullup.cpp
+++ b/src/optimizer/empty_result_pullup.cpp
@@ -8,11 +8,12 @@ namespace duckdb {
 
 unique_ptr<LogicalOperator> EmptyResultPullup::PullUpEmptyJoinChildren(unique_ptr<LogicalOperator> op) {
 	JoinType join_type = JoinType::INVALID;
-	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
-	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN ||
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op->type == LogicalOperatorType::LOGICAL_ANY_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN || op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN ||
 	         op->type == LogicalOperatorType::LOGICAL_EXCEPT);
 	switch (op->type) {
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 		join_type = op->Cast<LogicalComparisonJoin>().join_type;
 		break;
@@ -78,7 +79,6 @@ unique_ptr<LogicalOperator> EmptyResultPullup::Optimize(unique_ptr<LogicalOperat
 	case LogicalOperatorType::LOGICAL_GET:
 	case LogicalOperatorType::LOGICAL_INTERSECT:
 	case LogicalOperatorType::LOGICAL_PIVOT:
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT: {
 		for (auto &child : op->children) {
 			if (child->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
@@ -99,6 +99,7 @@ unique_ptr<LogicalOperator> EmptyResultPullup::Optimize(unique_ptr<LogicalOperat
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
 		op = PullUpEmptyJoinChildren(std::move(op));
 		break;

--- a/test/sql/join/asof/test_asof_empty_right.test
+++ b/test/sql/join/asof/test_asof_empty_right.test
@@ -1,0 +1,28 @@
+# name: test/sql/join/asof/test_asof_empty_right.test
+# description: Test ASOF join with empty right table
+# group: [asof]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+select lefttable.x, righttable.y
+from (select 1 as x) lefttable
+asof left join (select 1 as x, 1 as y limit 0) righttable
+on lefttable.x >= righttable.x;
+----
+1	NULL
+
+query II
+select lefttable.x, righttable.y
+from (select 1 as x limit 0) lefttable
+asof left join (select 1 as x, 1 as y) righttable
+on lefttable.x >= righttable.x;
+----
+
+query II
+select lefttable.x, righttable.y
+from (select 1 as x) lefttable
+asof join (select 1 as x, 1 as y limit 0) righttable
+on lefttable.x >= righttable.x;
+----


### PR DESCRIPTION
This PR targets the v1.5-variegata branch with the fix for #21514. 

Original PR #21519 was mistakenly retargeted which included many unrelated commits from main. This PR contains only the required fix.

Fixes #21514.