### PR TITLE
CLI: Add .help shortcuts

### DIFF
--- a/tools/shell/linenoise/include/shortcuts.hpp
+++ b/tools/shell/linenoise/include/shortcuts.hpp
@@ -19,6 +19,6 @@ struct ShortcutEntry {
 };
 
 //! Returns the list of keyboard shortcuts (for .help shortcuts)
-const vector<ShortcutEntry> &GetShellShortcuts();
+vector<ShortcutEntry> GetShellShortcuts();
 
 } // namespace duckdb

--- a/tools/shell/linenoise/include/shortcuts.hpp
+++ b/tools/shell/linenoise/include/shortcuts.hpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// shortcuts.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+struct ShortcutEntry {
+	const char *key_name;
+	const char *description;
+	const char *category;
+};
+
+//! Returns the list of keyboard shortcuts (for .help shortcuts)
+const vector<ShortcutEntry> &GetShellShortcuts();
+
+} // namespace duckdb

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1422,8 +1422,8 @@ bool Linenoise::Write(int fd, const char *data, idx_t size) {
 
 // Shortcut table — kept near the key handler switch so they stay in sync.
 // If you add or change a keybinding in Edit(), update this table too.
-const vector<ShortcutEntry> &GetShellShortcuts() {
-	static const vector<ShortcutEntry> shortcuts = {
+vector<ShortcutEntry> GetShellShortcuts() {
+	const vector<ShortcutEntry> shortcuts = {
 	    // Control
 	    {"Enter / Ctrl+J", "Submit input", "Control"},
 	    {"Ctrl+C", "Cancel current input or interrupt in-flight query", "Control"},

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -9,6 +9,7 @@
 #endif
 #include "linenoise.h"
 #include "linenoise.hpp"
+#include "shortcuts.hpp"
 #include "history.hpp"
 #include "highlighting.hpp"
 #include "terminal.hpp"
@@ -1418,6 +1419,54 @@ bool Linenoise::Write(int fd, const char *data, idx_t size) {
  * when ctrl+d is typed.
  *
  * The function returns the length of the current buffer. */
+
+// Shortcut table — kept near the key handler switch so they stay in sync.
+// If you add or change a keybinding in Edit(), update this table too.
+const vector<ShortcutEntry> &GetShellShortcuts() {
+	static const vector<ShortcutEntry> shortcuts = {
+	    // Control
+	    {"Enter / Ctrl+J", "Submit input", "Control"},
+	    {"Ctrl+C", "Cancel current input or interrupt in-flight query", "Control"},
+	    {"Ctrl+D", "Exit shell (when line is empty)", "Control"},
+	    {"Ctrl+G", "Submit input (in multiline mode)", "Control"},
+	    {"Ctrl+L", "Clear screen", "Control"},
+	    {"Ctrl+Z", "Suspend shell", "Control"},
+	    {"Tab", "Auto-complete", "Control"},
+	    {"Ctrl+Q, then click", "Move cursor to mouse click position", "Control"},
+	    // Editing
+	    {"Ctrl+D / Delete", "Delete character under cursor (or exit if line is empty)", "Editing"},
+	    {"Ctrl+H / Backspace", "Delete character before cursor", "Editing"},
+	    {"Ctrl+K", "Delete from cursor to end of line", "Editing"},
+	    {"Ctrl+U", "Delete entire line", "Editing"},
+	    {"Ctrl+W", "Delete previous word", "Editing"},
+	    {"Alt+D", "Delete next word", "Editing"},
+	    {"Alt+Backspace", "Delete previous word", "Editing"},
+	    {"Ctrl+T", "Swap character under cursor with previous", "Editing"},
+	    {"Alt+T", "Swap current word with previous", "Editing"},
+	    {"Alt+C", "Capitalize next word", "Editing"},
+	    {"Alt+L", "Lowercase next word", "Editing"},
+	    {"Alt+U", "Uppercase next word", "Editing"},
+	    {"Alt+R", "Delete entire line", "Editing"},
+	    {"Alt+\\", "Remove spaces around cursor", "Editing"},
+	    {"Ctrl+X", "Insert newline (multiline input)", "Editing"},
+	    // Navigation
+	    {"Ctrl+A / Home", "Go to beginning of line", "Navigation"},
+	    {"Ctrl+E / End", "Go to end of line", "Navigation"},
+	    {"Ctrl+B / Left", "Move cursor left", "Navigation"},
+	    {"Ctrl+F / Right", "Move cursor right", "Navigation"},
+	    {"Alt+B / Alt+Left", "Move cursor one word left", "Navigation"},
+	    {"Alt+F / Alt+Right", "Move cursor one word right", "Navigation"},
+	    // History
+	    {"Ctrl+P / Up", "Previous history entry", "History"},
+	    {"Ctrl+N / Down", "Next history entry", "History"},
+	    {"Ctrl+R", "Reverse search history", "History"},
+	    {"Ctrl+S", "Forward search history", "History"},
+	    {"Ctrl+Up", "Jump to first history entry", "History"},
+	    {"Ctrl+Down", "Jump to last history entry", "History"},
+	};
+	return shortcuts;
+}
+
 int Linenoise::Edit() {
 	/* The latest history entry is always our current buffer, that
 	 * initially is just an empty string. */

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -6,6 +6,7 @@
 
 #ifdef HAVE_LINENOISE
 #include "linenoise.h"
+#include "shortcuts.hpp"
 #endif
 
 namespace duckdb_shell {
@@ -217,6 +218,25 @@ MetadataResult ToggleHighlightResult(ShellState &state, const vector<string> &ar
 
 MetadataResult ShowHelp(ShellState &state, const vector<string> &args) {
 	if (args.size() >= 2) {
+#ifdef HAVE_LINENOISE
+		if (duckdb::StringUtil::CIEquals(args[1], "shortcuts")) {
+			auto &shortcuts = duckdb::GetShellShortcuts();
+			const char *current_category = nullptr;
+			for (auto &entry : shortcuts) {
+				if (!current_category || strcmp(current_category, entry.category) != 0) {
+					if (current_category) {
+						state.PrintF("\n");
+					}
+					current_category = entry.category;
+					duckdb_shell::ShellHighlight highlighter(state);
+					highlighter.PrintText(entry.category, PrintOutput::STDOUT, HighlightElementType::KEYWORD);
+					state.PrintF("\n");
+				}
+				state.PrintF("  %-24s %s\n", entry.key_name, entry.description);
+			}
+			return MetadataResult::SUCCESS;
+		}
+#endif
 		idx_t n = state.PrintHelp(args[1].c_str());
 		if (n == 0) {
 			state.PrintF("Nothing matches '%s'\n", args[1].c_str());
@@ -1044,6 +1064,9 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 	}
 	if (!print_extended) {
 		PrintF("\nRun .help --all for extended information\n");
+#ifdef HAVE_LINENOISE
+		PrintF("Run .help shortcuts for keyboard shortcuts\n");
+#endif
 	}
 	return print_info_list.size();
 }

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -220,7 +220,7 @@ MetadataResult ShowHelp(ShellState &state, const vector<string> &args) {
 	if (args.size() >= 2) {
 #ifdef HAVE_LINENOISE
 		if (duckdb::StringUtil::CIEquals(args[1], "shortcuts")) {
-			auto &shortcuts = duckdb::GetShellShortcuts();
+			auto shortcuts = duckdb::GetShellShortcuts();
 			const char *current_category = nullptr;
 			for (auto &entry : shortcuts) {
 				if (!current_category || strcmp(current_category, entry.category) != 0) {


### PR DESCRIPTION
I was trying to review what shortcuts are missing for duckdb-wasm shell and figured out there were many I was not aware (Ctrl+Q then click).

I think I might not be the only one, and might be helpful for CLI users to have a reference of all available commands.

Main risk I could see with this addition: docs and implementation migth (and will) get out of sync. I think that is maybe something that we accept as a cost.

Also add a line to `.help` that allow discoverability of `.help shortcuts`.

Preview:
```
duckdb -c ".help shortcuts"
```
```
Control
  Enter / Ctrl+J           Submit input
  Ctrl+C                   Cancel current input or interrupt in-flight query
  Ctrl+D                   Exit shell (when line is empty)
  Ctrl+G                   Submit input (in multiline mode)
  Ctrl+L                   Clear screen
  Ctrl+Z                   Suspend shell
  Tab                      Auto-complete
  Ctrl+Q, then click       Move cursor to mouse click position

Editing
  Ctrl+D / Delete          Delete character under cursor (or exit if line is empty)
  Ctrl+H / Backspace       Delete character before cursor
  Ctrl+K                   Delete from cursor to end of line
  Ctrl+U                   Delete entire line
  Ctrl+W                   Delete previous word
  Alt+D                    Delete next word
  Alt+Backspace            Delete previous word
  Ctrl+T                   Swap character under cursor with previous
  Alt+T                    Swap current word with previous
  Alt+C                    Capitalize next word
  Alt+L                    Lowercase next word
  Alt+U                    Uppercase next word
  Alt+R                    Delete entire line
  Alt+\                    Remove spaces around cursor
  Ctrl+X                   Insert newline (multiline input)

Navigation
  Ctrl+A / Home            Go to beginning of line
  Ctrl+E / End             Go to end of line
  Ctrl+B / Left            Move cursor left
  Ctrl+F / Right           Move cursor right
  Alt+B / Alt+Left         Move cursor one word left
  Alt+F / Alt+Right        Move cursor one word right

History
  Ctrl+P / Up              Previous history entry
  Ctrl+N / Down            Next history entry
  Ctrl+R                   Reverse search history
  Ctrl+S                   Forward search history
  Ctrl+Up                  Jump to first history entry
  Ctrl+Down                Jump to last history entry
```