### PR TITLE
Shred unsigned types in VARIANT when writing to Parquet

### DIFF
--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -137,6 +137,14 @@ static bool ConstructShreddedType(const VariantAnalyzeData &state, LogicalType &
 	CheckPrimitive<VariantLogicalType::BLOB, LogicalTypeId::BLOB>(state, result);
 	CheckPrimitive<VariantLogicalType::VARCHAR, LogicalTypeId::VARCHAR>(state, result);
 	CheckPrimitive<VariantLogicalType::UUID, LogicalTypeId::UUID>(state, result);
+	// these types are not natively supported in Parquet - we convert them during write
+	// during analysis map them to the type we convert them into
+	CheckPrimitive<VariantLogicalType::UINT8, LogicalTypeId::SMALLINT>(state, result);
+	CheckPrimitive<VariantLogicalType::UINT16, LogicalTypeId::INTEGER>(state, result);
+	CheckPrimitive<VariantLogicalType::UINT32, LogicalTypeId::BIGINT>(state, result);
+	CheckPrimitive<VariantLogicalType::UINT64, LogicalTypeId::BIGINT>(state, result);
+	CheckPrimitive<VariantLogicalType::UINT128, LogicalTypeId::BIGINT>(state, result);
+	CheckPrimitive<VariantLogicalType::INT128, LogicalTypeId::BIGINT>(state, result);
 
 	auto array_count = state.type_map[static_cast<uint8_t>(VariantLogicalType::ARRAY)];
 	auto object_count = state.type_map[static_cast<uint8_t>(VariantLogicalType::OBJECT)];

--- a/test/parquet/variant/variant_shred_unsigned_types.test
+++ b/test/parquet/variant/variant_shred_unsigned_types.test
@@ -3,15 +3,17 @@
 
 require parquet
 
+foreach type utinyint usmallint uinteger ubigint uhugeint hugeint
+
 # Shred unsigned types when writing to Parquet
 statement ok
 COPY (
-	SELECT {'field1': i::UBIGINT}::VARIANT AS obj
+	SELECT {'field1': i::{type}}::VARIANT AS obj
 	FROM range(5) t(i)
-) TO '{TEST_DIR}/unsigned_variant.parquet';
+) TO '{TEST_DIR}/{type}_variant.parquet';
 
 query I
-SELECT p.obj.field1 FROM '{TEST_DIR}/unsigned_variant.parquet' p;
+SELECT p.obj.field1 FROM '{TEST_DIR}/{type}_variant.parquet' p;
 ----
 0
 1
@@ -20,6 +22,8 @@ SELECT p.obj.field1 FROM '{TEST_DIR}/unsigned_variant.parquet' p;
 4
 
 query I
-SELECT COUNT(*) > 0 FROM parquet_schema('{TEST_DIR}/unsigned_variant.parquet') WHERE name='typed_value';
+SELECT COUNT(*) > 0 FROM parquet_schema('{TEST_DIR}/{type}_variant.parquet') WHERE name='typed_value';
 ----
 1
+
+endloop

--- a/test/parquet/variant/variant_shred_unsigned_types.test
+++ b/test/parquet/variant/variant_shred_unsigned_types.test
@@ -1,0 +1,25 @@
+# name: test/parquet/variant/variant_shred_unsigned_types.test
+# group: [variant]
+
+require parquet
+
+# Shred unsigned types when writing to Parquet
+statement ok
+COPY (
+	SELECT {'field1': i::UBIGINT}::VARIANT AS obj
+	FROM range(5) t(i)
+) TO '{TEST_DIR}/unsigned_variant.parquet';
+
+query I
+SELECT p.obj.field1 FROM '{TEST_DIR}/unsigned_variant.parquet' p;
+----
+0
+1
+2
+3
+4
+
+query I
+SELECT COUNT(*) > 0 FROM parquet_schema('{TEST_DIR}/unsigned_variant.parquet') WHERE name='typed_value';
+----
+1


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/21357

After that PR we allowed writing unsigned types to `VARIANT`, but would not shred on them. This PR also updates the analyze step to consider the relevant transformations.