### PR TITLE
Add HasMinMax for StringStats

### DIFF
--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -40,6 +40,8 @@ struct StringStats {
 	DUCKDB_API static BaseStatistics CreateUnknown(LogicalType type);
 	//! Empty statistics - i.e. "has_unicode" is false, "max_string_length" is 0, "min" is \xFF, max is \x00
 	DUCKDB_API static BaseStatistics CreateEmpty(LogicalType type);
+	//! Returns true if the stats has both a min and max value defined
+	DUCKDB_API static bool HasMinMax(const BaseStatistics &stats);
 	//! Whether or not the statistics have a maximum string length defined
 	DUCKDB_API static bool HasMaxStringLength(const BaseStatistics &stats);
 	//! Returns the maximum string length, or throws an exception if !HasMaxStringLength()

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -91,8 +91,7 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 		}
 	} else {
 		D_ASSERT(column_stats->GetStatsType() == StatisticsType::STRING_STATS);
-		if (StringStats::Min(*column_stats) > StringStats::Max(*column_stats)) {
-			// No min/max statistics availabe
+		if (!StringStats::HasMinMax(*column_stats)) {
 			return false;
 		}
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -529,7 +529,7 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 		if (stats.GetType().id() != LogicalTypeId::VARCHAR || key_type.id() != LogicalTypeId::VARCHAR) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
-		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
+		if (!StringStats::HasMinMax(stats)) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 		min = Value(StringStats::Min(stats));

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -2,7 +2,8 @@
 
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
-#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -10,6 +11,38 @@
 #include "duckdb/common/types/blob.hpp"
 
 namespace duckdb {
+
+namespace {
+
+bool AllCharsEqualTo(const data_t data[], data_t comp) {
+	for (idx_t i = 0; i < StringStatsData::MAX_STRING_MINMAX_SIZE; i++) {
+		if (data[i] != comp) {
+			return false;
+		}
+	}
+	return true;
+}
+
+int StringValueComparison(const_data_ptr_t data, idx_t len, const_data_ptr_t comparison) {
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] < comparison[i]) {
+			return -1;
+		} else if (data[i] > comparison[i]) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+void ConstructValue(const_data_ptr_t data, idx_t size, data_t target[]) {
+	idx_t value_size = size > StringStatsData::MAX_STRING_MINMAX_SIZE ? StringStatsData::MAX_STRING_MINMAX_SIZE : size;
+	memcpy(target, data, value_size);
+	for (idx_t i = value_size; i < StringStatsData::MAX_STRING_MINMAX_SIZE; i++) {
+		target[i] = '\0';
+	}
+}
+
+} // namespace
 
 BaseStatistics StringStats::CreateUnknown(LogicalType type) {
 	BaseStatistics result(std::move(type));
@@ -47,6 +80,23 @@ StringStatsData &StringStats::GetDataUnsafe(BaseStatistics &stats) {
 const StringStatsData &StringStats::GetDataUnsafe(const BaseStatistics &stats) {
 	D_ASSERT(stats.GetStatsType() == StatisticsType::STRING_STATS);
 	return stats.stats_union.string_data;
+}
+
+bool StringStats::HasMinMax(const BaseStatistics &stats) {
+	if (stats.GetType().id() == LogicalTypeId::SQLNULL) {
+		return false;
+	}
+	auto &string_data = StringStats::GetDataUnsafe(stats);
+	if (StringValueComparison(string_data.min, StringStatsData::MAX_STRING_MINMAX_SIZE, string_data.max) > 0) {
+		return false;
+	}
+	if (stats.GetType().id() == LogicalTypeId::BLOB) {
+		// Empty stats are allowed and usable
+		return true;
+	}
+	// The initial min value means either "empty string" or not set. Both effectively represent no lower bound. Thus,
+	// return true if at least max is set.
+	return !AllCharsEqualTo(string_data.max, 0xFF);
 }
 
 bool StringStats::HasMaxStringLength(const BaseStatistics &stats) {
@@ -118,25 +168,6 @@ void StringStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) 
 	deserializer.ReadProperty(202, "has_unicode", string_data.has_unicode);
 	deserializer.ReadProperty(203, "has_max_string_length", string_data.has_max_string_length);
 	deserializer.ReadProperty(204, "max_string_length", string_data.max_string_length);
-}
-
-static int StringValueComparison(const_data_ptr_t data, idx_t len, const_data_ptr_t comparison) {
-	for (idx_t i = 0; i < len; i++) {
-		if (data[i] < comparison[i]) {
-			return -1;
-		} else if (data[i] > comparison[i]) {
-			return 1;
-		}
-	}
-	return 0;
-}
-
-static void ConstructValue(const_data_ptr_t data, idx_t size, data_t target[]) {
-	idx_t value_size = size > StringStatsData::MAX_STRING_MINMAX_SIZE ? StringStatsData::MAX_STRING_MINMAX_SIZE : size;
-	memcpy(target, data, value_size);
-	for (idx_t i = value_size; i < StringStatsData::MAX_STRING_MINMAX_SIZE; i++) {
-		target[i] = '\0';
-	}
 }
 
 void StringStats::Update(BaseStatistics &stats, const string_t &value) {
@@ -273,8 +304,7 @@ child_list_t<Value> StringStats::ToStruct(const BaseStatistics &stats) {
 	auto max_len = GetValidMinMaxSubstring(string_data.max);
 	string_t min_str(const_char_ptr_cast(string_data.min), min_len);
 	string_t max_str(const_char_ptr_cast(string_data.max), max_len);
-	// if min > max the stats are empty and min/max is not yet initialized - so don't emit
-	if (min_str <= max_str) {
+	if (StringStats::HasMinMax(stats)) {
 		result.emplace_back("min", Blob::ToString(min_str));
 		result.emplace_back("max", Blob::ToString(max_str));
 	}

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1438,7 +1438,7 @@ struct DuckDBPartitionRowGroup : public PartitionRowGroup {
 			return false;
 		}
 		if (stats.GetStatsType() == StatisticsType::STRING_STATS) {
-			if (!StringStats::HasMaxStringLength(stats)) {
+			if (!StringStats::HasMinMax(stats) || !StringStats::HasMaxStringLength(stats)) {
 				return false;
 			}
 			const idx_t max_length = StringStats::MaxStringLength(stats);

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -227,8 +227,8 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 	}
 	if (column_type == OrderByColumnType::STRING) {
-		if (!stats.CanHaveNoNull()) {
-			// No non-null values exist in this row group - stats are meaningless for ordering
+		if (!StringStats::HasMinMax(stats)) {
+			// Row group is all nulls or has incomplete stats - stats are meaningless for ordering
 			return Value();
 		}
 		switch (order_by) {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   test_buffer_pool_reservation.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
+  test_string_stats.cpp
   test_string_util.cpp)
 
 set(ALL_OBJECT_FILES

--- a/test/common/test_string_stats.cpp
+++ b/test/common/test_string_stats.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "catch.hpp"
 

--- a/test/common/test_string_stats.cpp
+++ b/test/common/test_string_stats.cpp
@@ -1,0 +1,82 @@
+#include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/enums/filter_propagate_result.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
+#include "catch.hpp"
+
+using namespace duckdb;
+
+static FilterPropagateResult CheckStringStats(BaseStatistics &stats, ExpressionType comparison, const Value &constant) {
+	return StringStats::CheckZonemap(stats, comparison, array_ptr<const Value>(&constant, 1));
+}
+
+TEST_CASE("Test StringStats HasMinMax edge cases", "[string_stats]") {
+	SECTION("VARCHAR unknown and empty stats do not report min/max") {
+		auto unknown = StringStats::CreateUnknown(LogicalType::VARCHAR);
+		REQUIRE_FALSE(StringStats::HasMinMax(unknown));
+
+		auto empty = StringStats::CreateEmpty(LogicalType::VARCHAR);
+		REQUIRE_FALSE(StringStats::HasMinMax(empty));
+	}
+
+	SECTION("VARCHAR with only max set reports a usable range from empty string") {
+		auto stats = StringStats::CreateUnknown(LogicalType::VARCHAR);
+		StringStats::SetMax(stats, string_t("dog"));
+
+		REQUIRE(StringStats::HasMinMax(stats));
+		REQUIRE(StringStats::Min(stats) == "");
+		REQUIRE(StringStats::Max(stats) == "dog");
+
+		auto outside_upper_bound = Value("zzz");
+		REQUIRE(CheckStringStats(stats, ExpressionType::COMPARE_GREATERTHAN, outside_upper_bound) ==
+		        FilterPropagateResult::FILTER_ALWAYS_FALSE);
+
+		auto inside_range = Value("cat");
+		REQUIRE(CheckStringStats(stats, ExpressionType::COMPARE_EQUAL, inside_range) ==
+		        FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("VARCHAR with only min set remains unusable for HasMinMax but zonemaps can still use it") {
+		auto stats = StringStats::CreateUnknown(LogicalType::VARCHAR);
+		StringStats::SetMin(stats, string_t("dog"));
+
+		REQUIRE_FALSE(StringStats::HasMinMax(stats));
+
+		auto below_lower_bound = Value("cat");
+		REQUIRE(CheckStringStats(stats, ExpressionType::COMPARE_LESSTHAN, below_lower_bound) ==
+		        FilterPropagateResult::FILTER_ALWAYS_FALSE);
+	}
+
+	SECTION("VARCHAR stats with empty string minimum remain usable") {
+		auto stats = StringStats::CreateUnknown(LogicalType::VARCHAR);
+		StringStats::SetMin(stats, string_t(""));
+		StringStats::SetMax(stats, string_t("dog"));
+
+		REQUIRE(StringStats::HasMinMax(stats));
+		REQUIRE(StringStats::Min(stats) == "");
+		REQUIRE(StringStats::Max(stats) == "dog");
+	}
+
+	SECTION("BLOB stats can use one-sided and raw-byte ranges") {
+		auto unknown = StringStats::CreateUnknown(LogicalType::BLOB);
+		REQUIRE(StringStats::HasMinMax(unknown));
+
+		auto max_only = StringStats::CreateUnknown(LogicalType::BLOB);
+		auto max_blob = string("\x00\x7f", 2);
+		StringStats::SetMax(max_only, string_t(max_blob.data(), UnsafeNumericCast<uint32_t>(max_blob.size())));
+		REQUIRE(StringStats::HasMinMax(max_only));
+
+		auto outside_upper_bound = Value::BLOB_RAW(string("\x01\x00", 2));
+		REQUIRE(CheckStringStats(max_only, ExpressionType::COMPARE_GREATERTHAN, outside_upper_bound) ==
+		        FilterPropagateResult::FILTER_ALWAYS_FALSE);
+
+		auto min_only = StringStats::CreateUnknown(LogicalType::BLOB);
+		auto min_blob = string("\x10\x00", 2);
+		StringStats::SetMin(min_only, string_t(min_blob.data(), UnsafeNumericCast<uint32_t>(min_blob.size())));
+		REQUIRE(StringStats::HasMinMax(min_only));
+
+		auto below_lower_bound = Value::BLOB_RAW(string("\x00\xff", 2));
+		REQUIRE(CheckStringStats(min_only, ExpressionType::COMPARE_LESSTHAN, below_lower_bound) ==
+		        FilterPropagateResult::FILTER_ALWAYS_FALSE);
+	}
+}


### PR DESCRIPTION
This PR introduces `StringStats::HasMinMax` and proposes a way of interpreting string min/max statistics in the presence of an ambiguous representation.

Unlike `NumericStats`, `StringStats` does not store explicit nullability/presence bits for min and max. Instead, the raw min/max byte arrays are initialized with sentinel values:

- unknown stats initialize to min = 0xFF..., max = 0x00...
- empty stats initialize to min = 0x00..., max = 0xFF...

 This creates ambiguity (which results in the code trying to guess the availability of min/max via other fields like `has_max_string_length`):

- for VARCHAR, min = 0x00... is indistinguishable from a real minimum of the empty string
- for BLOB, both 0x00 and 0xFF are valid data bytes, so sentinel-like values can also be real bounds
- imported statistics, especially from Parquet, may contain only one of min or max, which means the stored pair can still be useful for pruning even if it does not represent a fully explicit “both bounds observed” state

This PR defines the intended semantics of HasMinMax under those constraints. The key understanding introduced here is:

- `StringStats::HasMinMax` does not mean explicit presence of information for both bounds, because that information is not representable in the current layout
- instead, it means “the stored min/max state can be safely treated as a usable range for the given logical type”

  The behavior is now type-specific:

  - for BLOB, raw byte ranges are meaningful, so min/max are considered usable whenever the stored range is ordered (min <= max)
  - for VARCHAR, we must avoid treating the 0xFF... upper sentinel as a valid string bound, but we do allow the all-zero lower bound because it materializes as empty string, which may be the actual min or else is a conservative lower bound
  - the unknown-state encoding (min > max) still means “no usable min/max”

fixes https://github.com/duckdblabs/duckdb-internal/issues/7658