### PR TITLE
catalog: suggest matching DROP statements on type mismatch

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/catalog/dependency_list.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/parser/constraints/foreign_key_constraint.hpp"
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
@@ -129,8 +130,15 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 				throw CatalogException("CREATE OR REPLACE is not allowed to depend on itself");
 			}
 			if (old_entry->type != entry_type) {
-				throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", entry_name,
-				                       CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type));
+				DropInfo suggested_drop;
+				suggested_drop.type = old_entry->type;
+				suggested_drop.schema = name;
+				suggested_drop.name = entry_name;
+				auto entry_qualifier = ParseInfo::QualifierToString("", name, entry_name);
+				throw CatalogException(
+				    "Existing object %s is of type %s, trying to replace with type %s. Use '%s' instead.",
+				    entry_qualifier, CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type),
+				    suggested_drop.ToString());
 			}
 			OnDropEntry(transaction, *old_entry);
 			(void)set.DropEntry(transaction, entry_name, false, entry->internal);
@@ -327,8 +335,12 @@ void DuckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 		throw InternalException("Failed to drop entry \"%s\" - entry could not be found", info.name);
 	}
 	if (existing_entry->type != info.type) {
-		throw CatalogException("Existing object %s is of type %s, trying to drop type %s", info.name,
-		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info.type));
+		auto suggested_drop = info.Copy();
+		suggested_drop->type = existing_entry->type;
+		auto entry_qualifier = ParseInfo::QualifierToString(info.catalog, info.schema, info.name);
+		throw CatalogException("Existing object %s is of type %s, not %s. Use '%s' instead.", entry_qualifier,
+		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info.type),
+		                       suggested_drop->ToString());
 	}
 
 	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -335,12 +335,15 @@ void DuckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 		throw InternalException("Failed to drop entry \"%s\" - entry could not be found", info.name);
 	}
 	if (existing_entry->type != info.type) {
-		auto suggested_drop = info.Copy();
-		suggested_drop->type = existing_entry->type;
-		auto entry_qualifier = ParseInfo::QualifierToString(info.catalog, info.schema, info.name);
+		DropInfo suggested_drop;
+		suggested_drop.type = existing_entry->type;
+		suggested_drop.schema = info.schema;
+		suggested_drop.name = info.name;
+		suggested_drop.if_not_found = info.if_not_found;
+		auto entry_qualifier = ParseInfo::QualifierToString("", info.schema, info.name);
 		throw CatalogException("Existing object %s is of type %s, not %s. Use '%s' instead.", entry_qualifier,
 		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info.type),
-		                       suggested_drop->ToString());
+		                       suggested_drop.ToString());
 	}
 
 	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -12,7 +12,7 @@ CREATE VIEW vintegers AS SELECT 42;
 statement error
 CREATE OR REPLACE VIEW integers AS SELECT 42;
 ----
-<REGEX>:Catalog Error: Existing object integers is of type Table, trying to replace with type View\. Use 'DROP TABLE integers;' instead\.
+<REGEX>:.*Catalog Error: Existing object integers is of type Table, trying to replace with type View\. Use 'DROP TABLE integers;' instead\..*
 
 statement ok
 CREATE TABLE "view with spaces"(i INTEGER);
@@ -21,7 +21,7 @@ CREATE TABLE "view with spaces"(i INTEGER);
 statement error
 CREATE OR REPLACE VIEW "view with spaces" AS SELECT 42;
 ----
-<REGEX>:Catalog Error: Existing object "view with spaces" is of type Table, trying to replace with type View\. Use 'DROP TABLE "view with spaces";' instead\.
+<REGEX>:.*Catalog Error: Existing object "view with spaces" is of type Table, trying to replace with type View\. Use 'DROP TABLE "view with spaces";' instead\..*
 
 statement ok
 CREATE SCHEMA "replace schema";
