### PR TITLE
Try clangd-tidy in CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -350,6 +350,7 @@ jobs:
     - name: Install
       run: |
         python3 scripts/ci/retry.py -- make toolsci
+        python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
         python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clang-tidy
         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
 
@@ -389,6 +390,7 @@ jobs:
      - name: Install
        run: |
          python3 scripts/ci/retry.py -- make toolsci
+         python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
          python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clangd
          python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
          python3 scripts/ci/retry.py -- make install-clangd-tidy

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -373,27 +373,34 @@ jobs:
       if: ${{ github.ref_name != 'main' && github.ref_name != 'feature' }}
       run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
 
- tidy-check-clangd:
-    name: Tidy Check clangd-tidy
-    needs: prepare
-    runs-on: ubuntu-24.04
-    env:
-      CC: gcc
-      CXX: g++
-      GEN: ninja
+ check-clangd-tidy:
+   name: Tidy Check (clangd)
+   if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'check-clangd-tidy') }}
+   needs: prepare
+   runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
-    steps:
-    - uses: actions/checkout@v6
+   steps:
+     - name: "Checkout"
+       uses: duckdb/duckdb-ci/.github/actions/checkout@main
+       with:
+         runner_provider: ${{ github.repository == 'duckdb/duckdb' && 'namespace' || 'github' }}
+         fetch_depth: 0
 
-    - name: Install
-      run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clangd
-        python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
-        python3 scripts/ci/retry.py -- make install-clangd-tidy
+     - name: Install
+       run: |
+         python3 scripts/ci/retry.py -- make toolsci
+         python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clangd
+         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
+         python3 scripts/ci/retry.py -- make install-clangd-tidy
 
-    - name: Tidy Check
-      run: make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
+     - name: Tidy Check
+       run: |
+         mkdir -p ~/.config/clangd
+         cat > ~/.config/clangd/config.yaml <<'EOF'
+         Diagnostics:
+           UnusedIncludes: None
+         EOF
+         make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
 
  extensions:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'extensions') }}
@@ -1204,6 +1211,7 @@ jobs:
       - linux-debug-tests
       - regression
       - tidy-check
+      - check-clangd-tidy
       - extensions
       - wasm-eh
       - linux-release

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -373,6 +373,28 @@ jobs:
       if: ${{ github.ref_name != 'main' && github.ref_name != 'feature' }}
       run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
 
+ tidy-check-clangd:
+    name: Tidy Check clangd-tidy
+    needs: prepare
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc
+      CXX: g++
+      GEN: ninja
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install
+      run: |
+        python3 scripts/ci/retry.py -- make toolsci
+        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clangd
+        python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
+        python3 scripts/ci/retry.py -- make install-clangd-tidy
+
+    - name: Tidy Check
+      run: make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
+
  extensions:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'extensions') }}
     uses: ./.github/workflows/Extensions.yml

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ ifndef CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL := $(CI_BUILD_JOBS)
 endif
 export CMAKE_BUILD_PARALLEL_LEVEL
+export CI_TIDY_JOBS := $(CI_BUILD_JOBS)
 
 # Assume Ninja is the default generator (if missing), but verify ninja exists.
 # Cache Ninja detection so we only probe `ninja --version` once.
@@ -624,7 +625,7 @@ tidy-check-clangd:
 	cd build/tidy && \
 	cmake $(GENERATOR) $(FORCE_COLOR) ${STATIC_LIBCPP} ${CMAKE_VARS} -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
 	trap 'rm -rf ./pchs' EXIT && \
-	$(PYTHON) ../../scripts/run-clangd-tidy.py -j $(CI_CPU_COUNT) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
+	$(PYTHON) ../../scripts/run-clangd-tidy.py -j $(CI_TIDY_JOBS) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
 
 tidy-check-diff:
 	mkdir -p ./build/tidy && \

--- a/Makefile
+++ b/Makefile
@@ -625,7 +625,7 @@ tidy-check-clangd:
 	cd build/tidy && \
 	cmake $(GENERATOR) $(FORCE_COLOR) ${STATIC_LIBCPP} ${CMAKE_VARS} -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
 	trap 'rm -rf ./pchs' EXIT && \
