### PR TITLE
Move statement splitting responsibility to the peg grammar

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -600,6 +600,10 @@ public:
 			if (!root_tokens.empty()) {
 				result = PEGTransformerFactory::Transform(root_tokens, options, root_matcher);
 			}
+			if (!result.empty()) {
+				auto &last_statement = result.back();
+				last_statement->stmt_length = query.size() - last_statement->stmt_location;
+			}
 			for (auto &statement : result) {
 				statement->query = query.substr(statement->stmt_location, statement->stmt_length);
 				statement->stmt_location = 0;

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -545,34 +545,32 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	if (!allow_complete) {
 		return nullptr;
 	}
-	tokenizer.statements.push_back(std::move(root_tokens));
 
-	for (auto &tokens : tokenizer.statements) {
-		if (tokens.empty()) {
-			continue;
-		}
-		vector<MatcherSuggestion> suggestions;
-		ParseResultAllocator parse_allocator;
-		idx_t max_token_index = 0;
-		MatchState state(tokens, suggestions, parse_allocator, max_token_index);
+	if (root_tokens.empty()) {
+		return nullptr;
+	}
 
-		auto peg_matcher = GetPEGMatcherCache(DBConfig::GetConfig(context)).GetMatcher();
-		auto match_result = peg_matcher->Root().Match(state);
-		if (match_result != MatchResultType::SUCCESS || state.token_index < tokens.size()) {
-			string token_list;
-			for (idx_t i = 0; i < tokens.size(); i++) {
-				if (!token_list.empty()) {
-					token_list += "\n";
-				}
-				if (i < 10) {
-					token_list += " ";
-				}
-				token_list += to_string(i) + ":" + tokens[i].text;
+	vector<MatcherSuggestion> suggestions;
+	ParseResultAllocator parse_allocator;
+	idx_t max_token_index = 0;
+	MatchState state(root_tokens, suggestions, parse_allocator, max_token_index);
+
+	auto peg_matcher = GetPEGMatcherCache(DBConfig::GetConfig(context)).GetMatcher();
+	auto match_result = peg_matcher->Root().Match(state);
+	if (match_result != MatchResultType::SUCCESS || state.token_index < root_tokens.size()) {
+		string token_list;
+		for (idx_t i = 0; i < root_tokens.size(); i++) {
+			if (!token_list.empty()) {
+				token_list += "\n";
 			}
-			throw BinderException(
-			    "Failed to parse query \"%s\" - did not consume all tokens (got to token %d - %s)\nTokens:\n%s", sql,
-			    state.token_index, tokens[state.token_index].text, token_list);
+			if (i < 10) {
+				token_list += " ";
+			}
+			token_list += to_string(i) + ":" + root_tokens[i].text;
 		}
+		throw BinderException(
+		    "Failed to parse query \"%s\" - did not consume all tokens (got to token %d - %s)\nTokens:\n%s", sql,
+		    state.token_index, root_tokens[state.token_index].text, token_list);
 	}
 	return nullptr;
 }
@@ -593,39 +591,22 @@ public:
 		auto &root_matcher = peg_matcher->Root();
 
 		vector<MatcherToken> root_tokens;
-		string clean_sql;
 
 		ParserTokenizer tokenizer(query, root_tokens);
 		tokenizer.TokenizeInput();
-		tokenizer.statements.push_back(std::move(root_tokens));
 
 		try {
 			vector<unique_ptr<SQLStatement>> result;
-			for (auto &tokenized_statement : tokenizer.statements) {
-				if (tokenized_statement.empty()) {
-					continue;
-				}
-				auto statement = PEGTransformerFactory::Transform(tokenized_statement, options, root_matcher);
-				if (statement) {
-					statement->stmt_location = NumericCast<idx_t>(tokenized_statement[0].offset);
-					auto last_pos = tokenized_statement[tokenized_statement.size() - 1].offset +
-					                tokenized_statement[tokenized_statement.size() - 1].length;
-					statement->stmt_length = last_pos - tokenized_statement[0].offset;
-				}
-				statement->query = query;
-				result.push_back(std::move(statement));
+			if (!root_tokens.empty()) {
+				result = PEGTransformerFactory::Transform(root_tokens, options, root_matcher);
 			}
-			if (!result.empty()) {
-				auto &last_statement = result.back();
-				last_statement->stmt_length = query.size() - last_statement->stmt_location;
-				for (auto &statement : result) {
-					statement->query = query.substr(statement->stmt_location, statement->stmt_length);
-					statement->stmt_location = 0;
-					statement->stmt_length = statement->query.size();
-					if (statement->type == StatementType::CREATE_STATEMENT) {
-						auto &create = statement->Cast<CreateStatement>();
-						create.info->sql = statement->query;
-					}
+			for (auto &statement : result) {
+				statement->query = query.substr(statement->stmt_location, statement->stmt_length);
+				statement->stmt_location = 0;
+				statement->stmt_length = statement->query.size();
+				if (statement->type == StatementType::CREATE_STATEMENT) {
+					auto &create = statement->Cast<CreateStatement>();
+					create.info->sql = statement->query;
 				}
 			}
 			return ParserOverrideResult(std::move(result));

--- a/extension/autocomplete/grammar/statements/common.gram
+++ b/extension/autocomplete/grammar/statements/common.gram
@@ -1,3 +1,5 @@
+Program <- Statement? (';'+ Statement)* ';'*
+
 Statement <-
 	CreateStatement /
 	SelectStatement /
@@ -34,6 +36,9 @@ Statement <-
 
 ExpressionStatement <- List(ExpressionAlias)
 ExpressionAlias <- ColIdExpression / ExpressionAsCollabel / Expression
+
+SemiList1(D) <- D (';' D)*
+SemiList(D) <- SemiList1(D) ';'?
 
 CatalogName <- Identifier
 SchemaName <- Identifier

--- a/extension/autocomplete/include/inlined_grammar.gram
+++ b/extension/autocomplete/include/inlined_grammar.gram
@@ -1,3 +1,5 @@
+Program <- Statement? (';'+ Statement)* ';'*
+
 Statement <-
 	CreateStatement /
 	SelectStatement /
@@ -34,6 +36,9 @@ Statement <-
 
 ExpressionStatement <- List(ExpressionAlias)
 ExpressionAlias <- ColIdExpression / ExpressionAsCollabel / Expression
+
+SemiList1(D) <- D (';' D)*
+SemiList(D) <- SemiList1(D) ';'?
 
 CatalogName <- Identifier
 SchemaName <- Identifier

--- a/extension/autocomplete/include/inlined_grammar.hpp
+++ b/extension/autocomplete/include/inlined_grammar.hpp
@@ -4,6 +4,7 @@
 namespace duckdb {
 
 const char INLINED_PEG_GRAMMAR[] = {
+	"Program <- Statement? (';'+ Statement)* ';'*\n"
 	"Statement <-\n"
 	"	CreateStatement /\n"
 	"	SelectStatement /\n"
@@ -39,6 +40,8 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"	ExpressionStatement\n"
 	"ExpressionStatement <- List(ExpressionAlias)\n"
 	"ExpressionAlias <- ColIdExpression / ExpressionAsCollabel / Expression\n"
+	"SemiList1(D) <- D (';' D)*\n"
+	"SemiList(D) <- SemiList1(D) ';'?\n"
 	"CatalogName <- Identifier\n"
 	"SchemaName <- Identifier\n"
 	"ReservedSchemaName <- Identifier\n"

--- a/extension/autocomplete/include/parser/tokenizer/parser_tokenizer.hpp
+++ b/extension/autocomplete/include/parser/tokenizer/parser_tokenizer.hpp
@@ -10,8 +10,6 @@ public:
 	~ParserTokenizer() override = default;
 
 	void OnStatementEnd(idx_t pos) override;
-
-	vector<vector<MatcherToken>> statements;
 };
 
 } // namespace duckdb

--- a/extension/autocomplete/include/transformer/peg_transformer.hpp
+++ b/extension/autocomplete/include/transformer/peg_transformer.hpp
@@ -200,8 +200,8 @@ public:
 	explicit PEGTransformerFactory();
 
 	//! Helper functions
-	static unique_ptr<SQLStatement> Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-	                                          Matcher &root_matcher);
+	static vector<unique_ptr<SQLStatement>> Transform(vector<MatcherToken> &tokens, ParserOptions &options,
+	                                                  Matcher &root_matcher);
 	static ParseResult &ExtractResultFromParens(ParseResult &parse_result);
 	static vector<reference<ParseResult>> ExtractParseResultsFromList(ParseResult &parse_result);
 	static bool ExpressionIsEmptyStar(ParsedExpression &expr);

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -1459,9 +1459,9 @@ shared_ptr<PEGMatcher> PEGMatcherCache::GetMatcher() {
 	buffer << t.rdbuf();
 	auto grammar_string = buffer.str();
 
-	new_matcher->root = factory.CreateMatcher(grammar_string.c_str(), "Statement");
+	new_matcher->root = factory.CreateMatcher(grammar_string.c_str(), "Program");
 #else
-	new_matcher->root = factory.CreateMatcher(const_char_ptr_cast(INLINED_PEG_GRAMMAR), "Statement");
+	new_matcher->root = factory.CreateMatcher(const_char_ptr_cast(INLINED_PEG_GRAMMAR), "Program");
 #endif
 	std::unique_lock<std::mutex> lock(mutex);
 	if (!matcher) {

--- a/extension/autocomplete/parser/tokenizer/parser_tokenizer.cpp
+++ b/extension/autocomplete/parser/tokenizer/parser_tokenizer.cpp
@@ -6,7 +6,9 @@ ParserTokenizer::ParserTokenizer(const string &sql, vector<MatcherToken> &tokens
 }
 
 void ParserTokenizer::OnStatementEnd(idx_t pos) {
-	statements.push_back(std::move(tokens));
-	tokens.clear();
+	// Always emit ';' as a TERMINATOR token so the grammar can consume it.
+	// Statement boundaries are determined by the PEG grammar (Program rule), not the tokenizer.
+	tokens.emplace_back(";", pos, TokenType::TERMINATOR);
 }
+
 } // namespace duckdb

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -47,38 +47,25 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 		if (error_token_idx >= tokens.size()) {
 			error_token_idx = tokens.size() - 1;
 		}
-		auto &error_token = tokens[error_token_idx];
-		auto error_text = error_token.text;
-		if (error_text == ";") {
-			vector<char> expected_closers;
-			for (idx_t i = 0; i <= error_token_idx; i++) {
-				auto &token = tokens[i].text;
-				if (token == "(") {
-					expected_closers.push_back(')');
-				} else if (token == "[") {
-					expected_closers.push_back(']');
-				} else if (token == "{") {
-					expected_closers.push_back('}');
-				} else if (!expected_closers.empty() && token.length() == 1 && token[0] == expected_closers.back()) {
-					expected_closers.pop_back();
-				}
-			}
-			if (!expected_closers.empty()) {
-				if (error_token_idx > 0) {
-					auto &previous_token = tokens[error_token_idx - 1];
-					auto prefer_closer = previous_token.type == TokenType::NUMBER_LITERAL ||
-					                     previous_token.type == TokenType::STRING_LITERAL ||
-					                     previous_token.type == TokenType::OPERATOR || previous_token.text == ")" ||
-					                     previous_token.text == "]" || previous_token.text == "}";
-					error_text = prefer_closer ? string(1, expected_closers.back()) : previous_token.text;
-				} else {
-					error_text = string(1, expected_closers.back());
-				}
-			} else if (error_token_idx > 0) {
-				error_text = tokens[error_token_idx - 1].text;
-			}
+		idx_t stmt_start = error_token_idx;
+		while (stmt_start > 0 && tokens[stmt_start - 1].text != ";") {
+			stmt_start--;
 		}
-		auto error_message = "syntax error at or near \"" + error_text + "\"";
+		idx_t stmt_end = error_token_idx;
+		while (stmt_end < tokens.size() && tokens[stmt_end].text != ";") {
+			stmt_end++;
+		}
+		if (stmt_start < stmt_end && (stmt_start > 0 || stmt_end < tokens.size())) {
+			vector<MatcherToken> statement_tokens;
+			statement_tokens.reserve(stmt_end - stmt_start);
+			for (idx_t i = stmt_start; i < stmt_end; i++) {
+				statement_tokens.push_back(tokens[i]);
+			}
+			Transform(statement_tokens, options, root_matcher);
+		}
+
+		auto &error_token = tokens[error_token_idx];
+		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
 		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);
 	}
 	match_result->name = "Program";

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -27,6 +27,55 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformStatement(PEGTransforme
 	return result;
 }
 
+static optional_ptr<ParseResult> UnwrapOptional(optional_ptr<ParseResult> parse_result) {
+	if (parse_result && parse_result->type == ParseResultType::OPTIONAL) {
+		auto &opt = parse_result->Cast<OptionalParseResult>();
+		return opt.HasResult() ? opt.optional_result : nullptr;
+	}
+	return parse_result;
+}
+
+static optional_ptr<RepeatParseResult> UnwrapRepeat(optional_ptr<ParseResult> parse_result) {
+	auto unwrapped = UnwrapOptional(parse_result);
+	if (!unwrapped) {
+		return nullptr;
+	}
+	if (unwrapped->type != ParseResultType::REPEAT) {
+		throw InternalException("Expected repeat parse result in Program rule, got %s",
+		                        ParseResultToString(unwrapped->type));
+	}
+	// Safely wrap the reference into an optional_ptr
+	return &unwrapped->Cast<RepeatParseResult>();
+}
+
+static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &transformer,
+                                                             const vector<MatcherToken> &tokens,
+                                                             optional_ptr<ParseResult> stmt_pr,
+                                                             optional_ptr<ParseResult> terminator_pr) {
+	auto stmt = transformer.Transform<unique_ptr<SQLStatement>>(stmt_pr);
+
+	if (!transformer.named_parameter_map.empty()) {
+		stmt->named_param_map = transformer.named_parameter_map;
+	}
+	if (!transformer.pivot_entries.empty()) {
+		stmt = transformer.CreatePivotStatement(std::move(stmt));
+	}
+	transformer.Clear();
+
+	// Calculate location and length cleanly
+	if (stmt_pr->offset.IsValid()) {
+		stmt->stmt_location = stmt_pr->offset.GetIndex();
+
+		idx_t end_index = (terminator_pr && terminator_pr->offset.IsValid())
+		                      ? terminator_pr->offset.GetIndex()
+		                      : (tokens.back().offset + tokens.back().length);
+
+		stmt->stmt_length = end_index - stmt->stmt_location;
+	}
+
+	return stmt;
+}
+
 vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<MatcherToken> &tokens, ParserOptions &options,
                                                                   Matcher &root_matcher) {
 	if (tokens.empty()) {
@@ -82,80 +131,28 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 	PEGTransformer transformer(transformer_allocator, transformer_state, factory.sql_transform_functions,
 	                           factory.parser.rules, factory.enum_mappings, options);
 
-	auto transform_stmt = [&](optional_ptr<ParseResult> stmt_pr) -> unique_ptr<SQLStatement> {
-		auto stmt = transformer.Transform<unique_ptr<SQLStatement>>(stmt_pr);
-		if (!transformer.named_parameter_map.empty()) {
-			stmt->named_param_map = transformer.named_parameter_map;
-		}
-		if (!transformer.pivot_entries.empty()) {
-			stmt = transformer.CreatePivotStatement(std::move(stmt));
-		}
-		transformer.Clear();
-		if (stmt_pr->offset.IsValid()) {
-			stmt->stmt_location = stmt_pr->offset.GetIndex();
-		}
-		return stmt;
-	};
-
-	auto unwrap_optional = [](optional_ptr<ParseResult> parse_result) -> optional_ptr<ParseResult> {
-		if (!parse_result) {
-			return nullptr;
-		}
-		if (parse_result->type != ParseResultType::OPTIONAL) {
-			return parse_result;
-		}
-		auto &opt = parse_result->Cast<OptionalParseResult>();
-		if (!opt.HasResult()) {
-			return nullptr;
-		}
-		return opt.optional_result;
-	};
-	auto unwrap_repeat = [&](optional_ptr<ParseResult> parse_result) -> RepeatParseResult * {
-		auto unwrapped = unwrap_optional(parse_result);
-		if (!unwrapped) {
-			return nullptr;
-		}
-		if (unwrapped->type != ParseResultType::REPEAT) {
-			throw InternalException("Expected repeat parse result in Program rule, got %s",
-			                        ParseResultToString(unwrapped->type));
-		}
-		return &unwrapped->Cast<RepeatParseResult>();
-	};
-	auto transform_program_stmt = [&](optional_ptr<ParseResult> stmt_pr,
-	                                  optional_ptr<ParseResult> terminator_pr) -> unique_ptr<SQLStatement> {
-		auto stmt = transform_stmt(stmt_pr);
-		if (stmt_pr->offset.IsValid()) {
-			if (terminator_pr && terminator_pr->offset.IsValid()) {
-				stmt->stmt_length = terminator_pr->offset.GetIndex() - stmt_pr->offset.GetIndex();
-			} else {
-				auto &last_token = tokens.back();
-				stmt->stmt_length = last_token.offset + last_token.length - stmt_pr->offset.GetIndex();
-			}
-		}
-		return stmt;
-	};
-
 	vector<unique_ptr<SQLStatement>> result;
-	auto current_stmt = unwrap_optional(prog.GetChild(0));
-	auto repeat = unwrap_repeat(prog.GetChild(1));
+	auto current_stmt = UnwrapOptional(prog.GetChild(0));
+	auto repeat = UnwrapRepeat(prog.GetChild(1));
 	if (repeat) {
 		for (auto &child : repeat->children) {
 			auto &child_list = child->Cast<ListParseResult>();
 			auto &separators = child_list.Child<RepeatParseResult>(0);
 			auto next_stmt = child_list.GetChild(1);
 			if (current_stmt) {
-				result.push_back(transform_program_stmt(current_stmt, separators.children[0]));
+				result.push_back(
+				    ExtractAndTransformStatement(transformer, tokens, current_stmt, separators.children[0]));
 			}
 			current_stmt = next_stmt;
 		}
 	}
 	if (current_stmt) {
-		auto trailing_repeat = unwrap_repeat(prog.GetChild(2));
+		auto trailing_repeat = UnwrapRepeat(prog.GetChild(2));
 		optional_ptr<ParseResult> trailing_terminator = nullptr;
 		if (trailing_repeat && !trailing_repeat->children.empty()) {
 			trailing_terminator = trailing_repeat->children[0];
 		}
-		result.push_back(transform_program_stmt(current_stmt, trailing_terminator));
+		result.push_back(ExtractAndTransformStatement(transformer, tokens, current_stmt, trailing_terminator));
 	}
 	return result;
 }

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -29,7 +29,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformStatement(PEGTransforme
 
 static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &transformer,
                                                              const vector<MatcherToken> &tokens, ParseResult &stmt_pr,
-                                                             optional_ptr<ParseResult> terminator_pr) {
+                                                             optional_idx terminator_offset) {
 	auto stmt = transformer.Transform<unique_ptr<SQLStatement>>(stmt_pr);
 
 	if (!transformer.named_parameter_map.empty()) {
@@ -44,9 +44,8 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 	if (stmt_pr.offset.IsValid()) {
 		stmt->stmt_location = stmt_pr.offset.GetIndex();
 
-		idx_t end_index = (terminator_pr && terminator_pr->offset.IsValid())
-		                      ? terminator_pr->offset.GetIndex()
-		                      : (tokens.back().offset + tokens.back().length);
+		idx_t end_index =
+		    terminator_offset.IsValid() ? terminator_offset.GetIndex() : (tokens.back().offset + tokens.back().length);
 
 		stmt->stmt_length = end_index - stmt->stmt_location;
 	}
@@ -127,18 +126,18 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 				auto separator_children = separators.GetChildren();
 				auto &separator_terminator = separator_children[0].get();
 				result.push_back(
-				    ExtractAndTransformStatement(transformer, tokens, *current_stmt, separator_terminator));
+				    ExtractAndTransformStatement(transformer, tokens, *current_stmt, separator_terminator.offset));
 			}
 			current_stmt = next_stmt;
 		}
 	}
 	if (current_stmt) {
-		optional_ptr<ParseResult> trailing_terminator = nullptr;
+		optional_idx trailing_terminator;
 		auto &trailing_repeat = prog.Child<OptionalParseResult>(2);
 		if (trailing_repeat.HasResult()) {
 			auto trailing_children = trailing_repeat.GetResult().Cast<RepeatParseResult>().GetChildren();
 			if (!trailing_children.empty()) {
-				trailing_terminator = trailing_children[0].get();
+				trailing_terminator = trailing_children[0].get().offset;
 			}
 		}
 		result.push_back(ExtractAndTransformStatement(transformer, tokens, *current_stmt, trailing_terminator));

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -27,8 +27,11 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformStatement(PEGTransforme
 	return result;
 }
 
-unique_ptr<SQLStatement> PEGTransformerFactory::Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-                                                          Matcher &root_matcher) {
+vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<MatcherToken> &tokens, ParserOptions &options,
+                                                                  Matcher &root_matcher) {
+	if (tokens.empty()) {
+		return {};
+	}
 	string token_stream;
 	for (auto &token : tokens) {
 		token_stream += token.text + " ";
@@ -45,30 +48,128 @@ unique_ptr<SQLStatement> PEGTransformerFactory::Transform(vector<MatcherToken> &
 			error_token_idx = tokens.size() - 1;
 		}
 		auto &error_token = tokens[error_token_idx];
-		string token_list;
-		for (idx_t i = 0; i < tokens.size(); i++) {
-			if (!token_list.empty()) {
-				token_list += "\n";
+		auto error_text = error_token.text;
+		if (error_text == ";") {
+			vector<char> expected_closers;
+			for (idx_t i = 0; i <= error_token_idx; i++) {
+				auto &token = tokens[i].text;
+				if (token == "(") {
+					expected_closers.push_back(')');
+				} else if (token == "[") {
+					expected_closers.push_back(']');
+				} else if (token == "{") {
+					expected_closers.push_back('}');
+				} else if (!expected_closers.empty() && token.length() == 1 && token[0] == expected_closers.back()) {
+					expected_closers.pop_back();
+				}
 			}
-			if (i < 10) {
-				token_list += " ";
+			if (!expected_closers.empty()) {
+				if (error_token_idx > 0) {
+					auto &previous_token = tokens[error_token_idx - 1];
+					auto prefer_closer = previous_token.type == TokenType::NUMBER_LITERAL ||
+					                     previous_token.type == TokenType::STRING_LITERAL ||
+					                     previous_token.type == TokenType::OPERATOR || previous_token.text == ")" ||
+					                     previous_token.text == "]" || previous_token.text == "}";
+					error_text = prefer_closer ? string(1, expected_closers.back()) : previous_token.text;
+				} else {
+					error_text = string(1, expected_closers.back());
+				}
+			} else if (error_token_idx > 0) {
+				error_text = tokens[error_token_idx - 1].text;
 			}
-			token_list += to_string(i) + ":" + tokens[i].text;
 		}
-		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
+		auto error_message = "syntax error at or near \"" + error_text + "\"";
 		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);
 	}
-	match_result->name = "Statement";
+	match_result->name = "Program";
+
+	// Program <- Statement? (';'+ Statement)* ';'*
+	// Program[0] = optional first Statement
+	// Program[1] = optional repeat of groups: (';'+ Statement)
+	// Program[2] = optional repeat of trailing ';'
+	auto &prog = match_result->Cast<ListParseResult>();
+
 	ArenaAllocator transformer_allocator(Allocator::DefaultAllocator());
 	PEGTransformerState transformer_state(tokens);
 	auto &factory = GetInstance();
 	PEGTransformer transformer(transformer_allocator, transformer_state, factory.sql_transform_functions,
 	                           factory.parser.rules, factory.enum_mappings, options);
-	auto result = transformer.Transform<unique_ptr<SQLStatement>>(*match_result);
-	if (!transformer.pivot_entries.empty()) {
-		result = transformer.CreatePivotStatement(std::move(result));
+
+	auto transform_stmt = [&](optional_ptr<ParseResult> stmt_pr) -> unique_ptr<SQLStatement> {
+		auto stmt = transformer.Transform<unique_ptr<SQLStatement>>(stmt_pr);
+		if (!transformer.named_parameter_map.empty()) {
+			stmt->named_param_map = transformer.named_parameter_map;
+		}
+		if (!transformer.pivot_entries.empty()) {
+			stmt = transformer.CreatePivotStatement(std::move(stmt));
+		}
+		transformer.Clear();
+		if (stmt_pr->offset.IsValid()) {
+			stmt->stmt_location = stmt_pr->offset.GetIndex();
+		}
+		return stmt;
+	};
+
+	auto unwrap_optional = [](optional_ptr<ParseResult> parse_result) -> optional_ptr<ParseResult> {
+		if (!parse_result) {
+			return nullptr;
+		}
+		if (parse_result->type != ParseResultType::OPTIONAL) {
+			return parse_result;
+		}
+		auto &opt = parse_result->Cast<OptionalParseResult>();
+		if (!opt.HasResult()) {
+			return nullptr;
+		}
+		return opt.optional_result;
+	};
+	auto unwrap_repeat = [&](optional_ptr<ParseResult> parse_result) -> RepeatParseResult * {
+		auto unwrapped = unwrap_optional(parse_result);
+		if (!unwrapped) {
+			return nullptr;
+		}
+		if (unwrapped->type != ParseResultType::REPEAT) {
+			throw InternalException("Expected repeat parse result in Program rule, got %s",
+			                        ParseResultToString(unwrapped->type));
+		}
+		return &unwrapped->Cast<RepeatParseResult>();
+	};
+	auto transform_program_stmt = [&](optional_ptr<ParseResult> stmt_pr,
+	                                  optional_ptr<ParseResult> terminator_pr) -> unique_ptr<SQLStatement> {
+		auto stmt = transform_stmt(stmt_pr);
+		if (stmt_pr->offset.IsValid()) {
+			if (terminator_pr && terminator_pr->offset.IsValid()) {
+				stmt->stmt_length = terminator_pr->offset.GetIndex() - stmt_pr->offset.GetIndex();
+			} else {
+				auto &last_token = tokens.back();
+				stmt->stmt_length = last_token.offset + last_token.length - stmt_pr->offset.GetIndex();
+			}
+		}
+		return stmt;
+	};
+
+	vector<unique_ptr<SQLStatement>> result;
+	auto current_stmt = unwrap_optional(prog.GetChild(0));
+	auto repeat = unwrap_repeat(prog.GetChild(1));
+	if (repeat) {
+		for (auto &child : repeat->children) {
+			auto &child_list = child->Cast<ListParseResult>();
+			auto &separators = child_list.Child<RepeatParseResult>(0);
+			auto next_stmt = child_list.GetChild(1);
+			if (current_stmt) {
+				result.push_back(transform_program_stmt(current_stmt, separators.children[0]));
+			}
+			current_stmt = next_stmt;
+		}
 	}
-	transformer.Clear();
+	if (current_stmt) {
+		auto trailing_repeat = unwrap_repeat(prog.GetChild(2));
+		optional_ptr<ParseResult> trailing_terminator = nullptr;
+		if (trailing_repeat && !trailing_repeat->children.empty()) {
+			trailing_terminator = trailing_repeat->children[0];
+		}
+		result.push_back(transform_program_stmt(current_stmt, trailing_terminator));
+	}
 	return result;
 }
 

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -27,30 +27,8 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformStatement(PEGTransforme
 	return result;
 }
 
-static optional_ptr<ParseResult> UnwrapOptional(optional_ptr<ParseResult> parse_result) {
-	if (parse_result && parse_result->type == ParseResultType::OPTIONAL) {
-		auto &opt = parse_result->Cast<OptionalParseResult>();
-		return opt.HasResult() ? opt.optional_result : nullptr;
-	}
-	return parse_result;
-}
-
-static optional_ptr<RepeatParseResult> UnwrapRepeat(optional_ptr<ParseResult> parse_result) {
-	auto unwrapped = UnwrapOptional(parse_result);
-	if (!unwrapped) {
-		return nullptr;
-	}
-	if (unwrapped->type != ParseResultType::REPEAT) {
-		throw InternalException("Expected repeat parse result in Program rule, got %s",
-		                        ParseResultToString(unwrapped->type));
-	}
-	// Safely wrap the reference into an optional_ptr
-	return &unwrapped->Cast<RepeatParseResult>();
-}
-
 static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &transformer,
-                                                             const vector<MatcherToken> &tokens,
-                                                             optional_ptr<ParseResult> stmt_pr,
+                                                             const vector<MatcherToken> &tokens, ParseResult &stmt_pr,
                                                              optional_ptr<ParseResult> terminator_pr) {
 	auto stmt = transformer.Transform<unique_ptr<SQLStatement>>(stmt_pr);
 
@@ -63,8 +41,8 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 	transformer.Clear();
 
 	// Calculate location and length cleanly
-	if (stmt_pr->offset.IsValid()) {
-		stmt->stmt_location = stmt_pr->offset.GetIndex();
+	if (stmt_pr.offset.IsValid()) {
+		stmt->stmt_location = stmt_pr.offset.GetIndex();
 
 		idx_t end_index = (terminator_pr && terminator_pr->offset.IsValid())
 		                      ? terminator_pr->offset.GetIndex()
@@ -132,27 +110,38 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 	                           factory.parser.rules, factory.enum_mappings, options);
 
 	vector<unique_ptr<SQLStatement>> result;
-	auto current_stmt = UnwrapOptional(prog.GetChild(0));
-	auto repeat = UnwrapRepeat(prog.GetChild(1));
-	if (repeat) {
-		for (auto &child : repeat->children) {
-			auto &child_list = child->Cast<ListParseResult>();
+	optional_ptr<ParseResult> current_stmt;
+	auto &first_stmt = prog.Child<OptionalParseResult>(0);
+	if (first_stmt.HasResult()) {
+		current_stmt = first_stmt.GetResult();
+	}
+
+	auto &statement_repeat = prog.Child<OptionalParseResult>(1);
+	if (statement_repeat.HasResult()) {
+		auto &repeat = statement_repeat.GetResult().Cast<RepeatParseResult>();
+		for (auto &child : repeat.GetChildren()) {
+			auto &child_list = child.get().Cast<ListParseResult>();
 			auto &separators = child_list.Child<RepeatParseResult>(0);
-			auto next_stmt = child_list.GetChild(1);
+			auto &next_stmt = child_list.GetChild(1);
 			if (current_stmt) {
+				auto separator_children = separators.GetChildren();
+				auto &separator_terminator = separator_children[0].get();
 				result.push_back(
-				    ExtractAndTransformStatement(transformer, tokens, current_stmt, separators.children[0]));
+				    ExtractAndTransformStatement(transformer, tokens, *current_stmt, separator_terminator));
 			}
 			current_stmt = next_stmt;
 		}
 	}
 	if (current_stmt) {
-		auto trailing_repeat = UnwrapRepeat(prog.GetChild(2));
 		optional_ptr<ParseResult> trailing_terminator = nullptr;
-		if (trailing_repeat && !trailing_repeat->children.empty()) {
-			trailing_terminator = trailing_repeat->children[0];
+		auto &trailing_repeat = prog.Child<OptionalParseResult>(2);
+		if (trailing_repeat.HasResult()) {
+			auto trailing_children = trailing_repeat.GetResult().Cast<RepeatParseResult>().GetChildren();
+			if (!trailing_children.empty()) {
+				trailing_terminator = trailing_children[0].get();
+			}
 		}
-		result.push_back(ExtractAndTransformStatement(transformer, tokens, current_stmt, trailing_terminator));
+		result.push_back(ExtractAndTransformStatement(transformer, tokens, *current_stmt, trailing_terminator));
 	}
 	return result;
 }


### PR DESCRIPTION
Prior to this change, the tokenizer had control over where and when to split statements based on the semicolon. However, I think that the grammar should be responsible for that.

**Why is that relevant?**

It is currently impossible (or rather: pointless) to define grammar rules like this:
```
DuckPLStatements <- SemiList(DuckPLStatement)
DuckPLStatement <- DuckPLReturn / DuckPLAssign / ...

SemiList1(D) <- D (';' D)*
SemiList(D) <- SemiList1(D) ';'?
```

This is because the tokenizer would assume the statement ends at the first ';' encountered, leaving us with a bunch of separate statements, which is not what we want. By moving the responsibility of splitting statements to the grammar, we can define more complex statements that may contain multiple semicolons without the tokenizer interfering.