### PR TITLE
Add AllVarcharCast, and use both in BoxRenderer and RowRenderer

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -671,12 +671,12 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 		idx_t insert_count = MinValue<idx_t>(fetch_result.size(), top_rows - row_idx);
 
 		// cast all columns to varchar
+		auto varchar_chunk = fetch_result.CastToVarchar(context);
 		for (idx_t c = 0; c < column_count; c++) {
-			auto &source_vector = fetch_result.data[c];
 			auto &target_vector = top_collection.Values(insert_result, c);
 			auto &render_lengths = top_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
-			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
+			target_vector.Reference(varchar_chunk->data[c]);
+			ConvertRenderVector(target_vector, render_lengths, insert_count, fetch_result.data[c].GetType(),
 			                    null_render_length);
 		}
 		insert_result.SetCardinality(insert_count);
@@ -789,12 +789,12 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 			chunk.Flatten();
 		}
 
+		auto varchar_chunk = chunk.CastToVarchar(context);
 		for (idx_t c = 0; c < column_count; c++) {
-			auto &source_vector = chunk.data[c];
 			auto &target_vector = bottom_collection.Values(insert_result, c);
 			auto &render_lengths = bottom_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
-			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
+			target_vector.Reference(varchar_chunk->data[c]);
+			ConvertRenderVector(target_vector, render_lengths, insert_count, chunk.data[c].GetType(),
 			                    null_render_length);
 		}
 		insert_result.SetCardinality(insert_count);

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -246,6 +246,61 @@ vector<LogicalType> DataChunk::GetTypes() const {
 	return types;
 }
 
+static bool RequiresJSONCast(const LogicalType &type) {
+	if (type.IsNested()) {
+		return true;
+	}
+	if (type.IsFloating()) {
+		return true;
+	}
+	return false;
+}
+
+unique_ptr<DataChunk> DataChunk::CastToVarchar(ClientContext &context, bool complex_objects_as_json) {
+	auto col_count = ColumnCount();
+
+	// Step 1: set up the output chunk
+	auto varchar_chunk = make_uniq<DataChunk>();
+	vector<LogicalType> all_varchar(col_count, LogicalType::VARCHAR);
+	varchar_chunk->Initialize(Allocator::DefaultAllocator(), all_varchar);
+
+	// Step 2: if complex_objects_as_json, pre-cast nested/floating columns through JSON
+	DataChunk json_chunk;
+	if (complex_objects_as_json) {
+		vector<LogicalType> json_types;
+		for (idx_t c = 0; c < col_count; c++) {
+			if (RequiresJSONCast(data[c].GetType())) {
+				json_types.emplace_back(LogicalType::JSON());
+			} else {
+				json_types.emplace_back(data[c].GetType());
+			}
+		}
+		json_chunk.Initialize(Allocator::DefaultAllocator(), json_types);
+		for (idx_t c = 0; c < col_count; c++) {
+			if (data[c].GetType() == json_types[c]) {
+				json_chunk.data[c].Reference(data[c]);
+			} else {
+				VectorOperations::Cast(context, data[c], json_chunk.data[c], size());
+			}
+		}
+		json_chunk.SetCardinality(size());
+		json_chunk.Flatten();
+	}
+
+	// Step 3: cast all columns to VARCHAR
+	auto &source = complex_objects_as_json ? json_chunk : *this;
+	for (idx_t c = 0; c < col_count; c++) {
+		if (source.data[c].GetType().id() == LogicalTypeId::VARCHAR) {
+			varchar_chunk->data[c].Reference(source.data[c]);
+		} else {
+			VectorOperations::Cast(context, source.data[c], varchar_chunk->data[c], size());
+		}
+	}
+	varchar_chunk->SetCardinality(size());
+	varchar_chunk->Flatten();
+	return varchar_chunk;
+}
+
 string DataChunk::ToString() const {
 	string retval = "Chunk - [" + to_string(ColumnCount()) + " Columns]\n";
 	for (idx_t i = 0; i < ColumnCount(); i++) {

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -155,6 +155,10 @@ public:
 	//! Returns a list of types of the vectors of this data chunk
 	DUCKDB_API vector<LogicalType> GetTypes() const;
 
+	//! Cast all columns to VARCHAR and return a new DataChunk.
+	//! If complex_objects_as_json is true, nested and floating-point types are cast through JSON first.
+	DUCKDB_API unique_ptr<DataChunk> CastToVarchar(ClientContext &context, bool complex_objects_as_json = false);
+
 	//! Converts this DataChunk to a printable string representation
 	DUCKDB_API string ToString() const;
 	DUCKDB_API void Print() const;

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -294,20 +294,7 @@ ColumnRenderer::ColumnRenderer(ShellState &state) : ShellRenderer(state) {
 }
 
 unique_ptr<duckdb::DataChunk> ShellRenderer::ConvertChunk(duckdb::DataChunk &chunk) {
-	// cast to the varchar chunk
-	auto varchar_chunk = make_uniq<duckdb::DataChunk>();
-	vector<duckdb::LogicalType> all_varchar;
-	for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
-		all_varchar.emplace_back(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
-	}
-	varchar_chunk->Initialize(duckdb::Allocator::DefaultAllocator(), all_varchar);
-
-	for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
-		duckdb::VectorOperations::Cast(*state.conn->context, chunk.data[c], varchar_chunk->data[c], chunk.size());
-	}
-	varchar_chunk->SetCardinality(chunk.size());
-	varchar_chunk->Flatten();
-	return varchar_chunk;
+	return chunk.CastToVarchar(*state.conn->context);
 }
 
 bool RenderingQueryResult::TryConvertChunk() {
@@ -1289,38 +1276,8 @@ public:
 		return result;
 	}
 
-	static bool RequiresJSONCast(const duckdb::LogicalType &type) {
-		if (type.IsNested()) {
-			// cast nested types to JSON to preserve structure
-			return true;
-		}
-		if (type.IsFloating()) {
-			// cast floating point numbers to JSON to correctly deal with inf / nan
-			return true;
-		}
-		return false;
-	}
-
 	unique_ptr<duckdb::DataChunk> ConvertChunk(duckdb::DataChunk &chunk) override {
-		// convert all nested types to JSON directly
-		duckdb::DataChunk json_chunk;
-		vector<duckdb::LogicalType> all_json;
-		for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
-			if (!RequiresJSONCast(chunk.data[c].GetType())) {
-				all_json.emplace_back(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
-			} else {
-				all_json.emplace_back(duckdb::LogicalType::JSON());
-			}
-		}
-		json_chunk.Initialize(duckdb::Allocator::DefaultAllocator(), all_json);
-
-		for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
-			duckdb::VectorOperations::Cast(*state.conn->context, chunk.data[c], json_chunk.data[c], chunk.size());
-		}
-		json_chunk.SetCardinality(chunk.size());
-		json_chunk.Flatten();
-		// now convert the JSON chunk to VARCHAR
-		return ShellRenderer::ConvertChunk(json_chunk);
+		return chunk.CastToVarchar(*state.conn->context, true);
 	}
 
 	void RenderFooter(PrintStream &out, ResultMetadata &result) override {


### PR DESCRIPTION
Idea is centralizing logic that's currently in 3 different places.

Arguably the `complex_objects_as_json` param is somewhat hacky, maybe it should be an enum so it can be (potentially) expanded?