### PR TITLE
Prefix Range Filter VARCHAR support

### DIFF
--- a/benchmark/micro/pushdown/prefix_range_filter_strings.benchmark
+++ b/benchmark/micro/pushdown/prefix_range_filter_strings.benchmark
@@ -1,0 +1,21 @@
+# name: benchmark/micro/pushdown/prefix_range_filter_strings.benchmark
+# description: Prefix Range Filter Pushdown on VARCHAR Join Keys
+# group: [pushdown]
+
+name Prefix Range Filter Pushdown with VARCHAR Keys
+group join
+
+storage persistent
+
+load
+CREATE TABLE build AS
+SELECT lpad(i::VARCHAR, 8, '0') k, i NOT BETWEEN 100000 AND 4900000 p, CAST(random() AS VARCHAR) v
+FROM range(5000000) _(i);
+CREATE TABLE probe AS
+SELECT lpad((i // 20)::VARCHAR, 8, '0') k, CAST(random() AS VARCHAR) v
+FROM range(100000000) _(i);
+
+run
+SELECT any_value(probe.v), any_value(build.v)
+FROM build, probe
+WHERE build.k = probe.k AND p = TRUE;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -994,6 +994,10 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 
 	uhugeint_t span;
 	if (PrefixRangeFilter::TryComputeSpan(min, max, span)) {
+		if (span == 0) {
+			// Filter will not be more expressive than min/max, bail
+			return false;
+		}
 		static const auto SPAN_THRESHOLD = Uhugeint::Convert(1048576);
 		span_is_small = span <= SPAN_THRESHOLD;
 	} else {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1005,7 +1005,8 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 	}
 
 	const auto &key_type = ht->conditions[0].GetLHS().return_type;
-	if (key_type.id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(key_type).empty()) {
+	if (key_type.id() == LogicalTypeId::VARCHAR &&
+	    (!StringType::GetCollation(key_type).empty() || Settings::Get<DefaultCollationSetting>(context).empty())) {
 		return false;
 	}
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1005,11 +1005,6 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 	}
 
 	const auto &key_type = ht->conditions[0].GetLHS().return_type;
-	if (key_type.id() == LogicalTypeId::VARCHAR &&
-	    (!StringType::GetCollation(key_type).empty() || Settings::Get<DefaultCollationSetting>(context).empty())) {
-		return false;
-	}
-
 	return PrefixRangeTableFilter::SupportedType(key_type);
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1004,7 +1004,12 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 		return false;
 	}
 
-	return PrefixRangeTableFilter::SupportedType(ht->conditions[0].GetLHS().return_type);
+	const auto &key_type = ht->conditions[0].GetLHS().return_type;
+	if (key_type.id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(key_type).empty()) {
+		return false;
+	}
+
+	return PrefixRangeTableFilter::SupportedType(key_type);
 }
 
 void JoinFilterPushdownInfo::PushBloomFilter(const PhysicalOperator &op, JoinHashTable &ht,

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -94,6 +94,14 @@ public:
 		return value.inlined.inlined;
 	}
 
+	uint32_t GetPrefixIntegerComparable() const {
+#ifdef DUCKDB_DEBUG_NO_INLINE
+		return 0;
+#else
+		return BSwapIfLE(Load<uint32_t>(const_data_ptr_cast(GetPrefix())));
+#endif
+	}
+
 	idx_t GetSize() const {
 		return value.inlined.length;
 	}

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -25,6 +25,17 @@ class PrefixRangeFilter {
 public:
 	struct BuildState {
 		virtual ~BuildState() = default;
+		template <class TARGET>
+
+		TARGET &Cast() {
+			DynamicCastCheck<TARGET>(this);
+			return reinterpret_cast<TARGET &>(*this);
+		}
+		template <class TARGET>
+		const TARGET &Cast() const {
+			DynamicCastCheck<TARGET>(this);
+			return reinterpret_cast<const TARGET &>(*this);
+		}
 	};
 
 	virtual ~PrefixRangeFilter() = default;

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -44,7 +44,7 @@ public:
 	virtual void InsertKeys(Vector &keys, idx_t count, BuildState &state) const = 0;
 	virtual void MergeBuildState(BuildState &state) = 0;
 	virtual idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const = 0;
-	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) const = 0;
+	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;
 	virtual bool IsInitialized() const = 0;
 	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);
 	static bool TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result);

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -45,7 +45,7 @@ public:
 	virtual void MergeBuildState(BuildState &state) = 0;
 	virtual idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const = 0;
 	virtual bool LookupOneValue(const Value &key) const = 0;
-	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;
+	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) const = 0;
 	virtual bool IsInitialized() const = 0;
 	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);
 	static bool TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result);

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -44,7 +44,6 @@ public:
 	virtual void InsertKeys(Vector &keys, idx_t count, BuildState &state) const = 0;
 	virtual void MergeBuildState(BuildState &state) = 0;
 	virtual idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const = 0;
-	virtual bool LookupOneValue(const Value &key) const = 0;
 	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) const = 0;
 	virtual bool IsInitialized() const = 0;
 	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -73,7 +74,7 @@ public:
 	}
 
 	void Insert(U key, PrefixRangeFilter::BuildState &state_p) const {
-		auto &state = static_cast<PrefixRangeBuildState &>(state_p);
+		auto &state = state_p.Cast<PrefixRangeBuildState>();
 		const U y = key - min;
 		// All keys are in-range by construction, so the range check can be omitted here.
 		const U idx = y >> shift;
@@ -81,18 +82,18 @@ public:
 	}
 
 	void MergeBuildState(PrefixRangeFilter::BuildState &state_p) {
-		auto &state = static_cast<PrefixRangeBuildState &>(state_p);
+		auto &state = state_p.Cast<PrefixRangeBuildState>();
 		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
 			bitmap[word_idx] |= state.bitmap[word_idx];
 		}
 		initialized = true;
 	}
 
-	idx_t Lookup(U key) const {
+	inline idx_t Lookup(U key) const {
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = static_cast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint32_t word_idx = UnsafeNumericCast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
@@ -114,8 +115,8 @@ public:
 		const U ub_bit_idx = ub_y >> shift;
 		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
-		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));
-		const idx_t ub_bit_off = static_cast<idx_t>(ub_bit_idx & static_cast<U>(WORD_MASK));
+		const idx_t lb_bit_off = UnsafeNumericCast<idx_t>(lb_bit_idx & UnsafeNumericCast<U>(WORD_MASK));
+		const idx_t ub_bit_off = UnsafeNumericCast<idx_t>(ub_bit_idx & UnsafeNumericCast<U>(WORD_MASK));
 
 		// TODO: Count the amount of 1's in the range, compare to a threshold, and make a decision if we want to use the
 		// per-row filter for this row group.
@@ -132,7 +133,7 @@ public:
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 
-		for (idx_t i = NumericCast<idx_t>(lb_word_idx) + 1; i < NumericCast<idx_t>(ub_word_idx); i++) {
+		for (idx_t i = UnsafeNumericCast<idx_t>(lb_word_idx) + 1; i < UnsafeNumericCast<idx_t>(ub_word_idx); i++) {
 			if (bitmap[i]) {
 				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			}
@@ -179,6 +180,7 @@ struct NumericPrefixPolicy {
 	using comparable_type = typename MakeUnsigned<T>::type;
 
 	static comparable_type ToComparable(input_type value) {
+		// Overflow is explicitly allowed for unsigned to signed cast
 		return static_cast<comparable_type>(value);
 	}
 
@@ -198,14 +200,15 @@ struct NumericPrefixPolicy {
 		const auto lb = lower_bound.GetValueUnsafe<input_type>();
 		const auto ub = upper_bound.GetValueUnsafe<input_type>();
 
+		// static_cast is needed here as we need to allow overflow to cast from comparable_type
 		const auto min_t = static_cast<input_type>(bitmap.Min());
 		const auto max_t = static_cast<input_type>(bitmap.Min() + bitmap.Span());
 		if (ub < min_t || lb > max_t) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto adjusted_lb = static_cast<comparable_type>(MaxValue<input_type>(lb, min_t));
-		const auto adjusted_ub = static_cast<comparable_type>(MinValue<input_type>(ub, max_t));
+		const auto adjusted_lb = ToComparable(MaxValue<input_type>(lb, min_t));
+		const auto adjusted_ub = ToComparable(MinValue<input_type>(ub, max_t));
 		return bitmap.LookupClampedRange(adjusted_lb, adjusted_ub);
 	}
 };
@@ -336,8 +339,13 @@ bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound,
 #else
 	auto lb_value = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
 	auto ub_value = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-	result = Uhugeint::Convert(static_cast<uint64_t>(ub_value - lb_value));
-	return true;
+	uint32_t res;
+	if (TrySubtractOperator::Operation(ub_value, lb_value, res)) {
+		result = Uhugeint::Convert(res);
+		return true;
+	} else {
+		return false;
+	}
 #endif
 }
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -35,14 +35,13 @@ AllocatedData AllocateBitmap(ClientContext &context, const idx_t word_count, uin
 	return buffer;
 }
 
-struct PrefixRangeBuildState : public PrefixRangeFilter::BuildState {
-	explicit PrefixRangeBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
-	    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
+struct PrefixRangeBitmapBuildState : public PrefixRangeFilter::BuildState {
+	explicit PrefixRangeBitmapBuildState(AllocatedData data_p, uint64_t *bitmap_p)
+	    : data(std::move(data_p)), bitmap(bitmap_p) {
 	}
 
 	AllocatedData data;
 	uint64_t *bitmap;
-	idx_t word_count;
 };
 
 template <typename U>
@@ -67,22 +66,21 @@ public:
 		initialized = false;
 	}
 
-	unique_ptr<PrefixRangeFilter::BuildState> InitializeBuildState(ClientContext &context) const {
+	unique_ptr<PrefixRangeBitmapBuildState> InitializeBuildState(ClientContext &context) const {
 		D_ASSERT(bitmap);
 		uint64_t *state_bitmap;
 		auto state_data = AllocateBitmap(context, word_count, state_bitmap);
-		return make_uniq<PrefixRangeBuildState>(std::move(state_data), state_bitmap, word_count);
+		return make_uniq<PrefixRangeBitmapBuildState>(std::move(state_data), state_bitmap);
 	}
 
-	inline void Insert(U key, PrefixRangeBuildState &state) const {
+	inline void Insert(U key, uint64_t *state_bitmap) const {
 		const U y = key - min;
 		// All keys are in-range by construction, so the range check can be omitted here.
 		const U idx = y >> shift;
-		state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
+		state_bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
 	}
 
-	void MergeBuildState(PrefixRangeFilter::BuildState &state_p) {
-		auto &state = state_p.Cast<PrefixRangeBuildState>();
+	void MergeBuildState(PrefixRangeBitmapBuildState &state) {
 		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
 			bitmap[word_idx] |= state.bitmap[word_idx];
 		}
@@ -166,56 +164,6 @@ private:
 	uint64_t *bitmap;
 };
 
-template <typename T>
-struct NumericPrefixPolicy {
-	using input_type = T;
-	using comparable_type = typename MakeUnsigned<T>::type;
-
-	static bool SupportsStats(const BaseStatistics &stats) {
-		return stats.GetStatsType() == StatisticsType::NUMERIC_STATS;
-	}
-
-	static inline comparable_type ToComparable(input_type value) {
-		// Overflow is explicitly allowed for unsigned to signed cast
-		return static_cast<comparable_type>(value);
-	}
-
-	static comparable_type ToComparable(const Value &value) {
-		return ToComparable(value.GetValueUnsafe<input_type>());
-	}
-
-	static void InitializeBitmap(PrefixRangeBitmap<comparable_type> &bitmap, ClientContext &context,
-	                             const Value &min_val, const Value &max_val) {
-		const auto min = ToComparable(min_val);
-		const auto max = ToComparable(max_val);
-		bitmap.Initialize(context, min, max - min);
-	}
-
-	static bool ExtractClampedStatsRange(const PrefixRangeBitmap<comparable_type> &bitmap, BaseStatistics &stats,
-	                                     comparable_type &lower_bound, comparable_type &upper_bound) {
-		if (!NumericStats::HasMinMax(stats)) {
-			return false;
-		}
-
-		const auto min = NumericStats::Min(stats).GetValueUnsafe<input_type>();
-		const auto max = NumericStats::Max(stats).GetValueUnsafe<input_type>();
-		if (min > max) {
-			return false;
-		}
-
-		// static_cast is needed here as we need to allow overflow to cast from comparable_type
-		const auto min_t = static_cast<input_type>(bitmap.Min());
-		const auto max_t = static_cast<input_type>(bitmap.Min() + bitmap.Span());
-		if (max < min_t || min > max_t) {
-			return false;
-		}
-
-		lower_bound = ToComparable(MaxValue<input_type>(min, min_t));
-		upper_bound = ToComparable(MinValue<input_type>(max, max_t));
-		return true;
-	}
-};
-
 uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
 	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
 }
@@ -235,65 +183,18 @@ uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
 	return string_t(padded_prefix.data(), string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
 }
 
-struct StringPrefixPolicy {
-	using input_type = string_t;
-	using comparable_type = uint32_t;
-
-	static bool SupportsStats(const BaseStatistics &stats) {
-		return stats.GetStatsType() == StatisticsType::STRING_STATS;
-	}
-
-	static inline comparable_type ToComparable(const input_type &value) {
-		return value.GetPrefixIntegerComparable();
-	}
-
-	static comparable_type ToComparable(const Value &value) {
-		return ToComparable(value.GetValueUnsafe<input_type>());
-	}
-
-	static void InitializeBitmap(PrefixRangeBitmap<comparable_type> &bitmap, ClientContext &context,
-	                             const Value &min_val, const Value &max_val) {
-		const auto min = ToComparable(min_val);
-		const auto max = ToComparable(max_val);
-		D_ASSERT(min <= max);
-		bitmap.Initialize(context, min, max - min);
-	}
-
-	static bool ExtractClampedStatsRange(const PrefixRangeBitmap<comparable_type> &bitmap, BaseStatistics &stats,
-	                                     comparable_type &lower_bound, comparable_type &upper_bound) {
-		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
-			return false;
-		}
-
-		lower_bound = StringStatsMinComparable(stats);
-		upper_bound = StringStatsMaxComparable(stats);
-		if (lower_bound > upper_bound) {
-			return false;
-		}
-
-		const auto bitmap_min = bitmap.Min();
-		const auto bitmap_max = bitmap.Min() + bitmap.Span();
-		if (upper_bound < bitmap_min || lower_bound > bitmap_max) {
-			return false;
-		}
-
-		lower_bound = MaxValue<comparable_type>(lower_bound, bitmap_min);
-		upper_bound = MinValue<comparable_type>(upper_bound, bitmap_max);
-		return true;
-	}
-};
-
-template <typename Policy>
-class TemplatedPrefixRangeFilter : public PrefixRangeFilter {
+template <typename T>
+class NumericPrefixRangeFilter : public PrefixRangeFilter {
 private:
-	using Input = typename Policy::input_type;
-	using Comparable = typename Policy::comparable_type;
+	using Comparable = typename MakeUnsigned<T>::type;
 
 public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
 		D_ASSERT(number_of_rows > 0);
-		Policy::InitializeBitmap(bitmap, context, min_val, max_val);
+		const auto min = ToComparable(min_val.GetValueUnsafe<T>());
+		const auto max = ToComparable(max_val.GetValueUnsafe<T>());
+		bitmap.Initialize(context, min, max - min);
 	}
 
 	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
@@ -301,14 +202,15 @@ public:
 	}
 
 	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
-		auto &bitmap_state = state.Cast<PrefixRangeBuildState>();
-		for (const auto &entry : keys.template ValidValues<Input>(count)) {
-			bitmap.Insert(Policy::ToComparable(entry.value), bitmap_state);
+		auto &bitmap_state = state.Cast<PrefixRangeBitmapBuildState>();
+		auto *state_bitmap = bitmap_state.bitmap;
+		for (const auto &entry : keys.template ValidValues<T>(count)) {
+			bitmap.Insert(ToComparable(entry.value), state_bitmap);
 		}
 	}
 
 	void MergeBuildState(BuildState &state) override {
-		bitmap.MergeBuildState(state);
+		bitmap.MergeBuildState(state.Cast<PrefixRangeBitmapBuildState>());
 	}
 
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
@@ -317,9 +219,9 @@ public:
 		}
 
 		idx_t found_count = 0;
