### PR TITLE
Fix: Arrow union appender out-of-bounds write when from > 0

### DIFF
--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -28,7 +28,8 @@ void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t f
 		child_vectors.emplace_back(child.second, size);
 	}
 
-	for (idx_t input_idx = from; input_idx < to; input_idx++) {
+	for (idx_t i = 0; i < size; i++) {
+		auto input_idx = from + i;
 		const auto &val = input.GetValue(input_idx);
 
 		idx_t tag = 0;
@@ -40,7 +41,7 @@ void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t f
 		}
 
 		for (idx_t child_idx = 0; child_idx < child_vectors.size(); child_idx++) {
-			child_vectors[child_idx].SetValue(input_idx, child_idx == tag ? resolved_value : Value(nullptr));
+			child_vectors[child_idx].SetValue(i, child_idx == tag ? resolved_value : Value(nullptr));
 		}
 		types_buffer.push_back<data_t>(NumericCast<data_t>(tag));
 	}
@@ -48,7 +49,7 @@ void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t f
 	for (idx_t child_idx = 0; child_idx < child_vectors.size(); child_idx++) {
 		auto &child_buffer = append_data.child_data[child_idx];
 		auto &child = child_vectors[child_idx];
-		child_buffer->append_vector(*child_buffer, child, from, to, size);
+		child_buffer->append_vector(*child_buffer, child, 0, size, size);
 	}
 	append_data.row_count += size;
 }


### PR DESCRIPTION
## Summary

Fixes #21850

- **Fix heap buffer overflow** in `ArrowUnionData::Append` when `from > 0` (partially consumed chunk in `TryFetchChunk`). Temporary child vectors have capacity `size = to - from` but were indexed with raw `input_idx` starting at `from`, writing past the end of the buffer.
- **Use 0-based indexing** for temporary child vectors: loop with `i = 0..size-1`, compute `input_idx = from + i`, write to `child_vectors[child_idx].SetValue(i, ...)`, and pass `(0, size, size)` to the recursive `append_vector` call.
- This is consistent with how every other appender type (scalars, lists, etc.) handles the `from`/`to` range.

This bug is on the **DuckDB to Arrow export path**.

## Test plan

- [x] All existing `[arrow]` unit tests pass (31 test cases, 31515 assertions)
- [x] Release build succeeds
- [x] Format check passes