### PR TITLE
optimizer: eliminate LEFT JOIN when inner side has PK/UNIQUE constraint

### DIFF
--- a/src/optimizer/join_elimination.cpp
+++ b/src/optimizer/join_elimination.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
@@ -119,6 +121,36 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 		auto &get = op.Cast<LogicalGet>();
 		if (get.table_filters.HasFilters()) {
 			pipe_info.has_filter = true;
+		}
+		// Populate distinct_groups from PRIMARY KEY / UNIQUE constraints.
+		// If the table has a PK or UNIQUE constraint whose columns are all
+		// present in the scan, record those columns as a distinct group so
+		// TryEliminateJoin's Check 2 can use them.
+		auto table = get.GetTable();
+		if (table) {
+			auto &constraints = table->GetConstraints();
+			auto &columns = table->GetColumns();
+			for (auto &constraint : constraints) {
+				if (constraint->type != ConstraintType::UNIQUE) {
+					continue;
+				}
+				auto &unique = constraint->Cast<UniqueConstraint>();
+				auto logical_indexes = unique.GetLogicalIndexes(columns);
+				column_binding_set_t constraint_group;
+				bool all_in_scan = true;
+				for (auto &logical_idx : logical_indexes) {
+					auto proj_idx = get.TryGetProjectionIndex(logical_idx.index);
+					if (!proj_idx.IsValid()) {
+						all_in_scan = false;
+						break;
+					}
+					constraint_group.insert(ColumnBinding(get.table_index, proj_idx));
+				}
+				if (all_in_scan && !constraint_group.empty()) {
+					pipe_info.distinct_groups[get.table_index] = std::move(constraint_group);
+					break;
+				}
+			}
 		}
 		break;
 	}
