### PR TITLE
Add statistics hooks for extension types

### DIFF
--- a/src/include/duckdb/common/extension_type_info.hpp
+++ b/src/include/duckdb/common/extension_type_info.hpp
@@ -7,6 +7,10 @@ namespace duckdb {
 
 class Serializer;
 class Deserializer;
+class BaseStatistics;
+
+// Forward-declare StatisticsType (defined in base_statistics.hpp)
+enum class StatisticsType : uint8_t;
 
 struct LogicalTypeModifier {
 public:
@@ -24,9 +28,27 @@ public:
 	static LogicalTypeModifier Deserialize(Deserializer &source);
 };
 
+//! Callback type for custom statistics collection on extension type values.
+//! Called during checkpoint to update column statistics from each value.
+typedef void (*extension_stats_update_t)(BaseStatistics &stats, const string_t &value);
+
 struct ExtensionTypeInfo {
 	vector<LogicalTypeModifier> modifiers;
 	unordered_map<string, Value> properties;
+
+	//! Override the statistics type used for columns of this extension type.
+	//! When set to a valid StatisticsType (e.g., GEOMETRY_STATS), the column uses that
+	//! statistics format instead of the default for its physical type.
+	//! Default: unset (255) — use the base type's default statistics.
+	static constexpr uint8_t STATS_TYPE_DEFAULT = 255;
+	uint8_t stats_type = STATS_TYPE_DEFAULT;
+
+	//! Custom statistics update function for extension types.
+	//! If non-null, called instead of the default statistics Update function when
+	//! collecting column statistics during checkpoint. This allows extension types
+	//! to parse their custom binary format and produce correct statistics.
+	//! Not serialized — restored when the extension is loaded.
+	extension_stats_update_t stats_update = nullptr;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/src/include/duckdb/storage/serialization/types.json
+++ b/src/include/duckdb/storage/serialization/types.json
@@ -37,6 +37,12 @@
         "name": "properties",
         "type": "unordered_map<string, Value>",
         "default": "unordered_map<string, Value>()"
+      },
+      {
+        "id": 102,
+        "name": "stats_type",
+        "type": "uint8_t",
+        "default": "STATS_TYPE_DEFAULT"
       }
     ]
   },

--- a/src/storage/serialization/serialize_types.cpp
+++ b/src/storage/serialization/serialize_types.cpp
@@ -139,12 +139,14 @@ shared_ptr<ExtraTypeInfo> DecimalTypeInfo::Deserialize(Deserializer &deserialize
 void ExtensionTypeInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", modifiers);
 	serializer.WritePropertyWithDefault<unordered_map<string, Value>>(101, "properties", properties, unordered_map<string, Value>());
+	serializer.WritePropertyWithDefault<uint8_t>(102, "stats_type", stats_type, STATS_TYPE_DEFAULT);
 }
 
 unique_ptr<ExtensionTypeInfo> ExtensionTypeInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ExtensionTypeInfo>(new ExtensionTypeInfo());
 	deserializer.ReadPropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", result->modifiers);
 	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(101, "properties", result->properties, unordered_map<string, Value>());
+	deserializer.ReadPropertyWithExplicitDefault<uint8_t>(102, "stats_type", result->stats_type, STATS_TYPE_DEFAULT);
 	return result;
 }
 

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/function/variant/variant_shredding.hpp"
@@ -65,6 +66,13 @@ BaseStatistics &BaseStatistics::operator=(BaseStatistics &&other) noexcept {
 StatisticsType BaseStatistics::GetStatsType(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::SQLNULL) {
 		return StatisticsType::BASE_STATS;
+	}
+	// Extension types can override the statistics type
+	if (type.HasExtensionInfo()) {
+		auto &ext_info = *type.GetExtensionInfo();
+		if (ext_info.stats_type != ExtensionTypeInfo::STATS_TYPE_DEFAULT) {
+			return static_cast<StatisticsType>(ext_info.stats_type);
+		}
 	}
 	if (type.id() == LogicalTypeId::GEOMETRY) {
 		return StatisticsType::GEOMETRY_STATS;

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/storage/statistics/geometry_stats.hpp"
+#include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -178,6 +179,17 @@ child_list_t<Value> GeometryStats::ToStruct(const BaseStatistics &stats) {
 }
 
 void GeometryStats::Update(BaseStatistics &stats, const string_t &value) {
+	// Check if the column's extension type provides a custom update function.
+	// This allows extension types (e.g., compact geometry encodings) to produce
+	// correct geometry statistics from their own binary format.
+	auto &type = stats.GetType();
+	if (type.HasExtensionInfo()) {
+		auto ext_info = type.GetExtensionInfo();
+		if (ext_info && ext_info->stats_update) {
+			ext_info->stats_update(stats, value);
+			return;
+		}
+	}
 	auto &data = GetDataUnsafe(stats);
 	data.Update(value);
 }


### PR DESCRIPTION
## Summary

- Allow extension types to override column statistics type and provide custom statistics collection
- Enables extensions with custom binary geometry formats to produce correct `GEOMETRY_STATS` (bounding box extent, geometry type set, flags) for zone map pruning and predicate pushdown

## Motivation

Extension types that store geometry in custom binary formats (e.g., delta-encoded compact coordinates) currently get only `STRING_STATS` or `BASE_STATS` because the statistics type dispatch is hardcoded to `LogicalTypeId`. This means no bounding box tracking and no spatial predicate pushdown for these columns.  This affects my [`GEOSILO`](https://github.com/Query-farm/geosilo) data type that stores a geometry in a blob, but doesn't have a way to provide GEOMETRY_STATS.

With this change, an extension can set `stats_type = GEOMETRY_STATS` on its `ExtensionTypeInfo` and provide a `stats_update` callback that parses the extension's binary format and updates the standard `GeometryStatsData` (extent, types, flags). DuckDB's zone map pruning and `&&`/`st_intersects_extent` predicate pushdown then work automatically.

## Changes

Two new fields on `ExtensionTypeInfo`:
- **`stats_type`** (`uint8_t`, default 255=auto): Override the `StatisticsType` for columns of this type. Serialized to disk so stats remain readable across sessions.
- **`stats_update`** (`extension_stats_update_t`, default null): Callback for custom statistics collection. Called instead of the default `Update` during checkpoint. Not serialized — restored when the extension is loaded.

Integration points:
- `BaseStatistics::GetStatsType()`: checks extension info before the `LogicalTypeId` switch
- `GeometryStats::Update()`: delegates to custom callback if provided
- `ExtensionTypeInfo::Serialize/Deserialize`: persists `stats_type`

## Usage

```cpp
auto info = make_uniq<ExtensionTypeInfo>();
// Use GEOMETRY_STATS format (bounding box, type set, flags)
info->stats_type = static_cast<uint8_t>(StatisticsType::GEOMETRY_STATS);
// Custom update that parses our binary format instead of WKB
info->stats_update = MyExtensionStatsUpdate;
type.SetExtensionInfo(std::move(info));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)