### PR TITLE
Add preserve_duplicate_column_names setting

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -565,6 +565,13 @@
         "custom_implementation": true
     },
     {
+        "name": "error_on_duplicate_columns_in_select",
+        "description": "Throw an error when duplicate column names are produced in a SELECT clause",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "errors_as_json",
         "description": "Output error messages as structured JSON instead of as a raw string",
         "type": "BOOLEAN",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -565,13 +565,6 @@
         "custom_implementation": true
     },
     {
-        "name": "error_on_duplicate_columns_in_select",
-        "description": "Throw an error when duplicate column names are produced in a SELECT clause",
-        "type": "BOOLEAN",
-        "default_scope": "local",
-        "default_value": "false"
-    },
-    {
         "name": "errors_as_json",
         "description": "Output error messages as structured JSON instead of as a raw string",
         "type": "BOOLEAN",
@@ -944,6 +937,13 @@
     {
         "name": "prefer_range_joins",
         "description": "Force use of range joins with mixed predicates",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
+        "name": "preserve_duplicate_column_names",
+        "description": "Preserve duplicate column names instead of disambiguating them with _1, _2, etc. suffixes",
         "type": "BOOLEAN",
         "default_scope": "local",
         "default_value": "false"

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1378,6 +1378,17 @@ struct PreferRangeJoinsSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct PreserveDuplicateColumnNamesSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "preserve_duplicate_column_names";
+	static constexpr const char *Description =
+	    "Preserve duplicate column names instead of disambiguating them with _1, _2, etc. suffixes";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct PreserveIdentifierCaseSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "preserve_identifier_case";

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -147,9 +147,10 @@ public:
 	string GetActualColumnName(Binding &binding, const string &column_name);
 
 	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases
-	//! specified.
-	static vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
-	                                       const vector<string> &column_aliases);
+	//! specified. When preserve_duplicate_column_names is set, duplicate names are kept as-is instead of being
+	//! disambiguated with _1, _2, etc. suffixes.
+	vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
+	                                const vector<string> &column_aliases);
 
 	//! Add all the bindings from a BindContext to this BindContext. The other BindContext is destroyed in the process.
 	void AddContext(BindContext other);

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -147,10 +147,9 @@ public:
 	string GetActualColumnName(Binding &binding, const string &column_name);
 
 	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases
-	//! specified. When preserve_duplicate_column_names is set, duplicate names are kept as-is instead of being
-	//! disambiguated with _1, _2, etc. suffixes.
-	vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
-	                                const vector<string> &column_aliases);
+	//! specified.
+	static vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
+	                                       const vector<string> &column_aliases);
 
 	//! Add all the bindings from a BindContext to this BindContext. The other BindContext is destroyed in the process.
 	void AddContext(BindContext other);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -183,6 +183,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(PivotFilterThresholdSetting),
     DUCKDB_SETTING(PivotLimitSetting),
     DUCKDB_SETTING(PreferRangeJoinsSetting),
+    DUCKDB_SETTING(PreserveDuplicateColumnNamesSetting),
     DUCKDB_SETTING(PreserveIdentifierCaseSetting),
     DUCKDB_SETTING(PreserveInsertionOrderSetting),
     DUCKDB_SETTING(ProduceArrowStringViewSetting),
@@ -215,10 +216,10 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 101),
                                                      DUCKDB_SETTING_ALIAS("null_order", 44),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 121),
-                                                     DUCKDB_SETTING_ALIAS("user", 136),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 122),
+                                                     DUCKDB_SETTING_ALIAS("user", 137),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 135),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 136),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -723,12 +723,8 @@ void BindContext::AddView(TableIndex index, const string &alias, SubqueryRef &re
 }
 
 void BindContext::AddSubquery(TableIndex index, const string &alias, TableFunctionRef &ref, BoundStatement &subquery) {
-	if (Settings::Get<PreserveDuplicateColumnNamesSetting>(binder.context)) {
-		AddGenericBinding(index, alias, subquery.names, subquery.types);
-	} else {
-		auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
-		AddGenericBinding(index, alias, names, subquery.types);
-	}
+	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+	AddGenericBinding(index, alias, names, subquery.types);
 }
 
 void BindContext::AddGenericBinding(TableIndex index, const string &alias, const vector<string> &names,

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/main/settings.hpp"
 
 #include <algorithm>
 
@@ -689,14 +690,25 @@ vector<string> BindContext::AliasColumnNames(const string &table_name, const vec
 		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", table_name,
 		                      names.size(), column_aliases.size());
 	}
