### PR TITLE
Fix SYSTEM_PEAK_BUFFER_MEMORY profiler metric accumulating instead of tracking peak

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -67,7 +67,7 @@ struct OperatorInformation {
 			break;
 		case MetricType::SYSTEM_PEAK_BUFFER_MEMORY: {
 			if (metric > system_peak_buffer_manager_memory) {
-				system_peak_buffer_manager_memory += LossyNumericCast<idx_t>(metric);
+				system_peak_buffer_manager_memory = LossyNumericCast<idx_t>(metric);
 			}
 			break;
 		}


### PR DESCRIPTION
## Summary

The `SYSTEM_PEAK_BUFFER_MEMORY` profiler metric uses `+=` (accumulate) instead of `=` (assign) when recording a new peak, causing it to report inflated values that grow without bound.

### Root cause

In `OperatorInformation::AddMetric` (`query_profiler.hpp` line 70):

```cpp
case MetricType::SYSTEM_PEAK_BUFFER_MEMORY: {
    if (metric > system_peak_buffer_manager_memory) {
        system_peak_buffer_manager_memory += LossyNumericCast<idx_t>(metric);  // BUG: += instead of =
    }
    break;
}
```

Compare with the identical pattern for `SYSTEM_PEAK_TEMP_DIR_SIZE` (line 76) which correctly uses `=`:

```cpp
case MetricType::SYSTEM_PEAK_TEMP_DIR_SIZE: {
    if (metric > system_peak_temp_directory_size) {
        system_peak_temp_directory_size = LossyNumericCast<idx_t>(metric);  // correct: =
    }
    break;
}
```

### Example of incorrect behavior

For an operator sampled 3 times with buffer memory readings of 1MB, 0.8MB, 1.5MB:

| Sample | Metric | Before (+=) | After (=) |
|--------|--------|-------------|-----------|
| 1 | 1MB | 0 + 1MB = **1MB** | **1MB** |
| 2 | 0.8MB | no update (0.8 < 1) | no update |
| 3 | 1.5MB | 1MB + 1.5MB = **2.5MB** ✗ | **1.5MB** ✓ |

### Fix

One-character change: `+=` → `=`.

## Test plan

- [x] All profiling tests pass (1591 assertions in 18 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)