### PR TITLE
[minor] Fix CreateViewInfo::Copy() not copying names

### DIFF
--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -39,6 +39,7 @@ unique_ptr<CreateInfo> CreateViewInfo::Copy() const {
 	CopyProperties(*result);
 	result->aliases = aliases;
 	result->types = types;
+	result->names = names;
 	result->column_comments_map = column_comments_map;
 	result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
 	return std::move(result);


### PR DESCRIPTION
## Summary

`CreateViewInfo::Copy()` copies `aliases`, `types`, and `column_comments_map` but omits `names`. This causes a `types`/`names` size mismatch when the copy is later used to construct a `ViewCatalogEntry`.

Both `Serialize()`/`Deserialize()` (in `serialize_create_info.cpp`) and `ViewCatalogEntry::GetInfo()` correctly preserve `names` — only `Copy()` was missing it.

The fix adds one line: `result->names = names;`

## Context

Discovered while implementing Iceberg View support for [duckdb-iceberg](https://github.com/duckdb/duckdb-iceberg) (ref [#314](https://github.com/duckdb/duckdb-iceberg/issues/314)). External catalog extensions that use deferred commits need to `Copy()` a `CreateViewInfo` and later construct a `ViewCatalogEntry` from it — which triggers the mismatch validation in `ViewCatalogEntry::Initialize()`.

DuckDB's own `DuckSchemaEntry::CreateView()` passes `info` by reference directly (never calls `Copy()`), which is why this wasn't caught before.

Retargeted from #21817 as requested by @Mytherin.