### PR TITLE
Re-organize WAL replay slightly, and correctly deal with empty checkpoint WAL files in WAL recovery

### DIFF
--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -35,7 +35,6 @@ class WriteAheadLogDeserializer;
 struct PersistentCollectionData;
 
 enum class WALInitState { NO_WAL, UNINITIALIZED, UNINITIALIZED_REQUIRES_TRUNCATE, INITIALIZED };
-enum class WALReplayState { MAIN_WAL, CHECKPOINT_WAL };
 
 //! The WriteAheadLog (WAL) is a log that is used to provide durability. Prior
 //! to committing a transaction it writes the changes the transaction made to
@@ -120,12 +119,6 @@ public:
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
-
-protected:
-	//! Internally replay all WAL entries. QueryContext is passed for metric collection purposes only!!
-	static unique_ptr<WriteAheadLog> ReplayInternal(QueryContext context, StorageManager &storage_manager,
-	                                                unique_ptr<FileHandle> handle,
-	                                                WALReplayState replay_state = WALReplayState::MAIN_WAL);
 
 protected:
 	StorageManager &storage_manager;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -281,31 +281,34 @@ private:
 	                                    WALReplayState replay_state = WALReplayState::MAIN_WAL);
 	void CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer, idx_t buffer_size,
 	                 idx_t copy_end);
+	void MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state, BufferedFileReader &main_wal_reader,
+	                          const string &recovery_path, unique_ptr<FileHandle> checkpoint_handle);
 
 private:
 	QueryContext context;
 	StorageManager &storage_manager;
