### PR TITLE
Fix TIMESTAMPFORMAT being ignored for TIMESTAMPTZ columns in copy to json

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -96,7 +96,8 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			strftime_children.emplace_back(std::move(column));
 			strftime_children.emplace_back(make_uniq<ConstantExpression>(date_format));
 			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));
-		} else if (!timestamp_format.empty() && (type == LogicalTypeId::TIMESTAMP || type == LogicalTypeId::TIMESTAMP_TZ)) {
+		} else if (!timestamp_format.empty() &&
+		           (type == LogicalTypeId::TIMESTAMP || type == LogicalTypeId::TIMESTAMP_TZ)) {
 			if (type == LogicalTypeId::TIMESTAMP_TZ) {
 				column = make_uniq<CastExpression>(LogicalType::TIMESTAMP, std::move(column));
 			}

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -10,6 +10,7 @@
 #include "json_scan.hpp"
 #include "json_transform.hpp"
 #include "json_multi_file_info.hpp"
+#include "duckdb/parser/expression/cast_expression.hpp"
 
 namespace duckdb {
 
@@ -95,7 +96,10 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			strftime_children.emplace_back(std::move(column));
 			strftime_children.emplace_back(make_uniq<ConstantExpression>(date_format));
 			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));
-		} else if (!timestamp_format.empty() && type == LogicalTypeId::TIMESTAMP) {
+		} else if (!timestamp_format.empty() && (type == LogicalTypeId::TIMESTAMP || type == LogicalTypeId::TIMESTAMP_TZ)) {
+			if (type == LogicalTypeId::TIMESTAMP_TZ) {
+				column = make_uniq<CastExpression>(LogicalType::TIMESTAMP, std::move(column));
+			}
 			strftime_children.emplace_back(std::move(column));
 			strftime_children.emplace_back(make_uniq<ConstantExpression>(timestamp_format));
 			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -98,9 +98,6 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));
 		} else if (!timestamp_format.empty() &&
 		           (type == LogicalTypeId::TIMESTAMP || type == LogicalTypeId::TIMESTAMP_TZ)) {
-			if (type == LogicalTypeId::TIMESTAMP_TZ) {
-				column = make_uniq<CastExpression>(LogicalType::TIMESTAMP, std::move(column));
-			}
 			strftime_children.emplace_back(std::move(column));
 			strftime_children.emplace_back(make_uniq<ConstantExpression>(timestamp_format));
 			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -295,6 +295,10 @@ ScalarFunctionSet StrfTimeFun::GetFunctions() {
 	                                    StrfTimeFunctionTimestamp<true>, StrfTimeBindFunction<true>));
 	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP_NS}, LogicalType::VARCHAR,
 	                                    StrfTimeFunctionTimestampNS<true>, StrfTimeBindFunction<true>));
+	strftime.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<false>, StrfTimeBindFunction<false>));
+	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP_TZ}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<true>, StrfTimeBindFunction<true>));
 	return strftime;
 }
 ScalarFunctionSet StrpTimeFun::GetFunctions() {

--- a/test/sql/copy/csv/test_csv_timestamp_tz.test
+++ b/test/sql/copy/csv/test_csv_timestamp_tz.test
@@ -6,12 +6,10 @@ statement ok
 pragma enable_verification
 
 
-statement error
+statement ok
 copy (
 select '2021-05-25 04:55:03.382494 UTC'::timestamp as ts, '2021-05-25 04:55:03.382494 UTC'::timestamptz as tstz
 ) to '{TEMP_DIR}/timestamps.csv' ( timestampformat '%A');
-----
-No function matches the given name and argument types
 
 require icu
 

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -200,3 +200,11 @@ query II
 select ts, tstz from read_json('{TEMP_DIR}/my_file.json')
 ----
 Thu	Thu
+
+statement ok
+copy (select '2026-01-01 12:00:00+05:00'::TIMESTAMPTZ as ts) to '{TEMP_DIR}/my_file.json' (timestampformat '%Y-%m-%d %z', format json);
+
+query I
+select ts from '{TEMP_DIR}/my_file.json';
+----
+2026-01-01 +00

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -176,3 +176,27 @@ query II
 select typeof(ts), ts from read_json_auto('{TEMP_DIR}/iso8601_neg_offset.json')
 ----
 TIMESTAMP	2023-02-08 02:12:28.789
+
+# test that TIMESTAMPFORMAT also applies to TIMESTAMPTZ columns (e.g. now())
+statement ok
+create table timestamptz_test as select '1996-03-27 07:42:33+00'::TIMESTAMPTZ t
+
+statement ok
+copy (select t from timestamptz_test) to '{TEMP_DIR}/my_file.json' (format json, timestampformat '%Y-%m-%d')
+
+query I
+select t from '{TEMP_DIR}/my_file.json'
+----
+1996-03-27
+
+statement ok
+copy (
+    select
+        '2026-01-01T12:00:00Z'::TIMESTAMP as ts,
+        '2026-01-01T12:00:00Z'::TIMESTAMPTZ as tstz
+) to '{TEMP_DIR}/my_file.json' (format json, timestampformat '%a')
+
+query II
+select ts, tstz from read_json('{TEMP_DIR}/my_file.json')
+----
+Thu	Thu

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -177,7 +177,7 @@ select typeof(ts), ts from read_json_auto('{TEMP_DIR}/iso8601_neg_offset.json')
 ----
 TIMESTAMP	2023-02-08 02:12:28.789
 
-# test that TIMESTAMPFORMAT also applies to TIMESTAMPTZ columns (e.g. now())
+# test that TIMESTAMPFORMAT also applies to TIMESTAMPTZ columns
 statement ok
 create table timestamptz_test as select '1996-03-27 07:42:33+00'::TIMESTAMPTZ t
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21960
Fixes https://github.com/duckdb/duckdb/issues/17538

