### PR TITLE
Fix autocomplete for qualified name completions (schema. and catalog.schema.)

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/common/enums/on_entry_not_found.hpp"
 
 namespace duckdb {
 
@@ -154,7 +155,7 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 		if (entry == matches.end()) {
 			throw InternalException("Auto-complete match not found");
 		}
-		if (result.size() > fuzzy_suggestion_count) {
+		if (results.size() > fuzzy_suggestion_count) {
 			// after we exceed the "fuzzy_suggestion_count" we only accept exact suggestion matches
 			if (!StringUtil::StartsWith(StringUtil::Lower(result), lower_prefix)) {
 				break;
@@ -271,6 +272,187 @@ static vector<AutoCompleteCandidate> SuggestTableName(ClientContext &context) {
 		// prioritize user-defined entries (views & tables)
 		int32_t bonus = (entry.internal || entry.type == CatalogType::TABLE_FUNCTION_ENTRY) ? 0 : 1;
 		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
+	}
+	return suggestions;
+}
+
+//! Strip double-quotes from a quoted identifier token, returning the unquoted name.
+//! For unquoted tokens, returns the text as-is.
+static string UnquoteIdentifier(const string &text) {
+	if (text.size() >= 2 && text.front() == '"' && text.back() == '"') {
+		auto inner = text.substr(1, text.size() - 2);
+		return StringUtil::Replace(inner, "\"\"", "\"");
+	}
+	return text;
+}
+
+//! Returns true if a token looks like an identifier (quoted or unquoted keyword-like text).
+static bool TokenIsIdentifier(const string &text) {
+	if (text.empty()) {
+		return false;
+	}
+	if (text.front() == '"' && text.back() == '"') {
+		return true;
+	}
+	return BaseTokenizer::CharacterIsKeyword(text[0]);
+}
+
+//! Qualification context extracted from the token stream before the cursor.
+struct QualificationContext {
+	string catalog_name; //! The catalog qualifier, if present (empty otherwise).
+	string schema_name;  //! The schema qualifier, if present (empty otherwise).
+	bool has_qualification = false;
+};
+
+//! Extract catalog/schema qualification context from the end of the token stream.
+//! Recognizes patterns:
+//!   [..., identifier, '.']                        → schema (or catalog) qualifier
+//!   [..., identifier, '.', identifier, '.']        → catalog + schema qualifier
+//! Only fires when the token before '.' is an identifier (not ')' or a keyword).
+static QualificationContext ExtractQualificationContext(const vector<MatcherToken> &tokens) {
+	QualificationContext ctx;
+	auto sz = tokens.size();
+	if (sz < 2 || tokens[sz - 1].text != ".") {
+		return ctx;
+	}
+	if (!TokenIsIdentifier(tokens[sz - 2].text)) {
+		return ctx;
+	}
+	// Single qualifier: "identifier."
+	string first_qualifier = UnquoteIdentifier(tokens[sz - 2].text);
+	if (sz >= 4 && tokens[sz - 3].text == "." && TokenIsIdentifier(tokens[sz - 4].text)) {
+		// Double qualifier: "identifier.identifier."
+		ctx.catalog_name = UnquoteIdentifier(tokens[sz - 4].text);
+		ctx.schema_name = first_qualifier;
+	} else {
+		// Ambiguous single qualifier — could be catalog or schema.
+		// Store as schema_name; the caller disambiguates per suggestion type.
+		ctx.schema_name = first_qualifier;
+	}
+	ctx.has_qualification = true;
+	return ctx;
+}
+
+static void ScanSchemaForTables(ClientContext &context, SchemaCatalogEntry &schema,
+                                vector<AutoCompleteCandidate> &suggestions) {
+	schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
+		int32_t bonus = entry.internal ? 0 : 1;
+		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
+	});
+	schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
+		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, 0);
+	});
+}
+
+static void ScanSchemaForColumns(ClientContext &context, SchemaCatalogEntry &schema,
+                                 vector<AutoCompleteCandidate> &suggestions) {
+	schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
+		auto &table = entry.Cast<TableCatalogEntry>();
+		int32_t bonus = entry.internal ? 0 : 3;
+		for (auto &col : table.GetColumns().Logical()) {
+			suggestions.emplace_back(col.GetName(), SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+		}
+	});
+	schema.Scan(context, CatalogType::VIEW_ENTRY, [&](CatalogEntry &entry) {
+		auto &view = entry.Cast<ViewCatalogEntry>();
+		int32_t bonus = entry.internal ? 0 : 3;
+		auto column_info = view.GetColumnInfo();
+		if (column_info) {
+			for (idx_t n = 0; n < column_info->names.size(); n++) {
+				auto &name = n < view.aliases.size() ? view.aliases[n] : column_info->names[n];
+				suggestions.emplace_back(name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+			}
+		} else {
+			for (auto &col : view.aliases) {
+				suggestions.emplace_back(col, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+			}
+		}
+	});
+	schema.Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
+		if (StringUtil::CharacterIsOperator(entry.name[0])) {
+			return;
+		}
+		int32_t bonus = entry.internal ? 0 : 2;
+		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+	});
+}
+
+static void ScanSchemaForFunctions(ClientContext &context, SchemaCatalogEntry &schema, SuggestionState suggestion_type,
+                                   vector<AutoCompleteCandidate> &suggestions) {
+	auto catalog_type = suggestion_type == SuggestionState::SUGGEST_TABLE_FUNCTION_NAME
+	                        ? CatalogType::TABLE_FUNCTION_ENTRY
+	                        : CatalogType::SCALAR_FUNCTION_ENTRY;
+	schema.Scan(context, catalog_type,
+	            [&](CatalogEntry &entry) { suggestions.emplace_back(entry.name, suggestion_type, 0); });
+}
+
+//! Look up a schema by catalog_name + schema_name. Uses direct Catalog API.
+//! When catalog_name is empty, searches all catalogs for matching schema.
+static vector<reference<SchemaCatalogEntry>> FindSchemas(ClientContext &context, const string &catalog_name,
+                                                         const string &schema_name) {
+	vector<reference<SchemaCatalogEntry>> result;
+	if (!catalog_name.empty()) {
+		// Direct lookup in the specified catalog
+		auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
+		if (catalog_ptr) {
+			auto schema_ptr = catalog_ptr->GetSchema(context, schema_name, OnEntryNotFound::RETURN_NULL);
+			if (schema_ptr) {
+				result.push_back(*schema_ptr);
+			}
+		}
+	} else {
+		// Search all catalogs for schemas matching this name
+		auto all_schemas = GetAllSchemas(context);
+		for (auto &schema_ref : all_schemas) {
+			if (StringUtil::CIEquals(schema_ref.get().name, schema_name)) {
+				result.push_back(schema_ref);
+			}
+		}
+	}
+	return result;
+}
+
+static vector<AutoCompleteCandidate> SuggestSchemaNameInCatalog(ClientContext &context, const string &catalog_name) {
+	vector<AutoCompleteCandidate> suggestions;
+	auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
+	if (!catalog_ptr) {
+		return suggestions;
+	}
+	catalog_ptr->ScanSchemas(context, [&](SchemaCatalogEntry &schema) {
+		AutoCompleteCandidate candidate(schema.name, SuggestionState::SUGGEST_SCHEMA_NAME, 0);
+		candidate.extra_char = '.';
+		suggestions.push_back(std::move(candidate));
+	});
+	return suggestions;
+}
+
+static vector<AutoCompleteCandidate> SuggestTableNameInSchema(ClientContext &context, const string &catalog_name,
+                                                              const string &schema_name) {
+	vector<AutoCompleteCandidate> suggestions;
+	auto schemas = FindSchemas(context, catalog_name, schema_name);
+	for (auto &schema_ref : schemas) {
+		ScanSchemaForTables(context, schema_ref.get(), suggestions);
+	}
+	return suggestions;
+}
+
+static vector<AutoCompleteCandidate> SuggestColumnNameInSchema(ClientContext &context, const string &catalog_name,
+                                                               const string &schema_name) {
+	vector<AutoCompleteCandidate> suggestions;
+	auto schemas = FindSchemas(context, catalog_name, schema_name);
+	for (auto &schema_ref : schemas) {
+		ScanSchemaForColumns(context, schema_ref.get(), suggestions);
+	}
+	return suggestions;
+}
+
+static vector<AutoCompleteCandidate> SuggestFunctionNameInSchema(ClientContext &context, const string &catalog_name,
+                                                                 const string &schema_name,
+                                                                 SuggestionState suggestion_type) {
+	vector<AutoCompleteCandidate> suggestions;
+	auto schemas = FindSchemas(context, catalog_name, schema_name);
+	for (auto &schema_ref : schemas) {
+		ScanSchemaForFunctions(context, schema_ref.get(), suggestion_type, suggestions);
 	}
 	return suggestions;
 }
