### PR TITLE
lance: bump lance-duckdb to 1b4ef68

### DIFF
--- a/.github/config/extensions/lance.cmake
+++ b/.github/config/extensions/lance.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(lance
             GIT_URL https://github.com/lance-format/lance-duckdb
-            GIT_TAG 4d9ecabf7dc8f3fd07b4ae4a77ff699018a8f4dc
+            GIT_TAG 1b4ef6865a8a1056c587e763366bcfda02939716
             SUBMODULES extension-ci-tools
             LOAD_TESTS
             DONT_LINK


### PR DESCRIPTION
This updates the `lance` external extension on `v1.5-variegata` from `4d9ecabf7dc8f3fd07b4ae4a77ff699018a8f4dc` to `1b4ef6865a8a1056c587e763366bcfda02939716`.

It picks up the latest `lance-duckdb` changes for the v1.5 Lance integration.

## Changes

- Bumped to lance v4.0
- Full Cache Support: now query lance tables is much faster! 
- Polished vector index controls in hybrid search: use vector index or not, nprobs, refine_factor and more.