-		for (const auto &entry : keys.template ValidValues<Input>(count)) {
+		for (const auto &entry : keys.template ValidValues<T>(count)) {
 			result_sel.set_index(found_count, entry.index);
-			found_count += bitmap.Lookup(Policy::ToComparable(entry.value));
+			found_count += bitmap.Lookup(ToComparable(entry.value));
 		}
 		return found_count;
 	}
@@ -328,16 +230,27 @@ public:
 		if (key.IsNull()) {
 			return false;
 		}
-		return bitmap.Lookup(Policy::ToComparable(key));
+		return bitmap.Lookup(ToComparable(key.GetValueUnsafe<T>()));
 	}
 
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
-		Comparable lower_bound;
-		Comparable upper_bound;
-		if (!Policy::SupportsStats(stats) ||
-		    !Policy::ExtractClampedStatsRange(bitmap, stats, lower_bound, upper_bound)) {
+		if (stats.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(stats)) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
+		const auto min = NumericStats::Min(stats).GetValueUnsafe<T>();
+		const auto max = NumericStats::Max(stats).GetValueUnsafe<T>();
+		if (min > max) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		const auto bitmap_min = static_cast<T>(bitmap.Min());
+		const auto bitmap_max = static_cast<T>(bitmap.Min() + bitmap.Span());
+		if (max < bitmap_min || min > bitmap_max) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto lower_bound = ToComparable(MaxValue<T>(min, bitmap_min));
+		const auto upper_bound = ToComparable(MinValue<T>(max, bitmap_max));
 		return bitmap.LookupRange(lower_bound, upper_bound);
 	}
 
@@ -347,6 +260,93 @@ public:
 
 private:
 	PrefixRangeBitmap<Comparable> bitmap;
+
+	static inline Comparable ToComparable(T value) {
+		// Overflow is explicitly allowed for unsigned to signed cast
+		return static_cast<Comparable>(value);
+	}
+};
+
+class StringPrefixRangeFilter : public PrefixRangeFilter {
+public:
+	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
+		D_ASSERT(min_val <= max_val);
+		D_ASSERT(number_of_rows > 0);
+		const auto min = ToComparable(min_val.GetValueUnsafe<string_t>());
+		const auto max = ToComparable(max_val.GetValueUnsafe<string_t>());
+		D_ASSERT(min <= max);
+		bitmap.Initialize(context, min, max - min);
+	}
+
+	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
+		return bitmap.InitializeBuildState(context);
+	}
+
+	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
+		auto &bitmap_state = state.Cast<PrefixRangeBitmapBuildState>();
+		auto *state_bitmap = bitmap_state.bitmap;
+		for (const auto &entry : keys.template ValidValues<string_t>(count)) {
+			bitmap.Insert(ToComparable(entry.value), state_bitmap);
+		}
+	}
+
+	void MergeBuildState(BuildState &state) override {
+		bitmap.MergeBuildState(state.Cast<PrefixRangeBitmapBuildState>());
+	}
+
+	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
+		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+		}
+
+		idx_t found_count = 0;
+		for (const auto &entry : keys.template ValidValues<string_t>(count)) {
+			result_sel.set_index(found_count, entry.index);
+			found_count += bitmap.Lookup(ToComparable(entry.value));
+		}
+		return found_count;
+	}
+
+	bool LookupOneValue(const Value &key) const override {
+		if (key.IsNull()) {
+			return false;
+		}
+		return bitmap.Lookup(ToComparable(key.GetValueUnsafe<string_t>()));
+	}
+
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
+		if (stats.GetStatsType() != StatisticsType::STRING_STATS || !stats.CanHaveNoNull() ||
+		    !StringStats::HasMaxStringLength(stats)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		auto lower_bound = StringStatsMinComparable(stats);
+		auto upper_bound = StringStatsMaxComparable(stats);
+		if (lower_bound > upper_bound) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		const auto bitmap_min = bitmap.Min();
+		const auto bitmap_max = bitmap.Min() + bitmap.Span();
+		if (upper_bound < bitmap_min || lower_bound > bitmap_max) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		lower_bound = MaxValue<uint32_t>(lower_bound, bitmap_min);
+		upper_bound = MinValue<uint32_t>(upper_bound, bitmap_max);
+		return bitmap.LookupRange(lower_bound, upper_bound);
+	}
+
+	bool IsInitialized() const override {
+		return bitmap.IsInitialized();
+	}
+
+private:
+	static inline uint32_t ToComparable(const string_t &value) {
+		return value.GetPrefixIntegerComparable();
+	}
+
+	PrefixRangeBitmap<uint32_t> bitmap;
 };
 
 template <typename T>
@@ -383,26 +383,26 @@ bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound,
 unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const LogicalType &key_type) {
 	switch (key_type.InternalType()) {
 	case PhysicalType::UINT8:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint8_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<uint8_t>>();
 	case PhysicalType::UINT16:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint16_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<uint16_t>>();
 	case PhysicalType::UINT32:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint32_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<uint32_t>>();
 	case PhysicalType::UINT64:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint64_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<uint64_t>>();
 	case PhysicalType::INT8:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int8_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<int8_t>>();
 	case PhysicalType::INT16:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int16_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<int16_t>>();
 	case PhysicalType::INT32:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int32_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<int32_t>>();
 	case PhysicalType::INT64:
-		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int64_t>>>();
+		return make_uniq<NumericPrefixRangeFilter<int64_t>>();
 	case PhysicalType::VARCHAR:
 #ifdef DUCKDB_DEBUG_NO_INLINE
 		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
 #else
-		return make_uniq<TemplatedPrefixRangeFilter<StringPrefixPolicy>>();
+		return make_uniq<StringPrefixRangeFilter>();
 #endif
 	case PhysicalType::INT128:
 	case PhysicalType::UINT128:

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -231,24 +231,8 @@ public:
 	}
 
 	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
-		UnifiedVectorFormat vector_data;
-		keys.ToUnifiedFormat(count, vector_data);
-		const auto data = UnifiedVectorFormat::GetData<const Input>(vector_data);
-		const auto &validity_mask = vector_data.validity;
-
-		if (validity_mask.AllValid()) {
-			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				bitmap.Insert(Policy::ToComparable(data[data_idx]), state);
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
-					continue;
-				}
-				bitmap.Insert(Policy::ToComparable(data[data_idx]), state);
-			}
+		for (const auto &entry : keys.template ValidValues<Input>(count)) {
+			bitmap.Insert(Policy::ToComparable(entry.value), state);
 		}
 	}
 
@@ -261,29 +245,11 @@ public:
 			return LookupOneValue(keys.GetValue(0)) ? count : 0;
 		}
 
-		UnifiedVectorFormat vector_data;
-		keys.ToUnifiedFormat(count, vector_data);
-		const auto data = UnifiedVectorFormat::GetData<const Input>(vector_data);
-		const auto &validity_mask = vector_data.validity;
-
 		idx_t found_count = 0;
-		if (validity_mask.AllValid()) {
-			for (idx_t i = 0; i < count; i++) {
-				result_sel.set_index(found_count, i);
-				const auto data_idx = vector_data.sel->get_index(i);
-				found_count += bitmap.Lookup(Policy::ToComparable(data[data_idx]));
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
-					continue;
-				}
-				result_sel.set_index(found_count, i);
-				found_count += bitmap.Lookup(Policy::ToComparable(data[data_idx]));
-			}
+		for (const auto &entry : keys.template ValidValues<Input>(count)) {
+			result_sel.set_index(found_count, entry.index);
+			found_count += bitmap.Lookup(Policy::ToComparable(entry.value));
 		}
-
 		return found_count;
 	}
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -74,8 +74,7 @@ public:
 		return make_uniq<PrefixRangeBuildState>(std::move(state_data), state_bitmap, word_count);
 	}
 
-	void Insert(U key, PrefixRangeFilter::BuildState &state_p) const {
-		auto &state = state_p.Cast<PrefixRangeBuildState>();
+	inline void Insert(U key, PrefixRangeBuildState &state) const {
 		const U y = key - min;
 		// All keys are in-range by construction, so the range check can be omitted here.
 		const U idx = y >> shift;
@@ -302,8 +301,9 @@ public:
 	}
 
 	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
+		auto &bitmap_state = state.Cast<PrefixRangeBuildState>();
 		for (const auto &entry : keys.template ValidValues<Input>(count)) {
-			bitmap.Insert(Policy::ToComparable(entry.value), state);
+			bitmap.Insert(Policy::ToComparable(entry.value), bitmap_state);
 		}
 	}
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -93,7 +93,7 @@ public:
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = NumericCast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint32_t word_idx = static_cast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
@@ -113,8 +113,8 @@ public:
 		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
 		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
-		const idx_t lb_bit_off = NumericCast<idx_t>(lb_bit_idx & NumericCast<U>(WORD_MASK));
-		const idx_t ub_bit_off = NumericCast<idx_t>(ub_bit_idx & NumericCast<U>(WORD_MASK));
+		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));
+		const idx_t ub_bit_off = static_cast<idx_t>(ub_bit_idx & static_cast<U>(WORD_MASK));
 
 		// TODO: Count the amount of 1's in the range, compare to a threshold, and make a decision if we want to use the
 		// per-row filter for this row group.
