### PR TITLE
Fix connection_id regression in EndQueryInternal logging

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -307,7 +307,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 	// Refresh the logger
 	logger->Flush();
 	LoggingContext context(LogContextScope::CONNECTION);
-	context.connection_id = reinterpret_cast<idx_t>(this);
+	context.connection_id = connection_id;
 	logger = db->GetLogManager().CreateLogger(context, true);
 
 	// Notify any registered state of query end


### PR DESCRIPTION
## Summary

`EndQueryInternal` uses `reinterpret_cast<idx_t>(this)` (the raw pointer address) as the `connection_id` when recreating the logger after a query ends, while `BeginQueryInternal` correctly uses the `connection_id` member variable (a monotonically increasing integer assigned by `ConnectionManager`).

This means log entries emitted during query execution have a different connection identifier than log entries emitted after the query ends, breaking log correlation and any downstream systems that rely on consistent connection IDs.

### Root cause

This is a regression — commit 4b130fe2b98 ("improve logging context information") previously fixed this exact inconsistency, but the fix was lost (likely during a merge or rebase).

### The fix

One-line change in `EndQueryInternal`: replace `reinterpret_cast<idx_t>(this)` with `connection_id` to match `BeginQueryInternal`.

**Before (line 310):**
```cpp
context.connection_id = reinterpret_cast<idx_t>(this);
```

**After:**
```cpp
context.connection_id = connection_id;
```

## Test plan

- [ ] Verify log entries have consistent `connection_id` across query begin/end
- [ ] Existing logging tests continue to pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>