### PR TITLE
Parquet writer: allow partial variant shredding in Parquet, instead of bailing out when a single struct field does not match

### DIFF
--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -160,9 +160,14 @@ static bool ConstructShreddedType(const VariantAnalyzeData &state, LogicalType &
 			for (auto &field : object_data.fields) {
 				LogicalType child_type;
 				if (!ConstructShreddedType(field.second, child_type)) {
-					return false;
+					// cannot shred on this field - skip
+					continue;
 				}
 				field_types.emplace_back(field.first, child_type);
+			}
+			if (field_types.empty()) {
+				// no field types to shred on - avoid shredding
+				return false;
 			}
 			out = LogicalType::STRUCT(field_types);
 			return true;

--- a/test/parquet/variant/variant_write_partially_shredded.test
+++ b/test/parquet/variant/variant_write_partially_shredded.test
@@ -1,0 +1,28 @@
+# name: test/parquet/variant/variant_write_partially_shredded.test
+# group: [variant]
+
+require parquet
+
+# Verify we can perform partial shredding
+statement ok
+COPY (
+	SELECT {
+		'field1': CASE WHEN i%2=0 THEN CONCAT('hello', i)::VARIANT ELSE i::VARIANT END,
+		'field2': i::INT
+	}::VARIANT AS obj
+	FROM range(5) t(i)
+) TO '{TEST_DIR}/partially_shredded_struct.parquet';
+
+query II
+SELECT p.obj.field1, p.obj.field2 FROM '{TEST_DIR}/partially_shredded_struct.parquet' p;
+----
+hello0	0
+1	1
+hello2	2
+3	3
+hello4	4
+
+query I
+SELECT COUNT(*) > 0 FROM parquet_schema('{TEST_DIR}/partially_shredded_struct.parquet') WHERE name='typed_value';
+----
+1


### PR DESCRIPTION
Otherwise in case of any inconsistencies we will fully bail out on shredding, instead of at least partially shredding.