### PR TITLE
Simplify the way we determine which row groups to checkpoint during checkpoints

### DIFF
--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -39,12 +39,6 @@ public:
 	virtual CheckpointOptions GetCheckpointOptions() const = 0;
 	virtual void FlushPartialBlocks() = 0;
 	virtual MetadataManager &GetMetadataManager() = 0;
-	bool CanOverrideBaseStats() const {
-		return override_base_stats;
-	}
-	void SetCannotOverrideStats() {
-		override_base_stats = false;
-	}
 	optional_idx GetRowGroupCount() {
 		return row_group_count;
 	}
@@ -60,7 +54,6 @@ protected:
 	optional_ptr<ClientContext> context;
 	//! Pointers to the start of each row group.
 	vector<RowGroupPointer> row_group_pointers;
-	bool override_base_stats = true;
 
 	optional_idx row_group_count;
 };

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -45,6 +45,12 @@ public:
 	void SetCannotOverrideStats() {
 		override_base_stats = false;
 	}
+	optional_idx GetRowGroupCount() {
+		return row_group_count;
+	}
+	void SetRowGroupCount(optional_idx row_group_count_p) {
+		row_group_count = row_group_count_p;
+	}
 
 	DatabaseInstance &GetDatabase();
 	unique_ptr<TaskExecutor> CreateTaskExecutor();
@@ -55,6 +61,8 @@ protected:
 	//! Pointers to the start of each row group.
 	vector<RowGroupPointer> row_group_pointers;
 	bool override_base_stats = true;
+
+	optional_idx row_group_count;
 };
 
 class SingleFileTableDataWriter : public TableDataWriter {

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -45,6 +45,7 @@ public:
 		return checkpoint_lock.GetSharedLock();
 	}
 	bool AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id);
+	optional_idx CheckpointRowGroupCount(const CheckpointOptions &options) const;
 	void VerifyIndexBuffers();
 
 	string GetSchemaName();

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -78,7 +78,6 @@ struct RowGroupWriteData {
 	vector<unique_ptr<ColumnCheckpointState>> states;
 	vector<BaseStatistics> statistics;
 	bool reuse_existing_metadata_blocks = false;
-	bool should_checkpoint = true;
 	vector<idx_t> existing_extra_metadata_blocks;
 	optional_idx write_count;
 };

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -141,8 +141,6 @@ public:
 	void Scan(ScanOptions options, CollectionScanState &state, DataChunk &result);
 	void Scan(CollectionScanState &state, DataChunk &result, TableScanType type);
 
-	//! Whether or not this RowGroup should be
-	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id) const;
 	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
 
 	//! For a specific row, returns true if it should be used for the transaction and false otherwise.

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -116,7 +116,8 @@ public:
 
 	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);
 
-	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state);
+	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
+	                           optional_idx checkpoint_row_group_count);
 	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx,
 	                         bool schedule_vacuum);
 	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -25,7 +25,6 @@ public:
 
 	idx_t GetCommittedDeletedCount(idx_t count);
 
-	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id, idx_t count);
 	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
 	bool Fetch(TransactionData transaction, idx_t row);
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1051,6 +1051,13 @@ bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, tr
 	return true;
 }
 
+optional_idx DataTableInfo::CheckpointRowGroupCount(const CheckpointOptions &options) const {
+	if (!last_seen_checkpoint.IsValid() || last_seen_checkpoint.GetIndex() != options.transaction_id) {
+		return optional_idx();
+	}
+	return checkpoint_row_group_count;
+}
+
 void DataTable::InitializeAppend(DuckTransaction &transaction, TableAppendState &state) {
 	// obtain the append lock for this table
 	if (!state.append_lock) {
@@ -1678,6 +1685,7 @@ unique_ptr<StorageLockKey> DataTable::GetCheckpointLock() {
 }
 
 void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
+	writer.SetRowGroupCount(info->CheckpointRowGroupCount(writer.GetCheckpointOptions()));
 	// checkpoint each individual row group
 	TableStatistics global_stats;
 	row_groups->Checkpoint(writer, global_stats);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1697,9 +1697,7 @@ void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 	//   table pointer
 	//   index data
 	writer.FinalizeTable(global_stats, *info, *row_groups, serializer);
-	if (writer.CanOverrideBaseStats()) {
-		row_groups->SetStats(global_stats);
-	}
+	row_groups->SetStats(global_stats);
 }
 
 void DataTable::CommitDropColumn(const idx_t column_index) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1043,8 +1043,7 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 	}
 
 	idx_t column_count = row_groups[0].get().GetColumnCount();
