### PR TITLE
BoxRenderer: Adding ColumnDataCollectionRenderInterface abstraction

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library_unity(
   assert.cpp
   bind_helpers.cpp
   box_renderer.cpp
+  column_data_collection_render_interface.cpp
   cgroups.cpp
   column_index.cpp
   csv_writer.cpp

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -171,7 +171,7 @@ public:
 
 struct BoxRendererImplementation : public BoxRendererState {
 	BoxRendererImplementation(BoxRendererConfig config, ClientContext &context, const vector<string> &names,
-	                          const ColumnDataCollection &result);
+	                          const ColumnDataCollectionRenderInterface &result);
 
 public:
 	idx_t TotalRenderWidth() override {
@@ -184,7 +184,7 @@ private:
 	ClientContext &context;
 	vector<string> column_names;
 	vector<LogicalType> result_types;
-	const ColumnDataCollection &result;
+	const ColumnDataCollectionRenderInterface &result;
 	vector<idx_t> column_widths;
 	vector<idx_t> column_boundary_positions;
 	idx_t total_render_length = 0;
@@ -212,12 +212,12 @@ private:
 	ValueRenderAlignment TypeAlignment(const LogicalType &type);
 	void ConvertRenderVector(Vector &vector, Vector &render_lengths, idx_t count, const LogicalType &original_type,
 	                         idx_t null_render_length);
-	void FetchTopCollection(RenderDataCollection &top_collection, const ColumnDataCollection &result, idx_t chunk_idx,
-	                        idx_t row_idx, idx_t top_rows, idx_t bottom_rows);
-	void FetchBottomCollection(RenderDataCollection &bottom_collection, const ColumnDataCollection &result,
-	                           idx_t bottom_rows);
-	vector<RenderDataCollection> FetchRenderCollections(const ColumnDataCollection &result, idx_t top_rows,
-	                                                    idx_t bottom_rows);
+	void FetchTopCollection(RenderDataCollection &top_collection, const ColumnDataCollectionRenderInterface &result,
+	                        idx_t chunk_idx, idx_t row_idx, idx_t top_rows, idx_t bottom_rows);
+	void FetchBottomCollection(RenderDataCollection &bottom_collection,
+	                           const ColumnDataCollectionRenderInterface &result, idx_t bottom_rows);
+	vector<RenderDataCollection> FetchRenderCollections(const ColumnDataCollectionRenderInterface &result,
+	                                                    idx_t top_rows, idx_t bottom_rows);
 	vector<RenderDataCollection> PivotCollections(vector<RenderDataCollection> input, idx_t row_count);
 	void ComputeRenderWidths(vector<RenderDataCollection> &collections, idx_t min_width, idx_t max_width);
 
@@ -248,7 +248,8 @@ private:
 };
 
 BoxRendererImplementation::BoxRendererImplementation(BoxRendererConfig config_p, ClientContext &context,
-                                                     const vector<string> &names, const ColumnDataCollection &result)
+                                                     const vector<string> &names,
+                                                     const ColumnDataCollectionRenderInterface &result)
     : config(std::move(config_p)), context(context), column_names(names), result(result) {
 	result_types = result.Types();
 	Initialize();
@@ -646,8 +647,8 @@ void RenderDataCollection::InitializeChunk(DataChunk &chunk) {
 }
 
 void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_collection,
-                                                   const ColumnDataCollection &result, idx_t chunk_idx, idx_t row_idx,
-                                                   idx_t top_rows, idx_t bottom_rows) {
+                                                   const ColumnDataCollectionRenderInterface &result, idx_t chunk_idx,
+                                                   idx_t row_idx, idx_t top_rows, idx_t bottom_rows) {
 	auto column_count = result.ColumnCount();
 
 	DataChunk fetch_result;
@@ -734,7 +735,8 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 }
 
 void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bottom_collection,
-                                                      const ColumnDataCollection &result, idx_t bottom_rows) {
+                                                      const ColumnDataCollectionRenderInterface &result,
+                                                      idx_t bottom_rows) {
 	if (bottom_rows == 0) {
 		return;
 	}
@@ -803,8 +805,9 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 	}
 }
 