-	case_insensitive_set_t current_names;
-	// use any provided column aliases first
-	for (idx_t i = 0; i < column_aliases.size(); i++) {
-		result.push_back(AddColumnNameToBinding(column_aliases[i], current_names));
-	}
-	// if not enough aliases were provided, use the default names for remaining columns
-	for (idx_t i = column_aliases.size(); i < names.size(); i++) {
-		result.push_back(AddColumnNameToBinding(names[i], current_names));
+	bool deduplicate = !Settings::Get<PreserveDuplicateColumnNamesSetting>(binder.context);
+	if (deduplicate) {
+		case_insensitive_set_t current_names;
+		// use any provided column aliases first
+		for (idx_t i = 0; i < column_aliases.size(); i++) {
+			result.push_back(AddColumnNameToBinding(column_aliases[i], current_names));
+		}
+		// if not enough aliases were provided, use the default names for remaining columns
+		for (idx_t i = column_aliases.size(); i < names.size(); i++) {
+			result.push_back(AddColumnNameToBinding(names[i], current_names));
+		}
+	} else {
+		// preserve duplicate column names as-is
+		for (idx_t i = 0; i < column_aliases.size(); i++) {
+			result.push_back(column_aliases[i]);
+		}
+		for (idx_t i = column_aliases.size(); i < names.size(); i++) {
+			result.push_back(names[i]);
+		}
 	}
 	return result;
 }

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -690,32 +690,25 @@ vector<string> BindContext::AliasColumnNames(const string &table_name, const vec
 		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", table_name,
 		                      names.size(), column_aliases.size());
 	}
