### PR TITLE
Use DB serialization compatibility for json_serialize_sql

### DIFF
--- a/extension/json/include/json_serializer.hpp
+++ b/extension/json/include/json_serializer.hpp
@@ -25,16 +25,18 @@ private:
 	void PushValue(yyjson_mut_val *val);
 
 public:
-	explicit JsonSerializer(yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty, bool skip_if_default)
+	explicit JsonSerializer(yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty, bool skip_if_default,
+	                        SerializationOptions options_p = SerializationOptions())
 	    : doc(doc), stack({yyjson_mut_obj(doc)}), skip_if_null(skip_if_null), skip_if_empty(skip_if_empty) {
+		options = std::move(options_p);
 		options.serialize_enum_as_string = true;
 		options.serialize_default_values = !skip_if_default;
 	}
 
 	template <class T>
 	static yyjson_mut_val *Serialize(T &value, yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty,
-	                                 bool skip_if_default) {
-		JsonSerializer serializer(doc, skip_if_null, skip_if_empty, skip_if_default);
+	                                 bool skip_if_default, SerializationOptions options_p = SerializationOptions()) {
+		JsonSerializer serializer(doc, skip_if_null, skip_if_empty, skip_if_default, options_p);
 		value.Serialize(serializer);
 		return serializer.GetRootObject();
 	}

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -106,8 +106,12 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 					throw NotImplementedException("Only SELECT statements can be serialized to json!");
 				}
 				auto &select = statement->Cast<SelectStatement>();
-				auto json =
-				    JsonSerializer::Serialize(select, doc, info.skip_if_null, info.skip_if_empty, info.skip_if_default);
+
+				auto options = make_uniq<SerializationOptions>();
+				options->serialization_compatibility =
+				    state.GetContext().db->config.options.serialization_compatibility;
+				auto json = JsonSerializer::Serialize(select, doc, info.skip_if_null, info.skip_if_empty,
+				                                      info.skip_if_default, *options);
 
 				yyjson_mut_arr_append(statements_arr, json);
 			}


### PR DESCRIPTION
The `JsonSerializer` currently always defaults the serialization compatibility to `SerializationCompatibility::Default()`. This PR updates the json serialization to respect the database's configured serialization compatibility setting. The default serialization context could lead to unexpected JSON output.

Another implementation alternative would be to add the serialization compatibility as an explicit function parameter, so that users could override it independently.

fix: https://github.com/duckdblabs/duckdb-internal/issues/8842