### PR TITLE
MERGE INTO - no need to extract logical get, we already know where it is

### DIFF
--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -182,18 +182,6 @@ void RewriteMergeBindings(LogicalOperator &op, const vector<ColumnBinding> &sour
 	    op, [&](unique_ptr<Expression> *child) { RewriteMergeBindings(*child, source_bindings, new_table_index); });
 }
 
-LogicalGet &ExtractLogicalGet(LogicalOperator &op) {
-	reference<LogicalOperator> current_op(op);
-	while (current_op.get().type == LogicalOperatorType::LOGICAL_FILTER) {
-		current_op = *current_op.get().children[0];
-	}
-	if (current_op.get().type != LogicalOperatorType::LOGICAL_GET) {
-		throw InvalidInputException("BindMerge - expected to find an operator of type LOGICAL_GET but got %s",
-		                            op.ToString());
-	}
-	return current_op.get().Cast<LogicalGet>();
-}
-
 void CheckMergeAction(MergeActionCondition condition, MergeActionType action_type) {
 	if (condition == MergeActionCondition::WHEN_NOT_MATCHED_BY_TARGET) {
 		switch (action_type) {
@@ -280,6 +268,7 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 	} else {
 		join.type = JoinType::INNER;
 	}
+	auto &get = bound_table.plan->Cast<LogicalGet>();
 	join.left = make_uniq<BoundRefWrapper>(std::move(source_binding), std::move(source_binder));
 	join.right = make_uniq<BoundRefWrapper>(std::move(bound_table), std::move(target_binder));
 	if (stmt.join_condition) {
@@ -301,7 +290,6 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 	// kind of hacky, CreatePlan turns a RIGHT join into a LEFT join so the children get reversed from what we need
 	bool inverted = join.type == JoinType::RIGHT;
 	auto &source = join_ref.get().children[inverted ? 1 : 0];
-	auto &get = ExtractLogicalGet(*join_ref.get().children[inverted ? 0 : 1]);
 
 	auto merge_into = make_uniq<LogicalMergeInto>(table);
 	merge_into->table_index = GenerateTableIndex();

--- a/test/sql/merge/merge_into_subquery_condition.test
+++ b/test/sql/merge/merge_into_subquery_condition.test
@@ -1,0 +1,23 @@
+# name: test/sql/merge/merge_into_subquery_condition.test
+# description: Test MERGE INTO with a subquery in the condition
+# group: [merge]
+
+statement ok
+CREATE TABLE target(id INT PRIMARY KEY, val INT);
+
+statement ok
+INSERT INTO target VALUES (1, 10), (2, 20);
+
+query I
+MERGE INTO target AS t
+USING (VALUES (1, 99)) AS s(id, val)
+ON t.id = s.id AND t.val > (SELECT 5)
+WHEN MATCHED THEN UPDATE SET val = s.val;
+----
+1
+
+query II
+FROM target ORDER BY id
+----
+1	99
+2	20


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21903

The original code was jumping through hoops to re-obtain a `LogicalGet` that we just ourselves created. This PR simplifies that code which also fixes the issue.