### PR TITLE
Preserve LEFT LATERAL filters during pushdown

### DIFF
--- a/src/optimizer/pushdown/pushdown_filter.cpp
+++ b/src/optimizer/pushdown/pushdown_filter.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_join.hpp"
 
 namespace duckdb {
 
@@ -9,6 +10,31 @@ using Filter = FilterPushdown::Filter;
 unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOperator> op) {
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_FILTER);
 	auto &filter = op->Cast<LogicalFilter>();
+	if (filter.children[0]->type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN ||
+	    filter.children[0]->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = filter.children[0]->Cast<LogicalJoin>();
+		if (join.join_type == JoinType::LEFT) {
+			// Filters above LEFT LATERAL joins can reference NULL-extended RHS outputs.
+			// Keep any filter that depends on the RHS above the join to preserve outer join semantics.
+			unordered_set<TableIndex> left_bindings, right_bindings;
+			LogicalJoin::GetTableReferences(*join.children[0], left_bindings);
+			LogicalJoin::GetTableReferences(*join.children[1], right_bindings);
+			vector<unique_ptr<Expression>> remain_expressions;
+			for (auto &expression : filter.expressions) {
+				auto side = JoinSide::GetJoinSide(*expression, left_bindings, right_bindings);
+				if (side != JoinSide::LEFT) {
+					remain_expressions.push_back(std::move(expression));
+					continue;
+				}
+				if (AddFilter(std::move(expression)) == FilterResult::UNSATISFIABLE) {
+					return make_uniq<LogicalEmptyResult>(std::move(op));
+				}
+			}
+			GenerateFilters();
+			auto child = Rewrite(std::move(filter.children[0]));
+			return AddLogicalFilter(std::move(child), std::move(remain_expressions));
+		}
+	}
 	if (filter.HasProjectionMap()) {
 		return FinishPushdown(std::move(op));
 	}

--- a/src/optimizer/pushdown/pushdown_filter.cpp
+++ b/src/optimizer/pushdown/pushdown_filter.cpp
@@ -10,6 +10,9 @@ using Filter = FilterPushdown::Filter;
 unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOperator> op) {
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_FILTER);
 	auto &filter = op->Cast<LogicalFilter>();
+	if (filter.HasProjectionMap()) {
+		return FinishPushdown(std::move(op));
+	}
 	if (filter.children[0]->type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN ||
 	    filter.children[0]->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		auto &join = filter.children[0]->Cast<LogicalJoin>();
@@ -21,22 +24,24 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOpe
 			LogicalJoin::GetTableReferences(*join.children[1], right_bindings);
 			vector<unique_ptr<Expression>> remain_expressions;
 			for (auto &expression : filter.expressions) {
-				auto side = JoinSide::GetJoinSide(*expression, left_bindings, right_bindings);
-				if (side != JoinSide::LEFT) {
-					remain_expressions.push_back(std::move(expression));
-					continue;
-				}
-				if (AddFilter(std::move(expression)) == FilterResult::UNSATISFIABLE) {
-					return make_uniq<LogicalEmptyResult>(std::move(op));
+				vector<unique_ptr<Expression>> predicates;
+				predicates.push_back(std::move(expression));
+				LogicalFilter::SplitPredicates(predicates);
+				for (auto &predicate : predicates) {
+					auto side = JoinSide::GetJoinSide(*predicate, left_bindings, right_bindings);
+					if (side != JoinSide::LEFT) {
+						remain_expressions.push_back(std::move(predicate));
+						continue;
+					}
+					if (AddFilter(std::move(predicate)) == FilterResult::UNSATISFIABLE) {
+						return make_uniq<LogicalEmptyResult>(std::move(op));
+					}
 				}
 			}
 			GenerateFilters();
 			auto child = Rewrite(std::move(filter.children[0]));
 			return AddLogicalFilter(std::move(child), std::move(remain_expressions));
 		}
-	}
-	if (filter.HasProjectionMap()) {
-		return FinishPushdown(std::move(op));
 	}
 	// filter: gather the filters and remove the filter from the set of operations
 	for (auto &expression : filter.expressions) {

--- a/test/sql/subquery/lateral/lateral_left_join.test
+++ b/test/sql/subquery/lateral/lateral_left_join.test
@@ -69,3 +69,30 @@ statement error
 SELECT * FROM (SELECT * FROM integers WHERE i=2) t(i) RIGHT JOIN LATERAL (SELECT t.i WHERE t.i IN (1, 3)) t2(b) ON (i=b) ORDER BY i, b;
 ----
 LATERAL
+
+statement ok
+CREATE TABLE src_r(k TIMESTAMP);
+
+statement ok
+CREATE TABLE src_l(k TIMESTAMP);
+
+statement ok
+INSERT INTO src_r VALUES (TIMESTAMP '2001-01-01 00:00:00');
+
+statement ok
+INSERT INTO src_l VALUES (TIMESTAMP '2001-01-01 00:00:00');
+
+query I
+SELECT COUNT(*)
+FROM (
+    SELECT 1, l.k, r.k
+    FROM src_r AS r
+    LEFT JOIN LATERAL (
+        SELECT *
+        FROM src_l AS l
+        WHERE l.k > r.k
+    ) AS l ON TRUE
+    WHERE l.k IS NOT NULL
+) t;
+----
+0


### PR DESCRIPTION
fix #21609 
This fixes a wrong-result issue for `LEFT JOIN LATERAL ... ON TRUE` when an outer filter rejects `NULL` values from the lateral side.

The problem was in `FilterPushdown::PushdownFilter`: filters above `LEFT` dependent/delim joins were treated like ordinary pushdown candidates, so a predicate such as `WHERE l.k IS NOT NULL` could be pushed into the RHS and removed from above the join. For a left lateral join that changes semantics, because the original outer filter should remove the `NULL`-extended row produced by the join.

This patch keeps any filter that depends on the RHS of a `LEFT` dependent/delim join above the join, while still pushing left-only predicates.

## Testing
- `build/release/test/unittest "test/sql/subquery/lateral/lateral_left_join.test"`
- `make allunit`