-	$(PYTHON) ../../scripts/run-clangd-tidy.py -j $(CI_TIDY_JOBS) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
+	$(PYTHON) -u ../../scripts/run-clangd-tidy.py -j $(CI_TIDY_JOBS) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
 
 tidy-check-diff:
 	mkdir -p ./build/tidy && \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifndef CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL := $(CI_BUILD_JOBS)
 endif
 export CMAKE_BUILD_PARALLEL_LEVEL
-export CI_TIDY_JOBS := 4
+export CI_TIDY_JOBS := $(shell jobs=$$(( $(CI_CPU_COUNT) * 25 / 100 )); [ $$jobs -lt 1 ] && jobs=1; echo $$jobs)
 
 # Assume Ninja is the default generator (if missing), but verify ninja exists.
 # Cache Ninja detection so we only probe `ninja --version` once.

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifndef CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL := $(CI_BUILD_JOBS)
 endif
 export CMAKE_BUILD_PARALLEL_LEVEL
-export CI_TIDY_JOBS := $(shell jobs=$$(( $(CI_CPU_COUNT) * 50 / 100 )); [ $$jobs -lt 1 ] && jobs=1; echo $$jobs)
+export CI_TIDY_JOBS := 4
 
 # Assume Ninja is the default generator (if missing), but verify ninja exists.
 # Cache Ninja detection so we only probe `ninja --version` once.

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,27 @@ endif
 ifneq ($(TIDY_BINARY),)
 	TIDY_BINARY_PARAMETER := -clang-tidy-binary ${TIDY_BINARY}
 endif
+CLANGD_TIDY_VERSION := 1.1.1
+CLANGD_TIDY_VENV ?= $(abspath build/clangd-tidy-venv)
+ifeq ($(CLANGD_TIDY_BINARY),)
+ifneq ($(wildcard $(CLANGD_TIDY_VENV)/bin/clangd-tidy),)
+CLANGD_TIDY_BINARY := $(CLANGD_TIDY_VENV)/bin/clangd-tidy
+endif
+endif
+ifeq ($(CLANGD_BINARY),)
+ifneq ("${CMAKE_LLVM_PATH}", "")
+CLANGD_BINARY := ${CMAKE_LLVM_PATH}/bin/clangd
+endif
+endif
+ifneq ($(CLANGD_TIDY_BINARY),)
+	CLANGD_TIDY_BINARY_PARAMETER := --clangd-tidy-binary ${CLANGD_TIDY_BINARY}
+endif
+ifneq ($(CLANGD_BINARY),)
+	CLANGD_BINARY_PARAMETER := --clangd-binary ${CLANGD_BINARY}
+endif
+ifneq ($(CLANGD_TIDY_QUERY_DRIVER),)
+	CLANGD_TIDY_QUERY_DRIVER_PARAMETER := --query-driver ${CLANGD_TIDY_QUERY_DRIVER}
+endif
 ifneq ($(TIDY_CHECKS),)
         TIDY_PERFORM_CHECKS := '-checks=${TIDY_CHECKS}'
 endif
@@ -592,6 +613,17 @@ tidy-check:
 	cd build/tidy && \
 	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
 	$(PYTHON) ../../scripts/run-clang-tidy.py -quiet -j $(CI_CPU_COUNT) ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS}
+
+install-clangd-tidy:
+	mkdir -p $(dir $(CLANGD_TIDY_VENV)) && \
+	$(PYTHON) -m venv $(CLANGD_TIDY_VENV) && \
+	$(CLANGD_TIDY_VENV)/bin/pip install --upgrade 'clangd-tidy==$(CLANGD_TIDY_VERSION)'
+
+tidy-check-clangd:
+	mkdir -p ./build/tidy && \
+	cd build/tidy && \
+	cmake $(GENERATOR) $(FORCE_COLOR) ${STATIC_LIBCPP} ${CMAKE_VARS} -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
+	$(PYTHON) ../../scripts/run-clangd-tidy.py -j $(CI_CPU_COUNT) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
 
 tidy-check-diff:
 	mkdir -p ./build/tidy && \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifndef CMAKE_BUILD_PARALLEL_LEVEL
 CMAKE_BUILD_PARALLEL_LEVEL := $(CI_BUILD_JOBS)
 endif
 export CMAKE_BUILD_PARALLEL_LEVEL
-export CI_TIDY_JOBS := $(CI_BUILD_JOBS)
+export CI_TIDY_JOBS := $(shell jobs=$$(( $(CI_CPU_COUNT) * 50 / 100 )); [ $$jobs -lt 1 ] && jobs=1; echo $$jobs)
 
 # Assume Ninja is the default generator (if missing), but verify ninja exists.
 # Cache Ninja detection so we only probe `ninja --version` once.

