### PR TITLE
lance: bump lance-duckdb to 4d9ecab

### DIFF
--- a/.github/config/extensions/lance.cmake
+++ b/.github/config/extensions/lance.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(lance
             GIT_URL https://github.com/lance-format/lance-duckdb
-            GIT_TAG adfa8f5601d1de9fbb85f1167c3859bacc775e4d
+            GIT_TAG 4d9ecabf7dc8f3fd07b4ae4a77ff699018a8f4dc
             SUBMODULES extension-ci-tools
             LOAD_TESTS
             DONT_LINK


### PR DESCRIPTION
This updates the `lance` external extension on `v1.5-variegata` from `adfa8f5601d1de9fbb85f1167c3859bacc775e4d` to `4d9ecabf7dc8f3fd07b4ae4a77ff699018a8f4dc`.
