### PR TITLE
Add COMMENT ON COLUMN support for STRUCT type fields

### DIFF
--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -3,7 +3,9 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parsed_data/comment_on_column_info.hpp"
 #include <algorithm>
 #include <sstream>
 
@@ -13,7 +15,7 @@ constexpr const char *TypeCatalogEntry::Name;
 
 TypeCatalogEntry::TypeCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTypeInfo &info)
     : StandardEntry(CatalogType::TYPE_ENTRY, schema, catalog, info.name), user_type(info.type),
-      bind_function(info.bind_function) {
+      bind_function(info.bind_function), field_comments(info.field_comments_map) {
 	this->temporary = info.temporary;
 	this->internal = info.internal;
 	this->extension_name = info.extension_name;
@@ -40,7 +42,48 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 	result->comment = comment;
 	result->tags = tags;
 	result->bind_function = bind_function;
+	result->field_comments_map = field_comments;
 	return std::move(result);
+}
+
+unique_ptr<CatalogEntry> TypeCatalogEntry::AlterEntry(ClientContext &context, AlterInfo &info) {
+	D_ASSERT(!internal);
+
+	if (info.type == AlterType::SET_COLUMN_COMMENT) {
+		auto &comment_on_column_info = info.Cast<SetColumnCommentInfo>();
+		auto copied_type = Copy(context);
+
+		// Verify that the type is a STRUCT and the field exists
+		if (user_type.id() != LogicalTypeId::STRUCT) {
+			throw CatalogException("Type \"%s\" is not a STRUCT type, cannot comment on its fields", name);
+		}
+		auto &child_types = StructType::GetChildTypes(user_type);
+		bool found = false;
+		for (auto &child : child_types) {
+			if (StringUtil::CIEquals(child.first, comment_on_column_info.column_name)) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			throw CatalogException("Type \"%s\" does not have a field with name \"%s\"", name,
+			                       comment_on_column_info.column_name);
+		}
+
+		auto &copied_type_entry = copied_type->Cast<TypeCatalogEntry>();
+		copied_type_entry.field_comments[comment_on_column_info.column_name] = comment_on_column_info.comment_value;
+		return copied_type;
+	}
+
+	throw CatalogException("Unsupported alter type for type entry");
+}
+
+Value TypeCatalogEntry::GetFieldComment(const string &field_name) {
+	auto entry = field_comments.find(field_name);
+	if (entry != field_comments.end()) {
+		return entry->second;
+	}
+	return Value();
 }
 
 string TypeCatalogEntry::ToSQL() const {

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -64,6 +64,9 @@ static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFun
 	names.emplace_back("labels");
 	return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
 
+	names.emplace_back("field_comments");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	return nullptr;
 }
 
@@ -195,6 +198,24 @@ void DuckDBTypesFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 			}
 
 			output.SetValue(col++, count, Value::LIST(LogicalType::VARCHAR, labels));
+		} else {
+			output.SetValue(col++, count, Value());
+		}
+		// field_comments, MAP(VARCHAR, VARCHAR) - for STRUCT types with field comments
+		if (type.id() == LogicalTypeId::STRUCT && type.AuxInfo()) {
+			auto &child_types = StructType::GetChildTypes(type);
+			InsertionOrderPreservingMap<string> field_comment_map;
+			for (auto &child : child_types) {
+				auto comment_val = type_entry.GetFieldComment(child.first);
+				if (!comment_val.IsNull()) {
+					field_comment_map[child.first] = comment_val.ToString();
+				}
+			}
+			if (field_comment_map.empty()) {
+				output.SetValue(col++, count, Value());
+			} else {
+				output.SetValue(col++, count, Value::MAP(field_comment_map));
+			}
 		} else {
 			output.SetValue(col++, count, Value());
 		}

--- a/src/include/duckdb/catalog/catalog_entry/type_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/type_catalog_entry.hpp
@@ -32,7 +32,15 @@ public:
 public:
 	unique_ptr<CreateInfo> GetInfo() const override;
 	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
+	unique_ptr<CatalogEntry> AlterEntry(ClientContext &context, AlterInfo &info) override;
+
+	//! Get the comment for a field in a STRUCT type
+	Value GetFieldComment(const string &field_name);
 
 	string ToSQL() const override;
+
+private:
+	//! Comments on fields of the type (for STRUCT types)
+	unordered_map<string, Value> field_comments;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_type_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_type_info.hpp
@@ -62,6 +62,8 @@ struct CreateTypeInfo : public CreateInfo {
 	unique_ptr<SQLStatement> query;
 	//! Bind type modifiers to the type
 	bind_logical_type_function_t bind_function;
+	//! Comments on fields of the type (for STRUCT types)
+	unordered_map<string, Value> field_comments_map;
 
 public:
 	unique_ptr<CreateInfo> Copy() const override;

--- a/src/include/duckdb/storage/serialization/create_info.json
+++ b/src/include/duckdb/storage/serialization/create_info.json
@@ -257,6 +257,12 @@
         "name": "logical_type",
         "property": "type",
         "type": "LogicalType"
+      },
+      {
+        "id": 202,
+        "name": "field_comments_map",
+        "type": "unordered_map<string, Value>",
+        "default": "unordered_map<string, Value>()"
       }
     ]
   },

