### PR TITLE
[minor] Fix compilation warning

### DIFF
--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -209,9 +209,9 @@ public:
 			auto entry_offset = result_data[new_count - 1];
 			if (entry_offset < 0) {
 				// overflow strings store the dict offset negatively - invert size
-				new_dictionary_size = -entry_offset;
+				new_dictionary_size = NumericCast<uint32_t>(-entry_offset);
 			} else {
-				new_dictionary_size = entry_offset;
+				new_dictionary_size = NumericCast<uint32_t>(entry_offset);
 			}
 		}
 		*dictionary_size = new_dictionary_size;


### PR DESCRIPTION
Build compilation warning
```sh
/Users/hjiang/Desktop/duckdb/src/include/duckdb/storage/string_uncompressed.hpp:212:27: warning: implicit conversion changes signedness: 'int32_t' (aka 'int') to 'uint32_t' (aka 'unsigned int') [-Wsign-conversion]
  212 |                                 new_dictionary_size = -entry_offset;
      |                                                     ~ ^~~~~~~~~~~~~
/Users/hjiang/Desktop/duckdb/src/include/duckdb/storage/string_uncompressed.hpp:214:27: warning: implicit conversion changes signedness: 'int32_t' (aka 'int') to 'uint32_t' (aka 'unsigned int') [-Wsign-conversion]
  214 |                                 new_dictionary_size = entry_offset;
      |                                                     ~ ^~~~~~~~~~~~
```