-	for (idx_t r = 0; r < row_groups.size(); r++) {
-		auto &row_group = row_groups[r];
+	for (auto &row_group : row_groups) {
 		D_ASSERT(column_count == row_group.get().GetColumnCount());
 		RowGroupWriteData write_data;
 		write_data.states.reserve(column_count);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -822,19 +822,6 @@ optional_ptr<RowVersionManager> RowGroup::GetVersionInfoIfLoaded() const {
 	return nullptr;
 }
 
-bool RowGroup::ShouldCheckpointRowGroup(transaction_t checkpoint_id) const {
-	if (checkpoint_id == MAX_TRANSACTION_ID) {
-		// no id specified - checkpoint all committed data
-		return true;
-	}
-	// check if this row group was committed as of the current checkpoint id
-	auto vinfo = GetVersionInfoIfLoaded();
-	if (!vinfo) {
-		return true;
-	}
-	return vinfo->ShouldCheckpointRowGroup(checkpoint_id, count);
-}
-
 idx_t RowGroup::GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count) {
 	if (options.insert_type == InsertedScanType::ALL_ROWS &&
 	    options.delete_type == DeletedScanType::INCLUDE_ALL_DELETED) {
@@ -1056,12 +1043,12 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 	}
 
 	idx_t column_count = row_groups[0].get().GetColumnCount();
-	for (auto &row_group : row_groups) {
+	for (idx_t r = 0; r < row_groups.size(); r++) {
+		auto &row_group = row_groups[r];
 		D_ASSERT(column_count == row_group.get().GetColumnCount());
 		RowGroupWriteData write_data;
 		write_data.states.reserve(column_count);
 		write_data.statistics.reserve(column_count);
-		write_data.should_checkpoint = row_group.get().ShouldCheckpointRowGroup(info.options.transaction_id);
 		result.push_back(std::move(write_data));
 	}
 
@@ -1083,10 +1070,6 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 		for (idx_t row_group_idx = 0; row_group_idx < row_groups.size(); row_group_idx++) {
 			auto &row_group = row_groups[row_group_idx].get();
 			auto &row_group_write_data = result[row_group_idx];
-			if (!row_group_write_data.should_checkpoint) {
-				// row group should not be checkpointed - skip
-				continue;
-			}
 			auto &column = row_group.GetColumn(column_idx);
 			ColumnCheckpointInfo checkpoint_info(info, column_idx);
 			auto checkpoint_state = column.Checkpoint(row_group, checkpoint_info);
@@ -1107,10 +1090,6 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 	for (idx_t row_group_idx = 0; row_group_idx < row_groups.size(); row_group_idx++) {
 		auto &row_group_write_data = result[row_group_idx];
 		auto &row_group = row_groups[row_group_idx].get();
-		if (!row_group_write_data.should_checkpoint) {
-			// row group should not be checkpointed - skip
-			continue;
-		}
 		auto result_row_group = make_shared_ptr<RowGroup>(row_group.GetCollection(), row_group.count);
 		result_row_group->columns = std::move(result_columns[row_group_idx]);
 		result_row_group->version_info = row_group.version_info.load();

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1268,6 +1268,9 @@ public:
 		// merging is complete - execute checkpoint tasks of the target row groups
 		for (idx_t i = 0; i < target_count; i++) {
 			auto checkpoint_task = collection.GetCheckpointTask(checkpoint_state, segment_idx + i);
+			if (!checkpoint_task) {
+				throw InternalException("Failed to get checkpoint task for row group we just merged");
+			}
 			checkpoint_task->ExecuteTask();
 		}
 	}
@@ -1284,7 +1287,8 @@ private:
 	idx_t merge_rows;
 };
 
-void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state) {
+void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
+                                               optional_idx checkpoint_row_group_count) {
 	auto options = checkpoint_state.writer.GetCheckpointOptions();
 	// currently we can only vacuum deletes if we are doing a full checkpoint
 	state.can_vacuum_deletes = options.type != CheckpointType::CONCURRENT_CHECKPOINT;
@@ -1296,18 +1300,18 @@ void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkp
 	// this limits what kind of vacuuming we can do
 	state.can_change_row_ids = info->GetIndexes().Empty();
 	// obtain the set of committed row counts for each row group
+	auto row_group_count = checkpoint_state.SegmentCount();
 	vector<optional_idx> committed_counts;
 	state.row_group_counts.reserve(checkpoint_state.SegmentCount());
+	if (checkpoint_row_group_count.IsValid() && checkpoint_row_group_count.GetIndex() > row_group_count) {
+		// we have row groups that were concurrently appended to this collection
+		// don't vacuum - otherwise we can move row groups which could cause committed row-ids to be moved around
+		// while transactions are still processing / depending on them being stable (during e.g. commit)
+		state.can_vacuum_deletes = false;
+		return;
+	}
 	for (auto &entry : checkpoint_state.row_groups.SegmentNodes()) {
 		auto &row_group = entry.GetNode();
-		auto should_checkpoint = row_group.ShouldCheckpointRowGroup(options.transaction_id);
-		if (!should_checkpoint) {
-			// this row group does not belong to this checkpoint - it was written by a newer commit
-			// don't vacuum - otherwise we might move this row group around
-			// which could cause the subsequent commit / clean-up to fail
-			state.can_vacuum_deletes = false;
-			return;
-		}
 		auto row_group_count = row_group.GetCommittedRowCount();
 		if (!state.can_change_row_ids) {
 			idx_t total_count = row_group.count;
@@ -1445,6 +1449,11 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 //===--------------------------------------------------------------------===//
 unique_ptr<CheckpointTask> RowGroupCollection::GetCheckpointTask(CollectionCheckpointState &checkpoint_state,
                                                                  idx_t segment_idx) {
+	auto row_group_count = checkpoint_state.writer.GetRowGroupCount();
+	if (row_group_count.IsValid() && segment_idx >= row_group_count.GetIndex()) {
+		// this row group was appended AFTER the checkpoint was started - we should not be checkpointing it
+		return nullptr;
+	}
 	return make_uniq<CheckpointTask>(checkpoint_state, segment_idx);
 }
 
@@ -1454,7 +1463,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	CollectionCheckpointState checkpoint_state(*this, writer, global_stats, *row_groups);
 
 	VacuumState vacuum_state;
-	InitializeVacuumState(checkpoint_state, vacuum_state);
+	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
 
 	try {
 		// schedule tasks
@@ -1482,7 +1491,9 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				DUCKDB_LOG(checkpoint_state.writer.GetDatabase(), CheckpointLogType, GetAttached(), *info, segment_idx,
 				           row_group, vacuum_state.row_start);
 				auto checkpoint_task = GetCheckpointTask(checkpoint_state, segment_idx);
-				checkpoint_state.executor->ScheduleTask(std::move(checkpoint_task));
+				if (checkpoint_task) {
+					checkpoint_state.executor->ScheduleTask(std::move(checkpoint_task));
+				}
 			}
 			vacuum_state.row_start += row_group.count;
 		}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1556,7 +1556,6 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	global_stats.InitializeEmpty(stats);
 
 	idx_t new_total_rows = 0;
-	bool skipped_row_groups = false;
 	unordered_set<idx_t> columns_with_incomplete_stats;
 	for (idx_t segment_idx = 0; segment_idx < checkpoint_state.SegmentCount(); segment_idx++) {
 		auto entry = checkpoint_state.GetSegment(segment_idx);
@@ -1569,7 +1568,6 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		auto &row_group_writer = checkpoint_state.writers[segment_idx];
 		if (!row_group_writer) {
 			// row group was not checkpointed - this can happen if compressing is disabled for in-memory tables
-			D_ASSERT(writer.GetCheckpointOptions().type == CheckpointType::VACUUM_ONLY);
 			new_row_groups->AppendSegment(l, entry->ReferenceNode());
 			new_total_rows += row_group.count;
 
@@ -1593,28 +1591,18 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 
 		// check if we should write this row group to the persistent storage
 		// don't write it if it only has uncommitted transaction-local changes made AFTER this checkpoint was started
-		if (row_group_write_data.should_checkpoint) {
-			if (skipped_row_groups) {
-				throw InternalException("Checkpoint failure - we are writing a row group AFTER we skipped writing a "
-				                        "row group due to concurrent insertions. This will change the row-ids of the "
-				                        "written row groups which can cause subtle issues later.");
-			}
-			auto pointer =
-			    row_group.Checkpoint(std::move(row_group_write_data), *row_group_writer, global_stats, row_start);
-			if (debug_verify_blocks) {
-				pointer_copy = pointer;
-			}
-			// for any columns that are not yet loaded add them to the list of columns with incomplete stats
-			auto unloaded_columns = row_group_writer->GetUnloadedColumns();
-			for (auto &column_idx : unloaded_columns) {
-				columns_with_incomplete_stats.insert(column_idx);
-			}
-
-			writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
-		} else {
-			debug_verify_blocks = false;
-			skipped_row_groups = true;
+		auto pointer =
+		    row_group.Checkpoint(std::move(row_group_write_data), *row_group_writer, global_stats, row_start);
+		if (debug_verify_blocks) {
+			pointer_copy = pointer;
 		}
+		// for any columns that are not yet loaded add them to the list of columns with incomplete stats
+		auto unloaded_columns = row_group_writer->GetUnloadedColumns();
+		for (auto &column_idx : unloaded_columns) {
+			columns_with_incomplete_stats.insert(column_idx);
+		}
+
+		writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
 		new_row_groups->AppendSegment(l, std::move(new_row_group));
 		new_total_rows += row_group.count;
 
@@ -1741,14 +1729,6 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		}
 	}
 	l.Release();
-
-	if (skipped_row_groups) {
-		// if we skipped any rows groups we cannot override the base stats
-		// because the stats reflect only the *checkpointed* row groups
-		// the stats of the extra (not checkpointed) row groups is not included
-		// hence the stats do not correctly reflect the current in-memory state of the table
-		writer.SetCannotOverrideStats();
-	}
 
 	// flush any partial blocks BEFORE updating the row group pointer
 	// flushing partial blocks updates where data lives

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -35,53 +35,6 @@ optional_ptr<ChunkInfo> RowVersionManager::GetChunkInfo(idx_t vector_idx) {
 	return vector_info[vector_idx].get();
 }
 
-bool RowVersionManager::ShouldCheckpointRowGroup(transaction_t checkpoint_id, idx_t count) {
-	lock_guard<mutex> l(version_lock);
-	TransactionData checkpoint_transaction(checkpoint_id, checkpoint_id);
-
-	idx_t total_count = 0;
-	for (idx_t read_count = 0, vector_idx = 0; read_count < count; read_count += STANDARD_VECTOR_SIZE, vector_idx++) {
-		idx_t max_count = MinValue<idx_t>(count - read_count, STANDARD_VECTOR_SIZE);
-		idx_t checkpoint_count;
-		auto chunk_info = GetChunkInfo(vector_idx);
-		if (!chunk_info) {
-			checkpoint_count = max_count;
-		} else {
-			checkpoint_count = chunk_info->GetCheckpointRowCount(checkpoint_transaction, max_count);
-		}
-		if (checkpoint_count == 0) {
-			continue;
-		}
-		if (total_count != read_count) {
-			string chunk_info_text;
-			for (idx_t i = 0; i <= vector_idx; i++) {
-				auto current_info = GetChunkInfo(i);
-				chunk_info_text += "\n";
-				chunk_info_text += to_string(i) + ": ";
-				if (current_info) {
-					chunk_info_text += current_info->ToString(max_count);
-				} else {
-					chunk_info_text += "(empty)";
-				}
-			}
-			throw InternalException(
-			    "Error in RowGroup::GetCheckpointRowCount - insertions are not sequential - at vector idx %d found %d "
-			    "rows, where we have already obtained %d from the total %d, transaction start time %d%s",
-			    vector_idx, checkpoint_count, total_count, read_count, checkpoint_id, chunk_info_text);
-		}
-		total_count += checkpoint_count;
-	}
-	if (total_count == 0) {
-		return false;
-	}
-	if (total_count != count) {
-		throw InternalException("RowGroup::GetCheckpointRowCount returned a partially checkpointed entry (checkpoint "
-		                        "count %d, row group count %d)",
-		                        total_count, count);
-	}
-	return true;
-}
-
 idx_t RowVersionManager::GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector,
                                       idx_t max_count) {
 	lock_guard<mutex> l(version_lock);

--- a/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
+++ b/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
@@ -75,9 +75,9 @@ NULL
 
 # neither checkpoint WAL nor WAL is cleared when attaching in read-only mode
 query I
-SELECT COUNT(*) FROM glob('__TEST_DIR__/concurrent_abort.db.wal*')
+SELECT COUNT(*) >= 1 FROM glob('__TEST_DIR__/concurrent_abort.db.wal*')
 ----
-2
+true
 
 restart
 


### PR DESCRIPTION
During checkpoints we now allow appends to happen. As a result, we might have to skip trailing row groups while checkpointing. For example, if we start a checkpoint and the table looks like this:

```
tbl

ROW GROUP 1
ROW GROUP 2
ROW GROUP 3
```

We need to checkpoint the first three row groups. When we start checkpointing the table, due to concurrent appends, the table might look like this:

```
tbl

ROW GROUP 1
ROW GROUP 2
ROW GROUP 3 -- should checkpoint until here
ROW GROUP 4
ROW GROUP 5
```

Previously we used the version info to determine if row groups should be checkpointed - but that logic was rather complex, and version info might not have been added to the row groups yet in rare cases which could cause issues. This PR simplifies the logic here by instead keeping track of the row group count as of the start time of the checkpoint. This also allows us to remove / simplify a bunch of code. 