### PR TITLE
Fix or and filter pushdown

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
@@ -567,6 +568,59 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
+// Try to create a table filter from a single comparison expression (column op constant).
+// Resolves struct_extract chains via TryGetProjectionIndex. Updates proj_id and column_expr
+// to track the column being filtered (all comparisons in an OR must reference the same column).
+// Returns nullptr if the comparison cannot be pushed down.
+static unique_ptr<TableFilter> TryCreateFilterFromComparison(BoundComparisonExpression &comp, ProjectionIndex &proj_id,
+                                                             optional_ptr<Expression> &column_expr) {
+	optional_ptr<Expression> col_side;
+	optional_ptr<BoundConstantExpression> const_val;
+	bool invert = false;
+	if (comp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		col_side = *comp.left;
+		const_val = comp.right->Cast<BoundConstantExpression>();
+	} else if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		col_side = *comp.right;
+		const_val = comp.left->Cast<BoundConstantExpression>();
+		invert = true;
+	} else {
+		return nullptr;
+	}
+	ProjectionIndex this_proj;
+	if (!TryGetProjectionIndex(*col_side, this_proj)) {
+		return nullptr;
+	}
+	if (!proj_id.IsValid()) {
+		proj_id = this_proj;
+		column_expr = col_side;
+	} else if (proj_id != this_proj || !col_side->Equals(*column_expr)) {
+		return nullptr;
+	}
+	auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
+	if (const_val->value.IsNull()) {
+		switch (comparison_type) {
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			return make_uniq<IsNotNullFilter>();
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			return make_uniq<IsNullFilter>();
+		default:
+			return nullptr;
+		}
+	}
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return make_uniq<ConstantFilter>(comparison_type, const_val->value);
+	default:
+		return nullptr;
+	}
+}
+
 FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_filters,
                                                          const vector<ColumnIndex> &column_ids, Expression &expr) {
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
@@ -581,61 +635,46 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	ProjectionIndex proj_id;
+	optional_ptr<Expression> column_expr;
 	for (idx_t i = 0; i < conj.children.size(); i++) {
 		auto &child = conj.children[i];
-		if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
-			return FilterPushdownResult::NO_PUSHDOWN;
-		}
-		optional_ptr<BoundColumnRefExpression> column_ref;
-		optional_ptr<BoundConstantExpression> const_val;
-		auto &comp = child->Cast<BoundComparisonExpression>();
-		bool invert = false;
-		if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
-		    comp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-			column_ref = comp.left->Cast<BoundColumnRefExpression>();
-			const_val = comp.right->Cast<BoundConstantExpression>();
-		} else if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
-		           comp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-			column_ref = comp.right->Cast<BoundColumnRefExpression>();
-			const_val = comp.left->Cast<BoundConstantExpression>();
-			invert = true;
+		if (child->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+			auto filter = TryCreateFilterFromComparison(child->Cast<BoundComparisonExpression>(), proj_id, column_expr);
+			if (!filter) {
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
+			conj_filter->child_filters.push_back(std::move(filter));
+		} else if (child->GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+			// AND branch within OR: e.g. (a > 10 AND a < 20) OR (a > 80 AND a < 90)
+			auto &inner_conj = child->Cast<BoundConjunctionExpression>();
+			if (inner_conj.GetExpressionType() != ExpressionType::CONJUNCTION_AND) {
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
+			auto and_filter = make_uniq<ConjunctionAndFilter>();
+			for (idx_t j = 0; j < inner_conj.children.size(); j++) {
+				auto &inner_child = inner_conj.children[j];
+				if (inner_child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+					return FilterPushdownResult::NO_PUSHDOWN;
+				}
+				auto filter =
+				    TryCreateFilterFromComparison(inner_child->Cast<BoundComparisonExpression>(), proj_id, column_expr);
+				if (!filter) {
+					return FilterPushdownResult::NO_PUSHDOWN;
+				}
+				and_filter->child_filters.push_back(std::move(filter));
+			}
+			conj_filter->child_filters.push_back(std::move(and_filter));
 		} else {
-			// child of OR filter is not simple so we do not push the or filter down at all
 			return FilterPushdownResult::NO_PUSHDOWN;
-		}
-		if (!proj_id.IsValid()) {
-			proj_id = column_ref->binding.column_index;
-		} else if (proj_id != column_ref->binding.column_index) {
-			return FilterPushdownResult::NO_PUSHDOWN;
-		}
-
-		auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
-		if (const_val->value.IsNull()) {
-			switch (comparison_type) {
-			case ExpressionType::COMPARE_DISTINCT_FROM: {
-				auto null_filter = make_uniq<IsNotNullFilter>();
-				conj_filter->child_filters.push_back(std::move(null_filter));
-				break;
-			}
-			case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
-				auto null_filter = make_uniq<IsNullFilter>();
-				conj_filter->child_filters.push_back(std::move(null_filter));
-				break;
-			}
-			default:
-				// if any other comparison type (i.e EQUAL, NOT_EQUAL) do not push a table filter - this is a nop
-				// since x = NULL is always falsey, and this is a chain of OR conditions, we can just ignore it
-				break;
-			}
-		} else {
-			auto const_filter = make_uniq<ConstantFilter>(comparison_type, const_val->value);
-			conj_filter->child_filters.push_back(std::move(const_filter));
 		}
 	}
