### PR TITLE
Optimize `TemplatedMergeJoinComplexBlocks` in `PhysicalPieceWiseMergeJoin`

### DIFF
--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/execution/operator/join/physical_piecewise_merge_join.hpp"
 
+#include <numeric>
+
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/types/row/block_iterator.hpp"
@@ -485,49 +487,50 @@ static idx_t TemplatedMergeJoinComplexBlocks(ChunkMergeInfo &l, ChunkMergeInfo &
 		return result_count;
 	}
 
-	BLOCK_ITERATOR l_ptr(l.state);
-	BLOCK_ITERATOR r_ptr(r.state);
+	auto *const lhs_sel = l.lhs.data();
 	while (true) {
+		// Phase 1: bulk-emit known matches (l.entry_idx < prev_left_index already matched current r)
 		if (l.entry_idx < prev_left_index) {
-			// left side smaller: found match
-			l.lhs.set_index(result_count, sel_t(l.entry_idx));
-			r.rhs.emplace_back(r.entry_idx);
-			result_count++;
-			// move left side forward
-			l.entry_idx++;
-			++l_ptr;
+			const idx_t batch = MinValue(prev_left_index - l.entry_idx, STANDARD_VECTOR_SIZE - result_count);
+			std::iota(lhs_sel + result_count, lhs_sel + result_count + batch, NumericCast<sel_t>(l.entry_idx));
+			r.rhs.resize(r.rhs.size() + batch, r.entry_idx);
+			result_count += batch;
+			l.entry_idx += batch;
 			if (result_count == STANDARD_VECTOR_SIZE) {
-				// out of space!
 				break;
 			}
-			continue;
 		}
+
+		// Phase 2: binary search for the new boundary on the left side
 		if (l.entry_idx < l.not_null) {
-			if (MergeJoinBefore(l_ptr[l.GetIndex()], r_ptr[r.GetIndex()], strict)) {
-				// left side smaller: found match
-				l.lhs.set_index(result_count, sel_t(l.entry_idx));
-				r.rhs.emplace_back(r.entry_idx);
-				result_count++;
-				// move left side forward
-				l.entry_idx++;
-				++l_ptr;
+			const BLOCK_ITERATOR search_begin(l.state, l.entry_idx);
+			const BLOCK_ITERATOR search_end(l.state, l.not_null);
+
+			const auto &r_val = r.state.template GetValueAtIndex<SORT_KEY>(r.block_idx, r.entry_idx);
+			const auto new_boundary_itr = std::lower_bound(search_begin, search_end, r_val,
+			                                               [strict](const SORT_KEY &lhs_val, const SORT_KEY &rhs_val) {
+				                                               return MergeJoinBefore(lhs_val, rhs_val, strict);
+			                                               });
+
+			const auto new_boundary = l.entry_idx + NumericCast<idx_t>(new_boundary_itr - search_begin);
+			if (new_boundary > l.entry_idx) {
+				const idx_t batch = MinValue(new_boundary - l.entry_idx, STANDARD_VECTOR_SIZE - result_count);
+				std::iota(lhs_sel + result_count, lhs_sel + result_count + batch, sel_t(l.entry_idx));
+				r.rhs.resize(r.rhs.size() + batch, r.entry_idx);
+				result_count += batch;
+				l.entry_idx += batch;
 				if (result_count == STANDARD_VECTOR_SIZE) {
-					// out of space!
+					prev_left_index = new_boundary;
 					break;
 				}
-				continue;
 			}
 		}
 
 		prev_left_index = l.entry_idx;
-		// right side smaller or equal, or left side exhausted: move
-		// right pointer forward reset left side to start
 		r.entry_idx++;
 		if (r.entry_idx >= r.not_null) {
 			break;
 		}
-		++r_ptr;
-
 		l.entry_idx = 0;
 	}
 

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -472,14 +472,16 @@ static void TemplatedSliceSortedPayload(DataChunk &chunk, const SortedRun &sorte
 	BLOCK_ITERATOR itr(state, chunk_idx, 0);
 
 	const auto sort_keys = FlatVector::GetData<SORT_KEY *>(sort_key_pointers);
-	for (idx_t i = 0; i < result.size(); ++i) {
+	const auto result_size = NumericCast<idx_t>(result.size());
+
+	for (idx_t i = 0; i < result_size; ++i) {
 		const auto idx = state.GetIndex(chunk_idx, result[i]);
 		sort_keys[i] = &itr[idx];
 	}
 
 	// Scan
 	chunk.Reset();
-	scan_state.Scan(sorted_run, sort_key_pointers, result.size(), chunk);
+	scan_state.Scan(sorted_run, sort_key_pointers, result_size, chunk);
 }
 
 void PhysicalRangeJoin::SliceSortedPayload(DataChunk &chunk, GlobalSortedTable &table,


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/8661#issuecomment-4138073409
Improves `range_join_big_result.benchmark` by ~2x.

I think `TemplatedSliceSortedPayload` should be optimized further, but I've held off on that because I don't fully understand all use-cases. I found that in some cases, a `chunk_idx` is passed, but not all indices in `result` are within that chunk. That's probably also why this is needed:
```C++
const auto idx = state.GetIndex(chunk_idx, result[i]);
sort_keys[i] = &itr[idx];
```
If all indices in `result` were in the same chunk, we could get the sort key pointers and access them directly. Now, a bunch of modulo/division is needed. I'm also not entirely sure if the current setup (accessing in multiple chunks) is safe in out-of-core situations - the `ExternalBlockIteratorState` can only guarantee one chunk is pinned at a time. Changing this would make it safer and improve performance.

Not sure how important this is, however, since this benchmark file is a really exploding join that stresses this loop, regular queries might not.