### PR TITLE
Add HTTPUtil::CloseClient(...) with trivial no-op implementation, and base_url field to HTTPClient

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -229,6 +229,14 @@ public:
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 
+	void SetBaseUrl(const string &url) {
+		base_url = url;
+	}
+	const string &GetBaseUrl() const {
+		return base_url;
+	}
+
+private:
 	//! The base URL (scheme + host + port) this client was created for
 	string base_url;
 };

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -217,6 +217,9 @@ struct PostRequestInfo : public BaseRequest {
 
 class HTTPClient {
 public:
+	HTTPClient() = default;
+	explicit HTTPClient(const string &proto_host_port) : base_url(proto_host_port) {
+	}
 	virtual ~HTTPClient() = default;
 	virtual void Initialize(HTTPParams &http_params) = 0;
 
@@ -229,16 +232,13 @@ public:
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 
-	void SetBaseUrl(const string &url) {
-		base_url = url;
-	}
 	const string &GetBaseUrl() const {
 		return base_url;
 	}
 
 private:
 	//! The base URL (scheme + host + port) this client was created for
-	string base_url;
+	const string base_url;
 };
 
 class HTTPUtil {

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -228,6 +228,9 @@ public:
 	virtual void Cleanup() {};
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
+
+	//! The base URL (scheme + host + port) this client was created for
+	string base_url;
 };
 
 class HTTPUtil {
@@ -249,6 +252,9 @@ public:
 	                                                    optional_ptr<FileOpenerInfo> info);
 
 	virtual unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port);
+
+	//! Close a client — implementations may cache it for reuse
+	virtual void CloseClient(unique_ptr<HTTPClient> &&client);
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 	unique_ptr<HTTPResponse> Request(BaseRequest &request, unique_ptr<HTTPClient> &client);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -133,8 +133,7 @@ BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders 
 
 class HTTPLibClient : public HTTPClient {
 public:
-	HTTPLibClient(HTTPParams &http_params, const string &proto_host_port) {
-		SetBaseUrl(proto_host_port);
+	HTTPLibClient(HTTPParams &http_params, const string &proto_host_port) : HTTPClient(proto_host_port) {
 		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
 		Initialize(http_params);
 	}

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -134,6 +134,7 @@ BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders 
 class HTTPLibClient : public HTTPClient {
 public:
 	HTTPLibClient(HTTPParams &http_params, const string &proto_host_port) {
+		base_url = proto_host_port;
 		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
 		Initialize(http_params);
 	}
@@ -223,6 +224,10 @@ private:
 
 unique_ptr<HTTPClient> HTTPUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {
 	return make_uniq<HTTPLibClient>(http_params, proto_host_port);
+}
+
+void HTTPUtil::CloseClient(unique_ptr<HTTPClient> &&) {
+	// default: no-op, client is destroyed
 }
 
 unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -134,7 +134,7 @@ BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders 
 class HTTPLibClient : public HTTPClient {
 public:
 	HTTPLibClient(HTTPParams &http_params, const string &proto_host_port) {
-		base_url = proto_host_port;
+		SetBaseUrl(proto_host_port);
 		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
 		Initialize(http_params);
 	}


### PR DESCRIPTION
This might be used in httpfs to enable recycling of initialized connections, and will be used to refine https://github.com/duckdb/duckdb-httpfs/pull/305

This does allow to fix a significant performance issue.
My plan would be for `httpfs` to offer, opt-in, and not by default, a path to reuse of connections that will speed up some workflows. This might be in some way considered a bug fix on the `curl` line of work.

Adding the virtual method should be trivially not changing behaviour.