### PR TITLE
Fix double free and memory leak in Arrow GeoArrow CRS serialization

### DIFF
--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -474,7 +474,6 @@ struct ArrowGeometry {
 
 				duckdb_yyjson::yyjson_doc_free(projjson_doc);
 			} else {
-				duckdb_yyjson::yyjson_mut_doc_free(doc);
 				throw SerializationException("Could not parse PROJJSON CRS for GeoArrow metadata");
 			}
 		} break;
@@ -523,6 +522,7 @@ struct ArrowGeometry {
 			duckdb_yyjson::yyjson_mut_doc_free(doc);
 			free(json_text);
 		} else {
+			duckdb_yyjson::yyjson_mut_doc_free(doc);
 			schema_metadata.AddOption(ArrowSchemaMetadata::ARROW_METADATA_KEY, "{}");
 		}
 


### PR DESCRIPTION
## Summary

Fixes #21853.

- **Double free fix**: Remove `yyjson_mut_doc_free(doc)` from inside `WriteCRS`. The function does not own the `doc` pointer -- the caller (`PopulateSchema`) owns it and already frees it in both the catch block (exception path) and the normal path. Having `WriteCRS` also free it on PROJJSON parse failure caused heap corruption via double free.
- **Memory leak fix**: Add `yyjson_mut_doc_free(doc)` to the else branch after `yyjson_mut_write` returns null, which previously leaked the `yyjson_mut_doc`.

The principle: `WriteCRS` should not free caller-owned resources. Ownership of `doc` stays exclusively with `PopulateSchema`.

## Test plan

- [x] All arrow unit tests pass (`build/release/test/unittest "[arrow]"` -- 31 test cases, 31515 assertions)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)