### PR TITLE
Fix datediff overflow for week and microsecond parts with extreme dates

### DIFF
--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -102,7 +102,7 @@ struct DateDiff {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
 			//	Weeks do not count Monday crossings, just distance
-			return (enddate.days - startdate.days) / Interval::DAYS_PER_WEEK;
+			return (TR(enddate.days) - TR(startdate.days)) / Interval::DAYS_PER_WEEK;
 		}
 	};
 
@@ -116,7 +116,9 @@ struct DateDiff {
 	struct MicrosecondsOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
-			return Date::EpochMicroseconds(enddate) - Date::EpochMicroseconds(startdate);
+			const auto start = Date::EpochMicroseconds(startdate);
+			const auto end = Date::EpochMicroseconds(enddate);
+			return SubtractOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(end, start);
 		}
 	};
 

--- a/test/sql/function/date/date_diff_extreme_dates.test
+++ b/test/sql/function/date/date_diff_extreme_dates.test
@@ -1,0 +1,50 @@
+# name: test/sql/function/date/date_diff_extreme_dates.test
+# description: Test datediff with extreme date ranges that previously overflowed
+# group: [date]
+
+statement ok
+PRAGMA enable_verification
+
+# Bug fix: datediff('week') used int32 subtraction of date.days which overflowed
+# for dates spanning the full int32 range, producing 0 instead of ~613 million
+query I
+SELECT datediff('week', DATE '-5877641-06-25', DATE '5881580-07-10');
+----
+613566756
+
+# Week diff should be consistent with day diff
+query I
+SELECT datediff('day', DATE '-5877641-06-25', DATE '5881580-07-10');
+----
+4294967292
+
+# Verify: day_diff / 7 = week_diff (integer division)
+query I
+SELECT datediff('day', DATE '-5877641-06-25', DATE '5881580-07-10') / 7;
+----
+613566756
+
+# Negative direction should also work
+query I
+SELECT datediff('week', DATE '5881580-07-10', DATE '-5877641-06-25');
+----
+-613566756
+
+# Bug fix: datediff('microsecond') for dates used unchecked int64 subtraction
+# which silently overflowed and returned a negative number for a positive range
+statement error
+SELECT datediff('microsecond', DATE '-290000-01-01', DATE '290000-01-01');
+----
+Overflow
+
+# Microseconds should work for smaller date ranges
+query I
+SELECT datediff('microsecond', DATE '2000-01-01', DATE '2000-01-02');
+----
+86400000000
+
+# Negative direction for microseconds
+query I
+SELECT datediff('microsecond', DATE '2000-01-02', DATE '2000-01-01');
+----
+-86400000000


### PR DESCRIPTION
## Summary

Two overflow bugs in `datediff` when used with the `DATE` type and extreme date ranges:

### Bug 1: `datediff('week')` returns 0 for dates ~11.7 million years apart

```sql
SELECT datediff('week', DATE '-5877641-06-25', DATE '5881580-07-10');
-- Before: 0 (wrong — int32 overflow)
-- After:  613566756
```

**Root cause:** `WeekOperator` computes `(enddate.days - startdate.days) / 7` where `.days` is `int32_t`. The subtraction overflows `int32_t` before widening to the `int64_t` return type.

**Fix:** Widen to `int64_t` before subtracting: `(TR(enddate.days) - TR(startdate.days)) / 7`, matching the pattern already used by `DayOperator`.

### Bug 2: `datediff('microsecond')` returns negative for positive date range

```sql
SELECT datediff('microsecond', DATE '-290000-01-01', DATE '290000-01-01');
-- Before: -143711913709551616 (wrong — int64 overflow, sign flipped)
-- After:  Out of Range Error: Overflow in subtraction of INT64
```

**Root cause:** `MicrosecondsOperator` computes `Date::EpochMicroseconds(enddate) - Date::EpochMicroseconds(startdate)`. Each individual epoch value fits in `int64_t`, but their difference exceeds `INT64_MAX` (~18.3 × 10¹⁸ vs 9.2 × 10¹⁸), causing silent overflow.

**Fix:** Use `SubtractOperatorOverflowCheck` for the subtraction, matching the `timestamp_t` specialization which already had this protection (line 210).

Note: the timestamp specialization was already correct — only the `date_t` code path was affected.

### Changes

| File | Change |
|------|--------|
| `extension/core_functions/scalar/date/date_diff.cpp` | Widen week subtraction to int64; use overflow-checked subtraction for microseconds |
| `test/sql/function/date/date_diff_extreme_dates.test` | New test covering both fixes with extreme dates |

## Test plan

- [x] `datediff('week')` returns 613566756 for full date range (was 0)
- [x] `datediff('week')` negative direction returns -613566756
- [x] `datediff('microsecond')` throws overflow for extreme dates (was silent garbage)
- [x] `datediff('microsecond')` still works for normal ranges (86400000000 for 1 day)
- [x] Existing `date_diff.test_slow` passes (812 assertions)
- [x] New `date_diff_extreme_dates.test` passes (8 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)