### PR TITLE
Add `FlatVector::Writer<T>(result, count)` method to standardize writing to a flat vector

### DIFF
--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -97,7 +97,7 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 
 	auto &mask = FlatVector::Validity(result);
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
 	size_t total_len = ListVector::GetListSize(result);
 
 	auto &list_bind_data = aggr_input_data.bind_data->Cast<ListBindData>();

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -97,7 +97,7 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 
 	auto &mask = FlatVector::Validity(result);
-	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, count + offset);
 	size_t total_len = ListVector::GetListSize(result);
 
 	auto &list_bind_data = aggr_input_data.bind_data->Cast<ListBindData>();

--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -191,8 +191,7 @@ static void IndexKeyFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 	idx_t count = args.size();
 
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 
 	// Create a DataChunk referencing only the key columns (skip path and index_name).
 	DataChunk key_chunk;
@@ -210,7 +209,7 @@ static void IndexKeyFunction(DataChunk &args, ExpressionState &state, Vector &re
 	for (idx_t i = 0; i < count; i++) {
 		auto &key = keys[i];
 		if (key.Empty()) {
-			result_validity.SetInvalid(i);
+			result_data.SetInvalid(i);
 		} else {
 			result_data[i] = StringVector::AddStringOrBlob(result, const_char_ptr_cast(key.data), key.len);
 		}

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -242,9 +242,7 @@ void ExecuteFlatSlice(Vector &result, Vector &list_vector, Vector &begin_vector,
 		sel.Initialize(ListVector::GetListSize(list_vector));
 	}
 
-	auto result_data = FlatVector::GetData<INPUT_TYPE>(result);
-	auto &result_mask = FlatVector::Validity(result);
-
+	auto result_data = FlatVector::Writer<INPUT_TYPE>(result, count);
 	for (idx_t i = 0; i < count; ++i) {
 		auto list_idx = list_data.sel->get_index(i);
 		auto begin_idx = begin_data.sel->get_index(i);
@@ -257,7 +255,7 @@ void ExecuteFlatSlice(Vector &result, Vector &list_vector, Vector &begin_vector,
 		auto step_valid = step_vector && step_data.validity.RowIsValid(step_idx);
 
 		if (!list_valid || !begin_valid || !end_valid || (step_vector && !step_valid)) {
-			result_mask.SetInvalid(i);
+			result_data.SetInvalid(i);
 			continue;
 		}
 
@@ -285,7 +283,7 @@ void ExecuteFlatSlice(Vector &result, Vector &list_vector, Vector &begin_vector,
 		sel_length += length;
 
 		if (!clamp_result) {
-			result_mask.SetInvalid(i);
+			result_data.SetInvalid(i);
 		} else if (!step_vector) {
 			result_data[i] = OP::SliceValue(result, sliced, begin, end);
 		} else {

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -185,7 +185,7 @@ struct UniqueFunctor {
 		state_vector.ToUnifiedFormat(count, sdata);
 		auto states = UnifiedVectorFormat::GetData<HistogramAggState<T, MAP_TYPE> *>(sdata);
 
-		auto result_data = FlatVector::GetData<uint64_t>(result);
+		auto result_data = FlatVector::Writer<uint64_t>(result, count);
 		for (idx_t i = 0; i < count; i++) {
 			auto state = states[sdata.sel->get_index(i)];
 

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -218,10 +218,10 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 			}
 
 			// construct the selection vector with the new order from the result vectors
-			Vector result_vector(Vector::Ref(result_chunk.data[0]));
-			auto result_data = FlatVector::GetData<uint32_t>(result_vector);
 			auto row_count = result_chunk.size();
+			Vector result_vector(Vector::Ref(result_chunk.data[0]));
 
+			auto result_data = FlatVector::Writer<uint32_t>(result_vector, row_count);
 			for (idx_t i = 0; i < row_count; i++) {
 				sel_sorted.set_index(sel_sorted_idx, result_data[i]);
 				D_ASSERT(result_data[i] < lists_size);

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -38,7 +38,7 @@ void TemplatedPopulateChild(DataChunk &args, Vector &result) {
 	const auto row_count = args.size();
 
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::Writer<T>(result, row_count);
+	auto result_data = FlatVector::Writer<T>(result, row_count * column_count);
 	auto unified_format = args.ToUnifiedFormat();
 	for (idx_t row = 0; row < row_count; row++) {
 		for (idx_t col = 0; col < column_count; col++) {
@@ -166,7 +166,7 @@ void ListFunction(DataChunk &args, Vector &result) {
 
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 
-	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
+	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size() * column_count);
 	for (idx_t row = 0; row < args.size(); row++) {
 		for (idx_t col = 0; col < column_count; col++) {
 			const auto input_idx = unified_format[col].sel->get_index(row);

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -38,16 +38,14 @@ void TemplatedPopulateChild(DataChunk &args, Vector &result) {
 	const auto row_count = args.size();
 
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<T>(result);
-	auto result_validity = &FlatVector::Validity(result);
-
+	auto result_data = FlatVector::Writer<T>(result, row_count);
 	auto unified_format = args.ToUnifiedFormat();
 	for (idx_t row = 0; row < row_count; row++) {
 		for (idx_t col = 0; col < column_count; col++) {
 			auto input_idx = unified_format[col].sel->get_index(row);
 			auto result_idx = row * column_count + col;
 			if (!unified_format[col].validity.RowIsValid(input_idx)) {
-				result_validity->SetInvalid(result_idx);
+				result_data.SetInvalid(result_idx);
 				continue;
 			}
 			const auto input_data = UnifiedVectorFormat::GetData<T>(unified_format[col]);
@@ -59,7 +57,7 @@ void TemplatedPopulateChild(DataChunk &args, Vector &result) {
 
 void PopulateChildFallback(DataChunk &args, Vector &result) {
 	auto &child_type = ListType::GetChildType(result.GetType());
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		result_data[i].offset = ListVector::GetListSize(result);
 		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
@@ -167,15 +165,14 @@ void ListFunction(DataChunk &args, Vector &result) {
 	}
 
 	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
-	auto result_validity = &FlatVector::Validity(result);
 
+	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
 	for (idx_t row = 0; row < args.size(); row++) {
 		for (idx_t col = 0; col < column_count; col++) {
 			const auto input_idx = unified_format[col].sel->get_index(row);
 			const auto result_idx = row * column_count + col;
 			if (!unified_format[col].validity.RowIsValid(input_idx)) {
-				result_validity->SetInvalid(result_idx);
+				result_data.SetInvalid(result_idx);
 				continue;
 			}
 			const auto input = col_data[col][input_idx];
@@ -236,19 +233,13 @@ bool StructFunction(DataChunk &args, Vector &result) {
 void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	if (args.ColumnCount() == 0) {
 		// Early out because the result is a constant empty list.
-		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<list_entry_t>(result);
 		result_data[0].length = 0;
 		result_data[0].offset = 0;
 		return;
-	}
-
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-		}
 	}
 
 	ListVector::Reserve(result, args.size() * args.ColumnCount());
@@ -259,7 +250,7 @@ void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	}
 
 	const idx_t column_count = args.ColumnCount();
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
 	for (idx_t row = 0; row < args.size(); row++) {
 		result_data[row].offset = row * column_count;
 		result_data[row].length = column_count;

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -10,18 +10,15 @@ namespace duckdb {
 static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &map = args.data[0];
 	auto entries = map.Values<list_entry_t>(args.size());
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<uint64_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
 
+	auto result_data = FlatVector::Writer<uint64_t>(result, args.size());
 	for (idx_t row = 0; row < args.size(); row++) {
 		auto entry = entries[row];
+		if (!entry.IsValid()) {
+			result_data.SetInvalid(row);
+			continue;
+		}
 		result_data[row] = entries.GetValueUnsafe(row).length;
-		result_validity.Set(row, entry.IsValid());
-	}
-
-	if (args.size() == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -51,8 +51,7 @@ void MapConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 		auto &map = args.data[i];
 		map.ToUnifiedFormat(count, map_formats[i]);
 	}
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
-
+	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		// Loop through all the maps per list
 		// we cant do better because all the entries of the child vector have to be contiguous

--- a/extension/core_functions/scalar/random/random.cpp
+++ b/extension/core_functions/scalar/random/random.cpp
@@ -72,7 +72,7 @@ void RandomFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RandomLocalState>();
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<double>(result);
+	auto result_data = FlatVector::Writer<double>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		result_data[i] = lstate.random_engine.NextRandom();
 	}
@@ -90,8 +90,7 @@ void GenerateUUIDv4Function(DataChunk &args, ExpressionState &state, Vector &res
 	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RandomLocalState>();
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<hugeint_t>(result);
-
+	auto result_data = FlatVector::Writer<hugeint_t>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		result_data[i] = UUIDv4::GenerateRandomUUID(lstate.random_engine);
 	}
@@ -102,8 +101,7 @@ void GenerateUUIDv7Function(DataChunk &args, ExpressionState &state, Vector &res
 	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RandomLocalState>();
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<hugeint_t>(result);
-
+	auto result_data = FlatVector::Writer<hugeint_t>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		result_data[i] = UUIDv7::GenerateRandomUUID(lstate.random_engine);
 	}

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -73,9 +73,8 @@ unique_ptr<FunctionData> BindPrintfFunction(ClientContext &context, ScalarFuncti
 
 template <class FORMAT_FUN, class CTX>
 static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &format_string = args.data[0];
+	auto &format_string_vec = args.data[0];
 	auto &result_validity = FlatVector::Validity(result);
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	result_validity.Initialize(args.size());
 	for (idx_t i = 0; i < args.ColumnCount(); i++) {
 		switch (args.data[i].GetVectorType()) {
@@ -89,15 +88,14 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 		default:
 			// FLAT VECTOR, we can directly OR the nullmask
 			args.data[i].Flatten(args.size());
-			result.SetVectorType(VectorType::FLAT_VECTOR);
 			result_validity.Combine(FlatVector::Validity(args.data[i]), args.size());
 			break;
 		}
 	}
-	idx_t count = result.GetVectorType() == VectorType::CONSTANT_VECTOR ? 1 : args.size();
+	idx_t count = args.size();
 
-	auto format_data = FlatVector::GetData<string_t>(format_string);
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto format_data = FlatVector::GetData<string_t>(format_string_vec);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t idx = 0; idx < count; idx++) {
 		if (result.GetVectorType() == VectorType::FLAT_VECTOR && FlatVector::IsNull(result, idx)) {
 			// this entry is NULL: skip it
@@ -105,7 +103,7 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 		}
 
 		// first fetch the format string
-		auto fmt_idx = format_string.GetVectorType() == VectorType::CONSTANT_VECTOR ? 0 : idx;
+		auto fmt_idx = format_string_vec.GetVectorType() == VectorType::CONSTANT_VECTOR ? 0 : idx;
 		auto format_string = format_data[fmt_idx].GetString();
 
 		// now gather all the format arguments

--- a/extension/json/json_functions/json_deep_merge.cpp
+++ b/extension/json/json_functions/json_deep_merge.cpp
@@ -95,11 +95,10 @@ static void DeepMergeFunction(DataChunk &args, ExpressionState &state, Vector &r
 		}
 	}
 
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		if (origs[i] == nullptr) {
-			result_validity.SetInvalid(i);
+			result_data.SetInvalid(i);
 		} else {
 			result_data[i] = JSONCommon::WriteVal<yyjson_mut_val>(origs[i], alc);
 		}

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -60,11 +60,10 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 	}
 
 	// Write to result vector
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		if (origs[i] == nullptr) {
-			result_validity.SetInvalid(i);
+			result_data.SetInvalid(i);
 		} else {
 			result_data[i] = JSONCommon::WriteVal<yyjson_mut_val>(origs[i], alc);
 		}

--- a/extension/json/json_functions/json_normalize.cpp
+++ b/extension/json/json_functions/json_normalize.cpp
@@ -67,13 +67,11 @@ static void NormalizeFunction(DataChunk &args, ExpressionState &state, Vector &r
 	args.data[0].ToUnifiedFormat(count, input_data);
 	auto inputs = UnifiedVectorFormat::GetData<string_t>(input_data);
 
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
-
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = input_data.sel->get_index(i);
 		if (!input_data.validity.RowIsValid(idx)) {
-			result_validity.SetInvalid(i);
+			result_data.SetInvalid(i);
 			continue;
 		}
 

--- a/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
+++ b/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
@@ -53,8 +53,6 @@ void DeltaLengthByteArrayDecoder::ReadInternal(shared_ptr<ResizeableBuffer> &blo
                                                const idx_t read_count, Vector &result, const idx_t result_offset) {
 	auto &block = *block_ref;
 	const auto length_data = reinterpret_cast<uint32_t *>(length_buffer.ptr);
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &result_mask = FlatVector::Validity(result);
 
 	if (!HAS_DEFINES) {
 		// Fast path: take this out of the loop below
@@ -69,11 +67,12 @@ void DeltaLengthByteArrayDecoder::ReadInternal(shared_ptr<ResizeableBuffer> &blo
 	const auto &string_column_reader = reader.Cast<StringColumnReader>();
 
 	const auto start_ptr = block.ptr;
+	auto result_data = FlatVector::Writer<string_t>(result, result_offset + read_count);
 	for (idx_t row_idx = 0; row_idx < read_count; row_idx++) {
 		const auto result_idx = result_offset + row_idx;
 		if (HAS_DEFINES) {
 			if (defines[result_idx] != reader.MaxDefine()) {
-				result_mask.SetInvalid(result_idx);
+				result_data.SetInvalid(result_idx);
 				continue;
 			}
 			if (length_idx >= byte_array_count) {

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -39,15 +39,16 @@ void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t
 	auto right_data = right.Values<uint8_t>(count);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<bool>(result);
-	auto &result_mask = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<bool>(result, count);
 	if (left_data.CanHaveNull() || right_data.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto left_entry = left_data[i];
 			auto right_entry = right_data[i];
 			bool is_null = OP::Operation(left_entry.value > 0, right_entry.value > 0, !left_entry.IsValid(),
 			                             !right_entry.IsValid(), result_data[i]);
-			result_mask.Set(i, !is_null);
+			if (is_null) {
+				result_data.SetInvalid(i);
+			}
 		}
 	} else {
 		for (idx_t i = 0; i < count; i++) {

--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -59,7 +59,7 @@ void TemplatedGenerateSequence(Vector &result, idx_t count, const SelectionVecto
 		throw InternalException("Sequence start or increment out of type range");
 	}
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::Writer<T>(result, count);
+	auto result_data = FlatVector::GetData<T>(result);
 	auto value = static_cast<uint64_t>(start);
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = sel.get_index(i);

--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -18,7 +18,8 @@ static void TemplatedGenerateSequence(Vector &result, idx_t count, int64_t start
 		throw InternalException("Sequence start or increment out of type range");
 	}
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<T>(result);
+
+	auto result_data = FlatVector::Writer<T>(result, count);
 	auto value = T(start);
 	for (idx_t i = 0; i < count; i++) {
 		if (i > 0) {
@@ -58,7 +59,7 @@ void TemplatedGenerateSequence(Vector &result, idx_t count, const SelectionVecto
 		throw InternalException("Sequence start or increment out of type range");
 	}
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<T>(result);
+	auto result_data = FlatVector::Writer<T>(result, count);
 	auto value = static_cast<uint64_t>(start);
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = sel.get_index(i);

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -1167,8 +1167,7 @@ void NestedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t co
 	    TemplatedDistinctSelectOperation<OP>(left, right, nullptr, count, &true_sel, &false_sel, nullptr);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<bool>(result);
-
+	auto result_data = FlatVector::Writer<bool>(result, count);
 	for (idx_t i = 0; i < match_count; ++i) {
 		const auto idx = true_sel.get_index(i);
 		result_data[idx] = true;

--- a/src/common/vector_operations/null_operations.cpp
+++ b/src/common/vector_operations/null_operations.cpp
@@ -21,7 +21,7 @@ static void IsNullLoop(Vector &input, Vector &result, idx_t count) {
 		*result_data = INVERSE ? !ConstantVector::IsNull(input) : ConstantVector::IsNull(input);
 	} else {
 		result.SetVectorType(VectorType::FLAT_VECTOR);
-		auto result_data = FlatVector::GetData<bool>(result);
+		auto result_data = FlatVector::Writer<bool>(result, count);
 		auto entries = input.Validity(count);
 		for (idx_t i = 0; i < count; i++) {
 			result_data[i] = INVERSE ? entries.IsValid(i) : !entries.IsValid(i);

--- a/src/common/vector_operations/vector_storage.cpp
+++ b/src/common/vector_operations/vector_storage.cpp
@@ -23,7 +23,7 @@ void CopyToStorageLoop(Vector &source, idx_t count, data_ptr_t target) {
 template <class T>
 void ReadFromStorageLoop(data_ptr_t source, idx_t count, Vector &result) {
 	auto ldata = (T *)source;
-	auto result_data = FlatVector::GetData<T>(result);
+	auto result_data = FlatVector::Writer<T>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		result_data[i] = ldata[i];
 	}

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -215,7 +215,7 @@ void ExpressionExecutor::FillSwitch(Vector &vector, Vector &result, const Select
 			break;
 		}
 
-		auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+		auto result_data = FlatVector::Writer<list_entry_t>(result);
 		for (idx_t i = 0; i < count; i++) {
 			auto result_idx = sel.get_index(i);
 			result_data[result_idx].offset += offset;

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -215,7 +215,7 @@ void ExpressionExecutor::FillSwitch(Vector &vector, Vector &result, const Select
 			break;
 		}
 
-		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		auto result_data = FlatVector::Writer<list_entry_t>(result, count);
 		for (idx_t i = 0; i < count; i++) {
 			auto result_idx = sel.get_index(i);
 			result_data[result_idx].offset += offset;

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -99,15 +99,15 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 	auto child_data = FlatVector::GetData<string_t>(child);
 	auto &child_validity = FlatVector::Validity(child);
 
-	auto result_data = FlatVector::GetData<string_t>(result);
 	static constexpr const idx_t SEP_LENGTH = 2;
 	static constexpr const idx_t NULL_LENGTH = 4;
 	unsafe_unique_array<bool> needs_quotes;
 	idx_t needs_quotes_length = DConstants::INVALID_INDEX;
 
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		if (!validity.RowIsValid(i)) {
-			FlatVector::SetNull(result, i, true);
+			result_data.SetInvalid(i);
 			continue;
 		}
 		auto list = list_data[i];
@@ -148,10 +148,6 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 		}
 		dataptr[offset] = ']';
 		result_data[i].Finalize();
-	}
-
-	if (constant) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 	return true;
 }

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -77,7 +77,6 @@ bool ListCast::ListToListCast(Vector &source, Vector &result, idx_t count, CastP
 }
 
 static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	auto constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	// first cast the child vector to varchar
 	Vector varchar_list(LogicalType::LIST(LogicalType::VARCHAR), count);
 	ListCast::ListToListCast(source, varchar_list, count, parameters);

--- a/src/function/cast/map_cast.cpp
+++ b/src/function/cast/map_cast.cpp
@@ -65,13 +65,13 @@ static bool MapToVarcharCast(Vector &source, Vector &result, idx_t count, CastPa
 	auto value_write_func =
 	    value_is_nested ? VectorCastHelpers::WriteString : VectorCastHelpers::WriteEscapedString<false>;
 
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	unsafe_unique_array<bool> key_needs_quotes;
 	unsafe_unique_array<bool> value_needs_quotes;
 	idx_t needs_quotes_length = DConstants::INVALID_INDEX;
 	for (idx_t i = 0; i < count; i++) {
 		if (!validity.RowIsValid(i)) {
-			FlatVector::SetNull(result, i, true);
+			result_data.SetInvalid(i);
 			continue;
 		}
 

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -152,7 +152,7 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 	auto &child_types = StructType::GetChildTypes(source.GetType());
 	auto &children = StructVector::GetEntries(varchar_struct);
 	auto &validity = FlatVector::Validity(varchar_struct);
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	static constexpr const idx_t SEP_LENGTH = 2;
 	static constexpr const idx_t NAME_SEP_LENGTH = 2;
 	static constexpr const idx_t NULL_LENGTH = 4;
@@ -161,7 +161,7 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 
 	for (idx_t i = 0; i < count; i++) {
 		if (!validity.RowIsValid(i)) {
-			FlatVector::SetNull(result, i, true);
+			result_data.SetInvalid(i);
 			continue;
 		}
 

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -307,12 +307,11 @@ static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, Cast
 	auto &tag_vector = UnionVector::GetTags(varchar_union);
 	auto tag_entries = tag_vector.Values<union_tag_t>(count);
 
-	auto result_data = FlatVector::GetData<string_t>(result);
-
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		auto tag_entry = tag_entries[i];
 		if (!tag_entry.IsValid()) {
-			FlatVector::SetNull(result, i, true);
+			result_data.SetInvalid(i);
 			continue;
 		}
 

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -82,7 +82,8 @@ void NextValFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	// sequence to use is hard coded
 	// increment the sequence
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<int64_t>(result);
+
+	auto result_data = FlatVector::Writer<int64_t>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		// get the next value from the sequence
 		result_data[i] = OP::Operation(lstate.transaction, lstate.sequence);

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -62,7 +62,7 @@ void StringConcatFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	}
 
 	// first we allocate the empty strings for each of the values
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		// allocate an empty string of the required size
 		idx_t str_length = constant_lengths + result_lengths[i];

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -37,7 +37,7 @@ static void TemplatedConcatWS(DataChunk &args, const string_t *sep_data, const S
 	}
 
 	// first we allocate the empty strings for each of the values
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		auto ridx = rsel.get_index(i);
 		// allocate an empty string of the required size

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -37,7 +37,7 @@ static void TemplatedConcatWS(DataChunk &args, const string_t *sep_data, const S
 	}
 
 	// first we allocate the empty strings for each of the values
-	auto result_data = FlatVector::Writer<string_t>(result, count);
+	auto result_data = FlatVector::Writer<string_t>(result);
 	for (idx_t i = 0; i < count; i++) {
 		auto ridx = rsel.get_index(i);
 		// allocate an empty string of the required size

--- a/src/function/scalar/string/path_join.cpp
+++ b/src/function/scalar/string/path_join.cpp
@@ -70,14 +70,11 @@ void PathJoinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 		return;
 	}
 
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto &validity = FlatVector::Validity(result);
-	auto result_data = FlatVector::GetData<string_t>(result);
-
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 		string joined;
 		if (!ProcessRow(row_idx, inputs, col_count, fs, joined)) {
-			validity.SetInvalid(row_idx);
+			result_data.SetInvalid(row_idx);
 			continue;
 		}
 		result_data[row_idx] = StringVector::AddString(result, joined);

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -46,16 +46,13 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 		return;
 	}
 
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<RETURN_TYPE>(result);
-	auto &result_validity = FlatVector::Validity(result);
-
+	auto result_data = FlatVector::Writer<RETURN_TYPE>(result, count);
 	const auto member_count = members.size();
 	for (idx_t row = 0; row < count; row++) {
 		const auto &member_row_idx = vector_format.sel->get_index(row);
 
 		if (!vector_format.validity.RowIsValid(member_row_idx)) {
-			result_validity.SetInvalid(row);
+			result_data.SetInvalid(row);
 			continue;
 		}
 
@@ -67,7 +64,7 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 		// We did not find the target (finished, or struct is empty).
 		if (finished) {
 			if (!target_valid || return_pos) {
-				result_validity.SetInvalid(row);
+				result_data.SetInvalid(row);
 			} else {
 				result_data[row] = false;
 			}
@@ -101,7 +98,7 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 
 		if (!found) {
 			if (return_pos) {
-				result_validity.SetInvalid(row);
+				result_data.SetInvalid(row);
 			} else {
 				result_data[row] = false;
 			}

--- a/src/function/scalar/variant/variant_typeof.cpp
+++ b/src/function/scalar/variant/variant_typeof.cpp
@@ -21,7 +21,7 @@ static void VariantTypeofFunction(DataChunk &input, ExpressionState &state, Vect
 
 	UnifiedVariantVectorData variant(source_format);
 
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		if (!variant.RowIsValid(i)) {
 			result_data[i] = StringVector::AddString(result, "VARIANT_NULL");

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -563,7 +563,7 @@ static void FlattenRunEnds(Vector &result, ArrowRunEndEncodingState &run_end_enc
 
 	auto run_ends_data = runs.Values<RUN_END_TYPE>(compressed_size);
 	auto values_data = values.Values<VALUE_TYPE>(compressed_size);
-	auto result_data = FlatVector::GetData<VALUE_TYPE>(result);
+	auto result_data = FlatVector::Writer<VALUE_TYPE>(result, count);
 	auto &validity = FlatVector::Validity(result);
 
 	// According to the arrow spec, the 'run_ends' array is always valid

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -59,7 +59,7 @@ static bool IsVariantStringType(VariantLogicalType type_id) {
 static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                 const SelectionVector &value_index_sel, const SelectionVector &result_sel,
                                 idx_t count) {
-	auto result_data = FlatVector::Writer<string_t>(result, count);
+	auto result_data = FlatVector::Writer<string_t>(result);
 	for (idx_t i = 0; i < count; i++) {
 		auto row = sel[i];
 		auto result_row = result_sel[i];
@@ -74,7 +74,7 @@ static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &resul
 static void WriteShreddedBoolean(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                  const SelectionVector &value_index_sel, const SelectionVector &result_sel,
                                  idx_t count) {
-	auto result_data = FlatVector::Writer<bool>(result, count);
+	auto result_data = FlatVector::Writer<bool>(result);
 	for (idx_t i = 0; i < count; i++) {
 		auto row = sel[i];
 		auto result_row = result_sel[i];

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -59,7 +59,7 @@ static bool IsVariantStringType(VariantLogicalType type_id) {
 static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                 const SelectionVector &value_index_sel, const SelectionVector &result_sel,
                                 idx_t count) {
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		auto row = sel[i];
 		auto result_row = result_sel[i];
@@ -74,7 +74,7 @@ static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &resul
 static void WriteShreddedBoolean(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                  const SelectionVector &value_index_sel, const SelectionVector &result_sel,
                                  idx_t count) {
-	auto result_data = FlatVector::GetData<bool>(result);
+	auto result_data = FlatVector::Writer<bool>(result, count);
 	for (idx_t i = 0; i < count; i++) {
 		auto row = sel[i];
 		auto result_row = result_sel[i];

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -100,16 +100,12 @@ private:
 		}
 
 		void SetInvalid(idx_t idx) {
-			if (idx >= count) {
-				throw InternalException("eek");
-			}
+			D_ASSERT(idx < count);
 			validity.SetInvalid(idx);
 		}
 
 		T &operator[](idx_t idx) {
-			if (idx >= count) {
-				throw InternalException("eek");
-			}
+			D_ASSERT(idx < count);
 			return data[idx];
 		}
 

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -100,12 +100,16 @@ private:
 		}
 
 		void SetInvalid(idx_t idx) {
-			D_ASSERT(idx < count);
+			if (idx >= count) {
+				throw InternalException("eek");
+			}
 			validity.SetInvalid(idx);
 		}
 
 		T &operator[](idx_t idx) {
-			D_ASSERT(idx < count);
+			if (idx >= count) {
+				throw InternalException("eek");
+			}
 			return data[idx];
 		}
 
@@ -119,6 +123,10 @@ public:
 	template <class T>
 	static FlatVectorWriter<T> Writer(Vector &vector, idx_t count) {
 		return FlatVectorWriter<T>(vector, count);
+	}
+	template <class T>
+	static FlatVectorWriter<T> Writer(Vector &vector) {
+		return Writer<T>(vector, NumericLimits<idx_t>::Maximum());
 	}
 };
 

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -91,6 +91,35 @@ struct FlatVector {
 		return !vector.validity.RowIsValid(idx);
 	}
 	DUCKDB_API static const SelectionVector *IncrementalSelectionVector();
+
+private:
+	template <class T>
+	struct FlatVectorWriter {
+		FlatVectorWriter(Vector &vector, idx_t count)
+		    : data(FlatVector::GetData<T>(vector)), validity(FlatVector::Validity(vector)), count(count) {
+		}
+
+		void SetInvalid(idx_t idx) {
+			D_ASSERT(idx < count);
+			validity.SetInvalid(idx);
+		}
+
+		T &operator[](idx_t idx) {
+			D_ASSERT(idx < count);
+			return data[idx];
+		}
+
+	private:
+		T *data;
+		ValidityMask &validity;
+		idx_t count;
+	};
+
+public:
+	template <class T>
+	static FlatVectorWriter<T> Writer(Vector &vector, idx_t count) {
+		return FlatVectorWriter<T>(vector, count);
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar/list/contains_or_position.hpp
+++ b/src/include/duckdb/function/scalar/list/contains_or_position.hpp
@@ -26,8 +26,7 @@ idx_t ListSearchSimpleOp(Vector &input_list, Vector &list_child, Vector &target,
 	const auto target_data = UnifiedVectorFormat::GetData<T>(target_format);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<RETURN_TYPE>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<RETURN_TYPE>(result, count);
 
 	idx_t total_matches = 0;
 
@@ -36,7 +35,7 @@ idx_t ListSearchSimpleOp(Vector &input_list, Vector &list_child, Vector &target,
 
 		// The entire list is NULL, the result is also NULL.
 		if (!list_format.validity.RowIsValid(list_entry_idx)) {
-			result_validity.SetInvalid(row_idx);
+			result_data.SetInvalid(row_idx);
 			continue;
 		}
 
@@ -49,7 +48,7 @@ idx_t ListSearchSimpleOp(Vector &input_list, Vector &list_child, Vector &target,
 		if (finished || list_entries[list_entry_idx].length == 0) {
 			if (finished || return_pos) {
 				// Return NULL as the position.
-				result_validity.SetInvalid(row_idx);
+				result_data.SetInvalid(row_idx);
 			} else {
 				// Set 'contains' to false.
 				result_data[row_idx] = false;
@@ -81,7 +80,7 @@ idx_t ListSearchSimpleOp(Vector &input_list, Vector &list_child, Vector &target,
 
 		if (!found) {
 			if (return_pos) {
-				result_validity.SetInvalid(row_idx);
+				result_data.SetInvalid(row_idx);
 			} else {
 				result_data[row_idx] = false;
 			}

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -151,8 +151,7 @@ const SelectionVector &CompressedStringScanState::GetSelVec(idx_t start, idx_t s
 }
 
 void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_offset, idx_t start, idx_t scan_count) {
-	auto result_data = FlatVector::GetData<string_t>(result);
-	auto &validity = FlatVector::Validity(result);
+	auto result_data = FlatVector::Writer<string_t>(result, result_offset + scan_count);
 
 	// Create a decompression buffer of sufficient size if we don't already have one.
 	auto &selvec = GetSelVec(start, scan_count);
@@ -167,7 +166,7 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 			// Lookup dict offset in index buffer
 			auto string_number = selvec.get_index(i + start_offset);
 			if (string_number == 0) {
-				validity.SetInvalid(result_offset + i);
+				result_data.SetInvalid(result_offset + i);
 			}
 			result_data[result_offset + i] = dictionary_values[string_number];
 		}
@@ -176,7 +175,7 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 			// Lookup dict offset in index buffer
 			auto string_number = selvec.get_index(start_offset + i);
 			if (string_number == 0) {
-				validity.SetInvalid(result_offset);
+				result_data.SetInvalid(result_offset);
 			}
 			if (decompress_position > string_number) {
 				throw InternalException("DICT_FSST: not performing a sequential scan?");
@@ -194,7 +193,7 @@ void CompressedStringScanState::Select(Vector &result, idx_t start, const Select
 	D_ASSERT(!dictionary);
 	D_ASSERT(mode == DictFSSTMode::FSST_ONLY);
 	idx_t start_offset = start + 1;
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, sel_count);
 	for (idx_t i = 0; i < sel_count; i++) {
 		// Lookup dict offset in index buffer
 		auto string_number = start_offset + sel.get_index(i);

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -60,7 +60,7 @@ void CompressedStringScanState::Initialize(ColumnSegment &segment, bool initiali
 }
 
 void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_offset, idx_t start, idx_t scan_count) {
-	auto result_data = FlatVector::GetData<string_t>(result);
+	auto result_data = FlatVector::Writer<string_t>(result, result_offset + scan_count);
 
 	// Handling non-bitpacking-group-aligned start values;
 	idx_t start_offset = start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -366,7 +366,6 @@ void RLEScanPartialInternal(ColumnSegment &segment, ColumnScanState &state, idx_
 	}
 
 	auto result_data = FlatVector::GetData<T>(result);
-	result.SetVectorType(VectorType::FLAT_VECTOR);
 
 	const idx_t result_end = result_offset + scan_count;
 	while (result_offset < result_end) {
@@ -417,8 +416,7 @@ void RLESelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector_coun
 		return;
 	}
 
-	auto result_data = FlatVector::GetData<T>(result);
-	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::Writer<T>(result, sel_count);
 
 	idx_t prev_idx = 0;
 	for (idx_t i = 0; i < sel_count; i++) {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -112,7 +112,7 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	auto last_entry = data[scan_count - 1].value;
 
 	// shift all offsets so they are 0 at the first entry
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto result_data = FlatVector::Writer<list_entry_t>(result, scan_count);
 	auto base_offset = state.last_offset;
 	idx_t current_offset = 0;
 	for (idx_t i = 0; i < scan_count; i++) {


### PR DESCRIPTION

Currently when writing to a `FlatVector` (which is the most common vector to write to) - we often use a pattern like this:


```cpp

auto result_data = FlatVector::GetData<T>(result);
auto &result_mask = FlatVector::Validity(result);

for(idx_t i = 0; i < count; i++) {
	if (!other.RowIsValid(i)) {
		result_mask.SetInvalid(i);
		continue;
	}
	result_data[i] = <some function>
}
```

This PR generalizes this by adding a `Writer` that can be used here instead:

```cpp
auto result_data = FlatVector::Writer<T>(result, count);

for(idx_t i = 0; i < count; i++) {
	if (!other.RowIsValid(i)) {
		result_data.SetInvalid(i);
		continue;
	}
	result_data[i] = <some function>
}
```

This means we no longer need to get the validity and data separately, and by passing in the `count` to the `Writer` function before-hand we can do a single (cheap) check if the vector has enough capacity. 