### PR TITLE
Windows shell: enable VT100 processing on startup

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3026,6 +3026,23 @@ void ShellState::Initialize() {
 		linenoiseSetPrompt(continuePrompt, continuePromptSelected, scrollUpPrompt, scrollDownPrompt);
 	}
 #endif
+#if defined(_WIN32) || defined(WIN32)
+	if (stdout_is_console) {
+		// On Windows virtual terminal processing may be disabled by default,
+		// we need it enabled (even when highlighting is off) to process
+		// ANSI escape sequences, for example the position of the cursor.
+		HANDLE out_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+		if (out_handle != INVALID_HANDLE_VALUE) {
+			DWORD mode = 0;
+			if (GetConsoleMode(out_handle, &mode)) {
+				if (!(mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+					mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+					SetConsoleMode(out_handle, mode);
+				}
+			}
+		}
+	}
+#endif
 }
 
 void ShellState::DetectDarkLightMode() {


### PR DESCRIPTION
On Windows the main CLI shell is the Windows Terminal. Its rendering library is also used in other terminals for example inside Visual Studio.

On Windows 11 when the Command Prompt or PowerShell is launched, the Windows Terminal is used by default in most cases, except when PowerShell Administrator session is launched. In the latter case, the older `conhost.exe` terminal is used instead.

This `conhost.exe` does not enable processing of the [Console Virtual Terminal Sequences](https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) (VT100 and others) by default, that causes broken prompt highligting and incorrect cursor position behaviour (even when highlighting is disabled).

This PR enables processing of the virtual terminal sequences on startup. If the terminal application does not support virtual terminal sequences, this change should not have any effect.

The enabled flag is not persistent in console between `duckdb.exe` runs and does not need to be reset on exit.

Testing: checked the behaviour with `conhost.exe`, Windows Terminal and MinTTY.

Fixes: #21571
Fixes: #21585