### PR TITLE
BoxRendererContext: make usage of BoxRenderer independent of ClientContext

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library_unity(
   assert.cpp
   bind_helpers.cpp
   box_renderer.cpp
+  box_renderer_context.cpp
+  client_box_renderer_context.cpp
   column_data_collection_render_interface.cpp
   cgroups.cpp
   column_index.cpp

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/box_renderer.hpp"
-#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -154,9 +154,9 @@ struct BoxRenderRow {
 };
 
 struct RenderDataCollection {
-	RenderDataCollection(ClientContext &context, idx_t column_count);
+	RenderDataCollection(BoxRendererContext &context, idx_t column_count);
 
-	ClientContext &context;
+	BoxRendererContext &context;
 	unique_ptr<ColumnDataCollection> render_values;
 
 public:
@@ -170,7 +170,7 @@ public:
 };
 
 struct BoxRendererImplementation : public BoxRendererState {
-	BoxRendererImplementation(BoxRendererConfig config, ClientContext &context, const vector<string> &names,
+	BoxRendererImplementation(BoxRendererConfig config, BoxRendererContext &context, const vector<string> &names,
 	                          const ColumnDataCollectionRenderInterface &result);
 
 public:
@@ -181,7 +181,7 @@ public:
 
 private:
 	BoxRendererConfig config;
-	ClientContext &context;
+	BoxRendererContext &context;
 	vector<string> column_names;
 	vector<LogicalType> result_types;
 	const ColumnDataCollectionRenderInterface &result;
@@ -247,7 +247,7 @@ private:
 	void HighlightValue(BoxRenderValue &render_value);
 };
 
-BoxRendererImplementation::BoxRendererImplementation(BoxRendererConfig config_p, ClientContext &context,
+BoxRendererImplementation::BoxRendererImplementation(BoxRendererConfig config_p, BoxRendererContext &context,
                                                      const vector<string> &names,
                                                      const ColumnDataCollectionRenderInterface &result)
     : config(std::move(config_p)), context(context), column_names(names), result(result) {
@@ -633,17 +633,17 @@ void BoxRendererImplementation::ConvertRenderVector(Vector &vector, Vector &rend
 	}
 }
 
-RenderDataCollection::RenderDataCollection(ClientContext &context, idx_t column_count) : context(context) {
+RenderDataCollection::RenderDataCollection(BoxRendererContext &context, idx_t column_count) : context(context) {
 	vector<LogicalType> render_value_types;
 	for (idx_t c = 0; c < column_count; c++) {
 		render_value_types.emplace_back(LogicalType::VARCHAR);
 		render_value_types.emplace_back(LogicalType::UBIGINT);
 	}
-	render_values = make_uniq<ColumnDataCollection>(context, render_value_types);
+	render_values = make_uniq<ColumnDataCollection>(context.GetAllocator(), render_value_types);
 }
 
 void RenderDataCollection::InitializeChunk(DataChunk &chunk) {
-	chunk.Initialize(context, render_values->Types());
+	chunk.Initialize(context.GetAllocator(), render_values->Types());
 }
 
 void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_collection,
@@ -652,7 +652,7 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 	auto column_count = result.ColumnCount();
 
 	DataChunk fetch_result;
-	fetch_result.Initialize(context, result.Types());
+	fetch_result.Initialize(context.GetAllocator(), result.Types());
 
 	DataChunk insert_result;
 	top_collection.InitializeChunk(insert_result);
@@ -676,7 +676,7 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 			auto &source_vector = fetch_result.data[c];
 			auto &target_vector = top_collection.Values(insert_result, c);
 			auto &render_lengths = top_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
+			context.CastToVarchar(source_vector, target_vector, insert_count);
 			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
 			                    null_render_length);
 		}
@@ -743,7 +743,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 	auto column_count = result.ColumnCount();
 
 	DataChunk fetch_result;
-	fetch_result.Initialize(context, result.Types());
+	fetch_result.Initialize(context.GetAllocator(), result.Types());
 
 	DataChunk insert_result;
 	bottom_collection.InitializeChunk(insert_result);
@@ -757,7 +757,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 	while (fetched_row_count < bottom_rows) {
 		// fetch the current chunk
 		auto fetch_chunk = make_uniq<DataChunk>();
-		fetch_chunk->Initialize(context, result.Types());
+		fetch_chunk->Initialize(context.GetAllocator(), result.Types());
 		result.FetchChunk(chunk_idx, *fetch_chunk);
 
 		fetched_row_count += fetch_chunk->size();
@@ -795,7 +795,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 			auto &source_vector = chunk.data[c];
 			auto &target_vector = bottom_collection.Values(insert_result, c);
 			auto &render_lengths = bottom_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
+			context.CastToVarchar(source_vector, target_vector, insert_count);
 			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
 			                    null_render_length);
 		}
