### PR TITLE
Refactor DeleteStatement as thin wrapper over DeleteQueryNode

### DIFF
--- a/.github/patches/extensions/sqlsmith/fix.patch
+++ b/.github/patches/extensions/sqlsmith/fix.patch
@@ -1,16 +1,62 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index 72e8f5b..06fc74a 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -18,6 +18,7 @@
+ #include "duckdb/parser/statement/attach_statement.hpp"
+ #include "duckdb/parser/statement/create_statement.hpp"
+ #include "duckdb/parser/statement/delete_statement.hpp"
++#include "duckdb/parser/query_node/delete_query_node.hpp"
+ #include "duckdb/parser/statement/detach_statement.hpp"
+ #include "duckdb/parser/statement/insert_statement.hpp"
+ #include "duckdb/parser/statement/multi_statement.hpp"
+@@ -189,12 +190,12 @@ unique_ptr<DeleteStatement> StatementGenerator::GenerateDelete() {
+ 		if (entry.type == CatalogType::TABLE_ENTRY) {
+ 			auto result = make_uniq<BaseTableRef>();
+ 			result->table_name = entry.name;
+-			delete_statement->table = std::move(result);
++			delete_statement->node->table = std::move(result);
+ 		} else {
+-			delete_statement->table = GenerateTableRef();
++			delete_statement->node->table = GenerateTableRef();
+ 		}
+ 	} else {
+-		delete_statement->table = GenerateTableRef();
++		delete_statement->node->table = GenerateTableRef();
+ 	}
+ 
+ 	return delete_statement;
 diff --git a/src/statement_simplifier.cpp b/src/statement_simplifier.cpp
-index 4602928..66efab0 100644
+index 4602928..c3cf639 100644
 --- a/src/statement_simplifier.cpp
 +++ b/src/statement_simplifier.cpp
-@@ -10,6 +10,7 @@
+@@ -10,6 +10,8 @@
  #include "duckdb/parser/statement/insert_statement.hpp"
  #include "duckdb/parser/statement/prepare_statement.hpp"
  #include "duckdb/parser/statement/update_statement.hpp"
 +#include "duckdb/parser/query_node/update_query_node.hpp"
++#include "duckdb/parser/query_node/delete_query_node.hpp"
  #include "duckdb/parser/statement/select_statement.hpp"
  #endif
  
