### PR TITLE
Windows: remove prefix from canonical paths

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -837,6 +837,9 @@ string LocalFileSystem::MakePathAbsolute(const string &path_p, optional_ptr<File
 
 constexpr char PIPE_PREFIX[] = "\\\\.\\pipe\\";
 
+static const std::wstring WINDOWS_LOCAL_LONG_PATH_PREFIX = L"\\\\?\\";
+static const std::wstring WINDOWS_UNC_LONG_PATH_PREFIX = L"\\\\?\\UNC\\";
+
 // Returns the last Win32 error, in string format. Returns an empty string if there is no error.
 std::string LocalFileSystem::GetLastErrorAsString() {
 	// Get the error message, if any.
@@ -1373,10 +1376,23 @@ bool LocalFileSystem::TryCanonicalizeExistingPath(string &input) {
 	DWORD len = GetFinalPathNameByHandleW(handle, resolved, MAX_PATH, FILE_NAME_NORMALIZED);
 	CloseHandle(handle);
 
-	if (len < 0 && len >= MAX_PATH) {
+	if (len < 0) {
 		return false;
 	}
-	input = WindowsUtil::UnicodeToUTF8(resolved);
+
+	std::wstring resolved_wstr(resolved, static_cast<size_t>(len));
+
+	if (resolved_wstr.find(WINDOWS_LOCAL_LONG_PATH_PREFIX) == 0) {
+		resolved_wstr = resolved_wstr.substr(WINDOWS_LOCAL_LONG_PATH_PREFIX.length());
+	} else if (resolved_wstr.find(WINDOWS_UNC_LONG_PATH_PREFIX) == 0) {
+		resolved_wstr = resolved_wstr.substr(WINDOWS_UNC_LONG_PATH_PREFIX.length());
+	}
+
+	if (resolved_wstr.length() >= MAX_PATH) {
+		return false;
+	}
+
+	input = WindowsUtil::UnicodeToUTF8(resolved_wstr.c_str());
 	return true;
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1376,20 +1376,16 @@ bool LocalFileSystem::TryCanonicalizeExistingPath(string &input) {
 	DWORD len = GetFinalPathNameByHandleW(handle, resolved, MAX_PATH, FILE_NAME_NORMALIZED);
 	CloseHandle(handle);
 
-	if (len < 0) {
+	if (len == 0 || len >= MAX_PATH) {
 		return false;
 	}
 
 	std::wstring resolved_wstr(resolved, static_cast<size_t>(len));
 
-	if (resolved_wstr.find(WINDOWS_LOCAL_LONG_PATH_PREFIX) == 0) {
+	if (resolved_wstr.find(WINDOWS_UNC_LONG_PATH_PREFIX) == 0) {
+		resolved_wstr = L"\\\\" + resolved_wstr.substr(WINDOWS_UNC_LONG_PATH_PREFIX.length());
+	} else if (resolved_wstr.find(WINDOWS_LOCAL_LONG_PATH_PREFIX) == 0) {
 		resolved_wstr = resolved_wstr.substr(WINDOWS_LOCAL_LONG_PATH_PREFIX.length());
-	} else if (resolved_wstr.find(WINDOWS_UNC_LONG_PATH_PREFIX) == 0) {
-		resolved_wstr = resolved_wstr.substr(WINDOWS_UNC_LONG_PATH_PREFIX.length());
-	}
-
-	if (resolved_wstr.length() >= MAX_PATH) {
-		return false;
 	}
 
 	input = WindowsUtil::UnicodeToUTF8(resolved_wstr.c_str());

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -975,3 +975,12 @@ TEST_CASE("Path one-off tests", "[file_system]") {
 	CHECK(Path::FromString("a").Join(std::vector<string>({"b"})).ToString() == "a/b");
 	CHECK(Path::FromString("a").Join(std::vector<string>({"b", "c"})).ToString() == "a/b/c");
 }
+
+#ifdef _WIN32
+TEST_CASE("Check path canonicalization on Windows", "[file_system]") {
+	auto fs = FileSystem::CreateLocal();
+	auto canonical_work_dir = fs->CanonicalizePath(fs->GetWorkingDirectory());
+	// check that long path prefix "\\?\" or "\\?\UNC\" is not present
+	REQUIRE(!StringUtil::StartsWith(canonical_work_dir, "\\\\"));
+}
+#endif // _WIN32


### PR DESCRIPTION
It seems that PR #20726 had an unintended consequence when canonicalized paths on Windows started to be prefixed with a long path prefix `\\?\` (or `\\?\UNC\` for UNC paths). These paths can "leak" to SQL clients, for example when reading a setting value for `temp_directory`.

Because canonicalization is not related to actual long-paths support (#20983 is submitted for that, but not targeted for 1.5) it is proposed to not expose prefixed paths to client code. As they can confuse users or some application code that is not aware of long paths prefixes.

This PR keeps the canonicalization logic intact and only strips the long-path prefix from the resulting canonical path.

The change is Windows-only.

Testing: new test added that checks canonicalization call.

Fixes: duckdb/duckdb-java#622