### PR TITLE
Add read-only accessors to PrefixRangeFilter and PrefixRangeTableFilter

### DIFF
--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -34,6 +34,18 @@ public:
 	virtual bool LookupOneValue(const Value &key) const = 0;
 	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;
 	virtual bool IsInitialized() const = 0;
+
+	//! Get the minimum key value (type-erased)
+	virtual Value GetMinValue() const = 0;
+	//! Get the span (max - min) as uhugeint
+	virtual uhugeint_t GetSpan() const = 0;
+	//! Get the shift factor (number of bits keys are right-shifted for bucketing)
+	virtual idx_t GetShift() const = 0;
+	//! Get the number of 64-bit words in the bitmap
+	virtual idx_t GetWordCount() const = 0;
+	//! Get a read-only pointer to the bitmap data
+	virtual const uint64_t *GetBitmapData() const = 0;
+
 	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);
 	static bool TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result);
 };
@@ -56,6 +68,15 @@ public:
 
 	LogicalType GetKeyType() const {
 		return key_type;
+	}
+
+	const string &GetKeyColumnName() const {
+		return key_column_name;
+	}
+
+	const PrefixRangeFilter &GetPrefixRangeFilter() const {
+		D_ASSERT(filter);
+		return *filter;
 	}
 
 	string ToString(const string &column_name) const override;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -182,6 +182,26 @@ public:
 		return initialized;
 	}
 
+	Value GetMinValue() const override {
+		return Value::CreateValue(static_cast<T>(min));
+	}
+
+	uhugeint_t GetSpan() const override {
+		return Uhugeint::Convert(span);
+	}
+
+	idx_t GetShift() const override {
+		return shift;
+	}
+
+	idx_t GetWordCount() const override {
+		return word_count;
+	}
+
+	const uint64_t *GetBitmapData() const override {
+		return bitmap;
+	}
+
 private:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
 	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;


### PR DESCRIPTION
## Summary

Adds public read-only accessors to `PrefixRangeFilter` (virtual, implemented by `NumericPrefixRangeFilter<T>`) and `PrefixRangeTableFilter` so extensions can inspect the prefix range filter's bucketed bitmap and parameters.

**PrefixRangeFilter (virtual):**
- `GetMinValue()` — minimum key value as type-erased `Value`
- `GetSpan()` — key range (max - min) as `uhugeint_t`
- `GetShift()` — bit shift factor for bucket indexing
- `GetWordCount()` — number of 64-bit words in the bitmap
- `GetBitmapData()` — const pointer to the raw `uint64_t` bitmap

**PrefixRangeTableFilter:**
- `GetKeyColumnName()` — the join key column name
- `GetPrefixRangeFilter()` — const reference to the underlying `PrefixRangeFilter`

## Motivation

Extensions that push table filters to remote workers need to serialize the prefix range filter's bitmap and parameters for transport. The remote side can replicate the probe with simple arithmetic: `bucket = (key - min) >> shift; check bitmap[bucket]`. Currently all relevant data members are private with no accessors.
