### PR TITLE
Fix intermittent wrong result for DISTINCT CTE with LEFT JOIN on empty table

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -150,4 +150,4 @@ jobs:
       - name: Tidy Check Diff
         shell: bash
         if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/feature' }}
-        run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
+        run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref || vars.DUCKDB_GIT_BASE_BRANCH || '' }} make tidy-check-diff

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -48,7 +48,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
+  BASE_BRANCH: ${{ github.base_ref || vars.DUCKDB_GIT_BASE_BRANCH || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
   BASE_HASH: ${{ inputs.base_hash }}
 
 jobs:

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -64,13 +64,16 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 	case LogicalOperatorType::LOGICAL_FILTER:
 	case LogicalOperatorType::LOGICAL_ORDER_BY:
 	case LogicalOperatorType::LOGICAL_TOP_N:
-	case LogicalOperatorType::LOGICAL_DISTINCT:
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
 		// does not affect probe side - recurse into left child
 		// FIXME: we can probably recurse into more operators here (e.g. window, unnest)
 		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		// DISTINCT can be generated from complex subtrees (e.g. joins), and pushing
+		// dynamic join filters below it can lead to incorrect results.
+		return;
 	case LogicalOperatorType::LOGICAL_UNNEST: {
 		auto &unnest = probe_child.Cast<LogicalUnnest>();
 		// check if the filters apply to the unnest index

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -20,6 +20,27 @@ namespace duckdb {
 JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
 }
 
+static bool ContainsJoin(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_JOIN:
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+	case LogicalOperatorType::LOGICAL_DEPENDENT_JOIN:
+		return true;
+	default:
+		for (auto &child : op.children) {
+			if (ContainsJoin(*child)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
 bool PushdownJoinFilterExpression(Expression &expr, JoinFilterPushdownColumn &filter) {
 	if (expr.return_type.IsNested()) {
 		// nested columns are not supported for pushdown
@@ -71,9 +92,13 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	case LogicalOperatorType::LOGICAL_DISTINCT:
-		// DISTINCT can be generated from complex subtrees (e.g. joins), and pushing
-		// dynamic join filters below it can lead to incorrect results.
-		return;
+		if (ContainsJoin(*probe_child.children[0])) {
+			// DISTINCT can be generated from complex subtrees (e.g. joins), and pushing
+			// dynamic join filters below it can lead to incorrect results.
+			return;
+		}
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
+		break;
 	case LogicalOperatorType::LOGICAL_UNNEST: {
 		auto &unnest = probe_child.Cast<LogicalUnnest>();
 		// check if the filters apply to the unnest index

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -20,23 +20,35 @@ namespace duckdb {
 JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
 }
 
-static bool ContainsJoin(LogicalOperator &op) {
+static bool DistinctHasUnsafeJoinPath(LogicalOperator &op) {
 	switch (op.type) {
-	case LogicalOperatorType::LOGICAL_JOIN:
-	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
 	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
 	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
 	case LogicalOperatorType::LOGICAL_DEPENDENT_JOIN:
 		return true;
-	default:
-		for (auto &child : op.children) {
-			if (ContainsJoin(*child)) {
-				return true;
-			}
+	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_FILTER:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+	case LogicalOperatorType::LOGICAL_TOP_N:
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+	case LogicalOperatorType::LOGICAL_UNNEST:
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return DistinctHasUnsafeJoinPath(*op.children[0]);
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		switch (join.join_type) {
+		case JoinType::INNER:
+		case JoinType::SEMI:
+		case JoinType::RIGHT_SEMI:
+			return DistinctHasUnsafeJoinPath(*op.children[0]);
+		default:
+			return true;
 		}
+	}
+	default:
 		return false;
 	}
 }
@@ -92,7 +104,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	case LogicalOperatorType::LOGICAL_DISTINCT:
-		if (ContainsJoin(*probe_child.children[0])) {
+		if (DistinctHasUnsafeJoinPath(*probe_child.children[0])) {
 			// DISTINCT can be generated from complex subtrees (e.g. joins), and pushing
 			// dynamic join filters below it can lead to incorrect results.
 			return;

--- a/test/sql/optimizer/test_join_filter_pushdown_distinct_cte.test
+++ b/test/sql/optimizer/test_join_filter_pushdown_distinct_cte.test
@@ -1,0 +1,48 @@
+# name: test/sql/optimizer/test_join_filter_pushdown_distinct_cte.test
+# description: Ensure DISTINCT CTE with LEFT JOIN and empty table is stable under parallel execution
+# group: [optimizer]
+
+statement ok
+SET threads=8;
+
+statement ok
+CREATE TABLE items (id VARCHAR, category VARCHAR);
+
+statement ok
+INSERT INTO items VALUES
+('5f9fa092-5f11-4796-8151-0d2e3c79fed0', 'A'),
+('d215a25f-a9b6-4ace-8b8a-35d0b3233b64', 'A'),
+('809cef32-2965-4df1-8330-7e8b217e9d92', 'B'),
+('51d28a95-0b11-4a53-800a-429454c4f732', 'B'),
+('67ce60eb-31a3-43f6-b4a2-380a49bee2fa', 'A');
+
+statement ok
+CREATE TABLE mappings (id VARCHAR, parent_id VARCHAR);
+
+statement ok
+INSERT INTO mappings VALUES ('51d28a95-0b11-4a53-800a-429454c4f732', '67ce60eb-31a3-43f6-b4a2-380a49bee2fa');
+
+statement ok
+CREATE TABLE groups (id VARCHAR, group_id VARCHAR);
+
+loop i 0 300
+
+query I
+WITH resolved AS (
+    SELECT DISTINCT i.id,
+           COALESCE(g.group_id, m.parent_id, i.id) AS resolved_id
+    FROM items i
+    LEFT JOIN mappings m ON i.id = m.id
+    LEFT JOIN groups g ON COALESCE(m.parent_id, i.id) = g.id
+)
+SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT r.resolved_id
+    FROM items i
+    JOIN resolved r ON i.id = r.id
+    WHERE i.category = 'A'
+) result;
+----
+3
+
+endloop


### PR DESCRIPTION
## Summary:
- stop join filter pushdown traversal at LOGICAL_DISTINCT in join filter target discovery.
- add regression sqllogictest for issue #21757 with repeated execution under parallel threads.

## Root Cause:
Dynamic join filters were being pushed below DISTINCT derived subtrees. In the reported CTE shape, this could intermittently over prune and return missing rows.

### The reproduced issue screenshot:

<img width="1366" height="421" alt="Screenshot 2026-04-03 132559" src="https://github.com/user-attachments/assets/0c5f213d-8e9b-476b-939f-1130f1c2df65" />


## Validation:
- [x] Baseline (DuckDB Python 1.5.1, WSL): deterministic scenario failed intermittently (13/240).
- [x] Patched debug build: deterministic scenario had 0/240 failures.
- [x] New sqllogictest passes:
  - make unittest T=test/sql/optimizer/test_join_filter_pushdown_distinct_cte.test

### The validation test suite run screenshot:

<img width="1907" height="1085" alt="image" src="https://github.com/user-attachments/assets/0d4313ef-c9cd-4061-82b4-5f2f59e6b29e" />


Closes #21757