### PR TITLE
Lint workflows and fix existing lint errors/warnings

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actions/ccache-action/action.yml
+++ b/.github/actions/ccache-action/action.yml
@@ -1,4 +1,5 @@
 name: 'Setup Ccache'
+description: 'Configure ccache for workflow jobs'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/cleanup_runner/action.yml
+++ b/.github/actions/cleanup_runner/action.yml
@@ -1,4 +1,5 @@
 name: 'Cleanup Runner'
+description: 'Free disk space on GitHub-hosted runners'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -133,12 +133,14 @@ jobs:
       - name: Build Environment
         shell: bash
         run: |
-          # bash from Git
-          echo 'C:/Program Files/Git/bin' >> "${GITHUB_PATH}"
-          # make, ninja and ccache from Chocolatey
-          echo 'C:/ProgramData/Chocolatey/bin' >> "${GITHUB_PATH}"
-          # g++ from Chocolatey
-          echo 'C:/ProgramData/mingw64/mingw64/bin' >> "${GITHUB_PATH}"
+          {
+            # bash from Git
+            echo 'C:/Program Files/Git/bin'
+            # make, ninja and ccache from Chocolatey
+            echo 'C:/ProgramData/Chocolatey/bin'
+            # g++ from Chocolatey
+            echo 'C:/ProgramData/mingw64/mingw64/bin'
+          } >> "${GITHUB_PATH}"
 
       - name: Build Environment Check
         shell: cmd
@@ -194,11 +196,10 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          export PWD=`pwd`
           docker run                                                             \
-          -v$PWD:$PWD                                                            \
+          -v"$PWD:$PWD"                                                          \
           -e CMAKE_BUILD_PARALLEL_LEVEL=2                                        \
-          -e OVERRIDE_GIT_DESCRIBE=$OVERRIDE_GIT_DESCRIBE                        \
+          -e OVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE"                      \
           -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake"    \
           -e ENABLE_EXTENSION_AUTOLOADING=1                                      \
           -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
@@ -214,8 +215,8 @@ jobs:
             export CC=gcc
             export CXX=g++
 
-            git config --global --add safe.directory $PWD
-            make gather-libs -C $PWD
+            git config --global --add safe.directory \"$PWD\"
+            make gather-libs -C \"$PWD\"
           "
       - name: Print platform
         shell: bash

--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Check issue for code formatting
         run: |
           echo "$ISSUE_BODY" >> issue-text.md
-          if ! cat issue-text.md | python3 scripts/check-issue-for-code-formatting.py; then
+          if ! python3 scripts/check-issue-for-code-formatting.py < issue-text.md; then
               gh issue comment ${{ github.event.issue.number }} --body-file .github/workflows/code-formatting-warning.md
           fi

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           python3 scripts/ci/retry.py -- make toolsci
           python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clang-tidy
