### PR TITLE
Add expression as DatabasePath argument to ATTACH

### DIFF
--- a/extension/autocomplete/grammar/statements/attach.gram
+++ b/extension/autocomplete/grammar/statements/attach.gram
@@ -1,6 +1,6 @@
 AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?
 
 Database <- 'DATABASE'
-DatabasePath <- StringLiteral
+DatabasePath <- Expression
 AttachAlias <- 'AS' ColId
 AttachOptions <- GenericCopyOptionList

--- a/extension/autocomplete/include/inlined_grammar.gram
+++ b/extension/autocomplete/include/inlined_grammar.gram
@@ -1618,7 +1618,7 @@ ForEachStatement <- 'FOR' 'EACH' 'STATEMENT'
 AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?
 
 Database <- 'DATABASE'
-DatabasePath <- StringLiteral
+DatabasePath <- Expression
 AttachAlias <- 'AS' ColId
 AttachOptions <- GenericCopyOptionList
 

--- a/extension/autocomplete/include/inlined_grammar.hpp
+++ b/extension/autocomplete/include/inlined_grammar.hpp
@@ -1451,7 +1451,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"ForEachStatement <- 'FOR' 'EACH' 'STATEMENT'\n"
 	"AttachStatement <- 'ATTACH' OrReplace? IfNotExists? Database? DatabasePath AttachAlias? AttachOptions?\n"
 	"Database <- 'DATABASE'\n"
-	"DatabasePath <- StringLiteral\n"
+	"DatabasePath <- Expression\n"
 	"AttachAlias <- 'AS' ColId\n"
 	"AttachOptions <- GenericCopyOptionList\n"
 	"DetachStatement <- 'DETACH' Database? IfExists? CatalogName\n"

--- a/extension/autocomplete/include/transformer/peg_transformer.hpp
+++ b/extension/autocomplete/include/transformer/peg_transformer.hpp
@@ -376,7 +376,8 @@ private:
 	                                                                optional_ptr<ParseResult> parse_result);
 	static GenericCopyOption TransformGenericCopyOption(PEGTransformer &transformer,
 	                                                    optional_ptr<ParseResult> parse_result);
