### PR TITLE
Fix crash in `Vector::Resize` for STRUCT types

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -347,7 +347,9 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 }
 
 void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multiplier) {
-	ResizeInfo resize_info(*this, buffer.get(), multiplier);
+	const auto type_size = GetTypeIdSize(type.InternalType());
+	auto buffer_ptr = type_size ? buffer.get() : nullptr;
+	ResizeInfo resize_info(*this, buffer_ptr, multiplier);
 	resize_infos.emplace_back(resize_info);
 
 	if (!auxiliary) {
@@ -1184,9 +1186,8 @@ void Vector::Shred(Vector &shredded_data) {
 		throw InternalException("Vector::Shred parameter must be a struct with two children");
 	}
 	this->vector_type = VectorType::SHREDDED_VECTOR;
-	this->buffer = make_buffer<ShreddedVectorBuffer>(shredded_data);
+	this->auxiliary = make_buffer<ShreddedVectorBuffer>(shredded_data);
 	validity.Reset();
-	auxiliary.reset();
 }
 
 // FIXME: This should ideally be const

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -6,27 +6,27 @@ namespace duckdb {
 
 const Vector &ShreddedVector::GetUnshreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 Vector &ShreddedVector::GetUnshreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 const Vector &ShreddedVector::GetShreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 Vector &ShreddedVector::GetShreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 	Vector unshredded_vector(LogicalType::VARIANT(), MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
-	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.auxiliary->Cast<ShreddedVectorBuffer>();
 	VariantUtils::UnshredVariantData(shredded_buffer.GetChild(), unshredded_vector, count);
 	vec.ConstReference(unshredded_vector);
 }
@@ -34,7 +34,7 @@ void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 void ShreddedVector::Unshred(const Vector &vec, const SelectionVector &sel, idx_t count) {
 	VerifyShreddedVector(vec);
 	// slice the underlying shredded buffer
-	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.auxiliary->Cast<ShreddedVectorBuffer>();
 	Vector sliced_shredded_buffer(shredded_buffer.GetChild(), sel, count);
 	// unshred the vector
 	Vector unshredded_vector(LogicalType::VARIANT());


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/8651

The `ResizeInfo` is used to do a reallocation for the buffer, for structs this causes a problem because `type_size` becomes 0:
```c++
		// For nested data types, we only need to resize the validity mask.
		if (!resize_info_entry.data) {
			continue;
		}

		auto type_size = GetTypeIdSize(resize_info_entry.vec.GetType().InternalType());
		auto old_size = current_size * type_size * resize_info_entry.multiplier * sizeof(data_t);
		auto target_size = new_size * type_size * resize_info_entry.multiplier * sizeof(data_t);
```

Aside from this fix, I also moved the `ShreddedVectorBuffer` to `auxiliary`, because its size has no relation to the type, and it also replaces the `VectorStructBuffer` (because of the previously present `auxiliary.reset()`)