### PR TITLE
Better ownership semantics for client context on client properties

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -41,8 +41,7 @@ void ArrowAppender::Append(DataChunk &input, const idx_t from, const idx_t to, c
 	for (idx_t i = 0; i < input.ColumnCount(); i++) {
 		if (root_data[i]->extension_data && root_data[i]->extension_data->duckdb_to_arrow) {
 			Vector input_data(root_data[i]->extension_data->GetInternalType());
-			root_data[i]->extension_data->duckdb_to_arrow(*client_context, input.data[i], input_data,
-			                                              input_size);
+			root_data[i]->extension_data->duckdb_to_arrow(*client_context, input.data[i], input_data, input_size);
 			root_data[i]->append_vector(*root_data[i], input_data, from, to, input_size);
 		} else {
 			root_data[i]->append_vector(*root_data[i], input.data[i], from, to, input_size);

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -37,10 +37,11 @@ ArrowAppender::~ArrowAppender() {
 void ArrowAppender::Append(DataChunk &input, const idx_t from, const idx_t to, const idx_t input_size) {
 	D_ASSERT(types == input.GetTypes());
 	D_ASSERT(to >= from);
+	auto client_context = options.GetClientContextOrThrow();
 	for (idx_t i = 0; i < input.ColumnCount(); i++) {
 		if (root_data[i]->extension_data && root_data[i]->extension_data->duckdb_to_arrow) {
 			Vector input_data(root_data[i]->extension_data->GetInternalType());
-			root_data[i]->extension_data->duckdb_to_arrow(*options.client_context, input.data[i], input_data,
+			root_data[i]->extension_data->duckdb_to_arrow(*client_context, input.data[i], input_data,
 			                                              input_size);
 			root_data[i]->append_vector(*root_data[i], input_data, from, to, input_size);
 		} else {

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -417,8 +417,8 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
                                    const vector<string> &names, ClientProperties &options) {
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
-	D_ASSERT(options.client_context);
-	auto get_schema_func = [&types, &out_schema, &names, &options]() {
+	auto context = options.GetClientContextOrThrow();
+	auto get_schema_func = [&types, &out_schema, &names, &options, &context]() {
 		const idx_t column_count = types.size();
 		// Allocate as unique_ptr first to clean-up properly on error
 		auto root_holder = make_uniq<DuckDBArrowSchemaHolder>();
@@ -444,19 +444,18 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 			root_holder->owned_column_names.push_back(AddName(names[col_idx]));
 			auto &child = root_holder->children[col_idx];
 			InitializeChild(child, *root_holder, names[col_idx]);
-			SetArrowFormat(*root_holder, child, types[col_idx], options, *options.client_context);
+			SetArrowFormat(*root_holder, child, types[col_idx], options, *context.get());
 		}
 
 		// Release ownership to caller
 		out_schema->private_data = root_holder.release();
 		out_schema->release = ReleaseDuckDBArrowSchema;
 	};
-	auto &context = *options.client_context;
-	if (context.transaction.HasActiveTransaction()) {
+	if (context->transaction.HasActiveTransaction()) {
 		get_schema_func();
 	} else {
 		// We need to run this in a transaction. The arrow schema callback might use the catalog to do lookups.
-		options.client_context->RunFunctionInTransaction(get_schema_func);
+		context->RunFunctionInTransaction(get_schema_func);
 	}
 }
 

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -444,7 +444,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 			root_holder->owned_column_names.push_back(AddName(names[col_idx]));
 			auto &child = root_holder->children[col_idx];
 			InitializeChild(child, *root_holder, names[col_idx]);
-			SetArrowFormat(*root_holder, child, types[col_idx], options, *context.get());
+			SetArrowFormat(*root_holder, child, types[col_idx], options, *context);
 		}
 
 		// Release ownership to caller

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -171,6 +171,7 @@ const char *ResultArrowArrayStreamWrapper::MyStreamGetLastError(struct ArrowArra
 
 ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result_p, idx_t batch_size_p)
     : result(std::move(result_p)), scan_state(make_uniq<QueryResultChunkScanState>(*result)) {
+	const auto client_context = result->client_properties.GetClientContextOrThrow();
 	//! We first initialize the private data of the stream
 	stream.private_data = this;
 	//! Ceil Approx_Batch_Size/STANDARD_VECTOR_SIZE
@@ -185,7 +186,7 @@ ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryRes
 	stream.get_last_error = ResultArrowArrayStreamWrapper::MyStreamGetLastError;
 
 	extension_types =
-	    ArrowTypeExtensionData::GetExtensionTypes(*result->client_properties.client_context, result->types);
+	    ArrowTypeExtensionData::GetExtensionTypes(*client_context, result->types);
 }
 
 } // namespace duckdb

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -187,8 +187,7 @@ ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryRes
 	stream.release = ResultArrowArrayStreamWrapper::MyStreamRelease;
 	stream.get_last_error = ResultArrowArrayStreamWrapper::MyStreamGetLastError;
 
-	extension_types =
-	    ArrowTypeExtensionData::GetExtensionTypes(*client_context, result->types);
+	extension_types = ArrowTypeExtensionData::GetExtensionTypes(*client_context, result->types);
 }
 
 } // namespace duckdb

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -171,6 +171,8 @@ const char *ResultArrowArrayStreamWrapper::MyStreamGetLastError(struct ArrowArra
 
 ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result_p, idx_t batch_size_p)
     : result(std::move(result_p)), scan_state(make_uniq<QueryResultChunkScanState>(*result)) {
+	// This should not fail on construction since we expect to always have a client context here. In the
+	// callbacks the same check is done again, so this check is here just to be sure.
 	const auto client_context = result->client_properties.GetClientContextOrThrow();
 	//! We first initialize the private data of the stream
 	stream.private_data = this;

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 struct ClientProperties {
 	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
 	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
-	                 const ArrowFormatVersion arrow_output_version, const optional_ptr<ClientContext> client_context)
+	                 const ArrowFormatVersion arrow_output_version, const weak_ptr<ClientContext>& client_context = {})
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
 	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
@@ -32,6 +32,24 @@ struct ClientProperties {
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
 	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_0;
-	optional_ptr<ClientContext> client_context;
+
+	//! Returns a live ClientContext or throws if the owning connection has been closed.
+	shared_ptr<ClientContext> GetClientContextOrThrow() const {
+		auto ctx = client_context.lock();
+		if (!ctx) {
+			throw ConnectionException(
+			    "Cannot perform this operation: the connection has been closed");
+		}
+		return ctx;
+	}
+
+	//! Get a shared pointer to the client context. Might be nullptr if not on a connection.
+	shared_ptr<ClientContext> TryGetClientContext() const {
+		return client_context.lock();
+	}
+
+private:
+	weak_ptr<ClientContext> client_context;
+
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -50,6 +50,5 @@ struct ClientProperties {
 
 private:
 	weak_ptr<ClientContext> client_context;
-
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 struct ClientProperties {
 	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
 	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
-	                 const ArrowFormatVersion arrow_output_version, const weak_ptr<ClientContext>& client_context = {})
+	                 const ArrowFormatVersion arrow_output_version, const weak_ptr<ClientContext> &client_context = {})
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
 	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
@@ -37,8 +37,7 @@ struct ClientProperties {
 	shared_ptr<ClientContext> GetClientContextOrThrow() const {
 		auto ctx = client_context.lock();
 		if (!ctx) {
-			throw ConnectionException(
-			    "Cannot perform this operation: the connection has been closed");
+			throw ConnectionException("Cannot perform this operation: the connection has been closed");
 		}
 		return ctx;
 	}

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -22,7 +22,7 @@ struct ClientProperties {
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
 	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
-	      client_context(client_context) {
+	      client_context(client_context.lock()), weak_client_context(client_context) {
 	}
 	ClientProperties() {};
 
@@ -32,10 +32,16 @@ struct ClientProperties {
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
 	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_0;
+	//! DEPRECATED — will be removed in the next feature release.
+	//! UNSAFE: this raw pointer becomes dangling once the owning connection
+	//! is closed, and dereferencing it is undefined behavior. New code MUST
+	//! use GetClientContextOrThrow() / TryGetClientContext() instead, which
+	//! detect a closed connection and throw a ConnectionException.
+	optional_ptr<ClientContext> client_context;
 
 	//! Returns a live ClientContext or throws if the owning connection has been closed.
 	shared_ptr<ClientContext> GetClientContextOrThrow() const {
-		auto ctx = client_context.lock();
+		auto ctx = weak_client_context.lock();
 		if (!ctx) {
 			throw ConnectionException("Cannot perform this operation: the connection has been closed");
 		}
@@ -44,10 +50,10 @@ struct ClientProperties {
 
 	//! Get a shared pointer to the client context. Might be nullptr if not on a connection.
 	shared_ptr<ClientContext> TryGetClientContext() const {
-		return client_context.lock();
+		return weak_client_context.lock();
 	}
 
 private:
-	weak_ptr<ClientContext> client_context;
+	weak_ptr<ClientContext> weak_client_context;
 };
 } // namespace duckdb

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -243,11 +243,19 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	if (!wrapper->current_chunk || wrapper->current_chunk->size() == 0) {
 		return DuckDBSuccess;
 	}
-	auto client_context = wrapper->result->client_properties.GetClientContextOrThrow();
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *client_context, wrapper->result->types);
-	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
-	                             wrapper->result->client_properties, extension_type_cast);
+	try {
+		auto client_context = wrapper->result->client_properties.GetClientContextOrThrow();
+		auto extension_type_cast =
+		    duckdb::ArrowTypeExtensionData::GetExtensionTypes(*client_context, wrapper->result->types);
+		ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
+		                             wrapper->result->client_properties, extension_type_cast);
+	} catch (std::exception &ex) {
+		wrapper->result->SetError(duckdb::ErrorData(ex));
+		return DuckDBError;
+	} catch (...) {
+		wrapper->result->SetError(duckdb::ErrorData("Unknown error in duckdb_query_arrow_array"));
+		return DuckDBError;
+	}
 	return DuckDBSuccess;
 }
 

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -54,8 +54,9 @@ duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options arrow_options,
 	}
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto arrow_options_wrapper = reinterpret_cast<CClientArrowOptionsWrapper *>(arrow_options);
+	auto client_context = arrow_options_wrapper->properties.GetClientContextOrThrow();
 	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *arrow_options_wrapper->properties.client_context, dchunk->GetTypes());
+	    *client_context, dchunk->GetTypes());
 
 	try {
 		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, arrow_options_wrapper->properties, extension_type_cast);
@@ -242,8 +243,9 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	if (!wrapper->current_chunk || wrapper->current_chunk->size() == 0) {
 		return DuckDBSuccess;
 	}
+	auto client_context = wrapper->result->client_properties.GetClientContextOrThrow();
 	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *wrapper->result->client_properties.client_context, wrapper->result->types);
+	    *client_context, wrapper->result->types);
 	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
 	                             wrapper->result->client_properties, extension_type_cast);
 	return DuckDBSuccess;