@@ -329,7 +329,7 @@ bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound,
 #else
 	auto lb_value = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
 	auto ub_value = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-	result = Uhugeint::Convert(NumericCast<uint64_t>(ub_value - lb_value));
+	result = Uhugeint::Convert(static_cast<uint64_t>(ub_value - lb_value));
 	return true;
 #endif
 }

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -204,10 +204,12 @@ static uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
 		return string_t(max_string).GetPrefixIntegerComparable();
 	}
 
-	char padded_prefix[string_t::PREFIX_BYTES];
-	memset(padded_prefix, 0xFF, sizeof(padded_prefix));
-	memcpy(padded_prefix, max_string.data(), max_string.size());
-	return string_t(padded_prefix, string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
+	array<char, string_t::PREFIX_BYTES> padded_prefix;
+	padded_prefix.fill(char(0xFF));
+	for (idx_t i = 0; i < max_string.size(); i++) {
+		padded_prefix[i] = max_string[i];
+	}
+	return string_t(padded_prefix.data(), string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
 }
 
 template <typename Policy>

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -46,10 +46,9 @@ struct PrefixRangeBuildState : public PrefixRangeFilter::BuildState {
 template <typename U>
 class PrefixRangeBitmap {
 public:
-	void Initialize(ClientContext &context, U min_p, U max_p) {
-		D_ASSERT(min_p <= max_p);
+	void Initialize(ClientContext &context, U min_p, U span_p) {
 		min = min_p;
-		span = max_p - min;
+		span = span_p;
 		shift = 0;
 
 		if (span >= CAP_BITS) {
@@ -185,6 +184,13 @@ struct NumericPrefixPolicy {
 		return ToComparable(value.GetValueUnsafe<input_type>());
 	}
 
+	static void InitializeBitmap(PrefixRangeBitmap<comparable_type> &bitmap, ClientContext &context,
+	                             const Value &min_val, const Value &max_val) {
+		const auto min = ToComparable(min_val);
+		const auto max = ToComparable(max_val);
+		bitmap.Initialize(context, min, max - min);
+	}
+
 	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
 	                                         const Value &upper_bound) {
 		const auto lb = lower_bound.GetValueUnsafe<input_type>();
@@ -212,6 +218,14 @@ struct StringPrefixPolicy {
 
 	static comparable_type ToComparable(const Value &value) {
 		return ToComparable(value.GetValueUnsafe<input_type>());
+	}
+
+	static void InitializeBitmap(PrefixRangeBitmap<comparable_type> &bitmap, ClientContext &context,
+	                             const Value &min_val, const Value &max_val) {
+		const auto min = ToComparable(min_val);
+		const auto max = ToComparable(max_val);
+		D_ASSERT(min <= max);
+		bitmap.Initialize(context, min, max - min);
 	}
 
 	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
@@ -248,7 +262,7 @@ public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
 		D_ASSERT(number_of_rows > 0);
-		bitmap.Initialize(context, Policy::ToComparable(min_val), Policy::ToComparable(max_val));
+		Policy::InitializeBitmap(bitmap, context, min_val, max_val);
 	}
 
 	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/array.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -52,11 +52,11 @@ public:
 		shift = 0;
 
 		if (span >= CAP_BITS) {
-			const auto q = static_cast<uint64_t>(span >> MAX_PREFIX_LENGTH);
+			const auto q = NumericCast<uint64_t>(span >> MAX_PREFIX_LENGTH);
 			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
 		}
 
-		const idx_t buckets = static_cast<idx_t>((span >> shift) + 1);
+		const idx_t buckets = NumericCast<idx_t>((span >> shift) + 1);
 		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
 
 		buf_ = AllocateBitmap(context, word_count, bitmap);
@@ -92,7 +92,7 @@ public:
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = static_cast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint32_t word_idx = NumericCast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
@@ -112,8 +112,8 @@ public:
 		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
 		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
-		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));
-		const idx_t ub_bit_off = static_cast<idx_t>(ub_bit_idx & static_cast<U>(WORD_MASK));
+		const idx_t lb_bit_off = NumericCast<idx_t>(lb_bit_idx & NumericCast<U>(WORD_MASK));
+		const idx_t ub_bit_off = NumericCast<idx_t>(ub_bit_idx & NumericCast<U>(WORD_MASK));
 
 		// TODO: Count the amount of 1's in the range, compare to a threshold, and make a decision if we want to use the
 		// per-row filter for this row group.
@@ -130,7 +130,7 @@ public:
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 
-		for (idx_t i = static_cast<idx_t>(lb_word_idx) + 1; i < static_cast<idx_t>(ub_word_idx); i++) {
+		for (idx_t i = NumericCast<idx_t>(lb_word_idx) + 1; i < NumericCast<idx_t>(ub_word_idx); i++) {
 			if (bitmap[i]) {
 				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			}
@@ -194,7 +194,7 @@ struct StringPrefixPolicy {
 	}
 };
 
-template <class Policy>
+template <typename Policy>
 class TemplatedPrefixRangeFilter : public PrefixRangeFilter {
 private:
 	using Input = typename Policy::input_type;
@@ -306,7 +306,7 @@ bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound,
 #else
 	auto lb_value = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
 	auto ub_value = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-	result = Uhugeint::Convert(static_cast<uint64_t>(ub_value - lb_value));
+	result = Uhugeint::Convert(NumericCast<uint64_t>(ub_value - lb_value));
 	return true;
 #endif
 }

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/enums/vector_type.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/optional_ptr.hpp"
@@ -99,14 +100,6 @@ public:
 	}
 
 	FilterPropagateResult LookupRange(U lower_bound, U upper_bound) const {
-		const U max = min + span;
-		if (upper_bound < min || lower_bound > max) {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-		}
-		return LookupClampedRange(MaxValue<U>(lower_bound, min), MinValue<U>(upper_bound, max));
-	}
-
-	FilterPropagateResult LookupClampedRange(U lower_bound, U upper_bound) const {
 		const U lb_y = lower_bound - min;
 		const U lb_bit_idx = lb_y >> shift;
 		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
@@ -179,7 +172,11 @@ struct NumericPrefixPolicy {
 	using input_type = T;
 	using comparable_type = typename MakeUnsigned<T>::type;
 
-	static comparable_type ToComparable(input_type value) {
+	static bool SupportsStats(const BaseStatistics &stats) {
+		return stats.GetStatsType() == StatisticsType::NUMERIC_STATS;
+	}
+
+	static inline comparable_type ToComparable(input_type value) {
 		// Overflow is explicitly allowed for unsigned to signed cast
 		return static_cast<comparable_type>(value);
 	}
@@ -195,29 +192,59 @@ struct NumericPrefixPolicy {
 		bitmap.Initialize(context, min, max - min);
 	}
 
-	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
-	                                         const Value &upper_bound) {
-		const auto lb = lower_bound.GetValueUnsafe<input_type>();
-		const auto ub = upper_bound.GetValueUnsafe<input_type>();
+	static bool ExtractClampedStatsRange(const PrefixRangeBitmap<comparable_type> &bitmap, BaseStatistics &stats,
+	                                     comparable_type &lower_bound, comparable_type &upper_bound) {
+		if (!NumericStats::HasMinMax(stats)) {
+			return false;
+		}
+
+		const auto min = NumericStats::Min(stats).GetValueUnsafe<input_type>();
+		const auto max = NumericStats::Max(stats).GetValueUnsafe<input_type>();
+		if (min > max) {
+			return false;
+		}
 
 		// static_cast is needed here as we need to allow overflow to cast from comparable_type
 		const auto min_t = static_cast<input_type>(bitmap.Min());
 		const auto max_t = static_cast<input_type>(bitmap.Min() + bitmap.Span());
-		if (ub < min_t || lb > max_t) {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		if (max < min_t || min > max_t) {
+			return false;
 		}
 
-		const auto adjusted_lb = ToComparable(MaxValue<input_type>(lb, min_t));
-		const auto adjusted_ub = ToComparable(MinValue<input_type>(ub, max_t));
-		return bitmap.LookupClampedRange(adjusted_lb, adjusted_ub);
+		lower_bound = ToComparable(MaxValue<input_type>(min, min_t));
+		upper_bound = ToComparable(MinValue<input_type>(max, max_t));
+		return true;
 	}
 };
+
+uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
+	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
+}
+
+uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
+	const auto max_string = StringStats::Max(stats);
+	if (max_string.size() >= string_t::PREFIX_BYTES) {
+		return string_t(max_string).GetPrefixIntegerComparable();
+	}
+
+	// Pad string prefix with 0xFF to keep correctness if max is truncated at \0 char, e.g., ab\0c -> ab
+	array<char, string_t::PREFIX_BYTES> padded_prefix;
+	padded_prefix.fill(char(0xFF));
+	for (idx_t i = 0; i < max_string.size(); i++) {
+		padded_prefix[i] = max_string[i];
+	}
+	return string_t(padded_prefix.data(), string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
+}
 
 struct StringPrefixPolicy {
 	using input_type = string_t;
 	using comparable_type = uint32_t;
 
-	static comparable_type ToComparable(const input_type &value) {
+	static bool SupportsStats(const BaseStatistics &stats) {
+		return stats.GetStatsType() == StatisticsType::STRING_STATS;
+	}
+
+	static inline comparable_type ToComparable(const input_type &value) {
 		return value.GetPrefixIntegerComparable();
 	}
 
@@ -233,29 +260,29 @@ struct StringPrefixPolicy {
 		bitmap.Initialize(context, min, max - min);
 	}
 
-	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
-	                                         const Value &upper_bound) {
-		return bitmap.LookupRange(ToComparable(lower_bound), ToComparable(upper_bound));
+	static bool ExtractClampedStatsRange(const PrefixRangeBitmap<comparable_type> &bitmap, BaseStatistics &stats,
+	                                     comparable_type &lower_bound, comparable_type &upper_bound) {
+		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
+			return false;
+		}
+
+		lower_bound = StringStatsMinComparable(stats);
+		upper_bound = StringStatsMaxComparable(stats);
+		if (lower_bound > upper_bound) {
+			return false;
+		}
+
+		const auto bitmap_min = bitmap.Min();
+		const auto bitmap_max = bitmap.Min() + bitmap.Span();
+		if (upper_bound < bitmap_min || lower_bound > bitmap_max) {
+			return false;
+		}
+
+		lower_bound = MaxValue<comparable_type>(lower_bound, bitmap_min);
+		upper_bound = MinValue<comparable_type>(upper_bound, bitmap_max);
+		return true;
 	}
 };
-
-uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
-	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
-}
-
-uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
-	const auto max_string = StringStats::Max(stats);
-	if (max_string.size() >= string_t::PREFIX_BYTES) {
-		return string_t(max_string).GetPrefixIntegerComparable();
-	}
-
-	array<char, string_t::PREFIX_BYTES> padded_prefix;
-	padded_prefix.fill(char(0xFF));
-	for (idx_t i = 0; i < max_string.size(); i++) {
-		padded_prefix[i] = max_string[i];
-	}
-	return string_t(padded_prefix.data(), string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
-}
 
 template <typename Policy>
 class TemplatedPrefixRangeFilter : public PrefixRangeFilter {
@@ -304,11 +331,13 @@ public:
 		return bitmap.Lookup(Policy::ToComparable(key));
 	}
 
-	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		return Policy::LookupRange(bitmap, lower_bound, upper_bound);
-	}
-
-	FilterPropagateResult LookupComparableRange(Comparable lower_bound, Comparable upper_bound) const {
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
+		Comparable lower_bound;
+		Comparable upper_bound;
+		if (!Policy::SupportsStats(stats) ||
+		    !Policy::ExtractClampedStatsRange(bitmap, stats, lower_bound, upper_bound)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
 		return bitmap.LookupRange(lower_bound, upper_bound);
 	}
 
@@ -495,47 +524,7 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 	if (!filter || !filter->IsInitialized()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-
-	switch (stats.GetStatsType()) {
-	case StatisticsType::NUMERIC_STATS:
-		if (!NumericStats::HasMinMax(stats)) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-		break;
-	case StatisticsType::STRING_STATS:
-		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-		break;
-	default:
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	Value min;
-	Value max;
-	if (stats.GetStatsType() == StatisticsType::STRING_STATS) {
-		const auto min_comparable = StringStatsMinComparable(stats);
-		const auto max_comparable = StringStatsMaxComparable(stats);
-		auto *string_filter = dynamic_cast<const TemplatedPrefixRangeFilter<StringPrefixPolicy> *>(filter.get());
-		D_ASSERT(string_filter);
-		if (min_comparable > max_comparable) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-		return string_filter->LookupComparableRange(min_comparable, max_comparable);
-	}
-
-	min = NumericStats::Min(stats);
-	max = NumericStats::Max(stats);
-	if (min > max) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	// The filter was built with key_type (condition_type), but stats are in storage_type
-	if (stats.GetType() != key_type && (!min.DefaultTryCastAs(key_type) || !max.DefaultTryCastAs(key_type))) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-
-	return filter->LookupRange(min, max);
+	return filter->CheckStatistics(stats);
 }
 
 bool PrefixRangeTableFilter::Equals(const TableFilter &other_p) const {

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -95,7 +95,6 @@ public:
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
-
 	FilterPropagateResult LookupRange(U lower_bound, U upper_bound) const {
 		const U lb_y = lower_bound - min;
 		const U lb_bit_idx = lb_y >> shift;
@@ -149,7 +148,7 @@ public:
 		return span;
 	}
 
-private:
+public:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
 	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
 	static constexpr idx_t WORD_SHIFT = 6;
@@ -205,7 +204,10 @@ public:
 		auto &bitmap_state = state.Cast<PrefixRangeBitmapBuildState>();
 		auto *state_bitmap = bitmap_state.bitmap;
 		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			bitmap.Insert(ToComparable(entry.value), state_bitmap);
+			const Comparable y = static_cast<Comparable>(entry.value) - bitmap.min;
+			// All keys are in-range by construction, so the range check can be omitted here.
+			const Comparable idx = y >> bitmap.shift;
+			state_bitmap[idx >> bitmap.WORD_SHIFT] |= 1ULL << (idx & bitmap.WORD_MASK);
 		}
 	}
 
@@ -221,7 +223,12 @@ public:
 		idx_t found_count = 0;
 		for (const auto &entry : keys.template ValidValues<T>(count)) {
 			result_sel.set_index(found_count, entry.index);
-			found_count += bitmap.Lookup(ToComparable(entry.value));
+			const Comparable y = static_cast<Comparable>(entry.value) - bitmap.min;
+			const Comparable bit_idx = y >> bitmap.shift;
+			const uint8_t in_range = y <= bitmap.span;
+			const uint32_t word_idx = UnsafeNumericCast<uint32_t>(bit_idx >> bitmap.WORD_SHIFT) & (0U - in_range);
+			const uint8_t bit = (bitmap.bitmap[word_idx] >> (bit_idx & bitmap.WORD_MASK)) & 1ULL;
+			found_count += bit & in_range;
 		}
 		return found_count;
 	}
@@ -258,7 +265,7 @@ public:
 		return bitmap.IsInitialized();
 	}
 
-private:
+public:
 	PrefixRangeBitmap<Comparable> bitmap;
 
 	static inline Comparable ToComparable(T value) {

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -32,124 +32,88 @@ AllocatedData AllocateBitmap(ClientContext &context, const idx_t word_count, uin
 	return buffer;
 }
 
-template <typename T>
-class NumericPrefixRangeFilter : public PrefixRangeFilter {
-private:
-	using U = typename MakeUnsigned<T>::type;
+struct PrefixRangeBuildState : public PrefixRangeFilter::BuildState {
+	explicit PrefixRangeBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
+	    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
+	}
 
-	struct NumericBuildState : public PrefixRangeFilter::BuildState {
-		explicit NumericBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
-		    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
-		}
+	AllocatedData data;
+	uint64_t *bitmap;
+	idx_t word_count;
+};
 
-		AllocatedData data;
-		uint64_t *bitmap;
-		idx_t word_count;
-	};
-
+template <typename U>
+class PrefixRangeBitmap {
 public:
-	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
-		D_ASSERT(min_val <= max_val);
-		D_ASSERT(number_of_rows > 0);
-		min = static_cast<U>(min_val.GetValueUnsafe<T>());
-		span = (static_cast<U>(max_val.GetValueUnsafe<T>()) - min);
+	void Initialize(ClientContext &context, U min_p, U max_p) {
+		D_ASSERT(min_p <= max_p);
+		min = min_p;
+		span = max_p - min;
 		shift = 0;
 
 		if (span >= CAP_BITS) {
-			const auto q = static_cast<uint64_t>((span) >> MAX_PREFIX_LENGTH);
+			const auto q = static_cast<uint64_t>(span >> MAX_PREFIX_LENGTH);
 			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
 		}
 
-		const idx_t buckets = (span >> shift) + 1;
+		const idx_t buckets = static_cast<idx_t>((span >> shift) + 1);
 		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
 
 		buf_ = AllocateBitmap(context, word_count, bitmap);
 
-		// Only mark initialized as true, when local bitmaps are merged
+		// Only mark initialized as true when local bitmaps are merged.
 		initialized = false;
 	}
 
-	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
+	unique_ptr<PrefixRangeFilter::BuildState> InitializeBuildState(ClientContext &context) const {
 		D_ASSERT(bitmap);
 		uint64_t *state_bitmap;
 		auto state_data = AllocateBitmap(context, word_count, state_bitmap);
-
-		return make_uniq<NumericBuildState>(std::move(state_data), state_bitmap, word_count);
+		return make_uniq<PrefixRangeBuildState>(std::move(state_data), state_bitmap, word_count);
 	}
 
-	void InsertKeys(Vector &keys, idx_t count, BuildState &state_p) const override {
-		auto &state = static_cast<NumericBuildState &>(state_p);
-		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			const U &key = static_cast<U>(entry.value);
-			const U y = key - min;
-			// All x are in-range by construction, so range check can be omitted here.
-			const U idx = y >> shift;
-			state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
-		}
+	void Insert(U key, PrefixRangeFilter::BuildState &state_p) const {
+		auto &state = static_cast<PrefixRangeBuildState &>(state_p);
+		const U y = key - min;
+		// All keys are in-range by construction, so the range check can be omitted here.
+		const U idx = y >> shift;
+		state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
 	}
 
-	void MergeBuildState(BuildState &state_p) override {
-		auto &state = static_cast<NumericBuildState &>(state_p);
+	void MergeBuildState(PrefixRangeFilter::BuildState &state_p) {
+		auto &state = static_cast<PrefixRangeBuildState &>(state_p);
 		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
 			bitmap[word_idx] |= state.bitmap[word_idx];
 		}
 		initialized = true;
 	}
 
-	inline idx_t LookupOne(const T &k) const {
-		const U &key = static_cast<U>(k);
+	idx_t Lookup(U key) const {
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint32_t word_idx = static_cast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
 
-	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
-		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return LookupOneValue(keys.GetValue(0)) ? count : 0;
-		}
-
-		idx_t found_count = 0;
-		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			result_sel.set_index(found_count, entry.index);
-			const auto &key = entry.value;
-			found_count += LookupOne(key);
-		}
-		return found_count;
-	}
-
-	bool LookupOneValue(const Value &key) const override {
-		if (key.IsNull()) {
-			return false;
-		}
-		return LookupOne(key.GetValueUnsafe<T>());
-	}
-
-	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		const auto lb = lower_bound.GetValueUnsafe<T>();
-		const auto ub = upper_bound.GetValueUnsafe<T>();
-
-		const auto min_t = static_cast<T>(min);
-		const auto max_t = static_cast<T>(min + span);
-		if (ub < min_t || lb > max_t) {
+	FilterPropagateResult LookupRange(U lower_bound, U upper_bound) const {
+		const U max = min + span;
+		if (upper_bound < min || lower_bound > max) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto adjusted_lb = static_cast<U>(std::max(lb, min_t));
-		const auto adjusted_ub = static_cast<U>(std::min(ub, max_t));
+		const auto adjusted_lb = MaxValue<U>(lower_bound, min);
+		const auto adjusted_ub = MinValue<U>(upper_bound, max);
 
-		const auto lb_y = static_cast<U>(adjusted_lb - static_cast<U>(min_t));
-		const U lb_bit_idx = lb_y >> shift;
-		const U lb_word_idx = lb_bit_idx >> WORD_SHIFT;
+		const auto lb_bit_idx = (adjusted_lb - min) >> shift;
+		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
 
-		const auto ub_y = static_cast<U>(adjusted_ub - static_cast<U>(min_t));
-		const U ub_bit_idx = ub_y >> shift;
-		const U ub_word_idx = ub_bit_idx >> WORD_SHIFT;
+		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
+		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
-		const auto lb_bit_off = lb_bit_idx & WORD_MASK;
-		const auto ub_bit_off = ub_bit_idx & WORD_MASK;
+		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));
+		const idx_t ub_bit_off = static_cast<idx_t>(ub_bit_idx & static_cast<U>(WORD_MASK));
 
 		// TODO: Count the amount of 1's in the range, compare to a threshold, and make a decision if we want to use the
 		// per-row filter for this row group.
@@ -180,7 +144,7 @@ public:
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 
-	bool IsInitialized() const override {
+	bool IsInitialized() const {
 		return initialized;
 	}
 
@@ -197,6 +161,130 @@ private:
 	idx_t word_count;
 	AllocatedData buf_;
 	uint64_t *bitmap;
+};
+
+template <typename T>
+struct NumericPrefixPolicy {
+	using input_type = T;
+	using comparable_type = typename MakeUnsigned<T>::type;
+
+	static comparable_type ToComparable(input_type value) {
+		auto result = static_cast<comparable_type>(value);
+		if (std::is_signed<T>::value) {
+			result ^= comparable_type(1) << ((sizeof(T) * 8) - 1);
+		}
+		return result;
+	}
+
+	static comparable_type ToComparable(const Value &value) {
+		return ToComparable(value.GetValueUnsafe<input_type>());
+	}
+};
+
+struct StringPrefixPolicy {
+	using input_type = string_t;
+	using comparable_type = uint32_t;
+
+	static comparable_type ToComparable(const input_type &value) {
+		return value.GetPrefixIntegerComparable();
+	}
+
+	static comparable_type ToComparable(const Value &value) {
+		return ToComparable(value.GetValueUnsafe<input_type>());
+	}
+};
+
+template <class Policy>
+class TemplatedPrefixRangeFilter : public PrefixRangeFilter {
+private:
+	using Input = typename Policy::input_type;
+	using Comparable = typename Policy::comparable_type;
+
+public:
+	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
+		D_ASSERT(min_val <= max_val);
+		D_ASSERT(number_of_rows > 0);
+		bitmap.Initialize(context, Policy::ToComparable(min_val), Policy::ToComparable(max_val));
+	}
+
+	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
+		return bitmap.InitializeBuildState(context);
+	}
+
+	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto data = UnifiedVectorFormat::GetData<const Input>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				bitmap.Insert(Policy::ToComparable(data[data_idx]), state);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+				bitmap.Insert(Policy::ToComparable(data[data_idx]), state);
+			}
+		}
+	}
+
+	void MergeBuildState(BuildState &state) override {
+		bitmap.MergeBuildState(state);
+	}
+
+	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
+		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+		}
+
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto data = UnifiedVectorFormat::GetData<const Input>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+
+		idx_t found_count = 0;
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				result_sel.set_index(found_count, i);
+				const auto data_idx = vector_data.sel->get_index(i);
+				found_count += bitmap.Lookup(Policy::ToComparable(data[data_idx]));
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+				result_sel.set_index(found_count, i);
+				found_count += bitmap.Lookup(Policy::ToComparable(data[data_idx]));
+			}
+		}
+
+		return found_count;
+	}
+
+	bool LookupOneValue(const Value &key) const override {
+		if (key.IsNull()) {
+			return false;
+		}
+		return bitmap.Lookup(Policy::ToComparable(key));
+	}
+
+	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
+		return bitmap.LookupRange(Policy::ToComparable(lower_bound), Policy::ToComparable(upper_bound));
+	}
+
+	bool IsInitialized() const override {
+		return bitmap.IsInitialized();
+	}
+
+private:
+	PrefixRangeBitmap<Comparable> bitmap;
 };
 
 template <typename T>
