### PR TITLE
Add ubigint_t class which does checked arithmetic, and use it in list_resize

### DIFF
--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -1,4 +1,4 @@
-#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/ubigint.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/list_functions.hpp"
@@ -32,22 +32,21 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 	UnifiedVectorFormat new_sizes_data;
 	new_sizes.ToUnifiedFormat(row_count, new_sizes_data);
 	D_ASSERT(new_sizes.GetType().id() == LogicalTypeId::UBIGINT);
-	auto new_size_entries = UnifiedVectorFormat::GetData<uint64_t>(new_sizes_data);
+	auto new_size_entries = UnifiedVectorFormat::GetData<ubigint_t>(new_sizes_data);
 
 	// Get the new size of the result child vector.
 	// We skip rows with NULL values in the input lists.
-	idx_t child_vector_size = 0;
+	ubigint_t child_vector_size(0);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		auto list_idx = lists_data.sel->get_index(row_idx);
 		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
 
 		if (lists_data.validity.RowIsValid(list_idx) && new_sizes_data.validity.RowIsValid(new_size_idx)) {
-			child_vector_size = AddOperatorOverflowCheck::Operation<idx_t, idx_t, idx_t>(
-			    child_vector_size, new_size_entries[new_size_idx]);
+			child_vector_size += new_size_entries[new_size_idx];
 		}
 	}
-	ListVector::Reserve(result, child_vector_size);
-	ListVector::SetListSize(result, child_vector_size);
+	ListVector::Reserve(result, child_vector_size.value);
+	ListVector::SetListSize(result, child_vector_size.value);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_entries = FlatVector::GetData<list_entry_t>(result);
@@ -62,7 +61,7 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 		default_vector->ToUnifiedFormat(row_count, default_data);
 	}
 
-	idx_t offset = 0;
+	ubigint_t offset(0);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		auto list_idx = lists_data.sel->get_index(row_idx);
 		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
@@ -73,47 +72,49 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 			continue;
 		}
 
-		idx_t new_size = 0;
+		ubigint_t new_size(0);
 		if (new_sizes_data.validity.RowIsValid(new_size_idx)) {
 			new_size = new_size_entries[new_size_idx];
 		}
 
 		// If new_size >= length, then we copy [0, length) values.
 		// If new_size < length, then we copy [0, new_size) values.
-		auto copy_count = MinValue<idx_t>(list_entries[list_idx].length, new_size);
+		auto copy_count = MinValue<ubigint_t>(list_entries[list_idx].length, new_size);
 
 		// Set the result entry.
-		result_entries[row_idx].offset = offset;
-		result_entries[row_idx].length = new_size;
+		result_entries[row_idx].offset = offset.value;
+		result_entries[row_idx].length = new_size.value;
 
 		// Copy the child vector's values.
 		// The number of elements to copy is later determined like so: source_count - source_offset.
