### PR TITLE
Remove all_profiling_output()

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -111,10 +111,6 @@ static string PragmaShowDatabases(ClientContext &context, const FunctionParamete
 string PragmaShowVariables() {
 	return "SELECT * FROM duckdb_variables() ORDER BY name";
 }
-static string PragmaAllProfiling(ClientContext &context, const FunctionParameters &parameters) {
-	return "SELECT * FROM pragma_last_profiling_output() JOIN pragma_detailed_profiling_output() ON "
-	       "(pragma_last_profiling_output.operator_id);";
-}
 
 static string PragmaDatabaseList(ClientContext &context, const FunctionParameters &parameters) {
 	return "SELECT * FROM pragma_database_list;";
@@ -231,7 +227,6 @@ void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));
 	set.AddFunction(
 	    PragmaFunction::PragmaCall("copy_database", PragmaCopyDatabase, {LogicalType::VARCHAR, LogicalType::VARCHAR}));
-	set.AddFunction(PragmaFunction::PragmaStatement("all_profiling_output", PragmaAllProfiling));
 	set.AddFunction(PragmaFunction::PragmaStatement("user_agent", PragmaUserAgent));
 }
 


### PR DESCRIPTION
The functions used by the macro `all_profiling_output()` were removed in https://github.com/duckdb/duckdb/pull/10504, as a result the it is no longer functional.

Related issue: https://github.com/duckdb/duckdb/issues/21735