### PR TITLE
Fix three bugs in extension loading code

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -309,7 +309,7 @@ static void WriteExtensionFiles(QueryContext &query_context, FileSystem &fs, con
 	if (!StringUtil::EndsWith(local_extension_path, ".duckdb_extension")) {
 		throw InternalException("Extension install local_extension_path of '%s' is not valid, should end in "
 		                        "'.duckdb_extension'",
-		                        temp_path);
+		                        local_extension_path);
 	}
 
 	// Write extension to tmp file
@@ -518,7 +518,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &
 }
 
 static bool IsHTTP(const string &path) {
-	return StringUtil::StartsWith(path, "http://") || !StringUtil::StartsWith(path, "https://");
+	return StringUtil::StartsWith(path, "http://") || StringUtil::StartsWith(path, "https://");
 }
 
 static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string &local_extension_path,

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -694,7 +694,7 @@ void ExtensionHelper::LoadExternalExtensionInternal(DatabaseInstance &db, FileSy
 		return;
 	}
 
-	throw IOException("Unknown ABI type of value '%s' for extension '%s'",
+	throw IOException("Unknown ABI type of value '%d' for extension '%s'",
 	                  static_cast<uint8_t>(extension_init_result.abi_type), extension);
 #endif
 }


### PR DESCRIPTION
## Summary

Fix three independent bugs in the extension loading/install code paths.

## Bug 1: `IsHTTP()` has completely inverted logic

**File:** `src/main/extension/extension_install.cpp`, line 520-522

**What was wrong:**

```cpp
static bool IsHTTP(const string &path) {
    return StringUtil::StartsWith(path, "http://") || !StringUtil::StartsWith(path, "https://");
}
```

The `!` before the second `StartsWith` inverts the entire function's behavior. Here is the truth table showing how the function was broken:

| Input path | `StartsWith("http://")` | `!StartsWith("https://")` | Result (OR) | Correct result |
|---|---|---|---|---|
| `"http://example.com/ext"` | true | true | **true** | true |
| `"https://example.com/ext"` | false | false | **false** | true |
| `"/local/path/ext.duckdb_extension"` | false | true | **true** | false |
| `"s3://bucket/ext"` | false | true | **true** | false |

The function returned `true` for almost all inputs (any string not starting with `"https://"`), and returned `false` specifically for HTTPS URLs -- the exact opposite of the intended behavior.

**Impact:** This breaks direct HTTPS extension installs (`INSTALL 'https://...'`) by routing them through `LocalFileSystem` instead of `HTTPFileSystem`. It also misroutes local repository installs by treating local paths as HTTP URLs. The function is used at lines 591 and 598 in `InstallExtensionInternal`.

**Fix:** Remove the `!` so the condition correctly checks for both HTTP and HTTPS prefixes.

## Bug 2: Format string mismatch causes undefined behavior

**File:** `src/main/extension/extension_load.cpp`, line 697-698

**What was wrong:**

```cpp
throw IOException("Unknown ABI type of value '%s' for extension '%s'",
                  static_cast<uint8_t>(extension_init_result.abi_type), extension);
```

The first format specifier is `%s` (string) but the argument is a `uint8_t` (integer). This is undefined behavior -- the formatter would interpret the integer value as a pointer to a null-terminated string. Compare with line 129 in the same file which correctly uses `%d` for the same pattern.

**Fix:** Change `'%s'` to `'%d'`.

## Bug 3: Wrong variable passed in error message

**File:** `src/main/extension/extension_install.cpp`, lines 309-312

**What was wrong:**

```cpp
if (!StringUtil::EndsWith(local_extension_path, ".duckdb_extension")) {
    throw InternalException("Extension install local_extension_path of '%s' is not valid, ...",
                            temp_path);  // <-- should be local_extension_path
}
```

The error message says it is reporting `local_extension_path` but actually passes `temp_path`. This is a copy-paste error from the block immediately above (lines 303-305) which correctly uses `temp_path` for its own validation check.

**Fix:** Change `temp_path` to `local_extension_path` so the error message reports the correct value.

## Test plan

- [ ] Verify `INSTALL 'https://...'` direct extension installs work correctly (Bug 1)
- [ ] Verify local repository extension installs are not misrouted through HTTP (Bug 1)
- [ ] Verify unknown ABI type error message prints the numeric value instead of crashing (Bug 2)
- [ ] Verify the `local_extension_path` validation error prints the correct path (Bug 3)