### PR TITLE
Improve some CI jobs

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -232,14 +232,14 @@ runs:
       run: |
         rm -rf build/extension_tmp
         mv build/release/extension build/extension_tmp
-        choco install wget -y --no-progress
+        python scripts/ci/retry.py -- choco install wget -y --no-progress
         cd  ${{ inputs.build_dir }}
         TEST_RUNNER_DIR=./build/release/test/Release
         if [ ! -f ${TEST_RUNNER_DIR}/unittest.exe ]; then
           echo "Invalid unit tests runner dir: ${TEST_RUNNER_DIR}, check 'inputs.unittest_script' argument"
           exit 1
         fi
-        wget -P ${TEST_RUNNER_DIR} https://blobs.duckdb.org/ci/msvcp140.dll
+        python scripts/ci/retry.py -- wget -P ${TEST_RUNNER_DIR} https://blobs.duckdb.org/ci/msvcp140.dll
         ls ${TEST_RUNNER_DIR}
         # test.list is generated on the previous step
         ${{ inputs.unittest_script }} '-f test.list'

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install Android NDK
       shell: bash
       run: |
-        wget https://dl.google.com/android/repository/android-ndk-r27-linux.zip
+        python3 scripts/ci/retry.py -- wget https://dl.google.com/android/repository/android-ndk-r27-linux.zip
         unzip android-ndk-r27-linux.zip
         mv android-ndk-r27 android-ndk
 

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ninja
-        run: brew install ninja
+        run: python3 scripts/ci/retry.py -- brew install ninja
 
       - uses: ./.github/actions/ccache-action
 
@@ -119,13 +119,13 @@ jobs:
       - name: Dependencies
         shell: bash
         run: |
-          choco install \
+          python scripts/ci/retry.py -- choco install \
             ccache \
             make \
             ninja \
             zip \
             --no-progress
-          choco install \
+          python scripts/ci/retry.py -- choco install \
             mingw --version 14.2.0 \
             --no-progress
 

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ninja
-        run: brew install ninja file
+        run: python3 scripts/ci/retry.py -- brew install ninja file
 
       - name: Build
         shell: bash
@@ -104,7 +104,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ninja
-        run: brew install ninja
+        run: python3 scripts/ci/retry.py -- brew install ninja
 
       - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -84,7 +84,9 @@ jobs:
 
      - name: Install
        shell: bash
-       run: brew install ninja llvm && pip install requests
+       run: |
+         python3 scripts/ci/retry.py -- brew install ninja llvm
+         python3 scripts/ci/retry.py -- pip install requests
 
      - uses: ./.github/actions/ccache-action
 
@@ -160,7 +162,9 @@ jobs:
 
      - name: Install
        shell: bash
-       run: brew install ninja llvm && pip install requests
+       run: |
+         python3 scripts/ci/retry.py -- brew install ninja llvm
+         python3 scripts/ci/retry.py -- pip install requests
 
      - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -330,7 +330,7 @@ jobs:
           DUCKDB_DEPLOY_SCRIPT_MODE: for_real
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
-          pip install --break-system-packages awscli
+          python3 scripts/ci/retry.py -- pip install --break-system-packages awscli
           make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/extension-repository
 
   autoload-tests:
@@ -435,9 +435,7 @@ jobs:
         run: |
           make extension_configuration
           python scripts/generate_extensions_function.py
-          pip install "black>=24"
-          pip install cmake-format
-          pip install "clang_format==11.0.1"
+          python3 scripts/ci/retry.py -- pip install "black>=24" cmake-format "clang_format==11.0.1"
           make format-fix
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -51,18 +51,18 @@ jobs:
       (github.event.action != 'synchronize' || github.event.pull_request.user.login == 'smvv')
     runs-on: ${{ github.repository == 'duckdb/duckdb' && 'namespace-profile-linux-small' || 'ubuntu-latest' }}
     outputs:
-      runner_linux_small: ${{ steps.select_runner.outputs.runner_linux_small }}
-      runner_linux_x64: ${{ steps.select_runner.outputs.runner_linux_x64 }}
-      runner_linux_22_x64: ${{ steps.select_runner.outputs.runner_linux_22_x64 }}
-      runner_linux_arm64: ${{ steps.select_runner.outputs.runner_linux_arm64 }}
-      runner_windows_2022_x64: ${{ steps.select_runner.outputs.runner_windows_2022_x64 }}
-      runner_macos_arm64: ${{ steps.select_runner.outputs.runner_macos_arm64 }}
-      runner_macos_14_arm64: ${{ steps.select_runner.outputs.runner_macos_14_arm64 }}
-      runners: ${{ steps.build_runners.outputs.runners }}
-      linux_cli_matrix: ${{ steps.build_linux_cli_matrices.outputs.linux_cli_matrix }}
-      linux_musl_cli_matrix: ${{ steps.build_linux_cli_matrices.outputs.linux_musl_cli_matrix }}
+      runner_linux_small: ${{ steps.config.outputs.runner_linux_small }}
+      runner_linux_x64: ${{ steps.config.outputs.runner_linux_x64 }}
+      runner_linux_22_x64: ${{ steps.config.outputs.runner_linux_22_x64 }}
+      runner_linux_arm64: ${{ steps.config.outputs.runner_linux_arm64 }}
+      runner_windows_2022_x64: ${{ steps.config.outputs.runner_windows_2022_x64 }}
+      runner_macos_arm64: ${{ steps.config.outputs.runner_macos_arm64 }}
+      runner_macos_14_arm64: ${{ steps.config.outputs.runner_macos_14_arm64 }}
+      runners: ${{ steps.config.outputs.runners }}
+      linux_cli_matrix: ${{ steps.config.outputs.linux_cli_matrix }}
+      linux_musl_cli_matrix: ${{ steps.config.outputs.linux_musl_cli_matrix }}
       extensions_changed: ${{ steps.changed.outputs.extensions_any_changed }}
-      extensions_extra_exclude_archs: ${{ steps.extensions.outputs.extra_exclude_archs }}
+      extensions_extra_exclude_archs: ${{ steps.config.outputs.extra_exclude_archs }}
     env:
       CC: gcc-10
       CXX: g++-10
@@ -109,107 +109,107 @@ jobs:
           ./actionlint -color
         shell: bash
 
-      - name: Configure extensions
-        id: extensions
+      - name: Configure CI
+        id: config
         run: |
           if [[ "${{ github.event_name }}" != "pull_request" || "${{ steps.changed.outputs.extensions_any_changed }}" == "true" ]]; then
-            echo "extra_exclude_archs=" >> "$GITHUB_OUTPUT"
+            extra_exclude_archs=
           else
-            echo "extra_exclude_archs=windows_amd64;wasm_eh" >> "$GITHUB_OUTPUT"
+            extra_exclude_archs=windows_amd64\;wasm_eh
           fi
 
-      - name: Select CI runner
-        id: select_runner
-        run: |
+          echo "extra_exclude_archs=$extra_exclude_archs" >> "$GITHUB_OUTPUT"
+
           # Fall back to GitHub-native runners for forks.
           if [[ "${{ github.repository }}" == "duckdb/duckdb" ]]; then
-            {
-              echo "runner_linux_small=namespace-profile-linux-small"
-              echo "runner_linux_x64=namespace-profile-linux-x64"
-              echo "runner_linux_22_x64=namespace-profile-linux-22-x64"
-              echo "runner_linux_arm64=namespace-profile-linux-arm64"
-              echo "runner_windows_2022_x64=namespace-profile-windows-x64"
-              echo "runner_macos_arm64=namespace-profile-macos-arm64"
-              echo "runner_macos_14_arm64=namespace-profile-macos-14-arm64"
-            } >> "$GITHUB_OUTPUT"
+            runner_linux_small=namespace-profile-linux-small
+            runner_linux_x64=namespace-profile-linux-x64
+            runner_linux_22_x64=namespace-profile-linux-22-x64
+            runner_linux_arm64=namespace-profile-linux-arm64
+            runner_windows_2022_x64=namespace-profile-windows-x64
+            runner_macos_arm64=namespace-profile-macos-arm64
+            runner_macos_14_arm64=namespace-profile-macos-14-arm64
           else
-            {
-              echo "runner_linux_small=ubuntu-latest"
-              echo "runner_linux_x64=ubuntu-latest"
-              echo "runner_linux_22_x64=ubuntu-22.04"
-              echo "runner_linux_arm64=ubuntu-24.04-arm"
-              echo "runner_windows_2022_x64=windows-2022"
-              echo "runner_macos_arm64=macos-14"
-              echo "runner_macos_14_arm64=macos-14"
-            } >> "$GITHUB_OUTPUT"
+            runner_linux_small=ubuntu-latest
+            runner_linux_x64=ubuntu-latest
+            runner_linux_22_x64=ubuntu-22.04
+            runner_linux_arm64=ubuntu-24.04-arm
+            runner_windows_2022_x64=windows-2022
+            runner_macos_arm64=macos-14
+            runner_macos_14_arm64=macos-14
           fi
 
