### PR TITLE
Fix in-place update to look only at updated columns

### DIFF
--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -56,8 +56,9 @@ void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 		return;
 	}
 	auto needs_reinsert = false;
-	for (auto &col : update.table.GetColumns().GetColumnTypes()) {
-		if (!col.SupportsRegularUpdate()) {
+	for (auto &col_idx : update.columns) {
+		auto &column = update.table.GetColumns().GetColumn(col_idx);
+		if (!column.Type().SupportsRegularUpdate()) {
 			needs_reinsert = true;
 			break;
 		}

--- a/test/api/serialized_plans/cases/geo_update_5.sql
+++ b/test/api/serialized_plans/cases/geo_update_5.sql
@@ -1,0 +1,5 @@
+CREATE TABLE src (old_id VARCHAR, new_id VARCHAR, g GEOMETRY);
+INSERT INTO src VALUES ('A', 'B', 'POINT(1 2)');
+CREATE TABLE tgt (id INT, val VARCHAR, g GEOMETRY);
+INSERT INTO tgt VALUES (1, 'A', 'POINT(3 4)');
+UPDATE tgt SET val = src.new_id FROM src WHERE src.old_id = tgt.val;

--- a/test/api/serialized_plans/cases/list_update_1.sql
+++ b/test/api/serialized_plans/cases/list_update_1.sql
@@ -1,0 +1,6 @@
+-- updates varchar column
+CREATE TABLE src (old_id VARCHAR, new_id VARCHAR);
+INSERT INTO src VALUES ('A', 'B');
+CREATE TABLE tgt (id INT, val VARCHAR, tags VARCHAR[]);
+INSERT INTO tgt VALUES (1, 'A', ARRAY['tag1', 'tag2']);
+UPDATE tgt SET val = src.new_id FROM src WHERE src.old_id = tgt.val;

--- a/test/api/serialized_plans/cases/list_update_2.sql
+++ b/test/api/serialized_plans/cases/list_update_2.sql
@@ -1,0 +1,6 @@
+-- updates array column
+CREATE TABLE src (old_id VARCHAR, new_id VARCHAR);
+INSERT INTO src VALUES ('A', 'B');
+CREATE TABLE tgt (id INT, val VARCHAR, tags VARCHAR[]);
+INSERT INTO tgt VALUES (1, 'A', ARRAY['tag1', 'tag2']);
+UPDATE tgt SET tags = ARRAY['tag3'] FROM src WHERE src.old_id = tgt.val;

--- a/test/api/serialized_plans/cases/list_update_3.sql
+++ b/test/api/serialized_plans/cases/list_update_3.sql
@@ -1,0 +1,4 @@
+-- simple update, varchar column
+CREATE TABLE t1 (id INT, val VARCHAR, tags VARCHAR[]);
+INSERT INTO t1 VALUES (1, 'A', ARRAY['tag1', 'tag2']);
+UPDATE t1 SET val = 'B' WHERE id = 1;

--- a/test/api/serialized_plans/cases/struct_update_1.sql
+++ b/test/api/serialized_plans/cases/struct_update_1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE src (old_id VARCHAR, new_id VARCHAR);
+INSERT INTO src VALUES ('A', 'B');
+CREATE TABLE tgt (id INT, val VARCHAR, meta STRUCT(name VARCHAR, tags VARCHAR[]));
+INSERT INTO tgt VALUES (1, 'A', {'name': 'foo', 'tags': ['t1', 't2']});
+UPDATE tgt SET val = src.new_id FROM src WHERE src.old_id = tgt.val;

--- a/test/api/serialized_plans/cases/struct_update_2.sql
+++ b/test/api/serialized_plans/cases/struct_update_2.sql
@@ -1,0 +1,3 @@
+CREATE TABLE t1 (id INT, val VARCHAR, meta STRUCT(name VARCHAR, tags VARCHAR[]));
+INSERT INTO t1 VALUES (1, 'A', {'name': 'foo', 'tags': ['t1', 't2']});
+UPDATE t1 SET val = 'B' WHERE id = 1;

--- a/test/api/serialized_plans/cases/variant_update_1.sql
+++ b/test/api/serialized_plans/cases/variant_update_1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE src (old_id VARCHAR, new_id VARCHAR);
+INSERT INTO src VALUES ('A', 'B');
+CREATE TABLE tgt (id INT, val VARCHAR, data VARIANT);
+INSERT INTO tgt VALUES (1, 'A', 42::VARIANT);
+UPDATE tgt SET val = src.new_id FROM src WHERE src.old_id = tgt.val;

--- a/test/api/serialized_plans/cases/variant_update_2.sql
+++ b/test/api/serialized_plans/cases/variant_update_2.sql
@@ -1,0 +1,4 @@
+-- simple update, varchar column
+CREATE TABLE t1 (id INT, val VARCHAR, data VARIANT);
+INSERT INTO t1 VALUES (1, 'A', 42::VARIANT);
+UPDATE t1 SET val = 'B' WHERE id = 1;

--- a/test/sql/update/test_update_with_non_regular_type.test
+++ b/test/sql/update/test_update_with_non_regular_type.test
@@ -1,0 +1,35 @@
+# name: test/sql/update/test_update_with_non_regular_type.test
+# description: Test UPDATE on tables with columns that don't support regular (in-place) updates
+# group: [update]
+
+# --- LIST ---
+
+statement ok
+CREATE TABLE t1 (id VARCHAR, new_id VARCHAR, tags VARCHAR[], g GEOMETRY);
+
+statement ok
+INSERT INTO t1 VALUES ('A', 'B', ARRAY['tag1', 'tag2'], 'POINT(1 2)');
+
+statement ok
+UPDATE t1 SET new_id = 'C' WHERE id='A';
+
+statement ok
+UPDATE t1 SET tags = ['tag3'] WHERE id='A';
+
+statement ok
+UPDATE t1 SET g = 'POINT(3 4)' WHERE id='A';
+
+statement ok
+CREATE TABLE t2 (id INT, val VARCHAR, tags VARCHAR[], g GEOMETRY);
+
+statement ok
+INSERT INTO t2 VALUES (1, 'A', ARRAY['tag1', 'tag2'], 'POINT (5 6)');
+
+statement ok
+UPDATE t2 SET val = t1.new_id FROM t1 WHERE t2.val=t1.id;
+
+statement ok
+UPDATE t2 SET tags = ['tag3'] FROM t1 WHERE t2.val=t1.new_id;
+
+statement ok
+UPDATE t2 SET g = 'POINT(0 0)' FROM t1 WHERE t2.val=t1.new_id;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,5 +3,5 @@ if(NOT SUN AND BUILD_SHELL)
 endif()
 
 add_executable(plan_serializer utils/plan_serializer.cpp)
-target_link_libraries(plan_serializer duckdb_static
-                      dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
+target_link_libraries(plan_serializer duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
+link_extension_libraries(plan_serializer "")

--- a/tools/utils/plan_serializer.cpp
+++ b/tools/utils/plan_serializer.cpp
@@ -115,7 +115,10 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 
+		con.Rollback();
+
 		// Now execute the original statement as well and compare results
+		con.BeginTransaction();
 		Parser p;
 		p.ParseQuery(target_stmt);
 		Planner planner(*con.context);


### PR DESCRIPTION
#21718 added a plan rewrite logic in deserialization to be backward compatible with old clients sending geometry in-place update plans (more context https://github.com/duckdblabs/motherduck/issues/486). However, in `RewriteInPlaceUpdates`, iterates over all columns of a table instead of those that are actually being updated. Therefore, incorrectly triggering rewrites due to columns whose `SupportsRegularUpdate() = false` even though they are not part of update.

In the following example, the table `t2` contains `UUID[]`, which doesn't support regular updates. Running the code in MotherDuck, fails to find a corresponding LOGICAL_GET because it is wrapped in an ExtensionOperator. When DuckDB triggers a plan rewrite, it fails to find a corresponding LOGICAL_GET, and throws "Could not find the expected GET operator in the LogicalUpdate operator children". Even for non-extension perspective, I think the fix makes sense to avoid unncessary rewrites.

```
-- setup
CREATE TABLE t1 (old_id VARCHAR, new_id VARCHAR);
INSERT INTO t1 VALUES ('aaa', 'xxx');
CREATE TABLE t2 (id INT, val VARCHAR, ids UUID[]);
INSERT INTO t2 VALUES (1, 'aaa', ARRAY['550e8400-e29b-41d4-a716-446655440000']::UUID[]);

-- fails
UPDATE t2 SET val = t1.new_id FROM t1 WHERE t1.old_id = t2.val;
```

I added the serialization tests and a basic sqllogictest.