-          python3 scripts/ci/retry.py -- sudo pip3 install pybind11[global] --break-system-packages
+          python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
 
       - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -171,26 +171,24 @@ jobs:
           touch report
           for folder in linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_3_2 linux_v1_4-andium linux_v1_2 osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_4-andium osx_v1_2_2 osx_v1_3_2 osx_v1_2; do
             for filename in "$folder"/*; do
-              touch "$filename.wal" &&
+              if touch "$filename.wal" &&
                 cp "$filename.wal" a.db.wal 2>/dev/null &&
-                cp "$filename" a.db 2>/dev/null &&
-                (
-                  ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out ||
-                    (
-                      grep "but it is not a valid DuckDB database file!" out 2>/dev/null ||
-                        (
-                          echo "--> $filename"
-                          cat out
-                          echo
-                          grep -i "internal error" out &&
-                            {
-                              echo "--> $filename"
-                              cat out
-                              echo
-                            } >> report
-                        )
-                    )
-                ) || true
+                cp "$filename" a.db 2>/dev/null; then
+                if ! ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out; then
+                  if ! grep "but it is not a valid DuckDB database file!" out 2>/dev/null; then
+                    echo "--> $filename"
+                    cat out
+                    echo
+                    if grep -i "internal error" out; then
+                      {
+                        echo "--> $filename"
+                        cat out
+                        echo
+                      } >> report
+                    fi
+                  fi
+                fi
+              fi
               rm -f b.db a.db b.db.wal a.db.wal
             done
           done
@@ -358,26 +356,24 @@ jobs:
           touch report
           for folder in osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_3_2 osx_v1_4-andium linux_main linux_v1_3_2 linux_v1_4-andium linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_2 osx_v1_2_2 osx_v1_2; do
             for filename in "$folder"/*; do
-              touch "$filename.wal" &&
+              if touch "$filename.wal" &&
                 cp "$filename.wal" a.db.wal 2>/dev/null &&
-                cp "$filename" a.db 2>/dev/null &&
-                (
-                  ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out ||
-                    (
-                      grep "but it is not a valid DuckDB database file!" out 2>/dev/null ||
-                        (
-                          echo "--> $filename"
-                          cat out
-                          echo
-                          grep -i "internal error" out &&
-                            {
-                              echo "--> $filename"
-                              cat out
-                              echo
-                            } >> report
-                        )
-                    )
-                ) || true
+                cp "$filename" a.db 2>/dev/null; then
+                if ! ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out; then
+                  if ! grep "but it is not a valid DuckDB database file!" out 2>/dev/null; then
+                    echo "--> $filename"
+                    cat out
+                    echo
+                    if grep -i "internal error" out; then
+                      {
+                        echo "--> $filename"
+                        cat out
+                        echo
+                      } >> report
+                    fi
+                  fi
+                fi
+              fi
               rm -f b.db a.db b.db.wal a.db.wal
             done
           done

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -170,8 +170,27 @@ jobs:
         run: |
           touch report
           for folder in linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_3_2 linux_v1_4-andium linux_v1_2 osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_4-andium osx_v1_2_2 osx_v1_3_2 osx_v1_2; do
-            for filename in $folder/*; do
-              touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
+            for filename in "$folder"/*; do
+              touch "$filename.wal" &&
+                cp "$filename.wal" a.db.wal 2>/dev/null &&
+                cp "$filename" a.db 2>/dev/null &&
+                (
+                  ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out ||
+                    (
+                      grep "but it is not a valid DuckDB database file!" out 2>/dev/null ||
+                        (
+                          echo "--> $filename"
+                          cat out
+                          echo
+                          grep -i "internal error" out &&
+                            {
+                              echo "--> $filename"
+                              cat out
+                              echo
+                            } >> report
+                        )
+                    )
+                ) || true
               rm -f b.db a.db b.db.wal a.db.wal
             done
           done
@@ -338,8 +357,27 @@ jobs:
         run: |
           touch report
           for folder in osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_3_2 osx_v1_4-andium linux_main linux_v1_3_2 linux_v1_4-andium linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_2 osx_v1_2_2 osx_v1_2; do
-            for filename in $folder/*; do
-              touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
+            for filename in "$folder"/*; do
+              touch "$filename.wal" &&
+                cp "$filename.wal" a.db.wal 2>/dev/null &&
+                cp "$filename" a.db 2>/dev/null &&
+                (
+                  ./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out ||
+                    (
+                      grep "but it is not a valid DuckDB database file!" out 2>/dev/null ||
+                        (
+                          echo "--> $filename"
+                          cat out
+                          echo
+                          grep -i "internal error" out &&
+                            {
+                              echo "--> $filename"
+                              cat out
+                              echo
+                            } >> report
+                        )
+                    )
+                ) || true
               rm -f b.db a.db b.db.wal a.db.wal
             done
           done

--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -19,7 +19,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.node_id }}
         run: |
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
+          echo "$PR_NUMBER" > ./pr/pr_number
       - uses: actions/upload-artifact@v7
         with:
           name: pr_number

--- a/.github/workflows/DraftMeNot.yml
+++ b/.github/workflows/DraftMeNot.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.node_id }}
         run: |
-          echo $PR_NUMBER
+          echo "$PR_NUMBER"

--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 'Extract PR node id'
         shell: bash
         run: |
-          (echo -n "PR_NUMBER=" | cat - pr_number) >> $GITHUB_ENV
+          (echo -n "PR_NUMBER=" | cat - pr_number) >> "$GITHUB_ENV"
 
       - name: 'Actually move to draft'
         shell: bash
@@ -46,9 +46,9 @@ jobs:
           MOVE_PR_TO_DRAFT_TOKEN_ENV: ${{ secrets.MOVE_PR_TO_DRAFT_TOKEN }}
         if: ${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV != '' }}
         run: |
-          echo ${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV }} | gh auth login --with-token
-          gh api graphql -F id=${{ env.PR_NUMBER }} -f query='
-            mutation($id: ID!) {
+          echo "${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV }}" | gh auth login --with-token
+          gh api graphql -F "id=${{ env.PR_NUMBER }}" -f query="
+            mutation(\$id: ID!) {
               convertPullRequestToDraft(input: { pullRequestId: $id }) {
                 pullRequest {
                   id
@@ -57,4 +57,4 @@ jobs:
                 }
               }
             }
-          '
+          "

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -15,9 +15,9 @@ on:
         required: false
         default: ''
       skip_tests:
-        type: string
+        type: boolean
       run_all:
-        type: string
+        type: boolean
       # disabling this can result in faster builds, but may run out of space on some runners
       run_disk_clean_step:
         type: boolean
@@ -56,9 +56,9 @@ on:
         required: false
         default: false
       run_all:
-        type: string
+        type: boolean
         required: false
-        default: 'true'
+        default: true
       run_disk_clean_step:
         description: 'Disabling this can result in faster builds, but may run out of space on some runners'
         type: boolean
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       # NOTE: on PRs we exclude some archs to speed things up
-      reduced_ci_mode: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'enabled' || 'disabled' }}
+      reduced_ci_mode: ${{ (github.event_name == 'pull_request' || !inputs.run_all) && 'enabled' || 'disabled' }}
       main_extensions_config: ${{ steps.set-main-extensions.outputs.extension_config }}
       main_extensions_exclude_archs: ${{ steps.set-main-extensions.outputs.exclude_archs }}
       main_extensions_opt_in_archs: ${{ steps.set-main-extensions.outputs.opt_in_archs }}
@@ -112,16 +112,18 @@ jobs:
           DEFAULT_EXCLUDE_ARCHS: ''
         run: |
           # Set config
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
-          echo opt_in_archs="$OPT_IN_ARCHS" >> $GITHUB_OUTPUT
-          in_tree_extensions="`cat $IN_TREE_CONFIG_FILE`"
-          out_of_tree_extensions="`cat $OUT_OF_TREE_CONFIG_FILE`"
-          echo "extension_config<<EOF" >> $GITHUB_OUTPUT
-          echo "$in_tree_extensions" >> $GITHUB_OUTPUT
-          echo -e "\n" >> $GITHUB_OUTPUT
-          echo "$out_of_tree_extensions" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          echo "exclude_archs=$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> "$GITHUB_OUTPUT"
+          echo "opt_in_archs=$OPT_IN_ARCHS" >> "$GITHUB_OUTPUT"
+          in_tree_extensions="$(<"$IN_TREE_CONFIG_FILE")"
+          out_of_tree_extensions="$(<"$OUT_OF_TREE_CONFIG_FILE")"
+          {
+            echo "extension_config<<EOF"
+            echo "$in_tree_extensions"
+            echo
+            echo "$out_of_tree_extensions"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
       - id: set-rust-based-extensions
         name: Configure Rust-based extensions
@@ -129,12 +131,14 @@ jobs:
           CONFIG_FILE: .github/config/rust_based_extensions.cmake
           DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
         run: |
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
-          rust_based_extensions="`cat .github/config/rust_based_extensions.cmake`"
-          echo "extension_config<<EOF" >> $GITHUB_OUTPUT
-          echo "$rust_based_extensions" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          echo "exclude_archs=$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> "$GITHUB_OUTPUT"
+          rust_based_extensions="$(<"$CONFIG_FILE")"
+          {
+            echo "extension_config<<EOF"
+            echo "$rust_based_extensions"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
       - id: set-external-extensions1
         name: Configure External extensions (batch 1)
@@ -142,12 +146,14 @@ jobs:
           CONFIG_FILE: .github/config/external_extensions.cmake
           DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
         run: |
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
-          external_extensions="`cat .github/config/external_extensions.cmake`"
-          echo "extension_config<<EOF" >> $GITHUB_OUTPUT
-          echo "$external_extensions" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          echo "exclude_archs=$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> "$GITHUB_OUTPUT"
+          external_extensions="$(<"$CONFIG_FILE")"
+          {
+            echo "extension_config<<EOF"
+            echo "$external_extensions"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
       - id: set-external-extensions2
         name: Configure External extensions (batch 2)
@@ -155,12 +161,14 @@ jobs:
           CONFIG_FILE: .github/config/external_extensions2.cmake
           DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
         run: |
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS;osx_amd64" >> $GITHUB_OUTPUT
-          external_extensions="`cat .github/config/external_extensions2.cmake`"
-          echo "extension_config<<EOF" >> $GITHUB_OUTPUT
-          echo "$external_extensions" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          echo "exclude_archs=$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS;osx_amd64" >> "$GITHUB_OUTPUT"
+          external_extensions="$(<"$CONFIG_FILE")"
+          {
+            echo "extension_config<<EOF"
+            echo "$external_extensions"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   # Build the extensions from .github/config/{in_tree,rust_based,external}_extensions.cmake
   extensions-build:
@@ -207,7 +215,7 @@ jobs:
       extra_toolchains: ${{ matrix.extra_toolchains }}
       use_merged_vcpkg_manifest: '1'
       duckdb_tag: ${{ inputs.override_git_describe }}
-      skip_tests: ${{ inputs.skip_tests == 'true' && true || false }}
+      skip_tests: ${{ inputs.skip_tests }}
       save_cache: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
       extensions_test_selection: 'complete'
       extra_extension_config: ${{ matrix.extension_config }}
@@ -233,7 +241,7 @@ jobs:
       extra_toolchains: 'rust'
       use_merged_vcpkg_manifest: '1'
       duckdb_tag: ${{ inputs.override_git_describe }}
-      skip_tests: ${{ inputs.skip_tests == 'true' && true || false }}
+      skip_tests: ${{ inputs.skip_tests }}
       save_cache: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
       extensions_test_selection: 'complete'
       extra_extension_config: ${{ needs.load-extension-configs.outputs.external_extensions2_config }}
@@ -327,7 +335,7 @@ jobs:
 
   autoload-tests:
     name: Extension Autoloading Tests
-    if: ${{ inputs.skip_tests != 'true' }}
+    if: ${{ !inputs.skip_tests }}
     runs-on: ${{ fromJSON(inputs.runners).linux_x64 || 'ubuntu-latest' }}
     needs:
       - create-extension-repository
@@ -373,7 +381,7 @@ jobs:
 
   check-load-install-extensions:
     name: Checks extension entries
-    if: ${{ inputs.skip_tests != 'true' }}
+    if: ${{ !inputs.skip_tests }}
     runs-on: ${{ fromJSON(inputs.runners).linux_22_x64 || 'ubuntu-22.04' }}
     needs:
       - create-extension-repository

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -44,7 +44,7 @@ jobs:
         python3 scripts/ci/retry.py -- make
         python3 scripts/ci/retry.py -- git clone https://github.com/duckdb/duckdb.git
         cd duckdb
-        git checkout `git tag --list | tail -n 1`
+        git checkout "$(git tag --list | tail -n 1)"
         python3 ../scripts/ci/retry.py -- make
         cd ..
 

--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -32,7 +32,7 @@ jobs:
           * A lot of issues can be reproduced with plain SQL code executed in the [DuckDB command line client](https://duckdb.org/docs/api/cli/overview). If you can provide such an example, it greatly simplifies the reproduction process and likely results in a faster fix.
           * If the script needs additional data, please share the data as a CSV, JSON, or Parquet file. Unfortunately, we cannot fix issues that can only be reproduced with a confidential data set. [Support contracts](https://duckdblabs.com/#support) allow sharing confidential data with the core DuckDB team under NDA.
 
-          For more detailed guidelines on how to create reproducible examples, please visit Stack Overflow's [“Minimal, Reproducible Example”](https://stackoverflow.com/help/minimal-reproducible-example) page.
+          For more detailed guidelines on how to create reproducible examples, please visit Stack Overflow's ["Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example) page.
           EOF
           gh issue comment --repo duckdb/duckdb ${{ github.event.issue.number }} --body-file needs-reproducible-example-comment.md
 
@@ -58,7 +58,7 @@ jobs:
       - name: Get mirror issue number
         run: |
           gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
-          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> "$GITHUB_ENV"
 
       - name: Print whether mirror issue exists
         run: |
@@ -71,11 +71,11 @@ jobs:
       - name: Set label environment variable
         run: |
           if ${{ github.event.label.name == 'reproduced' }}; then
-            echo "LABEL=reproduced" >> $GITHUB_ENV
-            echo "UNLABEL=under review" >> $GITHUB_ENV
+            echo "LABEL=reproduced" >> "$GITHUB_ENV"
+            echo "UNLABEL=under review" >> "$GITHUB_ENV"
           else
-            echo "LABEL=under review" >> $GITHUB_ENV
-            echo "UNLABEL=reproduced" >> $GITHUB_ENV
+            echo "LABEL=under review" >> "$GITHUB_ENV"
+            echo "UNLABEL=reproduced" >> "$GITHUB_ENV"
           fi
 
       - name: Create or label issue
@@ -83,5 +83,5 @@ jobs:
           if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
             gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }}"
           else
-            gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --remove-label "$UNLABEL" --add-label "$LABEL"
+            gh issue edit --repo duckdblabs/duckdb-internal "$MIRROR_ISSUE_NUMBER" --remove-label "$UNLABEL" --add-label "$LABEL"
           fi

--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get mirror issue number
         run: |
           gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
-          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> "$GITHUB_ENV"
 
       - name: Print whether mirror issue exists
         run: |
@@ -32,20 +32,20 @@ jobs:
       - name: Add comment with status to mirror issue
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
-            gh issue comment --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --body "The issue has been ${{ github.event.action }} (https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number || github.event.discussion.number }})."
+            gh issue comment --repo duckdblabs/duckdb-internal "$MIRROR_ISSUE_NUMBER" --body "The issue has been ${{ github.event.action }} (https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number || github.event.discussion.number }})."
           fi
 
       - name: Add closed label to mirror issue
         if: github.event.action == 'closed'
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
-            gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --add-label "public closed" --remove-label "public reopened"
+            gh issue edit --repo duckdblabs/duckdb-internal "$MIRROR_ISSUE_NUMBER" --add-label "public closed" --remove-label "public reopened"
           fi
 
       - name: Reopen mirror issue and add reopened label
         if: github.event.action == 'reopened'
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
-            gh issue reopen --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER
-            gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --add-label "public reopened" --remove-label "public closed"
+            gh issue reopen --repo duckdblabs/duckdb-internal "$MIRROR_ISSUE_NUMBER"
+            gh issue edit --repo duckdblabs/duckdb-internal "$MIRROR_ISSUE_NUMBER" --add-label "public reopened" --remove-label "public closed"
           fi

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -74,9 +74,9 @@ jobs:
                 "${{ needs.osx.result }}" == "success" && \
                 "${{ needs.windows.result }}" == "success" && \
                 "${{ needs.static-libraries.result }}" == "success" ]]; then
-            echo "success=true" >> $GITHUB_OUTPUT
+            echo "success=true" >> "$GITHUB_OUTPUT"
           else
-            echo "success=false" >> $GITHUB_OUTPUT
+            echo "success=false" >> "$GITHUB_OUTPUT"
           fi
 
   notify-external-repos:
@@ -89,5 +89,5 @@ jobs:
       target-branch: ${{ inputs.git_ref == '' && github.ref || inputs.git_ref }}
       duckdb-sha: ${{ github.sha }}
       triggering-event: ${{ github.event_name }}
-      should-publish: 'true'
+      should-publish: true
       override-git-describe: ${{ inputs.override_git_describe }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -78,10 +78,21 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files_yaml: |
+            github:
+              - .github/**
             extensions:
               - .github/config/**
               - .github/patches/**
               - extensions/**
+
+      - name: Check workflow files
+        if: steps.changed.outputs.github_any_changed == 'true'
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          shellcheck --version
+          bash <(curl --retry 5 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash
 
       - name: Configure extensions
         id: extensions

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -134,8 +134,9 @@ jobs:
       - name: Build runners JSON
         id: build_runners
         run: |
-          echo "runners<<EOF" >> "$GITHUB_OUTPUT"
-          cat <<EOF >> "$GITHUB_OUTPUT"
+          {
+            echo "runners<<EOF"
+            cat <<EOF
           {
             "linux_x64": "${{ steps.select_runner.outputs.runner_linux_x64 }}",
             "linux_22_x64": "${{ steps.select_runner.outputs.runner_linux_22_x64 }}",
@@ -146,7 +147,8 @@ jobs:
             "macos_14_arm64": "${{ steps.select_runner.outputs.runner_macos_14_arm64 }}"
           }
           EOF
-          echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Linux CLI matrices
         id: build_linux_cli_matrices
@@ -265,10 +267,10 @@ jobs:
         ls -lh build/relassert/test/unittest
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
-      run: echo "DUCKDB_INSTALL_LIB=$(find `pwd` -name "libduck*.so" | head -n 1)" >> $GITHUB_ENV
+      run: echo "DUCKDB_INSTALL_LIB=$(find "$PWD" -name 'libduck*.so' | head -n 1)" >> "$GITHUB_ENV"
 
     - name: Test DUCKDB_INSTALL_LIB variable
-      run: echo $DUCKDB_INSTALL_LIB
+      run: echo "$DUCKDB_INSTALL_LIB"
 
     - name: Test
       run: make unittest_relassert
@@ -281,7 +283,7 @@ jobs:
       - linux-debug
       - linux-release
     with:
-      build_current_release: 'false'
+      build_current_release: false
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 
@@ -299,8 +301,8 @@ jobs:
     with:
       git_ref: ${{ github.sha }}
       extra_exclude_archs: ${{ needs.prepare.outputs.extensions_extra_exclude_archs }}
-      skip_tests: 'false'
-      run_all: 'true'
+      skip_tests: false
+      run_all: true
       runners: ${{ needs.prepare.outputs.runners }}
 
  wasm-eh:
@@ -442,13 +444,12 @@ jobs:
 
     - name: Build
       run: |
-        export PWD=`pwd`
         docker run                                                             \
-        -v$PWD:$PWD                                                            \
+        -v"$PWD:$PWD"                                                          \
         -e GEN=ninja                                                           \
         -e CC='ccache gcc'                                                     \
         -e CXX='ccache g++'                                                    \
-        -e CCACHE_DIR=$PWD/.ccache                                             \
+        -e CCACHE_DIR="$PWD/.ccache"                                           \
         -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake"    \
         -e ENABLE_EXTENSION_AUTOLOADING=1                                      \
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
@@ -462,8 +463,8 @@ jobs:
             ccache       \
             ninja-build  \
             perl-IPC-Cmd
-          git config --global --add safe.directory $PWD
-          make -C $PWD
+          git config --global --add safe.directory \"$PWD\"
+          make -C \"$PWD\"
         "
 
     - name: Print platform
@@ -527,13 +528,12 @@ jobs:
     - name: Build
       shell: bash
       run: |
-        export PWD=`pwd`
         docker run                                                          \
-        -v$PWD:$PWD                                                         \
+        -v"$PWD:$PWD"                                                       \
         -e GEN=ninja                                                        \
         -e CC='ccache gcc'                                                  \
         -e CXX='ccache g++'                                                 \
-        -e CCACHE_DIR=$PWD/.ccache                                          \
+        -e CCACHE_DIR="$PWD/.ccache"                                        \
         -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake" \
         -e ENABLE_EXTENSION_AUTOLOADING=1                                   \
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                   \
@@ -550,8 +550,8 @@ jobs:
             git     \
             make    \
             samurai
-          git config --global --add safe.directory $PWD
-          make -C $PWD
+          git config --global --add safe.directory \"$PWD\"
+          make -C \"$PWD\"
         "
 
     - name: Deploy
@@ -578,9 +578,8 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        export PWD=`pwd`
         docker run   \
-        -v$PWD:$PWD  \
+        -v"$PWD:$PWD" \
         -e CI=1      \
         alpine:3.22                                                         \
         sh -c "
@@ -590,7 +589,7 @@ jobs:
             make       \
             python3    \
             py3-pytest
-          cd $PWD
+          cd \"$PWD\"
           echo Tests
           make allunit
           echo Release specific tests
@@ -701,8 +700,8 @@ jobs:
     with:
       git_ref: ${{ github.sha }}
       runner_windows_2022_x64: ${{ needs.prepare.outputs.runner_windows_2022_x64 }}
-      skip_tests: 'false'
-      run_all: 'true'
+      skip_tests: false
+      run_all: true
 
  no-string-inline:
     name: No String Inline / Destroy Unpinned Blocks

--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get mirror issue number
         run: |
           gh issue list --repo duckdb/duckdb-web --json title,number --state all --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
-          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> ${GITHUB_ENV}
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> "${GITHUB_ENV}"
 
       - name: Print whether mirror issue exists
         run: |

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -566,7 +566,7 @@ jobs:
   linux-wasm-experimental:
     name: WebAssembly duckdb-wasm builds
     # disable in NightlyTests
-    if: false
+    if: ${{ vars.ENABLE_WASM_EXPERIMENTAL == 'true' }}
     needs: check-draft
     runs-on: ubuntu-22.04
     steps:
@@ -579,10 +579,10 @@ jobs:
       run: |
         python3 scripts/ci/retry.py -- git clone https://github.com/duckdb/duckdb-wasm
         cd duckdb-wasm
-        git checkout ${{ env.DUCKDB_WASM_VERSION }}
+        git checkout "${{ env.DUCKDB_WASM_VERSION }}"
         shopt -s nullglob
         for filename in ../.github/patches/duckdb-wasm/*.patch; do
-          git apply $filename
+          git apply "$filename"
         done
         git submodule init
         git submodule update
@@ -618,19 +618,19 @@ jobs:
       shell: bash
       run: |
         cd duckdb-wasm
-        bash scripts/wasm_build_lib.sh relsize mvp $(pwd)/submodules/duckdb
+        bash scripts/wasm_build_lib.sh relsize mvp "$PWD/submodules/duckdb"
 
     - name: Build WebAssembly EH
       shell: bash
       run: |
         cd duckdb-wasm
-        bash scripts/wasm_build_lib.sh relsize eh $(pwd)/submodules/duckdb
+        bash scripts/wasm_build_lib.sh relsize eh "$PWD/submodules/duckdb"
 
     - name: Build WebAssembly COI
       shell: bash
       run: |
         cd duckdb-wasm
-        bash scripts/wasm_build_lib.sh relsize coi $(pwd)/submodules/duckdb
+        bash scripts/wasm_build_lib.sh relsize coi "$PWD/submodules/duckdb"
 
     - name: Package
       shell: bash
@@ -750,7 +750,7 @@ jobs:
         run: pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
 
       - name: Download BWC cache
-        if: false
+        if: ${{ vars.ENABLE_BWC_CACHE_DOWNLOAD == 'true' }}
         run: |
           VERSION=${{ matrix.old_duckdb_version }}
           CACHE_ARCHIVE="runtime_${VERSION}.tar.gz"
@@ -813,7 +813,8 @@ jobs:
           failed=0
           for summary in tests_summary_*.txt; do
             [ -f "$summary" ] || continue
-            version=$(echo "$summary" | sed 's/tests_summary_\(.*\)\.txt/\1/')
+            version="${summary#tests_summary_}"
+            version="${version%.txt}"
             failures=$(grep '# FAILED' "$summary" || true)
             if [ -n "$failures" ]; then
               echo ""

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -10,7 +10,6 @@ on:
       target-branch:
         description: 'Which Branch to Target'
         required: true
-        default: ''
         type: 'string'
       triggering-event:
         description: 'Which event triggered the run'
@@ -18,12 +17,12 @@ on:
         type: 'string'
       should-publish:
         description: 'Should the called workflow push updates or not'
-        default: 'false'
-        type: 'string'
+        default: false
+        type: boolean
       is-success:
         description: 'True, if all the builds in InvokeCI had succeeded'
-        default: 'false'
-        type: 'string'
+        default: false
+        type: boolean
       override-git-describe:
         description: 'The name of the release tag, used for release builds'
         required: false
@@ -47,12 +46,12 @@ on:
         type: 'string'
       should-publish:
         description: 'Should the called workflow push updates'
-        default: 'false'
-        type: 'string'
+        default: false
+        type: boolean
       is-success:
         description: 'True, if all the builds in InvokeCI had succeeded'
-        default: 'false'
-        type: 'string'
+        default: false
+        type: boolean
       override-git-describe:
         description: 'The name of the release tag, used for release builds'
         required: false
@@ -71,7 +70,7 @@ jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' && inputs.override-git-describe == '' }}
+    if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
     steps:
       - name: Run ODBC Vendor
         if: ${{ github.repository == 'duckdb/duckdb' }}
@@ -83,7 +82,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' && inputs.override-git-describe == '' }}
+    if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
     steps:
       - name: Run JDBC Vendor
         if: ${{ github.repository == 'duckdb/duckdb' }}
@@ -100,8 +99,8 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": ${{ inputs.should-publish }}}}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
   notify-python-nightly:
     name: Dispatch Python nightly build

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -7,9 +7,9 @@ on:
       git_ref:
         type: string
       skip_tests:
-        type: string
+        type: boolean
       run_all:
-        type: string
+        type: boolean
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -17,9 +17,11 @@ on:
       git_ref:
         type: string
       skip_tests:
-        type: string
+        type: boolean
+        default: false
       run_all:
-        type: string
+        type: boolean
+        default: true
   push:
     branches-ignore:
       - 'main'
@@ -77,18 +79,18 @@ jobs:
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
-      run: echo "DUCKDB_INSTALL_LIB=$(find `pwd` -name "libduck*.dylib" | head -n 1)" >> $GITHUB_ENV
+      run: echo "DUCKDB_INSTALL_LIB=$(find "$PWD" -name 'libduck*.dylib' | head -n 1)" >> "$GITHUB_ENV"
 
     - name: Test DUCKDB_INSTALL_LIB variable
-      run: echo $DUCKDB_INSTALL_LIB
+      run: echo "$DUCKDB_INSTALL_LIB"
 
     - name: Test
-      if: ${{ inputs.skip_tests != 'true' }}
+      if: ${{ !inputs.skip_tests }}
       shell: bash
       run: make unittest_release
 
     - name: Amalgamation
-      if: ${{ inputs.skip_tests != 'true' }}
+      if: ${{ !inputs.skip_tests }}
       shell: bash
       run: |
         python scripts/amalgamation.py --extended
@@ -155,11 +157,12 @@ jobs:
             codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
           
             zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
-            export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
+            XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
+            export XCRUN_RESPONSE
             rm notarize.zip
             if [[ $(./build/release/duckdb -csv -noheader -c "SELECT (getenv('XCRUN_RESPONSE')::JSON)->>'status'") != "Accepted" ]] ; then 
               echo "Notarization failed!"
-              echo $XCRUN_RESPONSE
+              echo "$XCRUN_RESPONSE"
               exit 1
             fi
           fi
@@ -197,18 +200,18 @@ jobs:
 
       - name: Unit Test
         shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
+        if: ${{ !inputs.skip_tests }}
         run: make allunit
 
       - name: Tools Tests
         shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
+        if: ${{ !inputs.skip_tests }}
         run: |
           python -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
       - name: Examples
         shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
+        if: ${{ !inputs.skip_tests }}
         run: |
           (cd examples/embedded-c; make)
           (cd examples/embedded-c++; make)

--- a/.github/workflows/PRNeedsMaintainerApproval.yml
+++ b/.github/workflows/PRNeedsMaintainerApproval.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get mirror issue number
         run: |
           gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
-          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> ${GITHUB_ENV}
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> "${GITHUB_ENV}"
 
       - name: Print whether mirror issue exists
         run: |

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -5,8 +5,8 @@ on:
       base_hash:
         type: string
       build_current_release:
-        default: 'false'
-        type: string
+        default: false
+        type: boolean
       runner_linux_x64:
         default: ubuntu-latest
         type: string
@@ -20,8 +20,8 @@ on:
         type: string
       build_current_release:
         description: 'Build and upload linux-release-build in this workflow'
-        default: 'true'
-        type: string
+        default: true
+        type: boolean
       runner_linux_x64:
         description: 'Optional x64 runner label override'
         default: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
       - uses: ./.github/actions/ccache-action
 
       - name: Build current release
-        if: ${{ inputs.build_current_release != 'false' }}
+        if: ${{ inputs.build_current_release }}
         uses: ./.github/actions/linux_release_build
         with:
           artifact_name: linux-release-build

--- a/.github/workflows/SwiftRelease.yml
+++ b/.github/workflows/SwiftRelease.yml
@@ -59,12 +59,13 @@ jobs:
       - name: Tag Release
         run: |
           cd source-repo
-          export TAG_NAME=`python3 -c "import sys, os; sys.path.append(os.path.join('scripts')); import package_build; print(package_build.git_dev_version())"`
+          TAG_NAME="$(python3 -c "import sys, os; sys.path.append(os.path.join('scripts')); import package_build; print(package_build.git_dev_version())")"
+          export TAG_NAME
           cd ..
           git -C updated-repo fetch --tags
-          if [[ $(git -C updated-repo tag -l $TAG_NAME) ]]; then
-            echo 'Tag '$TAG_NAME' already exists - skipping'
+          if [[ $(git -C updated-repo tag -l "$TAG_NAME") ]]; then
+            echo "Tag $TAG_NAME already exists - skipping"
           else
-            git -C updated-repo tag -a $TAG_NAME -m "Release $TAG_NAME"
-            git -C updated-repo push origin $TAG_NAME
+            git -C updated-repo tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+            git -C updated-repo push origin "$TAG_NAME"
           fi

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -7,9 +7,9 @@ on:
       git_ref:
         type: string
       skip_tests:
-        type: string
+        type: boolean
       run_all:
-        type: string
+        type: boolean
       runner_windows_2022_x64:
         type: string
   workflow_dispatch:
@@ -19,9 +19,11 @@ on:
       git_ref:
         type: string
       skip_tests:
-        type: string
+        type: boolean
+        default: false
       run_all:
-        type: string
+        type: boolean
+        default: true
       runner_windows_2022_x64:
         type: string
 
@@ -61,21 +63,21 @@ jobs:
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: pwsh
-      run: echo "DUCKDB_INSTALL_LIB=$((Get-ChildItem -Recurse -Filter "duckdb.dll" | Select-Object -First 1).FullName)" >> $GITHUB_ENV
+      run: echo "DUCKDB_INSTALL_LIB=$((Get-ChildItem -Recurse -Filter "duckdb.dll" | Select-Object -First 1).FullName)" >> $env:GITHUB_ENV
 
     - name: Test DUCKDB_INSTALL_LIB variable
       shell: bash
-      run: echo $DUCKDB_INSTALL_LIB
+      run: echo "$DUCKDB_INSTALL_LIB"
 
     - name: Test
       shell: bash
-      if: ${{ inputs.skip_tests != 'true' }}
+      if: ${{ !inputs.skip_tests }}
       run: |
         test/Release/unittest.exe
 
     - name: Test with VS2019 C++ stdlib
       shell: bash
-      if: ${{ inputs.skip_tests != 'true' }}
+      if: ${{ !inputs.skip_tests }}
       run: |
         choco install wget -y --no-progress
         wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
@@ -85,7 +87,7 @@ jobs:
 
     - name: Tools Test
       shell: bash
-      if: ${{ inputs.skip_tests != 'true' }}
+      if: ${{ !inputs.skip_tests }}
       run: |
         python -m pip install pytest
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
@@ -170,7 +172,7 @@ jobs:
    name: Windows (ARM64)
    needs:
     - win-release-64
-   if: ${{ github.ref_name == 'main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true' }}
+   if: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all }}
    runs-on: windows-latest
 
    steps:
@@ -232,7 +234,7 @@ jobs:
      name: MinGW (64 Bit)
      needs:
       - win-release-64
-     if: ${{ inputs.skip_tests != 'true' }}
+     if: ${{ !inputs.skip_tests }}
      runs-on: ${{ inputs.runner_windows_2022_x64 || 'windows-2022' }}
      env:
        GEN: ninja
@@ -264,12 +266,14 @@ jobs:
        - name: Build Environment
          shell: bash
          run: |
-           # bash from Git
-           echo 'C:/Program Files/Git/bin' >> "${GITHUB_PATH}"
-           # make, ninja and ccache from Chocolatey
-           echo 'C:/ProgramData/Chocolatey/bin' >> "${GITHUB_PATH}"
-           # g++ from Chocolatey
-           echo 'C:/ProgramData/mingw64/mingw64/bin' >> "${GITHUB_PATH}"
+           {
+             # bash from Git
+             echo 'C:/Program Files/Git/bin'
+             # make, ninja and ccache from Chocolatey
+             echo 'C:/ProgramData/Chocolatey/bin'
+             # g++ from Chocolatey
+             echo 'C:/ProgramData/mingw64/mingw64/bin'
+           } >> "${GITHUB_PATH}"
 
        - name: Build Environment Check
          shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -172,7 +172,7 @@ jobs:
    name: Windows (ARM64)
    needs:
     - win-release-64
-   if: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all }}
+   if: ${{ github.ref_name == 'main' || github.repository != 'duckdb/duckdb' || inputs.run_all }}
    runs-on: windows-latest
 
    steps:

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -61,12 +61,14 @@ jobs:
           EXT_CONFIG: .github/config/extensions/${{ inputs.extension_name }}.cmake
         run: |
           # Set config
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
-          ext_config="`cat $EXT_CONFIG`"
-          echo "extension_config<<EOF" >> $GITHUB_OUTPUT
-          echo "$ext_config" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          echo "exclude_archs=$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> "$GITHUB_OUTPUT"
+          ext_config="$(<"$EXT_CONFIG")"
+          {
+            echo "extension_config<<EOF"
+            echo "$ext_config"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   vars:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- Check workflow files in CI if files in `.github/**` changed.
  - Lint with [actionlint](https://github.com/rhysd/actionlint/) and [shellcheck](https://github.com/koalaman/shellcheck).
  - This detects many errors/typos for changed workflow scripts and CI jobs in the first CI job.
- Fix the existing linting issues.