-	const string &wal_path;
+	AttachedDatabase &database;
+	const string &main_wal_path;
 	FileSystem &fs;
 };
 
 unique_ptr<WriteAheadLog> WriteAheadLog::Replay(QueryContext context, StorageManager &storage_manager,
-                                                const string &wal_path) {
-	WriteAheadLogReplayer wal_replay(context, storage_manager, wal_path);
+                                                const string &main_wal_path) {
+	WriteAheadLogReplayer wal_replay(context, storage_manager, main_wal_path);
 	return wal_replay.Replay();
 }
 
 WriteAheadLogReplayer::WriteAheadLogReplayer(QueryContext context, StorageManager &storage_manager,
-                                             const string &wal_path)
-    : context(context), storage_manager(storage_manager), wal_path(wal_path),
-      fs(FileSystem::Get(storage_manager.GetAttached())) {
+                                             const string &main_wal_path)
+    : context(context), storage_manager(storage_manager), database(storage_manager.GetAttached()),
+      main_wal_path(main_wal_path), fs(FileSystem::Get(storage_manager.GetAttached())) {
 }
 
 unique_ptr<WriteAheadLog> WriteAheadLogReplayer::Replay() {
-	auto handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+	auto handle = fs.OpenFile(main_wal_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 	if (!handle) {
 		// WAL does not exist - instantiate an empty WAL
-		return make_uniq<WriteAheadLog>(storage_manager, wal_path);
+		return make_uniq<WriteAheadLog>(storage_manager, main_wal_path);
 	}
 
 	// context is passed for metric collection purposes only!!
@@ -315,9 +318,9 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::Replay() {
 	}
 	// replay returning NULL indicates we can nuke the WAL entirely - but only if this is not a read-only connection
 	if (!storage_manager.GetAttached().IsReadOnly()) {
-		fs.TryRemoveFile(wal_path);
+		fs.TryRemoveFile(main_wal_path);
 	}
-	return make_uniq<WriteAheadLog>(storage_manager, wal_path);
+	return make_uniq<WriteAheadLog>(storage_manager, main_wal_path);
 }
 
 void WriteAheadLogReplayer::CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer,
@@ -331,6 +334,64 @@ void WriteAheadLogReplayer::CopyOverWAL(BufferedFileReader &reader, FileHandle &
 
 		target.Write(buffer, read_count);
 	}
+}
+
+void WriteAheadLogReplayer::MergeIntoRecoveryWAL(Connection &con, const ReplayState &checkpoint_state,
+                                                 BufferedFileReader &main_wal_reader, const string &recovery_path,
+                                                 unique_ptr<FileHandle> checkpoint_handle) {
+	auto recovery_handle =
+	    fs.OpenFile(recovery_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+
+	static constexpr idx_t BATCH_SIZE = Storage::DEFAULT_BLOCK_SIZE;
+	auto buffer = make_uniq_array<data_t>(BATCH_SIZE);
+
+	// first copy over the main WAL contents
+	auto copy_end = checkpoint_state.checkpoint_position.GetIndex();
+	main_wal_reader.Reset();
+	CopyOverWAL(main_wal_reader, *recovery_handle, buffer.get(), BATCH_SIZE, copy_end);
+
+	auto checkpoint_wal_path = checkpoint_handle->GetPath();
+	// now copy over the checkpoint WAL
+	{
+		BufferedFileReader checkpoint_reader(fs, std::move(checkpoint_handle));
+
+		if (checkpoint_reader.FileSize() != 0) {
+			// skip over the version entry
+			ReplayState checkpoint_replay_state(database, *con.context, WALReplayState::CHECKPOINT_WAL);
+
+			auto deserializer =
+			    WriteAheadLogDeserializer::GetEntryDeserializer(checkpoint_replay_state, checkpoint_reader, true);
+			deserializer.ReplayEntry();
+
+			if (checkpoint_replay_state.wal_version != checkpoint_state.wal_version) {
+				throw InvalidInputException("Failure while replaying checkpoint WAL file \"%s\": checkpoint "
+				                            "WAL version is different from main WAL version",
+				                            checkpoint_wal_path);
+			}
+
+			CopyOverWAL(checkpoint_reader, *recovery_handle, buffer.get(), BATCH_SIZE, checkpoint_reader.FileSize());
+		}
+	}
+
+	auto debug_checkpoint_abort = Settings::Get<DebugCheckpointAbortSetting>(storage_manager.GetDatabase());
+
+	// move over the recovery WAL over the main WAL
+	recovery_handle->Sync();
+	recovery_handle.reset();
+
+	if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_MOVING_RECOVERY) {
+		throw FatalException("Checkpoint aborted before moving recovery file because of PRAGMA checkpoint_abort flag");
+	}
+
+	fs.MoveFile(recovery_path, main_wal_path);
+
+	if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_DELETING_CHECKPOINT_WAL) {
+		throw FatalException(
+		    "Checkpoint aborted before deleting checkpoint file because of PRAGMA checkpoint_abort flag");
+	}
+
+	// delete the checkpoint WAL
+	fs.RemoveFile(checkpoint_wal_path);
 }
 
 unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle> handle, WALReplayState replay_state) {
@@ -389,7 +450,6 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		// we need to reconcile this with what is in the data file
 		// first check if there is a checkpoint WAL
 		auto &manager = database.GetStorageManager();
-		auto &fs = FileSystem::Get(storage_manager.GetAttached());
 		auto checkpoint_wal = manager.GetCheckpointWALPath();
 		checkpoint_handle =
 		    fs.OpenFile(checkpoint_wal, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
@@ -427,57 +487,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 				// if this is not a read-only connection, then merge the two WALs and replay the merged WAL
 				// we merge into the recovery WAL path
 				auto recovery_path = manager.GetRecoveryWALPath();
-				auto recovery_handle =
-				    fs.OpenFile(recovery_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
-
-				static constexpr idx_t BATCH_SIZE = Storage::DEFAULT_BLOCK_SIZE;
-				auto buffer = make_uniq_array<data_t>(BATCH_SIZE);
-
-				// first copy over the main WAL contents
-				auto copy_end = checkpoint_state.checkpoint_position.GetIndex();
-				reader.Reset();
-				CopyOverWAL(reader, *recovery_handle, buffer.get(), BATCH_SIZE, copy_end);
-
-				// now copy over the checkpoint WAL
-				{
-					BufferedFileReader checkpoint_reader(FileSystem::Get(database), std::move(checkpoint_handle));
-
-					// skip over the version entry
-					ReplayState checkpoint_replay_state(database, *con.context, WALReplayState::CHECKPOINT_WAL);
-					auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(checkpoint_replay_state,
-					                                                                    checkpoint_reader, true);
-					deserializer.ReplayEntry();
-
-					if (checkpoint_replay_state.wal_version != checkpoint_state.wal_version) {
-						throw InvalidInputException("Failure while replaying checkpoint WAL file \"%s\": checkpoint "
-						                            "WAL version is different from main WAL version",
-						                            wal_path);
-					}
-
-					CopyOverWAL(checkpoint_reader, *recovery_handle, buffer.get(), BATCH_SIZE,
-					            checkpoint_reader.FileSize());
-				}
-
-				auto debug_checkpoint_abort = Settings::Get<DebugCheckpointAbortSetting>(storage_manager.GetDatabase());
-
-				// move over the recovery WAL over the main WAL
-				recovery_handle->Sync();
-				recovery_handle.reset();
-
-				if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_MOVING_RECOVERY) {
-					throw FatalException(
-					    "Checkpoint aborted before moving recovery file because of PRAGMA checkpoint_abort flag");
-				}
-
-				fs.MoveFile(recovery_path, wal_path);
-
-				if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_DELETING_CHECKPOINT_WAL) {
-					throw FatalException(
-					    "Checkpoint aborted before deleting checkpoint file because of PRAGMA checkpoint_abort flag");
-				}
-
-				// delete the checkpoint WAL
-				fs.RemoveFile(checkpoint_wal);
+				MergeIntoRecoveryWAL(con, checkpoint_state, reader, recovery_path, std::move(checkpoint_handle));
 
 				// replay the (combined) recovery WAL
 				auto main_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ);

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -33,6 +33,7 @@
 #include "duckdb/main/settings.hpp"
 
 namespace duckdb {
+enum class WALReplayState { MAIN_WAL, CHECKPOINT_WAL };
 
 class ReplayState {
 public:
@@ -269,9 +270,38 @@ private:
 //===--------------------------------------------------------------------===//
 // Replay
 //===--------------------------------------------------------------------===//
+struct WriteAheadLogReplayer {
+public:
+	WriteAheadLogReplayer(QueryContext context, StorageManager &storage_manager, const string &wal_path);
+
+	unique_ptr<WriteAheadLog> Replay();
+
+private:
+	unique_ptr<WriteAheadLog> ReplayLog(unique_ptr<FileHandle> handle,
+	                                    WALReplayState replay_state = WALReplayState::MAIN_WAL);
+	void CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer, idx_t buffer_size,
+	                 idx_t copy_end);
+
+private:
+	QueryContext context;
+	StorageManager &storage_manager;
+	const string &wal_path;
+	FileSystem &fs;
+};
+
 unique_ptr<WriteAheadLog> WriteAheadLog::Replay(QueryContext context, StorageManager &storage_manager,
                                                 const string &wal_path) {
-	auto &fs = FileSystem::Get(storage_manager.GetAttached());
+	WriteAheadLogReplayer wal_replay(context, storage_manager, wal_path);
+	return wal_replay.Replay();
+}
+
+WriteAheadLogReplayer::WriteAheadLogReplayer(QueryContext context, StorageManager &storage_manager,
+                                             const string &wal_path)
+    : context(context), storage_manager(storage_manager), wal_path(wal_path),
+      fs(FileSystem::Get(storage_manager.GetAttached())) {
+}
+
+unique_ptr<WriteAheadLog> WriteAheadLogReplayer::Replay() {
 	auto handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 	if (!handle) {
 		// WAL does not exist - instantiate an empty WAL
@@ -279,7 +309,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::Replay(QueryContext context, StorageMan
 	}
 
 	// context is passed for metric collection purposes only!!
-	auto wal_handle = ReplayInternal(context, storage_manager, std::move(handle));
+	auto wal_handle = ReplayLog(std::move(handle));
 	if (wal_handle) {
 		return wal_handle;
 	}
@@ -290,8 +320,8 @@ unique_ptr<WriteAheadLog> WriteAheadLog::Replay(QueryContext context, StorageMan
 	return make_uniq<WriteAheadLog>(storage_manager, wal_path);
 }
 
-static void CopyOverWAL(QueryContext context, BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer,
-                        idx_t buffer_size, idx_t copy_end) {
+void WriteAheadLogReplayer::CopyOverWAL(BufferedFileReader &reader, FileHandle &target, data_ptr_t buffer,
+                                        idx_t buffer_size, idx_t copy_end) {
 	while (!reader.Finished()) {
 		idx_t read_count = MinValue<idx_t>(buffer_size, copy_end - reader.CurrentOffset());
 		if (read_count == 0) {
@@ -303,8 +333,7 @@ static void CopyOverWAL(QueryContext context, BufferedFileReader &reader, FileHa
 	}
 }
 
-unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, StorageManager &storage_manager,
-                                                        unique_ptr<FileHandle> handle, WALReplayState replay_state) {
+unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle> handle, WALReplayState replay_state) {
 	auto &database = storage_manager.GetAttached();
 	Connection con(database.GetDatabase());
 	auto wal_path = handle->GetPath();
@@ -378,8 +407,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 				// the main WAL is no longer needed, we only need to replay the checkpoint WAL
 				// if this is a read-only connection then replay the checkpoint WAL directly
 				if (storage_manager.GetAttached().IsReadOnly()) {
-					return ReplayInternal(context, storage_manager, std::move(checkpoint_handle),
-					                      WALReplayState::CHECKPOINT_WAL);
+					return ReplayLog(std::move(checkpoint_handle), WALReplayState::CHECKPOINT_WAL);
 				}
 				// if this is not a read-only connection we need to finish the checkpoint
 				// overwrite the current WAL with the checkpoint WAL
@@ -390,8 +418,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 				// now open the handle again and replay the checkpoint WAL
 				checkpoint_handle =
 				    fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
-				return ReplayInternal(context, storage_manager, std::move(checkpoint_handle),
-				                      WALReplayState::CHECKPOINT_WAL);
+				return ReplayLog(std::move(checkpoint_handle), WALReplayState::CHECKPOINT_WAL);
 			}
 			// the checkpoint was unsuccessful
 			// this means we need to replay both this WAL and the checkpoint WAL
@@ -409,7 +436,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 				// first copy over the main WAL contents
 				auto copy_end = checkpoint_state.checkpoint_position.GetIndex();
 				reader.Reset();
-				CopyOverWAL(context, reader, *recovery_handle, buffer.get(), BATCH_SIZE, copy_end);
+				CopyOverWAL(reader, *recovery_handle, buffer.get(), BATCH_SIZE, copy_end);
 
 				// now copy over the checkpoint WAL
 				{
@@ -427,7 +454,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 						                            wal_path);
 					}
 
-					CopyOverWAL(context, checkpoint_reader, *recovery_handle, buffer.get(), BATCH_SIZE,
+					CopyOverWAL(checkpoint_reader, *recovery_handle, buffer.get(), BATCH_SIZE,
 					            checkpoint_reader.FileSize());
 				}
 
@@ -454,7 +481,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 
 				// replay the (combined) recovery WAL
 				auto main_handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ);
-				return ReplayInternal(context, storage_manager, std::move(main_handle), WALReplayState::CHECKPOINT_WAL);
+				return ReplayLog(std::move(main_handle), WALReplayState::CHECKPOINT_WAL);
 			}
 		}
 	}