-	static string TransformDatabasePath(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
+	static unique_ptr<ParsedExpression> TransformDatabasePath(PEGTransformer &transformer,
+	                                                          optional_ptr<ParseResult> parse_result);
 
 	// analyze.gram
 	static unique_ptr<SQLStatement> TransformAnalyzeStatement(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_attach.cpp
+++ b/extension/autocomplete/transformer/transform_attach.cpp
@@ -28,7 +28,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAttachStatement(PEGTran
 		info->on_conflict = OnCreateConflict::ERROR_ON_CONFLICT;
 	}
 
-	info->path = transformer.Transform<string>(list_pr.Child<ListParseResult>(4));
+	info->parsed_path = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.Child<ListParseResult>(4));
 	transformer.TransformOptional<string>(list_pr, 5, info->name);
 	vector<GenericCopyOption> copy_options;
 	transformer.TransformOptional<vector<GenericCopyOption>>(list_pr, 6, copy_options);
@@ -134,10 +134,10 @@ GenericCopyOption PEGTransformerFactory::TransformGenericCopyOption(PEGTransform
 	return copy_option;
 }
 
-string PEGTransformerFactory::TransformDatabasePath(PEGTransformer &transformer,
-                                                    optional_ptr<ParseResult> parse_result) {
+unique_ptr<ParsedExpression> PEGTransformerFactory::TransformDatabasePath(PEGTransformer &transformer,
+                                                                          optional_ptr<ParseResult> parse_result) {
 	auto &list_pr = parse_result->Cast<ListParseResult>();
-	return transformer.Transform<string>(list_pr.Child<StringLiteralParseResult>(0));
+	return transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.GetChild(0));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/attach_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/attach_info.hpp
@@ -28,6 +28,8 @@ public:
 	string name;
 	//! The path to the attached database
 	string path;
+	//! The path expression to the attached database
+	unique_ptr<ParsedExpression> parsed_path;
 	//! Set of (key, value) options
 	case_insensitive_map_t<unique_ptr<ParsedExpression>> parsed_options;
 	//! Set of bound (key, value) options

--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -8,6 +8,9 @@ unique_ptr<AttachInfo> AttachInfo::Copy() const {
 	auto result = make_uniq<AttachInfo>();
 	result->name = name;
 	result->path = path;
+	if (parsed_path) {
+		result->parsed_path = parsed_path->Copy();
+	}
 	result->options = options;
 	for (auto &entry : parsed_options) {
 		result->parsed_options[entry.first] = entry.second->Copy();
@@ -25,7 +28,11 @@ string AttachInfo::ToString() const {
 		result += " OR REPLACE";
 	}
 	result += " DATABASE ";
-	result += KeywordHelper::WriteQuoted(path, '\'');
+	if (parsed_path) {
+		result += parsed_path->ToString();
+	} else {
+		result += KeywordHelper::WriteQuoted(path, '\'');
+	}
 	if (!name.empty()) {
 		result += " AS " + KeywordHelper::WriteOptionallyQuoted(name);
 	}

--- a/src/planner/binder/statement/bind_attach.cpp
+++ b/src/planner/binder/statement/bind_attach.cpp
@@ -12,6 +12,18 @@ BoundStatement Binder::Bind(AttachStatement &stmt) {
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
 
+	// resolve the path expression if set by the parser
+	if (stmt.info->parsed_path) {
+		TableFunctionBinder path_binder(*this, context, "Attach", "Attach path");
+		auto bound_path = path_binder.Bind(stmt.info->parsed_path);
+		auto path_val = ExpressionExecutor::EvaluateScalar(context, *bound_path);
+		if (path_val.IsNull()) {
+			throw BinderException("ATTACH path expression must not evaluate to NULL");
+		}
+		stmt.info->path = path_val.ToString();
+		stmt.info->parsed_path.reset();
+	}
+
 	// bind the options
 	TableFunctionBinder option_binder(*this, context, "Attach", "Attach parameter");
 	unordered_map<string, Value> kv_options;

--- a/test/sql/attach/attach_issue_21491.test
+++ b/test/sql/attach/attach_issue_21491.test
@@ -7,7 +7,7 @@ require autocomplete
 statement error
 ATTACH unknown_scalar('test.db') AS db;
 ----
-syntax error at or near
+<REGEX>:(.*Parser Error: syntax error at or near.*|.*Catalog Error: Scalar function with name.*)
 
 statement ok
 ATTACH ':memory:' AS memdb

--- a/test/sql/attach/attach_issue_21491.test
+++ b/test/sql/attach/attach_issue_21491.test
@@ -7,7 +7,7 @@ require autocomplete
 statement error
 ATTACH unknown_scalar('test.db') AS db;
 ----
-<REGEX>:(.*Parser Error: syntax error at or near.*|.*Catalog Error: Scalar function with name.*)
+<REGEX>:(.*Parser Error: syntax error at or near.*|.*Catalog Error: Scalar Function with name.*)
 
 statement ok
 ATTACH ':memory:' AS memdb

--- a/test/sql/attach/attach_issue_21491.test
+++ b/test/sql/attach/attach_issue_21491.test
@@ -1,0 +1,30 @@
+# name: test/sql/attach/attach_issue_21491.test
+# description: Issue #21491 - ATTACH expression support (PEG parser)
+# group: [attach]
+
+require autocomplete
+
+statement error
+ATTACH unknown_scalar('test.db') AS db;
+----
+syntax error at or near
+
+statement ok
+ATTACH ':memory:' AS memdb
+
+statement ok
+DETACH memdb
+
+statement ok
+call enable_peg_parser();
+
+statement error
+ATTACH unknown_scalar('test.db') AS db;
+----
+Scalar Function with name unknown_scalar does not exist!
+
+statement ok
+ATTACH lower(':MEMORY:') AS memdb
+
+statement ok
+DETACH memdb


### PR DESCRIPTION
This PR addresses the comments of a previous PR https://github.com/duckdb/duckdb/pull/21529

As requested, I have made the changes on the new parser, while leaving the old one in-tact.

In the test file I test that the previous parser works as intended and when switching to the new parser (enable_peg_parser()) we can see that the DatabaesPath is parsed as an expression and resolved at bind time.

I could not test getenv() in the .test file:
Catalog Error: Scalar Function with name getenv does not exist!
Did you mean "geomean"?
so that it why I tested other scalar functions in the test file.

From my terminal, I got:

memory D FROM enable_peg_parser();
┌─────────┐
│ success │
│ boolean │
└─────────┘
  0 rows 
memory D ATTACH getenv('HOME') as db;
IO Error:
Could not read from file "...": Is a directory

Which looks like the correct behavior.

Please let me know if this approach works.