### PR TITLE
FIX #21506 UNNEST ARRAY type functionality

### DIFF
--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/execution/operator/projection/physical_unnest.hpp"
 
 namespace duckdb {
@@ -43,12 +44,18 @@ struct UnnestLocalState : public LocalTableFunctionState {
 
 static unique_ptr<FunctionData> UnnestBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
-	if (input.input_table_types.size() != 1 || input.input_table_types[0].id() != LogicalTypeId::LIST) {
-		throw BinderException("UNNEST requires a single list as input");
+	if (input.input_table_types.size() != 1 || (input.input_table_types[0].id() != LogicalTypeId::LIST &&
+	                                            input.input_table_types[0].id() != LogicalTypeId::ARRAY)) {
+		throw BinderException("UNNEST requires a single list or array as input");
 	}
-	return_types.push_back(ListType::GetChildType(input.input_table_types[0]));
+	auto &input_type = input.input_table_types[0];
+	if (input_type.id() == LogicalTypeId::LIST) {
+		return_types.push_back(ListType::GetChildType(input_type));
+	} else {
+		return_types.push_back(ArrayType::GetChildType(input_type));
+	}
 	names.push_back("unnest");
-	return make_uniq<UnnestBindData>(input.input_table_types[0]);
+	return make_uniq<UnnestBindData>(input_type);
 }
 
 static unique_ptr<LocalTableFunctionState> UnnestLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
@@ -63,9 +70,14 @@ static unique_ptr<LocalTableFunctionState> UnnestLocalInit(ExecutionContext &con
 static unique_ptr<GlobalTableFunctionState> UnnestInit(ClientContext &context, TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<UnnestBindData>();
 	auto result = make_uniq<UnnestGlobalState>();
-	auto ref = make_uniq<BoundReferenceExpression>(bind_data.input_type, 0U);
-	auto bound_unnest = make_uniq<BoundUnnestExpression>(ListType::GetChildType(bind_data.input_type));
-	bound_unnest->child = std::move(ref);
+
+	unique_ptr<Expression> child = make_uniq<BoundReferenceExpression>(bind_data.input_type, 0U);
+	if (child->return_type.id() == LogicalTypeId::ARRAY) {
+		child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
+	}
+
+	auto bound_unnest = make_uniq<BoundUnnestExpression>(ListType::GetChildType(child->return_type));
+	bound_unnest->child = std::move(child);
 	result->select_list.push_back(std::move(bound_unnest));
 	return std::move(result);
 }

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -173,11 +173,15 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	if (child_type.id() == LogicalTypeId::SQLNULL) {
 		list_unnests = 1;
 	} else {
-		// perform all LIST unnests
+		// perform all LIST/ARRAY unnests
 		auto type = child_type;
 		list_unnests = 0;
-		while (type.id() == LogicalTypeId::LIST) {
-			type = ListType::GetChildType(type);
+		while (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::ARRAY) {
+			if (type.id() == LogicalTypeId::LIST) {
+				type = ListType::GetChildType(type);
+			} else {
+				type = ArrayType::GetChildType(type);
+			}
 			list_unnests++;
 			if (list_unnests >= max_depth) {
 				break;
@@ -198,7 +202,14 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	for (idx_t current_depth = 0; current_depth < list_unnests; current_depth++) {
 		if (return_type.id() == LogicalTypeId::LIST) {
 			return_type = ListType::GetChildType(return_type);
+		} else if (return_type.id() == LogicalTypeId::ARRAY) {
+			return_type = ArrayType::GetChildType(return_type);
 		}
+
+		if (unnest_expr->return_type.id() == LogicalTypeId::ARRAY) {
+			unnest_expr = BoundCastExpression::AddArrayCastToList(context, std::move(unnest_expr));
+		}
+
 		auto result = make_uniq<BoundUnnestExpression>(return_type);
 		result->child = std::move(unnest_expr);
 		auto alias = function.GetAlias().empty() ? result->ToString() : function.GetAlias();

--- a/test/sql/types/list/unnest_array.test
+++ b/test/sql/types/list/unnest_array.test
@@ -1,0 +1,39 @@
+# name: test/sql/types/list/unnest_array.test
+# description: Test unnest recursive with ARRAY types (#21506)
+# group: [list]
+
+query I
+SELECT unnest([[1, 2], [3, 4]]::int[][], recursive:=true)
+----
+1
+2
+3
+4
+
+query I
+SELECT unnest([[1, 2], [3, 4]]::int[2][2], recursive:=true)
+----
+1
+2
+3
+4
+
+query I
+SELECT unnest([[1, 2], [3, 4]]::int[2][], recursive:=true)
+----
+1
+2
+3
+4
+
+query I
+SELECT unnest([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]::int[2][2][2], recursive:=true)
+----
+1
+2
+3
+4
+5
+6
+7
+8

--- a/test/sql/types/nested/array/array_cast.test
+++ b/test/sql/types/nested/array/array_cast.test
@@ -25,11 +25,13 @@ SELECT list_extract(array_value(1, 2, 3), 2)
 ----
 2
 
-# Should not be able to implicitly cast to list with unnest
-statement error
+# Should be able to implicitly cast to list with unnest
+query I
 SELECT * FROM UNNEST(array_value(1, 2, 3))
 ----
-UNNEST requires a single list as input
+1
+2
+3
 
 # Should be able to cast to list with unnest
 query I


### PR DESCRIPTION
This PR adds support for unnesting the ARRAY type. Previously, UNNEST could only use the LIST type , leading to issues when attempting to recursively unnest deeper levels of ARRAYs.

Changes: 
- Binder Support: Updated UnnestBind to recognize ARRAY types as valid input for UNNEST.
- Recursive Unnesting: Updated SelectBinder and UnnestLocalInit to iterate through nested ARRAY dimensions when recursive:=true is used.
- Implicit Casting: Updated an automatic cast from ARRAY to LIST during the unnesting process (now it also applies on children of ARRAY).
- Testing: Added a new test file `test/sql/types/list/unnest_array.test ` covering few multi-dimensional array unnesting cases (e.g., int[2][2][2]).

FIXES #21506