### PR TITLE
fix path test warnings

### DIFF
--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -848,7 +848,8 @@ TEST_CASE("Path attributes", "[file_system]") {
 	std::string input;
 
 	SECTION("IsAbsolute + IsLocal") {
-		bool is_absolute_exp, is_local_exp;
+		bool is_absolute_exp = false;
+		bool is_local_exp = false;
 		enum AbsType { REL = false, ABS = true };
 		enum LocalTypeType { REMOTE = false, LOCAL_ = true };
 
@@ -885,7 +886,7 @@ TEST_CASE("Path attributes", "[file_system]") {
 	}
 
 	SECTION("HasTrailingSeparator") {
-		bool exp;
+		bool exp = false;
 
 		// clang-format off
 		SECTION("posix and URI") {


### PR DESCRIPTION
fix silly warnings when using SECTION Check macros