@@ -441,6 +623,13 @@ public:
 	void OnLastToken(TokenizeState state, string last_word_p, idx_t last_pos_p) override {
 		if (state == TokenizeState::STRING_LITERAL) {
 			suggestions.emplace_back(SuggestionState::SUGGEST_FILE_NAME);
+		}
+		// A trailing dot in NUMERIC state is a qualifier separator (e.g., "schema."), not a number.
+		// Push it as a token so the PEG matcher can recognize the qualified-name pattern.
+		if (state == TokenizeState::NUMERIC && last_word_p == ".") {
+			tokens.emplace_back(".", last_pos_p);
+			last_word_p = "";
+			last_pos_p = last_pos_p + 1;
 		}
 		last_word = std::move(last_word_p);
 		last_pos = last_pos_p;
@@ -623,6 +812,9 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 		// still no suggestions - return
 		return make_uniq<SQLAutoCompleteFunctionData>(vector<AutoCompleteSuggestion>());
 	}
+	// extract qualification context from the token stream (e.g., "catalog.schema." or "schema.")
+	auto qual = ExtractQualificationContext(tokens);
+
 	vector<AutoCompleteCandidate> available_suggestions;
 	for (auto &suggestion : suggestions) {
 		idx_t suggestion_pos = tokenizer.last_pos;
@@ -630,7 +822,12 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 		vector<AutoCompleteCandidate> new_suggestions;
 		switch (suggestion.type) {
 		case SuggestionState::SUGGEST_VARIABLE:
-			// variables have no suggestions available
+			// Variables normally have no suggestions. But QualifiedName (used by CREATE TABLE etc.)
+			// uses ReservedIdentifier which maps to SUGGEST_VARIABLE. When we're inside a qualified
+			// name (tokens end with "schema."), suggest tables in that schema.
+			if (qual.has_qualification) {
+				new_suggestions = SuggestTableNameInSchema(context, qual.catalog_name, qual.schema_name);
+			}
 			break;
 		case SuggestionState::SUGGEST_KEYWORD:
 			new_suggestions.emplace_back(suggestion.keyword);
@@ -639,13 +836,27 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			new_suggestions = SuggestCatalogName(context);
 			break;
 		case SuggestionState::SUGGEST_SCHEMA_NAME:
-			new_suggestions = SuggestSchemaName(context);
+			if (qual.has_qualification) {
+				// The single qualifier is the catalog name in this context:
+				// the grammar matched "catalog." via CatalogQualification and now wants a schema.
+				new_suggestions = SuggestSchemaNameInCatalog(context, qual.schema_name);
+			} else {
+				new_suggestions = SuggestSchemaName(context);
+			}
 			break;
 		case SuggestionState::SUGGEST_TABLE_NAME:
-			new_suggestions = SuggestTableName(context);
+			if (qual.has_qualification) {
+				new_suggestions = SuggestTableNameInSchema(context, qual.catalog_name, qual.schema_name);
+			} else {
+				new_suggestions = SuggestTableName(context);
+			}
 			break;
 		case SuggestionState::SUGGEST_COLUMN_NAME:
-			new_suggestions = SuggestColumnName(context);
+			if (qual.has_qualification) {
+				new_suggestions = SuggestColumnNameInSchema(context, qual.catalog_name, qual.schema_name);
+			} else {
+				new_suggestions = SuggestColumnName(context);
+			}
 			break;
 		case SuggestionState::SUGGEST_TYPE_NAME:
 			new_suggestions = SuggestType(context);
@@ -657,10 +868,20 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			}
 			break;
 		case SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME:
-			new_suggestions = SuggestScalarFunctionName(context);
+			if (qual.has_qualification) {
+				new_suggestions = SuggestFunctionNameInSchema(context, qual.catalog_name, qual.schema_name,
+				                                              SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME);
+			} else {
+				new_suggestions = SuggestScalarFunctionName(context);
+			}
 			break;
 		case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
-			new_suggestions = SuggestTableFunctionName(context);
+			if (qual.has_qualification) {
+				new_suggestions = SuggestFunctionNameInSchema(context, qual.catalog_name, qual.schema_name,
+				                                              SuggestionState::SUGGEST_TABLE_FUNCTION_NAME);
+			} else {
+				new_suggestions = SuggestTableFunctionName(context);
+			}
 			break;
 		case SuggestionState::SUGGEST_PRAGMA_NAME:
 			new_suggestions = SuggestPragmaName(context);

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -252,26 +252,77 @@ static vector<AutoCompleteCandidate> SuggestCatalogName(ClientContext &context) 
 	return suggestions;
 }
 
