### PR TITLE
CLI: Avoid division by zero when formatting a large result with a non-wide shell

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1915,8 +1915,8 @@ void BoxRendererImplementation::ComputeRenderWidths(vector<RenderDataCollection>
 
 	// check if we shortened any columns that would be rendered and if we can expand them
 	// we only expand columns in the ".mode rows", and only if we haven't hidden any columns
-	if (shortened_columns && config.render_mode == RenderMode::ROWS && row_count + 5 < config.max_rows &&
-	    pruned_columns.empty()) {
+	if (shortened_columns && config.render_mode == RenderMode::ROWS && row_count > 0 &&
+	    row_count + 5 < config.max_rows && pruned_columns.empty()) {
 		max_rows_per_row = MaxValue<idx_t>(1, config.max_rows <= 5 ? 0 : (config.max_rows - 5) / row_count);
 		if (max_rows_per_row > 1) {
 			// we can expand rows - check if we should expand any rows

--- a/tools/shell/tests/test_shell_rendering.py
+++ b/tools/shell/tests/test_shell_rendering.py
@@ -109,3 +109,13 @@ def test_mode_json_empty_result(shell):
 
     result = test.run()
     result.check_stdout("[]")
+
+def test_long_type_empty_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".maxwidth 80")
+        .statement("select * from (values ({'thisisalongfieldnamethatresultsinalongtypename': 42, 'thisisyetanotherlongfieldname': 84})) t(s) limit 0;")
+    )
+
+    result = test.run()
+    result.check_stdout("thisisalongfieldnamethatresultsinalongtypename")


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21470
Fixes https://github.com/duckdb/duckdb/issues/21429

The issue depends on the render width of the CLI, but is triggered when there is a very large header (column name or type name) together with a result with zero rows. 