### PR TITLE
Add `TableFunctionParallelism` enum and `parallelize_sequential_sources` setting

### DIFF
--- a/.github/patches/extensions/spatial/sequential-opt-in.patch
+++ b/.github/patches/extensions/spatial/sequential-opt-in.patch
@@ -1,0 +1,36 @@
+diff --git a/src/spatial/index/rtree/rtree_index_scan.cpp b/src/spatial/index/rtree/rtree_index_scan.cpp
+index aba73b9..a1bfbe3 100644
+--- a/src/spatial/index/rtree/rtree_index_scan.cpp
++++ b/src/spatial/index/rtree/rtree_index_scan.cpp
+@@ -261,6 +261,7 @@ TableFunction RTreeIndexScanFunction::GetFunction() {
+ 	func.get_bind_info = RTreeIndexScanBindInfo;
+ 	func.serialize = RTreeScanSerialize;
+ 	func.deserialize = RTreeScanDeserialize;
++	func.parallelism = TableFunctionParallelism::SEQUENTIAL;
+ 
+ 	return func;
+ }
+diff --git a/src/spatial/modules/gdal/gdal_module.cpp b/src/spatial/modules/gdal/gdal_module.cpp
+index 996e0ff..b1030cd 100644
+--- a/src/spatial/modules/gdal/gdal_module.cpp
++++ b/src/spatial/modules/gdal/gdal_module.cpp
+@@ -1172,6 +1172,7 @@ void Register(ExtensionLoader &loader) {
+ 	read_func.named_parameters["layer"] = LogicalType::VARCHAR;
+ 	read_func.named_parameters["max_batch_size"] = LogicalType::INTEGER;
+ 	read_func.named_parameters["keep_wkb"] = LogicalType::BOOLEAN;
++	read_func.parallelism = TableFunctionParallelism::SEQUENTIAL;
+ 
+ 	loader.RegisterFunction(read_func);
+ 
+diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
+index 57b34d0..fda8e1b 100644
+--- a/src/spatial/modules/shapefile/shapefile_module.cpp
++++ b/src/spatial/modules/shapefile/shapefile_module.cpp
+@@ -894,6 +894,7 @@ struct ST_ReadSHP {
+ 		read_func.table_scan_progress = GetProgress;
+ 		read_func.cardinality = GetCardinality;
+ 		read_func.projection_pushdown = true;
++		read_func.parallelism = TableFunctionParallelism::SEQUENTIAL;
+ 		loader.RegisterFunction(read_func);
+ 
+ 		InsertionOrderPreservingMap<string> tags;

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5257,7 +5257,7 @@ const StringUtil::EnumStringLiteral *GetTableFunctionParallelismValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(TableFunctionParallelism::SELF_MANAGED_PARALLELISM), "SELF_MANAGED_PARALLELISM" },
 		{ static_cast<uint32_t>(TableFunctionParallelism::SEQUENTIAL), "SEQUENTIAL" },
-		{ static_cast<uint32_t>(TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED), "SEQUENTIAL_PREFER_SINGLE_THREADED" }
+		{ static_cast<uint32_t>(TableFunctionParallelism::FORCE_SINGLE_THREADED), "FORCE_SINGLE_THREADED" }
 	};
 	return values;
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5253,6 +5253,25 @@ TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
 	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 13, "TableFilterType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetTableFunctionParallelismValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(TableFunctionParallelism::SELF_MANAGED_PARALLELISM), "SELF_MANAGED_PARALLELISM" },
