### PR TITLE
Preserve table sample in InitializeAddConstraint

### DIFF
--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -129,6 +129,9 @@ void TableStatistics::InitializeAddConstraint(TableStatistics &parent) {
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		column_stats.push_back(parent.column_stats[i]);
 	}
+	if (parent.table_sample) {
+		table_sample = std::move(parent.table_sample);
+	}
 }
 
 void TableStatistics::MergeStats(TableStatistics &other) {


### PR DESCRIPTION
## Summary
- `TableStatistics::InitializeAddConstraint` was not transferring the `table_sample` from the parent statistics, causing it to be silently lost when a constraint is added to a table
- All other `Initialize*` methods (`InitializeAddColumn`, `InitializeRemoveColumn`, `InitializeAlterType`) transfer the sample from the parent. The first three destroy it afterwards because the schema changes, but adding a constraint does not change the data or schema, so the sample should be preserved.

## Test plan
- Existing tests continue to pass
- Straightforward addition of missing sample transfer consistent with all sibling methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)