### PR TITLE
Fix linux base and extension deployment on main

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -254,7 +254,7 @@ jobs:
 
       - uses: actions/download-artifact@v5
         with:
-          pattern: extension-repository
+          name: extension-repository
           path: /tmp/extension-repository
 
       - name: List extensions to deploy
@@ -294,7 +294,7 @@ jobs:
 
       - uses: actions/download-artifact@v5
         with:
-          pattern: extension-repository
+          name: extension-repository
           path: /tmp/extension-repository
 
       - name: List extensions to test with
@@ -358,7 +358,7 @@ jobs:
       - uses: actions/download-artifact@v5
         name: Download extension repository artifact
         with:
-          pattern: extension-repository
+          name: extension-repository
           path: /tmp/extension-repository
 
       - name: Copy over local extension repository

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -272,7 +272,7 @@ jobs:
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
           pip install awscli
-          ./scripts/extension-upload-repository.sh /tmp/extension-repository
+          make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/extension-repository
 
   autoload-tests:
     name: Extension Autoloading Tests

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           if [[ "${{ github.repository }}" == "duckdb/duckdb" && "${{ github.ref_name }}" == "main" ]]; then
             if [[ -z "${BASE_HASH}" ]]; then
-              echo "BASE_REF=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --event=repository_dispatch --status=completed --json=headSha --limit=1 --jq '.[0].headSha')" >> "$GITHUB_ENV"
+              echo "BASE_REF=$(make last_main_success_commit)" >> "$GITHUB_ENV"
             else
               echo "BASE_REF=${BASE_HASH}" >> "$GITHUB_ENV"
             fi

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -129,42 +129,6 @@ jobs:
       shell: bash
       run: cl -I src/include examples/embedded-c++-windows/cppintegration.cpp -link src/Release/duckdb.lib
 
-# win-release-32:
-#    name: Windows (32 Bit)
-#    needs:
-#      - win-release-64
-#    if: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true' }}
-#    runs-on: windows-latest
-#
-#    steps:
-#    - uses: actions/checkout@v6
-#      with:
-#        fetch-depth: 0
-#        ref: ${{ inputs.git_ref }}
-#
-#    - uses: actions/setup-python@v6
-#      with:
-#        python-version: '3.12'
-#
-#    - uses: ./.github/actions/ccache-action
-#
-#    - name: Build
-#      shell: bash
-#      run: |
-#        python scripts/ci/retry.py -- cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=Win32 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE"
-#        python scripts/ci/retry.py -- cmake --build . --config Release --parallel
-#
-#    - name: Test
-#      shell: bash
-#      run: test/Release/unittest.exe
-#
-#    - name: Tools Test
-#      shell: bash
-#      run: |
-#        python -m pip install pytest
-#        python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
-
-
  win-release-arm64:
    name: Windows (ARM64)
    needs:

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -172,4 +172,4 @@ jobs:
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
           pip install awscli
-          ./scripts/extension-upload-repository.sh /tmp/extension-repository-${{ inputs.duckdb_ref }} duckdb-staging
+          make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/extension-repository-${{ inputs.duckdb_ref }} EXTENSION_BUCKET=duckdb-staging

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/download-artifact@v5
         with:
-          pattern: extension-repository-${{ inputs.duckdb_ref }}
+          name: extension-repository-${{ inputs.duckdb_ref }}
           path: /tmp
 
       - name: List extensions to deploy

--- a/Makefile
+++ b/Makefile
@@ -653,3 +653,8 @@ cleanup-vcpkg:
 
 test-utils:
 	make release EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
+
+.PHONY: last_main_success_commit
+
+last_main_success_commit:
+	PAGER= gh run list --repo duckdb/duckdb --branch=main --workflow=Main --event=workflow_dispatch --status=success --json=headSha --limit=1 --jq '.[0].headSha'

--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,13 @@ endif
 clean:
 	rm -rf build
 
+EXTENSION_REPOSITORY_PATH ?= build/release/repository
+EXTENSION_BUCKET ?= duckdb-core-extensions
+
+.PHONY: upload-extensions
+upload-extensions:
+	CI_CPU_COUNT="$(CI_CPU_COUNT)" ./scripts/extension-upload-repository.sh "$(EXTENSION_REPOSITORY_PATH)" "$(EXTENSION_BUCKET)"
+
 debug: ${EXTENSION_CONFIG_STEP}
 	mkdir -p ./build/debug && \
 	cd build/debug && \

