### PR TITLE
Invalid input exception for corrupted encrypted parquet files

### DIFF
--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -102,9 +102,9 @@ public:
 		if (encryption_algorithm.__isset.AES_GCM_V1) {
 			unique_file_identifier = encryption_algorithm.AES_GCM_V1.aad_file_unique;
 		} else if (encryption_algorithm.__isset.AES_GCM_CTR_V1) {
-			throw InternalException("File is encrypted with AES_GCM_CTR_V1, but this is not supported by DuckDB");
+			throw InvalidInputException("File is encrypted with AES_GCM_CTR_V1, but this is not supported by DuckDB");
 		} else {
-			throw InternalException("File is encrypted but no encryption algorithm is set");
+			throw InvalidInputException("File is encrypted but no encryption algorithm is set");
 		}
 
 		aad_crypto_metadata.Initialize(unique_file_identifier, row_group_ordinal_p, ColumnIndex());

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -972,9 +972,9 @@ string ParquetReader::GetUniqueFileIdentifier(const duckdb_parquet::EncryptionAl
 	if (encryption_algorithm.__isset.AES_GCM_V1) {
 		return encryption_algorithm.AES_GCM_V1.aad_file_unique;
 	} else if (encryption_algorithm.__isset.AES_GCM_CTR_V1) {
-		throw InternalException("File is encrypted with AES_GCM_CTR_V1, but this is not supported by DuckDB");
+		throw InvalidInputException("File is encrypted with AES_GCM_CTR_V1, but this is not supported by DuckDB");
 	} else {
-		throw InternalException("File is encrypted but no encryption algorithm is set");
+		throw InvalidInputException("File is encrypted but no encryption algorithm is set");
 	}
 }
 


### PR DESCRIPTION
```
SIGABRT: ABORT THROWN BY INTERNAL EXCEPTION: File is encrypted but no encryption algorithm is set
```

Since this error points to a corrupted Parquet file, we should throw invalid input exceptions instead of internal errors.

fixes https://github.com/duckdblabs/duckdb-internal/issues/8584