+		{ static_cast<uint32_t>(TableFunctionParallelism::SEQUENTIAL), "SEQUENTIAL" },
+		{ static_cast<uint32_t>(TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED), "SEQUENTIAL_PREFER_SINGLE_THREADED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionParallelism>(TableFunctionParallelism value) {
+	return StringUtil::EnumToString(GetTableFunctionParallelismValues(), 3, "TableFunctionParallelism", static_cast<uint32_t>(value));
+}
+
+template<>
+TableFunctionParallelism EnumUtil::FromString<TableFunctionParallelism>(const char *value) {
+	return static_cast<TableFunctionParallelism>(StringUtil::StringToEnum(GetTableFunctionParallelismValues(), 3, "TableFunctionParallelism", value));
+}
+
 const StringUtil::EnumStringLiteral *GetTablePartitionInfoValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(TablePartitionInfo::NOT_PARTITIONED), "NOT_PARTITIONED" },

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -925,6 +925,16 @@
         ]
     },
     {
+        "name": "parallelize_sequential_sources",
+        "description": "Controls automatic parallelization of sequential sources (automatic/enabled/disabled)",
+        "type": "VARCHAR",
+        "default_scope": "local",
+        "default_value": "automatic",
+        "on_callbacks": [
+            "set"
+        ]
+    },
+    {
         "name": "partitioned_write_flush_threshold",
         "description": "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY",
         "type": "UBIGINT",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -926,13 +926,10 @@
     },
     {
         "name": "parallelize_sequential_sources",
-        "description": "Controls automatic parallelization of sequential sources (automatic/enabled/disabled)",
-        "type": "VARCHAR",
+        "description": "Whether to automatically parallelize sequential sources",
+        "type": "BOOLEAN",
         "default_scope": "local",
-        "default_value": "automatic",
-        "on_callbacks": [
-            "set"
-        ]
+        "default_value": "true"
     },
     {
         "name": "partitioned_write_flush_threshold",

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -411,6 +411,10 @@ bool PhysicalTableScan::ParallelSource() const {
 	return true;
 }
 
+TableFunctionParallelism PhysicalTableScan::SourceParallelism() const {
+	return function.parallelism;
+}
+
 InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalSourceState &gstate_p,
                                                                          LocalSourceState &lstate) const {
 	if (!function.dynamic_to_string) {

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/function/table_function.hpp"
 
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/render_tree.hpp"
@@ -138,6 +139,10 @@ OperatorPartitionData PhysicalOperator::GetPartitionData(ExecutionContext &conte
                                                          GlobalSourceState &gstate, LocalSourceState &lstate,
                                                          const OperatorPartitionInfo &partition_info) const {
 	throw InternalException("Calling GetPartitionData on a node that does not support it");
+}
+
+TableFunctionParallelism PhysicalOperator::SourceParallelism() const {
+	return TableFunctionParallelism::SELF_MANAGED_PARALLELISM;
 }
 
 ProgressData PhysicalOperator::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -339,6 +339,7 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	arrow.filter_pushdown = true;
 	arrow.filter_prune = true;
 	arrow.supports_pushdown_type = ArrowPushdownType;
+	arrow.parallelism = TableFunctionParallelism::SEQUENTIAL;
 	set.AddFunction(arrow);
 
 	TableFunction arrow_dumb("arrow_scan_dumb", {LogicalType::POINTER, LogicalType::POINTER, LogicalType::POINTER},
@@ -348,6 +349,7 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	arrow_dumb.projection_pushdown = false;
 	arrow_dumb.filter_pushdown = false;
 	arrow_dumb.filter_prune = false;
+	arrow_dumb.parallelism = TableFunctionParallelism::SEQUENTIAL;
 	set.AddFunction(arrow_dumb);
 }
 

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -387,6 +387,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                             RangeFunctionLocalInit);
 	range_function.in_out_function = RangeFunction<false>;
 	range_function.cardinality = RangeCardinality;
+	range_function.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
 
 	// single argument range: (end) - implicit start = 0 and increment = 1
 	range.AddFunction(range_function);
@@ -400,6 +401,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                           RangeDateTimeBind<false>, nullptr, RangeDateTimeLocalInit);
 	range_in_out.in_out_function = RangeDateTimeFunction<false>;
 	range_in_out.cardinality = RangeDateTimeCardinality;
