### PR TITLE
Fix count_star index shifting in aggregate statistics propagation

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -282,7 +282,10 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			}
 			count += stats.count;
 		}
-		for (const auto count_star_idx : count_star_idxs) {
+		// Iterate in reverse order so that insertions at higher indices don't shift
+		// the positions of lower-index insertions
+		for (auto it = count_star_idxs.rbegin(); it != count_star_idxs.rend(); ++it) {
+			auto count_star_idx = *it;
 			auto count_result = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(count)));
 			agg_results.emplace(agg_results.begin() + NumericCast<int64_t>(count_star_idx), std::move(count_result));
 			types.insert(types.begin() + NumericCast<int64_t>(count_star_idx), LogicalType::BIGINT);


### PR DESCRIPTION
## Summary

Fixes an index shifting bug in `propagate_aggregate.cpp` where multiple COUNT(*) aggregate results were inserted at incorrect positions.

### The bug

When the statistics propagator encounters COUNT(*) aggregates, it removes them from the aggregate list (since they can be computed as constants), processes the remaining aggregates, then re-inserts the COUNT(*) results at their original indices.

The re-insertion loop iterated forward through `count_star_idxs`:

```cpp
for (const auto count_star_idx : count_star_idxs) {
    agg_results.emplace(agg_results.begin() + count_star_idx, ...);
    types.insert(types.begin() + count_star_idx, ...);
}
```

When there are multiple COUNT(*) aggregates, each `emplace`/`insert` shifts all subsequent elements by one position. This means the second insertion uses an index that is now off by one (shifted by the first insertion), the third is off by two, etc.

**Example:** With `count_star_idxs = [1, 3]` and `agg_results` of size 3:
- Insert at index 1 -> vector is now size 4, elements after index 1 shifted right
- Insert at index 3 -> this inserts at what was originally index 2, not index 3

### The fix

Iterate through `count_star_idxs` in reverse order. Inserting at higher indices first ensures that lower-index insertions are not affected by the shifting.

## Test plan
- Existing tests continue to pass
- The bug only manifests with 2+ COUNT(*) aggregates in the same query, which is uncommon but valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)