@@ -255,8 +257,9 @@ void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, du
 	}
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
+	auto client_context = result_data.result->client_properties.GetClientContextOrThrow();
 	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *result_data.result->client_properties.client_context, result_data.result->types);
+	    *client_context, result_data.result->types);
 
 	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
 	                             result_data.result->client_properties, extension_type_cast);

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -55,8 +55,7 @@ duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options arrow_options,
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto arrow_options_wrapper = reinterpret_cast<CClientArrowOptionsWrapper *>(arrow_options);
 	auto client_context = arrow_options_wrapper->properties.GetClientContextOrThrow();
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *client_context, dchunk->GetTypes());
+	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(*client_context, dchunk->GetTypes());
 
 	try {
 		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, arrow_options_wrapper->properties, extension_type_cast);
@@ -266,8 +265,8 @@ void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, du
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
 	auto client_context = result_data.result->client_properties.GetClientContextOrThrow();
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *client_context, result_data.result->types);
+	auto extension_type_cast =
+	    duckdb::ArrowTypeExtensionData::GetExtensionTypes(*client_context, result_data.result->types);
 
 	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
 	                             result_data.result->client_properties, extension_type_cast);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1489,7 +1489,7 @@ ClientProperties ClientContext::GetClientProperties() {
 	        arrow_use_string_view,
 	        arrow_lossless_conversion,
 	        arrow_format_version,
-	        this};
+	        shared_from_this()};
 }
 
 bool ClientContext::ExecutionIsFinished() {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -62,7 +62,7 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type, Sta
 
 QueryResult::QueryResult(QueryResultType type, ErrorData error)
     : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0, nullptr) {
+      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0) {
 }
 
 QueryResult::~QueryResult() {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(udf_function)
 
 set(TEST_API_OBJECTS
     test_api.cpp
+    test_client_properties.cpp
     test_config.cpp
     test_custom_allocator.cpp
     test_extension_setting_autoload.cpp

--- a/test/api/capi/test_capi_geometry.cpp
+++ b/test/api/capi/test_capi_geometry.cpp
@@ -95,3 +95,64 @@ TEST_CASE("Test C API GEOMETRY arrow schema export with CRS", "[capi][arrow]") {
 	}
 	duckdb_destroy_arrow(&arrow_result);
 }
+
+TEST_CASE("Test C API arrow schema export after connection close", "[capi][arrow]") {
+	// After the connection is closed, consuming a previously-issued arrow
+	// result must fail cleanly with a ConnectionException-style error rather
+	// than crashing on a dangling ClientContext pointer.
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY('OGC:CRS84'))"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)')"));
+
+	duckdb_arrow arrow_result = nullptr;
+	auto state = duckdb_query_arrow(tester.connection, "SELECT data FROM t1", &arrow_result);
+	REQUIRE(state == DuckDBSuccess);
+
+	// Close the connection while still holding on to the arrow result handle.
+	duckdb_disconnect(&tester.connection);
+
+	ArrowSchema arrow_schema;
+	arrow_schema.Init();
+	auto arrow_schema_ptr = &arrow_schema;
+	state = duckdb_query_arrow_schema(arrow_result, reinterpret_cast<duckdb_arrow_schema *>(&arrow_schema_ptr));
+
+	REQUIRE(state == DuckDBError);
+	auto err_cstr = duckdb_query_arrow_error(arrow_result);
+	REQUIRE(err_cstr != nullptr);
+	std::string err = err_cstr;
+	INFO("duckdb_query_arrow_schema error: " << err);
+	REQUIRE(err.find("connection has been closed") != std::string::npos);
+
+	duckdb_destroy_arrow(&arrow_result);
+}
+
+TEST_CASE("Test C API arrow array fetch after connection close", "[capi][arrow]") {
+	// Same regression as the schema-export case but for the per-batch
+	// ArrowArray fetch path: duckdb_query_arrow_array also resolves extension
+	// types via the client context and must error gracefully on a closed
+	// connection instead of reading freed memory.
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE t1 (data GEOMETRY('OGC:CRS84'))"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO t1 VALUES ('POINT(42 1337)')"));
+
+	duckdb_arrow arrow_result = nullptr;
+	auto state = duckdb_query_arrow(tester.connection, "SELECT data FROM t1", &arrow_result);
+	REQUIRE(state == DuckDBSuccess);
+
+	duckdb_disconnect(&tester.connection);
+
+	ArrowArray arrow_array;
+	auto arrow_array_ptr = &arrow_array;
+	state = duckdb_query_arrow_array(arrow_result, reinterpret_cast<duckdb_arrow_array *>(&arrow_array_ptr));
+
+	REQUIRE(state == DuckDBError);
+	auto err_cstr = duckdb_query_arrow_error(arrow_result);
+	REQUIRE(err_cstr != nullptr);
+	std::string err = err_cstr;
+	INFO("duckdb_query_arrow_array error: " << err);
+	REQUIRE(err.find("connection has been closed") != std::string::npos);
+
+	duckdb_destroy_arrow(&arrow_result);
+}