@@ -223,221 +311,31 @@ bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound,
 #endif
 }
 
-class StringPrefixRangeFilter : public PrefixRangeFilter {
-private:
-	struct StringBuildState : public PrefixRangeFilter::BuildState {
-		explicit StringBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
-		    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
-		}
-
-		AllocatedData data;
-		uint64_t *bitmap;
-		idx_t word_count;
-	};
-
-public:
-	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
-		D_ASSERT(min_val <= max_val);
-		D_ASSERT(number_of_rows > 0);
-		min = min_val.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-		span = max_val.GetValueUnsafe<string_t>().GetPrefixIntegerComparable() - min;
-		shift = 0;
-
-		if (span >= CAP_BITS) {
-			const auto q = static_cast<uint64_t>((span) >> MAX_PREFIX_LENGTH);
-			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
-		}
-
-		const idx_t buckets = (span >> shift) + 1;
-		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
-
-		buf_ = AllocateBitmap(context, word_count, bitmap);
-		initialized = false;
-	}
-
-	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
-		D_ASSERT(bitmap);
-		uint64_t *state_bitmap;
-		auto state_data = AllocateBitmap(context, word_count, state_bitmap);
-
-		return make_uniq<StringBuildState>(std::move(state_data), state_bitmap, word_count);
-	}
-
-	void InsertKeys(Vector &keys, idx_t count, BuildState &state_p) const override {
-		auto &state = static_cast<StringBuildState &>(state_p);
-		UnifiedVectorFormat vector_data;
-		keys.ToUnifiedFormat(count, vector_data);
-		const auto key_data = UnifiedVectorFormat::GetData<const string_t>(vector_data);
-		const auto &validity_mask = vector_data.validity;
-
-		if (validity_mask.AllValid()) {
-			for (idx_t i = 0; i < count; i++) {
-				const idx_t data_idx = vector_data.sel->get_index(i);
-				const auto key = key_data[data_idx].GetPrefixIntegerComparable();
-				const auto idx = (key - min) >> shift;
-				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
-					continue;
-				}
-				const auto key = key_data[data_idx].GetPrefixIntegerComparable();
-				const auto idx = (key - min) >> shift;
-				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
-			}
-		}
-	}
-
-	void MergeBuildState(BuildState &state_p) override {
-		auto &state = static_cast<StringBuildState &>(state_p);
-		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
-			bitmap[word_idx] |= state.bitmap[word_idx];
-		}
-		initialized = true;
-	}
-
-	idx_t LookupOne(const string_t &k) const {
-		const auto key = k.GetPrefixIntegerComparable();
-		const auto y = key - min;
-		const auto bit_idx = y >> shift;
-		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
-		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
-		return bit & in_range;
-	}
-
-	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
-		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return LookupOneValue(keys.GetValue(0)) ? count : 0;
-		}
-
-		UnifiedVectorFormat vector_data;
-		keys.ToUnifiedFormat(count, vector_data);
-		const auto data = UnifiedVectorFormat::GetData<const string_t>(vector_data);
-		const auto &validity_mask = vector_data.validity;
-
-		idx_t found_count = 0;
-		if (validity_mask.AllValid()) {
-			for (idx_t i = 0; i < count; i++) {
-				result_sel.set_index(found_count, i);
-				const auto data_idx = vector_data.sel->get_index(i);
-				found_count += LookupOne(data[data_idx]);
-			}
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
-					continue;
-				}
-				result_sel.set_index(found_count, i);
-				found_count += LookupOne(data[data_idx]);
-			}
-		}
-
-		return found_count;
-	}
-
-	bool LookupOneValue(const Value &key) const override {
-		if (key.IsNull()) {
-			return false;
-		}
-		return LookupOne(key.GetValueUnsafe<string_t>());
-	}
-
-	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		const auto lb = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-		const auto ub = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
-
-		const auto max = min + span;
-		if (ub < min || lb > max) {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-		}
-
-		const auto adjusted_lb = MaxValue<uint32_t>(lb, min);
-		const auto adjusted_ub = MinValue<uint32_t>(ub, max);
-
-		const auto lb_bit_idx = (adjusted_lb - min) >> shift;
-		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
-
-		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
-		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
-
-		const auto lb_bit_off = lb_bit_idx & WORD_MASK;
-		const auto ub_bit_off = ub_bit_idx & WORD_MASK;
-
-		if (lb_word_idx == ub_word_idx) {
-			const auto range_mask = ((~0ULL << lb_bit_off) & (~0ULL >> (WORD_MASK - ub_bit_off)));
-			if (bitmap[lb_word_idx] & range_mask) {
-				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-			}
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-		}
-
-		const auto lb_word_mask = (~0ULL << lb_bit_off);
-		if (bitmap[lb_word_idx] & lb_word_mask) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-
-		for (idx_t i = static_cast<idx_t>(lb_word_idx) + 1; i < static_cast<idx_t>(ub_word_idx); i++) {
-			if (bitmap[i]) {
-				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-			}
-		}
-
-		const auto ub_word_mask = ~0ULL >> (WORD_MASK - ub_bit_off);
-		if (bitmap[ub_word_idx] & ub_word_mask) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-
-	bool IsInitialized() const override {
-		return initialized;
-	}
-
-private:
-	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
-	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
-	static constexpr idx_t WORD_SHIFT = 6;
-	static constexpr idx_t WORD_MASK = 63;
-
-	bool initialized = false;
-	uint32_t min;
-	uint32_t span;
-	idx_t shift;
-	idx_t word_count;
-	AllocatedData buf_;
-	uint64_t *bitmap;
-};
-
 } // namespace
 
 unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const LogicalType &key_type) {
 	switch (key_type.InternalType()) {
 	case PhysicalType::UINT8:
-		return make_uniq<NumericPrefixRangeFilter<uint8_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint8_t>>>();
 	case PhysicalType::UINT16:
-		return make_uniq<NumericPrefixRangeFilter<uint16_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint16_t>>>();
 	case PhysicalType::UINT32:
-		return make_uniq<NumericPrefixRangeFilter<uint32_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint32_t>>>();
 	case PhysicalType::UINT64:
-		return make_uniq<NumericPrefixRangeFilter<uint64_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<uint64_t>>>();
 	case PhysicalType::INT8:
-		return make_uniq<NumericPrefixRangeFilter<int8_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int8_t>>>();
 	case PhysicalType::INT16:
-		return make_uniq<NumericPrefixRangeFilter<int16_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int16_t>>>();
 	case PhysicalType::INT32:
-		return make_uniq<NumericPrefixRangeFilter<int32_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int32_t>>>();
 	case PhysicalType::INT64:
-		return make_uniq<NumericPrefixRangeFilter<int64_t>>();
+		return make_uniq<TemplatedPrefixRangeFilter<NumericPrefixPolicy<int64_t>>>();
 	case PhysicalType::VARCHAR:
 #ifdef DUCKDB_DEBUG_NO_INLINE
 		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
 #else
-		return make_uniq<StringPrefixRangeFilter>();
+		return make_uniq<TemplatedPrefixRangeFilter<StringPrefixPolicy>>();
 #endif
 	case PhysicalType::INT128:
 	case PhysicalType::UINT128:

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -53,11 +53,11 @@ public:
 		shift = 0;
 
 		if (span >= CAP_BITS) {
-			const auto q = NumericCast<uint64_t>(span >> MAX_PREFIX_LENGTH);
+			const auto q = UnsafeNumericCast<uint64_t>(span >> MAX_PREFIX_LENGTH);
 			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
 		}
 
-		const idx_t buckets = NumericCast<idx_t>((span >> shift) + 1);
+		const idx_t buckets = UnsafeNumericCast<idx_t>((span >> shift) + 1);
 		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
 
 		buf_ = AllocateBitmap(context, word_count, bitmap);

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -73,11 +73,14 @@ public:
 		return make_uniq<PrefixRangeBitmapBuildState>(std::move(state_data), state_bitmap);
 	}
 
-	inline void Insert(U key, uint64_t *state_bitmap) const {
-		const U y = key - min;
-		// All keys are in-range by construction, so the range check can be omitted here.
-		const U idx = y >> shift;
-		state_bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
+	template <typename T, typename CONVERTER>
+	void InsertKeys(Vector &keys, idx_t count, uint64_t *state_bitmap) const {
+		for (const auto &entry : keys.template ValidValues<T>(count)) {
+			const U y = CONVERTER::Convert(entry.value) - min;
+			// All keys are in-range by construction, so the range check can be omitted here.
+			const U idx = y >> shift;
+			state_bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
+		}
 	}
 
 	void MergeBuildState(PrefixRangeBitmapBuildState &state) {
@@ -87,14 +90,38 @@ public:
 		initialized = true;
 	}
 
-	inline idx_t Lookup(U key) const {
-		const U y = key - min;
+	template <typename T, typename CONVERTER>
+	inline bool LookupOne(const Value &value) const {
+		if (value.IsNull()) {
+			return false;
+		}
+
+		const U comparable = CONVERTER::Convert(value.GetValueUnsafe<T>());
+		const U y = comparable - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = UnsafeNumericCast<uint32_t>(bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
+
+	template <typename T, typename CONVERTER>
+	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const {
+		idx_t found_count = 0;
+		for (const auto &entry : keys.template ValidValues<T>(count)) {
+			const U comparable = CONVERTER::Convert(entry.value);
+			const U y = comparable - min;
+			const U bit_idx = y >> shift;
+			const uint8_t in_range = y <= span;
+			const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
+			const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
+
+			result_sel.set_index(found_count, entry.index);
+			found_count += bit & in_range;
+		}
+		return found_count;
+	}
+
 	FilterPropagateResult LookupRange(U lower_bound, U upper_bound) const {
 		const U lb_y = lower_bound - min;
 		const U lb_bit_idx = lb_y >> shift;
@@ -148,7 +175,7 @@ public:
 		return span;
 	}
 
-public:
+private:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
 	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
 	static constexpr idx_t WORD_SHIFT = 6;
@@ -161,6 +188,22 @@ public:
 	idx_t word_count;
 	AllocatedData buf_;
 	uint64_t *bitmap;
+};
+
+template <typename T>
+struct NumericConverter {
+	using comparable_type = typename MakeUnsigned<T>::type;
+
+	static inline comparable_type Convert(T value) {
+		// Overflow is explicitly allowed for unsigned to signed cast
+		return static_cast<comparable_type>(value);
+	}
+};
+
+struct StringPrefixConverter {
+	static inline uint32_t Convert(const string_t &value) {
+		return value.GetPrefixIntegerComparable();
+	}
 };
 
 uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
@@ -191,8 +234,8 @@ public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
 		D_ASSERT(number_of_rows > 0);
-		const auto min = ToComparable(min_val.GetValueUnsafe<T>());
-		const auto max = ToComparable(max_val.GetValueUnsafe<T>());
+		const auto min = NumericConverter<T>::Convert(min_val.GetValueUnsafe<T>());
+		const auto max = NumericConverter<T>::Convert(max_val.GetValueUnsafe<T>());
 		bitmap.Initialize(context, min, max - min);
 	}
 
@@ -202,13 +245,7 @@ public:
 
 	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
 		auto &bitmap_state = state.Cast<PrefixRangeBitmapBuildState>();
-		auto *state_bitmap = bitmap_state.bitmap;
-		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			const Comparable y = static_cast<Comparable>(entry.value) - bitmap.min;
-			// All keys are in-range by construction, so the range check can be omitted here.
-			const Comparable idx = y >> bitmap.shift;
-			state_bitmap[idx >> bitmap.WORD_SHIFT] |= 1ULL << (idx & bitmap.WORD_MASK);
-		}
+		bitmap.template InsertKeys<T, NumericConverter<T>>(keys, count, bitmap_state.bitmap);
 	}
 
 	void MergeBuildState(BuildState &state) override {
@@ -217,27 +254,9 @@ public:
 
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
 		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+			return bitmap.template LookupOne<T, NumericConverter<T>>(keys.GetValue(0)) ? count : 0;
 		}
-
-		idx_t found_count = 0;
-		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			result_sel.set_index(found_count, entry.index);
-			const Comparable y = static_cast<Comparable>(entry.value) - bitmap.min;
-			const Comparable bit_idx = y >> bitmap.shift;
-			const uint8_t in_range = y <= bitmap.span;
-			const uint32_t word_idx = UnsafeNumericCast<uint32_t>(bit_idx >> bitmap.WORD_SHIFT) & (0U - in_range);
-			const uint8_t bit = (bitmap.bitmap[word_idx] >> (bit_idx & bitmap.WORD_MASK)) & 1ULL;
-			found_count += bit & in_range;
-		}
-		return found_count;
-	}
-
-	bool LookupOneValue(const Value &key) const override {
-		if (key.IsNull()) {
-			return false;
-		}
-		return bitmap.Lookup(ToComparable(key.GetValueUnsafe<T>()));
+		return bitmap.template LookupKeys<T, NumericConverter<T>>(keys, result_sel, count);
 	}
 
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
@@ -256,8 +275,8 @@ public:
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto lower_bound = ToComparable(MaxValue<T>(min, bitmap_min));
-		const auto upper_bound = ToComparable(MinValue<T>(max, bitmap_max));
+		const auto lower_bound = NumericConverter<T>::Convert(MaxValue<T>(min, bitmap_min));
+		const auto upper_bound = NumericConverter<T>::Convert(MinValue<T>(max, bitmap_max));
 		return bitmap.LookupRange(lower_bound, upper_bound);
 	}
 
