### PR TITLE
Fix wasm build: use __EMSCRIPTEN__ instead of deprecated EMSCRIPTEN

### DIFF
--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -461,7 +461,7 @@ void TaskScheduler::YieldThread() {
 }
 
 idx_t TaskScheduler::GetEstimatedCPUId() {
-#if defined(EMSCRIPTEN)
+#if defined(__EMSCRIPTEN__)
 	// FIXME: Wasm + multithreads can likely be implemented as
 	//   return return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
 	return 0;


### PR DESCRIPTION
`EMSCRIPTEN` was (re)moved yesterday: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#504---032326