### PR TITLE
Fix geometry TextWriter corrupting coordinates in scientific notation

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -205,9 +205,19 @@ public:
 		buffer.push_back(c);
 	}
 	void Write(double value) {
+		auto start = buffer.size();
 		duckdb_fmt::format_to(std::back_inserter(buffer), "{}", value);
-		// Remove trailing zero
-		if (buffer.back() == '0') {
+		// Remove trailing ".0" (e.g. "10.0" -> "10"), but only when the number
+		// is in fixed notation. Scientific notation like "1e+20" must not be
+		// touched — stripping the trailing '0' would corrupt the exponent.
+		bool has_exponent = false;
+		for (auto i = start; i < buffer.size(); i++) {
+			if (buffer[i] == 'e' || buffer[i] == 'E') {
+				has_exponent = true;
+				break;
+			}
+		}
+		if (!has_exponent && buffer.back() == '0') {
 			buffer.pop_back();
 			if (buffer.back() == '.') {
 				buffer.pop_back();

--- a/test/sql/types/geo/geometry.test
+++ b/test/sql/types/geo/geometry.test
@@ -121,3 +121,26 @@ statement error
 select 'GEOMETRYCOLLECTION Z (POINT Z (1 1 2), LINESTRING (0 0, 1 1))'::GEOMETRY;
 ----
 Invalid Input Error: Geometry has inconsistent Z/M dimensions
+
+# Scientific notation coordinates must not be corrupted during text rendering
+# (exponents ending in 0 were previously truncated, e.g. 1e+20 -> 1e+2)
+query I
+SELECT 'POINT(1e20 1e-10)'::GEOMETRY::VARCHAR;
+----
+POINT (1e+20 1e-10)
+
+query I
+SELECT 'POINT(5e30 3e-20)'::GEOMETRY::VARCHAR;
+----
+POINT (5e+30 3e-20)
+
+query I
+SELECT 'POINT(4.56e20 1.23e-10)'::GEOMETRY::VARCHAR;
+----
+POINT (4.56e+20 1.23e-10)
+
+# Round-trip through text must preserve scientific notation values
+query I
+SELECT ('POINT(1e20 1e-10)'::GEOMETRY::VARCHAR)::GEOMETRY::VARCHAR;
+----
+POINT (1e+20 1e-10)


### PR DESCRIPTION
## Summary

`TextWriter::Write(double)` in `src/common/types/geometry.cpp` blindly strips a trailing `'0'` from formatted numbers to remove cosmetic `.0` suffixes (e.g. `"10.0"` → `"10"`). However, it doesn't check for scientific notation — when `{fmt}` formats a value like `1e20` as `"1e+20"`, the code strips the exponent's trailing `'0'`, producing `"1e+2"` (= 100 instead of 1×10²⁰).

### Impact

Any `GEOMETRY → VARCHAR` cast silently corrupts coordinate values when:
- The magnitude is ≥ 1e16 or ≤ 1e-5 (where `{fmt}` uses scientific notation), **AND**
- The exponent ends in `0` (e.g. 10, 20, 30)

The corruption compounds on round-trips (`GEOMETRY::VARCHAR::GEOMETRY`), permanently destroying the stored WKB data.

### Reproducer

```sql
-- Before fix: POINT (1e+2 1e-1)  (wrong! 100x and 0.1 instead of 1e20 and 1e-10)
-- After fix:  POINT (1e+20 1e-10) (correct)
SELECT 'POINT(1e20 1e-10)'::GEOMETRY::VARCHAR;

-- Corruption becomes permanent after round-trip through text:
SELECT ('POINT(1e20 1e-10)'::GEOMETRY::VARCHAR)::GEOMETRY::VARCHAR;
-- Before fix: POINT (100 0.1)
-- After fix:  POINT (1e+20 1e-10)
```

### Fix

Skip the trailing-zero removal when the formatted number contains `'e'` or `'E'` (scientific notation).

## Test plan

- [x] Added test cases for scientific notation coordinates and round-trips
- [x] All 2785 assertions across 20 geometry test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)