@@ -265,13 +284,8 @@ public:
 		return bitmap.IsInitialized();
 	}
 
-public:
+private:
 	PrefixRangeBitmap<Comparable> bitmap;
-
-	static inline Comparable ToComparable(T value) {
-		// Overflow is explicitly allowed for unsigned to signed cast
-		return static_cast<Comparable>(value);
-	}
 };
 
 class StringPrefixRangeFilter : public PrefixRangeFilter {
@@ -279,8 +293,8 @@ public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
 		D_ASSERT(number_of_rows > 0);
-		const auto min = ToComparable(min_val.GetValueUnsafe<string_t>());
-		const auto max = ToComparable(max_val.GetValueUnsafe<string_t>());
+		const auto min = StringPrefixConverter::Convert(min_val.GetValueUnsafe<string_t>());
+		const auto max = StringPrefixConverter::Convert(max_val.GetValueUnsafe<string_t>());
 		D_ASSERT(min <= max);
 		bitmap.Initialize(context, min, max - min);
 	}
@@ -291,10 +305,7 @@ public:
 
 	void InsertKeys(Vector &keys, idx_t count, BuildState &state) const override {
 		auto &bitmap_state = state.Cast<PrefixRangeBitmapBuildState>();
-		auto *state_bitmap = bitmap_state.bitmap;
-		for (const auto &entry : keys.template ValidValues<string_t>(count)) {
-			bitmap.Insert(ToComparable(entry.value), state_bitmap);
-		}
+		bitmap.template InsertKeys<string_t, StringPrefixConverter>(keys, count, bitmap_state.bitmap);
 	}
 
 	void MergeBuildState(BuildState &state) override {
@@ -303,22 +314,9 @@ public:
 
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
 		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+			return bitmap.template LookupOne<string_t, StringPrefixConverter>(keys.GetValue(0)) ? count : 0;
 		}
