### PR TITLE
fix: resolve current catalog in ADBC Ingest to avoid temp table shadowing

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -1210,6 +1210,7 @@ AdbcStatusCode Ingest(duckdb_connection connection, const char *catalog, const c
 	// Prefer explicit three-part names; two-part names can be ambiguous.
 	const char *effective_catalog = catalog;
 	const char *effective_schema = schema;
+	std::string resolved_catalog;
 	if (temporary) {
 		// Temporary tables live in the special "temp" catalog.
 		// "CREATE TEMP TABLE" automatically places tables in temp.main.
@@ -1220,6 +1221,26 @@ AdbcStatusCode Ingest(duckdb_connection connection, const char *catalog, const c
 		// Default schema for attached catalogs (DEFAULT_SCHEMA).
 		// Use catalog.main.table to avoid catalog/schema name ambiguity.
 		effective_schema = "main";
+	} else if (!catalog) {
+		// DuckDB's name resolution prioritizes the "temp" catalog, so without an explicit
+		// catalog a same-named temp table would shadow the persistent target. Resolve the
+		// current catalog explicitly to avoid that. Fallback "memory" may not match the
+		// actual catalog for file-based databases.
+		duckdb_result cat_result = {};
+		if (duckdb_query(connection, "SELECT current_catalog()", &cat_result) == DuckDBSuccess) {
+			char *val = duckdb_value_varchar(&cat_result, 0, 0);
+			if (val) {
+				resolved_catalog = val;
+				duckdb_free(val);
+			}
+			effective_catalog = !resolved_catalog.empty() ? resolved_catalog.c_str() : "memory";
+		} else {
+			effective_catalog = "memory";
+		}
+		duckdb_destroy_result(&cat_result);
+		if (!schema) {
+			effective_schema = "main";
+		}
 	}
 
 	duckdb::ArrowSchemaWrapper arrow_schema_wrapper;

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -482,6 +482,48 @@ TEST_CASE("ADBC - Test ingestion - Temporary Table", "[adbc]") {
 	}
 }
 
+TEST_CASE("ADBC - Test ingestion - Temporary Table - Persistent Without Catalog", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	// create a temp table with data1 on adbc_connection
+	auto &input_temp = db.QueryArrowForIngest("SELECT 1 AS idx, 'foo' AS value");
+	db.CreateTable("my_table", input_temp, "", true);
+
+	// create a persistent table with data2 on the SAME adbc_connection (no catalog/schema).
+	// This triggers the bug: the appender resolves "my_table" to the temp table.
+	{
+		auto &input_persistent = db.QueryArrowForIngest("SELECT 2 AS idx, 'bar' AS value");
+		AdbcStatement stmt = {};
+		REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt, &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetOption(&stmt, ADBC_INGEST_OPTION_TARGET_TABLE, "my_table", &db.adbc_error)));
+		// No catalog, no schema, no temporary flag — should go to memory.main
+		REQUIRE(SUCCESS(AdbcStatementBindStream(&stmt, &input_persistent, &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt, nullptr, nullptr, &db.adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementRelease(&stmt, &db.adbc_error)));
+		if (input_persistent.release) {
+			input_persistent.release(&input_persistent);
+		}
+	}
+
+	// Temp table should still contain only data1 (idx=1)
+	{
+		auto res = db.Query("SELECT idx FROM temp.my_table ORDER BY idx");
+		REQUIRE(!res->HasError());
+		REQUIRE(res->RowCount() == 1);
+		REQUIRE(res->GetValue(0, 0).ToString() == "1");
+	}
+	// Persistent table should contain data2 (idx=2)
+	{
+		auto res = db.Query("SELECT idx FROM memory.main.my_table ORDER BY idx");
+		REQUIRE(!res->HasError());
+		REQUIRE(res->RowCount() == 1);
+		REQUIRE(res->GetValue(0, 0).ToString() == "2");
+	}
+}
+
 TEST_CASE("ADBC - Test ingestion - Temporary Table - Schema Set", "[adbc]") {
 	if (!duckdb_lib) {
 		return;


### PR DESCRIPTION
When `temporary=False` and no catalog is specified, DuckDB's default name resolution prioritizes the `temp` catalog.
This caused ADBC `Ingest` to silently write to a same-named temporary table instead of the intended persistent table.

cc @lidavidm