### PR TITLE
Fix qualified alias method calls in HAVING/WHERE/QUALIFY

### DIFF
--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -45,7 +45,7 @@ bool ColumnAliasBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) 
 	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;
 	}
-	return bind_state.alias_map.find(colref.column_names[0]) != bind_state.alias_map.end();
+	return bind_state.alias_map.find(colref.column_names.back()) != bind_state.alias_map.end();
 }
 
 } // namespace duckdb

--- a/test/sql/binder/qualified_alias_method_call.test
+++ b/test/sql/binder/qualified_alias_method_call.test
@@ -1,0 +1,70 @@
+# name: test/sql/binder/qualified_alias_method_call.test
+# description: Test qualified alias (alias.name) with method-style function calls
+# group: [binder]
+
+statement ok
+CREATE TABLE test_alias(a INT, b VARCHAR);
+
+statement ok
+INSERT INTO test_alias VALUES (1, 'hello'), (2, 'world'), (3, 'foo');
+
+# HAVING clause: unqualified alias method call works
+query II
+SELECT a, b || '!' AS greeting FROM test_alias GROUP BY a, b HAVING greeting.lower() != 'foo!' ORDER BY a;
+----
+1	hello!
+2	world!
+
+# HAVING clause: qualified alias method call should also work
+query II
+SELECT a, b || '!' AS greeting FROM test_alias GROUP BY a, b HAVING alias.greeting.lower() != 'foo!' ORDER BY a;
+----
+1	hello!
+2	world!
+
+# WHERE clause: unqualified alias method call works
+query II
+SELECT a, (a*10)::VARCHAR AS big FROM test_alias WHERE big.length() > 1 ORDER BY a;
+----
+1	10
+2	20
+3	30
+
+# WHERE clause: qualified alias method call should also work
+query II
+SELECT a, (a*10)::VARCHAR AS big FROM test_alias WHERE alias.big.length() > 1 ORDER BY a;
+----
+1	10
+2	20
+3	30
+
+# QUALIFY clause: unqualified alias method call works
+query III
+SELECT a, b, row_number() OVER (ORDER BY a)::VARCHAR AS rn FROM test_alias QUALIFY rn.length() > 0 ORDER BY a;
+----
+1	hello	1
+2	world	2
+3	foo	3
+
+# QUALIFY clause: qualified alias method call should also work
+query III
+SELECT a, b, row_number() OVER (ORDER BY a)::VARCHAR AS rn FROM test_alias QUALIFY alias.rn.length() > 0 ORDER BY a;
+----
+1	hello	1
+2	world	2
+3	foo	3
+
+# SELECT clause: qualified alias method call works (uses SelectBinder with correct back())
+query III
+SELECT a, b AS x, alias.x.upper() AS y FROM test_alias ORDER BY a;
+----
+1	hello	HELLO
+2	world	WORLD
+3	foo	FOO
+
+# Verify simple qualified alias comparisons still work in HAVING
+query II
+SELECT a, sum(a) AS total FROM test_alias GROUP BY a HAVING alias.total > 1 ORDER BY a;
+----
+2	2
+3	3


### PR DESCRIPTION
## Summary

Fixes #21864

`ColumnAliasBinder::DoesColumnAliasExist()` used `column_names[0]` to look up aliases in the alias map. For qualified alias references like `alias.greeting` (where `column_names = ["alias", "greeting"]`), this looked up `"alias"` (the table qualifier) instead of `"greeting"` (the actual alias name), causing the lookup to always fail.

This caused method-style function calls on qualified aliases to fail in HAVING, WHERE, and QUALIFY clauses:

```sql
-- Worked (unqualified):
HAVING greeting.lower() != 'foo!'

-- Failed (qualified): "Referenced table 'alias' not found!"
HAVING alias.greeting.lower() != 'foo!'
```

### The fix

Changed `column_names[0]` to `column_names.back()` in `ColumnAliasBinder::DoesColumnAliasExist()`, making it consistent with:
- `ColumnAliasBinder::BindAlias()` (same file, line 24) which already uses `back()`
- `SelectBinder::DoesColumnAliasExist()` which uses `back()` with a comment: "Using back() to support both qualified and unqualified aliasing"

For unqualified references (e.g., `greeting`), `column_names` has one element so `[0] == back()` — no behavior change. The fix only affects qualified `alias.<name>` references.

## Test plan
- Added sqllogictest covering qualified alias method calls in HAVING, WHERE, QUALIFY, and SELECT
- All 53 assertions pass in the new test
- Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)