### PR TITLE
Use simpler checkout logic

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -82,8 +82,6 @@ jobs:
         id: changed
         uses: tj-actions/changed-files@v47
         with:
-          base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
-          skip_initial_fetch: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           files_yaml: |
             github:
               - .github/**
@@ -245,6 +243,7 @@ jobs:
       uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
         runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+        fetch_depth: 0
 
     - id: describe_step
       run: echo "git_describe=$(git describe --tags --long)" >> "$GITHUB_OUTPUT"
@@ -423,6 +422,7 @@ jobs:
       uses: duckdb/duckdb-ci/.github/actions/checkout@main
       with:
         runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+        fetch_depth: 0
 
     - name: Install tools
       run: python3 scripts/ci/retry.py -- make toolsci


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/actions/runs/24082005893/job/70244796916?pr=21920:
```yaml
Run tj-actions/changed-files@v47
  with:
    base_sha: 07e8327d8192737b94a92187005fb332f2079947
    skip_initial_fetch: true
changed-files
  Using local .git directory
  Running on a pull_request (ready_for_review) event...
  Error: Not Found - https://docs.github.com/rest/git/refs#get-a-reference
```
where the value of `base_sha` did not exist anymore.