### PR TITLE
Extend TopN dynamic filter pushdown to FLOAT and DOUBLE

### DIFF
--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -68,8 +68,8 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	// pushdown dynamic filters through the Top-N operator
 	bool nulls_first = op.orders[0].null_order == OrderByNullType::NULLS_FIRST;
 	auto &type = op.orders[0].expression->return_type;
-	if (!TypeIsIntegral(type.InternalType()) && type.id() != LogicalTypeId::VARCHAR) {
-		// only supported for integral types currently
+	if (!TypeIsNumeric(type.InternalType()) && type.id() != LogicalTypeId::VARCHAR) {
+		// only supported for numeric and varchar types
 		return;
 	}
 	if (op.orders[0].expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {


### PR DESCRIPTION
## Summary
- Widens the type guard in `TopN::PushdownDynamicFilters` from `TypeIsIntegral` to `TypeIsNumeric`, enabling dynamic filter pushdown for FLOAT and DOUBLE columns during Top-N operations.
- Previously, `ORDER BY float_col LIMIT N` queries could not push down a dynamic filter to prune rows at the scan level. Now they can, matching the behavior already available for integer and VARCHAR types.

## Rationale
The restriction to integral types was conservative — the underlying machinery (`ConstantFilter`, `DynamicFilterData::SetValue`, sort key encode/decode, `FilterSelectionSwitch<float/double>`) is already fully type-agnostic and handles FLOAT/DOUBLE correctly.

DuckDB's NaN semantics (NaN is always treated as the largest value) are consistent across:
- **Sort key encoding** (`radix.hpp`): NaN → `UINT_MAX`/`ULLONG_MAX`
- **Comparison operators**: `NaN > x` is always true; `x > NaN` is always false
- **`Value::MinimumValue`**: returns `-infinity` for FLOAT/DOUBLE (not NaN)

This means all dynamic filter boundary scenarios (ASC/DESC, boundary is normal/NaN/infinity) produce correct filtering behavior without any special-casing.
