### PR TITLE
Investigate ccache hit rate for linux debug and release

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -229,6 +229,7 @@ jobs:
       FORCE_ASSERT: 1
       REDUCE_SYMBOLS: 1
       EXTENSIONS_STATIC_BUILD: 0
+      CCACHE_DIAGNOSTICS_DIR: ${{ github.workspace }}/ccache-debug/linux-debug
 
     steps:
     - uses: actions/checkout@v6
@@ -240,6 +241,28 @@ jobs:
       run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
+
+    - name: Prepare ccache diagnostics
+      shell: bash
+      run: |
+        rm -rf "$CCACHE_DIAGNOSTICS_DIR"
+        mkdir -p "$CCACHE_DIAGNOSTICS_DIR/files"
+        {
+          echo "CCACHE_DEBUG=1"
+          echo "CCACHE_DEBUGLEVEL=3"
+          echo "CCACHE_DEBUGDIR=$CCACHE_DIAGNOSTICS_DIR/files"
+          echo "CCACHE_LOGFILE=$CCACHE_DIAGNOSTICS_DIR/ccache.log"
+          echo "CCACHE_STATSLOG=$CCACHE_DIAGNOSTICS_DIR/ccache.stats.log"
+        } >> "$GITHUB_ENV"
+        ccache -p > "$CCACHE_DIAGNOSTICS_DIR/ccache-config.txt"
+        ccache -s > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-summary.before.txt"
+        ccache --print-stats > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-raw.before.txt"
+        ccache -z
+        {
+          echo "job=${GITHUB_JOB}"
+          echo "sha=${GITHUB_SHA}"
+          echo "runner=${RUNNER_NAME}"
+        } > "$CCACHE_DIAGNOSTICS_DIR/metadata.txt"
 
     - name: Build
       run: python3 scripts/ci/retry.py -- make relassert
@@ -260,8 +283,25 @@ jobs:
         path: build/relassert-artifact.tar.gz
         if-no-files-found: error
 
+    - name: Collect ccache diagnostics
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        ccache -s > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-summary.after.txt"
+        ccache --print-stats > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-raw.after.txt"
+        find "$CCACHE_DIAGNOSTICS_DIR" -type f | sort > "$CCACHE_DIAGNOSTICS_DIR/files.txt"
+
+    - name: Upload ccache diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: linux-debug-ccache-diagnostics
+        path: ${{ env.CCACHE_DIAGNOSTICS_DIR }}
+        if-no-files-found: error
+
  linux-debug-tests:
     name: Linux Debug Tests
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-debug
@@ -294,6 +334,7 @@ jobs:
       run: make unittest_relassert
 
  regression:
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     uses: ./.github/workflows/Regression.yml
     secrets: inherit
     needs:
@@ -306,11 +347,13 @@ jobs:
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 
  code-quality:
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     uses: ./.github/workflows/CodeQuality.yml
     secrets: inherit
     needs: prepare
 
  extensions:
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     uses: ./.github/workflows/Extensions.yml
     secrets: inherit
     needs:
@@ -325,6 +368,7 @@ jobs:
 
  wasm-eh:
     name: Wasm EH
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-debug
@@ -349,6 +393,7 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     env:
       GEN: ninja
+      CCACHE_DIAGNOSTICS_DIR: ${{ github.workspace }}/ccache-debug/linux-release
 
     steps:
     - uses: actions/checkout@v6
@@ -357,6 +402,28 @@ jobs:
       run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
+
+    - name: Prepare ccache diagnostics
+      shell: bash
+      run: |
+        rm -rf "$CCACHE_DIAGNOSTICS_DIR"
+        mkdir -p "$CCACHE_DIAGNOSTICS_DIR/files"
+        {
+          echo "CCACHE_DEBUG=1"
+          echo "CCACHE_DEBUGLEVEL=3"
+          echo "CCACHE_DEBUGDIR=$CCACHE_DIAGNOSTICS_DIR/files"
+          echo "CCACHE_LOGFILE=$CCACHE_DIAGNOSTICS_DIR/ccache.log"
+          echo "CCACHE_STATSLOG=$CCACHE_DIAGNOSTICS_DIR/ccache.stats.log"
+        } >> "$GITHUB_ENV"
+        ccache -p > "$CCACHE_DIAGNOSTICS_DIR/ccache-config.txt"
+        ccache -s > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-summary.before.txt"
+        ccache --print-stats > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-raw.before.txt"
+        ccache -z
+        {
+          echo "job=${GITHUB_JOB}"
+          echo "sha=${GITHUB_SHA}"
+          echo "runner=${RUNNER_NAME}"
+        } > "$CCACHE_DIAGNOSTICS_DIR/metadata.txt"
 
     - uses: ./.github/actions/linux_release_build
       with:
@@ -377,8 +444,25 @@ jobs:
         path: build/linux-default-release.tar.gz
         if-no-files-found: error
 
