### PR TITLE
Fix workflow lint issue

### DIFF
--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -47,14 +47,16 @@ jobs:
         if: ${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV != '' }}
         run: |
           echo "${{ env.MOVE_PR_TO_DRAFT_TOKEN_ENV }}" | gh auth login --with-token
-          gh api graphql -F "id=${{ env.PR_NUMBER }}" -f query='
-            mutation($id: ID!) {
-              convertPullRequestToDraft(input: { pullRequestId: $id }) {
-                pullRequest {
-                  id
-                  number
-                  isDraft
-                }
+          query="$(cat <<'EOF'
+          mutation($id: ID!) {
+            convertPullRequestToDraft(input: { pullRequestId: $id }) {
+              pullRequest {
+                id
+                number
+                isDraft
               }
             }
-          '
+          }
+          EOF
+          )"
+          gh api graphql -F "id=${{ env.PR_NUMBER }}" -f query="$query"


### PR DESCRIPTION
Follow-up PR of #21701 that fixes the workflow lint issue:
```
Error: .github/workflows/DraftPR.yml:48:9: shellcheck reported issue in this script: SC2016:info:2:54: Expressions don't expand in single quotes, use double quotes for that [shellcheck]
   |
48 |         run: |
   |         ^~~~
Error: Process completed with exit code 1.
```