### PR TITLE
Use correct ccache keys for linux release and CLI jobs

### DIFF
--- a/.github/actions/ccache-action/action.yml
+++ b/.github/actions/ccache-action/action.yml
@@ -1,5 +1,10 @@
 name: 'Setup Ccache'
 description: 'Configure ccache for workflow jobs'
+inputs:
+  key:
+    description: 'Override the ccache key prefix; defaults to github.job'
+    required: false
+    default: ${{ github.job }}
 runs:
   using: "composite"
   steps:
@@ -7,8 +12,8 @@ runs:
        if: ${{ github.workflow != 'NightlyTests' }}
        uses: hendrikmuhs/ccache-action@main
        with:
-         key: ${{ github.job }}
-         save: ${{ github.repository != 'duckdb/duckdb' || contains('["refs/heads/main", "refs/heads/v1.4-andium", "refs/heads/v1.5-variegata"]', github.ref) }}
+         key: ${{ inputs.key }}
+         save: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
          # Dump verbose ccache statistics report at end of CI job.
          verbose: 1
          # Increase per-directory limit: 5*1024 MB / 16 = 320 MB.

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -459,6 +459,8 @@ jobs:
         python3 -m pip install --break-system-packages pytest
 
     - uses: ./.github/actions/ccache-action
+      with:
+        key: linux-cli-${{ matrix.config.arch }}-glibc
 
     - name: Build
       run: |
@@ -542,6 +544,8 @@ jobs:
     - uses: ./.github/actions/cleanup_runner
 
     - uses: ./.github/actions/ccache-action
+      with:
+        key: linux-cli-${{ matrix.config.arch }}-musl
 
     - name: Build
       shell: bash


### PR DESCRIPTION
I've [analysed](https://github.com/duckdb/duckdb/pull/21703) the ccache hit rate and cache restore keys for these CI jobs:
- linux release
- linux CLI

I noticed that their caches are **not isolated** per arch/libc/CI job: 

| Job | Restored entry in this run | Hit rate | Notes |
|---|---|---|---|
| Linux Release | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 544 / 1790 (30.39%) | Wrong restore source; linux-release fell into linux-release-cli |
| Linux CLI (amd64) | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 0 / 2123 (0.00%) | Shares cache family with arm64 CLI jobs |
| Linux CLI (arm64) | ccache-linux-release-cli-2026-03-28T01:27:51.242Z | 641 / 1484 (43.19%) | Same key family as amd64 |
| Linux CLI (amd64-musl) | ccache-linux-musl-release-cli-2026-03-28T01:56:44.129Z | 0 / 1062 (0.00%) | Separate musl family |
| Linux CLI (arm64-musl) | ccache-linux-musl-release-cli-2026-03-28T01:56:44.129Z | 641 / 1062 (60.36%) | Same musl key family across archs |

This reduced the effect of ccache significantly:
- `linux-release` reused a ccache file from `linux-release-cli` and the different build configuration resulted in zero ccache hits.
- mixing architectures and libc's results in a low (~60%) or zero hit rate.

By overriding the ccache key explicitly, we avoid re-using caches from different architectures/libc/CI jobs for those CI jobs.