### PR TITLE
Add Arrow dense union read/write support

### DIFF
--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -67,4 +67,92 @@ void ArrowUnionData::Finalize(ArrowAppendData &append_data, const LogicalType &t
 	}
 }
 
+//===--------------------------------------------------------------------===//
+// Dense Unions
+//===--------------------------------------------------------------------===//
+void ArrowDenseUnionData::Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
+	// Main buffer = type_ids (int8_t per row)
+	result.GetMainBuffer().reserve(capacity * sizeof(int8_t));
+	// Aux buffer = offsets (int32_t per row)
+	result.GetAuxBuffer().reserve(capacity * sizeof(int32_t));
+
+	for (auto &child : UnionType::CopyMemberTypes(type)) {
+		auto child_buffer = ArrowAppender::InitializeChild(child.second, capacity, result.options);
+		result.child_data.push_back(std::move(child_buffer));
+	}
+}
+
+void ArrowDenseUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t from, idx_t to, idx_t input_size) {
+	auto &types_buffer = append_data.GetMainBuffer();
+	auto &offsets_buffer = append_data.GetAuxBuffer();
+
+	auto member_types = UnionType::CopyMemberTypes(input.GetType());
+	idx_t n_children = member_types.size();
+
+	// Track per-child row counts to compute offsets
+	duckdb::vector<idx_t> child_counts(n_children, 0);
+	// Count existing rows in each child to get the starting offset
+	for (idx_t child_idx = 0; child_idx < n_children; child_idx++) {
+		child_counts[child_idx] = append_data.child_data[child_idx]->row_count;
+	}
+
+	// Build per-child vectors containing only the values for that child
+	duckdb::vector<duckdb::vector<Value>> child_values(n_children);
+
+	idx_t append_count = to - from;
+	// Pre-allocate space for offsets buffer (int32_t per row, managed at byte level)
+	idx_t offsets_byte_start = offsets_buffer.size();
+	offsets_buffer.resize(offsets_byte_start + append_count * sizeof(int32_t));
+	auto offsets_data = reinterpret_cast<int32_t *>(offsets_buffer.data() + offsets_byte_start);
+
+	for (idx_t input_idx = from; input_idx < to; input_idx++) {
+		const auto &val = input.GetValue(input_idx);
+
+		idx_t tag = 0;
+		Value resolved_value(nullptr);
+		if (!val.IsNull()) {
+			tag = UnionValue::GetTag(val);
+			resolved_value = UnionValue::GetValue(val);
+		}
+
+		types_buffer.push_back<data_t>(NumericCast<data_t>(tag));
+		offsets_data[input_idx - from] = NumericCast<int32_t>(child_counts[tag]);
+		child_values[tag].push_back(std::move(resolved_value));
+		child_counts[tag]++;
+	}
+
+	// Append each child's collected values
+	for (idx_t child_idx = 0; child_idx < n_children; child_idx++) {
+		auto &values = child_values[child_idx];
+		if (values.empty()) {
+			continue;
+		}
+		idx_t child_size = values.size();
+		Vector child_vector(member_types[child_idx].second, child_size);
+		for (idx_t i = 0; i < child_size; i++) {
+			child_vector.SetValue(i, values[i]);
+		}
+		auto &child_buffer = append_data.child_data[child_idx];
+		child_buffer->append_vector(*child_buffer, child_vector, 0, child_size, child_size);
+	}
+	append_data.row_count += to - from;
+}
+
+void ArrowDenseUnionData::Finalize(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result) {
+	// Arrow C Data Interface: dense union has 3 buffers = [null_bitmap (always null), type_ids, offsets]
+	result->n_buffers = 3;
+	result->buffers[0] = nullptr;
+	result->buffers[1] = append_data.GetMainBuffer().data();
+	result->buffers[2] = append_data.GetAuxBuffer().data();
+
+	auto &child_types = UnionType::CopyMemberTypes(type);
+	ArrowAppender::AddChildren(append_data, child_types.size());
+	result->children = append_data.child_pointers.data();
+	result->n_children = NumericCast<int64_t>(child_types.size());
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		auto &child_type = child_types[i].second;
+		append_data.child_arrays[i] = *ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
+	}
+}
+
 } // namespace duckdb

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -277,7 +277,11 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 		InitializeAppenderForType<ArrowScalarData<ArrowInterval, interval_t, ArrowIntervalConverter>>(append_data);
 		break;
 	case LogicalTypeId::UNION:
-		InitializeAppenderForType<ArrowUnionData>(append_data);
+		if (append_data.options.arrow_output_dense_union) {
+			InitializeAppenderForType<ArrowDenseUnionData>(append_data);
+		} else {
+			InitializeAppenderForType<ArrowUnionData>(append_data);
+		}
 		break;
 	case LogicalTypeId::STRUCT:
 		InitializeAppenderForType<ArrowStructData>(append_data);

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -349,7 +349,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	}
 	case LogicalTypeId::UNION: {
-		std::string format = "+us:";
+		std::string format = options.arrow_output_dense_union ? "+ud:" : "+us:";
 
 		auto &child_types = UnionType::CopyMemberTypes(type);
 		child.n_children = NumericCast<int64_t>(child_types.size());

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -661,19 +661,20 @@ const StringUtil::EnumStringLiteral *GetArrowTypeInfoTypeValues() {
 		{ static_cast<uint32_t>(ArrowTypeInfoType::DATE_TIME), "DATE_TIME" },
 		{ static_cast<uint32_t>(ArrowTypeInfoType::STRING), "STRING" },
 		{ static_cast<uint32_t>(ArrowTypeInfoType::ARRAY), "ARRAY" },
-		{ static_cast<uint32_t>(ArrowTypeInfoType::DECIMAL), "DECIMAL" }
+		{ static_cast<uint32_t>(ArrowTypeInfoType::DECIMAL), "DECIMAL" },
+		{ static_cast<uint32_t>(ArrowTypeInfoType::UNION), "UNION" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<ArrowTypeInfoType>(ArrowTypeInfoType value) {
-	return StringUtil::EnumToString(GetArrowTypeInfoTypeValues(), 6, "ArrowTypeInfoType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetArrowTypeInfoTypeValues(), 7, "ArrowTypeInfoType", static_cast<uint32_t>(value));
 }
 
 template<>
 ArrowTypeInfoType EnumUtil::FromString<ArrowTypeInfoType>(const char *value) {
-	return static_cast<ArrowTypeInfoType>(StringUtil::StringToEnum(GetArrowTypeInfoTypeValues(), 6, "ArrowTypeInfoType", value));
+	return static_cast<ArrowTypeInfoType>(StringUtil::StringToEnum(GetArrowTypeInfoTypeValues(), 7, "ArrowTypeInfoType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetArrowVariableSizeTypeValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -126,6 +126,14 @@
         "default_value": "false"
     },
     {
+        "name": "arrow_output_dense_union",
+        "description": "Whether Arrow UNION columns should be exported using dense union layout instead of sparse",
+        "type": "BOOLEAN",
+        "internal_setting": "arrow_output_dense_union",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "arrow_output_list_view",
         "description": "Whether export to Arrow format should use ListView as the physical layout for LIST columns",
         "type": "BOOLEAN",

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -257,14 +257,25 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(ClientContext &context, Arrow
 		auto struct_type = make_uniq<ArrowType>(LogicalType::STRUCT(std::move(child_types)), std::move(type_info));
 		return struct_type;
 	} else if (format[0] == '+' && format[1] == 'u') {
-		if (format[2] != 's') {
+		bool is_dense;
+		if (format[2] == 's') {
+			is_dense = false;
+		} else if (format[2] == 'd') {
+			is_dense = true;
+		} else {
 			throw NotImplementedException("Unsupported Internal Arrow Type: \"%c\" Union", format[2]);
 		}
 		D_ASSERT(format[3] == ':');
 
-		std::string prefix = "+us:";
-		// TODO: what are these type ids actually for?
-		auto type_ids = StringUtil::Split(format.substr(prefix.size()), ',');
+		std::string prefix = is_dense ? "+ud:" : "+us:";
+		auto type_id_strings = StringUtil::Split(format.substr(prefix.size()), ',');
+
+		// Build mapping from type_id values (in the buffer) to child indices
+		unordered_map<int8_t, idx_t> type_id_to_child_idx;
+		for (idx_t i = 0; i < type_id_strings.size(); i++) {
+			auto type_id = NumericCast<int8_t>(std::stoi(type_id_strings[i]));
+			type_id_to_child_idx[type_id] = i;
+		}
 
 		child_list_t<LogicalType> members;
 		vector<shared_ptr<ArrowType>> children;
@@ -278,7 +289,7 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(ClientContext &context, Arrow
 			members.emplace_back(type->name, children.back()->GetDuckType());
 		}
 
-		auto type_info = make_uniq<ArrowStructInfo>(std::move(children));
+		auto type_info = make_uniq<ArrowUnionInfo>(std::move(children), is_dense, std::move(type_id_to_child_idx));
 		auto union_type = make_uniq<ArrowType>(LogicalType::UNION(members), std::move(type_info));
 		return union_type;
 	} else if (format == "+r") {
@@ -367,7 +378,7 @@ LogicalType ArrowType::GetDuckType(bool use_dictionary) const {
 		return LogicalType::MAP(StructType::GetChildType(struct_type, 0), StructType::GetChildType(struct_type, 1));
 	}
 	case LogicalTypeId::UNION: {
-		auto &union_info = type_info->Cast<ArrowStructInfo>();
+		auto &union_info = type_info->Cast<ArrowUnionInfo>();
 		child_list_t<LogicalType> new_children;
 		for (idx_t i = 0; i < union_info.ChildCount(); i++) {
 			auto &child = union_info.GetChild(i);

--- a/src/function/table/arrow/arrow_type_info.cpp
+++ b/src/function/table/arrow/arrow_type_info.cpp
@@ -128,6 +128,40 @@ ArrowType &ArrowListInfo::GetChild() const {
 }
 
 //===--------------------------------------------------------------------===//
+// ArrowUnionInfo
+//===--------------------------------------------------------------------===//
+
+ArrowUnionInfo::ArrowUnionInfo(vector<shared_ptr<ArrowType>> children, bool is_dense,
+                               unordered_map<int8_t, idx_t> type_id_to_child_idx)
+    : ArrowTypeInfo(ArrowTypeInfoType::UNION), children(std::move(children)), is_dense(is_dense),
+      type_id_to_child_idx(std::move(type_id_to_child_idx)) {
+}
+
+ArrowUnionInfo::~ArrowUnionInfo() {
+}
+
+idx_t ArrowUnionInfo::ChildCount() const {
+	return children.size();
+}
+
+const ArrowType &ArrowUnionInfo::GetChild(idx_t index) const {
+	D_ASSERT(index < children.size());
+	return *children[index];
+}
+
+bool ArrowUnionInfo::IsDense() const {
+	return is_dense;
+}
+
+idx_t ArrowUnionInfo::GetChildIndexForTypeId(int8_t type_id) const {
+	auto it = type_id_to_child_idx.find(type_id);
+	if (it == type_id_to_child_idx.end()) {
+		throw InvalidInputException("Arrow union type_id %d not found in union type mapping", type_id);
+	}
+	return it->second;
+}
+
+//===--------------------------------------------------------------------===//
 // ArrowArrayInfo
 //===--------------------------------------------------------------------===//
 

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1199,35 +1199,69 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 		break;
 	}
 	case LogicalTypeId::UNION: {
-		auto type_ids = ArrowBufferData<int8_t>(array, array.n_buffers == 1 ? 0 : 1);
+		auto &union_info = arrow_type.GetTypeInfo<ArrowUnionInfo>();
+		bool is_dense = union_info.IsDense();
+
+		// Buffer layout per the C Data Interface:
+		//   Sparse union: buffers = [null_bitmap (always null), type_ids] => n_buffers=2
+		//   Dense union:  buffers = [null_bitmap (always null), type_ids, offsets] => n_buffers=3
+		// DuckDB's own sparse output uses n_buffers=1 (no null bitmap slot), so handle both conventions.
+		idx_t type_ids_buf_idx;
+		if (is_dense) {
+			type_ids_buf_idx = (array.n_buffers == 2) ? 0 : 1;
+		} else {
+			type_ids_buf_idx = (array.n_buffers == 1) ? 0 : 1;
+		}
+
+		// Adjust type_ids and offsets pointers by the effective offset to account for
+		// array.offset, parent_offset, and chunk_offset when scanning in chunks.
+		auto effective_offset =
+		    GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), chunk_offset, nested_offset);
+		auto type_ids = ArrowBufferData<int8_t>(array, type_ids_buf_idx) + effective_offset;
 		D_ASSERT(type_ids);
+
+		int32_t *offsets = nullptr;
+		if (is_dense) {
+			offsets = ArrowBufferData<int32_t>(array, type_ids_buf_idx + 1) + effective_offset;
+			D_ASSERT(offsets);
+		}
+
 		auto members = UnionType::CopyMemberTypes(vector.GetType());
 
 		auto &validity_mask = FlatVector::Validity(vector);
-		auto &union_info = arrow_type.GetTypeInfo<ArrowStructInfo>();
 		duckdb::vector<Vector> children;
 		for (idx_t child_idx = 0; child_idx < NumericCast<idx_t>(array.n_children); child_idx++) {
-			Vector child(members[child_idx].second, size);
 			auto &child_array = *array.children[child_idx];
 			auto &child_state = array_state.GetChild(child_idx);
 			auto &child_type = union_info.GetChild(child_idx);
 
-			ArrowToDuckDBConversion::SetValidityMask(child, child_array, chunk_offset, size,
-			                                         NumericCast<int64_t>(parent_offset), nested_offset);
+			// For dense unions, each child array has its own independent coordinate system —
+			// use child_array.length for sizing, chunk_offset=0, and nested_offset=-1.
+			// For sparse unions, children share the parent's layout.
+			idx_t child_size = is_dense ? NumericCast<idx_t>(child_array.length) : size;
+			idx_t child_chunk_offset = is_dense ? 0 : chunk_offset;
+			int64_t child_nested_offset = is_dense ? -1 : nested_offset;
+			Vector child(members[child_idx].second, child_size);
+
+			// For dense children, parent_offset=0 since they have independent coordinate systems.
+			int64_t child_parent_offset = is_dense ? 0 : NumericCast<int64_t>(parent_offset);
+			ArrowToDuckDBConversion::SetValidityMask(child, child_array, child_chunk_offset, child_size,
+			                                         child_parent_offset, child_nested_offset);
 			auto array_physical_type = child_type.GetPhysicalType();
 
 			switch (array_physical_type) {
 			case ArrowArrayPhysicalType::DICTIONARY_ENCODED:
-				ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(child, child_array, chunk_offset, child_state,
-				                                                       size, child_type);
+				ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(child, child_array, child_chunk_offset,
+				                                                       child_state, child_size, child_type);
 				break;
 			case ArrowArrayPhysicalType::RUN_END_ENCODED:
-				ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(child, child_array, chunk_offset, child_state,
-				                                                          size, child_type);
+				ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(child, child_array, child_chunk_offset,
+				                                                          child_state, child_size, child_type);
 				break;
 			case ArrowArrayPhysicalType::DEFAULT:
-				ArrowToDuckDBConversion::ColumnArrowToDuckDB(child, child_array, chunk_offset, child_state, size,
-				                                             child_type, nested_offset, &validity_mask, false);
+				ArrowToDuckDBConversion::ColumnArrowToDuckDB(child, child_array, child_chunk_offset, child_state,
+				                                             child_size, child_type, child_nested_offset,
+				                                             &validity_mask, /*parent_offset=*/0);
 				break;
 			default:
 				throw NotImplementedException("ArrowArrayPhysicalType not recognized");
@@ -1237,14 +1271,16 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 		}
 
 		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
-			auto tag = NumericCast<uint8_t>(type_ids[row_idx]);
+			auto raw_type_id = type_ids[row_idx];
+			auto child_idx = union_info.GetChildIndexForTypeId(raw_type_id);
 
-			auto out_of_range = tag >= array.n_children;
-			if (out_of_range) {
-				throw InvalidInputException("Arrow union tag out of range: %d", tag);
+			if (child_idx >= NumericCast<idx_t>(array.n_children)) {
+				throw InvalidInputException("Arrow union tag out of range: %d", raw_type_id);
 			}
 
-			const Value &value = children[tag].GetValue(row_idx);
+			idx_t value_idx = is_dense ? NumericCast<idx_t>(offsets[row_idx]) : row_idx;
+			const Value &value = children[child_idx].GetValue(value_idx);
+			auto tag = NumericCast<uint8_t>(child_idx);
 			vector.SetValue(row_idx, value.IsNull() ? Value() : Value::UNION(members, tag, value));
 		}
 

--- a/src/include/duckdb/common/arrow/appender/union_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/union_data.hpp
@@ -26,4 +26,11 @@ public:
 	static void Finalize(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result);
 };
 
+struct ArrowDenseUnionData {
+public:
+	static void Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity);
+	static void Append(ArrowAppendData &append_data, Vector &input, idx_t from, idx_t to, idx_t input_size);
+	static void Finalize(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/function/table/arrow/arrow_type_info.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_type_info.hpp
@@ -144,6 +144,27 @@ private:
 	shared_ptr<ArrowType> child;
 };
 
+struct ArrowUnionInfo : public ArrowTypeInfo {
+public:
+	static constexpr const ArrowTypeInfoType TYPE = ArrowTypeInfoType::UNION;
+
+public:
+	ArrowUnionInfo(vector<shared_ptr<ArrowType>> children, bool is_dense,
+	               unordered_map<int8_t, idx_t> type_id_to_child_idx);
+	~ArrowUnionInfo() override;
+
+public:
+	idx_t ChildCount() const;
+	const ArrowType &GetChild(idx_t index) const;
+	bool IsDense() const;
+	idx_t GetChildIndexForTypeId(int8_t type_id) const;
+
+private:
+	vector<shared_ptr<ArrowType>> children;
+	bool is_dense;
+	unordered_map<int8_t, idx_t> type_id_to_child_idx;
+};
+
 struct ArrowArrayInfo : public ArrowTypeInfo {
 public:
 	static constexpr const ArrowTypeInfoType TYPE = ArrowTypeInfoType::ARRAY;

--- a/src/include/duckdb/function/table/arrow/enum/arrow_type_info_type.hpp
+++ b/src/include/duckdb/function/table/arrow/enum/arrow_type_info_type.hpp
@@ -4,6 +4,6 @@
 
 namespace duckdb {
 
-enum class ArrowTypeInfoType : uint8_t { LIST, STRUCT, DATE_TIME, STRING, ARRAY, DECIMAL };
+enum class ArrowTypeInfoType : uint8_t { LIST, STRUCT, DATE_TIME, STRING, ARRAY, DECIMAL, UNION };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -18,11 +18,12 @@ namespace duckdb {
 struct ClientProperties {
 	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
 	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
-	                 const ArrowFormatVersion arrow_output_version, const optional_ptr<ClientContext> client_context)
+	                 const ArrowFormatVersion arrow_output_version, const bool arrow_output_dense_union_p,
+	                 const optional_ptr<ClientContext> client_context)
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
 	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
-	      client_context(client_context) {
+	      arrow_output_dense_union(arrow_output_dense_union_p), client_context(client_context) {
 	}
 	ClientProperties() {};
 
@@ -32,6 +33,7 @@ struct ClientProperties {
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
 	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_0;
+	bool arrow_output_dense_union = false;
 	optional_ptr<ClientContext> client_context;
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -266,6 +266,17 @@ struct ArrowLosslessConversionSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct ArrowOutputDenseUnionSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "arrow_output_dense_union";
+	static constexpr const char *Description =
+	    "Whether Arrow UNION columns should be exported using dense union layout instead of sparse";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct ArrowOutputListViewSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "arrow_output_list_view";

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1515,12 +1515,14 @@ ClientProperties ClientContext::GetClientProperties() {
 	bool arrow_lossless_conversion = Settings::Get<ArrowLosslessConversionSetting>(*this);
 	bool arrow_use_string_view = Settings::Get<ProduceArrowStringViewSetting>(*this);
 	auto arrow_format_version = Settings::Get<ArrowOutputVersionSetting>(*this);
+	bool arrow_output_dense_union = Settings::Get<ArrowOutputDenseUnionSetting>(*this);
 	return {timezone,
 	        arrow_offset_size,
 	        arrow_use_list_view,
 	        arrow_use_string_view,
 	        arrow_lossless_conversion,
 	        arrow_format_version,
+	        arrow_output_dense_union,
 	        this};
 }
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -81,6 +81,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AllowedPathsSetting),
     DUCKDB_SETTING(ArrowLargeBufferSizeSetting),
     DUCKDB_SETTING(ArrowLosslessConversionSetting),
+    DUCKDB_SETTING(ArrowOutputDenseUnionSetting),
     DUCKDB_SETTING(ArrowOutputListViewSetting),
     DUCKDB_SETTING_CALLBACK(ArrowOutputVersionSetting),
     DUCKDB_SETTING(AsofLoopJoinThresholdSetting),
@@ -210,14 +211,14 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 101),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 44),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 121),
-                                                     DUCKDB_SETTING_ALIAS("user", 136),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 135),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 28),
+                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 28),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 102),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 45),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 122),
+                                                     DUCKDB_SETTING_ALIAS("user", 137),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 27),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 136),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -61,8 +61,8 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type, Sta
 }
 
 QueryResult::QueryResult(QueryResultType type, ErrorData error)
