### PR TITLE
Fix "make clangd"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,7 @@ bloaty: reldebug bloaty/bloaty
 # Generate compile commands without actually building
 clangd:
 	cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_VARS} -B .cache/clangd/debug .
+	cp .cache/clangd/debug/compile_commands.json .cache/clangd/compile_commands.json
 
 coverage-check:
 	./scripts/coverage_check.sh


### PR DESCRIPTION
In #21361 the compile_commands.json file that is configured for clangd automatically gets updated on normal builds. But it actually broke the dedicated "make clangd" command. I use the "make clangd" command quite often for checkouts where I have the duckdb sources and include them in another build (like for an extension), but don't actually build duckdb itself separately. In those cases I still want to browse the code, but I will never run "make build_*" from the duckdb directory. So "make clangd" was an easy way to get "go to definition" working.
