### PR TITLE
.git pre-commit hook for `make format-fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,3 +681,20 @@ cleanup-vcpkg:
 
 test-utils:
 	make release EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
+
+add-git-pre-commit-hooks:
+	@if [ -f .git/hooks/pre-commit ]; then \
+		echo "pre-commit hook exists"; \
+		if grep -qF '# make format-fix hook #' .git/hooks/pre-commit; then \
+			echo "hook exists and contains make format-fix"; \
+			echo "no action needed. exiting."; \
+		else \
+			echo "hook exists but does not contain make format-fix"; \
+			echo "adding make format-fix"; \
+			printf '\n# make format-fix hook #\n# Get list of staged files\nstaged_files=$$(git diff --cached --name-only)\n# Run formatter on staged files\necho "$$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm\n# Re-stage files that were:\n# 1. Originally staged\n# 2. Modified by the formatter\necho "$$staged_files" | while read -r file; do\n    if [ -n "$$file" ] && git diff --name-only | grep -Fxq "$$file"; then\n        git add "$$file"\n    fi\ndone\n' >> .git/hooks/pre-commit; \
+		fi \
+	else \
+		echo "pre-commit hook does not exist, creating it with make format-fix"; \
+		printf '#!/bin/sh\n# make format-fix hook #\n# Get list of staged files\nstaged_files=$$(git diff --cached --name-only)\n# Run formatter on staged files\necho "$$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm\n# Re-stage files that were:\n# 1. Originally staged\n# 2. Modified by the formatter\necho "$$staged_files" | while read -r file; do\n    if [ -n "$$file" ] && git diff --name-only | grep -Fxq "$$file"; then\n        git add "$$file"\n    fi\ndone\n' > .git/hooks/pre-commit; \
+		chmod +x .git/hooks/pre-commit; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,3 @@ cleanup-vcpkg:
 
 test-utils:
 	make release EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
-
-add-git-pre-commit-hooks:
-	@python3 scripts/add_git_hooks.py

--- a/Makefile
+++ b/Makefile
@@ -683,18 +683,4 @@ test-utils:
 	make release EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
 
 add-git-pre-commit-hooks:
-	@if [ -f .git/hooks/pre-commit ]; then \
-		echo "pre-commit hook exists"; \
-		if grep -qF '# make format-fix hook #' .git/hooks/pre-commit; then \
-			echo "hook exists and contains make format-fix"; \
-			echo "no action needed. exiting."; \
-		else \
-			echo "hook exists but does not contain make format-fix"; \
-			echo "adding make format-fix"; \
-			printf '\n# make format-fix hook #\n# Get list of staged files\nstaged_files=$$(git diff --cached --name-only)\n# Run formatter on staged files\necho "$$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm\n# Re-stage files that were:\n# 1. Originally staged\n# 2. Modified by the formatter\necho "$$staged_files" | while read -r file; do\n    if [ -n "$$file" ] && git diff --name-only | grep -Fxq "$$file"; then\n        git add "$$file"\n    fi\ndone\n' >> .git/hooks/pre-commit; \
-		fi \
-	else \
-		echo "pre-commit hook does not exist, creating it with make format-fix"; \
-		printf '#!/bin/sh\n# make format-fix hook #\n# Get list of staged files\nstaged_files=$$(git diff --cached --name-only)\n# Run formatter on staged files\necho "$$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm\n# Re-stage files that were:\n# 1. Originally staged\n# 2. Modified by the formatter\necho "$$staged_files" | while read -r file; do\n    if [ -n "$$file" ] && git diff --name-only | grep -Fxq "$$file"; then\n        git add "$$file"\n    fi\ndone\n' > .git/hooks/pre-commit; \
-		chmod +x .git/hooks/pre-commit; \
-	fi
+	@python3 scripts/add_git_hooks.py

--- a/scripts/add_git_hooks.py
+++ b/scripts/add_git_hooks.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Adds the make format-fix pre-commit hook to .git/hooks/pre-commit."""
+
+import os
+
+HOOK_MARKER = '# make format-fix hook #'
+HOOK_PATH = '.git/hooks/pre-commit'
+
+HOOK_BODY = """\
+
+# make format-fix hook #
+# Get list of staged files
+staged_files=$(git diff --cached --name-only)
+# Run formatter on staged files
+echo "$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm
+# Re-stage files that were:
+# 1. Originally staged
+# 2. Modified by the formatter
+echo "$staged_files" | while read -r file; do
+    if [ -n "$file" ] && git diff --name-only | grep -Fxq "$file"; then
+        git add "$file"
+    fi
+done
+"""
+
+
+def main():
+    if os.path.isfile(HOOK_PATH):
+        with open(HOOK_PATH, 'r') as f:
+            content = f.read()
+        if HOOK_MARKER in content:
+            print("Hook already exists, no action needed. exiting.")
+        else:
+            print(
+                ".git/hooks/pre-commit file exists but does not contain make `make format-fix` functionality for staged files"
+            )
+            print("Adding `make format-fix` functionality for staged files")
+            with open(HOOK_PATH, 'a') as f:
+                f.write(HOOK_BODY)
+    else:
+        print("Creating .git/hooks/pre-commit file with `make format-fix` functionality for staged files")
+        with open(HOOK_PATH, 'w') as f:
+            f.write('#!/bin/sh\n' + HOOK_BODY)
+        os.chmod(HOOK_PATH, 0o755)  # make it executable
+    print("Done! ✅")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/add_git_hooks.py
+++ b/scripts/add_git_hooks.py
@@ -6,13 +6,17 @@ import os
 HOOK_MARKER = '# make format-fix hook #'
 HOOK_PATH = '.git/hooks/pre-commit'
 
-HOOK_BODY = """\
+
+FORMAT_SCRIPT = 'duckdb/scripts/format.py' if os.path.isfile('duckdb/scripts/format.py') else 'scripts/format.py' # this is to support extension repos
+FORMAT_CMD = f'python3 {FORMAT_SCRIPT} {{}} --fix --noconfirm'
+
+HOOK_BODY = f"""\
 
 # make format-fix hook #
 # Get list of staged files
 staged_files=$(git diff --cached --name-only)
 # Run formatter on staged files
-echo "$staged_files" | xargs -P 0 -I {} python3 scripts/format.py {} --fix --noconfirm
+echo "$staged_files" | xargs -P 0 -I {{}} {FORMAT_CMD}
 # Re-stage files that were:
 # 1. Originally staged
 # 2. Modified by the formatter
@@ -31,9 +35,7 @@ def main():
         if HOOK_MARKER in content:
             print("Hook already exists, no action needed. exiting.")
         else:
-            print(
-                ".git/hooks/pre-commit file exists but does not contain make `make format-fix` functionality for staged files"
-            )
+            print(".git/hooks/pre-commit file exists but does not contain make `make format-fix` functionality for staged files")
             print("Adding `make format-fix` functionality for staged files")
             with open(HOOK_PATH, 'a') as f:
                 f.write(HOOK_BODY)
@@ -41,7 +43,7 @@ def main():
         print("Creating .git/hooks/pre-commit file with `make format-fix` functionality for staged files")
         with open(HOOK_PATH, 'w') as f:
             f.write('#!/bin/sh\n' + HOOK_BODY)
-        os.chmod(HOOK_PATH, 0o755)  # make it executable
+        os.chmod(HOOK_PATH, 0o755)
     print("Done! ✅")
 
 

--- a/scripts/add_git_hooks.py
+++ b/scripts/add_git_hooks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adds the make format-fix pre-commit hook to .git/hooks/pre-commit."""
+"""Adds `make format-fix` functionality to .git/hooks/pre-commit."""
 
 import os
 
@@ -7,7 +7,9 @@ HOOK_MARKER = '# make format-fix hook #'
 HOOK_PATH = '.git/hooks/pre-commit'
 
 
-FORMAT_SCRIPT = 'duckdb/scripts/format.py' if os.path.isfile('duckdb/scripts/format.py') else 'scripts/format.py' # this is to support extension repos
+FORMAT_SCRIPT = (
+    'duckdb/scripts/format.py' if os.path.isfile('duckdb/scripts/format.py') else 'scripts/format.py'
+)  # this is to support extension repos
 FORMAT_CMD = f'python3 {FORMAT_SCRIPT} {{}} --fix --noconfirm'
 
 HOOK_BODY = f"""\
@@ -35,7 +37,9 @@ def main():
         if HOOK_MARKER in content:
             print("Hook already exists, no action needed. exiting.")
         else:
-            print(".git/hooks/pre-commit file exists but does not contain make `make format-fix` functionality for staged files")
+            print(
+                ".git/hooks/pre-commit file exists but does not contain make `make format-fix` functionality for staged files"
+            )
             print("Adding `make format-fix` functionality for staged files")
             with open(HOOK_PATH, 'a') as f:
                 f.write(HOOK_BODY)


### PR DESCRIPTION
Added a command `make add-git-pre-commit-hooks` to add a pre-commit hook to the `.git/hooks/pre-commit` file.
This hook currently runs `make format-fix` for staged files before committing, that way the files are formatted before going through the commit. We could extend it to do a tidy check too.

I made this hook and have been using it myself for a while now. @smvv recommended me to share it so that others can benefit as well.
> [!NOTE]
> I'm not sure how to document this / make it discoverable. Adding it to the `README.md` seems overkill. Any ideas?