### PR TITLE
Add read-only accessors to PerfectHashJoinExecutor and PerfectHashJoinFilter

### DIFF
--- a/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
+++ b/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
@@ -39,6 +39,21 @@ public:
 
 	bool BuildPerfectHashTable(LogicalType &type);
 
+	//! Get the build-side statistics (min, max, range)
+	const PerfectHashJoinStats &GetStatistics() const {
+		return perfect_join_statistics;
+	}
+
+	//! Get the build-side key existence bitmap
+	const ValidityMask &GetBitmap() const {
+		return bitmap_build_idx;
+	}
+
+	//! Get the number of unique keys in the build side
+	idx_t GetUniqueKeys() const {
+		return unique_keys;
+	}
+
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context);
 	OperatorResultType ProbePerfectHashTable(ExecutionContext &context, DataChunk &input, DataChunk &lhs_output_columns,
 	                                         DataChunk &chunk, OperatorState &state);

--- a/src/include/duckdb/planner/filter/perfect_hash_join_filter.hpp
+++ b/src/include/duckdb/planner/filter/perfect_hash_join_filter.hpp
@@ -32,6 +32,16 @@ public:
 	idx_t Filter(Vector &keys, SelectionVector &sel, idx_t &approved_tuple_count) const;
 	bool FilterValue(const Value &value) const;
 
+	//! Get the key column name
+	const string &GetKeyColumnName() const {
+		return key_column_name;
+	}
+
+	//! Get the underlying executor (may be null)
+	optional_ptr<const PerfectHashJoinExecutor> GetExecutor() const {
+		return perfect_join_executor;
+	}
+
 private:
 	bool Equals(const TableFilter &other) const override;
 	unique_ptr<TableFilter> Copy() const override;


### PR DESCRIPTION
## Summary

Adds public read-only accessors to `PerfectHashJoinExecutor` and `PerfectHashJoinFilter` so extensions can inspect the perfect hash join's bitmap and statistics.

**PerfectHashJoinExecutor:**
- `GetStatistics()` — const reference to `PerfectHashJoinStats` (build_min, build_max, build_range, density flags)
- `GetBitmap()` — const reference to the `ValidityMask` key existence bitmap
- `GetUniqueKeys()` — number of unique keys in the build side

**PerfectHashJoinFilter:**
- `GetKeyColumnName()` — the join key column name
- `GetExecutor()` — `optional_ptr` to the underlying executor

## Motivation

Extensions that push table filters to remote workers need to serialize the perfect hash join filter's bitmap for transport. The bitmap enables a simple `key >= min && key <= max && bitmap[key - min]` check on the remote side — no hash function or executor needed. Currently all relevant data members are private with no accessors.