-vector<RenderDataCollection> BoxRendererImplementation::FetchRenderCollections(const ColumnDataCollection &result,
-                                                                               idx_t top_rows, idx_t bottom_rows) {
+vector<RenderDataCollection>
+BoxRendererImplementation::FetchRenderCollections(const ColumnDataCollectionRenderInterface &result, idx_t top_rows,
+                                                  idx_t bottom_rows) {
 	auto column_count = result.ColumnCount();
 	vector<RenderDataCollection> collections;
 	collections.emplace_back(context, column_count);
@@ -2287,23 +2290,25 @@ void BoxRendererImplementation::RenderFooter(BaseResultRenderer &ss, idx_t row_c
 BoxRenderer::BoxRenderer(BoxRendererConfig config_p) : config(std::move(config_p)) {
 }
 
-string BoxRenderer::ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result) {
+string BoxRenderer::ToString(ClientContext &context, const vector<string> &names,
+                             const ColumnDataCollectionRenderInterface &result) {
 	StringResultRenderer ss;
 	Render(context, names, result, ss);
 	return ss.str();
 }
 
-void BoxRenderer::Print(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result) {
+void BoxRenderer::Print(ClientContext &context, const vector<string> &names,
+                        const ColumnDataCollectionRenderInterface &result) {
 	Printer::Print(ToString(context, names, result));
 }
 
 unique_ptr<BoxRendererState> BoxRenderer::Prepare(ClientContext &context, const vector<string> &names,
-                                                  const ColumnDataCollection &result) {
+                                                  const ColumnDataCollectionRenderInterface &result) {
 	return make_uniq<BoxRendererImplementation>(config, context, names, result);
 }
 
-void BoxRenderer::Render(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result,
-                         BaseResultRenderer &ss) {
+void BoxRenderer::Render(ClientContext &context, const vector<string> &names,
+                         const ColumnDataCollectionRenderInterface &result, BaseResultRenderer &ss) {
 	auto state = Prepare(context, names, result);
 	state->Render(ss);
 }

--- a/src/common/column_data_collection_render_interface.cpp
+++ b/src/common/column_data_collection_render_interface.cpp
@@ -1,0 +1,30 @@
+#include "duckdb/common/column_data_collection_render_interface.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+
+namespace duckdb {
+
+ColumnDataCollectionWrapper::ColumnDataCollectionWrapper(const ColumnDataCollection &collection)
+    : collection(collection) {
+}
+
+const vector<LogicalType> &ColumnDataCollectionWrapper::Types() const {
+	return collection.Types();
+}
+
+idx_t ColumnDataCollectionWrapper::Count() const {
+	return collection.Count();
+}
+
+idx_t ColumnDataCollectionWrapper::ColumnCount() const {
+	return collection.ColumnCount();
+}
+
+idx_t ColumnDataCollectionWrapper::ChunkCount() const {
+	return collection.ChunkCount();
+}
+
+void ColumnDataCollectionWrapper::FetchChunk(idx_t chunk_idx, DataChunk &result) const {
+	collection.FetchChunk(chunk_idx, result);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/list.hpp"
+#include "duckdb/common/column_data_collection_render_interface.hpp"
 
 namespace duckdb {
 class ColumnDataCollection;
@@ -150,13 +151,13 @@ class BoxRenderer {
 public:
 	explicit BoxRenderer(BoxRendererConfig config_p = BoxRendererConfig());
 
-	string ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op);
+	string ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op);
 
 	unique_ptr<BoxRendererState> Prepare(ClientContext &context, const vector<string> &names,
-	                                     const ColumnDataCollection &op);
-	void Render(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op,
+	                                     const ColumnDataCollectionRenderInterface &op);
+	void Render(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op,
 	            BaseResultRenderer &ss);
-	void Print(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op);
+	void Print(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op);
 
 	static string TryFormatLargeNumber(const string &numeric, char decimal_sep);
 	static string TruncateValue(const string &value, idx_t column_width, idx_t &pos, idx_t &current_render_width);

--- a/src/include/duckdb/common/column_data_collection_render_interface.hpp
+++ b/src/include/duckdb/common/column_data_collection_render_interface.hpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/column_data_collection_render_interface.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+
+namespace duckdb {
+class ColumnDataCollection;
+
+//! Abstract read-only interface over columnar data, used by BoxRenderer.
+//! Two implementations: one wrapping a real ColumnDataCollection, one fetching lazily.
+class ColumnDataCollectionRenderInterface {
+public:
+	virtual ~ColumnDataCollectionRenderInterface() = default;
+
+	virtual const vector<LogicalType> &Types() const = 0;
+	virtual idx_t Count() const = 0;
+	virtual idx_t ColumnCount() const = 0;
+	virtual idx_t ChunkCount() const = 0;
+	virtual void FetchChunk(idx_t chunk_idx, DataChunk &result) const = 0;
+};
+
+//! Classic implementation: wraps a real ColumnDataCollection and forwards all calls.
+class ColumnDataCollectionWrapper : public ColumnDataCollectionRenderInterface {
+public:
+	explicit ColumnDataCollectionWrapper(const ColumnDataCollection &collection);
+
+	const vector<LogicalType> &Types() const override;
+	idx_t Count() const override;
+	idx_t ColumnCount() const override;
+	idx_t ChunkCount() const override;
+	void FetchChunk(idx_t chunk_idx, DataChunk &result) const override;
+
+private:
+	const ColumnDataCollection &collection;
+};
+
+} // namespace duckdb

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -48,7 +48,8 @@ string MaterializedQueryResult::ToBox(ClientContext &context, const BoxRendererC
 		return "Internal error - result was successful but there was no collection";
 	}
 	BoxRenderer renderer(config);
-	return renderer.ToString(context, names, Collection());
+	ColumnDataCollectionWrapper wrapper(Collection());
+	return renderer.ToString(context, names, wrapper);
 }
 
 Value MaterializedQueryResult::GetValue(idx_t column, idx_t index) {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1630,6 +1630,7 @@ public:
 private:
 	duckdb::BoxRendererConfig config;
 	unique_ptr<duckdb::BoxRendererState> render_state;
+	unique_ptr<duckdb::ColumnDataCollectionWrapper> wrapper;
 	string error_str;
 };
 
@@ -1680,7 +1681,8 @@ void ModeDuckBoxRenderer::Analyze(RenderingQueryResult &result) {
 	auto &materialized = query_result.Cast<duckdb::MaterializedQueryResult>();
 	auto &con = *state.conn;
 	try {
-		render_state = renderer.Prepare(*con.context, result.metadata.column_names, materialized.Collection());
+		wrapper = make_uniq<duckdb::ColumnDataCollectionWrapper>(materialized.Collection());
+		render_state = renderer.Prepare(*con.context, result.metadata.column_names, *wrapper);
 	} catch (std::exception &ex) {
 		// store the error - throw on render
 		error_str = ex.what();


### PR DESCRIPTION
Similar to the sibling PR at https://github.com/duckdb/duckdb/pull/21621 (but independent).

Abstract details about `ColumnDataCollection` to the less powerful (and potentially re-implementable) `ColumnDataCollectionRenderInterface`.

This PR should be just moving code around, no actual behavioural changes.