### PR TITLE
TopNWindowElimination Column Binding Fix

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -685,10 +685,22 @@ void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const 
 
 	// Project the group columns
 	const auto compact_group_columns = group_table_idx == aggregate_table_idx;
+	map<idx_t, idx_t> compact_group_projection_idxs;
+	if (compact_group_columns) {
+		set<idx_t> ordered_group_projection_idxs;
+		for (const auto &group_idx : group_idxs) {
+			ordered_group_projection_idxs.insert(group_idx.second);
+		}
+		idx_t compact_idx = 0;
+		for (const auto group_projection_idx : ordered_group_projection_idxs) {
+			compact_group_projection_idxs[group_projection_idx] = compact_idx++;
+		}
+	}
 	idx_t current_column_idx = 0;
 	for (auto group_idx : group_idxs) {
 		const auto group_referencing_idx = group_idx.first;
-		const auto column_idx = compact_group_columns ? current_column_idx : group_idx.second;
+		const auto column_idx =
+		    compact_group_columns ? compact_group_projection_idxs[group_idx.second] : group_idx.second;
 		new_bindings[group_referencing_idx].table_index = group_table_idx;
 		new_bindings[group_referencing_idx].column_index = column_idx;
 

--- a/test/optimizer/issue_topn_window_elimination_cte_mixed_partition_types.test
+++ b/test/optimizer/issue_topn_window_elimination_cte_mixed_partition_types.test
@@ -1,0 +1,51 @@
+# name: test/optimizer/issue_topn_window_elimination_cte_mixed_partition_types.test
+# description: TopN window elimination should preserve mixed-type partition bindings through CTE/projection rewrites
+# group: [optimizer]
+
+statement ok
+PRAGMA enable_verification
+
+query TT
+WITH
+	src(name, date) AS (
+		VALUES ('A', '2022-01-01'::DATE)
+	),
+	dates(date) AS (
+		VALUES ('2022-01-01'::DATE), ('2022-02-01'::DATE)
+	),
+	ranked AS (
+		SELECT
+			n.name,
+			d.date,
+			ROW_NUMBER() OVER (PARTITION BY n.name, d.date ORDER BY d.date) AS rn
+		FROM dates d
+		CROSS JOIN (SELECT DISTINCT name FROM src) n
+		LEFT JOIN src t1 ON t1.date = d.date AND t1.name = n.name
+	)
+SELECT name, date FROM ranked WHERE rn = 1 ORDER BY ALL
+----
+A	2022-01-01
+A	2022-02-01
+
+query TT
+WITH
+	src(name, date) AS (
+		VALUES ('A', '2022-01-01'::DATE)
+	),
+	dates(date) AS (
+		VALUES ('2022-01-01'::DATE), ('2022-02-01'::DATE)
+	),
+	ranked AS (
+		SELECT
+			n.name,
+			d.date,
+			ROW_NUMBER() OVER (PARTITION BY n.name, d.date ORDER BY d.date) AS rn
+		FROM dates d
+		CROSS JOIN (SELECT DISTINCT name FROM src) n
+		LEFT JOIN src t1 ON t1.date = d.date AND t1.name = n.name
+	)
+SELECT date, name FROM ranked WHERE rn = 1 ORDER BY ALL
+----
+2022-01-01	A
+2022-02-01	A
+


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/21560

This PR fixes a bug in `UpdateTopmostBindings` in which the group columns were projected in partition order (`PARTITION BY x, y`) instead of projection order (`SELECT y, x`).