-		idx_t source_offset = list_entries[list_idx].offset;
-		idx_t source_count = source_offset + copy_count;
-		VectorOperations::Copy(child_vector, result_child_vector, source_count, source_offset, offset);
+		ubigint_t source_offset = list_entries[list_idx].offset;
+		ubigint_t source_count = source_offset + copy_count;
+		VectorOperations::Copy(child_vector, result_child_vector, source_count.value, source_offset.value,
+		                       offset.value);
 		offset += copy_count;
 
 		// Fill the remaining space with the default values.
 		if (copy_count < new_size) {
-			idx_t remaining_count = new_size - copy_count;
+			ubigint_t remaining_count = new_size - copy_count;
 
 			if (default_vector) {
 				auto default_idx = default_data.sel->get_index(row_idx);
 				if (default_data.validity.RowIsValid(default_idx)) {
-					SelectionVector sel(remaining_count);
-					for (idx_t j = 0; j < remaining_count; j++) {
+					SelectionVector sel(remaining_count.value);
+					for (idx_t j = 0; j < remaining_count.value; j++) {
 						sel.set_index(j, row_idx);
 					}
-					VectorOperations::Copy(*default_vector, result_child_vector, sel, remaining_count, 0, offset);
+					VectorOperations::Copy(*default_vector, result_child_vector, sel, remaining_count.value, 0,
+					                       offset.value);
 					offset += remaining_count;
 					continue;
 				}
 			}
 
 			// Fill the remaining space with NULL.
-			for (idx_t j = copy_count; j < new_size; j++) {
-				FlatVector::SetNull(result_child_vector, offset, true);
-				offset++;
+			for (idx_t j = copy_count.value; j < new_size.value; j++) {
+				FlatVector::SetNull(result_child_vector, offset.value, true);
+				offset += 1;
 			}
 		}
 	}

--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/types/double_na_equal.hpp"
+#include "duckdb/common/ubigint.hpp"
 
 namespace duckdb {
 struct bignum_t;
@@ -40,7 +41,7 @@ PhysicalType GetTypeId() {
 		return PhysicalType::UINT16;
 	} else if (std::is_same<TYPE, uint32_t>()) {
 		return PhysicalType::UINT32;
-	} else if (std::is_same<TYPE, uint64_t>()) {
+	} else if (std::is_same<TYPE, uint64_t>() || std::is_same<TYPE, ubigint_t>()) {
 		return PhysicalType::UINT64;
 	} else if (std::is_same<TYPE, idx_t>() || std::is_same<TYPE, const idx_t>()) {
 		return PhysicalType::UINT64;

--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -15,10 +15,10 @@
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/types/double_na_equal.hpp"
-#include "duckdb/common/ubigint.hpp"
 
 namespace duckdb {
 struct bignum_t;
+struct ubigint_t;
 
 //! Returns the PhysicalType for the given type
 template <class T>

--- a/src/include/duckdb/common/ubigint.hpp
+++ b/src/include/duckdb/common/ubigint.hpp
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/ubigint.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/subtract.hpp"
+#include "duckdb/common/operator/multiply.hpp"
+
+namespace duckdb {
+
+struct ubigint_t { // NOLINT
+public:
+	uint64_t value;
+
+	ubigint_t() : value(0) {
+	}
+	ubigint_t(uint64_t value) : value(value) { // NOLINT: allow implicit conversion
+	}
+
+	// Comparison operators
+	inline bool operator==(const ubigint_t &rhs) const {
+		return value == rhs.value;
+	}
+	inline bool operator!=(const ubigint_t &rhs) const {
+		return value != rhs.value;
+	}
+	inline bool operator<(const ubigint_t &rhs) const {
+		return value < rhs.value;
+	}
+	inline bool operator<=(const ubigint_t &rhs) const {
+		return value <= rhs.value;
+	}
+	inline bool operator>(const ubigint_t &rhs) const {
+		return value > rhs.value;
+	}
+	inline bool operator>=(const ubigint_t &rhs) const {
+		return value >= rhs.value;
+	}
+
+	// Checked arithmetic operators
+	inline ubigint_t operator+(const ubigint_t &rhs) const {
+		return ubigint_t(AddOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value));
+	}
+	inline ubigint_t operator-(const ubigint_t &rhs) const {
+		return ubigint_t(SubtractOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value));
+	}
+	inline ubigint_t operator*(const ubigint_t &rhs) const {
+		return ubigint_t(MultiplyOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value));
+	}
+	inline ubigint_t operator/(const ubigint_t &rhs) const {
+		if (rhs.value == 0) {
+			throw OutOfRangeException("Division by zero!");
+		}
+		return ubigint_t(value / rhs.value);
+	}
+	inline ubigint_t operator%(const ubigint_t &rhs) const {
+		if (rhs.value == 0) {
+			throw OutOfRangeException("Modulo by zero!");
+		}
+		return ubigint_t(value % rhs.value);
+	}
+
+	// Compound assignment operators
+	inline ubigint_t &operator+=(const ubigint_t &rhs) {
+		value = AddOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value);
+		return *this;
+	}
+	inline ubigint_t &operator-=(const ubigint_t &rhs) {
+		value = SubtractOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value);
+		return *this;
+	}
+	inline ubigint_t &operator*=(const ubigint_t &rhs) {
+		value = MultiplyOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, rhs.value);
+		return *this;
+	}
+	inline ubigint_t &operator/=(const ubigint_t &rhs) {
+		if (rhs.value == 0) {
+			throw OutOfRangeException("Division by zero!");
+		}
+		value /= rhs.value;
+		return *this;
+	}
+	inline ubigint_t &operator%=(const ubigint_t &rhs) {
+		if (rhs.value == 0) {
+			throw OutOfRangeException("Modulo by zero!");
+		}
+		value %= rhs.value;
+		return *this;
+	}
+
+	// Pre/post increment/decrement
+	inline ubigint_t &operator++() {
+		value = AddOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, 1);
+		return *this;
+	}
+	inline ubigint_t operator++(int) {
+		ubigint_t result = *this;
+		value = AddOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, 1);
+		return result;
+	}
+	inline ubigint_t &operator--() {
+		value = SubtractOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, 1);
+		return *this;
+	}
+	inline ubigint_t operator--(int) {
+		ubigint_t result = *this;
+		value = SubtractOperatorOverflowCheck::Operation<uint64_t, uint64_t, uint64_t>(value, 1);
+		return result;
+	}
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Currently we use the standard C++ numeric types like `uint64_t` and friends - also for operating on data stored in vectors. These types use unchecked arithmetic by default and can overflow. In order to catch overflows, we need to manually use verbose functions like `AddOperatorOverflowCheck::Operation`.

This PR makes a small step towards solving this in a more generic way by introducing a `ubigint_t` class. This class is effectively identical to `uint64_t` - but uses checked arithmetic. This is more of a POC - we're still using the regular numeric types in almost all cases - but this could be a path towards making it easier to implement checked arithmetic in the system.