--- a/Makefile
+++ b/Makefile
@@ -623,6 +623,7 @@ tidy-check-clangd:
 	mkdir -p ./build/tidy && \
 	cd build/tidy && \
 	cmake $(GENERATOR) $(FORCE_COLOR) ${STATIC_LIBCPP} ${CMAKE_VARS} -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
+	trap 'rm -rf ./pchs' EXIT && \
 	$(PYTHON) ../../scripts/run-clangd-tidy.py -j $(CI_CPU_COUNT) ${CLANGD_TIDY_BINARY_PARAMETER} ${CLANGD_BINARY_PARAMETER} ${CLANGD_TIDY_QUERY_DRIVER_PARAMETER}
 
 tidy-check-diff:

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -13,7 +13,6 @@ PULL_REQUEST_JOBS = [
     "linux-debug-tests",
     "regression",
     "tidy-check",
-    "check-clangd-tidy",
     "extensions",
     "wasm-eh",
     "linux-release",
@@ -32,6 +31,7 @@ PULL_REQUEST_JOBS = [
 
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
+    "check-clangd-tidy",
     "valgrind",
 ]
 
@@ -41,6 +41,7 @@ MERGE_GROUP_JOBS = [
     "linux-debug",
     "linux-release",
     "linux-release-tests",
+    "check-clangd-tidy",
     "tidy-check",
 ]
 

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -13,6 +13,7 @@ PULL_REQUEST_JOBS = [
     "linux-debug-tests",
     "regression",
     "tidy-check",
+    "check-clangd-tidy",
     "extensions",
     "wasm-eh",
     "linux-release",

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import multiprocessing
+import os
+import shlex
+import subprocess
+import sys
+
+
+def make_absolute(path, directory):
+    if os.path.isabs(path):
+        return os.path.normpath(path)
+    return os.path.normpath(os.path.join(directory, path))
+
+
+def is_ignored_file(path, repo_root):
+    normalized = os.path.normpath(path)
+    try:
+        relative = os.path.relpath(normalized, repo_root)
+    except ValueError:
+        return False
+    return relative == 'third_party' or relative.startswith('third_party' + os.sep)
+
+
+def chunk_files(files, max_chars=100000):
+    chunk = []
+    current_chars = 0
+    for path in files:
+        path_len = len(path) + 1
+        if chunk and current_chars + path_len > max_chars:
+            yield chunk
+            chunk = []
+            current_chars = 0
+        chunk.append(path)
+        current_chars += path_len
+    if chunk:
+        yield chunk
+
+
+def load_files(build_path):
+    database_path = os.path.join(build_path, 'compile_commands.json')
+    repo_root = os.path.abspath(os.path.join(build_path, '..', '..'))
+    with open(database_path, 'r', encoding='utf-8') as handle:
+        database = json.load(handle)
+
+    seen = set()
+    files = []
+    for entry in database:
+        path = make_absolute(entry['file'], entry['directory'])
+        if path in seen or is_ignored_file(path, repo_root):
+            continue
+        seen.add(path)
+        files.append(os.path.relpath(path, repo_root))
+    return repo_root, files
+
+
+def create_clangd_wrapper(build_path, clangd_binary):
+    build_path = os.path.abspath(build_path)
+    pch_dir = os.path.join(build_path, 'pchs')
+    os.makedirs(pch_dir, exist_ok=True)
+
+    wrapper_path = os.path.join(build_path, 'clangd-tidy-clangd-wrapper.sh')
+    wrapper = f"""#!/bin/sh
+set -eu
+export TMPDIR={shlex.quote(pch_dir)}
+export TMP={shlex.quote(pch_dir)}
+export TEMP={shlex.quote(pch_dir)}
+exec {shlex.quote(clangd_binary)} "$@" --pch-storage=disk
+"""
+    with open(wrapper_path, 'w', encoding='utf-8') as handle:
+        handle.write(wrapper)
+    os.chmod(wrapper_path, 0o755)
+    return wrapper_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run clangd-tidy over all files in a compilation database.')
+    parser.add_argument('-j', '--jobs', type=int, default=0, help='number of async workers passed to clangd-tidy')
+    parser.add_argument('-p', '--build-path', default=None, help='path containing compile_commands.json')
+    parser.add_argument(
+        '--clangd-tidy-binary',
+        default='clangd-tidy',
+        help='path to the clangd-tidy executable',
+    )
+    parser.add_argument(
+        '--clangd-binary',
+        default='clangd',
+        help='path to the clangd executable used by clangd-tidy',
+    )
+    parser.add_argument(
+        '--query-driver',
+        default=None,
+        help='comma-separated list of query-driver globs passed to clangd-tidy',
+    )
+    args = parser.parse_args()
+
+    build_path = os.path.abspath(args.build_path or os.getcwd())
+    repo_root, files = load_files(build_path)
+    if not files:
+        print('No files found in compile_commands.json', file=sys.stderr)
+        return 1
+
+    jobs = args.jobs if args.jobs > 0 else multiprocessing.cpu_count()
+
+    try:
+        clangd_tidy_version = subprocess.check_output([args.clangd_tidy_binary, '--version'], text=True).splitlines()[0]
+        clangd_version = subprocess.check_output([args.clangd_binary, '--version'], text=True).splitlines()[0]
+    except Exception:
+        print('Unable to run clangd-tidy or clangd.', file=sys.stderr)
+        return 1
+    print(f'Using clangd-tidy: {clangd_tidy_version}')
+    print(f'Using clangd: {clangd_version}')
+
+    clangd_wrapper = create_clangd_wrapper(build_path, args.clangd_binary)
+    base_command = [
+        args.clangd_tidy_binary,
+        '--compile-commands-dir',
+        build_path,
+        '--jobs',
+        str(jobs),
+        '--clangd-executable',
+        clangd_wrapper,
+    ]
+    if args.query_driver:
+        base_command.extend(['--query-driver', args.query_driver])
+
+    return_code = 0
+    for chunk in chunk_files(files):
+        result = subprocess.run(base_command + chunk, check=False, cwd=repo_root)
+        if result.returncode != 0:
+            return_code = result.returncode
+
+    return return_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/third_party/.clangd
+++ b/third_party/.clangd
@@ -1,0 +1,2 @@
+Diagnostics:
+  UnusedIncludes: None


### PR DESCRIPTION
Try [clangd-tidy](https://github.com/lljbash/clangd-tidy) in CI.

On my macbook M1, it takes ~5 min to run tidy checks on the full code base:
```
...
src/verification/statement_verifier.cpp:5:1: Warning: Included header cte_node.hpp is not used directly (fixes available) [unused-includes]
    3 |  #include "duckdb/parser/query_node/select_node.hpp"
    4 |  #include "duckdb/parser/query_node/set_operation_node.hpp"
    5 |  #include "duckdb/parser/query_node/cte_node.hpp"
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |  
    7 |  #include "duckdb/common/error_data.hpp"

src/verification/statement_verifier.cpp:9:1: Warning: Included header parser.hpp is not used directly (fixes available) [unused-includes]
    7 |  #include "duckdb/common/error_data.hpp"
    8 |  #include "duckdb/common/types/column/column_data_collection.hpp"
    9 |  #include "duckdb/parser/parser.hpp"
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |  #include "duckdb/verification/copied_statement_verifier.hpp"
   11 |  #include "duckdb/verification/deserialized_statement_verifier.hpp"
make: *** [tidy-check-clangd-tidy] Error 1
make tidy-check-clangd-tidy CMAKE_LLVM_PATH="/opt/homebrew/opt/llvm"  2116.23s user 123.23s system 739% cpu 5:02.73 total
```
with:
- -j8 workers
- clang/LLVM v22 from homebrew (using `CMAKE_LLVM_PATH="/opt/homebrew/opt/llvm"`).

I've disabled `UnusedImports` in CI, because it lists [thousands](https://github.com/duckdb/duckdb/actions/runs/23811167465/job/69398517721) of warnings.

### Before
- on main, `clang-tidy` takes [2h 2m](https://github.com/duckdb/duckdb/actions/runs/24559281734/job/71803653593). (On a GitHub runner).
- on PR, `clang-tidy-diff` takes ~30s - [1 min](https://github.com/duckdb/duckdb/actions/runs/24454130506/job/71450421725) (depending on changed files).

### After (9min)

A full `clangd-tidy` takes [9m](https://github.com/duckdb/duckdb/actions/runs/24603026581/job/71944769503) for the whole codebase. (On a namespace runner).

Note: I need to verify how long `clangd-tidy-diff` takes.