### PR TITLE
Use prepare, linux-release, linux-debug and linux-base jobs.

### DIFF
--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -35,6 +35,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set vcpkg binary cache path
+      shell: bash
+      run: echo "VCPKG_DEFAULT_BINARY_CACHE=${GITHUB_WORKSPACE}/vcpkg-cache" >> "$GITHUB_ENV"
+
+    - name: Cache vcpkg binaries
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: vcpkg-${{ runner.os }}-${{ hashFiles('build/extension_configuration/vcpkg.json') }}
+        restore-keys: |
+          vcpkg-${{ runner.os }}-
+
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.5
       env:

--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Path to a newline-delimited list of changed tests to include in smoke tests
     required: false
     default: ""
+  save_cache:
+    description: Whether to save vcpkg binary cache
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -39,8 +43,9 @@ runs:
       shell: bash
       run: echo "VCPKG_DEFAULT_BINARY_CACHE=${GITHUB_WORKSPACE}/vcpkg-cache" >> "$GITHUB_ENV"
 
-    - name: Cache vcpkg binaries
-      uses: actions/cache@v4
+    - name: Restore vcpkg binaries
+      id: vcpkg-binary-cache
+      uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/vcpkg-cache
         key: vcpkg-${{ runner.os }}-${{ hashFiles('build/extension_configuration/vcpkg.json') }}
@@ -69,6 +74,13 @@ runs:
       if: ${{ inputs.run_smoke_tests == 'true' }}
       shell: bash
       run: make smoke SMOKE_UNITTEST=build/release/test/unittest T="--changed-tests=${{ inputs.changed_tests_file }}"
+
+    - name: Save vcpkg binaries
+      if: ${{ inputs.save_cache == 'true' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: ${{ steps.vcpkg-binary-cache.outputs.cache-primary-key }}
 
     - name: Prepare release artifact
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -66,26 +66,15 @@ jobs:
       extensions_extra_exclude_archs: ${{ steps.config.outputs.extra_exclude_archs }}
       enabled_jobs: ${{ steps.config.outputs.enabled_jobs }}
       save_cache: ${{ steps.config.outputs.save_cache }}
+      runner_provider: ${{ steps.config.outputs.runner_provider }}
     env:
       GEN: ninja
-      # Avoid downloading blobs >50 KB until they are actually needed by git.
-      GIT_FETCH_FILTER: blob:limit=50k
-      GIT_CONFIG_COUNT: 1
-      GIT_CONFIG_KEY_0: checkout.workers
-      GIT_CONFIG_VALUE_0: 4
     steps:
-      - uses: actions/checkout@v6
+      - name: "Checkout"
+        uses: duckdb/duckdb-ci/.github/actions/checkout@main
         with:
-          filter: ${{ env.GIT_FETCH_FILTER }}
-
-      - name: Fetch PR base branch history
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          # changed-files needs base branch history for merge-base lookup
-          # and the exact base SHA for comparison.
-          git fetch --no-tags --depth=100 --filter="${GIT_FETCH_FILTER}" origin \
-            +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }} \
-            ${{ github.event.pull_request.base.sha }}
+          runner_provider: ${{ github.repository == 'duckdb/duckdb' && 'namespace' || 'github' }}
+          fetch_depth: 0
 
       - name: Detect changes
         id: changed
@@ -130,6 +119,7 @@ jobs:
 
           # Fall back to GitHub-native runners for forks.
           if [[ "${{ github.repository }}" == "duckdb/duckdb" ]]; then
+            runner_provider=namespace
             runner_linux_small=namespace-profile-linux-small
             runner_linux_x64=namespace-profile-linux-x64
             runner_linux_22_x64=namespace-profile-linux-22-x64
@@ -138,6 +128,7 @@ jobs:
             runner_macos_arm64=namespace-profile-macos-arm64
             runner_macos_14_arm64=namespace-profile-macos-14-arm64
           else
+            runner_provider=github
             runner_linux_small=ubuntu-latest
             runner_linux_x64=ubuntu-latest
             runner_linux_22_x64=ubuntu-22.04
@@ -148,6 +139,7 @@ jobs:
           fi
 
           {
+            echo "runner_provider=$runner_provider"
             echo "runner_linux_small=$runner_linux_small"
             echo "runner_linux_x64=$runner_linux_x64"
             echo "runner_linux_22_x64=$runner_linux_22_x64"
@@ -237,7 +229,10 @@ jobs:
       EXTENSIONS_STATIC_BUILD: 0
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
+      with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
 
     - id: describe_step
       run: echo "git_describe=$(git describe --tags --long)" >> "$GITHUB_OUTPUT"
@@ -411,7 +406,10 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v6
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
+      with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
 
     - name: Install tools
       run: python3 scripts/ci/retry.py -- make toolsci

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1134,7 +1134,6 @@ jobs:
         shell: bash
         run: |
           NEEDS_JSON='${{ toJSON(needs) }}'
-          echo "$NEEDS_JSON"
 
           failed_or_cancelled=$(
             jq -r '

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -44,7 +44,6 @@ env:
 jobs:
   linux-base:
     name: Linux Base
-    if: ${{ github.repository != 'duckdb/duckdb' || github.ref_name != 'main' }}
     runs-on: ${{ inputs.runner_linux_x64 }}
     env:
       GEN: ninja

--- a/Makefile
+++ b/Makefile
@@ -442,8 +442,8 @@ extension/extension_config_local.cmake:
 build/extension_configuration/vcpkg.json: extension/extension_config_local.cmake extension/extension_config.cmake
 	mkdir -p ./build/extension_configuration && \
 	cd build/extension_configuration && \
-	cmake $(GENERATOR) $(FORCE_COLOR) ${CMAKE_VARS} -DEXTENSION_CONFIG_BUILD=TRUE -DVCPKG_BUILD=1 -DCMAKE_BUILD_TYPE=Debug ../.. && \
-	cmake --build . --config RelWithDebInfo
+	cmake $(GENERATOR) $(FORCE_COLOR) ${CMAKE_VARS} -DEXTENSION_CONFIG_BUILD=TRUE -DVCPKG_BUILD=1 -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake --build . --config Release
 
 unittest: debug
 	$(PYTHON) scripts/ci/run_tests.py build/debug/$(UNITTEST_BINARY) $(T)


### PR DESCRIPTION
- Use optimized checkout for namespace runners.
- Re-enable `linux-base` on branch main. (We have [green](https://github.com/duckdb/duckdb/actions/runs/23928982555) main run!)
- Cache vcpkg binaries for linux-release and linux-base on main branch.