### PR TITLE
Rework vector buffers to remove the `auxiliary` buffer and move everything into a single `VectorBuffer`

### DIFF
--- a/benchmark/realnest/micro/01_aggregate-first-level-struct-members.benchmark
+++ b/benchmark/realnest/micro/01_aggregate-first-level-struct-members.benchmark
@@ -8,7 +8,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/02_list_sort.benchmark
+++ b/benchmark/realnest/micro/02_list_sort.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/03_create_table_from_unnested_structs.benchmark
+++ b/benchmark/realnest/micro/03_create_table_from_unnested_structs.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/04_list_transform_and_list_aggregate.benchmark
+++ b/benchmark/realnest/micro/04_list_transform_and_list_aggregate.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/05_list_filter.benchmark
+++ b/benchmark/realnest/micro/05_list_filter.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/06_list_filter_on_unnested_structure.benchmark
+++ b/benchmark/realnest/micro/06_list_filter_on_unnested_structure.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/07_list_unique_on_transformed_and_aggregated_list.benchmark
+++ b/benchmark/realnest/micro/07_list_unique_on_transformed_and_aggregated_list.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/08_count_map_keys.benchmark
+++ b/benchmark/realnest/micro/08_count_map_keys.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/09_array_agg.benchmark
+++ b/benchmark/realnest/micro/09_array_agg.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/10_list_intersect_hashtags.benchmark
+++ b/benchmark/realnest/micro/10_list_intersect_hashtags.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/11_list_sort_reduce_transform.benchmark
+++ b/benchmark/realnest/micro/11_list_sort_reduce_transform.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/12_map_list_values.benchmark
+++ b/benchmark/realnest/micro/12_map_list_values.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/13_multi_join_nested_data_with_filtering.benchmark
+++ b/benchmark/realnest/micro/13_multi_join_nested_data_with_filtering.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/14_list_slice.benchmark
+++ b/benchmark/realnest/micro/14_list_slice.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/15_list_sort.benchmark
+++ b/benchmark/realnest/micro/15_list_sort.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/16_most_common_list_aggregates.benchmark
+++ b/benchmark/realnest/micro/16_most_common_list_aggregates.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/benchmark/realnest/micro/17_list_aggregates_histogram_stddev_mode.benchmark
+++ b/benchmark/realnest/micro/17_list_aggregates_histogram_stddev_mode.benchmark
@@ -7,7 +7,7 @@ group real_nest
 
 require json
 
-require httpfs
+require httpfs load_only
 
 cache real_nest.duckdb
 

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -27,7 +27,7 @@ static void MapExtractValueFunc(DataChunk &args, ExpressionState &state, Vector 
 	map_vec.ToUnifiedFormat(count, lst_format);
 
 	const auto pos_data = UnifiedVectorFormat::GetData<int32_t>(pos_format);
-	const auto inc_list_data = ListVector::GetData(map_vec);
+	const auto inc_list_data = UnifiedVectorFormat::GetData<list_entry_t>(lst_format);
 
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 		auto lst_idx = lst_format.sel->get_index(row_idx);

--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -21,10 +21,9 @@ namespace duckdb {
 
 class JSONAllocator;
 
-class JSONStringVectorBuffer : public VectorBuffer {
+class JSONStringVectorBuffer : public AuxiliaryDataHolder {
 public:
-	explicit JSONStringVectorBuffer(shared_ptr<JSONAllocator> allocator_p)
-	    : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), allocator(std::move(allocator_p)) {
+	explicit JSONStringVectorBuffer(shared_ptr<JSONAllocator> allocator_p) : allocator(std::move(allocator_p)) {
 	}
 
 private:
@@ -48,7 +47,7 @@ public:
 
 	void AddBuffer(Vector &vector) {
 		if (vector.GetType().InternalType() == PhysicalType::VARCHAR) {
-			StringVector::AddBuffer(vector, make_buffer<JSONStringVectorBuffer>(shared_from_this()));
+			StringVector::AddAuxiliaryData(vector, make_uniq<JSONStringVectorBuffer>(shared_from_this()));
 		}
 	}
 

--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -23,14 +23,15 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 	// we use the last entry as a NULL, dictionary vectors don't have a separate validity mask
 	const auto duckdb_dictionary_size = dictionary_size + can_have_nulls;
 	dictionary = DictionaryVector::CreateReusableDictionary(reader.Type(), duckdb_dictionary_size);
-	auto &dict_validity = FlatVector::Validity(dictionary->data);
+	auto &dictionary_data = dictionary->data;
+	auto &dict_validity = FlatVector::Validity(dictionary_data);
 	dict_validity.Reset(duckdb_dictionary_size);
 	if (can_have_nulls) {
 		dict_validity.SetInvalid(dictionary_size);
 	}
 
 	// now read the non-NULL values from Parquet
-	reader.Plain(reader.block, nullptr, dictionary_size, 0, dictionary->data);
+	reader.Plain(reader.block, nullptr, dictionary_size, 0, dictionary_data);
 
 	// immediately filter the dictionary, if applicable
 	if (filter && CanFilter(*filter, *filter_state)) {
@@ -40,11 +41,11 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 
 		// apply the filter
 		UnifiedVectorFormat vdata;
-		dictionary->data.ToUnifiedFormat(duckdb_dictionary_size, vdata);
+		dictionary_data.ToUnifiedFormat(duckdb_dictionary_size, vdata);
 		SelectionVector dict_sel;
 		filter_count = duckdb_dictionary_size;
-		ColumnSegment::FilterSelection(dict_sel, dictionary->data, vdata, *filter, *filter_state,
-		                               duckdb_dictionary_size, filter_count);
+		ColumnSegment::FilterSelection(dict_sel, dictionary_data, vdata, *filter, *filter_state, duckdb_dictionary_size,
+		                               filter_count);
 
 		// now set all matching tuples to true
 		for (idx_t i = 0; i < filter_count; i++) {

--- a/extension/parquet/include/decoder/dictionary_decoder.hpp
+++ b/extension/parquet/include/decoder/dictionary_decoder.hpp
@@ -47,7 +47,7 @@ private:
 	SelectionVector valid_sel;
 	SelectionVector dictionary_selection_vector;
 	idx_t dictionary_size;
-	buffer_ptr<VectorChildBuffer> dictionary;
+	buffer_ptr<DictionaryEntry> dictionary;
 	unsafe_unique_array<bool> filter_result;
 	idx_t filter_count;
 	bool can_have_nulls;

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -56,10 +56,9 @@ void StringColumnReader::VerifyString(const char *str_data, uint32_t str_len) co
 	}
 }
 
-class ParquetStringVectorBuffer : public VectorBuffer {
+class ParquetStringVectorBuffer : public AuxiliaryDataHolder {
 public:
-	explicit ParquetStringVectorBuffer(shared_ptr<ResizeableBuffer> buffer_p)
-	    : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), buffer(std::move(buffer_p)) {
+	explicit ParquetStringVectorBuffer(shared_ptr<ResizeableBuffer> buffer_p) : buffer(std::move(buffer_p)) {
 	}
 
 private:
@@ -67,7 +66,7 @@ private:
 };
 
 void StringColumnReader::ReferenceBlock(Vector &result, shared_ptr<ResizeableBuffer> &block) {
-	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(block));
+	StringVector::AddAuxiliaryData(result, make_uniq<ParquetStringVectorBuffer>(block));
 }
 
 void StringColumnReader::Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5610,19 +5610,20 @@ const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 		{ static_cast<uint32_t>(VectorBufferType::MANAGED_BUFFER), "MANAGED_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::OPAQUE_BUFFER), "OPAQUE_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::ARRAY_BUFFER), "ARRAY_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::SHREDDED_BUFFER), "SHREDDED_BUFFER" }
+		{ static_cast<uint32_t>(VectorBufferType::SHREDDED_BUFFER), "SHREDDED_BUFFER" },
+		{ static_cast<uint32_t>(VectorBufferType::SEQUENCE_BUFFER), "SEQUENCE_BUFFER" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value) {
-	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 11, "VectorBufferType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 12, "VectorBufferType", static_cast<uint32_t>(value));
 }
 
 template<>
 VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value) {
-	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 11, "VectorBufferType", value));
+	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 12, "VectorBufferType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetVectorTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5584,14 +5584,12 @@ VariantValueType EnumUtil::FromString<VariantValueType>(const char *value) {
 const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(VectorBufferType::STANDARD_BUFFER), "STANDARD_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::DICTIONARY_BUFFER), "DICTIONARY_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::STRING_BUFFER), "STRING_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::FSST_BUFFER), "FSST_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::STRUCT_BUFFER), "STRUCT_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::LIST_BUFFER), "LIST_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::MANAGED_BUFFER), "MANAGED_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::OPAQUE_BUFFER), "OPAQUE_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::ARRAY_BUFFER), "ARRAY_BUFFER" },
+		{ static_cast<uint32_t>(VectorBufferType::DICTIONARY_BUFFER), "DICTIONARY_BUFFER" },
+		{ static_cast<uint32_t>(VectorBufferType::FSST_BUFFER), "FSST_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::SHREDDED_BUFFER), "SHREDDED_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::SEQUENCE_BUFFER), "SEQUENCE_BUFFER" }
 	};
@@ -5600,12 +5598,12 @@ const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value) {
-	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 11, "VectorBufferType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 9, "VectorBufferType", static_cast<uint32_t>(value));
 }
 
 template<>
 VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value) {
-	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 11, "VectorBufferType", value));
+	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 9, "VectorBufferType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetVectorTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5581,23 +5581,6 @@ VariantValueType EnumUtil::FromString<VariantValueType>(const char *value) {
 	return static_cast<VariantValueType>(StringUtil::StringToEnum(GetVariantValueTypeValues(), 4, "VariantValueType", value));
 }
 
-const StringUtil::EnumStringLiteral *GetVectorAuxiliaryDataTypeValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(VectorAuxiliaryDataType::ARROW_AUXILIARY), "ARROW_AUXILIARY" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<VectorAuxiliaryDataType>(VectorAuxiliaryDataType value) {
-	return StringUtil::EnumToString(GetVectorAuxiliaryDataTypeValues(), 1, "VectorAuxiliaryDataType", static_cast<uint32_t>(value));
-}
-
-template<>
-VectorAuxiliaryDataType EnumUtil::FromString<VectorAuxiliaryDataType>(const char *value) {
-	return static_cast<VectorAuxiliaryDataType>(StringUtil::StringToEnum(GetVectorAuxiliaryDataTypeValues(), 1, "VectorAuxiliaryDataType", value));
-}
-
 const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(VectorBufferType::STANDARD_BUFFER), "STANDARD_BUFFER" },

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5585,7 +5585,6 @@ const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(VectorBufferType::STANDARD_BUFFER), "STANDARD_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::DICTIONARY_BUFFER), "DICTIONARY_BUFFER" },
-		{ static_cast<uint32_t>(VectorBufferType::VECTOR_CHILD_BUFFER), "VECTOR_CHILD_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::STRING_BUFFER), "STRING_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::FSST_BUFFER), "FSST_BUFFER" },
 		{ static_cast<uint32_t>(VectorBufferType::STRUCT_BUFFER), "STRUCT_BUFFER" },
@@ -5601,12 +5600,12 @@ const StringUtil::EnumStringLiteral *GetVectorBufferTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value) {
-	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 12, "VectorBufferType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetVectorBufferTypeValues(), 11, "VectorBufferType", static_cast<uint32_t>(value));
 }
 
 template<>
 VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value) {
-	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 12, "VectorBufferType", value));
+	return static_cast<VectorBufferType>(StringUtil::StringToEnum(GetVectorBufferTypeValues(), 11, "VectorBufferType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetVectorTypeValues() {

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -170,7 +170,9 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 	auto validity_data = GetValidityPointer(base_ptr, type_size, vdata.count);
 	if (!vdata.next_data.IsValid() && state.properties != ColumnDataScanProperties::DISALLOW_ZERO_COPY) {
 		// no next data, we can do a zero-copy read of this vector
-		FlatVector::SetData(result, base_ptr);
+		if (result.GetType().InternalType() != PhysicalType::ARRAY) {
+			FlatVector::SetData(result, base_ptr);
+		}
 		FlatVector::Validity(result).Initialize(validity_data, STANDARD_VECTOR_SIZE);
 		return vdata.count;
 	}

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -159,6 +159,10 @@ void ColumnDataCollectionSegment::SetChildIndex(VectorChildIndex base_idx, idx_t
 	child_indices[base_idx.index + child_number] = index;
 }
 
+bool TypeHasData(const LogicalType &type) {
+	return type.InternalType() != PhysicalType::STRUCT && type.InternalType() != PhysicalType::ARRAY;
+}
+
 idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &state, VectorDataIndex vector_index,
                                                       Vector &result) {
 	auto &vector_type = result.GetType();
@@ -170,7 +174,7 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 	auto validity_data = GetValidityPointer(base_ptr, type_size, vdata.count);
 	if (!vdata.next_data.IsValid() && state.properties != ColumnDataScanProperties::DISALLOW_ZERO_COPY) {
 		// no next data, we can do a zero-copy read of this vector
-		if (result.GetType().InternalType() != PhysicalType::ARRAY) {
+		if (TypeHasData(result.GetType())) {
 			FlatVector::SetData(result, base_ptr);
 		}
 		FlatVector::Validity(result).Initialize(validity_data, STANDARD_VECTOR_SIZE);

--- a/src/common/types/variant/variant_value.cpp
+++ b/src/common/types/variant/variant_value.cpp
@@ -664,7 +664,7 @@ void VariantValue::ToVARIANT(vector<VariantValue> &input, Vector &result) {
 
 	auto &keys = VariantVector::GetKeys(result);
 	auto &keys_entry = ListVector::GetEntry(keys);
-	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringBuffer(keys_entry).GetStringAllocator());
+	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringAllocator(keys_entry));
 
 	DataChunk conversion_offsets;
 	conversion_offsets.Initialize(

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -58,7 +58,11 @@ Vector::Vector(LogicalType type_p, data_ptr_t dataptr) : vector_type(VectorType:
 	if (type.IsNested()) {
 		throw InternalException("Cannot create a nested vector from a single data pointer");
 	}
-	buffer = make_buffer<StandardVectorBuffer>(dataptr);
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		buffer = make_buffer<VectorStringBuffer>(dataptr);
+	} else {
+		buffer = make_buffer<StandardVectorBuffer>(dataptr);
+	}
 }
 
 Vector::Vector(const VectorCache &cache) : type(cache.GetType()) {
@@ -210,15 +214,23 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<VectorListBuffer>(offset_ptr, list_buffer);
+		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
-		AssignSharedPointer(auxiliary, other.auxiliary);
+	} else if (internal_type == PhysicalType::VARCHAR) {
+		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
+		auto string_buffer = make_buffer<VectorStringBuffer>(offset_ptr);
+		StringVector::AddHeapReference(*this, other);
+		buffer = std::move(string_buffer);
+		auxiliary.reset();
+		validity.Slice(other.validity, offset, end - offset);
+		vector_type = other.vector_type;
 	} else {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
+		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
-		AssignSharedPointer(auxiliary, other.auxiliary);
 	}
 }
 
@@ -398,7 +410,11 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 		if (GetType().InternalType() == PhysicalType::LIST) {
 			throw InternalException("Resize for empty list not supported");
 		}
-		buffer = make_buffer<StandardVectorBuffer>(0);
+		if (GetType().InternalType() == PhysicalType::VARCHAR) {
+			buffer = make_buffer<VectorStringBuffer>(idx_t(0));
+		} else {
+			buffer = make_buffer<StandardVectorBuffer>(0);
+		}
 	}
 
 	// Obtain the resize information for each (nested) vector.
@@ -434,6 +450,9 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 		if (resize_info_entry.vec.GetType().InternalType() == PhysicalType::LIST) {
 			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorListBuffer>();
 			new_buffer = make_buffer<VectorListBuffer>(std::move(new_data), old_buffer);
+		} else if (resize_info_entry.vec.GetType().InternalType() == PhysicalType::VARCHAR) {
+			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorStringBuffer>();
+			new_buffer = make_buffer<VectorStringBuffer>(std::move(new_data), old_buffer);
 		} else {
 			new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
 		}
@@ -1421,9 +1440,9 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 	}
 }
 
-class StringDeserializeBuffer : public VectorBuffer {
+class StringDeserializeHolder : public AuxiliaryDataHolder {
 public:
-	explicit StringDeserializeBuffer(idx_t size) : VectorBuffer(VectorBufferType::OPAQUE_BUFFER) {
+	explicit StringDeserializeHolder(idx_t size) {
 		data = unique_ptr<data_t[]>(new data_t[size]);
 	}
 	unique_ptr<data_t[]> data;
@@ -1511,12 +1530,12 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 				auto length_data = make_unsafe_uniq_array_uninitialized<data_t>(length_data_length);
 				deserializer.ReadProperty(108, "length_data", length_data.get(), length_data_length);
 
-				auto byte_data_buffer = make_buffer<StringDeserializeBuffer>(byte_data_length.GetIndex());
+				auto byte_data_buffer = make_uniq<StringDeserializeHolder>(byte_data_length.GetIndex());
 				// directly read into a string buffer we can glue to the vector
 				deserializer.ReadProperty(109, "byte_data", byte_data_buffer->data.get(), byte_data_length.GetIndex());
 				auto lengths_read_ptr = reinterpret_cast<uint32_t *>(length_data.get());
 				auto byte_read_ptr = reinterpret_cast<const char *>(byte_data_buffer->data.get());
-				StringVector::AddBuffer(*this, byte_data_buffer);
+				StringVector::AddAuxiliaryData(*this, std::move(byte_data_buffer));
 
 				for (idx_t i = 0; i < count; ++i) {
 					if (!validity.RowIsValid(i)) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1155,12 +1155,15 @@ void Vector::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format) const {
 			// dictionary with non-flat child: create a new reference to the child and flatten it
 			Vector child_vector(Vector::Ref(child));
 			child_vector.Flatten(sel, count);
-			auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(child_vector));
-			auto &dict_buffer = this->buffer->Cast<DictionaryBuffer>();
-			dict_buffer.SetEntry(std::move(new_entry));
+			auto new_entry = make_buffer<DictionaryEntry>(std::move(child_vector));
+			auto &dict_entry = *new_entry;
+			auto &old_dict_buffer = this->buffer->Cast<DictionaryBuffer>();
+			auto new_dict_buffer = make_buffer<DictionaryBuffer>(old_dict_buffer.GetSelVector(), std::move(new_entry));
+			auto &dict_buffer = *new_dict_buffer;
+			this->buffer = std::move(new_dict_buffer);
 
-			format.data = FlatVector::GetData(dict_buffer.GetEntry().data);
-			format.validity = FlatVector::Validity(dict_buffer.GetEntry().data);
+			format.data = FlatVector::GetData(dict_entry.data);
+			format.validity = FlatVector::Validity(dict_entry.data);
 		}
 		break;
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -401,6 +401,26 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 	}
 }
 
