### PR TITLE
Use correct size in struct to variant to unified format

### DIFF
--- a/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
@@ -87,7 +87,7 @@ bool ConvertStructToVariant(ToVariantSourceData &source, ToVariantGlobalResultDa
 			//! Some of the STRUCT rows are NULL entirely, we have to filter these rows out of the children
 			Vector new_child(child.GetType(), nullptr);
 			new_child.Dictionary(child, count, sel.non_null_selection, sel.count);
-			ToVariantSourceData child_source_data(new_child, source.source_size);
+			ToVariantSourceData child_source_data(new_child, sel.count);
 			if (!ConvertToVariant<WRITE_DATA>(child_source_data, result, sel.count, &sel.new_selection,
 			                                  &sel.children_selection, false)) {
 				return false;


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/duckdb/duckdb/pull/21964