-
-		idx_t found_count = 0;
-		for (const auto &entry : keys.template ValidValues<string_t>(count)) {
-			result_sel.set_index(found_count, entry.index);
-			found_count += bitmap.Lookup(ToComparable(entry.value));
-		}
-		return found_count;
-	}
-
-	bool LookupOneValue(const Value &key) const override {
-		if (key.IsNull()) {
-			return false;
-		}
-		return bitmap.Lookup(ToComparable(key.GetValueUnsafe<string_t>()));
+		return bitmap.template LookupKeys<string_t, StringPrefixConverter>(keys, result_sel, count);
 	}
 
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
@@ -349,10 +347,6 @@ public:
 	}
 
 private:
-	static inline uint32_t ToComparable(const string_t &value) {
-		return value.GetPrefixIntegerComparable();
-	}
-
 	PrefixRangeBitmap<uint32_t> bitmap;
 };
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -106,10 +106,12 @@ public:
 	}
 
 	FilterPropagateResult LookupClampedRange(U lower_bound, U upper_bound) const {
-		const auto lb_bit_idx = (lower_bound - min) >> shift;
+		const U lb_y = lower_bound - min;
+		const U lb_bit_idx = lb_y >> shift;
 		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
 
-		const auto ub_bit_idx = (upper_bound - min) >> shift;
+		const U ub_y = upper_bound - min;
+		const U ub_bit_idx = ub_y >> shift;
 		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
 		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/planner/table_filter_state.hpp"
 
@@ -211,6 +212,207 @@ bool ComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t 
 	}
 }
 
