### PR TITLE
Fix hex string literal conversion to blob

### DIFF
--- a/src/parser/transform/expression/transform_constant.cpp
+++ b/src/parser/transform/expression/transform_constant.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
@@ -14,7 +15,37 @@ unique_ptr<ConstantExpression> Transformer::TransformValue(duckdb_libpgquery::PG
 	case duckdb_libpgquery::T_PGInteger:
 		D_ASSERT(val.val.ival <= NumericLimits<int32_t>::Maximum());
 		return make_uniq<ConstantExpression>(Value::INTEGER((int32_t)val.val.ival));
-	case duckdb_libpgquery::T_PGBitString: // FIXME: this should actually convert to BLOB
+	case duckdb_libpgquery::T_PGBitString: {
+		// SQL hex string literal X'...' - convert to BLOB
+		// PostgreSQL parser returns the string as "xDEADBEEF" format
+		string hex_str(val.val.str);
+
+		// Skip the 'x' or 'X' prefix if present
+		idx_t start_pos = 0;
+		if (!hex_str.empty() && (hex_str[0] == 'x' || hex_str[0] == 'X')) {
+			start_pos = 1;
+		}
+
+		// Validate and convert hex string to binary
+		idx_t hex_len = hex_str.size() - start_pos;
+		if (hex_len % 2 != 0) {
+			throw ParserException("Invalid hexadecimal string literal: odd number of hex digits");
+		}
+
+		idx_t blob_size = hex_len / 2;
+		auto blob_data = make_unsafe_uniq_array_uninitialized<data_t>(blob_size);
+
+		for (idx_t i = 0; i < blob_size; i++) {
+			int high = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[start_pos + i * 2])];
+			int low = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[start_pos + i * 2 + 1])];
+			if (high < 0 || low < 0) {
+				throw ParserException("Invalid hexadecimal string literal: invalid hex character");
+			}
+			blob_data[i] = static_cast<data_t>((high << 4) | low);
+		}
+
+		return make_uniq<ConstantExpression>(Value::BLOB(const_data_ptr_cast(blob_data.get()), blob_size));
+	}
 	case duckdb_libpgquery::T_PGString:
 		return make_uniq<ConstantExpression>(Value(string(val.val.str)));
 	case duckdb_libpgquery::T_PGFloat: {

--- a/src/parser/transform/expression/transform_constant.cpp
+++ b/src/parser/transform/expression/transform_constant.cpp
@@ -18,16 +18,19 @@ unique_ptr<ConstantExpression> Transformer::TransformValue(duckdb_libpgquery::PG
 	case duckdb_libpgquery::T_PGBitString: {
 		// SQL hex string literal X'...' - convert to BLOB
 		// PostgreSQL parser returns the string as "xDEADBEEF" format
-		string hex_str(val.val.str);
+		const char* hex_str = val.val.str;
+		if (!hex_str) {
+			throw ParserException("Invalid hexadecimal string literal: null string");
+		}
 
 		// Skip the 'x' or 'X' prefix if present
 		idx_t start_pos = 0;
-		if (!hex_str.empty() && (hex_str[0] == 'x' || hex_str[0] == 'X')) {
+		if (hex_str[0] == 'x' || hex_str[0] == 'X') {
 			start_pos = 1;
 		}
 
 		// Validate and convert hex string to binary
-		idx_t hex_len = hex_str.size() - start_pos;
+		idx_t hex_len = strlen(hex_str + start_pos);
 		if (hex_len % 2 != 0) {
 			throw ParserException("Invalid hexadecimal string literal: odd number of hex digits");
 		}
@@ -37,7 +40,7 @@ unique_ptr<ConstantExpression> Transformer::TransformValue(duckdb_libpgquery::PG
 
 		for (idx_t i = 0; i < blob_size; i++) {
 			int high = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[start_pos + i * 2])];
-			int low = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[start_pos + i * 2 + 1])];
+			int low  = Blob::HEX_MAP[static_cast<unsigned char>(hex_str[start_pos + i * 2 + 1])];
 			if (high < 0 || low < 0) {
 				throw ParserException("Invalid hexadecimal string literal: invalid hex character");
 			}

--- a/test/sql/types/blob/test_hex_string_literal.test
+++ b/test/sql/types/blob/test_hex_string_literal.test
@@ -1,0 +1,115 @@
+# name: test/sql/types/blob/test_hex_string_literal.test
+# description: Test SQL hex string literal X'...' syntax
+# group: [blob]
+
+# Basic hex string literal should return BLOB type
+query T
+SELECT typeof(X'DEADBEEF');
+----
+BLOB
+
+# Hex string literal should have correct length (4 bytes, not 9)
+query I
+SELECT octet_length(X'DEADBEEF');
+----
+4
+
+# Hex string literal content should be correct binary data
+query T
+SELECT X'DEADBEEF';
+----
+\xDE\xAD\xBE\xEF
+
+# Empty hex string literal
+query T
+SELECT X'';
+----
+(empty)
+
+query T
+SELECT typeof(X'');
+----
+BLOB
+
+query I
+SELECT octet_length(X'');
+----
+0
+
+# Case insensitivity - lowercase and uppercase should produce same result
+query T
+SELECT X'ff';
+----
+\xFF
+
+query T
+SELECT X'FF';
+----
+\xFF
+
+query I
+SELECT X'ff' = X'FF';
+----
+1
+
+# Single byte
+query T
+SELECT X'00';
+----
+\x00
+
+query T
+SELECT X'FF';
+----
+\xFF
+
+# Multiple bytes
+query T
+SELECT X'0123456789ABCDEF';
+----
+\x01#Eg\x89\xAB\xCD\xEF
+
+# Insert hex string literal into BLOB column
+statement ok
+CREATE TABLE hex_test (b BLOB);
+
+statement ok
+INSERT INTO hex_test VALUES (X'DEADBEEF');
+
+query T
+SELECT * FROM hex_test;
+----
+\xDE\xAD\xBE\xEF
+
+query I
+SELECT octet_length(b) FROM hex_test;
+----
+4
+
+# Error: odd number of hex digits
+statement error
+SELECT X'F';
+----
+Invalid hexadecimal string literal: odd number of hex digits
+
+statement error
+SELECT X'ABC';
+----
+Invalid hexadecimal string literal: odd number of hex digits
+
+# Error: invalid hex character
+statement error
+SELECT X'GG';
+----
+Invalid hexadecimal string literal: invalid hex character
+
+statement error
+SELECT X'ZZ';
+----
+Invalid hexadecimal string literal: invalid hex character
+
+# Comparison with BLOB cast from string
+query I
+SELECT X'DEADBEEF' = '\xDE\xAD\xBE\xEF'::BLOB;
+----
+1


### PR DESCRIPTION
# Fixes String Literal Conversion to Blob
Fixes #21897 
- Added conversion from hex string literal (e.g., `X'deadbeef'`) to blob type, now they are treated as a binary value.
- Added unit tests for this module.