### PR TITLE
Expose column tags via duckdb_columns()

### DIFF
--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -79,6 +79,9 @@ static unique_ptr<FunctionData> DuckDBColumnsBind(ClientContext &context, TableF
 	names.emplace_back("numeric_scale");
 	return_types.emplace_back(LogicalType::INTEGER);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	return nullptr;
 }
 
@@ -108,6 +111,7 @@ public:
 	virtual const Value ColumnDefault(idx_t col) = 0;
 	virtual bool IsNullable(idx_t col) = 0;
 	virtual const Value ColumnComment(idx_t col) = 0;
+	virtual const Value ColumnTags(idx_t col) = 0;
 
 	void WriteColumns(idx_t index, idx_t start_col, idx_t end_col, DataChunk &output);
 };
@@ -150,6 +154,9 @@ public:
 	const Value ColumnComment(idx_t col) override {
 		return entry.GetColumn(LogicalIndex(col)).Comment();
 	}
+	const Value ColumnTags(idx_t col) override {
+		return Value::MAP(entry.GetColumn(LogicalIndex(col)).Tags());
+	}
 
 private:
 	TableCatalogEntry &entry;
@@ -185,6 +192,10 @@ public:
 	}
 	const Value ColumnComment(idx_t col) override {
 		return entry.GetColumnComment(col);
+	}
+	const Value ColumnTags(idx_t col) override {
+		InsertionOrderPreservingMap<string> empty;
+		return Value::MAP(empty);
 	}
 
 private:
@@ -304,6 +315,8 @@ void ColumnHelper::WriteColumns(idx_t start_index, idx_t start_col, idx_t end_co
 		output.SetValue(col++, index, numeric_precision_radix);
 		// numeric_scale, INTEGER
 		output.SetValue(col++, index, numeric_scale);
+		// tags, MAP(VARCHAR, VARCHAR)
+		output.SetValue(col++, index, ColumnTags(i));
 	}
 }
 

--- a/src/include/duckdb/parser/column_definition.hpp
+++ b/src/include/duckdb/parser/column_definition.hpp
@@ -47,6 +47,10 @@ public:
 	DUCKDB_API const Value &Comment() const;
 	void SetComment(const Value &comment);
 
+	//! tags
+	DUCKDB_API const InsertionOrderPreservingMap<string> &Tags() const;
+	void SetTags(InsertionOrderPreservingMap<string> new_tags);
+
 	//! compression_type
 	const duckdb::CompressionType &CompressionType() const;
 	void SetCompressionType(duckdb::CompressionType compression_type);
@@ -104,7 +108,7 @@ private:
 	//! Comment on this column
 	Value comment;
 	//! Tags on this column
-	unordered_map<string, string> tags;
+	InsertionOrderPreservingMap<string> tags;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -393,8 +393,8 @@
       {
         "id": 106,
         "name": "tags",
-        "type": "unordered_map<string, string>",
-        "default": "unordered_map<string, string>()"
+        "type": "InsertionOrderPreservingMap<string>",
+        "default": "InsertionOrderPreservingMap<string>()"
       }
     ],
     "constructor": ["name", "type", "expression", "category"],

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -78,6 +78,14 @@ void ColumnDefinition::SetComment(const Value &comment) {
 	this->comment = comment;
 }
 
+const InsertionOrderPreservingMap<string> &ColumnDefinition::Tags() const {
+	return tags;
+}
+
+void ColumnDefinition::SetTags(InsertionOrderPreservingMap<string> new_tags) {
+	this->tags = std::move(new_tags);
+}
+
 const duckdb::CompressionType &ColumnDefinition::CompressionType() const {
 	return compression_type;
 }

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -200,7 +200,7 @@ void ColumnDefinition::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<TableColumnType>(103, "category", category);
 	serializer.WriteProperty<duckdb::CompressionType>(104, "compression_type", compression_type);
 	serializer.WritePropertyWithDefault<Value>(105, "comment", comment, Value());
-	serializer.WritePropertyWithDefault<unordered_map<string, string>>(106, "tags", tags, unordered_map<string, string>());
+	serializer.WritePropertyWithDefault<InsertionOrderPreservingMap<string>>(106, "tags", tags, InsertionOrderPreservingMap<string>());
 }
 
 ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
@@ -211,7 +211,7 @@ ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
 	ColumnDefinition result(std::move(name), std::move(type), std::move(expression), category);
 	deserializer.ReadProperty<duckdb::CompressionType>(104, "compression_type", result.compression_type);
 	deserializer.ReadPropertyWithExplicitDefault<Value>(105, "comment", result.comment, Value());
