### PR TITLE
Fix move assignment for buffer pool reservation

### DIFF
--- a/src/storage/buffer/buffer_pool_reservation.cpp
+++ b/src/storage/buffer/buffer_pool_reservation.cpp
@@ -13,6 +13,7 @@ BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) noexce
 }
 
 BufferPoolReservation &BufferPoolReservation::operator=(BufferPoolReservation &&src) noexcept {
+	pool.UpdateUsedMemory(tag, -UnsafeNumericCast<int64_t>(size));
 	tag = src.tag;
 	size = src.size;
 	src.size = 0;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_parse_logical_type.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
+  test_buffer_pool_reservation.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp)

--- a/test/common/test_buffer_pool_reservation.cpp
+++ b/test/common/test_buffer_pool_reservation.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+#include "duckdb/storage/buffer/buffer_pool.hpp"
+#include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
+#include "duckdb/main/database.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("BufferPoolReservation move assignment releases old reservation", "[storage][buffer_pool]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	auto &pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
+
+	auto baseline = pool.GetUsedMemory();
+
+	BufferPoolReservation r1(MemoryTag::BASE_TABLE, pool);
+	r1.Resize(1000);
+	REQUIRE(pool.GetUsedMemory() == baseline + 1000);
+
+	BufferPoolReservation r2(MemoryTag::BASE_TABLE, pool);
+	r2.Resize(500);
+	REQUIRE(pool.GetUsedMemory() == baseline + 1500);
+
+	r1 = std::move(r2);
+	REQUIRE(r1.size == 500);
+	REQUIRE(r2.size == 0);
+	REQUIRE(pool.GetUsedMemory() == baseline + 500);
+
+	r1.Resize(0);
+}


### PR DESCRIPTION
Hi team, I think when a buffer reservation is moved out, its memory usage should be released.
I tested CI on my own fork: https://github.com/dentiny/duckdb/pull/83