--- a/scripts/extension-upload-repository.sh
+++ b/scripts/extension-upload-repository.sh
@@ -45,20 +45,32 @@ for version_dir in $BASE_DIR/*; do
         echo ""
 
         for f in $FILES; do
-            if [[ $architecture == wasm* ]]; then
-                ext_name=`basename $f .duckdb_extension.wasm`
-            else
-                ext_name=`basename $f .duckdb_extension`
-            fi
-            
-            echo "Processing extension: $ext_name (architecture: $architecture, version: $duckdb_version, path: $f)"
-            
-            # args: <name> <extension_version> <duckdb_version> <architecture> <s3_bucket> <copy_to_latest> <copy_to_versioned> [<path_to_ext>]
-            $script_dir/extension-upload-single.sh $ext_name "" "$duckdb_version" "$architecture" "$TARGET_BUCKET" true false "$(dirname "$f")"
-
-            echo ""
+            printf '%s\0%s\0%s\0' "$duckdb_version" "$architecture" "$f"
         done
-        echo ""
     done
-done
+done | xargs -0 -n 3 -P "${CI_CPU_COUNT:-1}" bash -c '
+    script_dir="$1"
+    target_bucket="$2"
+    duckdb_version="$3"
+    architecture="$4"
+    f="$5"
 
+    if [[ $architecture == wasm* ]]; then
+        ext_name=$(basename "$f" .duckdb_extension.wasm)
+    else
+        ext_name=$(basename "$f" .duckdb_extension)
+    fi
+
+    log_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-upload.XXXXXX") || exit 1
+    trap '\''rm -f "$log_file"'\'' EXIT
+
+    {
+        echo "Processing extension: $ext_name (architecture: $architecture, version: $duckdb_version, path: $f)"
+        "$script_dir/extension-upload-single.sh" "$ext_name" "" "$duckdb_version" "$architecture" "$target_bucket" true false "$(dirname "$f")"
+        echo ""
+    } >"$log_file" 2>&1
+
+    cat "$log_file"
+    rm -f "$log_file"
+    trap - EXIT
+' bash "$script_dir" "$TARGET_BUCKET"

--- a/scripts/extension-upload-repository.sh
+++ b/scripts/extension-upload-repository.sh
@@ -32,6 +32,8 @@ else
     echo "Deploying extensions from '$BASE_DIR' to bucket '$TARGET_BUCKET'.. (DRY RUN)"
 fi
 
+files=()
+
 for version_dir in $BASE_DIR/*; do
     duckdb_version=$(basename "$version_dir")
     for arch_dir in "$version_dir"/*; do
@@ -45,10 +47,19 @@ for version_dir in $BASE_DIR/*; do
         echo ""
 
         for f in $FILES; do
-            printf '%s\0%s\0%s\0' "$duckdb_version" "$architecture" "$f"
+            files+=("$duckdb_version" "$architecture" "$f")
         done
     done
-done | xargs -0 -n 3 -P "${CI_CPU_COUNT:-1}" bash -c '
+done
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "No extensions found in '$BASE_DIR'"
+    exit 1
+fi
+
+echo "Uploading $((${#files[@]} / 3)) extension files"
+
+printf '%s\0' "${files[@]}" | xargs -0 -n 3 -P "${CI_CPU_COUNT:-1}" bash -c '
     script_dir="$1"
     target_bucket="$2"
     duckdb_version="$3"

--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -29,21 +29,30 @@ else
 fi
 
 script_dir="$(dirname "$(readlink -f "$0")")"
+private_key_file=""
+
+cleanup() {
+  if [ -n "$private_key_file" ]; then
+    rm -f "$private_key_file"
+  fi
+}
+
+trap cleanup EXIT
 
 # calculate SHA256 hash of extension binary
 cat $ext > $ext.append
 
-( command -v truncate && truncate -s -256 $ext.append ) || ( command -v gtruncate && gtruncate -s -256 $ext.append ) || exit 1
+( command -v truncate >/dev/null 2>&1 && truncate -s -256 $ext.append ) || ( command -v gtruncate >/dev/null 2>&1 && gtruncate -s -256 $ext.append ) || exit 1
 
 # (Optionally) Sign binary
 if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
-  echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+  private_key_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-signing.XXXXXX.pem")
+  echo "$DUCKDB_EXTENSION_SIGNING_PK" > "$private_key_file"
   $script_dir/compute-extension-hash.sh $ext.append > $ext.hash
-  openssl pkeyutl -sign -in $ext.hash -inkey private.pem -pkeyopt digest:sha256 -out $ext.sign
-  rm -f private.pem
+  openssl pkeyutl -sign -in $ext.hash -inkey "$private_key_file" -pkeyopt digest:sha256 -out $ext.sign
 else
   # Default to 256 zeros
-  dd if=/dev/zero of=$ext.sign bs=256 count=1
+  dd if=/dev/zero of=$ext.sign bs=256 count=1 status=none
 fi
 
 # append signature to extension binary


### PR DESCRIPTION
### Fix linux base build

Fix linux base [build](https://github.com/duckdb/duckdb/actions/runs/23416834562/job/68114256859#step:9:337) on branch `main`:
```
[...]
-- Load extension 'core_functions' from '/home/runner/work/duckdb/duckdb/extensions' @ c43ab41ad4
CMake Error at CMakeLists.txt:1354 (add_subdirectory):
Error:   add_subdirectory given source
  "/home/runner/work/duckdb/duckdb/extension/fts" which is not an existing
  directory.
[...]
```
The extension `fts` did not exist (yet) for the commit `c43ab41ad426f758cb0b246c410c21960938910c` and caused the build to fail.

The commit was too old:
```
commit c43ab41ad426f758cb0b246c410c21960938910c
Merge: f249c2ce5c 3e7292aa5f
Author: Mark <mark.raasveldt@gmail.com>
Date:   Thu May 15 22:32:08 2025 +0200

    Remove spatial from OSX Relassert (#17509)
    
    This was added recently, but has never worked
```
and came from the `gh run ...` command that relied on an earlier workflow setup.

I've updated the `gh run` command and moved it to the makefile so we can easily test the same command locally.

### Fix extension deployment and upload in parallel

The extension deploy step did [not](https://github.com/duckdb/duckdb/actions/runs/23416836692/job/68141948484) upload any extensions because the file path layout slightly changed by upgrading the download-artifact action version.

I changed:
- download action to use the expected file path layout.
- print the number of found extension files.
- the script to fail when no files are found.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/8445.

Also, I made the deploy script run the uploads in parallel (up to `CI_CPU_COUNT`). This should reduce the time to upload all extensions from `22 min` to roughly `22/4=5.5 min`.

### Clean up

Fixes https://github.com/duckdblabs/duckdb-internal/issues/7627 (windows 32-bit's CI job was already commented, but now also removed).