### PR TITLE
Fix remaining clang-tidy issues on main

### DIFF
--- a/extension/parquet/reader/variant/variant_binary_decoder.cpp
+++ b/extension/parquet/reader/variant/variant_binary_decoder.cpp
@@ -323,7 +323,7 @@ VariantValue VariantBinaryDecoder::ArrayDecode(const VariantMetadata &metadata,
 	}
 
 	auto field_offsets = data;
-	auto values = field_offsets + ((num_elements + 1) * field_offset_size);
+	auto values = field_offsets + (NumericCast<idx_t>(num_elements) + 1) * field_offset_size;
 
 	idx_t last_offset = ReadVariableLengthLittleEndian(field_offset_size, field_offsets);
 	for (idx_t i = 0; i < num_elements; i++) {

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -70,7 +70,9 @@ void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *
 	if (parent) {
 		// propagate empty entries from the parent
 		if (state.is_empty.size() < parent->is_empty.size()) {
-			state.is_empty.insert(state.is_empty.end(), parent->is_empty.begin() + state.is_empty.size(),
+			state.is_empty.insert(state.is_empty.end(),
+			                      parent->is_empty.begin() +
+			                          NumericCast<duckdb::vector<bool>::difference_type>(state.is_empty.size()),
 			                      parent->is_empty.end());
 		}
 	}

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -78,6 +78,15 @@ def make_absolute(f, directory):
     return os.path.normpath(os.path.join(directory, f))
 
 
+IGNORED_DIRECTORIES = {'third_party'}
+
+
+def is_ignored_file(path):
+    normalized = os.path.normpath(path)
+    path_parts = normalized.split(os.sep)
+    return any(directory in path_parts for directory in IGNORED_DIRECTORIES)
+
+
 def get_tidy_invocation(
     f, clang_tidy_binary, checks, tmpdir, build_path, header_filter, extra_arg, extra_arg_before, quiet, config
 ):
@@ -304,6 +313,8 @@ def main():
 
         # Fill the queue with files.
         for name in files:
+            if is_ignored_file(name):
+                continue
             if file_name_re.search(name):
                 task_queue.put(name)
 

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -78,13 +78,9 @@ def make_absolute(f, directory):
     return os.path.normpath(os.path.join(directory, f))
 
 
-IGNORED_DIRECTORIES = {'third_party'}
-
-
 def is_ignored_file(path):
     normalized = os.path.normpath(path)
-    path_parts = normalized.split(os.sep)
-    return any(directory in path_parts for directory in IGNORED_DIRECTORIES)
+    return normalized.startswith('third_party' + os.sep)
 
 
 def get_tidy_invocation(

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -1,7 +1,10 @@
 #include "duckdb/parser/transformer.hpp"
 
 #include "duckdb/parser/expression/list.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
+#include "duckdb/parser/query_node/insert_query_node.hpp"
 #include "duckdb/parser/statement/list.hpp"
+#include "duckdb/parser/query_node/update_query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/parser_options.hpp"
 


### PR DESCRIPTION
### Disabling third_party/ in tidy script

After disabling linting of `third_party/`, `clang-tidy` reported [errors](https://github.com/duckdb/duckdb/actions/runs/23698173001/job/69037051317#step:6:12113):

```
/tmp/clang-tidy-cache -p=/home/runner/work/duckdb/duckdb/build/tidy --quiet /home/runner/work/duckdb/duckdb/third_party/zstd/deprecated/zbuff_compress.cpp
USAGE: clang-tidy [options] <source0> [... <sourceN>]

OPTIONS:

Generic Options:
...
  --warnings-as-errors=<string>   - Upgrades warnings to errors. Same format as
                                    '-checks'.
                                    This option's value is appended to the value of
                                    the 'WarningsAsErrors' option in .clang-tidy
                                    file, if any.
Failed to get commands: exit status 1
make: *** [Makefile:541: tidy-check] Error 1
Error: Process completed with exit code 2.
```
so we're now ignoring clang-tidy for `third_party/**` in the python script. 

### Fixed three remaining issues

Clang tidy found three more issues:

- `extension/parquet/reader/variant/variant_binary_decoder.cpp:326:` cast `num_elements` to `idx_t` before the multiplication so the pointer offset is computed in the widened type.
- `extension/parquet/writer/struct_column_writer.cpp:73:` cast `state.is_empty.size()` to `vector<bool>::difference_type` before iterator arithmetic to avoid the narrowing-conversion warning.
- `src/parser/transformer.cpp:4:` included the concrete delete/insert/update_query_node headers so clang-tidy sees complete types for those `unique_ptr` members.