@@ -33,7 +33,7 @@ CREATE TABLE "replace schema"."replace table"(i INTEGER);
 statement error
 CREATE OR REPLACE VIEW "replace schema"."replace table" AS SELECT 42;
 ----
-<REGEX>:Catalog Error: Existing object "replace schema"\."replace table" is of type Table, trying to replace with type View\. Use 'DROP TABLE "replace schema"\."replace table";' instead\.
+<REGEX>:.*Catalog Error: Existing object "replace schema"\."replace table" is of type Table, trying to replace with type View\. Use 'DROP TABLE "replace schema"\."replace table";' instead\..*
 
 statement ok
 CREATE TABLE "table with spaces"(i INTEGER);
@@ -42,12 +42,12 @@ CREATE TABLE "table with spaces"(i INTEGER);
 statement error
 DROP VIEW "table with spaces"
 ----
-<REGEX>:Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE "table with spaces";' instead\.
+<REGEX>:.*Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE "table with spaces";' instead\..*
 
 statement error
 DROP VIEW IF EXISTS "table with spaces"
 ----
-<REGEX>:Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE IF EXISTS "table with spaces";' instead\.
+<REGEX>:.*Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE IF EXISTS "table with spaces";' instead\..*
 
 
 statement ok
@@ -60,13 +60,13 @@ CREATE TABLE "schema with spaces"."table with spaces 2"(i INTEGER);
 statement error
 CREATE OR REPLACE VIEW "schema with spaces"."table with spaces 2" AS SELECT 42;
 ----
-<REGEX>:Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, trying to replace with type View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\.
+<REGEX>:.*Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, trying to replace with type View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\..*
 
 # mismatch errors include schema-qualified quoted names
 statement error
 DROP VIEW "schema with spaces"."table with spaces 2"
 ----
-<REGEX>:Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, not View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\.
+<REGEX>:.*Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, not View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\..*
 # cannot use DROP VIEW to drop a table
 statement error
 DROP VIEW integers
@@ -89,7 +89,7 @@ ALTER TABLE blabla RENAME COLUMN i TO k
 statement error
 DROP TABLE IF EXISTS vintegers
 ----
-<REGEX>:Catalog Error: Existing object vintegers is of type View, not Table\. Use 'DROP VIEW IF EXISTS vintegers;' instead\.
+<REGEX>:.*Catalog Error: Existing object vintegers is of type View, not Table\. Use 'DROP VIEW IF EXISTS vintegers;' instead\..*
 
 statement ok
 CREATE INDEX i_index ON integers(i);

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -12,8 +12,61 @@ CREATE VIEW vintegers AS SELECT 42;
 statement error
 CREATE OR REPLACE VIEW integers AS SELECT 42;
 ----
-<REGEX>:.*Catalog Error: Existing object integers.*
+<REGEX>:Catalog Error: Existing object integers is of type Table, trying to replace with type View\. Use 'DROP TABLE integers;' instead\.
 
