### PR TITLE
Use test runner in all windows CI jobs

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -160,7 +160,7 @@ jobs:
 
     - name: Test
       shell: bash
-      run: test/Release/unittest.exe
+      run: python scripts/ci/run_tests.py test/Release/unittest.exe
 
     - name: Tools Test
       shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -73,7 +73,7 @@ jobs:
       shell: bash
       if: ${{ !inputs.skip_tests }}
       run: |
-        test/Release/unittest.exe
+        python scripts/ci/run_tests.py test/Release/unittest.exe
 
     - name: Test with VS2019 C++ stdlib
       shell: bash
@@ -82,7 +82,7 @@ jobs:
         choco install wget -y --no-progress
         wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
         ls ./test/Release
-        ./test/Release/unittest.exe
+        python scripts/ci/run_tests.py test/Release/unittest.exe
         rm ./test/Release/msvcp140.dll
 
     - name: Tools Test

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -299,6 +299,8 @@ def run_batch(config: TestRunnerConfig, batch):
     message = None
     peak_rss_bytes = 0
 
+    # On Windows the child process cannot reopen a NamedTemporaryFile while it
+    # is still open here, so keep it after close and unlink it ourselves.
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as batch_file:
         batch_file.write("\n".join(batch))
         batch_file.write("\n")


### PR DESCRIPTION
> [!IMPORTANT]
> The test `Test ADBC URI option` is already [failing](https://github.com/duckdb/duckdb/actions/runs/23625709372/job/68815259632#step:8:66) on branch `main`.

```
[7/10] (70%): Test ADBC URI option
-------------------------------------------------------------------------------
Test ADBC URI option
-------------------------------------------------------------------------------
D:\a\duckdb\duckdb\test\api\adbc\test_adbc.cpp(3312)
...............................................................................

D:\a\duckdb\duckdb\test\api\adbc\test_adbc.cpp(3473): FAILED:
  REQUIRE( SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)) )
with expansion:
  false
```