### PR TITLE
Fix wrong cast in expression_heuristics.cpp

### DIFF
--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -211,7 +211,7 @@ idx_t ExpressionHeuristics::Cost(Expression &expr) {
 		return ExpressionCost(const_expr.return_type.InternalType(), 1);
 	}
 	case ExpressionClass::BOUND_REF: {
-		auto &col_expr = expr.Cast<BoundColumnRefExpression>();
+		auto &col_expr = expr.Cast<BoundReferenceExpression>();
 		return ExpressionCost(col_expr.return_type.InternalType(), 8);
 	}
 	default: {


### PR DESCRIPTION
The code matches `ExpressionClass::BOUND_REF`, but casts to `BoundColumnRefExpression`, instead of `BoundReferenceExpression`.