### PR TITLE
Use correct error message for name conflicts between table and views

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -140,7 +140,9 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 	if (!set.CreateEntry(transaction, entry_name, std::move(entry), dependencies)) {
 		// entry already exists!
 		if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-			throw CatalogException::EntryAlreadyExists(entry_type, entry_name);
+			auto existing_entry = set.GetEntry(transaction, entry_name);
+			auto existing_type = existing_entry ? existing_entry->type : entry_type;
+			throw CatalogException::EntryAlreadyExists(existing_type, entry_name);
 		} else {
 			return nullptr;
 		}

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -8,6 +8,18 @@ CREATE TABLE integers(i INTEGER);
 statement ok
 CREATE VIEW vintegers AS SELECT 42;
 
+# cannot create a table with the same name as a view
+statement error
+CREATE TABLE vintegers(i INTEGER);
+----
+Catalog Error: View with name "vintegers" already exists!
+
+# cannot create a view with the same name as a table
+statement error
+CREATE VIEW integers AS SELECT 42;
+----
+Catalog Error: Table with name "integers" already exists!
+
 # cannot CREATE OR REPLACE a table with a view
 statement error
 CREATE OR REPLACE VIEW integers AS SELECT 42;


### PR DESCRIPTION
It's not possible to have tables and views with the same name, but the error message produced was confusing. It would always say that a 'Table with name "X" already exists', when failing to create a table due to a naming conflict. Even when if the thing that already exists was actually a view.
