### PR TITLE
Truncate InFilter display in EXPLAIN plans

### DIFF
--- a/src/planner/filter/in_filter.cpp
+++ b/src/planner/filter/in_filter.cpp
@@ -51,12 +51,17 @@ FilterPropagateResult InFilter::CheckStatistics(BaseStatistics &stats) const {
 }
 
 string InFilter::ToString(const string &column_name) const {
+	static constexpr idx_t MAX_DISPLAY_VALUES = 10;
 	string in_list;
-	for (auto &val : values) {
+	idx_t display_count = MinValue<idx_t>(values.size(), MAX_DISPLAY_VALUES);
+	for (idx_t i = 0; i < display_count; i++) {
 		if (!in_list.empty()) {
 			in_list += ", ";
 		}
-		in_list += val.ToSQLString();
+		in_list += values[i].ToSQLString();
+	}
+	if (values.size() > MAX_DISPLAY_VALUES) {
+		in_list += ", ... " + to_string(values.size()) + " total values";
 	}
 	return column_name + " IN (" + in_list + ")";
 }

--- a/test/sql/explain/test_explain_in_filter_truncation.test
+++ b/test/sql/explain/test_explain_in_filter_truncation.test
@@ -1,0 +1,30 @@
+# name: test/sql/explain/test_explain_in_filter_truncation.test
+# description: Test that large IN filters are truncated in EXPLAIN output
+# group: [explain]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA explain_output='physical_only'
+
+statement ok
+CREATE TABLE t_filter AS SELECT range i FROM range(1000)
+
+# InFilter pushed down as table filter - small (all values shown)
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM t_filter WHERE i IN (1, 3, 7)
+----
+physical_plan	<REGEX>:.*IN \(1, 3, 7\).*
+
+# InFilter pushed down as table filter - large (truncated with total count)
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM t_filter WHERE i IN (2, 5, 9, 13, 19, 29, 37, 43, 59, 71, 89, 101)
+----
+physical_plan	<REGEX>:.*12 total values.*
+
+# Verify truncation shows first 10 values then total count
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM t_filter WHERE i IN (2, 5, 9, 13, 19, 29, 37, 43, 59, 71, 89, 101)
+----
+physical_plan	<REGEX>:.*IN \(2, 5, 9, 13, 19, 29, 37, 43, 59, 71,.*12 total values.*


### PR DESCRIPTION
## Summary
- When `dynamic_or_filter_threshold` is increased beyond the default of 50, `InFilter::ToString` rendered all values on a single line, making EXPLAIN output unusable
- Now truncates to show the first 10 values followed by a total count summary (e.g. `col IN (1, 3, 7, 11, 17, 23, 31, 41, 53, 67, ... 15 total values)`)
- Applies to all EXPLAIN formats (text, JSON, HTML, etc.) since they all flow through `InFilter::ToString`