+	range_in_out.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
 	range.AddFunction(range_in_out);
 	set.AddFunction(range);
 	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS
@@ -415,6 +417,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction generate_series_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
 	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
 	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
+	generate_series_in_out.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
 	generate_series.AddFunction(generate_series_in_out);
 	set.AddFunction(generate_series);
 }

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -387,7 +387,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                             RangeFunctionLocalInit);
 	range_function.in_out_function = RangeFunction<false>;
 	range_function.cardinality = RangeCardinality;
-	range_function.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
+	range_function.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
 
 	// single argument range: (end) - implicit start = 0 and increment = 1
 	range.AddFunction(range_function);
@@ -401,7 +401,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                           RangeDateTimeBind<false>, nullptr, RangeDateTimeLocalInit);
 	range_in_out.in_out_function = RangeDateTimeFunction<false>;
 	range_in_out.cardinality = RangeDateTimeCardinality;
-	range_in_out.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
+	range_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
 	range.AddFunction(range_in_out);
 	set.AddFunction(range);
 	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS
@@ -417,7 +417,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction generate_series_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
 	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
 	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
-	generate_series_in_out.parallelism = TableFunctionParallelism::SEQUENTIAL_PREFER_SINGLE_THREADED;
+	generate_series_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
 	generate_series.AddFunction(generate_series_in_out);
 	set.AddFunction(generate_series);
 }

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -466,6 +466,8 @@ enum class TableColumnType : uint8_t;
 
 enum class TableFilterType : uint8_t;
 
+enum class TableFunctionParallelism : uint8_t;
+
 enum class TablePartitionInfo : uint8_t;
 
 enum class TableReferenceType : uint8_t;
@@ -1181,6 +1183,9 @@ const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value);
 
 template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionParallelism>(TableFunctionParallelism value);
 
 template<>
 const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
@@ -1929,6 +1934,9 @@ TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
+
+template<>
+TableFunctionParallelism EnumUtil::FromString<TableFunctionParallelism>(const char *value);
 
 template<>
 TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -81,6 +81,7 @@ public:
 		return true;
 	}
 	bool ParallelSource() const override;
+	TableFunctionParallelism SourceParallelism() const override;
 
 	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
 

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -34,6 +34,7 @@ class PipelineBuildState;
 class MetaPipeline;
 class PhysicalPlan;
 
+enum class TableFunctionParallelism : uint8_t;
 enum class OperatorCachingMode : uint8_t { NONE, PARTITIONED, ORDERED, UNORDERED };
 
 //! PhysicalOperator is the base class of the physical operators present in the execution plan.
@@ -144,6 +145,9 @@ public:
 	virtual bool ParallelSource() const {
 		return false;
 	}
