### PR TITLE
Segfault due to unchecked malloc/realloc, proposed fix to #21593

### DIFF
--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -131,23 +131,23 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 		my_stream->column_names = result.names;
 	}
 
-    try {
-        idx_t result_count;
-        ErrorData error;
-        if (!ArrowUtil::TryFetchChunk(scan_state, result.client_properties, my_stream->batch_size, out, result_count,
-                                      error, my_stream->extension_types)) {
-            D_ASSERT(error.HasError()); 
-            my_stream->last_error = error;
-            return -1;
-        } 
-        if (result_count == 0) {
-            // Nothing to output
-            out->release = nullptr;
-        }
-    } catch (std::exception &e) {
-        my_stream->last_error = ErrorData(e);
-        return -1;
-    }
+	try {
+		idx_t result_count;
+		ErrorData error;
+		if (!ArrowUtil::TryFetchChunk(scan_state, result.client_properties, my_stream->batch_size, out, result_count,
+		                              error, my_stream->extension_types)) {
+			D_ASSERT(error.HasError());
+			my_stream->last_error = error;
+			return -1;
+		}
+		if (result_count == 0) {
+			// Nothing to output
+			out->release = nullptr;
+		}
+	} catch (std::exception &e) {
+		my_stream->last_error = ErrorData(e);
+		return -1;
+	}
 
 	return 0;
 }

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -130,18 +130,25 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 		my_stream->column_types = result.types;
 		my_stream->column_names = result.names;
 	}
-	idx_t result_count;
-	ErrorData error;
-	if (!ArrowUtil::TryFetchChunk(scan_state, result.client_properties, my_stream->batch_size, out, result_count, error,
-	                              my_stream->extension_types)) {
-		D_ASSERT(error.HasError());
-		my_stream->last_error = error;
-		return -1;
-	}
-	if (result_count == 0) {
-		// Nothing to output
-		out->release = nullptr;
-	}
+
+    try {
+        idx_t result_count;
+        ErrorData error;
+        if (!ArrowUtil::TryFetchChunk(scan_state, result.client_properties, my_stream->batch_size, out, result_count,
+                                      error, my_stream->extension_types)) {
+            D_ASSERT(error.HasError()); 
+            my_stream->last_error = error;
+            return -1;
+        } 
+        if (result_count == 0) {
+            // Nothing to output
+            out->release = nullptr;
+        }
+    } catch (std::exception &e) {
+        my_stream->last_error = ErrorData(e);
+        return -1;
+    }
+
 	return 0;
 }
 

--- a/src/include/duckdb/common/arrow/arrow_buffer.hpp
+++ b/src/include/duckdb/common/arrow/arrow_buffer.hpp
@@ -86,19 +86,19 @@ struct ArrowBuffer {
 	}
 
 private:
-    void ReserveInternal(idx_t bytes) {
-        data_ptr_t new_ptr;
-        if (dataptr) {
-            new_ptr = data_ptr_cast(realloc(dataptr, bytes));
-        } else {
-            new_ptr = data_ptr_cast(malloc(bytes));
-        }
-        if (!new_ptr) {
-            throw OutOfMemoryException("ArrowBuffer: failed to allocate %llu bytes", (unsigned long long)bytes);
-        }
-        dataptr = new_ptr;
-        capacity = bytes;
-    }
+	void ReserveInternal(idx_t bytes) {
+		data_ptr_t new_ptr;
+		if (dataptr) {
+			new_ptr = data_ptr_cast(realloc(dataptr, bytes));
+		} else {
+			new_ptr = data_ptr_cast(malloc(bytes));
+		}
+		if (!new_ptr) {
+			throw OutOfMemoryException("ArrowBuffer: failed to allocate %llu bytes", (unsigned long long)bytes);
+		}
+		dataptr = new_ptr;
+		capacity = bytes;
+	}
 
 private:
 	data_ptr_t dataptr = nullptr;

--- a/src/include/duckdb/common/arrow/arrow_buffer.hpp
+++ b/src/include/duckdb/common/arrow/arrow_buffer.hpp
@@ -86,14 +86,19 @@ struct ArrowBuffer {
 	}
 
 private:
-	void ReserveInternal(idx_t bytes) {
-		if (dataptr) {
-			dataptr = data_ptr_cast(realloc(dataptr, bytes));
-		} else {
-			dataptr = data_ptr_cast(malloc(bytes));
-		}
-		capacity = bytes;
-	}
+    void ReserveInternal(idx_t bytes) {
+        data_ptr_t new_ptr;
+        if (dataptr) {
+            new_ptr = data_ptr_cast(realloc(dataptr, bytes));
+        } else {
+            new_ptr = data_ptr_cast(malloc(bytes));
+        }
+        if (!new_ptr) {
+            throw OutOfMemoryException("ArrowBuffer: failed to allocate %llu bytes", (unsigned long long)bytes);
+        }
+        dataptr = new_ptr;
+        capacity = bytes;
+    }
 
 private:
 	data_ptr_t dataptr = nullptr;

--- a/src/include/duckdb/common/arrow/arrow_buffer.hpp
+++ b/src/include/duckdb/common/arrow/arrow_buffer.hpp
@@ -94,7 +94,7 @@ private:
 			new_ptr = data_ptr_cast(malloc(bytes));
 		}
 		if (!new_ptr) {
-			throw OutOfMemoryException("ArrowBuffer: failed to allocate %llu bytes", (unsigned long long)bytes);
+			throw OutOfMemoryException("ArrowBuffer: failed to allocate %llu bytes", bytes);
 		}
 		dataptr = new_ptr;
 		capacity = bytes;


### PR DESCRIPTION
Fixes a missing check on `malloc`/`realloc` with `ArrowBuffer`. Details in #21593. Cowritten with @claude 