### PR TITLE
Fix constant struct args in lateral table in-out functions

### DIFF
--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -106,7 +106,8 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 		state.input_chunk.Reset();
 		// set up the input data to the table in-out function
 		for (idx_t col_idx = 0; col_idx < state.input_chunk.ColumnCount(); col_idx++) {
-			ConstantVector::Reference(state.input_chunk.data[col_idx], input.data[col_idx], state.row_index, input.size());
+			ConstantVector::Reference(state.input_chunk.data[col_idx], input.data[col_idx], state.row_index,
+			                          input.size());
 		}
 		state.input_chunk.SetCardinality(1);
 		state.row_index++;

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -106,7 +106,7 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 		state.input_chunk.Reset();
 		// set up the input data to the table in-out function
 		for (idx_t col_idx = 0; col_idx < state.input_chunk.ColumnCount(); col_idx++) {
-			ConstantVector::Reference(state.input_chunk.data[col_idx], input.data[col_idx], state.row_index, 1);
+			ConstantVector::Reference(state.input_chunk.data[col_idx], input.data[col_idx], state.row_index, input.size());
 		}
 		state.input_chunk.SetCardinality(1);
 		state.row_index++;
@@ -120,7 +120,7 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 	for (idx_t project_idx = 0; project_idx < projected_input.size(); project_idx++) {
 		auto source_idx = projected_input[project_idx];
 		auto target_idx = base_idx + project_idx;
-		ConstantVector::Reference(chunk.data[target_idx], input.data[source_idx], state.row_index - 1, 1);
+		ConstantVector::Reference(chunk.data[target_idx], input.data[source_idx], state.row_index - 1, input.size());
 	}
 	auto result = function.in_out_function(context, data, state.input_chunk, chunk);
 	if (this->ordinality_idx.IsValid()) {

--- a/test/sql/function/table/table_in_out.cpp
+++ b/test/sql/function/table/table_in_out.cpp
@@ -101,6 +101,46 @@ struct ThrottlingSum {
 	}
 };
 
+struct LateralStructEcho {
+	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                             duckdb::vector<LogicalType> &return_types,
+	                                             duckdb::vector<string> &names) {
+		return_types.emplace_back(LogicalType::BIGINT);
+		names.emplace_back("outer_i");
+		return_types.emplace_back(LogicalType::BIGINT);
+		names.emplace_back("limit_value");
+		return_types.emplace_back(LogicalType::VARCHAR);
+		names.emplace_back("label_value");
+		return make_uniq<TableFunctionData>();
+	}
+
+	static OperatorResultType Function(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+	                                   DataChunk &output) {
+		for (idx_t row_idx = 0; row_idx < input.size(); row_idx++) {
+			auto struct_value = input.data[0].GetValue(row_idx);
+			auto &children = StructValue::GetChildren(struct_value);
+			output.SetValue(0, row_idx, children[0]);
+			output.SetValue(1, row_idx, children[1]);
+			output.SetValue(2, row_idx, children[2]);
+		}
+		output.SetCardinality(input.size());
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	static void Register(Connection &con) {
+		con.BeginTransaction();
+		auto &client_context = *con.context;
+		auto &catalog = Catalog::GetSystemCatalog(client_context);
+		auto struct_type = LogicalType::STRUCT(
+		    {{"outer_i", LogicalType::BIGINT}, {"limit", LogicalType::BIGINT}, {"label", LogicalType::VARCHAR}});
+		TableFunction lateral_struct_echo("lateral_struct_echo", {struct_type}, nullptr, LateralStructEcho::Bind);
+		lateral_struct_echo.in_out_function = LateralStructEcho::Function;
+		CreateTableFunctionInfo lateral_struct_echo_info(lateral_struct_echo);
+		catalog.CreateTableFunction(*con.context, lateral_struct_echo_info);
+		con.Commit();
+	}
+};
+
 TEST_CASE("Caching TableInOutFunction", "[filter][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
@@ -134,4 +174,24 @@ TEST_CASE("Parallel execution with caching table in out functions", "[filter][.]
 	REQUIRE(result2->ColumnCount() == 1);
 	REQUIRE(result2->RowCount() == 200000);
 	REQUIRE(CHECK_COLUMN(result2, 0, {0, 1, 2, 3, 4, 5}));
+}
+
+TEST_CASE("Lateral table in out function preserves constant struct fields", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	LateralStructEcho::Register(con);
+
+	auto result = con.Query(R"(
+		SELECT echoed.outer_i, echoed.limit_value, echoed.label_value
+		FROM range(3) outer_rows(i)
+		CROSS JOIN LATERAL lateral_struct_echo({'outer_i': i, 'limit': 1, 'label': 'fixed'}) AS echoed
+		ORDER BY echoed.outer_i
+	)");
+	INFO(result->GetError());
+	REQUIRE(!result->HasError());
+	REQUIRE(result->ColumnCount() == 3);
+	REQUIRE(CHECK_COLUMN(result, 0, {0, 1, 2}));
+	REQUIRE(CHECK_COLUMN(result, 1, {1, 1, 1}));
+	REQUIRE(CHECK_COLUMN(result, 2, {"fixed", "fixed", "fixed"}));
 }

--- a/test/sql/function/table/table_in_out.cpp
+++ b/test/sql/function/table/table_in_out.cpp
@@ -188,7 +188,9 @@ TEST_CASE("Lateral table in out function preserves constant struct fields", "[ta
 		CROSS JOIN LATERAL lateral_struct_echo({'outer_i': i, 'limit': 1, 'label': 'fixed'}) AS echoed
 		ORDER BY echoed.outer_i
 	)");
-	INFO(result->GetError());
+	if (result->HasError()) {
+		INFO(result->GetError());
+	}
 	REQUIRE(!result->HasError());
 	REQUIRE(result->ColumnCount() == 3);
 	REQUIRE(CHECK_COLUMN(result, 0, {0, 1, 2}));


### PR DESCRIPTION
## Summary

I ran into this while using a lateral table in-out function with a struct containing both outer-row values and constant fields.

The constant fields were correct for the first outer row, but could be corrupted for later rows. This fixes that behavior.

```sql
select
  outer_rows.id,
  echoed.outer_id,
  echoed.limit_value,
  echoed.label_value
from (select * from range(3) t(id)) as outer_rows
cross join lateral my_table_function({
  'outer_id': outer_rows.id,
  'limit': 1,
  'label': 'fixed'
}) as echoed
```

In this example, outer_id is correlated from the outer row, while limit and label are constant fields inside the same struct argument. Before this fix, those constant fields could be preserved for the first outer row but read incorrectly for later rows.

## Changes

- preserve the full input cardinality when creating constant row references in lateral table in-out execution
- add a regression test for mixed struct arguments with correlated and constant fields

## Testing

I've successfully used these changes in my use case. I've also added a regression test.