### PR TITLE
Fix copy-paste typo: sequence dependency error message says "index"

### DIFF
--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -367,7 +367,7 @@ static string EntryToString(CatalogEntryInfo &info) {
 		return StringUtil::Format("index \"%s\"", info.name);
 	}
 	case CatalogType::SEQUENCE_ENTRY: {
-		return StringUtil::Format("index \"%s\"", info.name);
+		return StringUtil::Format("sequence \"%s\"", info.name);
 	}
 	case CatalogType::COLLATION_ENTRY: {
 		return StringUtil::Format("collation \"%s\"", info.name);

--- a/test/fuzzer/pedro/currval_sequence_dependency.test
+++ b/test/fuzzer/pedro/currval_sequence_dependency.test
@@ -19,7 +19,7 @@ CREATE TABLE t1(c1 INT, CHECK(${fun}('seq')));
 statement error
 DROP SEQUENCE seq;
 ----
-<REGEX>:Dependency Error.*table "t1" depends on index "seq".*
+<REGEX>:Dependency Error.*table "t1" depends on sequence "seq".*
 
 statement ok
 DROP SEQUENCE seq CASCADE;

--- a/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
+++ b/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
@@ -79,7 +79,7 @@ ALTER SEQUENCE sequence1 OWNED BY tablename;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -245,12 +245,12 @@ sequence1 is already owned by new_tablename
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "new_tablename" depends on index "sequence1".
+table "new_tablename" depends on sequence "sequence1".
 
 statement error
 CREATE OR REPLACE SEQUENCE sequence1;
 ----
-table "new_tablename" depends on index "sequence1".
+table "new_tablename" depends on sequence "sequence1".
 
 # Owning the sequence with the same table shouldn't return any error
 statement ok
@@ -283,7 +283,7 @@ ALTER SEQUENCE sequence1 OWNED BY tablename;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -307,7 +307,7 @@ ALTER TABLE tablename DROP colname2;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -330,7 +330,7 @@ ALTER TABLE tablename ALTER colname TYPE float;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -356,7 +356,7 @@ ALTER TABLE tablename DROP colname4;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 ALTER TABLE tablename DROP colname3;
@@ -364,7 +364,7 @@ ALTER TABLE tablename DROP colname3;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 ALTER TABLE tablename DROP colname2;
@@ -372,7 +372,7 @@ ALTER TABLE tablename DROP colname2;
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -411,7 +411,7 @@ select nextval('sequence1');
 statement error
 DROP SEQUENCE sequence1;
 ----
-table "tablename" depends on index "sequence1".
+table "tablename" depends on sequence "sequence1".
 
 statement ok
 DROP TABLE tablename;
@@ -429,7 +429,7 @@ ALTER SEQUENCE sequence1 OWNED BY v1_sequence1;
 statement error
 DROP SEQUENCE sequence1;
 ----
-view "v1_sequence1" depends on index "sequence1".
+view "v1_sequence1" depends on sequence "sequence1".
 
 statement ok
 DROP VIEW v1_sequence1;
@@ -452,7 +452,7 @@ ALTER SEQUENCE sequence1 OWNED BY sequence2;
 statement error
 DROP SEQUENCE sequence1;
 ----
-index "sequence2" depends on index "sequence1".
+sequence "sequence2" depends on sequence "sequence1".
 
 statement ok
 DROP SEQUENCE sequence2;

--- a/test/sql/catalog/dependencies/test_alter_owning_table.test
+++ b/test/sql/catalog/dependencies/test_alter_owning_table.test
@@ -25,12 +25,12 @@ alter table tbl rename to tbl2;
 statement error
 drop sequence seq;
 ----
-table "tbl2" depends on index "seq".
+table "tbl2" depends on sequence "seq".
 
 statement error
 drop sequence other_seq;
 ----
-table "tbl2" depends on index "other_seq".
+table "tbl2" depends on sequence "other_seq".
 
 statement ok
 drop table tbl2;


### PR DESCRIPTION
## Summary

- One-line fix: the `SEQUENCE_ENTRY` case in `EntryToString` (`dependency_manager.cpp:370`) was copy-pasted from the `INDEX_ENTRY` case and still prints `"index"` instead of `"sequence"`.

## Reproduction

```sql
CREATE SEQUENCE seq;
CREATE TABLE t(id INTEGER DEFAULT nextval('seq'));
DROP SEQUENCE seq;
```

**Before:**
```
table "t" depends on index "seq".
```

**After:**
```
table "t" depends on sequence "seq".
```

## Test plan

- [x] Verified the corrected error message manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)