### PR TITLE
Fix SIGSEGV when querying Iceberg MAP columns with WHERE clause

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -208,6 +208,9 @@ bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
 	if (local_column.type != global_column.type) {
 		return false;
 	}
+	if (global_column.type.id() == LogicalTypeId::MAP) {
+		return true;
+	}
 	if (local_column.children.size() != global_column.children.size()) {
 		// child count difference - cannot map trivially
 		return false;


### PR DESCRIPTION
## Problem

Querying an Iceberg table that contains a `MAP` column crashes with SIGSEGV (or `double free or corruption`) when a `WHERE` clause is present.

```sql
-- Works
SELECT map_col FROM iceberg_scan('table/metadata/v1.metadata.json') LIMIT 10;

-- Works (no MAP column selected)
SELECT id FROM iceberg_scan('table/metadata/v1.metadata.json') WHERE id > 5;

-- SIGSEGV
SELECT map_col FROM iceberg_scan('table/metadata/v1.metadata.json') WHERE id > 5;
```

## Root Cause

Iceberg and Parquet represent `MAP` children differently in `MultiFileColumnDefinition`:

```
Iceberg global schema:          Parquet local schema:
  scores: MAP(int, float)         scores: MAP(int, float)
    ├── key   (field_id=4)          └── key_value  (no field_id)
    └── value (field_id=5)              ├── key   (field_id=4)
    children.size() = 2                 └── value (field_id=5)
                                    children.size() = 1
```

`IsTriviallyMappable` compares `children.size()` (2 ≠ 1) and returns `false`, even though the `LogicalType` is identical on both sides. This forces the column through `MapColumnMap` → `ConstructMapExpression` → `remap_struct`.

The `RemapMap` function in `remap_struct.cpp` then corrupts Vector internals — it uses `Reference()` to make the result MAP's key/value child vectors point to the input's child vector memory, causing a double-free when both are destructed.

Without `WHERE`, DuckDB uses a streaming collector that never materializes the Vector into `ColumnDataCollection`, so the corruption is not exposed. With `WHERE`, the batch materialization path (`ColumnDataCollection::Append`) recursively traverses the corrupted Vector tree and crashes.

## Fix

In `IsTriviallyMappable`, return `true` for MAP columns when `LogicalType` equality has already been confirmed:

```cpp
if (local_column.type != global_column.type) {
    return false;
}
if (global_column.type.id() == LogicalTypeId::MAP) {
    return true;
}
if (local_column.children.size() != global_column.children.size()) {
    ...
```

This is safe because:

- `LogicalType::MAP(K, V)` encodes the full key and value types. The preceding `type !=` check already rejects any key/value type mismatch (including schema evolution cases).
- The children structure difference (`[key, value]` vs `[key_value]`) is purely a metadata representation difference between Iceberg and Parquet specs, not a data layout difference.
- With `IsTriviallyMappable` returning `true`, `ConstructMapExpression` takes the direct-cast path (line 590) and `filter_conversion` is set to `COPY_DIRECTLY`, both of which are correct for type-identical MAPs.