### PR TITLE
Fix ADBC data race

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -138,8 +138,6 @@ struct DuckDBAdbcStreamWrapper {
 	duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper;
 };
 
-static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper);
-
 static bool IsInterruptError(const char *message) {
 	if (!message) {
 		return false;
@@ -965,17 +963,9 @@ AdbcStatusCode ConnectionRelease(struct AdbcConnection *connection, struct AdbcE
 	if (connection && connection->private_data) {
 		auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);
 		// Materialize active streams before disconnecting so they remain readable
-		MaterializeActiveStreams(conn_wrapper);
+		conn_wrapper->MaterializeStreams();
 		// Detach active streams before deleting conn_wrapper to avoid dangling pointers
-		{
-			const duckdb::lock_guard<duckdb::mutex> guard(conn_wrapper->stream_mutex);
-			for (auto *stream_wrapper : conn_wrapper->active_streams) {
-				if (stream_wrapper) {
-					stream_wrapper->conn_wrapper = nullptr;
-				}
-			}
-			conn_wrapper->active_streams.clear();
-		}
+		conn_wrapper->DetachAndClearStreams();
 		auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 		duckdb_disconnect(reinterpret_cast<duckdb_connection *>(&conn));
 		delete conn_wrapper;
@@ -1075,14 +1065,9 @@ void release(struct ArrowArrayStream *stream) {
 	}
 	auto result_wrapper = reinterpret_cast<DuckDBAdbcStreamWrapper *>(stream->private_data);
 	if (result_wrapper) {
-		// Unregister from connection's active_streams
+		// Unregister from connection's active streams
 		if (result_wrapper->conn_wrapper) {
-			const duckdb::lock_guard<duckdb::mutex> guard(result_wrapper->conn_wrapper->stream_mutex);
-			auto &active = result_wrapper->conn_wrapper->active_streams;
-			auto it = std::find(active.begin(), active.end(), result_wrapper);
-			if (it != active.end()) {
-				active.erase(it);
-			}
+			result_wrapper->conn_wrapper->UnregisterStream(result_wrapper);
 		}
 		// Clean up materialized data if present
 		if (result_wrapper->materialized) {
@@ -1510,76 +1495,6 @@ static AdbcStatusCode IngestToTableFromBoundStream(DuckDBAdbcStatementWrapper *s
 	              rows_affected);
 }
 
-// Materialize all active streams on a connection so that a new query can execute.
-// This fetches remaining data from each streaming result into memory, making the
-// streams independent of the connection's active query context.
-static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper) {
-	const duckdb::lock_guard<duckdb::mutex> guard(conn_wrapper->stream_mutex);
-	for (auto *result_wrapper : conn_wrapper->active_streams) {
-		if (!result_wrapper || result_wrapper->materialized) {
-			continue;
-		}
-
-		// Collect remaining batches from the streaming result
-		duckdb::vector<ArrowArray> batches;
-		auto arrow_options = duckdb_result_get_arrow_options(&result_wrapper->result);
-		while (true) {
-			ArrowArray array;
-			std::memset(&array, 0, sizeof(ArrowArray));
-
-			auto duckdb_chunk = duckdb_fetch_chunk(result_wrapper->result);
-			if (!duckdb_chunk) {
-				break;
-			}
-			auto conversion_err = duckdb_data_chunk_to_arrow(arrow_options, duckdb_chunk, &array);
-			duckdb_destroy_data_chunk(&duckdb_chunk);
-
-			if (conversion_err) {
-				duckdb_destroy_error_data(&conversion_err);
-				if (array.release) {
-					array.release(&array);
-				}
-				break;
-			}
-			batches.push_back(array);
-		}
-		duckdb_destroy_arrow_options(&arrow_options);
-
-		// Store materialized data
-		auto mat = static_cast<MaterializedData *>(malloc(sizeof(MaterializedData)));
-		if (!mat) {
-			// Allocation failed — release fetched batches and skip materialization
-			for (auto &batch : batches) {
-				if (batch.release) {
-					batch.release(&batch);
-				}
-			}
-			continue;
-		}
-		mat->current = 0;
-		mat->count = static_cast<idx_t>(batches.size());
-		if (!batches.empty()) {
-			mat->batches = static_cast<ArrowArray *>(malloc(sizeof(ArrowArray) * batches.size()));
-			if (!mat->batches) {
-				// Allocation failed — release fetched batches and skip materialization
-				for (auto &batch : batches) {
-					if (batch.release) {
-						batch.release(&batch);
-					}
-				}
-				free(mat);
-				continue;
-			}
-			for (idx_t i = 0; i < batches.size(); i++) {
-				mat->batches[i] = batches[i];
-			}
-		} else {
-			mat->batches = nullptr;
-		}
-		result_wrapper->materialized = mat;
-	}
-}
-
 AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct ArrowArrayStream *out,
                                      int64_t *rows_affected, struct AdbcError *error) {
 	if (!statement) {
@@ -1600,7 +1515,7 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 	// Without materialization, executing a new query would silently invalidate any existing streaming results on the
 	// same connection.
 	if (wrapper->conn_wrapper) {
-		MaterializeActiveStreams(wrapper->conn_wrapper);
+		wrapper->conn_wrapper->MaterializeStreams();
 	}
 
 	// TODO: Set affected rows, careful with early return
@@ -1760,8 +1675,7 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		out->get_last_error = get_last_error;
 		// Register this stream wrapper so it can be materialized if another query runs
 		if (wrapper->conn_wrapper) {
-			const duckdb::lock_guard<duckdb::mutex> guard(wrapper->conn_wrapper->stream_mutex);
-			wrapper->conn_wrapper->active_streams.push_back(stream_wrapper);
+			wrapper->conn_wrapper->RegisterStream(stream_wrapper);
 		}
 	} else {
 		// Caller didn't request a stream; clean up resources
@@ -1809,7 +1723,7 @@ AdbcStatusCode StatementSetSqlQuery(struct AdbcStatement *statement, const char 
 
 	// Materialize any active streams before preparing
 	if (wrapper->conn_wrapper) {
-		MaterializeActiveStreams(wrapper->conn_wrapper);
+		wrapper->conn_wrapper->MaterializeStreams();
 	}
 
 	if (wrapper->ingestion_stream.release) {
@@ -2473,6 +2387,96 @@ AdbcStatusCode ConnectionGetTableTypes(struct AdbcConnection *connection, struct
 }
 
 } // namespace duckdb_adbc
+
+void duckdb::DuckDBAdbcConnectionWrapper::RegisterStream(duckdb_adbc::DuckDBAdbcStreamWrapper *stream) {
+	const duckdb::lock_guard<duckdb::mutex> guard(stream_mutex);
+	active_streams.push_back(stream);
+}
+
+void duckdb::DuckDBAdbcConnectionWrapper::UnregisterStream(duckdb_adbc::DuckDBAdbcStreamWrapper *stream) {
+	const duckdb::lock_guard<duckdb::mutex> guard(stream_mutex);
+	auto it = std::find(active_streams.begin(), active_streams.end(), stream);
+	if (it != active_streams.end()) {
+		active_streams.erase(it);
+	}
+}
+
+void duckdb::DuckDBAdbcConnectionWrapper::MaterializeStreams() {
+	const duckdb::lock_guard<duckdb::mutex> guard(stream_mutex);
+	for (auto *result_wrapper : active_streams) {
+		if (!result_wrapper || result_wrapper->materialized) {
+			continue;
+		}
+
+		// Collect remaining batches from the streaming result
+		duckdb::vector<ArrowArray> batches;
+		auto arrow_options = duckdb_result_get_arrow_options(&result_wrapper->result);
+		while (true) {
+			ArrowArray array;
+			std::memset(&array, 0, sizeof(ArrowArray));
+
+			auto duckdb_chunk = duckdb_fetch_chunk(result_wrapper->result);
+			if (!duckdb_chunk) {
+				break;
+			}
+			auto conversion_err = duckdb_data_chunk_to_arrow(arrow_options, duckdb_chunk, &array);
+			duckdb_destroy_data_chunk(&duckdb_chunk);
+
+			if (conversion_err) {
+				duckdb_destroy_error_data(&conversion_err);
+				if (array.release) {
+					array.release(&array);
+				}
+				break;
+			}
+			batches.push_back(array);
+		}
+		duckdb_destroy_arrow_options(&arrow_options);
+
+		// Store materialized data
+		auto mat = static_cast<duckdb_adbc::MaterializedData *>(malloc(sizeof(duckdb_adbc::MaterializedData)));
+		if (!mat) {
+			// Allocation failed — release fetched batches and skip materialization
+			for (auto &batch : batches) {
+				if (batch.release) {
+					batch.release(&batch);
+				}
+			}
+			continue;
+		}
+		mat->current = 0;
+		mat->count = static_cast<idx_t>(batches.size());
+		if (!batches.empty()) {
+			mat->batches = static_cast<ArrowArray *>(malloc(sizeof(ArrowArray) * batches.size()));
+			if (!mat->batches) {
+				// Allocation failed — release fetched batches and skip materialization
+				for (auto &batch : batches) {
+					if (batch.release) {
+						batch.release(&batch);
+					}
+				}
+				free(mat);
+				continue;
+			}
+			for (idx_t i = 0; i < batches.size(); i++) {
+				mat->batches[i] = batches[i];
+			}
+		} else {
+			mat->batches = nullptr;
+		}
+		result_wrapper->materialized = mat;
+	}
+}
+
+void duckdb::DuckDBAdbcConnectionWrapper::DetachAndClearStreams() {
+	const duckdb::lock_guard<duckdb::mutex> guard(stream_mutex);
+	for (auto *stream_wrapper : active_streams) {
+		if (stream_wrapper) {
+			stream_wrapper->conn_wrapper = nullptr;
+		}
+	}
+	active_streams.clear();
+}
 
 static void ReleaseError(struct AdbcError *error) {
 	if (error) {

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -967,15 +967,12 @@ AdbcStatusCode ConnectionRelease(struct AdbcConnection *connection, struct AdbcE
 		// Materialize active streams before disconnecting so they remain readable
 		MaterializeActiveStreams(conn_wrapper);
 		// Detach active streams before deleting conn_wrapper to avoid dangling pointers
-		{
-			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(conn_wrapper->stream_mutex);
-			for (auto *stream_wrapper : conn_wrapper->active_streams) {
-				if (stream_wrapper) {
-					stream_wrapper->conn_wrapper = nullptr;
-				}
+		for (auto *stream_wrapper : conn_wrapper->active_streams) {
+			if (stream_wrapper) {
+				stream_wrapper->conn_wrapper = nullptr;
 			}
-			conn_wrapper->active_streams.clear();
 		}
+		conn_wrapper->active_streams.clear();
 		auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 		duckdb_disconnect(reinterpret_cast<duckdb_connection *>(&conn));
 		delete conn_wrapper;
@@ -1077,8 +1074,6 @@ void release(struct ArrowArrayStream *stream) {
 	if (result_wrapper) {
 		// Unregister from connection's active_streams
 		if (result_wrapper->conn_wrapper) {
-			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(
-			    result_wrapper->conn_wrapper->stream_mutex);
 			auto &active = result_wrapper->conn_wrapper->active_streams;
 			auto it = std::find(active.begin(), active.end(), result_wrapper);
 			if (it != active.end()) {
@@ -1515,7 +1510,6 @@ static AdbcStatusCode IngestToTableFromBoundStream(DuckDBAdbcStatementWrapper *s
 // This fetches remaining data from each streaming result into memory, making the
 // streams independent of the connection's active query context.
 static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper) {
-	const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(conn_wrapper->stream_mutex);
 	for (auto *result_wrapper : conn_wrapper->active_streams) {
 		if (!result_wrapper || result_wrapper->materialized) {
 			continue;
@@ -1761,7 +1755,6 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		out->get_last_error = get_last_error;
 		// Register this stream wrapper so it can be materialized if another query runs
 		if (wrapper->conn_wrapper) {
-			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(wrapper->conn_wrapper->stream_mutex);
 			wrapper->conn_wrapper->active_streams.push_back(stream_wrapper);
 		}
 	} else {

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -967,12 +967,15 @@ AdbcStatusCode ConnectionRelease(struct AdbcConnection *connection, struct AdbcE
 		// Materialize active streams before disconnecting so they remain readable
 		MaterializeActiveStreams(conn_wrapper);
 		// Detach active streams before deleting conn_wrapper to avoid dangling pointers
-		for (auto *stream_wrapper : conn_wrapper->active_streams) {
-			if (stream_wrapper) {
-				stream_wrapper->conn_wrapper = nullptr;
+		{
+			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(conn_wrapper->stream_mutex);
+			for (auto *stream_wrapper : conn_wrapper->active_streams) {
+				if (stream_wrapper) {
+					stream_wrapper->conn_wrapper = nullptr;
+				}
 			}
+			conn_wrapper->active_streams.clear();
 		}
-		conn_wrapper->active_streams.clear();
 		auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 		duckdb_disconnect(reinterpret_cast<duckdb_connection *>(&conn));
 		delete conn_wrapper;
@@ -1074,6 +1077,8 @@ void release(struct ArrowArrayStream *stream) {
 	if (result_wrapper) {
 		// Unregister from connection's active_streams
 		if (result_wrapper->conn_wrapper) {
+			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(
+			    result_wrapper->conn_wrapper->stream_mutex);
 			auto &active = result_wrapper->conn_wrapper->active_streams;
 			auto it = std::find(active.begin(), active.end(), result_wrapper);
 			if (it != active.end()) {
@@ -1510,6 +1515,7 @@ static AdbcStatusCode IngestToTableFromBoundStream(DuckDBAdbcStatementWrapper *s
 // This fetches remaining data from each streaming result into memory, making the
 // streams independent of the connection's active query context.
 static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper) {
+	const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(conn_wrapper->stream_mutex);
 	for (auto *result_wrapper : conn_wrapper->active_streams) {
 		if (!result_wrapper || result_wrapper->materialized) {
 			continue;
@@ -1755,6 +1761,7 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		out->get_last_error = get_last_error;
 		// Register this stream wrapper so it can be materialized if another query runs
 		if (wrapper->conn_wrapper) {
+			const duckdb::annotated_lock_guard<duckdb::annotated_mutex> guard(wrapper->conn_wrapper->stream_mutex);
 			wrapper->conn_wrapper->active_streams.push_back(stream_wrapper);
 		}
 	} else {

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -967,12 +967,15 @@ AdbcStatusCode ConnectionRelease(struct AdbcConnection *connection, struct AdbcE
 		// Materialize active streams before disconnecting so they remain readable
 		MaterializeActiveStreams(conn_wrapper);
 		// Detach active streams before deleting conn_wrapper to avoid dangling pointers
-		for (auto *stream_wrapper : conn_wrapper->active_streams) {
-			if (stream_wrapper) {
-				stream_wrapper->conn_wrapper = nullptr;
+		{
+			const duckdb::lock_guard<duckdb::mutex> guard(conn_wrapper->stream_mutex);
+			for (auto *stream_wrapper : conn_wrapper->active_streams) {
+				if (stream_wrapper) {
+					stream_wrapper->conn_wrapper = nullptr;
+				}
 			}
+			conn_wrapper->active_streams.clear();
 		}
-		conn_wrapper->active_streams.clear();
 		auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 		duckdb_disconnect(reinterpret_cast<duckdb_connection *>(&conn));
 		delete conn_wrapper;
@@ -1074,6 +1077,7 @@ void release(struct ArrowArrayStream *stream) {
 	if (result_wrapper) {
 		// Unregister from connection's active_streams
 		if (result_wrapper->conn_wrapper) {
+			const duckdb::lock_guard<duckdb::mutex> guard(result_wrapper->conn_wrapper->stream_mutex);
 			auto &active = result_wrapper->conn_wrapper->active_streams;
 			auto it = std::find(active.begin(), active.end(), result_wrapper);
 			if (it != active.end()) {
@@ -1510,6 +1514,7 @@ static AdbcStatusCode IngestToTableFromBoundStream(DuckDBAdbcStatementWrapper *s
 // This fetches remaining data from each streaming result into memory, making the
 // streams independent of the connection's active query context.
 static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper) {
+	const duckdb::lock_guard<duckdb::mutex> guard(conn_wrapper->stream_mutex);
 	for (auto *result_wrapper : conn_wrapper->active_streams) {
 		if (!result_wrapper || result_wrapper->materialized) {
 			continue;
@@ -1755,6 +1760,7 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		out->get_last_error = get_last_error;
 		// Register this stream wrapper so it can be materialized if another query runs
 		if (wrapper->conn_wrapper) {
+			const duckdb::lock_guard<duckdb::mutex> guard(wrapper->conn_wrapper->stream_mutex);
 			wrapper->conn_wrapper->active_streams.push_back(stream_wrapper);
 		}
 	} else {

--- a/src/include/duckdb/common/adbc/wrappers.hpp
+++ b/src/include/duckdb/common/adbc/wrappers.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb.h"
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
@@ -23,8 +22,7 @@ namespace duckdb {
 struct DuckDBAdbcConnectionWrapper {
 	duckdb_connection connection;
 	unordered_map<string, string> options;
-	annotated_mutex stream_mutex;
 	//! Active stream wrappers on this connection (for materialization on concurrent execute)
-	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams DUCKDB_GUARDED_BY(stream_mutex);
+	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams;
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/adbc/wrappers.hpp
+++ b/src/include/duckdb/common/adbc/wrappers.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.h"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
@@ -22,6 +23,7 @@ namespace duckdb {
 struct DuckDBAdbcConnectionWrapper {
 	duckdb_connection connection;
 	unordered_map<string, string> options;
+	mutex stream_mutex;
 	//! Active stream wrappers on this connection (for materialization on concurrent execute)
 	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams;
 };

--- a/src/include/duckdb/common/adbc/wrappers.hpp
+++ b/src/include/duckdb/common/adbc/wrappers.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.h"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
@@ -22,7 +23,8 @@ namespace duckdb {
 struct DuckDBAdbcConnectionWrapper {
 	duckdb_connection connection;
 	unordered_map<string, string> options;
+	annotated_mutex stream_mutex;
 	//! Active stream wrappers on this connection (for materialization on concurrent execute)
-	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams;
+	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams DUCKDB_GUARDED_BY(stream_mutex);
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/adbc/wrappers.hpp
+++ b/src/include/duckdb/common/adbc/wrappers.hpp
@@ -23,8 +23,18 @@ namespace duckdb {
 struct DuckDBAdbcConnectionWrapper {
 	duckdb_connection connection;
 	unordered_map<string, string> options;
+
+	//! Register a stream wrapper so it can be materialized if another query runs on this connection.
+	void RegisterStream(duckdb_adbc::DuckDBAdbcStreamWrapper *stream);
+	//! Unregister a stream wrapper.
+	void UnregisterStream(duckdb_adbc::DuckDBAdbcStreamWrapper *stream);
+	//! Materialize all active streams, fetching remaining data into memory.
+	void MaterializeStreams();
+	//! Detach all streams from this connection and clear the list (called on connection release).
+	void DetachAndClearStreams();
+
+private:
 	mutex stream_mutex;
-	//! Active stream wrappers on this connection (for materialization on concurrent execute)
 	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams;
 };
 } // namespace duckdb

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -4470,4 +4470,75 @@ TEST_CASE("ADBC - Parameterized statement breaking unique constraint (unhappy)",
 	db.adbc_error.release(&db.adbc_error);
 	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt, &db.adbc_error)));
 }
+
+TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+
+	AdbcError adbc_error = {};
+	InitializeADBCError(&adbc_error);
+
+	AdbcDatabase adbc_database;
+	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "path", ":memory:", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
+
+	AdbcConnection adbc_connection;
+	REQUIRE(SUCCESS(AdbcConnectionNew(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)));
+
+	// Create a table large enough that streaming requires multiple fetch calls.
+	{
+		AdbcStatement setup_stmt;
+		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &setup_stmt, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&setup_stmt, "CREATE TABLE big AS SELECT * FROM range(500000) r(i)",
+		                                         &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&setup_stmt, nullptr, nullptr, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementRelease(&setup_stmt, &adbc_error)));
+	}
+
+	constexpr int ITERATIONS = 50;
+
+	for (int iter = 0; iter < ITERATIONS; iter++) {
+		AdbcStatement query_stmt;
+		ArrowArrayStream stream;
+		stream.release = nullptr;
+		int64_t rows_affected;
+
+		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &query_stmt, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&query_stmt, "SELECT * FROM big", &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&query_stmt, &stream, &rows_affected, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementRelease(&query_stmt, &adbc_error)));
+
+		std::thread releaser([&stream]() {
+			if (stream.release) {
+				stream.release(&stream);
+			}
+		});
+
+		{
+			AdbcStatement materialize_stmt;
+			auto status = AdbcStatementNew(&adbc_connection, &materialize_stmt, &adbc_error);
+			if (status == ADBC_STATUS_OK) {
+				AdbcStatementSetSqlQuery(&materialize_stmt, "SELECT 1", &adbc_error);
+				AdbcStatementRelease(&materialize_stmt, &adbc_error);
+			}
+		}
+
+		releaser.join();
+		if (stream.release) {
+			stream.release(&stream);
+		}
+	}
+
+	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
+	if (adbc_error.release) {
+		adbc_error.release(&adbc_error);
+	}
+}
+
 } // namespace duckdb

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -4476,29 +4476,11 @@ TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
 		return;
 	}
 
-	AdbcError adbc_error = {};
-	InitializeADBCError(&adbc_error);
-
-	AdbcDatabase adbc_database;
-	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
-	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
-	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
-	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "path", ":memory:", &adbc_error)));
-	REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
-
-	AdbcConnection adbc_connection;
-	REQUIRE(SUCCESS(AdbcConnectionNew(&adbc_connection, &adbc_error)));
-	REQUIRE(SUCCESS(AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)));
+	ADBCTestDatabase db;
 
 	// Create a table large enough that streaming requires multiple fetch calls.
-	{
-		AdbcStatement setup_stmt;
-		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &setup_stmt, &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&setup_stmt, "CREATE TABLE big AS SELECT * FROM range(500000) r(i)",
-		                                         &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&setup_stmt, nullptr, nullptr, &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementRelease(&setup_stmt, &adbc_error)));
-	}
+	auto r = db.Query("CREATE TABLE big AS SELECT * FROM range(500000) r(i)");
+	REQUIRE(!r->HasError());
 
 	constexpr int ITERATIONS = 50;
 
@@ -4508,10 +4490,10 @@ TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
 		stream.release = nullptr;
 		int64_t rows_affected;
 
-		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &query_stmt, &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&query_stmt, "SELECT * FROM big", &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&query_stmt, &stream, &rows_affected, &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementRelease(&query_stmt, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &query_stmt, &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&query_stmt, "SELECT * FROM big", &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&query_stmt, &stream, &rows_affected, &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementRelease(&query_stmt, &db.adbc_error)));
 
 		std::thread releaser([&stream]() {
 			if (stream.release) {
@@ -4521,10 +4503,10 @@ TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
 
 		{
 			AdbcStatement materialize_stmt;
-			auto status = AdbcStatementNew(&adbc_connection, &materialize_stmt, &adbc_error);
+			auto status = AdbcStatementNew(&db.adbc_connection, &materialize_stmt, &db.adbc_error);
 			if (status == ADBC_STATUS_OK) {
-				AdbcStatementSetSqlQuery(&materialize_stmt, "SELECT 1", &adbc_error);
-				AdbcStatementRelease(&materialize_stmt, &adbc_error);
+				AdbcStatementSetSqlQuery(&materialize_stmt, "SELECT 1", &db.adbc_error);
+				AdbcStatementRelease(&materialize_stmt, &db.adbc_error);
 			}
 		}
 
@@ -4532,12 +4514,6 @@ TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
 		if (stream.release) {
 			stream.release(&stream);
 		}
-	}
-
-	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));
-	REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
-	if (adbc_error.release) {
-		adbc_error.release(&adbc_error);
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/21772

I used opus to rewrite the golang reproduction script and able to reproduce the use-after-free issue https://github.com/duckdb/duckdb/issues/21772#issuecomment-4176146600

How does the newly added C++ unit test simulates golang issue:
- GC finalizer goroutine -> ArrowArrayStreamRelease → duckdb_adbc::release() → erases from active_streams + destroys result
- Main goroutine calls stmt.SetSqlQuery(...) → triggers MaterializeActiveStreams → iterates active_streams + fetches data
- So essentially it's data race between two active stream operations: release + set query

It reads to me that `active_streams` on `DuckDBAdbcConnectionWrapper` is accessed from multiple threads without synchronization, so this PR adds mutex on access.
I was using `annotated_mutex` in my draft PR and I confirm no compilation issue (all access are locked).

Perform concern
- In this PR, I acquire the mutex in the whole materialization function to protect `active_streams`
- Checking the call sites, there're only a few possible callers `StatementSetSqlQuery`, `StatementExecuteQuery` and `ReleaseConnection`; it reads to me the only lock contention is release against the other two, so not a big issue

I ran CI in my own fork: https://github.com/dentiny/duckdb/pull/76 (with slight modification after CI passes).
Local test command: `DUCKDB_INSTALL_LIB=./build/debug/src/libduckdb.dylib ./build/debug/test/unittest "[adbc]"`