+void Vector::AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> data) {
+	buffer->AddAuxiliaryData(std::move(data));
+}
+
+void Vector::AddHeapReference(const Vector &other) {
+	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		AddHeapReference(DictionaryVector::Child(other));
+		return;
+	}
+	if (!other.buffer) {
+		return;
+	}
+	auto data = other.buffer->GetAuxiliaryData();
+	if (!data) {
+		// no auxiliary data to reference
+		return;
+	}
+	AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
+}
+
 void Vector::Resize(idx_t current_size, idx_t new_size) {
 	// The vector does not contain any data.
 	if (!buffer) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -87,7 +87,7 @@ Vector::Vector(const Value &value) : type(value.type()) {
 
 Vector::Vector(Vector &&other) noexcept
     : vector_type(other.vector_type), type(std::move(other.type)), validity(std::move(other.validity)),
-      buffer(std::move(other.buffer)), auxiliary(std::move(other.auxiliary)) {
+      buffer(std::move(other.buffer)) {
 }
 
 Vector Vector::Ref(const Vector &other) {
@@ -118,7 +118,6 @@ void Vector::Reference(const Value &value) {
 		SetValue(0, value);
 	} else {
 		buffer = VectorBuffer::CreateConstantVector(value.type());
-		auxiliary.reset();
 		SetValue(0, value);
 	}
 }
@@ -170,7 +169,6 @@ void Vector::Reinterpret(const Vector &other) {
 void Vector::ConstReference(const Vector &other) const {
 	vector_type = other.vector_type;
 	AssignSharedPointer(buffer, other.buffer);
-	AssignSharedPointer(auxiliary, other.auxiliary);
 	validity = other.validity;
 }
 
@@ -221,7 +219,6 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<VectorListBuffer>(offset_ptr, list_buffer);
-		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
 	} else if (internal_type == PhysicalType::VARCHAR) {
@@ -229,13 +226,11 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto string_buffer = make_buffer<VectorStringBuffer>(offset_ptr);
 		buffer = std::move(string_buffer);
 		StringVector::AddHeapReference(*this, other);
-		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
 	} else {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
-		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
 	}
@@ -289,7 +284,6 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 	auto entry = make_shared_ptr<DictionaryEntry>(std::move(child_vector));
 	buffer = make_buffer<DictionaryBuffer>(sel, std::move(entry));
 	vector_type = VectorType::DICTIONARY_VECTOR;
-	auxiliary.reset();
 }
 
 void Vector::Dictionary(idx_t dictionary_size, const SelectionVector &sel, idx_t count) {
@@ -311,7 +305,6 @@ void Vector::Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const Selecti
 	validity.Reset();
 
 	buffer = make_buffer<DictionaryBuffer>(sel, std::move(reusable_dict));
-	auxiliary.reset();
 }
 
 void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
@@ -345,7 +338,6 @@ void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
 }
 
 void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
-	auxiliary.reset();
 	validity.Reset();
 	auto &type = GetType();
 	auto internal_type = type.InternalType();
@@ -1223,7 +1215,6 @@ void Vector::Sequence(int64_t start, int64_t increment, idx_t count) {
 	this->vector_type = VectorType::SEQUENCE_VECTOR;
 	this->buffer = make_buffer<SequenceBuffer>(start, increment, static_cast<int64_t>(count));
 	validity.Reset();
-	auxiliary.reset();
 }
 
 void Vector::Shred(Vector &shredded_data) {
@@ -1235,7 +1226,7 @@ void Vector::Shred(Vector &shredded_data) {
 		throw InternalException("Vector::Shred parameter must be a struct with two children");
 	}
 	this->vector_type = VectorType::SHREDDED_VECTOR;
-	this->auxiliary = make_buffer<ShreddedVectorBuffer>(shredded_data);
+	this->buffer = make_buffer<ShreddedVectorBuffer>(shredded_data);
 	validity.Reset();
 }
 
@@ -1607,10 +1598,6 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 void Vector::SetVectorType(VectorType vector_type_p) {
 	vector_type = vector_type_p;
 	auto physical_type = GetType().InternalType();
-	auto flat_or_const = GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR;
-	if (TypeIsConstantSize(physical_type) && flat_or_const) {
-		auxiliary.reset();
-	}
 	if (vector_type == VectorType::CONSTANT_VECTOR && physical_type == PhysicalType::STRUCT) {
 		auto &entries = StructVector::GetEntries(*this);
 		for (auto &entry : entries) {
@@ -1719,10 +1706,6 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 		sel = &owned_sel;
 		vector = &child;
 		vtype = vector->GetVectorType();
-	}
-	if (TypeIsConstantSize(type.InternalType()) &&
-	    (vtype == VectorType::CONSTANT_VECTOR || vtype == VectorType::FLAT_VECTOR)) {
-		D_ASSERT(!vector->auxiliary);
 	}
 	if (type.id() == LogicalTypeId::VARCHAR) {
 		// verify that the string is correct unicode

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -412,10 +412,12 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 
 		// Copy the data buffer to a resized buffer.
 		auto stored_allocator = resize_info_entry.buffer->GetAllocator();
-		auto new_data = stored_allocator ? stored_allocator->Allocate(target_size)
-		                                 : Allocator::DefaultAllocator().Allocate(target_size);
+		auto &allocator = stored_allocator ? *stored_allocator : Allocator::DefaultAllocator();
+		auto new_data = allocator.Allocate(target_size);
 		memcpy(new_data.get(), resize_info_entry.data, old_size);
-		resize_info_entry.buffer->SetData(std::move(new_data));
+		auto new_buffer = make_buffer<VectorBuffer>(std::move(new_data));
+		resize_info_entry.buffer = new_buffer.get();
+		resize_info_entry.vec.buffer = std::move(new_buffer);
 	}
 }
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -49,8 +49,14 @@ Vector::Vector(LogicalType type_p, idx_t capacity) : Vector(std::move(type_p), t
 }
 
 Vector::Vector(LogicalType type_p, data_ptr_t dataptr) : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)) {
-	if (dataptr && !type.IsValid()) {
+	if (!dataptr) {
+		return;
+	}
+	if (!type.IsValid()) {
 		throw InternalException("Cannot create a vector of type INVALID!");
+	}
+	if (type.IsNested()) {
+		throw InternalException("Cannot create a nested vector from a single data pointer");
 	}
 	buffer = make_buffer<StandardVectorBuffer>(dataptr);
 }
@@ -102,8 +108,6 @@ void Vector::Reference(const Value &value) {
 		}
 	} else if (internal_type == PhysicalType::LIST) {
 		buffer = VectorBuffer::CreateConstantVector(value.type());
-		auto list_buffer = make_uniq<VectorListBuffer>(value.type());
-		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
 		SetValue(0, value);
 	} else if (internal_type == PhysicalType::ARRAY) {
 		buffer = make_buffer<VectorArrayBuffer>(value.type());
@@ -165,7 +169,7 @@ void Vector::ResetFromCache(const VectorCache &cache) {
 
 void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 	D_ASSERT(end >= offset);
-	if (other.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+	if (other.GetVectorType() == VectorType::CONSTANT_VECTOR || offset == 0) {
 		Reference(other);
 		return;
 	}
@@ -202,13 +206,15 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		child_vec.Slice(other_child_vec, offset * array_size, end * array_size);
 		new_vector.validity.Slice(other.validity, offset, end - offset);
 		Reference(new_vector);
+	} else if (internal_type == PhysicalType::LIST) {
+		auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
+		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
+		buffer = make_buffer<VectorListBuffer>(offset_ptr, list_buffer);
+		validity.Slice(other.validity, offset, end - offset);
 	} else {
-		Reference(other);
-		if (offset > 0) {
-			auto offset_ptr = buffer->GetData() + GetTypeIdSize(internal_type) * offset;
-			buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
-			validity.Slice(other.validity, offset, end - offset);
-		}
+		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
+		buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
+		validity.Slice(other.validity, offset, end - offset);
 	}
 }
 
@@ -325,13 +331,18 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 	if (internal_type == PhysicalType::STRUCT) {
 		buffer = make_buffer<VectorStructBuffer>(type, capacity);
 	} else if (internal_type == PhysicalType::LIST) {
-		auto list_buffer = make_uniq<VectorListBuffer>(type, capacity);
-		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
+		buffer = make_buffer<VectorListBuffer>(capacity, type);
+		if (initialize_to_zero) {
+			auto data = buffer->GetData();
+			memset(data, 0, capacity * sizeof(list_entry_t));
+		}
 	} else if (internal_type == PhysicalType::ARRAY) {
 		buffer = make_buffer<VectorArrayBuffer>(type, capacity);
-	}
-	auto type_size = GetTypeIdSize(internal_type);
-	if (type_size > 0) {
+	} else {
+		auto type_size = GetTypeIdSize(internal_type);
+		if (type_size == 0) {
+			throw InternalException("Trying to create buffer for zero-length type");
+		}
 		buffer = VectorBuffer::CreateStandardVector(type, capacity);
 		if (initialize_to_zero) {
 			auto data = buffer->GetData();
@@ -380,6 +391,9 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 void Vector::Resize(idx_t current_size, idx_t new_size) {
 	// The vector does not contain any data.
 	if (!buffer) {
+		if (GetType().InternalType() == PhysicalType::LIST) {
+			throw InternalException("Resize for empty list not supported");
+		}
 		buffer = make_buffer<StandardVectorBuffer>(0);
 	}
 
@@ -407,13 +421,18 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 			                          StringUtil::BytesToHumanReadableString(target_size),
 			                          StringUtil::BytesToHumanReadableString(DConstants::MAX_VECTOR_SIZE));
 		}
-
 		// Copy the data buffer to a resized buffer.
 		auto stored_allocator = resize_info_entry.buffer->GetAllocator();
 		auto &allocator = stored_allocator ? *stored_allocator : Allocator::DefaultAllocator();
 		auto new_data = allocator.Allocate(target_size);
 		memcpy(new_data.get(), resize_info_entry.data, old_size);
-		auto new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
+		buffer_ptr<VectorBuffer> new_buffer;
+		if (resize_info_entry.vec.GetType().InternalType() == PhysicalType::LIST) {
+			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorListBuffer>();
+			new_buffer = make_buffer<VectorListBuffer>(std::move(new_data), old_buffer);
+		} else {
+			new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
+		}
 		resize_info_entry.buffer = new_buffer.get();
 		resize_info_entry.vec.buffer = std::move(new_buffer);
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1234,9 +1234,9 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 			return Vector::Serialize(serializer, 1, false); // just serialize one value
 		} else if (vtype == VectorType::SEQUENCE_VECTOR) {
 			serializer.WriteProperty(90, "vector_type", VectorType::SEQUENCE_VECTOR);
-			auto data = reinterpret_cast<int64_t *>(buffer->GetData());
-			serializer.WriteProperty(91, "seq_start", data[0]);
-			serializer.WriteProperty(92, "seq_increment", data[1]);
+			auto &sequence = buffer->Cast<SequenceBuffer>();
+			serializer.WriteProperty(91, "seq_start", sequence.start);
+			serializer.WriteProperty(92, "seq_increment", sequence.increment);
 			return; // for sequence vectors we do not serialize anything else
 		} else {
 			// TODO: other compressed vector types (SHREDDED, FSST)

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -52,7 +52,7 @@ Vector::Vector(LogicalType type_p, data_ptr_t dataptr) : vector_type(VectorType:
 	if (dataptr && !type.IsValid()) {
 		throw InternalException("Cannot create a vector of type INVALID!");
 	}
-	buffer = make_uniq<VectorBuffer>(dataptr);
+	buffer = make_buffer<StandardVectorBuffer>(dataptr);
 }
 
 Vector::Vector(const VectorCache &cache) : type(cache.GetType()) {
@@ -206,7 +206,7 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		Reference(other);
 		if (offset > 0) {
 			auto offset_ptr = buffer->GetData() + GetTypeIdSize(internal_type) * offset;
-			buffer = make_buffer<VectorBuffer>(offset_ptr);
+			buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
 			validity.Slice(other.validity, offset, end - offset);
 		}
 	}
@@ -382,7 +382,7 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 void Vector::Resize(idx_t current_size, idx_t new_size) {
 	// The vector does not contain any data.
 	if (!buffer) {
-		buffer = make_buffer<VectorBuffer>(0);
+		buffer = make_buffer<StandardVectorBuffer>(0);
 	}
 
 	// Obtain the resize information for each (nested) vector.
@@ -415,7 +415,7 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 		auto &allocator = stored_allocator ? *stored_allocator : Allocator::DefaultAllocator();
 		auto new_data = allocator.Allocate(target_size);
 		memcpy(new_data.get(), resize_info_entry.data, old_size);
-		auto new_buffer = make_buffer<VectorBuffer>(std::move(new_data));
+		auto new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
 		resize_info_entry.buffer = new_buffer.get();
 		resize_info_entry.vec.buffer = std::move(new_buffer);
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -156,7 +156,14 @@ void Vector::Reinterpret(const Vector &other) {
 	if (vector_type == VectorType::DICTIONARY_VECTOR && other_type != this_type) {
 		Vector new_vector(this_type, nullptr);
 		new_vector.Reinterpret(DictionaryVector::Child(other));
-		auxiliary = make_shared_ptr<VectorChildBuffer>(std::move(new_vector));
+		auto &old_dict = buffer->Cast<DictionaryBuffer>();
+		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
+		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), std::move(new_entry));
+		auto dict_size = old_dict.GetDictionarySize();
+		if (dict_size.IsValid()) {
+			buffer->Cast<DictionaryBuffer>().SetDictionarySize(dict_size.GetIndex());
+		}
+		buffer->Cast<DictionaryBuffer>().SetDictionaryId(old_dict.GetDictionaryId());
 	}
 }
 
@@ -249,18 +256,18 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 	}
 	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		// already a dictionary, slice the current dictionary
-		auto &current_sel = DictionaryVector::SelVector(*this);
+		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto dictionary_size = DictionaryVector::DictionarySize(*this);
 		auto dictionary_id = DictionaryVector::DictionaryId(*this);
-		auto sliced_dictionary = current_sel.Slice(sel, count);
-		buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary));
+		auto sliced_dictionary = old_dict.GetSelVector().Slice(sel, count);
+		auto entry = old_dict.GetEntryPtr();
 		if (GetType().InternalType() == PhysicalType::STRUCT) {
-			auto &child_vector = DictionaryVector::Child(*this);
-
+			auto &child_vector = entry->data;
 			Vector new_child(Vector::Ref(child_vector));
 			new_child.buffer = make_buffer<VectorStructBuffer>(new_child, sel, count);
-			auxiliary = make_buffer<VectorChildBuffer>(std::move(new_child));
+			entry = make_shared_ptr<DictionaryEntry>(std::move(new_child));
 		}
+		buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary), std::move(entry));
 		if (dictionary_size.IsValid()) {
 			auto &dict_buffer = buffer->Cast<DictionaryBuffer>();
 			dict_buffer.SetDictionarySize(dictionary_size.GetIndex());
@@ -279,11 +286,10 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 	if (internal_type == PhysicalType::STRUCT) {
 		child_vector.buffer = make_buffer<VectorStructBuffer>(*this, sel, count);
 	}
-	auto child_ref = make_buffer<VectorChildBuffer>(std::move(child_vector));
-	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
+	auto entry = make_shared_ptr<DictionaryEntry>(std::move(child_vector));
+	buffer = make_buffer<DictionaryBuffer>(sel, std::move(entry));
 	vector_type = VectorType::DICTIONARY_VECTOR;
-	buffer = std::move(dict_buffer);
-	auxiliary = std::move(child_ref);
+	auxiliary.reset();
 }
 
 void Vector::Dictionary(idx_t dictionary_size, const SelectionVector &sel, idx_t count) {
@@ -298,18 +304,14 @@ void Vector::Dictionary(Vector &dict, idx_t dictionary_size, const SelectionVect
 	Dictionary(dictionary_size, sel, count);
 }
 
-void Vector::Dictionary(buffer_ptr<VectorChildBuffer> reusable_dict, const SelectionVector &sel) {
+void Vector::Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel) {
 	D_ASSERT(type.InternalType() != PhysicalType::STRUCT);
 	D_ASSERT(type == reusable_dict->data.GetType());
 	vector_type = VectorType::DICTIONARY_VECTOR;
 	validity.Reset();
 
-	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
-	dict_buffer->SetDictionarySize(reusable_dict->size.GetIndex());
-	dict_buffer->SetDictionaryId(reusable_dict->id);
-	buffer = std::move(dict_buffer);
-
-	auxiliary = std::move(reusable_dict);
+	buffer = make_buffer<DictionaryBuffer>(sel, std::move(reusable_dict));
+	auxiliary.reset();
 }
 
 void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
@@ -320,10 +322,13 @@ void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
 		auto dictionary_size = DictionaryVector::DictionarySize(*this);
 		auto dictionary_id = DictionaryVector::DictionaryId(*this);
 		auto target_data = current_sel.data();
-		auto entry = cache.cache.find(target_data);
-		if (entry != cache.cache.end()) {
-			// cached entry exists: use that
-			this->buffer = make_buffer<DictionaryBuffer>(entry->second->Cast<DictionaryBuffer>().GetSelVector());
+		auto cache_entry = cache.cache.find(target_data);
+		if (cache_entry != cache.cache.end()) {
+			// cached entry exists: use the cached selection vector with our dictionary entry
+			auto &old_dict = this->buffer->Cast<DictionaryBuffer>();
+			auto dict_entry = old_dict.GetEntryPtr();
+			this->buffer = make_buffer<DictionaryBuffer>(cache_entry->second->Cast<DictionaryBuffer>().GetSelVector(),
+			                                             std::move(dict_entry));
 			vector_type = VectorType::DICTIONARY_VECTOR;
 		} else {
 			Slice(sel, count);
@@ -1158,11 +1163,12 @@ void Vector::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format) const {
 			// dictionary with non-flat child: create a new reference to the child and flatten it
 			Vector child_vector(Vector::Ref(child));
 			child_vector.Flatten(sel, count);
-			auto new_aux = make_buffer<VectorChildBuffer>(std::move(child_vector));
+			auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(child_vector));
+			auto &dict_buffer = this->buffer->Cast<DictionaryBuffer>();
+			dict_buffer.SetEntry(std::move(new_entry));
 
-			format.data = FlatVector::GetData(new_aux->data);
-			format.validity = FlatVector::Validity(new_aux->data);
-			this->auxiliary = std::move(new_aux);
+			format.data = FlatVector::GetData(dict_buffer.GetEntry().data);
+			format.validity = FlatVector::Validity(dict_buffer.GetEntry().data);
 		}
 		break;
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -89,15 +89,14 @@ void Vector::Reference(const Value &value) {
 	this->vector_type = VectorType::CONSTANT_VECTOR;
 	auto internal_type = value.type().InternalType();
 	if (internal_type == PhysicalType::STRUCT) {
-		auto struct_buffer = make_uniq<VectorStructBuffer>();
+		auto struct_buffer = make_buffer<VectorStructBuffer>();
 		auto &child_types = StructType::GetChildTypes(value.type());
 		auto &child_vectors = struct_buffer->GetChildren();
 		for (idx_t i = 0; i < child_types.size(); i++) {
 			child_vectors.emplace_back(value.IsNull() ? Value(child_types[i].second)
 			                                          : StructValue::GetChildren(value)[i]);
 		}
-		buffer = VectorBuffer::CreateConstantVector(value.type());
-		auxiliary = shared_ptr<VectorBuffer>(struct_buffer.release());
+		buffer = std::move(struct_buffer);
 		if (value.IsNull()) {
 			SetValue(0, value);
 		}
@@ -237,7 +236,7 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 			auto &child_vector = DictionaryVector::Child(*this);
 
 			Vector new_child(Vector::Ref(child_vector));
-			new_child.auxiliary = make_buffer<VectorStructBuffer>(new_child, sel, count);
+			new_child.buffer = make_buffer<VectorStructBuffer>(new_child, sel, count);
 			auxiliary = make_buffer<VectorChildBuffer>(std::move(new_child));
 		}
 		if (dictionary_size.IsValid()) {
@@ -256,7 +255,7 @@ void Vector::Slice(const SelectionVector &sel, idx_t count) {
 	Vector child_vector(Vector::Ref(*this));
 	auto internal_type = GetType().InternalType();
 	if (internal_type == PhysicalType::STRUCT) {
-		child_vector.auxiliary = make_buffer<VectorStructBuffer>(*this, sel, count);
+		child_vector.buffer = make_buffer<VectorStructBuffer>(*this, sel, count);
 	}
 	auto child_ref = make_buffer<VectorChildBuffer>(std::move(child_vector));
 	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
@@ -324,8 +323,7 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 	auto &type = GetType();
 	auto internal_type = type.InternalType();
 	if (internal_type == PhysicalType::STRUCT) {
-		auto struct_buffer = make_uniq<VectorStructBuffer>(type, capacity);
-		auxiliary = shared_ptr<VectorBuffer>(struct_buffer.release());
+		buffer = make_buffer<VectorStructBuffer>(type, capacity);
 	} else if (internal_type == PhysicalType::LIST) {
 		auto list_buffer = make_uniq<VectorListBuffer>(type, capacity);
 		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
@@ -352,23 +350,22 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 	ResizeInfo resize_info(*this, buffer_ptr, multiplier);
 	resize_infos.emplace_back(resize_info);
 
-	if (buffer && buffer->GetBufferType() == VectorBufferType::ARRAY_BUFFER) {
+	if (!buffer) {
+		return;
+	}
+
+	switch (buffer->GetBufferType()) {
+	case VectorBufferType::ARRAY_BUFFER: {
 		// We need to multiply the multiplier by the array size because
 		// the child vectors of ARRAY types are always child_count * array_size.
 		auto &vector_array_buffer = buffer->Cast<VectorArrayBuffer>();
 		auto new_multiplier = vector_array_buffer.GetArraySize() * multiplier;
 		auto &child = vector_array_buffer.GetChild();
 		child.FindResizeInfos(resize_infos, new_multiplier);
-		return;
+		break;
 	}
-
-	if (!auxiliary) {
-		return;
-	}
-
-	switch (GetAuxiliary()->GetBufferType()) {
 	case VectorBufferType::STRUCT_BUFFER: {
-		auto &vector_struct_buffer = auxiliary->Cast<VectorStructBuffer>();
+		auto &vector_struct_buffer = buffer->Cast<VectorStructBuffer>();
 		auto &children = vector_struct_buffer.GetChildren();
 		for (auto &child : children) {
 			child.FindResizeInfos(resize_infos, multiplier);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -217,7 +217,8 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		Reference(new_vector);
 	} else if (internal_type == PhysicalType::LIST) {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
-		buffer = make_buffer<VectorListBuffer>(offset_ptr, other.buffer);
+		auto &parent = other.buffer->Cast<VectorListBuffer>();
+		buffer = make_buffer<VectorListBuffer>(offset_ptr, parent);
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
 	} else if (internal_type == PhysicalType::VARCHAR) {
@@ -409,10 +410,11 @@ void Vector::AddHeapReference(const Vector &other) {
 		AddHeapReference(DictionaryVector::Child(other));
 		return;
 	}
-	if (!other.buffer) {
+	auto &auxiliary_data = other.buffer->GetAuxiliaryData();
+	if (!auxiliary_data) {
 		return;
 	}
-	AddAuxiliaryData(make_uniq<VectorBufferHolder>(other.buffer));
+	AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(auxiliary_data));
 }
 
 void Vector::Resize(idx_t current_size, idx_t new_size) {
@@ -462,7 +464,8 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorListBuffer>();
 			new_buffer = make_buffer<VectorListBuffer>(std::move(new_data), old_buffer);
 		} else if (resize_info_entry.vec.GetType().InternalType() == PhysicalType::VARCHAR) {
-			new_buffer = make_buffer<VectorStringBuffer>(std::move(new_data), resize_info_entry.vec.buffer);
+			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorStringBuffer>();
+			new_buffer = make_buffer<VectorStringBuffer>(std::move(new_data), old_buffer);
 		} else {
 			new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
 		}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -211,10 +211,14 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<VectorListBuffer>(offset_ptr, list_buffer);
 		validity.Slice(other.validity, offset, end - offset);
+		vector_type = other.vector_type;
+		AssignSharedPointer(auxiliary, other.auxiliary);
 	} else {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		buffer = make_buffer<StandardVectorBuffer>(offset_ptr);
 		validity.Slice(other.validity, offset, end - offset);
+		vector_type = other.vector_type;
+		AssignSharedPointer(auxiliary, other.auxiliary);
 	}
 }
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1168,11 +1168,7 @@ void Vector::RecursiveToUnifiedFormat(const Vector &input, idx_t count, Recursiv
 
 void Vector::Sequence(int64_t start, int64_t increment, idx_t count) {
 	this->vector_type = VectorType::SEQUENCE_VECTOR;
-	this->buffer = make_buffer<VectorBuffer>(sizeof(int64_t) * 3);
-	auto data = reinterpret_cast<int64_t *>(buffer->GetData());
-	data[0] = start;
-	data[1] = increment;
-	data[2] = int64_t(count);
+	this->buffer = make_buffer<SequenceBuffer>(start, increment, static_cast<int64_t>(count));
 	validity.Reset();
 	auxiliary.reset();
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -216,9 +216,8 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		new_vector.validity.Slice(other.validity, offset, end - offset);
 		Reference(new_vector);
 	} else if (internal_type == PhysicalType::LIST) {
-		auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
-		buffer = make_buffer<VectorListBuffer>(offset_ptr, list_buffer);
+		buffer = make_buffer<VectorListBuffer>(offset_ptr, other.buffer);
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;
 	} else if (internal_type == PhysicalType::VARCHAR) {
@@ -413,12 +412,7 @@ void Vector::AddHeapReference(const Vector &other) {
 	if (!other.buffer) {
 		return;
 	}
-	auto data = other.buffer->GetAuxiliaryData();
-	if (!data) {
-		// no auxiliary data to reference
-		return;
-	}
-	AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
+	AddAuxiliaryData(make_uniq<VectorBufferHolder>(other.buffer));
 }
 
 void Vector::Resize(idx_t current_size, idx_t new_size) {
@@ -468,8 +462,7 @@ void Vector::Resize(idx_t current_size, idx_t new_size) {
 			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorListBuffer>();
 			new_buffer = make_buffer<VectorListBuffer>(std::move(new_data), old_buffer);
 		} else if (resize_info_entry.vec.GetType().InternalType() == PhysicalType::VARCHAR) {
-			auto &old_buffer = resize_info_entry.vec.buffer->Cast<VectorStringBuffer>();
-			new_buffer = make_buffer<VectorStringBuffer>(std::move(new_data), old_buffer);
+			new_buffer = make_buffer<VectorStringBuffer>(std::move(new_data), resize_info_entry.vec.buffer);
 		} else {
 			new_buffer = make_buffer<StandardVectorBuffer>(std::move(new_data));
 		}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -87,7 +87,6 @@ Vector Vector::Ref(const Vector &other) {
 void Vector::Reference(const Value &value) {
 	D_ASSERT(GetType().id() == value.type().id());
 	this->vector_type = VectorType::CONSTANT_VECTOR;
-	buffer = VectorBuffer::CreateConstantVector(value.type());
 	auto internal_type = value.type().InternalType();
 	if (internal_type == PhysicalType::STRUCT) {
 		auto struct_buffer = make_uniq<VectorStructBuffer>();
@@ -97,19 +96,21 @@ void Vector::Reference(const Value &value) {
 			child_vectors.emplace_back(value.IsNull() ? Value(child_types[i].second)
 			                                          : StructValue::GetChildren(value)[i]);
 		}
+		buffer = VectorBuffer::CreateConstantVector(value.type());
 		auxiliary = shared_ptr<VectorBuffer>(struct_buffer.release());
 		if (value.IsNull()) {
 			SetValue(0, value);
 		}
 	} else if (internal_type == PhysicalType::LIST) {
+		buffer = VectorBuffer::CreateConstantVector(value.type());
 		auto list_buffer = make_uniq<VectorListBuffer>(value.type());
 		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
 		SetValue(0, value);
 	} else if (internal_type == PhysicalType::ARRAY) {
-		auto array_buffer = make_uniq<VectorArrayBuffer>(value.type());
-		auxiliary = shared_ptr<VectorBuffer>(array_buffer.release());
+		buffer = make_buffer<VectorArrayBuffer>(value.type());
 		SetValue(0, value);
 	} else {
+		buffer = VectorBuffer::CreateConstantVector(value.type());
 		auxiliary.reset();
 		SetValue(0, value);
 	}
@@ -329,8 +330,7 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 		auto list_buffer = make_uniq<VectorListBuffer>(type, capacity);
 		auxiliary = shared_ptr<VectorBuffer>(list_buffer.release());
 	} else if (internal_type == PhysicalType::ARRAY) {
-		auto array_buffer = make_uniq<VectorArrayBuffer>(type, capacity);
-		auxiliary = shared_ptr<VectorBuffer>(array_buffer.release());
+		buffer = make_buffer<VectorArrayBuffer>(type, capacity);
 	}
 	auto type_size = GetTypeIdSize(internal_type);
 	if (type_size > 0) {
@@ -352,6 +352,16 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 	ResizeInfo resize_info(*this, buffer_ptr, multiplier);
 	resize_infos.emplace_back(resize_info);
 
+	if (buffer && buffer->GetBufferType() == VectorBufferType::ARRAY_BUFFER) {
+		// We need to multiply the multiplier by the array size because
+		// the child vectors of ARRAY types are always child_count * array_size.
+		auto &vector_array_buffer = buffer->Cast<VectorArrayBuffer>();
+		auto new_multiplier = vector_array_buffer.GetArraySize() * multiplier;
+		auto &child = vector_array_buffer.GetChild();
+		child.FindResizeInfos(resize_infos, new_multiplier);
+		return;
+	}
+
 	if (!auxiliary) {
 		return;
 	}
@@ -363,15 +373,6 @@ void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multi
 		for (auto &child : children) {
 			child.FindResizeInfos(resize_infos, multiplier);
 		}
-		break;
-	}
-	case VectorBufferType::ARRAY_BUFFER: {
-		// We need to multiply the multiplier by the array size because
-		// the child vectors of ARRAY types are always child_count * array_size.
-		auto &vector_array_buffer = auxiliary->Cast<VectorArrayBuffer>();
-		auto new_multiplier = vector_array_buffer.GetArraySize() * multiplier;
-		auto &child = vector_array_buffer.GetChild();
-		child.FindResizeInfos(resize_infos, new_multiplier);
 		break;
 	}
 	default:

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -928,7 +928,12 @@ idx_t Vector::GetAllocationSize(idx_t cardinality) const {
 		auto physical_size = GetTypeIdSize(type.InternalType());
 		auto total_size = physical_size * cardinality;
 
-		auto child_cardinality = ListVector::GetListCapacity(*this);
+		idx_t child_cardinality = 0;
+		if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+			child_cardinality = ListVector::GetListCapacity(DictionaryVector::Child(*this));
+		} else {
+			child_cardinality = ListVector::GetListCapacity(*this);
+		}
 		auto &child_entry = ListVector::GetEntry(*this);
 		total_size += (child_entry.GetAllocationSize(child_cardinality));
 		return total_size;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1179,7 +1179,6 @@ void Vector::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format) const {
 			auto &dict_entry = *new_entry;
 			auto &old_dict_buffer = this->buffer->Cast<DictionaryBuffer>();
 			auto new_dict_buffer = make_buffer<DictionaryBuffer>(old_dict_buffer.GetSelVector(), std::move(new_entry));
-			auto &dict_buffer = *new_dict_buffer;
 			this->buffer = std::move(new_dict_buffer);
 
 			format.data = FlatVector::GetData(dict_entry.data);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -220,8 +220,8 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 	} else if (internal_type == PhysicalType::VARCHAR) {
 		auto offset_ptr = other.buffer->GetData() + GetTypeIdSize(internal_type) * offset;
 		auto string_buffer = make_buffer<VectorStringBuffer>(offset_ptr);
-		StringVector::AddHeapReference(*this, other);
 		buffer = std::move(string_buffer);
+		StringVector::AddHeapReference(*this, other);
 		auxiliary.reset();
 		validity.Slice(other.validity, offset, end - offset);
 		vector_type = other.vector_type;

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -16,11 +16,11 @@
 namespace duckdb {
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, idx_t capacity) {
-	return make_buffer<VectorBuffer>(capacity * GetTypeIdSize(type));
+	return make_buffer<StandardVectorBuffer>(capacity * GetTypeIdSize(type));
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
-	return make_buffer<VectorBuffer>(GetTypeIdSize(type));
+	return make_buffer<StandardVectorBuffer>(GetTypeIdSize(type));
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(const LogicalType &type) {

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/vector/array_vector.hpp"
 #include "duckdb/common/vector/constant_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/fsst_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/vector/map_vector.hpp"
@@ -69,86 +70,6 @@ VectorStructBuffer::VectorStructBuffer(Vector &other, const SelectionVector &sel
 }
 
 VectorStructBuffer::~VectorStructBuffer() {
-}
-
-VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector,
-                                   idx_t child_capacity)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), child(std::move(vector)), capacity(child_capacity) {
-	if (capacity > 0) {
-		allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
-		data_ptr = allocated_data.get();
-	}
-}
-VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
-                                   idx_t child_capacity)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER),
-      child(make_uniq<Vector>(ListType::GetChildType(list_type), child_capacity)), capacity(child_capacity) {
-	if (capacity > 0) {
-		allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
-		data_ptr = allocated_data.get();
-	}
-}
-
-VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type, idx_t child_capacity)
-    : VectorListBuffer(Allocator::DefaultAllocator(), capacity, list_type, child_capacity) {
-}
-
-VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
-	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
-}
-
-VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), allocated_data(std::move(allocated_data_p)),
-      capacity(parent.capacity), size(parent.size) {
-	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
-	data_ptr = allocated_data.get();
-}
-
-void VectorListBuffer::Reserve(idx_t to_reserve) {
-	if (to_reserve > capacity) {
-		if (to_reserve > DConstants::MAX_VECTOR_SIZE) {
-			// overflow: throw an exception
-			throw OutOfRangeException("Cannot resize vector to %d rows: maximum allowed vector size is %s", to_reserve,
-			                          StringUtil::BytesToHumanReadableString(DConstants::MAX_VECTOR_SIZE));
-		}
-		idx_t new_capacity = NextPowerOfTwo(to_reserve);
-		D_ASSERT(new_capacity >= to_reserve);
-		child->Resize(capacity, new_capacity);
-		capacity = new_capacity;
-	}
-}
-
-void VectorListBuffer::Append(const Vector &to_append, idx_t to_append_size, idx_t source_offset) {
-	Reserve(size + to_append_size - source_offset);
-	VectorOperations::Copy(to_append, *child, to_append_size, source_offset, size);
-	size += to_append_size - source_offset;
-}
-
-void VectorListBuffer::Append(const Vector &to_append, const SelectionVector &sel, idx_t to_append_size,
-                              idx_t source_offset) {
-	Reserve(size + to_append_size - source_offset);
-	VectorOperations::Copy(to_append, *child, sel, to_append_size, source_offset, size);
-	size += to_append_size - source_offset;
-}
-
-void VectorListBuffer::PushBack(const Value &insert) {
-	while (size + 1 > capacity) {
-		child->Resize(capacity, capacity * 2);
-		capacity *= 2;
-	}
-	child->SetValue(size++, insert);
-}
-
-void VectorListBuffer::SetCapacity(idx_t new_capacity) {
-	this->capacity = new_capacity;
-}
-
-void VectorListBuffer::SetSize(idx_t new_size) {
-	this->size = new_size;
-}
-
-VectorListBuffer::~VectorListBuffer() {
 }
 
 VectorArrayBuffer::VectorArrayBuffer(unique_ptr<Vector> child_vector, idx_t array_size, idx_t initial_capacity)

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -16,18 +16,30 @@
 namespace duckdb {
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, idx_t capacity) {
+	if (type == PhysicalType::LIST) {
+		throw InternalException("VectorBuffer::CreateStandardVector requires full list type");
+	}
 	return make_buffer<StandardVectorBuffer>(capacity * GetTypeIdSize(type));
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
+	if (type == PhysicalType::LIST) {
+		throw InternalException("VectorBuffer::CreateConstantVector requires full list type");
+	}
 	return make_buffer<StandardVectorBuffer>(GetTypeIdSize(type));
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::LIST) {
+		return make_buffer<VectorListBuffer>(1ULL, type);
+	}
 	return VectorBuffer::CreateConstantVector(type.InternalType());
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &type, idx_t capacity) {
+	if (type.InternalType() == PhysicalType::LIST) {
+		throw InternalException("VectorBuffer::CreateStandardVector not supported for list");
+	}
 	return VectorBuffer::CreateStandardVector(type.InternalType(), capacity);
 }
 
@@ -66,13 +78,38 @@ VectorStructBuffer::VectorStructBuffer(Vector &other, const SelectionVector &sel
 VectorStructBuffer::~VectorStructBuffer() {
 }
 
-VectorListBuffer::VectorListBuffer(unique_ptr<Vector> vector, idx_t initial_capacity)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), child(std::move(vector)), capacity(initial_capacity) {
+VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector,
+                                   idx_t child_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), child(std::move(vector)), capacity(child_capacity) {
+	if (capacity > 0) {
+		allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
+		data_ptr = allocated_data.get();
+	}
+}
+VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
+                                   idx_t child_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER),
+      child(make_uniq<Vector>(ListType::GetChildType(list_type), child_capacity)), capacity(child_capacity) {
+	if (capacity > 0) {
+		allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
+		data_ptr = allocated_data.get();
+	}
 }
 
-VectorListBuffer::VectorListBuffer(const LogicalType &list_type, idx_t initial_capacity)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER),
-      child(make_uniq<Vector>(ListType::GetChildType(list_type), initial_capacity)), capacity(initial_capacity) {
+VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type, idx_t child_capacity)
+    : VectorListBuffer(Allocator::DefaultAllocator(), capacity, list_type, child_capacity) {
+}
+
+VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
+	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
+}
+
+VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), allocated_data(std::move(allocated_data_p)),
+      capacity(parent.capacity), size(parent.size) {
+	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
+	data_ptr = allocated_data.get();
 }
 
 void VectorListBuffer::Reserve(idx_t to_reserve) {

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -19,12 +19,18 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, i
 	if (type == PhysicalType::LIST) {
 		throw InternalException("VectorBuffer::CreateStandardVector requires full list type");
 	}
+	if (type == PhysicalType::VARCHAR) {
+		return make_buffer<VectorStringBuffer>(capacity * GetTypeIdSize(type));
+	}
 	return make_buffer<StandardVectorBuffer>(capacity * GetTypeIdSize(type));
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
 	if (type == PhysicalType::LIST) {
 		throw InternalException("VectorBuffer::CreateConstantVector requires full list type");
+	}
+	if (type == PhysicalType::VARCHAR) {
+		return make_buffer<VectorStringBuffer>(GetTypeIdSize(type));
 	}
 	return make_buffer<StandardVectorBuffer>(GetTypeIdSize(type));
 }
@@ -41,16 +47,6 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &t
 		throw InternalException("VectorBuffer::CreateStandardVector not supported for list");
 	}
 	return VectorBuffer::CreateStandardVector(type.InternalType(), capacity);
