### PR TITLE
Add json_set() to set value at path in JSON document

### DIFF
--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -34,6 +34,7 @@ set(JSON_EXTENSION_FILES
     json_functions/json_serialize_sql.cpp
     json_functions/json_serialize_plan.cpp
     json_functions/json_normalize.cpp
+    json_functions/json_set.cpp
     json_functions/json_deep_merge.cpp
     json_functions/json_merge_patch_diff.cpp
     json_functions/json_strip_nulls.cpp

--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -34,7 +34,7 @@ set(JSON_EXTENSION_FILES
     json_functions/json_serialize_sql.cpp
     json_functions/json_serialize_plan.cpp
     json_functions/json_normalize.cpp
-    json_functions/json_set.cpp
+    json_functions/json_modify.cpp
     json_functions/json_deep_merge.cpp
     json_functions/json_merge_patch_diff.cpp
     json_functions/json_strip_nulls.cpp

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -115,6 +115,7 @@ private:
 	static ScalarFunctionSet GetPrettyPrintFunction();
 	static ScalarFunctionSet GetNormalizeFunction();
 	static ScalarFunctionSet GetStripNullsFunction();
+	static ScalarFunctionSet GetSetFunction();
 
 	static PragmaFunctionSet GetExecuteJsonSerializedSqlPragmaFunction();
 

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -189,6 +189,7 @@ vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
 	functions.push_back(GetPrettyPrintFunction());
 	functions.push_back(GetNormalizeFunction());
 	functions.push_back(GetStripNullsFunction());
+	functions.push_back(GetSetFunction());
 
 	return functions;
 }

--- a/extension/json/json_functions/CMakeLists.txt
+++ b/extension/json/json_functions/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   json_value.cpp
   json_serialize_plan.cpp
   json_normalize.cpp
+  json_set.cpp
   json_serialize_sql.cpp
   json_deep_merge.cpp
   json_merge_patch_diff.cpp

--- a/extension/json/json_functions/CMakeLists.txt
+++ b/extension/json/json_functions/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library_unity(
   json_value.cpp
   json_serialize_plan.cpp
   json_normalize.cpp
-  json_set.cpp
+  json_modify.cpp
   json_serialize_sql.cpp
   json_deep_merge.cpp
   json_merge_patch_diff.cpp

--- a/extension/json/json_functions/json_modify.cpp
+++ b/extension/json/json_functions/json_modify.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/vector_operations/ternary_executor.hpp"
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
@@ -91,9 +92,8 @@ static void JsonSetFunction(DataChunk &args, ExpressionState &state, Vector &res
 	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
 	auto alc = lstate.json_allocator->GetYYAlc();
 
-	TernaryExecutor::ExecuteWithNulls<string_t, string_t, string_t, string_t>(
-	    args.data[0], args.data[1], args.data[2], result, args.size(),
-	    [&](string_t doc_str, string_t path_str, string_t val_str, ValidityMask &mask, idx_t idx) {
+	TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
+	    args.data[0], args.data[1], args.data[2], result, [&](string_t doc_str, string_t path_str, string_t val_str) {
 		    auto doc = JSONCommon::ReadDocument(doc_str, JSONCommon::READ_FLAG, alc);
 		    auto mut_doc = yyjson_doc_mut_copy(doc, alc);
 
@@ -109,10 +109,6 @@ static void JsonSetFunction(DataChunk &args, ExpressionState &state, Vector &res
 		    }
 
 		    auto root = yyjson_mut_doc_get_root(mut_doc);
-		    if (!root) {
-			    mask.SetInvalid(idx);
-			    return string_t {};
-		    }
 		    return JSONCommon::WriteVal<yyjson_mut_val>(root, alc);
 	    });
 
@@ -121,7 +117,7 @@ static void JsonSetFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 ScalarFunctionSet JSONFunctions::GetSetFunction() {
 	ScalarFunction fun("json_set", {LogicalType::JSON(), LogicalType::VARCHAR, LogicalType::JSON()},
-	                   LogicalType::JSON(), JsonSetFunction, nullptr, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   LogicalType::JSON(), JsonSetFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
 
 	return ScalarFunctionSet(fun);
 }

--- a/extension/json/json_functions/json_set.cpp
+++ b/extension/json/json_functions/json_set.cpp
@@ -91,55 +91,30 @@ static void JsonSetFunction(DataChunk &args, ExpressionState &state, Vector &res
 	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
 	auto alc = lstate.json_allocator->GetYYAlc();
 
-	const auto count = args.size();
+	TernaryExecutor::ExecuteWithNulls<string_t, string_t, string_t, string_t>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [&](string_t doc_str, string_t path_str, string_t val_str, ValidityMask &mask, idx_t idx) {
+		    auto doc = JSONCommon::ReadDocument(doc_str, JSONCommon::READ_FLAG, alc);
+		    auto mut_doc = yyjson_doc_mut_copy(doc, alc);
 
-	UnifiedVectorFormat doc_data, path_data, val_data;
-	args.data[0].ToUnifiedFormat(count, doc_data);
-	args.data[1].ToUnifiedFormat(count, path_data);
-	args.data[2].ToUnifiedFormat(count, val_data);
-	auto doc_inputs = UnifiedVectorFormat::GetData<string_t>(doc_data);
-	auto path_inputs = UnifiedVectorFormat::GetData<string_t>(path_data);
-	auto val_inputs = UnifiedVectorFormat::GetData<string_t>(val_data);
+		    auto val_doc = JSONCommon::ReadDocument(val_str, JSONCommon::READ_FLAG, alc);
+		    auto new_val = yyjson_val_mut_copy(mut_doc, val_doc->root);
 
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
+		    auto pointer = ConvertToJsonPointer(path_str);
 
-	for (idx_t i = 0; i < count; i++) {
-		auto doc_idx = doc_data.sel->get_index(i);
-		auto path_idx = path_data.sel->get_index(i);
-		auto val_idx = val_data.sel->get_index(i);
+		    // Try set first (overwrites existing, creates missing).
+		    // Fall back to add for cases set cannot handle (e.g. appending with /-).
+		    if (!yyjson_mut_doc_ptr_setx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr)) {
+			    yyjson_mut_doc_ptr_addx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr);
+		    }
 
-		if (!doc_data.validity.RowIsValid(doc_idx) || !path_data.validity.RowIsValid(path_idx) ||
-		    !val_data.validity.RowIsValid(val_idx)) {
-			result_validity.SetInvalid(i);
-			continue;
-		}
-
-		auto doc = JSONCommon::ReadDocument(doc_inputs[doc_idx], JSONCommon::READ_FLAG, alc);
-		auto mut_doc = yyjson_doc_mut_copy(doc, alc);
-
-		auto val_doc = JSONCommon::ReadDocument(val_inputs[val_idx], JSONCommon::READ_FLAG, alc);
-		auto new_val = yyjson_val_mut_copy(mut_doc, val_doc->root);
-
-		auto pointer = ConvertToJsonPointer(path_inputs[path_idx]);
-
-		// Try set first (overwrites existing, creates missing).
-		// Fall back to add for cases set cannot handle (e.g. appending with /-).
-		if (!yyjson_mut_doc_ptr_setx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr)) {
-			yyjson_mut_doc_ptr_addx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr);
-		}
-
-		auto root = yyjson_mut_doc_get_root(mut_doc);
-		if (root) {
-			result_data[i] = JSONCommon::WriteVal<yyjson_mut_val>(root, alc);
-		} else {
-			result_validity.SetInvalid(i);
-		}
-	}
-
-	if (args.AllConstant()) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
+		    auto root = yyjson_mut_doc_get_root(mut_doc);
+		    if (!root) {
+			    mask.SetInvalid(idx);
+			    return string_t {};
+		    }
+		    return JSONCommon::WriteVal<yyjson_mut_val>(root, alc);
+	    });
 
 	JSONAllocator::AddBuffer(result, alc);
 }