-	auto optional_filter = make_uniq<OptionalFilter>();
-	optional_filter->child_filter = std::move(conj_filter);
-	table_filters.PushFilter(proj_id, std::move(optional_filter));
-	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
+	// Wrap in StructFilter if the column expression involves struct_extract
+	unique_ptr<TableFilter> result_filter = std::move(conj_filter);
+	if (column_expr) {
+		result_filter = PushDownFilterIntoExpr(*column_expr, std::move(result_filter));
+	}
+	table_filters.PushFilter(proj_id, std::move(result_filter));
+	return FilterPushdownResult::PUSHED_DOWN_FULLY;
 }
 
 static bool IsGreaterThan(ExpressionType type) {

--- a/src/optimizer/rule/predicate_factoring.cpp
+++ b/src/optimizer/rule/predicate_factoring.cpp
@@ -54,6 +54,21 @@ static bool GetSingleColumnBinding(const Expression &expr, ColumnBinding &column
 	return ColumnBindingIsvalid(column_binding) && !found_multiple;
 }
 
+// Predicates from a single branch for a single column, preserving the conjunction type.
+struct BranchPredicates {
+	ExpressionType conjunction_type;
+	vector<reference<Expression>> predicates;
+};
+
+// Return the conjunction type for a branch expression. Non-conjunction expressions (e.g. a single
+// comparison) default to CONJUNCTION_AND so that BoundConjunctionExpression is always well-formed.
+static ExpressionType GetBranchConjunctionType(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		return expr.GetExpressionType();
+	}
+	return ExpressionType::CONJUNCTION_AND;
+}
+
 static void ExtractDisjunctedPredicates(Expression &expression,
                                         column_binding_map_t<vector<reference<Expression>>> &binding_map);
 
@@ -83,16 +98,25 @@ static void ExtractDisjunctedPredicates(Expression &expression,
 	}
 }
 