-static vector<AutoCompleteCandidate> SuggestSchemaName(ClientContext &context) {
+static vector<AutoCompleteCandidate> SuggestSchemaName(ClientContext &context, const string &catalog_name = "") {
 	vector<AutoCompleteCandidate> suggestions;
-	auto all_entries = GetAllSchemas(context);
-	for (auto &entry_ref : all_entries) {
-		auto &entry = entry_ref.get();
-		AutoCompleteCandidate candidate(entry.name, SuggestionState::SUGGEST_SCHEMA_NAME, 0);
-		candidate.extra_char = '.';
-		suggestions.push_back(std::move(candidate));
+	if (!catalog_name.empty()) {
+		auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
+		if (!catalog_ptr) {
+			return suggestions;
+		}
+		catalog_ptr->ScanSchemas(context, [&](SchemaCatalogEntry &schema) {
+			AutoCompleteCandidate candidate(schema.name, SuggestionState::SUGGEST_SCHEMA_NAME, 0);
+			candidate.extra_char = '.';
+			suggestions.push_back(std::move(candidate));
+		});
+	} else {
+		auto all_entries = GetAllSchemas(context);
+		for (auto &entry_ref : all_entries) {
+			auto &entry = entry_ref.get();
+			AutoCompleteCandidate candidate(entry.name, SuggestionState::SUGGEST_SCHEMA_NAME, 0);
+			candidate.extra_char = '.';
+			suggestions.push_back(std::move(candidate));
+		}
 	}
 	return suggestions;
 }
 
-static vector<AutoCompleteCandidate> SuggestTableName(ClientContext &context) {
+//! Look up a schema by catalog_name + schema_name. Uses direct Catalog API.
+//! When catalog_name is empty, searches all catalogs for matching schema.
+static vector<reference<SchemaCatalogEntry>> FindSchemas(ClientContext &context, const string &catalog_name,
+                                                         const string &schema_name) {
+	vector<reference<SchemaCatalogEntry>> result;
+	if (!catalog_name.empty()) {
+		auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
+		if (catalog_ptr) {
+			auto schema_ptr = catalog_ptr->GetSchema(context, schema_name, OnEntryNotFound::RETURN_NULL);
+			if (schema_ptr) {
+				result.push_back(*schema_ptr);
+			}
+		}
+	} else {
+		auto all_schemas = GetAllSchemas(context);
+		for (auto &schema_ref : all_schemas) {
+			if (StringUtil::CIEquals(schema_ref.get().name, schema_name)) {
+				result.push_back(schema_ref);
+			}
+		}
+	}
+	return result;
+}
+
+static vector<AutoCompleteCandidate> SuggestTableName(ClientContext &context, const string &catalog_name = "",
+                                                      const string &schema_name = "") {
 	vector<AutoCompleteCandidate> suggestions;
-	auto all_entries = GetAllTables(context, true);
-	for (auto &entry_ref : all_entries) {
-		auto &entry = entry_ref.get();
-		// prioritize user-defined entries (views & tables)
-		int32_t bonus = (entry.internal || entry.type == CatalogType::TABLE_FUNCTION_ENTRY) ? 0 : 1;
-		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
+	if (!schema_name.empty()) {
+		auto schemas = FindSchemas(context, catalog_name, schema_name);
+		for (auto &schema_ref : schemas) {
+			auto &schema = schema_ref.get();
+			schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
+				int32_t bonus = entry.internal ? 0 : 1;
+				suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
+			});
+			schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
+				suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, 0);
+			});
+		}
+	} else {
+		auto all_entries = GetAllTables(context, true);
+		for (auto &entry_ref : all_entries) {
+			auto &entry = entry_ref.get();
+			// prioritize user-defined entries (views & tables)
+			int32_t bonus = (entry.internal || entry.type == CatalogType::TABLE_FUNCTION_ENTRY) ? 0 : 1;
+			suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
+		}
 	}
 	return suggestions;
 }
