### PR TITLE
Fix acosh() silently returning NaN for out-of-domain inputs

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1433,14 +1433,19 @@ namespace {
 struct AcoshOperator {
 	template <class TA, class TR>
 	static inline TR Operation(TA input) {
+		if (input < 1) {
+			throw InvalidInputException("ACOSH is undefined for values less than 1");
+		}
 		return (double)std::acosh(input);
 	}
 };
 } // namespace
 
 ScalarFunction AcoshFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, AcoshOperator>);
+	ScalarFunction function({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                        ScalarFunction::UnaryFunction<double, double, AcoshOperator>);
+	function.SetFallible();
+	return function;
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/function/numeric/test_trigo.test
+++ b/test/sql/function/numeric/test_trigo.test
@@ -481,10 +481,25 @@ select atanh(-0.5), atanh(0), atanh(0.5);
 -0.5493061443340549	0.0	0.5493061443340549
 
 # ACOSH
-query IIII
-select acosh(-1), acosh(0), acosh(1), acosh(2);
+query II
+select acosh(1), acosh(2);
 ----
-NaN	NaN	0.0	1.3169578969248166
+0.0	1.3169578969248166
+
+statement error
+select acosh(0);
+----
+Invalid Input Error: ACOSH is undefined for values less than 1
+
+statement error
+select acosh(-1);
+----
+Invalid Input Error: ACOSH is undefined for values less than 1
+
+statement error
+select acosh(0.5);
+----
+Invalid Input Error: ACOSH is undefined for values less than 1
 
 # ASINH
 query III


### PR DESCRIPTION
## Summary

`acosh()` silently returns `NaN` for inputs less than 1 instead of throwing an error. All other inverse trigonometric/hyperbolic functions in DuckDB validate their domain and throw `InvalidInputException`.

### Current behavior

```sql
SELECT acosh(0.5);  -- Returns: NaN (should be an error)
SELECT acosh(0);    -- Returns: NaN (should be an error)
SELECT acosh(-1);   -- Returns: NaN (should be an error)
```

### Expected behavior (matches PostgreSQL)

```sql
SELECT acosh(0.5);  -- ERROR: ACOSH is undefined for values less than 1
```

### Inconsistency with other DuckDB functions

| Function | Domain | Out-of-domain behavior |
|----------|--------|----------------------|
| `asin(x)` | [-1, 1] | Throws `"ASIN is undefined outside [-1,1]"` |
| `acos(x)` | [-1, 1] | Throws `"ACOS is undefined outside [-1,1]"` |
| `atanh(x)` | [-1, 1] | Throws `"ATANH is undefined outside [-1,1]"` |
| **`acosh(x)`** | **[1, ∞)** | **Silently returns NaN** |

### Fix

Add domain validation to `AcoshOperator` matching the pattern used by `asin`, `acos`, and `atanh`, and mark the function as fallible.

### Changes

| File | Change |
|------|--------|
| `extension/core_functions/scalar/math/numeric.cpp` | Add `input < 1` check, throw `InvalidInputException`, mark function fallible |
| `test/sql/function/numeric/test_trigo.test` | Update: valid inputs tested separately, invalid inputs expect errors |

## Test plan

- [x] `acosh(1)` returns `0.0`, `acosh(2)` returns `1.317...` (valid inputs unchanged)
- [x] `acosh(0.5)`, `acosh(0)`, `acosh(-1)` all throw `InvalidInputException`
- [x] `test/sql/function/numeric/test_trigo.test` passes (273 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)