### PR TITLE
Use changed tests from prepare in smoke tests

### DIFF
--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Whether to run smoke tests
     required: false
     default: "true"
+  changed_tests_file:
+    description: Path to a newline-delimited list of changed tests to include in smoke tests
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -52,7 +56,7 @@ runs:
     - name: Smoke tests
       if: ${{ inputs.run_smoke_tests == 'true' }}
       shell: bash
-      run: make smoke SMOKE_UNITTEST=build/release/test/unittest
+      run: make smoke SMOKE_UNITTEST=build/release/test/unittest T="--changed-tests=${{ inputs.changed_tests_file }}"
 
     - name: Prepare release artifact
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -62,6 +62,7 @@ jobs:
       linux_cli_matrix: ${{ steps.config.outputs.linux_cli_matrix }}
       linux_musl_cli_matrix: ${{ steps.config.outputs.linux_musl_cli_matrix }}
       extensions_changed: ${{ steps.changed.outputs.extensions_any_changed }}
+      changed_tests_files: ${{ steps.changed.outputs.tests_all_changed_files }}
       extensions_extra_exclude_archs: ${{ steps.config.outputs.extra_exclude_archs }}
     env:
       GEN: ninja
@@ -97,6 +98,8 @@ jobs:
               - .github/config/**
               - .github/patches/**
               - extensions/**
+            tests:
+              - test/**/*.test
 
       - name: Check CI
         if: steps.changed.outputs.github_any_changed == 'true'
@@ -235,8 +238,12 @@ jobs:
     - name: Build
       run: python3 scripts/ci/retry.py -- make relassert
 
+    - name: Write changed tests file
+      shell: bash
+      run: printf '%s\n' "${{ needs.prepare.outputs.changed_tests_files }}" | tr ' ' '\n' | sed '/^$/d' > "${{ runner.temp }}/changed_tests.txt"
+
     - name: Smoke tests
-      run: make smoke
+      run: make smoke T="--changed-tests=${{ runner.temp }}/changed_tests.txt"
 
     - name: Output version info
       run: ./build/relassert/duckdb -c "PRAGMA version;"
@@ -384,9 +391,14 @@ jobs:
 
     - uses: ./.github/actions/ccache-action
 
+    - name: Write changed tests file
+      shell: bash
+      run: printf '%s\n' "${{ needs.prepare.outputs.changed_tests_files }}" | tr ' ' '\n' | sed '/^$/d' > "${{ runner.temp }}/changed_tests.txt"
+
     - uses: ./.github/actions/linux_release_build
       with:
         artifact_name: linux-release-build
+        changed_tests_file: ${{ runner.temp }}/changed_tests.txt
 
     - name: Build linux default release
       run: make clean release

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -93,6 +93,7 @@ jobs:
         uses: ./.github/actions/linux_release_build
         with:
           artifact_name: linux-base-build
+          run_smoke_tests: false
 
   regression-bench:
     name: Bench ${{ matrix.name }}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for script helpers used in tests.

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for CI script helpers used in tests.

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -8,7 +8,9 @@ import subprocess
 import sys
 import tempfile
 import time
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import asdict, dataclass
+from io import StringIO
 from pathlib import Path
 
 DEFAULT_BATCH_SIZE = 10
@@ -140,6 +142,8 @@ def load_tests(path: Path):
     with path.open("r", encoding="utf8") as f:
         for line in f:
             line = line.rstrip("\n")
+            if not line:
+                continue
 
             # Skip header row from `--list-tests`.
             if line == "name\tgroup":
@@ -222,10 +226,19 @@ def resolve_workers(workers: str):
     return max(1, int(workers))
 
 
-def generate_test_list(test_file, unittest_bin: str, test_flags: str, patterns: list[str]):
+def generate_test_list(
+    test_file,
+    unittest_bin: str,
+    test_flags: str,
+    patterns: list[str],
+    test_list_files: list[Path] | None = None,
+):
     # Catch can return a non-zero status code for list commands when tests
     # are found, so we accept non-zero if stdout still contains test output.