-	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, string>>(106, "tags", result.tags, unordered_map<string, string>());
+	deserializer.ReadPropertyWithExplicitDefault<InsertionOrderPreservingMap<string>>(106, "tags", result.tags, InsertionOrderPreservingMap<string>());
 	return result;
 }
 

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -12,7 +12,10 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/planner/extension_callback.hpp"
 #include "duckdb/planner/planner_extension.hpp"
@@ -804,6 +807,37 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	catalog.CreateTableFunction(client_context, quack_info);
 
 	con.Commit();
+
+	// Table with tagged columns
+	{
+		auto tagged_table_info = make_uniq<CreateTableInfo>();
+		tagged_table_info->schema = DEFAULT_SCHEMA;
+		tagged_table_info->table = "tagged_table";
+		tagged_table_info->on_conflict = OnCreateConflict::ERROR_ON_CONFLICT;
+		tagged_table_info->temporary = false;
+		tagged_table_info->internal = true;
+
+		ColumnDefinition col_a("a", LogicalType::INTEGER);
+		InsertionOrderPreservingMap<string> col_a_tags;
+		col_a_tags["ext:name"] = "loadable_extension_demo";
+		col_a_tags["ext:column_type"] = "primary";
+		col_a.SetTags(std::move(col_a_tags));
+		tagged_table_info->columns.AddColumn(std::move(col_a));
+
+		ColumnDefinition col_b("b", LogicalType::VARCHAR);
+		InsertionOrderPreservingMap<string> col_b_tags;
+		col_b_tags["ext:name"] = "loadable_extension_demo";
+		col_b_tags["ext:column_type"] = "dimension";
+		col_b.SetTags(std::move(col_b_tags));
+		tagged_table_info->columns.AddColumn(std::move(col_b));
+
+		con.BeginTransaction();
+		auto &default_db_name = DatabaseManager::GetDefaultDatabase(client_context);
+		auto &default_catalog = Catalog::GetCatalog(client_context, default_db_name);
+		MetaTransaction::Get(client_context).ModifyDatabase(default_catalog.GetAttached(), DatabaseModificationType());
+		default_catalog.CreateTable(client_context, std::move(tagged_table_info));
+		con.Commit();
+	}
 
 	// add a parser extension
 	auto &config = DBConfig::GetConfig(db);

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -813,7 +813,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 		auto tagged_table_info = make_uniq<CreateTableInfo>();
 		tagged_table_info->schema = DEFAULT_SCHEMA;
 		tagged_table_info->table = "tagged_table";
-		tagged_table_info->on_conflict = OnCreateConflict::ERROR_ON_CONFLICT;
+		tagged_table_info->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 		tagged_table_info->temporary = false;
 		tagged_table_info->internal = true;
 

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -24,3 +24,9 @@ query II
 SELECT type_name, tags['ext:author'] FROM duckdb_types() WHERE tags['ext:name'] = 'loadable_extension_demo' ORDER BY type_name;
 ----
 POINT	DuckDB Labs
+
+query III
+SELECT column_name, tags['ext:name'], tags['ext:column_type'] FROM duckdb_columns() WHERE table_name = 'tagged_table' ORDER BY column_index;
+----
+a	loadable_extension_demo	primary
+b	loadable_extension_demo	dimension


### PR DESCRIPTION
## Summary

`ColumnDefinition` already had a `tags` field that was serialized and copied but never exposed through `duckdb_columns()`. Every other catalog object (tables, schemas, views, functions, types, sequences, indexes, databases) already exposes tags through its respective `duckdb_*()` system function — columns were the odd one out.

This PR:
- Adds a `tags` column (`MAP(VARCHAR, VARCHAR)`) to `duckdb_columns()`, following the same pattern as `duckdb_tables()`, `duckdb_schemas()`, etc.
- Fixes the `ColumnDefinition::tags` type from `unordered_map<string, string>` to `InsertionOrderPreservingMap<string>` for consistency with `CatalogEntry::tags` and `CreateInfo::tags`
- Adds `Tags()` getter and `SetTags()` setter to `ColumnDefinition`, following the existing accessor pattern (`Comment()`/`SetComment()`, etc.)
- Extends `loadable_extension_demo` with a table that has tagged columns
- Extends `test/extension/test_tags.test` to verify column tags are returned correctly, including multiple tags per column

The serialization type change is backwards compatible since column tags were never settable via SQL, so no existing database would have non-empty column tags serialized.

## Test plan
- [x] `test/extension/test_tags.test` — verifies tagged columns created by the extension demo are returned by `duckdb_columns()` with correct tag values
- [x] `test/sql/catalog/comment_on_column.test` — existing column metadata test still passes