### PR TITLE
Json function should be set CanThrow

### DIFF
--- a/extension/json/json_functions/json_array_length.cpp
+++ b/extension/json/json_functions/json_array_length.cpp
@@ -32,6 +32,12 @@ ScalarFunctionSet JSONFunctions::GetArrayLengthFunction() {
 	ScalarFunctionSet set("json_array_length");
 	GetArrayLengthFunctionsInternal(set, LogicalType::VARCHAR);
 	GetArrayLengthFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments.size() == 1 && func.arguments[0].IsJSONType()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -146,6 +146,9 @@ ScalarFunctionSet JSONFunctions::GetContainsFunction() {
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, LogicalType::VARCHAR);
 	GetContainsFunctionInternal(set, LogicalType::VARCHAR, LogicalType::JSON());
 	GetContainsFunctionInternal(set, LogicalType::JSON(), LogicalType::VARCHAR);
+	for (auto &func : set.functions) {
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	GetContainsFunctionInternal(set, LogicalType::JSON(), LogicalType::JSON());
 	// TODO: implement json_contains that accepts path argument as well
 

--- a/extension/json/json_functions/json_exists.cpp
+++ b/extension/json/json_functions/json_exists.cpp
@@ -26,6 +26,9 @@ ScalarFunctionSet JSONFunctions::GetExistsFunction() {
 	ScalarFunctionSet set("json_exists");
 	GetExistsFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExistsFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -50,6 +50,12 @@ ScalarFunctionSet JSONFunctions::GetExtractFunction() {
 	ScalarFunctionSet set("json_extract");
 	GetExtractFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments[0].IsJSONType() && func.arguments[1].IsNumeric()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 
@@ -68,6 +74,12 @@ ScalarFunctionSet JSONFunctions::GetExtractStringFunction() {
 	ScalarFunctionSet set("json_extract_string");
 	GetExtractStringFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractStringFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments[0].IsJSONType() && func.arguments[1].IsNumeric()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_keys.cpp
+++ b/extension/json/json_functions/json_keys.cpp
@@ -53,6 +53,12 @@ ScalarFunctionSet JSONFunctions::GetKeysFunction() {
 	ScalarFunctionSet set("json_keys");
 	GetJSONKeysFunctionsInternal(set, LogicalType::VARCHAR);
 	GetJSONKeysFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments.size() == 1 && func.arguments[0].IsJSONType()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -534,6 +534,9 @@ static void GetStructureFunctionInternal(ScalarFunctionSet &set, const LogicalTy
 ScalarFunctionSet JSONFunctions::GetStructureFunction() {
 	ScalarFunctionSet set("json_structure");
 	GetStructureFunctionInternal(set, LogicalType::VARCHAR);
+	for (auto &func : set.functions) {
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	GetStructureFunctionInternal(set, LogicalType::JSON());
 	return set;
 }

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -995,6 +995,9 @@ ScalarFunctionSet JSONFunctions::GetTransformFunction() {
 	ScalarFunctionSet set("json_transform");
 	GetTransformFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformFunctionInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 
@@ -1007,6 +1010,9 @@ ScalarFunctionSet JSONFunctions::GetTransformStrictFunction() {
 	ScalarFunctionSet set("json_transform_strict");
 	GetTransformStrictFunctionInternal(set, LogicalType::VARCHAR);
 	GetTransformStrictFunctionInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -32,6 +32,12 @@ ScalarFunctionSet JSONFunctions::GetTypeFunction() {
 	ScalarFunctionSet set("json_type");
 	GetTypeFunctionsInternal(set, LogicalType::VARCHAR);
 	GetTypeFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments.size() == 1 && func.arguments[0].IsJSONType()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/extension/json/json_functions/json_value.cpp
+++ b/extension/json/json_functions/json_value.cpp
@@ -25,6 +25,12 @@ ScalarFunctionSet JSONFunctions::GetValueFunction() {
 	ScalarFunctionSet set("json_value");
 	GetValueFunctionsInternal(set, LogicalType::VARCHAR);
 	GetValueFunctionsInternal(set, LogicalType::JSON());
+	for (auto &func : set.functions) {
+		if (func.arguments[0].IsJSONType() && func.arguments[1].IsNumeric()) {
+			continue;
+		}
+		func.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 	return set;
 }
 

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -232,6 +232,10 @@ bool BoundCastExpression::CanThrow() const {
 	    LogicalType::ForceMaxLogicalType(return_type, child_type) == child_type.id()) {
 		return true;
 	}
+	// Casting VARCHAR to JSON involves parsing and validation that can throw on malformed input
+	if (return_type.IsJSONType() && !child_type.IsJSONType()) {
+		return true;
+	}
 	bool changes_type = false;
 	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) { changes_type |= child.CanThrow(); });
 	return changes_type;


### PR DESCRIPTION
In current JSON function implementations, a runtime error is thrown if there is a JSON parsing error or a path parsing error. However, none of the JSON functions have set CAN_THROW_RUNTIME_ERROR. This can cause filters to be incorrectly reordered, such as `json_valid(text) = 1` and `json_extract(text, path) is not null`. 
```
CREATE TABLE t1 (text varchar);
INSERT INTO t1 VALUES ('{"a":a1}');
SELECT * FROM t1 WHERE json_valid(text) = 1 and (json_extract(text,'$.a') is not null);
```

In addition, type conversion from VARCHAR to JSON can also throw error, but `BoundCastExpression::CanThrow` does not consider this.