### PR TITLE
Add NOT(IS NULL) and NOT(IS NOT NULL) elimination in TransformBoolExpr

### DIFF
--- a/src/parser/transform/expression/transform_bool_expr.cpp
+++ b/src/parser/transform/expression/transform_bool_expr.cpp
@@ -42,6 +42,14 @@ unique_ptr<ParsedExpression> Transformer::TransformBoolExpr(duckdb_libpgquery::P
 				// NOT(x IS DISTINCT FROM y) is equivalent to x IS NOT DISTINCT FROM y
 				next->SetExpressionTypeUnsafe(NegateComparisonExpression(next->GetExpressionType()));
 				result = std::move(next);
+			} else if (next->GetExpressionType() == ExpressionType::OPERATOR_IS_NULL) {
+				// NOT(IS NULL) → IS NOT NULL
+				next->SetExpressionTypeUnsafe(ExpressionType::OPERATOR_IS_NOT_NULL);
+				result = std::move(next);
+			} else if (next->GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+				// NOT(IS NOT NULL) → IS NULL
+				next->SetExpressionTypeUnsafe(ExpressionType::OPERATOR_IS_NULL);
+				result = std::move(next);
 			} else {
 				result = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_NOT, std::move(next));
 			}


### PR DESCRIPTION
The PG_NOT_EXPR case already eliminates NOT wrappers for IN, comparisons, and DISTINCT FROM expressions at parse time, but misses the analogous IS NULL / IS NOT NULL cases. This leaves a redundant OPERATOR_NOT node in the expression tree that no downstream optimizer pass eliminates, reducing the effectiveness of filter pushdown and statistics propagation.

Add two else-if branches to flip OPERATOR_IS_NULL <-> OPERATOR_IS_NOT_NULL, using the same SetExpressionTypeUnsafe pattern as the existing eliminations.

Fixes #21809