### PR TITLE
Remove shadowed event member and unused names from ArrowBatchTask

### DIFF
--- a/src/common/arrow/arrow_merge_event.cpp
+++ b/src/common/arrow/arrow_merge_event.cpp
@@ -9,10 +9,9 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 ArrowBatchTask::ArrowBatchTask(ArrowQueryResult &result, vector<idx_t> record_batch_indices, Executor &executor,
-                               shared_ptr<Event> event_p, BatchCollectionChunkScanState scan_state,
-                               vector<string> names, idx_t batch_size)
-    : ExecutorTask(executor, event_p), result(result), record_batch_indices(std::move(record_batch_indices)),
-      event(std::move(event_p)), batch_size(batch_size), names(std::move(names)), scan_state(std::move(scan_state)) {
+                               shared_ptr<Event> event_p, BatchCollectionChunkScanState scan_state, idx_t batch_size)
+    : ExecutorTask(executor, std::move(event_p)), result(result), record_batch_indices(std::move(record_batch_indices)),
+      batch_size(batch_size), scan_state(std::move(scan_state)) {
 }
 
 void ArrowBatchTask::ProduceRecordBatches() {
@@ -124,8 +123,7 @@ void ArrowMergeEvent::Schedule() {
 
 		BatchCollectionChunkScanState scan_state(batches, data.batches, pipeline->executor.context);
 		tasks.push_back(make_uniq<ArrowBatchTask>(result, std::move(record_batch_indices), pipeline->executor,
-		                                          shared_from_this(), std::move(scan_state), result.names,
-		                                          record_batch_size));
+		                                          shared_from_this(), std::move(scan_state), record_batch_size));
 	}
 
 	// Allocate the list of record batches inside the query result

--- a/src/include/duckdb/common/arrow/arrow_merge_event.hpp
+++ b/src/include/duckdb/common/arrow/arrow_merge_event.hpp
@@ -29,8 +29,7 @@ namespace duckdb {
 class ArrowBatchTask : public ExecutorTask {
 public:
 	ArrowBatchTask(ArrowQueryResult &result, vector<idx_t> record_batch_indices, Executor &executor,
-	               shared_ptr<Event> event_p, BatchCollectionChunkScanState scan_state, vector<string> names,
-	               idx_t batch_size);
+	               shared_ptr<Event> event_p, BatchCollectionChunkScanState scan_state, idx_t batch_size);
 	void ProduceRecordBatches();
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
@@ -41,9 +40,7 @@ public:
 private:
 	ArrowQueryResult &result;
 	vector<idx_t> record_batch_indices;
-	shared_ptr<Event> event;
 	idx_t batch_size;
-	vector<string> names;
 	BatchCollectionChunkScanState scan_state;
 };
 


### PR DESCRIPTION
## Summary

Fixes two issues in `ArrowBatchTask`:

### 1. Shadowed `event` member

`ArrowBatchTask` declared its own `shared_ptr<Event> event` member that shadowed the identically-named `ExecutorTask::event` inherited from its base class. Both were initialized in the constructor — `ExecutorTask(executor, event_p)` copied into the base member, then `event(std::move(event_p))` moved into the derived member.

This is a latent correctness bug: if any `ExecutorTask` base class method (e.g., `Deschedule()`, `Reschedule()`) ever mutates or resets `ExecutorTask::event`, the derived class's shadowing copy would remain stale, leading to use of an outdated or null pointer. The reverse is also true — code operating on the derived member would not be visible to the base class.

**Fix:** Removed the redundant `event` member from `ArrowBatchTask`. The base class `ExecutorTask::event` (which is public) is now used directly.

### 2. Unused `names` member

`ArrowBatchTask` accepted a `vector<string> names` constructor parameter and stored it as a member, but never read it — not in `ProduceRecordBatches()`, `ExecuteTask()`, or anywhere else. `ArrowUtil::FetchChunk` does not take a names parameter. This caused a needless copy of the full column names vector for every task.

**Fix:** Removed the `names` parameter and member entirely.

## Test plan
- Existing tests continue to pass
- These are straightforward dead-code removals with no behavioral change for correct callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)