### PR TITLE
Disable regular updates for geometry

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -710,6 +710,7 @@ bool LogicalType::SupportsRegularUpdate() const {
 	case LogicalTypeId::MAP:
 	case LogicalTypeId::UNION:
 	case LogicalTypeId::VARIANT:
+	case LogicalTypeId::GEOMETRY: // If geometry is shredded, its parts (lists/structs) can't be regularly updated.
 		return false;
 	case LogicalTypeId::STRUCT: {
 		auto &child_types = StructType::GetChildTypes(*this);

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -154,18 +154,17 @@ void GeoColumnData::FetchRow(TransactionData transaction, ColumnFetchState &stat
 
 void GeoColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
                            Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
-	return base_column->Update(transaction, data_table, column_index, update_vector, row_ids, update_count,
-	                           row_group_start);
+	throw NotImplementedException("GEOMETRY Update is not supported");
 }
+
 void GeoColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
                                  const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                  idx_t update_count, idx_t depth, idx_t row_group_start) {
-	return base_column->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth,
-	                                 row_group_start);
+	throw NotImplementedException("GEOMETRY Update is not supported");
 }
 
 unique_ptr<BaseStatistics> GeoColumnData::GetUpdateStatistics() {
-	return base_column->GetUpdateStatistics();
+	return nullptr;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/test/sql/types/geo/geometry_update.test
+++ b/test/sql/types/geo/geometry_update.test
@@ -1,0 +1,53 @@
+# name: test/sql/types/geo/geometry_update.test
+# group: [geo]
+
+load __TEST_DIR__/test_update_geo.db readwrite v1.4.4
+
+statement ok
+CREATE TABLE t (id INT, geo GEOMETRY)
+
+statement ok
+INSERT INTO t VALUES (1, NULL), (2, 'POINT(1.0 2.0)')
+
+statement ok
+CHECKPOINT
+
+statement ok
+UPDATE t SET geo = 'POINT(0 1)' WHERE id = 1;
+
+statement ok
+CHECKPOINT
+
+query II
+SELECT id, ST_AsText(geo) FROM t ORDER BY id;
+----
+1	POINT (0 1)
+2	POINT (1 2)
+
+
+# Now lets do it with shredding enabled
+load __TEST_DIR__/test_update_geo_2.db readwrite v1.5.0
+
+statement ok
+CREATE TABLE t (id INT, geo GEOMETRY)
+
+statement ok
+SET geometry_minimum_shredding_size = 0;
+
+statement ok
+INSERT INTO t VALUES (1, NULL), (2, 'POINT(1.0 2.0)')
+
+statement ok
+CHECKPOINT
+
+statement ok
+UPDATE t SET geo = 'POINT(0 1)' WHERE id = 1;
+
+statement ok
+CHECKPOINT
+
+query II
+SELECT id, ST_AsText(geo) FROM t ORDER BY id;
+----
+1	POINT (0 1)
+2	POINT (1 2)


### PR DESCRIPTION
If a `GEOMETRY` column uses alternative storage (legacy spatial geometry format) or is shredded, we need to convert to/from the new geometry format when updating the column data. However, in the case where the geometry column is shredded on linestrings/polygons, we can't update the segment in-place anyway as in-place updates are not supported for `LIST` column segments.

Since we can't detect if a geometry column has shredded row-groups when planning the UPDATE statement (which is where we decide whether we can do in-place updates), the only safe option is to disable in-place updates for geometry columns entirely.

It is on our todo list to improve updates for complex types in general, and we could also look into making the update-strategy more fine grained so that it can be decided per row group instead of for the whole column at once.