+    - name: Collect ccache diagnostics
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        ccache -s > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-summary.after.txt"
+        ccache --print-stats > "$CCACHE_DIAGNOSTICS_DIR/ccache-stats-raw.after.txt"
+        find "$CCACHE_DIAGNOSTICS_DIR" -type f | sort > "$CCACHE_DIAGNOSTICS_DIR/files.txt"
+
+    - name: Upload ccache diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: linux-release-ccache-diagnostics
+        path: ${{ env.CCACHE_DIAGNOSTICS_DIR }}
+        if-no-files-found: error
+
  linux-release-tests:
     name: Linux Release Tests
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-release
@@ -406,6 +490,7 @@ jobs:
 
  symbol-leakage:
     name: Symbol Leakage
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ubuntu-24.04
     needs:
       - prepare
@@ -437,6 +522,7 @@ jobs:
 
  linux-release-cli:
     name: Linux CLI (${{ matrix.config.arch }})
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-release-tests
@@ -524,6 +610,7 @@ jobs:
 
  linux-musl-release-cli:
     name: Linux CLI (${{ matrix.config.arch }}-musl)
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-release-tests
@@ -621,7 +708,7 @@ jobs:
 
  main_julia:
     name: Julia ${{ matrix.version }}
-    if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs: linux-release-cli
     runs-on: ubuntu-latest
     strategy:
@@ -680,6 +767,7 @@ jobs:
 
  upload-libduckdb-src:
     name: Upload libduckdb-src.zip
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs: linux-release-cli
     runs-on: ubuntu-latest
 
@@ -701,6 +789,7 @@ jobs:
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip
 
  swift:
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     uses: ./.github/workflows/Swift.yml
     secrets: inherit
     needs:
@@ -710,6 +799,7 @@ jobs:
       runner_macos_arm64: ${{ needs.prepare.outputs.runner_macos_14_arm64 }}
 
  windows:
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     uses: ./.github/workflows/Windows.yml
     secrets: inherit
     needs:
@@ -723,6 +813,7 @@ jobs:
 
  no-string-inline:
     name: No String Inline / Destroy Unpinned Blocks
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     needs:
       - prepare
@@ -754,6 +845,7 @@ jobs:
 
  vector-sizes:
     name: Vector Sizes
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ${{ needs.prepare.outputs.runner_linux_22_x64 }}
     needs:
       - prepare
@@ -780,7 +872,7 @@ jobs:
 
  valgrind:
     name: Valgrind
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ubuntu-24.04
     needs: linux-debug
     env:
@@ -816,6 +908,7 @@ jobs:
 
  threadsan:
     name: Thread Sanitizer
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     needs:
       - prepare
       - linux-debug
@@ -845,6 +938,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ${{ needs.prepare.outputs.runner_linux_small }}
     needs:
       - prepare
@@ -870,6 +964,7 @@ jobs:
  # TODO: DEBUG_STACKTRACE: 1 + reldebug ?
  linux-configs:
     name: Tests a release build with different configurations
+    if: ${{ github.repository == '__ccache_analysis_only__/__disabled__' }}
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     needs:
       - prepare


### PR DESCRIPTION
- `linux-release` ccache restores `linux-release-cli`

Key Schemes
| Scope | Requested key | Fallback when exact key is absent | What this means |
|---|---|---|---|
| Main/Regression/CodeQuality/Windows jobs using local composite action | github.job via .github/actions/ccache-action/action.yml:8 | No explicit restore-keys; effective restore is primary-prefix match on ccache-<github.job>- | Unsafe when one job id is a prefix of another, e.g. linux-release vs linux-release-cli |
| Extension Linux container jobs | ccache-extension-distribution-<arch>-<sha>-<timestamp> | Explicit restore keys observed in logs: `ccache-extension-distribution-<arch>-<sha>` then `ccache-extension-distribution-<arch>-` | Much safer: `arch` and `sha` are encoded |
| Extension macOS/Windows/Wasm jobs | input key `ccache-extension-distribution-<arch>-<sha>` | Explicit restore key `ccache-extension-distribution-<arch>-`; upstream action prepends ccache- on save/restore | Effective stored keys become ccache-ccache-extension-distribution-..., which is odd but branch/sha-safe |

Main
| Job | Restored entry in this run | Hit rate | Notes |
|---|---|---|---|
| Linux Debug | ccache-linux-debug-2026-03-28T01:02:10.173Z | 242 / 548 (44.16%) | Fine; family is ccache-linux-debug-* |
| Linux Release | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 544 / 1790 (30.39%) | Wrong restore source; linux-release fell into linux-release-cli |
| Thread Sanitizer | ccache-threadsan-2026-03-28T01:27:17.270Z | 696 / 1111 (62.65%) | Fine |
| Valgrind | ccache-valgrind-2026-03-28T01:47:59.870Z | 579 / 978 (59.20%) | Fine |
| No String Inline / Destroy Unpinned Blocks | ccache-no-string-inline-2026-03-28T01:19:21.296Z | 696 / 1112 (62.59%) | Fine |
| Vector Sizes | ccache-vector-sizes-2026-03-28T01:08:48.472Z | 785 / 1104 (71.11%) | Stats format differed slightly, but hit rate is visible |
| Linux CLI (amd64) | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 0 / 2123 (0.00%) | Shares cache family with arm64 CLI jobs |
| Linux CLI (arm64) | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 641 / 1484 (43.19%) | Same key family as amd64 |
| Linux CLI (amd64-musl) | ccache-linux-musl-release-cli-2026-03-28T01:56:44.129Z | 0 / 1062 (0.00%) | Separate musl family |
| Linux CLI (arm64-musl) | ccache-linux-musl-release-cli-2026-03-28T01:56:44.129Z | 641 / 1062 (60.36%) | Same musl key family across archs |

