### PR TITLE
Fix autocomplete fuzzy suggestion limit comparing string length instead of result count

### DIFF
--- a/extension/autocomplete/autocomplete_core.cpp
+++ b/extension/autocomplete/autocomplete_core.cpp
@@ -117,7 +117,7 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 		if (entry == matches.end()) {
 			throw InternalException("Auto-complete match not found");
 		}
-		if (result.size() > fuzzy_suggestion_count) {
+		if (results.size() > fuzzy_suggestion_count) {
 			// after we exceed the "fuzzy_suggestion_count" we only accept exact suggestion matches
 			if (!StringUtil::StartsWith(StringUtil::Lower(result), lower_prefix)) {
 				break;


### PR DESCRIPTION
## Summary

- `ComputeSuggestions` in the autocomplete extension has a two-tier filtering system: return up to `fuzzy_suggestion_count` (default 20) fuzzy matches, then only accept exact prefix matches up to `suggestion_count` (default 100). The check on line 120 used `result.size()` (the character length of the current suggestion string) instead of `results.size()` (the number of suggestions emitted so far), making the filter based on name length rather than result count.
- This effectively disabled the fuzzy limit for suggestions with short names (≤20 chars) and incorrectly applied exact-prefix filtering to suggestions with long names even when well within the fuzzy limit.

## Test plan

- [x] All 22 existing autocomplete tests pass (338 assertions)
- [ ] Verify that autocomplete with many fuzzy matches now correctly limits to 20 fuzzy results before requiring exact prefix matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)