@@ -308,40 +359,50 @@ struct QualificationContext {
 //! Recognizes patterns:
 //!   [..., identifier, '.']                        → schema (or catalog) qualifier
 //!   [..., identifier, '.', identifier, '.']        → catalog + schema qualifier
-//! Only fires when the token before '.' is an identifier (not ')' or a keyword).
 static QualificationContext ExtractQualificationContext(const vector<MatcherToken> &tokens) {
-	QualificationContext ctx;
-	auto sz = tokens.size();
-	if (sz < 2 || tokens[sz - 1].text != ".") {
-		return ctx;
+	QualificationContext result;
+	auto token_count = tokens.size();
+	if (token_count < 2) {
+		return result;
 	}
-	if (!TokenIsIdentifier(tokens[sz - 2].text)) {
-		return ctx;
+	// The last token must be a dot separator
+	auto &last_token = tokens[token_count - 1];
+	if (last_token.text != ".") {
+		return result;
 	}
-	// Single qualifier: "identifier."
-	string first_qualifier = UnquoteIdentifier(tokens[sz - 2].text);
-	if (sz >= 4 && tokens[sz - 3].text == "." && TokenIsIdentifier(tokens[sz - 4].text)) {
-		// Double qualifier: "identifier.identifier."
-		ctx.catalog_name = UnquoteIdentifier(tokens[sz - 4].text);
-		ctx.schema_name = first_qualifier;
-	} else {
-		// Ambiguous single qualifier — could be catalog or schema.
-		// Store as schema_name; the caller disambiguates per suggestion type.
-		ctx.schema_name = first_qualifier;
+	// The token before the dot must be an identifier
+	auto &qualifier_token = tokens[token_count - 2];
+	if (!TokenIsIdentifier(qualifier_token.text)) {
+		return result;
 	}
-	ctx.has_qualification = true;
-	return ctx;
+	string first_qualifier = UnquoteIdentifier(qualifier_token.text);
+	// Check for double qualification: "catalog.schema."
+	if (token_count >= 4) {
+		auto &dot_token = tokens[token_count - 3];
+		auto &catalog_token = tokens[token_count - 4];
+		if (dot_token.text == "." && TokenIsIdentifier(catalog_token.text)) {
+			result.catalog_name = UnquoteIdentifier(catalog_token.text);
+			result.schema_name = first_qualifier;
+			result.has_qualification = true;
+			return result;
+		}
+	}
+	// Single qualifier — could be catalog or schema; the caller disambiguates.
+	result.schema_name = first_qualifier;
+	result.has_qualification = true;
+	return result;
 }
 
-static void ScanSchemaForTables(ClientContext &context, SchemaCatalogEntry &schema,
-                                vector<AutoCompleteCandidate> &suggestions) {
-	schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
-		int32_t bonus = entry.internal ? 0 : 1;
-		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, bonus);
-	});
-	schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
-		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TABLE_NAME, 0);
-	});
+static vector<AutoCompleteCandidate> SuggestType(ClientContext &context) {
+	vector<AutoCompleteCandidate> suggestions;
+	auto all_entries = GetAllTypes(context);
+	for (auto &entry_ref : all_entries) {
+		auto &entry = entry_ref.get();
+		// prioritize user-defined types
+		int32_t bonus = (entry.internal) ? 0 : 1;
+		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TYPE_NAME, bonus, CandidateType::KEYWORD);
+	}
+	return suggestions;
 }
 
 static void ScanSchemaForColumns(ClientContext &context, SchemaCatalogEntry &schema,
@@ -377,131 +438,46 @@ static void ScanSchemaForColumns(ClientContext &context, SchemaCatalogEntry &sch
 	});
 }
 
