### PR TITLE
Use `BLOB`, not `VARCHAR` for row group pruning

### DIFF
--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -233,9 +233,9 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 		switch (order_by) {
 		case OrderByStatistics::MIN:
-			return StringStats::Min(stats);
+			return Value::BLOB_RAW(StringStats::Min(stats));
 		case OrderByStatistics::MAX:
-			return StringStats::Max(stats);
+			return Value::BLOB_RAW(StringStats::Max(stats));
 		default:
 			throw InternalException("Unsupported OrderByStatistics for string");
 		}

--- a/test/issues/general/test_21832.test
+++ b/test/issues/general/test_21832.test
@@ -1,0 +1,11 @@
+# name: test/issues/general/test_21832.test
+# description: Issue 21832: DuckDB 1.5.1: ORDER BY ... LIMIT on some VARCHAR values containing Til Ærø raises InvalidInputException
+# group: [general]
+
+statement ok
+CREATE TABLE t AS SELECT 'Til Ærø' AS name;
+
+query I
+SELECT name FROM t ORDER BY 1 LIMIT 3;
+----
+Til Ærø


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21832