### PR TITLE
Pass runners to extension jobs and reuse linux build

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -316,7 +316,7 @@ jobs:
           DUCKDB_DEPLOY_SCRIPT_MODE: for_real
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
-          pip install awscli
+          pip install --break-system-packages awscli
           make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/extension-repository
 
   autoload-tests:

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -27,6 +27,9 @@ on:
         type: string
         required: false
         default: ''
+      runners:
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -61,6 +64,11 @@ on:
         type: boolean
         required: false
         default: true
+      runners:
+        description: 'JSON object with runner labels, e.g. {"linux_x64":"ubuntu-latest","linux_22_x64":"ubuntu-22.04","linux_arm64":"ubuntu-24.04-arm"}'
+        type: string
+        required: false
+        default: '{}'
 
 concurrency:
   group: extensions-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
@@ -74,7 +82,7 @@ jobs:
   # This first step loads the various extension configs from the ~/.github/config directory storing them to drive the build jobs
   load-extension-configs:
     name: Load Extension Configs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       # NOTE: on PRs we exclude some archs to speed things up
       reduced_ci_mode: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'enabled' || 'disabled' }}
@@ -94,7 +102,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
       - id: set-main-extensions
@@ -204,6 +211,7 @@ jobs:
       save_cache: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
       extensions_test_selection: 'complete'
       extra_extension_config: ${{ matrix.extension_config }}
+      runners: ${{ inputs.runners }}
 
   # Build the extensions from .github/config/external_extensions2.cmake
   external-extensions2:
@@ -229,20 +237,17 @@ jobs:
       save_cache: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
       extensions_test_selection: 'complete'
       extra_extension_config: ${{ needs.load-extension-configs.outputs.external_extensions2_config }}
+      runners: ${{ inputs.runners }}
 
   # Merge all extensions into a single, versioned repository
   create-extension-repository:
     name: Create Extension Repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       - extensions-build
       - external-extensions2
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/cleanup_runner
 
       - uses: actions/download-artifact@v5
         name: Download main extensions
@@ -287,17 +292,12 @@ jobs:
 
   upload-extensions:
     name: Upload Extensions
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runners).linux_x64 || 'ubuntu-latest' }}
     needs:
         - create-extension-repository
 
     steps:
-
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/cleanup_runner
 
       - uses: actions/download-artifact@v5
         with:
@@ -305,9 +305,7 @@ jobs:
           path: /tmp/extension-repository
 
       - name: List extensions to deploy
-        shell: bash
-        run: |
-          tree /tmp/extension-repository
+        run: tree /tmp/extension-repository
 
       - name: Deploy extensions
         shell: bash
@@ -324,8 +322,9 @@ jobs:
   autoload-tests:
     name: Extension Autoloading Tests
     if: ${{ inputs.skip_tests != 'true' }}
-    runs-on: ubuntu-latest
-    needs: create-extension-repository
+    runs-on: ${{ fromJSON(inputs.runners).linux_x64 || 'ubuntu-latest' }}
+    needs:
+      - create-extension-repository
 
     steps:
       - uses: actions/checkout@v6
@@ -345,9 +344,7 @@ jobs:
           path: /tmp/extension-repository
 
       - name: List extensions to test with
-        shell: bash
-        run: |
-          tree /tmp/extension-repository
+        run: tree /tmp/extension-repository
 
       - name: Build DuckDB
         env:
@@ -371,8 +368,9 @@ jobs:
   check-load-install-extensions:
     name: Checks extension entries
     if: ${{ inputs.skip_tests != 'true' }}
-    runs-on: ubuntu-22.04
-    needs: create-extension-repository
+    runs-on: ${{ fromJSON(inputs.runners).linux_22_x64 || 'ubuntu-22.04' }}
+    needs:
+      - create-extension-repository
     env:
       CC: gcc-10
       CXX: g++-10

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -189,7 +189,7 @@ jobs:
             opt_in_archs: ''
             extension_config: ${{ needs.load-extension-configs.outputs.external_extensions_config }}
             extra_toolchains: rust
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: smvv/extension-ci-tools/.github/workflows/_extension_distribution.yml@allow-custom-runners
     with:
       # We piggy-back extension-template to build the extensions in extension_config
       override_repository: duckdb/extension-template
@@ -200,8 +200,8 @@ jobs:
       reduced_ci_mode: ${{ needs.load-extension-configs.outputs.reduced_ci_mode }}
       set_caller_as_duckdb: true
       duckdb_version: ${{ inputs.git_ref }}
-      override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: main
+      override_ci_tools_repository: smvv/extension-ci-tools
+      ci_tools_version: allow-custom-runners
       exclude_archs: ${{ matrix.exclude_archs }}
       opt_in_archs: ${{ matrix.opt_in_archs }}
       extra_toolchains: ${{ matrix.extra_toolchains }}
@@ -218,7 +218,7 @@ jobs:
     name: External Extensions (2nd batch)
     needs:
       - load-extension-configs
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: smvv/extension-ci-tools/.github/workflows/_extension_distribution.yml@allow-custom-runners
     with:
       # We piggy-back extension-template to build the extensions in extension_config
       override_repository: duckdb/extension-template
@@ -227,8 +227,8 @@ jobs:
       extension_name: external-extensions2
       set_caller_as_duckdb: true
       duckdb_version: ${{ inputs.git_ref }}
-      override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: main
+      override_ci_tools_repository: smvv/extension-ci-tools
+      ci_tools_version: allow-custom-runners
       exclude_archs: ${{ needs.load-extension-configs.outputs.external_extensions2_exclude_archs }}
       extra_toolchains: 'rust'
       use_merged_vcpkg_manifest: '1'

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -189,7 +189,7 @@ jobs:
             opt_in_archs: ''
             extension_config: ${{ needs.load-extension-configs.outputs.external_extensions_config }}
             extra_toolchains: rust
