### PR TITLE
Add call to SetEstimatedCardinality in more physical operators

### DIFF
--- a/src/execution/operator/aggregate/physical_partitioned_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_partitioned_aggregate.cpp
@@ -222,6 +222,7 @@ InsertionOrderPreservingMap<string> PhysicalPartitionedAggregate::ParamsToString
 		}
 	}
 	result["Aggregates"] = aggregate_info;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
@@ -225,6 +225,7 @@ InsertionOrderPreservingMap<string> PhysicalPerfectHashAggregate::ParamsToString
 		}
 	}
 	result["Aggregates"] = aggregate_info;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -760,6 +760,7 @@ InsertionOrderPreservingMap<string> PhysicalStreamingWindow::ParamsToString() co
 		projections += select_list[i]->GetName();
 	}
 	result["Projections"] = projections;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -683,6 +683,7 @@ InsertionOrderPreservingMap<string> PhysicalUngroupedAggregate::ParamsToString()
 		}
 	}
 	result["Aggregates"] = aggregate_info;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -1149,6 +1149,7 @@ InsertionOrderPreservingMap<string> PhysicalWindow::ParamsToString() const {
 		projections += select_list[i]->GetName();
 	}
 	result["Projections"] = projections;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -257,6 +257,7 @@ InsertionOrderPreservingMap<string> PhysicalLimit::ParamsToString() const {
 			result["Offset"] = to_string(offset);
 		}
 	}
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_limit_percent.cpp
+++ b/src/execution/operator/helper/physical_limit_percent.cpp
@@ -175,6 +175,7 @@ InsertionOrderPreservingMap<string> PhysicalLimitPercent::ParamsToString() const
 			result["Offset"] = to_string(offset);
 		}
 	}
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_reservoir_sample.cpp
+++ b/src/execution/operator/helper/physical_reservoir_sample.cpp
@@ -98,6 +98,7 @@ SourceResultType PhysicalReservoirSample::GetDataInternal(ExecutionContext &cont
 InsertionOrderPreservingMap<string> PhysicalReservoirSample::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	result["Sample Size"] = options->sample_size.ToString() + (options->is_percentage ? "%" : " rows");
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -81,6 +81,7 @@ InsertionOrderPreservingMap<string> PhysicalStreamingLimit::ParamsToString() con
 			result["Offset"] = to_string(offset);
 		}
 	}
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -82,6 +82,7 @@ OperatorResultType PhysicalStreamingSample::Execute(ExecutionContext &context, D
 InsertionOrderPreservingMap<string> PhysicalStreamingSample::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	result["Sample Method"] = EnumUtil::ToString(sample_options->method) + ": " + to_string(100 * percentage) + "%";
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -217,6 +217,7 @@ InsertionOrderPreservingMap<string> PhysicalBlockwiseNLJoin::ParamsToString() co
 	InsertionOrderPreservingMap<string> result;
 	result["Join Type"] = EnumUtil::ToString(join_type);
 	result["Condition"] = condition->GetName();
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -26,6 +26,7 @@ vector<const_reference<PhysicalOperator>> PhysicalDelimJoin::GetChildren() const
 InsertionOrderPreservingMap<string> PhysicalDelimJoin::ParamsToString() const {
 	auto result = join.ParamsToString();
 	result["Delim Index"] = StringUtil::Format("%llu", delim_idx.GetIndex());
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -149,6 +149,7 @@ InsertionOrderPreservingMap<string> PhysicalOrder::ParamsToString() const {
 		orders_info += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
 	}
 	result["__order_by__"] = orders_info;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -629,6 +629,7 @@ InsertionOrderPreservingMap<string> PhysicalTopN::ParamsToString() const {
 		orders_info += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
 	}
 	result["Order By"] = orders_info;
+	SetEstimatedCardinality(result, estimated_cardinality);
 	return result;
 }
 


### PR DESCRIPTION
A bunch of physical operators were missing a call to SetEstimatedCardinality() in their respective ParamsToString() functions