### PR TITLE
Fix incorrect results when using `try` within `if`

### DIFF
--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -120,11 +120,7 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 				result.Reference(try_result);
 				return;
 			}
-			if (sel) {
-				VectorOperations::Copy(try_result, result, *sel, count, 0, 0, count);
-			} else {
-				VectorOperations::Copy(try_result, result, count, 0, 0);
-			}
+			VectorOperations::Copy(try_result, result, count, 0, 0);
 			return;
 		} catch (std::exception &ex) {
 			ErrorData error(ex);

--- a/test/sql/error/test_try_expression.test_slow
+++ b/test/sql/error/test_try_expression.test_slow
@@ -148,3 +148,11 @@ select TRY('hello');
 
 statement ok
 select TRY(123);
+
+query I
+select if(a, try(b), null) x
+from values (0, null), (1, 1), (1, 1) t(a, b);
+----
+NULL
+1
+1


### PR DESCRIPTION
This PR fixes an issue that occurs when using a `try` within an `if` expression referencing columns containing `null` values. 

See the following example (same result on both v1.5.1 and v1.5.2-dev2702):

```sql
select a, b, if(a, try(b), null) x from values (0, null), (1, 1), (1, 1) t(a,b);
┌───┬───┬───┐
│ a ┆ b ┆ x │
╞═══╪═══╪═══╡
│ 0 ┆   ┆   │
│ 1 ┆ 1 ┆ 1 │
│ 1 ┆ 1 ┆   │ -- expected x to be 1
└───┴───┴───┘
```

On debug builds, this triggers an assertion:
```
ValidityMask::RowIsValid - row_idx 4294967295 is out-of-range for mask with capacity 2048

Stack Trace:

0        duckdb::Exception::ToJSON(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 76
1        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 68
2        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 40
3        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 36
4        duckdb::InternalException::InternalException<unsigned long long&, unsigned long long const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long&, unsigned long long const&) + 88
5        duckdb::TemplatedValidityMask<unsigned long long>::RowIsValid(unsigned long long) const + 136
6        duckdb::ValidityMask::CopySel(duckdb::ValidityMask const&, duckdb::SelectionVector const&, unsigned long long, unsigned long long, unsigned long long) + 236
7        duckdb::VectorOperations::Copy(duckdb::Vector const&, duckdb::Vector&, duckdb::SelectionVector const&, unsigned long long, unsigned long long, unsigned long long, unsigned long long) + 1652
8        duckdb::ExpressionExecutor::Execute(duckdb::BoundOperatorExpression const&, duckdb::ExpressionState*, duckdb::SelectionVector const*, unsigned long long, duckdb::Vector&) + 3396
9        duckdb::ExpressionExecutor::Execute(duckdb::Expression const&, duckdb::ExpressionState*, duckdb::SelectionVector const*, unsigned long long, duckdb::Vector&) + 868
```

It looks like this issue was introduced in #20238. I believe this also fixes #21933.