-static void ScanSchemaForFunctions(ClientContext &context, SchemaCatalogEntry &schema, SuggestionState suggestion_type,
-                                   vector<AutoCompleteCandidate> &suggestions) {
-	auto catalog_type = suggestion_type == SuggestionState::SUGGEST_TABLE_FUNCTION_NAME
-	                        ? CatalogType::TABLE_FUNCTION_ENTRY
-	                        : CatalogType::SCALAR_FUNCTION_ENTRY;
-	schema.Scan(context, catalog_type,
-	            [&](CatalogEntry &entry) { suggestions.emplace_back(entry.name, suggestion_type, 0); });
-}
-
-//! Look up a schema by catalog_name + schema_name. Uses direct Catalog API.
-//! When catalog_name is empty, searches all catalogs for matching schema.
-static vector<reference<SchemaCatalogEntry>> FindSchemas(ClientContext &context, const string &catalog_name,
-                                                         const string &schema_name) {
-	vector<reference<SchemaCatalogEntry>> result;
-	if (!catalog_name.empty()) {
-		// Direct lookup in the specified catalog
-		auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
-		if (catalog_ptr) {
-			auto schema_ptr = catalog_ptr->GetSchema(context, schema_name, OnEntryNotFound::RETURN_NULL);
-			if (schema_ptr) {
-				result.push_back(*schema_ptr);
-			}
+static vector<AutoCompleteCandidate> SuggestColumnName(ClientContext &context, const string &catalog_name = "",
+                                                       const string &schema_name = "") {
+	vector<AutoCompleteCandidate> suggestions;
+	if (!schema_name.empty()) {
+		auto schemas = FindSchemas(context, catalog_name, schema_name);
+		for (auto &schema_ref : schemas) {
+			ScanSchemaForColumns(context, schema_ref.get(), suggestions);
 		}
 	} else {
-		// Search all catalogs for schemas matching this name
-		auto all_schemas = GetAllSchemas(context);
-		for (auto &schema_ref : all_schemas) {
-			if (StringUtil::CIEquals(schema_ref.get().name, schema_name)) {
-				result.push_back(schema_ref);
-			}
-		}
-	}
-	return result;
-}
-
-static vector<AutoCompleteCandidate> SuggestSchemaNameInCatalog(ClientContext &context, const string &catalog_name) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto catalog_ptr = Catalog::GetCatalogEntry(context, catalog_name);
-	if (!catalog_ptr) {
-		return suggestions;
-	}
-	catalog_ptr->ScanSchemas(context, [&](SchemaCatalogEntry &schema) {
-		AutoCompleteCandidate candidate(schema.name, SuggestionState::SUGGEST_SCHEMA_NAME, 0);
-		candidate.extra_char = '.';
-		suggestions.push_back(std::move(candidate));
-	});
-	return suggestions;
-}
-
-static vector<AutoCompleteCandidate> SuggestTableNameInSchema(ClientContext &context, const string &catalog_name,
-                                                              const string &schema_name) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto schemas = FindSchemas(context, catalog_name, schema_name);
-	for (auto &schema_ref : schemas) {
-		ScanSchemaForTables(context, schema_ref.get(), suggestions);
-	}
-	return suggestions;
-}
-
-static vector<AutoCompleteCandidate> SuggestColumnNameInSchema(ClientContext &context, const string &catalog_name,
-                                                               const string &schema_name) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto schemas = FindSchemas(context, catalog_name, schema_name);
-	for (auto &schema_ref : schemas) {
-		ScanSchemaForColumns(context, schema_ref.get(), suggestions);
-	}
-	return suggestions;
-}
-
-static vector<AutoCompleteCandidate> SuggestFunctionNameInSchema(ClientContext &context, const string &catalog_name,
-                                                                 const string &schema_name,
-                                                                 SuggestionState suggestion_type) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto schemas = FindSchemas(context, catalog_name, schema_name);
-	for (auto &schema_ref : schemas) {
-		ScanSchemaForFunctions(context, schema_ref.get(), suggestion_type, suggestions);
-	}
-	return suggestions;
-}
-
-static vector<AutoCompleteCandidate> SuggestType(ClientContext &context) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto all_entries = GetAllTypes(context);
-	for (auto &entry_ref : all_entries) {
-		auto &entry = entry_ref.get();
-		// prioritize user-defined types
-		int32_t bonus = (entry.internal) ? 0 : 1;
-		suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_TYPE_NAME, bonus, CandidateType::KEYWORD);
-	}
-	return suggestions;
-}
-static vector<AutoCompleteCandidate> SuggestColumnName(ClientContext &context) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto all_entries = GetAllTables(context, false);
-	for (auto &entry_ref : all_entries) {
-		auto &entry = entry_ref.get();
-		if (entry.type == CatalogType::TABLE_ENTRY) {
-			auto &table = entry.Cast<TableCatalogEntry>();
-			int32_t bonus = entry.internal ? 0 : 3;
-			for (auto &col : table.GetColumns().Logical()) {
-				suggestions.emplace_back(col.GetName(), SuggestionState::SUGGEST_COLUMN_NAME, bonus);
-			}
-		} else if (entry.type == CatalogType::VIEW_ENTRY) {
-			auto &view = entry.Cast<ViewCatalogEntry>();
-			int32_t bonus = entry.internal ? 0 : 3;
-			auto column_info = view.GetColumnInfo();
-			if (column_info) {
-				// view has names
-				for (idx_t n = 0; n < column_info->names.size(); n++) {
-					auto &name = n < view.aliases.size() ? view.aliases[n] : column_info->names[n];
-					suggestions.emplace_back(name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+		auto all_entries = GetAllTables(context, false);
+		for (auto &entry_ref : all_entries) {
+			auto &entry = entry_ref.get();
+			if (entry.type == CatalogType::TABLE_ENTRY) {
+				auto &table = entry.Cast<TableCatalogEntry>();
+				int32_t bonus = entry.internal ? 0 : 3;
+				for (auto &col : table.GetColumns().Logical()) {
+					suggestions.emplace_back(col.GetName(), SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+				}
+			} else if (entry.type == CatalogType::VIEW_ENTRY) {
+				auto &view = entry.Cast<ViewCatalogEntry>();
+				int32_t bonus = entry.internal ? 0 : 3;
+				auto column_info = view.GetColumnInfo();
+				if (column_info) {
+					for (idx_t n = 0; n < column_info->names.size(); n++) {
+						auto &name = n < view.aliases.size() ? view.aliases[n] : column_info->names[n];
+						suggestions.emplace_back(name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+					}
+				} else {
+					for (auto &col : view.aliases) {
+						suggestions.emplace_back(col, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+					}
 				}
 			} else {
-				// add only aliases
-				for (auto &col : view.aliases) {
-					suggestions.emplace_back(col, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+				if (StringUtil::CharacterIsOperator(entry.name[0])) {
+					continue;
 				}
-			}
-		} else {
-			if (StringUtil::CharacterIsOperator(entry.name[0])) {
-				continue;
-			}
-			int32_t bonus = entry.internal ? 0 : 2;
-			suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
-		};
+				int32_t bonus = entry.internal ? 0 : 2;
+				suggestions.emplace_back(entry.name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+			};
+		}
 	}
 	return suggestions;
 }
@@ -546,25 +522,24 @@ static vector<AutoCompleteCandidate> SuggestSettingName(ClientContext &context) 
 	return suggestions;
 }
 
-static vector<AutoCompleteCandidate> SuggestScalarFunctionName(ClientContext &context) {
+static vector<AutoCompleteCandidate> SuggestFunctionName(ClientContext &context, CatalogType catalog_type,
+                                                         SuggestionState suggestion_type,
+                                                         const string &catalog_name = "",
+                                                         const string &schema_name = "") {
 	vector<AutoCompleteCandidate> suggestions;
-	auto scalar_functions = Catalog::GetAllEntries(context, CatalogType::SCALAR_FUNCTION_ENTRY);
-	for (const auto &scalar_function : scalar_functions) {
-		AutoCompleteCandidate candidate(scalar_function.get().name, SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME, 0);
-		suggestions.push_back(std::move(candidate));
+	if (!schema_name.empty()) {
+		auto schemas = FindSchemas(context, catalog_name, schema_name);
+		for (auto &schema_ref : schemas) {
+			auto &schema = schema_ref.get();
+			schema.Scan(context, catalog_type,
+			            [&](CatalogEntry &entry) { suggestions.emplace_back(entry.name, suggestion_type, 0); });
+		}
+	} else {
+		auto functions = Catalog::GetAllEntries(context, catalog_type);
+		for (const auto &function : functions) {
+			suggestions.emplace_back(function.get().name, suggestion_type, 0);
+		}
 	}
-
-	return suggestions;
-}
-
-static vector<AutoCompleteCandidate> SuggestTableFunctionName(ClientContext &context) {
-	vector<AutoCompleteCandidate> suggestions;
-	auto table_functions = Catalog::GetAllEntries(context, CatalogType::TABLE_FUNCTION_ENTRY);
-	for (const auto &table_function : table_functions) {
-		AutoCompleteCandidate candidate(table_function.get().name, SuggestionState::SUGGEST_TABLE_FUNCTION_NAME, 0);
-		suggestions.push_back(std::move(candidate));
-	}
-
 	return suggestions;
 }
 
@@ -826,7 +801,7 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			// uses ReservedIdentifier which maps to SUGGEST_VARIABLE. When we're inside a qualified
 			// name (tokens end with "schema."), suggest tables in that schema.
 			if (qual.has_qualification) {
-				new_suggestions = SuggestTableNameInSchema(context, qual.catalog_name, qual.schema_name);
+				new_suggestions = SuggestTableName(context, qual.catalog_name, qual.schema_name);
 			}
 			break;
 		case SuggestionState::SUGGEST_KEYWORD:
@@ -836,27 +811,13 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			new_suggestions = SuggestCatalogName(context);
 			break;
 		case SuggestionState::SUGGEST_SCHEMA_NAME:
-			if (qual.has_qualification) {
-				// The single qualifier is the catalog name in this context:
-				// the grammar matched "catalog." via CatalogQualification and now wants a schema.
-				new_suggestions = SuggestSchemaNameInCatalog(context, qual.schema_name);
-			} else {
-				new_suggestions = SuggestSchemaName(context);
-			}
+			new_suggestions = SuggestSchemaName(context, qual.has_qualification ? qual.schema_name : "");
 			break;
 		case SuggestionState::SUGGEST_TABLE_NAME:
-			if (qual.has_qualification) {
-				new_suggestions = SuggestTableNameInSchema(context, qual.catalog_name, qual.schema_name);
-			} else {
-				new_suggestions = SuggestTableName(context);
-			}
+			new_suggestions = SuggestTableName(context, qual.catalog_name, qual.schema_name);
 			break;
 		case SuggestionState::SUGGEST_COLUMN_NAME:
-			if (qual.has_qualification) {
-				new_suggestions = SuggestColumnNameInSchema(context, qual.catalog_name, qual.schema_name);
-			} else {
-				new_suggestions = SuggestColumnName(context);
-			}
+			new_suggestions = SuggestColumnName(context, qual.catalog_name, qual.schema_name);
 			break;
 		case SuggestionState::SUGGEST_TYPE_NAME:
 			new_suggestions = SuggestType(context);
@@ -868,20 +829,14 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			}
 			break;
 		case SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME:
-			if (qual.has_qualification) {
-				new_suggestions = SuggestFunctionNameInSchema(context, qual.catalog_name, qual.schema_name,
-				                                              SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME);
-			} else {
-				new_suggestions = SuggestScalarFunctionName(context);
-			}
+			new_suggestions =
+			    SuggestFunctionName(context, CatalogType::SCALAR_FUNCTION_ENTRY,
+			                        SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME, qual.catalog_name, qual.schema_name);
 			break;
 		case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
-			if (qual.has_qualification) {
-				new_suggestions = SuggestFunctionNameInSchema(context, qual.catalog_name, qual.schema_name,
-				                                              SuggestionState::SUGGEST_TABLE_FUNCTION_NAME);
-			} else {
-				new_suggestions = SuggestTableFunctionName(context);
-			}
+			new_suggestions =
+			    SuggestFunctionName(context, CatalogType::TABLE_FUNCTION_ENTRY,
+			                        SuggestionState::SUGGEST_TABLE_FUNCTION_NAME, qual.catalog_name, qual.schema_name);
 			break;
 		case SuggestionState::SUGGEST_PRAGMA_NAME:
 			new_suggestions = SuggestPragmaName(context);

--- a/test/sql/function/autocomplete/create_table.test
+++ b/test/sql/function/autocomplete/create_table.test
@@ -122,8 +122,9 @@ SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE attac')
 ----
 attached_in_memory.	13
 
+# suggest schemas in attached catalog matching prefix
 query II
-SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE attached_in_memory.a') LIMIT 1;
+SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE attached_in_memory.m') LIMIT 1;
 ----
 main.	32
 

--- a/test/sql/function/autocomplete/create_table.test
+++ b/test/sql/function/autocomplete/create_table.test
@@ -83,16 +83,20 @@ PRIMARY 	28
 statement ok
 CREATE SCHEMA abcdefgh;
 
+statement ok
+CREATE TABLE abcdefgh.tbl_in_schema(i INTEGER);
+
 # suggest a schema name
 query II
 SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE abcd') LIMIT 1;
 ----
 abcdefgh.	13
 
+# after typing "schema.", suggest tables in that schema
 query II
 SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE abcdefgh.') LIMIT 1;
 ----
-.	21
+tbl_in_schema	22
 
 # we suggest the original schema
 query II
@@ -121,7 +125,7 @@ attached_in_memory.	13
 query II
 SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE attached_in_memory.a') LIMIT 1;
 ----
-abcdefgh.	32
+main.	32
 
 statement error
 FROM sql_auto_complete(NULL);

--- a/test/sql/function/autocomplete/qualified_names.test
+++ b/test/sql/function/autocomplete/qualified_names.test
@@ -1,0 +1,97 @@
+# name: test/sql/function/autocomplete/qualified_names.test
+# description: Test qualified name autocomplete (catalog.schema.table)
+# group: [autocomplete]
+
+require autocomplete
+
+# --- Setup ---
+statement ok
+CREATE SCHEMA test_schema;
+
+statement ok
+CREATE TABLE test_schema.schema_table1(i INTEGER);
+
+statement ok
+CREATE TABLE test_schema.schema_table2(j INTEGER);
+
+statement ok
+CREATE TABLE main_table(k INTEGER);
+
+# --- Bug 1: Trailing dot triggers table suggestions, not "." keyword ---
+# After typing "test_schema.", we should get tables from that schema
+query III
+SELECT suggestion, suggestion_start, suggestion_type FROM sql_auto_complete('SELECT * FROM test_schema.') ORDER BY suggestion_score ASC LIMIT 1;
+----
+schema_table1	26	table
+
+# Partial name after dot still works
+query II
+SELECT suggestion, suggestion_start FROM sql_auto_complete('SELECT * FROM test_schema.schema_t') LIMIT 1;
+----
+schema_table1	26
+
+# --- Bug 3: Context-aware filtering ---
+# Tables from other schemas should NOT appear when qualifying with test_schema
+query I
+SELECT count(*) FROM sql_auto_complete('SELECT * FROM test_schema.') WHERE suggestion = 'main_table';
+----
+0
+
+# --- Catalog-qualified completions ---
+statement ok
+ATTACH ':memory:' AS test_db;
+
+statement ok
+CREATE SCHEMA test_db.db_schema;
+
+statement ok
+CREATE TABLE test_db.db_schema.db_table(i INTEGER);
+
+# catalog.schema. should suggest tables in that schema
+query III
+SELECT suggestion, suggestion_start, suggestion_type FROM sql_auto_complete('SELECT * FROM test_db.db_schema.') ORDER BY suggestion_score ASC LIMIT 1;
+----
+db_table	32	table
+
+# catalog. should suggest schemas in that catalog
+query III
+SELECT suggestion, suggestion_start, suggestion_type FROM sql_auto_complete('SELECT * FROM test_db.db_') ORDER BY suggestion_score ASC LIMIT 1;
+----
+db_schema.	22	schema
+
+# catalog.schema. filtering: tables from a different schema in the same catalog should NOT appear
+statement ok
+CREATE SCHEMA test_db.other_schema;
+
+statement ok
+CREATE TABLE test_db.other_schema.other_table(i INTEGER);
+
+query I
+SELECT count(*) FROM sql_auto_complete('SELECT * FROM test_db.db_schema.') WHERE suggestion = 'other_table';
+----
+0
+
+# catalog. with just trailing dot should include schemas from that catalog
+query I
+SELECT count(*) FROM sql_auto_complete('SELECT * FROM test_db.') WHERE suggestion = 'db_schema.' AND suggestion_type = 'schema';
+----
+1
+
+# catalog. filtering: schemas from a different catalog should NOT appear
+# test_schema exists in the default catalog, not in test_db
+query I
+SELECT count(*) FROM sql_auto_complete('SELECT * FROM test_db.') WHERE suggestion = 'test_schema.';
+----
+0
+
+# Also works for DROP TABLE with schema qualification
+query III
+SELECT suggestion, suggestion_start, suggestion_type FROM sql_auto_complete('DROP TABLE test_schema.') ORDER BY suggestion_score ASC LIMIT 1;
+----
+schema_table1	23	table
+
+# Also works for CREATE TABLE with catalog.schema qualification
+query III
+SELECT suggestion, suggestion_start, suggestion_type FROM sql_auto_complete('CREATE TABLE test_db.db_schema.') ORDER BY suggestion_score ASC LIMIT 1;
+----
+db_table	31	table


### PR DESCRIPTION
## Summary

Autocomplete doesn't work when typing qualified names like `schema.` or `catalog.schema.` — the most common complaint is that after typing the dot, suggestions are either empty, irrelevant, or show the literal `.` character instead of objects in that schema.

This PR fixes three bugs that combine to cause this:

**1. Trailing dot not tokenized** — When input ends with `.` (e.g., `my_schema.`), the tokenizer treats `.` as a numeric literal start (for `.5`-style numbers) and stores it as the scoring prefix instead of pushing it as a token. The PEG grammar matcher never sees the dot and can't recognize `SchemaQualification`. Fixed by detecting a standalone trailing `.` in `OnLastToken` and pushing it as a real token.

**2. No context-aware filtering** — `SuggestTableName()` returns every table from every schema in every catalog. After the dot fix, the grammar correctly identifies that a table name is needed, but the suggestion is polluted with hundreds of irrelevant entries. Fixed by extracting the already-typed qualifier from the token stream and using direct catalog API lookups (`Catalog::GetCatalogEntry` → `GetSchema` → `Scan`) to return only matching objects.

**3. Fuzzy suggestion limit compares string length instead of result count** — `result.size()` (the string length of one suggestion) was used instead of `results.size()` (the number of results so far), causing the exact-match-only cutoff to fire prematurely for suggestions longer than 20 characters.

### Before / After

| Input | Before | After |
|-------|--------|-------|
| `SELECT * FROM my_schema.` | `.` (keyword) or empty | Tables in `my_schema` |
| `SELECT * FROM catalog.schema.` | empty | Tables in `catalog.schema` |
| `CREATE TABLE my_schema.` | `.` (keyword) | Tables in `my_schema` |
| `SELECT * FROM catalog.` | mixed results from all catalogs | Schemas in `catalog` |
| `DROP TABLE my_schema.` | `.` (keyword) | Tables in `my_schema` |

Context-aware filtering also applies to column names, scalar functions, and table functions when schema-qualified.

## Test plan

- [x] New test file `test/sql/function/autocomplete/qualified_names.test` covering:
  - `schema.` → table completion (SELECT, DROP, CREATE TABLE contexts)
  - `catalog.schema.` → table completion
  - `catalog.` → schema completion
  - Negative tests: cross-schema and cross-catalog filtering verified with `count(*) WHERE suggestion = ...`
- [x] Updated `test/sql/function/autocomplete/create_table.test` expectations to match improved behavior
- [x] All 21 existing autocomplete tests pass (367 assertions, 2 skipped for missing icu/tpch)
- [x] PEG parser tests pass
- [x] Release build, format check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)