### PR TITLE
Fix case-sensitive default database check allowing detach of default database

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -242,7 +242,7 @@ optional_ptr<AttachedDatabase> DatabaseManager::FinalizeAttach(ClientContext &co
 }
 
 void DatabaseManager::DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found) {
-	if (GetDefaultDatabase(context) == name) {
+	if (StringUtil::CIEquals(GetDefaultDatabase(context), name)) {
 		throw BinderException("Cannot detach database \"%s\" because it is the default database. Select a different "
 		                      "database using `USE` to allow detaching this database",
 		                      name);
@@ -305,7 +305,7 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const string &old_n
 		databases[new_name] = attached_db;
 	}
 
-	if (default_database == old_name) {
+	if (StringUtil::CIEquals(default_database, old_name)) {
 		default_database = new_name;
 	}
 }

--- a/test/sql/attach/attach_default_database_case.test
+++ b/test/sql/attach/attach_default_database_case.test
@@ -1,0 +1,36 @@
+# name: test/sql/attach/attach_default_database_case.test
+# description: Test that detaching the default database works correctly with different cases
+# group: [attach]
+
+require skip_reload
+
+statement ok
+ATTACH ':memory:' AS MyDB;
+
+statement ok
+USE MyDB;
+
+query I
+SELECT current_database()
+----
+MyDB
+
+# Detaching with different case should be blocked (it's the default database)
+statement error
+DETACH mydb;
+----
+Cannot detach database
+
+# Detaching with exact case should also be blocked
+statement error
+DETACH MyDB;
+----
+Cannot detach database
+
+# Switch back to the original default
+statement ok
+USE memory;
+
+# Now detaching with different case should work
+statement ok
+DETACH mydb;

--- a/test/sql/attach/attach_default_database_case.test
+++ b/test/sql/attach/attach_default_database_case.test
@@ -4,6 +4,8 @@
 
 require skip_reload
 
+require noforcestorage
+
 statement ok
 ATTACH ':memory:' AS MyDB;
 


### PR DESCRIPTION
## Summary

When using `DETACH` with a different case than the original attach name, the default database check was bypassed, leaving a dangling `default_database` reference that caused subsequent "Catalog does not exist" errors.

**Reproduction:**

```sql
ATTACH ':memory:' AS MyDB;
USE MyDB;
DETACH mydb;  -- Should fail but succeeded, leaving dangling reference
SELECT 1;     -- ERROR: Catalog "MyDB" does not exist
```

## Root Cause

`DatabaseManager::databases` is a `case_insensitive_map_t`, so `DETACH mydb` correctly finds the entry for `MyDB` in the map. However, the guard that prevents detaching the default database compared `default_database` against the detach name using case-sensitive `==`:

```cpp
if (GetDefaultDatabase(context) == name) {  // "MyDB" != "mydb" → bypassed!
```

The same issue existed in `RenameDatabase`, where `default_database` would not be updated if the old name differed in case.

## Fix

Replace case-sensitive `==` with `StringUtil::CIEquals` in both `DetachDatabase` and `RenameDatabase`:

```cpp
if (StringUtil::CIEquals(GetDefaultDatabase(context), name)) {
```

```cpp
if (StringUtil::CIEquals(default_database, old_name)) {
```

## Testing

- Added `test/sql/attach/attach_default_database_case.test` covering the case-insensitive detach guard and successful detach after switching away.
- All 84 existing attach tests pass (`test/sql/attach/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)