### PR TITLE
Add helper method for ConstantVector::SetNull

### DIFF
--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -429,8 +429,7 @@ void DateDiffFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
 			DateDiffBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2015,12 +2015,10 @@ struct StructDatePart {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 
 			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
-				ConstantVector::SetNull(result, false);
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
-					ConstantVector::SetNull(child_entry, false);
 					const auto part_index = size_t(info.part_codes[col]);
 					if (owners[part_index] == col) {
 						if (IsBigintDatepart(info.part_codes[col])) {
@@ -2037,7 +2035,7 @@ struct StructDatePart {
 					DatePart::StructOperator::Operation(bigint_values, double_values, tdata[0], 0, part_mask);
 				} else {
 					for (auto &child_entry : child_entries) {
-						ConstantVector::SetNull(child_entry, true);
+						ConstantVector::SetNull(child_entry);
 					}
 				}
 			}

--- a/extension/core_functions/scalar/date/date_sub.cpp
+++ b/extension/core_functions/scalar/date/date_sub.cpp
@@ -428,8 +428,7 @@ void DateSubFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
 			DateSubBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -482,8 +482,7 @@ void DateTruncFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
 			DateTruncUnaryExecutor<TA, TR>(type, date_arg, result, args.size());

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -235,8 +235,7 @@ void TimeBucketFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 	if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(bucket_width_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 			TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
@@ -275,8 +274,7 @@ void TimeBucketOffsetFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 	if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(bucket_width_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 			TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
@@ -319,8 +317,7 @@ void TimeBucketOriginFunction(DataChunk &args, ExpressionState &state, Vector &r
 	    origin_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(bucket_width_arg) || ConstantVector::IsNull(origin_arg) ||
 		    !Value::IsFinite(*ConstantVector::GetData<T>(origin_arg))) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 			TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -168,7 +168,7 @@ void ExecuteConstantSlice(Vector &result, Vector &str_vector, Vector &begin_vect
 	auto step_valid = step_vector && !ConstantVector::IsNull(*step_vector);
 
 	if (!str_valid || !begin_valid || !end_valid || (step_vector && !step_valid)) {
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 
@@ -213,7 +213,7 @@ void ExecuteConstantSlice(Vector &result, Vector &str_vector, Vector &begin_vect
 
 	// Try to slice
 	if (!clamp_result) {
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 	} else if (step == 1) {
 		result_data[0] = OP::SliceValue(result, str, begin, end);
 	} else {
@@ -336,8 +336,7 @@ void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	VectorOperations::Copy(args.data[0], list_or_str_vector, count, 0, 0);
 
 	if (list_or_str_vector.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -209,8 +209,7 @@ void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &res
 	auto &result_validity = FlatVector::Validity(result);
 
 	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/extension/core_functions/scalar/map/map_entries.cpp
+++ b/extension/core_functions/scalar/map/map_entries.cpp
@@ -14,9 +14,7 @@ static void MapEntriesFunction(DataChunk &args, ExpressionState &state, Vector &
 
 	auto &map = args.data[0];
 	if (map.GetType().id() == LogicalTypeId::SQLNULL) {
-		// Input is a constant NULL
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	MapUtil::ReinterpretMap(result, map, count);

--- a/extension/core_functions/scalar/map/map_keys_values.cpp
+++ b/extension/core_functions/scalar/map/map_keys_values.cpp
@@ -15,8 +15,7 @@ static void MapKeyValueFunction(DataChunk &args, ExpressionState &state, Vector 
 
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 	if (map.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	auto count = args.size();

--- a/extension/core_functions/scalar/random/setseed.cpp
+++ b/extension/core_functions/scalar/random/setseed.cpp
@@ -45,8 +45,7 @@ void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		random_engine.SetSeed(norm_seed);
 	}
 
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	ConstantVector::SetNull(result, true);
+	ConstantVector::SetNull(result);
 }
 
 unique_ptr<FunctionData> SetSeedBind(ClientContext &context, ScalarFunction &bound_function,

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -82,8 +82,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 		case VectorType::CONSTANT_VECTOR:
 			if (ConstantVector::IsNull(args.data[i])) {
 				// constant null! result is always NULL regardless of other input
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 				return;
 			}
 			break;

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -52,7 +52,7 @@ static void StructKeysFunction(DataChunk &args, ExpressionState &state, Vector &
 	// If the input is a constant, we must return a CONSTANT_VECTOR
 	if (args.AllConstant()) {
 		if (ConstantVector::IsNull(input)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		ConstantVector::Reference(result, keys_vector, 0, count);

--- a/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/extension/core_functions/scalar/struct/struct_values.cpp
@@ -29,9 +29,9 @@ static void StructValuesFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		const bool is_null = ConstantVector::IsNull(input);
-		ConstantVector::SetNull(result, is_null);
+		if (ConstantVector::IsNull(input)) {
+			ConstantVector::SetNull(result);
+		}
 	} else {
 		result.SetVectorType(VectorType::FLAT_VECTOR);
 

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -387,9 +387,8 @@ struct ICUDatePart : public ICUDateFunc {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 
 			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
-				ConstantVector::SetNull(result, false);
 				auto tdata = ConstantVector::GetData<INPUT_TYPE>(input);
 				auto micros = SetTime(calendar, tdata[0]);
 				const auto is_finite = Timestamp::IsFinite(*tdata);
@@ -397,7 +396,6 @@ struct ICUDatePart : public ICUDateFunc {
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
 					if (is_finite) {
-						ConstantVector::SetNull(child_entry, false);
 						if (IsBigintDatepart(info.part_codes[col])) {
 							auto pdata = ConstantVector::GetData<int64_t>(child_entry);
 							auto adapter = info.bigints[col];
@@ -408,7 +406,7 @@ struct ICUDatePart : public ICUDateFunc {
 							pdata[0] = adapter(calendar, micros);
 						}
 					} else {
-						ConstantVector::SetNull(child_entry, true);
+						ConstantVector::SetNull(child_entry);
 					}
 				}
 			}

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -102,8 +102,7 @@ struct ICUCalendarSub : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
 				auto part_func = SubtractFactory(GetDatePartSpecifier(specifier));
@@ -233,8 +232,7 @@ struct ICUCalendarDiff : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
 				const auto part = GetDatePartSpecifier(specifier);

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -136,8 +136,7 @@ struct ICUDateTrunc : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
 				auto truncator = TruncationFactory(GetDatePartSpecifier(specifier));

--- a/extension/icu/icu-makedate.cpp
+++ b/extension/icu/icu-makedate.cpp
@@ -125,8 +125,7 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 			auto &tz_vec = input.data.back();
 			if (tz_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 				if (ConstantVector::IsNull(tz_vec)) {
-					result.SetVectorType(VectorType::CONSTANT_VECTOR);
-					ConstantVector::SetNull(result, true);
+					ConstantVector::SetNull(result);
 				} else {
 					SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
 					SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -114,8 +114,7 @@ struct ICUStrptime : public ICUDateFunc {
 		D_ASSERT(fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR);
 
 		if (ConstantVector::IsNull(fmt_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			UnaryExecutor::Execute<string_t, timestamp_t>(str_arg, result, args.size(), [&](string_t input) {
 				ParseResult parsed;
@@ -152,8 +151,7 @@ struct ICUStrptime : public ICUDateFunc {
 		D_ASSERT(fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR);
 
 		if (ConstantVector::IsNull(fmt_arg)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			UnaryExecutor::ExecuteWithNulls<string_t, timestamp_t>(
 			    str_arg, result, args.size(), [&](string_t input, ValidityMask &mask, idx_t idx) {
@@ -427,8 +425,7 @@ struct ICUStrftime : public ICUDateFunc {
 		if (fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(fmt_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				StrfTimeFormat format;
 				ParseFormatSpecifier(*ConstantVector::GetData<string_t>(fmt_arg), format);

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -376,8 +376,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
@@ -432,8 +431,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
@@ -498,8 +496,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		    origin_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg) || ConstantVector::IsNull(origin_arg) ||
 			    !Value::IsFinite(*ConstantVector::GetData<timestamp_t>(origin_arg))) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
@@ -563,8 +560,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR &&
 		    tz_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg) || ConstantVector::IsNull(tz_arg)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
 				SetTimeZone(calendar.GetICUCalendar(), *ConstantVector::GetData<string_t>(tz_arg));

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -423,8 +423,7 @@ struct ICUTimeZoneFunc : public ICUDateFunc {
 		auto &ts_vec = input.data[1];
 		if (tz_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(tz_vec)) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
 				UnaryExecutor::Execute<T, T>(ts_vec, result, input.size(),

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -116,8 +116,7 @@ static void JSONContainsFunction(DataChunk &args, ExpressionState &state, Vector
 
 	if (needles.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(needles)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		auto &needle_str = *ConstantVector::GetData<string_t>(needles);

--- a/extension/json/json_functions/json_table_in_out.cpp
+++ b/extension/json/json_functions/json_table_in_out.cpp
@@ -355,8 +355,7 @@ static OperatorResultType JSONTableInOutFunction(ExecutionContext &, TableFuncti
 	}
 	if (gstate.empty_column_idex.IsValid()) {
 		auto &empty_vector = output.data[gstate.empty_column_idex.GetIndex()];
-		empty_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(empty_vector, true);
+		ConstantVector::SetNull(empty_vector);
 	}
 
 	if (output.size() == 0) {

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -519,8 +519,7 @@ static bool TransformObjectInternal(yyjson_val *objects[], yyjson_alc *alc, Vect
 
 	for (idx_t child_i = 0; child_i < child_vs.size(); child_i++) {
 		if (projected_indices.find(child_i) == projected_indices.end()) {
-			child_vs[child_i].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(child_vs[child_i], true);
+			ConstantVector::SetNull(child_vs[child_i]);
 		}
 	}
 

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -48,8 +48,7 @@ idx_t StructColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_
 		auto &target_vector = struct_entries[i];
 		if (!child) {
 			// if we are not scanning this vector - set it to NULL
-			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(target_vector, true);
+			ConstantVector::SetNull(target_vector);
 			continue;
 		}
 		auto child_num_values = child->Read(num_values, define_out, repeat_out, target_vector);

--- a/src/common/sort/full_sort.cpp
+++ b/src/common/sort/full_sort.cpp
@@ -173,8 +173,7 @@ SinkResultType FullSort::Sink(ExecutionContext &context, DataChunk &input_chunk,
 	if (force_payload) {
 		auto &vec = payload_chunk.data[input_chunk.ColumnCount() + sort_chunk.ColumnCount()];
 		D_ASSERT(vec.GetType().id() == LogicalTypeId::BOOLEAN);
-		vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(vec, true);
+		ConstantVector::SetNull(vec);
 	}
 
 	payload_chunk.SetCardinality(input_chunk);

--- a/src/common/sort/hashed_sort.cpp
+++ b/src/common/sort/hashed_sort.cpp
@@ -367,8 +367,7 @@ SinkResultType HashedSort::Sink(ExecutionContext &context, DataChunk &input_chun
 	if (force_payload) {
 		auto &vec = payload_chunk.data[input_chunk.ColumnCount() + sort_chunk.ColumnCount()];
 		D_ASSERT(vec.GetType().id() == LogicalTypeId::BOOLEAN);
-		vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(vec, true);
+		ConstantVector::SetNull(vec);
 	}
 
 	payload_chunk.SetCardinality(input_chunk);

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -8,6 +8,11 @@
 
 namespace duckdb {
 
+void ConstantVector::SetNull(Vector &vector) {
+	vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+	SetNull(vector, true);
+}
+
 void ConstantVector::SetNull(Vector &vector, bool is_null) {
 	D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
 	vector.validity.Set(0, !is_null);
@@ -33,20 +38,6 @@ void ConstantVector::SetNull(Vector &vector, bool is_null) {
 				for (idx_t i = 0; i < array_size; i++) {
 					FlatVector::SetNull(child, i, is_null);
 				}
-			}
-		} else if (internal_type == PhysicalType::LIST) {
-			// for list - don't do anything
-			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::LIST_BUFFER) {
-				throw InternalException("Not a list buffer!?");
-			}
-		} else if (internal_type == PhysicalType::VARCHAR) {
-			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STRING_BUFFER) {
-				vector.buffer = make_buffer<VectorStringBuffer>(1);
-			}
-		} else {
-			// if we don't have a standard buffer overwrite it
-			if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::STANDARD_BUFFER) {
-				vector.buffer = make_buffer<StandardVectorBuffer>(GetTypeIdSize(internal_type));
 			}
 		}
 	}

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -28,7 +28,9 @@ void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t
 
 		bool is_null = OP::Operation(*ldata > 0, *rdata > 0, ConstantVector::IsNull(left),
 		                             ConstantVector::IsNull(right), *result_data);
-		ConstantVector::SetNull(result, is_null);
+		if (is_null) {
+			ConstantVector::SetNull(result);
+		}
 		return;
 	}
 	// perform generic loop

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -156,8 +156,7 @@ static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result
 
 	if ((left_constant && ConstantVector::IsNull(left)) || (right_constant && ConstantVector::IsNull(right))) {
 		// either left or right is constant NULL: result is constant NULL
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1469,8 +1469,7 @@ void ScanStructure::NextLeftJoin(DataChunk &keys, DataChunk &probe_data, DataChu
 			// now set the right side to NULL
 			for (idx_t i = ht.lhs_output_in_probe.size(); i < result.ColumnCount(); i++) {
 				Vector &vec = result.data[i];
-				vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(vec, true);
+				ConstantVector::SetNull(vec);
 			}
 		}
 		finished = true;
@@ -1592,8 +1591,7 @@ void JoinHashTable::ScanFullOuter(JoinHTScanState &state, Vector &addresses, Dat
 	// set the left side as a constant NULL
 	for (idx_t i = 0; i < left_column_count; i++) {
 		Vector &vec = result.data[i];
-		vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(vec, true);
+		ConstantVector::SetNull(vec);
 	}
 
 	// gather the values from the RHS

--- a/src/execution/operator/join/outer_join_marker.cpp
+++ b/src/execution/operator/join/outer_join_marker.cpp
@@ -56,8 +56,7 @@ void OuterJoinMarker::ConstructLeftJoinResult(DataChunk &left, DataChunk &result
 	if (remaining_count > 0) {
 		result.Slice(left, remaining_sel, remaining_count);
 		for (idx_t idx = left.ColumnCount(); idx < result.ColumnCount(); idx++) {
-			result.data[idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result.data[idx], true);
+			ConstantVector::SetNull(result.data[idx]);
 		}
 	}
 }
@@ -92,8 +91,7 @@ void OuterJoinMarker::Scan(OuterJoinGlobalScanState &gstate, OuterJoinLocalScanS
 			// if there were any tuples that didn't find a match, output them
 			idx_t left_column_count = result.ColumnCount() - lstate.scan_chunk.ColumnCount();
 			for (idx_t i = 0; i < left_column_count; i++) {
-				result.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result.data[i], true);
+				ConstantVector::SetNull(result.data[i]);
 			}
 			for (idx_t col_idx = left_column_count; col_idx < result.ColumnCount(); col_idx++) {
 				result.data[col_idx].Slice(lstate.scan_chunk.data[col_idx - left_column_count], lstate.match_sel,

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -1623,8 +1623,7 @@ void AsOfLocalSourceState::ExecuteRightTask(ExecutionContext &context, DataChunk
 		const auto &op = gsource.op;
 		const idx_t left_column_count = op.children[0].get().GetTypes().size();
 		for (idx_t col_idx = 0; col_idx < left_column_count; ++col_idx) {
-			chunk.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(chunk.data[col_idx], true);
+			ConstantVector::SetNull(chunk.data[col_idx]);
 		}
 		for (idx_t col_idx = 0; col_idx < op.right_projection_map.size(); ++col_idx) {
 			const auto rhs_idx = op.right_projection_map[col_idx];

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -150,8 +150,7 @@ void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool h
 		}
 		// for the RHS
 		for (idx_t k = input.ColumnCount(); k < result.ColumnCount(); k++) {
-			result.data[k].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result.data[k], true);
+			ConstantVector::SetNull(result.data[k]);
 		}
 	}
 }

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1966,8 +1966,7 @@ void IEJoinLocalSourceState::ExecuteLeftTask(ExecutionContext &context, DataChun
 		if (col_idx < left_cols) {
 			chunk.data[col_idx].Reference(lpayload.data[col_idx]);
 		} else {
-			chunk.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(chunk.data[col_idx], true);
+			ConstantVector::SetNull(chunk.data[col_idx]);
 		}
 	}
 
@@ -1998,8 +1997,7 @@ void IEJoinLocalSourceState::ExecuteRightTask(ExecutionContext &context, DataChu
 	chunk.Reset();
 	for (column_t col_idx = 0; col_idx < chunk.ColumnCount(); ++col_idx) {
 		if (col_idx < left_cols) {
-			chunk.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(chunk.data[col_idx], true);
+			ConstantVector::SetNull(chunk.data[col_idx]);
 		} else {
 			chunk.data[col_idx].Reference(rpayload.data[col_idx - left_cols]);
 		}

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -825,8 +825,7 @@ SourceResultType PhysicalPiecewiseMergeJoin::GetDataInternal(ExecutionContext &c
 			// if there were any tuples that didn't find a match, output them
 			const idx_t left_column_count = children[0].get().GetTypes().size();
 			for (idx_t col_idx = 0; col_idx < left_column_count; ++col_idx) {
-				result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result.data[col_idx], true);
+				ConstantVector::SetNull(result.data[col_idx]);
 			}
 			const idx_t right_column_count = children[1].get().GetTypes().size();
 			for (idx_t col_idx = 0; col_idx < right_column_count; ++col_idx) {

--- a/src/execution/operator/join/physical_positional_join.cpp
+++ b/src/execution/operator/join/physical_positional_join.cpp
@@ -79,8 +79,7 @@ idx_t PositionalJoinGlobalState::Refill() {
 			source.Reset();
 			for (idx_t i = 0; i < source.ColumnCount(); ++i) {
 				auto &vec = source.data[i];
-				vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(vec, true);
+				ConstantVector::SetNull(vec);
 			}
 			exhausted = true;
 		}
@@ -161,8 +160,7 @@ void PositionalJoinGlobalState::GetData(DataChunk &output) {
 	const auto col_offset = output.ColumnCount() - source.ColumnCount();
 	for (idx_t i = 0; i < col_offset; ++i) {
 		auto &vec = output.data[i];
-		vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(vec, true);
+		ConstantVector::SetNull(vec);
 	}
 
 	//	RHS still has data, so copy it

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -385,10 +385,11 @@ idx_t PhysicalRangeJoin::LocalSortedTable::MergeNulls(Vector &primary, const vec
 			auto &v = keys.data[c];
 			if (ConstantVector::IsNull(v)) {
 				// Create a new validity mask to avoid modifying original mask
+				// FIXME: why?
 				auto &pvalidity = ConstantVector::Validity(primary);
 				ValidityMask pvalidity_copy = ConstantVector::Validity(primary);
 				pvalidity.Copy(pvalidity_copy, count);
-				ConstantVector::SetNull(primary, true);
+				ConstantVector::SetNull(primary);
 				return count;
 			}
 		}

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -239,8 +239,7 @@ OperatorResultType PhysicalUnnest::ExecuteInternal(ExecutionContext &context, Da
 			    ListVector::GetListSize(list_vector) == 0) {
 				// UNNEST(NULL) or UNNEST([])
 				// we cannot slice empty lists - but if our child list is empty we can only return NULL anyway
-				result_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result_vector, true);
+				ConstantVector::SetNull(result_vector);
 				continue;
 			}
 			auto &child_vector = ListVector::GetEntry(list_vector);

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -85,8 +85,7 @@ public:
 				source.Reset();
 				for (idx_t i = 0; i < source.ColumnCount(); ++i) {
 					auto &vec = source.data[i];
-					vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-					ConstantVector::SetNull(vec, true);
+					ConstantVector::SetNull(vec);
 				}
 				exhausted = true;
 			}

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -924,8 +924,7 @@ void RadixHTLocalSourceState::Scan(RadixHTGlobalSinkState &sink, RadixHTGlobalSo
 		chunk.data[entry].Reference(scan_chunk.data[chunk_index++]);
 	}
 	for (auto null_group : radix_ht.null_groups) {
-		chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(chunk.data[null_group], true);
+		ConstantVector::SetNull(chunk.data[null_group]);
 	}
 	D_ASSERT(radix_ht.grouping_set.size() + radix_ht.null_groups.size() == radix_ht.op.GroupCount());
 	for (idx_t col_idx = 0; col_idx < radix_ht.op.aggregates.size(); col_idx++) {
@@ -973,8 +972,7 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 			// For each column in the aggregates, set to initial state
 			chunk.SetCardinality(1);
 			for (auto null_group : null_groups) {
-				chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(chunk.data[null_group], true);
+				ConstantVector::SetNull(chunk.data[null_group]);
 			}
 			ArenaAllocator allocator(BufferAllocator::Get(context.client));
 			for (idx_t i = 0; i < op.aggregates.size(); i++) {

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -159,8 +159,7 @@ unique_ptr<ReservoirChunk> ReservoirSample::CreateNewSampleChunk(vector<LogicalT
 	// set the NULL columns correctly
 	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
 		if (!ValidSampleType(types[col_idx]) && stats_sample) {
-			new_sample_chunk->chunk.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(new_sample_chunk->chunk.data[col_idx], true);
+			ConstantVector::SetNull(new_sample_chunk->chunk.data[col_idx]);
 		}
 	}
 	return new_sample_chunk;

--- a/src/function/cast/array_casts.cpp
+++ b/src/function/cast/array_casts.cpp
@@ -53,8 +53,7 @@ static bool ArrayToArrayCast(Vector &source, Vector &result, idx_t count, CastPa
 		HandleCastError::AssignError(msg, parameters);
 		if (!parameters.strict) {
 			// if this was a TRY_CAST, we know every row will fail, so just return null
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return false;
 		}
 	}
@@ -64,7 +63,7 @@ static bool ArrayToArrayCast(Vector &source, Vector &result, idx_t count, CastPa
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 
 		if (ConstantVector::IsNull(source)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		}
 
 		auto &source_cc = ArrayVector::GetEntry(source);

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -62,8 +62,7 @@ bool DefaultCasts::TryVectorNullCast(Vector &source, Vector &result, idx_t count
 		HandleCastError::AssignError(TryCast::UnimplementedCastMessage(source.GetType(), result.GetType()), parameters);
 		success = false;
 	}
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	ConstantVector::SetNull(result, true);
+	ConstantVector::SetNull(result);
 	return success;
 }
 
@@ -117,8 +116,7 @@ static BoundCastInfo AggregateStateCast(BindCastInput &input, const LogicalType 
 
 static bool NullTypeCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	// cast a NULL to another type, just copy the properties and change the type
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	ConstantVector::SetNull(result, true);
+	ConstantVector::SetNull(result);
 	return true;
 }
 

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -164,7 +164,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		result.SetVectorType(source.GetVectorType());
 		if (ConstantVector::IsNull(source)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return true;
 		}
 
@@ -174,7 +174,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 			auto msg = StringUtil::Format("Cannot cast list with length %llu to array with length %u", ldata.length,
 			                              array_size);
 			HandleCastError::AssignError(msg, parameters);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return false;
 		}
 

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -121,8 +121,7 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 			auto target_idx = cast_data.target_null_indexes[i];
 			auto &target_vector = target_children[target_idx];
 
-			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(target_vector, true);
+			ConstantVector::SetNull(target_vector);
 		}
 	}
 
@@ -281,7 +280,7 @@ static bool StructToMapCast(Vector &source, Vector &result, idx_t count, CastPar
 		count = 1;
 		if (ConstantVector::IsNull(source)) {
 			// If there's only a null in there we don't need to cast anything
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return true;
 		}
 	}

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -242,8 +242,7 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 	for (idx_t target_member_idx = 0; target_member_idx < target_member_count; target_member_idx++) {
 		if (!target_member_is_mapped[target_member_idx]) {
 			auto &target_member_vector = UnionVector::GetMember(result, target_member_idx);
-			target_member_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(target_member_vector, true);
+			ConstantVector::SetNull(target_member_vector);
 		}
 	}
 
@@ -255,7 +254,7 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 		// Constant vector case optimization
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		if (ConstantVector::IsNull(source)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			// map the tag
 			auto source_tag = ConstantVector::GetData<union_tag_t>(source_tag_vector)[0];

--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -127,11 +127,9 @@ struct VariantLocalData : FunctionLocalState {
 		// NULL out everything in the unshredded part
 		auto &unshredded_child = top_shredded[0];
 		for (auto &unshredded_entry : StructVector::GetEntries(unshredded_child)) {
-			unshredded_entry.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(unshredded_entry, true);
+			ConstantVector::SetNull(unshredded_entry);
 		}
-		unshredded_child.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(unshredded_child, true);
+		ConstantVector::SetNull(unshredded_child);
 	}
 
 	Vector &GetShreddedVector(idx_t req_capacity) {

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -72,8 +72,7 @@ static void StrfTimeFunctionDate(DataChunk &args, ExpressionState &state, Vector
 	auto &info = func_expr.bind_info->Cast<StrfTimeBindData>();
 
 	if (info.is_null) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	info.format.ConvertDateVector(args.data[REVERSED ? 1 : 0], result, args.size());
@@ -85,8 +84,7 @@ static void StrfTimeFunctionTimestamp(DataChunk &args, ExpressionState &state, V
 	auto &info = func_expr.bind_info->Cast<StrfTimeBindData>();
 
 	if (info.is_null) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	info.format.ConvertTimestampVector(args.data[REVERSED ? 1 : 0], result, args.size());
@@ -98,8 +96,7 @@ static void StrfTimeFunctionTimestampNS(DataChunk &args, ExpressionState &state,
 	auto &info = func_expr.bind_info->Cast<StrfTimeBindData>();
 
 	if (info.is_null) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	info.format.ConvertTimestampNSVector(args.data[REVERSED ? 1 : 0], result, args.size());
@@ -159,8 +156,7 @@ struct StrpTimeFunction {
 		auto format_entries = args.data[1].Validity(args.size());
 
 		if (!format_entries.IsValid(0)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		UnaryExecutor::Execute<string_t, T>(args.data[0], result, args.size(), [&](string_t input) {
@@ -180,8 +176,7 @@ struct StrpTimeFunction {
 		auto &info = func_expr.bind_info->Cast<StrpTimeBindData>();
 
 		if (args.data[1].GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(args.data[1])) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -45,11 +45,10 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 		case VectorType::CONSTANT_VECTOR: {
 			if (ConstantVector::IsNull(args.data[idx])) {
 				// input is constant null, return constant null
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
 				auto &result_mask = ConstantVector::Validity(result);
 				auto &input_mask = ConstantVector::Validity(args.data[idx]);
 				result_mask.Initialize(input_mask);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 				return;
 			}
 			break;

--- a/src/function/scalar/list/contains_or_position.cpp
+++ b/src/function/scalar/list/contains_or_position.cpp
@@ -9,8 +9,7 @@ namespace duckdb {
 template <class RETURN_TYPE, bool FIND_NULLS = false>
 static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -113,8 +113,7 @@ static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector 
 		ExecuteStringExtract(result, base, subscript, count);
 		break;
 	case LogicalTypeId::SQLNULL:
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		break;
 	default:
 		throw NotImplementedException("Specifier type not implemented");

--- a/src/function/scalar/list/list_intersect.cpp
+++ b/src/function/scalar/list/list_intersect.cpp
@@ -30,8 +30,7 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 
 	// Handle NULL return type case
 	if (result.GetType() == LogicalType::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -11,8 +11,7 @@ namespace duckdb {
 static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	// Early-out, if the return value is a constant NULL.
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -75,8 +75,7 @@ void NextValFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	if (!func_expr.bind_info) {
 		// no bind info - return null
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<NextValLocalState>();

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -86,8 +86,7 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 	case VectorType::CONSTANT_VECTOR: {
 		if (ConstantVector::IsNull(separator)) {
 			// constant NULL as separator: return constant NULL vector
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		// no null values

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -280,7 +280,7 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 
 		if (ConstantVector::IsNull(input)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			ConstantVector::SetNull(result, false);
 			auto idata = ConstantVector::GetData<string_t>(input);

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -101,8 +101,7 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 	// copy over the NULL values from the input vector
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(input)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		auto list_data = FlatVector::GetData<list_entry_t>(input);
@@ -151,8 +150,7 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 	// copy over the NULL values from the input vector
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(input)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		auto list_data = FlatVector::GetData<list_entry_t>(input);
@@ -196,8 +194,7 @@ void RemapStruct(Vector &input, Vector &default_vector, Vector &result, idx_t re
 	// copy over the NULL values from the input vector
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(input)) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 	} else {

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -42,8 +42,7 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 
 	if (total_matches == 0 && return_pos) {
 		// if there are no members that match the target type, we cannot return a position
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 
@@ -179,8 +178,7 @@ static void StructSearchOp(Vector &input_vector, vector<Vector> &members, Vector
 template <class RETURN_TYPE, bool FIND_NULLS = false>
 static void StructSearchFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::SetNull(result);
 		return;
 	}
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -116,11 +116,9 @@ static bool TryShreddedExtractRecursive(Vector &input, const vector<VariantPathC
 		// NULL out everything in the unshredded part
 		auto &unshredded_child = top_shredded[0];
 		for (auto &unshredded_entry : StructVector::GetEntries(unshredded_child)) {
-			unshredded_entry.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(unshredded_entry, true);
+			ConstantVector::SetNull(unshredded_entry);
 		}
-		unshredded_child.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(unshredded_child, true);
+		ConstantVector::SetNull(unshredded_child);
 		auto &shredded_child = top_shredded[1];
 		shredded_child.Reference(input);
 

--- a/src/include/duckdb/common/vector/constant_vector.hpp
+++ b/src/include/duckdb/common/vector/constant_vector.hpp
@@ -57,6 +57,8 @@ struct ConstantVector {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
 		return !vector.validity.RowIsValid(0);
 	}
+	//! Sets a vector to be a constant NULL vector
+	DUCKDB_API static void SetNull(Vector &vector);
 	DUCKDB_API static void SetNull(Vector &vector, bool is_null);
 	static inline ValidityMask &Validity(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -135,7 +135,7 @@ struct BinaryExecutor {
 		auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
 
 		if (ConstantVector::IsNull(left) || ConstantVector::IsNull(right)) {
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 		*result_data = OPWRAPPER::template Operation<FUNC, OP, LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
@@ -151,8 +151,7 @@ struct BinaryExecutor {
 
 		if ((LEFT_CONSTANT && ConstantVector::IsNull(left)) || (RIGHT_CONSTANT && ConstantVector::IsNull(right))) {
 			// either left or right is constant NULL: result is constant NULL
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			return;
 		}
 

--- a/src/include/duckdb/common/vector_operations/senary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/senary_executor.hpp
@@ -41,7 +41,7 @@ struct SenaryExecutor {
 		if (all_constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			if (any_null) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				auto adata = ConstantVector::GetData<TA>(input.data[0]);
 				auto bdata = ConstantVector::GetData<TB>(input.data[1]);

--- a/src/include/duckdb/common/vector_operations/septenary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/septenary_executor.hpp
@@ -41,7 +41,7 @@ struct SeptenaryExecutor {
 		if (all_constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			if (any_null) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				auto adata = ConstantVector::GetData<TA>(input.data[0]);
 				auto bdata = ConstantVector::GetData<TB>(input.data[1]);

--- a/src/include/duckdb/common/vector_operations/ternary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/ternary_executor.hpp
@@ -78,7 +78,7 @@ public:
 		    c.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			if (ConstantVector::IsNull(a) || ConstantVector::IsNull(b) || ConstantVector::IsNull(c)) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				auto adata = ConstantVector::GetData<A_TYPE>(a);
 				auto bdata = ConstantVector::GetData<B_TYPE>(b);

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -152,7 +152,7 @@ private:
 			auto ldata = ConstantVector::GetData<INPUT_TYPE>(input);
 
 			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 			} else {
 				ConstantVector::SetNull(result, false);
 				*result_data = OPWRAPPER::template Operation<OP, INPUT_TYPE, RESULT_TYPE>(

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -78,7 +78,7 @@ struct AggregateFinalizeData {
 			FlatVector::SetNull(result, result_idx, true);
 			break;
 		case VectorType::CONSTANT_VECTOR:
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 			break;
 		default:
 			throw InternalException("Invalid result vector type for aggregate");

--- a/src/include/duckdb/function/lambda_functions.hpp
+++ b/src/include/duckdb/function/lambda_functions.hpp
@@ -101,8 +101,7 @@ public:
 			result_validity = &FlatVector::Validity(result);
 
 			if (list_column.GetType().id() == LogicalTypeId::SQLNULL) {
-				result.SetVectorType(VectorType::CONSTANT_VECTOR);
-				ConstantVector::SetNull(result, true);
+				ConstantVector::SetNull(result);
 				result_is_null = true;
 				return;
 			}

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -62,8 +62,7 @@ void ConstantScanFunctionValidity(ColumnSegment &segment, ColumnScanState &state
 	if (stats.CanHaveNull()) {
 		if (result.GetType().InternalType() == PhysicalType::STRUCT ||
 		    result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(result, true);
+			ConstantVector::SetNull(result);
 		} else {
 			result.Flatten(scan_count);
 			ConstantFillFunctionValidity(segment, result, 0, scan_count);

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -162,8 +162,7 @@ idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, Co
 		auto &target_vector = GetFieldVectorForScan(result, child.vector_index);
 		if (!child.should_scan) {
 			// if we are not scanning this vector - set it to NULL
-			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(target_vector, true);
+			ConstantVector::SetNull(target_vector);
 			continue;
 		}
 		ScanChild(state, target_vector, [&](Vector &child_result) {


### PR DESCRIPTION
This pattern occurs in many places in the code:

```cpp
result.SetVectorType(VectorType::CONSTANT_VECTOR);
ConstantVector::SetNull(result, true);
```

This PR replaces that pattern with:

```cpp
ConstantVector::SetNull(result);
```