### PR TITLE
Fix off-by-one in PropagateStatistics upper bounds for date_part

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -340,7 +340,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<1, 53>(input.child_stats);
 		}
 	};
 
@@ -429,7 +429,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999999>(input.child_stats);
 		}
 	};
 
@@ -441,7 +441,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999>(input.child_stats);
 		}
 	};
 
@@ -453,7 +453,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999>(input.child_stats);
 		}
 	};
 
@@ -465,7 +465,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 
@@ -477,7 +477,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 


### PR DESCRIPTION
Fixes #21478.

Several `date_part` operators had their `PropagateStatistics` upper bounds set 1 higher than the actual maximum value that `extract()` can return:

| Operator | Before | After | Standard range |
|---|---|---|---|
| WeekOperator | 54 | 53 | ISO week: 1-53 |
| MinutesOperator | 60 | 59 | 0-59 |
| SecondsOperator | 60 | 59 | 0-59 (no leap seconds) |
| MillisecondsOperator | 60000 | 59999 | 0-59999 |
| MicrosecondsOperator | 60000000 | 59999999 | 0-59999999 |
| NanosecondsOperator | 60000000000 | 59999999999 | 0-59999999999 |

This brings these operators in line with other operators in the same file (e.g., `MonthOperator<1, 12>`, `DayOperator<1, 31>`) which already use the actual maximum as the upper bound.

After this fix, the optimizer can correctly prune impossible predicates like `WHERE extract(week FROM d) = 54` into `EMPTY_RESULT` at plan time, avoiding unnecessary table scans.