### PR TITLE
Allow ALTER TABLE ... RENAME TO on views

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -90,6 +90,18 @@ unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, Al
 		return copied_view;
 	}
 
+	// PostgreSQL allows `ALTER TABLE ... RENAME TO` on views, so we convert it
+	// to the equivalent ALTER VIEW operation to support tools like dbt-postgres.
+	if (info.type == AlterType::ALTER_TABLE) {
+		auto &table_info = info.Cast<AlterTableInfo>();
+		if (table_info.alter_table_type == AlterTableType::RENAME_TABLE) {
+			auto &rename_info = table_info.Cast<RenameTableInfo>();
+			auto copied_view = Copy(context);
+			copied_view->name = rename_info.new_table_name;
+			return copied_view;
+		}
+	}
+
 	if (info.type != AlterType::ALTER_VIEW) {
 		throw CatalogException("Can only modify view with ALTER VIEW statement");
 	}

--- a/test/sql/alter/rename_table/test_rename_table_view.test
+++ b/test/sql/alter/rename_table/test_rename_table_view.test
@@ -11,12 +11,15 @@ INSERT INTO tbl VALUES (999), (100)
 statement ok
 CREATE VIEW v1 AS SELECT * FROM tbl
 
-statement error
+statement ok
 ALTER TABLE v1 RENAME TO v2
+
+statement error
+SELECT * FROM v1
 ----
 
 query I
-SELECT * FROM v1
+SELECT * FROM v2
 ----
 999
 100


### PR DESCRIPTION
In Postgres it's allowed to rename a VIEW using ALTER TABLE ... RENAME. But in DuckDB this returns an error:

```sql
memory D CREATE VIEW v1 as SELECT 1;
memory D ALTER TABLE v1 RENAME to v2;
Catalog Error:
Can only modify view with ALTER VIEW statement
```

This adds support for this to DuckDB too, so more Postgres queries can run on DuckDB without changes.
