### PR TITLE
Fix TRY_CAST from BIT to small integer types throwing instead of returning NULL

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1491,8 +1491,9 @@ bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, CastPara
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(hugeint_t)) {
-		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
-		                          GetTypeId<hugeint_t>());
+		HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<hugeint_t>()),
+		                             parameters);
+		return false;
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);
@@ -1503,8 +1504,9 @@ bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, CastPar
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(uhugeint_t)) {
-		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
-		                          GetTypeId<uhugeint_t>());
+		HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<uhugeint_t>()),
+		                             parameters);
+		return false;
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -992,8 +992,9 @@ struct CastFromBitToNumeric {
 		// TODO: Allow conversion if the significant bytes of the bitstring can be cast to the target type
 		// Currently only allows bitstring -> numeric if the full bitstring fits inside the numeric type
 		if (input.GetSize() - 1 > sizeof(DST)) {
-			throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
-			                          GetTypeId<DST>());
+			HandleCastError::AssignError("Bitstring doesn't fit inside of " + TypeIdToString(GetTypeId<DST>()),
+			                             parameters);
+			return false;
 		}
 		Bit::BitToNumeric(input, result);
 		return (true);

--- a/test/sql/types/bit/bit_try_cast.test
+++ b/test/sql/types/bit/bit_try_cast.test
@@ -1,0 +1,128 @@
+# name: test/sql/types/bit/bit_try_cast.test
+# description: TRY_CAST from BIT to numeric types
+# group: [bit]
+
+statement ok
+PRAGMA enable_verification
+
+# TRY_CAST returns NULL for oversized bitstrings
+query I
+SELECT try_cast(1::BIT as TINYINT);
+----
+NULL
+
+query I
+SELECT try_cast(1::BIT as SMALLINT);
+----
+NULL
+
+query I
+SELECT try_cast(1::BIT as UTINYINT);
+----
+NULL
+
+query I
+SELECT try_cast(1::BIT as USMALLINT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 9) as TINYINT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 17) as SMALLINT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 33) as INT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 65) as BIGINT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 33) as FLOAT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 65) as DOUBLE);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 129) as HUGEINT);
+----
+NULL
+
+query I
+SELECT try_cast(bitstring('1', 129) as UHUGEINT);
+----
+NULL
+
+# TRY_CAST succeeds for valid bitstring conversions
+query I
+SELECT try_cast('00001111'::BIT as TINYINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as SMALLINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as INTEGER);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as BIGINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as UTINYINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as USMALLINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as UINTEGER);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as UBIGINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as HUGEINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as UHUGEINT);
+----
+15
+
+query I
+SELECT try_cast('00001111'::BIT as FLOAT);
+----
+2.1e-44
+
+query I
+SELECT try_cast('00001111'::BIT as DOUBLE);
+----
+7.4e-323


### PR DESCRIPTION
`CastFromBitToNumeric::Operation` was unconditionally throwing a `ConversionException` when the bitstring didn't fit, bypassing `TRY_CAST`'s error handling. Replace with `HandleCastError::AssignError` + return false so the cast framework can return `NULL` for `TRY_CAST` and still throw for regular CAST.

Fixes duckdb#13097