### PR TITLE
Stabilize main workflow

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -238,12 +238,14 @@ jobs:
       - name: Merge into single repository
         shell: bash
         run: |
-          mkdir -p /tmp/merged_repository/${{ inputs.git_ref }}
           shopt -s nullglob
-          for platform_dir in /tmp/repository_generation/*/*/*; do
-            platform="$(basename "$platform_dir")"
-            mkdir -p /tmp/merged_repository/${{ inputs.git_ref }}/"$platform"
-            cp -r "$platform_dir"/. /tmp/merged_repository/${{ inputs.git_ref }}/"$platform"
+          for version_dir in /tmp/repository_generation/*/*/*; do
+            version="$(basename "$version_dir")"
+            for platform_dir in "$version_dir"/*; do
+              platform="$(basename "$platform_dir")"
+              mkdir -p /tmp/merged_repository/"$version"/"$platform"
+              cp -r "$platform_dir"/. /tmp/merged_repository/"$version"/"$platform"
+            done
           done
           tree /tmp/merged_repository
 

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -44,6 +44,7 @@ env:
 jobs:
   linux-base:
     name: Linux Base
+    if: ${{ github.repository != 'duckdb/duckdb' || github.ref_name != 'main' }}
     runs-on: ${{ inputs.runner_linux_x64 }}
     env:
       GEN: ninja

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -128,12 +128,14 @@ jobs:
       - name: Merge into single repository
         shell: bash
         run: |
-          mkdir -p /tmp/merged_repository/${{ inputs.duckdb_ref }}
           shopt -s nullglob
-          for platform_dir in /tmp/repository_generation/*/*/*; do
-            platform="$(basename "$platform_dir")"
-            mkdir -p /tmp/merged_repository/${{ inputs.duckdb_ref }}/"$platform"
-            cp -r "$platform_dir"/. /tmp/merged_repository/${{ inputs.duckdb_ref }}/"$platform"
+          for version_dir in /tmp/repository_generation/*/*/*; do
+            version="$(basename "$version_dir")"
+            for platform_dir in "$version_dir"/*; do
+              platform="$(basename "$platform_dir")"
+              mkdir -p /tmp/merged_repository/"$version"/"$platform"
+              cp -r "$platform_dir"/. /tmp/merged_repository/"$version"/"$platform"
+            done
           done
           tree /tmp/merged_repository
 

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -78,9 +78,9 @@ def make_absolute(f, directory):
     return os.path.normpath(os.path.join(directory, f))
 
 
-def is_ignored_file(path):
+def is_ignored_file(path, third_party_path):
     normalized = os.path.normpath(path)
-    return normalized.startswith('third_party' + os.sep)
+    return normalized == third_party_path or normalized.startswith(third_party_path + os.sep)
 
 
 def get_tidy_invocation(
@@ -282,6 +282,8 @@ def main():
     # Load the database and extract all files.
     database = json.load(open(os.path.join(build_path, db_path)))
     files = [make_absolute(entry['file'], entry['directory']) for entry in database]
+    source_root = os.path.commonpath(files)
+    third_party_path = os.path.join(source_root, 'third_party')
 
     max_task = args.j
     if max_task == 0:
@@ -309,7 +311,7 @@ def main():
 
         # Fill the queue with files.
         for name in files:
-            if is_ignored_file(name):
+            if is_ignored_file(name, third_party_path):
                 continue
             if file_name_re.search(name):
                 task_queue.put(name)


### PR DESCRIPTION
- Temporarily disable `linux-base` on main.
- Let clang-tidy skip files in `third_party/`.
- Merge extensions correctly into single repository.