### PR TITLE
Bump httpfs, now with implemented httpfs_connection_caching (opt-in)

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 56d1cf901d7bdbce788c132fba4d8976696591e8
+    GIT_TAG 13e18b3c9f3810334f5972b76a3acc247b28e537
 )


### PR DESCRIPTION
This brings in https://github.com/duckdb/duckdb-httpfs/pull/305, enabling HTTP connection caching (for Curl backed) via `SET httpfs_connection_caching=true;`