### PR TITLE
Issue #21908: Window Macro Expansion 

### DIFF
--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -81,9 +81,12 @@ private:
 	vector<reference<CommonTableExpressionMap>> stored_cte_map;
 	//! Whether or not we are currently binding a window definition
 	bool in_window_definition = false;
+	//! Whether or not we are currently binding a macro definition
+	bool in_macro_definition = false;
 
 	void Clear();
 	bool InWindowDefinition();
+	bool InMacroDefinition();
 
 	Transformer &RootTransformer();
 	const Transformer &RootTransformer() const;

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -151,6 +151,16 @@ bool Transformer::InWindowDefinition() {
 	return false;
 }
 
+bool Transformer::InMacroDefinition() {
+	if (in_macro_definition) {
+		return true;
+	}
+	if (parent) {
+		return parent->InMacroDefinition();
+	}
+	return false;
+}
+
 static bool IsOrderableWindowFunction(ExpressionType type) {
 	switch (type) {
 	case ExpressionType::WINDOW_FIRST_VALUE:
@@ -404,7 +414,7 @@ unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::P
 		coalesce_op->children.push_back(std::move(children[0]));
 		coalesce_op->children.push_back(std::move(children[1]));
 		return std::move(coalesce_op);
-	} else if (lowercase_name == "list" && order_bys->orders.size() == 1) {
+	} else if (lowercase_name == "list" && order_bys->orders.size() == 1 && !InMacroDefinition()) {
 		// list(expr ORDER BY expr <sense> <nulls>) => list_sort(list(expr), <sense>, <nulls>)
 		if (children.size() != 1) {
 			throw ParserException("Wrong number of arguments to LIST.");

--- a/src/parser/transform/statement/transform_create_function.cpp
+++ b/src/parser/transform/statement/transform_create_function.cpp
@@ -1,13 +1,28 @@
 #include "duckdb/function/scalar_macro_function.hpp"
 #include "duckdb/function/table_macro_function.hpp"
-#include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
 namespace duckdb {
 
+template <typename T>
+class RestoreValue {
+public:
+	explicit RestoreValue(T &ref) : ref(ref), val(ref) {
+	}
+	~RestoreValue() {
+		ref = val;
+	}
+
+private:
+	T &ref;
+	const T val;
+};
+
 unique_ptr<MacroFunction> Transformer::TransformMacroFunction(duckdb_libpgquery::PGFunctionDefinition &def) {
+	RestoreValue<bool> save_in_macro(in_macro_definition);
+	in_macro_definition = true;
 	unique_ptr<MacroFunction> macro_func;
 	if (def.function) {
 		auto expression = TransformExpression(def.function);

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/function/scalar_macro_function.hpp"
+#include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/expression/window_expression.hpp"
@@ -123,9 +124,22 @@ void ExpressionBinder::UnfoldMacroExpression(FunctionExpression &function, Scala
 		window_expr.schema = macro_expr.schema;
 		window_expr.function_name = macro_expr.function_name;
 		window_expr.children = std::move(macro_expr.children);
-		window_expr.distinct = macro_expr.distinct;
-		window_expr.filter_expr = std::move(macro_expr.filter);
-		// TODO: transfer order_bys when window functions support them
+		if (!window_expr.distinct) {
+			window_expr.distinct = macro_expr.distinct;
+		}
+		if (window_expr.filter_expr && macro_expr.filter) {
+			// Two FILTER clauses: combine
+			window_expr.filter_expr = make_uniq<ConjunctionExpression>(
+			    ExpressionType::CONJUNCTION_AND, std::move(window_expr.filter_expr), std::move(macro_expr.filter));
+		} else if (macro_expr.filter) {
+			//	One FILTER from the MACRO
+			window_expr.filter_expr = std::move(macro_expr.filter);
+		}
+		// Transfer argument ORDER BYs
+		if (macro_expr.order_bys) {
+			auto clone = macro_expr.order_bys->Copy();
+			window_expr.arg_orders = std::move(clone->Cast<OrderModifier>().orders);
+		}
 	} else {
 		expr = macro_def.expression->Copy();
 	}

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -158,10 +158,10 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	auto entry = GetCatalogEntry(window.catalog, window.schema, function_lookup, OnEntryNotFound::RETURN_NULL);
 	if (window.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE && entry &&
 	    entry->type == CatalogType::MACRO_ENTRY) {
+		auto macro_expr = window.Copy();
 		auto macro = make_uniq<FunctionExpression>(window.catalog, window.schema, window.function_name,
 		                                           std::move(window.children), std::move(window.filter_expr), nullptr,
 		                                           window.distinct);
-		auto macro_expr = window.Copy();
 		return BindMacro(*macro, entry->Cast<ScalarMacroCatalogEntry>(), depth, macro_expr);
 	}
 

--- a/test/sql/catalog/function/test_window_macro.test
+++ b/test/sql/catalog/function/test_window_macro.test
@@ -44,3 +44,28 @@ select my_case(range) OVER ()
 from range(2);
 ----
 Window function macros must be functions
+
+statement error
+CREATE MACRO my_lag(x) AS LAG(x);
+----
+Scalar Function with name
+
+statement error
+CREATE MACRO my_lead(x) AS LEAD(x);
+----
+Scalar Function with name
+
+statement error
+CREATE MACRO my_rn() AS ROW_NUMBER();
+----
+Scalar Function with name
+
+statement error
+CREATE MACRO my_rank() AS RANK();
+----
+Scalar Function with name
+
+statement error
+CREATE MACRO my_dense_rank() AS DENSE_RANK();
+----
+Scalar Function with name

--- a/test/sql/catalog/function/test_window_macro.test
+++ b/test/sql/catalog/function/test_window_macro.test
@@ -69,3 +69,55 @@ statement error
 CREATE MACRO my_dense_rank() AS DENSE_RANK();
 ----
 Scalar Function with name
+
+statement ok
+CREATE MACRO my_sum(x) AS SUM(x);
+
+# Via macro: FILTER lost, wrong result
+query I
+SELECT my_sum(i) FILTER (WHERE i > 3) OVER () FROM range(10) t(i) LIMIT 1;
+----
+39
+
+statement ok
+CREATE MACRO my_count(x) AS COUNT(x);
+
+# Via macro: DISTINCT lost, wrong result
+query I
+SELECT my_count(DISTINCT i % 3) OVER () FROM range(10) t(i) LIMIT 1;
+----
+3
+
+statement ok
+CREATE MACRO sum_positive(x) AS SUM(x) FILTER (WHERE x > 0);
+
+# Expected: FILTER WHERE (i-5) > 0 AND (i-5) < 3 → SUM(1, 2) = 3
+query I
+SELECT sum_positive(i-5) FILTER (WHERE (i-5) < 3) OVER () FROM range(10) t(i) LIMIT 1;
+----
+3
+
+# Secondary ordering
+query I
+SELECT LIST(i ORDER BY i DESC) OVER (PARTITION BY i % 2) FROM range(6) t(i) ORDER BY i;
+----
+[4, 2, 0]
+[5, 3, 1]
+[4, 2, 0]
+[5, 3, 1]
+[4, 2, 0]
+[5, 3, 1]
+
+statement ok
+CREATE MACRO my_list(x) AS LIST(x ORDER BY x DESC);
+
+# Fails as window function:
+query I
+SELECT my_list(i) OVER (PARTITION BY i % 2) FROM range(6) t(i) ORDER BY i;
+----
+[4, 2, 0]
+[5, 3, 1]
+[4, 2, 0]
+[5, 3, 1]
+[4, 2, 0]
+[5, 3, 1]


### PR DESCRIPTION
* Don't drop FILTER clauses
* Don't drop DISTINCT tags
* Combine multiple FILTER clauses
* Don't expand LIST(...ORDER BY) when parsing a macro (so it can be used in windowing)
* Transfer argument ORDER BYs to the window's arg_order_bys.