-          grep runner_ "$GITHUB_OUTPUT"
+          {
+            echo "runner_linux_small=$runner_linux_small"
+            echo "runner_linux_x64=$runner_linux_x64"
+            echo "runner_linux_22_x64=$runner_linux_22_x64"
+            echo "runner_linux_arm64=$runner_linux_arm64"
+            echo "runner_windows_2022_x64=$runner_windows_2022_x64"
+            echo "runner_macos_arm64=$runner_macos_arm64"
+            echo "runner_macos_14_arm64=$runner_macos_14_arm64"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Build runners JSON
-        id: build_runners
-        run: |
           {
             echo "runners<<EOF"
             cat <<EOF
           {
-            "linux_x64": "${{ steps.select_runner.outputs.runner_linux_x64 }}",
-            "linux_22_x64": "${{ steps.select_runner.outputs.runner_linux_22_x64 }}",
-            "linux_arm64": "${{ steps.select_runner.outputs.runner_linux_arm64 }}",
-            "windows_2022_x64": "${{ steps.select_runner.outputs.runner_windows_2022_x64 }}",
-            "windows_x64": "${{ steps.select_runner.outputs.runner_windows_2022_x64 }}",
-            "macos_arm64": "${{ steps.select_runner.outputs.runner_macos_arm64 }}",
-            "macos_14_arm64": "${{ steps.select_runner.outputs.runner_macos_14_arm64 }}"
+            "linux_x64": "$runner_linux_x64",
+            "linux_22_x64": "$runner_linux_22_x64",
+            "linux_arm64": "$runner_linux_arm64",
+            "windows_2022_x64": "$runner_windows_2022_x64",
+            "windows_x64": "$runner_windows_2022_x64",
+            "macos_arm64": "$runner_macos_arm64",
+            "macos_14_arm64": "$runner_macos_14_arm64"
           }
           EOF
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build Linux CLI matrices
-        id: build_linux_cli_matrices
-        run: |
           linux_cli_matrix=$(
-            jq -nc --arg runner "${{ steps.select_runner.outputs.runner_linux_x64 }}" \
+            jq -nc --arg runner "$runner_linux_x64" \
               '[{runner: $runner, arch: "amd64", image: "x86_64"}]'
           )
 
           linux_musl_cli_matrix=$(
-            jq -nc --arg runner "${{ steps.select_runner.outputs.runner_linux_arm64 }}" \
+            jq -nc --arg runner "$runner_linux_arm64" \
               '[{runner: $runner, arch: "arm64"}]'
           )
 
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             linux_cli_matrix=$(
-              jq -c --arg runner "${{ steps.select_runner.outputs.runner_linux_arm64 }}" \
+              jq -c --arg runner "$runner_linux_arm64" \
                 '. += [{runner: $runner, arch: "arm64", image: "aarch64"}]' <<<"$linux_cli_matrix"
             )
 
             linux_musl_cli_matrix=$(
-              jq -c --arg runner "${{ steps.select_runner.outputs.runner_linux_x64 }}" \
+              jq -c --arg runner "$runner_linux_x64" \
                 '. |= [{runner: $runner, arch: "amd64"}] + .' <<<"$linux_musl_cli_matrix"
             )
           fi
 
+          grep -E '^(extra_exclude_archs|runner_)' "$GITHUB_OUTPUT"
           echo "linux_cli_matrix=$linux_cli_matrix" >> "$GITHUB_OUTPUT"
           echo "linux_musl_cli_matrix=$linux_musl_cli_matrix" >> "$GITHUB_OUTPUT"
 
       - name: Install tools
-        run: make format_tools
-
-      - name: List Installed Packages
-        run: pip3 freeze
+        run: |
+          make format_tools
+          echo "::group::Installed Python packages"
+          pip3 freeze
+          echo "::endgroup::"
 
       - name: Check format
         run: |
+          echo "::group::Formatter versions and config"
           clang-format --version
           clang-format --dump-config
           black --version
+          echo "::endgroup::"
           make format-check-silent enum-integrity-check
-
-      - name: Check generated files
-        run: |
+          echo "::group::Check generated files"
           make generate-files
           git diff --exit-code
+          echo "::endgroup::"
 
       - name: Test CI scripts
         run: make test_ci

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -100,13 +100,18 @@ jobs:
               - .github/patches/**
               - extensions/**
 
-      - name: Check workflow files
+      - name: Check CI
         if: steps.changed.outputs.github_any_changed == 'true'
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
+          echo "::group::ShellCheck version"
           shellcheck --version
+          echo "::endgroup::"
+          echo "::group::Install actionlint"
           bash <(curl --retry 5 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          echo "::endgroup::"
           ./actionlint -color
+          make test_ci
         shell: bash
 
       - name: Configure CI
@@ -210,9 +215,6 @@ jobs:
           make generate-files
           git diff --exit-code
           echo "::endgroup::"
-
-      - name: Test CI scripts
-        run: make test_ci
 
  linux-debug:
     name: Linux Debug

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -543,11 +543,8 @@ jobs:
           duckdb_cli-linux-${{ matrix.config.arch }}.zip
           duckdb_cli-linux-${{ matrix.config.arch }}.gz
 
-    - name: Test
-      run: make allunit
-
-    - name: Release specific tests
-      run: make unittest_release_tag
+    - name: Release tests
+      run: make alltest_release_tag
 
     - name: Tools Tests
       run: python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
@@ -645,10 +642,8 @@ jobs:
             python3    \
             py3-pytest
           cd \"$PWD\"
-          echo Tests
-          make allunit
-          echo Release specific tests
-          make unittest_release_tag
+          echo Release tests
+          make alltest_release_tag
           echo Tools Tests
           python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
           echo Examples

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -139,7 +139,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install Ninja
-      run: brew install ninja
+      run: python3 scripts/ci/retry.py -- brew install ninja
 
     - uses: ./.github/actions/ccache-action
 
@@ -338,7 +338,7 @@ jobs:
 
       - name: Install
         shell: bash
-        run: pip install awscli
+        run: python3 scripts/ci/retry.py -- pip install awscli
 
       - uses: ./.github/actions/ccache-action
 
@@ -747,7 +747,7 @@ jobs:
         run: chmod +x build/release/duckdb
 
       - name: Install Python dependencies
-        run: pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
+        run: python3 scripts/ci/retry.py -- pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
 
       - name: Download BWC cache
         if: ${{ vars.ENABLE_BWC_CACHE_DOWNLOAD == 'true' }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Install ninja
       shell: bash
-      run: brew install ninja
+      run: python3 scripts/ci/retry.py -- brew install ninja
 
     - uses: ./.github/actions/cleanup_runner
 
@@ -122,13 +122,13 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ninja
-        run: brew install ninja
+        run: python3 scripts/ci/retry.py -- brew install ninja
 
       - uses: ./.github/actions/ccache-action
 
       - name: Install pytest
         run: |
-          python -m pip install pytest
+          python3 scripts/ci/retry.py -- python -m pip install pytest
 
       - name: Build
         shell: bash

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -112,7 +112,7 @@ jobs:
             benchmarks: .github/regression/realnest.csv
             data_setup: |
               mkdir -p duckdb_benchmark_data
-              wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
+              python3 scripts/ci/retry.py -- wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -24,7 +24,7 @@ jobs:
 
      - name: Install
        shell: bash
-       run: pip install awscli
+       run: python3 scripts/ci/retry.py -- pip install awscli
 
      - name: Download from staging bucket
        shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -311,7 +311,7 @@ jobs:
            ./build/release/test/unittest.exe --list-tests || true
 
        - name: Build
-         run: make release
+         run: python scripts/ci/retry.py -- make release
 
        - name: Test
          run: make unittest_release SKIP_BUILD=1

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -79,8 +79,8 @@ jobs:
       shell: bash
       if: ${{ !inputs.skip_tests }}
       run: |
-        choco install wget -y --no-progress
-        wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
+        python scripts/ci/retry.py -- choco install wget -y --no-progress
+        python scripts/ci/retry.py -- wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
         ls ./test/Release
         python scripts/ci/run_tests.py test/Release/unittest.exe
         rm ./test/Release/msvcp140.dll
@@ -89,7 +89,7 @@ jobs:
       shell: bash
       if: ${{ !inputs.skip_tests }}
       run: |
-        python -m pip install pytest
+        python scripts/ci/retry.py -- python -m pip install pytest
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
 
     - name: Sign files with Azure Trusted Signing (TM)
@@ -165,7 +165,7 @@ jobs:
     - name: Tools Test
       shell: bash
       run: |
-        python -m pip install pytest
+        python scripts/ci/retry.py -- python -m pip install pytest
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
 
  win-release-arm64:
@@ -252,12 +252,12 @@ jobs:
        - name: Dependencies
          shell: bash
          run: |
-           choco install \
+           python scripts/ci/retry.py -- choco install \
              ccache \
              make \
              ninja \
              --no-progress
-           choco install \
+           python scripts/ci/retry.py -- choco install \
              mingw --version 14.2.0 \
              --no-progress
 

--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: make debug_python
 
       - name: Install Python test dependencies
-        run: python -m pip install --upgrade pytest
+        run: python scripts/ci/retry.py -- python -m pip install --upgrade pytest
 
       - name: Run Python client tests
         run: |

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -179,5 +179,5 @@ jobs:
           DUCKDB_DEPLOY_SCRIPT_MODE: for_real
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
-          pip install awscli
+          python3 scripts/ci/retry.py -- pip install awscli
           make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/extension-repository-${{ inputs.duckdb_ref }} EXTENSION_BUCKET=duckdb-staging

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Download and extract the Coverity Build Tool
       run: |
-          wget https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${{ env.COVERITY_PROJECT_NAME  }}" -O cov-analysis-linux64.tar.gz
+          python3 scripts/ci/retry.py -- wget https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${{ env.COVERITY_PROJECT_NAME  }}" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -438,8 +438,8 @@ endif
 unittest_release:
 	$(PYTHON) scripts/ci/run_tests.py build/release/$(UNITTEST_BINARY) $(T)
 
-unittest_release_tag:
-	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/$(UNITTEST_BINARY) $(T)
+alltest_release_tag:
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/$(UNITTEST_BINARY) '*' $(T)
 
 unittest_relassert:
 	$(PYTHON) scripts/ci/run_tests.py build/relassert/$(UNITTEST_BINARY) $(T)

--- a/scripts/ci/retry.py
+++ b/scripts/ci/retry.py
@@ -44,6 +44,12 @@ def format_command(command):
     return subprocess.list2cmdline(command) if os.name == "nt" else " ".join(command)
 
 
+def run_command(command, command_text, timeout):
+    if os.name == "nt":
+        return subprocess.run(command_text, timeout=timeout, shell=True)
+    return subprocess.run(command, timeout=timeout)
+
+
 def main() -> int:
     args = parse_args()
     attempts = args.retries + 1
@@ -51,12 +57,18 @@ def main() -> int:
 
     for attempt in range(1, attempts + 1):
         try:
-            completed = subprocess.run(args.command, timeout=args.timeout)
+            completed = run_command(args.command, command_text, args.timeout)
             exit_code = completed.returncode
         except subprocess.TimeoutExpired:
             exit_code = 124
             print(
                 f"[retry] attempt {attempt}/{attempts} timed out after {args.timeout} sec",
+                flush=True,
+            )
+        except OSError as exc:
+            exit_code = 127
+            print(
+                f"[retry] attempt {attempt}/{attempts} could not start command: {exc}",
                 flush=True,
             )
 


### PR DESCRIPTION
### Run all tests including release tag once

Linux CLI jobs are running `Tests` and `Release specific tests`:

```
Tests
python3 scripts/ci/run_tests.py --workers=50% build/release/test/unittest '*'
CI detected, enabling retry=2 per batch
generated test list using: build/release/test/unittest --list-tests '*'
found 5433 tests
config: patterns=['*'], workers=8, retry=2, max_retries=4, batch_size=10, batch_timeout_seconds=600
.................................................. [ 50%]
.................................................. [100%]
all tests passed in 1841s
Release specific tests
python3 scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/test/unittest
CI detected, enabling retry=2 per batch
generated test list using: ./build/release/test/unittest --select-tag release --list-tests
found 4529 tests
config: test_flags=--select-tag release, workers=12, retry=2, max_retries=4, batch_size=10, batch_timeout_seconds=600
.................................................. [ 50%]
.................................................. [100%]
all tests passed in 50s
```

The difference:
- The first `Tests` matches `*` and thus includes slow tests.
- The second `Release specific tests` uses the default list, excludes slow tests and includes tests with a release tag.

However, when printing the test names:
```shell
build/release/test/unittest --list-tests > default.txt
build/release/test/unittest --list-tests --select-tag release > release.txt
build/release/test/unittest --list-tests '*' > star.txt
build/release/test/unittest --list-tests --select-tag release '*' > both.txt
```
I saw that:
- `default.txt` and `release.txt` are the same.`
- `both.txt` and `star.txt` are the same.

So, we can run take all tests and (defensively) add `--select-tag release` to run all relevant tests in one test runner process.

### Make job `prepare` easier to read

- Merged `List Installed Packages` into `Install tools`
- Merged `Check generated files` into `Check format`
- Added log groups to make CI output easier to read
- Updated job outputs to use `steps.config.outputs.*`

### Retry more commands

Use fine-grained retry script for more install commands (choco, brew, wget, etc) to reduce CI failures caused by network [flakes](https://github.com/duckdb/duckdb/actions/runs/23796674228/job/69349534543#step:4:30).

Also, retry `make release` which could [fail](https://github.com/duckdb/duckdb/actions/runs/23799469809/job/69359393295?pr=21736#step:9:169) for MinGW.