### PR TITLE
Fix off-by-one error in PropagateStatistics for date_part

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -340,7 +340,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<1, 53>(input.child_stats);
 		}
 	};
 
@@ -429,7 +429,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999999>(input.child_stats);
 		}
 	};
 
@@ -441,7 +441,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999>(input.child_stats);
 		}
 	};
 
@@ -453,7 +453,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999>(input.child_stats);
 		}
 	};
 
@@ -465,7 +465,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 
@@ -477,7 +477,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 

--- a/test/sql/function/date/date_part_stats.test
+++ b/test/sql/function/date/date_part_stats.test
@@ -107,19 +107,19 @@ CREATE TABLE expected_result AS FROM (VALUES
 	('decade', 199, 200),
 	('century', 20, 20),
 	('millenium', 2, 2),
-	('microseconds', 0, 60000000),
-	('milliseconds', 0, 60000),
-	('second', 0, 60),
-	('minute', 0, 60),
+	('microseconds', 0, 59999999),
+	('milliseconds', 0, 59999),
+	('second', 0, 59),
+	('minute', 0, 59),
 	('hour', 0, 24),
 	('dow', 0, 6),
-	('week', 1, 54),
+	('week', 1, 53),
 	('doy', 1, 366),
 	('quarter', 1, 4),
 	('yearweek', 199201, 200052),
 	('dayofmonth', 1, 31),
 	('weekday', 0, 6),
-	('weekofyear', 1, 54)
+	('weekofyear', 1, 53)
 	) t(component, min, max)
 
 foreach component year month day decade century millenium microseconds milliseconds second minute hour dow week doy quarter yearweek dayofmonth weekday weekofyear

--- a/test/sql/function/time/test_extract_stats.test
+++ b/test/sql/function/time/test_extract_stats.test
@@ -16,10 +16,10 @@ PRAGMA disable_verification
 
 statement ok
 CREATE TABLE expected_result AS FROM (VALUES
-	('microseconds', 0, 60000000),
-	('milliseconds', 0, 60000),
-	('second', 0, 60),
-	('minute', 0, 60),
+	('microseconds', 0, 59999999),
+	('milliseconds', 0, 59999),
+	('second', 0, 59),
+	('minute', 0, 59),
 	('hour', 0, 24),
 	('epoch', 0, 86400)
 	) t(component, min, max)


### PR DESCRIPTION
Fix #21478

  Several `date_part` operators in `PropagateStatistics` have their upper bounds set 1 higher than the actual maximum values. This prevents the optimizer from pruning impossible filter conditions into `EMPTY_RESULT`.

  For example, `WHERE extract(week FROM d) = 54` should be pruned (ISO weeks are 1–53), but the current bound of 54 allows it through as a full table scan.

  ### Corrected bounds

  | Operator | Before | After |
  |---|---|---|
  | week | 54 | 53 |
  | minute | 60 | 59 |
  | second | 60 | 59 |
  | millisecond | 60000 | 59999 |
  | microsecond | 60000000 | 59999999 |
  | nanosecond | 60000000000 | 59999999999 |

  Other operators in the same file (month, day, quarter, hour, etc.) already use correct inclusive bounds — this change makes the above six consistent.

  ## Test plan

  - [x] Updated expected bounds in `test/sql/function/date/date_part_stats.test`
  - [x] Updated expected bounds in `test/sql/function/time/test_extract_stats.test`
  - [x] Verified locally: both test files pass with corrected value