@@ -257,7 +289,7 @@ unique_ptr<LogicalOperator> JoinElimination::TryEliminateJoin() {
 	if (pipe_info.distinct_groups.empty()) {
 		return std::move(pipe_info.root);
 	}
-	// 1. TODO: guarantee by primary/foreign key
+	// 1. guarantee by primary key / unique constraint (populated from LOGICAL_GET constraints above)
 
 	if (!is_output_unique) {
 		is_output_unique = true;

--- a/test/optimizer/join_elimination.test
+++ b/test/optimizer/join_elimination.test
@@ -244,3 +244,97 @@ query II
 explain select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
 ----
 physical_plan	<REGEX>:.*JOIN.*
+
+# ----------------------------------------------------------------------------
+# PRIMARY KEY / UNIQUE constraint-based join elimination.
+# When the inner side of a LEFT JOIN has a PK or UNIQUE constraint covering
+# the join's equality columns, the inner side produces at most one row per
+# key. If no inner columns appear in the output, the join is a no-op.
+# ----------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE pk_dim (id INTEGER PRIMARY KEY, name VARCHAR, value INTEGER);
+
+statement ok
+INSERT INTO pk_dim VALUES (1, 'one', 10), (2, 'two', 20), (3, 'three', 30), (4, 'four', 40);
+
+# Single-column PK, no inner columns in output → join eliminated.
+query II
+EXPLAIN SELECT b.* FROM b LEFT JOIN pk_dim ON pk_dim.id = b.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# Correctness check: result matches with and without join elimination.
+query II rowsort
+SELECT b.* FROM b LEFT JOIN pk_dim ON pk_dim.id = b.idb;
+----
+1	1
+2	2
+3	3
+3	3
+3	NULL
+4	4
+NULL	4
+NULL	NULL
+
+# Inner column referenced in output → join NOT eliminated.
+query II
+EXPLAIN SELECT b.idb, pk_dim.name FROM b LEFT JOIN pk_dim ON pk_dim.id = b.idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# Composite PRIMARY KEY — all columns covered → eliminated.
+statement ok
+CREATE TABLE composite_pk (x INTEGER, y INTEGER, value INTEGER, PRIMARY KEY(x, y));
+
+statement ok
+INSERT INTO composite_pk VALUES (1, 1, 10), (1, 2, 20), (2, 1, 30), (3, 3, 40);
+
+query II
+EXPLAIN SELECT b.* FROM b LEFT JOIN composite_pk ON composite_pk.x = b.idb AND composite_pk.y = b.valueb;
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# Correctness.
+query II rowsort
+SELECT b.* FROM b LEFT JOIN composite_pk ON composite_pk.x = b.idb AND composite_pk.y = b.valueb;
+----
+1	1
+2	2
+3	3
+3	3
+3	NULL
+4	4
+NULL	4
+NULL	NULL
+
+# Composite PK — only partial coverage → NOT eliminated.
+query II
+EXPLAIN SELECT b.* FROM b LEFT JOIN composite_pk ON composite_pk.x = b.idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# UNIQUE constraint (not PK) → eliminated.
+statement ok
+CREATE TABLE unique_dim (id INTEGER, code INTEGER UNIQUE, value INTEGER);
+
+statement ok
+INSERT INTO unique_dim VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30);
+
+query II
+EXPLAIN SELECT b.* FROM b LEFT JOIN unique_dim ON unique_dim.code = b.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# Subquery wrapping the PK table — projection remapping should still work.
+query II
+EXPLAIN SELECT b.* FROM b LEFT JOIN (SELECT id FROM pk_dim) sub ON sub.id = b.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# RIGHT JOIN with PK on the inner side (which is children[0] for RIGHT),
+# no inner columns in output → eliminated.
+query II
+EXPLAIN SELECT b.* FROM pk_dim RIGHT JOIN b ON pk_dim.id = b.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*


### PR DESCRIPTION
## Summary

Implements the TODO at `join_elimination.cpp:260` (`// 1. TODO: guarantee by primary/foreign key`).

When the inner side of a `LEFT` (or `RIGHT`) `JOIN` is a scan on a table with a `PRIMARY KEY` or `UNIQUE` constraint, and the join's equality conditions cover all columns of that constraint, the inner side is guaranteed to produce at most one row per key. If no inner-side columns appear in the query's output, the join is provably a no-op and is eliminated entirely.

```sql
-- dim.id is PRIMARY KEY
-- No dim columns in SELECT → join eliminated
SELECT f.* FROM facts f LEFT JOIN dim d ON d.id = f.dim_id;
```

## How it works

Extends the `LOGICAL_GET` case in `JoinElimination::OptimizeChildren` to populate `pipe_info.distinct_groups` from the table's catalog constraints. The existing Check 2 in `TryEliminateJoin` ("inner table join condition columns contains a whole distinct group") then automatically picks up these constraint-based groups — no new elimination logic needed.

Column mapping chain:
```
UniqueConstraint::GetLogicalIndexes(columns) → LogicalIndex (table definition)
  → LogicalGet::TryGetProjectionIndex() → ProjectionIndex (scan output)
    → ColumnBinding(table_index, proj_idx) (matches join condition bindings)
```

The existing projection remapping code handles any `LogicalProjection` nodes between the `LogicalGet` and the join, so constraint-based groups propagate correctly through intervening projections (compressed materialization, column pruning, etc.).

## Safety

- `GetTable()` returns `nullptr` for table functions (Parquet, CSV, etc.) → null check skips them safely.
- **UNIQUE with NULLs**: safe because `NULL = NULL` evaluates to `FALSE` in equality joins, so NULL keys never produce a match.
- `TryGetProjectionIndex` returns invalid if a constraint column isn't in the scan → `all_in_scan` check bails.
- Only one constraint stored per table (data structure limitation of `distinct_groups`) → conservative, no false positives.
- `has_filter` on the inner child correctly blocks elimination when there are filters on the PK table.

## Test plan

- [x] `build/release/test/unittest "test/optimizer/join_elimination.test"` — 131 assertions (14 new)
- [x] `build/release/test/unittest "[join]"` — 4117 assertions
- [x] `build/release/test/unittest "[optimizer]"` — 20040 assertions

New test cases:
- Single-column PK, join eliminated + correctness verification
- Composite PK with full coverage (eliminated) and partial coverage (not eliminated)
- UNIQUE constraint (not PK) → eliminated
- Inner columns in output → not eliminated
- Subquery wrapping PK table → still eliminated (projection remapping handles it)
- RIGHT JOIN with PK on inner side → eliminated

## Not in scope

- Foreign key relationships (the other half of the TODO)
- Multiple constraints per table (only the first matching constraint is stored, due to the `distinct_groups` map being keyed by `TableIndex`)
- Table functions / external tables without catalog entries

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `src/optimizer/join_elimination.cpp` | +32 | Constraint scanning in `LOGICAL_GET` case + TODO comment update |
| `test/optimizer/join_elimination.test` | +96 | 14 new assertions across 7 test cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)