-    uses: smvv/extension-ci-tools/.github/workflows/_extension_distribution.yml@allow-custom-runners
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       # We piggy-back extension-template to build the extensions in extension_config
       override_repository: duckdb/extension-template
@@ -200,8 +200,8 @@ jobs:
       reduced_ci_mode: ${{ needs.load-extension-configs.outputs.reduced_ci_mode }}
       set_caller_as_duckdb: true
       duckdb_version: ${{ inputs.git_ref }}
-      override_ci_tools_repository: smvv/extension-ci-tools
-      ci_tools_version: allow-custom-runners
+      override_ci_tools_repository: duckdb/extension-ci-tools
+      ci_tools_version: main
       exclude_archs: ${{ matrix.exclude_archs }}
       opt_in_archs: ${{ matrix.opt_in_archs }}
       extra_toolchains: ${{ matrix.extra_toolchains }}
@@ -218,7 +218,7 @@ jobs:
     name: External Extensions (2nd batch)
     needs:
       - load-extension-configs
-    uses: smvv/extension-ci-tools/.github/workflows/_extension_distribution.yml@allow-custom-runners
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       # We piggy-back extension-template to build the extensions in extension_config
       override_repository: duckdb/extension-template
@@ -227,8 +227,8 @@ jobs:
       extension_name: external-extensions2
       set_caller_as_duckdb: true
       duckdb_version: ${{ inputs.git_ref }}
-      override_ci_tools_repository: smvv/extension-ci-tools
-      ci_tools_version: allow-custom-runners
+      override_ci_tools_repository: duckdb/extension-ci-tools
+      ci_tools_version: main
       exclude_archs: ${{ needs.load-extension-configs.outputs.external_extensions2_exclude_archs }}
       extra_toolchains: 'rust'
       use_merged_vcpkg_manifest: '1'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -241,6 +241,14 @@ jobs:
       extra_exclude_archs: ${{ needs.prepare.outputs.extensions_extra_exclude_archs }}
       skip_tests: 'false'
       run_all: 'true'
+      runners: >-
+        {
+          "linux_x64": "${{ needs.prepare.outputs.runner_linux_x64 }}",
+          "linux_22_x64": "${{ needs.prepare.outputs.runner_linux_22_x64 }}",
+          "linux_arm64": "${{ needs.prepare.outputs.runner_linux_arm64 }}",
+          "macos_arm64": "${{ needs.prepare.outputs.runner_macos_arm64 }}",
+          "macos_14_arm64": "${{ needs.prepare.outputs.runner_macos_14_arm64 }}"
+        }
 
  wasm-eh:
     name: Wasm EH

--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,7 @@ endef
 .PHONY: toolsci format_tools
 
 toolsci:
-	$(call ensure_apt_commands,ninja mold ccache pkg-config,ninja-build mold ccache pkg-config)
+	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
 	pkg-config --exists libcurl || { \
 		sudo apt-get update -y -qq; \
 		sudo apt-get install -y -qq libcurl4-openssl-dev; \

--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -86,6 +86,12 @@ set -x
 
 # Use a tarball so executable bits are preserved when passing build artifacts between jobs.
 # Use -4 to balance compression ratio (small enough output size) with compression time (a few sec).
-tar -C "$ARTIFACT_ROOT" -cf - "$BUILD_TYPE" | gzip -4 > "$ARTIFACT_TARBALL"
+if command -v pigz >/dev/null 2>&1; then
+	COMPRESSOR=(pigz -4)
+else
+	COMPRESSOR=(gzip -4)
+fi
+
+tar -C "$ARTIFACT_ROOT" -cf - "$BUILD_TYPE" | "${COMPRESSOR[@]}" > "$ARTIFACT_TARBALL"
 
 ls -lh "$ARTIFACT_TARBALL"


### PR DESCRIPTION
### Speed up creating release artifact files 

Use pigz (if available) to prepare build artifact file by using all CPU cores (instead of using the single-threaded `gzip`).

This speeds up creating the release artifact file for:
- `linux-debug` from 66 sec to 12 sec.
- `linux-release` from 16 sec to 3 sec.

(This is important because both CI jobs are part of the critical CI path.)

### Use namespace runners in extensions workflow

Pass runners JSON object from `prepare` through the extensions workflow call.

See also the related [PR](https://github.com/duckdb/extension-ci-tools/pull/346) for `extension-ci-tools`.

This PR can only be merged once the extension-ci-tools' PR is merged. Otherwise, we get an error in CI:
```
Invalid workflow file: .github/workflows/Main.yml#L214
The workflow is not valid. duckdb/duckdb/.github/workflows/Extensions.yml@6c1b0504a92706deb2ac0b2fc9dfa79a8d909c2e (Line: 214, Col: 16): Invalid input, runners is not defined in the referenced workflow.
```
because the `runners` input parameter does not exist (yet).

## Results

This is a duckdb CI [run](https://github.com/duckdb/duckdb/actions/runs/23489092831) that successfully uses the namespace runners.

### Before on github runner (1h 37m)

<img width="702" height="561" alt="Screenshot 2026-03-24 at 14 45 26" src="https://github.com/user-attachments/assets/2b788960-0a3b-4a9b-8062-b0bf5e4f83ca" />

### After on namespace runner (21m)

<img width="692" height="533" alt="Screenshot 2026-03-24 at 14 41 33" src="https://github.com/user-attachments/assets/bf7b19b3-8c7b-4c7c-88d1-3b60f8acdb02" />
