### PR TITLE
Add default compression type support for extension types

### DIFF
--- a/src/include/duckdb/common/extension_type_info.hpp
+++ b/src/include/duckdb/common/extension_type_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/enums/compression_type.hpp"
 #include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
@@ -27,6 +28,9 @@ public:
 struct ExtensionTypeInfo {
 	vector<LogicalTypeModifier> modifiers;
 	unordered_map<string, Value> properties;
+
+	//! Default compression method for columns of this type. COMPRESSION_AUTO means no preference.
+	CompressionType default_compression = CompressionType::COMPRESSION_AUTO;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/src/include/duckdb/storage/serialization/types.json
+++ b/src/include/duckdb/storage/serialization/types.json
@@ -37,6 +37,12 @@
         "name": "properties",
         "type": "unordered_map<string, Value>",
         "default": "unordered_map<string, Value>()"
+      },
+      {
+        "id": 102,
+        "name": "default_compression",
+        "type": "CompressionType",
+        "default": "CompressionType::COMPRESSION_AUTO"
       }
     ]
   },

--- a/src/storage/serialization/serialize_types.cpp
+++ b/src/storage/serialization/serialize_types.cpp
@@ -146,7 +146,7 @@ unique_ptr<ExtensionTypeInfo> ExtensionTypeInfo::Deserialize(Deserializer &deser
 	auto result = duckdb::unique_ptr<ExtensionTypeInfo>(new ExtensionTypeInfo());
 	deserializer.ReadPropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", result->modifiers);
 	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(101, "properties", result->properties, unordered_map<string, Value>());
-	result->default_compression = deserializer.ReadPropertyWithExplicitDefault<CompressionType>(102, "default_compression", CompressionType::COMPRESSION_AUTO);
+	deserializer.ReadPropertyWithExplicitDefault<CompressionType>(102, "default_compression", result->default_compression, CompressionType::COMPRESSION_AUTO);
 	return result;
 }
 

--- a/src/storage/serialization/serialize_types.cpp
+++ b/src/storage/serialization/serialize_types.cpp
@@ -139,12 +139,14 @@ shared_ptr<ExtraTypeInfo> DecimalTypeInfo::Deserialize(Deserializer &deserialize
 void ExtensionTypeInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", modifiers);
 	serializer.WritePropertyWithDefault<unordered_map<string, Value>>(101, "properties", properties, unordered_map<string, Value>());
+	serializer.WritePropertyWithDefault<CompressionType>(102, "default_compression", default_compression, CompressionType::COMPRESSION_AUTO);
 }
 
 unique_ptr<ExtensionTypeInfo> ExtensionTypeInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ExtensionTypeInfo>(new ExtensionTypeInfo());
 	deserializer.ReadPropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", result->modifiers);
 	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(101, "properties", result->properties, unordered_map<string, Value>());
+	result->default_compression = deserializer.ReadPropertyWithExplicitDefault<CompressionType>(102, "default_compression", CompressionType::COMPRESSION_AUTO);
 	return result;
 }
 

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/table/column_data_checkpointer.hpp"
 
+#include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/settings.hpp"
@@ -172,6 +173,16 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 			forced_methods[i] = ForceCompression(storage_manager, functions, compression_type);
 		}
 		if (compression_type == CompressionType::COMPRESSION_AUTO) {
+			// Check if the column's type has a default compression preference
+			auto &col_data = checkpoint_states[i].get().original_column;
+			if (col_data.type.HasExtensionInfo()) {
+				auto &ext_info = *col_data.type.GetExtensionInfo();
+				if (ext_info.default_compression != CompressionType::COMPRESSION_AUTO) {
+					forced_methods[i] = ForceCompression(storage_manager, functions, ext_info.default_compression);
+				}
+			}
+		}
+		if (forced_methods[i] == CompressionType::COMPRESSION_AUTO) {
 			auto force_compression = Settings::Get<ForceCompressionSetting>(config);
 			if (force_compression != CompressionType::COMPRESSION_AUTO) {
 				forced_methods[i] = ForceCompression(storage_manager, functions, force_compression);


### PR DESCRIPTION
## Summary

- Adds a `default_compression` field to `ExtensionTypeInfo`, allowing extensions to specify a preferred compression method for their custom types
- The column data checkpointer respects this preference during checkpointing, falling back to the global `force_compression` setting if no preference is set
- Serialization is backward-compatible using `WritePropertyWithDefault`/`ReadPropertyWithExplicitDefault` with `COMPRESSION_AUTO` as the default

I have the [`GEOSILO`](https://github.com/Query-farm/geosilo) type that is a BLOB like type that works really well with zstd compression. I'd like to allow users to use without forcing them to have to specify `geom GEOSILO('EPSG:4326') USING COMPRESSION zstd`.  
