### PR TITLE
Fix the issue of lost LOGs after truncate duckdb_logs

### DIFF
--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -553,6 +553,7 @@ void BufferingLogStorage::ResetLogBuffers() {
 		buffers[LoggingTargetTable::ALL_LOGS]->Initialize(Allocator::DefaultAllocator(),
 		                                                  GetSchema(LoggingTargetTable::ALL_LOGS), buffer_size);
 	}
+	registered_contexts.clear();
 }
 
 void BufferingLogStorage::ResetAllBuffers() {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -31,6 +31,7 @@
       "reason": "Logging setting doesn't survive restarts",
       "paths": [
         "test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow",
+        "test/sql/logging/logging_memory_after_truncate.test",
         "test/sql/logging/physical_operator_logging.test_slow",
         "test/logging/warnings_as_errors.test"
       ]

--- a/test/sql/logging/logging_memory_after_truncate.test
+++ b/test/sql/logging/logging_memory_after_truncate.test
@@ -1,0 +1,34 @@
+# name: test/sql/logging/logging_memory_after_truncate.test
+# group: [logging]
+
+statement ok
+SET GLOBAL logging_level = 'INFO';
+
+statement ok
+SET GLOBAL logging_storage = 'memory';
+
+statement ok
+SET GLOBAL enable_logging = true;
+
+statement error
+LOAD invalid_extension;
+----
+<REGEX>:IO Error: Extension.*not found.*
+
+query I
+SELECT COUNT(*) FROM duckdb_logs WHERE starts_with(message, 'Failed to load');
+----
+1
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement error
+LOAD invalid_extension;
+----
+<REGEX>:IO Error: Extension.*not found.*
+
+query I
+SELECT COUNT(*) FROM duckdb_logs WHERE starts_with(message, 'Failed to load');
+----
+1

--- a/test/sql/logging/test_logging_function_large.test_slow
+++ b/test/sql/logging/test_logging_function_large.test_slow
@@ -12,7 +12,7 @@ statement ok
 CALL enable_logging();
 
 statement ok
-set logging_level='debug';
+set logging_level='info';
 
 loop i 0 100
 


### PR DESCRIPTION
When `CALL truncate_duckdb_logs()` is executed, the latest code(5c2c9c2f45de1887bd080bcab101b905264dcf74) does not clear `registered_contexts`, which will cause subsequent log loss:

```
diff --git a/src/logging/log_storage.cpp b/src/logging/log_storage.cpp
index e8f37584c2..233c9e2340 100644
--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -553,6 +553,7 @@ void BufferingLogStorage::ResetLogBuffers() {
                buffers[LoggingTargetTable::ALL_LOGS]->Initialize(Allocator::DefaultAllocator(),
                                                                  GetSchema(LoggingTargetTable::ALL_LOGS), buffer_size);
        }
+       registered_contexts.clear();
 }
```

I added a test case to the PR to reproduce this issue, triggering log writing by loading a non-existent extension. You can see that the behavior before and after truncating is different:

```shell
build/debug/test/unittest test/sql/logging/logging_memory_after_truncate.test
Filters: test/sql/logging/logging_memory_after_truncate.test
[0/1] (0%): test/sql/logging/logging_memory_after_truncate.test                                                                                                                                                             
1. test/sql/logging/logging_memory_after_truncate.test:31
================================================================================
Wrong result in query! (test/sql/logging/logging_memory_after_truncate.test:31)!
================================================================================
SELECT COUNT(*) FROM duckdb_logs WHERE message LIKE '%Failed to load%';
================================================================================
Mismatch on row 1, column count_star()(index 1)
0 <> 1
================================================================================
Expected result:
================================================================================
1

================================================================================
Actual result:
================================================================================
0


~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
test/sql/logging/logging_memory_after_truncate.test
-------------------------------------------------------------------------------
/flash1/xizhe.zxz/duckdb/test/sqlite/test_sqllogictest.cpp:41
...............................................................................

test/sql/logging/logging_memory_after_truncate.test:31: FAILED:
explicitly with message:
  0

[1/1] (100%): test/sql/logging/logging_memory_after_truncate.test                                                                                                                                                           
===============================================================================
test cases: 1 | 1 failed
assertions: 8 | 7 passed | 1 failed
```