-@@ -432,11 +433,11 @@ void StatementSimplifier::Simplify(PrepareStatement &stmt) {
+@@ -401,11 +403,11 @@ void StatementSimplifier::Simplify(InsertStatement &stmt) {
+ }
+ 
+ void StatementSimplifier::Simplify(DeleteStatement &stmt) {
+-	Simplify(stmt.cte_map);
+-	SimplifyOptional(stmt.condition);
+-	SimplifyExpression(stmt.condition);
+-	SimplifyList(stmt.using_clauses);
+-	SimplifyList(stmt.returning_list);
++	Simplify(stmt.node->cte_map);
++	SimplifyOptional(stmt.node->condition);
++	SimplifyExpression(stmt.node->condition);
++	SimplifyList(stmt.node->using_clauses);
++	SimplifyList(stmt.node->returning_list);
+ }
+ 
+ void StatementSimplifier::Simplify(UpdateSetInfo &info) {
+@@ -432,11 +434,11 @@ void StatementSimplifier::Simplify(PrepareStatement &stmt) {
  }
  
  void StatementSimplifier::Simplify(UpdateStatement &stmt) {

--- a/extension/autocomplete/transformer/transform_delete.cpp
+++ b/extension/autocomplete/transformer/transform_delete.cpp
@@ -1,5 +1,6 @@
 #include "transformer/peg_transformer.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 
 namespace duckdb {
 
@@ -8,14 +9,15 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformDeleteStatement(PEGTran
 	auto &list_pr = parse_result->Cast<ListParseResult>();
 
 	auto result = make_uniq<DeleteStatement>();
+	auto &node = *result->node;
 	auto with_opt = list_pr.Child<OptionalParseResult>(0);
 	if (with_opt.HasResult()) {
-		result->cte_map = transformer.Transform<CommonTableExpressionMap>(with_opt.optional_result);
+		node.cte_map = transformer.Transform<CommonTableExpressionMap>(with_opt.optional_result);
 	}
-	result->table = transformer.Transform<unique_ptr<BaseTableRef>>(list_pr.Child<ListParseResult>(3));
-	transformer.TransformOptional<vector<unique_ptr<TableRef>>>(list_pr, 4, result->using_clauses);
-	transformer.TransformOptional<unique_ptr<ParsedExpression>>(list_pr, 5, result->condition);
-	transformer.TransformOptional<vector<unique_ptr<ParsedExpression>>>(list_pr, 6, result->returning_list);
+	node.table = transformer.Transform<unique_ptr<BaseTableRef>>(list_pr.Child<ListParseResult>(3));
+	transformer.TransformOptional<vector<unique_ptr<TableRef>>>(list_pr, 4, node.using_clauses);
+	transformer.TransformOptional<unique_ptr<ParsedExpression>>(list_pr, 5, node.condition);
+	transformer.TransformOptional<vector<unique_ptr<ParsedExpression>>>(list_pr, 6, node.returning_list);
 	return std::move(result);
 }
 
@@ -42,7 +44,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTruncateStatement(PEGTr
                                                                            optional_ptr<ParseResult> parse_result) {
 	auto &list_pr = parse_result->Cast<ListParseResult>();
 	auto result = make_uniq<DeleteStatement>();
-	result->table = transformer.Transform<unique_ptr<BaseTableRef>>(list_pr.Child<ListParseResult>(2));
+	result->node->table = transformer.Transform<unique_ptr<BaseTableRef>>(list_pr.Child<ListParseResult>(2));
 	return std::move(result);
 }
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4096,19 +4096,20 @@ const StringUtil::EnumStringLiteral *GetQueryNodeTypeValues() {
 		{ static_cast<uint32_t>(QueryNodeType::RECURSIVE_CTE_NODE), "RECURSIVE_CTE_NODE" },
 		{ static_cast<uint32_t>(QueryNodeType::CTE_NODE), "CTE_NODE" },
 		{ static_cast<uint32_t>(QueryNodeType::STATEMENT_NODE), "STATEMENT_NODE" },
-		{ static_cast<uint32_t>(QueryNodeType::UPDATE_QUERY_NODE), "UPDATE_QUERY_NODE" }
+		{ static_cast<uint32_t>(QueryNodeType::UPDATE_QUERY_NODE), "UPDATE_QUERY_NODE" },
+		{ static_cast<uint32_t>(QueryNodeType::DELETE_QUERY_NODE), "DELETE_QUERY_NODE" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<QueryNodeType>(QueryNodeType value) {
-	return StringUtil::EnumToString(GetQueryNodeTypeValues(), 7, "QueryNodeType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetQueryNodeTypeValues(), 8, "QueryNodeType", static_cast<uint32_t>(value));
 }
 
 template<>
 QueryNodeType EnumUtil::FromString<QueryNodeType>(const char *value) {
-	return static_cast<QueryNodeType>(StringUtil::StringToEnum(GetQueryNodeTypeValues(), 7, "QueryNodeType", value));
+	return static_cast<QueryNodeType>(StringUtil::StringToEnum(GetQueryNodeTypeValues(), 8, "QueryNodeType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetQueryResultMemoryTypeValues() {

--- a/src/common/symbols.cpp
+++ b/src/common/symbols.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/statement/list.hpp"
 #include "duckdb/parser/tableref/list.hpp"
 #include "duckdb/planner/expression/list.hpp"
@@ -62,6 +63,7 @@ template class unique_ptr<QueryNode>;
 template class unique_ptr<SelectNode>;
 template class unique_ptr<SetOperationNode>;
 template class unique_ptr<UpdateQueryNode>;
+template class unique_ptr<DeleteQueryNode>;
 template class unique_ptr<ParsedExpression>;
 template class unique_ptr<CaseExpression>;
 template class unique_ptr<CastExpression>;

--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -26,7 +26,8 @@ enum class QueryNodeType : uint8_t {
 	RECURSIVE_CTE_NODE = 4,
 	CTE_NODE = 5,
 	STATEMENT_NODE = 6,
-	UPDATE_QUERY_NODE = 7
+	UPDATE_QUERY_NODE = 7,
+	DELETE_QUERY_NODE = 8
 };
 
 struct CommonTableExpressionInfo;

--- a/src/include/duckdb/parser/query_node/delete_query_node.hpp
+++ b/src/include/duckdb/parser/query_node/delete_query_node.hpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/query_node/delete_query_node.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/tableref.hpp"
+#include "duckdb/parser/parsed_expression.hpp"
+
+namespace duckdb {
+class Serializer;
+class Deserializer;
+
+//! DeleteQueryNode represents a DELETE DML statement as a QueryNode,
+//! enabling serialization and use as a CTE body.
+class DeleteQueryNode : public QueryNode {
+public:
+	static constexpr const QueryNodeType TYPE = QueryNodeType::DELETE_QUERY_NODE;
+
+public:
+	DeleteQueryNode();
+
+	//! The condition for the DELETE (WHERE clause)
+	unique_ptr<ParsedExpression> condition;
+	//! The table to delete from
+	unique_ptr<TableRef> table;
+	//! USING clauses
+	vector<unique_ptr<TableRef>> using_clauses;
+	//! keep track of optional returningList if statement contains a RETURNING keyword
+	vector<unique_ptr<ParsedExpression>> returning_list;
+
+public:
+	string ToString() const override;
+	bool Equals(const QueryNode *other) const override;
+	unique_ptr<QueryNode> Copy() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<QueryNode> Deserialize(Deserializer &deserializer);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/query_node/list.hpp
+++ b/src/include/duckdb/parser/query_node/list.hpp
@@ -4,3 +4,4 @@
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/query_node/statement_node.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 
+class DeleteQueryNode;
+
 class DeleteStatement : public SQLStatement {
 public:
 	static constexpr const StatementType TYPE = StatementType::DELETE_STATEMENT;
@@ -22,12 +24,7 @@ public:
 public:
 	DeleteStatement();
 
-	unique_ptr<ParsedExpression> condition;
-	unique_ptr<TableRef> table;
-	vector<unique_ptr<TableRef>> using_clauses;
-	vector<unique_ptr<ParsedExpression>> returning_list;
-	//! CTEs
-	CommonTableExpressionMap cte_map;
+	unique_ptr<DeleteQueryNode> node;
 
 protected:
 	DeleteStatement(const DeleteStatement &other);

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -26,7 +26,7 @@ public:
 public:
 	unique_ptr<UpdateSetInfo> Copy() const;
 	string ToString() const;
-	static bool Equals(const unique_ptr<UpdateSetInfo> &a, const unique_ptr<UpdateSetInfo> &b);
+	static bool Equals(const unique_ptr<UpdateSetInfo> &left, const unique_ptr<UpdateSetInfo> &right);
 
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<UpdateSetInfo> Deserialize(Deserializer &deserializer);

--- a/src/include/duckdb/parser/tokens.hpp
+++ b/src/include/duckdb/parser/tokens.hpp
@@ -55,6 +55,7 @@ class RecursiveCTENode;
 class CTENode;
 class StatementNode;
 class UpdateQueryNode;
+class DeleteQueryNode;
 
 //===--------------------------------------------------------------------===//
 // Expressions

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -441,6 +441,7 @@ private:
 	BoundStatement BindNode(QueryNode &node);
 	BoundStatement BindNode(StatementNode &node);
 	BoundStatement BindNode(UpdateQueryNode &node);
+	BoundStatement BindNode(DeleteQueryNode &node);
 
 	unique_ptr<LogicalOperator> VisitQueryNode(BoundQueryNode &node, unique_ptr<LogicalOperator> root);
 	unique_ptr<LogicalOperator> CreatePlan(BoundSelectNode &statement);

--- a/src/include/duckdb/storage/serialization/query_node.json
+++ b/src/include/duckdb/storage/serialization/query_node.json
@@ -227,5 +227,35 @@
         "default": "false"
       }
     ]
+  },
+  {
+    "class": "DeleteQueryNode",
+    "base": "QueryNode",
+    "enum": "DELETE_QUERY_NODE",
+    "includes": [
+      "duckdb/parser/query_node/delete_query_node.hpp"
+    ],
+    "members": [
+      {
+        "id": 200,
+        "name": "condition",
+        "type": "ParsedExpression*"
+      },
+      {
+        "id": 201,
+        "name": "table",
+        "type": "TableRef*"
+      },
+      {
+        "id": 202,
+        "name": "using_clauses",
+        "type": "vector<TableRef*>"
+      },
+      {
+        "id": 203,
+        "name": "returning_list",
+        "type": "vector<ParsedExpression*>"
+      }
+    ]
   }
 ]

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
 #include "duckdb/parser/statement/merge_into_statement.hpp"
@@ -448,7 +449,7 @@ CommonTableExpressionMap &GetCTEMap(SQLStatement &statement) {
 	case StatementType::INSERT_STATEMENT:
 		return statement.Cast<InsertStatement>().cte_map;
 	case StatementType::DELETE_STATEMENT:
-		return statement.Cast<DeleteStatement>().cte_map;
+		return statement.Cast<DeleteStatement>().node->cte_map;
 	case StatementType::UPDATE_STATEMENT:
 		return statement.Cast<UpdateStatement>().node->cte_map;
 	case StatementType::MERGE_INTO_STATEMENT:

--- a/src/main/relation/delete_relation.cpp
+++ b/src/main/relation/delete_relation.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/relation/delete_relation.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
@@ -21,8 +22,9 @@ BoundStatement DeleteRelation::Bind(Binder &binder) {
 	basetable->table_name = table_name;
 
 	DeleteStatement stmt;
-	stmt.condition = condition ? condition->Copy() : nullptr;
-	stmt.table = std::move(basetable);
+	auto &node = *stmt.node;
+	node.condition = condition ? condition->Copy() : nullptr;
+	node.table = std::move(basetable);
 	return binder.Bind(stmt.Cast<SQLStatement>());
 }
 

--- a/src/parser/parsed_expression_iterator.cpp
+++ b/src/parser/parsed_expression_iterator.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/tableref/list.hpp"
 
 namespace duckdb {
@@ -323,6 +324,22 @@ void ParsedExpressionIterator::EnumerateQueryNodeChildren(
 			}
 		}
 		for (auto &expr : upd_node.returning_list) {
+			expr_callback(expr);
+		}
+		break;
+	}
+	case QueryNodeType::DELETE_QUERY_NODE: {
+		auto &del_node = node.Cast<DeleteQueryNode>();
+		if (del_node.table) {
+			EnumerateTableRefChildren(*del_node.table, expr_callback, ref_callback);
+		}
+		for (auto &using_clause : del_node.using_clauses) {
+			EnumerateTableRefChildren(*using_clause, expr_callback, ref_callback);
+		}
+		if (del_node.condition) {
+			expr_callback(del_node.condition);
+		}
+		for (auto &expr : del_node.returning_list) {
 			expr_callback(expr);
 		}
 		break;

--- a/src/parser/query_node/CMakeLists.txt
+++ b/src/parser/query_node/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library_unity(
   select_node.cpp
   set_operation_node.cpp
   statement_node.cpp
-  update_query_node.cpp)
+  update_query_node.cpp
+  delete_query_node.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_query_node>
     PARENT_SCOPE)

--- a/src/parser/query_node/delete_query_node.cpp
+++ b/src/parser/query_node/delete_query_node.cpp
@@ -1,25 +1,28 @@
-#include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
-UpdateQueryNode::UpdateQueryNode() : QueryNode(QueryNodeType::UPDATE_QUERY_NODE) {
+DeleteQueryNode::DeleteQueryNode() : QueryNode(QueryNodeType::DELETE_QUERY_NODE) {
 }
 
-string UpdateQueryNode::ToString() const {
-	D_ASSERT(table && set_info);
+string DeleteQueryNode::ToString() const {
 	string result;
 	result = cte_map.ToString();
-	result += "UPDATE ";
+	result += "DELETE FROM ";
 	result += table->ToString();
-	result += " ";
-	result += set_info->ToString();
-	if (from_table) {
-		result += " FROM " + from_table->ToString();
+	if (!using_clauses.empty()) {
+		result += " USING ";
+		for (idx_t i = 0; i < using_clauses.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += using_clauses[i]->ToString();
+		}
 	}
-	if (set_info->condition) {
-		result += " WHERE " + set_info->condition->ToString();
+	if (condition) {
+		result += " WHERE " + condition->ToString();
 	}
 	if (!returning_list.empty()) {
 		result += " RETURNING ";
@@ -38,22 +41,27 @@ string UpdateQueryNode::ToString() const {
 	return result;
 }
 
-bool UpdateQueryNode::Equals(const QueryNode *other_p) const {
+bool DeleteQueryNode::Equals(const QueryNode *other_p) const {
 	if (this == other_p) {
 		return true;
 	}
 	if (!QueryNode::Equals(other_p)) {
 		return false;
 	}
-	auto &other = other_p->Cast<UpdateQueryNode>();
+	auto &other = other_p->Cast<DeleteQueryNode>();
 	if (!TableRef::Equals(table, other.table)) {
 		return false;
 	}
-	if (!TableRef::Equals(from_table, other.from_table)) {
+	if (!ParsedExpression::Equals(condition, other.condition)) {
 		return false;
 	}
-	if (!UpdateSetInfo::Equals(set_info, other.set_info)) {
+	if (using_clauses.size() != other.using_clauses.size()) {
 		return false;
+	}
+	for (idx_t i = 0; i < using_clauses.size(); i++) {
+		if (!TableRef::Equals(using_clauses[i], other.using_clauses[i])) {
+			return false;
+		}
 	}
 	if (returning_list.size() != other.returning_list.size()) {
 		return false;
@@ -63,23 +71,21 @@ bool UpdateQueryNode::Equals(const QueryNode *other_p) const {
 			return false;
 		}
 	}
-	if (prioritize_table_when_binding != other.prioritize_table_when_binding) {
-		return false;
-	}
 	return true;
 }
 
-unique_ptr<QueryNode> UpdateQueryNode::Copy() const {
-	auto result = make_uniq<UpdateQueryNode>();
+unique_ptr<QueryNode> DeleteQueryNode::Copy() const {
+	auto result = make_uniq<DeleteQueryNode>();
 	result->table = table->Copy();
-	if (from_table) {
-		result->from_table = from_table->Copy();
+	if (condition) {
+		result->condition = condition->Copy();
+	}
+	for (auto &using_clause : using_clauses) {
+		result->using_clauses.push_back(using_clause->Copy());
 	}
 	for (auto &expr : returning_list) {
 		result->returning_list.push_back(expr->Copy());
 	}
-	result->set_info = set_info->Copy();
-	result->prioritize_table_when_binding = prioritize_table_when_binding;
 	CopyProperties(*result);
 	return std::move(result);
 }

--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -1,57 +1,18 @@
 #include "duckdb/parser/statement/delete_statement.hpp"
-#include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
 
 namespace duckdb {
 
-DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMENT) {
+DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMENT), node(make_uniq<DeleteQueryNode>()) {
 }
 
-DeleteStatement::DeleteStatement(const DeleteStatement &other) : SQLStatement(other), table(other.table->Copy()) {
-	if (other.condition) {
-		condition = other.condition->Copy();
-	}
-	for (const auto &using_clause : other.using_clauses) {
-		using_clauses.push_back(using_clause->Copy());
-	}
-	for (auto &expr : other.returning_list) {
-		returning_list.emplace_back(expr->Copy());
-	}
-	cte_map = other.cte_map.Copy();
+DeleteStatement::DeleteStatement(const DeleteStatement &other)
+    : SQLStatement(other), node(unique_ptr_cast<QueryNode, DeleteQueryNode>(other.node->Copy())) {
 }
 
 string DeleteStatement::ToString() const {
-	string result;
-	result = cte_map.ToString();
-	result += "DELETE FROM ";
-	result += table->ToString();
-	if (!using_clauses.empty()) {
-		result += " USING ";
-		for (idx_t i = 0; i < using_clauses.size(); i++) {
-			if (i > 0) {
-				result += ", ";
-			}
-			result += using_clauses[i]->ToString();
-		}
-	}
-	if (condition) {
-		result += " WHERE " + condition->ToString();
-	}
-
-	if (!returning_list.empty()) {
-		result += " RETURNING ";
-		for (idx_t i = 0; i < returning_list.size(); i++) {
-			if (i > 0) {
-				result += ", ";
-			}
-			auto column = returning_list[i]->ToString();
-			if (!returning_list[i]->GetAlias().empty()) {
-				column +=
-				    StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->GetAlias()));
-			}
-			result += column;
-		}
-	}
-	return result;
+	return node->ToString();
 }
 
 unique_ptr<SQLStatement> DeleteStatement::Copy() const {

--- a/src/parser/transform/statement/transform_delete.cpp
+++ b/src/parser/transform/statement/transform_delete.cpp
@@ -1,29 +1,31 @@
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/transformer.hpp"
 
 namespace duckdb {
 
 unique_ptr<DeleteStatement> Transformer::TransformDelete(duckdb_libpgquery::PGDeleteStmt &stmt) {
 	auto result = make_uniq<DeleteStatement>();
+	auto &node = *result->node;
 	if (stmt.withClause) {
-		TransformCTE(*PGPointerCast<duckdb_libpgquery::PGWithClause>(stmt.withClause), result->cte_map);
+		TransformCTE(*PGPointerCast<duckdb_libpgquery::PGWithClause>(stmt.withClause), node.cte_map);
 	}
 
-	result->condition = TransformExpression(stmt.whereClause);
-	result->table = TransformRangeVar(*stmt.relation);
-	if (result->table->type != TableReferenceType::BASE_TABLE) {
+	node.condition = TransformExpression(stmt.whereClause);
+	node.table = TransformRangeVar(*stmt.relation);
+	if (node.table->type != TableReferenceType::BASE_TABLE) {
 		throw InvalidInputException("Can only delete from base tables!");
 	}
 	if (stmt.usingClause) {
 		for (auto n = stmt.usingClause->head; n != nullptr; n = n->next) {
 			auto target = PGPointerCast<duckdb_libpgquery::PGNode>(n->data.ptr_value);
 			auto using_entry = TransformTableRefNode(*target);
-			result->using_clauses.push_back(std::move(using_entry));
+			node.using_clauses.push_back(std::move(using_entry));
 		}
 	}
 
 	if (stmt.returningList) {
-		TransformExpressionList(*stmt.returningList, result->returning_list);
+		TransformExpressionList(*stmt.returningList, node.returning_list);
 	}
 
 	return result;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/query_node/list.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/statement/list.hpp"
 #include "duckdb/parser/tableref/list.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
@@ -86,8 +87,16 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 		return BindWithCTE(statement.Cast<InsertStatement>());
 	case StatementType::COPY_STATEMENT:
 		return Bind(statement.Cast<CopyStatement>(), CopyToType::COPY_TO_FILE);
-	case StatementType::DELETE_STATEMENT:
-		return BindWithCTE(statement.Cast<DeleteStatement>());
+	case StatementType::DELETE_STATEMENT: {
+		auto &del = statement.Cast<DeleteStatement>();
+		auto &cte_map = del.node->cte_map;
+		if (cte_map.map.empty()) {
+			return Bind(del);
+		}
+		auto stmt_node = make_uniq<StatementNode>(del);
+		stmt_node->cte_map = cte_map.Copy();
+		return Bind(*stmt_node);
+	}
 	case StatementType::UPDATE_STATEMENT: {
 		auto &update = statement.Cast<UpdateStatement>();
 		auto &cte_map = update.node->cte_map;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -87,26 +87,10 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 		return BindWithCTE(statement.Cast<InsertStatement>());
 	case StatementType::COPY_STATEMENT:
 		return Bind(statement.Cast<CopyStatement>(), CopyToType::COPY_TO_FILE);
-	case StatementType::DELETE_STATEMENT: {
-		auto &del = statement.Cast<DeleteStatement>();
-		auto &cte_map = del.node->cte_map;
-		if (cte_map.map.empty()) {
-			return Bind(del);
-		}
-		auto stmt_node = make_uniq<StatementNode>(del);
-		stmt_node->cte_map = cte_map.Copy();
-		return Bind(*stmt_node);
-	}
-	case StatementType::UPDATE_STATEMENT: {
-		auto &update = statement.Cast<UpdateStatement>();
-		auto &cte_map = update.node->cte_map;
-		if (cte_map.map.empty()) {
-			return Bind(update);
-		}
-		auto stmt_node = make_uniq<StatementNode>(update);
-		stmt_node->cte_map = cte_map.Copy();
-		return Bind(*stmt_node);
-	}
+	case StatementType::DELETE_STATEMENT:
+		return Bind(statement.Cast<DeleteStatement>());
+	case StatementType::UPDATE_STATEMENT:
+		return Bind(statement.Cast<UpdateStatement>());
 	case StatementType::RELATION_STATEMENT:
 		return Bind(statement.Cast<RelationStatement>());
 	case StatementType::CREATE_STATEMENT:

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parser/query_node/cte_node.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/parser/query_node/list.hpp"
@@ -40,6 +41,9 @@ BoundStatement Binder::BindNode(QueryNode &node) {
 		break;
 	case QueryNodeType::UPDATE_QUERY_NODE:
 		result = current_binder.get().BindNode(node.Cast<UpdateQueryNode>());
+		break;
+	case QueryNodeType::DELETE_QUERY_NODE:
+		result = current_binder.get().BindNode(node.Cast<DeleteQueryNode>());
 		break;
 	default:
 		throw InternalException("Unsupported query node type");

--- a/src/planner/binder/query_node/bind_statement_node.cpp
+++ b/src/planner/binder/query_node/bind_statement_node.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parser/query_node/statement_node.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
 #include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
@@ -27,6 +28,16 @@ BoundStatement Binder::BindNode(StatementNode &statement) {
 BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 	UpdateStatement stmt;
 	stmt.node = unique_ptr_cast<QueryNode, UpdateQueryNode>(node.Copy());
+	// CTEs were already processed by BindNode(QueryNode &) — clear to prevent double-processing
+	stmt.node->cte_map.map.clear();
+	return Bind(stmt);
+}
+
+BoundStatement Binder::BindNode(DeleteQueryNode &node) {
+	DeleteStatement stmt;
+	stmt.node = unique_ptr_cast<QueryNode, DeleteQueryNode>(node.Copy());
+	// CTEs were already processed by BindNode(QueryNode &) — clear to prevent double-processing
+	stmt.node->cte_map.map.clear();
 	return Bind(stmt);
 }
 

--- a/src/planner/binder/query_node/bind_statement_node.cpp
+++ b/src/planner/binder/query_node/bind_statement_node.cpp
@@ -25,20 +25,4 @@ BoundStatement Binder::BindNode(StatementNode &statement) {
 	}
 }
 
-BoundStatement Binder::BindNode(UpdateQueryNode &node) {
-	UpdateStatement stmt;
-	stmt.node = unique_ptr_cast<QueryNode, UpdateQueryNode>(node.Copy());
-	// CTEs were already processed by BindNode(QueryNode &) — clear to prevent double-processing
-	stmt.node->cte_map.map.clear();
-	return Bind(stmt);
-}
-
-BoundStatement Binder::BindNode(DeleteQueryNode &node) {
-	DeleteStatement stmt;
-	stmt.node = unique_ptr_cast<QueryNode, DeleteQueryNode>(node.Copy());
-	// CTEs were already processed by BindNode(QueryNode &) — clear to prevent double-processing
-	stmt.node->cte_map.map.clear();
-	return Bind(stmt);
-}
-
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -13,7 +13,10 @@
 namespace duckdb {
 
 BoundStatement Binder::Bind(DeleteStatement &stmt) {
-	auto &node = *stmt.node;
+	return Bind(*stmt.node);
+}
+
+BoundStatement Binder::BindNode(DeleteQueryNode &node) {
 	// visit the table reference
 	auto bound_table = Bind(*node.table);
 	auto root = std::move(bound_table.plan);

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_binder/where_binder.hpp"
 #include "duckdb/planner/expression_binder/returning_binder.hpp"
@@ -12,8 +13,9 @@
 namespace duckdb {
 
 BoundStatement Binder::Bind(DeleteStatement &stmt) {
+	auto &node = *stmt.node;
 	// visit the table reference
-	auto bound_table = Bind(*stmt.table);
+	auto bound_table = Bind(*node.table);
 	auto root = std::move(bound_table.plan);
 	if (root->type != LogicalOperatorType::LOGICAL_GET) {
 		throw BinderException("Can only delete from base table");
@@ -31,9 +33,9 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	}
 
 	// plan any tables from the various using clauses
-	if (!stmt.using_clauses.empty()) {
+	if (!node.using_clauses.empty()) {
 		unique_ptr<LogicalOperator> child_operator;
-		for (auto &using_clause : stmt.using_clauses) {
+		for (auto &using_clause : node.using_clauses) {
 			// bind the using clause
 			auto using_binder = Binder::CreateBinder(context, this);
 			auto op = using_binder->Bind(*using_clause);
@@ -52,9 +54,9 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 
 	// project any additional columns required for the condition
 	unique_ptr<Expression> condition;
-	if (stmt.condition) {
+	if (node.condition) {
 		WhereBinder binder(*this, context);
-		condition = binder.Bind(stmt.condition);
+		condition = binder.Bind(node.condition);
 
 		PlanSubqueries(condition, root);
 		auto filter = make_uniq<LogicalFilter>(std::move(condition));
@@ -68,7 +70,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	// Add columns to the scan to avoid fetching by row ID in PhysicalDelete:
 	// - If RETURNING: add all physical columns (for RETURNING projection)
 	// - Else if unique indexes exist: add only indexed columns (for delete index tracking)
-	if (!stmt.returning_list.empty()) {
+	if (!node.returning_list.empty()) {
 		// Add all physical columns for RETURNING
 		BindDeleteReturningColumns(table, get, del->return_columns);
 	} else if (table.IsDuckTable()) {
@@ -84,7 +86,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	// bind the row id columns and add them to the projection list
 	BindRowIdColumns(table, get, del->expressions);
 
-	if (!stmt.returning_list.empty()) {
+	if (!node.returning_list.empty()) {
 		del->return_chunk = true;
 
 		auto update_table_index = GenerateTableIndex();
@@ -93,7 +95,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		unique_ptr<LogicalOperator> del_as_logicaloperator = std::move(del);
 		// Include virtual columns (like rowid) so they can be referenced in RETURNING
 		auto virtual_columns = table.GetVirtualColumns();
-		return BindReturning(std::move(stmt.returning_list), table, stmt.table->alias, update_table_index,
+		return BindReturning(std::move(node.returning_list), table, node.table->alias, update_table_index,
 		                     std::move(del_as_logicaloperator), std::move(virtual_columns));
 	}
 	BoundStatement result;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -118,7 +118,10 @@ void Binder::BindRowIdColumns(TableCatalogEntry &table, LogicalGet &get, vector<
 }
 
 BoundStatement Binder::Bind(UpdateStatement &stmt) {
-	auto &node = *stmt.node;
+	return Bind(*stmt.node);
+}
+
+BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 	unique_ptr<LogicalOperator> root;
 
 	// visit the table reference

--- a/src/storage/serialization/serialize_query_node.cpp
+++ b/src/storage/serialization/serialize_query_node.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/parser/query_node/list.hpp"
 #include "duckdb/parser/query_node/update_query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 
 namespace duckdb {
 
@@ -36,6 +37,9 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 		break;
 	case QueryNodeType::UPDATE_QUERY_NODE:
 		result = UpdateQueryNode::Deserialize(deserializer);
+		break;
+	case QueryNodeType::DELETE_QUERY_NODE:
+		result = DeleteQueryNode::Deserialize(deserializer);
 		break;
 	default:
 		throw SerializationException("Unsupported type for deserialization of QueryNode!");
@@ -152,6 +156,23 @@ unique_ptr<QueryNode> UpdateQueryNode::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(202, "returning_list", result->returning_list);
 	deserializer.ReadPropertyWithDefault<unique_ptr<UpdateSetInfo>>(203, "set_info", result->set_info);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(204, "prioritize_table_when_binding", result->prioritize_table_when_binding, false);
+	return std::move(result);
+}
+
+void DeleteQueryNode::Serialize(Serializer &serializer) const {
+	QueryNode::Serialize(serializer);
+	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", condition);
+	serializer.WritePropertyWithDefault<unique_ptr<TableRef>>(201, "table", table);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", using_clauses);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", returning_list);
+}
+
+unique_ptr<QueryNode> DeleteQueryNode::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<DeleteQueryNode>(new DeleteQueryNode());
+	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", result->condition);
+	deserializer.ReadPropertyWithDefault<unique_ptr<TableRef>>(201, "table", result->table);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", result->using_clauses);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", result->returning_list);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_query_node.cpp
+++ b/src/storage/serialization/serialize_query_node.cpp
@@ -26,6 +26,9 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 	case QueryNodeType::CTE_NODE:
 		result = CTENode::Deserialize(deserializer);
 		break;
+	case QueryNodeType::DELETE_QUERY_NODE:
+		result = DeleteQueryNode::Deserialize(deserializer);
+		break;
 	case QueryNodeType::RECURSIVE_CTE_NODE:
 		result = RecursiveCTENode::Deserialize(deserializer);
 		break;
@@ -37,9 +40,6 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 		break;
 	case QueryNodeType::UPDATE_QUERY_NODE:
 		result = UpdateQueryNode::Deserialize(deserializer);
-		break;
-	case QueryNodeType::DELETE_QUERY_NODE:
-		result = DeleteQueryNode::Deserialize(deserializer);
 		break;
 	default:
 		throw SerializationException("Unsupported type for deserialization of QueryNode!");
@@ -68,6 +68,23 @@ unique_ptr<QueryNode> CTENode::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(202, "child", result->child);
 	deserializer.ReadPropertyWithDefault<vector<string>>(203, "aliases", result->aliases);
 	deserializer.ReadPropertyWithExplicitDefault<CTEMaterialize>(204, "materialized", result->materialized, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
+	return std::move(result);
+}
+
+void DeleteQueryNode::Serialize(Serializer &serializer) const {
+	QueryNode::Serialize(serializer);
+	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", condition);
+	serializer.WritePropertyWithDefault<unique_ptr<TableRef>>(201, "table", table);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", using_clauses);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", returning_list);
+}
+
+unique_ptr<QueryNode> DeleteQueryNode::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<DeleteQueryNode>(new DeleteQueryNode());
+	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", result->condition);
+	deserializer.ReadPropertyWithDefault<unique_ptr<TableRef>>(201, "table", result->table);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", result->using_clauses);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", result->returning_list);
 	return std::move(result);
 }
 
@@ -156,23 +173,6 @@ unique_ptr<QueryNode> UpdateQueryNode::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(202, "returning_list", result->returning_list);
 	deserializer.ReadPropertyWithDefault<unique_ptr<UpdateSetInfo>>(203, "set_info", result->set_info);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(204, "prioritize_table_when_binding", result->prioritize_table_when_binding, false);
-	return std::move(result);
-}
-
-void DeleteQueryNode::Serialize(Serializer &serializer) const {
-	QueryNode::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", condition);
-	serializer.WritePropertyWithDefault<unique_ptr<TableRef>>(201, "table", table);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", using_clauses);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", returning_list);
-}
-
-unique_ptr<QueryNode> DeleteQueryNode::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<DeleteQueryNode>(new DeleteQueryNode());
-	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(200, "condition", result->condition);
-	deserializer.ReadPropertyWithDefault<unique_ptr<TableRef>>(201, "table", result->table);
-	deserializer.ReadPropertyWithDefault<vector<unique_ptr<TableRef>>>(202, "using_clauses", result->using_clauses);
-	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(203, "returning_list", result->returning_list);
 	return std::move(result);
 }
 

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -39,7 +39,8 @@ set(TEST_API_OBJECTS
     test_windows_unicode_path.cpp
     test_object_cache.cpp
     test_buffer_pool_eviction.cpp
-    test_update_query_node.cpp)
+    test_update_query_node.cpp
+    test_delete_query_node.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_delete_query_node.cpp
+++ b/test/api/test_delete_query_node.cpp
@@ -1,0 +1,98 @@
+#include "catch.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/delete_statement.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+
+using namespace duckdb;
+
+static unique_ptr<DeleteStatement> ParseDelete(const string &sql) {
+	Parser p;
+	p.ParseQuery(sql);
+	REQUIRE(p.statements.size() == 1);
+	REQUIRE(p.statements[0]->type == StatementType::DELETE_STATEMENT);
+	return unique_ptr<DeleteStatement>(static_cast<DeleteStatement *>(p.statements[0].release()));
+}
+
+TEST_CASE("DeleteQueryNode - DeleteStatement is thin wrapper", "[delete_query_node]") {
+	auto stmt = ParseDelete("DELETE FROM t WHERE a > 0");
+	REQUIRE(stmt->node != nullptr);
+	REQUIRE(stmt->node->type == QueryNodeType::DELETE_QUERY_NODE);
+	REQUIRE(stmt->node->table != nullptr);
+	REQUIRE(stmt->node->condition != nullptr);
+}
+
+TEST_CASE("DeleteQueryNode - ToString round-trip", "[delete_query_node]") {
+	const string sql = "DELETE FROM t WHERE a > 0";
+	auto stmt = ParseDelete(sql);
+	auto str = stmt->ToString();
+
+	auto stmt2 = ParseDelete(str);
+	REQUIRE(stmt->node->Equals(stmt2->node.get()));
+}
+
+TEST_CASE("DeleteQueryNode - ToString with RETURNING", "[delete_query_node]") {
+	const string sql = "DELETE FROM t WHERE a > 0 RETURNING a, b";
+	auto stmt = ParseDelete(sql);
+	auto str = stmt->ToString();
+	REQUIRE(str.find("RETURNING") != string::npos);
+
+	auto stmt2 = ParseDelete(str);
+	REQUIRE(stmt->node->Equals(stmt2->node.get()));
+}
+
+TEST_CASE("DeleteQueryNode - ToString with USING", "[delete_query_node]") {
+	const string sql = "DELETE FROM t USING src WHERE t.id = src.id";
+	auto stmt = ParseDelete(sql);
+	REQUIRE(!stmt->node->using_clauses.empty());
+	auto str = stmt->ToString();
+	REQUIRE(str.find("USING") != string::npos);
+
+	auto stmt2 = ParseDelete(str);
+	REQUIRE(stmt->node->Equals(stmt2->node.get()));
+}
+
+TEST_CASE("DeleteQueryNode - Copy and Equals", "[delete_query_node]") {
+	auto stmt = ParseDelete("DELETE FROM t WHERE a > 0");
+	auto &node = *stmt->node;
+
+	auto copy = node.Copy();
+	REQUIRE(copy != nullptr);
+	REQUIRE(node.Equals(copy.get()));
+
+	// Verify deep copy
+	auto &copy_node = copy->Cast<DeleteQueryNode>();
+	copy_node.condition = nullptr;
+	REQUIRE(!node.Equals(copy.get()));
+}
+
+TEST_CASE("DeleteQueryNode - Inequality on different tables", "[delete_query_node]") {
+	auto stmt1 = ParseDelete("DELETE FROM t1");
+	auto stmt2 = ParseDelete("DELETE FROM t2");
+	REQUIRE(!stmt1->node->Equals(stmt2->node.get()));
+}
+
+TEST_CASE("DeleteQueryNode - Serialization round-trip", "[delete_query_node]") {
+	auto stmt = ParseDelete("DELETE FROM t WHERE a > 0 RETURNING a");
+	DeleteQueryNode &node = *stmt->node;
+
+	MemoryStream stream;
+	BinarySerializer::Serialize(static_cast<QueryNode &>(node), stream);
+
+	stream.Rewind();
+	auto deserialized = BinaryDeserializer::Deserialize<QueryNode>(stream);
+	REQUIRE(deserialized->type == QueryNodeType::DELETE_QUERY_NODE);
+	REQUIRE(node.Equals(deserialized.get()));
+}
+
+TEST_CASE("DeleteQueryNode - CTE in node", "[delete_query_node]") {
+	auto stmt = ParseDelete("WITH cte AS (SELECT 1 AS x) DELETE FROM t WHERE a IN (SELECT x FROM cte)");
+	REQUIRE(!stmt->node->cte_map.map.empty());
+	auto str = stmt->ToString();
+	REQUIRE(str.find("WITH") != string::npos);
+
+	auto stmt2 = ParseDelete(str);
+	REQUIRE(stmt->node->Equals(stmt2->node.get()));
+}

--- a/test/sql/delete/delete_query_node.test
+++ b/test/sql/delete/delete_query_node.test
@@ -1,0 +1,96 @@
+# name: test/sql/delete/delete_query_node.test
+# description: Tests for DeleteQueryNode (DeleteStatement as thin wrapper over DeleteQueryNode)
+# group: [delete]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t(a INT, b TEXT, c DOUBLE);
+
+statement ok
+INSERT INTO t VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
+
+# Basic DELETE
+statement ok
+DELETE FROM t WHERE a = 1;
+
+query III
+SELECT * FROM t ORDER BY a;
+----
+2	world	2.5
+3	foo	3.5
+
+# DELETE with RETURNING
+query III
+DELETE FROM t WHERE a = 2 RETURNING a, b, c;
+----
+2	world	2.5
+
+query III
+SELECT * FROM t ORDER BY a;
+----
+3	foo	3.5
+
+# Re-insert for further tests
+statement ok
+INSERT INTO t VALUES (1, 'hello', 1.5), (2, 'world', 2.5);
+
+# DELETE with USING clause
+statement ok
+CREATE TABLE to_delete(id INT);
+
+statement ok
+INSERT INTO to_delete VALUES (1);
+
+statement ok
+DELETE FROM t USING to_delete WHERE t.a = to_delete.id;
+
+query III
+SELECT * FROM t ORDER BY a;
+----
+2	world	2.5
+3	foo	3.5
+
+# DELETE with CTE
+statement ok
+INSERT INTO t VALUES (10, 'ten', 10.5);
+
+query I
+WITH targets AS (SELECT 10 AS target_a)
+DELETE FROM t WHERE a IN (SELECT target_a FROM targets) RETURNING a;
+----
+10
+
+query III
+SELECT * FROM t ORDER BY a;
+----
+2	world	2.5
+3	foo	3.5
+
+# DELETE all rows (no WHERE)
+statement ok
+DELETE FROM t;
+
+query I
+SELECT count(*) FROM t;
+----
+0
+
+# DELETE with schema-qualified table
+statement ok
+CREATE SCHEMA myschema;
+
+statement ok
+CREATE TABLE myschema.t2(x INT);
+
+statement ok
+INSERT INTO myschema.t2 VALUES (1), (2), (3);
+
+statement ok
+DELETE FROM myschema.t2 WHERE x > 1;
+
+query I rowsort
+SELECT * FROM myschema.t2;
+----
+1


### PR DESCRIPTION
## Summary

- Introduce `DeleteQueryNode` (analogous to `UpdateQueryNode` from #21524) that holds all DELETE fields: `table`, `condition`, `using_clauses`, and `returning_list`. `DeleteStatement` becomes a thin wrapper containing only a `unique_ptr<DeleteQueryNode> node`.
- Wire up parsing, binding, serialization/deserialization, expression iteration, autocomplete, and `enum_util` for the new `DELETE_QUERY_NODE` variant.
- Fix `Equals()` check order in both `UpdateQueryNode` and `DeleteQueryNode` (identity check before base-class type check), fix `QueryNodeType` enum count, rename `UpdateSetInfo::Equals` parameters to `left`/`right`, and clear CTEs in `BindNode` to prevent double-processing.

## Test plan

- [x] New C++ API tests (`test/api/test_delete_query_node.cpp`): thin-wrapper structure, `ToString` round-trip, `Copy`/`Equals`, serialization round-trip, CTE propagation, USING / RETURNING coverage.
- [x] New SQL tests (`test/sql/delete/delete_query_node.test`): basic DELETE, DELETE with WHERE, RETURNING, USING, CTE, delete-all, schema-qualified table — all under `PRAGMA enable_verification`.
