### PR TITLE
Fix prepared temp-table INSERT invalidation after DROP

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -521,11 +521,13 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 		auto merge_into = GenerateMergeInto(stmt, table);
 		return Bind(*merge_into);
 	}
-	if (!table.temporary) {
+	if (table.temporary) {
+		// Temporary inserts still need a catalog dependency so prepared statements are rebound if the table is dropped.
+		GetStatementProperties().RegisterDBRead(table.catalog, context);
+	} else {
 		// inserting into a non-temporary table: alters underlying database
-		auto &properties = GetStatementProperties();
 		DatabaseModificationType modification_type = DatabaseModificationType::INSERT_DATA;
-		properties.RegisterDBModify(table.catalog, context, modification_type);
+		GetStatementProperties().RegisterDBModify(table.catalog, context, modification_type);
 	}
 
 	auto insert = make_uniq<LogicalInsert>(table, GenerateTableIndex());

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -96,6 +96,21 @@ TEST_CASE("Test prepared statements and dependencies", "[api]") {
 	REQUIRE_FAIL(prepare->Execute(11));
 }
 
+TEST_CASE("Prepared temp table insert is invalidated after drop", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TEMP TABLE t(i INTEGER)"));
+	auto prepared = con.Prepare("INSERT INTO t VALUES (42)");
+	REQUIRE(!prepared->HasError());
+
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE t"));
+
+	auto result = prepared->Execute();
+	REQUIRE(result->HasError());
+	REQUIRE(result->GetError().find("does not exist") != string::npos);
+}
+
 TEST_CASE("Dropping connection with prepared statement resets dependencies", "[api]") {
 	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);


### PR DESCRIPTION
## Summary

Fix a use-after-free when executing a prepared INSERT into a temporary table after that table has been dropped.

The root cause was that temp-table INSERT statements did not register any catalog dependency during bind. As a result, a prepared statement could survive DROP TABLE without being rebound/invalidated, and execution could still dereference a stale TableCatalogEntry.

This change makes temp-table INSERT register a temp-catalog dependency so execution after DROP TABLE fails cleanly with a normal catalog error instead of touching freed memory.

## Changes

- register a temp-catalog dependency for temp-table INSERT in the binder
- add a regression test for:
  - CREATE TEMP TABLE
  - PREPARE INSERT
  - DROP TABLE
  - executing the prepared statement afterwards

## Testing

Ran:
- 	est\\unittest.exe 'Prepared temp table insert is invalidated after drop'
- 	est\\unittest.exe 'Test prepared statements and dependencies'