--- a/extension/json/json_functions/json_set.cpp
+++ b/extension/json/json_functions/json_set.cpp
@@ -1,0 +1,154 @@
+#include "json_common.hpp"
+#include "json_functions.hpp"
+
+namespace duckdb {
+
+//! Convert a JSONPath ($.key[0].nested) to a JSON Pointer (/key/0/nested).
+//! Paths starting with '/' are returned as-is. Bare key names are wrapped as /key.
+static string ConvertToJsonPointer(const string_t &path_str) {
+	auto ptr = path_str.GetData();
+	auto len = path_str.GetSize();
+	if (len == 0) {
+		return "";
+	}
+	// Already a JSON Pointer
+	if (*ptr == '/') {
+		return string(ptr, len);
+	}
+	// Bare key name
+	if (*ptr != '$') {
+		string result = "/";
+		for (idx_t i = 0; i < len; i++) {
+			if (ptr[i] == '~') {
+				result += "~0";
+			} else if (ptr[i] == '/') {
+				result += "~1";
+			} else {
+				result += ptr[i];
+			}
+		}
+		return result;
+	}
+	// JSONPath: convert $.key[0].nested to /key/0/nested
+	string result;
+	idx_t i = 1; // Skip '$'
+	while (i < len) {
+		auto c = ptr[i++];
+		if (c == '.') {
+			result += '/';
+			if (i < len && ptr[i] == '"') {
+				i++; // Skip opening quote
+				while (i < len && ptr[i] != '"') {
+					if (ptr[i] == '~') {
+						result += "~0";
+					} else if (ptr[i] == '/') {
+						result += "~1";
+					} else {
+						result += ptr[i];
+					}
+					i++;
+				}
+				if (i < len) {
+					i++; // Skip closing quote
+				}
+			} else {
+				while (i < len && ptr[i] != '.' && ptr[i] != '[') {
+					if (ptr[i] == '~') {
+						result += "~0";
+					} else if (ptr[i] == '/') {
+						result += "~1";
+					} else {
+						result += ptr[i];
+					}
+					i++;
+				}
+			}
+		} else if (c == '[') {
+			result += '/';
+			if (i < len && ptr[i] == '#') {
+				// $[#] -> /- (append)
+				result += '-';
+				i++; // Skip '#'
+				if (i < len && ptr[i] == ']') {
+					i++; // Skip ']'
+				}
+			} else {
+				while (i < len && ptr[i] != ']') {
+					result += ptr[i];
+					i++;
+				}
+				if (i < len) {
+					i++; // Skip ']'
+				}
+			}
+		}
+	}
+	return result;
+}
+
+//! Set a value at a path in a JSON document (create if missing, overwrite if exists)
+static void JsonSetFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
+	auto alc = lstate.json_allocator->GetYYAlc();
+
+	const auto count = args.size();
+
+	UnifiedVectorFormat doc_data, path_data, val_data;
+	args.data[0].ToUnifiedFormat(count, doc_data);
+	args.data[1].ToUnifiedFormat(count, path_data);
+	args.data[2].ToUnifiedFormat(count, val_data);
+	auto doc_inputs = UnifiedVectorFormat::GetData<string_t>(doc_data);
+	auto path_inputs = UnifiedVectorFormat::GetData<string_t>(path_data);
+	auto val_inputs = UnifiedVectorFormat::GetData<string_t>(val_data);
+
+	auto result_data = FlatVector::GetData<string_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto doc_idx = doc_data.sel->get_index(i);
+		auto path_idx = path_data.sel->get_index(i);
+		auto val_idx = val_data.sel->get_index(i);
+
+		if (!doc_data.validity.RowIsValid(doc_idx) || !path_data.validity.RowIsValid(path_idx) ||
+		    !val_data.validity.RowIsValid(val_idx)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto doc = JSONCommon::ReadDocument(doc_inputs[doc_idx], JSONCommon::READ_FLAG, alc);
+		auto mut_doc = yyjson_doc_mut_copy(doc, alc);
+
+		auto val_doc = JSONCommon::ReadDocument(val_inputs[val_idx], JSONCommon::READ_FLAG, alc);
+		auto new_val = yyjson_val_mut_copy(mut_doc, val_doc->root);
+
+		auto pointer = ConvertToJsonPointer(path_inputs[path_idx]);
+
+		// Try set first (overwrites existing, creates missing).
+		// Fall back to add for cases set cannot handle (e.g. appending with /-).
+		if (!yyjson_mut_doc_ptr_setx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr)) {
+			yyjson_mut_doc_ptr_addx(mut_doc, pointer.c_str(), pointer.size(), new_val, true, nullptr, nullptr);
+		}
+
+		auto root = yyjson_mut_doc_get_root(mut_doc);
+		if (root) {
+			result_data[i] = JSONCommon::WriteVal<yyjson_mut_val>(root, alc);
+		} else {
+			result_validity.SetInvalid(i);
+		}
+	}
+
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
+	JSONAllocator::AddBuffer(result, alc);
+}
+
+ScalarFunctionSet JSONFunctions::GetSetFunction() {
+	ScalarFunction fun("json_set", {LogicalType::JSON(), LogicalType::VARCHAR, LogicalType::JSON()},
+	                   LogicalType::JSON(), JsonSetFunction, nullptr, nullptr, nullptr, JSONFunctionLocalState::Init);
+
+	return ScalarFunctionSet(fun);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -424,6 +424,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"json_quote", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_serialize_plan", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_serialize_sql", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"json_set", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_strip_nulls", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_structure", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_transform", "json", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/test/sql/json/scalar/test_json_set.test
+++ b/test/sql/json/scalar/test_json_set.test
@@ -1,0 +1,187 @@
+# name: test/sql/json/scalar/test_json_set.test
+# description: Test JSON set (set value at path, create if missing, overwrite if exists)
+# group: [scalar]
+
+require json
+
+statement ok
+pragma enable_verification
+
+# Basic: add new key to object
+query T
+SELECT json_set('{"a":1}', '$.b', '2'::JSON)
+----
+{"a":1,"b":2}
+
+# Overwrite existing key
+query T
+SELECT json_set('{"a":1}', '$.a', '99'::JSON)
+----
+{"a":99}
+
+# JSON Pointer syntax works too
+query T
+SELECT json_set('{"a":1}', '/b', '2'::JSON)
+----
+{"a":1,"b":2}
+
+# Nested path: set inside nested object
+query T
+SELECT json_set('{"a":{"x":1}}', '$.a.y', '2'::JSON)
+----
+{"a":{"x":1,"y":2}}
+
+# Nested path: overwrite inside nested object
+query T
+SELECT json_set('{"a":{"x":1}}', '$.a.x', '99'::JSON)
+----
+{"a":{"x":99}}
+
+# Create intermediate parents
+query T
+SELECT json_set('{}', '$.a.b.c', '1'::JSON)
+----
+{"a":{"b":{"c":1}}}
+
+# Array index: overwrite element
+query T
+SELECT json_set('[1,2,3]', '$[1]', '99'::JSON)
+----
+[1,99,3]
+
+# Array append with JSON Pointer /- syntax
+query T
+SELECT json_set('[1,2]', '/-', '3'::JSON)
+----
+[1,2,3]
+
+# Set inside object in array
+query T
+SELECT json_set('[{"a":1}]', '$[0].b', '2'::JSON)
+----
+[{"a":1,"b":2}]
+
+# Set different value types
+query T
+SELECT json_set('{}', '$.s', '"hello"'::JSON)
+----
+{"s":"hello"}
+
+query T
+SELECT json_set('{}', '$.b', 'true'::JSON)
+----
+{"b":true}
+
+query T
+SELECT json_set('{}', '$.n', 'null'::JSON)
+----
+{"n":null}
+
+query T
+SELECT json_set('{}', '$.arr', '[1,2,3]'::JSON)
+----
+{"arr":[1,2,3]}
+
+query T
+SELECT json_set('{}', '$.obj', '{"x":1}'::JSON)
+----
+{"obj":{"x":1}}
+
+# Overwrite with different type (number to object)
+query T
+SELECT json_set('{"a":1}', '$.a', '{"nested":true}'::JSON)
+----
+{"a":{"nested":true}}
+
+# Overwrite with different type (object to scalar)
+query T
+SELECT json_set('{"a":{"x":1}}', '$.a', '42'::JSON)
+----
+{"a":42}
+
+# Deeply nested set
+query T
+SELECT json_set('{"a":{"b":{"c":1}}}', '$.a.b.c', '99'::JSON)
+----
+{"a":{"b":{"c":99}}}
+
+# Set on nested array path with JSON Pointer
+query T
+SELECT json_set('{"a":[1,[2,3],4]}', '/a/1/0', '99'::JSON)
+----
+{"a":[1,[99,3],4]}
+
+# NULL handling: NULL in any argument produces NULL
+query T
+SELECT json_set(NULL, '$.a', '1'::JSON)
+----
+NULL
+
+query T
+SELECT json_set('{"a":1}', NULL, '1'::JSON)
+----
+NULL
+
+query T
+SELECT json_set('{"a":1}', '$.a', NULL)
+----
+NULL
+
+# Empty object
+query T
+SELECT json_set('{}', '$.a', '1'::JSON)
+----
+{"a":1}
+
+# Set preserves existing keys
+query T
+SELECT json_set('{"a":1,"b":2,"c":3}', '$.b', '99'::JSON)
+----
+{"a":1,"b":99,"c":3}
+
+# Bare key name (treated as top-level key)
+query T
+SELECT json_set('{"a":1}', 'b', '2'::JSON)
+----
+{"a":1,"b":2}
+
+# Constant vector test
+query T
+SELECT json_set('{"a":1}', '$.b', '2'::JSON) FROM range(3)
+----
+{"a":1,"b":2}
+{"a":1,"b":2}
+{"a":1,"b":2}
+
+# Table-based test
+statement ok
+CREATE TABLE entities (id INTEGER, data JSON, path VARCHAR, val JSON);
+
+statement ok
+INSERT INTO entities VALUES
+    (1, '{"a":1}', '$.b', '2'::JSON),
+    (2, '{"x":{"y":1}}', '$.x.z', '3'::JSON),
+    (3, '{"arr":[1,2]}', '/arr/-', '3'::JSON);
+
+query IT
+SELECT id, json_set(data, path, val) FROM entities ORDER BY id
+----
+1	{"a":1,"b":2}
+2	{"x":{"y":1,"z":3}}
+3	{"arr":[1,2,3]}
+
+# Real-world: add relationship to entity
+query T
+SELECT json_set(
+    '{"typeName":"Column","attributes":{"name":"col1","dataType":"VARCHAR"}}',
+    '$.attributes.table',
+    '{"typeName":"Table","uniqueAttributes":{"qualifiedName":"t1"}}'::JSON
+)
+----
+{"typeName":"Column","attributes":{"name":"col1","dataType":"VARCHAR","table":{"typeName":"Table","uniqueAttributes":{"qualifiedName":"t1"}}}}
+
+# Composability: set then normalize
+query T
+SELECT json_normalize(json_set('{"z":1}', '$.a', '2'::JSON))
+----
+{"a":2,"z":1}

--- a/test/sql/json/scalar/test_json_set.test
+++ b/test/sql/json/scalar/test_json_set.test
@@ -9,116 +9,116 @@ pragma enable_verification
 
 # Basic: add new key to object
 query T
-SELECT json_set('{"a":1}', '$.b', '2'::JSON)
+SELECT json_set('{"a":1}', '$.b', '2')
 ----
 {"a":1,"b":2}
 
 # Overwrite existing key
 query T
-SELECT json_set('{"a":1}', '$.a', '99'::JSON)
+SELECT json_set('{"a":1}', '$.a', '99')
 ----
 {"a":99}
 
 # JSON Pointer syntax works too
 query T
-SELECT json_set('{"a":1}', '/b', '2'::JSON)
+SELECT json_set('{"a":1}', '/b', '2')
 ----
 {"a":1,"b":2}
 
 # Nested path: set inside nested object
 query T
-SELECT json_set('{"a":{"x":1}}', '$.a.y', '2'::JSON)
+SELECT json_set('{"a":{"x":1}}', '$.a.y', '2')
 ----
 {"a":{"x":1,"y":2}}
 
 # Nested path: overwrite inside nested object
 query T
-SELECT json_set('{"a":{"x":1}}', '$.a.x', '99'::JSON)
+SELECT json_set('{"a":{"x":1}}', '$.a.x', '99')
 ----
 {"a":{"x":99}}
 
 # Create intermediate parents
 query T
-SELECT json_set('{}', '$.a.b.c', '1'::JSON)
+SELECT json_set('{}', '$.a.b.c', '1')
 ----
 {"a":{"b":{"c":1}}}
 
 # Array index: overwrite element
 query T
-SELECT json_set('[1,2,3]', '$[1]', '99'::JSON)
+SELECT json_set('[1,2,3]', '$[1]', '99')
 ----
 [1,99,3]
 
 # Array append with JSON Pointer /- syntax
 query T
-SELECT json_set('[1,2]', '/-', '3'::JSON)
+SELECT json_set('[1,2]', '/-', '3')
 ----
 [1,2,3]
 
 # Set inside object in array
 query T
-SELECT json_set('[{"a":1}]', '$[0].b', '2'::JSON)
+SELECT json_set('[{"a":1}]', '$[0].b', '2')
 ----
 [{"a":1,"b":2}]
 
 # Set different value types
 query T
-SELECT json_set('{}', '$.s', '"hello"'::JSON)
+SELECT json_set('{}', '$.s', '"hello"')
 ----
 {"s":"hello"}
 
 query T
-SELECT json_set('{}', '$.b', 'true'::JSON)
+SELECT json_set('{}', '$.b', 'true')
 ----
 {"b":true}
 
 query T
-SELECT json_set('{}', '$.n', 'null'::JSON)
+SELECT json_set('{}', '$.n', 'null')
 ----
 {"n":null}
 
 query T
-SELECT json_set('{}', '$.arr', '[1,2,3]'::JSON)
+SELECT json_set('{}', '$.arr', '[1,2,3]')
 ----
 {"arr":[1,2,3]}
 
 query T
-SELECT json_set('{}', '$.obj', '{"x":1}'::JSON)
+SELECT json_set('{}', '$.obj', '{"x":1}')
 ----
 {"obj":{"x":1}}
 
 # Overwrite with different type (number to object)
 query T
-SELECT json_set('{"a":1}', '$.a', '{"nested":true}'::JSON)
+SELECT json_set('{"a":1}', '$.a', '{"nested":true}')
 ----
 {"a":{"nested":true}}
 
 # Overwrite with different type (object to scalar)
 query T
-SELECT json_set('{"a":{"x":1}}', '$.a', '42'::JSON)
+SELECT json_set('{"a":{"x":1}}', '$.a', '42')
 ----
 {"a":42}
 
 # Deeply nested set
 query T
-SELECT json_set('{"a":{"b":{"c":1}}}', '$.a.b.c', '99'::JSON)
+SELECT json_set('{"a":{"b":{"c":1}}}', '$.a.b.c', '99')
 ----
 {"a":{"b":{"c":99}}}
 
 # Set on nested array path with JSON Pointer
 query T
-SELECT json_set('{"a":[1,[2,3],4]}', '/a/1/0', '99'::JSON)
+SELECT json_set('{"a":[1,[2,3],4]}', '/a/1/0', '99')
 ----
 {"a":[1,[99,3],4]}
 
 # NULL handling: NULL in any argument produces NULL
 query T
-SELECT json_set(NULL, '$.a', '1'::JSON)
+SELECT json_set(NULL, '$.a', '1')
 ----
 NULL
 
 query T
-SELECT json_set('{"a":1}', NULL, '1'::JSON)
+SELECT json_set('{"a":1}', NULL, '1')
 ----
 NULL
 
@@ -129,25 +129,31 @@ NULL
 
 # Empty object
 query T
-SELECT json_set('{}', '$.a', '1'::JSON)
+SELECT json_set('{}', '$.a', '1')
 ----
 {"a":1}
 
 # Set preserves existing keys
 query T
-SELECT json_set('{"a":1,"b":2,"c":3}', '$.b', '99'::JSON)
+SELECT json_set('{"a":1,"b":2,"c":3}', '$.b', '99')
 ----
 {"a":1,"b":99,"c":3}
 
 # Bare key name (treated as top-level key)
 query T
-SELECT json_set('{"a":1}', 'b', '2'::JSON)
+SELECT json_set('{"a":1}', 'b', '2')
+----
+{"a":1,"b":2}
+
+# Explicit ::JSON cast also works
+query T
+SELECT json_set('{"a":1}', '$.b', '2'::JSON)
 ----
 {"a":1,"b":2}
 
 # Constant vector test
 query T
-SELECT json_set('{"a":1}', '$.b', '2'::JSON) FROM range(3)
+SELECT json_set('{"a":1}', '$.b', '2') FROM range(3)
 ----
 {"a":1,"b":2}
 {"a":1,"b":2}
@@ -159,9 +165,9 @@ CREATE TABLE entities (id INTEGER, data JSON, path VARCHAR, val JSON);
 
 statement ok
 INSERT INTO entities VALUES
-    (1, '{"a":1}', '$.b', '2'::JSON),
-    (2, '{"x":{"y":1}}', '$.x.z', '3'::JSON),
-    (3, '{"arr":[1,2]}', '/arr/-', '3'::JSON);
+    (1, '{"a":1}', '$.b', '2'),
+    (2, '{"x":{"y":1}}', '$.x.z', '3'),
+    (3, '{"arr":[1,2]}', '/arr/-', '3');
 
 query IT
 SELECT id, json_set(data, path, val) FROM entities ORDER BY id
@@ -175,13 +181,13 @@ query T
 SELECT json_set(
     '{"typeName":"Column","attributes":{"name":"col1","dataType":"VARCHAR"}}',
     '$.attributes.table',
-    '{"typeName":"Table","uniqueAttributes":{"qualifiedName":"t1"}}'::JSON
+    '{"typeName":"Table","uniqueAttributes":{"qualifiedName":"t1"}}'
 )
 ----
 {"typeName":"Column","attributes":{"name":"col1","dataType":"VARCHAR","table":{"typeName":"Table","uniqueAttributes":{"qualifiedName":"t1"}}}}
 
 # Composability: set then normalize
 query T
-SELECT json_normalize(json_set('{"z":1}', '$.a', '2'::JSON))
+SELECT json_normalize(json_set('{"z":1}', '$.a', '2'))
 ----
 {"a":2,"z":1}


### PR DESCRIPTION
## Summary

Adds `json_set(json, path, value) -> JSON` which sets a value at a given path in a JSON document. Creates intermediate parents if the path does not exist, overwrites if it does. This is the most commonly requested missing JSON mutation function, available in SQLite (`json_set`), MySQL (`JSON_SET`), and PostgreSQL (`jsonb_set`).

Related (closed): https://github.com/duckdb/duckdb/pull/12386

```sql
-- Add a new key
SELECT json_set('{"a":1}', '$.b', '2');
-- {"a":1,"b":2}

-- Overwrite existing
SELECT json_set('{"a":1}', '$.a', '99');
-- {"a":99}

-- Create intermediate parents
SELECT json_set('{}', '$.a.b.c', '1');
-- {"a":{"b":{"c":1}}}

-- Array index
SELECT json_set('[1,2,3]', '$[1]', '99');
-- [1,99,3]

-- Append to array
SELECT json_set('[1,2]', '/-', '3');
-- [1,2,3]

-- Set nested value
SELECT json_set('[{"a":1}]', '$[0].b', '2');
-- [{"a":1,"b":2}]
```

Supports both JSONPath (`$.key[0]`) and JSON Pointer (`/key/0`) syntax, matching DuckDB's existing `json_extract` path format. Bare key names are also accepted.

### Implementation

Converts JSONPath to JSON Pointer internally (with proper RFC 6901 escaping for `~` and `/`), then delegates to yyjson's native `yyjson_mut_doc_ptr_set` with fallback to `ptr_add` for array append operations. Uses `TernaryExecutor::ExecuteWithNulls` for the vectorized loop.

## Test plan

- [x] `test_json_set.test` - 39 assertions covering: add/overwrite keys, JSON Pointer and JSONPath syntax, nested paths, intermediate parent creation, array index overwrite, array append (`/-` and `$[#]`), objects in arrays, all value types, type changes, deeply nested, NULL handling, bare key names, explicit JSON cast, constant vectors, table-based queries, real-world entity mutation, composability with json_normalize
- [x] All existing JSON tests pass (80 test cases, 6724 assertions)
- [x] `clang-format 11.0.1` applied