### PR TITLE
Allow `SET DEFAULT / DROP DEFAULT` for tables that have dependencies

### DIFF
--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -647,7 +647,8 @@ void DependencyManager::AlterObject(CatalogTransaction transaction, CatalogEntry
 				disallow_alter = false;
 				break;
 			}
-			case AlterTableType::ADD_COLUMN: {
+			case AlterTableType::ADD_COLUMN:
+			case AlterTableType::SET_DEFAULT: {
 				disallow_alter = false;
 				break;
 			}

--- a/test/sql/catalog/dependencies/set_default_of_table_column_referenced_by_index.test
+++ b/test/sql/catalog/dependencies/set_default_of_table_column_referenced_by_index.test
@@ -10,8 +10,17 @@ create table tbl(a varchar, b integer);
 statement ok
 create index idx on tbl(a);
 
-statement error
+statement ok
 alter table tbl alter a set default 'test';
+
+statement ok
+insert into tbl(b) values (1);
+
+query II
+select a, b from tbl;
 ----
-Dependency Error: Cannot alter entry "tbl" because there are entries that depend on it.
+test	1
+
+statement ok
+alter table tbl alter a drop default;
 


### PR DESCRIPTION
Certain ALTER operations are currently blocked for tables that have dependencies - as we don't have code to correctly deal with downstream effects, e.g. if we drop a column that an index is referring to. However, `SET DEFAULT / DROP DEFAULT` make no such changes to the table that can influence downstream dependent catalog entries, so we can just allow them.