-}
-
-VectorStringBuffer::VectorStringBuffer() : VectorBuffer(VectorBufferType::STRING_BUFFER) {
-}
-
-VectorStringBuffer::VectorStringBuffer(Allocator &allocator)
-    : VectorBuffer(VectorBufferType::STRING_BUFFER), heap(allocator) {
-}
-
-VectorStringBuffer::VectorStringBuffer(VectorBufferType type) : VectorBuffer(type) {
 }
 
 VectorFSSTStringBuffer::VectorFSSTStringBuffer() : VectorStringBuffer(VectorBufferType::FSST_BUFFER) {
@@ -187,11 +183,10 @@ idx_t VectorArrayBuffer::GetChildSize() {
 	return size * array_size;
 }
 
-ManagedVectorBuffer::ManagedVectorBuffer(BufferHandle handle)
-    : VectorBuffer(VectorBufferType::MANAGED_BUFFER), handle(std::move(handle)) {
+PinnedBufferHolder::PinnedBufferHolder(BufferHandle handle) : handle(std::move(handle)) {
 }
 
-ManagedVectorBuffer::~ManagedVectorBuffer() {
+PinnedBufferHolder::~PinnedBufferHolder() {
 }
 
 ShreddedVectorBuffer::ShreddedVectorBuffer(Vector &shredded_data_p)

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -20,7 +20,7 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, i
 		throw InternalException("VectorBuffer::CreateStandardVector requires full list type");
 	}
 	if (type == PhysicalType::VARCHAR) {
-		return make_buffer<VectorStringBuffer>(capacity * GetTypeIdSize(type));
+		return make_buffer<VectorStringBuffer>(capacity);
 	}
 	return make_buffer<StandardVectorBuffer>(capacity * GetTypeIdSize(type));
 }
@@ -30,7 +30,7 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
 		throw InternalException("VectorBuffer::CreateConstantVector requires full list type");
 	}
 	if (type == PhysicalType::VARCHAR) {
-		return make_buffer<VectorStringBuffer>(GetTypeIdSize(type));
+		return make_buffer<VectorStringBuffer>(1);
 	}
 	return make_buffer<StandardVectorBuffer>(GetTypeIdSize(type));
 }
@@ -47,9 +47,6 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &t
 		throw InternalException("VectorBuffer::CreateStandardVector not supported for list");
 	}
 	return VectorBuffer::CreateStandardVector(type.InternalType(), capacity);
-}
-
-VectorFSSTStringBuffer::VectorFSSTStringBuffer() : VectorStringBuffer(VectorBufferType::FSST_BUFFER) {
 }
 
 VectorStructBuffer::VectorStructBuffer() : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -53,9 +53,9 @@ public:
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
 		// clear any extra accumulated auxiliary data (reset to only the initial AllocatedData)
-		auto auxiliary = buffer->GetAuxiliaryData();
-		if (auxiliary && auxiliary->data.size() > 1) {
-			auxiliary->data.erase(auxiliary->data.begin() + 1, auxiliary->data.end());
+		auto &auxiliary_data = buffer->GetAuxiliaryDataMutable();
+		if (auxiliary_data.size() > 1) {
+			auxiliary_data.erase(auxiliary_data.begin() + 1, auxiliary_data.end());
 		}
 		AssignSharedPointer(result.buffer, buffer);
 		result.validity.Reset(capacity);

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -57,7 +57,6 @@ public:
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// reinitialize the VectorListBuffer
-			result.auxiliary.reset();
 			// propagate through child
 			auto &child_cache = *child_caches[0];
 			auto &list_buffer = result.buffer->Cast<VectorListBuffer>();
@@ -70,8 +69,6 @@ public:
 		}
 		case PhysicalType::ARRAY: {
 			// reinitialize the VectorArrayBuffer
-			result.auxiliary.reset();
-
 			// propagate through child
 			auto &child_cache = *child_caches[0];
 			auto &array_child = result.buffer->Cast<VectorArrayBuffer>().GetChild();
@@ -80,7 +77,6 @@ public:
 		}
 		case PhysicalType::STRUCT: {
 			// reinitialize the VectorStructBuffer
-			result.auxiliary.reset();
 			// propagate through children
 			auto &children = result.buffer->Cast<VectorStructBuffer>().GetChildren();
 			for (idx_t i = 0; i < children.size(); i++) {
@@ -90,8 +86,6 @@ public:
 			break;
 		}
 		default:
-			// regular type: no aux data and reset data to cached data
-			result.auxiliary.reset();
 			break;
 		}
 	}
@@ -107,8 +101,6 @@ private:
 	vector<unique_ptr<VectorCacheEntry>> child_caches;
 	//! Buffer data for the vector (if any)
 	buffer_ptr<VectorBuffer> buffer;
-	//! Aux data for the vector (if any)
-	buffer_ptr<VectorBuffer> auxiliary;
 	//! Capacity of the vector
 	idx_t capacity;
 };

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -16,8 +16,7 @@ public:
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// memory for the list offsets
-			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
-			buffer = make_buffer<VectorBuffer>(owned_data.get());
+			buffer = make_buffer<VectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			// child data of the list
 			auto &child_type = ListType::GetChildType(type);
 			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, capacity));
@@ -43,8 +42,7 @@ public:
 			break;
 		}
 		default:
-			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
-			buffer = make_buffer<VectorBuffer>(owned_data.get());
+			buffer = make_buffer<VectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			break;
 		}
 	}
@@ -57,7 +55,7 @@ public:
 		result.validity.Reset(capacity);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
-			result.buffer->SetData(owned_data.get());
+			result.buffer->ResetData();
 			// reinitialize the VectorListBuffer
 			AssignSharedPointer(result.auxiliary, auxiliary);
 			// propagate through child
@@ -96,7 +94,7 @@ public:
 		}
 		default:
 			// regular type: no aux data and reset data to cached data
-			result.buffer->SetData(owned_data.get());
+			result.buffer->ResetData();
 			result.auxiliary.reset();
 			break;
 		}
@@ -109,8 +107,6 @@ public:
 private:
 	//! The type of the vector cache
 	LogicalType type;
-	//! Owned data
-	AllocatedData owned_data;
 	//! Child caches (if any). Used for nested types.
 	vector<unique_ptr<VectorCacheEntry>> child_caches;
 	//! Buffer data for the vector (if any)

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -52,11 +52,7 @@ public:
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
-		// clear any extra accumulated auxiliary data (reset to only the initial AllocatedData)
-		auto &auxiliary_data = buffer->GetAuxiliaryDataMutable();
-		if (auxiliary_data.size() > 1) {
-			auxiliary_data.erase(auxiliary_data.begin() + 1, auxiliary_data.end());
-		}
+		buffer->ClearAuxiliaryData();
 		AssignSharedPointer(result.buffer, buffer);
 		result.validity.Reset(capacity);
 		switch (internal_type) {
@@ -88,12 +84,6 @@ public:
 				auto &child_cache = *child_caches[i];
 				child_cache.ResetFromCache(children[i]);
 			}
-			break;
-		}
-		case PhysicalType::VARCHAR: {
-			// reset the heap reference for strings
-			auto &string_buffer = result.buffer->Cast<VectorStringBuffer>();
-			string_buffer.ResetHeap();
 			break;
 		}
 		default:

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -8,19 +8,19 @@
 
 namespace duckdb {
 
-class VectorCacheBuffer : public VectorBuffer {
+class VectorCacheEntry {
 public:
-	explicit VectorCacheBuffer(Allocator &allocator, const LogicalType &type_p, idx_t capacity_p = STANDARD_VECTOR_SIZE)
-	    : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), type(type_p), capacity(capacity_p) {
+	explicit VectorCacheEntry(Allocator &allocator, const LogicalType &type_p, idx_t capacity_p = STANDARD_VECTOR_SIZE)
+	    : type(type_p), capacity(capacity_p) {
 		auto internal_type = type.InternalType();
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// memory for the list offsets
 			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
-			data_ptr = owned_data.get();
+			buffer = make_buffer<VectorBuffer>(owned_data.get());
 			// child data of the list
 			auto &child_type = ListType::GetChildType(type);
-			child_caches.push_back(make_buffer<VectorCacheBuffer>(allocator, child_type, capacity));
+			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, capacity));
 			auto child_vector = make_uniq<Vector>(child_type, false, false);
 			auxiliary = make_shared_ptr<VectorListBuffer>(std::move(child_vector));
 			break;
@@ -28,7 +28,7 @@ public:
 		case PhysicalType::ARRAY: {
 			auto &child_type = ArrayType::GetChildType(type);
 			auto array_size = ArrayType::GetSize(type);
-			child_caches.push_back(make_buffer<VectorCacheBuffer>(allocator, child_type, array_size * capacity));
+			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, array_size * capacity));
 			auto child_vector = make_uniq<Vector>(child_type, true, false, array_size * capacity);
 			auxiliary = make_shared_ptr<VectorArrayBuffer>(std::move(child_vector), array_size, capacity);
 			break;
@@ -36,7 +36,7 @@ public:
 		case PhysicalType::STRUCT: {
 			auto &child_types = StructType::GetChildTypes(type);
 			for (auto &child_type : child_types) {
-				child_caches.push_back(make_buffer<VectorCacheBuffer>(allocator, child_type.second, capacity));
+				child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type.second, capacity));
 			}
 			auto struct_buffer = make_shared_ptr<VectorStructBuffer>(type);
 			auxiliary = std::move(struct_buffer);
@@ -44,12 +44,12 @@ public:
 		}
 		default:
 			owned_data = allocator.Allocate(capacity * GetTypeIdSize(internal_type));
-			data_ptr = owned_data.get();
+			buffer = make_buffer<VectorBuffer>(owned_data.get());
 			break;
 		}
 	}
 
-	void ResetFromCache(Vector &result, const buffer_ptr<VectorBuffer> &buffer) {
+	void ResetFromCache(Vector &result) {
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
@@ -61,14 +61,14 @@ public:
 			// reinitialize the VectorListBuffer
 			AssignSharedPointer(result.auxiliary, auxiliary);
 			// propagate through child
-			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
+			auto &child_cache = *child_caches[0];
 			auto &list_buffer = result.auxiliary->Cast<VectorListBuffer>();
 			list_buffer.SetCapacity(child_cache.capacity);
 			list_buffer.SetSize(0);
 			list_buffer.SetAuxiliaryData(nullptr);
 
 			auto &list_child = list_buffer.GetChild();
-			child_cache.ResetFromCache(list_child, child_caches[0]);
+			child_cache.ResetFromCache(list_child);
 			break;
 		}
 		case PhysicalType::ARRAY: {
@@ -77,9 +77,9 @@ public:
 			AssignSharedPointer(result.auxiliary, auxiliary);
 
 			// propagate through child
-			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
+			auto &child_cache = *child_caches[0];
 			auto &array_child = result.auxiliary->Cast<VectorArrayBuffer>().GetChild();
-			child_cache.ResetFromCache(array_child, child_caches[0]);
+			child_cache.ResetFromCache(array_child);
 			break;
 		}
 		case PhysicalType::STRUCT: {
@@ -89,8 +89,8 @@ public:
 			// propagate through children
 			auto &children = result.auxiliary->Cast<VectorStructBuffer>().GetChildren();
 			for (idx_t i = 0; i < children.size(); i++) {
-				auto &child_cache = child_caches[i]->Cast<VectorCacheBuffer>();
-				child_cache.ResetFromCache(children[i], child_caches[i]);
+				auto &child_cache = *child_caches[i];
+				child_cache.ResetFromCache(children[i]);
 			}
 			break;
 		}
@@ -100,10 +100,6 @@ public:
 			result.auxiliary.reset();
 			break;
 		}
-	}
-
-	optional_ptr<Allocator> GetAllocator() const override {
-		return owned_data.GetAllocator();
 	}
 
 	const LogicalType &GetType() {
@@ -116,32 +112,42 @@ private:
 	//! Owned data
 	AllocatedData owned_data;
 	//! Child caches (if any). Used for nested types.
-	vector<buffer_ptr<VectorBuffer>> child_caches;
+	vector<unique_ptr<VectorCacheEntry>> child_caches;
+	//! Buffer data for the vector (if any)
+	buffer_ptr<VectorBuffer> buffer;
 	//! Aux data for the vector (if any)
 	buffer_ptr<VectorBuffer> auxiliary;
 	//! Capacity of the vector
 	idx_t capacity;
 };
 
-VectorCache::VectorCache() : buffer(nullptr) {
+VectorCache::VectorCache() {
 }
 
 VectorCache::VectorCache(Allocator &allocator, const LogicalType &type_p, const idx_t capacity_p) {
-	buffer = make_buffer<VectorCacheBuffer>(allocator, type_p, capacity_p);
+	cache_entry = make_uniq<VectorCacheEntry>(allocator, type_p, capacity_p);
+}
+
+VectorCache::~VectorCache() {
+}
+
+VectorCache::VectorCache(VectorCache &&other) noexcept : cache_entry(std::move(other.cache_entry)) {
+}
+
+VectorCache &VectorCache::operator=(VectorCache &&other) noexcept {
+	cache_entry = std::move(other.cache_entry);
+	return *this;
 }
 
 void VectorCache::ResetFromCache(Vector &result) const {
-	if (!buffer) {
+	if (!cache_entry) {
 		return;
 	}
-	auto &vector_cache = buffer->Cast<VectorCacheBuffer>();
-	vector_cache.ResetFromCache(result, buffer);
+	cache_entry->ResetFromCache(result);
 }
 
 const LogicalType &VectorCache::GetType() const {
-	D_ASSERT(buffer);
-	auto &vector_cache = buffer->Cast<VectorCacheBuffer>();
-	return vector_cache.GetType();
+	return cache_entry->GetType();
 }
 
 } // namespace duckdb

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -37,8 +37,7 @@ public:
 			for (auto &child_type : child_types) {
 				child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type.second, capacity));
 			}
-			auto struct_buffer = make_shared_ptr<VectorStructBuffer>(type);
-			auxiliary = std::move(struct_buffer);
+			buffer = make_buffer<VectorStructBuffer>(type);
 			break;
 		}
 		default:
@@ -70,8 +69,7 @@ public:
 		}
 		case PhysicalType::ARRAY: {
 			// reinitialize the VectorArrayBuffer
-			// auxiliary->SetAuxiliaryData(nullptr);
-			AssignSharedPointer(result.auxiliary, auxiliary);
+			result.auxiliary.reset();
 
 			// propagate through child
 			auto &child_cache = *child_caches[0];
@@ -81,10 +79,9 @@ public:
 		}
 		case PhysicalType::STRUCT: {
 			// reinitialize the VectorStructBuffer
-			auxiliary->SetAuxiliaryData(nullptr);
-			AssignSharedPointer(result.auxiliary, auxiliary);
+			result.auxiliary.reset();
 			// propagate through children
-			auto &children = result.auxiliary->Cast<VectorStructBuffer>().GetChildren();
+			auto &children = result.buffer->Cast<VectorStructBuffer>().GetChildren();
 			for (idx_t i = 0; i < children.size(); i++) {
 				auto &child_cache = *child_caches[i];
 				child_cache.ResetFromCache(children[i]);

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -29,7 +29,7 @@ public:
 			auto array_size = ArrayType::GetSize(type);
 			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, array_size * capacity));
 			auto child_vector = make_uniq<Vector>(child_type, true, false, array_size * capacity);
-			auxiliary = make_shared_ptr<VectorArrayBuffer>(std::move(child_vector), array_size, capacity);
+			buffer = make_shared_ptr<VectorArrayBuffer>(std::move(child_vector), array_size, capacity);
 			break;
 		}
 		case PhysicalType::STRUCT: {
@@ -75,7 +75,7 @@ public:
 
 			// propagate through child
 			auto &child_cache = *child_caches[0];
-			auto &array_child = result.auxiliary->Cast<VectorArrayBuffer>().GetChild();
+			auto &array_child = result.buffer->Cast<VectorArrayBuffer>().GetChild();
 			child_cache.ResetFromCache(array_child);
 			break;
 		}

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -16,7 +16,7 @@ public:
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// memory for the list offsets
-			buffer = make_buffer<VectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
+			buffer = make_buffer<StandardVectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			// child data of the list
 			auto &child_type = ListType::GetChildType(type);
 			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, capacity));
@@ -42,7 +42,7 @@ public:
 			break;
 		}
 		default:
-			buffer = make_buffer<VectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
+			buffer = make_buffer<StandardVectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			break;
 		}
 	}

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -38,6 +38,9 @@ public:
 			buffer = make_buffer<VectorStructBuffer>(type);
 			break;
 		}
