### PR TITLE
Return inf/nan instead of throwing for stddev/variance overflow

### DIFF
--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -43,17 +43,11 @@ struct RegrR2Operation {
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
 		auto var_pop_x = state.var_pop_x.count > 1 ? (state.var_pop_x.dsquared / state.var_pop_x.count) : 0;
-		if (!Value::DoubleIsFinite(var_pop_x)) {
-			throw OutOfRangeException("VARPOP(X) is out of range!");
-		}
 		if (var_pop_x == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
 		auto var_pop_y = state.var_pop_y.count > 1 ? (state.var_pop_y.dsquared / state.var_pop_y.count) : 0;
-		if (!Value::DoubleIsFinite(var_pop_y)) {
-			throw OutOfRangeException("VARPOP(Y) is out of range!");
-		}
 		if (var_pop_y == 0) {
 			target = 1;
 			return;

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -35,9 +35,6 @@ struct RegrBaseOperation {
 			return;
 		}
 		auto var_pop = state.var_pop.count > 1 ? (state.var_pop.dsquared / state.var_pop.count) : 0;
-		if (!Value::DoubleIsFinite(var_pop)) {
-			throw OutOfRangeException("VARPOP is out of range!");
-		}
 		RegrCountFunction::Finalize<T, uint64_t>(state.count, target, finalize_data);
 		target *= var_pop;
 	}

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
@@ -51,13 +51,7 @@ struct CorrOperation {
 		} else {
 			auto cov = state.cov_pop.co_moment / state.cov_pop.count;
 			auto std_x = state.dev_pop_x.count > 1 ? sqrt(state.dev_pop_x.dsquared / state.dev_pop_x.count) : 0;
-			if (!Value::DoubleIsFinite(std_x)) {
-				throw OutOfRangeException("STDDEV_POP for X is out of range!");
-			}
 			auto std_y = state.dev_pop_y.count > 1 ? sqrt(state.dev_pop_y.dsquared / state.dev_pop_y.count) : 0;
-			if (!Value::DoubleIsFinite(std_y)) {
-				throw OutOfRangeException("STDDEV_POP for Y is out of range!");
-			}
 			target = std_x * std_y != 0 ? cov / (std_x * std_y) : NAN;
 		}
 	}

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -87,9 +87,6 @@ struct VarSampOperation : public STDDevBaseOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = state.dsquared / (state.count - 1);
-			if (!Value::DoubleIsFinite(target)) {
-				throw OutOfRangeException("VARSAMP is out of range!");
-			}
 		}
 	}
 };
@@ -101,9 +98,6 @@ struct VarPopOperation : public STDDevBaseOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = state.count > 1 ? (state.dsquared / state.count) : 0;
-			if (!Value::DoubleIsFinite(target)) {
-				throw OutOfRangeException("VARPOP is out of range!");
-			}
 		}
 	}
 };
@@ -115,9 +109,6 @@ struct STDDevSampOperation : public STDDevBaseOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = sqrt(state.dsquared / (state.count - 1));
-			if (!Value::DoubleIsFinite(target)) {
-				throw OutOfRangeException("STDDEV_SAMP is out of range!");
-			}
 		}
 	}
 };
@@ -129,9 +120,6 @@ struct STDDevPopOperation : public STDDevBaseOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = state.count > 1 ? sqrt(state.dsquared / state.count) : 0;
-			if (!Value::DoubleIsFinite(target)) {
-				throw OutOfRangeException("STDDEV_POP is out of range!");
-			}
 		}
 	}
 };
@@ -143,9 +131,6 @@ struct StandardErrorOfTheMeanOperation : public STDDevBaseOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = sqrt(state.dsquared / state.count) / sqrt((state.count));
-			if (!Value::DoubleIsFinite(target)) {
-				throw OutOfRangeException("SEM is out of range!");
-			}
 		}
 	}
 };

--- a/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
@@ -43,9 +43,6 @@ struct RegrSlopeOperation {
 		} else {
 			auto cov = state.cov_pop.co_moment / state.cov_pop.count;
 			auto var_pop = state.var_pop.count > 1 ? (state.var_pop.dsquared / state.var_pop.count) : 0;
-			if (!Value::DoubleIsFinite(var_pop)) {
-				throw OutOfRangeException("VARPOP is out of range!");
-			}
 			target = var_pop != 0 ? cov / var_pop : NAN;
 		}
 	}

--- a/test/issues/rigger/test_596.test
+++ b/test/issues/rigger/test_596.test
@@ -12,7 +12,7 @@ CREATE TABLE t0(c0 DOUBLE);
 statement ok
 INSERT INTO t0(c0) VALUES(1E200), (0);
 
-statement error
+query R
 SELECT STDDEV_POP(c0) FROM t0;
 ----
-<REGEX>:Out of Range Error.*STDDEV_POP.*
+inf

--- a/test/sql/aggregate/aggregates/test_corr.test
+++ b/test/sql/aggregate/aggregates/test_corr.test
@@ -52,10 +52,12 @@ select  corr(v, v2) over (partition by k)
 0.998845
 NULL
 
-statement error
+query R
 SELECT corr(a,b) FROM (values (1e301, 0), (-1e301, 0)) tbl(a,b);
 ----
