### PR TITLE
Cleanup the build

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -67,16 +67,31 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
+      # Avoid downloading blobs >50 KB until they are actually needed by git.
+      GIT_FETCH_FILTER: blob:limit=50k
+      GIT_CONFIG_COUNT: 1
+      GIT_CONFIG_KEY_0: checkout.workers
+      GIT_CONFIG_VALUE_0: 4
     steps:
       - uses: actions/checkout@v6
+        with:
+          filter: ${{ env.GIT_FETCH_FILTER }}
 
-      - name: Preliminary checks on CI
-        run: echo "Event name is ${{ github.event_name }}"
+      - name: Fetch PR base branch history
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          # changed-files needs base branch history for merge-base lookup
+          # and the exact base SHA for comparison.
+          git fetch --no-tags --depth=100 --filter="${GIT_FETCH_FILTER}" origin \
+            +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }} \
+            ${{ github.event.pull_request.base.sha }}
 
       - name: Detect changes
         id: changed
         uses: tj-actions/changed-files@v47
         with:
+          base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          skip_initial_fetch: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           files_yaml: |
             extensions:
               - .github/config/**

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -198,6 +198,9 @@ jobs:
           make generate-files
           git diff --exit-code
 
+      - name: Test CI scripts
+        run: make test_ci
+
  linux-debug:
     name: Linux Debug
     # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -167,6 +167,7 @@ jobs:
               --threads 2 \
               "${extra_args[@]}"; then
               status=1
+              echo "::error title=Regression suite failed::$(basename "$benchmark" .csv) in ${{ matrix.name }}"
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -73,7 +73,8 @@ jobs:
               echo "BASE_REF=${BASE_HASH}" >> "$GITHUB_ENV"
             fi
           else
-            echo "BASE_REF=origin/${BASE_BRANCH}" >> "$GITHUB_ENV"
+            git fetch https://github.com/duckdb/duckdb.git "${BASE_BRANCH}:refs/remotes/duckdb/${BASE_BRANCH}"
+            echo "BASE_REF=duckdb/${BASE_BRANCH}" >> "$GITHUB_ENV"
           fi
 
       - name: Reset workspace to base ref

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...3.29)
+cmake_minimum_required(VERSION 3.14...3.29)
 
 if(NOT CLANG_TIDY)
   find_package(Python3)
@@ -947,5 +947,4 @@ if(EXISTS ${CMAKE_CONFIG_TEMPLATE} AND EXISTS ${CMAKE_CONFIG_VERSION_TEMPLATE})
           "${PROJECT_BINARY_DIR}/DuckDBConfigVersion.cmake"
     DESTINATION "${INSTALL_CMAKE_DIR}")
 endif()
-
 

--- a/Makefile
+++ b/Makefile
@@ -450,9 +450,6 @@ unittest_relassert:
 smoke:
 	$(PYTHON) scripts/ci/run_tests.py --batch-timeout 120 --test-list test/smoke_tests.list $(SMOKE_UNITTEST) $(T)
 
-runnertests:
-	python3 -m unittest scripts.ci.test_run_tests
-
 unittestarrow:
 	$(PYTHON) scripts/ci/run_tests.py build/debug/$(UNITTEST_BINARY) "[arrow]"
 
@@ -519,6 +516,9 @@ toolsci:
 	ls -lh /usr/bin/gcc* /usr/bin/g++*
 	gcc --version
 	g++ --version
+
+test_ci:
+	python3 -m unittest discover --buffer --start-directory scripts/ci $(T)
 
 format_tools:
 	$(call ensure_apt_commands,ninja clang-format,ninja-build clang-format-11)

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -325,8 +325,8 @@ macro(register_external_extension NAME URL COMMIT DONT_LINK DONT_BUILD LOAD_TEST
     string(TOUPPER "DUCKDB_${NAME}_DIRECTORY" DIRECTORY_OVERRIDE)
     if(DEFINED ENV{${DIRECTORY_OVERRIDE}})
         set("${NAME}_extension_fc_SOURCE_DIR" "$ENV{${DIRECTORY_OVERRIDE}}")
-        message(STATUS "Load extension '${NAME}' from local path \"${${NAME}_extension_fc_SOURCE_DIR}\"")
     else()
+        unset(PATCH_COMMAND)
         if (${APPLY_PATCHES})
             set(PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/apply_extension_patches.py ${CMAKE_SOURCE_DIR}/.github/patches/extensions/${NAME}/)
         endif()
@@ -336,9 +336,9 @@ macro(register_external_extension NAME URL COMMIT DONT_LINK DONT_BUILD LOAD_TEST
                 GIT_TAG ${COMMIT}
                 GIT_SUBMODULES "${SUBMODULES}"
                 PATCH_COMMAND ${PATCH_COMMAND}
+                SOURCE_SUBDIR __duckdb_no_add_subdirectory__
         )
-        FETCHCONTENT_POPULATE(${NAME}_EXTENSION_FC)
-        message(STATUS "Load extension '${NAME}' from ${URL} @ ${EXTERNAL_EXTENSION_VERSION}")
+        FETCHCONTENT_MAKEAVAILABLE(${NAME}_EXTENSION_FC)
     endif()
 
     # Autogenerate version tag if not provided
@@ -350,6 +350,12 @@ macro(register_external_extension NAME URL COMMIT DONT_LINK DONT_BUILD LOAD_TEST
 
     string(TOUPPER ${NAME} EXTENSION_NAME_UPPERCASE)
     set(DUCKDB_EXTENSION_${EXTENSION_NAME_UPPERCASE}_EXT_VERSION "${EXTERNAL_EXTENSION_VERSION}" PARENT_SCOPE)
+
+    if(DEFINED ENV{${DIRECTORY_OVERRIDE}})
+        message(STATUS "Load extension '${NAME}' from local path \"${${NAME}_extension_fc_SOURCE_DIR}\" @ ${EXTERNAL_EXTENSION_VERSION}")
+    else()
+        message(STATUS "Load extension '${NAME}' from ${URL} @ ${EXTERNAL_EXTENSION_VERSION}")
+    endif()
 
     if ("${INCLUDE_PATH}" STREQUAL "")
         set(INCLUDE_FULL_PATH "${${NAME}_extension_fc_SOURCE_DIR}/src/include")

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -39,7 +39,7 @@ class TestRunnerConfig:
     retry: int
     max_retries: int
     batch_size: int
-    batch_timeout_seconds: int
+    batch_timeout_seconds: float
     rss_memory_threshold_mib: int | None
     runtime_threshold_seconds: int | None
     max_failures: int | None
@@ -466,7 +466,7 @@ def parse_args():
     parser.add_argument("--retry", type=int, default=0)
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
-    parser.add_argument("--batch-timeout", type=int, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
+    parser.add_argument("--batch-timeout", type=float, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
     # Accept options interleaved with positional patterns, e.g.:
     #   run_tests.py bin "[tag]" --fail-fast test/sql/foo.test
     return parser.parse_intermixed_args()

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -165,11 +165,13 @@ class RunTestsScriptTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as state_file:
             state_file_path = Path(state_file.name)
 
+        batch_timeout = 0.3
+
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as helper:
             helper.write("#!/bin/sh\n")
             helper.write(f"if [ ! -f {state_file_path} ]; then\n")
             helper.write(f"  touch {state_file_path}\n")
-            helper.write("  sleep 2\n")
+            helper.write(f"  sleep {batch_timeout + 0.1}\n")
             helper.write("fi\n")
             helper.write("echo fake success\n")
             helper.write("exit 0\n")
@@ -187,7 +189,7 @@ class RunTestsScriptTest(unittest.TestCase):
                     "--retry",
                     "1",
                     "--batch-timeout",
-                    "1",
+                    str(batch_timeout),
                     "--test-list",
                     str(test_list_path),
                     "--test-command",
@@ -205,7 +207,7 @@ class RunTestsScriptTest(unittest.TestCase):
             helper_path.unlink(missing_ok=True)
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-        self.assertIn("batch timed out after 1 seconds", proc.stdout)
+        self.assertIn(f"batch timed out after {batch_timeout} seconds", proc.stdout)
         self.assertIn("retrying failed test", proc.stdout)
         self.assertIn("all tests passed in ", proc.stdout)
 

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -6,6 +6,7 @@ from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
 from dataclasses import dataclass
 from typing import Optional, List, Union
 import subprocess
+from pathlib import Path
 
 print = functools.partial(print, flush=True)
 
@@ -79,6 +80,75 @@ NUMBER_REPETITIONS = 5
 REGRESSION_THRESHOLD_PERCENTAGE = 0.1
 # minimal seconds diff for something to be a regression (for very fast benchmarks)
 REGRESSION_THRESHOLD_SECONDS = regression_threshold_seconds
+
+
+def in_ci():
+    return os.getenv('CI') == 'true'
+
+
+def suite_name():
+    return Path(benchmark_file).stem
+
+
+def append_step_summary(lines: List[str]):
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
+
+def format_seconds(value: Union[float, str]) -> str:
+    if isinstance(value, str):
+        return value
+    return f"{value:.3f}s"
+
+
+def regression_delta(old_value: float, new_value: float) -> str:
+    delta_sec = new_value - old_value
+    delta_pct = ((new_value / old_value) - 1.0) * 100.0 if old_value > 0 else math.inf
+    if math.isfinite(delta_pct):
+        return f"+{delta_sec:.3f}s ({delta_pct:.2f}%)"
+    return f"+{delta_sec:.3f}s"
+
+
+def emit_github_error(title: str, message: str):
+    if in_ci():
+        print(f"::error title={title}::{message}")
+
+
+def benchmark_timing_summary(regression: "BenchmarkResult"):
+    old_timing = format_seconds(regression.old_result)
+    new_timing = format_seconds(regression.new_result)
+    return old_timing, new_timing
+
+
+def report_regression(regression: "BenchmarkResult", summary: List[dict], summary_lines: List[str]):
+    print(f"{regression.benchmark}")
+    print(f"Old timing: {regression.old_result}")
+    print(f"New timing: {regression.new_result}")
+    old_timing, new_timing = benchmark_timing_summary(regression)
+    error_title = "Regression benchmark"
+    if not isinstance(regression.old_result, str) and not isinstance(regression.new_result, str):
+        delta = regression_delta(regression.old_result, regression.new_result)
+        print(f"Delta: {delta}")
+        message = f"{suite_name()}: {regression.benchmark} regressed from {old_timing} to {new_timing} ({delta})"
+        summary_delta = delta
+    else:
+        message = f"{suite_name()}: {regression.benchmark} failed while comparing base and PR benchmark runs"
+        summary_delta = "benchmark run failed"
+    emit_github_error(error_title, message)
+    summary_lines.append(f"| `{regression.benchmark}` | `{old_timing}` | `{new_timing}` | `{summary_delta}` |")
+    if regression.old_failure or regression.new_failure:
+        new_data = {
+            "benchmark": regression.benchmark,
+            "old_failure": regression.old_failure,
+            "new_failure": regression.new_failure,
+        }
+        summary.append(new_data)
+    print("")
+
 
 if not os.path.isfile(old_runner_path):
     print(f"Failed to find old runner {old_runner_path}")
@@ -165,18 +235,15 @@ if len(regression_list) > 0:
 ====================================================
 '''
     )
+    summary_lines = [
+        f"## Regression Suite: `{suite_name()}`",
+        "",
+        "| Benchmark | Base | PR | Delta |",
+        "| --- | --- | --- | --- |",
+    ]
     for regression in regression_list:
-        print(f"{regression.benchmark}")
-        print(f"Old timing: {regression.old_result}")
-        print(f"New timing: {regression.new_result}")
-        if regression.old_failure or regression.new_failure:
-            new_data = {
-                "benchmark": regression.benchmark,
-                "old_failure": regression.old_failure,
-                "new_failure": regression.new_failure,
-            }
-            summary.append(new_data)
-        print("")
+        report_regression(regression, summary, summary_lines)
+    append_step_summary(summary_lines + [""])
     print(
         '''====================================================
 ==============     OTHER TIMINGS       =============
@@ -228,7 +295,7 @@ if summary and not no_summary:
 '''
     )
     # check the value is "true" otherwise you'll see the prefix in local run outputs
-    prefix = "::error::" if ('CI' in os.environ and os.getenv('CI') == 'true') else ""
+    prefix = "::error::" if in_ci() else ""
     for i, failure_message in enumerate(summary, start=1):
         prefix_str = f"{prefix}{i}" if len(prefix) > 0 else f"{i}"
         print(f"{prefix_str}: ", failure_message["benchmark"])

--- a/test/sql/index/art/memory/test_art_varchar.test_slow
+++ b/test/sql/index/art/memory/test_art_varchar.test_slow
@@ -8,6 +8,10 @@ require vector_size 2048
 
 require ram 16gb
 
+# This test results in a timeout after 600s on Linux CLI musl in CI.
+
+require notmusl
+
 statement ok
 set temp_directory=null;
 


### PR DESCRIPTION
- Resolve CMake `FetchContent_Populate is deprecated` warnings.
  - Set minimum cmake version to 3.14.
  - Fixes https://github.com/duckdblabs/duckdb-internal/issues/4558.
- Fetch base branch in job `linux-base` from `duckdb/duckdb` to avoid comparing the PR to an old branch inside the contributor's fork.
- Regression failures now appear as GitHub error annotations and as step summary.
  - The error annotations show the suite and benchmark name. 
  - The regression step summary shows the base/PR timings and delta.
  - This makes it easier to scan/see what benchmark regressed.
- Use `GIT_FETCH_FILTER: blob:limit=50k` to skip downloading large blobs for prepare's `git fetch`.
  - Prepare went from `1m 11s` to `55s` for pull requests.
  - I'll look into why `Prepare` runs for ~1 min in the future.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/8650.