-	bool deduplicate = !Settings::Get<PreserveDuplicateColumnNamesSetting>(binder.context);
-	if (deduplicate) {
-		case_insensitive_set_t current_names;
-		// use any provided column aliases first
-		for (idx_t i = 0; i < column_aliases.size(); i++) {
-			result.push_back(AddColumnNameToBinding(column_aliases[i], current_names));
-		}
-		// if not enough aliases were provided, use the default names for remaining columns
-		for (idx_t i = column_aliases.size(); i < names.size(); i++) {
-			result.push_back(AddColumnNameToBinding(names[i], current_names));
-		}
-	} else {
-		// preserve duplicate column names as-is
-		for (idx_t i = 0; i < column_aliases.size(); i++) {
-			result.push_back(column_aliases[i]);
-		}
-		for (idx_t i = column_aliases.size(); i < names.size(); i++) {
-			result.push_back(names[i]);
-		}
+	case_insensitive_set_t current_names;
+	// use any provided column aliases first
+	for (idx_t i = 0; i < column_aliases.size(); i++) {
+		result.push_back(AddColumnNameToBinding(column_aliases[i], current_names));
+	}
+	// if not enough aliases were provided, use the default names for remaining columns
+	for (idx_t i = column_aliases.size(); i < names.size(); i++) {
+		result.push_back(AddColumnNameToBinding(names[i], current_names));
 	}
 	return result;
 }
 
 void BindContext::AddSubquery(TableIndex index, const string &alias, SubqueryRef &ref, BoundStatement &subquery) {
-	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
-	AddGenericBinding(index, alias, names, subquery.types);
+	if (Settings::Get<PreserveDuplicateColumnNamesSetting>(binder.context)) {
+		AddGenericBinding(index, alias, subquery.names, subquery.types);
+	} else {
+		auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+		AddGenericBinding(index, alias, names, subquery.types);
+	}
 }
 
 void BindContext::AddEntryBinding(TableIndex index, const string &alias, const vector<string> &names,
@@ -730,8 +723,12 @@ void BindContext::AddView(TableIndex index, const string &alias, SubqueryRef &re
 }
 
 void BindContext::AddSubquery(TableIndex index, const string &alias, TableFunctionRef &ref, BoundStatement &subquery) {
-	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
-	AddGenericBinding(index, alias, names, subquery.types);
+	if (Settings::Get<PreserveDuplicateColumnNamesSetting>(binder.context)) {
+		AddGenericBinding(index, alias, subquery.names, subquery.types);
+	} else {
+		auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+		AddGenericBinding(index, alias, names, subquery.types);
+	}
 }
 
 void BindContext::AddGenericBinding(TableIndex index, const string &alias, const vector<string> &names,

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
@@ -140,7 +141,9 @@ void CTEBindState::Bind(CTEBinding &binding) {
 	}
 
 	// Rename columns if duplicate names are detected
-	QueryResult::DeduplicateColumns(names);
+	if (!Settings::Get<PreserveDuplicateColumnNamesSetting>(parent_binder.context)) {
+		QueryResult::DeduplicateColumns(names);
+	}
 }
 
 BoundCTEData Binder::PrepareCTE(const string &ctename, CommonTableExpressionInfo &statement) {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -134,7 +134,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 		auto index = GenerateTableIndex();
 
 		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		auto names = bind_context.AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
+		auto names = BindContext::AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
 
 		bind_context.AddGenericBinding(index, alias, names, ctebinding->GetColumnTypes());
 
@@ -250,7 +250,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 			return_types.push_back(col.Type());
 			return_names.push_back(col.Name());
 		}
-		table_names = bind_context.AliasColumnNames(ref.table_name, table_names, ref.column_name_alias);
+		table_names = BindContext::AliasColumnNames(ref.table_name, table_names, ref.column_name_alias);
 
 		virtual_column_map_t virtual_columns;
 		if (scan_function.get_virtual_columns) {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
@@ -134,7 +135,12 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 		auto index = GenerateTableIndex();
 
 		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		auto names = BindContext::AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
+		vector<string> names;
+		if (Settings::Get<PreserveDuplicateColumnNamesSetting>(context)) {
+			names = ctebinding->GetColumnNames();
+		} else {
+			names = BindContext::AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
+		}
 
 		bind_context.AddGenericBinding(index, alias, names, ctebinding->GetColumnTypes());
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -134,7 +134,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 		auto index = GenerateTableIndex();
 
 		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
-		auto names = BindContext::AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
+		auto names = bind_context.AliasColumnNames(alias, ctebinding->GetColumnNames(), ref.column_name_alias);
 
 		bind_context.AddGenericBinding(index, alias, names, ctebinding->GetColumnTypes());
 
@@ -250,7 +250,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 			return_types.push_back(col.Type());
 			return_names.push_back(col.Name());
 		}
-		table_names = BindContext::AliasColumnNames(ref.table_name, table_names, ref.column_name_alias);
+		table_names = bind_context.AliasColumnNames(ref.table_name, table_names, ref.column_name_alias);
 
 		virtual_column_map_t virtual_columns;
 		if (scan_function.get_virtual_columns) {

--- a/test/sql/select/test_error_on_duplicate_columns.test
+++ b/test/sql/select/test_error_on_duplicate_columns.test
@@ -1,0 +1,69 @@
+# name: test/sql/select/test_error_on_duplicate_columns.test
+# group: [select]
+
+# default behavior: duplicate column names in subqueries are disambiguated
+query II
+SELECT * FROM (SELECT 42 a, 84 a) sub;
+----
+42	84
+
+query I
+SELECT a_1 FROM (SELECT 42 a, 84 a) sub;
+----
+84
+
+# enable preserve_duplicate_column_names: disambiguation is disabled
+statement ok
+SET preserve_duplicate_column_names = true;
+
+# duplicate column names in a top-level SELECT are always fine
+query II
+SELECT 42 a, 84 a;
+----
+42	84
+
+# subquery with duplicate column names now errors (no longer disambiguated)
+statement error
+SELECT * FROM (SELECT 42 a, 84 a) sub;
+----
+duplicate column name "a"
+
+# unique columns in subquery still work fine
+query II
+SELECT * FROM (SELECT 1 AS a, 2 AS b) sub;
+----
+1	2
+
+# cross join producing duplicates in subquery context
+statement error
+SELECT * FROM (SELECT * FROM (SELECT 1 AS x) a, (SELECT 2 AS x) b) sub;
+----
+duplicate column name "x"
+
+# but cross join at the top level is fine (different bindings)
+query II
+SELECT * FROM (SELECT 1 AS x) a, (SELECT 2 AS x) b;
+----
+1	2
+
+# can be toggled off within session
+statement ok
+SET preserve_duplicate_column_names = false;
+
+# back to default: disambiguation happens
+query II
+SELECT * FROM (SELECT 42 a, 84 a) sub;
+----
+42	84
+
+# reset also works
+statement ok
+SET preserve_duplicate_column_names = true;
+
+statement ok
+RESET preserve_duplicate_column_names;
+
+query II
+SELECT * FROM (SELECT 42 a, 84 a) sub;
+----
+42	84

--- a/test/sql/select/test_error_on_duplicate_columns.test
+++ b/test/sql/select/test_error_on_duplicate_columns.test
@@ -46,6 +46,25 @@ SELECT * FROM (SELECT 1 AS x) a, (SELECT 2 AS x) b;
 ----
 1	2
 
+# CTE with duplicate column names errors
+statement error
+WITH cte AS (SELECT 42 a, 84 a) SELECT * FROM cte;
+----
+duplicate column name "a"
+
+# top-level UNION with duplicate column names is fine
+query II
+SELECT 42 a, 84 a UNION ALL SELECT 1, 2;
+----
+42	84
+1	2
+
+# UNION inside a subquery with duplicate column names errors
+statement error
+SELECT * FROM (SELECT 42 a, 84 a UNION ALL SELECT 1, 2) sub;
+----
+duplicate column name "a"
+
 # can be toggled off within session
 statement ok
 SET preserve_duplicate_column_names = false;

--- a/test/sql/select/test_error_on_duplicate_columns.test
+++ b/test/sql/select/test_error_on_duplicate_columns.test
@@ -34,6 +34,18 @@ SELECT * FROM (SELECT 1 AS a, 2 AS b) sub;
 ----
 1	2
 
+# explicit AS aliases inside the subquery are preserved
+query II
+SELECT foo, bar FROM (SELECT 1 AS foo, 2 AS bar) sub;
+----
+1	2
+
+# explicit AS aliases are preserved even when the underlying expressions would collide
+query II
+SELECT foo, bar FROM (SELECT 42 AS foo, 42 AS bar) sub;
+----
+42	42
+
 # cross join producing duplicates in subquery context
 statement error
 SELECT * FROM (SELECT * FROM (SELECT 1 AS x) a, (SELECT 2 AS x) b) sub;


### PR DESCRIPTION
Add a session-local boolean setting (default false) that disables disambiguation when there are column name conflicts. 

With this setting enabled, ambiguous column names raise a `BinderException` during `Binding::Initialize`. This allows duplicate names to be used within the same binder instance (i.e. top-level projections) but raises an exception when names become ambiguous. This is similar to how MySQL handles column name conflicts.                                               
                                                                                                                                                                                                                                                    
For example:                                                                                                                                                                                                                                      
```
SET preserve_duplicate_column_names = true;                                                                                                                                                                                                       
SELECT 42 a, 84 a;
```                                                                                                                                                                                                                      
is valid as there is no ambiguity in the projection.

However, the following would throw because `a` is now ambiguous in the outer `SELECT`:
```                                                                                                                                                                
statement error
SELECT * FROM (SELECT 42 a, 84 a) sub;                                                                                                                                                                                                            
----                                                                                                                                                                                                                                            
duplicate column name "a"
```

Closes duckdb/duckdb#11520