-    command = [unittest_bin, *shlex.split(test_flags), "--list-tests", *patterns]
+    list_file_args = []
+    if test_list_files:
+        list_file_args = [arg for test_list_file in test_list_files for arg in ("-f", str(test_list_file))]
+    command = [unittest_bin, *shlex.split(test_flags), "--list-tests", *list_file_args, *patterns]
     print(f"generated test list using: {shlex.join(command)}")
     proc = subprocess.run(
         command,
@@ -241,13 +254,19 @@ def generate_test_list(test_file, unittest_bin: str, test_flags: str, patterns: 
 
 
 @contextlib.contextmanager
-def open_test_list(test_list: Path | None, unittest_bin: str, test_flags: str, patterns: list[str]):
-    if test_list is not None:
+def open_test_list(
+    test_list: Path | None,
+    unittest_bin: str,
+    test_flags: str,
+    patterns: list[str],
+    test_list_files: list[Path] | None = None,
+):
+    if test_list is not None and (test_list_files is None or len(test_list_files) == 1):
         yield test_list
         return
 
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_file:
-        generate_test_list(test_file, unittest_bin, test_flags, patterns)
+        generate_test_list(test_file, unittest_bin, test_flags, patterns, test_list_files)
     result = Path(test_file.name)
     yield result
     result.unlink()
@@ -426,9 +445,12 @@ def report_batch_metrics(ctx: RunContext, batch_info, result, elapsed: float):
         )
 
 
-def parse_args():
+def parse_args(argv: list[str] | None = None):
+    if argv is None:
+        argv = sys.argv[1:]
     parser = argparse.ArgumentParser()
     parser.add_argument("--test-list", type=Path)
+    parser.add_argument("--changed-tests", type=Path, help="extra test list file; requires --test-list")
     parser.add_argument("--workers", default=DEFAULT_WORKERS)
     parser.add_argument(
         "--test-config",
@@ -471,12 +493,24 @@ def parse_args():
     parser.add_argument("--batch-timeout", type=float, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
     # Accept options interleaved with positional patterns, e.g.:
     #   run_tests.py bin "[tag]" --fail-fast test/sql/foo.test
-    return parser.parse_intermixed_args()
+    return parser.parse_intermixed_args(argv)
 
 
-def main():
+@dataclass(frozen=True)
+class InvocationResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def main(argv: list[str] | None = None):
     enable_line_buffering()
-    args = parse_args()
+    args = parse_args(argv)
+    if args.changed_tests is not None and args.test_list is None:
+        print("error: --changed-tests requires --test-list", file=sys.stderr)
+        return 1
+
+    test_list_files = [path for path in [args.test_list, args.changed_tests] if path is not None]
     test_flags = args.test_flags
     for config in args.test_config:
         # The unittest binary parses "--test-config" as a separate option + value pair.
@@ -499,7 +533,7 @@ def main():
         batch_size = 1
     else:
         batch_size = args.batch_size
-    with open_test_list(args.test_list, unittest_bin, test_flags, args.patterns) as test_file:
+    with open_test_list(args.test_list, unittest_bin, test_flags, args.patterns, test_list_files) as test_file:
         config = TestRunnerConfig(
             test_list=test_file,
             unittest_bin=unittest_bin,
@@ -517,6 +551,11 @@ def main():
         )
 
         tests = load_tests(config.test_list)
+        if args.changed_tests is not None:
+            merged_names = {test.name for test in tests}
+            base_names = {test.name for test in load_tests(args.test_list)}
+            added_test_count = len(merged_names - base_names)
+            print(f"added {added_test_count} tests from --changed-tests file to the smoke test run")
         batch_size = compute_batch_size(len(tests), config)
 
         print(f"found {len(tests)} tests")
@@ -531,6 +570,20 @@ def main():
 
         batches = list(chunked(tests, batch_size))
         return run_tests(config, batches)
+
+
+def invoke(argv: list[str], cwd: Path | None = None) -> InvocationResult:
+    stdout_buffer = StringIO()
+    stderr_buffer = StringIO()
+    old_cwd = os.getcwd()
+    try:
+        if cwd is not None:
+            os.chdir(cwd)
+        with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+            returncode = int(main(argv) or 0)
+    finally:
+        os.chdir(old_cwd)
+    return InvocationResult(returncode=returncode, stdout=stdout_buffer.getvalue(), stderr=stderr_buffer.getvalue())
 
 
 def run_tests(config: TestRunnerConfig, batches):

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1,42 +1,57 @@
 #!/usr/bin/env python3
 import os
-import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-RUN_TESTS = REPO_ROOT / "scripts" / "ci" / "run_tests.py"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ci import run_tests
+
+
+def create_temp_file(content: str, **format_vars: object) -> Path:
+    rendered_content = textwrap.dedent(content).lstrip().format(**format_vars)
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as tmp_file:
+        tmp_file.write(rendered_content)
+        tmp_file.flush()
+        return Path(tmp_file.name)
+
+
+def start_runner(cli_args: list[str]):
+    return run_tests.invoke(cli_args, cwd=REPO_ROOT)
 
 
 class RunTestsScriptTest(unittest.TestCase):
     def test_generate_list(self):
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as listed_tests:
-            listed_tests.write("name\tgroup\n")
-            listed_tests.write("test/sql/slow.test\t[.][slow]\n")
-            listed_tests.write("test/sql/fast.test\t[fast]\n")
-            listed_tests.flush()
-            listed_tests_path = Path(listed_tests.name)
+        listed_tests_path = create_temp_file(
+            """
+            name\tgroup
+            test/sql/slow.test\t[.][slow]
+            test/sql/fast.test\t[fast]
+            """
+        )
 
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as list_helper:
-            list_helper.write("#!/bin/sh\n")
+        list_helper_path = create_temp_file(
+            """
+            #!/bin/sh
             # run_tests.py calls: <helper> --list-tests <pattern>
-            list_helper.write('if [ "$1" != "--list-tests" ]; then\n')
-            list_helper.write("  exit 2\n")
-            list_helper.write("fi\n")
-            list_helper.write('cat "$2"\n')
-            list_helper.write("exit 2\n")
-            list_helper.flush()
-            list_helper_path = Path(list_helper.name)
+            if [ "$1" != "--list-tests" ]; then
+              exit 2
+            fi
+            cat "$2"
+            exit 2
+            """
+        )
 
         os.chmod(list_helper_path, 0o755)
 
         try:
-            proc = subprocess.run(
+            proc = start_runner(
                 [
-                    sys.executable,
-                    str(RUN_TESTS),
                     "--workers",
                     "1",
                     "--batch-size",
@@ -47,11 +62,7 @@ class RunTestsScriptTest(unittest.TestCase):
                     "echo fake-run {test_list}",
                     str(list_helper_path),
                     str(listed_tests_path),
-                ],
-                cwd=REPO_ROOT,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                ]
             )
         finally:
             listed_tests_path.unlink(missing_ok=True)
@@ -65,17 +76,11 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertIn("all tests passed in ", proc.stdout)
 
     def test_runs_with_echo_test_command(self):
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
-            test_list.write("test/sql/a.test\n")
-            test_list.write("test/sql/b.test\n")
-            test_list.flush()
-            test_list_path = Path(test_list.name)
+        test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
 
         try:
-            proc = subprocess.run(
+            proc = start_runner(
                 [
-                    sys.executable,
-                    str(RUN_TESTS),
                     "--workers",
                     "1",
                     "--batch-size",
@@ -85,11 +90,7 @@ class RunTestsScriptTest(unittest.TestCase):
                     "--test-command",
                     "echo fake-run {test_list}",
                     "unused-binary",
-                ],
-                cwd=REPO_ROOT,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                ]
             )
         finally:
             test_list_path.unlink(missing_ok=True)
@@ -98,35 +99,90 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertIn("found 2 tests", proc.stdout)
         self.assertIn("all tests passed in ", proc.stdout)
 
+    def test_changed_tests_flag_uses_second_list_file(self):
+        base_test_list_path = create_temp_file(
+            """
+            test/sql/a.test
+            test/sql/b.test
+            """
+        )
+        changed_test_list_path = create_temp_file(
+            """
+            test/sql/b.test
+            test/sql/c.test
+            """
+        )
+
+        list_helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            if [ "$1" != "--list-tests" ]; then
+              exit 2
+            fi
+            shift
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "-f" ]; then
+                shift
+                cat "$1"
+              fi
+              shift
+            done
+            exit 0
+            """
+        )
+
+        os.chmod(list_helper_path, 0o755)
+
+        try:
+            proc = start_runner(
+                [
+                    "--workers",
+                    "1",
+                    "--batch-size",
+                    "2",
+                    "--test-list",
+                    str(base_test_list_path),
+                    "--changed-tests",
+                    str(changed_test_list_path),
+                    "--test-command",
+                    "echo fake-run {test_list}",
+                    str(list_helper_path),
+                ]
+            )
+        finally:
+            base_test_list_path.unlink(missing_ok=True)
+            changed_test_list_path.unlink(missing_ok=True)
+            list_helper_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn(f"-f {base_test_list_path}", proc.stdout)
+        self.assertIn(f"-f {changed_test_list_path}", proc.stdout)
+        self.assertIn("added 1 tests from --changed-tests file to the smoke test run", proc.stdout)
+        self.assertIn("all tests passed in ", proc.stdout)
+
     def test_retries_failed_fake_job(self):
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
-            test_list.write("test/sql/a.test\n")
-            test_list.flush()
-            test_list_path = Path(test_list.name)
-
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as state_file:
-            state_file_path = Path(state_file.name)
-
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as helper:
-            helper.write("#!/bin/sh\n")
-            helper.write(f"if [ ! -f {state_file_path} ]; then\n")
-            helper.write(f"  touch {state_file_path}\n")
-            helper.write("  echo fake failure\n")
-            helper.write("  exit 1\n")
-            helper.write("fi\n")
-            helper.write("echo fake success\n")
-            helper.write("exit 0\n")
-            helper.flush()
-            helper_path = Path(helper.name)
+        test_list_path = create_temp_file("test/sql/a.test\n")
+        state_file_path = create_temp_file("")
+        helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            if [ ! -f {state_file_path} ]; then
+              touch {state_file_path}
+              echo fake failure
+              exit 1
+            fi
+            echo fake success
+            exit 0
+            """,
+            state_file_path=state_file_path,
+        )
 
         os.chmod(helper_path, 0o755)
         state_file_path.unlink(missing_ok=True)
 
         try:
-            proc = subprocess.run(
+            proc = start_runner(
                 [
-                    sys.executable,
-                    str(RUN_TESTS),
                     "--workers",
                     "1",
                     "--batch-size",
@@ -140,11 +196,7 @@ class RunTestsScriptTest(unittest.TestCase):
                     "--test-command",
                     f"{helper_path} {{test_list}}",
                     "unused-binary",
-                ],
-                cwd=REPO_ROOT,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                ]
             )
         finally:
             test_list_path.unlink(missing_ok=True)
@@ -157,35 +209,31 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertIn("all tests passed in ", proc.stdout)
 
     def test_retries_timed_out_sleep_job(self):
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
-            test_list.write("test/sql/a.test\n")
-            test_list.flush()
-            test_list_path = Path(test_list.name)
-
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as state_file:
-            state_file_path = Path(state_file.name)
+        test_list_path = create_temp_file("test/sql/a.test\n")
+        state_file_path = create_temp_file("")
 
         batch_timeout = 0.3
 
-        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as helper:
-            helper.write("#!/bin/sh\n")
-            helper.write(f"if [ ! -f {state_file_path} ]; then\n")
-            helper.write(f"  touch {state_file_path}\n")
-            helper.write(f"  sleep {batch_timeout + 0.1}\n")
-            helper.write("fi\n")
-            helper.write("echo fake success\n")
-            helper.write("exit 0\n")
-            helper.flush()
-            helper_path = Path(helper.name)
+        helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            if [ ! -f {state_file_path} ]; then
+              touch {state_file_path}
+              sleep {sleep_seconds}
+            fi
+            echo fake success
+            exit 0
+            """,
+            state_file_path=state_file_path,
+            sleep_seconds=batch_timeout + 0.1,
+        )
 
         os.chmod(helper_path, 0o755)
         state_file_path.unlink(missing_ok=True)
 
         try:
-            proc = subprocess.run(
+            proc = start_runner(
                 [
-                    sys.executable,
-                    str(RUN_TESTS),
                     "--retry",
                     "1",
                     "--batch-timeout",
@@ -195,11 +243,7 @@ class RunTestsScriptTest(unittest.TestCase):
                     "--test-command",
                     f"{helper_path} {{test_list}}",
                     "unused-binary",
-                ],
-                cwd=REPO_ROOT,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                ]
             )
         finally:
             test_list_path.unlink(missing_ok=True)

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -9431,6 +9431,7 @@ namespace detail {
     class Opt : public ParserRefImpl<Opt> {
     protected:
         std::vector<std::string> m_optNames;
+        bool m_acceptsMany = false;
 
     public:
         template<typename LambdaT>
@@ -9447,6 +9448,18 @@ namespace detail {
         auto operator[]( std::string const &optName ) -> Opt & {
             m_optNames.push_back( optName );
             return *this;
+        }
+
+        auto acceptingMultiple() -> Opt & {
+            m_acceptsMany = true;
+            return *this;
+        }
+
+        auto cardinality() const -> size_t override {
+            if (m_acceptsMany) {
+                return 0;
+            }
+            return ParserRefImpl::cardinality();
         }
 
         auto getHelpColumns() const -> std::vector<HelpColumns> {
@@ -9785,15 +9798,14 @@ namespace Catch {
                 while( std::getline( f, line ) ) {
                     line = trim(line);
                     if( !line.empty() && !startsWith( line, '#' ) ) {
+                        if( !config.testsOrTags.empty() ) {
+                            config.testsOrTags.emplace_back( "," );
+                        }
                         if( !startsWith( line, '"' ) )
                             line = '"' + line + '"';
                         config.testsOrTags.push_back( line );
-                        config.testsOrTags.emplace_back( "," );
                     }
                 }
-                //Remove comma in the end
-                if(!config.testsOrTags.empty())
-                    config.testsOrTags.erase( config.testsOrTags.end()-1 );
                 config.testListFile = filename;
                 return ParserResult::ok( ParseResultType::Matched );
             };
@@ -9913,6 +9925,7 @@ namespace Catch {
                 ( "show test durations for tests taking at least the given number of seconds" )
             | Opt( loadTestNamesFromFile, "filename" )
                 ["-f"]["--input-file"]
+                .acceptingMultiple()
                 ( "load test names to run from a file" )
             | Opt( config.filenamesAsTags )
                 ["-#"]["--filenames-as-tags"]


### PR DESCRIPTION
See also comments in https://github.com/duckdb/duckdb/pull/21755:
> Mark: maybe it also makes sense to include any tests that were added in the PR?
>
> Another idea is that we could have a set of tests per directory or source file and then run tests based on the files that are changed in the PR - so that if a PR changes the CSV reader, we run the CSV reader tests as smoke tests.

For now, dynamically add the list of [changed](https://github.com/tj-actions/changed-files#output_all_changed_files) files to the smoke tests.

The unittest binary is used to select both the smoke test list and the changed tests.