### PR TITLE
Remove unused `ArrowArrayStreamWrapper::number_of_rows` member

### DIFF
--- a/src/include/duckdb/common/arrow/arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/arrow_wrapper.hpp
@@ -49,7 +49,6 @@ public:
 class ArrowArrayStreamWrapper {
 public:
 	ArrowArrayStream arrow_array_stream;
-	int64_t number_of_rows;
 
 public:
 	void GetSchema(ArrowSchemaWrapper &schema);

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -9,7 +9,6 @@
 duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper>
 ArrowStreamTestFactory::CreateStream(uintptr_t this_ptr, duckdb::ArrowStreamParameters &parameters) {
 	auto stream_wrapper = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
-	stream_wrapper->number_of_rows = -1;
 	stream_wrapper->arrow_array_stream = *(ArrowArrayStream *)this_ptr;
 
 	return stream_wrapper;
@@ -113,7 +112,6 @@ duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> ArrowTestFactory::CreateStre
 	}
 
 	auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
-	stream_wrapper->number_of_rows = -1;
 	auto private_data = make_uniq<ArrowArrayStreamData>(factory, factory.options);
 	stream_wrapper->arrow_array_stream.get_schema = ArrowArrayStreamGetSchema;
 	stream_wrapper->arrow_array_stream.get_next = ArrowArrayStreamGetNext;


### PR DESCRIPTION
## Summary

- Remove the unused `int64_t number_of_rows` member from the `ArrowArrayStreamWrapper` class
- Remove the two corresponding `stream_wrapper->number_of_rows = -1` assignments in test helper code

The field was declared and assigned but never read anywhere in the codebase, making it pure dead code.

## Changes

| File | Change |
|------|--------|
| `src/include/duckdb/common/arrow/arrow_wrapper.hpp` | Remove `int64_t number_of_rows` member |
| `test/arrow/arrow_test_helper.cpp` | Remove two `number_of_rows = -1` assignments |

## Test plan

- [ ] Existing CI tests pass (no code reads this member, so removing it is purely subtractive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)