@@ -2290,24 +2290,24 @@ void BoxRendererImplementation::RenderFooter(BaseResultRenderer &ss, idx_t row_c
 BoxRenderer::BoxRenderer(BoxRendererConfig config_p) : config(std::move(config_p)) {
 }
 
-string BoxRenderer::ToString(ClientContext &context, const vector<string> &names,
+string BoxRenderer::ToString(BoxRendererContext &context, const vector<string> &names,
                              const ColumnDataCollectionRenderInterface &result) {
 	StringResultRenderer ss;
 	Render(context, names, result, ss);
 	return ss.str();
 }
 
-void BoxRenderer::Print(ClientContext &context, const vector<string> &names,
+void BoxRenderer::Print(BoxRendererContext &context, const vector<string> &names,
                         const ColumnDataCollectionRenderInterface &result) {
 	Printer::Print(ToString(context, names, result));
 }
 
-unique_ptr<BoxRendererState> BoxRenderer::Prepare(ClientContext &context, const vector<string> &names,
+unique_ptr<BoxRendererState> BoxRenderer::Prepare(BoxRendererContext &context, const vector<string> &names,
                                                   const ColumnDataCollectionRenderInterface &result) {
 	return make_uniq<BoxRendererImplementation>(config, context, names, result);
 }
 
-void BoxRenderer::Render(ClientContext &context, const vector<string> &names,
+void BoxRenderer::Render(BoxRendererContext &context, const vector<string> &names,
                          const ColumnDataCollectionRenderInterface &result, BaseResultRenderer &ss) {
 	auto state = Prepare(context, names, result);
 	state->Render(ss);

--- a/src/common/box_renderer_context.cpp
+++ b/src/common/box_renderer_context.cpp
@@ -1,0 +1,21 @@
+#include "duckdb/common/box_renderer_context.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+
+namespace duckdb {
+
+void BoxRendererContext::CastToVarchar(Vector &source, Vector &result, idx_t count, bool as_json) {
+	DataChunk source_chunk;
+	source_chunk.InitializeEmpty({source.GetType()});
+	source_chunk.data[0].Reference(source);
+	source_chunk.SetCardinality(count);
+
+	DataChunk result_chunk;
+	result_chunk.Initialize(GetAllocator(), {LogicalType::VARCHAR});
+
+	CastToVarchar(source_chunk, result_chunk, count, as_json);
+
+	result.Reference(result_chunk.data[0]);
+}
+
+} // namespace duckdb

--- a/src/common/box_renderer_context.cpp
+++ b/src/common/box_renderer_context.cpp
@@ -4,7 +4,7 @@
 
 namespace duckdb {
 
-void BoxRendererContext::CastToVarchar(Vector &source, Vector &result, idx_t count, bool as_json) {
+void BoxRendererContext::CastToVarchar(Vector &source, Vector &result, idx_t count) {
 	DataChunk source_chunk;
 	source_chunk.InitializeEmpty({source.GetType()});
 	source_chunk.data[0].Reference(source);
@@ -13,7 +13,7 @@ void BoxRendererContext::CastToVarchar(Vector &source, Vector &result, idx_t cou
 	DataChunk result_chunk;
 	result_chunk.Initialize(GetAllocator(), {LogicalType::VARCHAR});
 
-	CastToVarchar(source_chunk, result_chunk, count, as_json);
+	CastToVarchar(source_chunk, result_chunk, count);
 
 	result.Reference(result_chunk.data[0]);
 }

--- a/src/common/box_renderer_context.cpp
+++ b/src/common/box_renderer_context.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/box_renderer_context.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
 
@@ -15,7 +16,7 @@ void BoxRendererContext::CastToVarchar(Vector &source, Vector &result, idx_t cou
 
 	CastToVarchar(source_chunk, result_chunk, count);
 
-	result.Reference(result_chunk.data[0]);
+	VectorOperations::Copy(result_chunk.data[0], result, count, 0, 0);
 }
 
 } // namespace duckdb

--- a/src/common/client_box_renderer_context.cpp
+++ b/src/common/client_box_renderer_context.cpp
@@ -12,7 +12,7 @@ bool ClientBoxRendererContext::IsInterrupted() const {
 	return context.IsInterrupted();
 }
 
-void ClientBoxRendererContext::CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json) {
+void ClientBoxRendererContext::CastToVarchar(DataChunk &source, DataChunk &result, idx_t count) {
 	for (idx_t c = 0; c < source.ColumnCount(); c++) {
 		VectorOperations::TryCast(context, source.data[c], result.data[c], count, nullptr, false);
 	}

--- a/src/common/client_box_renderer_context.cpp
+++ b/src/common/client_box_renderer_context.cpp
@@ -1,0 +1,25 @@
+#include "duckdb/common/box_renderer_context.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+namespace duckdb {
+
+ClientBoxRendererContext::ClientBoxRendererContext(ClientContext &context) : context(context) {
+}
+
+bool ClientBoxRendererContext::IsInterrupted() const {
+	return context.IsInterrupted();
+}
+
+void ClientBoxRendererContext::CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json) {
+	for (idx_t c = 0; c < source.ColumnCount(); c++) {
+		VectorOperations::TryCast(context, source.data[c], result.data[c], count, nullptr, false);
+	}
+}
+
+Allocator &ClientBoxRendererContext::GetAllocator() {
+	return Allocator::Get(context);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/column_data_collection_render_interface.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
 class ColumnDataCollection;
@@ -151,13 +152,15 @@ class BoxRenderer {
 public:
 	explicit BoxRenderer(BoxRendererConfig config_p = BoxRendererConfig());
 
-	string ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op);
+	string ToString(BoxRendererContext &context, const vector<string> &names,
+	                const ColumnDataCollectionRenderInterface &op);
 
-	unique_ptr<BoxRendererState> Prepare(ClientContext &context, const vector<string> &names,
+	unique_ptr<BoxRendererState> Prepare(BoxRendererContext &context, const vector<string> &names,
 	                                     const ColumnDataCollectionRenderInterface &op);
-	void Render(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op,
-	            BaseResultRenderer &ss);
-	void Print(ClientContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op);
+	void Render(BoxRendererContext &context, const vector<string> &names,
+	            const ColumnDataCollectionRenderInterface &op, BaseResultRenderer &ss);
+	void Print(BoxRendererContext &context, const vector<string> &names,
+	           const ColumnDataCollectionRenderInterface &op);
 
 	static string TryFormatLargeNumber(const string &numeric, char decimal_sep);
 	static string TruncateValue(const string &value, idx_t column_width, idx_t &pos, idx_t &current_render_width);

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/column_data_collection_render_interface.hpp"
+
 #include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
@@ -157,10 +158,9 @@ public:
 
 	unique_ptr<BoxRendererState> Prepare(BoxRendererContext &context, const vector<string> &names,
 	                                     const ColumnDataCollectionRenderInterface &op);
-	void Render(BoxRendererContext &context, const vector<string> &names,
-	            const ColumnDataCollectionRenderInterface &op, BaseResultRenderer &ss);
-	void Print(BoxRendererContext &context, const vector<string> &names,
-	           const ColumnDataCollectionRenderInterface &op);
+	void Render(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op,
+	            BaseResultRenderer &ss);
+	void Print(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollectionRenderInterface &op);
 
 	static string TryFormatLargeNumber(const string &numeric, char decimal_sep);
 	static string TruncateValue(const string &value, idx_t column_width, idx_t &pos, idx_t &current_render_width);

--- a/src/include/duckdb/common/box_renderer_context.hpp
+++ b/src/include/duckdb/common/box_renderer_context.hpp
@@ -29,11 +29,11 @@ public:
 	virtual Allocator &GetAllocator() = 0;
 
 	//! Cast a single source vector to VARCHAR. Delegates to the chunk-level virtual.
-	void CastToVarchar(Vector &source, Vector &result, idx_t count, bool as_json = false);
+	void CastToVarchar(Vector &source, Vector &result, idx_t count);
 
 protected:
 	//! Cast source chunk columns to VARCHAR into result chunk. Derived classes implement this.
-	virtual void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json = false) = 0;
+	virtual void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count) = 0;
 };
 
 //! ClientBoxRendererContext wraps a ClientContext to implement BoxRendererContext.
@@ -45,7 +45,7 @@ public:
 	Allocator &GetAllocator() override;
 
 protected:
-	void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json = false) override;
+	void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count) override;
 
 private:
 	ClientContext &context;

--- a/src/include/duckdb/common/box_renderer_context.hpp
+++ b/src/include/duckdb/common/box_renderer_context.hpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/box_renderer_context.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+class Allocator;
+class ClientContext;
+class DataChunk;
+class Vector;
+
+//! BoxRendererContext provides the minimal interface needed by the BoxRenderer
+//! for allocating memory, casting vectors, and checking for interrupts.
+class BoxRendererContext {
+public:
+	virtual ~BoxRendererContext() = default;
+
+	//! Whether execution has been interrupted
+	virtual bool IsInterrupted() const = 0;
+
+	//! Get the allocator for temporary data
+	virtual Allocator &GetAllocator() = 0;
+
+	//! Cast a single source vector to VARCHAR. Delegates to the chunk-level virtual.
+	void CastToVarchar(Vector &source, Vector &result, idx_t count, bool as_json = false);
+
+protected:
+	//! Cast source chunk columns to VARCHAR into result chunk. Derived classes implement this.
+	virtual void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json = false) = 0;
+};
+
+//! ClientBoxRendererContext wraps a ClientContext to implement BoxRendererContext.
+class ClientBoxRendererContext : public BoxRendererContext {
+public:
+	explicit ClientBoxRendererContext(ClientContext &context);
+
+	bool IsInterrupted() const override;
+	Allocator &GetAllocator() override;
+
+protected:
+	void CastToVarchar(DataChunk &source, DataChunk &result, idx_t count, bool as_json = false) override;
+
+private:
+	ClientContext &context;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -32,7 +32,7 @@ public:
 public:
 	//! Converts the QueryResult to a string
 	DUCKDB_API string ToString() override;
-	DUCKDB_API string ToBox(ClientContext &context, const BoxRendererConfig &config) override;
+	DUCKDB_API string ToBox(BoxRendererContext &context, const BoxRendererConfig &config) override;
 
 	//! Gets the (index) value of the (column index) column.
 	//! Note: this is very slow. Scanning over the underlying collection is much faster.

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/main/client_properties.hpp"
 
 namespace duckdb {
+class BoxRendererContext;
 struct BoxRendererConfig;
 
 enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDING_RESULT, ARROW_RESULT };
@@ -105,7 +106,7 @@ public:
 	//! Converts the QueryResult to a string
 	DUCKDB_API virtual string ToString() = 0;
 	//! Converts the QueryResult to a box-rendered string
-	DUCKDB_API virtual string ToBox(ClientContext &context, const BoxRendererConfig &config);
+	DUCKDB_API virtual string ToBox(BoxRendererContext &context, const BoxRendererConfig &config);
 	//! Prints the QueryResult to the console
 	DUCKDB_API void Print();
 	//! Returns true if the two results are identical; false otherwise. Note that this method is destructive; it calls

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/verification/statement_verifier.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
 
@@ -172,7 +173,8 @@ ErrorData ClientContext::VerifyQuery(ClientContextLock &lock, const string &quer
 		config.max_width = random.NextRandomInteger() % 500;
 		BoxRenderer renderer(config);
 		auto pinned_result_set = original->materialized_result->Pin();
-		renderer.ToString(*this, original->materialized_result->names, pinned_result_set->collection);
+		ClientBoxRendererContext render_context(*this);
+		renderer.ToString(render_context, original->materialized_result->names, pinned_result_set->collection);
 #endif
 	}
 

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -40,7 +40,7 @@ string MaterializedQueryResult::ToString() {
 	return result;
 }
 
-string MaterializedQueryResult::ToBox(ClientContext &context, const BoxRendererConfig &config) {
+string MaterializedQueryResult::ToBox(BoxRendererContext &context, const BoxRendererConfig &config) {
 	if (!success) {
 		return GetError() + "\n";
 	}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -97,7 +97,7 @@ const string &QueryResult::ColumnName(idx_t index) const {
 	return names[index];
 }
 
-string QueryResult::ToBox(ClientContext &context, const BoxRendererConfig &config) {
+string QueryResult::ToBox(BoxRendererContext &context, const BoxRendererConfig &config) {
 	return ToString();
 }
 

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -5,6 +5,7 @@
 #include "sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
 
@@ -165,7 +166,8 @@ string SQLLogicTestLogger::ResultToString(MaterializedQueryResult &result) {
 	BoxRendererConfig config;
 	config.max_rows = 100;
 	config.max_width = -1;
-	return result.ToBox(*connection.context, config);
+	ClientBoxRendererContext render_context(*connection.context);
+	return result.ToBox(render_context, config);
 }
 
 void SQLLogicTestLogger::PrintResultString(MaterializedQueryResult &result) {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1629,6 +1629,7 @@ public:
 
 private:
 	duckdb::BoxRendererConfig config;
+	unique_ptr<duckdb::ClientBoxRendererContext> render_context;
 	unique_ptr<duckdb::BoxRendererState> render_state;
 	unique_ptr<duckdb::ColumnDataCollectionWrapper> wrapper;
 	string error_str;
@@ -1682,8 +1683,8 @@ void ModeDuckBoxRenderer::Analyze(RenderingQueryResult &result) {
 	auto &con = *state.conn;
 	try {
 		wrapper = make_uniq<duckdb::ColumnDataCollectionWrapper>(materialized.Collection());
-		duckdb::ClientBoxRendererContext render_context(*con.context);
-		render_state = renderer.Prepare(render_context, result.metadata.column_names, *wrapper);
+		render_context = make_uniq<duckdb::ClientBoxRendererContext>(*con.context);
+		render_state = renderer.Prepare(*render_context, result.metadata.column_names, *wrapper);
 	} catch (std::exception &ex) {
 		// store the error - throw on render
 		error_str = ex.what();

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1682,7 +1682,8 @@ void ModeDuckBoxRenderer::Analyze(RenderingQueryResult &result) {
 	auto &con = *state.conn;
 	try {
 		wrapper = make_uniq<duckdb::ColumnDataCollectionWrapper>(materialized.Collection());
-		render_state = renderer.Prepare(*con.context, result.metadata.column_names, *wrapper);
+		duckdb::ClientBoxRendererContext render_context(*con.context);
+		render_state = renderer.Prepare(render_context, result.metadata.column_names, *wrapper);
 	} catch (std::exception &ex) {
 		// store the error - throw on render
 		error_str = ex.what();


### PR DESCRIPTION
Hide all usage of ClientContext behind an interface that can be instantiated also without having access to a ClientContext, as long as one can provide a subset of the functionality.

This is required in the duckdb-wasm shell refactor to make shell code independent of ClientContext.

PR it's a bunch of line diff, but most of them are just swapping name / wrapping with an interface, it should be a NOP (but for the fact that interface it's now more separate).

Follow up of https://github.com/duckdb/duckdb/pull/21624