### PR TITLE
Improve vcpkg caching

### DIFF
--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Path to a newline-delimited list of changed tests to include in smoke tests
     required: false
     default: ""
+  save_cache:
+    description: Whether to save vcpkg binary cache
+    required: true
+    default: "true"
 runs:
   using: composite
   steps:
@@ -42,6 +46,15 @@ runs:
         mkdir -p "${cache_path}"
         echo "VCPKG_DEFAULT_BINARY_CACHE=${cache_path}" >> "$GITHUB_ENV"
         echo "VCPKG_BINARY_SOURCES=clear;files,${cache_path},readwrite" >> "$GITHUB_ENV"
+
+    - name: Restore vcpkg binaries
+      id: vcpkg-binary-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: vcpkg-${{ runner.os }}-${{ hashFiles('build/extension_configuration/vcpkg.json') }}
+        restore-keys: |
+          vcpkg-${{ runner.os }}-
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.5
@@ -67,6 +80,13 @@ runs:
       if: ${{ inputs.run_smoke_tests == 'true' }}
       shell: bash
       run: make smoke SMOKE_UNITTEST=build/release/test/unittest T="--changed-tests=${{ inputs.changed_tests_file }}"
+
+    - name: Save vcpkg binaries
+      if: ${{ inputs.save_cache == 'true' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: ${{ steps.vcpkg-binary-cache.outputs.cache-primary-key }}
 
     - name: Prepare release artifact
       shell: bash

--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -32,25 +32,16 @@ inputs:
     description: Path to a newline-delimited list of changed tests to include in smoke tests
     required: false
     default: ""
-  save_cache:
-    description: Whether to save vcpkg binary cache
-    required: false
-    default: "true"
 runs:
   using: composite
   steps:
-    - name: Set vcpkg binary cache path
+    - name: Configure vcpkg binary cache
       shell: bash
-      run: echo "VCPKG_DEFAULT_BINARY_CACHE=${GITHUB_WORKSPACE}/vcpkg-cache" >> "$GITHUB_ENV"
-
-    - name: Restore vcpkg binaries
-      id: vcpkg-binary-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ github.workspace }}/vcpkg-cache
-        key: vcpkg-${{ runner.os }}-${{ hashFiles('build/extension_configuration/vcpkg.json') }}
-        restore-keys: |
-          vcpkg-${{ runner.os }}-
+      run: |
+        cache_path="${GITHUB_WORKSPACE}/vcpkg-cache"
+        mkdir -p "${cache_path}"
+        echo "VCPKG_DEFAULT_BINARY_CACHE=${cache_path}" >> "$GITHUB_ENV"
+        echo "VCPKG_BINARY_SOURCES=clear;files,${cache_path},readwrite" >> "$GITHUB_ENV"
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.5
@@ -67,6 +58,8 @@ runs:
         CORE_EXTENSIONS: ${{ inputs.core_extensions }}
         DISABLE_SANITIZER: ${{ inputs.disable_sanitizer }}
         VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-cache
+        VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg-cache,readwrite
         USE_MERGED_VCPKG_MANIFEST: 1
       run: python3 scripts/ci/retry.py -- make release
 
@@ -74,13 +67,6 @@ runs:
       if: ${{ inputs.run_smoke_tests == 'true' }}
       shell: bash
       run: make smoke SMOKE_UNITTEST=build/release/test/unittest T="--changed-tests=${{ inputs.changed_tests_file }}"
-
-    - name: Save vcpkg binaries
-      if: ${{ inputs.save_cache == 'true' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ github.workspace }}/vcpkg-cache
-        key: ${{ steps.vcpkg-binary-cache.outputs.cache-primary-key }}
 
     - name: Prepare release artifact
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -325,6 +325,7 @@ jobs:
       run_slow_tests: ${{ needs.prepare.outputs.run_slow_tests == 'true' }}
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
+      save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
  tidy-check:
     name: Tidy Check
@@ -439,6 +440,7 @@ jobs:
       with:
         artifact_name: linux-release-build
         changed_tests_file: ${{ runner.temp }}/changed_tests.txt
+        save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
     - name: Test
       shell: bash

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -16,6 +16,9 @@ on:
       runner_linux_small:
         default: ubuntu-latest
         type: string
+      save_cache:
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       base_hash:
@@ -37,6 +40,9 @@ on:
         description: 'Optional small runner label override'
         default: ubuntu-latest
         type: string
+      save_cache:
+        default: false
+        type: boolean
   repository_dispatch:
 
 concurrency:
@@ -70,6 +76,7 @@ jobs:
         uses: ./.github/actions/linux_release_build
         with:
           artifact_name: linux-release-build
+          save_cache: ${{ inputs.save_cache }}
 
       - name: Select base ref
         run: |
@@ -100,6 +107,7 @@ jobs:
         with:
           artifact_name: linux-base-build
           run_smoke_tests: false
+          save_cache: ${{ inputs.save_cache }}
 
   regression-bench:
     name: Bench ${{ matrix.name }}


### PR DESCRIPTION
- Improve vcpkg caching by setting `VCPKG_BINARY_SOURCES` and `VCPKG_DEFAULT_BINARY_CACHE` correctly.
  - It was [overridden](https://github.com/duckdb/duckdb/actions/runs/24111959893/job/70348335321#step:7:77) by run-vcpkg and caused an [empty cache](https://github.com/duckdb/duckdb/actions/runs/24111959893/job/70348335321#step:7:1810) on the CI run of the main branch.