### PR TITLE
Add read-only accessors to BloomFilter and BFTableFilter

### DIFF
--- a/src/include/duckdb/planner/filter/bloom_filter.hpp
+++ b/src/include/duckdb/planner/filter/bloom_filter.hpp
@@ -32,6 +32,16 @@ public:
 		return initialized;
 	}
 
+	//! Get the number of 64-bit sectors in the bloom filter
+	idx_t GetNumSectors() const {
+		return num_sectors;
+	}
+
+	//! Get a read-only pointer to the raw bloom filter bit array
+	const uint64_t *GetData() const {
+		return bf;
+	}
+
 private:
 	idx_t num_sectors;
 	uint64_t bitmask; // num_sectors - 1 -> used to get the sector offset
@@ -67,6 +77,14 @@ public:
 
 	LogicalType GetKeyType() const {
 		return key_type;
+	}
+
+	const string &GetKeyColumnName() const {
+		return key_column_name;
+	}
+
+	const BloomFilter &GetBloomFilter() const {
+		return filter;
 	}
 
 	string ToString(const string &column_name) const override;


### PR DESCRIPTION
## Summary

Adds public read-only accessors to `BloomFilter` and `BFTableFilter` so extensions can serialize and transport bloom filters.

**BloomFilter:**
- `GetNumSectors()` — number of 64-bit sectors in the bit array
- `GetData()` — const pointer to the raw `uint64_t` bit array

**BFTableFilter:**
- `GetKeyColumnName()` — the join key column name
- `GetBloomFilter()` — const reference to the underlying `BloomFilter`

## Motivation

Extensions that push table filters to remote workers (e.g., for remote table scan optimization) need to serialize the bloom filter's bit array for transport. The existing `Serialize()` method only persists metadata (key name, type, null handling) but not the actual bit data. These accessors enable extensions to read the bloom filter contents for custom serialization.

## Test plan

- Non-breaking additive change (new `const` methods only, no existing code modified)
- All existing tests pass unchanged