### PR TITLE
[Fuzzer] Fix `is_histogram_other_bin` null handling

### DIFF
--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -282,7 +282,6 @@ void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector
 	auto v = OtherBucketValue(input_type);
 	Vector ref(v);
 	VectorOperations::NotDistinctFrom(args.data[0], ref, result, count);
-	auto column_count = args.ColumnCount();
 
 	ValidityMask combined_mask(count);
 	CombineMasks(args, combined_mask);

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -293,6 +293,9 @@ void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector
 			validity_mask.SetInvalid(i);
 		}
 	}
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
 }
 
 template <class OP, class T>

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -257,15 +257,43 @@ Value OtherBucketValue(const LogicalType &type) {
 	}
 }
 
+static void CombineMasks(DataChunk &args, ValidityMask &result) {
+	auto count = args.size();
+	for (auto &arg : args.data) {
+		UnifiedVectorFormat arg_data;
+		arg.ToUnifiedFormat(count, arg_data);
+
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = arg_data.sel->get_index(i);
+			if (!arg_data.validity.RowIsValid(idx)) {
+				result.SetInvalid(i);
+			}
+		}
+	}
+}
+
 void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &input_type = args.data[0].GetType();
 	if (!SupportsOtherBucket(input_type)) {
 		result.Reference(Value::BOOLEAN(false));
 		return;
 	}
+	auto count = args.size();
 	auto v = OtherBucketValue(input_type);
 	Vector ref(v);
-	VectorOperations::NotDistinctFrom(args.data[0], ref, result, args.size());
+	VectorOperations::NotDistinctFrom(args.data[0], ref, result, count);
+	auto column_count = args.ColumnCount();
+
+	ValidityMask combined_mask(count);
+	CombineMasks(args, combined_mask);
+
+	result.Flatten(count);
+	auto &validity_mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		if (!combined_mask.RowIsValid(i)) {
+			validity_mask.SetInvalid(i);
+		}
+	}
 }
 
 template <class OP, class T>

--- a/test/sql/aggregate/aggregates/histogram_null_handling.test
+++ b/test/sql/aggregate/aggregates/histogram_null_handling.test
@@ -1,0 +1,66 @@
+# name: test/sql/aggregate/aggregates/histogram_null_handling.test
+# group: [aggregates]
+
+statement ok
+create table all_types as select * exclude(
+	small_enum,
+	medium_enum,
+	large_enum
+) from test_all_types();
+
+query I
+SELECT NULL FROM all_types AS t53(
+	c1,
+	c2,
+	c3,
+	c4,
+	c5,
+	c6,
+	c7,
+	c8,
+	c9,
+	c10,
+	c11,
+	c12,
+	c13,
+	c14,
+	c15,
+	c16,
+	c17,
+	c18,
+	c19,
+	c20,
+	c21,
+	c22,
+	c23,
+	c24,
+	c25,
+	c26,
+	c27,
+	c28,
+	c29,
+	c30,
+	c31,
+	c32,
+	c33,
+	c34,
+	c35,
+	c36,
+	c37,
+	c38,
+	c39,
+	c40,
+	c41,
+	c42,
+	c43,
+	c44,
+	c45,
+	c46,
+	c47,
+	c48,
+	c49,
+	c50,
+	c51,
+	c52
+) WHERE is_histogram_other_bin(c16)
+----


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/8582

Null handling is by default NULL IN == NULL OUT, `is_histogram_other_bin` wasn't respecting this and outputting non-null results for input rows that contain null values.

EDIT:
The other solution would be to change the null handling to special, so it's allowed to return non-null rows for null inputs