### PR TITLE
AddToBeRescheduled: Avoid UB in assigning vs move

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -542,7 +542,9 @@ void Executor::AddToBeRescheduled(shared_ptr<Task> &task_p) {
 	if (to_be_rescheduled_tasks.find(task_p.get()) != to_be_rescheduled_tasks.end()) {
 		return;
 	}
-	to_be_rescheduled_tasks[task_p.get()] = std::move(task_p);
+	// Save raw pointer before move — evaluation order of operator[] key and assignment value is unspecified pre-C++17
+	auto raw_ptr = task_p.get();
+	to_be_rescheduled_tasks[raw_ptr] = std::move(task_p);
 }
 
 bool Executor::ExecutionIsFinished() {


### PR DESCRIPTION
This in practice it's not an issue (with the current struct definition), but we could as well just fix it.