### PR TITLE
GetLocalFileSystem improvements

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,4 +1,5 @@
 duckdb_extension_load(httpfs
+    APPLY_PATCHES
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 3139e40a1b224bdb7b104f2f48d9bba8684da013

--- a/.github/patches/extensions/httpfs/file_system_logging.patch
+++ b/.github/patches/extensions/httpfs/file_system_logging.patch
@@ -1,0 +1,13 @@
+diff --git a/test/sql/logging/file_system_logging.test b/test/sql/logging/file_system_logging.test
+index 6aa2ed0..a1d8d5f 100644
+--- a/test/sql/logging/file_system_logging.test
++++ b/test/sql/logging/file_system_logging.test
+@@ -47,7 +47,7 @@ FROM 'https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv'
+ query IIII
+ SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*test.csv"', '"test.csv"')
+ FROM duckdb_logs
+-WHERE type = 'FileSystem' AND message NOT LIKE '%duckdb_extension%'
++WHERE type = 'FileSystem' AND message NOT LIKE '%duckdb_extension%' AND message ILIKE '%HTTPFileSystem%'
+ ORDER BY timestamp
+ ----
+ CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"OPEN"}

--- a/.github/patches/extensions/httpfs/getlocalfilesystem.patch
+++ b/.github/patches/extensions/httpfs/getlocalfilesystem.patch
@@ -1,0 +1,16 @@
+diff --git a/test/sql/settings/test_disabled_file_system_httpfs.test b/test/sql/settings/test_disabled_file_system_httpfs.test
+index 9cc1ee839bb..67f0e6b3296 100644
+--- a/test/sql/settings/test_disabled_file_system_httpfs.test
++++ b/test/sql/settings/test_disabled_file_system_httpfs.test
+@@ -15,8 +15,10 @@ statement ok
+ SET disabled_filesystems='LocalFileSystem';
+ 
+ # httpfs works
+-statement ok
++statement maybe
+ from read_csv_auto('https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv');
++----
++Invalid Configuration Error
+ 
+ statement ok
+ SET disabled_filesystems='LocalFileSystem,HTTPFileSystem';

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -736,6 +736,10 @@ unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, uniq
 	throw NotImplementedException("%s: OpenCompressedFile is not implemented!", GetName());
 }
 
+bool FileSystem::IsLocalFileSystem() const {
+	return false;
+}
+
 bool FileSystem::OnDiskFile(FileHandle &handle) {
 	throw NotImplementedException("%s: OnDiskFile is not implemented!", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -112,6 +112,10 @@ VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner)
 VirtualFileSystem::~VirtualFileSystem() {
 }
 
+FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
+	return *file_system_registry->default_fs->file_system;
+}
+
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                            optional_ptr<FileOpener> opener) {
 	auto compression = flags.Compression();

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -113,7 +113,11 @@ VirtualFileSystem::~VirtualFileSystem() {
 }
 
 FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
-	return *file_system_registry->default_fs->file_system;
+	auto &fs = *file_system_registry->default_fs->file_system;
+	if (SubSystemIsDisabled(fs.GetName())) {
+		throw PermissionException("File system %s has been disabled by configuration", fs.GetName());
+	}
+	return fs;
 }
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -299,6 +299,9 @@ public:
 	//! Create a LocalFileSystem.
 	DUCKDB_API static unique_ptr<FileSystem> CreateLocal();
 
+	//! Whether this is a LocalFileSystem instance.
+	DUCKDB_API virtual bool IsLocalFileSystem() const;
+
 	//! Return the name of the filesytem. Used for forming diagnosis messages.
 	DUCKDB_API virtual std::string GetName() const = 0;
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -143,6 +143,7 @@ public:
 public:
 	DUCKDB_API static FileSystem &GetFileSystem(ClientContext &context);
 	DUCKDB_API static FileSystem &GetFileSystem(DatabaseInstance &db);
+	DUCKDB_API static FileSystem &GetLocal(DatabaseInstance &db);
 	DUCKDB_API static FileSystem &Get(AttachedDatabase &db);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -88,6 +88,10 @@ public:
 	//! in a file on-disk are much cheaper than e.g. random reads in a file over the network
 	bool OnDiskFile(FileHandle &handle) override;
 
+	bool IsLocalFileSystem() const override {
+		return true;
+	}
+
 	std::string GetName() const override {
 		return "LocalFileSystem";
 	}

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -106,6 +106,34 @@ public:
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
 
