### PR TITLE
Unlock transaction lock during fallback WAL write

### DIFF
--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -363,7 +363,10 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 			// we have not written to the WAL but we have now realized we can't checkpoint after all
 			// in order to commit we need backpeddle and write to the WAL after all
 			D_ASSERT(held_wal_lock);
+			// unlock the transaction lock while we are writing to the WAL
+			t_lock.unlock();
 			error = transaction.WriteToWAL(context, db, commit_state);
+			t_lock.lock();
 			skip_wal_write_due_to_checkpoint = false;
 		}
 	}


### PR DESCRIPTION
In the above code path we unlock transactions during the WAL write, allowing new transactions to start while doing this I/O operation. During the fallback WAL write we were still holding the transaction lock, which is not required, so we can unlock it.

* New transactions can start, but because we are holding the WAL lock write transactions can't finish (commit) and overtake us since they would also need to take the WAL lock in order to commit
* The locking order `WAL lock -> transaction lock` is the same as the locking order above, so this does not introduce any lock order inversions / potential deadlocks