### PR TITLE
Fix shell expansion issue in draft PR workflow

### DIFF
--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -47,8 +47,8 @@ jobs:
         if: ${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV != '' }}
         run: |
           echo "${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV }}" | gh auth login --with-token
-          gh api graphql -F "id=${{ env.PR_NUMBER }}" -f query="
-            mutation(\$id: ID!) {
+          gh api graphql -F "id=${{ env.PR_NUMBER }}" -f query='
+            mutation($id: ID!) {
               convertPullRequestToDraft(input: { pullRequestId: $id }) {
                 pullRequest {
                   id
@@ -57,4 +57,4 @@ jobs:
                 }
               }
             }
-          "
+          '


### PR DESCRIPTION
Move PR to draft was [failing](https://github.com/duckdb/duckdb/actions/runs/23649151820/job/68889044949):
```
Run echo "***" | gh auth login --with-token
  echo "***" | gh auth login --with-token
  gh api graphql -F "id=PR_kwDOCEU65s7OCeAz" -f query="
    mutation(\$id: ID!) {
      convertPullRequestToDraft(input: { pullRequestId: $id }) {
        pullRequest {
          id
          number
          isDraft
        }
      }
    }
  "
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    PR_NUMBER: PR_kwDOCEU65s7OCeAz
    MOVE_PR_TO_DRAFT_TOKEN_ENV: ***
gh: Expected VALUE, actual: RCURLY ("}") at [3, 56]
{"errors":[{"message":"Expected VALUE, actual: RCURLY (\"}\") at [3, 56]","locations":[{"line":3,"column":56}]}]}
```
due to a shell expansion issue.