### PR TITLE
Disable bloom filter pushdown through casts

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -886,7 +886,9 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeFilters(ClientContext &con
 					break;
 				}
 
-				if (ht && CanUseBloomFilter(context, ht, op, cmp, is_perfect_hashtable)) {
+				auto condition_type = op.conditions[join_condition[filter_idx]].left->return_type;
+				bool has_cast = condition_type != pushdown_column.storage_type;
+				if (!has_cast && ht && CanUseBloomFilter(context, ht, op, cmp, is_perfect_hashtable)) {
 					PushBloomFilter(info, *ht, op, filter_col_idx);
 				}
 			}


### PR DESCRIPTION
Just to be safe

Proper fix in `main` is done in https://github.com/duckdb/duckdb/pull/21791

min/max/in pushdown is still OK