### PR TITLE
[Variant] Re-add the removed `variant_legacy_encoding` setting

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -107,6 +107,7 @@ struct ParquetOptions {
 	explicit ParquetOptions(ClientContext &context);
 
 	bool binary_as_string = false;
+	bool variant_legacy_encoding = false;
 	bool file_row_number = false;
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -533,18 +533,18 @@ static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnS
 	}
 	//! Names have to be 'metadata' and 'value' respectively
 	//! But apparently some writers can mix the order, so we are more lenient
-	if (children[0] != "metadata" && children[1] != "metadata") {
+	if (children[0].name != "metadata" && children[1].name != "metadata") {
 		return false;
 	}
-	if (children[0] != "value" && children[1] != "value") {
+	if (children[0].name != "value" && children[1].name != "value") {
 		return false;
 	}
 
 	//! Verify types
-	if (children[0] != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (children[0].parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
-	if (children[1] != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (children[1].parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
 	if (children.size() == 3) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -531,22 +531,20 @@ static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnS
 	if (children.size() < 2) {
 		return false;
 	}
-	auto &metadata = children[0];
-	auto &value = children[1];
-
-	//! Verify names
-	if (metadata.name != "metadata") {
+	//! Names have to be 'metadata' and 'value' respectively
+	//! But apparently some writers can mix the order, so we are more lenient
+	if (children[0] != "metadata" && children[1] != "metadata") {
 		return false;
 	}
-	if (value.name != "value") {
+	if (children[0] != "value" && children[1] != "value") {
 		return false;
 	}
 
 	//! Verify types
-	if (metadata.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (children[0] != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
-	if (value.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (children[1] != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
 	if (children.size() == 3) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -527,6 +527,40 @@ static bool IsGeometryType(const SchemaElement &s_ele, const ParquetFileMetadata
 	return false;
 }
 
+static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnSchema> &children) {
+	if (children.size() < 2) {
+		return false;
+	}
+	auto &metadata = children[0];
+	auto &value = children[1];
+
+	//! Verify names
+	if (metadata.name != "metadata") {
+		return false;
+	}
+	if (value.name != "value") {
+		return false;
+	}
+
+	//! Verify types
+	if (metadata.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+		return false;
+	}
+	if (value.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+		return false;
+	}
+	if (children.size() == 3) {
+		auto &typed_value = children[2];
+		if (typed_value.name != "typed_value") {
+			return false;
+		}
+		throw NotImplementedException("Shredded Variants are not supported yet");
+	} else if (children.size() != 2) {
+		return false;
+	}
+	return true;
+}
+
 ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat,
                                                         idx_t &next_schema_idx, idx_t &next_file_idx,
                                                         ClientContext &context) {
@@ -628,6 +662,9 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 		const bool is_map = s_ele.__isset.converted_type && s_ele.converted_type == ConvertedType::MAP;
 		bool is_map_kv = s_ele.__isset.converted_type && s_ele.converted_type == ConvertedType::MAP_KEY_VALUE;
 		bool is_variant = s_ele.__isset.logicalType && s_ele.logicalType.__isset.VARIANT == true;
+		if (!is_variant && parquet_options.variant_legacy_encoding && IsVariantType(s_ele, child_schemas)) {
+			is_variant = true;
+		}
 
 		if (!is_map_kv && this_idx > 0) {
 			// check if the parent node of this is a map
@@ -796,6 +833,8 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 	Value lookup_value;
 	if (context.TryGetCurrentSetting("binary_as_string", lookup_value)) {
 		binary_as_string = lookup_value.GetValue<bool>();
+	} else if (context.TryGetCurrentSetting("variant_legacy_encoding", lookup_value)) {
+		variant_legacy_encoding = lookup_value.GetValue<bool>();
 	}
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -831,7 +831,8 @@ ParquetOptions::ParquetOptions(ClientContext &context) {
 	Value lookup_value;
 	if (context.TryGetCurrentSetting("binary_as_string", lookup_value)) {
 		binary_as_string = lookup_value.GetValue<bool>();
-	} else if (context.TryGetCurrentSetting("variant_legacy_encoding", lookup_value)) {
+	}
+	if (context.TryGetCurrentSetting("__delta_only_variant_encoding_enabled", lookup_value)) {
 		variant_legacy_encoding = lookup_value.GetValue<bool>();
 	}
 }

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1065,6 +1065,13 @@
         "default_value": "VALIDATE_ALL"
     },
     {
+        "name": "variant_legacy_encoding",
+        "description": "Enables the Parquet reader to identify a Variant structurally.",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "variant_minimum_shredding_size",
         "description": "Minimum size of a rowgroup to enable VARIANT shredding, or set to -1 to disable entirely. Defaults to 1/4th of a rowgroup",
         "type": "BIGINT",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1,5 +1,12 @@
 [
     {
+        "name": "__delta_only_variant_encoding_enabled",
+        "description": "Enables the Parquet reader to identify a Variant structurally.",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "access_mode",
         "description": "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)",
         "type": "ENUM<AccessMode>",
@@ -1063,13 +1070,6 @@
         "type": "ENUM<CacheValidationMode>",
         "default_scope": "global",
         "default_value": "VALIDATE_ALL"
-    },
-    {
-        "name": "variant_legacy_encoding",
-        "description": "Enables the Parquet reader to identify a Variant structurally.",
-        "type": "BOOLEAN",
-        "scope": "global",
-        "default_value": "false"
     },
     {
         "name": "variant_minimum_shredding_size",

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -149,6 +149,8 @@ struct DBConfigOptions {
 	idx_t allocator_flush_threshold = 134217728ULL;
 	//! If bulk deallocation larger than this occurs, flush outstanding allocations (1 << 30, ~1GB)
 	idx_t allocator_bulk_deallocation_flush_threshold = 536870912ULL;
+	//! Delta Only! - Fall back to recognizing Variant columns structurally
+	bool variant_legacy_encoding = false;
 	//! Metadata from DuckDB callers
 	string custom_user_agent;
 	//! The default block header size for new duckdb database files.

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1550,6 +1550,16 @@ struct ValidateExternalFileCacheSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct VariantLegacyEncodingSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "variant_legacy_encoding";
+	static constexpr const char *Description = "Enables the Parquet reader to identify a Variant structurally.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = 91;
+};
+
 struct VariantMinimumShreddingSizeSetting {
 	using RETURN_TYPE = int64_t;
 	static constexpr const char *Name = "variant_minimum_shredding_size";
@@ -1558,7 +1568,7 @@ struct VariantMinimumShreddingSizeSetting {
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "30000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 91;
+	static constexpr idx_t SettingIndex = 92;
 };
 
 struct WalAutocheckpointEntriesSetting {
@@ -1569,7 +1579,7 @@ struct WalAutocheckpointEntriesSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 92;
+	static constexpr idx_t SettingIndex = 93;
 };
 
 struct WarningsAsErrorsSetting {
@@ -1579,7 +1589,7 @@ struct WarningsAsErrorsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 93;
+	static constexpr idx_t SettingIndex = 94;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1591,7 +1601,7 @@ struct WriteBufferRowGroupCountSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "5";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 94;
+	static constexpr idx_t SettingIndex = 95;
 };
 
 struct ZstdMinStringLengthSetting {
@@ -1602,11 +1612,11 @@ struct ZstdMinStringLengthSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "4096";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 95;
+	static constexpr idx_t SettingIndex = 96;
 };
 
 struct GeneratedSettingInfo {
-	static constexpr idx_t MaxSettingIndex = 96;
+	static constexpr idx_t MaxSettingIndex = 97;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -87,6 +87,16 @@ private:
 // Start of the auto-generated list of settings structures
 //===----------------------------------------------------------------------===//
 
+struct DeltaOnlyVariantEncodingEnabledSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "__delta_only_variant_encoding_enabled";
+	static constexpr const char *Description = "Enables the Parquet reader to identify a Variant structurally.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct AccessModeSetting {
 	using RETURN_TYPE = AccessMode;
 	static constexpr const char *Name = "access_mode";
@@ -1550,16 +1560,6 @@ struct ValidateExternalFileCacheSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
-struct VariantLegacyEncodingSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "variant_legacy_encoding";
-	static constexpr const char *Description = "Enables the Parquet reader to identify a Variant structurally.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 91;
-};
-
 struct VariantMinimumShreddingSizeSetting {
 	using RETURN_TYPE = int64_t;
 	static constexpr const char *Name = "variant_minimum_shredding_size";
@@ -1568,7 +1568,7 @@ struct VariantMinimumShreddingSizeSetting {
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "30000";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 92;
+	static constexpr idx_t SettingIndex = 91;
 };
 
 struct WalAutocheckpointEntriesSetting {
@@ -1579,7 +1579,7 @@ struct WalAutocheckpointEntriesSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 93;
+	static constexpr idx_t SettingIndex = 92;
 };
 
 struct WarningsAsErrorsSetting {
@@ -1589,7 +1589,7 @@ struct WarningsAsErrorsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 94;
+	static constexpr idx_t SettingIndex = 93;
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
@@ -1601,7 +1601,7 @@ struct WriteBufferRowGroupCountSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "5";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = 95;
+	static constexpr idx_t SettingIndex = 94;
 };
 
 struct ZstdMinStringLengthSetting {
@@ -1612,11 +1612,11 @@ struct ZstdMinStringLengthSetting {
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "4096";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = 96;
+	static constexpr idx_t SettingIndex = 95;
 };
 
 struct GeneratedSettingInfo {
-	static constexpr idx_t MaxSettingIndex = 97;
+	static constexpr idx_t MaxSettingIndex = 96;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -199,6 +199,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ThreadsSetting),
     DUCKDB_SETTING(UsernameSetting),
     DUCKDB_SETTING_CALLBACK(ValidateExternalFileCacheSetting),
+    DUCKDB_SETTING(VariantLegacyEncodingSetting),
     DUCKDB_SETTING(VariantMinimumShreddingSizeSetting),
     DUCKDB_SETTING(WalAutocheckpointEntriesSetting),
     DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -65,6 +65,7 @@ bool DBConfigOptions::debug_print_bindings = false;
 
 static const ConfigurationOption internal_options[] = {
 
+    DUCKDB_GLOBAL(DeltaOnlyVariantEncodingEnabledSetting),
     DUCKDB_GLOBAL(AccessModeSetting),
     DUCKDB_SETTING_CALLBACK(AllocatorBackgroundThreadsSetting),
     DUCKDB_GLOBAL(AllocatorBulkDeallocationFlushThresholdSetting),
@@ -199,7 +200,6 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ThreadsSetting),
     DUCKDB_SETTING(UsernameSetting),
     DUCKDB_SETTING_CALLBACK(ValidateExternalFileCacheSetting),
-    DUCKDB_SETTING(VariantLegacyEncodingSetting),
     DUCKDB_SETTING(VariantMinimumShreddingSizeSetting),
     DUCKDB_SETTING(WalAutocheckpointEntriesSetting),
     DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),
@@ -207,12 +207,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 98),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 42),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 117),
-                                                     DUCKDB_SETTING_ALIAS("user", 132),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 24),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 131),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 99),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 43),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 118),
+                                                     DUCKDB_SETTING_ALIAS("user", 133),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 25),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 132),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -109,6 +109,22 @@ Value AllocatorBulkDeallocationFlushThresholdSetting::GetSetting(const ClientCon
 }
 
 //===----------------------------------------------------------------------===//
+// Delta Only Variant Legacy Encoding
+//===----------------------------------------------------------------------===//
+void DeltaOnlyVariantEncodingEnabledSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	throw InvalidInputException("This setting is not adjustable by a user");
+}
+
+void DeltaOnlyVariantEncodingEnabledSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	throw InvalidInputException("This setting is not adjustable by a user");
+}
+
+Value DeltaOnlyVariantEncodingEnabledSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.variant_legacy_encoding);
+}
+
+//===----------------------------------------------------------------------===//
 // Allocator Flush Threshold
 //===----------------------------------------------------------------------===//
 void AllocatorFlushThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -157,6 +157,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 
 bool OptionIsExcludedFromTest(const string &name) {
 	static unordered_set<string> excluded_options = {
+	    "__delta_only_variant_encoding_enabled",
 	    "access_mode",
 	    "allowed_configs",
 	    "allowed_directories",

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -132,6 +132,7 @@
         "test/sql/storage/types/variant/variant_index.test",
         "test/sql/storage/types/variant/variant_shredding.test_slow",
         "test/sql/storage/types/variant/variant_stats_merging.test_slow",
+        "test/parquet/variant/variant_legacy_encoding.test",
         "test/sql/types/variant/tpch_test.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple.test",
         "test/sql/storage/compression/roaring/roaring_bool_array_simple_w_null.test",

--- a/test/parquet/variant/variant_legacy_encoding.test
+++ b/test/parquet/variant/variant_legacy_encoding.test
@@ -1,6 +1,8 @@
 # name: test/parquet/variant/variant_legacy_encoding.test
 # group: [variant]
 
+load __TEST_DIR__/variant_legacy_encoding.db readwrite v1.5.0
+
 require parquet
 
 query I

--- a/test/parquet/variant/variant_legacy_encoding.test
+++ b/test/parquet/variant/variant_legacy_encoding.test
@@ -1,0 +1,33 @@
+# name: test/parquet/variant/variant_legacy_encoding.test
+# group: [variant]
+
+require parquet
+
+query I
+select current_setting('__delta_only_variant_encoding_enabled')
+----
+false
+
+statement error
+set __delta_only_variant_encoding_enabled = true;
+----
+Invalid Input Error: This setting is not adjustable by a user
+
+statement error
+reset __delta_only_variant_encoding_enabled;
+----
+Invalid Input Error: This setting is not adjustable by a user
+
+statement ok
+create table tbl(col VARIANT)
+
+statement ok
+insert into tbl select 42;
+
+statement ok
+copy (select * from tbl) to '__TEST_DIR__/variant_parquet_simple.parquet'
+
+query I
+select * from '__TEST_DIR__/variant_parquet_simple.parquet';
+----
+42


### PR DESCRIPTION
Writers did not move quickly enough to add the Parquet `logicalType` `VariantLogicalType` to the created groups, so now we're stuck with supporting this.

Renamed the setting to `__delta_only_variant_encoding_enabled` and barred users from adjusting the setting.