-    : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0, nullptr) {
+    : BaseQueryResult(type, std::move(error)), client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false,
+                                                                 ArrowFormatVersion::V1_0, false, nullptr) {
 }
 
 QueryResult::~QueryResult() {

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -217,6 +217,100 @@ TEST_CASE("Test TPCH arrow roundtrip", "[arrow][.]") {
 	    ArrowTestHelper::RunArrowComparison(con, "SELECT [lineitem_no_constraint] FROM lineitem_no_constraint;", true));
 }
 
+// Helper to run a union roundtrip test with setup queries creating a table with a union column
+static void TestUnionRoundtrip(const std::initializer_list<string> &setup_queries, const string &query,
+                               bool dense = false) {
+	DuckDB db;
+	Connection con(db);
+	if (dense) {
+		REQUIRE(!con.Query("SET arrow_output_dense_union = true")->HasError());
+	}
+	for (auto &setup : setup_queries) {
+		REQUIRE(!con.Query(setup)->HasError());
+	}
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, true));
+	REQUIRE(ArrowTestHelper::RunArrowComparison(con, query, false));
+}
+
+TEST_CASE("Test Arrow union roundtrip", "[arrow]") {
+	// Each case is tested with both sparse (default) and dense union layout
+	for (bool dense : {false, true}) {
+		// Basic union with two members and nulls
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR))",
+		                    "INSERT INTO t VALUES (1), ('hello'), (42), ('world'), (NULL)"},
+		                   "SELECT * FROM t", dense);
+		// Larger dataset with mixed types
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR))",
+		                    "INSERT INTO t SELECT i::INTEGER FROM range(50) tbl(i)",
+		                    "INSERT INTO t SELECT 'str' || i::VARCHAR FROM range(50) tbl(i)"},
+		                   "SELECT * FROM t", dense);
+		// Skewed distribution (most values in one variant)
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR))",
+		                    "INSERT INTO t SELECT i::INTEGER FROM range(95) tbl(i)",
+		                    "INSERT INTO t VALUES ('rare'), ('rare2'), ('rare3')"},
+		                   "SELECT * FROM t", dense);
+		// Dataset larger than STANDARD_VECTOR_SIZE to exercise chunked scanning
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR))",
+		                    "INSERT INTO t SELECT i::INTEGER FROM range(3000) tbl(i)",
+		                    "INSERT INTO t SELECT 'str' || i::VARCHAR FROM range(1000) tbl(i)"},
+		                   "SELECT * FROM t", dense);
+		// Three member union
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR, c DOUBLE))",
+		                    "INSERT INTO t VALUES (1), ('hello'), (3.14), (42), ('world'), (2.71)"},
+		                   "SELECT * FROM t", dense);
+		// Single member union
+		TestUnionRoundtrip({"CREATE TABLE t(u UNION(a INTEGER))", "INSERT INTO t VALUES (1), (2), (NULL), (42)"},
+		                   "SELECT * FROM t", dense);
+		// All-null union
+		TestUnionRoundtrip(
+		    {"CREATE TABLE t(u UNION(a INTEGER, b VARCHAR))", "INSERT INTO t VALUES (NULL), (NULL), (NULL)"},
+		    "SELECT * FROM t", dense);
+	}
+}
+
+TEST_CASE("Test Arrow dense union schema format", "[arrow]") {
+	// Verify that when arrow_output_dense_union is set, the exported schema uses +ud: format
+	DuckDB db;
+	Connection con(db);
+	REQUIRE(!con.Query("SET arrow_output_dense_union = true")->HasError());
+
+	auto client_properties = con.context->GetClientProperties();
+	ArrowSchema schema;
+	schema.Init();
+
+	child_list_t<LogicalType> members;
+	members.emplace_back("a", LogicalType::INTEGER);
+	members.emplace_back("b", LogicalType::VARCHAR);
+
+	vector<LogicalType> types = {LogicalType::UNION(std::move(members))};
+	vector<string> names = {"u"};
+	ArrowConverter::ToArrowSchema(&schema, types, names, client_properties);
+
+	REQUIRE(schema.n_children == 1);
+	string format(schema.children[0]->format);
+	REQUIRE(format.substr(0, 3) == "+ud");
+
+	schema.release(&schema);
+
+	// Also verify sparse format when setting is off
+	REQUIRE(!con.Query("SET arrow_output_dense_union = false")->HasError());
+	client_properties = con.context->GetClientProperties();
+	ArrowSchema schema2;
+	schema2.Init();
+
+	child_list_t<LogicalType> members2;
+	members2.emplace_back("a", LogicalType::INTEGER);
+	members2.emplace_back("b", LogicalType::VARCHAR);
+	vector<LogicalType> types2 = {LogicalType::UNION(std::move(members2))};
+	ArrowConverter::ToArrowSchema(&schema2, types2, names, client_properties);
+
+	REQUIRE(schema2.n_children == 1);
+	string format2(schema2.children[0]->format);
+	REQUIRE(format2.substr(0, 3) == "+us");
+
+	schema2.release(&schema2);
+}
+
 TEST_CASE("Test Parquet Files round-trip", "[arrow][.]") {
 	std::vector<std::string> data;
 	// data.emplace_back("data/parquet-testing/7-set.snappy.arrow2.parquet");


### PR DESCRIPTION
## Summary

- **Read** dense Arrow unions (`+ud:` format) by handling the offsets buffer to index into compact child arrays, with correct `chunk_offset` handling for chunked scanning
- **Write** dense Arrow unions via a new `arrow_output_dense_union` setting (default `false`), producing spec-conformant output (`n_buffers=3` per the Arrow C Data Interface)
- **Fix** a latent bug where type_id mappings from the Arrow format string (e.g., `+us:5,7`) were parsed but ignored — type_ids are now correctly mapped to child indices via a new `ArrowUnionInfo` type info class

### Key changes

| Area | Files | What |
|------|-------|------|
| Type system | `arrow_type_info.hpp/cpp`, `arrow_type_info_type.hpp`, `enum_util.cpp` | New `ArrowUnionInfo` class with `is_dense` flag and type_id-to-child mapping |
| Reading | `arrow_duck_schema.cpp`, `arrow_conversion.cpp` | Accept `+ud:`, handle offsets buffer, use `GetEffectiveOffset` for chunked scanning, independent coordinate system for dense children |
| Writing | `union_data.hpp/cpp`, `arrow_appender.cpp`, `arrow_converter.cpp` | `ArrowDenseUnionData` appender with compact children + offsets; emits `+ud:` when setting active |
| Setting | `settings.hpp`, `client_properties.hpp`, `client_context.cpp`, `config.cpp` | `arrow_output_dense_union` boolean setting |
| Tests | `arrow_roundtrip.cpp` | Parameterized tests (sparse + dense) covering: basic, mixed types, skewed, multi-chunk (4000 rows), 3-member, single-member, all-null unions; schema format verification |

## Test plan

- [x] All 33 existing `[arrow]` tests pass
- [x] New parameterized union roundtrip tests cover both sparse and dense layouts
- [x] Multi-chunk test (4000 rows) exercises `chunk_offset > 0` code path
- [x] Schema format test verifies `+ud:` / `+us:` output based on setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)