+
+	//! How this source manages parallelism
+	virtual TableFunctionParallelism SourceParallelism() const;
 
 	virtual bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {
 		if (partition_info.AnyRequired()) {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -27,9 +27,9 @@ namespace duckdb {
 
 //! Controls how a table function manages parallelism.
 enum class TableFunctionParallelism : uint8_t {
-	SELF_MANAGED_PARALLELISM = 0,         //! Source handles its own parallelism (default)
-	SEQUENTIAL = 1,                       //! Sequential source, benefits from external parallelization
-	SEQUENTIAL_PREFER_SINGLE_THREADED = 2 //! Sequential source, prefers single-threaded execution
+	SELF_MANAGED_PARALLELISM = 0, //! Source handles its own parallelism (default)
+	SEQUENTIAL = 1,               //! Sequential source, benefits from external parallelization
+	FORCE_SINGLE_THREADED = 2     //! Sequential source, prefers single-threaded execution
 };
 
 class BaseStatistics;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -25,6 +25,13 @@
 
 namespace duckdb {
 
+//! Controls how a table function manages parallelism.
+enum class TableFunctionParallelism : uint8_t {
+	SELF_MANAGED_PARALLELISM = 0,         //! Source handles its own parallelism (default)
+	SEQUENTIAL = 1,                       //! Sequential source, benefits from external parallelization
+	SEQUENTIAL_PREFER_SINGLE_THREADED = 2 //! Sequential source, prefers single-threaded execution
+};
+
 class BaseStatistics;
 class LogicalDependencyList;
 class LogicalGet;
@@ -503,6 +510,9 @@ public:
 	//! By default init_global is called when the pipeline is ready for execution
 	//! If this is set to `INITIALIZE_ON_SCHEDULE` the table function is initialized when the query is scheduled
 	TableFunctionInitialization global_initialization = TableFunctionInitialization::INITIALIZE_ON_EXECUTE;
+
+	//! How this table function manages parallelism
+	TableFunctionParallelism parallelism = TableFunctionParallelism::SELF_MANAGED_PARALLELISM;
 
 	DUCKDB_API bool Equal(const TableFunction &rhs) const;
 	DUCKDB_API bool operator==(const TableFunction &rhs) const;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1355,15 +1355,13 @@ struct OrderedAggregateThresholdSetting {
 };
 
 struct ParallelizeSequentialSourcesSetting {
-	using RETURN_TYPE = string;
+	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "parallelize_sequential_sources";
-	static constexpr const char *Description =
-	    "Controls automatic parallelization of sequential sources (automatic/enabled/disabled)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "automatic";
+	static constexpr const char *Description = "Whether to automatically parallelize sequential sources";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct PartitionedWriteFlushThresholdSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1354,6 +1354,18 @@ struct OrderedAggregateThresholdSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct ParallelizeSequentialSourcesSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "parallelize_sequential_sources";
+	static constexpr const char *Description =
+	    "Controls automatic parallelization of sequential sources (automatic/enabled/disabled)";
+	static constexpr const char *InputType = "VARCHAR";
+	static constexpr const char *DefaultValue = "automatic";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct PartitionedWriteFlushThresholdSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "partitioned_write_flush_threshold";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -181,7 +181,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(OperatorMemoryLimitSetting),
     DUCKDB_SETTING(OrderByNonIntegerLiteralSetting),
     DUCKDB_SETTING_CALLBACK(OrderedAggregateThresholdSetting),
-    DUCKDB_SETTING_CALLBACK(ParallelizeSequentialSourcesSetting),
+    DUCKDB_SETTING(ParallelizeSequentialSourcesSetting),
     DUCKDB_SETTING(PartitionedWriteFlushThresholdSetting),
     DUCKDB_SETTING(PartitionedWriteMaxOpenFilesSetting),
     DUCKDB_SETTING(PasswordSetting),
@@ -222,10 +222,10 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 107),
                                                      DUCKDB_SETTING_ALIAS("null_order", 49),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 127),
-                                                     DUCKDB_SETTING_ALIAS("user", 142),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 128),
+                                                     DUCKDB_SETTING_ALIAS("user", 143),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 141),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 142),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -181,6 +181,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(OperatorMemoryLimitSetting),
     DUCKDB_SETTING(OrderByNonIntegerLiteralSetting),
     DUCKDB_SETTING_CALLBACK(OrderedAggregateThresholdSetting),
+    DUCKDB_SETTING_CALLBACK(ParallelizeSequentialSourcesSetting),
     DUCKDB_SETTING(PartitionedWriteFlushThresholdSetting),
     DUCKDB_SETTING(PartitionedWriteMaxOpenFilesSetting),
     DUCKDB_SETTING(PasswordSetting),

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1396,6 +1396,18 @@ void OrderedAggregateThresholdSetting::OnSet(SettingCallbackInfo &info, Value &i
 }
 
 //===----------------------------------------------------------------------===//
