### PR TITLE
Fix DROP SECRET IF EXISTS throwing IOException when using FROM storage

### DIFF
--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -88,11 +88,14 @@ vector<SecretEntry> CatalogSetSecretStorage::AllSecrets(optional_ptr<CatalogTran
 void CatalogSetSecretStorage::DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
                                                optional_ptr<CatalogTransaction> transaction) {
 	auto entry = secrets->GetEntry(GetTransactionOrDefault(transaction), name);
-	if (!entry && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-		string persist_string = persistent ? "persistent" : "temporary";
-		string storage_string = persistent ? " in secret storage '" + storage_name + "'" : "";
-		throw InvalidInputException("Failed to remove non-existent %s secret '%s'%s", persist_string, name,
-		                            storage_string);
+	if (!entry) {
+		if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+			string persist_string = persistent ? "persistent" : "temporary";
+			string storage_string = persistent ? " in secret storage '" + storage_name + "'" : "";
+			throw InvalidInputException("Failed to remove non-existent %s secret '%s'%s", persist_string, name,
+			                            storage_string);
+		}
+		return;
 	}
 
 	secrets->DropEntry(GetTransactionOrDefault(transaction), name, true, true);

--- a/test/sql/secrets/drop_persistent_secret_if_exists.test
+++ b/test/sql/secrets/drop_persistent_secret_if_exists.test
@@ -1,0 +1,22 @@
+# name: test/sql/secrets/drop_persistent_secret_if_exists.test
+# description: Test DROP PERSISTENT SECRET IF EXISTS with FROM storage
+# group: [secrets]
+
+require noforcestorage
+
+load {TEST_DIR}/drop_persistent_secret_if_exists.db
+
+statement ok
+set secret_directory='{TEST_DIR}/drop_persistent_secret_if_exists'
+
+# First create and drop a secret so the secret directory exists on disk
+statement ok
+CREATE PERSISTENT SECRET setup_secret (TYPE HTTP);
+
+statement ok
+DROP PERSISTENT SECRET setup_secret FROM local_file;
+
+# Now try to drop a non-existent secret with IF EXISTS
+# Before fix: threw IOException when trying to remove non-existent file
+statement ok
+DROP PERSISTENT SECRET IF EXISTS nonexistent_secret FROM local_file;


### PR DESCRIPTION
## Summary

- `DROP PERSISTENT SECRET IF EXISTS <name> FROM local_file` throws an `IOException` when the secret doesn't exist, instead of silently succeeding
- The root cause is a missing early return in `CatalogSetSecretStorage::DropSecretByName` — when the entry is not found and `IF EXISTS` is used, the code skips the error but still falls through to delete a nonexistent file from disk
- Fix adds an early `return` when the entry doesn't exist and `IF EXISTS` is specified

Fixes #21876

## Reproduction

```sql
-- Before fix: throws IOException
-- After fix: silently succeeds
DROP PERSISTENT SECRET IF EXISTS nonexistent_secret FROM local_file;

-- Without FROM (was already working, still works):
DROP PERSISTENT SECRET IF EXISTS nonexistent_secret;

-- Without IF EXISTS (should error, still does):
DROP PERSISTENT SECRET nonexistent_secret FROM local_file;
```

## Test plan

- [x] `DROP PERSISTENT SECRET IF EXISTS <name> FROM local_file` with nonexistent secret now silently succeeds
- [x] `DROP PERSISTENT SECRET <name> FROM local_file` with nonexistent secret still throws the expected error
- [x] `DROP PERSISTENT SECRET IF EXISTS <name>` (no FROM) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)