### PR TITLE
Run slow tests in CI if `run_slow_tests` is true

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -440,37 +440,6 @@ jobs:
         artifact_name: linux-release-build
         changed_tests_file: ${{ runner.temp }}/changed_tests.txt
 
-    - name: Build linux default release
-      run: make clean release
-
-    - name: Symbol Checks
-      run: make -j4 --output-sync=target symbol-checks
-
- linux-release-tests:
-    name: Linux Release Tests
-    if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-release-tests') }}
-    needs:
-      - prepare
-      - linux-release
-    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
-
-    steps:
-    - uses: actions/checkout@v6
-    - name: Install tools
-      run: python3 scripts/ci/retry.py -- make toolsci
-
-    - name: Download release build artifact
-      uses: actions/download-artifact@v5
-      with:
-        name: linux-release-build
-        path: build
-
-    - name: Extract release build artifact
-      shell: bash
-      run: |
-        rm -rf build/release
-        tar -xzf build/release-artifact.tar.gz -C build
-
     - name: Test
       shell: bash
       run: |
@@ -480,12 +449,18 @@ jobs:
           make unittest_release SKIP_BUILD=1
         fi
 
+    - name: Build linux default release
+      run: make clean release
+
+    - name: Symbol Checks
+      run: make -j4 --output-sync=target symbol-checks
+
  linux-release-cli:
     name: Linux CLI (${{ matrix.config.arch }})
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-release-cli') }}
     needs:
       - prepare
-      - linux-release-tests
+      - linux-release
     strategy:
       fail-fast: false
       matrix:
@@ -579,7 +554,7 @@ jobs:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-musl-release-cli') }}
     needs:
       - prepare
-      - linux-release-tests
+      - linux-release
     strategy:
       fail-fast: false
       matrix:
@@ -1148,7 +1123,6 @@ jobs:
       - extensions
       - wasm-eh
       - linux-release
-      - linux-release-tests
       - linux-release-cli
       - linux-musl-release-cli
       - main_julia

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -477,7 +477,7 @@ jobs:
         if [[ "${{ needs.prepare.outputs.run_slow_tests }}" == "true" ]]; then
           make allunit
         else
-          make unittest_release
+          make unittest_release SKIP_BUILD=1
         fi
 
  linux-release-cli:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -63,6 +63,8 @@ jobs:
       linux_musl_cli_matrix: ${{ steps.config.outputs.linux_musl_cli_matrix }}
       extensions_changed: ${{ steps.changed.outputs.extensions_any_changed }}
       changed_tests_files: ${{ steps.changed.outputs.tests_all_changed_files }}
+      changed_slow_tests_files: ${{ steps.changed.outputs.tests_slow_all_changed_files }}
+      run_slow_tests: ${{ steps.config.outputs.run_slow_tests }}
       extensions_extra_exclude_archs: ${{ steps.config.outputs.extra_exclude_archs }}
       enabled_jobs: ${{ steps.config.outputs.enabled_jobs }}
       save_cache: ${{ steps.config.outputs.save_cache }}
@@ -91,6 +93,9 @@ jobs:
               - extensions/**
             tests:
               - test/**/*.test
+            tests_slow:
+              - test/**/*.cpp
+              - test/**/*.test_slow
 
       - name: Check CI
         if: steps.changed.outputs.github_any_changed == 'true'
@@ -116,6 +121,13 @@ jobs:
           fi
 
           echo "extra_exclude_archs=$extra_exclude_archs" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ steps.changed.outputs.tests_slow_any_changed }}" == "true" || "${{ github.ref_name }}" == "main" ]]; then
+            run_slow_tests=true
+          else
+            run_slow_tests=false
+          fi
+          echo "run_slow_tests=$run_slow_tests" >> "$GITHUB_OUTPUT"
 
           # Fall back to GitHub-native runners for forks.
           if [[ "${{ github.repository }}" == "duckdb/duckdb" ]]; then
