### PR TITLE
Fix missing extension static libs in Windows MinGW bundle

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: windows-latest
     env:
       GEN: ninja
+      EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1
     steps:


### PR DESCRIPTION
The `bundle-mingw-static-lib` job was missing the `EXTENSION_CONFIGS` env var, as set by the Mac and Linux jobs, so no extensions were built.

Noticed here by @taniabogatsch: https://github.com/duckdb/duckdb-go-bindings/actions/runs/23441868894/job/68194751392?pr=74

Introduced in https://github.com/duckdb/duckdb/pull/21371