### PR TITLE
Set `query` field for statements in `ALTER TABLE ... ADD COLUMN ... DEFAULT ...` workaround

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -955,7 +955,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 						reparsed_transaction_stmt.info->invalidation_policy =
 						    previous_transaction_stmt.info->invalidation_policy;
 						// re-apply auto rollback
-						parser.statements[0]->Cast<TransactionStatement>().info->auto_rollback =
+						reparsed_transaction_stmt.info->auto_rollback =
 						    statement->Cast<TransactionStatement>().info->auto_rollback;
 					}
 					statement = std::move(parser.statements[0]);

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -220,11 +220,11 @@ unique_ptr<AlterInfo> AddColumnInfo::Copy() const {
 
 string AddColumnInfo::ToString() const {
 	string result = "";
-	result += "ALTER TABLE ";
+	result += "ALTER TABLE";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		result += " IF EXISTS";
 	}
-	result += QualifierToString(catalog, schema, name);
+	result += " " + QualifierToString(catalog, schema, name);
 	result += " ADD COLUMN";
 	if (if_column_not_exists) {
 		result += " IF NOT EXISTS";

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -229,7 +229,14 @@ string AddColumnInfo::ToString() const {
 	if (if_column_not_exists) {
 		result += " IF NOT EXISTS";
 	}
-	throw NotImplementedException("FIXME: column definition to string");
+	// TODO: What about columns in structs? e.g.: ALTER TABLE test ADD COLUMN s.a.value.b VARCHAR
+	result += " " + this->new_column.GetName();
+	result += " " + this->new_column.GetType().ToString();
+
+	if (this->new_column.HasDefaultValue()) {
+		result += " DEFAULT ";
+		result += this->new_column.DefaultValue().ToString();
+	}
 	result += ";";
 	return result;
 }

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -229,10 +229,8 @@ string AddColumnInfo::ToString() const {
 	if (if_column_not_exists) {
 		result += " IF NOT EXISTS";
 	}
-	// TODO: What about columns in structs? e.g.: ALTER TABLE test ADD COLUMN s.a.value.b VARCHAR
 	result += " " + this->new_column.GetName();
 	result += " " + this->new_column.GetType().ToString();
-
 	if (this->new_column.HasDefaultValue()) {
 		result += " DEFAULT ";
 		result += this->new_column.DefaultValue().ToString();

--- a/src/parser/query_node/update_query_node.cpp
+++ b/src/parser/query_node/update_query_node.cpp
@@ -35,7 +35,6 @@ string UpdateQueryNode::ToString() const {
 			result += col;
 		}
 	}
-	result += ";";
 	return result;
 }
 

--- a/src/parser/query_node/update_query_node.cpp
+++ b/src/parser/query_node/update_query_node.cpp
@@ -35,6 +35,7 @@ string UpdateQueryNode::ToString() const {
 			result += col;
 		}
 	}
+	result += ";";
 	return result;
 }
 

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -30,6 +30,7 @@ vector<string> Transformer::TransformNameList(duckdb_libpgquery::PGList &list) {
 void AddToMultiStatement(const unique_ptr<MultiStatement> &multi_statement, unique_ptr<AlterInfo> alter_info) {
 	auto alter_statement = make_uniq<AlterStatement>();
 	alter_statement->info = std::move(alter_info);
+	alter_statement->query = alter_statement->ToString();
 	multi_statement->statements.push_back(std::move(alter_statement));
 }
 
@@ -51,6 +52,7 @@ void AddUpdateToMultiStatement(const unique_ptr<MultiStatement> &multi_statement
 	set_info->expressions.push_back(original_expression->Copy());
 	node.set_info = std::move(set_info);
 
+	update_statement->query = update_statement->ToString();
 	multi_statement->statements.push_back(std::move(update_statement));
 }
 
@@ -75,17 +77,22 @@ unique_ptr<MultiStatement> TransformAndMaterializeAlter(const duckdb_libpgquery:
 	// 1. `ALTER TABLE t ADD COLUMN col <type> DEFAULT NULL;`
 	AddToMultiStatement(multi_statement, std::move(info_with_null_placeholder));
 
-	// 2. `UPDATE t SET u = <expression>;`
+	// 2. `UPDATE t SET col = <expression>;`
 	AddUpdateToMultiStatement(multi_statement, column_name, data, expression);
 
-	// 3. `ALTER TABLE t ALTER u SET DEFAULT <expression>;`
+	// 3. `ALTER TABLE t ALTER col SET DEFAULT <expression>;`
 	// Reinstate the original default expression.
 	AddToMultiStatement(multi_statement, make_uniq<SetDefaultInfo>(data, column_name, std::move(expression)));
+
+	auto test0 = multi_statement->statements[0]->ToString();
+	auto test1 = multi_statement->statements[1]->ToString();
+	auto test2 = multi_statement->statements[2]->ToString();
 
 	return multi_statement;
 }
 
-unique_ptr<SQLStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) {
+unique_ptr<SQLStatement>
+Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) { // NOTE: I think its this
 	D_ASSERT(stmt.relation);
 	if (stmt.cmds->length != 1) {
 		throw ParserException("Only one ALTER command per statement is supported");

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -64,7 +64,6 @@ unique_ptr<MultiStatement> TransformAndMaterializeAlter(const duckdb_libpgquery:
 	 *	 1. `ALTER TABLE t ADD COLUMN col <type> DEFAULT NULL;`
 	 *	 2. `UPDATE t SET col = <expression>;`
 	 *	 3. `ALTER TABLE t ALTER col SET DEFAULT <expression>;`
-
 	 *
 	 * This workaround exists because, when statements like this were executed:
 	 *	`ALTER TABLE ... ADD COLUMN ... DEFAULT <expression>`

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -52,7 +52,7 @@ void AddUpdateToMultiStatement(const unique_ptr<MultiStatement> &multi_statement
 	set_info->expressions.push_back(original_expression->Copy());
 	node.set_info = std::move(set_info);
 
-	update_statement->query = update_statement->ToString();
+	update_statement->query = update_statement->ToString() + ";";
 	multi_statement->statements.push_back(std::move(update_statement));
 }
 

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -84,15 +84,10 @@ unique_ptr<MultiStatement> TransformAndMaterializeAlter(const duckdb_libpgquery:
 	// Reinstate the original default expression.
 	AddToMultiStatement(multi_statement, make_uniq<SetDefaultInfo>(data, column_name, std::move(expression)));
 
-	auto test0 = multi_statement->statements[0]->ToString();
-	auto test1 = multi_statement->statements[1]->ToString();
-	auto test2 = multi_statement->statements[2]->ToString();
-
 	return multi_statement;
 }
 
-unique_ptr<SQLStatement>
-Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) { // NOTE: I think its this
+unique_ptr<SQLStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) {
 	D_ASSERT(stmt.relation);
 	if (stmt.cmds->length != 1) {
 		throw ParserException("Only one ALTER command per statement is supported");

--- a/src/planner/statement_preprocessor.cpp
+++ b/src/planner/statement_preprocessor.cpp
@@ -35,26 +35,36 @@ void AddStatements(vector<unique_ptr<SQLStatement>> &body_statements,
 	if (transaction_handling == PreprocessingTransactionHandling::WRAP_IN_TRANSACTION) {
 		auto begin_info = make_uniq<TransactionInfo>(
 		    TransactionType::BEGIN_TRANSACTION, TransactionInvalidationPolicy::ALL_ERRORS_INVALIDATE_TRANSACTION, true);
-		result_statements.push_back(make_uniq<TransactionStatement>(std::move(begin_info)));
+		auto begin_stmt = make_uniq<TransactionStatement>(std::move(begin_info));
+		begin_stmt->query = begin_stmt->ToString();
+		result_statements.push_back(std::move(begin_stmt));
 	} else if (transaction_handling == PreprocessingTransactionHandling::SET_INVALIDATION_POLICY) {
 		// Here we do a `SET current_transaction_invalidation_policy='ALL_ERRORS_INVALIDATE_TRANSACTION';`, for the
 		// current transaction, to make sure multistatements/pragmas are fully transactional, and invalidate even with
 		// minor errors such as binder, parser, etc.
-		result_statements.push_back(make_uniq<SetVariableStatement>(
+		auto set_stmt = make_uniq<SetVariableStatement>(
 		    "current_transaction_invalidation_policy",
-		    make_uniq<ConstantExpression>(Value("ALL_ERRORS_INVALIDATE_TRANSACTION")), SetScope::GLOBAL));
+		    make_uniq<ConstantExpression>(Value("ALL_ERRORS_INVALIDATE_TRANSACTION")), SetScope::GLOBAL);
+		set_stmt->query = set_stmt->ToString();
+		result_statements.push_back(std::move(set_stmt));
 	}
+
 	// insert body_statements into result_statements
 	result_statements.insert(result_statements.end(), std::make_move_iterator(body_statements.begin()),
 	                         std::make_move_iterator(body_statements.end()));
+
 	if (transaction_handling == PreprocessingTransactionHandling::WRAP_IN_TRANSACTION) {
 		auto commit_info = make_uniq<TransactionInfo>(
 		    TransactionType::COMMIT, TransactionInvalidationPolicy::ALL_ERRORS_INVALIDATE_TRANSACTION, true);
-		result_statements.push_back(make_uniq<TransactionStatement>(std::move(commit_info)));
+		auto commit_stmt = make_uniq<TransactionStatement>(std::move(commit_info));
+		commit_stmt->query = commit_stmt->ToString();
+		result_statements.push_back(std::move(commit_stmt));
 	} else if (transaction_handling == PreprocessingTransactionHandling::SET_INVALIDATION_POLICY) {
-		result_statements.push_back(
+		auto set_stmt =
 		    make_uniq<SetVariableStatement>("current_transaction_invalidation_policy",
-		                                    make_uniq<ConstantExpression>(Value("STANDARD_POLICY")), SetScope::GLOBAL));
+		                                    make_uniq<ConstantExpression>(Value("STANDARD_POLICY")), SetScope::GLOBAL);
+		set_stmt->query = set_stmt->ToString();
+		result_statements.push_back(std::move(set_stmt));
 	}
 }
 

--- a/test/api/capi/test_capi_extract.cpp
+++ b/test/api/capi/test_capi_extract.cpp
@@ -87,11 +87,7 @@ TEST_CASE("Test invalid PRAGMA in C API", "[capi]") {
 
 TEST_CASE("Test extract statements for `ALTER TABLE ... ADD COLUMN ... DEFAULT` in C API", "[capi]") {
 	CAPITester tester;
-	duckdb_result res;
 	duckdb_extracted_statements stmts = nullptr;
-	duckdb_state status;
-	const char *error;
-	duckdb_prepared_statement prepared = nullptr;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
 

--- a/test/api/capi/test_capi_extract.cpp
+++ b/test/api/capi/test_capi_extract.cpp
@@ -106,4 +106,6 @@ TEST_CASE("Test extract statements for `ALTER TABLE ... ADD COLUMN ... DEFAULT` 
 	REQUIRE(wrapper->statements[3]->query ==
 	        "ALTER TABLE my_table ALTER COLUMN my_column SET DEFAULT non_existent_function();");
 	REQUIRE(wrapper->statements[4]->query == "COMMIT;");
+
+	duckdb_destroy_extracted(&stmts);
 }

--- a/test/api/capi/test_capi_extract.cpp
+++ b/test/api/capi/test_capi_extract.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Test invalid PRAGMA in C API", "[capi]") {
 	duckdb_close(&db);
 }
 
-TEST_CASE("Test extract statements for `ALTER TABLE ... ADD COLUMN... DEFAULT` in C API", "[capi]") {
+TEST_CASE("Test extract statements for `ALTER TABLE ... ADD COLUMN ... DEFAULT` in C API", "[capi]") {
 	CAPITester tester;
 	duckdb_result res;
 	duckdb_extracted_statements stmts = nullptr;

--- a/test/api/capi/test_capi_extract.cpp
+++ b/test/api/capi/test_capi_extract.cpp
@@ -1,4 +1,6 @@
 #include "capi_tester.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/parser/statement/set_statement.hpp"
 
 using namespace duckdb;
 
@@ -81,4 +83,31 @@ TEST_CASE("Test invalid PRAGMA in C API", "[capi]") {
 	duckdb_destroy_extracted(&stmts);
 	duckdb_disconnect(&con);
 	duckdb_close(&db);
+}
+
+TEST_CASE("Test extract statements for `ALTER TABLE ... ADD COLUMN... DEFAULT` in C API", "[capi]") {
+	CAPITester tester;
+	duckdb_result res;
+	duckdb_extracted_statements stmts = nullptr;
+	duckdb_state status;
+	const char *error;
+	duckdb_prepared_statement prepared = nullptr;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	idx_t size = duckdb_extract_statements(
+	    tester.connection,
+	    "ALTER TABLE my_table ADD COLUMN my_column TIMESTAMP WITH TIME ZONE DEFAULT non_existent_function();", &stmts);
+
+	REQUIRE(size == 5);
+	REQUIRE(stmts != nullptr);
+	auto wrapper = (ExtractStatementsWrapper *)stmts;
+
+	REQUIRE(wrapper->statements[0]->query == "BEGIN;");
+	REQUIRE(wrapper->statements[1]->query ==
+	        "ALTER TABLE my_table ADD COLUMN my_column \"TIMESTAMP WITH TIME ZONE\" DEFAULT NULL;");
+	REQUIRE(wrapper->statements[2]->query == "UPDATE my_table SET my_column = non_existent_function();");
+	REQUIRE(wrapper->statements[3]->query ==
+	        "ALTER TABLE my_table ALTER COLUMN my_column SET DEFAULT non_existent_function();");
+	REQUIRE(wrapper->statements[4]->query == "COMMIT;");
 }


### PR DESCRIPTION
https://github.com/duckdblabs/duckdb-internal/issues/8843

This fixes not being able to see extracted statements of `ALTER TABLE ... ADD COLUMN ... DEFAULT ...`-like statements.

> [!NOTE]
> These extracted statements, if run one-by-one, differ in functionality compared to running the original SQL statement. 
>
>That is because the current SQL string representation of a TransactionStatement `BEGIN;` when parsed, defaults to using `TransactionInvalidationPolicy::STANDARD_POLICY`, and not the original `TransactionInvalidationPolicy::ALL_ERRORS_INVALIDATE_TRANSACTION` that ensures the multistatement is transactional even on binder errors.
>
> Also auto_rollback will default to `false` while the original was `true`. This will result now having to run `rollback;` manually on failure after executing the extracted statements.