@@ -311,6 +323,7 @@ jobs:
       - linux-release
     with:
       build_current_release: false
+      run_slow_tests: ${{ needs.prepare.outputs.run_slow_tests == 'true' }}
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 
@@ -459,7 +472,13 @@ jobs:
         tar -xzf build/release-artifact.tar.gz -C build
 
     - name: Test
-      run: make allunit
+      shell: bash
+      run: |
+        if [[ "${{ needs.prepare.outputs.run_slow_tests }}" == "true" ]]; then
+          make allunit
+        else
+          make unittest_release
+        fi
 
  linux-release-cli:
     name: Linux CLI (${{ matrix.config.arch }})
@@ -539,7 +558,13 @@ jobs:
           duckdb_cli-linux-${{ matrix.config.arch }}.gz
 
     - name: Release tests
-      run: make alltest_release_tag
+      shell: bash
+      run: |
+        if [[ "${{ needs.prepare.outputs.run_slow_tests }}" == "true" ]]; then
+          make alltest_release_tag
+        else
+          make test_release_tag
+        fi
 
     - name: Tools Tests
       run: python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
@@ -626,10 +651,13 @@ jobs:
 
     - name: Test
       shell: bash
+      env:
+        RUN_SLOW_TESTS: ${{ needs.prepare.outputs.run_slow_tests }}
       run: |
         docker run   \
         -v"$PWD:$PWD" \
         -e CI=1      \
+        -e RUN_SLOW_TESTS="$RUN_SLOW_TESTS" \
         alpine:3.22                                                         \
         sh -c "
           set -e
@@ -640,7 +668,11 @@ jobs:
             py3-pytest
           cd \"$PWD\"
           echo Release tests
-          make alltest_release_tag
+          if [ \"\$RUN_SLOW_TESTS\" = \"true\" ]; then
+            make alltest_release_tag
+          else
+            make test_release_tag
+          fi
           echo Tools Tests
           python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
           echo Examples

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -7,6 +7,9 @@ on:
       build_current_release:
         default: false
         type: boolean
+      run_slow_tests:
+        default: false
+        type: boolean
       runner_linux_x64:
         default: ubuntu-latest
         type: string
@@ -21,6 +24,10 @@ on:
       build_current_release:
         description: 'Build and upload linux-release-build in this workflow'
         default: true
+        type: boolean
+      run_slow_tests:
+        description: 'Run slow tests when applicable'
+        default: false
         type: boolean
       runner_linux_x64:
         description: 'Optional x64 runner label override'

--- a/Makefile
+++ b/Makefile
@@ -457,8 +457,12 @@ endif
 unittest_release:
 	$(PYTHON) scripts/ci/run_tests.py build/release/$(UNITTEST_BINARY) $(T)
 
+.PHONY: alltest_release_tag test_release_tag
 alltest_release_tag:
 	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/$(UNITTEST_BINARY) '*' $(T)
+
+test_release_tag:
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/$(UNITTEST_BINARY) $(T)
 
 unittest_relassert:
 	$(PYTHON) scripts/ci/run_tests.py build/relassert/$(UNITTEST_BINARY) $(T)

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -15,7 +15,6 @@ PULL_REQUEST_JOBS = [
     "extensions",
     "wasm-eh",
     "linux-release",
-    "linux-release-tests",
     "linux-release-cli",
     "linux-musl-release-cli",
     "upload-libduckdb-src",


### PR DESCRIPTION
- Add `changed_slow_tests_files` and `run_slow_tests` to `prepare` output.
- Run slow tests if `tests_slow_any_changed` is true, or on the branch `main` (like nightly runs).
- Changes to `test/**/*.cpp` are considered "slow tests".
  - This detects all tests marked with `[.]` as slow tests.
  - However, this also runs slow tests when a non-slow C++ test changed, which is "good enough".
- Merge Linux Release Tests job into Linux Release.