### PR TITLE
ExtensionInstall: Remove use of IsHTTP to IsRemoteFile

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -518,10 +518,6 @@ static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &
 	                              context);
 }
 
-static bool IsHTTP(const string &path) {
-	return StringUtil::StartsWith(path, "http://") || !StringUtil::StartsWith(path, "https://");
-}
-
 static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string &local_extension_path,
                                                    const string &extension_name, const string &extension,
                                                    optional_ptr<ExtensionRepository> repository) {
@@ -589,14 +585,14 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 	}
 
 	// Install extension from local, direct url
-	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
+	if (ExtensionHelper::IsFullPath(extension) && !FileSystem::IsRemoteFile(extension)) {
 		auto &local_fs = FileSystem::GetLocal(db);
 		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path, options,
 		                              context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
-	if (options.repository && !IsHTTP(options.repository->path)) {
+	if (options.repository && !FileSystem::IsRemoteFile(options.repository->path)) {
 		auto &local_fs = FileSystem::GetLocal(db);
 		return InstallFromRepository(db, local_fs, extension, extension_name, temp_path, local_extension_path, options,
 		                             context);


### PR DESCRIPTION
This takes starts from https://github.com/duckdb/duckdb/pull/21861 (part 1), but just remove `IsHTTP` completely in favor of `IsRemoteFile`.