-static column_binding_map_t<vector<reference<Expression>>> GetDisjunctedPredicateMap(Expression &expression) {
+// Returns per-column predicates grouped by OR branch, preserving the conjunction type within each branch.
+// For (lon>-139 AND lon<-128) OR (lon>152 AND lon<166), returns:
+//   lon -> [{AND, [lon>-139, lon<-128]}, {AND, [lon>152, lon<166]}]
+static column_binding_map_t<vector<BranchPredicates>> GetDisjunctedPredicateMap(Expression &expression) {
 	vector<reference<Expression>> disjuncted_children;
 	ExtractDisjunctedPredicates(expression, disjuncted_children);
 	D_ASSERT(disjuncted_children.size() > 1);
+
+	column_binding_map_t<vector<BranchPredicates>> result;
 
 	// Extract predicates of the first child
 	auto &first_child = disjuncted_children[0].get();
 	D_ASSERT(!ExpressionIsDisjunction(first_child));
 	column_binding_map_t<vector<reference<Expression>>> remaining_binding_map;
 	ExtractDisjunctedPredicates(first_child, remaining_binding_map);
+	// Seed result with the first branch's per-column predicates
+	for (auto &entry : remaining_binding_map) {
+		result[entry.first].push_back({GetBranchConjunctionType(first_child), std::move(entry.second)});
+	}
 
 	for (idx_t child_idx = 1; child_idx < disjuncted_children.size(); child_idx++) {
 		auto &child = disjuncted_children[child_idx].get();
@@ -101,29 +125,18 @@ static column_binding_map_t<vector<reference<Expression>>> GetDisjunctedPredicat
 		ExtractDisjunctedPredicates(child, child_binding_map);
 
 		// Bindings must appear in both maps to be considered for predicate factoring
-		for (auto it = remaining_binding_map.begin(); it != remaining_binding_map.end();) {
+		for (auto it = result.begin(); it != result.end();) {
 			auto child_it = child_binding_map.find(it->first);
 			if (child_it == child_binding_map.end()) {
-				it = remaining_binding_map.erase(it);
+				it = result.erase(it);
 			} else {
-				for (auto &new_predicate : child_it->second) {
-					bool found = false;
-					for (auto &existing_predicate : it->second) {
-						if (new_predicate.get().Equals(existing_predicate.get())) {
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-						it->second.push_back(new_predicate.get());
-					}
-				}
+				it->second.push_back({GetBranchConjunctionType(child), std::move(child_it->second)});
 				it++;
 			}
 		}
 	}
 
-	return remaining_binding_map;
+	return result;
 }
 
 unique_ptr<Expression> PredicateFactoringRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
@@ -156,13 +169,25 @@ unique_ptr<Expression> PredicateFactoringRule::Apply(LogicalOperator &op, vector
 
 		// Create disjunction on single-column predicates
 		unique_ptr<Expression> column_filter;
-		for (auto &expr : entry.second) {
+		for (auto &branch : entry.second) {
+			unique_ptr<Expression> branch_filter;
+			if (branch.predicates.size() == 1) {
+				branch_filter = branch.predicates[0].get().Copy();
+			} else {
+				// Reconstruct the conjunction for this branch's predicates on this column
+				auto conj = make_uniq<BoundConjunctionExpression>(branch.conjunction_type);
+				for (auto &pred : branch.predicates) {
+					conj->children.push_back(pred.get().Copy());
+				}
+				branch_filter = std::move(conj);
+			}
+
 			if (!column_filter) {
-				column_filter = expr.get().Copy();
+				column_filter = std::move(branch_filter);
 			} else {
 				auto new_disjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
 				new_disjunction->children.push_back(std::move(column_filter));
-				new_disjunction->children.push_back(expr.get().Copy());
+				new_disjunction->children.push_back(std::move(branch_filter));
 				column_filter = std::move(new_disjunction);
 			}
 		}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/planner/filter/perfect_hash_join_filter.hpp"
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 
+#include <algorithm>
 #include <cstring>
 
 namespace duckdb {
@@ -443,6 +444,7 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 				}
 			}
 		}
+		std::sort(result_sel.data(), result_sel.data() + count_total);
 		sel.Initialize(result_sel);
 		approved_tuple_count = count_total;
 		return approved_tuple_count;

--- a/test/optimizer/date_trunc_simplification.test
+++ b/test/optimizer/date_trunc_simplification.test
@@ -100,7 +100,7 @@ analyzed_plan	<REGEX>:.*Filters:[ \t\n│]*d>='2025.*AND.*d<'2025.*$
 query II
 explain analyze select * from test where date_trunc('day', d) != '2025-01-08';
 ----
-analyzed_plan	<REGEX>:.*FILTER[ \t\n│─]*\(\(d >= '2025.*OR.*\(d <[ \t\n│─]*'2025.*$
+analyzed_plan	<REGEX>:.*Filters:[ \t\n│─:()]*d[ \t\n│─()]*>=[ \t\n│─()]*'2025.*OR.*d[ \t\n│─()]*<[ \t\n│─()]*'2025.*$
 
 query II
 explain analyze select * from test where date_trunc('day', d) is not distinct from '2025-01-08';
@@ -110,7 +110,7 @@ analyzed_plan	<REGEX>:.*Filters:[ \t\n│]*d>='2025.*AND.*d<'2025.*$
 query II
 explain analyze select * from test where date_trunc('day', d) is distinct from '2025-01-08';
 ----
-analyzed_plan	<REGEX>:.*Filters:[ \t\n│─]*\(\(d >= '2025.*OR.*\(d <[ \t\n│─]*'2025.*$
+analyzed_plan	<REGEX>:.*Filters:[ \t\n│─:()]*d[ \t\n│─()]*>=[ \t\n│─()]*'2025.*OR.*d[ \t\n│─()]*<[ \t\n│─()]*'2025.*$
 
 #
 # check correctness of simple optimizations, column on rhs
@@ -421,4 +421,3 @@ select * from test where date_trunc('week', d) >= '2025-01-01';
 query I
 select * from test where date_trunc('quarter', d) >= '2025-04-01';
 ----
-

--- a/test/sql/filter/test_or_and_pushdown.test
+++ b/test/sql/filter/test_or_and_pushdown.test
@@ -1,0 +1,119 @@
+# name: test/sql/filter/test_or_and_pushdown.test
+# description: Test OR-of-AND filter pushdown into zone maps
+# group: [filter]
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+# Create table with enough rows for multiple row groups
+statement ok
+CREATE TABLE t1 AS SELECT range a, range * 10 b FROM range(900000);
+
+# Basic: OR-of-AND on the same column should get fully pushed as table filter (no FILTER node)
+query II
+EXPLAIN SELECT * FROM t1 WHERE (a > 10 AND a < 20) OR (a > 800000 AND a < 800010);
+----
+physical_plan	<!REGEX>:.*FILTER.*
+
+query I
+SELECT count(*) FROM t1 WHERE (a > 10 AND a < 20) OR (a > 800000 AND a < 800010);
+----
+18
+
+# Cross-column OR-of-AND: per-column filters pushed, original expression remains in FILTER
+query II
+EXPLAIN SELECT * FROM t1 WHERE (a > 10 AND a < 20 AND b > 100 AND b < 200) OR (a > 800000 AND a < 800010 AND b > 8000000 AND b < 8000100);
+----
+physical_plan	<REGEX>:.*FILTER.*
+
+query I
+SELECT count(*) FROM t1 WHERE (a > 10 AND a < 20 AND b > 100 AND b < 200) OR (a > 800000 AND a < 800010 AND b > 8000000 AND b < 8000100);
+----
+18
+
+# Verify correct results for basic case
+query I
+SELECT a FROM t1 WHERE (a > 10 AND a < 15) OR (a > 899995 AND a < 899999) ORDER BY a;
+----
+11
+12
+13
+14
+899996
+899997
+899998
+
+# Mixed: some branches are simple comparisons, some are AND conjunctions
+query II
+EXPLAIN SELECT * FROM t1 WHERE a = 5 OR (a > 800000 AND a < 800010);
+----
+physical_plan	<!REGEX>:.*FILTER.*
+
+query I
+SELECT count(*) FROM t1 WHERE a = 5 OR (a > 800000 AND a < 800010);
+----
+10
+
+# IS DISTINCT FROM / IS NOT DISTINCT FROM: should not crash (degrades to no pushdown)
+statement ok
+CREATE TABLE t2(a INTEGER);
+
+statement ok
+INSERT INTO t2 VALUES (1), (2), (NULL);
+
+query I
+SELECT count(*) FROM t2 WHERE a IS DISTINCT FROM 1 OR a = 2;
+----
+2
+
+query I
+SELECT count(*) FROM t2 WHERE a IS NOT DISTINCT FROM 1 OR a = 2;
+----
+2
+
+# Different struct fields from the same struct must not be conflated
+statement ok
+CREATE TABLE ts AS SELECT * FROM (VALUES ({'x': 1, 'y': 0}), ({'x': 0, 'y': 2}), ({'x': 2, 'y': 0})) v(s);
+
+query II
+SELECT s.x, s.y FROM ts WHERE s.x = 1 OR s.y = 2 ORDER BY 1, 2;
+----
+0	2
+1	0
+
+# Branch without column on one side: should degrade gracefully (no crash)
+query I
+SELECT count(*) FROM t1 WHERE (a > 10 AND b > 100) OR (a > 800000);
+----
+899989
+
+require parquet
+
+# Parquet: verify row group pruning works with OR-of-AND
+statement ok
+COPY (SELECT range a, range * 10 b FROM range(100000)) TO '{TEST_DIR}/or_and_test.parquet' (FORMAT 'parquet', ROW_GROUP_SIZE 5000);
+
+query II
+EXPLAIN SELECT * FROM read_parquet('{TEST_DIR}/or_and_test.parquet') WHERE (a > 10 AND a < 20) OR (a > 99980 AND a < 99990);
+----
+physical_plan	<!REGEX>:.*FILTER.*
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/or_and_test.parquet') WHERE (a > 10 AND a < 20) OR (a > 99980 AND a < 99990);
+----
+18
+
+# Cross-column parquet test
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/or_and_test.parquet') WHERE (a > 10 AND a < 20 AND b > 100 AND b < 200) OR (a > 99980 AND a < 99990 AND b > 999800 AND b < 999900);
+----
+18
+
+# Struct field OR-of-AND
+statement ok
+COPY (SELECT {'x': range, 'y': range * 10} AS s FROM generate_series(100000) AS t(range)) TO '{TEST_DIR}/struct_or_and.parquet' (FORMAT 'parquet', ROW_GROUP_SIZE 5000);
+
+query I
+SELECT count(*) FROM read_parquet('{TEST_DIR}/struct_or_and.parquet') WHERE (s.x > 10 AND s.x < 20) OR (s.x > 99980 AND s.x < 99990);
+----
+18

--- a/test/sql/filter/test_or_pushdown.test
+++ b/test/sql/filter/test_or_pushdown.test
@@ -33,21 +33,22 @@ select a from t1 where a=5 or a=899999;
 899999
 
 # check that multiple rows from mulitple row groups are being projected and not just 2.
+# with OR-of-AND pushdown, simple single-column ORs are now fully pushed (no optional)
 query II
 explain select * from t1 where a<5 or a>10;
 ----
-physical_plan	<REGEX>:.*optional.*a<5.*a>10.*
+physical_plan	<!REGEX>:.*optional.*
 
-# need to flip the comparison
+# need to flip the comparison - now fully pushed (no optional)
 query II
 explain select * from t1 where 5>a or 10<a;
 ----
-physical_plan	<REGEX>:.*optional.*a<5.*a>10.*
+physical_plan	<!REGEX>:.*optional.*
 
 query II
 explain select * from t1 where 5>=a or 10<=a;
 ----
-physical_plan	<REGEX>:.*optional.*a<=5.*a>=10.*
+physical_plan	<!REGEX>:.*optional.*
 
 query II
 explain select * from t1 where a in (1, 5, 10);
@@ -57,7 +58,7 @@ physical_plan	<REGEX>:.*optional.*
 query II
 explain select * from t1 where a = 1 or a = 5 or a = 10;
 ----
-physical_plan	<REGEX>:.*optional.*
+physical_plan	<!REGEX>:.*optional.*
 
 query II
 explain select * from t1 where a in (1, 2, 3);
@@ -72,7 +73,7 @@ physical_plan	<!REGEX>:.*optional.*
 query II
 explain select b from t1 where b = 'foo9' or b = 'foo10';
 ----
-physical_plan	<REGEX>:.*optional.*
+physical_plan	<!REGEX>:.*optional.*
 
 # two different row groups can be propagated here.
 query I
@@ -84,4 +85,4 @@ select a from t1 where d=timestamp '1992-01-01 01:40:00' or d=timestamp '2026-03
 query II
 explain select a from t1 where d=timestamp '1992-01-01 01:40:00' or d=timestamp '2026-03-22 23:40:00'
 ----
-physical_plan	<REGEX>:.*optional.*d.*
+physical_plan	<!REGEX>:.*optional.*

--- a/test/sql/function/operator/test_conjunction.test
+++ b/test/sql/function/operator/test_conjunction.test
@@ -17,7 +17,7 @@ SELECT * FROM a WHERE (i > 3 AND j < 5) OR (i > 3 AND j > 5);
 query II
 explain SELECT * FROM a WHERE (i > 3 AND j < 5) OR (i > 3 AND j > 5);
 ----
-physical_plan	<REGEX>:.*optional.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*i>3.*j<5 OR j>5.*
 
 # test boolean logic in conjunctions
 query T
@@ -191,4 +191,3 @@ SELECT i>3 AND NULL FROM a ORDER BY i
 0
 NULL
 NULL
-


### PR DESCRIPTION
This MR includes two commits to fix https://github.com/duckdb/duckdb/issues/21750. It improves performance in our use case 37 times!


| Metric                     | Original   | Patched    | UNION ALL  |
|---------------------------|---------------|----------------|-------------------|
| Data downloaded | 4.2 GiB    | 120 MiB    | 44.2 MiB        |
| GET requests         | 6,967       |           74    | 35                   |
| Rows from scan    | 91M         | 228K          | 2,153             |
| Total time              | 395s         | 10.68s       | 10.06s            |


The commits enable row group pruning and row-level filter pushdown for OR-of-AND predicates, such as multi-region spatial queries on geoparquet:

```sql
  WHERE (lon > -139 AND lon < -128 AND lat > -34 AND lat < -24)
     OR (lon > 152 AND lon < 166 AND lat > 31 AND lat < 38)                                                                                       
```
                                                            
Previously, DuckDB could not push these filters as table filters because TryPushdownOrClause only accepted simple column op constant OR branches, and PredicateFactoringRule flattened per-branch AND predicates into per-column ORs that were always true e.g. `lon > -139 OR lon <   -128 OR lon > 152 OR lon < 166`. 
                                                                                                       
The two commits:                                           

1. TryPushdownOrClause — accept AND conjunction branches, converting them to ConjunctionAndFilter children within the ConjunctionOrFilter. Push the filter directly (not wrapped in OptionalFilter) for both zone-map pruning and row-level filtering. Struct fields are supported via TryGetProjectionIndex / PushDownFilterIntoExpr.                                                                                               
2. PredicateFactoringRule — preserve per-branch AND grouping when decomposing multi-column OR-of-AND expressions into per-column ORs. The data  structure is changed from a flat predicate list to a BranchPredicates struct that carries the conjunction type from the original expression.   

The MR also adds a bunch of tests to verify these fixes and updates some existing tests.

Happy to split this into two MR's if that is better, but we need both commits to solve our peformance issue.

Thanks!