### PR TITLE
Improve README development guide and repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,27 @@ The documentation contains a [SQL introduction and reference](https://duckdb.org
 
 ## Development
 
-For development, DuckDB requires [CMake](https://cmake.org), Python 3 and a `C++17` compliant compiler. In the root directory, run `make` to compile the sources. For development, use `make debug` to build a non-optimized debug version. You should run `make unit` and `make allunit` to verify that your version works properly after making changes. To test performance, you can run `BUILD_BENCHMARK=1 BUILD_TPCH=1 make` and then perform several standard benchmarks from the root directory by executing `./build/release/benchmark/benchmark_runner`. The details of benchmarks are in our [Benchmark Guide](benchmark/README.md).
+DuckDB development requires [CMake](https://cmake.org), Python 3 and a `C++17` compliant compiler.
+
+Common commands from the repository root:
+
+- `make`: build the default release binaries
+- `make debug`: build a non-optimized debug version
+- `make unit`: run fast unit tests
+- `make allunit`: run the full unit test suite
+- `BUILD_BENCHMARK=1 BUILD_TPCH=1 make`: build benchmark binaries
+- `./build/release/benchmark/benchmark_runner`: run standard benchmarks
+
+Benchmark details are in the [Benchmark Guide](benchmark/README.md).
 
 Please also refer to our [Build Guide](https://duckdb.org/docs/current/dev/building/overview) and [Contribution Guide](CONTRIBUTING.md).
+
+## Repository Layout
+
+- `src/`: core DuckDB engine
+- `test/`: SQL logic tests and C++ unit tests
+- `extension/`: built-in and loadable extensions
+- `benchmark/`: benchmark suites and tools
 
 ## Support
 


### PR DESCRIPTION
Add a concise command-oriented development section and a short repository layout overview to make onboarding easier while keeping the README brief.