### PR TITLE
Ignore `NULL`/`__HIVE_DEFAULT_PARTITION__` when detecting types

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -88,6 +88,10 @@ string HivePartitioning::Unescape(const string &input) {
 	return StringUtil::URLDecode(input);
 }
 
+bool HivePartitioning::IsNull(const string &input) {
+	return StringUtil::CIEquals(input, "NULL") || input == "__HIVE_DEFAULT_PARTITION__";
+}
+
 // matches hive partitions in file name. For example:
 // 	- s3://bucket/var1=value1/bla/bla/var2=value2
 //  - http(s)://domain(:port)/lala/kasdl/var1=value1/?not-a-var=not-a-value
@@ -126,7 +130,7 @@ std::map<string, string> HivePartitioning::Parse(const string &filename) {
 Value HivePartitioning::GetValue(ClientContext &context, const string &key, const string &str_val,
                                  const LogicalType &type) {
 	// Handle nulls
-	if (StringUtil::CIEquals(str_val, "NULL") || str_val == "__HIVE_DEFAULT_PARTITION__") {
+	if (IsNull(str_val)) {
 		return Value(type);
 	}
 	if (type.id() == LogicalTypeId::VARCHAR) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -717,6 +717,9 @@ void MultiFileOptions::AutoDetectHiveTypesInternal(MultiFileList &files, ClientC
 				// type was explicitly provided by the user
 				continue;
 			}
+			if (HivePartitioning::IsNull(part.second)) {
+				continue; // don't update detected_types for this partition/file
+			}
 			LogicalType detected_type = LogicalType::VARCHAR;
 			Value value(part.second);
 			for (auto &candidate : candidates) {

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -46,6 +46,8 @@ public:
 	DUCKDB_API static string Escape(const string &input);
 	//! Unescape a hive partition key or value encoded using URL encoding
 	DUCKDB_API static string Unescape(const string &input);
+	//! Whether the column is "NULL"/"__HIVE_DEFAULT_PARTITION"
+	DUCKDB_API static bool IsNull(const string &input);
 };
 
 struct HivePartitionKey {

--- a/test/sql/copy/hive_types.test_slow
+++ b/test/sql/copy/hive_types.test_slow
@@ -129,3 +129,11 @@ query II
 explain from parquet_scan('{TEMP_DIR}/partition-written/**/*.parquet', HIVE_PARTITIONING=0, HIVE_TYPES_AUTOCAST=0) where aired < '2006-1-1';
 ----
 physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*aired.*
+
+statement ok
+copy (from values (42, 42), (null, null) tbl(i, j)) to '{TEMP_DIR}/hive_null' (format parquet, partition_by (i));
+
+query I
+select typeof(i) from read_parquet('{TEMP_DIR}/hive_null/**/*.parquet', hive_partitioning=1) limit 1
+----
+BIGINT


### PR DESCRIPTION
Otherwise we default to `VARCHAR`