+		case PhysicalType::VARCHAR:
+			buffer = make_buffer<VectorStringBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
+			break;
 		default:
 			buffer = make_buffer<StandardVectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			break;

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -48,6 +48,7 @@ public:
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
+		buffer->ClearAuxiliaryData();
 		AssignSharedPointer(result.buffer, buffer);
 		result.validity.Reset(capacity);
 		switch (internal_type) {
@@ -59,7 +60,6 @@ public:
 			auto &list_buffer = result.buffer->Cast<VectorListBuffer>();
 			list_buffer.SetCapacity(child_cache.capacity);
 			list_buffer.SetSize(0);
-			list_buffer.SetAuxiliaryData(nullptr);
 
 			auto &list_child = list_buffer.GetChild();
 			child_cache.ResetFromCache(list_child);

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector/array_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 
 namespace duckdb {

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -39,7 +39,7 @@ public:
 			break;
 		}
 		case PhysicalType::VARCHAR:
-			buffer = make_buffer<VectorStringBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
+			buffer = make_buffer<VectorStringBuffer>(allocator, capacity);
 			break;
 		default:
 			buffer = make_buffer<StandardVectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -51,7 +51,11 @@ public:
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
-		buffer->ClearAuxiliaryData();
+		// clear any extra accumulated auxiliary data (reset to only the initial AllocatedData)
+		auto auxiliary = buffer->GetAuxiliaryData();
+		if (auxiliary && auxiliary->data.size() > 1) {
+			auxiliary->data.erase(auxiliary->data.begin() + 1, auxiliary->data.end());
+		}
 		AssignSharedPointer(result.buffer, buffer);
 		result.validity.Reset(capacity);
 		switch (internal_type) {
@@ -83,6 +87,12 @@ public:
 				auto &child_cache = *child_caches[i];
 				child_cache.ResetFromCache(children[i]);
 			}
+			break;
+		}
+		case PhysicalType::VARCHAR: {
+			// reset the heap reference for strings
+			auto &string_buffer = result.buffer->Cast<VectorStringBuffer>();
+			string_buffer.ResetHeap();
 			break;
 		}
 		default:

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -15,13 +15,11 @@ public:
 		auto internal_type = type.InternalType();
 		switch (internal_type) {
 		case PhysicalType::LIST: {
-			// memory for the list offsets
-			buffer = make_buffer<StandardVectorBuffer>(allocator, capacity * GetTypeIdSize(internal_type));
 			// child data of the list
 			auto &child_type = ListType::GetChildType(type);
 			child_caches.push_back(make_uniq<VectorCacheEntry>(allocator, child_type, capacity));
 			auto child_vector = make_uniq<Vector>(child_type, false, false);
-			auxiliary = make_shared_ptr<VectorListBuffer>(std::move(child_vector));
+			buffer = make_buffer<VectorListBuffer>(allocator, capacity, std::move(child_vector), capacity);
 			break;
 		}
 		case PhysicalType::ARRAY: {
@@ -55,10 +53,10 @@ public:
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// reinitialize the VectorListBuffer
-			AssignSharedPointer(result.auxiliary, auxiliary);
+			result.auxiliary.reset();
 			// propagate through child
 			auto &child_cache = *child_caches[0];
-			auto &list_buffer = result.auxiliary->Cast<VectorListBuffer>();
+			auto &list_buffer = result.buffer->Cast<VectorListBuffer>();
 			list_buffer.SetCapacity(child_cache.capacity);
 			list_buffer.SetSize(0);
 			list_buffer.SetAuxiliaryData(nullptr);

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -55,7 +55,6 @@ public:
 		result.validity.Reset(capacity);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
-			result.buffer->ResetData();
 			// reinitialize the VectorListBuffer
 			AssignSharedPointer(result.auxiliary, auxiliary);
 			// propagate through child
@@ -94,7 +93,6 @@ public:
 		}
 		default:
 			// regular type: no aux data and reset data to cached data
-			result.buffer->ResetData();
 			result.auxiliary.reset();
 			break;
 		}

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -12,9 +12,9 @@ T &ArrayVector::GetEntryInternal(T &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.auxiliary);
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::ARRAY_BUFFER);
-	return vector.auxiliary->template Cast<VectorArrayBuffer>().GetChild();
+	D_ASSERT(vector.buffer);
+	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::ARRAY_BUFFER);
+	return vector.buffer->template Cast<VectorArrayBuffer>().GetChild();
 }
 
 const Vector &ArrayVector::GetEntry(const Vector &vector) {
@@ -27,12 +27,11 @@ Vector &ArrayVector::GetEntry(Vector &vector) {
 
 idx_t ArrayVector::GetTotalSize(const Vector &vector) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::ARRAY);
-	D_ASSERT(vector.auxiliary);
 	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(vector);
 		return ArrayVector::GetTotalSize(child);
 	}
-	return vector.auxiliary->Cast<VectorArrayBuffer>().GetChildSize();
+	return vector.buffer->Cast<VectorArrayBuffer>().GetChildSize();
 }
 
 } // namespace duckdb

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -39,6 +39,10 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::LIST_BUFFER) {
 				throw InternalException("Not a list buffer!?");
 			}
+		} else if (internal_type == PhysicalType::VARCHAR) {
+			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STRING_BUFFER) {
+				vector.buffer = make_buffer<VectorStringBuffer>(GetTypeIdSize(internal_type));
+			}
 		} else {
 			// if we don't have a standard buffer overwrite it
 			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STANDARD_BUFFER) {

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -34,9 +34,14 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 					FlatVector::SetNull(child, i, is_null);
 				}
 			}
+		} else if (internal_type == PhysicalType::LIST) {
+			// for list - don't do anything
+			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::LIST_BUFFER) {
+				throw InternalException("Not a list buffer!?");
+			}
 		} else {
 			// if we don't have a standard buffer overwrite it
-			if (vector.buffer->GetBufferType() != VectorBufferType::STANDARD_BUFFER) {
+			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STANDARD_BUFFER) {
 				vector.buffer = make_buffer<StandardVectorBuffer>(GetTypeIdSize(internal_type));
 			}
 		}

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -34,6 +34,11 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 					FlatVector::SetNull(child, i, is_null);
 				}
 			}
+		} else {
+			// if we don't have a standard buffer overwrite it
+			if (vector.buffer->GetBufferType() != VectorBufferType::STANDARD_BUFFER) {
+				vector.buffer = make_buffer<StandardVectorBuffer>(GetTypeIdSize(internal_type));
+			}
 		}
 	}
 }

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -41,7 +41,7 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 			}
 		} else if (internal_type == PhysicalType::VARCHAR) {
 			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STRING_BUFFER) {
-				vector.buffer = make_buffer<VectorStringBuffer>(GetTypeIdSize(internal_type));
+				vector.buffer = make_buffer<VectorStringBuffer>(1);
 			}
 		} else {
 			// if we don't have a standard buffer overwrite it

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -5,27 +5,27 @@
 
 namespace duckdb {
 
-buffer_ptr<VectorChildBuffer> DictionaryVector::CreateReusableDictionary(const LogicalType &type, const idx_t &size) {
-	auto res = make_buffer<VectorChildBuffer>(Vector(type, size));
-	res->size = size;
-	res->id = UUID::ToString(UUID::GenerateRandomUUID());
-	return res;
+buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const LogicalType &type, const idx_t &size) {
+	auto entry = make_buffer<DictionaryEntry>(Vector(type, size));
+	entry->size = size;
+	entry->id = UUID::ToString(UUID::GenerateRandomUUID());
+	return entry;
 }
 
 const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	D_ASSERT(CanCacheHashes(input));
 
-	auto &child = input.auxiliary->Cast<VectorChildBuffer>();
-	lock_guard<mutex> guard(child.cached_hashes_lock);
+	auto &entry = input.buffer->Cast<DictionaryBuffer>().GetEntry();
+	lock_guard<mutex> guard(entry.cached_hashes_lock);
 
-	if (!child.cached_hashes) {
+	if (!entry.cached_hashes) {
 		// Uninitialized: hash the dictionary
 		const auto dictionary_size = DictionarySize(input).GetIndex();
-		D_ASSERT(!child.size.IsValid() || child.size.GetIndex() == dictionary_size);
-		child.cached_hashes = make_uniq<Vector>(LogicalType::HASH, dictionary_size);
-		VectorOperations::Hash(child.data, *child.cached_hashes, dictionary_size);
+		D_ASSERT(!entry.size.IsValid() || entry.size.GetIndex() == dictionary_size);
+		entry.cached_hashes = make_uniq<Vector>(LogicalType::HASH, dictionary_size);
+		VectorOperations::Hash(entry.data, *entry.cached_hashes, dictionary_size);
 	}
-	return *child.cached_hashes;
+	return *entry.cached_hashes;
 }
 
 } // namespace duckdb

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -6,6 +6,25 @@
 
 namespace duckdb {
 
+StandardVectorBuffer::StandardVectorBuffer(Allocator &allocator, idx_t data_size)
+    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr), allocator(allocator) {
+	if (data_size > 0) {
+		auto allocated_data = allocator.Allocate(data_size);
+		data_ptr = allocated_data.get();
+		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
+	}
+}
+StandardVectorBuffer::StandardVectorBuffer(idx_t data_size)
+    : StandardVectorBuffer(Allocator::DefaultAllocator(), data_size) {
+}
+StandardVectorBuffer::StandardVectorBuffer(data_ptr_t data_ptr_p)
+    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
+}
+StandardVectorBuffer::StandardVectorBuffer(AllocatedData &&data_p)
+    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()), allocator(data_p.GetAllocator()) {
+	AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(data_p)));
+}
+
 void FlatVector::SetData(Vector &vector, data_ptr_t data) {
 	VerifyFlatVector(vector);
 	if (vector.GetType().InternalType() == PhysicalType::ARRAY) {

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/array_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 
 namespace duckdb {
@@ -16,6 +17,10 @@ void FlatVector::SetData(Vector &vector, data_ptr_t data) {
 	if (vector.GetType().InternalType() == PhysicalType::LIST) {
 		auto &current_buffer = vector.buffer->Cast<VectorListBuffer>();
 		vector.buffer = make_buffer<VectorListBuffer>(data, current_buffer);
+		return;
+	}
+	if (vector.GetType().InternalType() == PhysicalType::VARCHAR) {
+		vector.buffer = make_buffer<VectorStringBuffer>(data);
 		return;
 	}
 	vector.buffer = make_buffer<StandardVectorBuffer>(data);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -1,8 +1,25 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/array_vector.hpp"
+#include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 
 namespace duckdb {
+
+void FlatVector::SetData(Vector &vector, data_ptr_t data) {
+	VerifyFlatVector(vector);
+	if (vector.GetType().InternalType() == PhysicalType::ARRAY) {
+		throw InternalException("SetData not supported for array");
+	}
+	if (vector.GetType().InternalType() == PhysicalType::STRUCT) {
+		throw InternalException("SetData not supported for struct");
+	}
+	if (vector.GetType().InternalType() == PhysicalType::LIST) {
+		auto &current_buffer = vector.buffer->Cast<VectorListBuffer>();
+		vector.buffer = make_buffer<VectorListBuffer>(data, current_buffer);
+		return;
+	}
+	vector.buffer = make_buffer<StandardVectorBuffer>(data);
+}
 
 void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -7,11 +7,10 @@
 namespace duckdb {
 
 StandardVectorBuffer::StandardVectorBuffer(Allocator &allocator, idx_t data_size)
-    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr), allocator(allocator) {
+    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
 	if (data_size > 0) {
-		auto allocated_data = allocator.Allocate(data_size);
+		allocated_data = allocator.Allocate(data_size);
 		data_ptr = allocated_data.get();
-		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
 	}
 }
 StandardVectorBuffer::StandardVectorBuffer(idx_t data_size)
@@ -21,8 +20,7 @@ StandardVectorBuffer::StandardVectorBuffer(data_ptr_t data_ptr_p)
     : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
 }
 StandardVectorBuffer::StandardVectorBuffer(AllocatedData &&data_p)
-    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()), allocator(data_p.GetAllocator()) {
-	AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(data_p)));
+    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()), allocated_data(std::move(data_p)) {
 }
 
 void FlatVector::SetData(Vector &vector, data_ptr_t data) {
@@ -35,7 +33,8 @@ void FlatVector::SetData(Vector &vector, data_ptr_t data) {
 	}
 	if (vector.GetType().InternalType() == PhysicalType::LIST) {
 		auto &current_buffer = vector.buffer->Cast<VectorListBuffer>();
-		vector.buffer = make_buffer<VectorListBuffer>(data, current_buffer);
+		vector.buffer = make_buffer<VectorListBuffer>(data, current_buffer.GetChild(), current_buffer.GetCapacity(),
+		                                              current_buffer.GetSize());
 		return;
 	}
 	if (vector.GetType().InternalType() == PhysicalType::VARCHAR) {

--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -4,6 +4,21 @@
 
 namespace duckdb {
 
+VectorFSSTStringBuffer::VectorFSSTStringBuffer(idx_t capacity) : VectorStringBuffer(capacity) {
+	buffer_type = VectorBufferType::FSST_BUFFER;
+}
+
+VectorFSSTStringBuffer &FSSTVector::GetFSSTBuffer(const Vector &vector) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (vector.GetVectorType() != VectorType::FSST_VECTOR) {
+		throw InternalException("FSSTVector::GetFSSTBuffer called on a non-FSST vector");
+	}
+	if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::FSST_BUFFER) {
+		throw InternalException("FSSTVector has a non-FSST buffer");
+	}
+	return vector.buffer->Cast<VectorFSSTStringBuffer>();
+}
+
 string_t FSSTVector::AddCompressedString(Vector &vector, const char *data, idx_t len) {
 	return FSSTVector::AddCompressedString(vector, string_t(data, UnsafeNumericCast<uint32_t>(len)));
 }
@@ -14,68 +29,35 @@ string_t FSSTVector::AddCompressedString(Vector &vector, string_t data) {
 		// string will be inlined: no need to store in string heap
 		return data;
 	}
-	if (!vector.auxiliary) {
-		vector.auxiliary = make_buffer<VectorFSSTStringBuffer>();
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-	auto &fsst_string_buffer = vector.auxiliary.get()->Cast<VectorFSSTStringBuffer>();
+	auto &fsst_string_buffer = GetFSSTBuffer(vector);
 	return fsst_string_buffer.AddBlob(data);
 }
 
 void *FSSTVector::GetDecoder(const Vector &vector) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-	if (!vector.auxiliary) {
-		throw InternalException("GetDecoder called on FSST Vector without registered buffer");
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-	auto &fsst_string_buffer = vector.auxiliary->Cast<VectorFSSTStringBuffer>();
+	auto &fsst_string_buffer = GetFSSTBuffer(vector);
 	return fsst_string_buffer.GetDecoder();
 }
 
 vector<unsigned char> &FSSTVector::GetDecompressBuffer(const Vector &vector) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-	if (!vector.auxiliary) {
-		throw InternalException("GetDecompressBuffer called on FSST Vector without registered buffer");
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-	auto &fsst_string_buffer = vector.auxiliary->Cast<VectorFSSTStringBuffer>();
+	auto &fsst_string_buffer = GetFSSTBuffer(vector);
 	return fsst_string_buffer.GetDecompressBuffer();
 }
 
-void FSSTVector::RegisterDecoder(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder,
-                                 const idx_t string_block_limit) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-
-	if (!vector.auxiliary) {
-		vector.auxiliary = make_buffer<VectorFSSTStringBuffer>();
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-
-	auto &fsst_string_buffer = vector.auxiliary->Cast<VectorFSSTStringBuffer>();
+void FSSTVector::Create(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder, const idx_t string_block_limit,
+                        idx_t capacity) {
+	vector.buffer = make_buffer<VectorFSSTStringBuffer>(capacity);
+	vector.SetVectorType(VectorType::FSST_VECTOR);
+	auto &fsst_string_buffer = vector.buffer->Cast<VectorFSSTStringBuffer>();
 	fsst_string_buffer.AddDecoder(duckdb_fsst_decoder, string_block_limit);
 }
 
 void FSSTVector::SetCount(Vector &vector, idx_t count) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-
-	if (!vector.auxiliary) {
-		vector.auxiliary = make_buffer<VectorFSSTStringBuffer>();
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-
-	auto &fsst_string_buffer = vector.auxiliary->Cast<VectorFSSTStringBuffer>();
+	auto &fsst_string_buffer = GetFSSTBuffer(vector);
 	fsst_string_buffer.SetCount(count);
 }
 
 idx_t FSSTVector::GetCount(const Vector &vector) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-
-	if (!vector.auxiliary) {
-		vector.auxiliary = make_buffer<VectorFSSTStringBuffer>();
-	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::FSST_BUFFER);
-
-	auto &fsst_string_buffer = vector.auxiliary->Cast<VectorFSSTStringBuffer>();
+	auto &fsst_string_buffer = GetFSSTBuffer(vector);
 	return fsst_string_buffer.GetCount();
 }
 
@@ -85,6 +67,7 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 	D_ASSERT(dst.GetVectorType() == VectorType::FLAT_VECTOR);
 	auto dst_mask = FlatVector::Validity(dst);
 	auto ldata = FSSTVector::GetCompressedData(src);
+	auto decoder = FSSTVector::GetDecoder(src);
 	auto tdata = FlatVector::GetData<string_t>(dst);
 	auto &str_allocator = StringVector::GetStringAllocator(dst);
 	for (idx_t i = 0; i < copy_count; i++) {
@@ -92,7 +75,6 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 		auto target_idx = dst_offset + i;
 		string_t compressed_string = ldata[source_idx];
 		if (dst_mask.RowIsValid(target_idx) && compressed_string.GetSize() > 0) {
-			auto decoder = FSSTVector::GetDecoder(src);
 			tdata[target_idx] = FSSTPrimitives::DecompressValue(decoder, str_allocator, compressed_string.GetData(),
 			                                                    compressed_string.GetSize());
 		} else {

--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -86,14 +86,14 @@ void FSSTVector::DecompressVector(const Vector &src, Vector &dst, idx_t src_offs
 	auto dst_mask = FlatVector::Validity(dst);
 	auto ldata = FSSTVector::GetCompressedData(src);
 	auto tdata = FlatVector::GetData<string_t>(dst);
-	auto &str_buffer = StringVector::GetStringBuffer(dst);
+	auto &str_allocator = StringVector::GetStringAllocator(dst);
 	for (idx_t i = 0; i < copy_count; i++) {
 		auto source_idx = sel->get_index(src_offset + i);
 		auto target_idx = dst_offset + i;
 		string_t compressed_string = ldata[source_idx];
 		if (dst_mask.RowIsValid(target_idx) && compressed_string.GetSize() > 0) {
 			auto decoder = FSSTVector::GetDecoder(src);
-			tdata[target_idx] = FSSTPrimitives::DecompressValue(decoder, str_buffer, compressed_string.GetData(),
+			tdata[target_idx] = FSSTPrimitives::DecompressValue(decoder, str_allocator, compressed_string.GetData(),
 			                                                    compressed_string.GetSize());
 		} else {
 			tdata[target_idx] = string_t(nullptr, 0);

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -11,9 +11,9 @@ T &ListVector::GetEntryInternal(T &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.auxiliary);
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
-	return vector.auxiliary->template Cast<VectorListBuffer>().GetChild();
+	D_ASSERT(vector.buffer);
+	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	return vector.buffer->template Cast<VectorListBuffer>().GetChild();
 }
 
 const Vector &ListVector::GetEntry(const Vector &vector) {
@@ -28,9 +28,9 @@ void ListVector::Reserve(Vector &vector, idx_t required_capacity) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST || vector.GetType().id() == LogicalTypeId::MAP);
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.auxiliary);
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
-	auto &child_buffer = vector.auxiliary->Cast<VectorListBuffer>();
+	D_ASSERT(vector.buffer);
+	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	auto &child_buffer = vector.buffer->Cast<VectorListBuffer>();
 	child_buffer.Reserve(required_capacity);
 }
 
@@ -39,16 +39,16 @@ idx_t ListVector::GetListSize(const Vector &vec) {
 		auto &child = DictionaryVector::Child(vec);
 		return ListVector::GetListSize(child);
 	}
-	D_ASSERT(vec.auxiliary);
-	return vec.auxiliary->Cast<VectorListBuffer>().GetSize();
+	D_ASSERT(vec.buffer);
+	return vec.buffer->Cast<VectorListBuffer>().GetSize();
 }
 
 idx_t ListVector::GetListCapacity(const Vector &vec) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("ListVector::GetListCapacity called on dictionary vector");
 	}
-	D_ASSERT(vec.auxiliary);
-	return vec.auxiliary->Cast<VectorListBuffer>().GetCapacity();
+	D_ASSERT(vec.buffer);
+	return vec.buffer->Cast<VectorListBuffer>().GetCapacity();
 }
 
 void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
@@ -57,14 +57,14 @@ void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
 	D_ASSERT(other.GetType().id() == LogicalTypeId::LIST);
 	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR || other.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	vector.auxiliary = other.auxiliary;
+	vector.buffer = other.buffer;
 }
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("ListVector::SetListSize called on dictionary vector");
 	}
-	vec.auxiliary->Cast<VectorListBuffer>().SetSize(size);
+	vec.buffer->Cast<VectorListBuffer>().SetSize(size);
 }
 
 void ListVector::Append(Vector &target, const Vector &source, idx_t source_size, idx_t source_offset) {
@@ -72,7 +72,7 @@ void ListVector::Append(Vector &target, const Vector &source, idx_t source_size,
 		//! Nothing to add
 		return;
 	}
-	auto &target_buffer = target.auxiliary->Cast<VectorListBuffer>();
+	auto &target_buffer = target.buffer->Cast<VectorListBuffer>();
 	target_buffer.Append(source, source_size, source_offset);
 }
 
@@ -82,12 +82,12 @@ void ListVector::Append(Vector &target, const Vector &source, const SelectionVec
 		//! Nothing to add
 		return;
 	}
-	auto &target_buffer = target.auxiliary->Cast<VectorListBuffer>();
+	auto &target_buffer = target.buffer->Cast<VectorListBuffer>();
 	target_buffer.Append(source, sel, source_size, source_offset);
 }
 
 void ListVector::PushBack(Vector &target, const Value &insert) {
-	auto &target_buffer = target.auxiliary.get()->Cast<VectorListBuffer>();
+	auto &target_buffer = target.buffer.get()->Cast<VectorListBuffer>();
 	target_buffer.PushBack(insert);
 }
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -28,13 +28,9 @@ VectorListBuffer::VectorListBuffer(data_ptr_t data, const Vector &vector, idx_t 
 	child = make_uniq<Vector>(Vector::Ref(vector));
 }
 
-VectorListBuffer::VectorListBuffer(data_ptr_t data, buffer_ptr<VectorBuffer> parent_buffer)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data) {
-	auto &parent = parent_buffer->Cast<VectorListBuffer>();
-	capacity = parent.capacity;
-	size = parent.size;
+VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
-	AddAuxiliaryData(make_uniq<VectorBufferHolder>(std::move(parent_buffer)));
 }
 
 VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -7,9 +7,8 @@ VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, unique_
                                    idx_t child_capacity)
     : VectorBuffer(VectorBufferType::LIST_BUFFER), child(std::move(vector)), capacity(child_capacity) {
 	if (capacity > 0) {
-		auto allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
+		allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
 		data_ptr = allocated_data.get();
-		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
 	}
 }
 VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
@@ -22,17 +21,27 @@ VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type,
     : VectorListBuffer(Allocator::DefaultAllocator(), capacity, list_type, child_capacity) {
 }
 
-VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
+VectorListBuffer::VectorListBuffer(data_ptr_t data, const Vector &vector, idx_t child_capacity, idx_t child_size)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data) {
+	capacity = child_capacity;
+	size = child_size;
+	child = make_uniq<Vector>(Vector::Ref(vector));
+}
+
+VectorListBuffer::VectorListBuffer(data_ptr_t data, buffer_ptr<VectorBuffer> parent_buffer)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data) {
+	auto &parent = parent_buffer->Cast<VectorListBuffer>();
+	capacity = parent.capacity;
+	size = parent.size;
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
-	AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(parent.GetAuxiliaryData()));
+	AddAuxiliaryData(make_uniq<VectorBufferHolder>(std::move(parent_buffer)));
 }
 
 VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)
-    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(parent.capacity), size(parent.size) {
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), allocated_data(std::move(allocated_data_p)),
+      capacity(parent.capacity), size(parent.size) {
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
-	data_ptr = allocated_data_p.get();
-	AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data_p)));
+	data_ptr = allocated_data.get();
 }
 
 void VectorListBuffer::Reserve(idx_t to_reserve) {
@@ -128,23 +137,6 @@ idx_t ListVector::GetListCapacity(const Vector &vec) {
 	}
 	D_ASSERT(vec.buffer);
 	return vec.buffer->Cast<VectorListBuffer>().GetCapacity();
-}
-
-//! References the list offsets / sizes of another vector
-void ListVector::ReferenceListOffsets(Vector &list, const Vector &other) {
-	D_ASSERT(list.GetType().InternalType() == PhysicalType::LIST);
-	D_ASSERT(other.GetType().InternalType() == PhysicalType::LIST);
-	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		throw InternalException("ListVector::ReferenceListOffsets called on dictionary vector");
-	}
-	auto &other_buffer = other.buffer->Cast<VectorListBuffer>();
-	auto &list_buffer = list.buffer->Cast<VectorListBuffer>();
-	// Use list's own buffer as parent to preserve list's child (correct type), but take data pointer from other
-	list.buffer = make_buffer<VectorListBuffer>(other_buffer.GetData(), list_buffer);
-	// The constructor copies size from list_buffer (parent), so fix it to use other's size
-	list.buffer->Cast<VectorListBuffer>().SetSize(other_buffer.GetSize());
-	// Keep other's data alive since we're pointing into it
-	list.AddHeapReference(other);
 }
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -137,8 +137,14 @@ void ListVector::ReferenceListOffsets(Vector &list, const Vector &other) {
 	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("ListVector::ReferenceListOffsets called on dictionary vector");
 	}
-	auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
-	list.buffer = make_buffer<VectorListBuffer>(list_buffer.GetData(), list_buffer);
+	auto &other_buffer = other.buffer->Cast<VectorListBuffer>();
+	auto &list_buffer = list.buffer->Cast<VectorListBuffer>();
+	// Use list's own buffer as parent to preserve list's child (correct type), but take data pointer from other
+	list.buffer = make_buffer<VectorListBuffer>(other_buffer.GetData(), list_buffer);
+	// The constructor copies size from list_buffer (parent), so fix it to use other's size
+	list.buffer->Cast<VectorListBuffer>().SetSize(other_buffer.GetSize());
+	// Keep other's data alive since we're pointing into it
+	list.AddHeapReference(other);
 }
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -45,8 +45,7 @@ idx_t ListVector::GetListSize(const Vector &vec) {
 
 idx_t ListVector::GetListCapacity(const Vector &vec) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		auto &child = DictionaryVector::Child(vec);
-		return ListVector::GetListSize(child);
+		throw InternalException("ListVector::GetListCapacity called on dictionary vector");
 	}
 	D_ASSERT(vec.auxiliary);
 	return vec.auxiliary->Cast<VectorListBuffer>().GetCapacity();
