### PR TITLE
Fix CSV assertion failure for CSV type deduction incompatibility

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -179,7 +179,10 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 			names = options.name_list;
 			return_types = options.sql_type_list;
 		}
-		D_ASSERT(return_types.size() == names.size());
+		if (return_types.size() != names.size()) {
+			throw BinderException("read_csv: mismatch between the number of column names (%d) and column types (%d)",
+			                      names.size(), return_types.size());
+		}
 		csv_data.options.dialect_options.num_cols = names.size();
 
 		bind_data.multi_file_reader->BindOptions(bind_data.file_options, multi_file_list, return_types, names,

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -779,14 +779,14 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			parsed_types.push_back(std::move(def_type));
 		}
 
-		// If columns already set sql_type_list, verify they match
+		// If columns already set sql_type_list, verify they match but keep columns' mappings
 		if (columns_set && !sql_type_list.empty()) {
 			VerifyTypeListsMatch(sql_type_list, parsed_types);
 		} else {
 			sql_type_list = std::move(parsed_types);
-		}
-		if (!parsed_types_per_column.empty()) {
-			sql_types_per_column = std::move(parsed_types_per_column);
+			if (!parsed_types_per_column.empty()) {
+				sql_types_per_column = std::move(parsed_types_per_column);
+			}
 		}
 	} else if (loption == "all_varchar") {
 		all_varchar = GetBooleanValue(loption, val);

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -11,13 +11,21 @@ namespace duckdb {
 
 namespace {
 
-void VerifyTypeListsMatch(const vector<LogicalType> &existing, const vector<LogicalType> &incoming) {
-	if (existing.size() != incoming.size()) {
-		throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+void VerifyTypeListsMatch(const vector<LogicalType> &columns_types, const vector<LogicalType> &override_types) {
+	if (columns_types.size() != override_types.size()) {
+		throw BinderException(
+		    "read_csv: the 'columns' option specifies %d column(s), but 'types'/'dtypes'/'column_types' "
+		    "specifies %d type(s). When both are provided they must agree. "
+		    "Consider removing the 'type' option.",
+		    columns_types.size(), override_types.size());
 	}
-	for (idx_t i = 0; i < incoming.size(); i++) {
-		if (existing[i] != incoming[i]) {
-			throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+	for (idx_t i = 0; i < override_types.size(); i++) {
+		if (columns_types[i] != override_types[i]) {
+			throw BinderException(
+			    "read_csv: column type mismatch at position %d: 'columns' specifies '%s' but "
+			    "'types'/'dtypes'/'column_types' specifies '%s'. When both are provided they must agree. "
+			    "Consider removing the 'type' option.",
+			    i + 1, columns_types[i].ToString(), override_types[i].ToString());
 		}
 	}
 }
@@ -673,7 +681,7 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		}
 		// If types were already set by 'types'/'dtypes'/'column_types', verify they match
 		if (!sql_type_list.empty()) {
-			VerifyTypeListsMatch(sql_type_list, parsed_types);
+			VerifyTypeListsMatch(parsed_types, sql_type_list);
 		}
 		name_list = std::move(parsed_names);
 		sql_type_list = std::move(parsed_types);

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -9,6 +9,21 @@
 
 namespace duckdb {
 
+namespace {
+
+void VerifyTypeListsMatch(const vector<LogicalType> &existing, const vector<LogicalType> &incoming) {
+	if (existing.size() != incoming.size()) {
+		throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+	}
+	for (idx_t i = 0; i < incoming.size(); i++) {
+		if (existing[i] != incoming[i]) {
+			throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+		}
+	}
+}
+
+} // namespace
+
 CSVReaderOptions::CSVReaderOptions(const CSVOption<char> single_byte_delimiter,
                                    const CSVOption<string> &multi_byte_delimiter) {
 	if (multi_byte_delimiter.GetValue().empty()) {
@@ -638,19 +653,31 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		}
 		auto &struct_children = StructValue::GetChildren(val);
 		D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
+
+		// Parse into temporary lists first
+		vector<string> parsed_names;
+		vector<LogicalType> parsed_types;
+		case_insensitive_map_t<idx_t> parsed_types_per_column;
 		for (idx_t i = 0; i < struct_children.size(); i++) {
 			auto &name = StructType::GetChildName(child_type, i);
 			auto &val = struct_children[i];
-			name_list.push_back(name);
+			parsed_names.push_back(name);
 			if (val.type().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("read_csv requires a type specification as string");
 			}
-			sql_types_per_column[name] = i;
-			sql_type_list.emplace_back(TransformStringToLogicalType(StringValue::Get(val), context));
+			parsed_types_per_column[name] = i;
+			parsed_types.emplace_back(TransformStringToLogicalType(StringValue::Get(val), context));
 		}
-		if (name_list.empty()) {
+		if (parsed_names.empty()) {
 			throw BinderException("read_csv requires at least a single column as input!");
 		}
+		// If types were already set by 'types'/'dtypes'/'column_types', verify they match
+		if (!sql_type_list.empty()) {
+			VerifyTypeListsMatch(sql_type_list, parsed_types);
+		}
+		name_list = std::move(parsed_names);
+		sql_type_list = std::move(parsed_types);
+		sql_types_per_column = std::move(parsed_types_per_column);
 	} else if (loption == "auto_type_candidates") {
 		auto_type_candidates.clear();
 		map<uint8_t, LogicalType> candidate_types;
@@ -713,10 +740,13 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		if (child_type.id() != LogicalTypeId::STRUCT && child_type.id() != LogicalTypeId::LIST) {
 			throw BinderException("read_csv %s requires a struct or list as input", key);
 		}
-		if (!sql_type_list.empty()) {
+		if (!columns_set && !sql_type_list.empty()) {
 			throw BinderException("read_csv column_types/types/dtypes can only be supplied once");
 		}
+
+		// Parse into temporary lists first
 		vector<string> sql_type_names;
+		case_insensitive_map_t<idx_t> parsed_types_per_column;
 		if (child_type.id() == LogicalTypeId::STRUCT) {
 			auto &struct_children = StructValue::GetChildren(val);
 			D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
@@ -727,7 +757,7 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 					throw BinderException("read_csv %s requires a type specification as string", key);
 				}
 				sql_type_names.push_back(StringValue::Get(val));
-				sql_types_per_column[name] = i;
+				parsed_types_per_column[name] = i;
 			}
 		} else {
 			auto &list_child = ListType::GetChildType(child_type);
@@ -739,13 +769,24 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 				sql_type_names.push_back(StringValue::Get(child));
 			}
 		}
-		sql_type_list.reserve(sql_type_names.size());
+		vector<LogicalType> parsed_types;
+		parsed_types.reserve(sql_type_names.size());
 		for (auto &sql_type : sql_type_names) {
 			auto def_type = TransformStringToLogicalType(sql_type, context);
 			if (def_type.id() == LogicalTypeId::UNBOUND) {
 				throw BinderException("Unrecognized type \"%s\" for read_csv %s definition", sql_type, key);
 			}
-			sql_type_list.push_back(std::move(def_type));
+			parsed_types.push_back(std::move(def_type));
+		}
+
+		// If columns already set sql_type_list, verify they match
+		if (columns_set && !sql_type_list.empty()) {
+			VerifyTypeListsMatch(sql_type_list, parsed_types);
+		} else {
+			sql_type_list = std::move(parsed_types);
+		}
+		if (!parsed_types_per_column.empty()) {
+			sql_types_per_column = std::move(parsed_types_per_column);
 		}
 	} else if (loption == "all_varchar") {
 		all_varchar = GetBooleanValue(loption, val);

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -55,3 +55,39 @@ statement error
 select * from read_csv_auto('{DATA_DIR}/csv/auto/int_bol.csv', dtypes=['varchar', 'varchar', 'varchar']) LIMIT 1
 ----
 3 types were provided, but CSV file only has 2 columns
+
+# columns + types conflict (columns already defines types)
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, types=['BIGINT', 'DATE'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + dtypes conflict
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, dtypes=['BIGINT'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + column_types conflict
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, column_types={'a': 'BIGINT'})
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + types match each other but differ from sniffer (sniffer would detect BIGINT, BOOLEAN)
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, types=['VARCHAR', 'VARCHAR']) LIMIT 1
+----
+VARCHAR	VARCHAR
+
+# columns + types mismatch: same count but different types
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, types=['VARCHAR', 'INTEGER'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns types override sniffer auto-detection (sniffer would detect BIGINT, BOOLEAN)
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}) LIMIT 1
+----
+VARCHAR	VARCHAR

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -86,6 +86,18 @@ select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar'
 ----
 column types specified by 'columns' and 'types' doesn't match
 
+# columns + struct-style column_types with different key names but matching types: columns' name mapping must be preserved
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, column_types={'x': 'VARCHAR', 'y': 'VARCHAR'}) LIMIT 1
+----
+VARCHAR	VARCHAR
+
+# columns + struct-style column_types with different key names and mismatching types
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, column_types={'x': 'INTEGER', 'y': 'BOOLEAN'})
+----
+column types specified by 'columns' and 'types' doesn't match
+
 # columns types override sniffer auto-detection (sniffer would detect BIGINT, BOOLEAN)
 query II
 select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}) LIMIT 1

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -60,19 +60,19 @@ select * from read_csv_auto('{DATA_DIR}/csv/auto/int_bol.csv', dtypes=['varchar'
 statement error
 select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, types=['BIGINT', 'DATE'])
 ----
-column types specified by 'columns' and 'types' doesn't match
+'columns' option specifies 1 column(s), but 'types'/'dtypes'/'column_types' specifies 2 type(s)
 
 # columns + dtypes conflict
 statement error
 select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, dtypes=['BIGINT'])
 ----
-column types specified by 'columns' and 'types' doesn't match
+column type mismatch at position 1: 'columns' specifies 'VARCHAR' but 'types'/'dtypes'/'column_types' specifies 'BIGINT'
 
 # columns + column_types conflict
 statement error
 select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, column_types={'a': 'BIGINT'})
 ----
-column types specified by 'columns' and 'types' doesn't match
+column type mismatch at position 1: 'columns' specifies 'VARCHAR' but 'types'/'dtypes'/'column_types' specifies 'BIGINT'
 
 # columns + types match each other but differ from sniffer (sniffer would detect BIGINT, BOOLEAN)
 query II
@@ -84,7 +84,7 @@ VARCHAR	VARCHAR
 statement error
 select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, types=['VARCHAR', 'INTEGER'])
 ----
