### PR TITLE
MacOS: codesign debug / reldebug binaries on MacOS to allow debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,26 @@ else()
   set(OS_NAME "unknown")
 endif()
 
+# Codesign a target with get-task-allow so lldb can attach to it on macOS.
+# Only applied for debug build types where you'd actually want to debug.
+function(duckdb_codesign_for_debugging target)
+  if(APPLE AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+    set(ENTITLEMENTS_FILE "${CMAKE_BINARY_DIR}/debug_entitlements.plist")
+    if(NOT EXISTS "${ENTITLEMENTS_FILE}")
+      file(WRITE "${ENTITLEMENTS_FILE}"
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
+        "<plist version=\"1.0\"><dict><key>com.apple.security.get-task-allow</key><true/></dict></plist>"
+      )
+    endif()
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND codesign -s - -f --entitlements "${ENTITLEMENTS_FILE}" "$<TARGET_FILE:${target}>"
+      COMMENT "Codesigning ${target} for macOS debugging"
+      VERBATIM
+    )
+  endif()
+endfunction()
+
 option(FORCE_WARN_UNUSED "Unused code objects lead to compiler warnings." FALSE)
 
 option(ENABLE_EXTENSION_AUTOLOADING "Enable extension auto-loading by default." FALSE)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -30,3 +30,5 @@ add_executable(benchmark_runner benchmark_runner.cpp interpreted_benchmark.cpp
 
 target_link_libraries(benchmark_runner duckdb_static imdb test_helpers)
 link_extension_libraries(benchmark_runner "")
+
+duckdb_codesign_for_debugging(benchmark_runner)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,3 +56,5 @@ endif()
 target_link_libraries(unittest duckdb_static test_helpers)
 
 link_extension_libraries(unittest "")
+
+duckdb_codesign_for_debugging(unittest)

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -86,4 +86,6 @@ set_target_properties(shell PROPERTIES OUTPUT_NAME duckdb)
 set_target_properties(shell PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                        ${PROJECT_BINARY_DIR})
 
+duckdb_codesign_for_debugging(shell)
+
 install(TARGETS shell RUNTIME DESTINATION "${INSTALL_BIN_DIR}")


### PR DESCRIPTION
For MacOS, in order to enable debugging on binaries using `lldb` or enable Instruments, we need to sign the binary with `<key>com.apple.security.get-task-allow</key><true/>`. This PR automatically enables this for `Debug` and `RelWithDebInfo` builds so that this works out of the box.