### PR TITLE
Run ArrowConverter::ToArrowSchema in a transaction

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -452,7 +452,6 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 		out_schema->private_data = root_holder.release();
 		out_schema->release = ReleaseDuckDBArrowSchema;
 	});
-
 }
 
 } // namespace duckdb

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -417,37 +417,42 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
                                    const vector<string> &names, ClientProperties &options) {
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
-	const idx_t column_count = types.size();
-	// Allocate as unique_ptr first to clean-up properly on error
-	auto root_holder = make_uniq<DuckDBArrowSchemaHolder>();
+	D_ASSERT(options.client_context);
+	// We need to run this in a transaction. The arrow schema callback might use the catalog to do lookups.
+	options.client_context->RunFunctionInTransaction([&types, &out_schema, &names, &options]() {
+		const idx_t column_count = types.size();
+		// Allocate as unique_ptr first to clean-up properly on error
+		auto root_holder = make_uniq<DuckDBArrowSchemaHolder>();
 
-	// Allocate the children
-	root_holder->children.resize(column_count);
-	root_holder->children_ptrs.resize(column_count, nullptr);
-	for (size_t i = 0; i < column_count; ++i) {
-		root_holder->children_ptrs[i] = &root_holder->children[i];
-	}
-	out_schema->children = root_holder->children_ptrs.data();
-	out_schema->n_children = NumericCast<int64_t>(column_count);
+		// Allocate the children
+		root_holder->children.resize(column_count);
+		root_holder->children_ptrs.resize(column_count, nullptr);
+		for (size_t i = 0; i < column_count; ++i) {
+			root_holder->children_ptrs[i] = &root_holder->children[i];
+		}
+		out_schema->children = root_holder->children_ptrs.data();
+		out_schema->n_children = NumericCast<int64_t>(column_count);
 
-	// Store the schema
-	out_schema->format = "+s"; // struct apparently
-	out_schema->flags = 0;
-	out_schema->metadata = nullptr;
-	out_schema->name = "duckdb_query_result";
-	out_schema->dictionary = nullptr;
+		// Store the schema
+		out_schema->format = "+s"; // struct apparently
+		out_schema->flags = 0;
+		out_schema->metadata = nullptr;
+		out_schema->name = "duckdb_query_result";
+		out_schema->dictionary = nullptr;
 
-	// Configure all child schemas
-	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-		root_holder->owned_column_names.push_back(AddName(names[col_idx]));
-		auto &child = root_holder->children[col_idx];
-		InitializeChild(child, *root_holder, names[col_idx]);
-		SetArrowFormat(*root_holder, child, types[col_idx], options, *options.client_context);
-	}
+		// Configure all child schemas
+		for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+			root_holder->owned_column_names.push_back(AddName(names[col_idx]));
+			auto &child = root_holder->children[col_idx];
+			InitializeChild(child, *root_holder, names[col_idx]);
+			SetArrowFormat(*root_holder, child, types[col_idx], options, *options.client_context);
+		}
 
-	// Release ownership to caller
-	out_schema->private_data = root_holder.release();
-	out_schema->release = ReleaseDuckDBArrowSchema;
+		// Release ownership to caller
+		out_schema->private_data = root_holder.release();
+		out_schema->release = ReleaseDuckDBArrowSchema;
+	});
+
 }
 
 } // namespace duckdb

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -418,8 +418,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
 	D_ASSERT(options.client_context);
-	// We need to run this in a transaction. The arrow schema callback might use the catalog to do lookups.
-	options.client_context->RunFunctionInTransaction([&types, &out_schema, &names, &options]() {
+	auto get_schema_func = [&types, &out_schema, &names, &options]() {
 		const idx_t column_count = types.size();
 		// Allocate as unique_ptr first to clean-up properly on error
 		auto root_holder = make_uniq<DuckDBArrowSchemaHolder>();
@@ -451,7 +450,14 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 		// Release ownership to caller
 		out_schema->private_data = root_holder.release();
 		out_schema->release = ReleaseDuckDBArrowSchema;
-	});
+	};
+	auto &context = *options.client_context;
+	if (context.transaction.HasActiveTransaction()) {
+		get_schema_func();
+	} else {
+		// We need to run this in a transaction. The arrow schema callback might use the catalog to do lookups.
+		options.client_context->RunFunctionInTransaction(get_schema_func);
+	}
 }
 
 } // namespace duckdb

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -10,6 +10,7 @@ using duckdb::ArrowResultWrapper;
 using duckdb::CClientArrowOptionsWrapper;
 using duckdb::Connection;
 using duckdb::DataChunk;