-column types specified by 'columns' and 'types' doesn't match
+column type mismatch at position 2: 'columns' specifies 'VARCHAR' but 'types'/'dtypes'/'column_types' specifies 'INTEGER'
 
 # columns + struct-style column_types with different key names but matching types: columns' name mapping must be preserved
 query II
@@ -96,7 +96,7 @@ VARCHAR	VARCHAR
 statement error
 select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, column_types={'x': 'INTEGER', 'y': 'BOOLEAN'})
 ----
-column types specified by 'columns' and 'types' doesn't match
+column type mismatch at position 1: 'columns' specifies 'VARCHAR' but 'types'/'dtypes'/'column_types' specifies 'INTEGER'
 
 # columns types override sniffer auto-detection (sniffer would detect BIGINT, BOOLEAN)
 query II


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-fuzzer/issues/4223

The sql we failed is
```sql
from read_csv('20251001_d0986b.csv', auto_detect=false, columns={'a':'varchar'}, delim='', encoding='latin-1', header=true, types=['BIGINT', 'DATE']);
```
I could see a few issues:
- Both `columns` and `types` are used to provide column type information, but they don't match with each other
- The failure line of code [here](https://github.com/duckdb/duckdb/blob/7cdebc820e305c44bf4ac03ccff023a6c80f2071/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp#L182) acts as a safe net and invariant check, we should validate the improper read options earlier

In one word, for invalid read options, we should throw exception (which indicates it's an user error) instead of assertion failure (which interprets as DuckDB internal error).
Unit test added to cover possible read option combinations.

I have tested on my fork CI: https://github.com/dentiny/duckdb/pull/74, failure unrelated