### PR TITLE
Fix full tidy check on main

### DIFF
--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 namespace {
 struct SwitchFunctionBindData : FunctionData {
 	explicit SwitchFunctionBindData(const LogicalType &return_type_p, idx_t map_index_p)
-	    : return_type(std::move(return_type_p)), map_index(std::move(map_index_p)) {
+	    : return_type(return_type_p), map_index(map_index_p) {
 	}
 
 	LogicalType return_type;
@@ -115,8 +115,8 @@ unique_ptr<Expression> SwitchBindExpression(FunctionBindExpressionInput &input) 
 	ExtractConstantExprFromList(cases_func.children[1], values_unpacked);
 
 	result->case_checks.reserve(keys_unpacked.size());
-	BoundCaseCheck case_check;
 	for (idx_t i = 0; i < keys_unpacked.size(); i++) {
+		BoundCaseCheck case_check;
 		if (base_expr) {
 			auto max_type =
 			    LogicalType::MaxLogicalType(input.context, base_expr->return_type, keys_unpacked[i]->return_type);
@@ -158,7 +158,7 @@ ScalarFunctionSet SwitchFun::GetFunctions() {
 	                                                   {LogicalType::MAP(key_type, val_type), val_type},
 	                                                   {LogicalType::MAP(key_type, val_type)}};
 
-	for (auto variation : function_variations) {
+	for (const auto &variation : function_variations) {
 		auto switch_expression = ScalarFunction(variation, val_type, nullptr, SwitchBindReturnType, nullptr);
 		switch_expression.SetBindExpressionCallback(SwitchBindExpression);
 		func_set.AddFunction(std::move(switch_expression));

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -190,7 +190,8 @@ void ColumnWriter::HandleRepeatLevels(ColumnWriterState &state, ColumnWriterStat
 		return;
 	}
 	state.repetition_levels.insert(state.repetition_levels.end(),
-	                               parent->repetition_levels.begin() + state.repetition_levels.size(),
+	                               parent->repetition_levels.begin() +
+	                                   static_cast<vector<uint16_t>::difference_type>(state.repetition_levels.size()),
 	                               parent->repetition_levels.end());
 }
 

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -11,7 +11,6 @@
 #include "duckdb/common/allocator.hpp"
 
 using duckdb_parquet::ColumnChunk;
-class Allocator;
 
 namespace duckdb {
 
@@ -495,9 +494,9 @@ int16_t ParquetCrypto::GetFinalPageOrdinal(const ColumnChunk &chunk, uint8_t mod
 		} else if (chunk.meta_data.__isset.bloom_filter_offset) {
 			page_ordinal -= 1;
 		}
-		return page_ordinal;
+		return NumericCast<int16_t>(page_ordinal);
 	case DATA_PAGE:
-		return page_ordinal;
+		return NumericCast<int16_t>(page_ordinal);
 	default:
 		// All modules except DataPage(Header) are -1 (absent)
 		return -1;

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -111,7 +111,8 @@ struct ParquetMetadataGlobalState : public GlobalTableFunctionState {
 	double GetProgress() const {
 		// Not the most accurate, instantly assumes all files are done and equal
 		unique_lock<mutex> lock(file_paths->file_lock);
-		return static_cast<double>(file_paths->scan_data.current_file_idx) / file_paths->file_list->GetTotalFileCount();
+		return static_cast<double>(file_paths->scan_data.current_file_idx) /
+		       static_cast<double>(file_paths->file_list->GetTotalFileCount());
 	}
 
 	unique_ptr<ParquetMetadataFilePaths> file_paths;

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -24,7 +24,7 @@ public:
 	static bool FromString(const string &str, hugeint_t &result, bool strict = false);
 	//! Convert a uuid string to a hugeint object
 	static bool FromCString(const char *str, idx_t len, hugeint_t &result) {
-		return FromString(string(str, 0, len), result);
+		return FromString(string(str, len), result);
 	}
 	//! Convert a hugeint object to a uuid style string
 	static void ToString(hugeint_t input, char *buf);

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -119,10 +119,10 @@ public:
 	static void CheckMagicBytes(QueryContext context, FileHandle &handle);
 
 	string LibraryGitDesc() {
-		return string(char_ptr_cast(library_git_desc), 0, MAX_VERSION_SIZE);
+		return string(char_ptr_cast(library_git_desc), MAX_VERSION_SIZE);
 	}
 	string LibraryGitHash() {
-		return string(char_ptr_cast(library_git_hash), 0, MAX_VERSION_SIZE);
+		return string(char_ptr_cast(library_git_hash), MAX_VERSION_SIZE);
 	}
 
 	bool IsEncrypted() const {

--- a/third_party/fastpforlib/bitpacking.cpp
+++ b/third_party/fastpforlib/bitpacking.cpp
@@ -5,6 +5,7 @@
 
 namespace duckdb_fastpforlib {
 namespace internal {
+// NOLINTBEGIN(readability-braces-around-statements,bugprone-implicit-widening-of-multiplication-result)
 
 // Used for uint8_t, uint16_t and uint32_t
 template <uint8_t DELTA, uint8_t SHR, class TYPE, uint8_t TYPE_SIZE = sizeof(TYPE) * 8>
@@ -1280,5 +1281,6 @@ void __fastpack64(const uint64_t *__restrict in, uint32_t *__restrict out) {
 		out[2 * i + 1] = in[i] >> 32;
 	}
 }
+// NOLINTEND(readability-braces-around-statements,bugprone-implicit-widening-of-multiplication-result)
 } // namespace internal
 } // namespace duckdb_fastpforlib

--- a/third_party/re2/re2/dfa.cc
+++ b/third_party/re2/re2/dfa.cc
@@ -52,6 +52,7 @@
 #endif
 
 namespace duckdb_re2 {
+// NOLINTBEGIN(readability-braces-around-statements,modernize-use-nullptr,cppcoreguidelines-avoid-non-const-global-variables,bugprone-narrowing-conversions,bugprone-assignment-in-if-condition)
 
 // Controls whether the DFA should bail out early if the NFA would be faster.
 static bool dfa_should_bail_when_slow = true;
@@ -2069,4 +2070,5 @@ bool Prog::PossibleMatchRange(std::string* min, std::string* max, int maxlen) {
   return GetDFA(kLongestMatch)->PossibleMatchRange(min, max, maxlen);
 }
 
+// NOLINTEND(readability-braces-around-statements,modernize-use-nullptr,cppcoreguidelines-avoid-non-const-global-variables,bugprone-narrowing-conversions,bugprone-assignment-in-if-condition)
 }  // namespace re2


### PR DESCRIPTION
There are many tidy check [failures](https://github.com/duckdb/duckdb/actions/runs/23572052873/job/68636643574) on main:
- Some originate from the third party code `re2` and `fastpforlib`.
  - Disabling the tidy failing checks for those two files should solve the issue.
- Empty String constructors
- Performance or ineffective moves.