### PR TITLE
Add support for reading geometry type to the C-API

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -84,6 +84,7 @@ ORIGINAL_FUNCTION_GROUP_ORDER = [
     'copy_functions',
     'catalog_interface',
     'logging',
+    'geometry_helpers',
 ]
 
 # The file that forms the base for the header generation

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -6256,6 +6256,22 @@ Registers a custom log storage for the logger.
 */
 DUCKDB_C_API duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
 
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+DUCKDB_C_API char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -138,6 +138,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -592,6 +592,9 @@ typedef struct {
 	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file_handle);
 	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file_handle);
 	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file_handle);
+	// API to operate on GEOMETRY types.
+
+	char *(*duckdb_geometry_type_get_crs)(duckdb_logical_type type);
 	// API to register a custom log storage.
 
 	duckdb_log_storage (*duckdb_create_log_storage)();
@@ -1174,6 +1177,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_file_handle_tell = duckdb_file_handle_tell;
 	result.duckdb_file_handle_sync = duckdb_file_handle_sync;
 	result.duckdb_file_handle_size = duckdb_file_handle_size;
+	result.duckdb_geometry_type_get_crs = duckdb_geometry_type_get_crs;
 	result.duckdb_create_log_storage = duckdb_create_log_storage;
 	result.duckdb_destroy_log_storage = duckdb_destroy_log_storage;
 	result.duckdb_log_storage_set_write_log_entry = duckdb_log_storage_set_write_log_entry;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_geo_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_geo_functions.json
@@ -1,0 +1,7 @@
+{
+  "version": "unstable_new_geo_functions",
+  "description": "API to operate on GEOMETRY types.",
+  "entries": [
+    "duckdb_geometry_type_get_crs"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/geometry_helpers.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/geometry_helpers.json
@@ -1,0 +1,24 @@
+{
+    "group": "geometry_helpers",
+    "deprecated": false,
+    "description": "Functions to operate on GEOMETRY types`.",
+    "entries": [
+        {
+            "name": "duckdb_geometry_type_get_crs",
+            "return_type": "char*",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "type"
+                }
+            ],
+            "comment": {
+                "description": "Gets the CRS (Coordinate Reference System) of a GEOMETRY type.\nResult must be freed with `duckdb_free`.\n\n",
+                "param_comments": {
+                    "type": "The GEOMETRY type."
+                },
+                "return_value": "The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type."
+            }
+        }
+    ]
+}

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -132,6 +132,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -677,6 +677,11 @@ typedef struct {
 	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file_handle);
 #endif
 
