### PR TITLE
Fix TopN window elimination with external CTE refs

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -5,11 +5,14 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/optimizer/late_materialization_helper.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_cte.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
@@ -78,6 +81,36 @@ vector<LogicalType> ExtractReturnTypes(const vector<unique_ptr<Expression>> &exp
 bool BindingsReferenceRowNumber(const vector<ColumnBinding> &bindings, const LogicalWindow &window) {
 	for (const auto &binding : bindings) {
 		if (binding.table_index == window.window_index) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void GatherLocalCTEInfo(const LogicalOperator &op, unordered_set<idx_t> &definitions,
+                        unordered_set<idx_t> &references) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+		definitions.insert(op.Cast<LogicalCTE>().table_index);
+		break;
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		references.insert(op.Cast<LogicalCTERef>().cte_index);
+		break;
+	default:
+		break;
+	}
+	for (const auto &child : op.children) {
+		GatherLocalCTEInfo(*child, definitions, references);
+	}
+}
+
+bool HasExternalCTEReferences(const LogicalOperator &op) {
+	unordered_set<idx_t> definitions;
+	unordered_set<idx_t> references;
+	GatherLocalCTEInfo(op, definitions, references);
+	for (const auto &cte_index : references) {
+		if (!definitions.count(cte_index)) {
 			return true;
 		}
 	}
@@ -227,8 +260,10 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	UpdateTopmostBindings(window_idx, op, group_projection_idxs, topmost_bindings, new_bindings, replacer);
 	replacer.stop_operator = op.get();
 
-	RemoveUnusedColumns unused_optimizer(optimizer);
-	unused_optimizer.VisitOperator(*op);
+	if (!HasExternalCTEReferences(*op)) {
+		RemoveUnusedColumns unused_optimizer(optimizer);
+		unused_optimizer.VisitOperator(*op);
+	}
 
 	return unique_ptr<LogicalOperator>(std::move(op));
 }

--- a/test/issues/general/test_21582.test
+++ b/test/issues/general/test_21582.test
@@ -1,0 +1,26 @@
+# name: test/issues/general/test_21582.test
+# description: Issue 21582: TopN window elimination with external CTE refs should not fail CTE pruning
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE MACRO m(t) AS TABLE
+WITH i1 AS MATERIALIZED (
+	SELECT v
+	FROM query_table(t)
+)
+SELECT *
+FROM i1;
+
+query I
+WITH c AS MATERIALIZED (
+	SELECT NULL AS v
+)
+SELECT c.v
+FROM c
+LEFT JOIN m('c') ti USING (v)
+QUALIFY ROW_NUMBER() OVER (ORDER BY 1) = 1;
+----
+NULL


### PR DESCRIPTION
Fixes #21582.

This issue is triggered when `TopNWindowElimination` rewrites a subtree that contains `LogicalCTERef`s whose definitions live outside the rewritten subtree. The optimizer then runs a local `RemoveUnusedColumns` pass on that subtree, but the pass expects every visited `LogicalCTERef` to have a corresponding local CTE definition, which leads to:

```
INTERNAL Error: Could not find CTE definition for CTE reference
```

This patch keeps the rewrite, but skips the local `RemoveUnusedColumns` cleanup when the rewritten subtree contains external CTE references. That preserves correctness and avoids running CTE pruning without the required definition context.

Tests:
- `build/release/test/unittest "test/issues/general/test_21582.test"`
-  `make allunit`