+	bool DirectoryExists(const string &directory) {
+		return DirectoryExists(directory, nullptr);
+	}
+	void CreateDirectory(const string &directory) {
+		CreateDirectory(directory, nullptr);
+	}
+	void RemoveDirectory(const string &directory) {
+		RemoveDirectory(directory, nullptr);
+	}
+	void MoveFile(const string &source, const string &target) {
+		MoveFile(source, target, nullptr);
+	}
+	bool FileExists(const string &filename) {
+		return FileExists(filename, nullptr);
+	}
+	bool IsPipe(const string &filename) {
+		return IsPipe(filename, nullptr);
+	}
+	void RemoveFile(const string &filename) {
+		RemoveFile(filename, nullptr);
+	}
+	bool TryRemoveFile(const string &filename) {
+		return TryRemoveFile(filename, nullptr);
+	}
+	void RemoveFiles(const vector<string> &filenames) {
+		RemoveFiles(filenames, nullptr);
+	}
+
 	string GetHomeDirectory() override {
 		return FileSystem::GetHomeDirectory(GetOpener());
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -60,6 +60,8 @@ public:
 
 	vector<string> ListSubSystems() override;
 
+	FileSystem &GetDefaultFileSystem();
+
 	std::string GetName() const override;
 
 	void SetDisabledFileSystems(const vector<string> &names) override;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -17,7 +17,6 @@
 #include "duckdb/main/extension_manager.hpp"
 
 namespace duckdb {
-class LocalFileSystem;
 class LocalDatabaseFileSystem;
 
 class BufferManager;
@@ -54,7 +53,7 @@ public:
 	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API FileSystem &GetFileSystem();
-	DUCKDB_API LocalDatabaseFileSystem GetLocalFileSystem();
+	DUCKDB_API FileSystem &GetLocalFileSystem();
 	DUCKDB_API ExternalFileCache &GetExternalFileCache();
 	DUCKDB_API ResultSetManager &GetResultSetManager();
 	DUCKDB_API TaskScheduler &GetScheduler();
@@ -97,7 +96,7 @@ private:
 	unique_ptr<ExtensionManager> extension_manager;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
-	unique_ptr<LocalFileSystem> owned_unsafe_local_fs;
+	unique_ptr<LocalDatabaseFileSystem> local_db_file_system;
 	unique_ptr<LogManager> log_manager;
 	unique_ptr<ExternalFileCache> external_file_cache;
 	unique_ptr<ResultSetManager> result_set_manager;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/main/extension_manager.hpp"
 
 namespace duckdb {
+class LocalFileSystem;
 
 class BufferManager;
 class DatabaseManager;
@@ -52,6 +53,7 @@ public:
 	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API FileSystem &GetFileSystem();
+	DUCKDB_API LocalFileSystem &GetLocalFileSystem();
 	DUCKDB_API ExternalFileCache &GetExternalFileCache();
 	DUCKDB_API ResultSetManager &GetResultSetManager();
 	DUCKDB_API TaskScheduler &GetScheduler();
@@ -94,6 +96,7 @@ private:
 	unique_ptr<ExtensionManager> extension_manager;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
+	unique_ptr<LocalFileSystem> owned_local_file_system;
 	unique_ptr<LogManager> log_manager;
 	unique_ptr<ExternalFileCache> external_file_cache;
 	unique_ptr<ResultSetManager> result_set_manager;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -18,6 +18,7 @@
 
 namespace duckdb {
 class LocalFileSystem;
+class LocalDatabaseFileSystem;
 
 class BufferManager;
 class DatabaseManager;
@@ -53,7 +54,7 @@ public:
 	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API FileSystem &GetFileSystem();
-	DUCKDB_API LocalFileSystem &GetLocalFileSystem();
+	DUCKDB_API LocalDatabaseFileSystem GetLocalFileSystem();
 	DUCKDB_API ExternalFileCache &GetExternalFileCache();
 	DUCKDB_API ResultSetManager &GetResultSetManager();
 	DUCKDB_API TaskScheduler &GetScheduler();
@@ -96,7 +97,7 @@ private:
 	unique_ptr<ExtensionManager> extension_manager;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
-	unique_ptr<LocalFileSystem> owned_local_file_system;
+	unique_ptr<LocalFileSystem> owned_unsafe_local_fs;
 	unique_ptr<LogManager> log_manager;
 	unique_ptr<ExternalFileCache> external_file_cache;
 	unique_ptr<ResultSetManager> result_set_manager;

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/opener_file_system.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/database.hpp"
@@ -58,6 +59,23 @@ public:
 	FileSystem &GetFileSystem() const override {
 		auto &config = DBConfig::GetConfig(db);
 		return *config.file_system;
+	}
+	optional_ptr<FileOpener> GetOpener() const override {
+		return &database_opener;
+	}
+
+private:
+	DatabaseInstance &db;
+	mutable DatabaseFileOpener database_opener;
+};
+
+class LocalDatabaseFileSystem : public OpenerFileSystem {
+public:
+	explicit LocalDatabaseFileSystem(DatabaseInstance &db_p) : db(db_p), database_opener(db_p) {
+	}
+
+	FileSystem &GetFileSystem() const override {
+		return db.GetLocalFileSystem();
 	}
 	optional_ptr<FileOpener> GetOpener() const override {
 		return &database_opener;

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -71,18 +71,16 @@ private:
 
 class LocalDatabaseFileSystem : public OpenerFileSystem {
 public:
-	LocalDatabaseFileSystem(DatabaseInstance &db_p, FileSystem &local_fs_p)
-	    : local_fs(local_fs_p), database_opener(db_p) {
-	}
+	explicit LocalDatabaseFileSystem(DatabaseInstance &db_p);
 
-	FileSystem &GetFileSystem() const override {
-		return local_fs;
-	}
+	FileSystem &GetFileSystem() const override;
 	optional_ptr<FileOpener> GetOpener() const override {
 		return &database_opener;
 	}
 
 private:
+	DatabaseInstance &db;
+	unique_ptr<FileSystem> owned_file_system;
 	FileSystem &local_fs;
 	mutable DatabaseFileOpener database_opener;
 };

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -71,18 +71,19 @@ private:
 
 class LocalDatabaseFileSystem : public OpenerFileSystem {
 public:
-	explicit LocalDatabaseFileSystem(DatabaseInstance &db_p) : db(db_p), database_opener(db_p) {
+	LocalDatabaseFileSystem(DatabaseInstance &db_p, FileSystem &local_fs_p)
+	    : local_fs(local_fs_p), database_opener(db_p) {
 	}
 
 	FileSystem &GetFileSystem() const override {
-		return db.GetLocalFileSystem();
+		return local_fs;
 	}
 	optional_ptr<FileOpener> GetOpener() const override {
 		return &database_opener;
 	}
 
 private:
-	DatabaseInstance &db;
+	FileSystem &local_fs;
 	mutable DatabaseFileOpener database_opener;
 };
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -280,6 +280,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	create_api_v1 = CreateAPIv1Wrapper;
 
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
+	owned_unsafe_local_fs = make_uniq<LocalFileSystem>();
 	db_manager = make_uniq<DatabaseManager>(*this);
 	if (config.buffer_manager) {
 		buffer_manager = config.buffer_manager;
@@ -385,16 +386,13 @@ FileSystem &DatabaseInstance::GetFileSystem() {
 	return *db_file_system;
 }
 
-LocalFileSystem &DatabaseInstance::GetLocalFileSystem() {
+LocalDatabaseFileSystem DatabaseInstance::GetLocalFileSystem() {
 	auto &vfs = static_cast<VirtualFileSystem &>(*config.file_system);
 	auto &default_fs = vfs.GetDefaultFileSystem();
 	if (default_fs.IsLocalFileSystem()) {
-		return static_cast<LocalFileSystem &>(default_fs);
+		return LocalDatabaseFileSystem(*this, default_fs);
 	}
-	if (!owned_local_file_system) {
-		owned_local_file_system = make_uniq<LocalFileSystem>();
-	}
-	return *owned_local_file_system;
+	return LocalDatabaseFileSystem(*this, *owned_unsafe_local_fs);
 }
 
 ExternalFileCache &DatabaseInstance::GetExternalFileCache() {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -130,6 +130,10 @@ FileSystem &FileSystem::GetFileSystem(DatabaseInstance &db) {
 	return db.GetFileSystem();
 }
 
+FileSystem &FileSystem::GetLocal(DatabaseInstance &db) {
+	return db.GetLocalFileSystem();
+}
+
 FileSystem &FileSystem::Get(AttachedDatabase &db) {
 	return FileSystem::GetFileSystem(db.GetDatabase());
 }
@@ -280,7 +284,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	create_api_v1 = CreateAPIv1Wrapper;
 
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
-	owned_unsafe_local_fs = make_uniq<LocalFileSystem>();
+	local_db_file_system = make_uniq<LocalDatabaseFileSystem>(*this);
 	db_manager = make_uniq<DatabaseManager>(*this);
 	if (config.buffer_manager) {
 		buffer_manager = config.buffer_manager;
@@ -386,13 +390,30 @@ FileSystem &DatabaseInstance::GetFileSystem() {
 	return *db_file_system;
 }
 
-LocalDatabaseFileSystem DatabaseInstance::GetLocalFileSystem() {
-	auto &vfs = static_cast<VirtualFileSystem &>(*config.file_system);
+FileSystem &DatabaseInstance::GetLocalFileSystem() {
+	return *local_db_file_system;
+}
+
+static FileSystem &ResolveLocalFileSystem(DatabaseInstance &db, unique_ptr<FileSystem> &owned) {
+	auto &vfs = static_cast<VirtualFileSystem &>(*db.config.file_system);
 	auto &default_fs = vfs.GetDefaultFileSystem();
 	if (default_fs.IsLocalFileSystem()) {
-		return LocalDatabaseFileSystem(*this, default_fs);
+		return default_fs;
 	}
-	return LocalDatabaseFileSystem(*this, *owned_unsafe_local_fs);
+	owned = make_uniq<LocalFileSystem>();
+	return *owned;
+}
+
+LocalDatabaseFileSystem::LocalDatabaseFileSystem(DatabaseInstance &db_p)
+    : db(db_p), local_fs(ResolveLocalFileSystem(db_p, owned_file_system)), database_opener(db_p) {
+}
+
+FileSystem &LocalDatabaseFileSystem::GetFileSystem() const {
+	auto &vfs = static_cast<VirtualFileSystem &>(*db.config.file_system);
+	if (vfs.SubSystemIsDisabled(local_fs.GetName())) {
+		throw PermissionException("File system %s has been disabled by configuration", local_fs.GetName());
+	}
+	return local_fs;
 }
 
 ExternalFileCache &DatabaseInstance::GetExternalFileCache() {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/execution/index/index_type_set.hpp"
 #include "duckdb/execution/operator/helper/physical_set.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
@@ -382,6 +383,18 @@ ObjectCache &DatabaseInstance::GetObjectCache() {
 
 FileSystem &DatabaseInstance::GetFileSystem() {
 	return *db_file_system;
+}
+
+LocalFileSystem &DatabaseInstance::GetLocalFileSystem() {
+	auto &vfs = static_cast<VirtualFileSystem &>(*config.file_system);
+	auto &default_fs = vfs.GetDefaultFileSystem();
+	if (default_fs.IsLocalFileSystem()) {
+		return static_cast<LocalFileSystem &>(default_fs);
+	}
+	if (!owned_local_file_system) {
+		owned_local_file_system = make_uniq<LocalFileSystem>();
+	}
+	return *owned_local_file_system;
 }
 
 ExternalFileCache &DatabaseInstance::GetExternalFileCache() {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -404,7 +405,8 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 	}
 	auto &dbconfig = DBConfig::GetConfig(db);
 	try {
-		auto &fs = db.GetLocalFileSystem();
+		LocalDatabaseFileSystem local_db_fs(db);
+		FileSystem &fs = local_db_fs;
 #ifndef DUCKDB_WASM
 		if (Settings::Get<AutoinstallKnownExtensionsSetting>(db)) {
 			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -405,7 +405,7 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 	}
 	auto &dbconfig = DBConfig::GetConfig(db);
 	try {
-		auto fs = db.GetLocalFileSystem();
+		auto &fs = FileSystem::GetLocal(db);
 #ifndef DUCKDB_WASM
 		if (Settings::Get<AutoinstallKnownExtensionsSetting>(db)) {
 			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/extension_helper.hpp"
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -403,17 +404,17 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 	}
 	auto &dbconfig = DBConfig::GetConfig(db);
 	try {
-		auto fs = FileSystem::CreateLocal();
+		auto &fs = db.GetLocalFileSystem();
 #ifndef DUCKDB_WASM
 		if (Settings::Get<AutoinstallKnownExtensionsSetting>(db)) {
 			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig);
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(repository_url);
 			ExtensionInstallOptions options;
 			options.repository = autoinstall_repo;
-			ExtensionHelper::InstallExtension(db, *fs, extension_name, options);
+			ExtensionHelper::InstallExtension(db, fs, extension_name, options);
 		}
 #endif
-		ExtensionHelper::LoadExternalExtension(db, *fs, extension_name);
+		ExtensionHelper::LoadExternalExtension(db, fs, extension_name);
 		DUCKDB_LOG_INFO(db, "Loaded extension '%s'", extension_name);
 	} catch (std::exception &e) {
 		ErrorData error(e);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -405,8 +405,7 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 	}
 	auto &dbconfig = DBConfig::GetConfig(db);
 	try {
-		LocalDatabaseFileSystem local_db_fs(db);
-		FileSystem &fs = local_db_fs;
+		auto fs = db.GetLocalFileSystem();
 #ifndef DUCKDB_WASM
 		if (Settings::Get<AutoinstallKnownExtensionsSetting>(db)) {
 			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -411,11 +411,11 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
                                                            optional_ptr<ClientContext> context) {
 	unique_ptr<ExtensionInstallInfo> install_info;
 	{
-		auto fs = FileSystem::CreateLocal();
-		if (fs->FileExists(local_extension_path + ".info")) {
+		auto &fs = db.GetLocalFileSystem();
+		if (fs.FileExists(local_extension_path + ".info")) {
 			try {
 				install_info =
-				    ExtensionInstallInfo::TryReadInfoFile(*fs, local_extension_path + ".info", extension_name);
+				    ExtensionInstallInfo::TryReadInfoFile(fs, local_extension_path + ".info", extension_name);
 			} catch (...) {
 				if (!options.force_install) {
 					// We are going to rewrite the file anyhow, so this is fine
@@ -488,8 +488,8 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	}
 
 	QueryContext query_context(context);
-	auto fs = FileSystem::CreateLocal();
-	WriteExtensionFiles(query_context, *fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
+	auto &fs = db.GetLocalFileSystem();
+	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
 	                    decompressed_body.size(), info, db.config);
 
 	return make_uniq<ExtensionInstallInfo>(info);
@@ -589,14 +589,14 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 
 	// Install extension from local, direct url
 	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
-		LocalFileSystem local_fs;
+		auto &local_fs = db.GetLocalFileSystem();
 		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path, options,
 		                              context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
 	if (options.repository && !IsHTTP(options.repository->path)) {
-		LocalFileSystem local_fs;
+		auto &local_fs = db.GetLocalFileSystem();
 		return InstallFromRepository(db, fs, extension, extension_name, temp_path, local_extension_path, options,
 		                             context);
 	}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/gzip_file_system.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/uuid.hpp"
@@ -411,7 +412,8 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
                                                            optional_ptr<ClientContext> context) {
 	unique_ptr<ExtensionInstallInfo> install_info;
 	{
-		auto &fs = db.GetLocalFileSystem();
+		LocalDatabaseFileSystem local_db_fs(db);
+		FileSystem &fs = local_db_fs;
 		if (fs.FileExists(local_extension_path + ".info")) {
 			try {
 				install_info =
@@ -488,7 +490,8 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	}
 
 	QueryContext query_context(context);
-	auto &fs = db.GetLocalFileSystem();
+	LocalDatabaseFileSystem local_db_fs(db);
+	FileSystem &fs = local_db_fs;
 	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
 	                    decompressed_body.size(), info, db.config);
 
@@ -589,14 +592,14 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 
 	// Install extension from local, direct url
 	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
-		auto &local_fs = db.GetLocalFileSystem();
-		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path, options,
+		LocalDatabaseFileSystem local_db_fs(db);
+		return DirectInstallExtension(db, local_db_fs, extension, temp_path, extension, local_extension_path, options,
 		                              context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
 	if (options.repository && !IsHTTP(options.repository->path)) {
-		auto &local_fs = db.GetLocalFileSystem();
+		LocalDatabaseFileSystem local_db_fs(db);
 		return InstallFromRepository(db, fs, extension, extension_name, temp_path, local_extension_path, options,
 		                             context);
 	}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -412,8 +412,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
                                                            optional_ptr<ClientContext> context) {
 	unique_ptr<ExtensionInstallInfo> install_info;
 	{
-		LocalDatabaseFileSystem local_db_fs(db);
-		FileSystem &fs = local_db_fs;
+		auto fs = db.GetLocalFileSystem();
 		if (fs.FileExists(local_extension_path + ".info")) {
 			try {
 				install_info =
@@ -490,8 +489,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	}
 
 	QueryContext query_context(context);
-	LocalDatabaseFileSystem local_db_fs(db);
-	FileSystem &fs = local_db_fs;
+	auto fs = db.GetLocalFileSystem();
 	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
 	                    decompressed_body.size(), info, db.config);
 
@@ -592,15 +590,15 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 
 	// Install extension from local, direct url
 	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
-		LocalDatabaseFileSystem local_db_fs(db);
-		return DirectInstallExtension(db, local_db_fs, extension, temp_path, extension, local_extension_path, options,
+		auto local_fs = db.GetLocalFileSystem();
+		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path, options,
 		                              context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
 	if (options.repository && !IsHTTP(options.repository->path)) {
-		LocalDatabaseFileSystem local_db_fs(db);
-		return InstallFromRepository(db, fs, extension, extension_name, temp_path, local_extension_path, options,
+		auto local_fs = db.GetLocalFileSystem();
+		return InstallFromRepository(db, local_fs, extension, extension_name, temp_path, local_extension_path, options,
 		                             context);
 	}
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -412,7 +412,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
                                                            optional_ptr<ClientContext> context) {
 	unique_ptr<ExtensionInstallInfo> install_info;
 	{
-		auto fs = db.GetLocalFileSystem();
+		auto &fs = FileSystem::GetLocal(db);
 		if (fs.FileExists(local_extension_path + ".info")) {
 			try {
 				install_info =
@@ -489,7 +489,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	}
 
 	QueryContext query_context(context);
-	auto fs = db.GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(db);
 	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
 	                    decompressed_body.size(), info, db.config);
 
@@ -590,14 +590,14 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 
 	// Install extension from local, direct url
 	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
-		auto local_fs = db.GetLocalFileSystem();
+		auto &local_fs = FileSystem::GetLocal(db);
 		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path, options,
 		                              context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
 	if (options.repository && !IsHTTP(options.repository->path)) {
-		auto local_fs = db.GetLocalFileSystem();
+		auto &local_fs = FileSystem::GetLocal(db);
 		return InstallFromRepository(db, local_fs, extension, extension_name, temp_path, local_extension_path, options,
 		                             context);
 	}

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -656,7 +656,7 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(cons
 		return nullptr;
 	}
 
-	LocalFileSystem fs;
+	auto &fs = catalog.GetDatabase().GetLocalFileSystem();
 
 	string base_secret_path = secret_manager.PersistentSecretPath();
 	string secret_path = fs.JoinPath(base_secret_path, entry_name + ".duckdb_secret");

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -44,7 +44,7 @@ void SecretManager::Initialize(DatabaseInstance &db) {
 	lock_guard<mutex> lck(manager_lock);
 
 	// Construct default path
-	LocalFileSystem fs;
+	auto fs = db.GetLocalFileSystem();
 	config.default_secret_path = fs.GetHomeDirectory();
 	vector<string> path_components = {".duckdb", "stored_secrets"};
 	for (auto &path_ele : path_components) {

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
@@ -656,7 +657,8 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(cons
 		return nullptr;
 	}
 
-	auto &fs = catalog.GetDatabase().GetLocalFileSystem();
+	LocalDatabaseFileSystem local_db_fs(catalog.GetDatabase());
+	FileSystem &fs = local_db_fs;
 
 	string base_secret_path = secret_manager.PersistentSecretPath();
 	string secret_path = fs.JoinPath(base_secret_path, entry_name + ".duckdb_secret");

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -657,8 +657,7 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(cons
 		return nullptr;
 	}
 
-	LocalDatabaseFileSystem local_db_fs(catalog.GetDatabase());
-	FileSystem &fs = local_db_fs;
+	auto fs = catalog.GetDatabase().GetLocalFileSystem();
 
 	string base_secret_path = secret_manager.PersistentSecretPath();
 	string secret_path = fs.JoinPath(base_secret_path, entry_name + ".duckdb_secret");

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -44,7 +44,7 @@ void SecretManager::Initialize(DatabaseInstance &db) {
 	lock_guard<mutex> lck(manager_lock);
 
 	// Construct default path
-	auto fs = db.GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(db);
 	config.default_secret_path = fs.GetHomeDirectory();
 	vector<string> path_components = {".duckdb", "stored_secrets"};
 	for (auto &path_ele : path_components) {
@@ -657,7 +657,7 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(cons
 		return nullptr;
 	}
 
-	auto fs = catalog.GetDatabase().GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(catalog.GetDatabase());
 
 	string base_secret_path = secret_manager.PersistentSecretPath();
 	string secret_path = fs.JoinPath(base_secret_path, entry_name + ".duckdb_secret");

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
@@ -137,7 +138,8 @@ LocalFileSecretStorage::LocalFileSecretStorage(SecretManager &manager, DatabaseI
 	persistent = true;
 
 	// Check existence of persistent secret dir
-	auto &fs = db.GetLocalFileSystem();
+	LocalDatabaseFileSystem local_db_fs(db);
+	FileSystem &fs = local_db_fs;
 	if (fs.DirectoryExists(secret_path)) {
 		fs.ListFiles(secret_path, [&](const string &fname, bool is_dir) {
 			string full_path = fs.JoinPath(secret_path, fname);
@@ -186,7 +188,8 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 }
 
 void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	auto &fs = db.GetLocalFileSystem();
+	LocalDatabaseFileSystem local_db_fs(db);
+	FileSystem &fs = local_db_fs;
 
 	// We may need to create the secret dir here if the directory was not present during LocalFileSecretStorage
 	// construction
@@ -230,7 +233,8 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 }
 
 void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	auto &fs = db.GetLocalFileSystem();
+	LocalDatabaseFileSystem local_db_fs(db);
+	FileSystem &fs = local_db_fs;
 	string file = fs.JoinPath(secret_path, secret + ".duckdb_secret");
 	persistent_secrets.erase(secret);
 	try {

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -138,7 +138,7 @@ LocalFileSecretStorage::LocalFileSecretStorage(SecretManager &manager, DatabaseI
 	persistent = true;
 
 	// Check existence of persistent secret dir
-	auto fs = db.GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(db);
 	if (fs.DirectoryExists(secret_path)) {
 		fs.ListFiles(secret_path, [&](const string &fname, bool is_dir) {
 			string full_path = fs.JoinPath(secret_path, fname);
@@ -187,7 +187,7 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 }
 
 void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	auto fs = db.GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(db);
 
 	// We may need to create the secret dir here if the directory was not present during LocalFileSecretStorage
 	// construction
@@ -231,7 +231,7 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 }
 
 void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	auto fs = db.GetLocalFileSystem();
+	auto &fs = FileSystem::GetLocal(db);
 	string file = fs.JoinPath(secret_path, secret + ".duckdb_secret");
 	persistent_secrets.erase(secret);
 	try {

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -137,7 +137,7 @@ LocalFileSecretStorage::LocalFileSecretStorage(SecretManager &manager, DatabaseI
 	persistent = true;
 
 	// Check existence of persistent secret dir
-	LocalFileSystem fs;
+	auto &fs = db.GetLocalFileSystem();
 	if (fs.DirectoryExists(secret_path)) {
 		fs.ListFiles(secret_path, [&](const string &fname, bool is_dir) {
 			string full_path = fs.JoinPath(secret_path, fname);
@@ -186,7 +186,7 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 }
 
 void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	LocalFileSystem fs;
+	auto &fs = db.GetLocalFileSystem();
 
 	// We may need to create the secret dir here if the directory was not present during LocalFileSecretStorage
 	// construction
@@ -230,7 +230,7 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 }
 
 void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	LocalFileSystem fs;
+	auto &fs = db.GetLocalFileSystem();
 	string file = fs.JoinPath(secret_path, secret + ".duckdb_secret");
 	persistent_secrets.erase(secret);
 	try {

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -138,8 +138,7 @@ LocalFileSecretStorage::LocalFileSecretStorage(SecretManager &manager, DatabaseI
 	persistent = true;
 
 	// Check existence of persistent secret dir
-	LocalDatabaseFileSystem local_db_fs(db);
-	FileSystem &fs = local_db_fs;
+	auto fs = db.GetLocalFileSystem();
 	if (fs.DirectoryExists(secret_path)) {
 		fs.ListFiles(secret_path, [&](const string &fname, bool is_dir) {
 			string full_path = fs.JoinPath(secret_path, fname);
@@ -188,8 +187,7 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 }
 
 void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	LocalDatabaseFileSystem local_db_fs(db);
-	FileSystem &fs = local_db_fs;
+	auto fs = db.GetLocalFileSystem();
 
 	// We may need to create the secret dir here if the directory was not present during LocalFileSecretStorage
 	// construction
@@ -233,8 +231,7 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 }
 
 void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	LocalDatabaseFileSystem local_db_fs(db);
-	FileSystem &fs = local_db_fs;
+	auto fs = db.GetLocalFileSystem();
 	string file = fs.JoinPath(secret_path, secret + ".duckdb_secret");
 	persistent_secrets.erase(secret);
 	try {

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -11,6 +11,12 @@
       "paths": [
         "test/sql/attach/attach_filepath_roundtrip.test"
       ]
+    },
+    {
+      "reason": "Autoloading means errors will differ",
+      "paths": [
+        "test/sql/secrets/secret_autoloading_errors.test"
+      ]
     }
   ]
 }

--- a/test/sql/secrets/create_secret_filesystem_logging.test
+++ b/test/sql/secrets/create_secret_filesystem_logging.test
@@ -1,0 +1,41 @@
+# name: test/sql/secrets/create_secret_filesystem_logging.test
+# description: Test that persistent secret operations are tracked by filesystem logging
+# group: [secrets]
+
+require skip_reload
+
+statement ok
+CALL enable_logging('FileSystem');
+
+statement ok
+SET secret_directory='__TEST_DIR__/secret_fs_logging';
+
+statement ok
+CREATE PERSISTENT SECRET my_secret (TYPE HTTP);
+
+# verify that secret creation is tracked by filesystem logging
+query II
+SELECT fs, op FROM duckdb_logs_parsed('FileSystem') WHERE path LIKE '%my_secret%' ORDER BY timestamp;
+----
+LocalFileSystem	OPEN
+LocalFileSystem	WRITE
+LocalFileSystem	CLOSE
+
+restart
+
+statement ok
+CALL enable_logging('FileSystem');
+
+statement ok
+SET secret_directory='__TEST_DIR__/secret_fs_logging';
+
+statement ok
+FROM duckdb_secrets();
+
+# verify that secret reading is tracked by filesystem loggin
+query II
+SELECT fs, op FROM duckdb_logs_parsed('FileSystem') WHERE path LIKE '%my_secret%' ORDER BY timestamp;
+----
+LocalFileSystem	OPEN
+LocalFileSystem	READ
+LocalFileSystem	CLOSE

--- a/test/sql/settings/test_disabled_local_filesystem_metadata.test
+++ b/test/sql/settings/test_disabled_local_filesystem_metadata.test
@@ -1,0 +1,22 @@
+# name: test/sql/settings/test_disabled_local_filesystem_secrets.test
+# description: Test that persistent secrets fail when LocalFileSystem is disabled
+# group: [settings]
+
+require skip_reload
+
+statement ok
+SET secret_directory='__TEST_DIR__/disabled_fs_secrets';
+
+statement ok
+SET disabled_filesystems='LocalFileSystem';
+
+# metadata queries that touch the local filesystem should also fail
+statement error
+SELECT * FROM duckdb_secrets();
+----
+File system LocalFileSystem has been disabled by configuration
+
+statement error
+SELECT * FROM duckdb_extensions();
+----
+File system LocalFileSystem has been disabled by configuration

--- a/test/sql/settings/test_disabled_local_filesystem_metadata.test
+++ b/test/sql/settings/test_disabled_local_filesystem_metadata.test
@@ -1,4 +1,4 @@
-# name: test/sql/settings/test_disabled_local_filesystem_secrets.test
+# name: test/sql/settings/test_disabled_local_filesystem_metadata.test
 # description: Test that persistent secrets fail when LocalFileSystem is disabled
 # group: [settings]
 

--- a/test/sql/settings/test_disabled_local_filesystem_metadata.test
+++ b/test/sql/settings/test_disabled_local_filesystem_metadata.test
@@ -5,6 +5,9 @@
 require skip_reload
 
 statement ok
+PRAGMA disable_verification;
+
+statement ok
 SET secret_directory='__TEST_DIR__/disabled_fs_secrets';
 
 statement ok

--- a/test/sql/settings/test_disabled_local_filesystem_secrets.test
+++ b/test/sql/settings/test_disabled_local_filesystem_secrets.test
@@ -1,0 +1,16 @@
+# name: test/sql/settings/test_disabled_local_filesystem_secrets.test
+# description: Test that persistent secrets fail when LocalFileSystem is disabled
+# group: [settings]
+
+require skip_reload
+
+statement ok
+SET secret_directory='__TEST_DIR__/disabled_fs_secrets';
+
+statement ok
+SET disabled_filesystems='LocalFileSystem';
+
+statement error
+CREATE PERSISTENT SECRET my_s (TYPE S3);
+----
+File system LocalFileSystem has been disabled by configuration

--- a/test/sql/settings/test_external_access_metadata.test
+++ b/test/sql/settings/test_external_access_metadata.test
@@ -1,0 +1,18 @@
+# name: test/sql/settings/test_external_access_metadata.test
+# description: Test that metadata queries fail when external access is disabled
+# group: [settings]
+
+require skip_reload
+
+statement ok
+SET enable_external_access=false;
+
+statement error
+SELECT * FROM duckdb_secrets();
+----
+file system operations are disabled by configuration
+
+statement error
+SELECT * FROM duckdb_extensions();
+----
+file system operations are disabled by configuration

--- a/test/sql/settings/test_external_access_metadata.test
+++ b/test/sql/settings/test_external_access_metadata.test
@@ -5,6 +5,9 @@
 require skip_reload
 
 statement ok
+PRAGMA disable_verification;
+
+statement ok
 SET enable_external_access=false;
 
 statement error

--- a/test/sql/settings/test_external_access_secrets.test
+++ b/test/sql/settings/test_external_access_secrets.test
@@ -1,0 +1,16 @@
+# name: test/sql/settings/test_external_access_secrets.test
+# description: Test that persistent secrets fail when external access is disabled
+# group: [settings]
+
+require skip_reload
+
+statement ok
+SET secret_directory='__TEST_DIR__/external_access_secrets';
+
+statement ok
+SET enable_external_access=false;
+
+statement error
+CREATE PERSISTENT SECRET my_secret (TYPE S3)
+----
+file system operations are disabled by configuration


### PR DESCRIPTION
There are two parts to this PR:

1. avoiding constructing multiple LocalFileSystem, and add functionality from the DatabaseInstance to return a `LocalFileSystem` already constructucted. This allow for example to reuse any extra functionality that the default local file system from which VirtualFileSystem was constructed to be available in more places.
2. wrap a `LocalFileSystem` in a `LocalDatabaseFileSystem` that paired with a FileOpener guards access so that settings such as `enable_external_access` are guarded.

One benefit in reusing same codepath is also now FileSystem logging now works with secret creation / access and deletion, and also in the extension install path.