CodeQuality
| Job | Restored entry in this run | Hit rate | Notes |
|---|---|---|---|
| Tidy Check | MISS | not logged | Uses ccache in .github/workflows/CodeQuality.yml:71, but this run did not log a restore hit or a saved cache key |

Regression
| Job | Restored entry in this run | Hit rate | Notes |
|---|---|---|---|
| Linux Base | ccache-linux-base-2026-03-28T01:04:41.091Z | 1436 / 1510 (95.10%) | Very high reuse; family is ccache-linux-base-* |

Windows
| Job | Restored entry in this run | Hit rate | Notes |
|---|---|---|---|
| Windows (64 Bit) | MISS | Hits: 0, Misses: 0 | ccache action ran, but the job effectively did not use ccache |
| Windows (32 Bit) | MISS | Hits: 0, Misses: 0 | Same |
| Windows (ARM64) | MISS | Hits: 0, Misses: 0 | Same |
| MinGW (64 Bit) | ccache-mingw-2026-03-28T01:18:04.053Z | 180 / 482 (37.34%) | Only Windows job here with meaningful ccache use |

Extensions
| Job | Restore key chain / restored entry | Hit rate | Notes |
|---|---|---|---|
| Main Extensions / linux_amd64 | restore keys: ...linux_amd64-e6de... then ...linux_amd64-; restored ...01;55;42 | not emitted | Safe keying; log also shows save key ...02;01;15 |
| Main Extensions / linux_arm64 | restored ...linux_arm64-e6de...-01;56;23 | not emitted | Safe keying |
| Rust-based Extensions / linux_amd64 | restored ...linux_amd64-e6de...-01;40;40 | not emitted | Safe keying |
| Rust-based Extensions / linux_arm64 | restored ...linux_arm64-e6de...-01;42;23 | not emitted | Safe keying |
| External Extensions / linux_amd64 | restored ...linux_amd64-e6de...-01;55;42 | not emitted | Safe keying |
| External Extensions / linux_arm64 | restored ...linux_arm64-e6de...-01;56;23 | not emitted | Safe keying |
| External Extensions (2nd batch) / linux_amd64 | restored ...linux_amd64-9575...-01;29;37 | not emitted | Safe keying, but older base hash |
| External Extensions (2nd batch) / linux_arm64 | restored ...linux_arm64-9575...-01;30;58 | not emitted | Safe keying, but older base hash |
| Main Extensions / osx_arm64 | restored ccache-ccache-extension-distribution-osx_arm64-e6de...-02:19:29.307Z | stats incomplete in log | Explicit fallback is ccache-extension-distribution-osx_arm64- |
| Main Extensions / windows_amd64 | restored ccache-ccache-extension-distribution-windows_amd64-e6de...-02:07:23.875Z | 431 / 3770 (11.43%) | Double ccache- prefix comes from upstream action behavior |
| Main Extensions / windows_amd64_mingw | MISS | 2 / 1309 (0.15%) | Very weak reuse |
| Main Extensions / wasm_threads | MISS | 231 / 1415 (16.33%) | Saved under ccache-ccache-extension-distribution-wasm_threads-... |
| Main Extensions / wasm_eh | MISS | 250 / 1415 (17.67%) | Same pattern |
| Main Extensions / wasm_mvp | MISS | 251 / 1415 (17.74%) | Same pattern |
| Rust-based Extensions / osx_arm64 | restored ccache-ccache-extension-distribution-osx_arm64-e6de...-01:51:26.461Z | 98 / 577 (16.98%) | Same explicit arch fallback |
| Rust-based Extensions / osx_amd64 | MISS | 0 / 577 (0.00%) | Same key scheme |
| Rust-based Extensions / windows_amd64 | MISS | 36 / 478 (7.53%) | Same key scheme |
| External Extensions / osx_arm64 | restored ccache-ccache-extension-distribution-osx_arm64-e6de...-02:06:10.931Z | 527 / 527 (100.0%) | Best extension hit rate in this run |
| External Extensions / osx_amd64 | restored ccache-ccache-extension-distribution-osx_amd64-e6de...-02:35:59.308Z | 98 / 527 (18.60%) | Same scheme |

What looks wrong

- linux-release vs linux-release-cli: confirmed collision. Linux Release restored a CLI cache entry.
- linux-release-cli matrix jobs: confirmed shared key family across amd64 and arm64.
- Generic main-workflow keys do not encode branch, so repo-level branch attribution is opaque for a large part of the 50 GiB.