@@ -63,9 +62,7 @@ void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		auto &child = DictionaryVector::Child(vec);
-		ListVector::SetListSize(child, size);
-		return;
+		throw InternalException("ListVector::SetListSize called on dictionary vector");
 	}
 	vec.auxiliary->Cast<VectorListBuffer>().SetSize(size);
 }

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -2,6 +2,83 @@
 
 namespace duckdb {
 
+VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector,
+                                   idx_t child_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), child(std::move(vector)), capacity(child_capacity) {
+	if (capacity > 0) {
+		auto allocated_data = allocator.Allocate(capacity * sizeof(list_entry_t));
+		data_ptr = allocated_data.get();
+		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
+	}
+}
+VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
+                                   idx_t child_capacity)
+    : VectorListBuffer(allocator, capacity, make_uniq<Vector>(ListType::GetChildType(list_type), child_capacity),
+                       child_capacity) {
+}
+
+VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type, idx_t child_capacity)
+    : VectorListBuffer(Allocator::DefaultAllocator(), capacity, list_type, child_capacity) {
+}
+
+VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
+	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
+}
+
+VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(parent.capacity), size(parent.size) {
+	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
+	data_ptr = allocated_data_p.get();
+	AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data_p)));
+}
+
+void VectorListBuffer::Reserve(idx_t to_reserve) {
+	if (to_reserve > capacity) {
+		if (to_reserve > DConstants::MAX_VECTOR_SIZE) {
+			// overflow: throw an exception
+			throw OutOfRangeException("Cannot resize vector to %d rows: maximum allowed vector size is %s", to_reserve,
+			                          StringUtil::BytesToHumanReadableString(DConstants::MAX_VECTOR_SIZE));
+		}
+		idx_t new_capacity = NextPowerOfTwo(to_reserve);
+		D_ASSERT(new_capacity >= to_reserve);
+		child->Resize(capacity, new_capacity);
+		capacity = new_capacity;
+	}
+}
+
+void VectorListBuffer::Append(const Vector &to_append, idx_t to_append_size, idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::Append(const Vector &to_append, const SelectionVector &sel, idx_t to_append_size,
+                              idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, sel, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::PushBack(const Value &insert) {
+	while (size + 1 > capacity) {
+		child->Resize(capacity, capacity * 2);
+		capacity *= 2;
+	}
+	child->SetValue(size++, insert);
+}
+
+void VectorListBuffer::SetCapacity(idx_t new_capacity) {
+	this->capacity = new_capacity;
+}
+
+void VectorListBuffer::SetSize(idx_t new_size) {
+	this->size = new_size;
+}
+
+VectorListBuffer::~VectorListBuffer() {
+}
+
 template <class T>
 T &ListVector::GetEntryInternal(T &vector) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST || vector.GetType().id() == LogicalTypeId::MAP);

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -24,6 +24,7 @@ VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type,
 VectorListBuffer::VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent)
     : VectorBuffer(VectorBufferType::LIST_BUFFER), data_ptr(data), capacity(parent.capacity), size(parent.size) {
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
+	AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(parent.GetAuxiliaryData()));
 }
 
 VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, const VectorListBuffer &parent)
@@ -128,13 +129,15 @@ idx_t ListVector::GetListCapacity(const Vector &vec) {
 	return vec.buffer->Cast<VectorListBuffer>().GetCapacity();
 }
 
-void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
-	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
-	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
-	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(other.GetType().id() == LogicalTypeId::LIST);
-	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR || other.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	vector.buffer = other.buffer;
+//! References the list offsets / sizes of another vector
+void ListVector::ReferenceListOffsets(Vector &list, const Vector &other) {
+	D_ASSERT(list.GetType().InternalType() == PhysicalType::LIST);
+	D_ASSERT(other.GetType().InternalType() == PhysicalType::LIST);
+	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		throw InternalException("ListVector::ReferenceListOffsets called on dictionary vector");
+	}
+	auto &list_buffer = other.buffer->Cast<VectorListBuffer>();
+	list.buffer = make_buffer<VectorListBuffer>(list_buffer.GetData(), list_buffer);
 }
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {

--- a/src/common/vector/sequence_vector.cpp
+++ b/src/common/vector/sequence_vector.cpp
@@ -2,13 +2,18 @@
 
 namespace duckdb {
 
+SequenceBuffer::SequenceBuffer(int64_t start_p, int64_t increment_p, int64_t count_p)
+    : VectorBuffer(VectorBufferType::SEQUENCE_BUFFER), start(start_p), increment(increment_p), count(count_p) {
+}
+
 void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count) {
 	D_ASSERT(vector.GetVectorType() == VectorType::SEQUENCE_VECTOR);
-	auto data = reinterpret_cast<int64_t *>(vector.buffer->GetData());
-	start = data[0];
-	increment = data[1];
-	sequence_count = data[2];
+	auto &data = vector.buffer->Cast<SequenceBuffer>();
+	start = data.start;
+	increment = data.increment;
+	sequence_count = data.count;
 }
+
 void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment) {
 	int64_t sequence_count;
 	GetSequence(vector, start, increment, sequence_count);

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -6,27 +6,27 @@ namespace duckdb {
 
 const Vector &ShreddedVector::GetUnshreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 Vector &ShreddedVector::GetUnshreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 const Vector &ShreddedVector::GetShreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 Vector &ShreddedVector::GetShreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.auxiliary->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 	Vector unshredded_vector(LogicalType::VARIANT(), MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
-	auto &shredded_buffer = vec.auxiliary->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
 	VariantUtils::UnshredVariantData(shredded_buffer.GetChild(), unshredded_vector, count);
 	vec.ConstReference(unshredded_vector);
 }
@@ -34,7 +34,7 @@ void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 void ShreddedVector::Unshred(const Vector &vec, const SelectionVector &sel, idx_t count) {
 	VerifyShreddedVector(vec);
 	// slice the underlying shredded buffer
-	auto &shredded_buffer = vec.auxiliary->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
 	Vector sliced_shredded_buffer(shredded_buffer.GetChild(), sel, count);
 	// unshred the vector
 	Vector unshredded_vector(LogicalType::VARIANT());

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -32,7 +32,9 @@ VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
 
 VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other)
     : StandardVectorBuffer(std::move(data_p)) {
-	auxiliary_data = other.auxiliary_data;
+	if (other.auxiliary_data) {
+		AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(other.auxiliary_data));
+	}
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -30,11 +30,9 @@ VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other)
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, buffer_ptr<VectorBuffer> other)
     : StandardVectorBuffer(std::move(data_p)) {
-	if (other.auxiliary_data) {
-		AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(other.auxiliary_data));
-	}
+	AddAuxiliaryData(make_uniq<VectorBufferHolder>(std::move(other)));
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -36,6 +36,10 @@ VectorStringBuffer &StringVector::GetStringBuffer(Vector &vector) {
 	return vector.auxiliary.get()->Cast<VectorStringBuffer>();
 }
 
+ArenaAllocator &StringVector::GetStringAllocator(Vector &vector) {
+	return GetStringBuffer(vector).GetStringAllocator();
+}
+
 string_t StringVector::AddString(Vector &vector, string_t data) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::VARCHAR || vector.GetType().id() == LogicalTypeId::BIT);
 	if (data.IsInlined()) {

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -115,7 +115,7 @@ string_t StringVector::EmptyString(Vector &vector, idx_t len) {
 }
 
 void StringVector::AddAuxiliaryData(Vector &vector, unique_ptr<AuxiliaryDataHolder> data) {
-	vector.buffer->AddAuxiliaryData(std::move(data));
+	vector.AddAuxiliaryData(std::move(data));
 }
 
 void StringVector::AddHandle(Vector &vector, BufferHandle handle) {
@@ -123,22 +123,7 @@ void StringVector::AddHandle(Vector &vector, BufferHandle handle) {
 }
 
 void StringVector::AddHeapReference(Vector &vector, const Vector &other) {
-	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
-	D_ASSERT(other.GetType().InternalType() == PhysicalType::VARCHAR);
-
-	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		AddHeapReference(vector, DictionaryVector::Child(other));
-		return;
-	}
-	if (!other.buffer) {
-		return;
-	}
-	auto data = other.buffer->GetAuxiliaryData();
-	if (!data) {
-		// no auxiliary data to reference
-		return;
-	}
-	AddAuxiliaryData(vector, make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
+	vector.AddHeapReference(other);
 }
 
 } // namespace duckdb

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -3,6 +3,53 @@
 
 namespace duckdb {
 
+VectorStringBuffer::VectorStringBuffer() : StandardVectorBuffer(idx_t(0)), heap(AllocateHeap()) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(Allocator &allocator)
+    : StandardVectorBuffer(allocator, 0), heap(AllocateHeap(allocator)) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(Allocator &allocator, idx_t data_size)
+    : StandardVectorBuffer(allocator, data_size), heap(AllocateHeap(allocator)) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(idx_t data_size) : StandardVectorBuffer(data_size), heap(AllocateHeap()) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p) : StandardVectorBuffer(data_ptr_p), heap(AllocateHeap()) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
+    : StandardVectorBuffer(std::move(data_p)), heap(AllocateHeap()) {
+	buffer_type = VectorBufferType::STRING_BUFFER;
+}
+
+VectorStringBuffer::VectorStringBuffer(VectorBufferType type) : StandardVectorBuffer(idx_t(0)), heap(AllocateHeap()) {
+	buffer_type = type;
+}
+
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other)
+    : StandardVectorBuffer(std::move(data_p)), heap(AllocateHeap()) {
+	auxiliary_data = other.auxiliary_data;
+}
+
+StringHeap &VectorStringBuffer::AllocateHeap(Allocator &allocator) {
+	auto data = make_uniq<StringHeapHolder>(allocator);
+	auto &result = data->heap;
+	AddAuxiliaryData(std::move(data));
+	return result;
+}
+
+StringHeap &VectorStringBuffer::AllocateHeap() {
+	return AllocateHeap(Allocator::DefaultAllocator());
+}
+
 string_t StringVector::AddString(Vector &vector, const char *data, idx_t len) {
 	return StringVector::AddString(vector, string_t(data, UnsafeNumericCast<uint32_t>(len)));
 }
@@ -24,6 +71,11 @@ VectorStringBuffer &StringVector::GetStringBuffer(Vector &vector) {
 		throw InternalException("StringVector::GetStringBuffer - vector is not of internal type VARCHAR but of type %s",
 		                        vector.GetType());
 	}
