### PR TITLE
Fix Arrow REE INT64 run_ends using wrong template parameter

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -736,7 +736,7 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(Vector &vector, c
 		FlattenRunEndsSwitch<int32_t>(vector, run_end_encoding, compressed_size, scan_offset, size);
 		break;
 	case PhysicalType::INT64:
-		FlattenRunEndsSwitch<int32_t>(vector, run_end_encoding, compressed_size, scan_offset, size);
+		FlattenRunEndsSwitch<int64_t>(vector, run_end_encoding, compressed_size, scan_offset, size);
 		break;
 	default:
 		throw NotImplementedException("Type '%s' not implemented for RunEndEncoding", TypeIdToString(physical_type));


### PR DESCRIPTION
## Summary

- Fixes a copy-paste bug where `FlattenRunEndsSwitch<int32_t>` was used for the `PhysicalType::INT64` case instead of `FlattenRunEndsSwitch<int64_t>`
- Any Arrow Run-End Encoded column with int64 run_ends silently returned corrupted data

Fixes #21845

## Details

In `ColumnArrowToDuckDBRunEndEncoded`, the switch on `physical_type` dispatches to `FlattenRunEndsSwitch<RUN_END_TYPE>`. The `INT64` case was a copy-paste of the `INT32` case and used `int32_t` as the template parameter:

```cpp
case PhysicalType::INT64:
    FlattenRunEndsSwitch<int32_t>(...);  // was int32_t, should be int64_t
```

The template parameter controls how `VectorValueIterator` reads the underlying run-ends buffer. With `int32_t`, each read returns only the lower 4 bytes of each 8-byte entry, and the stride is wrong (4 bytes instead of 8), so every element after the first is read from the wrong byte offset. This produces completely corrupted run-end boundaries, and therefore corrupted output values.

## Test plan

- [x] Release build passes
- [x] All `[arrow]` unit tests pass (31,509 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>