### PR TITLE
Fix race condition: successful COMMIT incorrectly reported as interrupted

### DIFF
--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -127,7 +127,7 @@ void DSDGenWrapper::DSDGen(double scale, ClientContext &context, string catalog_
 		assert(builder_func);
 
 		for (ds_key_t i = k_first_row; k_row_count; i++, k_row_count--) {
-			if (k_row_count % 1000 == 0 && context.interrupted) {
+			if (k_row_count % 1000 == 0 && context.IsInterrupted()) {
 				throw InterruptException();
 			}
 			// append happens directly in builders since they dump child tables

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -257,7 +257,7 @@ static void gen_tbl(ClientContext &context, int tnum, DSS_HUGE count, tpch_appen
 	code_t code;
 
 	for (DSS_HUGE i = offset + 1; count; count--, i++) {
-		if (count % 1000 == 0 && context.interrupted) {
+		if (count % 1000 == 0 && context.IsInterrupted()) {
 			return;
 		}
 		row_start(tnum, dbgen_ctx);
@@ -520,7 +520,7 @@ public:
 				} else {
 					rowcnt = dbgen_ctx.tdefs[i].base;
 				}
-				if (context.interrupted) {
+				if (context.IsInterrupted()) {
 					return;
 				}
 				if (children > 1 && current_step != -1) {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -135,6 +135,7 @@
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/main/extension.hpp"
 #include "duckdb/main/extension_helper.hpp"
@@ -1078,6 +1079,25 @@ const char* EnumUtil::ToChars<ChunkInfoType>(ChunkInfoType value) {
 template<>
 ChunkInfoType EnumUtil::FromString<ChunkInfoType>(const char *value) {
 	return static_cast<ChunkInfoType>(StringUtil::StringToEnum(GetChunkInfoTypeValues(), 3, "ChunkInfoType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetClientInterruptStateValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ClientInterruptState::NOT_INTERRUPTED), "NOT_INTERRUPTED" },
+		{ static_cast<uint32_t>(ClientInterruptState::INTERRUPTED), "INTERRUPTED" },
+		{ static_cast<uint32_t>(ClientInterruptState::INTERRUPTS_SUPPRESSED), "INTERRUPTS_SUPPRESSED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ClientInterruptState>(ClientInterruptState value) {
+	return StringUtil::EnumToString(GetClientInterruptStateValues(), 3, "ClientInterruptState", static_cast<uint32_t>(value));
+}
+
+template<>
+ClientInterruptState EnumUtil::FromString<ClientInterruptState>(const char *value) {
+	return static_cast<ClientInterruptState>(StringUtil::StringToEnum(GetClientInterruptStateValues(), 3, "ClientInterruptState", value));
 }
 
 const StringUtil::EnumStringLiteral *GetColumnDataAllocatorTypeValues() {

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -332,7 +332,7 @@ bool LazyMultiFileList::ExpandNextPathInternal() const {
 	if (all_files_expanded) {
 		return false;
 	}
-	if (context && context->interrupted) {
+	if (context && context->IsInterrupted()) {
 		throw InterruptException();
 	}
 	if (!ExpandNextPath()) {

--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -218,9 +218,9 @@ template <class SORT_KEY>
 struct SkaExtractKey {
 	using result_type = uint64_t;
 	SkaExtractKey(bool requires_next_sort_p, idx_t ska_sort_width_p, const vector<idx_t> &sort_skippable_bytes_p,
-	              atomic<bool> &interrupted_p)
+	              atomic<ClientInterruptState> &interrupt_state_p)
 	    : requires_next_sort(requires_next_sort_p), ska_sort_width(ska_sort_width_p),
-	      sort_skippable_bytes(sort_skippable_bytes_p), interrupted(interrupted_p) {
+	      sort_skippable_bytes(sort_skippable_bytes_p), interrupt_state(interrupt_state_p) {
 	}
 
 	const result_type &operator()(const SORT_KEY &key) const {
@@ -233,13 +233,13 @@ struct SkaExtractKey {
 	}
 
 	bool Interrupted() const {
-		return interrupted.load(std::memory_order_relaxed);
+		return interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED;
 	}
 
 	bool requires_next_sort;
 	idx_t ska_sort_width;
 	const vector<idx_t> &sort_skippable_bytes;
-	atomic<bool> &interrupted;
+	atomic<ClientInterruptState> &interrupt_state;
 };
 
 template <SortKeyType SORT_KEY_TYPE>
@@ -259,7 +259,7 @@ static void TemplatedSort(ClientContext &context, const TupleDataCollection &key
 	const auto ska_sort_width = MinValue<idx_t>(layout.GetSortWidth(), sizeof(uint64_t));
 	const auto &sort_skippable_bytes = layout.GetSortSkippableBytes();
 	auto ska_extract_key =
-	    SkaExtractKey<SORT_KEY>(requires_next_sort, ska_sort_width, sort_skippable_bytes, context.interrupted);
+	    SkaExtractKey<SORT_KEY>(requires_next_sort, ska_sort_width, sort_skippable_bytes, context.interrupt_state);
 
 	const auto fallback = [ska_extract_key](const BLOCK_ITERATOR &fb_begin, const BLOCK_ITERATOR &fb_end) {
 		duckdb_ska_sort::ska_sort(fb_begin, fb_end, ska_extract_key);

--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -52,6 +52,12 @@ SourceResultType PhysicalTransaction::GetDataInternal(ExecutionContext &context,
 		} else {
 			// explicitly commit the current transaction
 			client.transaction.Commit();
+			// Suppress further interrupts for the remainder of this query.
+			// A committed transaction is irreversible. If a concurrent Interrupt()
+			// arrives after the physical commit, it must be silently discarded —
+			// otherwise the caller sees a failed COMMIT even though the data
+			// is already durably committed.
+			client.SuppressInterrupts();
 		}
 		break;
 	}

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -118,6 +118,8 @@ enum class CheckpointAbort : uint8_t;
 
 enum class ChunkInfoType : uint8_t;
 
+enum class ClientInterruptState : uint8_t;
+
 enum class ColumnDataAllocatorType : uint8_t;
 
 enum class ColumnDataScanProperties : uint8_t;
@@ -643,6 +645,9 @@ const char* EnumUtil::ToChars<CheckpointAbort>(CheckpointAbort value);
 
 template<>
 const char* EnumUtil::ToChars<ChunkInfoType>(ChunkInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<ClientInterruptState>(ClientInterruptState value);
 
 template<>
 const char* EnumUtil::ToChars<ColumnDataAllocatorType>(ColumnDataAllocatorType value);
@@ -1367,6 +1372,9 @@ CheckpointAbort EnumUtil::FromString<CheckpointAbort>(const char *value);
 
 template<>
 ChunkInfoType EnumUtil::FromString<ChunkInfoType>(const char *value);
+
+template<>
+ClientInterruptState EnumUtil::FromString<ClientInterruptState>(const char *value);
 
 template<>
 ColumnDataAllocatorType EnumUtil::FromString<ColumnDataAllocatorType>(const char *value);

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -62,6 +62,9 @@ struct PendingQueryParameters {
 	QueryParameters query_parameters;
 };
 
+//! Interrupt state for the client context
+enum class ClientInterruptState : uint8_t { NOT_INTERRUPTED, INTERRUPTED, INTERRUPTS_SUPPRESSED };
+
 //! The ClientContext holds information relevant to the current client session
 //! during execution
 class ClientContext : public enable_shared_from_this<ClientContext> {
@@ -78,8 +81,8 @@ public:
 
 	//! The database that this client is connected to
 	shared_ptr<DatabaseInstance> db;
-	//! Whether or not the query is interrupted
-	atomic<bool> interrupted;
+	//! Interrupt state for the current query
+	atomic<ClientInterruptState> interrupt_state {ClientInterruptState::NOT_INTERRUPTED};
 	//! The deadline for the current query (milliseconds since epoch)
 	optional_idx query_deadline;
 	//! Set of optional states (e.g. Caches) that can be held by the ClientContext
@@ -102,6 +105,8 @@ public:
 	DUCKDB_API void Interrupt();
 	DUCKDB_API bool IsInterrupted() const;
 	DUCKDB_API void ClearInterrupt();
+	//! Suppress all further interrupts for the current query (called after irreversible operations like COMMIT)
+	DUCKDB_API void SuppressInterrupts();
 	DUCKDB_API void CancelTransaction();
 
 	//! Check for interrupt or timeout, throws InterruptException if triggered

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -57,7 +57,7 @@ StreamExecutionResult SimpleBufferedData::ExecuteTaskInternal(StreamQueryResult 
 	}
 	// Check for interrupt even if the buffer is full.
 	// Without this check, cancel requests would not be detected until the buffer is drained.
-	if (cc->interrupted.load(std::memory_order_relaxed)) {
+	if (cc->interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
 		throw InterruptException();
 	}
 	if (BufferIsFull()) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -166,7 +166,8 @@ struct DebugClientContextState : public ClientContextState {
 #endif
 
 ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
-    : db(std::move(database)), interrupted(false), transaction(*this), connection_id(DConstants::INVALID_INDEX) {
+    : db(std::move(database)), interrupt_state(ClientInterruptState::NOT_INTERRUPTED), transaction(*this),
+      connection_id(DConstants::INVALID_INDEX) {
 	registered_state = make_uniq<RegisteredStateManager>();
 #ifdef DEBUG
 	registered_state->GetOrCreate<DebugClientContextState>("debug_client_context_state");
@@ -701,7 +702,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 void ClientContext::InitialCleanup(ClientContextLock &lock) {
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
-	interrupted = false;
+	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 }
 
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatements(const string &query) {
@@ -1087,7 +1088,7 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 			}
 			// Reset the interrupted flag, this was set by the task that found the error
 			// Next statements should not be bothered by that interruption
-			interrupted = false;
+			interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 			return current_result;
 		}
 		// now append the result to the list of results
@@ -1193,15 +1194,20 @@ unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContext
 }
 
 void ClientContext::Interrupt() {
-	interrupted = true;
+	ClientInterruptState expected = ClientInterruptState::NOT_INTERRUPTED;
+	interrupt_state.compare_exchange_strong(expected, ClientInterruptState::INTERRUPTED);
 }
 
 bool ClientContext::IsInterrupted() const {
-	return interrupted;
+	return interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED;
 }
 
 void ClientContext::ClearInterrupt() {
-	interrupted = false;
+	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
+}
+
+void ClientContext::SuppressInterrupts() {
+	interrupt_state = ClientInterruptState::INTERRUPTS_SUPPRESSED;
 }
 
 void ClientContext::InterruptCheck() const {
@@ -1209,7 +1215,7 @@ void ClientContext::InterruptCheck() const {
 	static constexpr uint32_t TIMEOUT_CHECK_INTERVAL = 256;
 	thread_local uint32_t timeout_check_counter = 0;
 
-	if (interrupted.load(std::memory_order_relaxed)) {
+	if (interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
 		throw InterruptException();
 	}
 	// Only check timeout every N calls to avoid expensive steady_clock::now() syscall
@@ -1268,7 +1274,7 @@ void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, co
 	if (require_new_transaction) {
 		D_ASSERT(!active_query);
 		transaction.BeginTransaction();
-		interrupted = false;
+		interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 	}
 	try {
 		fun();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -673,7 +673,7 @@ void Executor::PushError(ErrorData exception) {
 	// push the exception onto the stack
 	error_manager.PushError(std::move(exception));
 	// interrupt execution of any other pipelines that belong to this executor
-	context.interrupted = true;
+	context.interrupt_state = ClientInterruptState::INTERRUPTED;
 }
 
 bool Executor::HasError() {

--- a/src/verification/prepared_statement_verifier.cpp
+++ b/src/verification/prepared_statement_verifier.cpp
@@ -104,7 +104,7 @@ bool PreparedStatementVerifier::Run(
 		failed = true;
 	}
 	run(string(), std::move(dealloc_statement), parameters);
-	context.interrupted = false;
+	context.interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 
 	return failed;
 }

--- a/src/verification/statement_verifier.cpp
+++ b/src/verification/statement_verifier.cpp
@@ -132,7 +132,7 @@ bool StatementVerifier::Run(
                                                 optional_ptr<case_insensitive_map_t<BoundParameterData>>)> &run) {
 	bool failed = false;
 
-	context.interrupted = false;
+	context.interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 	context.config.enable_optimizer = !DisableOptimizer();
 	context.config.enable_caching_operators = !DisableOperatorCaching();
 	context.config.force_external = ForceExternal();
@@ -147,7 +147,7 @@ bool StatementVerifier::Run(
 		failed = true;
 		materialized_result = make_uniq<MaterializedQueryResult>(ErrorData(ex));
 	}
-	context.interrupted = false;
+	context.interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 
 	return failed;
 }

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -814,3 +814,65 @@ TEST_CASE("Test buffer managed query result", "[api]") {
 	// Query result is no longer accessible
 	REQUIRE_THROWS(result->ToString());
 }
+
+TEST_CASE("Test ClientInterruptState suppresses interrupts after irreversible operations", "[api]") {
+	// Verify the three-state interrupt mechanism that prevents a completed COMMIT
+	// from being incorrectly reported as failed due to a late Interrupt() call.
+
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+
+	SECTION("Normal interrupt works") {
+		context.Interrupt();
+		REQUIRE(context.IsInterrupted());
+		REQUIRE_THROWS(context.InterruptCheck());
+		context.ClearInterrupt();
+		REQUIRE(!context.IsInterrupted());
+		REQUIRE_NOTHROW(context.InterruptCheck());
+	}
+
+	SECTION("SuppressInterrupts blocks subsequent Interrupt calls") {
+		context.SuppressInterrupts();
+		// Interrupt() uses CAS: NOT_INTERRUPTED -> INTERRUPTED
+		// Since state is SUPPRESSED, CAS fails and interrupt is discarded
+		context.Interrupt();
+		REQUIRE(!context.IsInterrupted());
+		REQUIRE_NOTHROW(context.InterruptCheck());
+		context.ClearInterrupt();
+	}
+
+	SECTION("SuppressInterrupts overrides a pending interrupt") {
+		context.Interrupt();
+		REQUIRE(context.IsInterrupted());
+		// SuppressInterrupts unconditionally stores SUPPRESSED,
+		// overriding the INTERRUPTED state
+		context.SuppressInterrupts();
+		REQUIRE(!context.IsInterrupted());
+		REQUIRE_NOTHROW(context.InterruptCheck());
+		context.ClearInterrupt();
+	}
+
+	SECTION("ClearInterrupt resets from SUPPRESSED to allow future interrupts") {
+		context.SuppressInterrupts();
+		context.ClearInterrupt();
+		// Now back to NOT_INTERRUPTED, Interrupt() should work again
+		context.Interrupt();
+		REQUIRE(context.IsInterrupted());
+		REQUIRE_THROWS(context.InterruptCheck());
+		context.ClearInterrupt();
+	}
+
+	SECTION("End-to-end: COMMIT suppresses interrupts") {
+		REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE suppress_test (x INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("COMMIT"));
+		// After COMMIT, state should be SUPPRESSED — Interrupt() should be discarded
+		context.Interrupt();
+		REQUIRE(!context.IsInterrupted());
+		REQUIRE_NOTHROW(context.InterruptCheck());
+		// Cleanup
+		context.ClearInterrupt();
+		REQUIRE_NO_FAIL(con.Query("DROP TABLE suppress_test"));
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a race condition where a physically completed `COMMIT` can be
incorrectly reported as failed due to a late `InterruptException`.

### The Problem

When a `COMMIT` statement is executed via `PhysicalTransaction::GetDataInternal()`,
the physical commit (`client.transaction.Commit()`) completes successfully and the
method returns `SourceResultType::FINISHED`. However, since the COMMIT produces an
empty chunk, `PipelineExecutor::Execute()` hits the `continue` branch and loops
back to the top of its `do-while` loop, where `InterruptCheck()` is called again.

If an external `Interrupt()` call (e.g., from a client cancellation or a `KILL QUERY`
command in an embedding system) sets the `interrupted` flag between the physical
commit completing and this subsequent `InterruptCheck()`, an `InterruptException` is
thrown. This causes `ExecuteTaskInternal()` to report the query as failed — even
though the transaction has already been durably committed.

```
PipelineExecutor::Execute()
  do {
      InterruptCheck()                    // (1) passes (interrupted == false)
      ...
      FetchFromSource()
        -> GetDataInternal()
             -> client.transaction.Commit()   // (2) physical commit SUCCEEDS
             -> return FINISHED
      ...
      exhausted && chunk.size() == 0
      continue  ----.
                    |
      InterruptCheck()                    // (3) THROWS if another thread
                                          //     called Interrupt() between
                                          //     step (2) and step (3)
  } while (...)
```

### The Fix

Call `client.ClearInterrupt()` immediately after a successful
`client.transaction.Commit()` in `PhysicalTransaction::GetDataInternal()`.
Since a committed transaction is irreversible, any interrupt that arrives after
the physical commit is stale and must not affect the query result.

This is safe because:
- `ClearInterrupt()` uses an atomic store, so it is thread-safe.
- A committed transaction cannot be undone — reporting it as interrupted is always
  semantically incorrect.
- The next query's `InitialCleanup()` would reset the flag anyway; this simply
  does it slightly earlier for correctness.

### Testing

Added a concurrent stress test (`test/api/test_api.cpp`) that:
1. Runs 200 iterations of `BEGIN` → bulk `INSERT` → `COMMIT`
2. Fires continuous `Interrupt()` calls from a background thread during each `COMMIT`
3. Verifies the invariant: **if data is physically committed, the COMMIT result must
   report success** — not an interrupt error.

Without the fix, this test fails intermittently when the interrupt lands in the race
window. With the fix, it passes consistently.

### Changes

- `src/execution/operator/helper/physical_transaction.cpp`: Added
  `client.ClearInterrupt()` after successful `client.transaction.Commit()`.
- `test/api/test_api.cpp`: Added regression test for the race condition.