+// Parallelize Sequential Sources
+//===----------------------------------------------------------------------===//
+void ParallelizeSequentialSourcesSetting::OnSet(SettingCallbackInfo &info, Value &input) {
+	auto val = StringUtil::Lower(input.ToString());
+	if (val != "automatic" && val != "enabled" && val != "disabled") {
+		throw InvalidInputException(
+		    "Invalid value for parallelize_sequential_sources: '%s' (expected automatic/enabled/disabled)", val);
+	}
+	input = Value(val);
+}
+
+//===----------------------------------------------------------------------===//
 // Perfect Ht Threshold
 //===----------------------------------------------------------------------===//
 void PerfectHtThresholdSetting::OnSet(SettingCallbackInfo &info, Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1396,18 +1396,6 @@ void OrderedAggregateThresholdSetting::OnSet(SettingCallbackInfo &info, Value &i
 }
 
 //===----------------------------------------------------------------------===//
-// Parallelize Sequential Sources
-//===----------------------------------------------------------------------===//
-void ParallelizeSequentialSourcesSetting::OnSet(SettingCallbackInfo &info, Value &input) {
-	auto val = StringUtil::Lower(input.ToString());
-	if (val != "automatic" && val != "enabled" && val != "disabled") {
-		throw InvalidInputException(
-		    "Invalid value for parallelize_sequential_sources: '%s' (expected automatic/enabled/disabled)", val);
-	}
-	input = Value(val);
-}
-
-//===----------------------------------------------------------------------===//
 // Perfect Ht Threshold
 //===----------------------------------------------------------------------===//
 void PerfectHtThresholdSetting::OnSet(SettingCallbackInfo &info, Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -137,7 +137,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}},
 	    {"debug_verify_statement", {"copy_statement"}},
 	    {"enable_caching_operators", {false}},
-	    {"parallelize_sequential_sources", {"enabled"}}};
+	    {"parallelize_sequential_sources", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		switch (type.id()) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -136,7 +136,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"checkpoint_on_detach", {"ENABLED"}},
 	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}},
 	    {"debug_verify_statement", {"copy_statement"}},
-	    {"enable_caching_operators", {false}}};
+	    {"enable_caching_operators", {false}},
+	    {"parallelize_sequential_sources", {"enabled"}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		switch (type.id()) {


### PR DESCRIPTION
This is introducing building blocks that would allow table function to declare as inherently single threaded, and be able to opt-in to duckdb handling parallelism on top of a single threaded operator.

There are 3 places where this is at the moment wired:
* `range`-like functions, that are at the moment implemented as single-threaded
* arrow scan, currently handling multithreaded but producing behind a lock, so a sequential source
* `st_read`, `st_read_shp` and `rtree`, that due to underlying library limitations are also a sequential source. This is done via a patch.

Logic that is introduced is that a TableFunction can declare itself as:
* `SELF_MANAGED_PARALLELISM`, the default, meaning the source declare it's maximum amount of threads and downstream parallelism is based on that
* `SEQUENTIAL`, for sources where `GetData()` calls are, even between different threads, sequential, and duckdb can decide to wrap adding parallelization on top of that
* `FORCE_SINGLE_THREADED`, same as `SEQUENTIAL`, but where single threaded behaviour is a feature, duckdb do not wrap

`read_parquet`, or most other scans, is an example of `SELF_MANAGED_PARALLELISM`. `arrow` is a prime example for `SEQUENTIAL`, and `range` is an example of `FORCE_SINGLE_THREADED`, given users might rely or expect it to be single threaded (that for example guarantees results of `SELECT random() FROM range(<N>);`)

Second part, a boolean setting `parallelize_sequential_sources`, that defaults to `true`.
This setting is also currently NOT used, but intended usages would be as follow:
For `SELF_MANAGED_PARALLELISM` sources, no changes ever.
For `SEQUENTIAL` sources, DuckDB might change behaviour when `true`, but keep single threaded behaviour when `false`
For `FORCE_SINGLE_THREADED` sources, no changes.

This PR only adds mechanism to opt-in or opt-out to a not yet implemented behaviour, that's for a follow up PR.