--- a/test/api/test_client_properties.cpp
+++ b/test/api/test_client_properties.cpp
@@ -6,8 +6,8 @@
 #include "duckdb/main/database.hpp"
 
 using duckdb::ClientProperties;
-using duckdb::ConnectionException;
 using duckdb::Connection;
+using duckdb::ConnectionException;
 using duckdb::DuckDB;
 
 TEST_CASE("ClientProperties: default-constructed has no context", "[api][client_properties]") {

--- a/test/api/test_client_properties.cpp
+++ b/test/api/test_client_properties.cpp
@@ -1,0 +1,58 @@
+#include "catch.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_properties.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+using duckdb::ClientProperties;
+using duckdb::ConnectionException;
+using duckdb::Connection;
+using duckdb::DuckDB;
+
+TEST_CASE("ClientProperties: default-constructed has no context", "[api][client_properties]") {
+	ClientProperties props;
+
+	REQUIRE(props.TryGetClientContext() == nullptr);
+	REQUIRE_THROWS_AS(props.GetClientContextOrThrow(), ConnectionException);
+}
+
+TEST_CASE("ClientProperties: live context is returned", "[api][client_properties]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto props = con.context->GetClientProperties();
+
+	auto ctx = props.TryGetClientContext();
+	REQUIRE(ctx != nullptr);
+	REQUIRE(ctx.get() == con.context.get());
+
+	auto ctx2 = props.GetClientContextOrThrow();
+	REQUIRE(ctx2.get() == con.context.get());
+}
+
+TEST_CASE("ClientProperties: expired context throws ConnectionException", "[api][client_properties]") {
+	// Simulates a consumer (e.g. an Arrow C stream capsule) being consumed
+	// after the originating connection has been closed: the weak_ptr inside
+	// ClientProperties must detect this and throw instead of returning a
+	// dangling pointer.
+	ClientProperties props;
+	{
+		DuckDB db(nullptr);
+		Connection con(db);
+		props = con.context->GetClientProperties();
+		REQUIRE(props.TryGetClientContext() != nullptr);
+	}
+	// Connection (and thus its ClientContext) has been destroyed here.
+
+	REQUIRE(props.TryGetClientContext() == nullptr);
+	REQUIRE_THROWS_AS(props.GetClientContextOrThrow(), ConnectionException);
+
+	try {
+		props.GetClientContextOrThrow();
+		FAIL("expected ConnectionException");
+	} catch (const ConnectionException &ex) {
+		std::string msg = ex.what();
+		REQUIRE(msg.find("connection has been closed") != std::string::npos);
+	}
+}


### PR DESCRIPTION
Followup on #21927

`ClientProperties` used an `optional_ptr` to store an optional `ClientContext`. If this is used after a connection is closed then the pointer points to garbage. This PR changes `ClientProperties::client_context` to a `weak_ptr`, and introduces two functions that can be used to get a shared pointer to a client context:
- `GetClientContextOrThrow()`: throws a `ConnectionException` if there is no valid client context.
- `TryGetClientContext()`: returns a shared pointer that may be nullptr.

I've fixed all internal callsites but am unsure how / whether `ClientProperties::client_context` is used in extensions. It's not a huge change, but it _is_ a change to the API. We could also consider doing this in main instead.

cc @Mytherin 