### PR TITLE
Wrap Scalar/Aggr/Window function bind callback parameters

### DIFF
--- a/.github/patches/extensions/inet/0001-applied-patch-fix-patch.patch
+++ b/.github/patches/extensions/inet/0001-applied-patch-fix-patch.patch
@@ -1,3 +1,14 @@
+From 07270be76eaa3f764a74462b947a20623c115232 Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 13:16:42 +0200
+Subject: [PATCH] applied patch: fix.patch
+
+---
+ src/inet_functions.cpp               | 6 +++---
+ test/sql/test_inet_storage.test      | 2 +-
+ test/sql/test_ipv6_inet_storage.test | 3 +--
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
 diff --git a/src/inet_functions.cpp b/src/inet_functions.cpp
 index afa7446..f0466e1 100644
 --- a/src/inet_functions.cpp
@@ -42,3 +53,6 @@ index 7dc1930..c49c259 100644
  
  statement ok
  PRAGMA enable_verification
+-- 
+2.39.5 (Apple Git-154)
+

--- a/.github/patches/extensions/inet/0002-wrap-bind-input.patch
+++ b/.github/patches/extensions/inet/0002-wrap-bind-input.patch
@@ -1,0 +1,26 @@
+From 129bc3aeb4a9abb9f745ae53fe1281ce81556fd3 Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 15:54:04 +0200
+Subject: [PATCH] wrap bind input
+
+---
+ src/inet_escape_functions.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/inet_escape_functions.cpp b/src/inet_escape_functions.cpp
+index 1503440..dd16694 100644
+--- a/src/inet_escape_functions.cpp
++++ b/src/inet_escape_functions.cpp
+@@ -38,8 +38,7 @@ struct UnescapeBindData : public FunctionData {
+ };
+ 
+ unique_ptr<FunctionData>
+-UnescapeBind(ClientContext &context, ScalarFunction &bound_function,
+-             vector<unique_ptr<Expression>> &arguments) {
++UnescapeBind(BindScalarFunctionInput &) {
+   return make_uniq<UnescapeBindData>();
+ }
+ 
+-- 
+2.39.5 (Apple Git-154)
+

--- a/.github/patches/extensions/spatial/0001-applied-patch-fix-patch.patch
+++ b/.github/patches/extensions/spatial/0001-applied-patch-fix-patch.patch
@@ -1,3 +1,31 @@
+From d902db238d2bca76a919f4e12306da6e3771b0ec Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 12:54:05 +0200
+Subject: [PATCH] applied patch: fix.patch
+
+---
+ src/spatial/index/rtree/rtree_index.cpp       |  16 +-
+ .../rtree/rtree_index_create_logical.cpp      |   2 +-
+ .../rtree/rtree_index_create_physical.cpp     |  14 +-
+ .../index/rtree/rtree_index_plan_scan.cpp     |  50 ++-
+ .../index/rtree/rtree_index_pragmas.cpp       |  16 +-
+ src/spatial/modules/geos/geos_module.cpp      |  41 +-
+ .../modules/main/spatial_functions_cast.cpp   |  78 ++--
+ .../modules/main/spatial_functions_scalar.cpp | 360 +++++++++---------
+ .../modules/main/spatial_functions_table.cpp  |   9 +-
+ src/spatial/modules/mvt/mvt_module.cpp        |  17 +-
+ src/spatial/modules/osm/osm_module.cpp        |  54 +--
+ src/spatial/modules/proj/proj_module.cpp      |  12 +-
+ .../modules/shapefile/shapefile_module.cpp    |  26 +-
+ .../operators/spatial_join_logical.cpp        |  14 +-
+ .../operators/spatial_join_logical.hpp        |   6 +-
+ .../operators/spatial_join_optimizer.cpp      |  14 +-
+ .../operators/spatial_join_physical.cpp       |  46 +--
+ src/spatial/spatial_settings.cpp              |   1 +
+ src/spatial/spatial_types.cpp                 |   2 +-
+ src/spatial/util/function_builder.cpp         |  40 +-
+ 20 files changed, 411 insertions(+), 407 deletions(-)
+
 diff --git a/src/spatial/index/rtree/rtree_index.cpp b/src/spatial/index/rtree/rtree_index.cpp
 index 239d546..9de9355 100644
 --- a/src/spatial/index/rtree/rtree_index.cpp
@@ -2153,3 +2181,6 @@ index 5bd4f95..d4c6e43 100644
  }
  
  void FunctionBuilder::AddTableFunctionDocs(ExtensionLoader &loader, const char *name, const char *desc,
+-- 
+2.39.5 (Apple Git-154)
+

--- a/.github/patches/extensions/spatial/0002-wrap-bind.patch
+++ b/.github/patches/extensions/spatial/0002-wrap-bind.patch
@@ -1,0 +1,731 @@
+From 97d341e6763ebf57d1e69a0f637f9fa8cd3ceae0 Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 14:53:36 +0200
+Subject: [PATCH] wrap bind
+
+---
+ src/spatial/modules/geos/geos_module.cpp      |  29 +++--
+ .../modules/main/spatial_functions_cast.cpp   |  12 +--
+ .../modules/main/spatial_functions_scalar.cpp | 102 ++++++++++--------
+ src/spatial/modules/mvt/mvt_module.cpp        |   8 +-
+ src/spatial/modules/osm/osm_module.cpp        |  16 +--
+ src/spatial/modules/proj/proj_module.cpp      |  23 ++--
+ src/spatial/spatial_types.cpp                 |  14 ++-
+ src/spatial/spatial_types.hpp                 |  33 +++---
+ 8 files changed, 134 insertions(+), 103 deletions(-)
+
+diff --git a/src/spatial/modules/geos/geos_module.cpp b/src/spatial/modules/geos/geos_module.cpp
+index 4b0a544..91470a6 100644
+--- a/src/spatial/modules/geos/geos_module.cpp
++++ b/src/spatial/modules/geos/geos_module.cpp
+@@ -229,8 +229,11 @@ struct ST_AsMVTGeom {
+ 		}
+ 	};
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++		auto &bound_function = input.GetBoundFunction();
++		auto &context = input.GetClientContext();
++
+ 		auto result = make_uniq<BindData>();
+ 
+ 		// Extract parameters
+@@ -846,8 +849,9 @@ struct ST_ConvexHull {
+ 
+ struct ST_CoverageInvalidEdges {
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++
++		auto &arguments = input.GetArguments();
+ 
+ 		// Set the default value for the tolerance parameter
+ 		if (arguments.size() == 1) {
+@@ -941,8 +945,9 @@ struct ST_CoverageInvalidEdges {
+ 
+ struct ST_CoverageSimplify {
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++
+ 		// Set the default value for the simplify_boundary parameter
+ 		if (arguments.size() == 2) {
+ 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::BOOLEAN(true)));
+@@ -2876,8 +2881,10 @@ struct GEOSCoverageAggFunction {
+ 
+ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++		auto &function = input.GetBoundFunction();
++
+ 		if (arguments.size() == 2) {
+ 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::BOOLEAN(true)));
+ 			function.arguments.push_back(LogicalType::BOOLEAN);
+@@ -3045,8 +3052,10 @@ struct ST_CoverageUnion_Agg : GEOSCoverageAggFunction {
+ 
+ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++		auto &function = input.GetBoundFunction();
++
+ 		if (arguments.size() == 1) {
+ 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::DOUBLE(0.0)));
+ 			function.arguments.push_back(LogicalType::DOUBLE);
+diff --git a/src/spatial/modules/main/spatial_functions_cast.cpp b/src/spatial/modules/main/spatial_functions_cast.cpp
+index 8796650..cad93a6 100644
+--- a/src/spatial/modules/main/spatial_functions_cast.cpp
++++ b/src/spatial/modules/main/spatial_functions_cast.cpp
+@@ -586,7 +586,7 @@ struct PolygonCasts {
+ 		auto &arena = lstate.GetArena();
+ 
+ 		auto &ring_vec = ListVector::GetEntry(source);
+-		const auto ring_entries = ListVector::GetData(ring_vec);
++		const auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		const auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
+@@ -687,7 +687,7 @@ struct PolygonCasts {
+ 
+ 					ListVector::Reserve(ring_vec, total_coords + ring_size);
+ 
+-					const auto ring_entries = ListVector::GetData(ring_vec);
++					const auto ring_entries = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
+ 					auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 					auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 					auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+@@ -748,7 +748,7 @@ struct PolygonCasts {
+ 		auto &ring_dst = ListVector::GetEntry(result);
+ 
+ 		auto &ring_src = ListVector::GetEntry(source);
+-		const auto ring_entries_src = ListVector::GetData(ring_src);
++		const auto ring_entries_src = FlatVector::GetData<list_entry_t>(ring_src);
+ 		const auto &coord_src = ListVector::GetEntry(ring_src);
+ 		auto &coord_src_children = StructVector::GetEntries(coord_src);
+ 		auto x_src = FlatVector::GetData<double>(coord_src_children[0]);
+@@ -768,7 +768,7 @@ struct PolygonCasts {
+ 
+ 				ListVector::Reserve(ring_dst, total_coords + ring_size);
+ 
+-				const auto ring_entries_dst = ListVector::GetData(ring_dst);
++				const auto ring_entries_dst = FlatVector::GetDataMutable<list_entry_t>(ring_dst);
+ 				auto &coord_dst = ListVector::GetEntry(ring_dst);
+ 				auto &coord_dst_children = StructVector::GetEntries(coord_dst);
+ 				auto x_dst = FlatVector::GetDataMutable<double>(coord_dst_children[0]);
+@@ -1028,7 +1028,7 @@ void CoreVectorOperations::LineString3DToVarchar(Vector &source, Vector &result,
+ void CoreVectorOperations::Polygon2DToVarchar(Vector &source, Vector &result, idx_t count) {
+ 	auto &poly_vector = source;
+ 	auto &ring_vector = ListVector::GetEntry(poly_vector);
+-	auto ring_entries = ListVector::GetData(ring_vector);
++	auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vector);
+ 	auto &point_vector = ListVector::GetEntry(ring_vector);
+ 	auto &point_children = StructVector::GetEntries(point_vector);
+ 	auto x_data = FlatVector::GetDataMutable<double>(point_children[0]);
+@@ -1070,7 +1070,7 @@ void CoreVectorOperations::Polygon2DToVarchar(Vector &source, Vector &result, id
+ void CoreVectorOperations::Polygon3DToVarchar(Vector &source, Vector &result, idx_t count) {
+ 	auto &poly_vector = source;
+ 	auto &ring_vector = ListVector::GetEntry(poly_vector);
+-	auto ring_entries = ListVector::GetData(ring_vector);
++	auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vector);
+ 	auto &point_vector = ListVector::GetEntry(ring_vector);
+ 	auto &point_children = StructVector::GetEntries(point_vector);
+ 	auto x_data = FlatVector::GetDataMutable<double>(point_children[0]);
+diff --git a/src/spatial/modules/main/spatial_functions_scalar.cpp b/src/spatial/modules/main/spatial_functions_scalar.cpp
+index 5310f80..1c5031e 100644
+--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
++++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
+@@ -439,7 +439,7 @@ struct ST_Area {
+ 		auto count = args.size();
+ 
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+@@ -1391,7 +1391,7 @@ struct ST_Centroid {
+ 		UnifiedVectorFormat format;
+ 		input.ToUnifiedFormat(count, format);
+ 
+-		auto line_vertex_entries = ListVector::GetData(input);
++		auto line_vertex_entries = FlatVector::GetData<list_entry_t>(input);
+ 		auto &line_vertex_vec = ListVector::GetEntry(input);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+ 		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+@@ -1448,9 +1448,9 @@ struct ST_Centroid {
+ 		UnifiedVectorFormat format;
+ 		input.ToUnifiedFormat(count, format);
+ 
+-		auto poly_entries = ListVector::GetData(input);
++		auto poly_entries = FlatVector::GetData<list_entry_t>(input);
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+@@ -2016,9 +2016,9 @@ struct ST_Contains {
+ 		auto p_y_data = FlatVector::GetDataMutable<double>(p_children[1]);
+ 
+ 		// Setup polygon vectors
+-		auto polygon_entries = ListVector::GetData(in_polygon);
++		auto polygon_entries = FlatVector::GetData<list_entry_t>(in_polygon);
+ 		auto &ring_vec = ListVector::GetEntry(in_polygon);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(coord_children[0]);
+@@ -2445,7 +2445,7 @@ struct ST_Distance {
+ 		auto &y = children[1];
+ 		auto x_data = FlatVector::GetDataMutable<double>(x);
+ 		auto y_data = FlatVector::GetDataMutable<double>(y);
+-		auto lines = ListVector::GetData(in_line);
++		auto lines = FlatVector::GetData<list_entry_t>(in_line);
+ 
+ 		auto result_data = FlatVector::GetDataMutable<double>(result);
+ 		for (idx_t i = 0; i < count; i++) {
+@@ -2658,8 +2658,11 @@ struct ST_DistanceWithin {
+ 	};
+ 
+ 	// We try to constant-fold the distance parameter here, because it's a very common have a constant distance
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++
++		auto &arguments = input.GetArguments();
++		auto &bound_function = input.GetBoundFunction();
++		auto &context = input.GetClientContext();
+ 
+ 		if (arguments.back()->IsFoldable()) {
+ 			const auto dist_expr = ExpressionExecutor::EvaluateScalar(context, *arguments.back());
+@@ -2885,7 +2888,7 @@ struct ST_Dump {
+ 			}
+ 
+ 			// Push to the result vector
+-			auto result_entries = ListVector::GetData(result);
++			auto result_entries = FlatVector::GetDataMutable<list_entry_t>(result);
+ 
+ 			auto geom_offset = total_geom_count;
+ 			auto geom_length = items.size();
+@@ -2920,7 +2923,7 @@ struct ST_Dump {
+ 				ListVector::Reserve(result_path_vec, total_path_count);
+ 				ListVector::SetListSize(result_path_vec, total_path_count);
+ 
+-				auto path_entries = ListVector::GetData(result_path_vec);
++				auto path_entries = FlatVector::GetDataMutable<list_entry_t>(result_path_vec);
+ 
+ 				path_entries[geom_offset + i].offset = path_offset;
+ 				path_entries[geom_offset + i].length = path_length;
+@@ -3400,9 +3403,9 @@ struct ST_ExteriorRing {
+ 	static void ExecutePolygon(DataChunk &args, ExpressionState &state, Vector &result) {
+ 		D_ASSERT(args.data.size() == 1);
+ 		auto &poly_vec = args.data[0];
+-		auto poly_entries = ListVector::GetData(poly_vec);
++		auto poly_entries = FlatVector::GetData<list_entry_t>(poly_vec);
+ 		auto &ring_vec = ListVector::GetEntry(poly_vec);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+ 		auto poly_x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+@@ -3431,7 +3434,7 @@ struct ST_ExteriorRing {
+ 		ListVector::Reserve(line_vec, total_vertex_count);
+ 		ListVector::SetListSize(line_vec, total_vertex_count);
+ 
+-		auto line_entries = ListVector::GetData(line_vec);
++		auto line_entries = FlatVector::GetDataMutable<list_entry_t>(line_vec);
+ 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
+ 		auto line_data_x = FlatVector::GetDataMutable<double>(line_coord_vec[0]);
+ 		auto line_data_y = FlatVector::GetDataMutable<double>(line_coord_vec[1]);
+@@ -3559,8 +3562,8 @@ struct ST_FlipCoordinates {
+ 		ListVector::Reserve(result, coord_count);
+ 		ListVector::SetListSize(result, coord_count);
+ 
+-		auto line_entries_in = ListVector::GetData(input);
+-		auto line_entries_out = ListVector::GetData(result);
++		auto line_entries_in = FlatVector::GetData<list_entry_t>(input);
++		auto line_entries_out = FlatVector::GetDataMutable<list_entry_t>(result);
+ 		memcpy(line_entries_out, line_entries_in, count * sizeof(list_entry_t));
+ 
+ 		auto &coord_vec_out = ListVector::GetEntry(result);
+@@ -3602,12 +3605,12 @@ struct ST_FlipCoordinates {
+ 		ListVector::Reserve(ring_vec_out, coord_count);
+ 		ListVector::SetListSize(ring_vec_out, coord_count);
+ 
+-		auto ring_entries_in = ListVector::GetData(input);
+-		auto ring_entries_out = ListVector::GetData(result);
++		auto ring_entries_in = FlatVector::GetData<list_entry_t>(input);
++		auto ring_entries_out = FlatVector::GetDataMutable<list_entry_t>(result);
+ 		memcpy(ring_entries_out, ring_entries_in, count * sizeof(list_entry_t));
+ 
+-		auto coord_entries_in = ListVector::GetData(ring_vec_in);
+-		auto coord_entries_out = ListVector::GetData(ring_vec_out);
++		auto coord_entries_in = FlatVector::GetData<list_entry_t>(ring_vec_in);
++		auto coord_entries_out = FlatVector::GetDataMutable<list_entry_t>(ring_vec_out);
+ 		memcpy(coord_entries_out, coord_entries_in, ring_count * sizeof(list_entry_t));
+ 
+ 		auto &coord_vec_out = ListVector::GetEntry(ring_vec_out);
+@@ -3910,8 +3913,7 @@ struct ST_GeometryType {
+ 	static constexpr uint8_t LEGACY_GEOMETRYCOLLECTION_TYPE = 6;
+ 	static constexpr uint8_t LEGACY_UNKNOWN_TYPE = 7;
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+ 		// Create an enum type for all geometry types
+ 		// Ensure that these are in the same order as the LegacyGeometryType enum
+ 		const vector<string> enum_values = {"POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING",
+@@ -3919,7 +3921,7 @@ struct ST_GeometryType {
+ 		                                    // or...
+ 		                                    "UNKNOWN"};
+ 
+-		bound_function.return_type = GeoTypes::CreateEnumType("GEOMETRY_TYPE", enum_values);
++		input.GetBoundFunction().SetReturnType(GeoTypes::CreateEnumType("GEOMETRY_TYPE", enum_values));
+ 		return nullptr;
+ 	}
+ 
+@@ -4591,8 +4593,10 @@ struct ST_GeomFromText {
+ 		bool ignore_invalid = false;
+ 	};
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++		auto &context = input.GetClientContext();
++
+ 		if (arguments.empty()) {
+ 			throw InvalidInputException("ST_GeomFromText requires at least one argument");
+ 		}
+@@ -4800,7 +4804,7 @@ struct ST_GeomFromWKB {
+ 		wkb_blobs.Flatten(count);
+ 
+ 		auto &inner = ListVector::GetEntry(result);
+-		const auto lines = ListVector::GetData(result);
++		const auto lines = FlatVector::GetDataMutable<list_entry_t>(result);
+ 		const auto wkb_data = FlatVector::GetDataMutable<string_t>(wkb_blobs);
+ 
+ 		idx_t total_size = 0;
+@@ -4872,7 +4876,7 @@ struct ST_GeomFromWKB {
+ 
+ 		// Set up output data
+ 		auto &ring_vec = ListVector::GetEntry(result);
+-		auto polygons = ListVector::GetData(result);
++		auto polygons = FlatVector::GetDataMutable<list_entry_t>(result);
+ 
+ 		idx_t total_ring_count = 0;
+ 		idx_t total_point_count = 0;
+@@ -4914,7 +4918,7 @@ struct ST_GeomFromWKB {
+ 					const auto point_count = ring->get_vertex_count();
+ 
+ 					ListVector::Reserve(ring_vec, total_point_count + point_count);
+-					auto ring_entries = ListVector::GetData(ring_vec);
++					auto ring_entries = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
+ 					auto &inner = ListVector::GetEntry(ring_vec);
+ 
+ 					auto &children = StructVector::GetEntries(inner);
+@@ -5452,8 +5456,9 @@ struct ST_LocateAlong {
+ 	//------------------------------------------------------------------------------------------------------------------
+ 	// Bind
+ 	//------------------------------------------------------------------------------------------------------------------
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++
+ 		if (arguments.size() == 2) {
+ 			// Push back offset constant
+ 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
+@@ -5553,8 +5558,9 @@ struct ST_LocateBetween {
+ 	//------------------------------------------------------------------------------------------------------------------
+ 	// Bind
+ 	//------------------------------------------------------------------------------------------------------------------
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &arguments = input.GetArguments();
++
+ 		if (arguments.size() == 3) {
+ 			// Push back offset constant
+ 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
+@@ -5792,8 +5798,10 @@ struct ST_Distance_Sphere {
+ 		}
+ 	};
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &func,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &context = input.GetClientContext();
++		auto &func = input.GetBoundFunction();
++
+ 		auto bind_data = make_uniq<BindData>();
+ 
+ 		bool is_set = false;
+@@ -6193,9 +6201,9 @@ struct ST_InteriorRingN {
+ 		auto &n_vec = args.data[1];
+ 
+ 		// same layout as ST_ExteriorRing::ExecutePolygon
+-		auto poly_entries = ListVector::GetData(poly_vec);
++		auto poly_entries = FlatVector::GetData<list_entry_t>(poly_vec);
+ 		auto &ring_vec = ListVector::GetEntry(poly_vec);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+ 		auto poly_x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+@@ -6253,7 +6261,7 @@ struct ST_InteriorRingN {
+ 		ListVector::Reserve(line_vec, total_vertex_count);
+ 		ListVector::SetListSize(line_vec, total_vertex_count);
+ 
+-		auto line_entries = ListVector::GetData(line_vec);
++		auto line_entries = FlatVector::GetDataMutable<list_entry_t>(line_vec);
+ 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
+ 		auto line_data_x = FlatVector::GetDataMutable<double>(line_coord_vec[0]);
+ 		auto line_data_y = FlatVector::GetDataMutable<double>(line_coord_vec[1]);
+@@ -7604,7 +7612,7 @@ struct ST_NPoints {
+ 		auto &input = args.data[0];
+ 		auto count = args.size();
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 
+ 		UnaryExecutor::Execute<list_entry_t, idx_t>(input, result, count, [&](list_entry_t polygon) {
+ 			auto polygon_offset = polygon.offset;
+@@ -7718,7 +7726,7 @@ struct ST_Perimeter {
+ 		auto count = args.size();
+ 
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+@@ -8135,7 +8143,7 @@ struct ST_PointN {
+ 		UnifiedVectorFormat index_format;
+ 		index_vec.ToUnifiedFormat(count, index_format);
+ 
+-		auto line_vertex_entries = ListVector::GetData(geom_vec);
++		auto line_vertex_entries = FlatVector::GetData<list_entry_t>(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+ 		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+@@ -8434,12 +8442,12 @@ struct ST_RemoveRepeatedPoints {
+ 		UnifiedVectorFormat format;
+ 		input.ToUnifiedFormat(count, format);
+ 
+-		auto in_line_entries = ListVector::GetData(input);
++		auto in_line_entries = FlatVector::GetData<list_entry_t>(input);
+ 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
+ 		auto in_x_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[0]);
+ 		auto in_y_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[1]);
+ 
+-		auto out_line_entries = ListVector::GetData(result);
++		auto out_line_entries = FlatVector::GetDataMutable<list_entry_t>(result);
+ 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
+ 
+ 		idx_t out_offset = 0;
+@@ -8556,12 +8564,12 @@ struct ST_RemoveRepeatedPoints {
+ 		UnifiedVectorFormat tolerance_format;
+ 		tolerance.ToUnifiedFormat(count, tolerance_format);
+ 
+-		auto in_line_entries = ListVector::GetData(input);
++		auto in_line_entries = FlatVector::GetData<list_entry_t>(input);
+ 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
+ 		auto in_x_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[0]);
+ 		auto in_y_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[1]);
+ 
+-		auto out_line_entries = ListVector::GetData(result);
++		auto out_line_entries = FlatVector::GetDataMutable<list_entry_t>(result);
+ 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
+ 
+ 		idx_t out_offset = 0;
+@@ -8764,7 +8772,7 @@ struct ST_StartPoint {
+ 		UnifiedVectorFormat geom_format;
+ 		geom_vec.ToUnifiedFormat(count, geom_format);
+ 
+-		auto line_vertex_entries = ListVector::GetData(geom_vec);
++		auto line_vertex_entries = FlatVector::GetData<list_entry_t>(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+ 		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+@@ -8889,7 +8897,7 @@ struct ST_EndPoint {
+ 		UnifiedVectorFormat geom_format;
+ 		geom_vec.ToUnifiedFormat(count, geom_format);
+ 
+-		auto line_vertex_entries = ListVector::GetData(geom_vec);
++		auto line_vertex_entries = FlatVector::GetData<list_entry_t>(geom_vec);
+ 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
+ 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
+ 		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+@@ -9255,7 +9263,7 @@ struct VertexAggFunctionBase {
+ 		input.ToUnifiedFormat(count, format);
+ 
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
+ 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
+ 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
+diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
+index c0bd1ec..34b85e1 100644
+--- a/src/spatial/modules/mvt/mvt_module.cpp
++++ b/src/spatial/modules/mvt/mvt_module.cpp
+@@ -824,8 +824,12 @@ struct ST_AsMVT {
+ 		}
+ 	};
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+-	                                     vector<unique_ptr<Expression>> &arguments) {
++	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
++		auto &context = input.GetClientContext();
++		auto &arguments = input.GetArguments();
++		auto &function = input.GetBoundFunction();
++
++
+ 		auto result = make_uniq<BindData>();
+ 
+ 		// Figure part of the row is the geometry column
+diff --git a/src/spatial/modules/osm/osm_module.cpp b/src/spatial/modules/osm/osm_module.cpp
+index 06916d3..9154622 100644
+--- a/src/spatial/modules/osm/osm_module.cpp
++++ b/src/spatial/modules/osm/osm_module.cpp
+@@ -422,7 +422,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_tags = ListVector::GetListSize(output.data[2]);
+ 			ListVector::Reserve(output.data[2], total_tags + tag_count);
+ 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
+-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
++			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
+ 
+ 			tag_entry.offset = total_tags;
+ 			tag_entry.length = tag_count;
+@@ -541,7 +541,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_tags = ListVector::GetListSize(output.data[2]);
+ 			ListVector::Reserve(output.data[2], total_tags + tag_count);
+ 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
+-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
++			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
+ 
+ 			tag_entry.offset = total_tags;
+ 			tag_entry.length = tag_count;
+@@ -566,7 +566,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_refs = ListVector::GetListSize(output.data[3]);
+ 			ListVector::Reserve(output.data[3], total_refs + ref_count);
+ 			ListVector::SetListSize(output.data[3], total_refs + ref_count);
+-			auto &ref_entry = ListVector::GetData(output.data[3])[index];
++			auto &ref_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[3])[index];
+ 			auto &ref_vector = ListVector::GetEntry(output.data[3]);
+ 			ref_entry.offset = total_refs;
+ 			ref_entry.length = ref_count;
+@@ -630,7 +630,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_tags = ListVector::GetListSize(output.data[2]);
+ 			ListVector::Reserve(output.data[2], total_tags + tag_count);
+ 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
+-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
++			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
+ 
+ 			tag_entry.offset = total_tags;
+ 			tag_entry.length = tag_count;
+@@ -657,7 +657,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_roles = ListVector::GetListSize(output.data[6]);
+ 			ListVector::Reserve(output.data[6], total_roles + role_count);
+ 			ListVector::SetListSize(output.data[6], total_roles + role_count);
+-			auto &role_entry = ListVector::GetData(output.data[6])[index];
++			auto &role_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[6])[index];
+ 			auto &role_vector = ListVector::GetEntry(output.data[6]);
+ 			role_entry.offset = total_roles;
+ 			role_entry.length = role_count;
+@@ -682,7 +682,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_refs = ListVector::GetListSize(output.data[3]);
+ 			ListVector::Reserve(output.data[3], total_refs + ref_count);
+ 			ListVector::SetListSize(output.data[3], total_refs + ref_count);
+-			auto &ref_entry = ListVector::GetData(output.data[3])[index];
++			auto &ref_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[3])[index];
+ 			auto &ref_vector = ListVector::GetEntry(output.data[3]);
+ 			ref_entry.offset = total_refs;
+ 			ref_entry.length = ref_count;
+@@ -705,7 +705,7 @@ struct LocalState final : LocalTableFunctionState {
+ 			auto total_types = ListVector::GetListSize(output.data[7]);
+ 			ListVector::Reserve(output.data[7], total_types + type_count);
+ 			ListVector::SetListSize(output.data[7], total_types + type_count);
+-			auto &type_entry = ListVector::GetData(output.data[7])[index];
++			auto &type_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[7])[index];
+ 			auto &type_vector = ListVector::GetEntry(output.data[7]);
+ 			type_entry.offset = total_types;
+ 			type_entry.length = type_count;
+@@ -751,7 +751,7 @@ struct LocalState final : LocalTableFunctionState {
+ 					auto total_tags = ListVector::GetListSize(output.data[2]);
+ 					ListVector::Reserve(output.data[2], total_tags + tag_count);
+ 					ListVector::SetListSize(output.data[2], total_tags + tag_count);
+-					auto &tag_entry = ListVector::GetData(output.data[2])[index];
++					auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
+ 
+ 					tag_entry.offset = total_tags;
+ 					tag_entry.length = tag_count;
+diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
+index d11d09e..ec69387 100644
+--- a/src/spatial/modules/proj/proj_module.cpp
++++ b/src/spatial/modules/proj/proj_module.cpp
+@@ -163,7 +163,10 @@ struct ST_Transform {
+ 		}
+ 	};
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &ctx, ScalarFunction &, vector<unique_ptr<Expression>> &args) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &ctx = input.GetClientContext();
++		auto &args = input.GetArguments();
++
+ 		auto result = make_uniq<BindData>();
+ 
+ 		// If always_xy is set, then always normalize
+@@ -239,8 +242,10 @@ struct ST_Transform {
+ 		}
+ 	};
+ 
+-	static unique_ptr<FunctionData> BindTyped(ClientContext &ctx, ScalarFunction &func,
+-	                                          vector<unique_ptr<Expression>> &args) {
++	static unique_ptr<FunctionData> BindTyped(BindScalarFunctionInput &input) {
++		auto &ctx = input.GetClientContext();
++		auto &func = input.GetBoundFunction();
++		auto &args = input.GetArguments();
+ 
+ 		auto result = make_uniq<TypedBindData>();
+ 
+@@ -725,8 +730,10 @@ struct GeodesicBindData final : FunctionData {
+ 		return always_xy == data.always_xy;
+ 	}
+ 
+-	static unique_ptr<FunctionData> Bind(ClientContext &ctx, ScalarFunction &func,
+-	                                     vector<unique_ptr<Expression>> &args) {
++	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
++		auto &ctx = input.GetClientContext();
++		auto &func = input.GetBoundFunction();
++
+ 		auto result = make_uniq<GeodesicBindData>();
+ 
+ 		bool is_set = false;
+@@ -797,7 +804,7 @@ struct GeodesicLocalState final : FunctionLocalState {
+ 
+ struct ST_Area_Spheroid {
+ 
+-	//------------------------------------------------------------------------------------------------------------------
++	//--------------------------------------------------------------------------------------o----------------------------
+ 	// Execute (POLYGON_2D)
+ 	//------------------------------------------------------------------------------------------------------------------
+ 
+@@ -810,7 +817,7 @@ struct ST_Area_Spheroid {
+ 		auto count = args.size();
+ 
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+@@ -1004,7 +1011,7 @@ struct ST_Perimeter_Spheroid {
+ 		auto count = args.size();
+ 
+ 		auto &ring_vec = ListVector::GetEntry(input);
+-		auto ring_entries = ListVector::GetData(ring_vec);
++		auto ring_entries = FlatVector::GetData<list_entry_t>(ring_vec);
+ 		auto &coord_vec = ListVector::GetEntry(ring_vec);
+ 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
+ 		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index 1c0cf53..082b436 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -142,13 +142,19 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, B
+ 
+ 	return nullptr;
+ }
+-unique_ptr<FunctionData> GeoTypes::PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
+-                                                vector<unique_ptr<Expression>> &arguments) {
++unique_ptr<FunctionData> GeoTypes::PropagateCRS(BindScalarFunctionInput &input) {
++	auto &context = input.GetClientContext();
++	auto &bound_function = input.GetBoundFunction();
++	auto &arguments = input.GetArguments();
++
+ 	return PropagateTypesInternal(context, bound_function, arguments);
+ }
+ 
+-unique_ptr<FunctionData> GeoTypes::PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
+-                                                vector<unique_ptr<Expression>> &arguments) {
++unique_ptr<FunctionData> GeoTypes::PropagateCRS(BindAggregateFunctionInput &input) {
++	auto &context = input.GetClientContext();
++	auto &bound_function = input.GetBoundFunction();
++	auto &arguments = input.GetArguments();
++
+ 	return PropagateTypesInternal(context, bound_function, arguments);
+ }
+ 
+diff --git a/src/spatial/spatial_types.hpp b/src/spatial/spatial_types.hpp
+index 9af0cca..ae01922 100644
+--- a/src/spatial/spatial_types.hpp
++++ b/src/spatial/spatial_types.hpp
+@@ -13,11 +13,11 @@ class ScalarFunction;
+ class AggregateFunction;
+ class ClientContext;
+ class Expression;
++class BindScalarFunctionInput;
++class BindAggregateFunctionInput;
+ 
+-typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(ClientContext &context, ScalarFunction &bound_function,
+-                                                           vector<unique_ptr<Expression>> &arguments);
+-typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(ClientContext &context, AggregateFunction &function,
+-                                                              vector<unique_ptr<Expression>> &arguments);
++typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(BindScalarFunctionInput &input);
++typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(BindAggregateFunctionInput &input);
+ 
+ struct GeoTypes {
+ 	static LogicalType POINT_2D();
+@@ -34,25 +34,22 @@ struct GeoTypes {
+ 
+ 	static LogicalType CreateEnumType(const string &name, const vector<string> &members);
+ 
+-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
+-	                                             vector<unique_ptr<Expression>> &arguments);
++	static unique_ptr<FunctionData> PropagateCRS(BindScalarFunctionInput &input);
++	static unique_ptr<FunctionData> PropagateCRS(BindAggregateFunctionInput &input);
+ 
+-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
+-	                                             vector<unique_ptr<Expression>> &arguments);
+ 
+-	template <bind_aggregate_function_t BIND>
+-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
+-	                                             vector<unique_ptr<Expression>> &arguments) {
+-		PropagateCRS(context, bound_function, arguments);
+-		return BIND(context, bound_function, arguments);
++	template <bind_scalar_function_t BIND>
++	static unique_ptr<FunctionData> PropagateCRS(BindScalarFunctionInput &input) {
++		PropagateCRS(input);
++		return BIND(input);
+ 	}
+ 
+-	template <bind_scalar_function_t BIND>
+-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
+-	                                             vector<unique_ptr<Expression>> &arguments) {
+-		PropagateCRS(context, bound_function, arguments);
+-		return BIND(context, bound_function, arguments);
++	template <bind_aggregate_function_t BIND>
++	static unique_ptr<FunctionData> PropagateCRS(BindAggregateFunctionInput &input) {
++		PropagateCRS(input);
++		return BIND(input);
+ 	}
++
+ };
+ 
+ } // namespace duckdb
+-- 
+2.39.5 (Apple Git-154)
+

--- a/.github/patches/extensions/vss/0001-applied-patch-fix-patch.patch
+++ b/.github/patches/extensions/vss/0001-applied-patch-fix-patch.patch
@@ -1,3 +1,17 @@
+From 60948d8d30d65c8c7dfbfe712390ca169bb04e74 Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 13:16:42 +0200
+Subject: [PATCH] applied patch: fix.patch
+
+---
+ src/hnsw/hnsw_index.cpp                 | 11 ++++----
+ src/hnsw/hnsw_index_physical_create.cpp |  1 +
+ src/hnsw/hnsw_optimize_join.cpp         | 37 +++++++++++++------------
+ src/hnsw/hnsw_optimize_scan.cpp         | 28 ++++++-------------
+ src/hnsw/hnsw_optimize_topk.cpp         | 28 ++++++-------------
+ src/include/hnsw/hnsw_index.hpp         |  2 +-
+ 6 files changed, 46 insertions(+), 61 deletions(-)
+
 diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
 index 1af2a74..3e095b2 100644
 --- a/src/hnsw/hnsw_index.cpp
@@ -326,3 +340,6 @@ index 3606268..591e707 100644
  	bool TryBindIndexExpression(LogicalGet &get, unique_ptr<Expression> &result) const;
  
  public:
+-- 
+2.39.5 (Apple Git-154)
+

--- a/.github/patches/extensions/vss/0002-wrap-bind.patch
+++ b/.github/patches/extensions/vss/0002-wrap-bind.patch
@@ -1,0 +1,25 @@
+From 5bf790fe12b0f3f47304bdcb02d6efee66727423 Mon Sep 17 00:00:00 2001
+From: Max Gabrielsson <max@gabrielsson.com>
+Date: Mon, 13 Apr 2026 14:54:08 +0200
+Subject: [PATCH] wrap bind
+
+---
+ src/hnsw/hnsw_optimize_topk.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
+index 5e3a4b8..5d16215 100644
+--- a/src/hnsw/hnsw_optimize_topk.cpp
++++ b/src/hnsw/hnsw_optimize_topk.cpp
+@@ -36,7 +36,7 @@ static unique_ptr<Expression> CreateListOrderByExpr(ClientContext &context, uniq
+ 	vector<unique_ptr<Expression>> arguments;
+ 	arguments.push_back(std::move(elem_expr));
+ 
+-	auto agg_bind_data = func.bind(context, func, arguments);
++	auto agg_bind_data = func.Bind(context, arguments);
+ 	auto new_agg_expr =
+ 	    make_uniq<BoundAggregateExpression>(func, std::move(arguments), std::move(std::move(filter_expr)),
+ 	                                        std::move(agg_bind_data), AggregateType::NON_DISTINCT);
+-- 
+2.39.5 (Apple Git-154)
+

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -711,8 +711,10 @@ static FormatterConfig ParseFormatterConfig(ClientContext &context, vector<uniqu
 	return config;
 }
 
-static unique_ptr<FunctionData> FormatSQLBind(ClientContext &context, ScalarFunction &bound_function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> FormatSQLBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+
 	auto bind_data = make_uniq<FormatSQLBindData>();
 	bind_data->config = ParseFormatterConfig(context, arguments);
 	return std::move(bind_data);

--- a/extension/core_functions/aggregate/README.md
+++ b/extension/core_functions/aggregate/README.md
@@ -190,7 +190,7 @@ Window(const ArgType *arg, ValidityMask &filter, ValidityMask &valid,
 ### Bind
 
 ```cpp
-bind(ClientContext &context, AggregateFunction &function,vector<unique_ptr<Expression>> &arguments)
+bind(BindAggregateFunctionInput &input)
 ```
 
 Like scalar functions, aggregates can sometimes have complex binding rules

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -286,8 +286,9 @@ AggregateFunction GetAverageAggregate(PhysicalType type) {
 	}
 }
 
-unique_ptr<FunctionData> BindDecimalAvg(ClientContext &context, AggregateFunction &function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->return_type;
 	function = GetAverageAggregate(decimal_type.InternalType());
 	function.name = "avg";

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -185,8 +185,10 @@ struct ArgMinMaxBase {
 	}
 
 	template <ArgMinMaxNullHandling NULL_HANDLING>
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
 			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
 		}
@@ -348,8 +350,10 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 	}
 
 	template <ArgMinMaxNullHandling NULL_HANDLING>
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
 			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
 		}
@@ -518,8 +522,10 @@ AggregateFunction GetDecimalArgMinMaxFunction(const LogicalType &by_type, const 
 }
 
 template <class OP, ArgMinMaxNullHandling NULL_HANDLING>
-unique_ptr<FunctionData> BindDecimalArgMinMax(ClientContext &context, AggregateFunction &function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalArgMinMax(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->return_type;
 	auto by_type = arguments[1]->return_type;
 
@@ -848,8 +854,9 @@ void SpecializeArgMinMaxNullNFunction(PhysicalType val_type, PhysicalType arg_ty
 }
 
 template <ArgMinMaxNullHandling NULL_HANDLING, bool NULLS_LAST, class COMPARATOR>
-unique_ptr<FunctionData> ArgMinMaxNBind(ClientContext &context, AggregateFunction &function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ArgMinMaxNBind(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -243,8 +243,10 @@ unique_ptr<BaseStatistics> BitstringPropagateStats(ClientContext &context, Bound
 	return nullptr;
 }
 
-unique_ptr<FunctionData> BindBitstringAgg(ClientContext &context, AggregateFunction &function,
-                                          vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindBitstringAgg(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() == 3) {
 		if (!arguments[1]->IsFoldable() || !arguments[2]->IsFoldable()) {
 			throw BinderException("bitstring_agg requires a constant min and max argument");

--- a/extension/core_functions/aggregate/distributive/string_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/string_agg.cpp
@@ -113,8 +113,10 @@ struct StringAggFunction {
 	}
 };
 
-unique_ptr<FunctionData> StringAggBind(ClientContext &context, AggregateFunction &function,
-                                       vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> StringAggBind(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() == 1) {
 		// single argument: default to comma
 		return make_uniq<StringAggBindData>(",");

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -104,8 +104,7 @@ LogicalType GetSumStateType(const AggregateFunction &function) {
 	return LogicalType::STRUCT(std::move(child_types));
 }
 
-unique_ptr<FunctionData> SumNoOverflowBind(ClientContext &context, AggregateFunction &function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> SumNoOverflowBind(BindAggregateFunctionInput &input) {
 	throw BinderException("sum_no_overflow is for internal use only!");
 }
 
@@ -232,8 +231,9 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 	}
 }
 
-unique_ptr<FunctionData> BindDecimalSum(ClientContext &context, AggregateFunction &function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->return_type;
 	function = GetSumAggregate(decimal_type.InternalType());
 	function.name = "sum";

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -384,8 +384,9 @@ void ApproxTopKFinalize(Vector &state_vector, AggregateInputData &, Vector &resu
 	result.Verify(count);
 }
 
-unique_ptr<FunctionData> ApproxTopKBind(ClientContext &context, AggregateFunction &function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ApproxTopKBind(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -234,8 +234,10 @@ float CheckApproxQuantile(const Value &quantile_val) {
 	return quantile;
 }
 
-unique_ptr<FunctionData> BindApproxQuantile(ClientContext &context, AggregateFunction &function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindApproxQuantile(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
@@ -277,9 +279,10 @@ AggregateFunction ApproxQuantileDecimalFunction(const LogicalType &type) {
 	return function;
 }
 
-unique_ptr<FunctionData> BindApproxQuantileDecimal(ClientContext &context, AggregateFunction &function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
-	auto bind_data = BindApproxQuantile(context, function, arguments);
+unique_ptr<FunctionData> BindApproxQuantileDecimal(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+	auto bind_data = BindApproxQuantile(input);
 	function = ApproxQuantileDecimalFunction(arguments[0]->return_type);
 	return bind_data;
 }
@@ -397,9 +400,10 @@ AggregateFunction ApproxQuantileDecimalListFunction(const LogicalType &type) {
 	return function;
 }
 
-unique_ptr<FunctionData> BindApproxQuantileDecimalList(ClientContext &context, AggregateFunction &function,
-                                                       vector<unique_ptr<Expression>> &arguments) {
-	auto bind_data = BindApproxQuantile(context, function, arguments);
+unique_ptr<FunctionData> BindApproxQuantileDecimalList(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+	auto bind_data = BindApproxQuantile(input);
 	function = ApproxQuantileDecimalListFunction(arguments[0]->return_type);
 	return bind_data;
 }

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -255,8 +255,7 @@ struct MedianAbsoluteDeviationOperation : QuantileOperation {
 	}
 };
 
-unique_ptr<FunctionData> BindMAD(ClientContext &context, AggregateFunction &function,
-                                 vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindMAD(BindAggregateFunctionInput &input) {
 	return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
 }
 
@@ -320,12 +319,13 @@ AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType 
 	return result;
 }
 
-unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(ClientContext &context, AggregateFunction &function,
-                                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->return_type);
 	function.name = "mad";
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-	return BindMAD(context, function, arguments);
+	return BindMAD(input);
 }
 
 } // namespace

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -500,8 +500,9 @@ AggregateFunction GetModeAggregate(const LogicalType &type) {
 	}
 }
 
-unique_ptr<FunctionData> BindModeAggregate(ClientContext &context, AggregateFunction &function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindModeAggregate(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	function = GetModeAggregate(arguments[0]->return_type);
 	function.name = "mode";
 	return nullptr;
@@ -601,8 +602,9 @@ AggregateFunction GetEntropyFunction(const LogicalType &type) {
 	}
 }
 
-unique_ptr<FunctionData> BindEntropyAggregate(ClientContext &context, AggregateFunction &function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindEntropyAggregate(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	function = GetEntropyFunction(arguments[0]->return_type);
 	function.name = "entropy";
 	return nullptr;

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -566,8 +566,10 @@ static Value CheckQuantile(const Value &quantile_val) {
 	return quantile_val;
 }
 
-unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction &function,
-                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindQuantile(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() < 2) {
 		throw BinderException("QUANTILE requires a range argument between [0, 1]");
 	}
@@ -655,8 +657,9 @@ struct MedianFunction {
 		return bind_data;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function = GetAggregate(arguments[0]->return_type);
 		return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
 	}
@@ -683,10 +686,11 @@ struct DiscreteQuantileListFunction {
 		return bind_data;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function = GetAggregate(arguments[0]->return_type);
-		return BindQuantile(context, function, arguments);
+		return BindQuantile(input);
 	}
 };
 
@@ -716,10 +720,11 @@ struct DiscreteQuantileFunction {
 		return bind_data;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function = GetAggregate(arguments[0]->return_type);
-		return BindQuantile(context, function, arguments);
+		return BindQuantile(input);
 	}
 };
 
@@ -744,11 +749,12 @@ struct ContinuousQuantileFunction {
 		return bind_data;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function = GetAggregate(function.arguments[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->return_type
 		                                                                             : function.arguments[0]);
-		return BindQuantile(context, function, arguments);
+		return BindQuantile(input);
 	}
 };
 
@@ -774,11 +780,12 @@ struct ContinuousQuantileListFunction {
 		return bind_data;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function = GetAggregate(function.arguments[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->return_type
 		                                                                             : function.arguments[0]);
-		return BindQuantile(context, function, arguments);
+		return BindQuantile(input);
 	}
 };
 

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -309,8 +309,10 @@ double CheckReservoirQuantile(const Value &quantile_val) {
 	return quantile;
 }
 
-unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, AggregateFunction &function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindReservoirQuantile(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() >= 2);
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();
@@ -361,10 +363,11 @@ unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, Aggregate
 	return make_uniq<ReservoirQuantileBindData>(quantiles, NumericCast<idx_t>(sample_size));
 }
 
-unique_ptr<FunctionData> BindReservoirQuantileDecimal(ClientContext &context, AggregateFunction &function,
-                                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindReservoirQuantileDecimal(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	function = GetReservoirQuantileAggregateFunction(arguments[0]->return_type.InternalType());
-	auto bind_data = BindReservoirQuantile(context, function, arguments);
+	auto bind_data = BindReservoirQuantile(input);
 	function.name = "reservoir_quantile";
 	function.SetSerializeCallback(ReservoirQuantileBindData::Serialize);
 	function.SetDeserializeCallback(ReservoirQuantileBindData::Deserialize);

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -376,8 +376,9 @@ AggregateFunction GetHistogramBinFunction(const LogicalType &type) {
 }
 
 template <class HIST>
-unique_ptr<FunctionData> HistogramBinBindFunction(ClientContext &context, AggregateFunction &function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> HistogramBinBindFunction(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -205,8 +205,9 @@ AggregateFunction GetHistogramFunction(const LogicalType &type) {
 }
 
 template <bool IS_ORDERED = true>
-unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, AggregateFunction &function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> HistogramBindFunction(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() == 1);
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -167,8 +167,9 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 	}
 }
 
-unique_ptr<FunctionData> ListBindFunction(ClientContext &context, AggregateFunction &function,
-                                          vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ListBindFunction(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	function.SetReturnType(LogicalType::LIST(arguments[0]->return_type));
 	return make_uniq<ListBindData>(function.GetReturnType());
 }

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -5,8 +5,10 @@
 
 namespace duckdb {
 
-static unique_ptr<FunctionData> ArrayGenericBinaryBind(ClientContext &context, ScalarFunction &bound_function,
-                                                       vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	const auto &lhs_type = arguments[0]->return_type;
 	const auto &rhs_type = arguments[1]->return_type;
 

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -45,8 +45,10 @@ void ArrayValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	result.Verify(args.size());
 }
 
-unique_ptr<FunctionData> ArrayValueBind(ClientContext &context, ScalarFunction &bound_function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw InvalidInputException("array_value requires at least one argument");
 	}
@@ -83,8 +85,7 @@ unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &context, FunctionStati
 
 ScalarFunction ArrayValueFun::GetFunction() {
 	// the arguments and return types are actually set in the binder function
-	ScalarFunction fun("array_value", {}, LogicalTypeId::ARRAY, ArrayValueFunction, ArrayValueBind, nullptr,
-	                   ArrayValueStats);
+	ScalarFunction fun("array_value", {}, LogicalTypeId::ARRAY, ArrayValueFunction, ArrayValueBind, ArrayValueStats);
 	fun.varargs = LogicalType::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -1761,8 +1761,10 @@ void DatePartFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	    });
 }
 
-unique_ptr<FunctionData> DatePartBind(ClientContext &context, ScalarFunction &bound_function,
-                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	//	If we are only looking for Julian Days for timestamps,
 	//	then return doubles.
 	if (arguments[0]->HasParameter() || !arguments[0]->IsFoldable()) {
@@ -1845,9 +1847,9 @@ ScalarFunctionSet GetGenericDatePartFunction(scalar_function_t date_func, scalar
                                              function_statistics_t ts_stats) {
 	ScalarFunctionSet operator_set;
 	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BIGINT, std::move(date_func), nullptr,
-	                                        nullptr, date_stats, DATE_CACHE));
+	                                        date_stats, DATE_CACHE));
 	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, std::move(ts_func), nullptr,
-	                                        nullptr, ts_stats, DATE_CACHE));
+	                                        ts_stats, DATE_CACHE));
 	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, std::move(interval_func)));
 	for (auto &func : operator_set.functions) {
 		func.SetFallible();
@@ -1871,16 +1873,16 @@ ScalarFunctionSet GetGenericTimePartFunction(const LogicalType &result_type, sca
                                              function_statistics_t time_ns_stats, function_statistics_t timetz_stats) {
 	ScalarFunctionSet operator_set;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::DATE}, result_type, std::move(date_func), nullptr, nullptr, date_stats));
+	    ScalarFunction({LogicalType::DATE}, result_type, std::move(date_func), nullptr, date_stats));
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP}, result_type, std::move(ts_func), nullptr, nullptr, ts_stats));
+	    ScalarFunction({LogicalType::TIMESTAMP}, result_type, std::move(ts_func), nullptr, ts_stats));
 	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, result_type, std::move(interval_func)));
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIME}, result_type, std::move(time_func), nullptr, nullptr, time_stats));
+	    ScalarFunction({LogicalType::TIME}, result_type, std::move(time_func), nullptr, time_stats));
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIME_NS}, result_type, std::move(time_ns_func), nullptr, nullptr, time_ns_stats));
+	    ScalarFunction({LogicalType::TIME_NS}, result_type, std::move(time_ns_func), nullptr, time_ns_stats));
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIME_TZ}, result_type, std::move(timetz_func), nullptr, nullptr, timetz_stats));
+	    ScalarFunction({LogicalType::TIME_TZ}, result_type, std::move(timetz_func), nullptr, timetz_stats));
 	return operator_set;
 }
 
@@ -1941,8 +1943,10 @@ struct StructDatePart {
 		}
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &bound_function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		// collect names and deconflict, construct return type
 		if (arguments[0]->HasParameter()) {
 			throw ParameterNotResolvedException();
@@ -2242,7 +2246,7 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 	auto tstz_func = DatePart::UnaryFunction<timestamp_t, int64_t, OP>;
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, nullptr, tstz_stats));
+	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
@@ -2257,7 +2261,7 @@ ScalarFunctionSet EpochUsFun::GetFunctions() {
 	auto tstz_func = DatePart::UnaryFunction<timestamp_t, int64_t, OP>;
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, nullptr, tstz_stats));
+	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 	return operator_set;
 }
 
@@ -2269,7 +2273,7 @@ ScalarFunctionSet EpochMsFun::GetFunctions() {
 	auto tstz_func = DatePart::UnaryFunction<timestamp_t, int64_t, OP>;
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, nullptr, tstz_stats));
+	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 
 	//	Deprecated inverse BIGINT => TIMESTAMP
 	operator_set.AddFunction(
@@ -2293,14 +2297,13 @@ ScalarFunctionSet NanosecondsFun::GetFunctions() {
 
 	auto ns_func = DatePart::UnaryFunction<timestamp_ns_t, TR, OP>;
 	auto ns_stats = OP::template PropagateStatistics<timestamp_ns_t>;
-	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_NS}, result_type, ns_func, nullptr, nullptr, ns_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_NS}, result_type, ns_func, nullptr, ns_stats));
 
 	//	TIMESTAMP WITH TIME ZONE has the same representation as TIMESTAMP so no need to defer to ICU
 	auto tstz_func = DatePart::UnaryFunction<timestamp_t, TR, OP>;
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, nullptr, tstz_stats));
+	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
 
 	return operator_set;
 }
@@ -2374,12 +2377,10 @@ ScalarFunctionSet JulianDayFun::GetFunctions() {
 	ScalarFunctionSet operator_set;
 	auto date_func = DatePart::UnaryFunction<date_t, double, OP>;
 	auto date_stats = OP::template PropagateStatistics<date_t>;
-	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::DATE}, LogicalType::DOUBLE, date_func, nullptr, nullptr, date_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::DOUBLE, date_func, nullptr, date_stats));
 	auto ts_func = DatePart::UnaryFunction<timestamp_t, double, OP>;
 	auto ts_stats = OP::template PropagateStatistics<timestamp_t>;
-	operator_set.AddFunction(
-	    ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::DOUBLE, ts_func, nullptr, nullptr, ts_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::DOUBLE, ts_func, nullptr, ts_stats));
 
 	return operator_set;
 }

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -568,8 +568,10 @@ function_statistics_t DateTruncStats(DatePartSpecifier type) {
 	}
 }
 
-unique_ptr<FunctionData> DateTruncBind(ClientContext &context, ScalarFunction &bound_function,
-                                       vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> DateTruncBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (!arguments[0]->IsFoldable()) {
 		return nullptr;
 	}

--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -132,8 +132,10 @@ struct IndexKeyBindData : public FunctionData {
 	vector<LogicalType> key_types;
 };
 
-static unique_ptr<FunctionData> IndexKeyBind(ClientContext &context, ScalarFunction &bound_function,
-                                             vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> IndexKeyBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() < INDEX_KEY_FIXED_ARGS) {
 		throw BinderException("index_key: requires at least two arguments - path (STRUCT), index_name");
 	}

--- a/extension/core_functions/scalar/enum/enum_functions.cpp
+++ b/extension/core_functions/scalar/enum/enum_functions.cpp
@@ -71,8 +71,8 @@ static void CheckEnumParameter(const Expression &expr) {
 	}
 }
 
-static unique_ptr<FunctionData> BindEnumFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindEnumFunction(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
 	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
 		throw BinderException("This function needs an ENUM as an argument");
@@ -80,8 +80,9 @@ static unique_ptr<FunctionData> BindEnumFunction(ClientContext &context, ScalarF
 	return nullptr;
 }
 
-static unique_ptr<FunctionData> BindEnumCodeFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                     vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindEnumCodeFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
 	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
 		throw BinderException("This function needs an ENUM as an argument");
@@ -108,8 +109,8 @@ static unique_ptr<FunctionData> BindEnumCodeFunction(ClientContext &context, Sca
 	return nullptr;
 }
 
-static unique_ptr<FunctionData> BindEnumRangeBoundaryFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                              vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindEnumRangeBoundaryFunction(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
 	CheckEnumParameter(*arguments[1]);
 	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM && arguments[0]->return_type != LogicalType::SQLNULL) {

--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -405,8 +405,9 @@ struct EquiWidthBinsTimestamp {
 	}
 };
 
-unique_ptr<FunctionData> BindEquiWidthFunction(ClientContext &, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindEquiWidthFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// while internally the bins are computed over a unified type
 	// the equi_width_bins function returns the same type as the input MAX
 	LogicalType child_type;

--- a/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/extension/core_functions/scalar/generic/current_setting.cpp
@@ -33,8 +33,10 @@ void CurrentSettingFunction(DataChunk &args, ExpressionState &state, Vector &res
 	result.Reference(info.value);
 }
 
-unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CurrentSettingBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto &key_child = arguments[0];
 	if (key_child->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/generic/least.cpp
+++ b/extension/core_functions/scalar/generic/least.cpp
@@ -171,8 +171,10 @@ void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 template <class LEAST_GREATER_OP>
-unique_ptr<FunctionData> BindLeastGreatest(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindLeastGreatest(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	LogicalType child_type = ExpressionBinder::GetExpressionReturnType(*arguments[0]);
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		auto arg_type = ExpressionBinder::GetExpressionReturnType(*arguments[i]);
@@ -235,8 +237,7 @@ unique_ptr<FunctionData> BindLeastGreatest(ClientContext &context, ScalarFunctio
 template <class OP>
 ScalarFunction GetLeastGreatestFunction() {
 	return ScalarFunction({LogicalType::ANY}, LogicalType::ANY, nullptr, BindLeastGreatest<OP>, nullptr, nullptr,
-	                      nullptr, LogicalType::ANY, FunctionStability::CONSISTENT,
-	                      FunctionNullHandling::SPECIAL_HANDLING);
+	                      LogicalType::ANY, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 }
 
 template <class OP>

--- a/extension/core_functions/scalar/generic/stats.cpp
+++ b/extension/core_functions/scalar/generic/stats.cpp
@@ -27,8 +27,7 @@ void StatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	result.Reference(info.stats);
 }
 
-unique_ptr<FunctionData> StatsBind(ClientContext &context, ScalarFunction &bound_function,
-                                   vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> StatsBind(BindScalarFunctionInput &input) {
 	return make_uniq<StatsBindData>();
 }
 
@@ -43,8 +42,7 @@ unique_ptr<BaseStatistics> StatsPropagateStats(ClientContext &context, FunctionS
 } // namespace
 
 ScalarFunction StatsFun::GetFunction() {
-	ScalarFunction stats({LogicalType::ANY}, LogicalType::VARIANT(), StatsFunction, StatsBind, nullptr,
-	                     StatsPropagateStats);
+	ScalarFunction stats({LogicalType::ANY}, LogicalType::VARIANT(), StatsFunction, StatsBind, StatsPropagateStats);
 	stats.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	stats.SetStability(FunctionStability::VOLATILE);
 	return stats;

--- a/extension/core_functions/scalar/generic/system_functions.cpp
+++ b/extension/core_functions/scalar/generic/system_functions.cpp
@@ -47,8 +47,9 @@ public:
 	}
 };
 
-unique_ptr<FunctionData> CurrentSchemasBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CurrentSchemasBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->return_type.id() != LogicalTypeId::BOOLEAN) {
 		throw BinderException("current_schemas requires a boolean input");
 	}

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -44,8 +44,9 @@ static void GetTypeFunction(DataChunk &args, ExpressionState &state, Vector &res
 	result.Reference(v);
 }
 
-static unique_ptr<FunctionData> BindGetTypeFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                    vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindGetTypeFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -387,8 +387,10 @@ bool CheckIfParamIsEmpty(duckdb::unique_ptr<duckdb::Expression> &param) {
 	return is_empty;
 }
 
-unique_ptr<FunctionData> ArraySliceBind(ClientContext &context, ScalarFunction &bound_function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ArraySliceBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() == 3 || arguments.size() == 4);
 	D_ASSERT(bound_function.arguments.size() == 3 || bound_function.arguments.size() == 4);
 

--- a/extension/core_functions/scalar/list/flatten.cpp
+++ b/extension/core_functions/scalar/list/flatten.cpp
@@ -146,7 +146,7 @@ unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, FunctionStat
 
 ScalarFunction ListFlattenFun::GetFunction() {
 	return ScalarFunction({LogicalType::LIST(LogicalType::LIST(LogicalType::TEMPLATE("T")))},
-	                      LogicalType::LIST(LogicalType::TEMPLATE("T")), ListFlattenFunction, nullptr, nullptr,
+	                      LogicalType::LIST(LogicalType::TEMPLATE("T")), ListFlattenFunction, nullptr,
 	                      ListFlattenStats);
 }
 

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -413,8 +413,10 @@ ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_functio
 }
 
 template <bool IS_AGGR = false>
-unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
@@ -482,21 +484,21 @@ unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFuncti
 	return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, child_type, aggr_function, arguments);
 }
 
-unique_ptr<FunctionData> ListAggregateBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ListAggregateBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// the list column and the name of the aggregate function
 	D_ASSERT(bound_function.arguments.size() >= 2);
 	D_ASSERT(arguments.size() >= 2);
 
-	return ListAggregatesBind<true>(context, bound_function, arguments);
+	return ListAggregatesBind<true>(input);
 }
 
 } // namespace
 
 ScalarFunction ListAggregateFun::GetFunction() {
-	auto result =
-	    ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR}, LogicalType::ANY,
-	                   ListAggregateFunction, ListAggregateBind, nullptr, nullptr, ListAggregatesInitLocalState);
+	auto result = ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR}, LogicalType::ANY,
+	                             ListAggregateFunction, ListAggregateBind, nullptr, ListAggregatesInitLocalState);
 	result.SetFallible();
 	result.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	result.varargs = LogicalType::ANY;
@@ -508,12 +510,12 @@ ScalarFunction ListAggregateFun::GetFunction() {
 ScalarFunction ListDistinctFun::GetFunction() {
 	return ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T"))},
 	                      LogicalType::LIST(LogicalType::TEMPLATE("T")), ListDistinctFunction,
-	                      ListAggregatesBind<false>, nullptr, nullptr, ListAggregatesInitLocalState);
+	                      ListAggregatesBind<false>, nullptr, ListAggregatesInitLocalState);
 }
 
 ScalarFunction ListUniqueFun::GetFunction() {
 	return ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::UBIGINT, ListUniqueFunction,
-	                      ListAggregatesBind<false>, nullptr, nullptr, ListAggregatesInitLocalState);
+	                      ListAggregatesBind<false>, nullptr, ListAggregatesInitLocalState);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/scalar/list/list_filter.cpp
+++ b/extension/core_functions/scalar/list/list_filter.cpp
@@ -6,8 +6,10 @@
 
 namespace duckdb {
 
-static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListFilterBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -210,8 +210,10 @@ LogicalType ResolveReduceAccumulatorType(ClientContext &context, const LogicalTy
 	                      initial_type.ToString(), lambda_return_type.ToString());
 }
 
-unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFunction &bound_function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ListReduceBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -280,8 +280,10 @@ static T GetOrder(ClientContext &context, Expression &expr) {
 	return EnumUtil::FromString<T>(order_name.c_str());
 }
 
-static unique_ptr<FunctionData> ListGradeUpBind(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListGradeUpBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(!arguments.empty() && arguments.size() <= 3);
 	auto order = OrderType::ORDER_DEFAULT;
 	auto null_order = OrderByNullType::ORDER_DEFAULT;
@@ -306,8 +308,10 @@ static unique_ptr<FunctionData> ListGradeUpBind(ClientContext &context, ScalarFu
 	return make_uniq<ListSortBindData>(order, null_order, true, bound_function.GetReturnType(), child_type, context);
 }
 
-static unique_ptr<FunctionData> ListNormalSortBind(ClientContext &context, ScalarFunction &bound_function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListNormalSortBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(!arguments.empty() && arguments.size() <= 3);
 	auto order = OrderType::ORDER_DEFAULT;
 	auto null_order = OrderByNullType::ORDER_DEFAULT;
@@ -326,8 +330,10 @@ static unique_ptr<FunctionData> ListNormalSortBind(ClientContext &context, Scala
 	return ListSortBind(context, bound_function, arguments, order, null_order);
 }
 
-static unique_ptr<FunctionData> ListReverseSortBind(ClientContext &context, ScalarFunction &bound_function,
-                                                    vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListReverseSortBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto order = OrderType::ORDER_DEFAULT;
 	auto null_order = OrderByNullType::ORDER_DEFAULT;
 

--- a/extension/core_functions/scalar/list/list_transform.cpp
+++ b/extension/core_functions/scalar/list/list_transform.cpp
@@ -6,8 +6,10 @@
 
 namespace duckdb {
 
-static unique_ptr<FunctionData> ListTransformBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListTransformBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -243,8 +243,10 @@ void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	ListVector::SetListSize(result, column_count * args.size());
 }
 
-unique_ptr<FunctionData> UnpivotBind(ClientContext &context, ScalarFunction &bound_function,
-                                     vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> UnpivotBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// collect names and deconflict, construct return type
 	LogicalType child_type =
 	    arguments.empty() ? LogicalType::SQLNULL : ExpressionBinder::GetExpressionReturnType(*arguments[0]);
@@ -294,13 +296,12 @@ ScalarFunctionSet ListValueFun::GetFunctions() {
 	ScalarFunctionSet set("list_value");
 
 	// Overload for 0 arguments, which returns an empty list.
-	ScalarFunction empty_fun({}, LogicalType::LIST(LogicalType::SQLNULL), ListValueFunction, nullptr, nullptr,
-	                         ListValueStats);
+	ScalarFunction empty_fun({}, LogicalType::LIST(LogicalType::SQLNULL), ListValueFunction, nullptr, ListValueStats);
 	set.AddFunction(empty_fun);
 
 	// Overload for 1 + N arguments, which returns a list of the arguments.
 	auto element_type = LogicalType::TEMPLATE("T");
-	ScalarFunction value_fun({element_type}, LogicalType::LIST(element_type), ListValueFunction, nullptr, nullptr,
+	ScalarFunction value_fun({element_type}, LogicalType::LIST(element_type), ListValueFunction, nullptr,
 	                         ListValueStats);
 	value_fun.varargs = element_type;
 	value_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
@@ -310,8 +311,7 @@ ScalarFunctionSet ListValueFun::GetFunctions() {
 }
 
 ScalarFunction UnpivotListFun::GetFunction() {
-	ScalarFunction fun("unpivot_list", {}, LogicalTypeId::LIST, ListValueFunction, UnpivotBind, nullptr,
-	                   ListValueStats);
+	ScalarFunction fun("unpivot_list", {}, LogicalTypeId::LIST, ListValueFunction, UnpivotBind, ListValueStats);
 	fun.varargs = LogicalTypeId::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -22,8 +22,9 @@ static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector 
 	}
 }
 
-static unique_ptr<FunctionData> CardinalityBind(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> CardinalityBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("Cardinality must have exactly one arguments");
 	}

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -125,8 +125,9 @@ bool IsEmptyMap(const LogicalType &map) {
 	return key_type.id() == LogicalType::SQLNULL && value_type.id() == LogicalType::SQLNULL;
 }
 
-unique_ptr<FunctionData> MapConcatBind(ClientContext &context, ScalarFunction &bound_function,
-                                       vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> MapConcatBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto arg_count = arguments.size();
 	if (arg_count < 2) {
 		throw InvalidInputException("The provided amount of arguments is incorrect, please provide 2 or more maps");

--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -41,8 +41,9 @@ idx_t FindMapArgumentIndex(const vector<unique_ptr<Expression>> &arguments) {
 	return DConstants::INVALID_INDEX;
 }
 
-unique_ptr<FunctionData> SwitchBindReturnType(ClientContext &context, ScalarFunction &function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> SwitchBindReturnType(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	auto map_index = FindMapArgumentIndex(arguments);
 	if (map_index == DConstants::INVALID_INDEX) {
 		throw BinderException("Switch: No map argument found");

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -141,8 +141,9 @@ static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, Func
 }
 
 template <class OP>
-static unique_ptr<FunctionData> DecimalUnaryOpBind(ClientContext &context, ScalarFunction &bound_function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> DecimalUnaryOpBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->return_type;
 	switch (decimal_type.InternalType()) {
 	case PhysicalType::INT16:
@@ -331,8 +332,9 @@ static void GenericRoundFunctionDecimal(DataChunk &input, ExpressionState &state
 }
 
 template <class OP>
-static unique_ptr<FunctionData> BindGenericRoundFunctionDecimal(ClientContext &context, ScalarFunction &bound_function,
-                                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindGenericRoundFunctionDecimal(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// ceil essentially removes the scale
 	auto &decimal_type = arguments[0]->return_type;
 	auto scale = DecimalType::GetScale(decimal_type);
@@ -487,8 +489,10 @@ void GenericRoundPrecisionDecimal(DataChunk &input, ExpressionState &state, Vect
 }
 
 template <typename NEGOP, typename POSOP>
-unique_ptr<FunctionData> BindDecimalRoundPrecision(ClientContext &context, ScalarFunction &bound_function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalRoundPrecision(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto &decimal_type = arguments[0]->return_type;
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/random/random.cpp
+++ b/extension/core_functions/scalar/random/random.cpp
@@ -110,8 +110,7 @@ void GenerateUUIDv7Function(DataChunk &args, ExpressionState &state, Vector &res
 } // namespace
 
 ScalarFunction RandomFun::GetFunction() {
-	ScalarFunction random("random", {}, LogicalType::DOUBLE, RandomFunction, nullptr, nullptr, nullptr,
-	                      RandomInitLocalState);
+	ScalarFunction random("random", {}, LogicalType::DOUBLE, RandomFunction, nullptr, nullptr, RandomInitLocalState);
 	random.SetStability(FunctionStability::VOLATILE);
 	return random;
 }
@@ -121,7 +120,7 @@ ScalarFunction UUIDFun::GetFunction() {
 }
 
 ScalarFunction UUIDv4Fun::GetFunction() {
-	ScalarFunction uuid_v4_function({}, LogicalType::UUID, GenerateUUIDv4Function, nullptr, nullptr, nullptr,
+	ScalarFunction uuid_v4_function({}, LogicalType::UUID, GenerateUUIDv4Function, nullptr, nullptr,
 	                                RandomInitLocalState);
 	// generate a random uuid v4
 	uuid_v4_function.SetStability(FunctionStability::VOLATILE);
@@ -129,7 +128,7 @@ ScalarFunction UUIDv4Fun::GetFunction() {
 }
 
 ScalarFunction UUIDv7Fun::GetFunction() {
-	ScalarFunction uuid_v7_function({}, LogicalType::UUID, GenerateUUIDv7Function, nullptr, nullptr, nullptr,
+	ScalarFunction uuid_v7_function({}, LogicalType::UUID, GenerateUUIDv7Function, nullptr, nullptr,
 	                                RandomInitLocalState);
 	// generate a random uuid v7
 	uuid_v7_function.SetStability(FunctionStability::VOLATILE);

--- a/extension/core_functions/scalar/random/setseed.cpp
+++ b/extension/core_functions/scalar/random/setseed.cpp
@@ -48,8 +48,8 @@ void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	ConstantVector::SetNull(result);
 }
 
-unique_ptr<FunctionData> SetSeedBind(ClientContext &context, ScalarFunction &bound_function,
-                                     vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> SetSeedBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
 	return make_uniq<SetseedBindData>(context);
 }
 

--- a/extension/core_functions/scalar/string/instr.cpp
+++ b/extension/core_functions/scalar/string/instr.cpp
@@ -53,7 +53,7 @@ static unique_ptr<BaseStatistics> InStrPropagateStats(ClientContext &context, Fu
 ScalarFunction InstrFun::GetFunction() {
 	auto function = ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                               ScalarFunction::BinaryFunction<string_t, string_t, int64_t, InstrOperator>, nullptr,
-	                               nullptr, InStrPropagateStats);
+	                               InStrPropagateStats);
 	function.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return function;
 }

--- a/extension/core_functions/scalar/string/parse_path.cpp
+++ b/extension/core_functions/scalar/string/parse_path.cpp
@@ -292,8 +292,7 @@ static void ParsePathFunction(DataChunk &args, ExpressionState &state, Vector &r
 ScalarFunctionSet ParseDirnameFun::GetFunctions() {
 	ScalarFunctionSet parse_dirname;
 	ScalarFunction func({LogicalType::VARCHAR}, LogicalType::VARCHAR, TrimPathFunction<true>, nullptr, nullptr, nullptr,
-	                    nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                    FunctionNullHandling::SPECIAL_HANDLING);
+	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirname.AddFunction(func);
 	// separator options
 	func.arguments.emplace_back(LogicalType::VARCHAR);
@@ -304,8 +303,7 @@ ScalarFunctionSet ParseDirnameFun::GetFunctions() {
 ScalarFunctionSet ParseDirpathFun::GetFunctions() {
 	ScalarFunctionSet parse_dirpath;
 	ScalarFunction func({LogicalType::VARCHAR}, LogicalType::VARCHAR, ParseDirpathFunction, nullptr, nullptr, nullptr,
-	                    nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                    FunctionNullHandling::SPECIAL_HANDLING);
+	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirpath.AddFunction(func);
 	// separator options
 	func.arguments.emplace_back(LogicalType::VARCHAR);
@@ -316,17 +314,17 @@ ScalarFunctionSet ParseDirpathFun::GetFunctions() {
 ScalarFunctionSet ParseFilenameFun::GetFunctions() {
 	ScalarFunctionSet parse_filename;
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, TrimPathFunction<false>,
-	                                          nullptr, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                                          nullptr, nullptr, nullptr, LogicalType::INVALID,
 	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	parse_filename.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, TrimPathFunction<false>, nullptr, nullptr,
-	    nullptr, nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	parse_filename.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::VARCHAR, TrimPathFunction<false>, nullptr, nullptr,
-	    nullptr, nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::VARCHAR,
+	                                          TrimPathFunction<false>, nullptr, nullptr, nullptr, LogicalType::INVALID,
+	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	parse_filename.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::VARCHAR},
 	                                          LogicalType::VARCHAR, TrimPathFunction<false>, nullptr, nullptr, nullptr,
-	                                          nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          LogicalType::INVALID, FunctionStability::CONSISTENT,
 	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	return parse_filename;
 }
@@ -335,8 +333,7 @@ ScalarFunctionSet ParsePathFun::GetFunctions() {
 	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
 	ScalarFunctionSet parse_path;
 	ScalarFunction func({LogicalType::VARCHAR}, varchar_list_type, ParsePathFunction, nullptr, nullptr, nullptr,
-	                    nullptr, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                    FunctionNullHandling::SPECIAL_HANDLING);
+	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_path.AddFunction(func);
 	// separator options
 	func.arguments.emplace_back(LogicalType::VARCHAR);

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -22,8 +22,9 @@ struct FMTFormat {
 	}
 };
 
-unique_ptr<FunctionData> BindPrintfFunction(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		switch (arguments[i]->return_type.id()) {
 		case LogicalTypeId::BOOLEAN:

--- a/extension/core_functions/scalar/string/to_base.cpp
+++ b/extension/core_functions/scalar/string/to_base.cpp
@@ -6,8 +6,8 @@ namespace duckdb {
 
 static const char alphabet[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-static unique_ptr<FunctionData> ToBaseBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ToBaseBind(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
 	// If no min_length is specified, default to 0
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	if (arguments.size() == 2) {

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -30,8 +30,9 @@ static void StructInsertFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 }
 
-static unique_ptr<FunctionData> StructInsertBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw InvalidInputException("Missing required arguments for struct_insert function.");
 	}
@@ -89,7 +90,7 @@ static unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, Func
 }
 
 ScalarFunction StructInsertFun::GetFunction() {
-	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructInsertFunction, StructInsertBind, nullptr, StructInsertStats);
+	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructInsertFunction, StructInsertBind, StructInsertStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.varargs = LogicalType::ANY;
 	fun.SetSerializeCallback(VariableReturnBindData::Serialize);

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -70,8 +70,8 @@ static void StructKeysFunction(DataChunk &args, ExpressionState &state, Vector &
 	result.Slice(keys_vector, sel, count);
 }
 
-static unique_ptr<FunctionData> StructKeysBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructKeysBind(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
 	auto return_type = arguments[0]->return_type;
 	if (return_type.id() != LogicalTypeId::STRUCT && !return_type.IsAggregateStateStructType()) {
 		throw InvalidInputException("struct_keys() expects a STRUCT argument");

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -53,8 +53,9 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 }
 
-static unique_ptr<FunctionData> StructUpdateBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw InvalidInputException("Missing required arguments for struct_update function.");
 	}
@@ -147,7 +148,7 @@ unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionSta
 }
 
 ScalarFunction StructUpdateFun::GetFunction() {
-	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructUpdateFunction, StructUpdateBind, nullptr, StructUpdateStats);
+	ScalarFunction fun({}, LogicalTypeId::STRUCT, StructUpdateFunction, StructUpdateBind, StructUpdateStats);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.varargs = LogicalType::ANY;
 	fun.SetSerializeCallback(VariableReturnBindData::Serialize);

--- a/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/extension/core_functions/scalar/struct/struct_values.cpp
@@ -53,8 +53,9 @@ static void StructValuesFunction(DataChunk &args, ExpressionState &state, Vector
 }
 
 // Ensure input is a STRUCT, set return type to an unnamed STRUCT with same child types
-static unique_ptr<FunctionData> StructValuesBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructValuesBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	const auto arg_type = arguments[0]->return_type;
 	if (arg_type == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/union/union_extract.cpp
+++ b/extension/core_functions/scalar/union/union_extract.cpp
@@ -42,8 +42,10 @@ void UnionExtractFunction(DataChunk &args, ExpressionState &state, Vector &resul
 	result.Verify(args.size());
 }
 
-unique_ptr<FunctionData> UnionExtractBind(ClientContext &context, ScalarFunction &bound_function,
-                                          vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> UnionExtractBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/union/union_tag.cpp
+++ b/extension/core_functions/scalar/union/union_tag.cpp
@@ -9,8 +9,9 @@ namespace duckdb {
 
 namespace {
 
-unique_ptr<FunctionData> UnionTagBind(ClientContext &context, ScalarFunction &bound_function,
-                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> UnionTagBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw BinderException("Missing required arguments for union_tag function.");
 	}

--- a/extension/core_functions/scalar/union/union_value.cpp
+++ b/extension/core_functions/scalar/union/union_value.cpp
@@ -33,8 +33,9 @@ void UnionValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	ConstantVector::GetData<union_tag_t>(tag_vector)[0] = 0;
 }
 
-unique_ptr<FunctionData> UnionValueBind(ClientContext &context, ScalarFunction &bound_function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> UnionValueBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("union_value takes exactly one argument");
 	}

--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -12,9 +12,9 @@
 
 namespace duckdb {
 
-static duckdb::unique_ptr<FunctionData> ICUBindIntervalMonths(ClientContext &context, ScalarFunction &bound_function,
-                                                              vector<duckdb::unique_ptr<Expression>> &arguments) {
-	auto result = ICUDateFunc::Bind(context, bound_function, arguments);
+static duckdb::unique_ptr<FunctionData> ICUBindIntervalMonths(BindScalarFunctionInput &input) {
+	auto result = ICUDateFunc::Bind(input);
+
 	auto &info = result->Cast<ICUDateFunc::BindData>();
 	TZCalendar calendar(*info.calendar, info.cal_setting);
 	if (!calendar.SupportsIntervals()) {

--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -66,9 +66,8 @@ unique_ptr<FunctionData> ICUDateFunc::BindData::Copy() const {
 	return make_uniq<BindData>(*this);
 }
 
-unique_ptr<FunctionData> ICUDateFunc::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<duckdb::unique_ptr<Expression>> &arguments) {
-	return make_uniq<BindData>(context);
+unique_ptr<FunctionData> ICUDateFunc::Bind(BindScalarFunctionInput &input) {
+	return make_uniq<BindData>(input.GetClientContext());
 }
 
 bool ICUDateFunc::TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -462,8 +462,11 @@ struct ICUDatePart : public ICUDateFunc {
 		return make_uniq<BIND_TYPE>(context, adapter);
 	}
 
-	static duckdb::unique_ptr<FunctionData> BindUnaryDatePart(ClientContext &context, ScalarFunction &bound_function,
-	                                                          vector<duckdb::unique_ptr<Expression>> &arguments) {
+	static duckdb::unique_ptr<FunctionData> BindUnaryDatePart(BindScalarFunctionInput &input) {
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+
 		const auto part_code = GetDatePartSpecifier(bound_function.name);
 		if (IsBigintDatepart(part_code)) {
 			using data_t = BindAdapterData<int64_t>;
@@ -476,8 +479,11 @@ struct ICUDatePart : public ICUDateFunc {
 		}
 	}
 
-	static duckdb::unique_ptr<FunctionData> BindBinaryDatePart(ClientContext &context, ScalarFunction &bound_function,
-	                                                           vector<duckdb::unique_ptr<Expression>> &arguments) {
+	static duckdb::unique_ptr<FunctionData> BindBinaryDatePart(BindScalarFunctionInput &input) {
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+
 		//	If we are only looking for Julian Days, then patch in the unary function.
 		do {
 			if (arguments[0]->HasParameter() || !arguments[0]->IsFoldable()) {
@@ -501,15 +507,18 @@ struct ICUDatePart : public ICUDateFunc {
 			bound_function.SetReturnType(LogicalType::DOUBLE);
 			bound_function.SetFunctionCallback(UnaryTimestampFunction<timestamp_t, double>);
 
-			return BindUnaryDatePart(context, bound_function, arguments);
+			return BindUnaryDatePart(input);
 		} while (false);
 
 		using data_t = BindAdapterData<int64_t>;
 		return BindAdapter<data_t>(context, bound_function, arguments, nullptr);
 	}
 
-	static duckdb::unique_ptr<FunctionData> BindStruct(ClientContext &context, ScalarFunction &bound_function,
-	                                                   vector<duckdb::unique_ptr<Expression>> &arguments) {
+	static duckdb::unique_ptr<FunctionData> BindStruct(BindScalarFunctionInput &input) {
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+
 		// collect names and deconflict, construct return type
 		if (arguments[0]->HasParameter()) {
 			throw ParameterNotResolvedException();
@@ -614,8 +623,11 @@ struct ICUDatePart : public ICUDateFunc {
 		loader.RegisterFunction(set);
 	}
 
-	static duckdb::unique_ptr<FunctionData> BindLastDate(ClientContext &context, ScalarFunction &bound_function,
-	                                                     vector<duckdb::unique_ptr<Expression>> &arguments) {
+	static duckdb::unique_ptr<FunctionData> BindLastDate(BindScalarFunctionInput &input) {
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+
 		using data_t = BindAdapterData<date_t>;
 		return BindAdapter<data_t>(context, bound_function, arguments, MakeLastDay);
 	}
@@ -631,8 +643,10 @@ struct ICUDatePart : public ICUDateFunc {
 		loader.RegisterFunction(set);
 	}
 
-	static unique_ptr<FunctionData> BindMonthName(ClientContext &context, ScalarFunction &bound_function,
-	                                              vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> BindMonthName(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &bound_function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		using data_t = BindAdapterData<string_t>;
 		return BindAdapter<data_t>(context, bound_function, arguments, MonthName);
 	}
@@ -648,8 +662,10 @@ struct ICUDatePart : public ICUDateFunc {
 		loader.RegisterFunction(set);
 	}
 
-	static unique_ptr<FunctionData> BindDayName(ClientContext &context, ScalarFunction &bound_function,
-	                                            vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> BindDayName(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &bound_function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		using data_t = BindAdapterData<string_t>;
 		return BindAdapter<data_t>(context, bound_function, arguments, DayName);
 	}

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -177,8 +177,11 @@ struct ICUStrptime : public ICUDateFunc {
 
 	static bind_scalar_function_t bind_strptime; // NOLINT
 
-	static duckdb::unique_ptr<FunctionData> StrpTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
-	                                                             vector<duckdb::unique_ptr<Expression>> &arguments) {
+	static duckdb::unique_ptr<FunctionData> StrpTimeBindFunction(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &bound_function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
+
 		if (arguments[1]->HasParameter()) {
 			throw ParameterNotResolvedException();
 		}
@@ -233,7 +236,7 @@ struct ICUStrptime : public ICUDateFunc {
 
 		// Fall back to faster, non-TZ parsing
 		bound_function.SetBindCallback(bind_strptime);
-		return bind_strptime(context, bound_function, arguments);
+		return bound_function.Bind(context, arguments);
 	}
 
 	static void TailPatch(const string &name, ExtensionLoader &loader, const vector<LogicalType> &types) {

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -291,9 +291,8 @@ struct ICULocalTimestampFunc : public ICUDateFunc {
 		timestamp_t now;
 	};
 
-	static duckdb::unique_ptr<FunctionData> BindNow(ClientContext &context, ScalarFunction &bound_function,
-	                                                vector<duckdb::unique_ptr<Expression>> &arguments) {
-		return make_uniq<BindDataNow>(context);
+	static duckdb::unique_ptr<FunctionData> BindNow(BindScalarFunctionInput &input) {
+		return make_uniq<BindDataNow>(input.GetClientContext());
 	}
 
 	static timestamp_t GetLocalTimestamp(ExpressionState &state) {

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -153,8 +153,9 @@ static void ICUCollateFunction(DataChunk &args, ExpressionState &state, Vector &
 	});
 }
 
-static duckdb::unique_ptr<FunctionData> ICUCollateBind(ClientContext &context, ScalarFunction &bound_function,
-                                                       vector<duckdb::unique_ptr<Expression>> &arguments) {
+static duckdb::unique_ptr<FunctionData> ICUCollateBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+
 	//! Return a tagged collator
 	if (!bound_function.extra_info.empty()) {
 		return make_uniq<IcuBindData>(bound_function.extra_info);
@@ -171,8 +172,11 @@ static duckdb::unique_ptr<FunctionData> ICUCollateBind(ClientContext &context, S
 	}
 }
 
-static duckdb::unique_ptr<FunctionData> ICUSortKeyBind(ClientContext &context, ScalarFunction &bound_function,
-                                                       vector<duckdb::unique_ptr<Expression>> &arguments) {
+static duckdb::unique_ptr<FunctionData> ICUSortKeyBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	if (!arguments[1]->IsFoldable()) {
 		throw NotImplementedException("ICU_SORT_KEY(VARCHAR, VARCHAR) with non-constant collation is not supported");
 	}

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -44,8 +44,7 @@ struct ICUDateFunc {
 	};
 
 	//! Binds a default calendar object for use by the function
-	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                             vector<duckdb::unique_ptr<Expression>> &arguments);
+	static duckdb::unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 
 	//! Tries to set the time zone for the calendar and returns false if it is not valid.
 	static bool TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id);

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -28,8 +28,7 @@ public:
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
 	static JSONCommon::JSONPathType CheckPath(const Value &path_val, string &path, idx_t &len);
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 
 public:
 	const bool constant;
@@ -44,8 +43,7 @@ public:
 	JSONReadManyFunctionData(vector<string> paths_p, vector<idx_t> lens_p);
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 
 public:
 	const vector<string> paths;

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -58,8 +58,10 @@ bool JSONReadFunctionData::Equals(const FunctionData &other_p) const {
 	return constant == other.constant && path == other.path && len == other.len && path_type == other.path_type;
 }
 
-unique_ptr<FunctionData> JSONReadFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                                    vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> JSONReadFunctionData::Bind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	bool constant = false;
 	string path;
@@ -99,8 +101,10 @@ bool JSONReadManyFunctionData::Equals(const FunctionData &other_p) const {
 	return paths == other.paths && lens == other.lens;
 }
 
-unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();

--- a/extension/json/json_functions/json_array_length.cpp
+++ b/extension/json/json_functions/json_array_length.cpp
@@ -20,12 +20,12 @@ static void ManyArrayLengthFunction(DataChunk &args, ExpressionState &state, Vec
 
 static void GetArrayLengthFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type}, LogicalType::UBIGINT, UnaryArrayLengthFunction, nullptr, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	                               JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::UBIGINT, BinaryArrayLengthFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::UBIGINT), ManyArrayLengthFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayLengthFunction() {

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -136,7 +136,7 @@ static void JSONContainsFunction(DataChunk &args, ExpressionState &state, Vector
 }
 
 static void GetContainsFunctionInternal(ScalarFunctionSet &set, const LogicalType &lhs, const LogicalType &rhs) {
-	set.AddFunction(ScalarFunction({lhs, rhs}, LogicalType::BOOLEAN, JSONContainsFunction, nullptr, nullptr, nullptr,
+	set.AddFunction(ScalarFunction({lhs, rhs}, LogicalType::BOOLEAN, JSONContainsFunction, nullptr, nullptr,
 	                               JSONFunctionLocalState::Init));
 }
 

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -131,29 +131,33 @@ static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_funct
 	return make_uniq<JSONCreateFunctionData>(std::move(const_struct_names));
 }
 
-static unique_ptr<FunctionData> JSONObjectBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> JSONObjectBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() % 2 != 0) {
 		throw BinderException("json_object() requires an even number of arguments");
 	}
 	return JSONCreateBindParams(bound_function, arguments, true);
 }
 
-static unique_ptr<FunctionData> JSONArrayBind(ClientContext &context, ScalarFunction &bound_function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> JSONArrayBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
 
-static unique_ptr<FunctionData> ToJSONBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ToJSONBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("to_json() takes exactly one argument");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
 
-static unique_ptr<FunctionData> ArrayToJSONBind(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ArrayToJSONBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("array_to_json() takes exactly one argument");
 	}
@@ -167,8 +171,9 @@ static unique_ptr<FunctionData> ArrayToJSONBind(ClientContext &context, ScalarFu
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
 
-static unique_ptr<FunctionData> RowToJSONBind(ClientContext &context, ScalarFunction &bound_function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> RowToJSONBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.size() != 1) {
 		throw BinderException("row_to_json() takes exactly one argument");
 	}
@@ -725,7 +730,7 @@ static void ToJSONFunction(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
-	ScalarFunction fun("json_object", {}, LogicalType::JSON(), ObjectFunction, JSONObjectBind, nullptr, nullptr,
+	ScalarFunction fun("json_object", {}, LogicalType::JSON(), ObjectFunction, JSONObjectBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
@@ -733,7 +738,7 @@ ScalarFunctionSet JSONFunctions::GetObjectFunction() {
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayFunction() {
-	ScalarFunction fun("json_array", {}, LogicalType::JSON(), ArrayFunction, JSONArrayBind, nullptr, nullptr,
+	ScalarFunction fun("json_array", {}, LogicalType::JSON(), ArrayFunction, JSONArrayBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
@@ -741,21 +746,21 @@ ScalarFunctionSet JSONFunctions::GetArrayFunction() {
 }
 
 ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
-	ScalarFunction fun("to_json", {}, LogicalType::JSON(), ToJSONFunction, ToJSONBind, nullptr, nullptr,
+	ScalarFunction fun("to_json", {}, LogicalType::JSON(), ToJSONFunction, ToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayToJSONFunction() {
-	ScalarFunction fun("array_to_json", {}, LogicalType::JSON(), ToJSONFunction, ArrayToJSONBind, nullptr, nullptr,
+	ScalarFunction fun("array_to_json", {}, LogicalType::JSON(), ToJSONFunction, ArrayToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);
 }
 
 ScalarFunctionSet JSONFunctions::GetRowToJSONFunction() {
-	ScalarFunction fun("row_to_json", {}, LogicalType::JSON(), ToJSONFunction, RowToJSONBind, nullptr, nullptr,
+	ScalarFunction fun("row_to_json", {}, LogicalType::JSON(), ToJSONFunction, RowToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::ANY;
 	return ScalarFunctionSet(fun);

--- a/extension/json/json_functions/json_deep_merge.cpp
+++ b/extension/json/json_functions/json_deep_merge.cpp
@@ -109,7 +109,7 @@ static void DeepMergeFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 ScalarFunctionSet JSONFunctions::GetDeepMergeFunction() {
 	ScalarFunction fun("json_deep_merge", {LogicalType::JSON(), LogicalType::JSON()}, LogicalType::JSON(),
-	                   DeepMergeFunction, nullptr, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   DeepMergeFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::JSON();
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 

--- a/extension/json/json_functions/json_exists.cpp
+++ b/extension/json/json_functions/json_exists.cpp
@@ -16,10 +16,10 @@ static void ManyExistsFunction(DataChunk &args, ExpressionState &state, Vector &
 
 static void GetExistsFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BinaryExistsFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::BOOLEAN), ManyExistsFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetExistsFunction() {

--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -37,12 +37,12 @@ static void ExtractStringManyFunction(DataChunk &args, ExpressionState &state, V
 
 static void GetExtractFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::JSON(), ExtractFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::JSON(), ExtractFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::JSON()), ExtractManyFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetExtractFunction() {
@@ -55,12 +55,12 @@ ScalarFunctionSet JSONFunctions::GetExtractFunction() {
 
 static void GetExtractStringFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::VARCHAR, ExtractStringFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, ExtractStringFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::VARCHAR), ExtractStringManyFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetExtractStringFunction() {

--- a/extension/json/json_functions/json_keys.cpp
+++ b/extension/json/json_functions/json_keys.cpp
@@ -40,13 +40,13 @@ static void ManyJSONKeysFunction(DataChunk &args, ExpressionState &state, Vector
 
 static void GetJSONKeysFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type}, LogicalType::LIST(LogicalType::VARCHAR), UnaryJSONKeysFunction,
-	                               nullptr, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               nullptr, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	                               BinaryJSONKeysFunction, JSONReadFunctionData::Bind, nullptr, nullptr,
+	                               BinaryJSONKeysFunction, JSONReadFunctionData::Bind, nullptr,
 	                               JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)), ManyJSONKeysFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetKeysFunction() {

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -73,7 +73,7 @@ static void MergePatchFunction(DataChunk &args, ExpressionState &state, Vector &
 
 ScalarFunctionSet JSONFunctions::GetMergePatchFunction() {
 	ScalarFunction fun("json_merge_patch", {LogicalType::JSON(), LogicalType::JSON()}, LogicalType::JSON(),
-	                   MergePatchFunction, nullptr, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   MergePatchFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
 	fun.varargs = LogicalType::JSON();
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 

--- a/extension/json/json_functions/json_merge_patch_diff.cpp
+++ b/extension/json/json_functions/json_merge_patch_diff.cpp
@@ -106,7 +106,7 @@ static void MergePatchDiffFunction(DataChunk &args, ExpressionState &state, Vect
 
 ScalarFunctionSet JSONFunctions::GetMergePatchDiffFunction() {
 	ScalarFunction fun("json_merge_patch_diff", {LogicalType::JSON(), LogicalType::JSON()}, LogicalType::JSON(),
-	                   MergePatchDiffFunction, nullptr, nullptr, nullptr, JSONFunctionLocalState::Init);
+	                   MergePatchDiffFunction, nullptr, nullptr, JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 
 	return ScalarFunctionSet(fun);

--- a/extension/json/json_functions/json_normalize.cpp
+++ b/extension/json/json_functions/json_normalize.cpp
@@ -88,7 +88,7 @@ static void NormalizeFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 static void GetNormalizeFunctionInternal(ScalarFunctionSet &set, const LogicalType &json) {
 	set.AddFunction(ScalarFunction("json_normalize", {json}, LogicalType::VARCHAR, NormalizeFunction, nullptr, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	                               JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetNormalizeFunction() {

--- a/extension/json/json_functions/json_pretty.cpp
+++ b/extension/json/json_functions/json_pretty.cpp
@@ -20,7 +20,7 @@ static void PrettyPrintFunction(DataChunk &args, ExpressionState &state, Vector 
 
 static void GetPrettyPrintFunctionInternal(ScalarFunctionSet &set, const LogicalType &json) {
 	set.AddFunction(ScalarFunction("json_pretty", {json}, LogicalType::VARCHAR, PrettyPrintFunction, nullptr, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	                               JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetPrettyPrintFunction() {

--- a/extension/json/json_functions/json_serialize_plan.cpp
+++ b/extension/json/json_functions/json_serialize_plan.cpp
@@ -38,8 +38,9 @@ public:
 	}
 };
 
-static unique_ptr<FunctionData> JsonSerializePlanBind(ClientContext &context, ScalarFunction &bound_function,
-                                                      vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> JsonSerializePlanBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw BinderException("json_serialize_plan takes at least one argument");
 	}
@@ -201,23 +202,22 @@ ScalarFunctionSet JSONFunctions::GetSerializePlanFunction() {
 	ScalarFunctionSet set("json_serialize_plan");
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), JsonSerializePlanFunction,
-	                               JsonSerializePlanBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JsonSerializePlanBind, nullptr, JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::JSON(),
-	                               JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
+	                               JsonSerializePlanFunction, JsonSerializePlanBind, nullptr,
 	                               JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
 	                               LogicalType::JSON(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	                               JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN}, LogicalType::JSON(),
-	    JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	    JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
-	    LogicalType::JSON(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
-	    JSONFunctionLocalState::Init));
+	    LogicalType::JSON(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, JSONFunctionLocalState::Init));
 	return set;
 }
 

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -29,8 +29,9 @@ public:
 	}
 };
 
-static unique_ptr<FunctionData> JsonSerializeBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> JsonSerializeBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		throw BinderException("json_serialize_sql takes at least one argument");
 	}
@@ -150,23 +151,22 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 ScalarFunctionSet JSONFunctions::GetSerializeSqlFunction() {
 	ScalarFunctionSet set("json_serialize_sql");
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), JsonSerializeFunction,
-	                               JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JsonSerializeBind, nullptr, JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::JSON(),
-	                               JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr,
-	                               JSONFunctionLocalState::Init));
+	                               JsonSerializeFunction, JsonSerializeBind, nullptr, JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
-	                               LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr,
+	                               LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr,
 	                               JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN}, LogicalType::JSON(),
-	    JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	    JsonSerializeFunction, JsonSerializeBind, nullptr, JSONFunctionLocalState::Init));
 
 	set.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
-	    LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	    LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr, JSONFunctionLocalState::Init));
 
 	return set;
 }
@@ -244,7 +244,7 @@ static void JsonDeserializeFunction(DataChunk &args, ExpressionState &state, Vec
 ScalarFunctionSet JSONFunctions::GetDeserializeSqlFunction() {
 	ScalarFunctionSet set("json_deserialize_sql");
 	set.AddFunction(ScalarFunction({LogicalType::JSON()}, LogicalType::VARCHAR, JsonDeserializeFunction, nullptr,
-	                               nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               nullptr, JSONFunctionLocalState::Init));
 	return set;
 }
 

--- a/extension/json/json_functions/json_strip_nulls.cpp
+++ b/extension/json/json_functions/json_strip_nulls.cpp
@@ -49,7 +49,7 @@ static void StripNullsFunction(DataChunk &args, ExpressionState &state, Vector &
 
 static void GetStripNullsFunctionInternal(ScalarFunctionSet &set, const LogicalType &json) {
 	set.AddFunction(ScalarFunction("json_strip_nulls", {json}, LogicalType::JSON(), StripNullsFunction, nullptr,
-	                               nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetStripNullsFunction() {

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -527,7 +527,7 @@ static void StructureFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 static void GetStructureFunctionInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
-	set.AddFunction(ScalarFunction({input_type}, LogicalType::JSON(), StructureFunction, nullptr, nullptr, nullptr,
+	set.AddFunction(ScalarFunction({input_type}, LogicalType::JSON(), StructureFunction, nullptr, nullptr,
 	                               JSONFunctionLocalState::Init));
 }
 

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -74,8 +74,10 @@ static LogicalType StructureStringToType(yyjson_val *val, ClientContext &context
 	}
 }
 
-static unique_ptr<FunctionData> JSONTransformBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> JSONTransformBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();
@@ -988,7 +990,7 @@ static void TransformFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 static void GetTransformFunctionInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::ANY, TransformFunction<false>,
-	                               JSONTransformBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONTransformBind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetTransformFunction() {
@@ -1000,7 +1002,7 @@ ScalarFunctionSet JSONFunctions::GetTransformFunction() {
 
 static void GetTransformStrictFunctionInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::ANY, TransformFunction<true>,
-	                               JSONTransformBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONTransformBind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetTransformStrictFunction() {

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -19,13 +19,13 @@ static void ManyTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 }
 
 static void GetTypeFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
-	set.AddFunction(ScalarFunction({input_type}, LogicalType::VARCHAR, UnaryTypeFunction, nullptr, nullptr, nullptr,
+	set.AddFunction(ScalarFunction({input_type}, LogicalType::VARCHAR, UnaryTypeFunction, nullptr, nullptr,
 	                               JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, BinaryTypeFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::VARCHAR), ManyTypeFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetTypeFunction() {

--- a/extension/json/json_functions/json_valid.cpp
+++ b/extension/json/json_functions/json_valid.cpp
@@ -13,7 +13,7 @@ static void ValidFunction(DataChunk &args, ExpressionState &state, Vector &resul
 
 static void GetValidFunctionInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction("json_valid", {input_type}, LogicalType::BOOLEAN, ValidFunction, nullptr, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	                               JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetValidFunction() {

--- a/extension/json/json_functions/json_value.cpp
+++ b/extension/json/json_functions/json_value.cpp
@@ -12,12 +12,12 @@ static void ValueManyFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 static void GetValueFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::VARCHAR, ValueFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueFunction,
-	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
 	                               LogicalType::LIST(LogicalType::VARCHAR), ValueManyFunction,
-	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
+	                               JSONReadManyFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 }
 
 ScalarFunctionSet JSONFunctions::GetValueFunction() {

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -994,8 +994,10 @@ static LogicalType GetParquetVariantType(optional_ptr<LogicalType> shredding = n
 	return res;
 }
 
-static unique_ptr<FunctionData> BindTransform(ClientContext &context, ScalarFunction &bound_function,
-                                              vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindTransform(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments.empty()) {
 		return nullptr;
 	}

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -594,7 +594,8 @@ unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileL
 		children.push_back(std::move(mapping.default_value));
 	}
 	auto remap_fun = RemapStructFun::GetFunction();
-	auto bind_data = remap_fun.GetBindCallback()(context, remap_fun, children);
+	auto bind_data = remap_fun.Bind(context, children);
+	;
 	children[0] = BoundCastExpression::AddCastToType(context, std::move(children[0]), remap_fun.arguments[0]);
 	return make_uniq<BoundFunctionExpression>(global_column.type, std::move(remap_fun), std::move(children),
 	                                          std::move(bind_data));

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -209,8 +209,10 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 		}
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
+
 		function.arguments[0] = arguments[0]->return_type;
 		function.SetReturnType(arguments[0]->return_type);
 		return nullptr;
@@ -348,8 +350,10 @@ AggregateFunction GetFirstFunction(const LogicalType &type) {
 }
 
 template <bool LAST, bool SKIP_NULLS>
-unique_ptr<FunctionData> BindDecimalFirst(ClientContext &context, AggregateFunction &function,
-                                          vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	auto decimal_type = arguments[0]->return_type;
 	auto name = std::move(function.name);
 	function = GetFirstFunction<LAST, SKIP_NULLS>(decimal_type);
@@ -368,15 +372,18 @@ AggregateFunction GetFirstOperator(const LogicalType &type) {
 }
 
 template <bool LAST, bool SKIP_NULLS>
-unique_ptr<FunctionData> BindFirst(ClientContext &context, AggregateFunction &function,
-                                   vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	auto input_type = arguments[0]->return_type;
 	auto name = std::move(function.name);
 	function = GetFirstOperator<LAST, SKIP_NULLS>(input_type);
 	function.name = std::move(name);
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	if (function.HasBindCallback()) {
-		return function.GetBindCallback()(context, function, arguments);
+		return function.Bind(input.GetClientContext(), arguments);
+		;
 	} else {
 		return nullptr;
 	}

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -293,8 +293,9 @@ struct VectorMinMaxBase {
 		}
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		function.arguments[0] = arguments[0]->return_type;
 		function.SetReturnType(arguments[0]->return_type);
 		return nullptr;
@@ -331,8 +332,11 @@ static AggregateFunction GetMinMaxOperator(const LogicalType &type) {
 }
 
 template <class OP, class OP_STRING, class OP_VECTOR>
-unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &function,
-                                    vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	// We should also push collations for non-VARCHAR here, but we aren't ready for it yet (see internal #8704)
 	const auto collation = arguments[0]->return_type.id() == LogicalTypeId::VARCHAR &&
 	                       (!StringType::GetCollation(arguments[0]->return_type).empty() ||
@@ -384,10 +388,9 @@ unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &f
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	if (function.HasBindCallback()) {
-		return function.GetBindCallback()(context, function, arguments);
-	} else {
-		return nullptr;
+		return function.Bind(context, arguments);
 	}
+	return nullptr;
 }
 
 template <class OP, class OP_STRING, class OP_VECTOR>
@@ -519,8 +522,9 @@ void SpecializeMinMaxNFunction(PhysicalType arg_type, AggregateFunction &functio
 }
 
 template <class COMPARATOR>
-unique_ptr<FunctionData> MinMaxNBind(ClientContext &context, AggregateFunction &function,
-                                     vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> MinMaxNBind(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -97,8 +97,11 @@ struct ExtensionFunctionInfo : public ScalarFunctionInfo {
 	string extension;
 };
 
-unique_ptr<FunctionData> BindExtensionFunction(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindExtensionFunction(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	// if this is triggered we are trying to call a method that is present in an extension
 	// but the extension is not loaded
 	// try to autoload the extension
@@ -124,7 +127,8 @@ unique_ptr<FunctionData> BindExtensionFunction(ClientContext &context, ScalarFun
 	if (!bound_function.HasBindCallback()) {
 		return nullptr;
 	}
-	return bound_function.GetBindCallback()(context, bound_function, arguments);
+	return bound_function.Bind(context, arguments);
+	;
 }
 
 void BuiltinFunctions::AddExtensionFunction(ScalarFunctionSet set) {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -655,15 +655,7 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
 	unique_ptr<FunctionData> bind_info;
 
 	if (bound_function.HasBindCallback()) {
-		bind_info = bound_function.GetBindCallback()(context, bound_function, children);
-	} else if (bound_function.HasBindExtendedCallback()) {
-		if (!binder) {
-			throw InternalException("Function '%s' has a 'bind_extended' but the FunctionBinder was created without "
-			                        "a reference to a Binder",
-			                        bound_function.name);
-		}
-		ScalarFunctionBindInput bind_input(*binder);
-		bind_info = bound_function.GetBindExtendedCallback()(bind_input, bound_function, children);
+		bind_info = bound_function.Bind(context, children, binder);
 	}
 
 	// After the "bind" callback, we verify that all template types are bound to concrete types.
@@ -703,7 +695,7 @@ unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(Aggre
 
 	unique_ptr<FunctionData> bind_info;
 	if (bound_function.HasBindCallback()) {
-		bind_info = bound_function.GetBindCallback()(context, bound_function, children);
+		bind_info = bound_function.Bind(context, children);
 		// we may have lost some arguments in the bind
 		children.resize(MinValue(bound_function.arguments.size(), children.size()));
 	}
@@ -726,7 +718,7 @@ unique_ptr<BoundWindowExpression> FunctionBinder::BindWindowFunction(WindowFunct
 
 	unique_ptr<FunctionData> bind_info;
 	if (bound_function.HasBindCallback()) {
-		bind_info = bound_function.GetBindCallback()(context, bound_function, children);
+		bind_info = bound_function.Bind(context, children);
 		// we may have lost some arguments in the bind
 		children.resize(MinValue(bound_function.arguments.size(), children.size()));
 	}

--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -261,7 +261,7 @@ ScalarFunction CMStringCompressFun::GetFunction(const LogicalType &result_type) 
 
 ScalarFunction CMStringDecompressFun::GetFunction(const LogicalType &input_type) {
 	ScalarFunction result(StringDecompressFunctionName(), {input_type}, LogicalType::VARCHAR,
-	                      GetStringDecompressFunctionSwitch(input_type), CMUtils::Bind, nullptr, nullptr,
+	                      GetStringDecompressFunctionSwitch(input_type), CMUtils::Bind, nullptr,
 	                      StringDecompressLocalState::Init);
 	result.SetSerializeCallback(CMStringDecompressSerialize);
 	result.SetDeserializeCallback(CMStringDecompressDeserialize);

--- a/src/function/scalar/compressed_materialization_utils.cpp
+++ b/src/function/scalar/compressed_materialization_utils.cpp
@@ -12,8 +12,7 @@ const vector<LogicalType> CMUtils::StringTypes() {
 }
 
 // LCOV_EXCL_START
-unique_ptr<FunctionData> CMUtils::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                       vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CMUtils::Bind(BindScalarFunctionInput &input) {
 	throw BinderException("Compressed materialization functions are for internal use only!");
 }
 // LCOV_EXCL_STOP

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -32,8 +32,10 @@ struct SortKeyBindData : public FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+
 	if (arguments.size() % 2 != 0) {
 		throw BinderException(
 		    "Arguments to create_sort_key must be [key1, sort_specifier1, key2, sort_specifier2, ...]");
@@ -45,7 +47,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunctio
 		}
 
 		// Rebind to return a date if we are truncating that far
-		Value sort_specifier = ExpressionExecutor::EvaluateScalar(context, *arguments[i]);
+		Value sort_specifier = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[i]);
 		if (sort_specifier.IsNull()) {
 			throw BinderException("sort_specifier cannot be NULL");
 		}
@@ -66,7 +68,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunctio
 	}
 	if (all_constant) {
 		if (constant_size <= sizeof(int64_t)) {
-			bound_function.SetReturnType(LogicalType::BIGINT);
+			function.SetReturnType(LogicalType::BIGINT);
 		}
 	}
 	return std::move(result);
@@ -799,8 +801,11 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 //===--------------------------------------------------------------------===//
 namespace {
 
-unique_ptr<FunctionData> DecodeSortKeyBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> DecodeSortKeyBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+
 	if ((arguments.size() - 1) % 2 != 0) {
 		throw BinderException(
 		    "Arguments to decode_sort_key must be [sort_key, col1, sort_specifier1, col2, sort_specifier2, ...]");
@@ -862,7 +867,7 @@ unique_ptr<FunctionData> DecodeSortKeyBind(ClientContext &context, ScalarFunctio
 		throw BinderException("sort_key must be either BIGINT or BLOB, got %s instead",
 		                      sort_key_arg.return_type.ToString());
 	}
-	bound_function.SetReturnType(LogicalType::STRUCT(std::move(children)));
+	function.SetReturnType(LogicalType::STRUCT(std::move(children)));
 
 	return std::move(result);
 }

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -43,8 +43,9 @@ struct StrfTimeBindData : public FunctionData {
 };
 
 template <bool REVERSED>
-static unique_ptr<FunctionData> StrfTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                     vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StrfTimeBindFunction(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	auto format_idx = REVERSED ? 0U : 1U;
 	auto &format_arg = arguments[format_idx];
 	if (format_arg->HasParameter()) {
@@ -195,8 +196,10 @@ struct StrpTimeFunction {
 		                                             });
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &bound_function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
 		if (arguments[1]->HasParameter()) {
 			throw ParameterNotResolvedException();
 		}

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -70,8 +70,11 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 	}
 }
 
-unique_ptr<FunctionData> ConstantOrNullBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ConstantOrNullBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
@@ -80,7 +83,7 @@ unique_ptr<FunctionData> ConstantOrNullBind(ClientContext &context, ScalarFuncti
 	}
 	D_ASSERT(arguments.size() >= 2);
 	auto value = ExpressionExecutor::EvaluateScalar(context, *arguments[0]);
-	bound_function.SetReturnType(arguments[0]->return_type);
+	function.SetReturnType(arguments[0]->return_type);
 	return make_uniq<ConstantOrNullBindData>(std::move(value));
 }
 

--- a/src/function/scalar/generic/getvariable.cpp
+++ b/src/function/scalar/generic/getvariable.cpp
@@ -23,8 +23,11 @@ struct GetVariableBindData : FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> GetVariableBind(ClientContext &context, ScalarFunction &function,
-                                         vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> GetVariableBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+
 	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -90,8 +90,10 @@ static unique_ptr<Expression> BindCRSFunctionExpression(FunctionBindExpressionIn
 	return make_uniq<BoundConstantExpression>(GetCRSValue(return_type));
 }
 
-static unique_ptr<FunctionData> BindCRSFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindCRSFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	if (arguments[0]->return_type.id() != LogicalTypeId::GEOMETRY) {
 		return nullptr;
 	}
@@ -108,8 +110,11 @@ ScalarFunction StCrsFun::GetFunction() {
 	return geom_func;
 }
 
-static unique_ptr<FunctionData> SetCRSBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> SetCRSBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	// Check if the CRS is set in the second argument
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -120,8 +120,10 @@ static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector 
 	}
 }
 
-static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListExtractBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 	return nullptr;
@@ -141,7 +143,7 @@ ScalarFunctionSet ListExtractFun::GetFunctions() {
 
 	// the arguments and return types are actually set in the binder function
 	ScalarFunction lfun({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::BIGINT},
-	                    LogicalType::TEMPLATE("T"), ListExtractFunction, ListExtractBind, nullptr, ListExtractStats);
+	                    LogicalType::TEMPLATE("T"), ListExtractFunction, ListExtractBind, ListExtractStats);
 
 	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, ListExtractFunction);
 	lfun.SetFallible();
@@ -156,7 +158,7 @@ ScalarFunctionSet ArrayExtractFun::GetFunctions() {
 
 	// the arguments and return types are actually set in the binder function
 	ScalarFunction lfun({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::BIGINT},
-	                    LogicalType::TEMPLATE("T"), ListExtractFunction, ListExtractBind, nullptr, ListExtractStats);
+	                    LogicalType::TEMPLATE("T"), ListExtractFunction, ListExtractBind, ListExtractStats);
 
 	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, ListExtractFunction);
 

--- a/src/function/scalar/list/list_intersect.cpp
+++ b/src/function/scalar/list/list_intersect.cpp
@@ -171,8 +171,10 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 	result_entry.Flatten(offset);
 	FlatVector::SetValidity(result_entry, result_entry_validity_mask);
 }
-static unique_ptr<FunctionData> ListIntersectBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListIntersectBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 	arguments[1] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[1]));

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -118,8 +118,10 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 	}
 }
 
-static unique_ptr<FunctionData> ListResizeBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListResizeBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2 || arguments.size() == 3);
 	bound_function.arguments[1] = LogicalType::UBIGINT;
 

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -127,8 +127,10 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 	}
 }
 
-static unique_ptr<FunctionData> ListZipBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	child_list_t<LogicalType> struct_children;
 
 	// The last argument could be a flag to be set if we want a minimal list or a maximal list

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -191,8 +191,9 @@ unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, Functio
 }
 
 template <bool IS_MODULO = false>
-unique_ptr<DecimalArithmeticBindData> BindDecimalArithmetic(ClientContext &context, ScalarFunction &bound_function,
-                                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<DecimalArithmeticBindData> BindDecimalArithmetic(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto bind_data = make_uniq<DecimalArithmeticBindData>();
 
 	// get the max width and scale of the input arguments
@@ -246,9 +247,10 @@ unique_ptr<DecimalArithmeticBindData> BindDecimalArithmetic(ClientContext &conte
 }
 
 template <class OP, class OPOVERFLOWCHECK, bool IS_SUBTRACT = false>
-unique_ptr<FunctionData> BindDecimalAddSubtract(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
-	auto bind_data = BindDecimalArithmetic(context, bound_function, arguments);
+unique_ptr<FunctionData> BindDecimalAddSubtract(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+
+	auto bind_data = BindDecimalArithmetic(input);
 
 	// now select the physical function to execute
 	auto &result_type = bound_function.GetReturnType();
@@ -298,8 +300,10 @@ unique_ptr<FunctionData> DeserializeDecimalArithmetic(Deserializer &deserializer
 	return std::move(bind_data);
 }
 
-unique_ptr<FunctionData> NopDecimalBind(ClientContext &context, ScalarFunction &bound_function,
-                                        vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> NopDecimalBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	bound_function.SetReturnType(arguments[0]->return_type);
 	bound_function.arguments[0] = arguments[0]->return_type;
 	return nullptr;
@@ -316,7 +320,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &type) {
 	}
 }
 
-void BignumAdd(DataChunk &args, ExpressionState &state, Vector &result) {
+static void BignumAdd(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &heap = StringVector::GetStringHeap(result);
 	BinaryExecutor::Execute<bignum_t, bignum_t, string_t>(args.data[0], args.data[1], result, args.size(),
 	                                                      [&](bignum_t a, bignum_t b) {
@@ -326,7 +330,7 @@ void BignumAdd(DataChunk &args, ExpressionState &state, Vector &result) {
 	                                                      });
 }
 
-void BignumSubtract(DataChunk &args, ExpressionState &state, Vector &result) {
+static void BignumSubtract(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &heap = StringVector::GetStringHeap(result);
 	BinaryExecutor::Execute<bignum_t, bignum_t, string_t>(
 	    args.data[0], args.data[1], result, args.size(), [&](bignum_t a, bignum_t b) {
@@ -339,7 +343,7 @@ void BignumSubtract(DataChunk &args, ExpressionState &state, Vector &result) {
 	    });
 }
 
-void BignumNegate(DataChunk &args, ExpressionState &state, Vector &result) {
+static void BignumNegate(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &heap = StringVector::GetStringHeap(result);
 	UnaryExecutor::Execute<bignum_t, string_t>(args.data[0], result, args.size(), [&](bignum_t a) {
 		const BignumIntermediate lhs(a);
@@ -359,7 +363,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 		} else if (left_type.IsIntegral()) {
 			ScalarFunction function("+", {left_type, right_type}, left_type,
 			                        GetScalarIntegerFunction<AddOperatorOverflowCheck>(left_type.InternalType()),
-			                        nullptr, nullptr,
+			                        nullptr,
 			                        PropagateNumericStats<TryAddOperator, AddPropagateStatistics, AddOperator>);
 			function.SetFallible();
 			return function;
@@ -557,8 +561,10 @@ struct DecimalNegateBindData : public FunctionData {
 	LogicalTypeId bound_type;
 };
 
-unique_ptr<FunctionData> DecimalNegateBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> DecimalNegateBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	auto bind_data = make_uniq<DecimalNegateBindData>();
 
 	auto &decimal_type = arguments[0]->return_type;
@@ -583,8 +589,10 @@ unique_ptr<FunctionData> DecimalNegateBind(ClientContext &context, ScalarFunctio
 	return nullptr;
 }
 
-unique_ptr<FunctionData> IntegerNegateBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> IntegerNegateBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	D_ASSERT(arguments.size() == 1);
 	if (arguments[0]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
 		return nullptr;
@@ -637,7 +645,7 @@ struct NegatePropagateStatistics {
 	}
 };
 
-unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 	D_ASSERT(child_stats.size() == 1);
@@ -684,7 +692,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &type) {
 		func.SetFallible();
 		return func;
 	} else if (type.id() == LogicalTypeId::DECIMAL) {
-		ScalarFunction func("-", {type}, type, nullptr, DecimalNegateBind, nullptr, NegateBindStatistics);
+		ScalarFunction func("-", {type}, type, nullptr, DecimalNegateBind, NegateBindStatistics);
 		return func;
 	} else if (type.id() == LogicalTypeId::BIGNUM) {
 		ScalarFunction func("+", {type}, LogicalType::BIGNUM, BignumNegate);
@@ -692,7 +700,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &type) {
 	} else {
 		D_ASSERT(type.IsNumeric());
 		ScalarFunction func("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type),
-		                    IntegerNegateBind, nullptr, NegateBindStatistics);
+		                    IntegerNegateBind, NegateBindStatistics);
 		func.SetFallible();
 		return func;
 	}
@@ -711,7 +719,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 		} else if (left_type.IsIntegral()) {
 			ScalarFunction function(
 			    "-", {left_type, right_type}, left_type,
-			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr, nullptr,
+			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr,
 			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
 			function.SetFallible();
 			return function;
@@ -869,8 +877,10 @@ struct MultiplyPropagateStatistics {
 	}
 };
 
-unique_ptr<FunctionData> BindDecimalMultiply(ClientContext &context, ScalarFunction &bound_function,
-                                             vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindDecimalMultiply(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	auto bind_data = make_uniq<DecimalArithmeticBindData>();
 
 	uint8_t result_width = 0, result_scale = 0;
@@ -953,8 +963,7 @@ ScalarFunctionSet OperatorMultiplyFun::GetFunctions() {
 		} else if (TypeIsIntegral(type.InternalType())) {
 			multiply.AddFunction(ScalarFunction(
 			    {type, type}, type, GetScalarIntegerFunction<MultiplyOperatorOverflowCheck>(type.InternalType()),
-			    nullptr, nullptr,
-			    PropagateNumericStats<TryMultiplyOperator, MultiplyPropagateStatistics, MultiplyOperator>));
+			    nullptr, PropagateNumericStats<TryMultiplyOperator, MultiplyPropagateStatistics, MultiplyOperator>));
 		} else {
 			multiply.AddFunction(
 			    ScalarFunction({type, type}, type, GetScalarBinaryFunction<MultiplyOperator>(type.InternalType())));
@@ -1104,8 +1113,10 @@ scalar_function_t GetBinaryFunctionIgnoreZero(PhysicalType type) {
 }
 
 template <class OP>
-unique_ptr<FunctionData> BindBinaryFloatingPoint(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindBinaryFloatingPoint(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+
 	if (Settings::Get<IeeeFloatingPointOpsSetting>(context)) {
 		bound_function.SetFunctionCallback(GetScalarBinaryFunction<OP>(bound_function.GetReturnType().InternalType()));
 	} else {
@@ -1151,9 +1162,9 @@ ScalarFunctionSet OperatorIntegerDivideFun::GetFunctions() {
 // % [modulo]
 //===--------------------------------------------------------------------===//
 template <class OP>
-static unique_ptr<FunctionData> BindDecimalModulo(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
-	auto bind_data = BindDecimalArithmetic<true>(context, bound_function, arguments);
+static unique_ptr<FunctionData> BindDecimalModulo(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto bind_data = BindDecimalArithmetic<true>(input);
 	// now select the physical function to execute
 	if (bind_data->check_overflow) {
 		// fallback to DOUBLE if the decimal type is not guaranteed to fit within the max decimal width

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -90,8 +90,9 @@ void NextValFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	}
 }
 
-unique_ptr<FunctionData> NextValBind(ScalarFunctionBindInput &bind_input, ScalarFunction &,
-                                     vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> NextValBind(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
+
 	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -99,7 +100,7 @@ unique_ptr<FunctionData> NextValBind(ScalarFunctionBindInput &bind_input, Scalar
 		throw NotImplementedException(
 		    "currval/nextval requires a constant sequence - non-constant sequences are no longer supported");
 	}
-	auto &binder = bind_input.binder;
+	auto &binder = input.GetBinder();
 	// parameter to nextval function is a foldable constant
 	// evaluate the constant and perform the catalog lookup already
 	auto seqname = ExpressionExecutor::EvaluateScalar(binder.context, *arguments[0]);
@@ -140,7 +141,7 @@ void NextValModifiedDatabases(ClientContext &context, FunctionModifiedDatabasesI
 ScalarFunction NextvalFun::GetFunction() {
 	ScalarFunction next_val("nextval", {LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                        NextValFunction<NextSequenceValueOperator>, nullptr, nullptr);
-	next_val.SetBindExtendedCallback(NextValBind);
+	next_val.SetBindCallback(NextValBind);
 	next_val.SetSerializeCallback(Serialize);
 	next_val.SetDeserializeCallback(Deserialize);
 	next_val.SetModifiedDatabasesCallback(NextValModifiedDatabases);
@@ -153,7 +154,7 @@ ScalarFunction NextvalFun::GetFunction() {
 ScalarFunction CurrvalFun::GetFunction() {
 	ScalarFunction curr_val("currval", {LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                        NextValFunction<CurrentSequenceValueOperator>, nullptr, nullptr);
-	curr_val.SetBindExtendedCallback(NextValBind);
+	curr_val.SetBindCallback(NextValBind);
 	curr_val.SetSerializeCallback(Serialize);
 	curr_val.SetDeserializeCallback(Deserialize);
 	curr_val.SetInitStateCallback(NextValLocalFunction);

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -142,12 +142,12 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 
 ScalarFunction LowerFun::GetFunction() {
 	return ScalarFunction("lower", {LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<false>, nullptr,
-	                      nullptr, CaseConvertPropagateStats<false>);
+	                      CaseConvertPropagateStats<false>);
 }
 
 ScalarFunction UpperFun::GetFunction() {
 	return ScalarFunction("upper", {LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<true>, nullptr,
-	                      nullptr, CaseConvertPropagateStats<true>);
+	                      CaseConvertPropagateStats<true>);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -315,13 +315,17 @@ unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, Scal
 	return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 }
 
-unique_ptr<FunctionData> BindConcatFunction(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindConcatFunction(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	return BindConcatFunctionInternal(context, bound_function, arguments, false);
 }
 
-unique_ptr<FunctionData> BindConcatOperator(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> BindConcatOperator(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	return BindConcatFunctionInternal(context, bound_function, arguments, true);
 }
 
@@ -338,8 +342,8 @@ unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStati
 
 ScalarFunction ListConcatFun::GetFunction() {
 	// The arguments and return types are set in the binder function.
-	auto fun = ScalarFunction({}, LogicalType::LIST(LogicalType::ANY), ConcatFunction, BindConcatFunction, nullptr,
-	                          ListConcatStats);
+	auto fun =
+	    ScalarFunction({}, LogicalType::LIST(LogicalType::ANY), ConcatFunction, BindConcatFunction, ListConcatStats);
 	fun.varargs = LogicalType::LIST(LogicalType::ANY);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -115,7 +115,6 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 static unique_ptr<FunctionData> BindConcatWSFunction(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
 	for (auto &arg : bound_function.arguments) {
 		arg = LogicalType::VARCHAR;
 	}

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -113,8 +113,9 @@ static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &re
 	}
 }
 
-static unique_ptr<FunctionData> BindConcatWSFunction(ClientContext &context, ScalarFunction &bound_function,
-                                                     vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BindConcatWSFunction(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	for (auto &arg : bound_function.arguments) {
 		arg = LogicalType::VARCHAR;
 	}

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -102,8 +102,9 @@ void ArrayLengthFunction(DataChunk &args, ExpressionState &state, Vector &result
 	}
 }
 
-unique_ptr<FunctionData> ArrayOrListLengthBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ArrayOrListLengthBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -170,8 +171,9 @@ void ArrayLengthBinaryFunction(DataChunk &args, ExpressionState &state, Vector &
 	});
 }
 
-unique_ptr<FunctionData> ArrayOrListLengthBinaryBind(ClientContext &context, ScalarFunction &bound_function,
-                                                     vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ArrayOrListLengthBinaryBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -210,7 +212,7 @@ ScalarFunctionSet LengthFun::GetFunctions() {
 	ScalarFunctionSet length("length");
 	length.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                                  ScalarFunction::UnaryFunction<string_t, int64_t, StringLengthOperator>, nullptr,
-	                                  nullptr, LengthPropagateStats));
+	                                  LengthPropagateStats));
 	length.AddFunction(ScalarFunction({LogicalType::BIT}, LogicalType::BIGINT,
 	                                  ScalarFunction::UnaryFunction<string_t, int64_t, BitStringLenOperator>));
 	length.AddFunction(
@@ -222,7 +224,7 @@ ScalarFunctionSet LengthGraphemeFun::GetFunctions() {
 	ScalarFunctionSet length_grapheme("length_grapheme");
 	length_grapheme.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
 	                                           ScalarFunction::UnaryFunction<string_t, int64_t, GraphemeCountOperator>,
-	                                           nullptr, nullptr, LengthPropagateStats));
+	                                           nullptr, LengthPropagateStats));
 	return (length_grapheme);
 }
 

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -341,8 +341,9 @@ private:
 	bool has_end_percentage;
 };
 
-unique_ptr<FunctionData> LikeBindFunction(ClientContext &context, ScalarFunction &bound_function,
-                                          vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> LikeBindFunction(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	for (auto &arg : arguments) {
@@ -537,7 +538,7 @@ ScalarFunction GlobPatternFun::GetFunction() {
 
 ScalarFunction ILikeFun::GetFunction() {
 	ScalarFunction ilike("~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                     ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, nullptr, nullptr,
+	                     ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, nullptr,
 	                     ILikePropagateStats<ILikeOperatorASCII>);
 	ilike.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return ilike;
@@ -546,7 +547,7 @@ ScalarFunction ILikeFun::GetFunction() {
 ScalarFunction NotILikeFun::GetFunction() {
 	ScalarFunction not_ilike("!~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
 	                         ScalarFunction::BinaryFunction<string_t, string_t, bool, NotILikeOperator>, nullptr,
-	                         nullptr, ILikePropagateStats<NotILikeOperatorASCII>);
+	                         ILikePropagateStats<NotILikeOperatorASCII>);
 	not_ilike.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return not_ilike;
 }

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -81,8 +81,9 @@ unique_ptr<FunctionData> RegexpMatchesBindData::Copy() const {
 	                                        range_success);
 }
 
-unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> RegexpMatchesBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	RE2::Options options;
@@ -155,8 +156,9 @@ bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
 	return RegexpBaseBindData::Equals(other) && global_replace == other.global_replace;
 }
 
-static unique_ptr<FunctionData> RegexReplaceBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
 	auto data = make_uniq<RegexpReplaceBindData>();
 
 	data->constant_pattern = TryParseConstantPattern(context, *arguments[1], data->constant_string);
@@ -326,8 +328,10 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 	}
 }
 
-static unique_ptr<FunctionData> RegexExtractBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() >= 2);
 
 	duckdb_re2::RE2::Options options;
@@ -376,25 +380,25 @@ ScalarFunctionSet RegexpFun::GetFunctions() {
 	ScalarFunctionSet regexp_full_match("regexp_full_match");
 	regexp_full_match.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                   RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState,
+	                   RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
 	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_full_match.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                   RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState,
+	                   RegexpMatchesFunction<RegexFullMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
 	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	return (regexp_full_match);
 }
 
 ScalarFunctionSet RegexpMatchesFun::GetFunctions() {
 	ScalarFunctionSet regexp_partial_match("regexp_matches");
-	regexp_partial_match.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, RegexpMatchesFunction<RegexPartialMatch>,
-	    RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	    FunctionNullHandling::SPECIAL_HANDLING));
-	regexp_partial_match.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	    RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_partial_match.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                   RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_partial_match.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                   RegexpMatchesFunction<RegexPartialMatch>, RegexpMatchesBind, nullptr, RegexInitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	for (auto &func : regexp_partial_match.functions) {
 		func.SetFallible();
 	}
@@ -405,68 +409,66 @@ ScalarFunctionSet RegexpReplaceFun::GetFunctions() {
 	ScalarFunctionSet regexp_replace("regexp_replace");
 	regexp_replace.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                          LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr,
-	                                          nullptr, RegexInitLocalState));
-	regexp_replace.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	    RegexReplaceFunction, RegexReplaceBind, nullptr, nullptr, RegexInitLocalState));
+	                                          RegexInitLocalState));
+	regexp_replace.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr, RegexInitLocalState));
 	return (regexp_replace);
 }
 
 ScalarFunctionSet RegexpExtractFun::GetFunctions() {
 	ScalarFunctionSet regexp_extract("regexp_extract");
 	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                          RegexExtractFunction, RegexExtractBind, nullptr, nullptr,
-	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                                          LogicalType::INVALID, FunctionStability::CONSISTENT,
 	                                          FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
 	                                          LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr,
-	                                          nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                                          FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	regexp_extract.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	    RegexExtractFunction, RegexExtractBind, nullptr, nullptr, RegexInitLocalState, LogicalType::INVALID,
-	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
+	                   LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...])
-	regexp_extract.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)}, LogicalType::VARCHAR,
-	    RegexExtractStructFunction, RegexExtractBind, nullptr, nullptr, RegexInitLocalState, LogicalType::INVALID,
-	    FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
+	                   LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...], <options>)
 	regexp_extract.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR), LogicalType::VARCHAR},
-	    LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind, nullptr, nullptr, RegexInitLocalState,
+	    LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind, nullptr, RegexInitLocalState,
 	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	return (regexp_extract);
 }
 
 ScalarFunctionSet RegexpExtractAllFun::GetFunctions() {
 	ScalarFunctionSet regexp_extract_all("regexp_extract_all");
-	regexp_extract_all.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
-	    RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr, nullptr, RegexpExtractAll::InitLocalState,
-	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract_all.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
+	                   RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr, RegexpExtractAll::InitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::LIST(LogicalType::VARCHAR),
-	    RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr, nullptr, RegexpExtractAll::InitLocalState,
+	    RegexpExtractAll::Execute, RegexpExtractAll::Bind, nullptr, RegexpExtractAll::InitLocalState,
 	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract_all.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
 	                   LogicalType::LIST(LogicalType::VARCHAR), RegexpExtractAll::Execute, RegexpExtractAll::Bind,
-	                   nullptr, nullptr, RegexpExtractAll::InitLocalState, LogicalType::INVALID,
-	                   FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	// Struct multi-match variant(s): pattern must be constant due to bind-time struct shape inference
-	regexp_extract_all.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
-	                   LogicalType::LIST(LogicalType::VARCHAR), // temporary, replaced in bind
-	                   RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, nullptr,
-	                   RegexpExtractAllStruct::InitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                   nullptr, RegexpExtractAll::InitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
 	                   FunctionNullHandling::SPECIAL_HANDLING));
+	// Struct multi-match variant(s): pattern must be constant due to bind-time struct shape inference
+	regexp_extract_all.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
+	    LogicalType::LIST(LogicalType::VARCHAR), // temporary, replaced in bind
+	    RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, RegexpExtractAllStruct::InitLocalState,
+	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	regexp_extract_all.AddFunction(ScalarFunction(
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR), LogicalType::VARCHAR},
 	    LogicalType::LIST(LogicalType::VARCHAR), // temporary, replaced in bind
-	    RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, nullptr,
-	    RegexpExtractAllStruct::InitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	    FunctionNullHandling::SPECIAL_HANDLING));
+	    RegexpExtractAllStruct::Execute, RegexpExtractAllStruct::Bind, nullptr, RegexpExtractAllStruct::InitLocalState,
+	    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	return (regexp_extract_all);
 }
 

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -326,8 +326,11 @@ void RegexpExtractAllStruct::Execute(DataChunk &args, ExpressionState &state, Ve
 	}
 }
 
-unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+
 	// arguments: string, pattern, LIST<VARCHAR> group_names [, options]
 	if (arguments.size() < 3) {
 		throw BinderException("regexp_extract_all struct variant requires at least 3 arguments");
@@ -336,7 +339,7 @@ unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(ClientContext &context, Sc
 	string constant_string;
 	bool constant_pattern = TryParseConstantPattern(context, *arguments[1], constant_string);
 	if (!constant_pattern) {
-		throw BinderException("%s with LIST requires a constant pattern", bound_function.name);
+		throw BinderException("%s with LIST requires a constant pattern", function.name);
 	}
 	if (arguments.size() >= 4) {
 		ParseRegexOptions(context, *arguments[3], options);
@@ -344,15 +347,17 @@ unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(ClientContext &context, Sc
 	options.set_log_errors(false);
 	vector<string> group_names;
 	child_list_t<LogicalType> struct_children;
-	regexp_util::ParseGroupNameList(context, bound_function.name, *arguments[2], constant_string, options, true,
-	                                group_names, struct_children);
-	bound_function.SetReturnType(LogicalType::LIST(LogicalType::STRUCT(struct_children)));
+	regexp_util::ParseGroupNameList(context, function.name, *arguments[2], constant_string, options, true, group_names,
+	                                struct_children);
+	function.SetReturnType(LogicalType::LIST(LogicalType::STRUCT(struct_children)));
 	return make_uniq<RegexpExtractAllStructBindData>(options, std::move(constant_string), constant_pattern,
 	                                                 std::move(group_names));
 }
 
-unique_ptr<FunctionData> RegexpExtractAll::Bind(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> RegexpExtractAll::Bind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+
 	D_ASSERT(arguments.size() >= 2);
 
 	duckdb_re2::RE2::Options options;

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -183,7 +183,7 @@ ScalarFunctionSet StringSplitRegexFun::GetFunctions() {
 	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
 	ScalarFunctionSet regexp_split;
 	ScalarFunction regex_fun({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitRegexFunction,
-	                         RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState, LogicalType::INVALID,
+	                         RegexpMatchesBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
 	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	regexp_split.AddFunction(regex_fun);
 	// regexp options

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -318,11 +318,10 @@ unique_ptr<BaseStatistics> SubstringPropagateStats(ClientContext &context, Funct
 ScalarFunctionSet SubstringFun::GetFunctions() {
 	ScalarFunctionSet substr("substring");
 	substr.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT},
-	                                  LogicalType::VARCHAR, SubstringFunction<SubstringUnicodeOp>, nullptr, nullptr,
+	                                  LogicalType::VARCHAR, SubstringFunction<SubstringUnicodeOp>, nullptr,
 	                                  SubstringPropagateStats));
 	substr.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                                  SubstringFunction<SubstringUnicodeOp>, nullptr, nullptr,
-	                                  SubstringPropagateStats));
+	                                  SubstringFunction<SubstringUnicodeOp>, nullptr, SubstringPropagateStats));
 	return (substr);
 }
 
@@ -330,9 +329,9 @@ ScalarFunctionSet SubstringGraphemeFun::GetFunctions() {
 	ScalarFunctionSet substr_grapheme("substring_grapheme");
 	substr_grapheme.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT},
 	                                           LogicalType::VARCHAR, SubstringFunction<SubstringGraphemeOp>, nullptr,
-	                                           nullptr, SubstringPropagateStats));
+	                                           SubstringPropagateStats));
 	substr_grapheme.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                                           SubstringFunction<SubstringGraphemeOp>, nullptr, nullptr,
+	                                           SubstringFunction<SubstringGraphemeOp>, nullptr,
 	                                           SubstringPropagateStats));
 	return (substr_grapheme);
 }

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -534,8 +534,10 @@ struct RemapEntry {
 	}
 };
 
-unique_ptr<FunctionData> RemapStructBind(ClientContext &context, ScalarFunction &bound_function,
-                                         vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() == 4);
 	for (idx_t arg_idx = 0; arg_idx < 3; arg_idx++) {
 		auto &arg = arguments[arg_idx];

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -27,8 +27,9 @@ static void StructConcatFunction(DataChunk &args, ExpressionState &state, Vector
 	D_ASSERT(offset == result_cols.size());
 }
 
-static unique_ptr<FunctionData> StructConcatBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	// collect names and deconflict, construct return type
 	if (arguments.empty()) {
 		throw InvalidInputException("struct_concat: At least one argument is required");
@@ -100,7 +101,7 @@ static unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, Func
 }
 
 ScalarFunction StructConcatFun::GetFunction() {
-	ScalarFunction fun("struct_concat", {}, LogicalTypeId::STRUCT, StructConcatFunction, StructConcatBind, nullptr,
+	ScalarFunction fun("struct_concat", {}, LogicalTypeId::STRUCT, StructConcatFunction, StructConcatBind,
 	                   StructConcatStats);
 	fun.varargs = LogicalType::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -187,8 +187,10 @@ static void StructSearchFunction(DataChunk &args, ExpressionState &state, Vector
 	StructSearchOp<RETURN_TYPE, FIND_NULLS>(input_vector, members, target, count, result);
 }
 
-static unique_ptr<FunctionData> StructContainsBind(ClientContext &context, ScalarFunction &bound_function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructContainsBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	auto &child_type = arguments[0]->return_type;
 	if (child_type.id() == LogicalTypeId::UNKNOWN) {

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -26,8 +26,10 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 	result.Verify(args.size());
 }
 
-static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.arguments.size() == 2);
 	auto &child_type = arguments[0]->return_type;
 	if (child_type.id() == LogicalTypeId::UNKNOWN) {
@@ -126,13 +128,17 @@ static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context
 	return StructExtractAtFun::GetBindData(NumericCast<idx_t>(index - 1));
 }
 
-static unique_ptr<FunctionData> StructExtractBindIndex(ClientContext &context, ScalarFunction &bound_function,
-                                                       vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructExtractBindIndex(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	return StructExtractBindInternal(context, bound_function, arguments, true);
 }
 
-static unique_ptr<FunctionData> StructExtractAtBind(ClientContext &context, ScalarFunction &bound_function,
-                                                    vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructExtractAtBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	return StructExtractBindInternal(context, bound_function, arguments, false);
 }
 
@@ -151,7 +157,7 @@ unique_ptr<FunctionData> StructExtractAtFun::GetBindData(idx_t index) {
 
 ScalarFunction GetKeyExtractFunction() {
 	return ScalarFunction("struct_extract", {LogicalTypeId::STRUCT, LogicalType::VARCHAR}, LogicalType::ANY,
-	                      StructExtractFunction, StructExtractBind, nullptr, PropagateStructExtractStats);
+	                      StructExtractFunction, StructExtractBind, PropagateStructExtractStats);
 }
 
 ScalarFunction GetIndexExtractFunction() {

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -34,8 +34,9 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 template <bool IS_STRUCT_PACK>
-static unique_ptr<FunctionData> StructPackBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> StructPackBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	case_insensitive_set_t name_collision_set;
 
 	// collect names and deconflict, construct return type
@@ -77,7 +78,7 @@ static unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, Functi
 template <bool IS_STRUCT_PACK>
 static ScalarFunction GetStructPackFunction() {
 	ScalarFunction fun(IS_STRUCT_PACK ? "struct_pack" : "row", {}, LogicalTypeId::STRUCT, StructPackFunction,
-	                   StructPackBind<IS_STRUCT_PACK>, nullptr, StructPackStats);
+	                   StructPackBind<IS_STRUCT_PACK>, StructPackStats);
 	fun.varargs = LogicalType::ANY;
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetSerializeCallback(VariableReturnBindData::Serialize);

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -44,7 +44,7 @@ struct ExportAggregateBindData : public FunctionData {
 };
 
 template <class OP, class... ARGS>
-static void TemplateDispatch(PhysicalType type, ARGS &&... args) {
+void TemplateDispatch(PhysicalType type, ARGS &&... args) {
 	switch (type) {
 	case PhysicalType::BOOL:
 		OP::template Operation<bool>(std::forward<ARGS>(args)...);
@@ -295,10 +295,10 @@ void SerializeStructFields(const AggregateStateLayout &layout, Vector &result, i
 #ifdef DEBUG
 // Internal verification: export all states to struct, import back, finalize, and compare to main path result
 // using vector operations. Catches serialization/deserialization bugs for struct-based aggregate state.
-static void VerifyStructStateRoundtrip(const AggregateStateLayout &layout, const Vector &state_vec, idx_t count,
-                                       const UnifiedVectorFormat &state_data, const data_ptr_t *state_vec_ptr,
-                                       const Vector &result, const ExportAggregateBindData &bind_data,
-                                       AggregateInputData &aggr_input_data) {
+void VerifyStructStateRoundtrip(const AggregateStateLayout &layout, const Vector &state_vec, idx_t count,
+                                const UnifiedVectorFormat &state_data, const data_ptr_t *state_vec_ptr,
+                                const Vector &result, const ExportAggregateBindData &bind_data,
+                                AggregateInputData &aggr_input_data) {
 	// Build selection of valid state rows
 	SelectionVector valid_sel(count);
 	idx_t valid_count = 0;
@@ -670,7 +670,7 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 		for (auto &arg_type : state_type.bound_argument_types) {
 			args.push_back(make_uniq<BoundConstantExpression>(Value(arg_type)));
 		}
-		auto bind_info = bound_aggr.GetBindCallback()(context, bound_aggr, args);
+		auto bind_info = bound_aggr.Bind(context, args);
 		if (bind_info) {
 			throw BinderException("Aggregate function with bind info not supported yet in aggregate state export");
 		}
@@ -684,9 +684,11 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	return make_uniq<ExportAggregateBindData>(bound_aggr, bound_aggr.GetStateSizeCallback()(bound_aggr));
 }
 
-unique_ptr<FunctionData> BindAggregateState(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
-	auto bind_data = BindAggregateStateInternal(context, bound_function, arguments, true);
+unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+	auto bind_data =
+	    BindAggregateStateInternal(input.GetClientContext(), input.GetBoundFunction(), input.GetArguments(), true);
 
 	// combine
 	if (arguments.size() == 2 && arguments[0]->return_type != arguments[1]->return_type &&
@@ -754,8 +756,11 @@ unique_ptr<FunctionData> ExportStateScalarDeserialize(Deserializer &deserializer
 	throw NotImplementedException("FIXME: export state deserialize");
 }
 
-unique_ptr<FunctionData> CombineAggrBind(ClientContext &context, AggregateFunction &function,
-                                         vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	auto bind_data = BindAggregateStateInternal(context, function, arguments, false);
 
 	// Copy underlying aggregate's callbacks into this function (same pattern as `ExportAggregateFunction::Bind`)
@@ -894,9 +899,9 @@ bool ExportAggregateFunctionBindData::Equals(const FunctionData &other_p) const 
 	return aggregate->Equals(*other.aggregate);
 }
 
-ScalarFunction CreateFinalizeFun(LogicalTypeId aggregate_state_logical_type_id) {
+static ScalarFunction CreateFinalizeFun(LogicalTypeId aggregate_state_logical_type_id) {
 	auto function = ScalarFunction("finalize", {aggregate_state_logical_type_id}, LogicalTypeId::INVALID,
-	                               AggregateStateFinalize, BindAggregateState, nullptr, nullptr, InitFinalizeState);
+	                               AggregateStateFinalize, BindAggregateState, nullptr, InitFinalizeState);
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetSerializeCallback(ExportStateScalarSerialize);
 	function.SetDeserializeCallback(ExportStateScalarDeserialize);
@@ -904,10 +909,10 @@ ScalarFunction CreateFinalizeFun(LogicalTypeId aggregate_state_logical_type_id) 
 	return function;
 }
 
-ScalarFunction CreateCombineFun(LogicalTypeId aggregate_state_logical_type_id) {
+static ScalarFunction CreateCombineFun(LogicalTypeId aggregate_state_logical_type_id) {
 	auto function = ScalarFunction("combine", {aggregate_state_logical_type_id, LogicalTypeId::ANY},
 	                               aggregate_state_logical_type_id, AggregateStateCombine, BindAggregateState, nullptr,
-	                               nullptr, InitCombineState);
+	                               InitCombineState);
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetSerializeCallback(ExportStateScalarSerialize);
 	function.SetDeserializeCallback(ExportStateScalarDeserialize);

--- a/src/function/scalar/system/current_connection_id.cpp
+++ b/src/function/scalar/system/current_connection_id.cpp
@@ -22,8 +22,8 @@ struct CurrentConnectionIdData : FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> CurrentConnectionIdBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CurrentConnectionIdBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
 	return make_uniq<CurrentConnectionIdData>(Value::UBIGINT(context.GetConnectionId()));
 }
 
@@ -37,7 +37,7 @@ void CurrentConnectionIdFunction(DataChunk &args, ExpressionState &state, Vector
 
 ScalarFunction CurrentConnectionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_query_id.cpp
+++ b/src/function/scalar/system/current_query_id.cpp
@@ -22,8 +22,8 @@ struct CurrentQueryIdData : FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> CurrentQueryIdBind(ClientContext &context, ScalarFunction &bound_function,
-                                            vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CurrentQueryIdBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
 	Value query_id;
 	if (context.transaction.HasActiveTransaction()) {
 		query_id = Value::UBIGINT(context.transaction.GetActiveQuery());
@@ -43,7 +43,7 @@ void CurrentQueryIdFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 ScalarFunction CurrentQueryId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentQueryIdFunction, CurrentQueryIdBind, nullptr, nullptr,
-	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -23,8 +23,8 @@ struct CurrentTransactionIdData : FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> CurrentTransactionIdBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CurrentTransactionIdBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
 	Value transaction_id;
 	if (context.transaction.HasActiveTransaction()) {
 		transaction_id = Value::UBIGINT(context.transaction.ActiveTransaction().global_transaction_id);
@@ -44,7 +44,7 @@ void CurrentTransactionIdFunction(DataChunk &args, ExpressionState &state, Vecto
 
 ScalarFunction CurrentTransactionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -29,8 +29,11 @@ struct ParseLogMessageData : FunctionData {
 	}
 };
 
-unique_ptr<FunctionData> ParseLogMessageBind(ClientContext &context, ScalarFunction &bound_function,
-                                             vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ParseLogMessageBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	if (arguments.size() != 2) {
 		throw BinderException("structured_log_schema: expects 1 argument", arguments[0]->alias);
 	}
@@ -80,7 +83,7 @@ void ParseLogMessageFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 ScalarFunction ParseLogMessage::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::ANY, ParseLogMessageFunction,
-	                          ParseLogMessageBind, nullptr, nullptr, nullptr, LogicalType(LogicalTypeId::INVALID));
+	                          ParseLogMessageBind, nullptr, nullptr, LogicalType(LogicalTypeId::INVALID));
 	fun.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
 	return fun;
 }

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -51,8 +51,11 @@ void ThrowIfNotConstant(const Expression &arg) {
 	}
 }
 
-unique_ptr<FunctionData> WriteLogBind(ClientContext &context, ScalarFunction &bound_function,
-                                      vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	if (arguments.empty()) {
 		throw BinderException("write_log takes at least one argument");
 	}
@@ -160,7 +163,7 @@ ScalarFunctionSet WriteLogFun::GetFunctions() {
 	ScalarFunctionSet set("write_log");
 
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, WriteLogFunction, WriteLogBind, nullptr,
-	                               nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE));
+	                               nullptr, LogicalType::ANY, FunctionStability::VOLATILE));
 
 	return set;
 }

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -76,8 +76,10 @@ static unique_ptr<BaseStatistics> VariantExtractPropagateStats(ClientContext &co
 	return VariantStats::WrapExtractedFieldAsVariant(variant_stats, *found_stats);
 }
 
-static unique_ptr<FunctionData> VariantExtractBind(ClientContext &context, ScalarFunction &bound_function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &arguments = input.GetArguments();
+
 	if (arguments.size() != 2) {
 		throw BinderException("'variant_extract' expects two arguments, VARIANT column and VARCHAR path");
 	}
@@ -308,7 +310,7 @@ ScalarFunctionSet VariantExtractFun::GetFunctions() {
 
 	ScalarFunctionSet fun_set;
 	ScalarFunction variant_extract("variant_extract", {}, variant_type, VariantExtractFunction, VariantExtractBind,
-	                               nullptr, VariantExtractPropagateStats);
+	                               VariantExtractPropagateStats);
 
 	variant_extract.arguments = {variant_type, LogicalType::VARCHAR};
 	fun_set.AddFunction(variant_extract);

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -10,29 +10,27 @@ ScalarFunctionInfo::~ScalarFunctionInfo() {
 
 ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
                                scalar_function_t function, bind_scalar_function_t bind,
-                               bind_scalar_function_extended_t bind_extended, function_statistics_t statistics,
-                               init_local_state_t init_local_state, LogicalType varargs, FunctionStability side_effects,
-                               FunctionNullHandling null_handling, bind_lambda_function_t bind_lambda)
-    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
-                         std::move(varargs), null_handling),
-      function(std::move(function)), bind(bind), bind_extended(bind_extended), init_local_state(init_local_state),
-      statistics(statistics), bind_lambda(bind_lambda), bind_expression(nullptr), get_modified_databases(nullptr),
-      serialize(nullptr), deserialize(nullptr) {
-}
-
-ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
-                               bind_scalar_function_t bind, bind_scalar_function_extended_t bind_extended,
                                function_statistics_t statistics, init_local_state_t init_local_state,
                                LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : ScalarFunction(string(), std::move(arguments), std::move(return_type), std::move(function), bind, bind_extended,
-                     statistics, init_local_state, std::move(varargs), side_effects, null_handling, bind_lambda) {
+    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
+                         std::move(varargs), null_handling),
+      function(std::move(function)), bind(bind), init_local_state(init_local_state), statistics(statistics),
+      bind_lambda(bind_lambda), bind_expression(nullptr), get_modified_databases(nullptr), serialize(nullptr),
+      deserialize(nullptr) {
+}
+
+ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
+                               bind_scalar_function_t bind, function_statistics_t statistics,
+                               init_local_state_t init_local_state, LogicalType varargs, FunctionStability side_effects,
+                               FunctionNullHandling null_handling, bind_lambda_function_t bind_lambda)
+    : ScalarFunction(string(), std::move(arguments), std::move(return_type), std::move(function), bind, statistics,
+                     init_local_state, std::move(varargs), side_effects, null_handling, bind_lambda) {
 }
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
 	return name == rhs.name && arguments == rhs.arguments && return_type == rhs.return_type && varargs == rhs.varargs &&
-	       bind == rhs.bind && bind_extended == rhs.bind_extended && statistics == rhs.statistics &&
-	       bind_lambda == rhs.bind_lambda;
+	       bind == rhs.bind && statistics == rhs.statistics && bind_lambda == rhs.bind_lambda;
 }
 
 bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -135,8 +135,10 @@ void WindowValueLocalState::Finalize(ExecutionContext &context, CollectionPtr co
 //===--------------------------------------------------------------------===//
 // WindowValueExecutor
 //===--------------------------------------------------------------------===//
-unique_ptr<FunctionData> WindowValueExecutor::Bind(ClientContext &context, WindowFunction &function,
-                                                   vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> WindowValueExecutor::Bind(BindWindowFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	function.return_type = arguments[0]->return_type;
 
 	return nullptr;
@@ -297,9 +299,11 @@ void WindowLeadLagLocalState::Finalize(ExecutionContext &context, CollectionPtr 
 //===--------------------------------------------------------------------===//
 // WindowLeadLagExecutor
 //===--------------------------------------------------------------------===//
-unique_ptr<FunctionData> WindowLeadLagExecutor::Bind(ClientContext &context, WindowFunction &function,
-                                                     vector<unique_ptr<Expression>> &arguments) {
-	WindowValueExecutor::Bind(context, function, arguments);
+unique_ptr<FunctionData> WindowLeadLagExecutor::Bind(BindWindowFunctionInput &input) {
+	WindowValueExecutor::Bind(input);
+
+	auto &function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 
 	if (arguments.size() > 2) {
 		function.arguments[2] = function.return_type;
@@ -936,9 +940,10 @@ static bool IsFillType(const LogicalType &type) {
 	return type.IsNumeric() || (type.IsTemporal() && type.id() != LogicalTypeId::TIME_TZ);
 }
 
-unique_ptr<FunctionData> WindowFillExecutor::Bind(ClientContext &context, WindowFunction &function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
-	WindowValueExecutor::Bind(context, function, arguments);
+unique_ptr<FunctionData> WindowFillExecutor::Bind(BindWindowFunctionInput &input) {
+	WindowValueExecutor::Bind(input);
+
+	const auto &arguments = input.GetArguments();
 
 	//	Check FILL arguments support subtraction
 	if (!IsFillType(arguments[0]->return_type)) {
@@ -951,7 +956,9 @@ unique_ptr<FunctionData> WindowFillExecutor::Bind(ClientContext &context, Window
 void WindowFillExecutor::Validate(ClientContext &context, WindowFunction &function,
                                   vector<unique_ptr<Expression>> &arguments, vector<OrderByNode> &orders,
                                   vector<OrderByNode> &arg_orders) {
-	WindowValueExecutor::Bind(context, function, arguments);
+	BindWindowFunctionInput input(context, function, arguments);
+	WindowValueExecutor::Bind(input);
+
 	if (arg_orders.size() > 1 || (arg_orders.empty() && orders.size() != 1)) {
 		throw BinderException("FILL functions must have only one ORDER BY expression");
 	}

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -52,6 +52,29 @@ struct WindowPartitionInput {
 	InterruptState &interrupt_state;
 };
 
+class BindAggregateFunctionInput {
+public:
+	BindAggregateFunctionInput(ClientContext &context_p, AggregateFunction &bound_function_p,
+	                           vector<unique_ptr<Expression>> &arguments_p)
+	    : context(context_p), bound_function(bound_function_p), arguments(arguments_p) {
+	}
+
+	ClientContext &GetClientContext() const {
+		return context;
+	}
+	AggregateFunction &GetBoundFunction() const {
+		return bound_function;
+	}
+	vector<unique_ptr<Expression>> &GetArguments() const {
+		return arguments;
+	}
+
+private:
+	ClientContext &context;
+	AggregateFunction &bound_function;
+	vector<unique_ptr<Expression>> &arguments;
+};
+
 //! The type used for sizing hashed aggregate function states
 typedef idx_t (*aggregate_size_t)(const AggregateFunction &function);
 //! The type used for initializing hashed aggregate function states
@@ -68,8 +91,7 @@ typedef void (*aggregate_finalize_t)(Vector &state, AggregateInputData &aggr_inp
 typedef unique_ptr<BaseStatistics> (*aggregate_statistics_t)(ClientContext &context, BoundAggregateExpression &expr,
                                                              AggregateStatisticsInput &input);
 //! Binds the scalar function and creates the function data
-typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(ClientContext &context, AggregateFunction &function,
-                                                              vector<unique_ptr<Expression>> &arguments);
+typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(BindAggregateFunctionInput &input);
 //! The type used for the aggregate destructor method. NOTE: this method is used in destructors and MAY NOT throw.
 typedef void (*aggregate_destructor_t)(Vector &state, AggregateInputData &aggr_input_data, idx_t count);
 
@@ -190,6 +212,11 @@ public:
 	bool HasBindCallback() const { return bind != nullptr; }
 	bind_aggregate_function_t GetBindCallback() const { return bind; }
 	void SetBindCallback(bind_aggregate_function_t callback) { bind = callback; }
+	unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
+	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments) {
+		BindAggregateFunctionInput bind_input(context, *this, arguments);
+		return Bind(bind_input);
+	}
 
 	bool HasStateInitCallback() const { return initialize != nullptr; }
 	aggregate_initialize_t GetStateInitCallback() const { return initialize; }

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -164,7 +164,7 @@ public:
 
 			if (function.HasBindCallback()) {
 				try {
-					bind_data = function.GetBindCallback()(context, function, children);
+					bind_data = function.Bind(context, children);
 				} catch (std::exception &ex) {
 					ErrorData error(ex);
 					throw SerializationException("Error during bind of function in deserialization: %s",

--- a/src/include/duckdb/function/scalar/compressed_materialization_utils.hpp
+++ b/src/include/duckdb/function/scalar/compressed_materialization_utils.hpp
@@ -19,8 +19,7 @@ struct CMUtils {
 	//! The types we compress strings to
 	static const vector<LogicalType> StringTypes();
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 };
 
 //! Needed for (de)serialization without binding

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -41,8 +41,7 @@ inline string_t Extract(const string_t &input, StringHeap &heap, const RE2 &re,
 
 struct RegexpExtractAll {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result);
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 	static unique_ptr<FunctionLocalState> InitLocalState(ExpressionState &state, const BoundFunctionExpression &expr,
 	                                                     FunctionData *bind_data);
 };
@@ -80,8 +79,7 @@ struct RegexpExtractAllStructBindData : public RegexpBaseBindData {
 
 struct RegexpExtractAllStruct {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result);
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input);
 	static unique_ptr<FunctionLocalState> InitLocalState(ExpressionState &state, const BoundFunctionExpression &expr,
 	                                                     FunctionData *bind_data);
 };
@@ -192,7 +190,6 @@ struct RegexLocalState : public FunctionLocalState {
 
 unique_ptr<FunctionLocalState> RegexInitLocalState(ExpressionState &state, const BoundFunctionExpression &expr,
                                                    FunctionData *bind_data);
-unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments);
+unique_ptr<FunctionData> RegexpMatchesBind(BindScalarFunctionInput &input);
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -377,8 +377,8 @@ public:
 class BindScalarFunctionInput {
 public:
 	BindScalarFunctionInput(ClientContext &context_p, ScalarFunction &bound_function_p,
-	                        vector<unique_ptr<Expression>> &arguments_p, optional_ptr<Binder> binder = nullptr)
-	    : context(context_p), bound_function(bound_function_p), arguments(arguments_p) {
+	                        vector<unique_ptr<Expression>> &arguments_p, optional_ptr<Binder> binder_p = nullptr)
+	    : context(context_p), bound_function(bound_function_p), arguments(arguments_p), binder(binder_p) {
 	}
 
 	ClientContext &GetClientContext() const {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -19,7 +19,6 @@
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 
 namespace duckdb {
-
 struct FunctionLocalState {
 	DUCKDB_API virtual ~FunctionLocalState();
 
@@ -113,21 +112,12 @@ struct FunctionBindExpressionInput {
 	vector<unique_ptr<Expression>> &children;
 };
 
-struct ScalarFunctionBindInput {
-	explicit ScalarFunctionBindInput(Binder &binder) : binder(binder) {
-	}
-
-	Binder &binder;
-};
+class BindScalarFunctionInput;
 
 //! The scalar function type
 typedef std::function<void(DataChunk &, ExpressionState &, Vector &)> scalar_function_t;
 //! The type to bind the scalar function and to create the function data
-typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(ClientContext &context, ScalarFunction &bound_function,
-                                                           vector<unique_ptr<Expression>> &arguments);
-typedef unique_ptr<FunctionData> (*bind_scalar_function_extended_t)(ScalarFunctionBindInput &bind_input,
-                                                                    ScalarFunction &bound_function,
-                                                                    vector<unique_ptr<Expression>> &arguments);
+typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(BindScalarFunctionInput &input);
 //! The type to initialize a thread local state for the scalar function
 typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(ExpressionState &state,
                                                              const BoundFunctionExpression &expr,
@@ -159,7 +149,6 @@ class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in
 public:
 	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
-	                          bind_scalar_function_extended_t bind_extended = nullptr,
 	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
 	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
@@ -167,9 +156,8 @@ public:
 	                          bind_lambda_function_t bind_lambda = nullptr);
 
 	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
-	                          bind_scalar_function_t bind = nullptr,
-	                          bind_scalar_function_extended_t bind_extended = nullptr,
-	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
+	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
+	                          init_local_state_t init_local_state = nullptr,
 	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
 	                          FunctionStability stability = FunctionStability::CONSISTENT,
 	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
@@ -188,10 +176,9 @@ public:
 	bool HasBindCallback() const { return bind != nullptr; };
 	bind_scalar_function_t GetBindCallback() const { return bind; };
 	void SetBindCallback(bind_scalar_function_t callback) { bind = callback; }
-
-	bool HasBindExtendedCallback() const { return bind_extended != nullptr; }
-	bind_scalar_function_extended_t GetBindExtendedCallback() const { return bind_extended; }
-	void SetBindExtendedCallback(bind_scalar_function_extended_t callback) { bind_extended = callback; }
+	unique_ptr<FunctionData> Bind(BindScalarFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
+	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments,
+		optional_ptr<Binder> binder = nullptr);
 
 	bool HasBindLambdaCallback() const { return bind_lambda != nullptr; }
 	bind_lambda_function_t GetBindLambdaCallback() const { return bind_lambda; }
@@ -246,8 +233,6 @@ public:
 	scalar_function_select_t select_function = nullptr;
 	//! The bind function (if any)
 	bind_scalar_function_t bind;
-	//! The bind function that receives extra input to perform more complex binding operations (if any)
-	bind_scalar_function_extended_t bind_extended = nullptr;
 	//! Init thread local state for the function (if any)
 	init_local_state_t init_local_state;
 	//! The statistics propagation function (if any)
@@ -388,5 +373,44 @@ public:
 		return function;
 	}
 };
+
+class BindScalarFunctionInput {
+public:
+	BindScalarFunctionInput(ClientContext &context_p, ScalarFunction &bound_function_p,
+	                        vector<unique_ptr<Expression>> &arguments_p, optional_ptr<Binder> binder = nullptr)
+	    : context(context_p), bound_function(bound_function_p), arguments(arguments_p) {
+	}
+
+	ClientContext &GetClientContext() const {
+		return context;
+	}
+	ScalarFunction &GetBoundFunction() const {
+		return bound_function;
+	}
+	vector<unique_ptr<Expression>> &GetArguments() const {
+		return arguments;
+	}
+	bool HasBinder() const {
+		return binder != nullptr;
+	}
+	Binder &GetBinder() {
+		if (binder == nullptr) {
+			throw InternalException("Function '%s' has cannot be bound without a Binder!", bound_function.name);
+		}
+		return *binder;
+	}
+
+private:
+	ClientContext &context;
+	ScalarFunction &bound_function;
+	vector<unique_ptr<Expression>> &arguments;
+	optional_ptr<Binder> binder;
+};
+
+inline unique_ptr<FunctionData> ScalarFunction::Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments,
+                                                     optional_ptr<Binder> binder) {
+	BindScalarFunctionInput bind_input(context, *this, arguments, binder);
+	return Bind(bind_input);
+}
 
 } // namespace duckdb

--- a/src/include/duckdb/function/window/window_value_function.hpp
+++ b/src/include/duckdb/function/window/window_value_function.hpp
@@ -15,8 +15,7 @@ namespace duckdb {
 // Base class for non-aggregate functions that have a payload
 class WindowValueExecutor : public WindowExecutor {
 public:
-	static unique_ptr<FunctionData> Bind(ClientContext &context, WindowFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindWindowFunctionInput &input);
 	static void GetBounds(WindowBoundsSet &required, const BoundWindowExpression &wexpr);
 	static void GetSharing(WindowExecutor &executor, WindowSharedExpressions &shared);
 
@@ -33,8 +32,7 @@ public:
 
 class WindowLeadLagExecutor : public WindowValueExecutor {
 public:
-	static unique_ptr<FunctionData> Bind(ClientContext &context, WindowFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindWindowFunctionInput &input);
 
 	WindowLeadLagExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
 	    : WindowValueExecutor(wexpr, shared) {
@@ -85,8 +83,7 @@ protected:
 
 class WindowFillExecutor : public WindowValueExecutor {
 public:
-	static unique_ptr<FunctionData> Bind(ClientContext &context, WindowFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> Bind(BindWindowFunctionInput &input);
 	static void Validate(ClientContext &context, WindowFunction &function, vector<unique_ptr<Expression>> &arguments,
 	                     vector<OrderByNode> &orders, vector<OrderByNode> &arg_orders);
 	static void GetSharing(WindowExecutor &executor, WindowSharedExpressions &shared);

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -54,9 +54,31 @@ struct WindowFunctionInfo {
 	}
 };
 
+class BindWindowFunctionInput {
+public:
+	BindWindowFunctionInput(ClientContext &context_p, WindowFunction &bound_function_p,
+	                        vector<unique_ptr<Expression>> &arguments_p)
+	    : context(context_p), bound_function(bound_function_p), arguments(arguments_p) {
+	}
+
+	ClientContext &GetClientContext() const {
+		return context;
+	}
+	WindowFunction &GetBoundFunction() const {
+		return bound_function;
+	}
+	vector<unique_ptr<Expression>> &GetArguments() const {
+		return arguments;
+	}
+
+private:
+	ClientContext &context;
+	WindowFunction &bound_function;
+	vector<unique_ptr<Expression>> &arguments;
+};
+
 //! Binds the scalar function and creates the function data
-typedef unique_ptr<FunctionData> (*window_bind_function_t)(ClientContext &context, WindowFunction &function,
-                                                           vector<unique_ptr<Expression>> &arguments);
+typedef unique_ptr<FunctionData> (*window_bind_function_t)(BindWindowFunctionInput &input);
 
 //! Validates the additional ordering usage.
 typedef void (*window_validate_function_t)(ClientContext &context, WindowFunction &function,
@@ -102,6 +124,12 @@ public:
 	bool HasBindCallback() const { return bind != nullptr; }
 	window_bind_function_t GetBindCallback() const { return bind; }
 	void SetBindCallback(window_bind_function_t callback) { bind = callback; }
+	unique_ptr<FunctionData> Bind(BindWindowFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
+	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments) {
+		BindWindowFunctionInput bind_input(context, *this, arguments);
+		return Bind(bind_input);
+	}
+
 
 	bool HasValidateCallback() const { return validate != nullptr; }
 	window_validate_function_t GetValidateCallback() const { return validate; }

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -62,8 +62,8 @@ duckdb::AggregateFunctionSet &GetCAggregateFunctionSet(duckdb_aggregate_function
 	return *reinterpret_cast<duckdb::AggregateFunctionSet *>(function_set);
 }
 
-unique_ptr<FunctionData> CAPIAggregateBind(ClientContext &context, AggregateFunction &function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CAPIAggregateBind(BindAggregateFunctionInput &input) {
+	auto &function = input.GetBoundFunction();
 	auto &info = function.function_info->Cast<CAggregateFunctionInfo>();
 	return make_uniq<CAggregateFunctionBindData>(info);
 }

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -156,8 +156,10 @@ duckdb_function_info ToCScalarFunctionInfo(duckdb::CScalarFunctionInternalFuncti
 // Scalar Function Callbacks
 //===--------------------------------------------------------------------===//
 
-unique_ptr<FunctionData> CScalarFunctionBind(ClientContext &context, ScalarFunction &bound_function,
-                                             vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> CScalarFunctionBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	auto &info = bound_function.GetExtraFunctionInfo().Cast<CScalarFunctionInfo>();
 	D_ASSERT(info.function);
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -578,7 +578,8 @@ static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &cont
 		vector<unique_ptr<Expression>> arguments(2);
 		arguments[0] = (std::move(target));
 		arguments[1] = (make_uniq<BoundConstantExpression>(Value(key)));
-		auto bind_info = bind_callback(context, function, arguments);
+		BindScalarFunctionInput input(context, function, arguments);
+		auto bind_info = bind_callback(input);
 		auto return_type = function.GetReturnType();
 		target = make_uniq<BoundFunctionExpression>(return_type, std::move(function), std::move(arguments),
 		                                            std::move(bind_info));

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -25,7 +25,7 @@ static unique_ptr<Expression> CreateBoundStructExtract(ClientContext &context, u
 	arguments.push_back(std::move(expr));
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value(key_path.back())));
 	auto extract_function = GetKeyExtractFunction();
-	auto bind_info = extract_function.GetBindCallback()(context, extract_function, arguments);
+	auto bind_info = extract_function.Bind(context, arguments);
 	auto return_type = extract_function.GetReturnType();
 	auto result = make_uniq<BoundFunctionExpression>(return_type, std::move(extract_function), std::move(arguments),
 	                                                 std::move(bind_info));
@@ -48,7 +48,7 @@ static unique_ptr<Expression> CreateBoundStructExtractIndex(ClientContext &conte
 	arguments.push_back(std::move(expr));
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(int64_t(key))));
 	auto extract_function = GetIndexExtractFunction();
-	auto bind_info = extract_function.GetBindCallback()(context, extract_function, arguments);
+	auto bind_info = extract_function.Bind(context, arguments);
 	auto return_type = extract_function.GetReturnType();
 	auto result = make_uniq<BoundFunctionExpression>(return_type, std::move(extract_function), std::move(arguments),
 	                                                 std::move(bind_info));

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -333,7 +333,7 @@ unique_ptr<Expression> BoundWindowExpression::Deserialize(Deserializer &deserial
 
 		auto bound = func.functions.GetFunctionByOffset(best.GetIndex());
 		if (bound.HasBindCallback()) {
-			result->bind_info = bound.GetBindCallback()(context, bound, result->children);
+			result->bind_info = bound.Bind(context, result->children);
 			// Builtins do not change their argument counts
 		}
 

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -408,8 +408,9 @@ static void BoundedMaxFunc(DataChunk &args, ExpressionState &state, Vector &resu
 	result.Reference(BoundedType::GetMaxValue(args.data[0].GetType()));
 }
 
-static unique_ptr<FunctionData> BoundedMaxBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BoundedMaxBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->return_type == BoundedType::GetDefault()) {
 		bound_function.arguments[0] = arguments[0]->return_type;
 	} else {
@@ -426,8 +427,9 @@ static void BoundedAddFunc(DataChunk &args, ExpressionState &state, Vector &resu
 	                                                   [&](int32_t left, int32_t right) { return left + right; });
 }
 
-static unique_ptr<FunctionData> BoundedAddBind(ClientContext &context, ScalarFunction &bound_function,
-                                               vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BoundedAddBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (BoundedType::GetDefault() == arguments[0]->return_type &&
 	    BoundedType::GetDefault() == arguments[1]->return_type) {
 		auto left_max_val = BoundedType::GetMaxValue(arguments[0]->return_type);
@@ -458,8 +460,9 @@ struct BoundedFunctionData : public FunctionData {
 	}
 };
 
-static unique_ptr<FunctionData> BoundedInvertBind(ClientContext &context, ScalarFunction &bound_function,
-                                                  vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> BoundedInvertBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
 	if (arguments[0]->return_type == BoundedType::GetDefault()) {
 		bound_function.arguments[0] = arguments[0]->return_type;
 		bound_function.SetReturnType(arguments[0]->return_type);
@@ -630,7 +633,7 @@ static void MinMaxRangeFunc(DataChunk &args, ExpressionState &state, Vector &res
 //===--------------------------------------------------------------------===//
 
 // The bind callback is unused for most extensible table filters
-static unique_ptr<FunctionData> RowIdFilterBind(ClientContext &, ScalarFunction &, vector<unique_ptr<Expression>> &) {
+static unique_ptr<FunctionData> RowIdFilterBind(BindScalarFunctionInput &input) {
 	throw InternalException("rowid_filter: bind should never be called");
 }
 

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -27,8 +27,8 @@ static void GetEnvFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	});
 }
 
-static unique_ptr<FunctionData> GetEnvBind(ClientContext &context, ScalarFunction &bound_function,
-                                           vector<unique_ptr<Expression>> &arguments) {
+static unique_ptr<FunctionData> GetEnvBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
 	if (!Settings::Get<EnableExternalAccessSetting>(context)) {
 		throw PermissionException("getenv is disabled through configuration");
 	}


### PR DESCRIPTION
This PR wraps the parameters for the `scalar/aggregate/window_function_bind_t` callback in a struct with accessors.

It also removes the `scalar_function_bind_extended` callback completely as we can optionally pass the `Binder` in the same structure and throw a nice error if it is not present.

This is all in preparation for a larger rework of how function parameters are bound in general.