### PR TITLE
Fix #21623: flatten input chunk in TopNHeap::CheckBoundaryValues

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -290,6 +290,7 @@ bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload, To
 
 	SelectionVector remaining_sel(nullptr);
 	idx_t remaining_count = sort_chunk.size();
+	sort_chunk.Flatten();
 	for (idx_t i = 0; i < orders.size(); i++) {
 		if (remaining_sel.data()) {
 			compare_chunk.data[i].Slice(sort_chunk.data[i], remaining_sel, remaining_count);

--- a/test/sql/order/top_n_issue_21623.test
+++ b/test/sql/order/top_n_issue_21623.test
@@ -1,0 +1,67 @@
+# name: test/sql/order/top_n_issue_21623.test
+# description: Issue #21623: crash in Top-N
+# group: [order]
+
+require json
+
+statement ok
+CREATE OR REPLACE TABLE t3(c VARCHAR);
+
+statement ok
+INSERT INTO t3
+VALUES ('19'),
+    ('21'),
+    ('22'),
+    ('23');
+
+statement ok
+CREATE OR REPLACE TABLE t2(
+    a VARCHAR,
+    b VARCHAR
+);
+
+statement ok
+INSERT INTO t2
+VALUES ('3', '8'),
+    ('5', NULL),
+    ('8', NULL),
+    ('11', NULL);
+
+statement ok
+CREATE OR REPLACE TABLE t1(
+    a VARCHAR,
+    c VARCHAR
+);
+
+statement ok
+INSERT INTO t1
+VALUES ('2', '22'),
+    ('3', '21'),
+    ('11', '19'),
+    ('5', '23');
+
+query III
+WITH
+    cte1 AS (
+        SELECT
+            struct_pack(f := json_extract('[]', '$[*]')) AS s0, struct_pack(ff := c) AS s1, t1.a AS p
+        FROM t3
+        JOIN t1 USING (c)
+    ),
+    cte2 AS (
+        SELECT
+            cte1.s1, cte1.s0, struct_pack(fff := cte1.p) AS s2
+        FROM cte1
+        JOIN t2 AS t22 ON cte1.p = t22.a
+        LEFT JOIN t2 ON t22.b = t2.a
+    ),
+    cte3 AS (
+        SELECT cte2.*
+        FROM cte2
+        ORDER BY s1, s2
+    )
+SELECT *
+FROM cte3
+LIMIT 1;
+----
+{'ff': 19}	{'f': []}	{'fff': 11}


### PR DESCRIPTION
Fixes #21623

The code in `TopNHeap::CheckBoundaryValues` does not correctly deal with non-flat vectors of nested types, so we need to flatten the input.