### PR TITLE
Fix CreateViewInfo::Copy() not copying the names field

### DIFF
--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -39,6 +39,7 @@ unique_ptr<CreateInfo> CreateViewInfo::Copy() const {
 	CopyProperties(*result);
 	result->aliases = aliases;
 	result->types = types;
+	result->names = names;
 	result->column_comments_map = column_comments_map;
 	result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
 	return std::move(result);


### PR DESCRIPTION
## Summary

`CreateViewInfo::Copy()` copies the `types` vector but not the parallel `names` vector. After a copy, the resulting `CreateViewInfo` has column types but empty column names, which is inconsistent.

- `names` holds the column names from the bound view query
- `types` and `names` are parallel vectors: `types[i]` is the type for column `names[i]`
- Without `names`, `GetColumnCommentsList()` throws `InternalException("Attempting to serialize column comments using the legacy format, but view is not bound")` when `column_comments_map` is non-empty, because it checks `names.empty()` as a proxy for whether the view is bound
- The other code path that produces `CreateViewInfo` (`ViewCatalogEntry::GetInfo()`) correctly populates `names`, which is why this bug may not manifest in all workflows — it only triggers when `Copy()` is called on a bound `CreateViewInfo` that has column comments

## Fix

Add `result->names = names;` right after `result->types = types;` in `CreateViewInfo::Copy()`.

## Test plan

- [x] Verified `names` is the only field missing from `Copy()`
- [ ] CI passes