+using duckdb::ErrorData;
 using duckdb::LogicalType;
 using duckdb::MaterializedQueryResult;
 using duckdb::PreparedStatementWrapper;
@@ -180,7 +181,11 @@ duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema 
 	try {
 		ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
 		                              wrapper->result->client_properties);
+	} catch (std::exception &ex) {
+		wrapper->result->SetError(ErrorData(ex));
+		return DuckDBError;
 	} catch (...) {
+		wrapper->result->SetError(ErrorData("Unknown error in duckdb_query_arrow_schema"));
 		return DuckDBError;
 	}
 	return DuckDBSuccess;

--- a/test/api/capi/test_capi_geometry.cpp
+++ b/test/api/capi/test_capi_geometry.cpp
@@ -1,4 +1,5 @@
 #include "capi_tester.hpp"
+#include "duckdb/common/arrow/schema_metadata.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -51,4 +52,46 @@ TEST_CASE("Test C API GEOMETRY type support", "[capi]") {
 	REQUIRE(meta == 0x00000001); // WKB for POINT
 	REQUIRE(x == 42);
 	REQUIRE(y == 1337);
+}
+
+TEST_CASE("Test C API GEOMETRY arrow schema export with CRS", "[capi][arrow]") {
+	// Regression test: exporting a GEOMETRY column with a CRS to an Arrow schema
+	// used to assert in TransactionContext::ActiveTransaction(), because
+	// ArrowGeometry::PopulateSchema resolves the CRS via the catalog and the
+	// auto-commit transaction from the previous statement has already closed by
+	// the time duckdb_query_arrow_schema runs.
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY('OGC:CRS84'))"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)')"));
+
+	duckdb_arrow arrow_result = nullptr;
+	auto state = duckdb_query_arrow(tester.connection, "SELECT data FROM t1", &arrow_result);
+	REQUIRE(state == DuckDBSuccess);
+
+	ArrowSchema arrow_schema;
+	arrow_schema.Init();
+	auto arrow_schema_ptr = &arrow_schema;
+	state = duckdb_query_arrow_schema(arrow_result, reinterpret_cast<duckdb_arrow_schema *>(&arrow_schema_ptr));
+	std::string err;
+	if (state != DuckDBSuccess) {
+		auto err_cstr = duckdb_query_arrow_error(arrow_result);
+		err = err_cstr ? err_cstr : "(no error message)";
+		duckdb_destroy_arrow(&arrow_result);
+	}
+	INFO("duckdb_query_arrow_schema error: " << err);
+	REQUIRE(state == DuckDBSuccess);
+	REQUIRE(arrow_schema.n_children == 1);
+
+	// The geoarrow.wkb extension name should appear in the child schema metadata.
+	auto child = arrow_schema.children[0];
+	REQUIRE(child != nullptr);
+	REQUIRE(child->metadata != nullptr);
+	auto md = ArrowSchemaMetadata(child->metadata);
+	REQUIRE(md.GetOption(ArrowSchemaMetadata::ARROW_EXTENSION_NAME) == "geoarrow.wkb");
+
+	if (arrow_schema.release) {
+		arrow_schema.release(arrow_schema_ptr);
+	}
+	duckdb_destroy_arrow(&arrow_result);
 }


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-spatial/issues/788

When populating the arrow schema we might need access to the catalog. In this case the GeoArrow extension needs to figure out the CRS type in `ArrowGeometry::PopulateSchema`. This works fine in the context of an active transaction, but not when consuming the results as a stream (as `RecordBatch` or the Arrow C Stream API). E.g. through the C API or the python client.

This PR wraps `ArrowConverter::ToArrowSchema` in `RunFunctionInTransaction` to maek sure we always have a transaction.

It also fixes a bug in `duckdb_query_arrow_schema` which did not set an error if it occurred, resulting in an error if the error was fetched.