### PR TITLE
Rename `ValidityMask::AllValid` to `ValidityMask::CannotHaveNull`

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -32,7 +32,7 @@ struct QuantileCursor {
 		inputs.InitializeScanChunk(scan, page);
 
 		D_ASSERT(partition.all_valid.size() == 1);
-		all_valid = partition.all_valid[0];
+		cannot_have_null = partition.all_valid[0];
 	}
 
 	inline sel_t RowOffset(idx_t row_idx) const {
@@ -63,8 +63,8 @@ struct QuantileCursor {
 		return validity->RowIsValid(offset);
 	}
 
-	inline bool AllValid() {
-		return all_valid;
+	inline bool CannotHaveNull() {
+		return cannot_have_null;
 	}
 
 	//! Windowed paging
@@ -78,7 +78,7 @@ struct QuantileCursor {
 	//! The validity mask
 	const ValidityMask *validity = nullptr;
 	//! Paged chunks do not track this but it is really necessary for performance
-	bool all_valid;
+	bool cannot_have_null;
 };
 
 // Direct access
@@ -293,8 +293,11 @@ struct QuantileIncluded {
 		return fmask.RowIsValid(idx) && dmask.RowIsValid(idx);
 	}
 
+	inline bool CannotHaveNull() {
+		return fmask.CannotHaveNull() && dmask.CannotHaveNull();
+	}
 	inline bool AllValid() {
-		return fmask.AllValid() && dmask.AllValid();
+		return CannotHaveNull();
 	}
 
 	const ValidityMask &fmask;
@@ -331,7 +334,7 @@ struct QuantileSortTree {
 		SelectionVector filter_sel(STANDARD_VECTOR_SIZE);
 		while (inputs.Scan(scan, sort)) {
 			const auto row_idx = scan.current_row_index;
-			if (!filter_mask.AllValid() || !partition.all_valid[0]) {
+			if (filter_mask.CanHaveNull() || !partition.all_valid[0]) {
 				auto &key = sort.data[0];
 				auto &validity = FlatVector::Validity(key);
 				idx_t filtered = 0;

--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -77,7 +77,7 @@ struct QuantileOperation {
 	static idx_t FrameSize(QuantileIncluded<INPUT_TYPE> &included, const SubFrames &frames) {
 		//	Count the number of valid values
 		idx_t n = 0;
-		if (included.AllValid()) {
+		if (included.CannotHaveNull()) {
 			for (const auto &frame : frames) {
 				n += frame.end - frame.start;
 			}

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -388,7 +388,7 @@ static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyj
 	// Structs become values, therefore we initialize vals to JSON values
 	UnifiedVectorFormat value_data;
 	value_v.ToUnifiedFormat(count, value_data);
-	if (value_data.validity.AllValid()) {
+	if (value_data.validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			vals[i] = yyjson_mut_obj(doc);
 		}

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -293,7 +293,7 @@ bool TryParse(Vector &string_vector, StrpTimeFormat &format, const idx_t count) 
 
 	T result;
 	string error_message;
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			if (!OP::template Operation<T>(format, strings[i], result, error_message)) {
 				return false;

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -225,7 +225,7 @@ void ColumnWriter::HandleDefineLevels(ColumnWriterState &state, ColumnWriterStat
 	}
 
 	// no parent: set definition levels only from this validity mask
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		state.definition_levels.insert(state.definition_levels.end(), count, define_value);
 	} else {
 		for (idx_t i = 0; i < count; i++) {

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -206,7 +206,7 @@ public:
 
 		const auto &validity = FlatVector::Validity(vector);
 
-		if (!check_parent_empty && validity.AllValid()) {
+		if (!check_parent_empty && validity.CannotHaveNull()) {
 			// Fast path
 			for (; vector_index < vcount; vector_index++) {
 				const auto &src_value = data_ptr[vector_index];
@@ -280,7 +280,7 @@ public:
 	void WriteVector(WriteStream &temp_writer, ColumnWriterStatistics *stats, ColumnWriterPageState *page_state_p,
 	                 Vector &input_column, idx_t chunk_start, idx_t chunk_end) override {
 		const auto &mask = FlatVector::Validity(input_column);
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			WriteVectorInternal<true>(temp_writer, stats, page_state_p, input_column, chunk_start, chunk_end);
 		} else {
 			WriteVectorInternal<false>(temp_writer, stats, page_state_p, input_column, chunk_start, chunk_end);
@@ -434,7 +434,7 @@ private:
 		}
 		case duckdb_parquet::Encoding::PLAIN: {
 			D_ASSERT(page_state.encoding == duckdb_parquet::Encoding::PLAIN);
-			if (mask.AllValid()) {
+			if (mask.CannotHaveNull()) {
 				TemplatedWritePlain<SRC, TGT, OP, true>(input_column, stats, chunk_start, chunk_end, mask, temp_writer);
 			} else {
 				TemplatedWritePlain<SRC, TGT, OP, false>(input_column, stats, chunk_start, chunk_end, mask,

--- a/extension/parquet/reader/variant/variant_shredded_conversion.cpp
+++ b/extension/parquet/reader/variant/variant_shredded_conversion.cpp
@@ -149,7 +149,7 @@ vector<VariantValue> ConvertTypedValues(Vector &vec, Vector &metadata, Vector &b
 	}
 
 	vector<VariantValue> ret(length);
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < length; i++) {
 			auto index = typed_format.sel->get_index(i + offset);
 			if (TYPE_ID == LogicalTypeId::DECIMAL) {
@@ -438,7 +438,7 @@ vector<VariantValue> VariantShreddedConversion::ConvertShreddedObject(Vector &me
 	}
 
 	vector<VariantValue> ret(length);
-	if (typed_validity.AllValid()) {
+	if (typed_validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < length; i++) {
 			ret[i] = ConvertPartiallyShreddedObject(shredded_fields, metadata_format, value_format, i, offset);
 		}
@@ -493,7 +493,7 @@ vector<VariantValue> VariantShreddedConversion::ConvertShreddedArray(Vector &met
 	auto &value_validity = value_format.validity;
 
 	vector<VariantValue> ret(length);
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		//! We can be sure that none of the values are binary encoded
 		for (idx_t i = 0; i < length; i++) {
 			auto typed_index = list_format.sel->get_index(i + offset);

--- a/extension/parquet/writer/boolean_column_writer.cpp
+++ b/extension/parquet/writer/boolean_column_writer.cpp
@@ -52,7 +52,7 @@ void BooleanColumnWriter::WriteVector(WriteStream &temp_writer, ColumnWriterStat
 	const auto &mask = FlatVector::Validity(input_column);
 
 	const auto *const ptr = FlatVector::GetData<bool>(input_column);
-	if (stats.max && !stats.min && mask.AllValid()) {
+	if (stats.max && !stats.min && mask.CannotHaveNull()) {
 		// Fast path: stats have already been set, and there's no NULLs
 		for (idx_t r = chunk_start; r < chunk_end; r++) {
 			const auto &val = ptr[r];

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -55,7 +55,7 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 	col_chunk.meta_data.num_values += NumericCast<int64_t>(vcount);
 
 	const bool check_parent_empty = parent && !parent->is_empty.empty();
-	if (!check_parent_empty && validity.AllValid() && TypeIsConstantSize(vector.GetType().InternalType()) &&
+	if (!check_parent_empty && validity.CannotHaveNull() && TypeIsConstantSize(vector.GetType().InternalType()) &&
 	    page_info_ref.get().estimated_page_size + GetRowSize(vector, vector_index, state) * vcount <
 	        MAX_UNCOMPRESSED_PAGE_SIZE) {
 		// Fast path: fixed-size type, all valid, and it fits on the current page

--- a/src/common/arrow/appender/append_data.cpp
+++ b/src/common/arrow/appender/append_data.cpp
@@ -6,7 +6,7 @@ void ArrowAppendData::AppendValidity(UnifiedVectorFormat &format, idx_t from, id
 	// resize the buffer, filling the validity buffer with all valid values
 	idx_t size = to - from;
 	ResizeValidity(GetValidityBuffer(), row_count + size);
-	if (format.validity.AllValid()) {
+	if (format.validity.CannotHaveNull()) {
 		// if all values are valid we don't need to do anything else
 		return;
 	}

--- a/src/common/row_operations/row_matcher.cpp
+++ b/src/common/row_operations/row_matcher.cpp
@@ -27,8 +27,8 @@ static idx_t TemplatedMatchLoop(const TupleDataVectorFormat &lhs_format, Selecti
 	const auto &lhs_validity = lhs_format.unified.validity;
 
 #ifdef DUCKDB_SMALLER_BINARY
-	const auto LHS_ALL_VALID = lhs_validity.AllValid();
-	const auto RHS_ALL_VALID = rhs_layout.AllValid();
+	const auto LHS_ALL_VALID = lhs_validity.CannotHaveNull();
+	const auto RHS_ALL_VALID = rhs_layout.CannotHaveNull();
 #endif
 
 	// RHS
@@ -69,8 +69,8 @@ static idx_t TemplatedMatch(Vector &, const TupleDataVectorFormat &lhs_format, S
 	return TemplatedMatchLoop<NO_MATCH_SEL, T, OP>(lhs_format, sel, count, rhs_layout, rhs_row_locations, col_idx,
 	                                               no_match_sel, no_match_count);
 #else
-	if (lhs_format.unified.validity.AllValid()) {
-		if (rhs_layout.AllValid()) {
+	if (lhs_format.unified.validity.CannotHaveNull()) {
+		if (rhs_layout.CannotHaveNull()) {
 			return TemplatedMatchLoop<NO_MATCH_SEL, T, OP, true, true>(
 			    lhs_format, sel, count, rhs_layout, rhs_row_locations, col_idx, no_match_sel, no_match_count);
 		} else {
@@ -78,7 +78,7 @@ static idx_t TemplatedMatch(Vector &, const TupleDataVectorFormat &lhs_format, S
 			    lhs_format, sel, count, rhs_layout, rhs_row_locations, col_idx, no_match_sel, no_match_count);
 		}
 	} else {
-		if (rhs_layout.AllValid()) {
+		if (rhs_layout.CannotHaveNull()) {
 			return TemplatedMatchLoop<NO_MATCH_SEL, T, OP, false, true>(
 			    lhs_format, sel, count, rhs_layout, rhs_row_locations, col_idx, no_match_sel, no_match_count);
 		} else {
@@ -111,11 +111,11 @@ static idx_t StructMatchEquality(Vector &lhs_vector, const TupleDataVectorFormat
 		const auto idx = sel.get_index(i);
 
 		const auto lhs_idx = lhs_sel.get_index(idx);
-		const auto lhs_null = lhs_validity.AllValid() ? false : !lhs_validity.RowIsValid(lhs_idx);
+		const auto lhs_null = lhs_validity.CannotHaveNull() ? false : !lhs_validity.RowIsValid(lhs_idx);
 
 		const auto &rhs_location = rhs_locations[idx];
 		const auto rhs_null =
-		    !rhs_layout.AllValid() &&
+		    rhs_layout.CanHaveNull() &&
 		    !ValidityBytes::RowIsValid(
 		        ValidityBytes(rhs_location, rhs_layout.ColumnCount()).GetValidityEntryUnsafe(entry_idx), idx_in_entry);
 

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -351,7 +351,7 @@ void ColumnDataCopyValidity(const UnifiedVectorFormat &source_data, validity_t *
 		validity.SetAllValid(STANDARD_VECTOR_SIZE);
 	}
 	// FIXME: we can do something more optimized here using bitshifts & bitwise ors
-	if (!source_data.validity.AllValid()) {
+	if (source_data.validity.CanHaveNull()) {
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto idx = source_data.sel->get_index(source_offset + i);
 			if (!source_data.validity.RowIsValid(idx)) {
@@ -442,7 +442,7 @@ static void TemplatedColumnDataCopy(ColumnDataMetaData &meta_data, const Unified
 			// initialize the validity mask to set all to valid
 			result_validity.SetAllValid(STANDARD_VECTOR_SIZE);
 		}
-		if (source_data.validity.AllValid()) {
+		if (source_data.validity.CannotHaveNull()) {
 			// Fast path: all valid
 			for (idx_t i = 0; i < append_count; i++) {
 				auto source_idx = source_data.sel->get_index(offset + i);
@@ -505,7 +505,7 @@ bool ColumnDataCopyCompressedStrings(ColumnDataMetaData &meta_data, const Vector
 
 		// Compute total size needed for dictionary strings
 		const auto dictionary_size_idx = dictionary_size.GetIndex();
-		if (dictionary_validity.AllValid()) {
+		if (dictionary_validity.CannotHaveNull()) {
 			for (idx_t i = 0; i < dictionary_size_idx; i++) {
 				const auto &dictionary_string = dictionary_strings[i];
 				heap_size += !dictionary_string.IsInlined() * dictionary_string.GetSize();

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -481,7 +481,7 @@ static inline void VerifyStrings(const TupleDataLayout &layout, const LogicalTyp
 	for (idx_t i = 0; i < count; i++) {
 		const auto &row_location = row_locations[offset + i] + base_col_offset;
 		const auto valid =
-		    layout.AllValid() ||
+		    layout.CannotHaveNull() ||
 		    ValidityBytes::RowIsValid(
 		        ValidityBytes(row_location, layout.ColumnCount()).GetValidityEntryUnsafe(entry_idx), idx_in_entry);
 		if (valid) {
@@ -558,7 +558,7 @@ void TupleDataAllocator::RecomputeHeapPointers(Vector &old_heap_ptrs, const Sele
 	const auto new_heap_locations = UnifiedVectorFormat::GetData<data_ptr_t>(new_heap_data);
 	const auto new_heap_sel = *new_heap_data.sel;
 
-	const auto all_valid = layout.AllValid();
+	const auto all_valid = layout.CannotHaveNull();
 	const auto column_count = layout.ColumnCount();
 
 	for (const auto &col_idx : layout.GetVariableColumns()) {
@@ -642,7 +642,7 @@ void TupleDataAllocator::FindHeapPointers(TupleDataChunkState &chunk_state, Sele
 	const auto row_locations = FlatVector::GetData<data_ptr_t>(chunk_state.row_locations);
 	const auto heap_locations = FlatVector::GetData<data_ptr_t>(chunk_state.heap_locations);
 
-	const auto all_valid = layout.AllValid();
+	const auto all_valid = layout.CannotHaveNull();
 	const auto column_count = layout.ColumnCount();
 
 	for (const auto &col_idx : layout.GetVariableColumns()) {

--- a/src/common/types/row/tuple_data_layout.cpp
+++ b/src/common/types/row/tuple_data_layout.cpp
@@ -47,7 +47,7 @@ void TupleDataLayout::Initialize(vector<LogicalType> types_p, Aggregates aggrega
 
 	// Null mask at the front - 1 bit per value.
 	validity_type = validity_type_p;
-	flag_width = ValidityBytes::ValidityMaskSize(AllValid() ? 0 : types.size());
+	flag_width = ValidityBytes::ValidityMaskSize(CannotHaveNull() ? 0 : types.size());
 	row_width = flag_width;
 
 	// Whether all columns are constant size.

--- a/src/common/types/row/tuple_data_scatter_gather.cpp
+++ b/src/common/types/row/tuple_data_scatter_gather.cpp
@@ -134,7 +134,7 @@ void ComputeStringHeapSizesInternal(idx_t *const heap_sizes, const UnifiedVector
 	const auto &source_validity = source_vector_data.validity;
 
 #ifdef DUCKDB_SMALLER_BINARY
-	const auto ALL_VALID = source_validity.AllValid();
+	const auto ALL_VALID = source_validity.CannotHaveNull();
 	const auto HAS_APPEND_SEL = append_sel.IsSet();
 	const auto HAS_SOURCE_SEL = source_sel.IsSet();
 #endif
@@ -171,7 +171,7 @@ void TupleDataCollection::ComputeHeapSizes(Vector &heap_sizes_v, const Vector &s
 #ifdef DUCKDB_SMALLER_BINARY
 		ComputeStringHeapSizesInternal(heap_sizes, source_vector_data, append_sel, append_count);
 #else
-		if (source_validity.AllValid()) {
+		if (source_validity.CannotHaveNull()) {
 			if (append_sel.IsSet()) {
 				if (source_sel.IsSet()) {
 					ComputeStringHeapSizesInternal<true, true, true>(heap_sizes, source_vector_data, append_sel,
@@ -673,7 +673,7 @@ void TupleDataCollection::Scatter(TupleDataChunkState &chunk_state, const DataCh
 		const auto row_locations = FlatVector::GetData<data_ptr_t>(chunk_state.row_locations);
 
 		// Set the validity mask for each row before inserting data
-		if (!layout.AllValid()) {
+		if (layout.CanHaveNull()) {
 			InitializeValidityMask(row_locations, append_count, ValidityBytes::SizeInBytes(layout.ColumnCount()));
 		}
 
@@ -734,7 +734,7 @@ static void TupleDataTemplatedScatterInternal(const Vector &, const TupleDataVec
 #ifdef DUCKDB_SMALLER_BINARY
 	const auto HAS_APPEND_SEL = append_sel.IsSet();
 	const auto HAS_SOURCE_SEL = source_sel.IsSet();
-	const auto ALL_VALID = validity.AllValid();
+	const auto ALL_VALID = validity.CannotHaveNull();
 #endif
 
 	// Target
@@ -757,7 +757,7 @@ static void TupleDataTemplatedScatterInternal(const Vector &, const TupleDataVec
 		if (ALL_VALID || validity.RowIsValidUnsafe(source_idx)) {
 			TupleDataValueStore<T>(data[source_idx], target_location, offset_in_row, target_heap_locations[i]);
 		} else {
-			D_ASSERT(!layout.AllValid());
+			D_ASSERT(layout.CanHaveNull());
 			TupleDataValueStore<T>(null_value, target_location, offset_in_row, target_heap_locations[i]);
 			ValidityBytes(target_location, column_count).SetInvalidUnsafe(entry_idx, idx_in_entry);
 		}
@@ -776,7 +776,7 @@ static void TupleDataTemplatedScatter(const Vector &source, const TupleDataVecto
 #else
 	if (append_sel.IsSet()) {
 		if (source_format.unified.sel->IsSet()) {
-			if (source_format.unified.validity.AllValid()) {
+			if (source_format.unified.validity.CannotHaveNull()) {
 				TupleDataTemplatedScatterInternal<T, true, true, true>(source, source_format, append_sel, append_count,
 				                                                       layout, row_locations, heap_locations, col_idx,
 				                                                       dummy_arg, child_functions);
@@ -786,7 +786,7 @@ static void TupleDataTemplatedScatter(const Vector &source, const TupleDataVecto
 				                                                        dummy_arg, child_functions);
 			}
 		} else {
-			if (source_format.unified.validity.AllValid()) {
+			if (source_format.unified.validity.CannotHaveNull()) {
 				TupleDataTemplatedScatterInternal<T, true, false, true>(source, source_format, append_sel, append_count,
 				                                                        layout, row_locations, heap_locations, col_idx,
 				                                                        dummy_arg, child_functions);
@@ -798,7 +798,7 @@ static void TupleDataTemplatedScatter(const Vector &source, const TupleDataVecto
 		}
 	} else {
 		if (source_format.unified.sel->IsSet()) {
-			if (source_format.unified.validity.AllValid()) {
+			if (source_format.unified.validity.CannotHaveNull()) {
 				TupleDataTemplatedScatterInternal<T, false, true, true>(source, source_format, append_sel, append_count,
 				                                                        layout, row_locations, heap_locations, col_idx,
 				                                                        dummy_arg, child_functions);
@@ -808,7 +808,7 @@ static void TupleDataTemplatedScatter(const Vector &source, const TupleDataVecto
 				    dummy_arg, child_functions);
 			}
 		} else {
-			if (source_format.unified.validity.AllValid()) {
+			if (source_format.unified.validity.CannotHaveNull()) {
 				TupleDataTemplatedScatterInternal<T, false, false, true>(
 				    source, source_format, append_sel, append_count, layout, row_locations, heap_locations, col_idx,
 				    dummy_arg, child_functions);
@@ -841,7 +841,7 @@ void TupleDataSortKeyScatter(const Vector &, const TupleDataVectorFormat &source
 	const auto target_locations = FlatVector::GetData<SORT_KEY *>(row_locations);
 	const auto target_heap_locations = FlatVector::GetData<data_ptr_t>(heap_locations);
 
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		// Fast path
 		if (!append_sel.IsSet() && !source_sel.IsSet()) {
 			for (idx_t i = 0; i < append_count; i++) {
@@ -856,7 +856,7 @@ void TupleDataSortKeyScatter(const Vector &, const TupleDataVectorFormat &source
 	} else {
 		for (idx_t i = 0; i < append_count; i++) {
 			const auto source_idx = source_sel.get_index(append_sel.get_index(i));
-			// validity.AllValid() may not be true when doing aggressive vector verification
+			// validity.CannotHaveNull() may not be true when doing aggressive vector verification
 			// but the actual values should always all be valid
 			D_ASSERT(validity.RowIsValid(source_idx));
 			target_locations[i]->Construct(data[source_idx], target_heap_locations[i]);
@@ -883,8 +883,8 @@ static void TupleDataStructScatter(const Vector &source, const TupleDataVectorFo
 	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
 
 	// Set validity of the STRUCT in this layout
-	if (!validity.AllValid()) {
-		D_ASSERT(!layout.AllValid());
+	if (validity.CanHaveNull()) {
+		D_ASSERT(layout.CanHaveNull());
 		for (idx_t i = 0; i < append_count; i++) {
 			const auto source_idx = source_sel.get_index(append_sel.get_index(i));
 			if (!validity.RowIsValid(source_idx)) {
@@ -955,7 +955,7 @@ static void TupleDataListScatter(const Vector &source, const TupleDataVectorForm
 			Store<uint64_t>(data[source_idx].length, target_heap_location);
 			target_heap_location += sizeof(uint64_t);
 		} else {
-			D_ASSERT(!layout.AllValid());
+			D_ASSERT(layout.CanHaveNull());
 			ValidityBytes(target_locations[i], layout.ColumnCount()).SetInvalidUnsafe(entry_idx, idx_in_entry);
 		}
 	}
@@ -1005,7 +1005,7 @@ static void TupleDataArrayScatter(const Vector &source, const TupleDataVectorFor
 			Store<uint64_t>(data[source_idx].length, target_heap_location);
 			target_heap_location += sizeof(uint64_t);
 		} else {
-			D_ASSERT(!layout.AllValid());
+			D_ASSERT(layout.CanHaveNull());
 			ValidityBytes(target_locations[i], layout.ColumnCount()).SetInvalidUnsafe(entry_idx, idx_in_entry);
 		}
 	}
@@ -1364,7 +1364,8 @@ void TupleDataCollection::Gather(Vector &row_locations, const SelectionVector &s
 void TupleDataCollection::Gather(Vector &row_locations, const SelectionVector &scan_sel, const idx_t scan_count,
                                  const column_t column_id, Vector &result, const SelectionVector &target_sel,
                                  optional_ptr<Vector> cached_cast_vector) const {
-	D_ASSERT(!cached_cast_vector || FlatVector::Validity(*cached_cast_vector).AllValid()); // ResetCachedCastVectors
+	D_ASSERT(!cached_cast_vector ||
+	         FlatVector::Validity(*cached_cast_vector).CannotHaveNull()); // ResetCachedCastVectors
 	const auto &gather_function = gather_functions[column_id];
 	gather_function.function(layout, row_locations, column_id, scan_sel, scan_count, result, target_sel,
 	                         cached_cast_vector, gather_function.child_functions);
@@ -1383,7 +1384,7 @@ static void TupleDataTemplatedGatherInternal(const TupleDataLayout &layout, Vect
 #ifdef DUCKDB_SMALLER_BINARY
 	const bool HAS_SCAN_SEL = scan_sel.IsSet();
 	const bool HAS_TARGET_SEL = target_sel.IsSet();
-	const bool ALL_VALID = layout.AllValid();
+	const bool ALL_VALID = layout.CannotHaveNull();
 #endif
 	// Source
 	const auto source_locations = FlatVector::GetData<data_ptr_t>(row_locations);
@@ -1425,7 +1426,7 @@ static void TupleDataTemplatedGather(const TupleDataLayout &layout, Vector &row_
 #else
 	if (scan_sel.IsSet()) {
 		if (target_sel.IsSet()) {
-			if (layout.AllValid()) {
+			if (layout.CannotHaveNull()) {
 				TupleDataTemplatedGatherInternal<T, true, true, true>(layout, row_locations, col_idx, scan_sel,
 				                                                      scan_count, target, target_sel, list_vector,
 				                                                      child_functions);
@@ -1435,7 +1436,7 @@ static void TupleDataTemplatedGather(const TupleDataLayout &layout, Vector &row_
 				                                                       child_functions);
 			}
 		} else {
-			if (layout.AllValid()) {
+			if (layout.CannotHaveNull()) {
 				TupleDataTemplatedGatherInternal<T, true, false, true>(layout, row_locations, col_idx, scan_sel,
 				                                                       scan_count, target, target_sel, list_vector,
 				                                                       child_functions);
@@ -1447,7 +1448,7 @@ static void TupleDataTemplatedGather(const TupleDataLayout &layout, Vector &row_
 		}
 	} else {
 		if (target_sel.IsSet()) {
-			if (layout.AllValid()) {
+			if (layout.CannotHaveNull()) {
 				TupleDataTemplatedGatherInternal<T, false, true, true>(layout, row_locations, col_idx, scan_sel,
 				                                                       scan_count, target, target_sel, list_vector,
 				                                                       child_functions);
@@ -1457,7 +1458,7 @@ static void TupleDataTemplatedGather(const TupleDataLayout &layout, Vector &row_
 				                                                        child_functions);
 			}
 		} else {
-			if (layout.AllValid()) {
+			if (layout.CannotHaveNull()) {
 				TupleDataTemplatedGatherInternal<T, false, false, true>(layout, row_locations, col_idx, scan_sel,
 				                                                        scan_count, target, target_sel, list_vector,
 				                                                        child_functions);
@@ -1503,7 +1504,7 @@ static void TupleDataStructGather(const TupleDataLayout &layout, Vector &row_loc
 		const auto &source_row = source_locations[source_idx];
 
 		// Set the validity
-		if (!layout.AllValid() &&
+		if (layout.CanHaveNull() &&
 		    !ValidityBytes::RowIsValid(
 		        ValidityBytes(source_row, layout.ColumnCount()).GetValidityEntryUnsafe(entry_idx), idx_in_entry)) {
 			const auto target_idx = target_sel.get_index(i);
@@ -1559,7 +1560,7 @@ static void TupleDataListGather(const TupleDataLayout &layout, Vector &row_locat
 		const auto &source_row = source_locations[scan_sel.get_index(i)];
 
 		const auto target_idx = target_sel.get_index(i);
-		if (layout.AllValid() ||
+		if (layout.CannotHaveNull() ||
 		    ValidityBytes::RowIsValid(ValidityBytes(source_row, layout.ColumnCount()).GetValidityEntryUnsafe(entry_idx),
 		                              idx_in_entry)) {
 			auto &source_heap_location = source_heap_locations[i];

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -14,11 +14,11 @@ ValidityData::ValidityData(const ValidityMask &original, idx_t count)
 }
 
 void ValidityMask::Combine(const ValidityMask &other, idx_t count) {
-	if (other.AllValid()) {
+	if (other.CannotHaveNull()) {
 		// X & 1 = X
 		return;
 	}
-	if (AllValid()) {
+	if (CannotHaveNull()) {
 		// 1 & Y = Y
 		Initialize(other);
 		return;
@@ -84,7 +84,7 @@ idx_t ValidityMask::Capacity() const {
 }
 
 void ValidityMask::Slice(const ValidityMask &other, idx_t source_offset, idx_t count) {
-	if (other.AllValid()) {
+	if (other.CannotHaveNull()) {
 		validity_mask = nullptr;
 		validity_data.reset();
 		return;
@@ -121,7 +121,7 @@ void ValidityMask::CopySel(const ValidityMask &other, const SelectionVector &sel
 }
 
 void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count) {
-	if (AllValid() && other.AllValid()) {
+	if (CannotHaveNull() && other.CannotHaveNull()) {
 		// Both validity masks are uninitialized, nothing to do
 		return;
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1251,7 +1251,7 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 		serializer.WriteProperty<GeometryStorageType>(99, "geometry_format", GeometryStorageType::WKB);
 	}
 
-	const bool has_validity_mask = (count > 0) && !vdata.validity.AllValid();
+	const bool has_validity_mask = (count > 0) && vdata.validity.CanHaveNull();
 	serializer.WriteProperty(100, "has_validity_mask", has_validity_mask);
 	if (has_validity_mask) {
 		ValidityMask flat_mask(count);

--- a/src/common/vector/union_vector.cpp
+++ b/src/common/vector/union_vector.cpp
@@ -52,7 +52,7 @@ void UnionVector::SetToMember(Vector &union_vector, union_tag_t tag, Vector &mem
 		member_vector.Flatten(count);
 		union_vector.SetVectorType(VectorType::FLAT_VECTOR);
 
-		if (member_vector.validity.AllValid()) {
+		if (member_vector.validity.CannotHaveNull()) {
 			// if the member vector is all valid, we can set the tag to constant
 			tag_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
 			auto tag_data = ConstantVector::GetData<union_tag_t>(tag_vector);

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -182,7 +182,7 @@ static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result
 	UnifiedVectorFormat leftv, rightv;
 	left.ToUnifiedFormat(count, leftv);
 	right.ToUnifiedFormat(count, rightv);
-	if (!leftv.validity.AllValid() || !rightv.validity.AllValid()) {
+	if (leftv.validity.CanHaveNull() || rightv.validity.CanHaveNull()) {
 		ComparesNotNull(leftv, rightv, result_validity, count);
 	}
 	ValidityMask original_mask;

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -145,7 +145,7 @@ idx_t DistinctSelectGenericLoopSwitch(const LEFT_TYPE *__restrict ldata, const R
                                       const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
                                       ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
 #ifndef DUCKDB_SMALLER_BINARY
-	if (!lmask.AllValid() || !rmask.AllValid()) {
+	if (lmask.CanHaveNull() || rmask.CanHaveNull()) {
 		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
 		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
 	} else {

--- a/src/common/vector_operations/null_operations.cpp
+++ b/src/common/vector_operations/null_operations.cpp
@@ -82,7 +82,7 @@ idx_t VectorOperations::CountNotNull(Vector &input, const idx_t count) {
 
 	UnifiedVectorFormat vdata;
 	input.ToUnifiedFormat(count, vdata);
-	if (vdata.validity.AllValid()) {
+	if (vdata.validity.CannotHaveNull()) {
 		return count;
 	}
 	switch (input.GetVectorType()) {

--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -50,7 +50,7 @@ hash_t CombineHashScalar(hash_t a, hash_t b) {
 template <bool HAS_RSEL, bool HAS_SEL_VECTOR, class T, bool INPUT_IS_ALREADY_HASH>
 void TightLoopHash(const T *__restrict ldata, hash_t *__restrict result_data, const SelectionVector *rsel, idx_t count,
                    const SelectionVector *__restrict sel_vector, const ValidityMask &mask) {
-	if (!mask.AllValid()) {
+	if (mask.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto ridx = HAS_RSEL ? rsel->get_index_unsafe(i) : i;
 			auto idx = HAS_SEL_VECTOR ? sel_vector->get_index_unsafe(ridx) : ridx;
@@ -350,7 +350,7 @@ template <bool HAS_RSEL, class T, bool INPUT_IS_ALREADY_HASH>
 void TightLoopCombineHashConstant(const T *__restrict ldata, hash_t constant_hash, hash_t *__restrict hash_data,
                                   const SelectionVector *rsel, idx_t count,
                                   const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
-	if (!mask.AllValid()) {
+	if (mask.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
 			auto idx = sel_vector->get_index(ridx);
@@ -372,7 +372,7 @@ template <bool HAS_RSEL, bool HAS_SEL, class T, bool INPUT_IS_ALREADY_HASH>
 static inline void TightLoopCombineHash(const T *__restrict ldata, hash_t *__restrict const hash_data,
                                         const SelectionVector *__restrict const rsel, const idx_t count,
                                         const SelectionVector *__restrict const sel_vector, const ValidityMask &mask) {
-	if (!mask.AllValid()) {
+	if (mask.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto ridx = HAS_RSEL ? rsel->get_index_unsafe(i) : i;
 			auto idx = HAS_SEL ? sel_vector->get_index_unsafe(ridx) : ridx;

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -66,7 +66,7 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
 
 	// Predicates
 	const auto expr_type =
-	    layout_ptr->AllValid() ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+	    layout_ptr->CannotHaveNull() ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOT_DISTINCT_FROM;
 	predicates.resize(layout_ptr->ColumnCount() - 1, expr_type);
 	row_matcher.Initialize(true, *layout_ptr, predicates);
 }

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -362,7 +362,7 @@ idx_t ExpressionExecutor::DefaultSelect(const Expression &expr, ExpressionState 
 	if (!sel) {
 		sel = FlatVector::IncrementalSelectionVector();
 	}
-	if (!idata.validity.AllValid()) {
+	if (idata.validity.CanHaveNull()) {
 		return DefaultSelectSwitch<false>(idata, sel, count, true_sel, false_sel);
 	} else {
 		return DefaultSelectSwitch<true>(idata, sel, count, true_sel, false_sel);

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -475,7 +475,7 @@ idx_t JoinHashTable::PrepareKeys(DataChunk &keys, vector<TupleDataVectorFormat> 
 			continue;
 		}
 		auto &col_key_data = vector_data[col_idx].unified;
-		if (col_key_data.validity.AllValid()) {
+		if (col_key_data.validity.CannotHaveNull()) {
 			continue;
 		}
 		added_count = FilterNullValues(col_key_data, *current_sel, added_count, sel);
@@ -617,7 +617,7 @@ static void InsertHashesLoop(atomic<ht_entry_t> entries[], Vector &row_locations
 	idx_t remaining_count = count;
 	const auto *remaining_sel = FlatVector::IncrementalSelectionVector();
 
-	const auto all_valid = layout.AllValid();
+	const auto all_valid = layout.CannotHaveNull();
 	const auto column_count = layout.ColumnCount();
 
 	if (PropagatesBuildSide(ht.join_type)) {
@@ -1335,7 +1335,7 @@ void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &pro
 		}
 		UnifiedVectorFormat jdata;
 		join_keys.data[col_idx].ToUnifiedFormat(join_keys.size(), jdata);
-		if (!jdata.validity.AllValid()) {
+		if (jdata.validity.CanHaveNull()) {
 			for (idx_t i = 0; i < join_keys.size(); i++) {
 				auto jidx = jdata.sel->get_index(i);
 				if (!jdata.validity.RowIsValidUnsafe(jidx)) {

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -541,7 +541,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 				arg.ToUnifiedFormat(count, unified);
 				const auto &validity = unified.validity;
 				auto &prev = *state.const_vectors[expr_idx];
-				if (validity.AllValid()) {
+				if (validity.CannotHaveNull()) {
 					prev.Reference(arg.GetValue(0));
 					result.Reference(prev);
 				} else {
@@ -576,7 +576,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 				UnifiedVectorFormat unified;
 				arg.ToUnifiedFormat(count, unified);
 				const auto &validity = unified.validity;
-				if (validity.AllValid()) {
+				if (validity.CannotHaveNull()) {
 					VectorOperations::Copy(arg, result, count, 0, 0);
 				} else {
 					//	Copy the data as it may be a reference to the argument

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -1032,7 +1032,7 @@ void AsOfProbeBuffer::ScanLeft() {
 	}
 
 	// Filter out NULL matches
-	if (!lhs_valid_mask.AllValid()) {
+	if (lhs_valid_mask.CanHaveNull()) {
 		const auto count = lhs_match_count;
 		lhs_match_count = 0;
 		for (idx_t i = 0; i < count; ++i) {

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -427,7 +427,7 @@ void PhysicalPiecewiseMergeJoin::ResolveSimpleJoin(ExecutionContext &context, Da
 		for (auto &key : lhs_keys.data) {
 			key.Flatten(lhs_keys.size());
 			auto &mask = FlatVector::Validity(key);
-			if (mask.AllValid()) {
+			if (mask.CannotHaveNull()) {
 				continue;
 			}
 			mask.SetAllValid(lhs_not_null);

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -412,7 +412,7 @@ idx_t PhysicalRangeJoin::LocalSortedTable::MergeNulls(Vector &primary, const vec
 			UnifiedVectorFormat vdata;
 			v.ToUnifiedFormat(count, vdata);
 			auto &vvalidity = vdata.validity;
-			if (vvalidity.AllValid()) {
+			if (vvalidity.CannotHaveNull()) {
 				continue;
 			}
 			pvalidity.EnsureWritable();

--- a/src/execution/perfect_aggregate_hashtable.cpp
+++ b/src/execution/perfect_aggregate_hashtable.cpp
@@ -57,7 +57,7 @@ static void ComputeGroupLocationTemplated(UnifiedVectorFormat &group_data, Value
                                           idx_t current_shift, idx_t count) {
 	auto data = UnifiedVectorFormat::GetData<T>(group_data);
 	auto min_val = min.GetValueUnsafe<T>();
-	if (!group_data.validity.AllValid()) {
+	if (group_data.validity.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto index = group_data.sel->get_index(i);
 			// check if the value is NULL

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -47,7 +47,7 @@ struct CountStarFunction : public BaseCountFunction {
 			const auto end = frame.end;
 
 			// Slice to any filtered rows
-			if (partition.filter_mask.AllValid()) {
+			if (partition.filter_mask.CannotHaveNull()) {
 				total += end - begin;
 				continue;
 			}
@@ -75,7 +75,7 @@ struct CountFunction : public BaseCountFunction {
 	}
 
 	static inline void CountFlatLoop(STATE **__restrict states, ValidityMask &mask, idx_t count) {
-		if (!mask.AllValid()) {
+		if (mask.CanHaveNull()) {
 			idx_t base_idx = 0;
 			auto entry_count = ValidityMask::EntryCount(count);
 			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
@@ -110,7 +110,7 @@ struct CountFunction : public BaseCountFunction {
 
 	static inline void CountScatterLoop(STATE_PTR __restrict states, const SelectionVector &isel,
 	                                    const SelectionVector &ssel, ValidityMask &mask, idx_t count) {
-		if (!mask.AllValid()) {
+		if (mask.CanHaveNull()) {
 			// potential NULL values
 			for (idx_t i = 0; i < count; i++) {
 				auto idx = isel.get_index(i);
@@ -171,7 +171,7 @@ struct CountFunction : public BaseCountFunction {
 
 	static inline void CountUpdateLoop(STATE &result, ValidityMask &mask, idx_t count,
 	                                   const SelectionVector &sel_vector) {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			// no NULL values
 			result += UnsafeNumericCast<STATE>(count);
 			return;

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -411,7 +411,7 @@ static bool ConvertVariantToStruct(FromVariantConversionData &conversion_data, V
 		ValidityMask lookup_validity(count);
 		VariantUtils::FindChildValues(conversion_data.variant, component, row_sel, child_values_sel, lookup_validity,
 		                              child_data, validity, count);
-		if (!lookup_validity.AllValid()) {
+		if (lookup_validity.CanHaveNull()) {
 			optional_idx nested_index;
 			for (idx_t i = 0; i < count; i++) {
 				if (!lookup_validity.RowIsValid(i)) {

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -522,7 +522,7 @@ void TemplatedConstructSortKey(SortKeyVectorData &vector_data, SortKeyChunk chun
 	if (chunk.start == chunk.end) {
 		return;
 	}
-	if (vector_data.format.validity.AllValid()) {
+	if (vector_data.format.validity.CannotHaveNull()) {
 		if (!chunk.has_result_index && !vector_data.format.sel->IsSet()) {
 			TemplatedConstructSortKeyInternal<OP, true, false>(vector_data, chunk, info);
 		} else {
@@ -1185,7 +1185,7 @@ static void DecodeSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 	UnifiedVectorFormat sort_key_vec_format;
 	sort_key_vec.ToUnifiedFormat(count, sort_key_vec_format);
 
-	// When doing aggressive vector verification, the "sort_key_vec_format.validity.AllValid()" is not always true
+	// When doing aggressive vector verification, the "sort_key_vec_format.validity.CannotHaveNull()" is not always true
 	// However, all the actual values should be valid, so we assert that
 
 	// Construct utility for all sort keys that we will decode

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -33,7 +33,7 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 		switch (args.data[idx].GetVectorType()) {
 		case VectorType::FLAT_VECTOR: {
 			auto &input_mask = FlatVector::Validity(args.data[idx]);
-			if (!input_mask.AllValid()) {
+			if (input_mask.CanHaveNull()) {
 				// there are null values: need to merge them into the result
 				result.Flatten(args.size());
 				auto &result_mask = FlatVector::Validity(result);

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -117,7 +117,7 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 					result_validity.SetInvalid(i);
 				}
 			}
-			has_top_level_null = !result_validity.AllValid();
+			has_top_level_null = result_validity.CanHaveNull();
 		}
 		auto result_list_data = FlatVector::GetData<list_entry_t>(result);
 		for (idx_t i = 0; i < result_size; i++) {
@@ -167,7 +167,7 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 					result_validity.SetInvalid(i);
 				}
 			}
-			has_top_level_null = !result_validity.AllValid();
+			has_top_level_null = result_validity.CanHaveNull();
 		}
 		auto result_list_data = FlatVector::GetData<list_entry_t>(result);
 		for (idx_t i = 0; i < result_size; i++) {
@@ -209,7 +209,7 @@ void RemapStruct(Vector &input, Vector &default_vector, Vector &result, idx_t re
 					result_validity.SetInvalid(i);
 				}
 			}
-			has_top_level_null = !result_validity.AllValid();
+			has_top_level_null = result_validity.CanHaveNull();
 		}
 	}
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -211,7 +211,7 @@ void VariantUtils::VariantExtract(Vector &variant_vec, const vector<VariantPathC
 			if (!validity.RowIsValid(j)) {
 				continue;
 			}
-			if (!lookup_validity.AllValid() && !lookup_validity.RowIsValid(j)) {
+			if (lookup_validity.CanHaveNull() && !lookup_validity.RowIsValid(j)) {
 				//! No child could be extracted, set to NULL
 				validity.SetInvalid(j);
 				continue;
@@ -273,7 +273,7 @@ void VariantUtils::VariantExtract(Vector &variant_vec, const vector<VariantPathC
 	result_byte_offset.Dictionary(VariantVector::GetValuesByteOffset(variant_vec), values_list_size, new_sel,
 	                              values_list_size);
 
-	if (!validity.AllValid()) {
+	if (validity.CanHaveNull()) {
 		//! Create a copy of the vector, because we used Reference before, and we now need to adjust the data
 		//! Which is a problem if we're still sharing the memory with 'input'
 		Vector other(result.GetType(), count);

--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -231,7 +231,7 @@ bool VariantUtils::Verify(Vector &variant, const SelectionVector &sel_p, idx_t c
 	//! keys_entry
 	auto &keys_entry = UnifiedVariantVector::GetKeysEntry(format);
 	auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
-	D_ASSERT(keys_entry.validity.AllValid());
+	D_ASSERT(keys_entry.validity.CannotHaveNull());
 
 	//! children
 	auto &children = UnifiedVariantVector::GetChildren(format);

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -219,7 +219,7 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
 	auto &list_mask = FlatVector::Validity(vector);
 	if (parent_mask) {
 		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
-		if (!parent_mask->AllValid()) {
+		if (parent_mask->CanHaveNull()) {
 			for (idx_t i = 0; i < size; i++) {
 				if (!parent_mask->RowIsValid(i)) {
 					list_mask.SetInvalid(i);
@@ -277,7 +277,7 @@ static void ArrowToDuckDBArray(Vector &vector, ArrowArray &array, idx_t chunk_of
 	auto &array_mask = FlatVector::Validity(vector);
 	if (parent_mask) {
 		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
-		if (!parent_mask->AllValid()) {
+		if (parent_mask->CanHaveNull()) {
 			for (idx_t i = 0; i < size; i++) {
 				if (!parent_mask->RowIsValid(i)) {
 					array_mask.SetInvalid(i);
@@ -287,7 +287,7 @@ static void ArrowToDuckDBArray(Vector &vector, ArrowArray &array, idx_t chunk_of
 	}
 
 	// Broadcast the validity mask to the child vector
-	if (!array_mask.AllValid()) {
+	if (array_mask.CanHaveNull()) {
 		auto &child_validity_mask = FlatVector::Validity(child_vector);
 		for (idx_t i = 0; i < size; i++) {
 			if (!array_mask.RowIsValid(i)) {
@@ -395,7 +395,7 @@ static void TimeConversion(Vector &vector, ArrowArray &array, idx_t chunk_offset
 	auto &validity_mask = FlatVector::Validity(vector);
 	auto src_ptr = static_cast<const T *>(array.buffers[1]) +
 	               GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
-	if (validity_mask.AllValid()) {
+	if (validity_mask.CannotHaveNull()) {
 		for (idx_t row = 0; row < size; row++) {
 			if (!TryMultiplyOperator::Operation(static_cast<int64_t>(src_ptr[row]), conversion, tgt_ptr[row].micros)) {
 				throw ConversionException("Could not convert Time to Microsecond");
@@ -420,7 +420,7 @@ static void TimeNSConversion(Vector &vector, ArrowArray &array, idx_t chunk_offs
 	auto &validity_mask = FlatVector::Validity(vector);
 	auto src_ptr = static_cast<const T *>(array.buffers[1]) +
 	               GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
-	if (validity_mask.AllValid()) {
+	if (validity_mask.CannotHaveNull()) {
 		for (idx_t row = 0; row < size; row++) {
 			// dtime_ns_t.micros actually holds nanos (!)
 			if (!TryMultiplyOperator::Operation(static_cast<int64_t>(src_ptr[row]), conversion, tgt_ptr[row].micros)) {
@@ -446,7 +446,7 @@ static void UUIDConversion(Vector &vector, const ArrowArray &array, idx_t chunk_
 	auto &validity_mask = FlatVector::Validity(vector);
 	auto src_ptr = static_cast<const hugeint_t *>(array.buffers[1]) +
 	               GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
-	if (validity_mask.AllValid()) {
+	if (validity_mask.CannotHaveNull()) {
 		for (idx_t row = 0; row < size; row++) {
 			tgt_ptr[row].lower = static_cast<uint64_t>(BSwapIfLE(src_ptr[row].upper));
 			// flip Upper MSD
@@ -472,7 +472,7 @@ static void TimestampTZConversion(Vector &vector, ArrowArray &array, idx_t chunk
 	auto &validity_mask = FlatVector::Validity(vector);
 	auto src_ptr =
 	    ArrowBufferData<int64_t>(array, 1) + GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
-	if (validity_mask.AllValid()) {
+	if (validity_mask.CannotHaveNull()) {
 		for (idx_t row = 0; row < size; row++) {
 			if (!TryMultiplyOperator::Operation(src_ptr[row], conversion, tgt_ptr[row].value)) {
 				throw ConversionException("Could not convert TimestampTZ to Microsecond");
@@ -1167,7 +1167,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 
 			ArrowToDuckDBConversion::SetValidityMask(child_entry, child_array, chunk_offset, size, array.offset,
 			                                         nested_offset);
-			if (!struct_validity_mask.AllValid()) {
+			if (struct_validity_mask.CanHaveNull()) {
 				auto &child_validity_mark = FlatVector::Validity(child_entry);
 				for (idx_t i = 0; i < size; i++) {
 					if (!struct_validity_mask.RowIsValid(i)) {
@@ -1384,7 +1384,7 @@ static bool CanContainNull(const ArrowArray &array, const ValidityMask *parent_m
 	if (!parent_mask) {
 		return false;
 	}
-	return !parent_mask->AllValid();
+	return parent_mask->CanHaveNull();
 }
 
 void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, idx_t chunk_offset,
@@ -1437,7 +1437,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
 	if (has_nulls) {
 		ValidityMask indices_validity;
 		GetValidityMask(indices_validity, array, chunk_offset, size, NumericCast<int64_t>(parent_offset));
-		if (parent_mask && !parent_mask->AllValid()) {
+		if (parent_mask && parent_mask->CanHaveNull()) {
 			auto &struct_validity_mask = *parent_mask;
 			for (idx_t i = 0; i < size; i++) {
 				if (!struct_validity_mask.RowIsValid(i)) {

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -210,7 +210,7 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 		VariantUtils::FindChildValues(variant, path_component, sel, child_values_indexes, lookup_validity,
 		                              nested_data.get(), all_valid_validity, count);
 
-		if (!lookup_validity.AllValid()) {
+		if (lookup_validity.CanHaveNull()) {
 			optional_ptr<Vector> typed_value_vector;
 			optional_ptr<Vector> untyped_value_vector;
 			if (child_vec.GetType().id() == LogicalTypeId::STRUCT) {

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 // WindowBoundariesState
 //===--------------------------------------------------------------------===//
 idx_t WindowBoundariesState::FindNextStart(const ValidityMask &mask, idx_t l, const idx_t r, idx_t &n) {
-	if (mask.AllValid()) {
+	if (mask.CannotHaveNull()) {
 		auto start = MinValue(l + n - 1, r);
 		n -= MinValue(n, r - l);
 		return start;
@@ -41,7 +41,7 @@ idx_t WindowBoundariesState::FindNextStart(const ValidityMask &mask, idx_t l, co
 }
 
 idx_t WindowBoundariesState::FindPrevStart(const ValidityMask &mask, const idx_t l, idx_t r, idx_t &n) {
-	if (mask.AllValid()) {
+	if (mask.CannotHaveNull()) {
 		auto start = (r <= l + n) ? l : r - n;
 		n -= r - start;
 		return start;

--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -36,7 +36,7 @@ WindowConstantAggregatorGlobalState::WindowConstantAggregatorGlobalState(ClientC
                                                                          const ValidityMask &partition_mask)
     : WindowAggregatorGlobalState(client, aggregator, STANDARD_VECTOR_SIZE), statef(client, aggr) {
 	// Locate the partition boundaries
-	if (partition_mask.AllValid()) {
+	if (partition_mask.CannotHaveNull()) {
 		partition_offsets.emplace_back(0);
 	} else {
 		idx_t entry_idx;

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -220,7 +220,7 @@ void WindowSegmentTreePart::ExtractFrame(idx_t begin, idx_t end, data_ptr_t stat
 	//	just update the shared dictionary selection to the range
 	//	Otherwise set it to the input rows that pass the filter
 	auto states = FlatVector::GetData<data_ptr_t>(statep);
-	if (filter_mask.AllValid()) {
+	if (filter_mask.CannotHaveNull()) {
 		const auto offset = cursor->RowOffset(begin);
 		for (idx_t i = 0; i < count; ++i) {
 			states[flush_count] = state_ptr;

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -407,7 +407,7 @@ void WindowLeadLagExecutor::EvaluateInternal(ExecutionContext &context, DataChun
 	// We can't shift if we are ignoring NULLs (the rows may not be contiguous)
 	// or if we are using framing (the frame may change on each row)
 	auto &ignore_nulls = glstate.ignore_nulls;
-	bool can_shift = ignore_nulls->AllValid() && !glstate.use_framing;
+	bool can_shift = ignore_nulls->CannotHaveNull() && !glstate.use_framing;
 	if (wexpr.offset_expr) {
 		can_shift = can_shift && wexpr.offset_expr->IsFoldable();
 	}

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -92,7 +92,7 @@ public:
 			}
 		} else {
 			D_ASSERT(hash_vec.GetVectorType() == VectorType::FLAT_VECTOR);
-			if (idata.validity.AllValid()) {
+			if (idata.validity.CannotHaveNull()) {
 				for (idx_t i = 0; i < count; ++i) {
 					const auto hash = hashes[i];
 					InsertElement(hash);

--- a/src/include/duckdb/common/types/row/tuple_data_layout.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_layout.hpp
@@ -123,8 +123,11 @@ public:
 		return aggr_destructor_idxs;
 	}
 	//! Returns whether none of the columns have NULLs
-	inline bool AllValid() const {
+	inline bool CannotHaveNull() const {
 		return validity_type == TupleDataValidityType::CANNOT_HAVE_NULL_VALUES;
+	}
+	inline bool CanHaveNull() const {
+		return validity_type != TupleDataValidityType::CANNOT_HAVE_NULL_VALUES;
 	}
 
 private:

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -79,8 +79,15 @@ public:
 	static inline idx_t ValidityMaskSize(idx_t count = STANDARD_VECTOR_SIZE) {
 		return ValidityBuffer::EntryCount(count) * sizeof(V);
 	}
-	inline bool AllValid() const {
+	inline bool CannotHaveNull() const {
 		return !validity_mask;
+	}
+	inline bool CanHaveNull() const {
+		return validity_mask;
+	}
+	//! Deprecated - use CannotHaveNull() instead
+	[[deprecated("Use CannotHaveNull() instead")]] inline bool AllValid() const {
+		return CannotHaveNull();
 	}
 	inline bool CheckAllValid(idx_t count) const {
 		return CountValid(count) == count;
@@ -90,7 +97,7 @@ public:
 	}
 
 	inline bool CheckAllValid(idx_t to, idx_t from) const {
-		if (AllValid()) {
+		if (CannotHaveNull()) {
 			return true;
 		}
 		for (idx_t i = from; i < to; i++) {
@@ -102,7 +109,7 @@ public:
 	}
 
 	idx_t CountValid(const idx_t count) const {
-		if (AllValid() || count == 0) {
+		if (CannotHaveNull() || count == 0) {
 			return count;
 		}
 
@@ -177,8 +184,8 @@ public:
 		return (n + BITS_PER_VALUE - 1) / BITS_PER_VALUE;
 	}
 
-	//! RowIsValidUnsafe should only be used if AllValid() is false: it achieves the same as RowIsValid but skips a
-	//! not-null check
+	//! RowIsValidUnsafe should only be used if CannotHaveNull() is false: it achieves the same as RowIsValid but skips
+	//! a not-null check
 	inline bool RowIsValidUnsafe(idx_t row_idx) const {
 		D_ASSERT(validity_mask);
 		idx_t entry_idx, idx_in_entry;
@@ -218,7 +225,7 @@ public:
 		}
 #endif
 		if (!validity_mask) {
-			// if AllValid() we don't need to do anything
+			// if CannotHaveNull() we don't need to do anything
 			// the row is already valid
 			return;
 		}
@@ -336,7 +343,7 @@ public:
 	}
 	inline void Copy(const TemplatedValidityMask &other, idx_t count) {
 		capacity = count;
-		if (other.AllValid()) {
+		if (other.CannotHaveNull()) {
 			validity_data = nullptr;
 			validity_mask = nullptr;
 		} else {
@@ -386,8 +393,15 @@ struct ValidityArray {
 	inline ValidityArray() {
 	}
 
-	inline bool AllValid() const {
+	inline bool CannotHaveNull() const {
 		return !validity_mask;
+	}
+	inline bool CanHaveNull() const {
+		return validity_mask;
+	}
+	//! Deprecated - use CannotHaveNull() instead
+	[[deprecated("Use CannotHaveNull() instead")]] inline bool AllValid() const {
+		return CannotHaveNull();
 	}
 
 	inline void Initialize(idx_t count, bool initial = true) {
@@ -404,8 +418,8 @@ struct ValidityArray {
 		return capacity;
 	}
 
-	//! RowIsValidUnsafe should only be used if AllValid() is false: it achieves the same as RowIsValid but skips a
-	//! not-null check
+	//! RowIsValidUnsafe should only be used if CannotHaveNull() is false: it achieves the same as RowIsValid but skips
+	//! a not-null check
 	inline bool RowIsValidUnsafe(idx_t row_idx) const {
 		D_ASSERT(validity_mask);
 		return validity_mask[row_idx];
@@ -440,7 +454,7 @@ struct ValidityArray {
 		}
 #endif
 		if (!validity_mask) {
-			// if AllValid() we don't need to do anything
+			// if CannotHaveNull() we don't need to do anything
 			// the row is already valid
 			return;
 		}
@@ -449,7 +463,7 @@ struct ValidityArray {
 	}
 
 	inline void Pack(ValidityMask &mask, const idx_t count) const {
-		if (AllValid()) {
+		if (CannotHaveNull()) {
 			mask.Reset(count);
 			return;
 		}

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -22,7 +22,7 @@ public:
 		return format.validity.RowIsValid(format.sel->get_index(i));
 	}
 	bool CanHaveNull() const {
-		return !format.validity.AllValid();
+		return format.validity.CanHaveNull();
 	}
 	idx_t size() const {
 		return count;
@@ -158,7 +158,7 @@ public:
 		return data[format.sel->get_index(i)];
 	}
 	bool CanHaveNull() const {
-		return !format.validity.AllValid();
+		return format.validity.CanHaveNull();
 	}
 
 private:
@@ -185,7 +185,7 @@ private:
 	class VectorScanIterator {
 	public:
 		explicit VectorScanIterator(UnifiedVectorFormat &format, const T *data, idx_t index, idx_t count)
-		    : format(format), data(data), count(count), can_have_null(!format.validity.AllValid()) {
+		    : format(format), data(data), count(count), can_have_null(format.validity.CanHaveNull()) {
 			r.index = index;
 			AdvanceToValid();
 		}

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -63,7 +63,7 @@ private:
 	template <class STATE_TYPE, class INPUT_TYPE, class OP>
 	static inline void UnaryFlatLoop(const INPUT_TYPE *__restrict idata, AggregateInputData &aggr_input_data,
 	                                 STATE_TYPE **__restrict states, ValidityMask &mask, idx_t count) {
-		if (OP::IgnoreNull() && !mask.AllValid()) {
+		if (OP::IgnoreNull() && mask.CanHaveNull()) {
 			AggregateUnaryInput input(aggr_input_data, mask);
 			auto &base_idx = input.input_idx;
 			base_idx = 0;
@@ -113,7 +113,7 @@ private:
 		const auto HAS_ISEL = isel.IsSet();
 		const auto HAS_SSEL = ssel.IsSet();
 #endif
-		if (OP::IgnoreNull() && !mask.AllValid()) {
+		if (OP::IgnoreNull() && mask.CanHaveNull()) {
 			// potential NULL values and NULL values are ignored
 			AggregateUnaryInput input(aggr_input_data, mask);
 			for (idx_t i = 0; i < count; i++) {
@@ -172,7 +172,7 @@ private:
 	                                   STATE_TYPE *__restrict state, idx_t count, ValidityMask &mask,
 	                                   const SelectionVector &__restrict sel_vector) {
 		AggregateUnaryInput input(aggr_input_data, mask);
-		if (OP::IgnoreNull() && !mask.AllValid()) {
+		if (OP::IgnoreNull() && mask.CanHaveNull()) {
 			// potential NULL values and NULL values are ignored
 			for (idx_t i = 0; i < count; i++) {
 				input.input_idx = sel_vector.get_index(i);
@@ -196,7 +196,7 @@ private:
 	                                     const SelectionVector &ssel, ValidityMask &avalidity,
 	                                     ValidityMask &bvalidity) {
 		AggregateBinaryInput input(aggr_input_data, avalidity, bvalidity);
-		if (OP::IgnoreNull() && (!avalidity.AllValid() || !bvalidity.AllValid())) {
+		if (OP::IgnoreNull() && (avalidity.CanHaveNull() || bvalidity.CanHaveNull())) {
 			// potential NULL values and NULL values are ignored
 			for (idx_t i = 0; i < count; i++) {
 				input.lidx = asel.get_index(i);
@@ -225,7 +225,7 @@ private:
 	                                    const SelectionVector &asel, const SelectionVector &bsel,
 	                                    ValidityMask &avalidity, ValidityMask &bvalidity) {
 		AggregateBinaryInput input(aggr_input_data, avalidity, bvalidity);
-		if (OP::IgnoreNull() && (!avalidity.AllValid() || !bvalidity.AllValid())) {
+		if (OP::IgnoreNull() && (avalidity.CanHaveNull() || bvalidity.CanHaveNull())) {
 			// potential NULL values and NULL values are ignored
 			for (idx_t i = 0; i < count; i++) {
 				input.lidx = asel.get_index(i);

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -82,7 +82,7 @@ struct BinaryExecutor {
 			ASSERT_RESTRICT(rdata, rdata + count, result_data, result_data + count);
 		}
 
-		if (!mask.AllValid()) {
+		if (mask.CanHaveNull()) {
 			idx_t base_idx = 0;
 			auto entry_count = ValidityMask::EntryCount(count);
 			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
@@ -174,7 +174,7 @@ struct BinaryExecutor {
 		} else {
 			if (OPWRAPPER::AddsNulls()) {
 				result_validity.Copy(FlatVector::Validity(left), count);
-				if (result_validity.AllValid()) {
+				if (result_validity.CannotHaveNull()) {
 					result_validity.Copy(FlatVector::Validity(right), count);
 				} else {
 					result_validity.Combine(FlatVector::Validity(right), count);
@@ -194,7 +194,7 @@ struct BinaryExecutor {
 	                               RESULT_TYPE *__restrict result_data, const SelectionVector *__restrict lsel,
 	                               const SelectionVector *__restrict rsel, idx_t count, ValidityMask &lvalidity,
 	                               ValidityMask &rvalidity, ValidityMask &result_validity, FUNC fun) {
-		if (!lvalidity.AllValid() || !rvalidity.AllValid()) {
+		if (lvalidity.CanHaveNull() || rvalidity.CanHaveNull()) {
 			for (idx_t i = 0; i < count; i++) {
 				auto lindex = lsel->get_index(i);
 				auto rindex = rsel->get_index(i);
@@ -494,7 +494,7 @@ public:
 	                        const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lvalidity,
 	                        ValidityMask &rvalidity, SelectionVector *true_sel, SelectionVector *false_sel) {
 #ifndef DUCKDB_SMALLER_BINARY
-		if (!lvalidity.AllValid() || !rvalidity.AllValid()) {
+		if (lvalidity.CanHaveNull() || rvalidity.CanHaveNull()) {
 			return SelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
 			    ldata, rdata, lsel, rsel, result_sel, count, lvalidity, rvalidity, true_sel, false_sel);
 		} else {

--- a/src/include/duckdb/common/vector_operations/senary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/senary_executor.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 
 #include <functional>
 

--- a/src/include/duckdb/common/vector_operations/senary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/senary_executor.hpp
@@ -59,7 +59,7 @@ struct SenaryExecutor {
 			vector<UnifiedVectorFormat> vdata(NCOLS);
 			for (size_t c = 0; c < NCOLS; ++c) {
 				input.data[c].ToUnifiedFormat(count, vdata[c]);
-				all_valid = all_valid && vdata[c].validity.AllValid();
+				all_valid = all_valid && vdata[c].validity.CannotHaveNull();
 			}
 
 			auto adata = (const TA *)(vdata[0].data);

--- a/src/include/duckdb/common/vector_operations/septenary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/septenary_executor.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 
 #include <functional>
 

--- a/src/include/duckdb/common/vector_operations/septenary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/septenary_executor.hpp
@@ -60,7 +60,7 @@ struct SeptenaryExecutor {
 			vector<UnifiedVectorFormat> vdata(NCOLS);
 			for (size_t c = 0; c < NCOLS; ++c) {
 				input.data[c].ToUnifiedFormat(count, vdata[c]);
-				all_valid = all_valid && vdata[c].validity.AllValid();
+				all_valid = all_valid && vdata[c].validity.CannotHaveNull();
 			}
 
 			auto adata = (const TA *)(vdata[0].data);

--- a/src/include/duckdb/common/vector_operations/ternary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/ternary_executor.hpp
@@ -10,6 +10,8 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/constant_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
 #include <functional>

--- a/src/include/duckdb/common/vector_operations/ternary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/ternary_executor.hpp
@@ -46,7 +46,7 @@ private:
 	                               const SelectionVector &asel, const SelectionVector &bsel,
 	                               const SelectionVector &csel, ValidityMask &avalidity, ValidityMask &bvalidity,
 	                               ValidityMask &cvalidity, ValidityMask &result_validity, FUN fun) {
-		if (!avalidity.AllValid() || !bvalidity.AllValid() || !cvalidity.AllValid()) {
+		if (avalidity.CanHaveNull() || bvalidity.CanHaveNull() || cvalidity.CanHaveNull()) {
 			for (idx_t i = 0; i < count; i++) {
 				auto aidx = asel.get_index(i);
 				auto bidx = bsel.get_index(i);
@@ -180,7 +180,7 @@ private:
 	static inline idx_t SelectLoopSwitch(UnifiedVectorFormat &adata, UnifiedVectorFormat &bdata,
 	                                     UnifiedVectorFormat &cdata, const SelectionVector *sel, idx_t count,
 	                                     SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (!adata.validity.AllValid() || !bdata.validity.AllValid() || !cdata.validity.AllValid()) {
+		if (adata.validity.CanHaveNull() || bdata.validity.CanHaveNull() || cdata.validity.CanHaveNull()) {
 			return SelectLoopSelSwitch<A_TYPE, B_TYPE, C_TYPE, OP, false>(adata, bdata, cdata, sel, count, true_sel,
 			                                                              false_sel);
 		} else {

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -75,7 +75,7 @@ private:
 		ASSERT_RESTRICT(ldata, ldata + max_index, result_data, result_data + count);
 #endif
 
-		if (!mask.AllValid()) {
+		if (mask.CanHaveNull()) {
 			for (idx_t i = 0; i < count; i++) {
 				auto idx = sel_vector->get_index(i);
 				if (mask.RowIsValidUnsafe(idx)) {
@@ -100,7 +100,7 @@ private:
 	                               ValidityMask &mask, ValidityMask &result_mask, void *dataptr, bool adds_nulls) {
 		ASSERT_RESTRICT(ldata, ldata + count, result_data, result_data + count);
 
-		if (!mask.AllValid()) {
+		if (mask.CanHaveNull()) {
 			if (!adds_nulls) {
 				result_mask.Initialize(mask);
 			} else {
@@ -297,7 +297,7 @@ private:
 	template <class INPUT_TYPE, class FUNC = std::function<bool(INPUT_TYPE)>>
 	static inline idx_t SelectLoopSwitch(UnifiedVectorFormat &input_data, const SelectionVector *sel, const idx_t count,
 	                                     FUNC fun, SelectionVector *true_sel, SelectionVector *false_sel) {
-		if (!input_data.validity.AllValid()) {
+		if (input_data.validity.CanHaveNull()) {
 			return SelectLoopSelSwitch<INPUT_TYPE, FUNC, false>(input_data, sel, count, fun, true_sel, false_sel);
 		} else {
 			return SelectLoopSelSwitch<INPUT_TYPE, FUNC, true>(input_data, sel, count, fun, true_sel, false_sel);

--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -105,7 +105,7 @@ bool AlpAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 	//! We need to store the entire sampled vector to perform the 'analyze' compression in it
 	idx_t nulls_idx = 0;
 	// We optimize by doing a different loop when there are no nulls
-	if (vdata.validity.AllValid()) {
+	if (vdata.validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < sampling_params.n_lookup_values; i++) {
 			auto idx = vdata.sel->get_index(i);
 			T value = data[idx];

--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -262,7 +262,7 @@ public:
 			// to avoid checking if input_vector is filled in each iteration
 			auto values_to_fill_alp_input =
 			    MinValue<idx_t>(AlpConstants::ALP_VECTOR_SIZE - vector_idx, values_left_in_data);
-			if (vdata.validity.AllValid()) { //! We optimize a loop when there are no null
+			if (vdata.validity.CannotHaveNull()) { //! We optimize a loop when there are no null
 				for (idx_t i = 0; i < values_to_fill_alp_input; i++) {
 					auto idx = vdata.sel->get_index(offset_in_data + i);
 					T value = data[idx];

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -75,7 +75,7 @@ bool AlpRDAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 	idx_t sample_idx = 0;
 	idx_t nulls_idx = 0;
 	// We optimize by doing a different loop when there are no nulls
-	if (vdata.validity.AllValid()) {
+	if (vdata.validity.CannotHaveNull()) {
 		for (idx_t i = 0; i < sampling_params.n_lookup_values; i += sampling_params.n_sampled_increments) {
 			auto idx = vdata.sel->get_index(i);
 			EXACT_TYPE value = Load<EXACT_TYPE>(const_data_ptr_cast(&data[idx]));

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -274,7 +274,7 @@ public:
 			// to avoid checking if input_vector is filled in each iteration
 			auto values_to_fill_alp_input =
 			    MinValue<idx_t>(AlpConstants::ALP_VECTOR_SIZE - vector_idx, values_left_in_data);
-			if (vdata.validity.AllValid()) { //! We optimize a loop when there are no null
+			if (vdata.validity.CannotHaveNull()) { //! We optimize a loop when there are no null
 				for (idx_t i = 0; i < values_to_fill_alp_input; i++) {
 					auto idx = vdata.sel->get_index(offset_in_data + i);
 					EXACT_TYPE value = Load<EXACT_TYPE>(const_data_ptr_cast(&data[idx]));

--- a/src/include/duckdb/storage/compression/roaring/appender.hpp
+++ b/src/include/duckdb/storage/compression/roaring/appender.hpp
@@ -50,7 +50,7 @@ public:
 		input.ToUnifiedFormat(input_size, unified);
 		auto &validity = unified.validity;
 
-		if (validity.AllValid()) {
+		if (validity.CannotHaveNull()) {
 			// All bits are set implicitly
 			idx_t appended = 0;
 			while (appended < input_size) {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -208,7 +208,7 @@ struct StandardFixedSizeAppend {
 	                   idx_t offset, idx_t count) {
 		auto sdata = UnifiedVectorFormat::GetData<T>(adata);
 		auto tdata = reinterpret_cast<T *>(target);
-		if (!adata.validity.AllValid()) {
+		if (adata.validity.CanHaveNull()) {
 			for (idx_t i = 0; i < count; i++) {
 				auto source_idx = adata.sel->get_index(offset + i);
 				auto target_idx = target_offset + i;

--- a/src/storage/compression/roaring/analyze.cpp
+++ b/src/storage/compression/roaring/analyze.cpp
@@ -173,7 +173,7 @@ void RoaringAnalyzeState::Analyze<PhysicalType::BOOL>(Vector &input, idx_t count
 	auto dst = data_ptr_cast(bitpacked_vector_validity.GetData());
 	const bool *src = FlatVector::GetData<bool>(input);
 	const auto &validity = FlatVector::Validity(input);
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		BitPackBooleans<false, true>(dst, src, count);
 	} else {
 		BitPackBooleans<false, false>(dst, src, count, &validity);

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -221,7 +221,7 @@ void ExtractValidityMaskToData(Vector &src, Vector &dst, idx_t offset, idx_t sca
 	auto &validity = FlatVector::Validity(src);
 
 	auto write_ptr = FlatVector::GetData<uint8_t>(dst) + offset;
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		memset(write_ptr, 1, scan_count); // 1 is for valid
 	} else if (scan_count % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE == 0) {
 		// "Bit-Unpack" src's validity_mask and put it in dst's data

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -504,7 +504,7 @@ void RoaringCompressState::Compress<PhysicalType::BOOL>(Vector &input, idx_t cou
 	const auto &validity = FlatVector::Validity(input);
 	// Bitpack the booleans, so they can be fed through the current compression code, with the same format as a validity
 	// mask.
-	if (validity.AllValid()) {
+	if (validity.CannotHaveNull()) {
 		BitPackBooleans<true, true>(dst, src, count, &validity, &this->current_segment->stats.statistics);
 	} else {
 		BitPackBooleans<true, false>(dst, src, count, &validity, &this->current_segment->stats.statistics);

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -252,7 +252,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 	ValidityMask source_mask128(input_data, input_size);
 	for (idx_t i = 0; i < scan_count; i++) {
 		if (!source_mask128.RowIsValid(input_start + i)) {
-			if (result_mask.AllValid()) {
+			if (result_mask.CannotHaveNull()) {
 				result_mask.Initialize();
 			}
 			result_mask.SetInvalid(result_offset + i);
@@ -546,7 +546,7 @@ idx_t ValidityAppend(CompressionAppendState &append_state, ColumnSegment &segmen
 
 	auto max_tuples = segment.SegmentSize() / ValidityMask::STANDARD_MASK_SIZE * STANDARD_VECTOR_SIZE;
 	idx_t append_count = MinValue<idx_t>(vcount, max_tuples - segment.count);
-	if (data.validity.AllValid()) {
+	if (data.validity.CannotHaveNull()) {
 		// no null values: skip append
 		segment.count += append_count;
 		validity_stats.SetHasNoNullFast();

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -315,7 +315,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 	// the inplace loops take the result as the last parameter
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count =
 			    TemplatedFilterSelection<T, Equals, false>(vdata, predicate, sel, approved_tuple_count, new_sel);
 		} else {
@@ -325,7 +325,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 		break;
 	}
 	case ExpressionType::COMPARE_NOTEQUAL: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count =
 			    TemplatedFilterSelection<T, NotEquals, false>(vdata, predicate, sel, approved_tuple_count, new_sel);
 		} else {
@@ -335,7 +335,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 		break;
 	}
 	case ExpressionType::COMPARE_LESSTHAN: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count =
 			    TemplatedFilterSelection<T, LessThan, false>(vdata, predicate, sel, approved_tuple_count, new_sel);
 		} else {
@@ -345,7 +345,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 		break;
 	}
 	case ExpressionType::COMPARE_GREATERTHAN: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count =
 			    TemplatedFilterSelection<T, GreaterThan, false>(vdata, predicate, sel, approved_tuple_count, new_sel);
 		} else {
@@ -355,7 +355,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 		break;
 	}
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count = TemplatedFilterSelection<T, LessThanEquals, false>(vdata, predicate, sel,
 			                                                                          approved_tuple_count, new_sel);
 		} else {
@@ -365,7 +365,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 		break;
 	}
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
-		if (mask.AllValid()) {
+		if (mask.CannotHaveNull()) {
 			approved_tuple_count = TemplatedFilterSelection<T, GreaterThanEquals, false>(vdata, predicate, sel,
 			                                                                             approved_tuple_count, new_sel);
 		} else {
@@ -383,7 +383,7 @@ static void FilterSelectionSwitch(UnifiedVectorFormat &vdata, T predicate, Selec
 template <bool IS_NULL>
 static idx_t TemplatedNullSelection(UnifiedVectorFormat &vdata, SelectionVector &sel, idx_t &approved_tuple_count) {
 	auto &mask = vdata.validity;
-	if (mask.AllValid()) {
+	if (mask.CannotHaveNull()) {
 		// no NULL values
 		if (IS_NULL) {
 			approved_tuple_count = 0;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -672,7 +672,7 @@ static void InitializeUpdateValidity(UpdateInfo &base_info, Vector &base_data, U
 	auto &update_mask = update.validity;
 	auto tuple_data = update_info.GetData<bool>();
 
-	if (!update_mask.AllValid()) {
+	if (update_mask.CanHaveNull()) {
 		for (idx_t i = 0; i < update_info.N; i++) {
 			auto idx = update.sel->get_index(sel.get_index(i));
 			tuple_data[i] = update_mask.RowIsValidUnsafe(idx);
@@ -686,7 +686,7 @@ static void InitializeUpdateValidity(UpdateInfo &base_info, Vector &base_data, U
 	auto &base_mask = FlatVector::Validity(base_data);
 	auto base_tuple_data = base_info.GetData<bool>();
 	auto base_tuples = base_info.GetTuples();
-	if (!base_mask.AllValid()) {
+	if (base_mask.CanHaveNull()) {
 		for (idx_t i = 0; i < base_info.N; i++) {
 			base_tuple_data[i] = base_mask.RowIsValidUnsafe(base_tuples[i]);
 		}
@@ -999,7 +999,7 @@ idx_t UpdateValidityStatistics(UpdateSegment *segment, SegmentStatistics &stats,
                                idx_t count, SelectionVector &sel) {
 	auto &mask = update.validity;
 	auto &validity = stats.statistics;
-	if (!mask.AllValid() && !validity.CanHaveNull()) {
+	if (mask.CanHaveNull() && !validity.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = update.sel->get_index(i);
 			if (!mask.RowIsValid(idx)) {
@@ -1021,7 +1021,7 @@ idx_t TemplatedUpdateNumericStatistics(UpdateSegment *segment, SegmentStatistics
 	auto update_data = update.GetData<T>(update);
 	auto &mask = update.validity;
 
-	if (mask.AllValid()) {
+	if (mask.CannotHaveNull()) {
 		stats.statistics.SetHasNoNullFast();
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = update.sel->get_index(i);
@@ -1050,7 +1050,7 @@ idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, U
                              SelectionVector &sel) {
 	auto update_data = update.GetData<string_t>(update);
 	auto &mask = update.validity;
-	if (mask.AllValid()) {
+	if (mask.CannotHaveNull()) {
 		stats.statistics.SetHasNoNullFast();
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = update.sel->get_index(i);

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -496,7 +496,7 @@ struct UDFSum {
 			auto idata = FlatVector::GetData<INPUT_TYPE>(inputs[0]);
 			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
 			auto mask = FlatVector::Validity(inputs[0]);
-			if (!mask.AllValid()) {
+			if (mask.CanHaveNull()) {
 				// potential NULL values and NULL values are ignored
 				for (idx_t i = 0; i < count; i++) {
 					if (mask.RowIsValid(i)) {
@@ -529,7 +529,7 @@ struct UDFSum {
 			inputs[0].Flatten(count);
 			auto idata = FlatVector::GetData<INPUT_TYPE>(inputs[0]);
 			auto &mask = FlatVector::Validity(inputs[0]);
-			if (!mask.AllValid()) {
+			if (mask.CanHaveNull()) {
 				// potential NULL values and NULL values are ignored
 				for (idx_t i = 0; i < count; i++) {
 					if (mask.RowIsValid(i)) {


### PR DESCRIPTION
The `ValidityMask::AllValid` method is a bit of a misnomer, because it does not actually *check* if all values are valid. It only checks for the *presence* of a validity mask, i.e. if `AllValid` returns true we know there are no `NULL` values, but if `AllValid` returns false there might *still* not be `NULL` values. As such, the method is named confusingly. There is a separate method `CheckAllValid` that actually checks if there are no `NULL` values.

This PR fixes that by renaming the method to `CannotHaveNull` - which in my opinion is more descriptive. If `CannotHaveNull` returns true - we know that there are no `NULL` values. If it returns false, we know there **might** be `NULL` values and we need to check the validity mask. 

For backwards compatibility we keep the old function around, and use the `[[deprecated]]` attribute to deprecate it.