### PR TITLE
feat: add Windows ARM64 static libs job to BundleStaticLibs.yml

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -179,6 +179,81 @@ jobs:
           path: |
             static-libs-windows-mingw.zip
 
+  bundle-windows-arm64-static-libs:
+    name: Windows ARM64 static libs
+    runs-on: ubuntu-latest
+    env:
+      EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
+      ENABLE_EXTENSION_AUTOLOADING: 1
+      ENABLE_EXTENSION_AUTOINSTALL: 1
+      GEN: ninja
+      DUCKDB_PLATFORM: windows_arm64
+      # llvm-mingw version providing aarch64-w64-mingw32 cross-toolchain
+      LLVM_MINGW_VERSION: "20240619"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build make zip ccache
+
+      - name: Install llvm-mingw (ARM64 Windows cross-toolchain)
+        shell: bash
+        run: |
+          TARBALL="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-20.04-x86_64.tar.xz"
+          curl -fsSL -o /tmp/llvm-mingw.tar.xz \
+            "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${TARBALL}"
+          sudo tar -xf /tmp/llvm-mingw.tar.xz -C /opt
+          echo "/opt/llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-20.04-x86_64/bin" >> "${GITHUB_PATH}"
+
+      - uses: ./.github/actions/ccache-action
+
+      - name: Build Environment Check
+        shell: bash
+        run: |
+          aarch64-w64-mingw32-clang++ --version
+          aarch64-w64-mingw32-ar --version
+          ninja --version
+
+      - name: Bundle static library
+        shell: bash
+        env:
+          CC: aarch64-w64-mingw32-clang
+          CXX: aarch64-w64-mingw32-clang++
+          AR: aarch64-w64-mingw32-ar
+          RANLIB: aarch64-w64-mingw32-ranlib
+          WINDRES: aarch64-w64-mingw32-windres
+        run: |
+          make gather-libs \
+            DUCKDB_EXPLICIT_PLATFORM=windows_arm64 \
+            DUCKDB_CUSTOM_PLATFORM=windows_arm64
+
+      - name: Deploy
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        run: |
+          python3 scripts/amalgamation.py
+          zip -r -j static-libs-windows-arm64.zip src/include/duckdb.h build/release/libs/
+          ./scripts/upload-assets-to-staging.sh github_release static-libs-windows-arm64.zip
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: duckdb-static-libs-windows-arm64
+          path: |
+            static-libs-windows-arm64.zip
+
   bundle-linux-static-libs:
     strategy:
       fail-fast: false
@@ -211,7 +286,7 @@ jobs:
           bash -c "
             set -e
             yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
-            
+
             source /opt/rh/gcc-toolset-12/enable
             export CC=gcc
             export CXX=g++


### PR DESCRIPTION
## Summary

Adds a `bundle-windows-arm64-static-libs` job to produce `static-libs-windows-arm64.zip`, the last missing platform in the static libs release matrix.

Closes #21726

## Why this is needed

`duckdb-go-bindings` (and any CGo-based consumer) requires pre-built static `.a` libraries per platform. All platforms except Windows ARM64 are already covered:

| Asset | Before | After |
|-------|--------|-------|
| `static-libs-linux-amd64.zip` | ✅ | ✅ |
| `static-libs-linux-arm64.zip` | ✅ | ✅ |
| `static-libs-osx-amd64.zip` | ✅ | ✅ |
| `static-libs-osx-arm64.zip` | ✅ | ✅ |
| `static-libs-windows-mingw.zip` | ✅ | ✅ |
| `static-libs-windows-arm64.zip` | ❌ | ✅ |

Tracked in duckdb/duckdb-go-bindings#18.

## Approach

**CGo requires `.a` files (GCC/MinGW format)** — MSVC cross-compilation produces `.lib` files which are incompatible with CGo. The existing `win-release-arm64` job in `Windows.yml` uses MSVC and is suitable for the CLI/shared lib, but not for static libs consumed by CGo.

[`llvm-mingw`](https://github.com/mstorsjo/llvm-mingw) provides an `aarch64-w64-mingw32` cross-toolchain that produces ARM64 Windows `.a` files with MinGW-compatible output. The job runs on `ubuntu-latest` and cross-compiles using:

```
CC=aarch64-w64-mingw32-clang
CXX=aarch64-w64-mingw32-clang++
AR=aarch64-w64-mingw32-ar
```

Then calls the existing `make gather-libs` target (same as the MinGW job) with `DUCKDB_EXPLICIT_PLATFORM=windows_arm64`.

## Notes

- The `llvm-mingw` tarball version (`LLVM_MINGW_VERSION`) is pinned and can be updated as needed
- The `gather-libs` Makefile target is reused unchanged — only the toolchain differs
- No changes to any other jobs