+nan
 
-statement error
+query R
 SELECT corr(b,a) FROM (values (1e301, 0), (-1e301, 0)) tbl(a,b);
 ----
+nan

--- a/test/sql/aggregate/aggregates/test_regression.test
+++ b/test/sql/aggregate/aggregates/test_regression.test
@@ -93,13 +93,15 @@ select regr_r2(1,1)
 NULL
 
 #Corner cases
-statement error
+query R
 select regr_r2(0, 1e230*i) from range(5) tbl(i);
 ----
+1.0
 
-statement error
+query R
 select regr_r2(1e230*i, i) from range(5) tbl(i);
 ----
+0.0
 
 query I
 select regr_r2(1e230*i, 0) from range(5) tbl(i);
@@ -119,9 +121,10 @@ statement error
 select regr_sxx()
 ----
 
-statement error
+query R
 select regr_sxx(0, 2e230*i) from range(5) tbl(i)
 ----
+inf
 
 query I
 select regr_sxx(2e230*i, 0) from range(5) tbl(i)

--- a/test/sql/aggregate/aggregates/test_stddev.test
+++ b/test/sql/aggregate/aggregates/test_stddev.test
@@ -136,18 +136,47 @@ select stddev(0) from range(10)
 ----
 0
 
-statement error
+# extreme values produce inf variance/stddev (IEEE-754 compliant)
+query R
 select stddev(a) from (values (1e301), (-1e301)) tbl(a)
 ----
-Out of Range Error: STDDEV_SAMP is out of range
+inf
 
-statement error
+query R
 select var_samp(a) from (values (1e301), (-1e301)) tbl(a)
 ----
-Out of Range Error: VARSAMP is out of range
+inf
 
-statement error
+query R
 select var_pop(a) from (values (1e301), (-1e301)) tbl(a)
 ----
-Out of Range Error: VARPOP is out of range
+inf
+
+# infinity values produce nan variance/stddev (IEEE-754 compliant)
+query R
+select stddev(a) from (values (1.0/0.0), (2.0)) tbl(a)
+----
+nan
+
+query R
+select var_samp(a) from (values (1.0/0.0), (2.0)) tbl(a)
+----
+nan
+
+query R
+select var_pop(a) from (values (1.0/0.0), (2.0)) tbl(a)
+----
+nan
+
+query R
+select stddev(a) from (values (-1.0/0.0), (2.0)) tbl(a)
+----
+nan
+
+# summarize should not throw on infinity values
+statement ok
+CREATE TABLE inf_test AS SELECT 1.0/0.0 AS inf_col, 2.0 AS normal_col UNION ALL SELECT 2.0, 3.0;
+
+statement ok
+SUMMARIZE inf_test;
 

--- a/test/sql/function/list/aggregates/var_stddev.test
+++ b/test/sql/function/list/aggregates/var_stddev.test
@@ -123,20 +123,20 @@ select list_aggr([0, 0], 'stddev')
 ----
 0
 
-statement error
+query R
 select list_aggr([1e301, -1e301], 'stddev')
 ----
-<REGEX>:.*Out of Range Error.*out of range.*
+inf
 
-statement error
+query R
 select list_var_samp([1e301, -1e301])
 ----
-<REGEX>:.*Out of Range Error.*out of range.*
+inf
 
-statement error
+query R
 select list_var_pop([1e301, -1e301])
 ----
-<REGEX>:.*Out of Range Error.*out of range.*
+inf
 
 # incorrect usage
 statement error
@@ -151,7 +151,7 @@ CREATE TABLE t0 (c0 DOUBLE[]);
 statement ok
 INSERT INTO t0 VALUES([1E200, 0]);
 
-statement error
+query R
 SELECT list_stddev_pop(c0) FROM t0;
 ----
-<REGEX>:.*Out of Range Error.*out of range.*
+inf


### PR DESCRIPTION
## Summary

Remove out-of-range checks from `VARSAMP`, `VARPOP`, `STDDEV_SAMP`, `STDDEV_POP`, `SEM`, `CORR`, and `REGR_SLOPE` that previously threw `OutOfRangeException` when results were non-finite. Instead, return IEEE-754 compliant `inf`/`nan` values.

## Problem

Previously, operations like `SUMMARIZE` would throw on tables containing infinity values because the underlying stddev/variance functions raised out-of-range errors. This behavior is inconsistent with how other databases and IEEE-754 handle these cases.

## Changes

- **stddev.hpp**: Removed `DoubleIsFinite` checks and `OutOfRangeException` throws from `VarSampOperation`, `VarPopOperation`, `STDDevSampOperation`, `STDDevPopOperation`, and `StandardErrorOfTheMeanOperation`.
- **corr.hpp**: Removed finite checks for `std_x` and `std_y` in `CorrOperation`.
- **regr_slope.hpp**: Removed finite check for `var_pop` in `RegrSlopeOperation`.
- **test_stddev.test**: Updated tests to expect `inf`/`nan` results instead of errors; added tests for infinity input values and `SUMMARIZE` on tables with infinity.
- **var_stddev.test**: Updated list aggregate tests to expect `inf` instead of errors.