### PR TITLE
Allow join filter pushdown through integral up/down casts

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -728,9 +728,10 @@ void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 	for (idx_t k = 0; k < key_count; k++) {
 		// Cast to storage type, only insert if it succeeds
 		auto value = build_vector.GetValue(k);
-		if (value.DefaultTryCastAs(info.columns[filter_idx].storage_type)) {
-			unique_ht_values.insert(value);
+		if (!value.DefaultTryCastAs(info.columns[filter_idx].storage_type)) {
+			return; // it's all or nothing sadly
 		}
+		unique_ht_values.insert(value);
 	}
 	vector<Value> in_list(unique_ht_values.begin(), unique_ht_values.end());
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -726,7 +726,11 @@ void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 	// generate the OR-clause - note that we only need to consider unique values here (so we use a seT)
 	value_set_t unique_ht_values;
 	for (idx_t k = 0; k < key_count; k++) {
-		unique_ht_values.insert(build_vector.GetValue(k));
+		// Cast to storage type, only insert if it succeeds
+		auto value = build_vector.GetValue(k);
+		if (value.DefaultTryCastAs(info.columns[filter_idx].storage_type)) {
+			unique_ht_values.insert(value);
+		}
 	}
 	vector<Value> in_list(unique_ht_values.begin(), unique_ht_values.end());
 
@@ -811,12 +815,23 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 	for (idx_t filter_idx = 0; filter_idx < join_condition.size(); filter_idx++) {
 		const auto cmp = op.conditions[join_condition[filter_idx]].comparison;
 		for (auto &info : probe_info) {
-			auto filter_col_idx = info.columns[filter_idx].probe_column_index.column_index;
+			const auto &pushdown_column = info.columns[filter_idx];
+			auto &filter_col_idx = pushdown_column.probe_column_index.column_index;
 			auto min_idx = filter_idx * 2;
 			auto max_idx = min_idx + 1;
 
 			auto min_val = final_min_max->data[min_idx].GetValue(0);
 			auto max_val = final_min_max->data[max_idx].GetValue(0);
+
+			// Cast to storage type, skip if fails
+			D_ASSERT(pushdown_column.storage_type.IsValid());
+			if (!min_val.DefaultTryCastAs(pushdown_column.storage_type)) {
+				continue;
+			}
+			if (!max_val.DefaultTryCastAs(pushdown_column.storage_type)) {
+				continue;
+			}
+
 			if (min_val.IsNull() || max_val.IsNull()) {
 				// min/max is NULL
 				// this can happen in case all values in the RHS column are NULL, but they are still pushed into the

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -24,6 +24,8 @@ struct LocalUngroupedAggregateState;
 struct JoinFilterPushdownColumn {
 	//! The probe column index to which this filter should be applied
 	ColumnBinding probe_column_index;
+	//! The type of the value in storage (LogicalGet)
+	LogicalType storage_type;
 };
 
 struct JoinFilterGlobalState {

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
@@ -20,14 +21,38 @@ JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) :
 }
 
 bool PushdownJoinFilterExpression(Expression &expr, JoinFilterPushdownColumn &filter) {
-	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-		// not a simple column ref - bail-out
+	if (expr.return_type.IsNested()) {
+		// nested columns are not supported for pushdown
 		return false;
 	}
-	// column-ref - pass through the new column binding
-	auto &colref = expr.Cast<BoundColumnRefExpression>();
-	filter.probe_column_index = colref.binding;
-	return true;
+	if (expr.return_type.id() == LogicalTypeId::INTERVAL) {
+		// interval is not supported for pushdown
+		return false;
+	}
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COLUMN_REF: {
+		// column-ref - pass through the new column binding
+		auto &colref = expr.Cast<BoundColumnRefExpression>();
+		filter.probe_column_index = colref.binding;
+		return true;
+	}
+	case ExpressionClass::BOUND_CAST: {
+		// We allow pushing through integral down/upcasts, as long as source/target are (u)bigint or smaller
+		const auto &bound_cast = expr.Cast<BoundCastExpression>();
+		const auto &src = bound_cast.child->return_type;
+		const auto &tgt = bound_cast.return_type;
+		if (!src.IsIntegral() || !tgt.IsIntegral()) {
+			return false;
+		}
+		if (GetTypeIdSize(src.InternalType()) > GetTypeIdSize(PhysicalType::INT64) ||
+		    GetTypeIdSize(tgt.InternalType()) > GetTypeIdSize(PhysicalType::INT64)) {
+			return false; // Only do this for (u)bigint and smaller
+		}
+		return PushdownJoinFilterExpression(*bound_cast.child, filter);
+	}
+	default:
+		return false;
+	}
 }
 
 void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
@@ -97,11 +122,21 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 			// filter pushdown is not supported - no need to consider this node
 			return;
 		}
+		get.ResolveOperatorTypes();
+		const auto bindings = get.GetColumnBindings();
 		for (auto &filter : columns) {
 			if (filter.probe_column_index.table_index != get.table_index) {
 				// the filter does not apply to the probe side here - bail-out
 				return;
 			}
+			// add storage type to columns
+			for (idx_t i = 0; i < bindings.size(); i++) {
+				if (filter.probe_column_index.column_index == bindings[i].column_index) {
+					filter.storage_type = get.types[i];
+					break;
+				}
+			}
+			D_ASSERT(filter.storage_type != LogicalType::INVALID);
 		}
 		targets.emplace_back(get, std::move(columns));
 		break;
@@ -205,23 +240,13 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		default:
 			continue;
 		}
