### PR TITLE
Fix FK reference resolution for external catalogs

### DIFF
--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -554,9 +554,12 @@ static void BindCreateTableConstraints(CreateTableInfo &create_info, CatalogEntr
 			continue;
 		}
 
-		// Resolve the table reference.
+		// Resolve the table reference in the same catalog/schema as the table being
+		// created, so FK references work for external catalogs (not just the default).
+		string fk_catalog = fk.info.schema.empty() ? schema.ParentCatalog().GetName() : INVALID_CATALOG;
+		string fk_schema = fk.info.schema.empty() ? schema.name : fk.info.schema;
 		EntryLookupInfo table_lookup(CatalogType::TABLE_ENTRY, fk.info.table);
-		auto table_entry = entry_retriever.GetEntry(INVALID_CATALOG, fk.info.schema, table_lookup);
+		auto table_entry = entry_retriever.GetEntry(fk_catalog, fk_schema, table_lookup);
 		if (table_entry->type == CatalogType::VIEW_ENTRY) {
 			throw BinderException("cannot reference a VIEW with a FOREIGN KEY");
 		}

--- a/test/sql/attach/attach_foreign_key.test
+++ b/test/sql/attach/attach_foreign_key.test
@@ -11,7 +11,7 @@ CREATE TABLE album(artistid INTEGER, albumname TEXT, albumcover TEXT, UNIQUE (ar
 statement error
 CREATE TABLE db1.song(songid INTEGER, songartist INTEGER, songalbum TEXT, songname TEXT, FOREIGN KEY(songartist, songalbum) REFERENCES album(artistid, albumname));
 ----
-across different schemas or catalogs
+Table with name album does not exist
 
 statement ok
 USE db1;

--- a/test/sql/attach/attach_foreign_key_external_catalog.test
+++ b/test/sql/attach/attach_foreign_key_external_catalog.test
@@ -1,0 +1,69 @@
+# name: test/sql/attach/attach_foreign_key_external_catalog.test
+# description: Test that foreign key constraints resolve correctly in attached external catalogs
+# group: [attach]
+
+# attach an external database file
+statement ok
+ATTACH '__TEST_DIR__/fk_external.duckdb' AS ext;
+
+# create the referenced table in the external catalog
+statement ok
+CREATE TABLE ext.artist(id INTEGER PRIMARY KEY, name TEXT);
+
+# create a table with an unqualified FK reference - should resolve in the same catalog
+statement ok
+CREATE TABLE ext.album(id INTEGER PRIMARY KEY, artist_id INTEGER, title TEXT, FOREIGN KEY(artist_id) REFERENCES artist(id));
+
+# insert valid data
+statement ok
+INSERT INTO ext.artist VALUES (1, 'Alice'), (2, 'Bob');
+
+statement ok
+INSERT INTO ext.album VALUES (100, 1, 'First Album'), (101, 2, 'Second Album');
+
+# FK constraint is enforced: inserting a reference to a non-existent artist should fail
+statement error
+INSERT INTO ext.album VALUES (102, 999, 'Bad Album');
+----
+Constraint Error
+
+# FK constraint is enforced: deleting a referenced artist should fail
+statement error
+DELETE FROM ext.artist WHERE id = 1;
+----
+Constraint Error
+
+# create a second table with a composite FK in the external catalog
+statement ok
+CREATE TABLE ext.track(id INTEGER PRIMARY KEY, album_id INTEGER, artist_id INTEGER, title TEXT, FOREIGN KEY(album_id) REFERENCES album(id), FOREIGN KEY(artist_id) REFERENCES artist(id));
+
+statement ok
+INSERT INTO ext.track VALUES (1000, 100, 1, 'Track One'), (1001, 101, 2, 'Track Two');
+
+# composite FK enforcement works
+statement error
+INSERT INTO ext.track VALUES (1002, 999, 1, 'Bad Track');
+----
+Constraint Error
+
+# cross-catalog FK should still fail: table in ext referencing table in default catalog
+statement ok
+CREATE TABLE main_table(id INTEGER PRIMARY KEY);
+
+statement error
+CREATE TABLE ext.cross_ref(id INTEGER, ref_id INTEGER, FOREIGN KEY(ref_id) REFERENCES main_table(id));
+----
+Table with name main_table does not exist
+
+# clean up
+statement ok
+DROP TABLE ext.track;
+
+statement ok
+DROP TABLE ext.album;
+
+statement ok
+DROP TABLE ext.artist;
+
+statement ok
+DETACH ext;


### PR DESCRIPTION
## Summary

When creating a table in an external catalog with a `FOREIGN KEY` constraint referencing another table in the same catalog (e.g., `CREATE TABLE ext.main.orders (... REFERENCES products(id))`), the binder resolved the referenced table using the default catalog search path instead of the catalog where the table is being created.

This caused "Table does not exist" errors for FK constraints on tables in attached external catalogs, even when the referenced table exists in the same catalog and schema.

## Fix

In `BindCreateTableConstraints`, when the FK reference has no explicit schema qualifier, resolve it in the same catalog and schema as the table being created, rather than passing `INVALID_CATALOG` which triggers the default search path.

**Before:** `entry_retriever.GetEntry(INVALID_CATALOG, fk.info.schema, table_lookup)`

**After:** Uses `schema.ParentCatalog().GetName()` and `schema.name` when no explicit schema is provided.

## Reproduction

```sql
ATTACH 'ext_catalog' AS ext (TYPE some_extension);
CREATE TABLE ext.main.products (id BIGINT NOT NULL UNIQUE, name VARCHAR);
CREATE TABLE ext.main.orders (id BIGINT, product_id BIGINT REFERENCES products(id));
-- ERROR: Table with name products does not exist!
```

After fix, the unqualified `REFERENCES products(id)` correctly resolves within the `ext` catalog.