--- a/src/parser/parsed_data/comment_on_column_info.cpp
+++ b/src/parser/parsed_data/comment_on_column_info.cpp
@@ -36,7 +36,16 @@ string SetColumnCommentInfo::ToString() const {
 
 optional_ptr<CatalogEntry> SetColumnCommentInfo::TryResolveCatalogEntry(CatalogEntryRetriever &retriever) {
 	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, name);
-	auto entry = retriever.GetEntry(catalog, schema, lookup_info, if_not_found);
+	auto entry = retriever.GetEntry(catalog, schema, lookup_info, OnEntryNotFound::RETURN_NULL);
+
+	if (entry) {
+		catalog_entry_type = entry->type;
+		return entry;
+	}
+
+	// If not found as a table/view, try as a type entry (for STRUCT field comments)
+	EntryLookupInfo type_lookup_info(CatalogType::TYPE_ENTRY, name);
+	entry = retriever.GetEntry(catalog, schema, type_lookup_info, if_not_found);
 
 	if (entry) {
 		catalog_entry_type = entry->type;

--- a/src/storage/serialization/serialize_create_info.cpp
+++ b/src/storage/serialization/serialize_create_info.cpp
@@ -220,12 +220,14 @@ void CreateTypeInfo::Serialize(Serializer &serializer) const {
 	CreateInfo::Serialize(serializer);
 	serializer.WritePropertyWithDefault<string>(200, "name", name);
 	serializer.WriteProperty<LogicalType>(201, "logical_type", type);
+	serializer.WritePropertyWithDefault<unordered_map<string, Value>>(202, "field_comments_map", field_comments_map, unordered_map<string, Value>());
 }
 
 unique_ptr<CreateInfo> CreateTypeInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<CreateTypeInfo>(new CreateTypeInfo());
 	deserializer.ReadPropertyWithDefault<string>(200, "name", result->name);
 	deserializer.ReadProperty<LogicalType>(201, "logical_type", result->type);
+	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(202, "field_comments_map", result->field_comments_map, unordered_map<string, Value>());
 	return std::move(result);
 }
 

--- a/test/sql/catalog/comment_on.test
+++ b/test/sql/catalog/comment_on.test
@@ -253,6 +253,73 @@ SELECT 1::test_type as val;
 statement ok
 DROP TYPE test_type
 
+### Comment on STRUCT type field
+statement ok
+CREATE TYPE test_struct_type AS STRUCT(id INTEGER, some_text TEXT);
+
+# Initially no field comments
+query I
+select field_comments from duckdb_types() where type_name='test_struct_type';
+----
+NULL
+
+# Set comment on struct field
+statement ok
+COMMENT ON COLUMN test_struct_type.id IS 'this is an id'
+
+query I
+select field_comments from duckdb_types() where type_name='test_struct_type';
+----
+{id=this is an id}
+
+# Set comment on another field
+statement ok
+COMMENT ON COLUMN test_struct_type.some_text IS 'this is some text'
+
+query I
+select field_comments['id'] from duckdb_types() where type_name='test_struct_type';
+----
+this is an id
+
+query I
+select field_comments['some_text'] from duckdb_types() where type_name='test_struct_type';
+----
+this is some text
+
+restart
+
+# Verify persistence after restart
+query I
+select field_comments['id'] from duckdb_types() where type_name='test_struct_type';
+----
+this is an id
+
+query I
+select field_comments['some_text'] from duckdb_types() where type_name='test_struct_type';
+----
+this is some text
+
+# Error: non-existent field
+statement error
+COMMENT ON COLUMN test_struct_type.nonexistent IS 'fail'
+----
+does not have a field with name "nonexistent"
+
+# Error: non-STRUCT type cannot have field comments
+statement ok
+CREATE TYPE test_simple_type AS int32;
+
+statement error
+COMMENT ON COLUMN test_simple_type.something IS 'fail'
+----
+not a STRUCT type
+
+statement ok
+DROP TYPE test_simple_type
+
+statement ok
+DROP TYPE test_struct_type
+
 ### Comment on table column
 
 query I


### PR DESCRIPTION
Closes #17517

## Summary

- Adds support for `COMMENT ON COLUMN type_name.field_name IS '...'` on user-defined STRUCT types
- Previously, this failed with `Catalog Error: Table with name X does not exist!` because `SetColumnCommentInfo::TryResolveCatalogEntry` only looked up `TABLE_ENTRY`
- Follows the existing `ViewCatalogEntry` column comment pattern

## Changes

- **`comment_on_column_info.cpp`**: `TryResolveCatalogEntry` now falls back to `TYPE_ENTRY` when `TABLE_ENTRY` is not found
- **`TypeCatalogEntry`**: Added `field_comments` map, `AlterEntry` override for `SET_COLUMN_COMMENT`, and `GetFieldComment` accessor
- **`CreateTypeInfo`**: Added `field_comments_map` field for persistence
- **`duckdb_types()`**: Added `field_comments` column (`MAP(VARCHAR, VARCHAR)`) to expose struct field comments
- **Serialization**: Updated `create_info.json` and regenerated serialization code

## Example

```sql
CREATE TYPE destiny AS STRUCT(id INTEGER, some_text TEXT);
COMMENT ON COLUMN destiny.id IS 'this is an id';
COMMENT ON COLUMN destiny.some_text IS 'this is some text';

SELECT type_name, field_comments FROM duckdb_types() WHERE type_name='destiny';
-- ┌───────────┬─────────────────────────────────────────────────┐
-- │ type_name │                 field_comments                  │
-- ├───────────┼─────────────────────────────────────────────────┤
-- │ destiny   │ {id=this is an id, some_text=this is some text} │
-- └───────────┴─────────────────────────────────────────────────┘
```

## Test plan

- [x] Added tests to `test/sql/catalog/comment_on.test`
  - Field comment set and query via `duckdb_types()`
  - Persistence across `restart`
  - Error on non-existent field
  - Error on non-STRUCT type
- [x] All existing `comment_on.test` assertions pass (98 total)