-		if (cond.left->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-			// only bound column ref supported for now
-			continue;
-		}
-		if (cond.left->return_type.IsNested()) {
-			// nested columns are not supported for pushdown
-			continue;
-		}
-		if (cond.left->return_type.id() == LogicalTypeId::INTERVAL) {
-			// interval is not supported for pushdown
-			continue;
-		}
-		JoinFilterPushdownColumn pushdown_col;
-		auto &colref = cond.left->Cast<BoundColumnRefExpression>();
-		pushdown_col.probe_column_index = colref.binding;
-		pushdown_columns.push_back(pushdown_col);
 
+		JoinFilterPushdownColumn pushdown_col;
+		if (!PushdownJoinFilterExpression(*cond.left, pushdown_col)) {
+			continue;
+		}
+
+		pushdown_columns.push_back(pushdown_col);
 		pushdown_info->join_condition.push_back(cond_idx);
 	}
 	if (pushdown_columns.empty()) {

--- a/test/optimizer/pushdown/join_filter_pushdown_cast.test
+++ b/test/optimizer/pushdown/join_filter_pushdown_cast.test
@@ -2,12 +2,24 @@
 # description: Join filter pushdown through integral up/downcasts
 # group: [pushdown]
 
+statement ok
+PRAGMA explain_output='OPTIMIZED_ONLY';
+
+# disable this (for now - could be fixed by pushing casts instead of internal compress functions if possible)
+statement ok
+SET disabled_optimizers TO 'compressed_materialization';
+
 # Basic downcast: probe stored as INT, projected as BIGINT for the join
 statement ok
 CREATE TABLE probe_int AS SELECT range::INT AS a FROM range(100);
 
 statement ok
 CREATE TABLE build_bigint AS SELECT b::BIGINT AS b FROM (VALUES (10), (20), (30), (50)) t(b);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_bigint ON t.a = build_bigint.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
 
 query I
 SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_bigint ON t.a = build_bigint.b;
@@ -22,9 +34,14 @@ SELECT t.a FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_bigint ON t.
 30
 50
 
-# Out-of-range build values must not corrupt the filter or crash
+# Out-of-range build values aren't added
 statement ok
 CREATE TABLE build_overflow AS SELECT b::BIGINT AS b FROM (VALUES (5), (10), (9999999999)) t(b);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_overflow ON t.a = build_overflow.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
 
 # 9999999999 overflows INT32 — only 5 and 10 should match
 query I
@@ -32,10 +49,14 @@ SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_overflo
 ----
 2
 
-
 # All build values overflow: result is empty
 statement ok
 CREATE TABLE build_all_overflow AS SELECT b::BIGINT AS b FROM (VALUES (9999999999), (8888888888)) t(b);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_all_overflow ON t.a = build_all_overflow.b;
+----
+analyzed_plan	<!REGEX>:.*Dynamic Filters:.*
 
 query I
 SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_all_overflow ON t.a = build_all_overflow.b;
@@ -48,6 +69,11 @@ CREATE TABLE probe_tiny AS SELECT v::TINYINT AS a FROM (VALUES (1), (2), (3), (1
 
 statement ok
 CREATE TABLE build_for_tiny AS SELECT b::BIGINT AS b FROM (VALUES (1), (100), (200)) t(b);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_tiny) t JOIN build_for_tiny ON t.a = build_for_tiny.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
 
 # 200 does not fit in TINYINT — only 1 and 100 match
 query I
@@ -62,6 +88,11 @@ CREATE TABLE probe_small AS SELECT v::SMALLINT AS a FROM (VALUES (100), (200), (
 statement ok
 CREATE TABLE build_for_small AS SELECT b::INT AS b FROM (VALUES (100), (40000)) t(b);
 
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::INT AS a FROM probe_small) t JOIN build_for_small ON t.a = build_for_small.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
+
 query I
 SELECT COUNT(*) FROM (SELECT a::INT AS a FROM probe_small) t JOIN build_for_small ON t.a = build_for_small.b;
 ----
@@ -70,6 +101,11 @@ SELECT COUNT(*) FROM (SELECT a::INT AS a FROM probe_small) t JOIN build_for_smal
 # NULL values in the build side are handled gracefully
 statement ok
 CREATE TABLE build_with_nulls AS SELECT b::BIGINT AS b FROM (VALUES (10), (NULL), (20)) t(b);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_with_nulls ON t.a = build_with_nulls.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
 
 query I
 SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_with_nulls ON t.a = build_with_nulls.b;
@@ -97,6 +133,11 @@ CREATE TABLE probe_double AS SELECT v::DOUBLE AS a FROM (VALUES (1.0), (2.0), (3
 statement ok
 CREATE TABLE build_double AS SELECT v::DOUBLE AS b FROM (VALUES (1.0), (2.0)) t(v);
 
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM probe_double JOIN build_double ON probe_double.a = build_double.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
+
 query I
 SELECT COUNT(*) FROM probe_double JOIN build_double ON probe_double.a = build_double.b;
 ----
@@ -109,7 +150,11 @@ CREATE TABLE probe_bigint_for_huge AS SELECT v::BIGINT AS a FROM (VALUES (1), (2
 statement ok
 CREATE TABLE build_hugeint AS SELECT v::HUGEINT AS b FROM (VALUES (1), (2)) t(v);
 
-# Cast BIGINT -> HUGEINT in projection; optimizer rejects
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::HUGEINT AS a FROM probe_bigint_for_huge) t JOIN build_hugeint ON t.a = build_hugeint.b;
+----
+analyzed_plan	<!REGEX>:.*Dynamic Filters:.*
+
 query I
 SELECT COUNT(*) FROM (SELECT a::HUGEINT AS a FROM probe_bigint_for_huge) t JOIN build_hugeint ON t.a = build_hugeint.b;
 ----
@@ -121,6 +166,12 @@ CREATE TABLE probe_ubigint AS SELECT v::UBIGINT AS a FROM (VALUES (1), (5), (10)
 
 statement ok
 CREATE TABLE build_neg AS SELECT b::BIGINT AS b FROM (VALUES (5), (-1), (10)) t(b);
+
+# TODO HERE
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_ubigint) t JOIN build_neg ON t.a = build_neg.b;
+----
+analyzed_plan	<!REGEX>:.*Dynamic Filters:.*
 
 # -1 cannot be cast to UBIGINT — only 5 and 10 match
 query I
@@ -139,9 +190,13 @@ statement ok
 CREATE TABLE build_direct (b BIGINT);
 
 statement ok
-INSERT INTO build_direct VALUES (10), (20), (9999999999);
+INSERT INTO build_direct VALUES (10), (20);
 
-# 9999999999 overflows INT32
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
+
 query I
 SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
 ----
@@ -149,12 +204,17 @@ SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_di
 
 # All build values in range: all match
 statement ok
-INSERT INTO build_direct VALUES (30);
+INSERT INTO build_direct VALUES (9999999999);
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
+----
+analyzed_plan	<!REGEX>:.*Dynamic Filters:.*
 
 query I
 SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
 ----
-3
+2
 
 # UNION ALL: each branch must use its OWN storage type
 statement ok
@@ -166,6 +226,16 @@ CREATE TABLE t_union_small AS SELECT v::SMALLINT AS a FROM (VALUES (10), (99)) t
 statement ok
 CREATE TABLE build_union AS SELECT b::BIGINT AS b FROM (VALUES (10), (40000)) t(b);
 
+query II
+EXPLAIN ANALYZE
+SELECT COUNT(*) FROM (
+    SELECT a::BIGINT AS a FROM t_union_int
+    UNION ALL
+    SELECT a::BIGINT AS a FROM t_union_small
+) sub JOIN build_union ON sub.a = build_union.b;
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
+
 query I
 SELECT COUNT(*) FROM (
     SELECT a::BIGINT AS a FROM t_union_int
@@ -174,56 +244,3 @@ SELECT COUNT(*) FROM (
 ) sub JOIN build_union ON sub.a = build_union.b;
 ----
 3
-
-# Overflow build values are excluded for both branches
-statement ok
-CREATE TABLE build_union_overflow AS SELECT b::BIGINT AS b FROM (VALUES (10), (9999999999)) t(b);
-
-query I
-SELECT COUNT(*) FROM (
-    SELECT a::BIGINT AS a FROM t_union_int
-    UNION ALL
-    SELECT a::BIGINT AS a FROM t_union_small
-) sub JOIN build_union_overflow ON sub.a = build_union_overflow.b;
-----
-2
-
-# Aggregate GROUP BY with overflow build values
-statement ok
-CREATE TABLE build_agg_overflow AS SELECT b::BIGINT AS b FROM (VALUES (5), (10), (9999999999)) t(b);
-
-# probe_for_agg was created earlier: INT values 0..49
-query I
-SELECT COUNT(*)
-FROM (SELECT x::BIGINT AS xb FROM probe_for_agg GROUP BY x::BIGINT) t
-JOIN build_agg_overflow ON t.xb = build_agg_overflow.b;
-----
-2
-
-# All build values overflow storage type: empty result, no crash
-statement ok
-CREATE TABLE build_agg_all_overflow AS SELECT b::BIGINT AS b FROM (VALUES (9999999999), (8888888888)) t(b);
-
-query I
-SELECT COUNT(*)
-FROM (SELECT x::BIGINT AS xb FROM probe_for_agg GROUP BY x::BIGINT) t
-JOIN build_agg_all_overflow ON t.xb = build_agg_all_overflow.b;
-----
-0
-
-# Multiple join conditions through the aggregate
-statement ok
-CREATE TABLE probe_multi_agg AS SELECT v::SMALLINT AS x, v::INT AS y
-    FROM (VALUES (1), (2), (3), (100)) t(v);
-
-statement ok
-CREATE TABLE build_multi AS SELECT b::INT AS bx, b::BIGINT AS by
-    FROM (VALUES (1), (100), (40000)) t(b);
-
-# 40000 overflows SMALLINT for column x
-query I
-SELECT COUNT(*)
-FROM (SELECT x::INT AS xc, y::BIGINT AS yc FROM probe_multi_agg GROUP BY x::INT, y::BIGINT) t
-JOIN build_multi ON t.xc = build_multi.bx AND t.yc = build_multi.by;
-----
-2

--- a/test/optimizer/pushdown/join_filter_pushdown_cast.test
+++ b/test/optimizer/pushdown/join_filter_pushdown_cast.test
@@ -1,0 +1,229 @@
+# name: test/optimizer/pushdown/join_filter_pushdown_cast.test
+# description: Join filter pushdown through integral up/downcasts
+# group: [pushdown]
+
+# Basic downcast: probe stored as INT, projected as BIGINT for the join
+statement ok
+CREATE TABLE probe_int AS SELECT range::INT AS a FROM range(100);
+
+statement ok
+CREATE TABLE build_bigint AS SELECT b::BIGINT AS b FROM (VALUES (10), (20), (30), (50)) t(b);
+
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_bigint ON t.a = build_bigint.b;
+----
+4
+
+query I rowsort
+SELECT t.a FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_bigint ON t.a = build_bigint.b ORDER BY 1;
+----
+10
+20
+30
+50
+
+# Out-of-range build values must not corrupt the filter or crash
+statement ok
+CREATE TABLE build_overflow AS SELECT b::BIGINT AS b FROM (VALUES (5), (10), (9999999999)) t(b);
+
+# 9999999999 overflows INT32 — only 5 and 10 should match
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_overflow ON t.a = build_overflow.b;
+----
+2
+
+
+# All build values overflow: result is empty
+statement ok
+CREATE TABLE build_all_overflow AS SELECT b::BIGINT AS b FROM (VALUES (9999999999), (8888888888)) t(b);
+
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_all_overflow ON t.a = build_all_overflow.b;
+----
+0
+
+# TINYINT probe cast to BIGINT — 200 overflows
+statement ok
+CREATE TABLE probe_tiny AS SELECT v::TINYINT AS a FROM (VALUES (1), (2), (3), (100), (127)) t(v);
+
+statement ok
+CREATE TABLE build_for_tiny AS SELECT b::BIGINT AS b FROM (VALUES (1), (100), (200)) t(b);
+
+# 200 does not fit in TINYINT — only 1 and 100 match
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_tiny) t JOIN build_for_tiny ON t.a = build_for_tiny.b;
+----
+2
+
+# SMALLINT probe cast to INT — 40000 overflows
+statement ok
+CREATE TABLE probe_small AS SELECT v::SMALLINT AS a FROM (VALUES (100), (200), (300)) t(v);
+
+statement ok
+CREATE TABLE build_for_small AS SELECT b::INT AS b FROM (VALUES (100), (40000)) t(b);
+
+query I
+SELECT COUNT(*) FROM (SELECT a::INT AS a FROM probe_small) t JOIN build_for_small ON t.a = build_for_small.b;
+----
+1
+
+# NULL values in the build side are handled gracefully
+statement ok
+CREATE TABLE build_with_nulls AS SELECT b::BIGINT AS b FROM (VALUES (10), (NULL), (20)) t(b);
+
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_int) t JOIN build_with_nulls ON t.a = build_with_nulls.b;
+----
+2
+
+# Push through GROUP BY (aggregate node with an integral cast expression)
+statement ok
+CREATE TABLE probe_for_agg AS SELECT range::INT AS x FROM range(50);
+
+statement ok
+CREATE TABLE build_for_agg AS SELECT b::BIGINT AS y FROM (VALUES (5), (10), (15)) t(b);
+
+query I
+SELECT COUNT(*)
+FROM (SELECT x::BIGINT AS xb FROM probe_for_agg GROUP BY x::BIGINT) t
+JOIN build_for_agg ON t.xb = build_for_agg.y;
+----
+3
+
+# Non-integral cast
+statement ok
+CREATE TABLE probe_double AS SELECT v::DOUBLE AS a FROM (VALUES (1.0), (2.0), (3.0), (1.5)) t(v);
+
+statement ok
+CREATE TABLE build_double AS SELECT v::DOUBLE AS b FROM (VALUES (1.0), (2.0)) t(v);
+
+query I
+SELECT COUNT(*) FROM probe_double JOIN build_double ON probe_double.a = build_double.b;
+----
+2
+
+# HUGEINT: size check should prevent pushdown
+statement ok
+CREATE TABLE probe_bigint_for_huge AS SELECT v::BIGINT AS a FROM (VALUES (1), (2), (3)) t(v);
+
+statement ok
+CREATE TABLE build_hugeint AS SELECT v::HUGEINT AS b FROM (VALUES (1), (2)) t(v);
+
+# Cast BIGINT -> HUGEINT in projection; optimizer rejects
+query I
+SELECT COUNT(*) FROM (SELECT a::HUGEINT AS a FROM probe_bigint_for_huge) t JOIN build_hugeint ON t.a = build_hugeint.b;
+----
+2
+
+# Negative build values against UBIGINT probe
+statement ok
+CREATE TABLE probe_ubigint AS SELECT v::UBIGINT AS a FROM (VALUES (1), (5), (10)) t(v);
+
+statement ok
+CREATE TABLE build_neg AS SELECT b::BIGINT AS b FROM (VALUES (5), (-1), (10)) t(b);
+
+# -1 cannot be cast to UBIGINT — only 5 and 10 match
+query I
+SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_ubigint) t JOIN build_neg ON t.a = build_neg.b;
+----
+2
+
+# Cast directly in the join condition (not in a projection)
+statement ok
+CREATE TABLE probe_direct (a INT);
+
+statement ok
+INSERT INTO probe_direct SELECT range FROM range(100);
+
+statement ok
+CREATE TABLE build_direct (b BIGINT);
+
+statement ok
+INSERT INTO build_direct VALUES (10), (20), (9999999999);
+
+# 9999999999 overflows INT32
+query I
+SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
+----
+2
+
+# All build values in range: all match
+statement ok
+INSERT INTO build_direct VALUES (30);
+
+query I
+SELECT COUNT(*) FROM probe_direct JOIN build_direct ON probe_direct.a = build_direct.b;
+----
+3
+
+# UNION ALL: each branch must use its OWN storage type
+statement ok
+CREATE TABLE t_union_int AS SELECT v::INT AS a FROM (VALUES (10), (40000), (99)) t(v);
+
+statement ok
+CREATE TABLE t_union_small AS SELECT v::SMALLINT AS a FROM (VALUES (10), (99)) t(v);
+
+statement ok
+CREATE TABLE build_union AS SELECT b::BIGINT AS b FROM (VALUES (10), (40000)) t(b);
+
+query I
+SELECT COUNT(*) FROM (
+    SELECT a::BIGINT AS a FROM t_union_int
+    UNION ALL
+    SELECT a::BIGINT AS a FROM t_union_small
+) sub JOIN build_union ON sub.a = build_union.b;
+----
+3
+
+# Overflow build values are excluded for both branches
+statement ok
+CREATE TABLE build_union_overflow AS SELECT b::BIGINT AS b FROM (VALUES (10), (9999999999)) t(b);
+
+query I
+SELECT COUNT(*) FROM (
+    SELECT a::BIGINT AS a FROM t_union_int
+    UNION ALL
+    SELECT a::BIGINT AS a FROM t_union_small
+) sub JOIN build_union_overflow ON sub.a = build_union_overflow.b;
+----
+2
+
+# Aggregate GROUP BY with overflow build values
+statement ok
+CREATE TABLE build_agg_overflow AS SELECT b::BIGINT AS b FROM (VALUES (5), (10), (9999999999)) t(b);
+
+# probe_for_agg was created earlier: INT values 0..49
+query I
+SELECT COUNT(*)
+FROM (SELECT x::BIGINT AS xb FROM probe_for_agg GROUP BY x::BIGINT) t
+JOIN build_agg_overflow ON t.xb = build_agg_overflow.b;
+----
+2
+
+# All build values overflow storage type: empty result, no crash
+statement ok
+CREATE TABLE build_agg_all_overflow AS SELECT b::BIGINT AS b FROM (VALUES (9999999999), (8888888888)) t(b);
+
+query I
+SELECT COUNT(*)
+FROM (SELECT x::BIGINT AS xb FROM probe_for_agg GROUP BY x::BIGINT) t
+JOIN build_agg_all_overflow ON t.xb = build_agg_all_overflow.b;
+----
+0
+
+# Multiple join conditions through the aggregate
+statement ok
+CREATE TABLE probe_multi_agg AS SELECT v::SMALLINT AS x, v::INT AS y
+    FROM (VALUES (1), (2), (3), (100)) t(v);
+
+statement ok
+CREATE TABLE build_multi AS SELECT b::INT AS bx, b::BIGINT AS by
+    FROM (VALUES (1), (100), (40000)) t(b);
+
+# 40000 overflows SMALLINT for column x
+query I
+SELECT COUNT(*)
+FROM (SELECT x::INT AS xc, y::BIGINT AS yc FROM probe_multi_agg GROUP BY x::INT, y::BIGINT) t
+JOIN build_multi ON t.xc = build_multi.bx AND t.yc = build_multi.by;
+----
+2


### PR DESCRIPTION
This works because the comparisons for min/max filters (and even hashes for bloom filters) are the same for integral up/down casts, except (`U`)`HUGEINT`.

This is implemented by adding `LogicalType storage_type` to `JoinFilterPushdownColumn` (which is populated when the `LogicalGet` is encountered) and casting the values in the hash table to the storage type in `JoinFilterPushdownInfo::Finalize`. If the cast fails, we bail on the pushdown. This is a lot better than bailing in the optimizer like we are doing now if there is any cast present.

This opens up the opportunity to change some `CompressedMaterialization` expressions to casts instead (if that results in the same compressed type width) in the future, which would allow join filter pushdown through compression projections.