### PR TITLE
Fix InterruptCheck timeout counter not resetting between queries

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -331,6 +331,8 @@ private:
 	unique_ptr<ActiveQueryContext> active_query;
 	//! The current query progress
 	QueryProgress query_progress;
+	//! Counter for throttling timeout checks in InterruptCheck (mutable because InterruptCheck is const)
+	mutable uint32_t timeout_check_counter = 0;
 	//! The connection corresponding to this client context
 	connection_t connection_id;
 };

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -241,6 +241,7 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const string &qu
 	active_query->query = query;
 
 	query_progress.Initialize();
+	timeout_check_counter = 0;
 	// Set query deadline if max_execution_time is configured
 	auto max_execution_time = Settings::Get<MaxExecutionTimeSetting>(*this);
 	if (max_execution_time > 0) {
@@ -1211,9 +1212,7 @@ void ClientContext::SuppressInterrupts() {
 }
 
 void ClientContext::InterruptCheck() const {
-	// Counter for throttling timeout checks - only check every N iterations
 	static constexpr uint32_t TIMEOUT_CHECK_INTERVAL = 256;
-	thread_local uint32_t timeout_check_counter = 0;
 
 	if (interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
 		throw InterruptException();


### PR DESCRIPTION
## Summary

`ClientContext::InterruptCheck()` uses a `thread_local` counter to throttle expensive `steady_clock::now()` calls when checking `max_execution_time` deadlines. This counter is never reset between queries, causing two problems:

1. **Cross-query bleed**: The counter persists across queries on the same thread. A new query's first timeout check depends on where the previous query left the counter — it could take up to 255 additional `InterruptCheck` calls before the first deadline check occurs.

2. **Cross-context bleed**: If multiple `ClientContext` objects are used on the same thread, their counters are shared, so one context's calls affect the timing of timeout checks for another.

This can cause `max_execution_time` to be significantly exceeded in practice.

### Root cause

The timeout check counter was declared as `thread_local` inside `InterruptCheck()`:
```cpp
thread_local uint32_t timeout_check_counter = 0;
```

This makes it persist for the lifetime of the thread rather than being scoped to a query or context.

### The fix

- Move the counter to a `mutable` instance member of `ClientContext` (mutable because `InterruptCheck` is `const`)
- Reset it to 0 in `BeginQueryInternal` at the start of each query
- Remove the `thread_local` declaration from `InterruptCheck`

This ensures each query starts with a fresh counter and each context has its own independent counter.

## Test plan

- [ ] Verify `max_execution_time` is respected across consecutive queries on the same connection
- [ ] Verify `InterruptCheck` still throttles `steady_clock::now()` calls (counter increments correctly)
- [ ] Existing interrupt/timeout tests continue to pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>