@@ -518,7 +545,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, St
 		// we have successfully replayed the main WAL - but there is still a checkpoint WAL remaining
 		// this can only happen in read-only mode
 		// replay the checkpoint WAL and return
-		return ReplayInternal(context, storage_manager, std::move(checkpoint_handle), WALReplayState::CHECKPOINT_WAL);
+		return ReplayLog(std::move(checkpoint_handle), WALReplayState::CHECKPOINT_WAL);
 	}
 	auto init_state = all_succeeded ? WALInitState::UNINITIALIZED : WALInitState::UNINITIALIZED_REQUIRES_TRUNCATE;
 	return make_uniq<WriteAheadLog>(storage_manager, wal_path, successful_offset, init_state);

--- a/test/sql/storage/concurrent_wal/concurrent_checkpoint_empty_checkpoint.test_slow
+++ b/test/sql/storage/concurrent_wal/concurrent_checkpoint_empty_checkpoint.test_slow
@@ -1,0 +1,76 @@
+# name: test/sql/storage/concurrent_wal/concurrent_checkpoint_empty_checkpoint.test_slow
+# description: Test recovery when doing concurrent appends with an empty checkpoint WAL
+# group: [concurrent_wal]
+
+foreach wal_abort_mode before_wal_finish before_header
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_abort.db' AS main_db
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET debug_checkpoint_abort='${wal_abort_mode}'
+
+statement ok
+CREATE OR REPLACE TABLE main_db.integers(i INTEGER)
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_other_db.db' AS other_db
+
+statement ok
+CREATE OR REPLACE TABLE other_db.ranges(begin_range INT, end_range INT)
+
+concurrentloop threadid 0 20
+
+loop x 0 10
+
+# we write to two databases - the main database (that is being checkpointed) and a back-up database "concurrent_other_db"
+# we write to the database "concurrent_other_db" after a commit to the main database has succeeded
+# so anything that ends up there has to also be in the main database
+# otherwise we have lost data
+onlyif threadid<>10
+statement maybe
+INSERT INTO main_db.integers SELECT * FROM range(${x} * 2000 + ${threadid} * 100, ${x} * 2000 + (${threadid} + 1) * 100);
+----
+database has been invalidated because of a previous fatal error
+
+onlyif threadid<>10
+statement maybe
+INSERT INTO other_db.ranges VALUES (${x} * 2000 + ${threadid} * 100, ${x} * 2000 + (${threadid} + 1) * 100);
+----
+database has been invalidated because of a previous fatal error
+
+endloop
+
+onlyif threadid=10
+statement error
+CHECKPOINT main_db
+----
+Checkpoint aborted
+
+endloop
+
+restart
+
+# overwrite the checkpoint file with an empty file
+# note: we actually lose data here, so we can't verify anything about the data
+statement ok
+copy (select blob '') to '__TEST_DIR__/concurrent_abort.db.wal.checkpoint' (FORMAT blob);
+
+statement ok
+SET debug_checkpoint_abort='none'
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_abort.db' AS main_db
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_other_db.db' AS other_db
+
+restart
+
+endloop


### PR DESCRIPTION
When the checkpoint WAL is empty, we would previously fail to deserialize the header. We now deal with this scenario by checking the file size - if the checkpoint WAL is empty we just skip adding it to the recovery WAL.