### PR TITLE
Fix cardinality estimation for uncommitted rows

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -785,7 +785,7 @@ unique_ptr<NodeStatistics> TableScanCardinality(ClientContext &context, const Fu
 	auto &storage = duck_table.GetStorage();
 	idx_t table_rows = storage.GetTotalRows();
 	idx_t estimated_cardinality = table_rows + local_storage.AddedRows(duck_table.GetStorage());
-	return make_uniq<NodeStatistics>(table_rows, estimated_cardinality);
+	return make_uniq<NodeStatistics>(estimated_cardinality, estimated_cardinality);
 }
 
 idx_t TableScanRowsScanned(GlobalTableFunctionState &gstate_p, LocalTableFunctionState &local_state) {

--- a/test/sql/transactions/test_cardinality_estimation_uncommitted.test
+++ b/test/sql/transactions/test_cardinality_estimation_uncommitted.test
@@ -1,0 +1,33 @@
+# name: test/sql/transactions/test_cardinality_estimation_uncommitted.test
+# description: Test that cardinality estimation includes uncommitted rows from local storage
+# group: [transactions]
+
+statement ok
+PRAGMA enable_verification
+
+# create an empty table
+statement ok
+CREATE TABLE t1 (id INTEGER, val INTEGER)
+
+# begin a transaction and insert rows without committing
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO t1 SELECT range, range FROM range(10000)
+
+# the planner should estimate ~10000 rows, not 0
+# this verifies that TableScanCardinality accounts for LocalStorage rows
+query II
+EXPLAIN SELECT * FROM t1
+----
+physical_plan	<REGEX>:.*~10,000 rows.*
+
+statement ok
+COMMIT
+
+# after commit, cardinality should still be correct
+query II
+EXPLAIN SELECT * FROM t1
+----
+physical_plan	<REGEX>:.*~10,000 rows.*


### PR DESCRIPTION
## Summary

- **Fix swapped arguments** in `TableScanCardinality()` that caused the query planner to ignore uncommitted (local storage) rows when estimating table cardinality
- Within a transaction that inserts rows without committing, the planner saw cardinality = 0 (committed rows only), leading to suboptimal join plans
- The `NodeStatistics` constructor takes `(estimated_cardinality, max_cardinality)` but was called with `(table_rows, estimated_cardinality)` — the committed-only count went to `estimated_cardinality` while the correct total (including local storage) went to `max_cardinality`

## Test plan

- [x] Added `test/sql/transactions/test_cardinality_estimation_uncommitted.test` verifying EXPLAIN shows correct row estimates for uncommitted data