+// API to operate on GEOMETRY types.
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	char *(*duckdb_geometry_type_get_crs)(duckdb_logical_type type);
+#endif
+
 // API to register a custom log storage.
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	duckdb_log_storage (*duckdb_create_log_storage)();
@@ -1306,6 +1311,9 @@ typedef struct {
 #define duckdb_file_handle_seek               duckdb_ext_api.duckdb_file_handle_seek
 #define duckdb_file_handle_sync               duckdb_ext_api.duckdb_file_handle_sync
 #define duckdb_file_handle_close              duckdb_ext_api.duckdb_file_handle_close
+
+// Version unstable_new_geo_functions
+#define duckdb_geometry_type_get_crs duckdb_ext_api.duckdb_geometry_type_get_crs
 
 // Version unstable_new_logger_functions
 #define duckdb_create_log_storage              duckdb_ext_api.duckdb_create_log_storage

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -85,6 +85,8 @@ LogicalTypeId LogicalTypeIdFromC(const duckdb_type type) {
 		return LogicalTypeId::INTEGER_LITERAL;
 	case DUCKDB_TYPE_TIME_NS:
 		return LogicalTypeId::TIME_NS;
+	case DUCKDB_TYPE_GEOMETRY:
+		return LogicalTypeId::GEOMETRY;
 	default: // LCOV_EXCL_START
 		D_ASSERT(0);
 		return LogicalTypeId::INVALID;
@@ -175,6 +177,8 @@ duckdb_type LogicalTypeIdToC(const LogicalTypeId type) {
 		return DUCKDB_TYPE_INTEGER_LITERAL;
 	case LogicalTypeId::TIME_NS:
 		return DUCKDB_TYPE_TIME_NS;
+	case LogicalTypeId::GEOMETRY:
+		return DUCKDB_TYPE_GEOMETRY;
 	default: // LCOV_EXCL_START
 		D_ASSERT(0);
 		return DUCKDB_TYPE_INVALID;

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/types/geometry_crs.hpp"
 
 namespace duckdb {
 
@@ -404,4 +405,15 @@ duckdb_state duckdb_register_logical_type(duckdb_connection connection, duckdb_l
 		return DuckDBError;
 	}
 	return DuckDBSuccess;
+}
+
+char *duckdb_geometry_type_get_crs(duckdb_logical_type type) {
+	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::GEOMETRY)) {
+		return nullptr;
+	}
+	auto &logical_type = *(reinterpret_cast<duckdb::LogicalType *>(type));
+	if (!duckdb::GeoType::HasCRS(logical_type)) {
+		return nullptr;
+	}
+	return strdup(duckdb::GeoType::GetCRS(logical_type).GetDefinition().c_str());
 }

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   test_capi_arrow.cpp
   test_capi_data_chunk.cpp
   test_capi_extract.cpp
+  test_capi_geometry.cpp
   test_capi_instance_cache.cpp
   test_capi_logging.cpp
   test_capi_pending.cpp

--- a/test/api/capi/test_capi_geometry.cpp
+++ b/test/api/capi/test_capi_geometry.cpp
@@ -1,0 +1,41 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test C API GEOMETRY type support", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY)"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)::GEOMETRY')"));
+
+	result = tester.Query("SELECT data FROM t1");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ColumnType(0) == DUCKDB_TYPE_GEOMETRY);
+	auto chunk = result->FetchChunk(0);
+	REQUIRE(chunk);
+
+	auto vec = duckdb_data_chunk_get_vector(chunk->GetChunk(), 0);
+	auto blob = *static_cast<duckdb_string_t *>(duckdb_vector_get_data(vec));
+
+	REQUIRE(duckdb_string_t_length(blob) == 21);
+
+	auto data = duckdb_string_t_data(&blob);
+
+	uint8_t le = 0;
+	uint32_t meta = 0;
+	double x;
+	double y;
+
+	memcpy(&le, data, 1);
+	memcpy(&meta, data + 1, 4);
+	memcpy(&x, data + 5, 8);
+	memcpy(&y, data + 13, 8);
+
+	REQUIRE(le == 1);
+	REQUIRE(meta == 0x00000001); // WKB for POINT
+	REQUIRE(x == 42);
+	REQUIRE(y == 1337);
+}

--- a/test/api/capi/test_capi_geometry.cpp
+++ b/test/api/capi/test_capi_geometry.cpp
@@ -8,16 +8,29 @@ TEST_CASE("Test C API GEOMETRY type support", "[capi]") {
 	duckdb::unique_ptr<CAPIResult> result;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY)"));
-	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)::GEOMETRY')"));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY('OGC:CRS84'))"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)')"));
 
 	result = tester.Query("SELECT data FROM t1");
 	REQUIRE_NO_FAIL(*result);
+
 	REQUIRE(result->ColumnType(0) == DUCKDB_TYPE_GEOMETRY);
+
 	auto chunk = result->FetchChunk(0);
 	REQUIRE(chunk);
 
 	auto vec = duckdb_data_chunk_get_vector(chunk->GetChunk(), 0);
+
+	auto type = duckdb_vector_get_column_type(vec);
+
+	REQUIRE(duckdb_get_type_id(type) == DUCKDB_TYPE_GEOMETRY);
+	auto crs = duckdb_geometry_type_get_crs(type);
+	REQUIRE(crs);
+	REQUIRE(strcmp(crs, "OGC:CRS84") == 0);
+	duckdb_free(crs);
+
+	duckdb_destroy_logical_type(&type);
+
 	auto blob = *static_cast<duckdb_string_t *>(duckdb_vector_get_data(vec));
 
 	REQUIRE(duckdb_string_t_length(blob) == 21);


### PR DESCRIPTION
You can create geometry types too using `duckdb_create_logical_type`, just not with CRS.