### PR TITLE
Fix out-of-bounds read in list_where when boolean mask is longer than input list

### DIFF
--- a/src/function/scalar/list/list_select.cpp
+++ b/src/function/scalar/list/list_select.cpp
@@ -44,13 +44,15 @@ struct SetSelectionVectorWhere {
 			return;
 		}
 
-		selection_vector.set_index(target_offset, input_offset + child_idx);
-		if (!input_validity.RowIsValid(input_offset + child_idx)) {
-			validity_mask.SetInvalid(target_offset);
-		}
-
 		if (child_idx >= target_length) {
 			selection_vector.set_index(target_offset, 0);
+			validity_mask.SetInvalid(target_offset);
+			target_offset++;
+			return;
+		}
+
+		selection_vector.set_index(target_offset, input_offset + child_idx);
+		if (!input_validity.RowIsValid(input_offset + child_idx)) {
 			validity_mask.SetInvalid(target_offset);
 		}
 

--- a/test/sql/function/list/list_where.test
+++ b/test/sql/function/list/list_where.test
@@ -238,3 +238,10 @@ query I
 SELECT LIST_WHERE(ARRAY_VALUE('1', NULL), [TRUE, TRUE, FALSE]);
 ----
 [1, NULL]
+
+# boolean mask much longer than input list - previously caused out-of-bounds
+# read on the validity mask (row_idx >= capacity) in debug builds
+query I
+SELECT length(list_where([1], (SELECT list(true) FROM range(4096))));
+----
+4096


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds memory read in `list_where` (aka `array_where`) that occurs when the boolean mask list is longer than the input list.

### Root cause

In `SetSelectionVectorWhere::SetSelectionVector`, when `child_idx >= target_length` (the mask has more `true` entries than the input list has elements), lines 47-48 access the input validity bitmask at the out-of-bounds index **before** the bounds check at line 52 corrects it:

```cpp
// BEFORE: OOB access happens first, bounds check corrects afterward
selection_vector.set_index(target_offset, input_offset + child_idx);    // OOB index
if (!input_validity.RowIsValid(input_offset + child_idx)) {             // OOB read
    validity_mask.SetInvalid(target_offset);
}

if (child_idx >= target_length) {                                       // bounds check too late
    selection_vector.set_index(target_offset, 0);
    validity_mask.SetInvalid(target_offset);
}
```

The OOB read accesses validity bits belonging to other lists in the child vector, or past the end of allocated memory. While the result is immediately overwritten by the bounds check, the read itself is undefined behavior and could be detected by AddressSanitizer or cause a segfault if the child vector is at a page boundary.

### Fix

Move the bounds check before the access, and return early:

```cpp
// AFTER: bounds check first, no OOB access
if (child_idx >= target_length) {
    selection_vector.set_index(target_offset, 0);
    validity_mask.SetInvalid(target_offset);
    target_offset++;
    return;
}

selection_vector.set_index(target_offset, input_offset + child_idx);
if (!input_validity.RowIsValid(input_offset + child_idx)) {
    validity_mask.SetInvalid(target_offset);
}

target_offset++;
```

### Behavior preserved

The existing behavior — out-of-bounds mask positions produce NULL in the result — is unchanged. Existing tests confirm this:

```sql
SELECT LIST_WHERE(ARRAY_VALUE('1', NULL), [TRUE, TRUE, TRUE]);
-- [1, NULL, NULL]
```

### Changes

| File | Change |
|------|--------|
| `src/function/scalar/list/list_select.cpp` | Move bounds check before OOB access in `SetSelectionVectorWhere` |

## Test plan

- [x] `test/sql/function/list/list_where.test` passes (81 assertions)
- [x] `list_where([1], [true, true, true, true, true])` returns `[1, NULL, NULL, NULL, NULL]` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)