### PR TITLE
Fix invalid memory access when CSV columns less than expected

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -841,9 +841,14 @@ bool StringValueResult::AddRowInternal() {
 	// Keep the current parse progress, `HandleErrors` reset states.
 	const auto chunk_col_id_before = chunk_col_id;
 	if (current_errors.HandleErrors(*this)) {
-		// Invalid all columns that are not populated for this row.
-		for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < validity_mask.size(); ++cur_col_idx) {
-			validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
+		// There're two cases here:
+		// - ignore errors = true, with last row being removed
+		// - store rejects = true, with last row index being added to borked rows
+		// Invalid all columns that are not populated for this row, when the row still exists.
+		if (borked_rows.find(static_cast<idx_t>(number_of_rows)) != borked_rows.end()) {
+			for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < chunk_col_id; ++cur_col_idx) {
+				validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
+			}
 		}
 
 		D_ASSERT(buffer_handles.find(current_line_position.begin.buffer_idx) != buffer_handles.end());

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -834,17 +834,10 @@ bool StringValueResult::AddRowInternal() {
 		}
 	}
 
-	// Before we add row, invalid all columns that are not populated for this row (i.e., CSV rows have fewer fields
-	// than expected). Otherwise, uninitialized string_t with valid bits set would lead invalid memory access.
-	// Reference: https://github.com/duckdb/duckdb-fuzzer/issues/4379
-	//
-	// Keep the current parse progress, `HandleErrors` reset states.
 	const auto chunk_col_id_before = chunk_col_id;
 	if (current_errors.HandleErrors(*this)) {
-		// There're two cases here:
-		// - ignore errors = true, with last row being removed
-		// - store rejects = true, with last row index being added to borked rows
-		// Invalid all columns that are not populated for this row, when the row still exists.
+		// Before we add row, invalid all columns that are not populated for this row (i.e., CSV rows have fewer fields
+		// than expected). Otherwise, uninitialized string_t with valid bits set would lead invalid memory access.
 		if (borked_rows.find(static_cast<idx_t>(number_of_rows)) != borked_rows.end()) {
 			for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < validity_mask.size(); ++cur_col_idx) {
 				validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -834,7 +834,18 @@ bool StringValueResult::AddRowInternal() {
 		}
 	}
 
+	// Before we add row, invalid all columns that are not populated for this row (i.e., CSV rows have fewer fields
+	// than expected). Otherwise, uninitialized string_t with valid bits set would lead invalid memory access.
+	// Reference: https://github.com/duckdb/duckdb-fuzzer/issues/4379
+	//
+	// Keep the current parse progress, `HandleErrors` reset states.
+	const auto chunk_col_id_before = chunk_col_id;
 	if (current_errors.HandleErrors(*this)) {
+		// Invalid all columns that are not populated for this row.
+		for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < validity_mask.size(); ++cur_col_idx) {
+			validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
+		}
+
 		D_ASSERT(buffer_handles.find(current_line_position.begin.buffer_idx) != buffer_handles.end());
 		D_ASSERT(buffer_handles.find(current_line_position.end.buffer_idx) != buffer_handles.end());
 		line_positions_per_row[static_cast<idx_t>(number_of_rows)] = current_line_position;

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -846,7 +846,7 @@ bool StringValueResult::AddRowInternal() {
 		// - store rejects = true, with last row index being added to borked rows
 		// Invalid all columns that are not populated for this row, when the row still exists.
 		if (borked_rows.find(static_cast<idx_t>(number_of_rows)) != borked_rows.end()) {
-			for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < chunk_col_id; ++cur_col_idx) {
+			for (idx_t cur_col_idx = chunk_col_id_before; cur_col_idx < validity_mask.size(); ++cur_col_idx) {
 				validity_mask[cur_col_idx]->SetInvalid(static_cast<idx_t>(number_of_rows));
 			}
 		}

--- a/test/sql/copy/csv/afl/test_fuzz_4379.test
+++ b/test/sql/copy/csv/afl/test_fuzz_4379.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/csv/afl/test_fuzz_4379.test
+# description: fuzzer issue 4379
+# group: [afl]
+
+require skip_reload
+
+statement ok
+COPY (SELECT * FROM (VALUES
+    ('date,datetime,time,timestamp,time_tz'),
+    ('not-a-date,not-a-datetime,not-a-time,not-a-timestamp')
+) AS t(col)) TO '{TEST_DIR}/fuzz_4379.csv' (HEADER false, QUOTE '');
+
+statement ok
+FROM read_csv(
+    '{TEST_DIR}/fuzz_4379.csv',
+    columns={
+        'date': 'DATE',
+        'datetime': 'TIMESTAMPTZ',
+        'time': 'TIME',
+        'timestamp': 'TIMESTAMP',
+        'time_tz': 'TIMETZ'
+    },
+    null_padding=true,
+    store_rejects=true);


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-fuzzer/issues/4379

`StringValueResult` allocate a large chunk of uninitialized memory for chunk data at [constructor](https://github.com/duckdb/duckdb/blob/af66da7d6cb98a933e6f08390ba3661a15a54818/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp#L105-L110).

The CSV row which suffers invalid memory has 5 columns, but only 4 values in the culprit row, leaving the last 5-th untouched -- value uninitialized memory but validity bit true (default).

On `Flush`, `TryCast` consider the row to be valid and attempts to cast the whole row but access invalid memory.
The fix proposed in this PR is to mark the un-encountered values as invalid, so the whole row will be skipped to parse and [be in the result](https://github.com/duckdb/duckdb/blob/af66da7d6cb98a933e6f08390ba3661a15a54818/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp#L1174-L1176).

I have ran CI on my fork: https://github.com/dentiny/duckdb/pull/78