+	// check if the main buffer is a VectorStringBuffer
+	if (vector.buffer && vector.buffer->GetBufferType() == VectorBufferType::STRING_BUFFER) {
+		return vector.buffer->Cast<VectorStringBuffer>();
+	}
+	// fall back to auxiliary (e.g. for cached vectors or vectors with external data pointers)
 	if (!vector.auxiliary) {
 		auto stored_allocator = vector.buffer ? vector.buffer->GetAllocator() : nullptr;
 		if (stored_allocator) {
@@ -69,15 +121,12 @@ string_t StringVector::EmptyString(Vector &vector, idx_t len) {
 	return string_buffer.EmptyString(len);
 }
 
-void StringVector::AddHandle(Vector &vector, BufferHandle handle) {
-	auto &string_buffer = GetStringBuffer(vector);
-	string_buffer.AddHeapReference(make_buffer<ManagedVectorBuffer>(std::move(handle)));
+void StringVector::AddAuxiliaryData(Vector &vector, unique_ptr<AuxiliaryDataHolder> data) {
+	vector.buffer->AddAuxiliaryData(std::move(data));
 }
 
-void StringVector::AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer) {
-	D_ASSERT(buffer.get() != vector.auxiliary.get());
-	auto &string_buffer = GetStringBuffer(vector);
-	string_buffer.AddHeapReference(std::move(buffer));
+void StringVector::AddHandle(Vector &vector, BufferHandle handle) {
+	AddAuxiliaryData(vector, make_uniq<PinnedBufferHolder>(std::move(handle)));
 }
 
 void StringVector::AddHeapReference(Vector &vector, const Vector &other) {
@@ -85,13 +134,18 @@ void StringVector::AddHeapReference(Vector &vector, const Vector &other) {
 	D_ASSERT(other.GetType().InternalType() == PhysicalType::VARCHAR);
 
 	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		StringVector::AddHeapReference(vector, DictionaryVector::Child(other));
+		AddHeapReference(vector, DictionaryVector::Child(other));
 		return;
 	}
-	if (!other.auxiliary) {
+	if (!other.buffer) {
 		return;
 	}
-	StringVector::AddBuffer(vector, other.auxiliary);
+	auto data = other.buffer->GetAuxiliaryData();
+	if (!data) {
+		// no auxiliary data to reference
+		return;
+	}
+	AddAuxiliaryData(vector, make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
 }
 
 } // namespace duckdb

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -3,7 +3,7 @@
 
 namespace duckdb {
 
-VectorStringBuffer::VectorStringBuffer() : StandardVectorBuffer(idx_t(0)), heap(AllocateHeap()) {
+VectorStringBuffer::VectorStringBuffer() : StandardVectorBuffer(idx_t(0)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
@@ -13,15 +13,15 @@ VectorStringBuffer::VectorStringBuffer(Allocator &allocator)
 }
 
 VectorStringBuffer::VectorStringBuffer(Allocator &allocator, idx_t data_size)
-    : StandardVectorBuffer(allocator, data_size), heap(AllocateHeap(allocator)) {
+    : StandardVectorBuffer(allocator, data_size) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(idx_t data_size) : StandardVectorBuffer(data_size), heap(AllocateHeap()) {
+VectorStringBuffer::VectorStringBuffer(idx_t data_size) : StandardVectorBuffer(data_size) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p) : StandardVectorBuffer(data_ptr_p), heap(AllocateHeap()) {
+VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p) : StandardVectorBuffer(data_ptr_p) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
@@ -30,13 +30,14 @@ VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(VectorBufferType type) : StandardVectorBuffer(idx_t(0)), heap(AllocateHeap()) {
+VectorStringBuffer::VectorStringBuffer(VectorBufferType type) : StandardVectorBuffer(idx_t(0)) {
 	buffer_type = type;
 }
 
 VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other)
-    : StandardVectorBuffer(std::move(data_p)), heap(AllocateHeap()) {
+    : StandardVectorBuffer(std::move(data_p)) {
 	auxiliary_data = other.auxiliary_data;
+	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
 StringHeap &VectorStringBuffer::AllocateHeap(Allocator &allocator) {
@@ -72,20 +73,14 @@ VectorStringBuffer &StringVector::GetStringBuffer(Vector &vector) {
 		                        vector.GetType());
 	}
 	// check if the main buffer is a VectorStringBuffer
-	if (vector.buffer && vector.buffer->GetBufferType() == VectorBufferType::STRING_BUFFER) {
-		return vector.buffer->Cast<VectorStringBuffer>();
+	if (!vector.buffer) {
+		vector.buffer = make_buffer<VectorStringBuffer>(nullptr);
 	}
-	// fall back to auxiliary (e.g. for cached vectors or vectors with external data pointers)
-	if (!vector.auxiliary) {
-		auto stored_allocator = vector.buffer ? vector.buffer->GetAllocator() : nullptr;
-		if (stored_allocator) {
-			vector.auxiliary = make_buffer<VectorStringBuffer>(*stored_allocator);
-		} else {
-			vector.auxiliary = make_buffer<VectorStringBuffer>();
-		}
+	if (vector.buffer->GetBufferType() != VectorBufferType::STRING_BUFFER) {
+		throw InternalException(
+		    "StringVector::GetStringBuffer called on a vector - but that vector does NOT have a string buffer");
 	}
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
-	return vector.auxiliary.get()->Cast<VectorStringBuffer>();
+	return vector.buffer->Cast<VectorStringBuffer>();
 }
 
 ArenaAllocator &StringVector::GetStringAllocator(Vector &vector) {
@@ -136,6 +131,16 @@ void StringVector::AddHeapReference(Vector &vector, const Vector &other) {
 	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		AddHeapReference(vector, DictionaryVector::Child(other));
 		return;
+	}
+	if (other.auxiliary && other.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER) {
+		// FIXME: temp work-around
+		if (other.GetVectorType() != VectorType::FSST_VECTOR) {
+			throw InternalException("Auxiliary of non-FSST vector is a string!?");
+		}
+		auto data = other.auxiliary->GetAuxiliaryData();
+		if (data) {
+			AddAuxiliaryData(vector, make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
+		}
 	}
 	if (!other.buffer) {
 		return;

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -30,9 +30,12 @@ VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, buffer_ptr<VectorBuffer> other)
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, VectorStringBuffer &other)
     : StandardVectorBuffer(std::move(data_p)) {
-	AddAuxiliaryData(make_uniq<VectorBufferHolder>(std::move(other)));
+	auto auxiliary_data = other.GetAuxiliaryData();
+	if (auxiliary_data) {
+		AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(std::move(auxiliary_data)));
+	}
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -12,12 +12,12 @@ VectorStringBuffer::VectorStringBuffer(Allocator &allocator)
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(Allocator &allocator, idx_t data_size)
-    : StandardVectorBuffer(allocator, data_size) {
+VectorStringBuffer::VectorStringBuffer(Allocator &allocator, idx_t capacity)
+    : StandardVectorBuffer(allocator, capacity * sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(idx_t data_size) : StandardVectorBuffer(data_size) {
+VectorStringBuffer::VectorStringBuffer(idx_t capacity) : StandardVectorBuffer(capacity * sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
@@ -28,10 +28,6 @@ VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p) : StandardVectorBu
 VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p)
     : StandardVectorBuffer(std::move(data_p)), heap(AllocateHeap()) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
-}
-
-VectorStringBuffer::VectorStringBuffer(VectorBufferType type) : StandardVectorBuffer(idx_t(0)) {
-	buffer_type = type;
 }
 
 VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other)
@@ -131,16 +127,6 @@ void StringVector::AddHeapReference(Vector &vector, const Vector &other) {
 	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		AddHeapReference(vector, DictionaryVector::Child(other));
 		return;
-	}
-	if (other.auxiliary && other.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER) {
-		// FIXME: temp work-around
-		if (other.GetVectorType() != VectorType::FSST_VECTOR) {
-			throw InternalException("Auxiliary of non-FSST vector is a string!?");
-		}
-		auto data = other.auxiliary->GetAuxiliaryData();
-		if (data) {
-			AddAuxiliaryData(vector, make_uniq<AuxiliaryDataSetHolder>(std::move(data)));
-		}
 	}
 	if (!other.buffer) {
 		return;

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -14,9 +14,9 @@ vector<Vector> &StructVector::GetEntries(Vector &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.auxiliary);
-	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRUCT_BUFFER);
-	return vector.auxiliary->Cast<VectorStructBuffer>().GetChildren();
+	D_ASSERT(vector.buffer);
+	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::STRUCT_BUFFER);
+	return vector.buffer->Cast<VectorStructBuffer>().GetChildren();
 }
 
 const vector<Vector> &StructVector::GetEntries(const Vector &vector) {

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -176,11 +176,12 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 	case PhysicalType::VARCHAR: {
 		auto ldata = FlatVector::GetData<string_t>(*source);
 		auto tdata = FlatVector::GetData<string_t>(target);
+		auto &buffer = StringVector::GetStringBuffer(target);
 		for (idx_t i = 0; i < copy_count; i++) {
 			auto source_idx = sel->get_index(source_offset + i);
 			auto target_idx = target_offset + i;
 			if (tmask.RowIsValid(target_idx)) {
-				tdata[target_idx] = StringVector::AddStringOrBlob(target, ldata[source_idx]);
+				tdata[target_idx] = buffer.AddBlob(ldata[source_idx]);
 			}
 		}
 		break;

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -181,7 +181,11 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 			auto source_idx = sel->get_index(source_offset + i);
 			auto target_idx = target_offset + i;
 			if (tmask.RowIsValid(target_idx)) {
-				tdata[target_idx] = buffer.AddBlob(ldata[source_idx]);
+				if (ldata[source_idx].IsInlined()) {
+					tdata[target_idx] = ldata[source_idx];
+				} else {
+					tdata[target_idx] = buffer.AddBlob(ldata[source_idx]);
+				}
 			}
 		}
 		break;

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -61,9 +61,13 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 			auto &child = DictionaryVector::Child(*source);
 			auto &dict_sel = DictionaryVector::SelVector(*source);
 			// merge the selection vectors and verify the child
-			auto new_buffer = dict_sel.Slice(*sel, source_count);
-			owned_sel.Initialize(new_buffer);
-			sel = &owned_sel;
+			if (sel->IsSet()) {
+				auto new_buffer = dict_sel.Slice(*sel, source_count);
+				owned_sel.Initialize(new_buffer);
+				sel = &owned_sel;
+			} else {
+				sel = &dict_sel;
+			}
 			source = &child;
 			break;
 		}

--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -239,7 +239,7 @@ static bool CastToVARIANT(Vector &source, Vector &result, idx_t count, CastParam
 	auto &keys_entry = ListVector::GetEntry(keys);
 
 	//! Initialize the dictionary
-	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringBuffer(keys_entry).GetStringAllocator());
+	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringAllocator(keys_entry));
 	SelectionVector keys_selvec;
 	ToVariantSourceData source_data(source, count);
 

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -11,11 +11,17 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &input_keys = MapVector::GetKeys(input);
 	auto &input_values = MapVector::GetValues(input);
 
-	// Copy the list validity
-	FlatVector::SetValidity(result, FlatVector::Validity(input));
-
-	// Reference the list data
-	ListVector::ReferenceListOffsets(result, input);
+	// Copy the list offsets and top-level validity
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	for (auto entry : input.Values<list_entry_t>(count)) {
+		if (!entry.IsValid()) {
+			result_validity.SetInvalid(entry.index);
+			continue;
+		}
+		result_data[entry.index] = entry.value;
+	}
+	ListVector::SetListSize(result, ListVector::GetListSize(input));
 
 	// Copy the struct validity
 	auto &result_struct = ListVector::GetEntry(result);

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -11,16 +11,11 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &input_keys = MapVector::GetKeys(input);
 	auto &input_values = MapVector::GetValues(input);
 
-	// Copy the list size
-	const auto list_size = ListVector::GetListSize(input);
-	ListVector::SetListSize(result, list_size);
-
 	// Copy the list validity
 	FlatVector::SetValidity(result, FlatVector::Validity(input));
 
 	// Reference the list data
-	FlatVector::SetData(result, FlatVector::GetData(input));
-	result.AddHeapReference(input);
+	ListVector::ReferenceListOffsets(result, input);
 
 	// Copy the struct validity
 	auto &result_struct = ListVector::GetEntry(result);

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -8,6 +8,9 @@ namespace duckdb {
 void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	input.Flatten(count);
 
+	auto &input_keys = MapVector::GetKeys(input);
+	auto &input_values = MapVector::GetValues(input);
+
 	// Copy the list size
 	const auto list_size = ListVector::GetListSize(input);
 	ListVector::SetListSize(result, list_size);
@@ -15,25 +18,20 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	// Copy the list validity
 	FlatVector::SetValidity(result, FlatVector::Validity(input));
 
+	// Reference the list data
+	FlatVector::SetData(result, FlatVector::GetData(input));
+	result.AddHeapReference(input);
+
 	// Copy the struct validity
-	UnifiedVectorFormat input_struct_data;
-	ListVector::GetEntry(input).ToUnifiedFormat(list_size, input_struct_data);
 	auto &result_struct = ListVector::GetEntry(result);
-	FlatVector::SetValidity(result_struct, input_struct_data.validity);
+	FlatVector::SetValidity(result_struct, FlatVector::Validity(ListVector::GetEntry(input)));
 
-	// Copy the list buffer (the list_entry_t data)
-	result.CopyBuffer(input);
-
-	auto &input_keys = MapVector::GetKeys(input);
+	// reference the keys / values
 	auto &result_keys = MapVector::GetKeys(result);
 	result_keys.Reference(input_keys);
 
-	auto &input_values = MapVector::GetValues(input);
 	auto &result_values = MapVector::GetValues(result);
 	result_values.Reference(input_values);
-
-	// Set the right vector type
-	result.SetVectorType(input.GetVectorType());
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -265,7 +265,7 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 	// Reference the 'input' StringBuffer, because we won't need to allocate new data
 	// for the result, all returned strings are substrings of the originals
 	for (auto &child_entry : child_entries) {
-		child_entry.SetAuxiliary(input.GetAuxiliary());
+		StringVector::AddHeapReference(child_entry, input);
 	}
 
 	vector<RE2::Arg> argv(groupSize);

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -169,7 +169,7 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 	ListVector::Reserve(result, STANDARD_VECTOR_SIZE);
 	// Reference the 'strings' StringBuffer, because we won't need to allocate new data
 	// for the result, all returned strings are substrings of the originals
-	output_child.SetAuxiliary(strings.GetAuxiliary());
+	StringVector::AddHeapReference(output_child, strings);
 
 	unique_ptr<RegexStringPieceArgs> non_const_args;
 	unique_ptr<duckdb_re2::RE2> stored_re;
@@ -301,7 +301,7 @@ void RegexpExtractAllStruct::Execute(DataChunk &args, ExpressionState &state, Ve
 
 	// Reference original string buffer for zero-copy substring assignment
 	for (auto &child : child_entries) {
-		child.SetAuxiliary(strings.GetAuxiliary());
+		StringVector::AddHeapReference(child, strings);
 		child.SetVectorType(VectorType::FLAT_VECTOR);
 	}
 

--- a/src/function/scalar/variant/variant_normalize.cpp
+++ b/src/function/scalar/variant/variant_normalize.cpp
@@ -208,7 +208,7 @@ void VariantNormalizer::Normalize(Vector &variant_vec, Vector &result, idx_t cou
 
 	//! Initialize the dictionary
 	auto &keys_entry = ListVector::GetEntry(keys);
-	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringBuffer(keys_entry).GetStringAllocator());
+	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringAllocator(keys_entry));
 
 	VariantVectorData variant_data(result);
 	SelectionVector keys_selvec;

--- a/src/function/table/arrow/arrow_array_scan_state.cpp
+++ b/src/function/table/arrow/arrow_array_scan_state.cpp
@@ -31,7 +31,7 @@ void ArrowArrayScanState::AddDictionary(unique_ptr<Vector> dictionary_p, ArrowAr
 	D_ASSERT(arrow_dict);
 	arrow_dictionary = arrow_dict;
 	// Make sure the data referenced by the dictionary stays alive
-	dictionary->GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
+	dictionary->GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
 }
 
 bool ArrowArrayScanState::HasDictionary() const {

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -681,7 +681,7 @@ static void FlattenRunEndsSwitch(Vector &result, ArrowRunEndEncodingState &run_e
 		break;
 	case PhysicalType::VARCHAR: {
 		// Share the string heap, we don't need to allocate new strings, we just reference the existing ones
-		result.SetAuxiliary(values.GetAuxiliary());
+		StringVector::AddHeapReference(result, values);
 		FlattenRunEnds<RUN_END_TYPE, string_t>(result, run_end_encoding, compressed_size, scan_offset, size);
 		break;
 	}

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -706,7 +706,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(Vector &vector, c
 	D_ASSERT(vector.GetType() == values_type.GetDuckType());
 
 	if (vector.GetBuffer()) {
-		vector.GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 
 	D_ASSERT(run_ends_array.length == values_array.length);
@@ -839,7 +839,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 	}
 
 	if (vector.GetBuffer()) {
-		vector.GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 	switch (vector.GetType().id()) {
 	case LogicalTypeId::SQLNULL:
@@ -1392,7 +1392,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
                                                             const ArrowType &arrow_type, int64_t nested_offset,
                                                             const ValidityMask *parent_mask, uint64_t parent_offset) {
 	if (vector.GetBuffer()) {
-		vector.GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 	D_ASSERT(arrow_type.HasDictionary());
 	const bool has_nulls = CanContainNull(array, parent_mask);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -498,8 +498,6 @@ enum class VariantStatsShreddingState : uint8_t;
 
 enum class VariantValueType : uint8_t;
 
-enum class VectorAuxiliaryDataType : uint8_t;
-
 enum class VectorBufferType : uint8_t;
 
 enum class VectorType : uint8_t;
@@ -1219,9 +1217,6 @@ const char* EnumUtil::ToChars<VariantStatsShreddingState>(VariantStatsShreddingS
 
 template<>
 const char* EnumUtil::ToChars<VariantValueType>(VariantValueType value);
-
-template<>
-const char* EnumUtil::ToChars<VectorAuxiliaryDataType>(VectorAuxiliaryDataType value);
 
 template<>
 const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value);
@@ -1952,9 +1947,6 @@ VariantStatsShreddingState EnumUtil::FromString<VariantStatsShreddingState>(cons
 
 template<>
 VariantValueType EnumUtil::FromString<VariantValueType>(const char *value);
-
-template<>
-VectorAuxiliaryDataType EnumUtil::FromString<VectorAuxiliaryDataType>(const char *value);
 
 template<>
 VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value);

--- a/src/include/duckdb/common/fsst.hpp
+++ b/src/include/duckdb/common/fsst.hpp
@@ -14,7 +14,6 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/fsst.hpp"
 #include "fsst.h"
-#include "duckdb/common/types/vector_buffer.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
 
 namespace duckdb {
@@ -34,15 +33,16 @@ private:
 	};
 
 public:
-	static string_t DecompressValue(void *duckdb_fsst_decoder, VectorStringBuffer &str_buffer,
+	static string_t DecompressValue(void *duckdb_fsst_decoder, ArenaAllocator &str_allocator,
 	                                const char *compressed_string, const idx_t compressed_string_len) {
 		const auto max_uncompressed_length = compressed_string_len * 8;
 		const auto fsst_decoder = static_cast<duckdb_fsst_decoder_t *>(duckdb_fsst_decoder);
 		const auto compressed_string_ptr = (const unsigned char *)compressed_string; // NOLINT
-		const auto target_ptr = str_buffer.AllocateShrinkableBuffer(max_uncompressed_length);
+		const auto target_ptr = StringVector::AllocateShrinkableBuffer(str_allocator, max_uncompressed_length);
 		const auto decompressed_string_size = duckdb_fsst_decompress(
 		    fsst_decoder, compressed_string_len, compressed_string_ptr, max_uncompressed_length, target_ptr);
-		return str_buffer.FinalizeShrinkableBuffer(target_ptr, max_uncompressed_length, decompressed_string_size);
+		return StringVector::FinalizeShrinkableBuffer(str_allocator, target_ptr, max_uncompressed_length,
+		                                              decompressed_string_size);
 	}
 	static string_t DecompressInlinedValue(void *duckdb_fsst_decoder, const char *compressed_string,
 	                                       const idx_t compressed_string_len) {

--- a/src/include/duckdb/common/types/arrow_aux_data.hpp
+++ b/src/include/duckdb/common/types/arrow_aux_data.hpp
@@ -13,10 +13,8 @@
 
 namespace duckdb {
 
-struct ArrowAuxiliaryData : public VectorAuxiliaryData {
-	static constexpr const VectorAuxiliaryDataType TYPE = VectorAuxiliaryDataType::ARROW_AUXILIARY;
-	explicit ArrowAuxiliaryData(shared_ptr<ArrowArrayWrapper> arrow_array_p)
-	    : VectorAuxiliaryData(VectorAuxiliaryDataType::ARROW_AUXILIARY), arrow_array(std::move(arrow_array_p)) {
+struct ArrowAuxiliaryData : public AuxiliaryDataHolder {
+	explicit ArrowAuxiliaryData(shared_ptr<ArrowArrayWrapper> arrow_array_p) : arrow_array(std::move(arrow_array_p)) {
 	}
 	~ArrowAuxiliaryData() override {
 	}

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -221,9 +221,6 @@ protected:
 	mutable ValidityMask validity;
 	//! The main buffer holding the data of the vector
 	mutable buffer_ptr<VectorBuffer> buffer;
-	//! The buffer holding auxiliary data of the vector
-	//! e.g. a string vector uses this to store strings
-	mutable buffer_ptr<VectorBuffer> auxiliary;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -43,7 +43,7 @@ class Vector {
 	friend struct ShreddedVector;
 
 	friend class DataChunk;
-	friend class VectorCacheBuffer;
+	friend class VectorCacheEntry;
 
 public:
 	//! Create a vector that slices another vector

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -15,7 +15,8 @@
 namespace duckdb {
 
 class VectorCache;
-class VectorChildBuffer;
+class DictionaryBuffer;
+class DictionaryEntry;
 class VectorStringBuffer;
 class VectorStructBuffer;
 class VectorListBuffer;
@@ -104,7 +105,7 @@ public:
 	//! Creates a reference to a dictionary of the other vector
 	DUCKDB_API void Dictionary(Vector &dict, idx_t dictionary_size, const SelectionVector &sel, idx_t count);
 	//! Creates a dictionary on the reusable dict
-	DUCKDB_API void Dictionary(buffer_ptr<VectorChildBuffer> reusable_dict, const SelectionVector &sel);
+	DUCKDB_API void Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel);
 
 	//! Creates the data of this vector with the specified type. Any data that
 	//! is currently in the vector is destroyed.

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -159,6 +159,9 @@ public:
 		buffer = other.buffer;
 	}
 
+	void AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> data);
+	void AddHeapReference(const Vector &other);
+
 	//! Resizes the vector.
 	DUCKDB_API void Resize(idx_t cur_size, idx_t new_size);
 	//! Returns a vector of ResizeInfo containing each (nested) vector to resize.

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -154,10 +154,6 @@ public:
 	//! Sets the [index] element of the Vector to the specified Value.
 	DUCKDB_API void SetValue(idx_t index, const Value &val);
 
-	inline void SetAuxiliary(buffer_ptr<VectorBuffer> new_buffer) {
-		auxiliary = std::move(new_buffer);
-	};
-
 	inline void CopyBuffer(Vector &other) {
 		buffer = other.buffer;
 	}
@@ -178,10 +174,6 @@ public:
 	}
 	inline const LogicalType &GetType() const {
 		return type;
-	}
-
-	inline buffer_ptr<VectorBuffer> GetAuxiliary() {
-		return auxiliary;
 	}
 
 	inline buffer_ptr<VectorBuffer> GetBuffer() {

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -233,23 +233,6 @@ protected:
 	mutable buffer_ptr<VectorBuffer> auxiliary;
 };
 
-//! The VectorChildBuffer holds a child Vector
-class VectorChildBuffer : public VectorBuffer {
-public:
-	explicit VectorChildBuffer(Vector vector)
-	    : VectorBuffer(VectorBufferType::VECTOR_CHILD_BUFFER), data(std::move(vector)) {
-	}
-
-public:
-	Vector data;
-	//! Optional size/id to uniquely identify re-occurring dictionaries
-	optional_idx size;
-	string id;
-	//! For caching the hashes of a child buffer
-	mutex cached_hashes_lock;
-	unique_ptr<Vector> cached_hashes;
-};
-
 } // namespace duckdb
 
 #include "duckdb/common/vector/vector_iterator.hpp"

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -35,36 +35,30 @@ enum class VectorBufferType : uint8_t {
 	SEQUENCE_BUFFER      // holds a linear numeric sequence (start, increment)
 };
 
-enum class VectorAuxiliaryDataType : uint8_t {
-	ARROW_AUXILIARY // Holds Arrow Chunks that this vector depends on
+struct AuxiliaryDataHolder {
+	virtual ~AuxiliaryDataHolder() = default;
 };
 
-struct VectorAuxiliaryData {
-	explicit VectorAuxiliaryData(VectorAuxiliaryDataType type_p)
-	    : type(type_p) {
-
-	      };
-	VectorAuxiliaryDataType type;
-
-	virtual ~VectorAuxiliaryData() {
-	}
-
+class PinnedBufferHolder : public AuxiliaryDataHolder {
 public:
-	template <class TARGET>
-	TARGET &Cast() {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast vector auxiliary data to type - type mismatch");
-		}
-		return reinterpret_cast<TARGET &>(*this);
+	explicit PinnedBufferHolder(BufferHandle handle);
+	~PinnedBufferHolder() override;
+
+private:
+	BufferHandle handle;
+};
+
+struct AuxiliaryData {
+	vector<unique_ptr<AuxiliaryDataHolder>> data;
+};
+
+class AuxiliaryDataSetHolder : public AuxiliaryDataHolder {
+public:
+	explicit AuxiliaryDataSetHolder(buffer_ptr<AuxiliaryData> data) : auxiliary_data(std::move(data)) {
 	}
 
-	template <class TARGET>
-	const TARGET &Cast() const {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast vector auxiliary data to type - type mismatch");
-		}
-		return reinterpret_cast<const TARGET &>(*this);
-	}
+private:
+	buffer_ptr<AuxiliaryData> auxiliary_data;
 };
 
 //! The VectorBuffer is a class used by the vector to hold its data
@@ -79,16 +73,18 @@ public:
 	virtual data_ptr_t GetData() {
 		return nullptr;
 	}
-	VectorAuxiliaryData *GetAuxiliaryData() {
-		return aux_data.get();
-	}
 
-	void SetAuxiliaryData(unique_ptr<VectorAuxiliaryData> aux_data_p) {
-		aux_data = std::move(aux_data_p);
+	void AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> aux_data_p) {
+		if (!auxiliary_data) {
+			auxiliary_data = make_buffer<AuxiliaryData>();
+		}
+		auxiliary_data->data.push_back(std::move(aux_data_p));
 	}
-
-	void MoveAuxiliaryData(VectorBuffer &source_buffer) {
-		SetAuxiliaryData(std::move(source_buffer.aux_data));
+	buffer_ptr<AuxiliaryData> GetAuxiliaryData() {
+		return auxiliary_data;
+	}
+	void ClearAuxiliaryData() {
+		auxiliary_data.reset();
 	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
@@ -105,13 +101,9 @@ public:
 		return buffer_type;
 	}
 
-	inline VectorAuxiliaryDataType GetAuxiliaryDataType() const {
-		return aux_data->type;
-	}
-
 protected:
 	VectorBufferType buffer_type;
-	unique_ptr<VectorAuxiliaryData> aux_data;
+	buffer_ptr<AuxiliaryData> auxiliary_data;
 
 public:
 	template <class TARGET>
@@ -157,16 +149,6 @@ public:
 protected:
 	data_ptr_t data_ptr;
 	AllocatedData allocated_data;
-};
-
-//! The ManagedVectorBuffer holds a buffer handle
-class ManagedVectorBuffer : public VectorBuffer {
-public:
-	explicit ManagedVectorBuffer(BufferHandle handle);
-	~ManagedVectorBuffer() override;
-
-private:
-	BufferHandle handle;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -31,7 +31,8 @@ enum class VectorBufferType : uint8_t {
 	MANAGED_BUFFER,      // managed buffer, holds a buffer managed by the buffermanager
 	OPAQUE_BUFFER,       // opaque buffer, can be created for example by the parquet reader
 	ARRAY_BUFFER,        // array buffer, holds a single flatvector child
-	SHREDDED_BUFFER      // holds data for a shredded variant vector
+	SHREDDED_BUFFER,     // holds data for a shredded variant vector
+	SEQUENCE_BUFFER      // holds a linear numeric sequence (start, increment)
 };
 
 enum class VectorAuxiliaryDataType : uint8_t {

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -98,18 +98,6 @@ public:
 		return data_ptr;
 	}
 
-	void SetData(data_ptr_t data) {
-		data_ptr = data;
-	}
-	void SetData(AllocatedData &&new_data) {
-		allocated_data = std::move(new_data);
-		data_ptr = allocated_data.get();
-	}
-
-	void ResetData() {
-		data_ptr = allocated_data.get();
-	}
-
 	VectorAuxiliaryData *GetAuxiliaryData() {
 		return aux_data.get();
 	}

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -60,6 +60,15 @@ private:
 	buffer_ptr<AuxiliaryData> auxiliary_data;
 };
 
+class AuxiliaryAllocatedDataHolder : public AuxiliaryDataHolder {
+public:
+	explicit AuxiliaryAllocatedDataHolder(AllocatedData &&data_p) : allocated_data(std::move(data_p)) {
+	}
+
+private:
+	AllocatedData allocated_data;
+};
+
 //! The VectorBuffer is a class used by the vector to hold its data
 class VectorBuffer {
 public:
@@ -81,9 +90,6 @@ public:
 	}
 	buffer_ptr<AuxiliaryData> GetAuxiliaryData() {
 		return auxiliary_data;
-	}
-	virtual void ClearAuxiliaryData() {
-		auxiliary_data.reset();
 	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
@@ -120,10 +126,11 @@ public:
 class StandardVectorBuffer : public VectorBuffer {
 public:
 	StandardVectorBuffer(Allocator &allocator, idx_t data_size)
-	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
+	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr), allocator(allocator) {
 		if (data_size > 0) {
-			allocated_data = allocator.Allocate(data_size);
+			auto allocated_data = allocator.Allocate(data_size);
 			data_ptr = allocated_data.get();
+			AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
 		}
 	}
 	explicit StandardVectorBuffer(idx_t data_size) : StandardVectorBuffer(Allocator::DefaultAllocator(), data_size) {
@@ -132,8 +139,8 @@ public:
 	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
 	}
 	explicit StandardVectorBuffer(AllocatedData &&data_p)
-	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), allocated_data(std::move(data_p)) {
-		data_ptr = allocated_data.get();
+	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()), allocator(data_p.GetAllocator()) {
+		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(data_p)));
 	}
 
 public:
@@ -142,12 +149,12 @@ public:
 	}
 
 	optional_ptr<Allocator> GetAllocator() const override {
-		return allocated_data.GetAllocator();
+		return allocator;
 	}
 
 protected:
 	data_ptr_t data_ptr;
-	AllocatedData allocated_data;
+	optional_ptr<Allocator> allocator;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -38,6 +38,10 @@ struct AuxiliaryDataHolder {
 	virtual ~AuxiliaryDataHolder() = default;
 };
 
+struct AuxiliaryDataSet {
+	vector<unique_ptr<AuxiliaryDataHolder>> data;
+};
+
 class PinnedBufferHolder : public AuxiliaryDataHolder {
 public:
 	explicit PinnedBufferHolder(BufferHandle handle);
@@ -47,13 +51,13 @@ private:
 	BufferHandle handle;
 };
 
-class VectorBufferHolder : public AuxiliaryDataHolder {
+class AuxiliaryDataSetHolder : public AuxiliaryDataHolder {
 public:
-	explicit VectorBufferHolder(buffer_ptr<VectorBuffer> buffer) : vector_buffer(std::move(buffer)) {
+	explicit AuxiliaryDataSetHolder(buffer_ptr<AuxiliaryDataSet> buffer) : auxiliary_data(std::move(buffer)) {
 	}
 
 private:
-	buffer_ptr<VectorBuffer> vector_buffer;
+	buffer_ptr<AuxiliaryDataSet> auxiliary_data;
 };
 
 //! The VectorBuffer is a class used by the vector to hold its data
@@ -70,13 +74,16 @@ public:
 	}
 
 	void AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> aux_data_p) {
-		auxiliary_data.push_back(std::move(aux_data_p));
+		if (!auxiliary_data) {
+			auxiliary_data = make_buffer<AuxiliaryDataSet>();
+		}
+		auxiliary_data->data.push_back(std::move(aux_data_p));
 	}
-	vector<unique_ptr<AuxiliaryDataHolder>> &GetAuxiliaryDataMutable() {
+	buffer_ptr<AuxiliaryDataSet> &GetAuxiliaryData() {
 		return auxiliary_data;
 	}
 	virtual void ClearAuxiliaryData() {
-		auxiliary_data.clear();
+		auxiliary_data.reset();
 	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
@@ -95,7 +102,7 @@ public:
 
 protected:
 	VectorBufferType buffer_type;
-	vector<unique_ptr<AuxiliaryDataHolder>> auxiliary_data;
+	buffer_ptr<AuxiliaryDataSet> auxiliary_data;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -75,6 +75,9 @@ public:
 	vector<unique_ptr<AuxiliaryDataHolder>> &GetAuxiliaryDataMutable() {
 		return auxiliary_data;
 	}
+	virtual void ClearAuxiliaryData() {
+		auxiliary_data.clear();
+	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
 		return nullptr;

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -47,26 +47,13 @@ private:
 	BufferHandle handle;
 };
 
-struct AuxiliaryData {
-	vector<unique_ptr<AuxiliaryDataHolder>> data;
-};
-
-class AuxiliaryDataSetHolder : public AuxiliaryDataHolder {
+class VectorBufferHolder : public AuxiliaryDataHolder {
 public:
-	explicit AuxiliaryDataSetHolder(buffer_ptr<AuxiliaryData> data) : auxiliary_data(std::move(data)) {
+	explicit VectorBufferHolder(buffer_ptr<VectorBuffer> buffer) : vector_buffer(std::move(buffer)) {
 	}
 
 private:
-	buffer_ptr<AuxiliaryData> auxiliary_data;
-};
-
-class AuxiliaryAllocatedDataHolder : public AuxiliaryDataHolder {
-public:
-	explicit AuxiliaryAllocatedDataHolder(AllocatedData &&data_p) : allocated_data(std::move(data_p)) {
-	}
-
-private:
-	AllocatedData allocated_data;
+	buffer_ptr<VectorBuffer> vector_buffer;
 };
 
 //! The VectorBuffer is a class used by the vector to hold its data
@@ -83,12 +70,9 @@ public:
 	}
 
 	void AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> aux_data_p) {
-		if (!auxiliary_data) {
-			auxiliary_data = make_buffer<AuxiliaryData>();
-		}
-		auxiliary_data->data.push_back(std::move(aux_data_p));
+		auxiliary_data.push_back(std::move(aux_data_p));
 	}
-	buffer_ptr<AuxiliaryData> GetAuxiliaryData() const {
+	vector<unique_ptr<AuxiliaryDataHolder>> &GetAuxiliaryDataMutable() {
 		return auxiliary_data;
 	}
 
@@ -108,7 +92,7 @@ public:
 
 protected:
 	VectorBufferType buffer_type;
-	buffer_ptr<AuxiliaryData> auxiliary_data;
+	vector<unique_ptr<AuxiliaryDataHolder>> auxiliary_data;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -72,11 +72,14 @@ class VectorBuffer {
 public:
 	explicit VectorBuffer(VectorBufferType type) : buffer_type(type), data_ptr(nullptr) {
 	}
-	explicit VectorBuffer(idx_t data_size) : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
+	VectorBuffer(Allocator &allocator, idx_t data_size)
+	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
 		if (data_size > 0) {
-			allocated_data = Allocator::DefaultAllocator().Allocate(data_size);
+			allocated_data = allocator.Allocate(data_size);
 			data_ptr = allocated_data.get();
 		}
+	}
+	explicit VectorBuffer(idx_t data_size) : VectorBuffer(Allocator::DefaultAllocator(), data_size) {
 	}
 	explicit VectorBuffer(data_ptr_t data_ptr_p)
 	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
@@ -95,14 +98,16 @@ public:
 		return data_ptr;
 	}
 
+	void SetData(data_ptr_t data) {
+		data_ptr = data;
+	}
 	void SetData(AllocatedData &&new_data) {
 		allocated_data = std::move(new_data);
 		data_ptr = allocated_data.get();
 	}
 
-	void SetData(data_ptr_t data) {
-		data_ptr = data;
-		allocated_data.Reset();
+	void ResetData() {
+		data_ptr = allocated_data.get();
 	}
 
 	VectorAuxiliaryData *GetAuxiliaryData() {

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -70,34 +70,15 @@ public:
 //! The VectorBuffer is a class used by the vector to hold its data
 class VectorBuffer {
 public:
-	explicit VectorBuffer(VectorBufferType type) : buffer_type(type), data_ptr(nullptr) {
-	}
-	VectorBuffer(Allocator &allocator, idx_t data_size)
-	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
-		if (data_size > 0) {
-			allocated_data = allocator.Allocate(data_size);
-			data_ptr = allocated_data.get();
-		}
-	}
-	explicit VectorBuffer(idx_t data_size) : VectorBuffer(Allocator::DefaultAllocator(), data_size) {
-	}
-	explicit VectorBuffer(data_ptr_t data_ptr_p)
-	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
-	}
-	explicit VectorBuffer(AllocatedData &&data_p)
-	    : buffer_type(VectorBufferType::STANDARD_BUFFER), allocated_data(std::move(data_p)) {
-		data_ptr = allocated_data.get();
+	explicit VectorBuffer(VectorBufferType type) : buffer_type(type) {
 	}
 	virtual ~VectorBuffer() {
 	}
-	VectorBuffer() : data_ptr(nullptr) {
-	}
 
 public:
-	data_ptr_t GetData() {
-		return data_ptr;
+	virtual data_ptr_t GetData() {
+		throw InternalException("VectorBuffer does not have data!");
 	}
-
 	VectorAuxiliaryData *GetAuxiliaryData() {
 		return aux_data.get();
 	}
@@ -111,7 +92,7 @@ public:
 	}
 
 	virtual optional_ptr<Allocator> GetAllocator() const {
-		return allocated_data.GetAllocator();
+		return nullptr;
 	}
 
 	static buffer_ptr<VectorBuffer> CreateStandardVector(PhysicalType type, idx_t capacity = STANDARD_VECTOR_SIZE);
@@ -131,8 +112,6 @@ public:
 protected:
 	VectorBufferType buffer_type;
 	unique_ptr<VectorAuxiliaryData> aux_data;
-	data_ptr_t data_ptr;
-	AllocatedData allocated_data;
 
 public:
 	template <class TARGET>
@@ -147,6 +126,39 @@ public:
 	}
 };
 
+class StandardVectorBuffer : public VectorBuffer {
+public:
+	StandardVectorBuffer(Allocator &allocator, idx_t data_size)
+	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr) {
+		if (data_size > 0) {
+			allocated_data = allocator.Allocate(data_size);
+			data_ptr = allocated_data.get();
+		}
+	}
+	explicit StandardVectorBuffer(idx_t data_size) : StandardVectorBuffer(Allocator::DefaultAllocator(), data_size) {
+	}
+	explicit StandardVectorBuffer(data_ptr_t data_ptr_p)
+	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
+	}
+	explicit StandardVectorBuffer(AllocatedData &&data_p)
+	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), allocated_data(std::move(data_p)) {
+		data_ptr = allocated_data.get();
+	}
+
+public:
+	data_ptr_t GetData() override {
+		return data_ptr;
+	}
+
+	optional_ptr<Allocator> GetAllocator() const override {
+		return allocated_data.GetAllocator();
+	}
+
+protected:
+	data_ptr_t data_ptr;
+	AllocatedData allocated_data;
+};
+
 //! The ManagedVectorBuffer holds a buffer handle
 class ManagedVectorBuffer : public VectorBuffer {
 public:
@@ -157,18 +169,4 @@ private:
 	BufferHandle handle;
 };
 
-//! The DictionaryBuffer holds a selection vector
-class ShreddedVectorBuffer : public VectorBuffer {
-public:
-	explicit ShreddedVectorBuffer(Vector &shredded_data);
-	~ShreddedVectorBuffer() override;
-
-public:
-	Vector &GetChild() {
-		return *shredded_data;
-	}
-
-private:
-	unique_ptr<Vector> shredded_data;
-};
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -83,7 +83,7 @@ public:
 	buffer_ptr<AuxiliaryData> GetAuxiliaryData() {
 		return auxiliary_data;
 	}
-	void ClearAuxiliaryData() {
+	virtual void ClearAuxiliaryData() {
 		auxiliary_data.reset();
 	}
 

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -87,7 +87,7 @@ public:
 	}
 	virtual ~VectorBuffer() {
 	}
-	VectorBuffer() {
+	VectorBuffer() : data_ptr(nullptr) {
 	}
 
 public:

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -88,7 +88,7 @@ public:
 		}
 		auxiliary_data->data.push_back(std::move(aux_data_p));
 	}
-	buffer_ptr<AuxiliaryData> GetAuxiliaryData() {
+	buffer_ptr<AuxiliaryData> GetAuxiliaryData() const {
 		return auxiliary_data;
 	}
 

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -77,7 +77,7 @@ public:
 
 public:
 	virtual data_ptr_t GetData() {
-		throw InternalException("VectorBuffer does not have data!");
+		return nullptr;
 	}
 	VectorAuxiliaryData *GetAuxiliaryData() {
 		return aux_data.get();

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -21,18 +21,17 @@ class VectorBuffer;
 class Vector;
 
 enum class VectorBufferType : uint8_t {
-	STANDARD_BUFFER,     // standard buffer, holds a single array of data
-	DICTIONARY_BUFFER,   // dictionary buffer, holds a selection vector
-	VECTOR_CHILD_BUFFER, // vector child buffer: holds another vector
-	STRING_BUFFER,       // string buffer, holds a string heap
-	FSST_BUFFER,         // fsst compressed string buffer, holds a string heap, fsst symbol table and a string count
-	STRUCT_BUFFER,       // struct buffer, holds a ordered mapping from name to child vector
-	LIST_BUFFER,         // list buffer, holds a single flatvector child
-	MANAGED_BUFFER,      // managed buffer, holds a buffer managed by the buffermanager
-	OPAQUE_BUFFER,       // opaque buffer, can be created for example by the parquet reader
-	ARRAY_BUFFER,        // array buffer, holds a single flatvector child
-	SHREDDED_BUFFER,     // holds data for a shredded variant vector
-	SEQUENCE_BUFFER      // holds a linear numeric sequence (start, increment)
+	STANDARD_BUFFER,   // standard buffer, holds a single array of data
+	DICTIONARY_BUFFER, // dictionary buffer, holds a selection vector and child vector
+	STRING_BUFFER,     // string buffer, holds a string heap
+	FSST_BUFFER,       // fsst compressed string buffer, holds a string heap, fsst symbol table and a string count
+	STRUCT_BUFFER,     // struct buffer, holds a ordered mapping from name to child vector
+	LIST_BUFFER,       // list buffer, holds a single flatvector child
+	MANAGED_BUFFER,    // managed buffer, holds a buffer managed by the buffermanager
+	OPAQUE_BUFFER,     // opaque buffer, can be created for example by the parquet reader
+	ARRAY_BUFFER,      // array buffer, holds a single flatvector child
+	SHREDDED_BUFFER,   // holds data for a shredded variant vector
+	SEQUENCE_BUFFER    // holds a linear numeric sequence (start, increment)
 };
 
 struct AuxiliaryDataHolder {

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -123,38 +123,4 @@ public:
 	}
 };
 
-class StandardVectorBuffer : public VectorBuffer {
-public:
-	StandardVectorBuffer(Allocator &allocator, idx_t data_size)
-	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr), allocator(allocator) {
-		if (data_size > 0) {
-			auto allocated_data = allocator.Allocate(data_size);
-			data_ptr = allocated_data.get();
-			AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(allocated_data)));
-		}
-	}
-	explicit StandardVectorBuffer(idx_t data_size) : StandardVectorBuffer(Allocator::DefaultAllocator(), data_size) {
-	}
-	explicit StandardVectorBuffer(data_ptr_t data_ptr_p)
-	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p) {
-	}
-	explicit StandardVectorBuffer(AllocatedData &&data_p)
-	    : VectorBuffer(VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()), allocator(data_p.GetAllocator()) {
-		AddAuxiliaryData(make_uniq<AuxiliaryAllocatedDataHolder>(std::move(data_p)));
-	}
-
-public:
-	data_ptr_t GetData() override {
-		return data_ptr;
-	}
-
-	optional_ptr<Allocator> GetAllocator() const override {
-		return allocator;
-	}
-
-protected:
-	data_ptr_t data_ptr;
-	optional_ptr<Allocator> allocator;
-};
-
 } // namespace duckdb

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -21,17 +21,15 @@ class VectorBuffer;
 class Vector;
 
 enum class VectorBufferType : uint8_t {
-	STANDARD_BUFFER,   // standard buffer, holds a single array of data
-	DICTIONARY_BUFFER, // dictionary buffer, holds a selection vector and child vector
-	STRING_BUFFER,     // string buffer, holds a string heap
-	FSST_BUFFER,       // fsst compressed string buffer, holds a string heap, fsst symbol table and a string count
-	STRUCT_BUFFER,     // struct buffer, holds a ordered mapping from name to child vector
-	LIST_BUFFER,       // list buffer, holds a single flatvector child
-	MANAGED_BUFFER,    // managed buffer, holds a buffer managed by the buffermanager
-	OPAQUE_BUFFER,     // opaque buffer, can be created for example by the parquet reader
-	ARRAY_BUFFER,      // array buffer, holds a single flatvector child
-	SHREDDED_BUFFER,   // holds data for a shredded variant vector
-	SEQUENCE_BUFFER    // holds a linear numeric sequence (start, increment)
+	STANDARD_BUFFER,   // VectorType::FLAT/CONSTANT - Fixed-Size Type - Holds a single array of data
+	STRING_BUFFER,     // VectorType::FLAT/CONSTANT - String          - Holds string_t array and StringHeap
+	STRUCT_BUFFER,     // VectorType::FLAT/CONSTANT - Struct          - Holds struct child vectors
+	LIST_BUFFER,       // VectorType::FLAT/CONSTANT - List            - Holds list_entry_t array and list child vector
+	ARRAY_BUFFER,      // VectorType::FLAT/CONSTANT - Array           - Holds array child vector
+	DICTIONARY_BUFFER, // VectorType::DICTIONARY    - Any             - Holds SelectionVector and dict child vector
+	FSST_BUFFER,       // VectorType::FSST          - String          - Holds string_t array, StringHeap and FSST table
+	SHREDDED_BUFFER,   // VectorType::SHREDDED      - Variant         - Holds shredded variant
+	SEQUENCE_BUFFER    // VectorType::SEQUENCE      - Any             - Holds linear numeric sequence (start, increment)
 };
 
 struct AuxiliaryDataHolder {

--- a/src/include/duckdb/common/types/vector_cache.hpp
+++ b/src/include/duckdb/common/types/vector_cache.hpp
@@ -15,6 +15,7 @@
 namespace duckdb {
 class Allocator;
 class Vector;
+class VectorCacheEntry;
 
 //! The VectorCache holds cached vector data.
 //! It enables re-using the same memory for different vectors.
@@ -24,9 +25,12 @@ public:
 	DUCKDB_API VectorCache();
 	//! Instantiate a vector cache with the given type and capacity.
 	DUCKDB_API VectorCache(Allocator &allocator, const LogicalType &type, const idx_t capacity = STANDARD_VECTOR_SIZE);
+	~VectorCache();
+	DUCKDB_API VectorCache(VectorCache &&other) noexcept;
+	DUCKDB_API VectorCache &operator=(VectorCache &&other) noexcept;
 
-public:
-	buffer_ptr<VectorBuffer> buffer;
+private:
+	unique_ptr<VectorCacheEntry> cache_entry;
 
 public:
 	void ResetFromCache(Vector &result) const;

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -12,6 +12,23 @@
 
 namespace duckdb {
 
+//! The VectorChildBuffer holds a child Vector
+class VectorChildBuffer : public VectorBuffer {
+public:
+	explicit VectorChildBuffer(Vector vector)
+	    : VectorBuffer(VectorBufferType::VECTOR_CHILD_BUFFER), data(std::move(vector)) {
+	}
+
+public:
+	Vector data;
+	//! Optional size/id to uniquely identify re-occurring dictionaries
+	optional_idx size;
+	string id;
+	//! For caching the hashes of a child buffer
+	mutex cached_hashes_lock;
+	unique_ptr<Vector> cached_hashes;
+};
+
 //! The DictionaryBuffer holds a selection vector
 class DictionaryBuffer : public VectorBuffer {
 public:

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -12,11 +12,10 @@
 
 namespace duckdb {
 
-//! The VectorChildBuffer holds a child Vector
-class VectorChildBuffer : public VectorBuffer {
+//! The DictionaryEntry holds a child Vector for dictionary-encoded vectors
+class DictionaryEntry {
 public:
-	explicit VectorChildBuffer(Vector vector)
-	    : VectorBuffer(VectorBufferType::VECTOR_CHILD_BUFFER), data(std::move(vector)) {
+	explicit DictionaryEntry(Vector vector) : data(std::move(vector)) {
 	}
 
 public:
@@ -29,9 +28,15 @@ public:
 	unique_ptr<Vector> cached_hashes;
 };
 
-//! The DictionaryBuffer holds a selection vector
+//! The DictionaryBuffer holds a selection vector and a reference to a DictionaryEntry
 class DictionaryBuffer : public VectorBuffer {
 public:
+	explicit DictionaryBuffer(const SelectionVector &sel, buffer_ptr<DictionaryEntry> entry_p)
+	    : VectorBuffer(VectorBufferType::DICTIONARY_BUFFER), sel_vector(sel), entry(std::move(entry_p)) {
+	}
+	explicit DictionaryBuffer(buffer_ptr<SelectionData> data, buffer_ptr<DictionaryEntry> entry_p)
+	    : VectorBuffer(VectorBufferType::DICTIONARY_BUFFER), sel_vector(std::move(data)), entry(std::move(entry_p)) {
+	}
 	explicit DictionaryBuffer(const SelectionVector &sel)
 	    : VectorBuffer(VectorBufferType::DICTIONARY_BUFFER), sel_vector(sel) {
 	}
@@ -65,8 +70,22 @@ public:
 		return dictionary_id;
 	}
 
+	DictionaryEntry &GetEntry() {
+		return *entry;
+	}
+	const DictionaryEntry &GetEntry() const {
+		return *entry;
+	}
+	buffer_ptr<DictionaryEntry> GetEntryPtr() {
+		return entry;
+	}
+	void SetEntry(buffer_ptr<DictionaryEntry> entry_p) {
+		entry = std::move(entry_p);
+	}
+
 private:
 	SelectionVector sel_vector;
+	buffer_ptr<DictionaryEntry> entry;
 	optional_idx dictionary_size;
 	//! A unique identifier for the dictionary that can be used to check if two dictionaries are equivalent
 	string dictionary_id;
@@ -93,27 +112,29 @@ struct DictionaryVector {
 	}
 	static inline const Vector &Child(const Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.auxiliary->Cast<VectorChildBuffer>().data;
+		return vector.buffer->Cast<DictionaryBuffer>().GetEntry().data;
 	}
 	static inline Vector &Child(Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.auxiliary->Cast<VectorChildBuffer>().data;
+		return vector.buffer->Cast<DictionaryBuffer>().GetEntry().data;
 	}
 	static inline optional_idx DictionarySize(const Vector &vector) {
 		VerifyDictionary(vector);
-		const auto &child_buffer = vector.auxiliary->Cast<VectorChildBuffer>();
-		if (child_buffer.size.IsValid()) {
-			return child_buffer.size;
+		const auto &dict_buffer = vector.buffer->Cast<DictionaryBuffer>();
+		const auto &entry = dict_buffer.GetEntry();
+		if (entry.size.IsValid()) {
+			return entry.size;
 		}
-		return vector.buffer->Cast<DictionaryBuffer>().GetDictionarySize();
+		return dict_buffer.GetDictionarySize();
 	}
 	static inline const string &DictionaryId(const Vector &vector) {
 		VerifyDictionary(vector);
-		const auto &child_buffer = vector.auxiliary->Cast<VectorChildBuffer>();
-		if (!child_buffer.id.empty()) {
-			return child_buffer.id;
+		const auto &dict_buffer = vector.buffer->Cast<DictionaryBuffer>();
+		const auto &entry = dict_buffer.GetEntry();
+		if (!entry.id.empty()) {
+			return entry.id;
 		}
-		return vector.buffer->Cast<DictionaryBuffer>().GetDictionaryId();
+		return dict_buffer.GetDictionaryId();
 	}
 	static inline bool CanCacheHashes(const LogicalType &type) {
 		return type.InternalType() == PhysicalType::VARCHAR;
@@ -121,7 +142,7 @@ struct DictionaryVector {
 	static inline bool CanCacheHashes(const Vector &vector) {
 		return DictionarySize(vector).IsValid() && CanCacheHashes(vector.GetType());
 	}
-	static buffer_ptr<VectorChildBuffer> CreateReusableDictionary(const LogicalType &type, const idx_t &size);
+	static buffer_ptr<DictionaryEntry> CreateReusableDictionary(const LogicalType &type, const idx_t &size);
 	static const Vector &GetCachedHashes(Vector &input);
 };
 

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -48,6 +48,9 @@ struct FlatVector {
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
 		VerifyFlatVector(vector);
+		if (vector.GetType().InternalType() == PhysicalType::ARRAY) {
+			throw InternalException("SetData not supported for array");
+		}
 		vector.buffer = make_buffer<StandardVectorBuffer>(data);
 	}
 	template <class T>

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -46,16 +46,7 @@ struct FlatVector {
 	static inline T *GetDataUnsafe(Vector &vector) {
 		return ConstantVector::GetDataUnsafe<T>(vector);
 	}
-	static inline void SetData(Vector &vector, data_ptr_t data) {
-		VerifyFlatVector(vector);
-		if (vector.GetType().InternalType() == PhysicalType::ARRAY) {
-			throw InternalException("SetData not supported for array");
-		}
-		if (vector.GetType().InternalType() == PhysicalType::STRUCT) {
-			throw InternalException("SetData not supported for struct");
-		}
-		vector.buffer = make_buffer<StandardVectorBuffer>(data);
-	}
+	static void SetData(Vector &vector, data_ptr_t data);
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {
 		VerifyFlatVector(vector);

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -51,6 +51,9 @@ struct FlatVector {
 		if (vector.GetType().InternalType() == PhysicalType::ARRAY) {
 			throw InternalException("SetData not supported for array");
 		}
+		if (vector.GetType().InternalType() == PhysicalType::STRUCT) {
+			throw InternalException("SetData not supported for struct");
+		}
 		vector.buffer = make_buffer<StandardVectorBuffer>(data);
 	}
 	template <class T>

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -48,10 +48,7 @@ struct FlatVector {
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
 		VerifyFlatVector(vector);
-		// FIXME: this should probably throw an exception if "buffer" is not set
-		if (vector.buffer) {
-			vector.buffer->SetData(data);
-		}
+		vector.buffer = make_buffer<VectorBuffer>(data);
 	}
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -26,12 +26,12 @@ public:
 	}
 
 	optional_ptr<Allocator> GetAllocator() const override {
-		return allocator;
+		return allocated_data.GetAllocator();
 	}
 
 protected:
 	data_ptr_t data_ptr;
-	optional_ptr<Allocator> allocator;
+	AllocatedData allocated_data;
 };
 
 struct FlatVector {

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -48,7 +48,10 @@ struct FlatVector {
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
 		VerifyFlatVector(vector);
-		vector.buffer->SetData(data);
+		// FIXME: this should probably throw an exception if "buffer" is not set
+		if (vector.buffer) {
+			vector.buffer->SetData(data);
+		}
 	}
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -48,7 +48,7 @@ struct FlatVector {
 	}
 	static inline void SetData(Vector &vector, data_ptr_t data) {
 		VerifyFlatVector(vector);
-		vector.buffer = make_buffer<VectorBuffer>(data);
+		vector.buffer = make_buffer<StandardVectorBuffer>(data);
 	}
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -13,6 +13,27 @@
 
 namespace duckdb {
 
+class StandardVectorBuffer : public VectorBuffer {
+public:
+	StandardVectorBuffer(Allocator &allocator, idx_t data_size);
+	explicit StandardVectorBuffer(idx_t data_size);
+	explicit StandardVectorBuffer(data_ptr_t data_ptr_p);
+	explicit StandardVectorBuffer(AllocatedData &&data_p);
+
+public:
+	data_ptr_t GetData() override {
+		return data_ptr;
+	}
+
+	optional_ptr<Allocator> GetAllocator() const override {
+		return allocator;
+	}
+
+protected:
+	data_ptr_t data_ptr;
+	optional_ptr<Allocator> allocator;
+};
+
 struct FlatVector {
 	static void VerifyFlatVector(const Vector &vector) {
 #ifdef DUCKDB_DEBUG_NO_SAFETY

--- a/src/include/duckdb/common/vector/fsst_vector.hpp
+++ b/src/include/duckdb/common/vector/fsst_vector.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class VectorFSSTStringBuffer : public VectorStringBuffer {
 public:
-	VectorFSSTStringBuffer();
+	explicit VectorFSSTStringBuffer(idx_t capacity);
 
 public:
 	void AddDecoder(buffer_ptr<void> &duckdb_fsst_decoder_p, const idx_t string_block_limit) {
@@ -67,13 +67,16 @@ struct FSSTVector {
 
 	DUCKDB_API static string_t AddCompressedString(Vector &vector, string_t data);
 	DUCKDB_API static string_t AddCompressedString(Vector &vector, const char *data, idx_t len);
-	DUCKDB_API static void RegisterDecoder(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder,
-	                                       const idx_t string_block_limit);
+	DUCKDB_API static void Create(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder, const idx_t string_block_limit,
+	                              idx_t capacity);
 	DUCKDB_API static void *GetDecoder(const Vector &vector);
 	DUCKDB_API static vector<unsigned char> &GetDecompressBuffer(const Vector &vector);
 	//! Setting the string count is required to be able to correctly flatten the vector
 	DUCKDB_API static void SetCount(Vector &vector, idx_t count);
 	DUCKDB_API static idx_t GetCount(const Vector &vector);
+
+private:
+	static VectorFSSTStringBuffer &GetFSSTBuffer(const Vector &vector);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -56,13 +56,13 @@ public:
 	}
 
 	optional_ptr<Allocator> GetAllocator() const override {
-		return allocated_data.GetAllocator();
+		return allocator;
 	}
 
 private:
 	// data for list offsets
 	data_ptr_t data_ptr;
-	AllocatedData allocated_data;
+	optional_ptr<Allocator> allocator;
 	//! child vectors used for nested data
 	unique_ptr<Vector> child;
 	idx_t capacity = 0;

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -22,7 +22,8 @@ public:
 	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
 	explicit VectorListBuffer(idx_t capacity, const LogicalType &list_type,
 	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
-	explicit VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent);
+	explicit VectorListBuffer(data_ptr_t data, const Vector &vector, idx_t child_capacity, idx_t child_size);
+	explicit VectorListBuffer(data_ptr_t data, buffer_ptr<VectorBuffer> parent_buffer);
 	explicit VectorListBuffer(AllocatedData allocated_data, const VectorListBuffer &parent);
 	~VectorListBuffer() override;
 
@@ -56,13 +57,13 @@ public:
 	}
 
 	optional_ptr<Allocator> GetAllocator() const override {
-		return allocator;
+		return allocated_data.GetAllocator();
 	}
 
 private:
 	// data for list offsets
 	data_ptr_t data_ptr;
-	optional_ptr<Allocator> allocator;
+	AllocatedData allocated_data;
 	//! child vectors used for nested data
 	unique_ptr<Vector> child;
 	idx_t capacity = 0;
@@ -104,8 +105,6 @@ struct ListVector {
 	DUCKDB_API static ConsecutiveChildListInfo GetConsecutiveChildListInfo(Vector &list, idx_t offset, idx_t count);
 	//! Slice and flatten a child vector to only contain a consecutive subsection of the child entries
 	DUCKDB_API static void GetConsecutiveChildSelVector(Vector &list, SelectionVector &sel, idx_t offset, idx_t count);
-	//! References the list offsets / sizes of another vector
-	DUCKDB_API static void ReferenceListOffsets(Vector &list, const Vector &other);
 	//! Returns the total number of entries in the list
 	DUCKDB_API static idx_t GetTotalEntryCount(Vector &list, idx_t count);
 

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -16,12 +16,21 @@ namespace duckdb {
 
 class VectorListBuffer : public VectorBuffer {
 public:
-	explicit VectorListBuffer(unique_ptr<Vector> vector, idx_t initial_capacity = STANDARD_VECTOR_SIZE);
-	explicit VectorListBuffer(const LogicalType &list_type, idx_t initial_capacity = STANDARD_VECTOR_SIZE);
+	explicit VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector,
+	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
+	explicit VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
+	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
+	explicit VectorListBuffer(idx_t capacity, const LogicalType &list_type,
+	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
+	explicit VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent);
+	explicit VectorListBuffer(AllocatedData allocated_data, const VectorListBuffer &parent);
 	~VectorListBuffer() override;
 
 public:
 	Vector &GetChild() {
+		return *child;
+	}
+	const Vector &GetChild() const {
 		return *child;
 	}
 	void Reserve(idx_t to_reserve);
@@ -42,7 +51,18 @@ public:
 	void SetCapacity(idx_t new_capacity);
 	void SetSize(idx_t new_size);
 
+	data_ptr_t GetData() override {
+		return data_ptr;
+	}
+
+	optional_ptr<Allocator> GetAllocator() const override {
+		return allocated_data.GetAllocator();
+	}
+
 private:
+	// data for list offsets
+	data_ptr_t data_ptr;
+	AllocatedData allocated_data;
 	//! child vectors used for nested data
 	unique_ptr<Vector> child;
 	idx_t capacity = 0;

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -104,8 +104,8 @@ struct ListVector {
 	DUCKDB_API static ConsecutiveChildListInfo GetConsecutiveChildListInfo(Vector &list, idx_t offset, idx_t count);
 	//! Slice and flatten a child vector to only contain a consecutive subsection of the child entries
 	DUCKDB_API static void GetConsecutiveChildSelVector(Vector &list, SelectionVector &sel, idx_t offset, idx_t count);
-	//! Share the entry of the other list vector
-	DUCKDB_API static void ReferenceEntry(Vector &vector, Vector &other);
+	//! References the list offsets / sizes of another vector
+	DUCKDB_API static void ReferenceListOffsets(Vector &list, const Vector &other);
 	//! Returns the total number of entries in the list
 	DUCKDB_API static idx_t GetTotalEntryCount(Vector &list, idx_t count);
 

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -23,7 +23,7 @@ public:
 	explicit VectorListBuffer(idx_t capacity, const LogicalType &list_type,
 	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
 	explicit VectorListBuffer(data_ptr_t data, const Vector &vector, idx_t child_capacity, idx_t child_size);
-	explicit VectorListBuffer(data_ptr_t data, buffer_ptr<VectorBuffer> parent_buffer);
+	explicit VectorListBuffer(data_ptr_t data, const VectorListBuffer &parent);
 	explicit VectorListBuffer(AllocatedData allocated_data, const VectorListBuffer &parent);
 	~VectorListBuffer() override;
 

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -52,15 +52,13 @@ private:
 struct ListVector {
 	static inline const list_entry_t *GetData(const Vector &v) {
 		if (v.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-			auto &child = DictionaryVector::Child(v);
-			return GetData(child);
+			throw InternalException("ListVector::GetData called on dictionary vector");
 		}
 		return FlatVector::GetData<const list_entry_t>(v);
 	}
 	static inline list_entry_t *GetData(Vector &v) {
 		if (v.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-			auto &child = DictionaryVector::Child(v);
-			return GetData(child);
+			throw InternalException("ListVector::GetData called on dictionary vector");
 		}
 		return FlatVector::GetData<list_entry_t>(v);
 	}

--- a/src/include/duckdb/common/vector/sequence_vector.hpp
+++ b/src/include/duckdb/common/vector/sequence_vector.hpp
@@ -12,6 +12,16 @@
 
 namespace duckdb {
 
+class SequenceBuffer : public VectorBuffer {
+public:
+	explicit SequenceBuffer(int64_t start, int64_t increment, int64_t count);
+
+	int64_t start;
+	int64_t increment;
+	//! FIXME: should not be necessary once vector has count
+	int64_t count;
+};
+
 struct SequenceVector {
 	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count);
 	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment);

--- a/src/include/duckdb/common/vector/shredded_vector.hpp
+++ b/src/include/duckdb/common/vector/shredded_vector.hpp
@@ -12,6 +12,20 @@
 
 namespace duckdb {
 
+class ShreddedVectorBuffer : public VectorBuffer {
+public:
+	explicit ShreddedVectorBuffer(Vector &shredded_data);
+	~ShreddedVectorBuffer() override;
+
+public:
+	Vector &GetChild() {
+		return *shredded_data;
+	}
+
+private:
+	unique_ptr<Vector> shredded_data;
+};
+
 struct ShreddedVector {
 	static void VerifyShreddedVector(const Vector &vector) {
 #ifdef DUCKDB_DEBUG_NO_SAFETY

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -44,7 +44,8 @@ public:
 		return *heap;
 	}
 
-	void ResetHeap() {
+	void ClearAuxiliaryData() override {
+		StandardVectorBuffer::ClearAuxiliaryData();
 		heap = nullptr;
 	}
 

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/common/vector/map_vector.hpp
+// duckdb/common/vector/string_vector.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -31,23 +31,39 @@ public:
 	VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other);
 
 public:
-	StringHeap &GetHeap();
+	StringHeap &GetHeap() {
+		if (heap) {
+			return *heap;
+		}
+		auto allocator = GetAllocator();
+		if (allocator) {
+			heap = AllocateHeap(*allocator);
+		} else {
+			heap = AllocateHeap();
+		}
+		return *heap;
+	}
+
+	void ClearAuxiliaryData() override {
+		StandardVectorBuffer::ClearAuxiliaryData();
+		heap = nullptr;
+	}
 
 	string_t AddString(const char *data, idx_t len) {
-		return heap.AddString(data, len);
+		return GetHeap().AddString(data, len);
 	}
 	string_t AddString(string_t data) {
-		return heap.AddString(data);
+		return GetHeap().AddString(data);
 	}
 	string_t AddBlob(string_t data) {
-		return heap.AddBlob(data.GetData(), data.GetSize());
+		return GetHeap().AddBlob(data.GetData(), data.GetSize());
 	}
 	string_t EmptyString(idx_t len) {
-		return heap.EmptyString(len);
+		return GetHeap().EmptyString(len);
 	}
 
 	ArenaAllocator &GetStringAllocator() {
-		return heap.GetAllocator();
+		return GetHeap().GetAllocator();
 	}
 
 private:
@@ -55,7 +71,7 @@ private:
 	StringHeap &AllocateHeap();
 
 private:
-	StringHeap &heap;
+	optional_ptr<StringHeap> heap;
 };
 
 struct StringVector {

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -35,24 +35,6 @@ public:
 	ArenaAllocator &GetStringAllocator() {
 		return heap.GetAllocator();
 	}
-	//! Allocate a buffer to store up to "len" bytes for a string
-	//! This can be turned into a proper string by using FinalizeBuffer afterwards
-	//! Note that alloc_len only has to be an upper bound, the final string may be smaller
-	data_ptr_t AllocateShrinkableBuffer(idx_t alloc_len) {
-		auto &allocator = heap.GetAllocator();
-		return allocator.Allocate(alloc_len);
-	}
-	//! Finalize a buffer allocated with AllocateShrinkableBuffer into a string of size str_len
-	//! str_len must be <= alloc_len
-	string_t FinalizeShrinkableBuffer(data_ptr_t buffer, idx_t alloc_len, idx_t str_len) {
-		auto &allocator = heap.GetAllocator();
-		D_ASSERT(str_len <= alloc_len);
-		D_ASSERT(buffer == allocator.GetHead()->data.get() + allocator.GetHead()->current_position - alloc_len);
-		bool is_not_inlined = str_len > string_t::INLINE_LENGTH;
-		idx_t shrink_count = alloc_len - (str_len * is_not_inlined);
-		allocator.ShrinkHead(shrink_count);
-		return string_t(const_char_ptr_cast(buffer), UnsafeNumericCast<uint32_t>(str_len));
-	}
 
 	void AddHeapReference(buffer_ptr<VectorBuffer> heap) {
 		references.push_back(std::move(heap));
@@ -85,12 +67,32 @@ struct StringVector {
 	DUCKDB_API static string_t EmptyString(Vector &vector, idx_t len);
 	//! Returns a reference to the underlying VectorStringBuffer - throws an error if vector is not of type VARCHAR
 	DUCKDB_API static VectorStringBuffer &GetStringBuffer(Vector &vector);
+	//! Returns a reference to the string allocator
+	DUCKDB_API static ArenaAllocator &GetStringAllocator(Vector &vector);
 	//! Adds a reference to a handle that stores strings of this vector
 	DUCKDB_API static void AddHandle(Vector &vector, BufferHandle handle);
 	//! Adds a reference to an unspecified vector buffer that stores strings of this vector
 	DUCKDB_API static void AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer);
 	//! Add a reference from this vector to the string heap of the provided vector
 	DUCKDB_API static void AddHeapReference(Vector &vector, const Vector &other);
+
+	//! Allocate a buffer to store up to "len" bytes for a string
+	//! This can be turned into a proper string by using FinalizeBuffer afterwards
+	//! Note that alloc_len only has to be an upper bound, the final string may be smaller
+	static inline data_ptr_t AllocateShrinkableBuffer(ArenaAllocator &allocator, idx_t alloc_len) {
+		return allocator.Allocate(alloc_len);
+	}
+	//! Finalize a buffer allocated with AllocateShrinkableBuffer into a string of size str_len
+	//! str_len must be <= alloc_len
+	static inline string_t FinalizeShrinkableBuffer(ArenaAllocator &allocator, data_ptr_t buffer, idx_t alloc_len,
+	                                                idx_t str_len) {
+		D_ASSERT(str_len <= alloc_len);
+		D_ASSERT(buffer == allocator.GetHead()->data.get() + allocator.GetHead()->current_position - alloc_len);
+		bool is_not_inlined = str_len > string_t::INLINE_LENGTH;
+		idx_t shrink_count = alloc_len - (str_len * is_not_inlined);
+		allocator.ShrinkHead(shrink_count);
+		return string_t(const_char_ptr_cast(buffer), UnsafeNumericCast<uint32_t>(str_len));
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -43,8 +43,7 @@ public:
 		return *heap;
 	}
 
-	void ClearAuxiliaryData() override {
-		StandardVectorBuffer::ClearAuxiliaryData();
+	void ResetHeap() {
 		heap = nullptr;
 	}
 

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -12,13 +12,27 @@
 
 namespace duckdb {
 
-class VectorStringBuffer : public VectorBuffer {
+struct StringHeapHolder : public AuxiliaryDataHolder {
+	explicit StringHeapHolder(Allocator &allocator) : heap(allocator) {
+	}
+
+	StringHeap heap;
+};
+
+class VectorStringBuffer : public StandardVectorBuffer {
 public:
 	VectorStringBuffer();
 	explicit VectorStringBuffer(Allocator &allocator);
+	VectorStringBuffer(Allocator &allocator, idx_t data_size);
+	explicit VectorStringBuffer(idx_t data_size);
+	explicit VectorStringBuffer(data_ptr_t data_ptr_p);
+	explicit VectorStringBuffer(AllocatedData &&data_p);
 	explicit VectorStringBuffer(VectorBufferType type);
+	VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other);
 
 public:
+	StringHeap &GetHeap();
+
 	string_t AddString(const char *data, idx_t len) {
 		return heap.AddString(data, len);
 	}
@@ -36,15 +50,12 @@ public:
 		return heap.GetAllocator();
 	}
 
-	void AddHeapReference(buffer_ptr<VectorBuffer> heap) {
-		references.push_back(std::move(heap));
-	}
+private:
+	StringHeap &AllocateHeap(Allocator &allocator);
+	StringHeap &AllocateHeap();
 
 private:
-	//! The string heap of this buffer
-	StringHeap heap;
-	//! References to additional vector buffers referenced by this string buffer
-	vector<buffer_ptr<VectorBuffer>> references;
+	StringHeap &heap;
 };
 
 struct StringVector {
@@ -71,10 +82,10 @@ struct StringVector {
 	DUCKDB_API static ArenaAllocator &GetStringAllocator(Vector &vector);
 	//! Adds a reference to a handle that stores strings of this vector
 	DUCKDB_API static void AddHandle(Vector &vector, BufferHandle handle);
-	//! Adds a reference to an unspecified vector buffer that stores strings of this vector
-	DUCKDB_API static void AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer);
 	//! Add a reference from this vector to the string heap of the provided vector
 	DUCKDB_API static void AddHeapReference(Vector &vector, const Vector &other);
+	//! Add a reference from this vector to the auxiliary data
+	DUCKDB_API static void AddAuxiliaryData(Vector &vector, unique_ptr<AuxiliaryDataHolder> data);
 
 	//! Allocate a buffer to store up to "len" bytes for a string
 	//! This can be turned into a proper string by using FinalizeBuffer afterwards

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -9,10 +9,11 @@
 #pragma once
 
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 
 namespace duckdb {
 
-struct StringHeapHolder : public AuxiliaryDataHolder {
+struct StringHeapHolder : AuxiliaryDataHolder {
 	explicit StringHeapHolder(Allocator &allocator) : heap(allocator) {
 	}
 

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -28,7 +28,7 @@ public:
 	explicit VectorStringBuffer(idx_t capacity);
 	explicit VectorStringBuffer(data_ptr_t data_ptr_p);
 	explicit VectorStringBuffer(AllocatedData &&data_p);
-	VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other);
+	VectorStringBuffer(AllocatedData &&data_p, buffer_ptr<VectorBuffer> other);
 
 public:
 	StringHeap &GetHeap() {

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -23,11 +23,10 @@ class VectorStringBuffer : public StandardVectorBuffer {
 public:
 	VectorStringBuffer();
 	explicit VectorStringBuffer(Allocator &allocator);
-	VectorStringBuffer(Allocator &allocator, idx_t data_size);
-	explicit VectorStringBuffer(idx_t data_size);
+	VectorStringBuffer(Allocator &allocator, idx_t capacity);
+	explicit VectorStringBuffer(idx_t capacity);
 	explicit VectorStringBuffer(data_ptr_t data_ptr_p);
 	explicit VectorStringBuffer(AllocatedData &&data_p);
-	explicit VectorStringBuffer(VectorBufferType type);
 	VectorStringBuffer(AllocatedData &&data_p, const VectorStringBuffer &other);
 
 public:

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -28,7 +28,7 @@ public:
 	explicit VectorStringBuffer(idx_t capacity);
 	explicit VectorStringBuffer(data_ptr_t data_ptr_p);
 	explicit VectorStringBuffer(AllocatedData &&data_p);
-	VectorStringBuffer(AllocatedData &&data_p, buffer_ptr<VectorBuffer> other);
+	VectorStringBuffer(AllocatedData &&data_p, VectorStringBuffer &other);
 
 public:
 	StringHeap &GetHeap() {

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -81,7 +81,7 @@ private:
 	//! This is the case when the input is "practically unary", i.e., only one non-const input column
 	optional_idx input_col_idx;
 	//! Vector holding the expression executed on the entire dictionary
-	buffer_ptr<VectorChildBuffer> output_dictionary;
+	buffer_ptr<DictionaryEntry> output_dictionary;
 	//! ID of the input dictionary Vector
 	string current_input_dictionary_id;
 };

--- a/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
+++ b/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
@@ -29,7 +29,7 @@ struct PerfectHashJoinStats {
 
 //! PhysicalHashJoin represents a hash loop join between two tables
 class PerfectHashJoinExecutor {
-	using PerfectHashTable = vector<buffer_ptr<VectorChildBuffer>>;
+	using PerfectHashTable = vector<buffer_ptr<DictionaryEntry>>;
 
 public:
 	PerfectHashJoinExecutor(const PhysicalHashJoin &join, JoinHashTable &ht);

--- a/src/include/duckdb/parser/statement/delete_statement.hpp
+++ b/src/include/duckdb/parser/statement/delete_statement.hpp
@@ -12,10 +12,9 @@
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/query_node/delete_query_node.hpp"
 
 namespace duckdb {
-
-class DeleteQueryNode;
 
 class DeleteStatement : public SQLStatement {
 public:

--- a/src/include/duckdb/parser/statement/insert_statement.hpp
+++ b/src/include/duckdb/parser/statement/insert_statement.hpp
@@ -12,13 +12,13 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/statement/update_statement.hpp"
+#include "duckdb/parser/query_node/insert_query_node.hpp"
 
 namespace duckdb {
 class ExpressionListRef;
 class UpdateSetInfo;
 class Serializer;
 class Deserializer;
-class InsertQueryNode;
 
 enum class OnConflictAction : uint8_t {
 	THROW,

--- a/src/include/duckdb/parser/statement/update_statement.hpp
+++ b/src/include/duckdb/parser/statement/update_statement.hpp
@@ -51,6 +51,7 @@ public:
 
 public:
 	UpdateStatement();
+	~UpdateStatement() override;
 
 	unique_ptr<UpdateQueryNode> node;
 

--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -59,7 +59,7 @@ public:
 	data_ptr_t dictionary_indices_ptr;
 	data_ptr_t string_lengths_ptr;
 
-	buffer_ptr<VectorChildBuffer> dictionary;
+	buffer_ptr<DictionaryEntry> dictionary;
 	void *decoder = nullptr;
 	bool all_values_inlined = false;
 

--- a/src/include/duckdb/storage/compression/dictionary/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/decompression.hpp
@@ -41,7 +41,7 @@ public:
 	uint32_t *index_buffer_ptr;
 	uint32_t index_buffer_count;
 
-	buffer_ptr<VectorChildBuffer> dictionary;
+	buffer_ptr<DictionaryEntry> dictionary;
 	idx_t dictionary_size;
 	StringDictionaryContainer dict;
 	idx_t block_size;

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -59,6 +59,9 @@ bool UpdateSetInfo::Equals(const unique_ptr<UpdateSetInfo> &left, const unique_p
 UpdateStatement::UpdateStatement() : SQLStatement(StatementType::UPDATE_STATEMENT), node(make_uniq<UpdateQueryNode>()) {
 }
 
+UpdateStatement::~UpdateStatement() {
+}
+
 UpdateStatement::UpdateStatement(const UpdateStatement &other)
     : SQLStatement(other), node(unique_ptr_cast<QueryNode, UpdateQueryNode>(other.node->Copy())) {
 }

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -102,12 +102,12 @@ void CompressedStringScanState::Initialize(bool initialize_dictionary) {
 	}
 
 	dictionary = DictionaryVector::CreateReusableDictionary(segment.type, dict_count);
-	auto dict_child_data = FlatVector::GetData<string_t>(dictionary->data);
-	auto &validity = FlatVector::Validity(dictionary->data);
+	auto &dict_data = dictionary->data;
+	auto dict_child_data = FlatVector::GetData<string_t>(dict_data);
+	auto &validity = FlatVector::Validity(dict_data);
 	D_ASSERT(dict_count >= 1);
 	validity.SetInvalid(0);
 
-	auto &dict_data = dictionary->data;
 	uint32_t offset = 0;
 	for (uint32_t i = 0; i < dict_count; i++) {
 		//! We can uncompress during fetching, we need the length of the string inside the dictionary

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -32,7 +32,8 @@ string_t CompressedStringScanState::FetchStringFromDict(Vector &result, uint32_t
 		if (all_values_inlined) {
 			return FSSTPrimitives::DecompressInlinedValue(decoder, str_ptr, string_len);
 		} else {
-			return FSSTPrimitives::DecompressValue(decoder, StringVector::GetStringBuffer(result), str_ptr, string_len);
+			return FSSTPrimitives::DecompressValue(decoder, StringVector::GetStringAllocator(result), str_ptr,
+			                                       string_len);
 		}
 	}
 	default:

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -670,9 +670,8 @@ void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &sta
 		D_ASSERT(result_offset == 0);
 		if (scan_state.duckdb_fsst_decoder) {
 			D_ASSERT(result_offset == 0 || result.GetVectorType() == VectorType::FSST_VECTOR);
-			result.SetVectorType(VectorType::FSST_VECTOR);
 			auto string_block_limit = StringUncompressed::GetStringBlockLimit(segment.GetBlockSize());
-			FSSTVector::RegisterDecoder(result, scan_state.duckdb_fsst_decoder, string_block_limit);
+			FSSTVector::Create(result, scan_state.duckdb_fsst_decoder, string_block_limit, scan_count);
 			result_data = FSSTVector::GetCompressedData(result);
 		} else {
 			D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -558,7 +558,7 @@ struct FSSTScanState : public StringScanState {
 	}
 	inline string_t DecompressString(StringDictionaryContainer dict, data_ptr_t baseptr,
 	                                 const bp_delta_offsets_t &offsets, idx_t index,
-	                                 VectorStringBuffer &str_buffer) const {
+	                                 ArenaAllocator &str_allocator) const {
 		uint32_t str_len = bitunpack_buffer[offsets.scan_offset + index];
 		auto str_ptr = FSSTStorage::FetchStringPointer(
 		    dict, baseptr,
@@ -570,7 +570,7 @@ struct FSSTScanState : public StringScanState {
 		if (all_values_inlined) {
 			return FSSTPrimitives::DecompressInlinedValue(duckdb_fsst_decoder_ptr, str_ptr, str_len);
 		} else {
-			return FSSTPrimitives::DecompressValue(duckdb_fsst_decoder_ptr, str_buffer, str_ptr, str_len);
+			return FSSTPrimitives::DecompressValue(duckdb_fsst_decoder_ptr, str_allocator, str_ptr, str_len);
 		}
 	}
 };
@@ -698,9 +698,9 @@ void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &sta
 		}
 	} else {
 		// Just decompress
-		auto &str_buffer = StringVector::GetStringBuffer(result);
+		auto &str_allocator = StringVector::GetStringAllocator(result);
 		for (idx_t i = 0; i < scan_count; i++) {
-			result_data[i + result_offset] = scan_state.DecompressString(dict, baseptr, offsets, i, str_buffer);
+			result_data[i + result_offset] = scan_state.DecompressString(dict, baseptr, offsets, i, str_allocator);
 		}
 	}
 	EndScan(scan_state, offsets, start, scan_count);
@@ -724,13 +724,13 @@ void FSSTStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t v
 
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 
-	auto &str_buffer = StringVector::GetStringBuffer(result);
+	auto &str_allocator = StringVector::GetStringAllocator(result);
 	auto offsets = StartScan(scan_state, base_data, start, vector_count);
 	auto result_data = FlatVector::GetData<string_t>(result);
 
 	for (idx_t i = 0; i < sel_count; i++) {
 		idx_t index = sel.get_index(i);
-		result_data[i] = scan_state.DecompressString(dict, baseptr, offsets, index, str_buffer);
+		result_data[i] = scan_state.DecompressString(dict, baseptr, offsets, index, str_allocator);
 	}
 	EndScan(scan_state, offsets, start, vector_count);
 }
@@ -775,9 +775,9 @@ void FSSTStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state
 	    segment, dict.end, result, base_ptr,
 	    UnsafeNumericCast<int32_t>(delta_decode_buffer[offsets.unused_delta_decoded_values]), string_length);
 
-	auto &str_buffer = StringVector::GetStringBuffer(result);
-	result_data[result_idx] = FSSTPrimitives::DecompressValue((void *)&decoder, str_buffer, compressed_string.GetData(),
-	                                                          compressed_string.GetSize());
+	auto &str_allocator = StringVector::GetStringAllocator(result);
+	result_data[result_idx] = FSSTPrimitives::DecompressValue((void *)&decoder, str_allocator,
+	                                                          compressed_string.GetData(), compressed_string.GetSize());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -934,8 +934,8 @@ public:
 		for (idx_t i = 0; i < count; i++) {
 			uncompressed_length += string_lengths[i];
 		}
-		auto &buffer = StringVector::GetStringBuffer(result);
-		auto uncompressed_data = buffer.AllocateShrinkableBuffer(uncompressed_length);
+		auto &allocator = StringVector::GetStringAllocator(result);
+		auto uncompressed_data = StringVector::AllocateShrinkableBuffer(allocator, uncompressed_length);
 		auto string_data = FlatVector::GetData<string_t>(result);
 
 		DecompressString(scan_state, uncompressed_data, uncompressed_length);

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -704,7 +704,7 @@ void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t co
 	ListVector::SetListSize(values, 0);
 
 	auto &keys_entry = ListVector::GetEntry(keys);
-	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringBuffer(keys_entry).GetStringAllocator());
+	OrderedOwningStringMap<uint32_t> dictionary(StringVector::GetStringAllocator(keys_entry));
 	SelectionVector keys_selvec;
 	keys_selvec.Initialize(original_keys_size);
 

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -242,17 +242,8 @@ idx_t VariantColumnData::ScanWithCallback(
 				//! LIST(STRUCT(typed_value <child_type>, untyped_value_index UINTEGER))
 				//! We need to transform this to:
 				//! LIST(<child_type>)
-
-				auto &list_child = ListVector::GetEntry(result);
-				D_ASSERT(list_child.GetType().id() == LogicalTypeId::STRUCT);
-				D_ASSERT(StructType::GetChildCount(list_child.GetType()) == 2);
-
-				auto &typed_value = StructVector::GetEntries(list_child)[TYPED_VALUE_INDEX];
-				auto list_res = Vector(LogicalType::LIST(typed_value.GetType()));
-				ListVector::SetListSize(list_res, ListVector::GetListSize(result));
-				list_res.CopyBuffer(result);
-				ListVector::GetEntry(list_res).Reference(typed_value);
-				return res;
+				// FIXME: this is never called right now
+				throw InternalException("this is never called right");
 			}
 			return res;
 		}

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -186,11 +186,11 @@ TEST_CASE("Test TPCH arrow roundtrip", "[arrow][.]") {
 
 	// REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT * FROM lineitem_no_constraint;", false));
 	REQUIRE(ArrowTestHelper::RunArrowComparison(
-	    con, "SELECT l_orderkey, l_shipdate, l_comment FROM lineitem_no_constraint ORDER BY l_orderkey DESC;", false));
+	    con, "SELECT l_orderkey, l_shipdate, l_comment FROM lineitem_no_constraint ORDER BY l_orderkey DESC;", true));
 	REQUIRE(
-	    ArrowTestHelper::RunArrowComparison(con, "SELECT lineitem_no_constraint FROM lineitem_no_constraint;", false));
-	REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT [lineitem_no_constraint] FROM lineitem_no_constraint;",
-	                                            false));
+	    ArrowTestHelper::RunArrowComparison(con, "SELECT lineitem_no_constraint FROM lineitem_no_constraint;", true));
+	REQUIRE(
+	    ArrowTestHelper::RunArrowComparison(con, "SELECT [lineitem_no_constraint] FROM lineitem_no_constraint;", true));
 }
 
 TEST_CASE("Test Parquet Files round-trip", "[arrow][.]") {


### PR DESCRIPTION

DuckDB's vector class was originally designed with two `VectorBuffer` members: `buffer` and `auxiliary`. The original idea was that `buffer` would hold the main data field, and `auxiliary` would hold any data that the main data field depends on.

For example, for strings we would have this setup:

```
buffer: string_t[]
auxiliary: StringHeap
```

The `string_t` would then (optionally) point into the `StringHeap`.

This ended up getting pretty messy, however. For a given vector type / type combination, the `buffer / auxiliary` had to be of certain types. For example, for `FLAT / CONSTANT` strings, `buffer` had to be a `STANDARD_BUFFER`, and `auxiliary` had to be a `STRING_BUFFER`.

However, we started introducing other "auxiliary" members - such as the `MANAGED_BUFFER` (holds a `BufferHandle`) or the `ARROW_AUXILIARY` (holds an Arrow object), or the more general `OPAQUE_BUFFER`. These auxiliary members should then be placed in the `auxiliary` slot - but the `auxiliary` slot would, depending on the type, need to contain **something else specific**.

To fix that, the `VectorBuffer` **itself** would then **also** have auxiliary data - `VectorAuxiliaryData`. This auxiliary data could then itself, again, contain a `VectorBuffer`.

### One Vector Buffer per Vector

This was all pretty messy and made the code more complex and error prone than it needed to be. This PR moves to a simpler design: one `VectorBuffer` per vector. What this `VectorBuffer` is is defined based on the type / vector type. Here's the list:

|   Vector Type   |    Type    |      Buffer Type       |
|-----------------|------------|------------------------|
| FLAT / CONSTANT | Fixed-Size | StandardVectorBuffer   |
| FLAT / CONSTANT | String     | VectorStringBuffer     |
| FLAT / CONSTANT | List       | VectorListBuffer       |
| FLAT / CONSTANT | Struct     | VectorStructBuffer     |
| FLAT / CONSTANT | ARRAY      | VectorArrayBuffer      |
| DICTIONARY      | Any        | DictionaryBuffer       |
| SEQUENCE        | Any        | SequenceBuffer         |
| SHREDDED        | Any        | ShreddedVectorBuffer   |
| FSST            | Any        | VectorFSSTStringBuffer |

### AuxiliaryDataHolder 

Data dependencies are stored using an `AuxiliaryDataHolder`. This can be added to any vector buffer using the `AddAuxiliaryData` method. We can also create references to auxiliary data of other vector buffers as it is stored in a `buffer_ptr<AuxiliaryDataSet>`. For example, this is from the JSON reader:

```cpp

class JSONStringVectorBuffer : public AuxiliaryDataHolder {
public:
	explicit JSONStringVectorBuffer(shared_ptr<JSONAllocator> allocator_p) : allocator(std::move(allocator_p)) {
	}

private:
	shared_ptr<JSONAllocator> allocator;
};
```

Auxiliary data is opaque and can contain any object that manages life-times. 

### Remove Unnecessary Members

The previous `VectorBuffer` had a bunch of base data that only made sense in some situations, e.g. `data_ptr` and `AllocatedData`. This was only used for certain `FLAT / CONSTANT` vectors (specifically fixed-size, string and list). This PR removes them from the base `VectorBuffer` class. Instead, the specific buffers only implement members they need, so these members are added to `StandardVectorBuffer`, `VectorStringBuffer`, and `VectorListBuffer`.