### PR TITLE
Attempt to fix invalid memory access

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -38,20 +38,20 @@ public:
 enum class FilterConversionType { COPY_DIRECTLY, CAST_FILTER, CANNOT_CONVERT };
 
 struct MultiFileColumnMap {
-	MultiFileColumnMap(idx_t index, const LogicalType &local_type, const LogicalType &global_type)
-	    : mapping(index), local_type(local_type), global_type(global_type),
+	MultiFileColumnMap(idx_t index, const LogicalType &local_type_p, const LogicalType &global_type_p)
+	    : mapping(index), local_type(local_type_p), global_type(global_type_p),
 	      filter_conversion(local_type == global_type ? FilterConversionType::COPY_DIRECTLY
 	                                                  : FilterConversionType::CAST_FILTER) {
 	}
-	MultiFileColumnMap(MultiFileIndexMapping mapping_p, const LogicalType &local_type, const LogicalType &global_type,
+	MultiFileColumnMap(MultiFileIndexMapping mapping_p, const LogicalType &local_type_p, const LogicalType &global_type_p,
 	                   FilterConversionType filter_conversion)
-	    : mapping(std::move(mapping_p)), local_type(local_type), global_type(global_type),
+	    : mapping(std::move(mapping_p)), local_type(local_type_p), global_type(global_type_p),
 	      filter_conversion(filter_conversion) {
 	}
 
 	MultiFileIndexMapping mapping;
-	const LogicalType &local_type;
-	const LogicalType &global_type;
+	const LogicalType local_type;
+	const LogicalType global_type;
 	FilterConversionType filter_conversion;
 };
 

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -43,8 +43,8 @@ struct MultiFileColumnMap {
 	      filter_conversion(local_type == global_type ? FilterConversionType::COPY_DIRECTLY
 	                                                  : FilterConversionType::CAST_FILTER) {
 	}
-	MultiFileColumnMap(MultiFileIndexMapping mapping_p, const LogicalType &local_type_p, const LogicalType &global_type_p,
-	                   FilterConversionType filter_conversion)
+	MultiFileColumnMap(MultiFileIndexMapping mapping_p, const LogicalType &local_type_p,
+	                   const LogicalType &global_type_p, FilterConversionType filter_conversion)
 	    : mapping(std::move(mapping_p)), local_type(local_type_p), global_type(global_type_p),
 	      filter_conversion(filter_conversion) {
 	}


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/977

When I was using DuckLake I met certain issue
```sh
memory D ATTACH ':memory:' AS dl (TYPE ducklake, DATA_INLINING_ROW_LIMIT 1000);
memory D CREATE TABLE dl.test(id INTEGER, val TEXT);
memory D INSERT INTO dl.test VALUES (1, 'a'), (2, 'b'), (3, 'c');
memory D BEGIN;
memory D ALTER TABLE dl.test ALTER COLUMN id TYPE BIGINT;
memory D UPDATE dl.test SET val = 'X' WHERE id = 1;
=================================================================
==83726==ERROR: AddressSanitizer: heap-use-after-free on address 0x6160001cffb8 at pc 0x00010bf6c580 bp 0x00016f1a3cf0 sp 0x00016f1a3ce8
READ of size 1 at 0x6160001cffb8 thread T5
    #0 0x00010bf6c57c in duckdb::LogicalType::operator==(duckdb::LogicalType const&) const types.cpp:2071
    #1 0x000106c89ab8 in duckdb::StatisticsPropagator::CanPropagateCast(duckdb::LogicalType const&, duckdb::LogicalType const&) propagate_cast.cpp:31
    #2 0x00010a635dcc in duckdb::TryCastTableFilter(duckdb::TableFilter const&, duckdb::MultiFileIndexMapping&, duckdb::LogicalType const&) multi_file_column_mapper.cpp:1014
    #3 0x00010a632458 in duckdb::MultiFileColumnMapper::CreateFilters(std::__1::map<unsigned long long, std::__1::reference_wrapper<duckdb::TableFilter>, std::__1::less<unsigned long long>, std::__1::allocator<std::__1::pair<unsigned long long const, std::__1::reference_wrapper<duckdb::TableFilter>>>>&, duckdb::ResultColumnMapping&) multi_file_column_mapper.cpp:1104
```

I don't have too much knowledge on `MultiFileColumnMapper`, but considering (1) the invalid memory access is 1 byte; (2) stacktrace code location more or less indicates its logical type reference stored within `MultiFileColumnMapper` gets invalid.
Turning it into value fixes the ASAN complaint.