### PR TITLE
Move data from Vector into VectorBuffer

### DIFF
--- a/extension/core_functions/scalar/map/map_entries.cpp
+++ b/extension/core_functions/scalar/map/map_entries.cpp
@@ -21,7 +21,7 @@ static void MapEntriesFunction(DataChunk &args, ExpressionState &state, Vector &
 	}
 	auto all_constant = args.AllConstant();
 
-	MapUtil::ReinterpretMap(result, map, all_constant ? 1 : count);
+	MapUtil::ReinterpretMap(result, map, count);
 
 	if (all_constant) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/extension/core_functions/scalar/map/map_entries.cpp
+++ b/extension/core_functions/scalar/map/map_entries.cpp
@@ -19,10 +19,11 @@ static void MapEntriesFunction(DataChunk &args, ExpressionState &state, Vector &
 		ConstantVector::SetNull(result, true);
 		return;
 	}
+	auto all_constant = args.AllConstant();
 
-	MapUtil::ReinterpretMap(result, map, count);
+	MapUtil::ReinterpretMap(result, map, all_constant ? 1 : count);
 
-	if (args.AllConstant()) {
+	if (all_constant) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 	result.Verify(count);

--- a/extension/core_functions/scalar/map/map_from_entries.cpp
+++ b/extension/core_functions/scalar/map/map_from_entries.cpp
@@ -11,11 +11,13 @@ namespace duckdb {
 static void MapFromEntriesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto count = args.size();
 
+	auto all_constant = args.AllConstant();
+
 	MapUtil::ReinterpretMap(result, args.data[0], count);
 	MapVector::MapConversionVerify(result, count);
 	result.Verify(count);
 
-	if (args.AllConstant()) {
+	if (all_constant) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -37,7 +37,7 @@
 namespace duckdb {
 
 Vector::Vector(LogicalType type_p, bool create_data, bool initialize_to_zero, idx_t capacity)
-    : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), data(nullptr), validity(capacity) {
+    : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), validity(capacity) {
 	if (create_data) {
 		Initialize(initialize_to_zero, capacity);
 	}
@@ -46,11 +46,11 @@ Vector::Vector(LogicalType type_p, bool create_data, bool initialize_to_zero, id
 Vector::Vector(LogicalType type_p, idx_t capacity) : Vector(std::move(type_p), true, false, capacity) {
 }
 
-Vector::Vector(LogicalType type_p, data_ptr_t dataptr)
-    : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), data(dataptr) {
+Vector::Vector(LogicalType type_p, data_ptr_t dataptr) : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)) {
 	if (dataptr && !type.IsValid()) {
 		throw InternalException("Cannot create a vector of type INVALID!");
 	}
+	buffer = make_uniq<VectorBuffer>(dataptr);
 }
 
 Vector::Vector(const VectorCache &cache) : type(cache.GetType()) {
@@ -74,8 +74,8 @@ Vector::Vector(const Value &value) : type(value.type()) {
 }
 
 Vector::Vector(Vector &&other) noexcept
-    : vector_type(other.vector_type), type(std::move(other.type)), data(other.data),
-      validity(std::move(other.validity)), buffer(std::move(other.buffer)), auxiliary(std::move(other.auxiliary)) {
+    : vector_type(other.vector_type), type(std::move(other.type)), validity(std::move(other.validity)),
+      buffer(std::move(other.buffer)), auxiliary(std::move(other.auxiliary)) {
 }
 
 void Vector::Reference(const Value &value) {
@@ -98,7 +98,6 @@ void Vector::Reference(const Value &value) {
 	} else if (internal_type == PhysicalType::LIST) {
 		auto list_buffer = make_uniq<VectorListBuffer>(value.type());
 		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
-		data = buffer->GetData();
 		SetValue(0, value);
 	} else if (internal_type == PhysicalType::ARRAY) {
 		auto array_buffer = make_uniq<VectorArrayBuffer>(value.type());
@@ -106,7 +105,6 @@ void Vector::Reference(const Value &value) {
 		SetValue(0, value);
 	} else {
 		auxiliary.reset();
-		data = buffer->GetData();
 		SetValue(0, value);
 	}
 }
@@ -149,7 +147,6 @@ void Vector::Reinterpret(const Vector &other) {
 	} else {
 		AssignSharedPointer(auxiliary, other.auxiliary);
 	}
-	data = other.data;
 	validity = other.validity;
 }
 
@@ -199,7 +196,8 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 	} else {
 		Reference(other);
 		if (offset > 0) {
-			data = data + GetTypeIdSize(internal_type) * offset;
+			auto offset_ptr = buffer->GetData() + GetTypeIdSize(internal_type) * offset;
+			buffer = make_buffer<VectorBuffer>(offset_ptr);
 			validity.Slice(other.validity, offset, end - offset);
 		}
 	}
@@ -273,7 +271,6 @@ void Vector::Dictionary(buffer_ptr<VectorChildBuffer> reusable_dict, const Selec
 	D_ASSERT(type.InternalType() != PhysicalType::STRUCT);
 	D_ASSERT(type == reusable_dict->data.GetType());
 	vector_type = VectorType::DICTIONARY_VECTOR;
-	data = reusable_dict->data.data;
 	validity.Reset();
 
 	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
@@ -329,8 +326,8 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 	auto type_size = GetTypeIdSize(internal_type);
 	if (type_size > 0) {
 		buffer = VectorBuffer::CreateStandardVector(type, capacity);
-		data = buffer->GetData();
 		if (initialize_to_zero) {
+			auto data = buffer->GetData();
 			memset(data, 0, capacity * type_size);
 		}
 	}
@@ -341,15 +338,13 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 }
 
 void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multiplier) {
-	ResizeInfo resize_info(*this, data, buffer.get(), multiplier);
+	ResizeInfo resize_info(*this, buffer.get(), multiplier);
 	resize_infos.emplace_back(resize_info);
 
-	// Base case.
-	if (data) {
+	if (!auxiliary) {
 		return;
 	}
 
-	D_ASSERT(auxiliary);
 	switch (GetAuxiliary()->GetBufferType()) {
 	case VectorBufferType::LIST_BUFFER: {
 		auto &vector_list_buffer = auxiliary->Cast<VectorListBuffer>();
@@ -416,7 +411,6 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 		                                 : Allocator::DefaultAllocator().Allocate(target_size);
 		memcpy(new_data.get(), resize_info_entry.data, old_size);
 		resize_info_entry.buffer->SetData(std::move(new_data));
-		resize_info_entry.vec.data = resize_info_entry.buffer->GetData();
 	}
 }
 
@@ -447,53 +441,52 @@ void Vector::SetValue(idx_t index, const Value &val) {
 		// so we do not bail out yet
 		return;
 	}
-
 	switch (physical_type) {
 	case PhysicalType::BOOL:
-		reinterpret_cast<bool *>(data)[index] = val.GetValueUnsafe<bool>();
+		FlatVector::GetData<bool>(*this)[index] = val.GetValueUnsafe<bool>();
 		break;
 	case PhysicalType::INT8:
-		reinterpret_cast<int8_t *>(data)[index] = val.GetValueUnsafe<int8_t>();
+		FlatVector::GetData<int8_t>(*this)[index] = val.GetValueUnsafe<int8_t>();
 		break;
 	case PhysicalType::INT16:
-		reinterpret_cast<int16_t *>(data)[index] = val.GetValueUnsafe<int16_t>();
+		FlatVector::GetData<int16_t>(*this)[index] = val.GetValueUnsafe<int16_t>();
 		break;
 	case PhysicalType::INT32:
-		reinterpret_cast<int32_t *>(data)[index] = val.GetValueUnsafe<int32_t>();
+		FlatVector::GetData<int32_t>(*this)[index] = val.GetValueUnsafe<int32_t>();
 		break;
 	case PhysicalType::INT64:
-		reinterpret_cast<int64_t *>(data)[index] = val.GetValueUnsafe<int64_t>();
+		FlatVector::GetData<int64_t>(*this)[index] = val.GetValueUnsafe<int64_t>();
 		break;
 	case PhysicalType::INT128:
-		reinterpret_cast<hugeint_t *>(data)[index] = val.GetValueUnsafe<hugeint_t>();
+		FlatVector::GetData<hugeint_t>(*this)[index] = val.GetValueUnsafe<hugeint_t>();
 		break;
 	case PhysicalType::UINT8:
-		reinterpret_cast<uint8_t *>(data)[index] = val.GetValueUnsafe<uint8_t>();
+		FlatVector::GetData<uint8_t>(*this)[index] = val.GetValueUnsafe<uint8_t>();
 		break;
 	case PhysicalType::UINT16:
-		reinterpret_cast<uint16_t *>(data)[index] = val.GetValueUnsafe<uint16_t>();
+		FlatVector::GetData<uint16_t>(*this)[index] = val.GetValueUnsafe<uint16_t>();
 		break;
 	case PhysicalType::UINT32:
-		reinterpret_cast<uint32_t *>(data)[index] = val.GetValueUnsafe<uint32_t>();
+		FlatVector::GetData<uint32_t>(*this)[index] = val.GetValueUnsafe<uint32_t>();
 		break;
 	case PhysicalType::UINT64:
-		reinterpret_cast<uint64_t *>(data)[index] = val.GetValueUnsafe<uint64_t>();
+		FlatVector::GetData<uint64_t>(*this)[index] = val.GetValueUnsafe<uint64_t>();
 		break;
 	case PhysicalType::UINT128:
-		reinterpret_cast<uhugeint_t *>(data)[index] = val.GetValueUnsafe<uhugeint_t>();
+		FlatVector::GetData<uhugeint_t>(*this)[index] = val.GetValueUnsafe<uhugeint_t>();
 		break;
 	case PhysicalType::FLOAT:
-		reinterpret_cast<float *>(data)[index] = val.GetValueUnsafe<float>();
+		FlatVector::GetData<float>(*this)[index] = val.GetValueUnsafe<float>();
 		break;
 	case PhysicalType::DOUBLE:
-		reinterpret_cast<double *>(data)[index] = val.GetValueUnsafe<double>();
+		FlatVector::GetData<double>(*this)[index] = val.GetValueUnsafe<double>();
 		break;
 	case PhysicalType::INTERVAL:
-		reinterpret_cast<interval_t *>(data)[index] = val.GetValueUnsafe<interval_t>();
+		FlatVector::GetData<interval_t>(*this)[index] = val.GetValueUnsafe<interval_t>();
 		break;
 	case PhysicalType::VARCHAR: {
 		if (!val.IsNull()) {
-			reinterpret_cast<string_t *>(data)[index] = StringVector::AddStringOrBlob(*this, StringValue::Get(val));
+			FlatVector::GetData<string_t>(*this)[index] = StringVector::AddStringOrBlob(*this, StringValue::Get(val));
 		}
 		break;
 	}
@@ -520,7 +513,7 @@ void Vector::SetValue(idx_t index, const Value &val) {
 	case PhysicalType::LIST: {
 		auto offset = ListVector::GetListSize(*this);
 		if (val.IsNull()) {
-			auto &entry = reinterpret_cast<list_entry_t *>(data)[index];
+			auto &entry = FlatVector::GetData<list_entry_t>(*this)[index];
 			ListVector::PushBack(*this, Value());
 			entry.length = 1;
 			entry.offset = offset;
@@ -532,7 +525,7 @@ void Vector::SetValue(idx_t index, const Value &val) {
 				}
 			}
 			//! now set the pointer
-			auto &entry = reinterpret_cast<list_entry_t *>(data)[index];
+			auto &entry = FlatVector::GetData<list_entry_t>(*this)[index];
 			entry.length = val_children.size();
 			entry.offset = offset;
 		}
@@ -618,7 +611,6 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		}
 	}
 	auto &vector = current_vector_ref.get();
-	auto data = vector.data;
 	auto &validity = vector.validity;
 	auto &type = vector.GetType();
 	if (!validity.RowIsValid(index)) {
@@ -629,7 +621,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		if (vector.GetType().InternalType() != PhysicalType::VARCHAR) {
 			throw InternalException("FSST Vector with non-string datatype found!");
 		}
-		auto str_compressed = reinterpret_cast<string_t *>(data)[index];
+		auto str_compressed = FSSTVector::GetCompressedData(vector)[index];
 		auto decoder = FSSTVector::GetDecoder(vector);
 		auto &decompress_buffer = FSSTVector::GetDecompressBuffer(vector);
 		auto string_val = FSSTPrimitives::DecompressValue(decoder, str_compressed.GetData(), str_compressed.GetSize(),
@@ -646,59 +638,59 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
-		return Value::BOOLEAN(reinterpret_cast<bool *>(data)[index]);
+		return Value::BOOLEAN(FlatVector::GetData<bool>(vector)[index]);
 	case LogicalTypeId::TINYINT:
-		return Value::TINYINT(reinterpret_cast<int8_t *>(data)[index]);
+		return Value::TINYINT(FlatVector::GetData<int8_t>(vector)[index]);
 	case LogicalTypeId::SMALLINT:
-		return Value::SMALLINT(reinterpret_cast<int16_t *>(data)[index]);
+		return Value::SMALLINT(FlatVector::GetData<int16_t>(vector)[index]);
 	case LogicalTypeId::INTEGER:
-		return Value::INTEGER(reinterpret_cast<int32_t *>(data)[index]);
+		return Value::INTEGER(FlatVector::GetData<int32_t>(vector)[index]);
 	case LogicalTypeId::DATE:
-		return Value::DATE(reinterpret_cast<date_t *>(data)[index]);
+		return Value::DATE(FlatVector::GetData<date_t>(vector)[index]);
 	case LogicalTypeId::TIME:
-		return Value::TIME(reinterpret_cast<dtime_t *>(data)[index]);
+		return Value::TIME(FlatVector::GetData<dtime_t>(vector)[index]);
 	case LogicalTypeId::TIME_NS:
-		return Value::TIME_NS(reinterpret_cast<dtime_ns_t *>(data)[index]);
+		return Value::TIME_NS(FlatVector::GetData<dtime_ns_t>(vector)[index]);
 	case LogicalTypeId::TIME_TZ:
-		return Value::TIMETZ(reinterpret_cast<dtime_tz_t *>(data)[index]);
+		return Value::TIMETZ(FlatVector::GetData<dtime_tz_t>(vector)[index]);
 	case LogicalTypeId::BIGINT:
-		return Value::BIGINT(reinterpret_cast<int64_t *>(data)[index]);
+		return Value::BIGINT(FlatVector::GetData<int64_t>(vector)[index]);
 	case LogicalTypeId::UTINYINT:
-		return Value::UTINYINT(reinterpret_cast<uint8_t *>(data)[index]);
+		return Value::UTINYINT(FlatVector::GetData<uint8_t>(vector)[index]);
 	case LogicalTypeId::USMALLINT:
-		return Value::USMALLINT(reinterpret_cast<uint16_t *>(data)[index]);
+		return Value::USMALLINT(FlatVector::GetData<uint16_t>(vector)[index]);
 	case LogicalTypeId::UINTEGER:
-		return Value::UINTEGER(reinterpret_cast<uint32_t *>(data)[index]);
+		return Value::UINTEGER(FlatVector::GetData<uint32_t>(vector)[index]);
 	case LogicalTypeId::UBIGINT:
-		return Value::UBIGINT(reinterpret_cast<uint64_t *>(data)[index]);
+		return Value::UBIGINT(FlatVector::GetData<uint64_t>(vector)[index]);
 	case LogicalTypeId::TIMESTAMP:
-		return Value::TIMESTAMP(reinterpret_cast<timestamp_t *>(data)[index]);
+		return Value::TIMESTAMP(FlatVector::GetData<timestamp_t>(vector)[index]);
 	case LogicalTypeId::TIMESTAMP_NS:
-		return Value::TIMESTAMPNS(reinterpret_cast<timestamp_ns_t *>(data)[index]);
+		return Value::TIMESTAMPNS(FlatVector::GetData<timestamp_ns_t>(vector)[index]);
 	case LogicalTypeId::TIMESTAMP_MS:
-		return Value::TIMESTAMPMS(reinterpret_cast<timestamp_ms_t *>(data)[index]);
+		return Value::TIMESTAMPMS(FlatVector::GetData<timestamp_ms_t>(vector)[index]);
 	case LogicalTypeId::TIMESTAMP_SEC:
-		return Value::TIMESTAMPSEC(reinterpret_cast<timestamp_sec_t *>(data)[index]);
+		return Value::TIMESTAMPSEC(FlatVector::GetData<timestamp_sec_t>(vector)[index]);
 	case LogicalTypeId::TIMESTAMP_TZ:
-		return Value::TIMESTAMPTZ(reinterpret_cast<timestamp_tz_t *>(data)[index]);
+		return Value::TIMESTAMPTZ(FlatVector::GetData<timestamp_tz_t>(vector)[index]);
 	case LogicalTypeId::HUGEINT:
-		return Value::HUGEINT(reinterpret_cast<hugeint_t *>(data)[index]);
+		return Value::HUGEINT(FlatVector::GetData<hugeint_t>(vector)[index]);
 	case LogicalTypeId::UHUGEINT:
-		return Value::UHUGEINT(reinterpret_cast<uhugeint_t *>(data)[index]);
+		return Value::UHUGEINT(FlatVector::GetData<uhugeint_t>(vector)[index]);
 	case LogicalTypeId::UUID:
-		return Value::UUID(reinterpret_cast<hugeint_t *>(data)[index]);
+		return Value::UUID(FlatVector::GetData<hugeint_t>(vector)[index]);
 	case LogicalTypeId::DECIMAL: {
 		auto width = DecimalType::GetWidth(type);
 		auto scale = DecimalType::GetScale(type);
 		switch (type.InternalType()) {
 		case PhysicalType::INT16:
-			return Value::DECIMAL(reinterpret_cast<int16_t *>(data)[index], width, scale);
+			return Value::DECIMAL(FlatVector::GetData<int16_t>(vector)[index], width, scale);
 		case PhysicalType::INT32:
-			return Value::DECIMAL(reinterpret_cast<int32_t *>(data)[index], width, scale);
+			return Value::DECIMAL(FlatVector::GetData<int32_t>(vector)[index], width, scale);
 		case PhysicalType::INT64:
-			return Value::DECIMAL(reinterpret_cast<int64_t *>(data)[index], width, scale);
+			return Value::DECIMAL(FlatVector::GetData<int64_t>(vector)[index], width, scale);
 		case PhysicalType::INT128:
-			return Value::DECIMAL(reinterpret_cast<hugeint_t *>(data)[index], width, scale);
+			return Value::DECIMAL(FlatVector::GetData<hugeint_t>(vector)[index], width, scale);
 		default:
 			throw InternalException("Physical type '%s' has a width bigger than 38, which is not supported",
 			                        TypeIdToString(type.InternalType()));
@@ -707,55 +699,55 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 	case LogicalTypeId::ENUM: {
 		switch (type.InternalType()) {
 		case PhysicalType::UINT8:
-			return Value::ENUM(reinterpret_cast<uint8_t *>(data)[index], type);
+			return Value::ENUM(FlatVector::GetData<uint8_t>(vector)[index], type);
 		case PhysicalType::UINT16:
-			return Value::ENUM(reinterpret_cast<uint16_t *>(data)[index], type);
+			return Value::ENUM(FlatVector::GetData<uint16_t>(vector)[index], type);
 		case PhysicalType::UINT32:
-			return Value::ENUM(reinterpret_cast<uint32_t *>(data)[index], type);
+			return Value::ENUM(FlatVector::GetData<uint32_t>(vector)[index], type);
 		default:
 			throw InternalException("ENUM can only have unsigned integers as physical types");
 		}
 	}
 	case LogicalTypeId::POINTER:
-		return Value::POINTER(reinterpret_cast<uintptr_t *>(data)[index]);
+		return Value::POINTER(FlatVector::GetData<uintptr_t>(vector)[index]);
 	case LogicalTypeId::FLOAT:
-		return Value::FLOAT(reinterpret_cast<float *>(data)[index]);
+		return Value::FLOAT(FlatVector::GetData<float>(vector)[index]);
 	case LogicalTypeId::DOUBLE:
-		return Value::DOUBLE(reinterpret_cast<double *>(data)[index]);
+		return Value::DOUBLE(FlatVector::GetData<double>(vector)[index]);
 	case LogicalTypeId::INTERVAL:
-		return Value::INTERVAL(reinterpret_cast<interval_t *>(data)[index]);
+		return Value::INTERVAL(FlatVector::GetData<interval_t>(vector)[index]);
 	case LogicalTypeId::VARCHAR: {
-		auto str = reinterpret_cast<string_t *>(data)[index];
+		auto str = FlatVector::GetData<string_t>(vector)[index];
 		return Value(str.GetString());
 	}
 	case LogicalTypeId::BLOB: {
-		auto str = reinterpret_cast<string_t *>(data)[index];
+		auto str = FlatVector::GetData<string_t>(vector)[index];
 		return Value::BLOB(const_data_ptr_cast(str.GetData()), str.GetSize());
 	}
 	case LogicalTypeId::BIGNUM: {
-		auto str = reinterpret_cast<bignum_t *>(data)[index];
+		auto str = FlatVector::GetData<bignum_t>(vector)[index];
 		return Value::BIGNUM(const_data_ptr_cast(str.data.GetData()), str.data.GetSize());
 	}
 	case LogicalTypeId::GEOMETRY: {
-		auto str = reinterpret_cast<string_t *>(data)[index];
+		auto str = FlatVector::GetData<string_t>(vector)[index];
 		if (GeoType::HasCRS(type)) {
 			return Value::GEOMETRY(const_data_ptr_cast(str.GetData()), str.GetSize(), GeoType::GetCRS(type));
 		}
 		return Value::GEOMETRY(const_data_ptr_cast(str.GetData()), str.GetSize());
 	}
 	case LogicalTypeId::LEGACY_AGGREGATE_STATE: {
-		auto str = reinterpret_cast<string_t *>(data)[index];
+		auto str = FlatVector::GetData<string_t>(vector)[index];
 		return Value::LEGACY_AGGREGATE_STATE(type, const_data_ptr_cast(str.GetData()), str.GetSize());
 	}
 	case LogicalTypeId::BIT: {
-		auto str = reinterpret_cast<string_t *>(data)[index];
+		auto str = FlatVector::GetData<string_t>(vector)[index];
 		return Value::BIT(const_data_ptr_cast(str.GetData()), str.GetSize());
 	}
 	case LogicalTypeId::SQLNULL: {
 		return Value();
 	}
 	case LogicalTypeId::MAP: {
-		auto offlen = reinterpret_cast<list_entry_t *>(data)[index];
+		auto offlen = FlatVector::GetData<list_entry_t>(vector)[index];
 		auto &child_vec = ListVector::GetEntry(vector);
 		duckdb::vector<Value> children;
 		for (idx_t i = offlen.offset; i < offlen.offset + offlen.length; i++) {
@@ -801,7 +793,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		return Value::STRUCT(type, std::move(children));
 	}
 	case LogicalTypeId::LIST: {
-		auto offlen = reinterpret_cast<list_entry_t *>(data)[index];
+		auto offlen = FlatVector::GetData<list_entry_t>(vector)[index];
 		auto &child_vec = ListVector::GetEntry(vector);
 		duckdb::vector<Value> children;
 		for (idx_t i = offlen.offset; i < offlen.offset + offlen.length; i++) {
@@ -820,7 +812,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		return Value::ARRAY(ArrayType::GetChildType(type), std::move(children));
 	}
 	case LogicalTypeId::TYPE: {
-		auto blob = reinterpret_cast<string_t *>(data)[index];
+		auto blob = FlatVector::GetData<string_t>(vector)[index];
 		return Value::TYPE(blob);
 	}
 	default:
@@ -876,8 +868,9 @@ string Vector::ToString(idx_t count) const {
 		}
 		break;
 	case VectorType::FSST_VECTOR: {
+		auto compressed_data = FSSTVector::GetCompressedData(*this);
 		for (idx_t i = 0; i < count; i++) {
-			string_t compressed_string = reinterpret_cast<string_t *>(data)[i];
+			string_t compressed_string = compressed_data[i];
 			auto decoder = FSSTVector::GetDecoder(*this);
 			auto &decompress_buffer = FSSTVector::GetDecompressBuffer(*this);
 			Value val = FSSTPrimitives::DecompressValue(decoder, compressed_string.GetData(),
@@ -996,14 +989,14 @@ void Vector::FlattenConstant(idx_t count) {
 	bool is_null = ConstantVector::IsNull(*this);
 	// allocate a new buffer for the vector
 	auto old_buffer = std::move(buffer);
-	auto old_data = data;
+	auto old_data = old_buffer ? old_buffer->GetData() : nullptr;
 	buffer = VectorBuffer::CreateStandardVector(type, MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count));
 	if (old_buffer) {
 		D_ASSERT(buffer->GetAuxiliaryData() == nullptr);
 		// The old buffer might be relying on the auxiliary data, keep it alive
 		buffer->MoveAuxiliaryData(*old_buffer);
 	}
-	data = buffer->GetData();
+	auto data = buffer->GetData();
 	vector_type = VectorType::FLAT_VECTOR;
 	if (is_null && GetType().InternalType() != PhysicalType::ARRAY) {
 		// constant NULL, set nullmask
@@ -1198,7 +1191,6 @@ void Vector::Flatten(idx_t count) {
 		auto seq_count = NumericCast<idx_t>(sequence_count);
 
 		buffer = VectorBuffer::CreateStandardVector(GetType(), MaxValue<idx_t>(STANDARD_VECTOR_SIZE, seq_count));
-		data = buffer->GetData();
 		VectorOperations::GenerateSequence(*this, seq_count, start, increment);
 		break;
 	}
@@ -1240,7 +1232,6 @@ void Vector::Flatten(const SelectionVector &sel, idx_t count) {
 		SequenceVector::GetSequence(*this, start, increment);
 
 		buffer = VectorBuffer::CreateStandardVector(GetType());
-		data = buffer->GetData();
 		VectorOperations::GenerateSequence(*this, count, sel, start, increment);
 		break;
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -346,12 +346,6 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 	}
 
 	switch (GetAuxiliary()->GetBufferType()) {
-	case VectorBufferType::LIST_BUFFER: {
-		auto &vector_list_buffer = auxiliary->Cast<VectorListBuffer>();
-		auto &child = vector_list_buffer.GetChild();
-		child.FindResizeInfos(resize_infos, multiplier);
-		break;
-	}
 	case VectorBufferType::STRUCT_BUFFER: {
 		auto &vector_struct_buffer = auxiliary->Cast<VectorStructBuffer>();
 		auto &children = vector_struct_buffer.GetChildren();

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -17,6 +17,7 @@ public:
 		case PhysicalType::LIST: {
 			// memory for the list offsets
 			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
+			data_ptr = owned_data.get();
 			// child data of the list
 			auto &child_type = ListType::GetChildType(type);
 			child_caches.push_back(make_buffer<VectorCacheBuffer>(allocator, child_type, capacity));
@@ -43,6 +44,7 @@ public:
 		}
 		default:
 			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
+			data_ptr = owned_data.get();
 			break;
 		}
 	}
@@ -55,9 +57,9 @@ public:
 		result.validity.Reset(capacity);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
-			result.data = owned_data.get();
 			// reinitialize the VectorListBuffer
 			AssignSharedPointer(result.auxiliary, auxiliary);
+			result.buffer->SetData(owned_data.get());
 			// propagate through child
 			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
 			auto &list_buffer = result.auxiliary->Cast<VectorListBuffer>();
@@ -70,8 +72,6 @@ public:
 			break;
 		}
 		case PhysicalType::ARRAY: {
-			// fixed size list does not have own data
-			result.data = nullptr;
 			// reinitialize the VectorArrayBuffer
 			// auxiliary->SetAuxiliaryData(nullptr);
 			AssignSharedPointer(result.auxiliary, auxiliary);
@@ -83,8 +83,6 @@ public:
 			break;
 		}
 		case PhysicalType::STRUCT: {
-			// struct does not have data
-			result.data = nullptr;
 			// reinitialize the VectorStructBuffer
 			auxiliary->SetAuxiliaryData(nullptr);
 			AssignSharedPointer(result.auxiliary, auxiliary);
@@ -98,8 +96,8 @@ public:
 		}
 		default:
 			// regular type: no aux data and reset data to cached data
-			result.data = owned_data.get();
 			result.auxiliary.reset();
+			result.buffer->SetData(owned_data.get());
 			break;
 		}
 	}
@@ -119,7 +117,7 @@ private:
 	AllocatedData owned_data;
 	//! Child caches (if any). Used for nested types.
 	vector<buffer_ptr<VectorBuffer>> child_caches;
-	//! Aux data for the vector (if any)
+	//! Aux data for the vector git (if any)
 	buffer_ptr<VectorBuffer> auxiliary;
 	//! Capacity of the vector
 	idx_t capacity;

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -57,9 +57,9 @@ public:
 		result.validity.Reset(capacity);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
+			result.buffer->SetData(owned_data.get());
 			// reinitialize the VectorListBuffer
 			AssignSharedPointer(result.auxiliary, auxiliary);
-			result.buffer->SetData(owned_data.get());
 			// propagate through child
 			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
 			auto &list_buffer = result.auxiliary->Cast<VectorListBuffer>();
@@ -96,8 +96,8 @@ public:
 		}
 		default:
 			// regular type: no aux data and reset data to cached data
-			result.auxiliary.reset();
 			result.buffer->SetData(owned_data.get());
+			result.auxiliary.reset();
 			break;
 		}
 	}
@@ -117,7 +117,7 @@ private:
 	AllocatedData owned_data;
 	//! Child caches (if any). Used for nested types.
 	vector<buffer_ptr<VectorBuffer>> child_caches;
-	//! Aux data for the vector git (if any)
+	//! Aux data for the vector (if any)
 	buffer_ptr<VectorBuffer> auxiliary;
 	//! Capacity of the vector
 	idx_t capacity;

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/vector/dictionary_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -18,15 +18,14 @@ const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	auto &child = input.auxiliary->Cast<VectorChildBuffer>();
 	lock_guard<mutex> guard(child.cached_hashes_lock);
 
-	auto data_ptr = FlatVector::GetData(child.cached_hashes);
-	if (!data_ptr) {
+	if (!child.cached_hashes) {
 		// Uninitialized: hash the dictionary
 		const auto dictionary_size = DictionarySize(input).GetIndex();
 		D_ASSERT(!child.size.IsValid() || child.size.GetIndex() == dictionary_size);
-		child.cached_hashes.Initialize(false, dictionary_size);
-		VectorOperations::Hash(child.data, child.cached_hashes, dictionary_size);
+		child.cached_hashes = make_uniq<Vector>(LogicalType::HASH, dictionary_size);
+		VectorOperations::Hash(child.data, *child.cached_hashes, dictionary_size);
 	}
-	return child.cached_hashes;
+	return *child.cached_hashes;
 }
 
 } // namespace duckdb

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -17,7 +17,8 @@ const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	auto &child = input.auxiliary->Cast<VectorChildBuffer>();
 	lock_guard<mutex> guard(child.cached_hashes_lock);
 
-	if (!child.cached_hashes.data) {
+	auto data_ptr = FlatVector::GetData(child.cached_hashes);
+	if (!data_ptr) {
 		// Uninitialized: hash the dictionary
 		const auto dictionary_size = DictionarySize(input).GetIndex();
 		D_ASSERT(!child.size.IsValid() || child.size.GetIndex() == dictionary_size);

--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -84,7 +84,7 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 	D_ASSERT(src.GetVectorType() == VectorType::FSST_VECTOR);
 	D_ASSERT(dst.GetVectorType() == VectorType::FLAT_VECTOR);
 	auto dst_mask = FlatVector::Validity(dst);
-	auto ldata = FSSTVector::GetCompressedData<string_t>(src);
+	auto ldata = FSSTVector::GetCompressedData(src);
 	auto tdata = FlatVector::GetData<string_t>(dst);
 	auto &str_buffer = StringVector::GetStringBuffer(dst);
 	for (idx_t i = 0; i < copy_count; i++) {

--- a/src/common/vector/unified_vector_format.cpp
+++ b/src/common/vector/unified_vector_format.cpp
@@ -31,4 +31,11 @@ UnifiedVectorFormat &UnifiedVectorFormat::operator=(UnifiedVectorFormat &&other)
 	return *this;
 }
 
+ResizeInfo::ResizeInfo(Vector &vec, optional_ptr<VectorBuffer> buffer, const idx_t multiplier)
+    : vec(vec), data(nullptr), buffer(buffer), multiplier(multiplier) {
+	if (buffer) {
+		data = buffer->GetData();
+	}
+}
+
 } // namespace duckdb

--- a/src/common/vector/unified_vector_format.cpp
+++ b/src/common/vector/unified_vector_format.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/vector/unified_vector_format.hpp"
+#include "duckdb/common/types/vector_buffer.hpp"
 
 namespace duckdb {
 

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -163,7 +163,7 @@ void ExpressionExecutor::Verify(const Expression &expr, Vector &vector, idx_t co
 		if (TypeVisitor::Contains(vector.GetType(), [](const LogicalType &type) {
 			    if (type.IsJSONType() || type.id() == LogicalTypeId::VARIANT || type.id() == LogicalTypeId::UNION ||
 			        type.id() == LogicalTypeId::ENUM || type.id() == LogicalTypeId::LEGACY_AGGREGATE_STATE ||
-			        type.id() == LogicalTypeId::AGGREGATE_STATE) {
+			        type.id() == LogicalTypeId::AGGREGATE_STATE || type.id() == LogicalTypeId::TYPE) {
 				    return true;
 			    }
 			    if (type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(type)) {

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -10,11 +10,10 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	const auto list_size = ListVector::GetListSize(input);
 	ListVector::SetListSize(result, list_size);
 
-	UnifiedVectorFormat input_data;
-	input.ToUnifiedFormat(count, input_data);
+	input.Flatten(count);
 
 	// Copy the list validity
-	FlatVector::SetValidity(result, input_data.validity);
+	FlatVector::SetValidity(result, FlatVector::Validity(input));
 
 	// Copy the struct validity
 	UnifiedVectorFormat input_struct_data;
@@ -32,10 +31,6 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &input_values = MapVector::GetValues(input);
 	auto &result_values = MapVector::GetValues(result);
 	result_values.Reference(input_values);
-
-	if (input.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		result.Slice(*input_data.sel, count);
-	}
 
 	// Set the right vector type
 	result.SetVectorType(input.GetVectorType());

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -6,11 +6,11 @@
 namespace duckdb {
 
 void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
+	input.Flatten(count);
+
 	// Copy the list size
 	const auto list_size = ListVector::GetListSize(input);
 	ListVector::SetListSize(result, list_size);
-
-	input.Flatten(count);
 
 	// Copy the list validity
 	FlatVector::SetValidity(result, FlatVector::Validity(input));

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -152,7 +152,6 @@ public:
 
 	inline void CopyBuffer(Vector &other) {
 		buffer = other.buffer;
-		data = other.data;
 	}
 
 	//! Resizes the vector.
@@ -171,9 +170,6 @@ public:
 	}
 	inline const LogicalType &GetType() const {
 		return type;
-	}
-	inline data_ptr_t GetData() const {
-		return data;
 	}
 
 	inline buffer_ptr<VectorBuffer> GetAuxiliary() {
@@ -207,8 +203,6 @@ protected:
 	VectorType vector_type;
 	//! The type of the elements stored in the vector (e.g. integer, float)
 	LogicalType type;
-	//! A pointer to the data.
-	data_ptr_t data;
 	//! The validity mask of the vector
 	ValidityMask validity;
 	//! The main buffer holding the data of the vector

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -216,8 +216,7 @@ protected:
 class VectorChildBuffer : public VectorBuffer {
 public:
 	explicit VectorChildBuffer(Vector vector)
-	    : VectorBuffer(VectorBufferType::VECTOR_CHILD_BUFFER), data(std::move(vector)),
-	      cached_hashes(LogicalType::HASH, nullptr) {
+	    : VectorBuffer(VectorBufferType::VECTOR_CHILD_BUFFER), data(std::move(vector)) {
 	}
 
 public:
@@ -227,7 +226,7 @@ public:
 	string id;
 	//! For caching the hashes of a child buffer
 	mutex cached_hashes_lock;
-	Vector cached_hashes;
+	unique_ptr<Vector> cached_hashes;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -69,15 +69,20 @@ public:
 //! The VectorBuffer is a class used by the vector to hold its data
 class VectorBuffer {
 public:
-	explicit VectorBuffer(VectorBufferType type) : buffer_type(type) {
+	explicit VectorBuffer(VectorBufferType type) : buffer_type(type), data_ptr(nullptr) {
 	}
-	explicit VectorBuffer(idx_t data_size) : buffer_type(VectorBufferType::STANDARD_BUFFER) {
+	explicit VectorBuffer(idx_t data_size) : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
 		if (data_size > 0) {
-			data = Allocator::DefaultAllocator().Allocate(data_size);
+			allocated_data = Allocator::DefaultAllocator().Allocate(data_size);
+			data_ptr = allocated_data.get();
 		}
 	}
+	explicit VectorBuffer(data_ptr_t data_ptr_p)
+	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
+	}
 	explicit VectorBuffer(AllocatedData &&data_p)
-	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data(std::move(data_p)) {
+	    : buffer_type(VectorBufferType::STANDARD_BUFFER), allocated_data(std::move(data_p)) {
+		data_ptr = allocated_data.get();
 	}
 	virtual ~VectorBuffer() {
 	}
@@ -86,11 +91,17 @@ public:
 
 public:
 	data_ptr_t GetData() {
-		return data.get();
+		return data_ptr;
 	}
 
 	void SetData(AllocatedData &&new_data) {
-		data = std::move(new_data);
+		allocated_data = std::move(new_data);
+		data_ptr = allocated_data.get();
+	}
+
+	void SetData(data_ptr_t data) {
+		data_ptr = data;
+		allocated_data.Reset();
 	}
 
 	VectorAuxiliaryData *GetAuxiliaryData() {
@@ -106,7 +117,7 @@ public:
 	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
-		return data.GetAllocator();
+		return allocated_data.GetAllocator();
 	}
 
 	static buffer_ptr<VectorBuffer> CreateStandardVector(PhysicalType type, idx_t capacity = STANDARD_VECTOR_SIZE);
@@ -126,7 +137,8 @@ public:
 protected:
 	VectorBufferType buffer_type;
 	unique_ptr<VectorAuxiliaryData> aux_data;
-	AllocatedData data;
+	data_ptr_t data_ptr;
+	AllocatedData allocated_data;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/vector/constant_vector.hpp
+++ b/src/include/duckdb/common/vector/constant_vector.hpp
@@ -28,12 +28,12 @@ struct ConstantVector {
 	static inline const_data_ptr_t GetData(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR ||
 		         vector.GetVectorType() == VectorType::FLAT_VECTOR);
-		return vector.data;
+		return vector.buffer ? vector.buffer->GetData() : nullptr;
 	}
 	static inline data_ptr_t GetData(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR ||
 		         vector.GetVectorType() == VectorType::FLAT_VECTOR);
-		return vector.data;
+		return vector.buffer ? vector.buffer->GetData() : nullptr;
 	}
 	template <class T>
 	static inline const T *GetDataUnsafe(const Vector &vector) {

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -44,12 +44,12 @@ struct FlatVector {
 		return ConstantVector::GetDataUnsafe<T>(vector);
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
-		D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
-		vector.data = data;
+		VerifyFlatVector(vector);
+		vector.buffer->SetData(data);
 	}
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {
-		D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+		VerifyFlatVector(vector);
 		return FlatVector::GetData<T>(vector)[idx];
 	}
 	static inline const ValidityMask &Validity(const Vector &vector) {

--- a/src/include/duckdb/common/vector/fsst_vector.hpp
+++ b/src/include/duckdb/common/vector/fsst_vector.hpp
@@ -53,21 +53,13 @@ struct FSSTVector {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
 		vector.validity.Initialize(new_validity);
 	}
-	static inline const_data_ptr_t GetCompressedData(const Vector &vector) {
+	static inline const string_t *GetCompressedData(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return vector.data;
+		return reinterpret_cast<string_t *>(vector.buffer->GetData());
 	}
-	static inline data_ptr_t GetCompressedData(Vector &vector) {
+	static inline string_t *GetCompressedData(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return vector.data;
-	}
-	template <class T>
-	static inline const T *GetCompressedData(const Vector &vector) {
-		return (const T *)FSSTVector::GetCompressedData(vector);
-	}
-	template <class T>
-	static inline T *GetCompressedData(Vector &vector) {
-		return (T *)FSSTVector::GetCompressedData(vector);
+		return reinterpret_cast<string_t *>(vector.buffer->GetData());
 	}
 	//! Decompresses an FSST_VECTOR into a FLAT_VECTOR. Note: validity is not copied.
 	static void DecompressVector(const Vector &src, Vector &dst, idx_t src_offset, idx_t dst_offset, idx_t copy_count,

--- a/src/include/duckdb/common/vector/unified_vector_format.hpp
+++ b/src/include/duckdb/common/vector/unified_vector_format.hpp
@@ -95,9 +95,7 @@ struct UnifiedVariantVector {
 
 //! This is a helper data structure. It contains all fields necessary to resize a vector.
 struct ResizeInfo {
-	ResizeInfo(Vector &vec, data_ptr_t data, optional_ptr<VectorBuffer> buffer, const idx_t multiplier)
-	    : vec(vec), data(data), buffer(buffer), multiplier(multiplier) {
-	}
+	ResizeInfo(Vector &vec, optional_ptr<VectorBuffer> buffer, const idx_t multiplier);
 
 	Vector &vec;
 	data_ptr_t data;

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -673,7 +673,7 @@ void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &sta
 			result.SetVectorType(VectorType::FSST_VECTOR);
 			auto string_block_limit = StringUncompressed::GetStringBlockLimit(segment.GetBlockSize());
 			FSSTVector::RegisterDecoder(result, scan_state.duckdb_fsst_decoder, string_block_limit);
-			result_data = FSSTVector::GetCompressedData<string_t>(result);
+			result_data = FSSTVector::GetCompressedData(result);
 		} else {
 			D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 			result_data = FlatVector::GetData<string_t>(result);

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -220,21 +220,19 @@ void ExtractValidityMaskToData(Vector &src, Vector &dst, idx_t offset, idx_t sca
 	// Get src's validity mask
 	auto &validity = FlatVector::Validity(src);
 
-	auto write_ptr = dst.GetData() + offset;
+	auto write_ptr = FlatVector::GetData<uint8_t>(dst) + offset;
 	if (validity.AllValid()) {
 		memset(write_ptr, 1, scan_count); // 1 is for valid
 	} else if (scan_count % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE == 0) {
 		// "Bit-Unpack" src's validity_mask and put it in dst's data
-		BitpackingPrimitives::UnPackBuffer<uint8_t>(dst.GetData() + offset, data_ptr_cast(validity.GetData()),
-		                                            scan_count, 1);
+		BitpackingPrimitives::UnPackBuffer<uint8_t>(write_ptr, data_ptr_cast(validity.GetData()), scan_count, 1);
 	} else {
 		// Because UnPackBuffer writes in batches of BITPACKING_ALGORITHM_GROUP_SIZE, we create a tmp_buffer first to
 		// prevent overflow in the case dst is smaller than the batch.
-		const auto tmp_buffer =
-		    Vector(dst.GetType(), AlignValue<idx_t, BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE>(scan_count));
-		BitpackingPrimitives::UnPackBuffer<uint8_t>(tmp_buffer.GetData(), data_ptr_cast(validity.GetData()), scan_count,
-		                                            1);
-		memcpy(write_ptr, tmp_buffer.GetData(), scan_count);
+		auto tmp_data = make_uniq_array<uint8_t>(
+		    AlignValue<idx_t, BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE>(scan_count));
+		BitpackingPrimitives::UnPackBuffer<uint8_t>(tmp_data.get(), data_ptr_cast(validity.GetData()), scan_count, 1);
+		memcpy(write_ptr, tmp_data.get(), scan_count);
 	}
 }
 void RoaringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,


### PR DESCRIPTION
Currently the `Vector` class has a `data_ptr_t data` member. However, this data member is not used in many cases and doesn't make sense in many cases, e.g.:

* Dictionary vectors
* Array / struct type vectors

Rather than having this on the generic vector this PR moves it into the `VectorBuffer` class.