### PR TITLE
Fix bugs in ArrowQueryResult

### DIFF
--- a/src/common/arrow/arrow_query_result.cpp
+++ b/src/common/arrow/arrow_query_result.cpp
@@ -13,7 +13,8 @@ ArrowQueryResult::ArrowQueryResult(StatementType statement_type, StatementProper
       batch_size(batch_size) {
 }
 
-ArrowQueryResult::ArrowQueryResult(ErrorData error) : QueryResult(QueryResultType::ARROW_RESULT, std::move(error)) {
+ArrowQueryResult::ArrowQueryResult(ErrorData error)
+    : QueryResult(QueryResultType::ARROW_RESULT, std::move(error)), batch_size(0) {
 }
 
 unique_ptr<DataChunk> ArrowQueryResult::FetchInternal() {
@@ -27,7 +28,7 @@ string ArrowQueryResult::ToString() {
 
 vector<unique_ptr<ArrowArrayWrapper>> ArrowQueryResult::ConsumeArrays() {
 	if (HasError()) {
-		throw InvalidInputException("Attempting to fetch ArrowArrays from an unsuccessful query result\n: Error %s",
+		throw InvalidInputException("Attempting to fetch ArrowArrays from an unsuccessful query result: Error %s",
 		                            GetError());
 	}
 	return std::move(arrays);
@@ -35,7 +36,7 @@ vector<unique_ptr<ArrowArrayWrapper>> ArrowQueryResult::ConsumeArrays() {
 
 vector<unique_ptr<ArrowArrayWrapper>> &ArrowQueryResult::Arrays() {
 	if (HasError()) {
-		throw InvalidInputException("Attempting to fetch ArrowArrays from an unsuccessful query result\n: Error %s",
+		throw InvalidInputException("Attempting to fetch ArrowArrays from an unsuccessful query result: Error %s",
 		                            GetError());
 	}
 	return arrays;


### PR DESCRIPTION
## Summary
- Initialize `batch_size` to 0 in the error constructor to avoid reading uninitialized memory if `BatchSize()` is called on a failed result
- Remove stray `\n` in error messages in `ConsumeArrays()` and `Arrays()`

## Test plan
- Existing tests continue to pass
- These are straightforward correctness fixes (uninitialized member, malformed string literal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)