+bool ComputeStringPrefixSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result) {
+#ifdef DUCKDB_DEBUG_NO_INLINE
+	return false;
+#else
+	auto lb_value = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
+	auto ub_value = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
+	result = Uhugeint::Convert(static_cast<uint64_t>(ub_value - lb_value));
+	return true;
+#endif
+}
+
+class StringPrefixRangeFilter : public PrefixRangeFilter {
+private:
+	struct StringBuildState : public PrefixRangeFilter::BuildState {
+		explicit StringBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
+		    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
+		}
+
+		AllocatedData data;
+		uint64_t *bitmap;
+		idx_t word_count;
+	};
+
+public:
+	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
+		D_ASSERT(min_val <= max_val);
+		D_ASSERT(number_of_rows > 0);
+		min = min_val.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
+		span = max_val.GetValueUnsafe<string_t>().GetPrefixIntegerComparable() - min;
+		shift = 0;
+
+		if (span >= CAP_BITS) {
+			const auto q = static_cast<uint64_t>((span) >> MAX_PREFIX_LENGTH);
+			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
+		}
+
+		const idx_t buckets = (span >> shift) + 1;
+		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
+
+		buf_ = AllocateBitmap(context, word_count, bitmap);
+		initialized = false;
+	}
+
+	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
+		D_ASSERT(bitmap);
+		uint64_t *state_bitmap;
+		auto state_data = AllocateBitmap(context, word_count, state_bitmap);
+
+		return make_uniq<StringBuildState>(std::move(state_data), state_bitmap, word_count);
+	}
+
+	void InsertKeys(Vector &keys, idx_t count, BuildState &state_p) const override {
+		auto &state = static_cast<StringBuildState &>(state_p);
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto key_data = UnifiedVectorFormat::GetData<const string_t>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				const idx_t data_idx = vector_data.sel->get_index(i);
+				const auto key = key_data[data_idx].GetPrefixIntegerComparable();
+				const auto idx = (key - min) >> shift;
+				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+				const auto key = key_data[data_idx].GetPrefixIntegerComparable();
+				const auto idx = (key - min) >> shift;
+				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
+			}
+		}
+	}
+
+	void MergeBuildState(BuildState &state_p) override {
+		auto &state = static_cast<StringBuildState &>(state_p);
+		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
+			bitmap[word_idx] |= state.bitmap[word_idx];
+		}
+		initialized = true;
+	}
+
+	idx_t LookupOne(const string_t &k) const {
+		const auto key = k.GetPrefixIntegerComparable();
+		const auto y = key - min;
+		const auto bit_idx = y >> shift;
+		const uint8_t in_range = y <= span;
+		const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
+		return bit & in_range;
+	}
+
+	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
+		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+		}
+
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto data = UnifiedVectorFormat::GetData<const string_t>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+
+		idx_t found_count = 0;
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				result_sel.set_index(found_count, i);
+				const auto data_idx = vector_data.sel->get_index(i);
+				found_count += LookupOne(data[data_idx]);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+				result_sel.set_index(found_count, i);
+				found_count += LookupOne(data[data_idx]);
+			}
+		}
+
+		return found_count;
+	}
+
+	bool LookupOneValue(const Value &key) const override {
+		if (key.IsNull()) {
+			return false;
+		}
+		return LookupOne(key.GetValueUnsafe<string_t>());
+	}
+
+	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
+		const auto lb = lower_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
+		const auto ub = upper_bound.GetValueUnsafe<string_t>().GetPrefixIntegerComparable();
+
+		const auto max = min + span;
+		if (ub < min || lb > max) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto adjusted_lb = MaxValue<uint32_t>(lb, min);
+		const auto adjusted_ub = MinValue<uint32_t>(ub, max);
+
+		const auto lb_bit_idx = (adjusted_lb - min) >> shift;
+		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
+
+		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
+		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
+
+		const auto lb_bit_off = lb_bit_idx & WORD_MASK;
+		const auto ub_bit_off = ub_bit_idx & WORD_MASK;
+
+		if (lb_word_idx == ub_word_idx) {
+			const auto range_mask = ((~0ULL << lb_bit_off) & (~0ULL >> (WORD_MASK - ub_bit_off)));
+			if (bitmap[lb_word_idx] & range_mask) {
+				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+			}
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto lb_word_mask = (~0ULL << lb_bit_off);
+		if (bitmap[lb_word_idx] & lb_word_mask) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		for (idx_t i = static_cast<idx_t>(lb_word_idx) + 1; i < static_cast<idx_t>(ub_word_idx); i++) {
+			if (bitmap[i]) {
+				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+			}
+		}
+
+		const auto ub_word_mask = ~0ULL >> (WORD_MASK - ub_bit_off);
+		if (bitmap[ub_word_idx] & ub_word_mask) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	bool IsInitialized() const override {
+		return initialized;
+	}
+
+private:
+	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
+	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
+	static constexpr idx_t WORD_SHIFT = 6;
+	static constexpr idx_t WORD_MASK = 63;
+
+	bool initialized = false;
+	uint32_t min;
+	uint32_t span;
+	idx_t shift;
+	idx_t word_count;
+	AllocatedData buf_;
+	uint64_t *bitmap;
+};
+
 } // namespace
 
 unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const LogicalType &key_type) {
@@ -231,6 +433,12 @@ unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const L
 		return make_uniq<NumericPrefixRangeFilter<int32_t>>();
 	case PhysicalType::INT64:
 		return make_uniq<NumericPrefixRangeFilter<int64_t>>();
+	case PhysicalType::VARCHAR:
+#ifdef DUCKDB_DEBUG_NO_INLINE
+		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
+#else
+		return make_uniq<StringPrefixRangeFilter>();
+#endif
 	case PhysicalType::INT128:
 	case PhysicalType::UINT128:
 	default:
@@ -239,9 +447,6 @@ unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const L
 }
 
 bool PrefixRangeFilter::TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result) {
-	if (!TypeIsIntegral(lower_bound.type().InternalType())) {
-		return false;
-	}
 	if (lower_bound.type().InternalType() != upper_bound.type().InternalType()) {
 		return false;
 	}
@@ -263,6 +468,8 @@ bool PrefixRangeFilter::TryComputeSpan(const Value &lower_bound, const Value &up
 		return ComputeSpan<int32_t>(lower_bound, upper_bound, result);
 	case PhysicalType::INT64:
 		return ComputeSpan<int64_t>(lower_bound, upper_bound, result);
+	case PhysicalType::VARCHAR:
+		return ComputeStringPrefixSpan(lower_bound, upper_bound, result);
 	case PhysicalType::INT128:
 	case PhysicalType::UINT128:
 	default:
@@ -281,6 +488,12 @@ bool PrefixRangeTableFilter::SupportedType(const LogicalType &type) {
 	case PhysicalType::INT32:
 	case PhysicalType::INT64:
 		return true;
+	case PhysicalType::VARCHAR:
+#ifdef DUCKDB_DEBUG_NO_INLINE
+		return false;
+#else
+		return true;
+#endif
 	case PhysicalType::INT128:
 	case PhysicalType::UINT128:
 	default:
@@ -346,13 +559,40 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 	if (!filter || !filter->IsInitialized()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	D_ASSERT(stats.GetStatsType() == StatisticsType::NUMERIC_STATS);
-	if (!NumericStats::HasMinMax(stats)) {
+
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		if (!NumericStats::HasMinMax(stats)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		break;
+	case StatisticsType::STRING_STATS:
+		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		break;
+	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 
-	auto min = NumericStats::Min(stats);
-	auto max = NumericStats::Max(stats);
+	Value min;
+	Value max;
+	if (stats.GetStatsType() == StatisticsType::STRING_STATS) {
+		// FIXME: This path should eventually use the raw StringStats min/max bytes directly.
+		// Materializing std::string bounds is conservative for embedded NUL bytes, so it may reduce pruning quality,
+		// but the HasMaxStringLength/CanHaveNoNull guard above ensures the stats are initialized and avoids the unknown
+		// sentinel values that are unsafe to materialize as VARCHAR.
+		if (key_type.id() == LogicalTypeId::BLOB) {
+			min = Value::BLOB_RAW(StringStats::Min(stats));
+			max = Value::BLOB_RAW(StringStats::Max(stats));
+		} else {
+			min = Value(StringStats::Min(stats));
+			max = Value(StringStats::Max(stats));
+		}
+	} else {
+		min = NumericStats::Min(stats);
+		max = NumericStats::Max(stats);
+	}
 	if (min > max) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -103,14 +103,14 @@ public:
 		if (upper_bound < min || lower_bound > max) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
+		return LookupClampedRange(MaxValue<U>(lower_bound, min), MinValue<U>(upper_bound, max));
+	}
 
-		const auto adjusted_lb = MaxValue<U>(lower_bound, min);
-		const auto adjusted_ub = MinValue<U>(upper_bound, max);
-
-		const auto lb_bit_idx = (adjusted_lb - min) >> shift;
+	FilterPropagateResult LookupClampedRange(U lower_bound, U upper_bound) const {
+		const auto lb_bit_idx = (lower_bound - min) >> shift;
 		const auto lb_word_idx = lb_bit_idx >> WORD_SHIFT;
 
-		const auto ub_bit_idx = (adjusted_ub - min) >> shift;
+		const auto ub_bit_idx = (upper_bound - min) >> shift;
 		const auto ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
 		const idx_t lb_bit_off = static_cast<idx_t>(lb_bit_idx & static_cast<U>(WORD_MASK));
@@ -149,6 +149,14 @@ public:
 		return initialized;
 	}
 
+	U Min() const {
+		return min;
+	}
+
+	U Span() const {
+		return span;
+	}
+
 private:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
 	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
@@ -170,15 +178,27 @@ struct NumericPrefixPolicy {
 	using comparable_type = typename MakeUnsigned<T>::type;
 
 	static comparable_type ToComparable(input_type value) {
-		auto result = static_cast<comparable_type>(value);
-		if (std::is_signed<T>::value) {
-			result ^= comparable_type(1) << ((sizeof(T) * 8) - 1);
-		}
-		return result;
+		return static_cast<comparable_type>(value);
 	}
 
 	static comparable_type ToComparable(const Value &value) {
 		return ToComparable(value.GetValueUnsafe<input_type>());
+	}
+
+	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
+	                                         const Value &upper_bound) {
+		const auto lb = lower_bound.GetValueUnsafe<input_type>();
+		const auto ub = upper_bound.GetValueUnsafe<input_type>();
+
+		const auto min_t = static_cast<input_type>(bitmap.Min());
+		const auto max_t = static_cast<input_type>(bitmap.Min() + bitmap.Span());
+		if (ub < min_t || lb > max_t) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto adjusted_lb = static_cast<comparable_type>(MaxValue<input_type>(lb, min_t));
+		const auto adjusted_ub = static_cast<comparable_type>(MinValue<input_type>(ub, max_t));
+		return bitmap.LookupClampedRange(adjusted_lb, adjusted_ub);
 	}
 };
 
@@ -193,13 +213,18 @@ struct StringPrefixPolicy {
 	static comparable_type ToComparable(const Value &value) {
 		return ToComparable(value.GetValueUnsafe<input_type>());
 	}
+
+	static FilterPropagateResult LookupRange(const PrefixRangeBitmap<comparable_type> &bitmap, const Value &lower_bound,
+	                                         const Value &upper_bound) {
+		return bitmap.LookupRange(ToComparable(lower_bound), ToComparable(upper_bound));
+	}
 };
 
-static uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
+uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
 	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
 }
 
-static uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
+uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
 	const auto max_string = StringStats::Max(stats);
 	if (max_string.size() >= string_t::PREFIX_BYTES) {
 		return string_t(max_string).GetPrefixIntegerComparable();
@@ -261,7 +286,7 @@ public:
 	}
 
 	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		return bitmap.LookupRange(Policy::ToComparable(lower_bound), Policy::ToComparable(upper_bound));
+		return Policy::LookupRange(bitmap, lower_bound, upper_bound);
 	}
 
 	FilterPropagateResult LookupComparableRange(Comparable lower_bound, Comparable upper_bound) const {

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -194,6 +194,22 @@ struct StringPrefixPolicy {
 	}
 };
 
+static uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
+	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
+}
+
+static uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
+	const auto max_string = StringStats::Max(stats);
+	if (max_string.size() >= string_t::PREFIX_BYTES) {
+		return string_t(max_string).GetPrefixIntegerComparable();
+	}
+
+	char padded_prefix[string_t::PREFIX_BYTES];
+	memset(padded_prefix, 0xFF, sizeof(padded_prefix));
+	memcpy(padded_prefix, max_string.data(), max_string.size());
+	return string_t(padded_prefix, string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
+}
+
 template <typename Policy>
 class TemplatedPrefixRangeFilter : public PrefixRangeFilter {
 private:
@@ -277,6 +293,10 @@ public:
 
 	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
 		return bitmap.LookupRange(Policy::ToComparable(lower_bound), Policy::ToComparable(upper_bound));
+	}
+
+	FilterPropagateResult LookupComparableRange(Comparable lower_bound, Comparable upper_bound) const {
+		return bitmap.LookupRange(lower_bound, upper_bound);
 	}
 
 	bool IsInitialized() const override {
@@ -476,21 +496,18 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 	Value min;
 	Value max;
 	if (stats.GetStatsType() == StatisticsType::STRING_STATS) {
-		// FIXME: This path should eventually use the raw StringStats min/max bytes directly.
-		// Materializing std::string bounds is conservative for embedded NUL bytes, so it may reduce pruning quality,
-		// but the HasMaxStringLength/CanHaveNoNull guard above ensures the stats are initialized and avoids the unknown
-		// sentinel values that are unsafe to materialize as VARCHAR.
-		if (key_type.id() == LogicalTypeId::BLOB) {
-			min = Value::BLOB_RAW(StringStats::Min(stats));
-			max = Value::BLOB_RAW(StringStats::Max(stats));
-		} else {
-			min = Value(StringStats::Min(stats));
-			max = Value(StringStats::Max(stats));
+		const auto min_comparable = StringStatsMinComparable(stats);
+		const auto max_comparable = StringStatsMaxComparable(stats);
+		auto *string_filter = dynamic_cast<const TemplatedPrefixRangeFilter<StringPrefixPolicy> *>(filter.get());
+		D_ASSERT(string_filter);
+		if (min_comparable > max_comparable) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
-	} else {
-		min = NumericStats::Min(stats);
-		max = NumericStats::Max(stats);
+		return string_filter->LookupComparableRange(min_comparable, max_comparable);
 	}
+
+	min = NumericStats::Min(stats);
+	max = NumericStats::Max(stats);
 	if (min > max) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -206,21 +206,21 @@ struct StringPrefixConverter {
 	}
 };
 
-uint32_t StringStatsMinComparable(const BaseStatistics &stats) {
-	return string_t(StringStats::Min(stats)).GetPrefixIntegerComparable();
+uint32_t StringMinComparable(const Value &value) {
+	return StringPrefixConverter::Convert(value.GetValueUnsafe<string_t>());
 }
 
-uint32_t StringStatsMaxComparable(const BaseStatistics &stats) {
-	const auto max_string = StringStats::Max(stats);
-	if (max_string.size() >= string_t::PREFIX_BYTES) {
-		return string_t(max_string).GetPrefixIntegerComparable();
+uint32_t StringMaxComparable(const Value &value) {
+	const auto max_string = value.GetValueUnsafe<string_t>();
+	if (max_string.GetSize() >= string_t::PREFIX_BYTES) {
+		return max_string.GetPrefixIntegerComparable();
 	}
 
 	// Pad string prefix with 0xFF to keep correctness if max is truncated at \0 char, e.g., ab\0c -> ab
 	array<char, string_t::PREFIX_BYTES> padded_prefix;
 	padded_prefix.fill(char(0xFF));
-	for (idx_t i = 0; i < max_string.size(); i++) {
-		padded_prefix[i] = max_string[i];
+	for (idx_t i = 0; i < max_string.GetSize(); i++) {
+		padded_prefix[i] = max_string.GetData()[i];
 	}
 	return string_t(padded_prefix.data(), string_t::PREFIX_BYTES).GetPrefixIntegerComparable();
 }
@@ -259,25 +259,19 @@ public:
 		return bitmap.template LookupKeys<T, NumericConverter<T>>(keys, result_sel, count);
 	}
 
-	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
-		if (stats.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(stats)) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-		const auto min = NumericStats::Min(stats).GetValueUnsafe<T>();
-		const auto max = NumericStats::Max(stats).GetValueUnsafe<T>();
-		if (min > max) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
+	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
+		const auto lb = lower_bound.GetValueUnsafe<T>();
+		const auto ub = upper_bound.GetValueUnsafe<T>();
 
 		const auto bitmap_min = static_cast<T>(bitmap.Min());
 		const auto bitmap_max = static_cast<T>(bitmap.Min() + bitmap.Span());
-		if (max < bitmap_min || min > bitmap_max) {
+		if (ub < bitmap_min || lb > bitmap_max) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto lower_bound = NumericConverter<T>::Convert(MaxValue<T>(min, bitmap_min));
-		const auto upper_bound = NumericConverter<T>::Convert(MinValue<T>(max, bitmap_max));
-		return bitmap.LookupRange(lower_bound, upper_bound);
+		const auto adjusted_lb = NumericConverter<T>::Convert(MaxValue<T>(lb, bitmap_min));
+		const auto adjusted_ub = NumericConverter<T>::Convert(MinValue<T>(ub, bitmap_max));
+		return bitmap.LookupRange(adjusted_lb, adjusted_ub);
 	}
 
 	bool IsInitialized() const override {
@@ -319,27 +313,22 @@ public:
 		return bitmap.template LookupKeys<string_t, StringPrefixConverter>(keys, result_sel, count);
 	}
 
-	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override {
-		if (stats.GetStatsType() != StatisticsType::STRING_STATS || !stats.CanHaveNoNull() ||
-		    !StringStats::HasMaxStringLength(stats)) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
-
-		auto lower_bound = StringStatsMinComparable(stats);
-		auto upper_bound = StringStatsMaxComparable(stats);
-		if (lower_bound > upper_bound) {
+	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
+		auto lower_bound_comparable = StringMinComparable(lower_bound);
+		auto upper_bound_comparable = StringMaxComparable(upper_bound);
+		if (lower_bound_comparable > upper_bound_comparable) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 
 		const auto bitmap_min = bitmap.Min();
 		const auto bitmap_max = bitmap.Min() + bitmap.Span();
-		if (upper_bound < bitmap_min || lower_bound > bitmap_max) {
+		if (upper_bound_comparable < bitmap_min || lower_bound_comparable > bitmap_max) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		lower_bound = MaxValue<uint32_t>(lower_bound, bitmap_min);
-		upper_bound = MinValue<uint32_t>(upper_bound, bitmap_max);
-		return bitmap.LookupRange(lower_bound, upper_bound);
+		lower_bound_comparable = MaxValue<uint32_t>(lower_bound_comparable, bitmap_min);
+		upper_bound_comparable = MinValue<uint32_t>(upper_bound_comparable, bitmap_max);
+		return bitmap.LookupRange(lower_bound_comparable, upper_bound_comparable);
 	}
 
 	bool IsInitialized() const override {
@@ -525,7 +514,41 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 	if (!filter || !filter->IsInitialized()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	return filter->CheckStatistics(stats);
+
+	Value min;
+	Value max;
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		if (!NumericStats::HasMinMax(stats)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		min = NumericStats::Min(stats);
+		max = NumericStats::Max(stats);
+		break;
+	case StatisticsType::STRING_STATS:
+		if (stats.GetType().id() != LogicalTypeId::VARCHAR || key_type.id() != LogicalTypeId::VARCHAR) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		min = Value(StringStats::Min(stats));
+		max = Value(StringStats::Max(stats));
+		break;
+	default:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	if (min > max) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// The filter was built with key_type (condition_type), but stats are in storage_type.
+	if (stats.GetType() != key_type && (!min.DefaultTryCastAs(key_type) || !max.DefaultTryCastAs(key_type))) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	return filter->LookupRange(min, max);
 }
 
 bool PrefixRangeTableFilter::Equals(const TableFilter &other_p) const {

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -74,6 +74,33 @@ JOIN build_timestamp b
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 statement ok
+CREATE OR REPLACE TABLE probe_varchar AS
+SELECT lpad((i // 3)::VARCHAR, 8, '0') AS k, (i % 7)::INTEGER AS g
+FROM range(0, 100000) t(i);
+
+statement ok
+CREATE OR REPLACE TABLE build_varchar AS
+SELECT lpad(i::VARCHAR, 8, '0') AS k, (i % 7)::INTEGER AS g
+FROM range(0, 30000) t(i);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe_varchar p
+JOIN build_varchar b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
+SELECT count(*)
+FROM probe_varchar p
+JOIN build_varchar b
+  ON p.k = b.k
+ AND p.g >= b.g;
+
+statement ok
 CREATE OR REPLACE TABLE probe_hugeint AS
 SELECT i::HUGEINT AS k, (i % 7)::INTEGER AS g
 FROM range(0, 100000) t(i);
@@ -184,6 +211,142 @@ statement ok
 SET disabled_optimizers = '';
 
 endloop
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_string (
+	id INTEGER,
+	k VARCHAR,
+	g INTEGER
+);
+
+statement ok
+INSERT INTO prf_probe_string VALUES
+	(1, 'ab', 1),
+	(2, 'abc', 2),
+	(3, 'abcd0', 3),
+	(4, 'abcd1', 4),
+	(5, 'abcd9', 8),
+	(6, 'abce0', 5),
+	(7, '', 5),
+	(8, NULL, 1),
+	(9, 'zzzz', NULL),
+	(10, 'zzzzzz', 4);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string (
+	k VARCHAR,
+	g INTEGER,
+	payload INTEGER
+);
+
+statement ok
+INSERT INTO prf_build_string VALUES
+	('ab', 0, 100),
+	('abc', 2, 101),
+	('abcd0', 4, 102),
+	('abcd1', 3, 103),
+	('abce0', 6, 104),
+	('', 6, 105),
+	('zzzzzz', 4, 106),
+	(NULL, 0, 107),
+	('abcd2', 1, 108);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_probe_string p
+JOIN prf_build_string b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_string p
+JOIN prf_build_string b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	ab	1	100
+2	abc	2	101
+4	abcd1	4	103
+10	zzzzzz	4	106
+
+statement ok
+SET disabled_optimizers = 'join_filter_pushdown';
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_string p
+JOIN prf_build_string b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	ab	1	100
+2	abc	2	101
+4	abcd1	4	103
+10	zzzzzz	4	106
+
+statement ok
+SET disabled_optimizers = '';
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_string_nul (
+	id INTEGER,
+	k VARCHAR,
+	g INTEGER
+);
+
+statement ok
+INSERT INTO prf_probe_string_nul VALUES
+	(1, 'ab' || chr(0) || 'd', 2),
+	(2, 'ab' || chr(0) || 'x', 3),
+	(3, 'ab', 4),
+	(4, 'zzzz', 5);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string_nul (
+	k VARCHAR,
+	g INTEGER,
+	payload INTEGER
+);
+
+statement ok
+INSERT INTO prf_build_string_nul VALUES
+	('ab' || chr(0) || 'd', 1, 200),
+	('ab' || chr(0) || 'x', 4, 201),
+	('ab', 2, 202);
+
+query IIII
+SELECT p.id, hex(p.k), p.g, b.payload
+FROM prf_probe_string_nul p
+JOIN prf_build_string_nul b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	61620064	2	200
+3	6162	4	202
+
+statement ok
+SET disabled_optimizers = 'join_filter_pushdown';
+
+query IIII
+SELECT p.id, hex(p.k), p.g, b.payload
+FROM prf_probe_string_nul p
+JOIN prf_build_string_nul b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	61620064	2	200
+3	6162	4	202
+
+statement ok
+SET disabled_optimizers = '';
 
 statement ok
 CREATE OR REPLACE TABLE prf_probe_span (

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -83,16 +83,6 @@ CREATE OR REPLACE TABLE build_varchar AS
 SELECT lpad(i::VARCHAR, 8, '0') AS k, (i % 7)::INTEGER AS g
 FROM range(0, 30000) t(i);
 
-query II
-EXPLAIN ANALYZE
-SELECT count(*)
-FROM probe_varchar p
-JOIN build_varchar b
-  ON p.k = b.k
- AND p.g >= b.g;
-----
-analyzed_plan	<REGEX>:.*IN PRF\(k\).*
-
 statement ok
 SELECT count(*)
 FROM probe_varchar p
@@ -250,16 +240,6 @@ INSERT INTO prf_build_string VALUES
 	('zzzzzz', 4, 106),
 	(NULL, 0, 107),
 	('abcd2', 1, 108);
-
-query II
-EXPLAIN ANALYZE
-SELECT count(*)
-FROM prf_probe_string p
-JOIN prf_build_string b
-  ON p.k = b.k
- AND p.g >= b.g;
-----
-analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 query IIII
 SELECT p.id, p.k, p.g, b.payload

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -255,25 +255,6 @@ ORDER BY ALL;
 10	zzzzzz	4	106
 
 statement ok
-SET disabled_optimizers = 'join_filter_pushdown';
-
-query IIII
-SELECT p.id, p.k, p.g, b.payload
-FROM prf_probe_string p
-JOIN prf_build_string b
-  ON p.k = b.k
- AND p.g >= b.g
-ORDER BY ALL;
-----
-1	ab	1	100
-2	abc	2	101
-4	abcd1	4	103
-10	zzzzzz	4	106
-
-statement ok
-SET disabled_optimizers = '';
-
-statement ok
 CREATE OR REPLACE TABLE prf_probe_string_nul (
 	id INTEGER,
 	k VARCHAR,
@@ -310,23 +291,6 @@ ORDER BY ALL;
 ----
 1	61620064	2	200
 3	6162	4	202
-
-statement ok
-SET disabled_optimizers = 'join_filter_pushdown';
-
-query IIII
-SELECT p.id, hex(p.k), p.g, b.payload
-FROM prf_probe_string_nul p
-JOIN prf_build_string_nul b
-  ON p.k = b.k
- AND p.g >= b.g
-ORDER BY ALL;
-----
-1	61620064	2	200
-3	6162	4	202
-
-statement ok
-SET disabled_optimizers = '';
 
 statement ok
 CREATE OR REPLACE TABLE prf_probe_span (
@@ -369,19 +333,3 @@ ORDER BY ALL;
 1	0	0	10
 3	1048576	5	11
 
-statement ok
-SET disabled_optimizers = 'join_filter_pushdown';
-
-query IIII
-SELECT p.id, p.k, p.g, b.payload
-FROM prf_probe_span p
-JOIN prf_build_span b
-  ON p.k = b.k
- AND p.g >= b.g
-ORDER BY ALL;
-----
-1	0	0	10
-3	1048576	5	11
-
-statement ok
-SET disabled_optimizers = '';

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -333,3 +333,40 @@ ORDER BY ALL;
 1	0	0	10
 3	1048576	5	11
 
+statement ok
+ATTACH ':memory:' AS prf_row_group_bug (ROW_GROUP_SIZE 2);
+
+statement ok
+CREATE OR REPLACE TABLE prf_row_group_bug.prf_probe_small (
+	k SMALLINT,
+	g SMALLINT
+);
+
+statement ok
+INSERT INTO prf_row_group_bug.prf_probe_small VALUES
+	(1, 0), (2, 0),
+	(3, 0), (4, 0),
+	(5, 0), (6, 0);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_row_group_bug (
+	k SMALLINT,
+	g SMALLINT
+);
+
+statement ok
+INSERT INTO prf_build_row_group_bug VALUES
+	(-2, 0),
+	(5, 0),
+	(6, 0);
+
+query II
+SELECT b.k, p.k
+FROM prf_row_group_bug.prf_probe_small p
+RIGHT JOIN prf_build_row_group_bug b USING (k)
+ORDER BY ALL;
+----
+-2	NULL
+5	5
+6	6
+

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
@@ -5,6 +5,9 @@
 require strinline
 
 statement ok
+PRAGMA enable_verification
+
+statement ok
 CREATE OR REPLACE TABLE probe_varchar AS
 SELECT lpad(i::VARCHAR, 8, '0') AS k, (i % 11)::INTEGER AS g
 FROM range(0, 100000) t(i);
@@ -64,3 +67,61 @@ JOIN prf_build_string b
  AND p.g >= b.g;
 ----
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
+ATTACH '__TEST_DIR__/prf_string_nul_stats.db' AS prf_string_nul_stats (ROW_GROUP_SIZE 2048);
+
+statement ok
+CREATE OR REPLACE TABLE prf_string_nul_stats.prf_probe_string_nul_stats (
+	id INTEGER NOT NULL,
+	k VARCHAR NOT NULL,
+	g INTEGER NOT NULL
+);
+
+statement ok
+INSERT INTO prf_string_nul_stats.prf_probe_string_nul_stats
+SELECT i AS id,
+	   CASE
+		   WHEN i < 2048 THEN 'aa' || lpad(i::VARCHAR, 8, '0')
+		   ELSE 'ab' || chr(0) || 'd'
+	   END AS k,
+	   CASE
+		   WHEN i < 2048 THEN 0
+		   ELSE 2
+	   END AS g
+FROM range(4096) t(i);
+
+statement ok
+CHECKPOINT prf_string_nul_stats;
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string_nul_stats (
+	k VARCHAR,
+	g INTEGER,
+	payload INTEGER
+);
+
+statement ok
+INSERT INTO prf_build_string_nul_stats VALUES
+	('ab' || chr(0) || 'd', 1, 300),
+	('ab' || chr(0) || 'x', 1, 301);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_string_nul_stats.prf_probe_string_nul_stats p
+JOIN prf_build_string_nul_stats b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+query I
+SELECT count(*)
+FROM prf_string_nul_stats.prf_probe_string_nul_stats p
+JOIN prf_build_string_nul_stats b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+2048
+

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
@@ -69,6 +69,91 @@ JOIN prf_build_string b
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 statement ok
+CREATE OR REPLACE TABLE prf_probe_string_long AS
+SELECT * FROM (VALUES
+	('aaab_long_probe_0001', 0, 1),
+	('aaac_long_probe_0002', 0, 2),
+	('aaad_long_probe_0003', 1, 3),
+	('zzzz_long_probe_9999', 0, 4),
+	(NULL, 0, 5)
+) AS t(k, g, id);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string_long AS
+SELECT * FROM (VALUES
+	('aaab_long_build_1001', 0, 100),
+	('aaac_long_build_1002', 0, 101),
+	('aaad_long_build_1003', 0, 102),
+	('aaaz_long_build_1999', 0, 103),
+	(NULL, 0, 104)
+) AS t(k, g, payload);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_probe_string_long p
+JOIN prf_build_string_long b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_string_long_single AS
+SELECT * FROM (VALUES
+	('aaab_long_single_value_0001', 0, 1),
+	('aaab_long_single_value_0001', 1, 2),
+	('zzzz_long_single_value_9999', 0, 3),
+	(NULL, 0, 4)
+) AS t(k, g, id);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string_long_single AS
+SELECT * FROM (VALUES
+	('aaab_long_single_value_0001', 0, 200),
+	('aaab_long_single_value_0001', 1, 201),
+	(NULL, 0, 202)
+) AS t(k, g, payload);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_probe_string_long_single p
+JOIN prf_build_string_long_single b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<!REGEX>:.*IN PRF\(k\).*
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_string_long_same_prefix AS
+SELECT * FROM (VALUES
+	('aaaa_probe_suffix_0001', 0, 1),
+	('aaaa_probe_suffix_0002', 1, 2),
+	('zzzz_probe_suffix_9999', 0, 3),
+	(NULL, 0, 4)
+) AS t(k, g, id);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string_long_same_prefix AS
+SELECT * FROM (VALUES
+	('aaaa_build_suffix_1001', 0, 300),
+	('aaaa_build_suffix_2002', 0, 301),
+	('aaaa_build_suffix_3003', 1, 302),
+	(NULL, 0, 303)
+) AS t(k, g, payload);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_probe_string_long_same_prefix p
+JOIN prf_build_string_long_same_prefix b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<!REGEX>:.*IN PRF\(k\).*
+
+statement ok
 ATTACH '{TEST_DIR}/prf_string_nul_stats.db' AS prf_string_nul_stats (ROW_GROUP_SIZE 2048);
 
 statement ok

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
@@ -1,0 +1,66 @@
+# name: test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+# description: String-specific prefix range filter plan checks
+# group: [join]
+
+require strinline
+
+statement ok
+CREATE OR REPLACE TABLE probe_varchar AS
+SELECT lpad(i::VARCHAR, 8, '0') AS k, (i % 11)::INTEGER AS g
+FROM range(0, 100000) t(i);
+
+statement ok
+CREATE OR REPLACE TABLE build_varchar AS
+SELECT lpad(i::VARCHAR, 8, '0') AS k, (i % 7)::INTEGER AS g
+FROM range(0, 30000) t(i);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe_varchar p
+JOIN build_varchar b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_string (k VARCHAR, g INTEGER, id INTEGER);
+
+statement ok
+INSERT INTO prf_probe_string VALUES
+	('', 0, 1),
+	('a', 0, 2),
+	('ab', 1, 3),
+	('abc', 0, 4),
+	('abcd', 0, 5),
+	('abcd0', 0, 6),
+	('abcd9', 1, 7),
+	('abce', 0, 8),
+	('zzzz', 0, 9),
+	(NULL, 0, 10);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_string (k VARCHAR, g INTEGER, payload INTEGER);
+
+statement ok
+INSERT INTO prf_build_string VALUES
+	('', 0, 100),
+	('a', 0, 101),
+	('ab', 0, 102),
+	('abc', 0, 103),
+	('abcd', 0, 104),
+	('abcd1', 0, 105),
+	('abcf', 0, 106),
+	(NULL, 0, 107),
+	('abcd2', 1, 108);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM prf_probe_string p
+JOIN prf_build_string b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
@@ -1,6 +1,6 @@
 # name: test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
 # description: String-specific prefix range filter plan checks
-# group: [join]
+# group: [inner]
 
 require strinline
 

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test
@@ -69,7 +69,7 @@ JOIN prf_build_string b
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 statement ok
-ATTACH '__TEST_DIR__/prf_string_nul_stats.db' AS prf_string_nul_stats (ROW_GROUP_SIZE 2048);
+ATTACH '{TEST_DIR}/prf_string_nul_stats.db' AS prf_string_nul_stats (ROW_GROUP_SIZE 2048);
 
 statement ok
 CREATE OR REPLACE TABLE prf_string_nul_stats.prf_probe_string_nul_stats (


### PR DESCRIPTION
This PR adds VARCHAR support for prefix range filters via the inlined `string_t` prefix as suggested by @lnkuiper. This required a refactoring, which now allows to plug in different conversion policies depending on the input type (e.g., `int16_t -> uint16_t`, `string_t -> uint32_t`) and uses a generic bitmap implementation for the backend. This should help implementing other data types like hugeint in the future. 

I have also added another illustrative micro-benchmark for string joins that (analogous to the numeric version) shows a 10x improvement compared to main.