### PR TITLE
Add regression tests for CREATE SEQUENCE option order

### DIFF
--- a/test/sql/catalog/sequence/test_sequence.test
+++ b/test/sql/catalog/sequence/test_sequence.test
@@ -277,6 +277,20 @@ SELECT currval('seq')
 statement ok
 DROP SEQUENCE seq;
 
+# explicit MINVALUE should not be overwritten by a later INCREMENT option
+statement ok
+CREATE SEQUENCE seq MINVALUE 42 INCREMENT 1;
+
+query III
+SELECT start_value, min_value, increment_by
+FROM duckdb_sequences()
+WHERE sequence_name = 'seq';
+----
+42	42	1
+
+statement ok
+DROP SEQUENCE seq;
+
 # START WITH defaults to MINVALUE if increment is positive
 statement ok
 CREATE SEQUENCE seq INCREMENT BY 1 MINVALUE 0 MAXVALUE 2;

--- a/test/sql/catalog/sequence/test_sequence.test
+++ b/test/sql/catalog/sequence/test_sequence.test
@@ -291,6 +291,20 @@ WHERE sequence_name = 'seq';
 statement ok
 DROP SEQUENCE seq;
 
+# explicit MAXVALUE should not be overwritten by a later INCREMENT option
+statement ok
+CREATE SEQUENCE seq MAXVALUE -42 INCREMENT -1;
+
+query III
+SELECT start_value, max_value, increment_by
+FROM duckdb_sequences()
+WHERE sequence_name = 'seq';
+----
+-42	-42	-1
+
+statement ok
+DROP SEQUENCE seq;
+
 # START WITH defaults to MINVALUE if increment is positive
 statement ok
 CREATE SEQUENCE seq INCREMENT BY 1 MINVALUE 0 MAXVALUE 2;


### PR DESCRIPTION
## Summary:
- add regression coverage for `CREATE SEQUENCE` option-order handling
- cover both ascending `MINVALUE ... INCREMENT 1` and descending `MAXVALUE ... INCREMENT -1`

## Context:
Issue #21813 reproduces on DuckDB 1.5.1, where an explicit `MINVALUE` can be overwritten when `INCREMENT` is parsed later in the option list.

Current `main` already preserves explicit sequence bounds in the PEG parser path, so this PR is now narrowed to regression coverage only.

## Testing:
- reproduced the reported behavior locally on DuckDB Python 1.5.1 in WSL
- `build/release/test/unittest -s "test/sql/catalog/sequence/test_sequence.test"`


### The validation screenshots of the tests run, locally on WSL:

<img width="2540" height="1467" alt="image" src="https://github.com/user-attachments/assets/68f9ede2-9aa5-4c76-b5eb-d9773ae4432a" />
<img width="2514" height="1426" alt="image" src="https://github.com/user-attachments/assets/546532d0-39b7-46ef-8a4e-5c034ebd9839" />