+statement ok
+CREATE TABLE "view with spaces"(i INTEGER);
+
+# quoted identifiers in CREATE OR REPLACE type mismatch errors remain quoted
+statement error
+CREATE OR REPLACE VIEW "view with spaces" AS SELECT 42;
+----
+<REGEX>:Catalog Error: Existing object "view with spaces" is of type Table, trying to replace with type View\. Use 'DROP TABLE "view with spaces";' instead\.
+
+statement ok
+CREATE SCHEMA "replace schema";
+
+statement ok
+CREATE TABLE "replace schema"."replace table"(i INTEGER);
+
+# CREATE OR REPLACE mismatch errors include schema-qualified quoted names
+statement error
+CREATE OR REPLACE VIEW "replace schema"."replace table" AS SELECT 42;
+----
+<REGEX>:Catalog Error: Existing object "replace schema"\."replace table" is of type Table, trying to replace with type View\. Use 'DROP TABLE "replace schema"\."replace table";' instead\.
+
+statement ok
+CREATE TABLE "table with spaces"(i INTEGER);
+
+# quoted identifiers in type mismatch hints remain quoted
+statement error
+DROP VIEW "table with spaces"
+----
+<REGEX>:Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE "table with spaces";' instead\.
+
+statement error
+DROP VIEW IF EXISTS "table with spaces"
+----
+<REGEX>:Catalog Error: Existing object "table with spaces" is of type Table, not View\. Use 'DROP TABLE IF EXISTS "table with spaces";' instead\.
+
+
+statement ok
+CREATE SCHEMA "schema with spaces";
+
+statement ok
+CREATE TABLE "schema with spaces"."table with spaces 2"(i INTEGER);
+
+# schema-qualified CREATE OR REPLACE mismatch errors include quoted schema and name
+statement error
+CREATE OR REPLACE VIEW "schema with spaces"."table with spaces 2" AS SELECT 42;
+----
+<REGEX>:Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, trying to replace with type View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\.
+
+# mismatch errors include schema-qualified quoted names
+statement error
+DROP VIEW "schema with spaces"."table with spaces 2"
+----
+<REGEX>:Catalog Error: Existing object "schema with spaces"\."table with spaces 2" is of type Table, not View\. Use 'DROP TABLE "schema with spaces"\."table with spaces 2";' instead\.
 # cannot use DROP VIEW to drop a table
 statement error
 DROP VIEW integers
@@ -36,7 +89,7 @@ ALTER TABLE blabla RENAME COLUMN i TO k
 statement error
 DROP TABLE IF EXISTS vintegers
 ----
-<REGEX>:.*Catalog Error: Existing object vintegers.*
+<REGEX>:Catalog Error: Existing object vintegers is of type View, not Table\. Use 'DROP VIEW IF EXISTS vintegers;' instead\.
 
 statement ok
 CREATE INDEX i_index ON integers(i);

--- a/test/sql/catalog/test_if_not_exists.test
+++ b/test/sql/catalog/test_if_not_exists.test
@@ -21,7 +21,7 @@ CREATE VIEW IF NOT EXISTS integers2 AS SELECT 42
 statement error
 DROP VIEW IF EXISTS integers
 ----
-<REGEX>:Catalog Error.*trying to drop type View.*
+<REGEX>:Catalog Error: Existing object .*integers is of type Table, not View\. Use 'DROP TABLE IF EXISTS .*integers;' instead\.
 
 statement ok
 DROP TABLE IF EXISTS integers
@@ -31,4 +31,3 @@ DROP TABLE IF EXISTS integers
 
 statement ok
 DROP TABLE IF EXISTS no_such_scheme.integers
-

--- a/test/sql/catalog/test_if_not_exists.test
+++ b/test/sql/catalog/test_if_not_exists.test
@@ -21,7 +21,7 @@ CREATE VIEW IF NOT EXISTS integers2 AS SELECT 42
 statement error
 DROP VIEW IF EXISTS integers
 ----
-<REGEX>:Catalog Error: Existing object .*integers is of type Table, not View\. Use 'DROP TABLE IF EXISTS .*integers;' instead\.
+<REGEX>:.*Catalog Error: Existing object integers is of type Table, not View\. Use 'DROP TABLE IF EXISTS integers;' instead\..*
 
 statement ok
 DROP TABLE IF EXISTS integers


### PR DESCRIPTION
## Summary
- improve catalog type-mismatch errors by suggesting the matching DROP statement for the existing object type
- preserve schema qualification and quoting in both DROP and CREATE OR REPLACE mismatch messages
- add catalog SQL tests covering quoted identifiers, schema-qualified names, and IF EXISTS variants

## Test plan
- [x] cmake --build build/debug --target duckdb_catalog_entries -j2
- [x] cmake --build build/debug --target test_catalog -j1
- [ ] cmake --build build/debug --target unittest -j1 (timed out on the current /mnt/c WSL checkout before the unittest binary linked)
