### PR TITLE
Unify `LocalFileSystem::GetVersionTag` to use `FileMetadata`, and change Windows ListFiles so that we can compute version tags without additional system calls

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -946,7 +946,7 @@ static string GetWindowsVersionTag(const BY_HANDLE_FILE_INFORMATION &file_info) 
 	ULARGE_INTEGER last_write_time;
 	last_write_time.LowPart = file_info.ftLastWriteTime.dwLowDateTime;
 	last_write_time.HighPart = file_info.ftLastWriteTime.dwHighDateTime;
-	return WindowsComputeVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+	return GetWindowsVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
 }
 
 static string GetWindowsVersionTag(const WIN32_FIND_DATAW &ffd) {
@@ -958,7 +958,7 @@ static string GetWindowsVersionTag(const WIN32_FIND_DATAW &ffd) {
 	ULARGE_INTEGER last_write_time;
 	last_write_time.LowPart = ffd.ftLastWriteTime.dwLowDateTime;
 	last_write_time.HighPart = ffd.ftLastWriteTime.dwHighDateTime;
-	return WindowsComputeVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+	return GetWindowsVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
 }
 
 struct WindowsFileHandle : public FileHandle {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1330,13 +1330,14 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 	DWORD volume_serial_number = 0;
 	if (!GetVolumeInformationByHandleW(hDir, NULL, 0, &volume_serial_number, NULL, NULL, NULL, 0)) {
 		CloseHandle(hDir);
-		throw IOException("Failed to get volume serial number from directory \"%s\": %s", directory, error);
+		throw IOException("Failed to get volume serial number from directory \"%s\": %s", directory,
+		                  GetLastErrorAsString());
 	}
 
 	static constexpr DWORD BUFFER_SIZE = 65536;
 	auto buffer = unique_ptr<char[]>(new char[BUFFER_SIZE]);
 
-	FILE_INFORMATION_CLASS info_class = FileIdBothDirectoryRestartInfo;
+	FILE_INFO_BY_HANDLE_CLASS info_class = FileIdBothDirectoryRestartInfo;
 	while (true) {
 		if (!GetFileInformationByHandleEx(hDir, info_class, buffer.get(), BUFFER_SIZE)) {
 			CloseHandle(hDir);
@@ -1351,7 +1352,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		auto *entry = reinterpret_cast<FILE_ID_BOTH_DIR_INFO *>(buffer.get());
 		while (true) {
 			// FileName is not null-terminated; use FileNameLength (in bytes) to construct the string.
-			wstring wname(entry->FileName, entry->FileNameLength / sizeof(WCHAR));
+			std::wstring wname(entry->FileName, entry->FileNameLength / sizeof(WCHAR));
 			string name = WindowsUtil::UnicodeToUTF8(wname.c_str());
 
 			if (name != "." && name != "..") {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -945,6 +945,7 @@ static string GetWindowsVersionTag(const BY_HANDLE_FILE_INFORMATION &file_info) 
 	Store(file_index, data_ptr_cast(&version_tag[1]));
 	Store(file_size, data_ptr_cast(&version_tag[2]));
 	Store(last_write_time.QuadPart, data_ptr_cast(&version_tag[3]));
+	return string(char_ptr_cast(version_tag), sizeof(version_tag));
 }
 
 static string GetWindowsVersionTag(const FILE_ID_BOTH_DIR_INFO &entry, DWORD volume_serial_number) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -929,36 +929,31 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	return file_metadata;
 }
 
-static string GetWindowsVersionTag(uint64_t file_size, uint64_t creation_time, uint64_t last_write_time) {
-	uint64_t version_tag[3];
-	Store(file_size, data_ptr_cast(&version_tag[0]));
-	Store(creation_time, data_ptr_cast(&version_tag[1]));
-	Store(last_write_time, data_ptr_cast(&version_tag[2]));
-	return string(char_ptr_cast(version_tag), sizeof(version_tag));
-}
-
 static string GetWindowsVersionTag(const BY_HANDLE_FILE_INFORMATION &file_info) {
-	const uint64_t file_size =
-	    (static_cast<uint64_t>(file_info.nFileSizeHigh) << 32) | static_cast<uint64_t>(file_info.nFileSizeLow);
-	ULARGE_INTEGER creation_time;
-	creation_time.LowPart = file_info.ftCreationTime.dwLowDateTime;
-	creation_time.HighPart = file_info.ftCreationTime.dwHighDateTime;
 	ULARGE_INTEGER last_write_time;
 	last_write_time.LowPart = file_info.ftLastWriteTime.dwLowDateTime;
 	last_write_time.HighPart = file_info.ftLastWriteTime.dwHighDateTime;
-	return GetWindowsVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+
+	const uint64_t file_size =
+	    (static_cast<uint64_t>(file_info.nFileSizeHigh) << 32) | static_cast<uint64_t>(file_info.nFileSizeLow);
+	const uint64_t file_index =
+	    (static_cast<uint64_t>(file_info.nFileIndexHigh) << 32) | static_cast<uint64_t>(file_info.nFileIndexLow);
+
+	// volume serial + file index identify the file; size + last write time protect against in-place rewrites
+	uint64_t version_tag[4];
+	Store(static_cast<uint64_t>(file_info.dwVolumeSerialNumber), data_ptr_cast(&version_tag[0]));
+	Store(file_index, data_ptr_cast(&version_tag[1]));
+	Store(file_size, data_ptr_cast(&version_tag[2]));
+	Store(last_write_time.QuadPart, data_ptr_cast(&version_tag[3]));
 }
 
-static string GetWindowsVersionTag(const WIN32_FIND_DATAW &ffd) {
-	const uint64_t file_size =
-	    (static_cast<uint64_t>(ffd.nFileSizeHigh) << 32) | static_cast<uint64_t>(ffd.nFileSizeLow);
-	ULARGE_INTEGER creation_time;
-	creation_time.LowPart = ffd.ftCreationTime.dwLowDateTime;
-	creation_time.HighPart = ffd.ftCreationTime.dwHighDateTime;
-	ULARGE_INTEGER last_write_time;
-	last_write_time.LowPart = ffd.ftLastWriteTime.dwLowDateTime;
-	last_write_time.HighPart = ffd.ftLastWriteTime.dwHighDateTime;
-	return GetWindowsVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+static string GetWindowsVersionTag(const FILE_ID_BOTH_DIR_INFO &entry, DWORD volume_serial_number) {
+	uint64_t version_tag[4];
+	Store(static_cast<uint64_t>(volume_serial_number), data_ptr_cast(&version_tag[0]));
+	Store(static_cast<uint64_t>(entry.FileId.QuadPart), data_ptr_cast(&version_tag[1]));
+	Store(static_cast<uint64_t>(entry.CreationTime.QuadPart), data_ptr_cast(&version_tag[2]));
+	Store(static_cast<uint64_t>(entry.LastWriteTime.QuadPart), data_ptr_cast(&version_tag[3]));
+	return string(char_ptr_cast(version_tag), sizeof(version_tag));
 }
 
 struct WindowsFileHandle : public FileHandle {
@@ -1320,48 +1315,73 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 bool LocalFileSystem::ListFilesExtended(const string &directory,
                                         const std::function<void(OpenFileInfo &info)> &callback,
                                         optional_ptr<FileOpener> opener) {
-	string search_dir = JoinPath(directory, "*");
-	auto unicode_path = NormalizePathAndConvertToUnicode(*this, search_dir, opener);
+	auto unicode_path = NormalizePathAndConvertToUnicode(*this, directory, opener);
 
-	WIN32_FIND_DATAW ffd;
-	HANDLE hFind = FindFirstFileW(unicode_path.c_str(), &ffd);
-	if (hFind == INVALID_HANDLE_VALUE) {
+	// Open a handle to the directory itself so we can use GetFileInformationByHandleEx,
+	// which returns FILE_ID_BOTH_DIR_INFO entries that include the per-file FileId
+	// (equivalent to inode number) without requiring a separate handle per file.
+	HANDLE hDir =
+	    CreateFileW(unicode_path.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+	                NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+	if (hDir == INVALID_HANDLE_VALUE) {
 		return false;
 	}
-	do {
-		OpenFileInfo info(WindowsUtil::UnicodeToUTF8(ffd.cFileName));
-		auto &name = info.path;
-		if (name == "." || name == "..") {
-			continue;
+
+	DWORD volume_serial_number = 0;
+	if (!GetVolumeInformationByHandleW(hDir, NULL, 0, &volume_serial_number, NULL, NULL, NULL, 0)) {
+		CloseHandle(hDir);
+		throw IOException("Failed to get volume serial number from directory \"%s\": %s", directory, error);
+	}
+
+	static constexpr DWORD BUFFER_SIZE = 65536;
+	auto buffer = unique_ptr<char[]>(new char[BUFFER_SIZE]);
+
+	FILE_INFORMATION_CLASS info_class = FileIdBothDirectoryRestartInfo;
+	while (true) {
+		if (!GetFileInformationByHandleEx(hDir, info_class, buffer.get(), BUFFER_SIZE)) {
+			CloseHandle(hDir);
+			if (GetLastError() == ERROR_NO_MORE_FILES) {
+				// success - listed all files in the directory
+				return true;
+			}
+			auto error = LocalFileSystem::GetLastErrorAsString();
+			throw IOException("Failed to list directory \"%s\": %s", directory, error);
 		}
-		// create extended info
-		info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
-		auto &options = info.extended_info->options;
-		// file type
-		Value file_type(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ? "directory" : "file");
-		options.emplace("type", std::move(file_type));
-		// file size
-		int64_t file_size_bytes =
-		    (static_cast<int64_t>(ffd.nFileSizeHigh) << 32) | static_cast<int64_t>(ffd.nFileSizeLow);
-		options.emplace("file_size", Value::BIGINT(file_size_bytes));
-		// last modified time
-		auto last_modified_time = FiletimeToTimeStamp(ffd.ftLastWriteTime);
-		options.emplace("last_modified", Value::TIMESTAMP(last_modified_time));
-		// etag
-		options.emplace("etag", Value::BLOB_RAW(GetWindowsVersionTag(ffd)));
 
-		// callback
-		callback(info);
-	} while (FindNextFileW(hFind, &ffd) != 0);
+		auto *entry = reinterpret_cast<FILE_ID_BOTH_DIR_INFO *>(buffer.get());
+		while (true) {
+			// FileName is not null-terminated; use FileNameLength (in bytes) to construct the string.
+			wstring wname(entry->FileName, entry->FileNameLength / sizeof(WCHAR));
+			string name = WindowsUtil::UnicodeToUTF8(wname.c_str());
 
-	DWORD dwError = GetLastError();
-	if (dwError != ERROR_NO_MORE_FILES) {
-		FindClose(hFind);
-		return false;
+			if (name != "." && name != "..") {
+				OpenFileInfo info(name);
+				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+				auto &options = info.extended_info->options;
+				// file type
+				Value file_type(entry->FileAttributes & FILE_ATTRIBUTE_DIRECTORY ? "directory" : "file");
+				options.emplace("type", std::move(file_type));
+				// file size
+				options.emplace("file_size", Value::BIGINT(entry->EndOfFile.QuadPart));
+				// last modified time
+				FILETIME ft;
+				ft.dwLowDateTime = entry->LastWriteTime.LowPart;
+				ft.dwHighDateTime = entry->LastWriteTime.HighPart;
+				options.emplace("last_modified", Value::TIMESTAMP(FiletimeToTimeStamp(ft)));
+				// etag: includes FileId (file reference number) in addition to size and timestamps
+				options.emplace("etag", Value::BLOB_RAW(GetWindowsVersionTag(*entry, volume_serial_number)));
+
+				callback(info);
+			}
+
+			if (entry->NextEntryOffset == 0) {
+				break;
+			}
+			entry = reinterpret_cast<FILE_ID_BOTH_DIR_INFO *>(reinterpret_cast<char *>(entry) + entry->NextEntryOffset);
+		}
+		// next iteration -
+		info_class = FileIdBothDirectoryInfo;
 	}
-
-	FindClose(hFind);
-	return true;
 }
 
 void LocalFileSystem::FileSync(FileHandle &handle) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -926,12 +926,12 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 
 static FileMetadata StatsFromDirInfo(const FILE_ID_BOTH_DIR_INFO &entry) {
 	FileMetadata result;
-	result.file_size = static_cast<idx_t>(entry->EndOfFile.QuadPart);
+	result.file_size = static_cast<idx_t>(entry.EndOfFile.QuadPart);
 
 	FILETIME ft;
-	ft.dwLowDateTime = entry->LastWriteTime.LowPart;
-	ft.dwHighDateTime = entry->LastWriteTime.HighPart;
-	result.file_size = FiletimeToTimeStamp(ft);
+	ft.dwLowDateTime = entry.LastWriteTime.LowPart;
+	ft.dwHighDateTime = entry.LastWriteTime.HighPart;
+	result.last_modification_time = FiletimeToTimeStamp(ft);
 
 	result.file_id = entry.FileId.QuadPart;
 	return result;
@@ -1346,7 +1346,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 
 				auto metadata = StatsFromDirInfo(*entry);
 				metadata.device_id = volume_serial_number;
-				FillFileOptions(options, metadata);
+				FillFileOptions(metadata, options);
 
 				callback(info);
 			}

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -929,6 +929,38 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	return file_metadata;
 }
 
+static string GetWindowsVersionTag(uint64_t file_size, uint64_t creation_time, uint64_t last_write_time) {
+	uint64_t version_tag[3];
+	Store(file_size, data_ptr_cast(&version_tag[0]));
+	Store(creation_time, data_ptr_cast(&version_tag[1]));
+	Store(last_write_time, data_ptr_cast(&version_tag[2]));
+	return string(char_ptr_cast(version_tag), sizeof(version_tag));
+}
+
+static string GetWindowsVersionTag(const BY_HANDLE_FILE_INFORMATION &file_info) {
+	const uint64_t file_size =
+	    (static_cast<uint64_t>(file_info.nFileSizeHigh) << 32) | static_cast<uint64_t>(file_info.nFileSizeLow);
+	ULARGE_INTEGER creation_time;
+	creation_time.LowPart = file_info.ftCreationTime.dwLowDateTime;
+	creation_time.HighPart = file_info.ftCreationTime.dwHighDateTime;
+	ULARGE_INTEGER last_write_time;
+	last_write_time.LowPart = file_info.ftLastWriteTime.dwLowDateTime;
+	last_write_time.HighPart = file_info.ftLastWriteTime.dwHighDateTime;
+	return WindowsComputeVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+}
+
+static string GetWindowsVersionTag(const WIN32_FIND_DATAW &ffd) {
+	const uint64_t file_size =
+	    (static_cast<uint64_t>(ffd.nFileSizeHigh) << 32) | static_cast<uint64_t>(ffd.nFileSizeLow);
+	ULARGE_INTEGER creation_time;
+	creation_time.LowPart = ffd.ftCreationTime.dwLowDateTime;
+	creation_time.HighPart = ffd.ftCreationTime.dwHighDateTime;
+	ULARGE_INTEGER last_write_time;
+	last_write_time.LowPart = ffd.ftLastWriteTime.dwLowDateTime;
+	last_write_time.HighPart = ffd.ftLastWriteTime.dwHighDateTime;
+	return WindowsComputeVersionTag(file_size, creation_time.QuadPart, last_write_time.QuadPart);
+}
+
 struct WindowsFileHandle : public FileHandle {
 public:
 	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd, FileOpenFlags flags)
@@ -1315,6 +1347,8 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		// last modified time
 		auto last_modified_time = FiletimeToTimeStamp(ffd.ftLastWriteTime);
 		options.emplace("last_modified", Value::TIMESTAMP(last_modified_time));
+		// etag
+		options.emplace("etag", Value(GetWindowsVersionTag(ffd)));
 
 		// callback
 		callback(info);
@@ -1510,24 +1544,7 @@ string LocalFileSystem::GetVersionTag(FileHandle &handle) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
 		throw IOException("Failed to get version tag for file \"%s\": %s", handle.path, error);
 	}
-
-	ULARGE_INTEGER last_write_time;
-	last_write_time.LowPart = file_info.ftLastWriteTime.dwLowDateTime;
-	last_write_time.HighPart = file_info.ftLastWriteTime.dwHighDateTime;
-
-	const uint64_t file_size =
-	    (static_cast<uint64_t>(file_info.nFileSizeHigh) << 32) | static_cast<uint64_t>(file_info.nFileSizeLow);
-	const uint64_t file_index =
-	    (static_cast<uint64_t>(file_info.nFileIndexHigh) << 32) | static_cast<uint64_t>(file_info.nFileIndexLow);
-
-	// volume serial + file index identify the file; size + last write time protect against in-place rewrites
-	uint64_t version_tag[4];
-	Store(static_cast<uint64_t>(file_info.dwVolumeSerialNumber), data_ptr_cast(&version_tag[0]));
-	Store(file_index, data_ptr_cast(&version_tag[1]));
-	Store(file_size, data_ptr_cast(&version_tag[2]));
-	Store(last_write_time.QuadPart, data_ptr_cast(&version_tag[3]));
-
-	return string(char_ptr_cast(version_tag), sizeof(version_tag));
+	return GetWindowsVersionTag(file_info);
 #else
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	struct stat s;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1348,7 +1348,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		auto last_modified_time = FiletimeToTimeStamp(ffd.ftLastWriteTime);
 		options.emplace("last_modified", Value::TIMESTAMP(last_modified_time));
 		// etag
-		options.emplace("etag", Value(GetWindowsVersionTag(ffd)));
+		options.emplace("etag", Value::BLOB_RAW(GetWindowsVersionTag(ffd)));
 
 		// callback
 		callback(info);

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -63,6 +63,7 @@ extern "C" WINBASEAPI BOOL QueryFullProcessImageNameW(HANDLE, DWORD, LPWSTR, PDW
 #endif
 
 namespace duckdb {
+
 #ifndef _WIN32
 bool LocalFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	if (!filename.empty()) {
@@ -166,16 +167,12 @@ public:
 	};
 };
 
-static FileMetadata StatsInternal(int fd, const string &path) {
-	struct stat s;
-	if (fstat(fd, &s) == -1) {
-		throw IOException({{"errno", std::to_string(errno)}}, "Failed to get stats for file \"%s\": %s", path,
-		                  strerror(errno));
-	}
-
+static FileMetadata StatsFromStruct(struct stat s) {
 	FileMetadata file_metadata;
 	file_metadata.file_size = s.st_size;
 	file_metadata.last_modification_time = Timestamp::FromEpochSeconds(s.st_mtime);
+	file_metadata.device_id = static_cast<idx_t>(s.st_dev);
+	file_metadata.file_id = static_cast<idx_t>(s.st_ino);
 
 	switch (s.st_mode & S_IFMT) {
 	case S_IFBLK:
@@ -205,6 +202,15 @@ static FileMetadata StatsInternal(int fd, const string &path) {
 	}
 
 	return file_metadata;
+}
+
+static FileMetadata StatsInternal(int fd, const string &path) {
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		throw IOException({{"errno", std::to_string(errno)}}, "Failed to get stats for file \"%s\": %s", path,
+		                  strerror(errno));
+	}
+	return StatsFromStruct(s);
 } // LCOV_EXCL_STOP
 
 #if __APPLE__ && !TARGET_OS_IPHONE
@@ -705,17 +711,6 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 	}
 }
 
-string GetPosixVersionTag(struct stat s) {
-	// dev/ino should be enough, but to guard against in-place writes we also add file size and modification time
-	uint64_t version_tag[4];
-	Store(UnsafeNumericCast<uint64_t>(s.st_dev), data_ptr_cast(&version_tag[0]));
-	Store(UnsafeNumericCast<uint64_t>(s.st_ino), data_ptr_cast(&version_tag[1]));
-	Store(UnsafeNumericCast<uint64_t>(s.st_size), data_ptr_cast(&version_tag[2]));
-	Store(Timestamp::FromEpochSeconds(s.st_mtime).value, data_ptr_cast(&version_tag[3]));
-
-	return string(char_ptr_cast(version_tag), sizeof(uint64_t) * 4);
-}
-
 bool LocalFileSystem::ListFilesExtended(const string &directory,
                                         const std::function<void(OpenFileInfo &info)> &callback,
                                         optional_ptr<FileOpener> opener) {
@@ -753,13 +748,10 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		auto &options = info.extended_info->options;
 		// file type
 		Value file_type(S_ISDIR(status.st_mode) ? "directory" : "file");
+		auto file_metadata = StatsFromStruct(status);
 		options.emplace("type", std::move(file_type));
-		// file size
-		options.emplace("file_size", Value::BIGINT(UnsafeNumericCast<int64_t>(status.st_size)));
-		// last modified time
-		options.emplace("last_modified", Value::TIMESTAMP(Timestamp::FromTimeT(status.st_mtime)));
-		// version tag
-		options.emplace("etag", Value::BLOB_RAW(GetPosixVersionTag(status)));
+
+		FillFileOptions(file_metadata, options);
 
 		// invoke callback
 		callback(info);
@@ -906,6 +898,9 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	// Get file size from high and low parts.
 	file_metadata.file_size =
 	    (static_cast<int64_t>(file_info.nFileSizeHigh) << 32) | static_cast<int64_t>(file_info.nFileSizeLow);
+	file_metadata.device_id = static_cast<uint64_t>(file_info.dwVolumeSerialNumber);
+	file_metadata.file_id =
+	    (static_cast<uint64_t>(file_info.nFileIndexHigh) << 32) | static_cast<uint64_t>(file_info.nFileIndexLow);
 
 	// Get last modification time
 	file_metadata.last_modification_time = FiletimeToTimeStamp(file_info.ftLastWriteTime);
@@ -929,31 +924,17 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	return file_metadata;
 }
 
-static string GetWindowsVersionTag(const BY_HANDLE_FILE_INFORMATION &file_info) {
-	ULARGE_INTEGER last_write_time;
-	last_write_time.LowPart = file_info.ftLastWriteTime.dwLowDateTime;
-	last_write_time.HighPart = file_info.ftLastWriteTime.dwHighDateTime;
+static FileMetadata StatsFromDirInfo(const FILE_ID_BOTH_DIR_INFO &entry) {
+	FileMetadata result;
+	result.file_size = static_cast<idx_t>(entry->EndOfFile.QuadPart);
 
-	const uint64_t file_size =
-	    (static_cast<uint64_t>(file_info.nFileSizeHigh) << 32) | static_cast<uint64_t>(file_info.nFileSizeLow);
-	const uint64_t file_index =
-	    (static_cast<uint64_t>(file_info.nFileIndexHigh) << 32) | static_cast<uint64_t>(file_info.nFileIndexLow);
+	FILETIME ft;
+	ft.dwLowDateTime = entry->LastWriteTime.LowPart;
+	ft.dwHighDateTime = entry->LastWriteTime.HighPart;
+	result.file_size = FiletimeToTimeStamp(ft);
 
-	// volume serial + file index identify the file; size + last write time protect against in-place rewrites
-	uint64_t version_tag[4];
-	Store(static_cast<uint64_t>(file_info.dwVolumeSerialNumber), data_ptr_cast(&version_tag[0]));
-	Store(file_index, data_ptr_cast(&version_tag[1]));
-	Store(file_size, data_ptr_cast(&version_tag[2]));
-	Store(last_write_time.QuadPart, data_ptr_cast(&version_tag[3]));
-}
-
-static string GetWindowsVersionTag(const FILE_ID_BOTH_DIR_INFO &entry, DWORD volume_serial_number) {
-	uint64_t version_tag[4];
-	Store(static_cast<uint64_t>(volume_serial_number), data_ptr_cast(&version_tag[0]));
-	Store(static_cast<uint64_t>(entry.FileId.QuadPart), data_ptr_cast(&version_tag[1]));
-	Store(static_cast<uint64_t>(entry.CreationTime.QuadPart), data_ptr_cast(&version_tag[2]));
-	Store(static_cast<uint64_t>(entry.LastWriteTime.QuadPart), data_ptr_cast(&version_tag[3]));
-	return string(char_ptr_cast(version_tag), sizeof(version_tag));
+	result.file_id = entry.FileId.QuadPart;
+	return result;
 }
 
 struct WindowsFileHandle : public FileHandle {
@@ -1362,15 +1343,10 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 				// file type
 				Value file_type(entry->FileAttributes & FILE_ATTRIBUTE_DIRECTORY ? "directory" : "file");
 				options.emplace("type", std::move(file_type));
-				// file size
-				options.emplace("file_size", Value::BIGINT(entry->EndOfFile.QuadPart));
-				// last modified time
-				FILETIME ft;
-				ft.dwLowDateTime = entry->LastWriteTime.LowPart;
-				ft.dwHighDateTime = entry->LastWriteTime.HighPart;
-				options.emplace("last_modified", Value::TIMESTAMP(FiletimeToTimeStamp(ft)));
-				// etag: includes FileId (file reference number) in addition to size and timestamps
-				options.emplace("etag", Value::BLOB_RAW(GetWindowsVersionTag(*entry, volume_serial_number)));
+
+				auto metadata = StatsFromDirInfo(*entry);
+				metadata.device_id = volume_serial_number;
+				FillFileOptions(options, metadata);
 
 				callback(info);
 			}
@@ -1556,24 +1532,27 @@ string LocalFileSystem::CanonicalizePath(const string &input, optional_ptr<FileO
 	return FileSystem::CanonicalizePath(path);
 }
 
+string LocalFileSystem::VersionTagFromMetadata(const FileMetadata &stats) {
+	uint64_t version_tag[4];
+	Store(stats.device_id.IsValid() ? stats.device_id.GetIndex() : 0, data_ptr_cast(&version_tag[0]));
+	Store(stats.file_id.IsValid() ? stats.file_id.GetIndex() : 0, data_ptr_cast(&version_tag[1]));
+	Store(stats.file_size, data_ptr_cast(&version_tag[2]));
+	Store(stats.last_modification_time.value, data_ptr_cast(&version_tag[3]));
+	return string(char_ptr_cast(version_tag), sizeof(uint64_t) * 4);
+}
+
+void LocalFileSystem::FillFileOptions(const FileMetadata &file_metadata, unordered_map<string, Value> &options) {
+	// file size
+	options.emplace("file_size", Value::BIGINT(file_metadata.file_size));
+	// last modified time
+	options.emplace("last_modified", Value::TIMESTAMP(file_metadata.last_modification_time));
+	// version tag
+	options.emplace("etag", Value::BLOB_RAW(VersionTagFromMetadata(file_metadata)));
+}
+
 string LocalFileSystem::GetVersionTag(FileHandle &handle) {
-	// TODO: Fix using FileSystem::Stats for v1.5, which should also fix it for Windows
-#ifdef _WIN32
-	auto &whandle = handle.Cast<WindowsFileHandle>();
-	BY_HANDLE_FILE_INFORMATION file_info;
-	if (!GetFileInformationByHandle(whandle.fd, &file_info)) {
-		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Failed to get version tag for file \"%s\": %s", handle.path, error);
-	}
-	return GetWindowsVersionTag(file_info);
-#else
-	int fd = handle.Cast<UnixFileHandle>().fd;
-	struct stat s;
-	if (fstat(fd, &s) == -1) {
-		throw IOException("Failed to get file size for file \"%s\": %s", handle.path, strerror(errno));
-	}
-	return GetPosixVersionTag(s);
-#endif
+	auto stats = handle.Stats();
+	return VersionTagFromMetadata(stats);
 }
 
 void LocalFileSystem::Seek(FileHandle &handle, idx_t location) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -64,6 +64,8 @@ struct FileMetadata {
 	int64_t file_size = -1;
 	timestamp_t last_modification_time = timestamp_t::ninfinity();
 	FileType file_type = FileType::FILE_TYPE_INVALID;
+	optional_idx device_id;
+	optional_idx file_id;
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
 	unordered_map<string, Value> extended_file_info;

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -119,6 +119,9 @@ protected:
 
 	bool TryCanonicalizeExistingPath(string &path_p);
 
+	string VersionTagFromMetadata(const FileMetadata &file_metadata);
+	void FillFileOptions(const FileMetadata &file_metadata, unordered_map<string, Value> &options);
+
 private:
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
 	void SetFilePointer(FileHandle &handle, idx_t location);

--- a/test/sql/copy/parquet/parquet_glob_cache.test
+++ b/test/sql/copy/parquet/parquet_glob_cache.test
@@ -2,12 +2,6 @@
 # description: Test usage of metadata cache in COUNT(*)
 # group: [parquet]
 
-# On Windows, freshly checked-out files can fail the metadata cache validity
-# check because local-file reuse falls back to last_modified and requires files
-# without a version tag to be older than 10 seconds, so the bind rewrite keeps
-# PARQUET_SCAN even when the cache entry exists.
-require notwindows
-
 require parquet
 
 statement ok


### PR DESCRIPTION
This PR unifies the `GetVersionTag` to operate on `FileMetadata` instead of being operating-system dependent. In order for this to work, the `FileMetadata` is extended with two new members: `device_id` and `file_id`. We now generate the `FileMetadata` during file listing and call `Stats()` if `GetVersionTag` is called in isolation to be able to compute the version tag. 

In order to get this to work for Windows, we switch around the way that we do file listings. In the previous manner of doing file listings (`FindFirstFileW` followed by `FindNextFileW`) - we would only get a `WIN32_FIND_DATAW` which does not have a file id for each file. As a result, we would have to do another API call for each file (`GetFileInformationByHandleEx`) to be able to fetch that information.

To avoid that we now use a different loop - we open the directory using `CreateFileW` and then call `GetFileInformationByHandleEx` on the directory with a 65KB buffer. This returns a list of all files in the directory (or as much as fit within the 65KB buffer). We can then iterate over those files, and once we have exhausted the buffer, call `GetFileInformationByHandleEx` again to get the next batch of files. This gives us a `FILE_ID_BOTH_DIR_INFO` per file which has all the information we need (file type, file size, file id). The device id is obtained from the directory itself once at the start of the scan using `GetVolumeInformationByHandleW`.