### PR TITLE
Fix atanh(-1) returning +inf instead of -inf

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1504,8 +1504,11 @@ struct AtanhOperator {
 		if (input < -1 || input > 1) {
 			throw InvalidInputException("ATANH is undefined outside [-1,1]");
 		}
-		if (input == -1 || input == 1) {
+		if (input == 1) {
 			return INFINITY;
+		}
+		if (input == -1) {
+			return -INFINITY;
 		}
 		return (double)std::atanh(input);
 	}

--- a/test/sql/function/numeric/test_trigo.test
+++ b/test/sql/function/numeric/test_trigo.test
@@ -473,7 +473,7 @@ endloop
 query II
 select atanh(1), atanh(-1);
 ----
-inf	inf
+inf	-inf
 
 query III
 select atanh(-0.5), atanh(0), atanh(0.5);


### PR DESCRIPTION
## Summary

`atanh(-1)` incorrectly returns `+Infinity` instead of `-Infinity`.

The inverse hyperbolic tangent function has asymptotes at both boundary values: `atanh(1) → +∞` and `atanh(-1) → -∞`. The implementation returned `INFINITY` (positive) for both cases.

PostgreSQL correctly returns `-Infinity` for `atanh(-1)`.

### Root cause

In `AtanhOperator::Operation`, both boundary values were handled by a single check:

```cpp
if (input == -1 || input == 1) {
    return INFINITY;  // wrong: always positive
}
```

### Fix

Split into separate checks so each boundary returns the correct sign:

```cpp
if (input == 1) {
    return INFINITY;
}
if (input == -1) {
    return -INFINITY;
}
```

### Changes

| File | Change |
|------|--------|
| `extension/core_functions/scalar/math/numeric.cpp` | Return `-INFINITY` for `atanh(-1)` |
| `test/sql/function/numeric/test_trigo.test` | Update expected result from `inf` to `-inf` |

## Test plan

- [x] `SELECT atanh(-1.0)` returns `-inf`
- [x] `SELECT atanh(1.0)` returns `inf`
- [x] `test/sql/function/numeric/test_trigo.test` passes (272 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)