### PR TITLE
Fix integer overflow crash in list repeat function

### DIFF
--- a/extension/core_functions/scalar/string/repeat.cpp
+++ b/extension/core_functions/scalar/string/repeat.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "core_functions/scalar/string_functions.hpp"
+#include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 
 namespace duckdb {
@@ -42,8 +43,16 @@ static void RepeatListFunction(DataChunk &args, ExpressionState &, Vector &resul
 	BinaryExecutor::Execute<list_entry_t, int64_t, list_entry_t>(
 	    list_vector, cnt_vector, result, args.size(), [&](list_entry_t list_input, int64_t cnt) {
 		    idx_t copy_count = cnt <= 0 || list_input.length == 0 ? 0 : UnsafeNumericCast<idx_t>(cnt);
-		    idx_t result_length = list_input.length * copy_count;
-		    idx_t new_size = current_size + result_length;
+		    idx_t result_length;
+		    if (!TryMultiplyOperator::Operation(list_input.length, copy_count, result_length)) {
+			    throw OutOfRangeException("Cannot create a list of size: '%d' * '%d', the result is too large",
+			                              list_input.length, copy_count);
+		    }
+		    idx_t new_size;
+		    if (!TryAddOperator::Operation(current_size, result_length, new_size)) {
+			    throw OutOfRangeException("Cannot create a list of size: '%d' + '%d', the result is too large",
+			                              current_size, result_length);
+		    }
 		    ListVector::Reserve(result, new_size);
 		    list_entry_t result_list;
 		    result_list.offset = current_size;

--- a/test/sql/function/list/repeat_list.test
+++ b/test/sql/function/list/repeat_list.test
@@ -74,3 +74,9 @@ statement error
 SELECT repeat([1], 99999999999999999);
 ----
 maximum allowed vector size
+
+# overflow: 3 * 6148914691236517206 wraps to 2 in uint64, previously caused a segfault
+statement error
+SELECT repeat([1, 2, 3], 6148914691236517206);
+----
+Out of Range Error


### PR DESCRIPTION
## Summary

- **Crash bug**: `repeat()` on lists does not check for integer overflow when computing result size, while the string variant already does. A carefully chosen count causes the `length * count` multiplication to wrap to a small value in `uint64`, leading to an undersized buffer allocation followed by out-of-bounds writes and a **segfault**.
- Added overflow checks using `TryMultiplyOperator` (for `length * count`) and `TryAddOperator` (for `current_size + result_length`), matching the pattern already used by the string variant in the same file.

## Reproducer

```sql
-- Crashes with SIGSEGV (exit code 139)
SELECT repeat([1, 2, 3], 6148914691236517206);

-- The string variant already handles this correctly:
-- Out of Range Error: Cannot create a string of size: '3' * '6148914691236517206'...
SELECT repeat('abc', 6148914691236517206);
```

`3 * 6148914691236517206 = 2^64 + 2`, which wraps to `2` in `uint64`. The code allocates space for 2 elements, then tries to copy 3 elements 6.1×10¹⁸ times.

## Test plan

- [x] Added test case to `test/sql/function/list/repeat_list.test` verifying the overflow produces `Out of Range Error` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)