### PR TITLE
Move vector iterator to getters

### DIFF
--- a/extension/core_functions/aggregate/distributive/approx_count.cpp
+++ b/extension/core_functions/aggregate/distributive/approx_count.cpp
@@ -68,8 +68,8 @@ void ApproxCountDistinctUpdateFunction(Vector inputs[], AggregateInputData &, id
 		if (!input_validity.IsValid(i)) {
 			continue;
 		}
-		auto agg_state = states[i].value;
-		const auto hash = hashes[i].value;
+		auto agg_state = states[i].GetValue();
+		const auto hash = hashes[i].GetValue();
 		agg_state->hll.InsertElement(hash);
 	}
 }

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -206,10 +206,10 @@ struct ApproxTopKOperation {
 			// not initialized yet - initialize the K value and set all counters to 0
 			auto top_k_format = top_k_vector.Values<int64_t>(count);
 			auto top_k_entry = top_k_format[offset];
-			if (!top_k_entry.is_valid) {
+			if (!top_k_entry.IsValid()) {
 				throw InvalidInputException("Invalid input for approx_top_k: k value cannot be NULL");
 			}
-			auto kval = top_k_entry.value;
+			auto kval = top_k_entry.GetValue();
 			if (kval <= 0) {
 				throw InvalidInputException("Invalid input for approx_top_k: k value must be > 0");
 			}
@@ -334,7 +334,7 @@ void ApproxTopKUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t inp
 		if (!input_data.validity.RowIsValid(idx)) {
 			continue;
 		}
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		ApproxTopKOperation::Operation<T, STATE>(state, data[idx], aggr_input, top_k_vector, i, count);
 	}
 }
@@ -348,7 +348,7 @@ void ApproxTopKFinalize(Vector &state_vector, AggregateInputData &, Vector &resu
 	idx_t new_entries = 0;
 	// figure out how much space we need
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = states[i].value->GetState();
+		auto &state = states[i].GetValue()->GetState();
 		if (state.values.empty()) {
 			continue;
 		}
@@ -364,7 +364,7 @@ void ApproxTopKFinalize(Vector &state_vector, AggregateInputData &, Vector &resu
 	idx_t current_offset = old_len;
 	for (idx_t i = 0; i < count; i++) {
 		const auto rid = i + offset;
-		auto &state = states[i].value->GetState();
+		auto &state = states[i].GetValue()->GetState();
 		if (state.values.empty()) {
 			mask.SetInvalid(rid);
 			continue;

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -47,10 +47,10 @@ struct HistogramBinState {
 		counts = new unsafe_vector<idx_t>();
 		auto bin_counts = bin_vector.Values<list_entry_t>(count);
 		auto bin_entry = bin_counts[pos];
-		if (!bin_entry.is_valid) {
+		if (!bin_entry.IsValid()) {
 			throw BinderException("Histogram bin list cannot be NULL");
 		}
-		auto bin_list = bin_entry.value;
+		auto bin_list = bin_entry.GetValue();
 
 		auto &bin_child = ListVector::GetEntry(bin_vector);
 		auto bin_count = ListVector::GetListSize(bin_vector);
@@ -166,7 +166,7 @@ void HistogramBinUpdateFunction(Vector inputs[], AggregateInputData &aggr_input,
 		if (!input_data.validity.RowIsValid(idx)) {
 			continue;
 		}
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.IsSet()) {
 			state.template InitializeBins<OP>(bin_vector, count, i, aggr_input);
 		}
@@ -277,7 +277,7 @@ void HistogramBinFinalizeFunction(Vector &state_vector, AggregateInputData &, Ve
 	bool supports_other_bucket = SupportsOtherBucket(MapType::KeyType(result.GetType()));
 	// figure out how much space we need
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.bin_boundaries) {
 			continue;
 		}
@@ -297,7 +297,7 @@ void HistogramBinFinalizeFunction(Vector &state_vector, AggregateInputData &, Ve
 	idx_t current_offset = old_len;
 	for (idx_t i = 0; i < count; i++) {
 		const auto rid = i + offset;
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.bin_boundaries) {
 			mask.SetInvalid(rid);
 			continue;

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -79,7 +79,7 @@ void HistogramUpdateFunction(Vector inputs[], AggregateInputData &aggr_input, id
 		if (!input_data.validity.RowIsValid(idx)) {
 			continue;
 		}
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.hist) {
 			state.hist = MAP_TYPE::CreateEmpty(aggr_input.allocator);
 		}
@@ -99,7 +99,7 @@ void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vecto
 	idx_t new_entries = 0;
 	// figure out how much space we need
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.hist) {
 			continue;
 		}
@@ -115,7 +115,7 @@ void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vecto
 	idx_t current_offset = old_len;
 	for (idx_t i = 0; i < count; i++) {
 		const auto rid = i + offset;
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (!state.hist) {
 			mask.SetInvalid(rid);
 			continue;

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -58,7 +58,7 @@ void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_data, id
 	auto &list_bind_data = aggr_input_data.bind_data->Cast<ListBindData>();
 
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		aggr_input_data.allocator.AlignNext();
 		list_bind_data.functions.AppendRow(aggr_input_data.allocator, state.linked_list, input_data, i);
 	}
@@ -70,7 +70,7 @@ void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputD
 	auto states = states_vector.Values<ListAggState *>(count);
 	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		if (state.linked_list.total_capacity == 0) {
 			// NULL, no need to append
 			// this can happen when adding a FILTER to the grouping, e.g.,
@@ -104,7 +104,7 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 
 	// first iterate over all entries and set up the list entries, and get the newly required total length
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		const auto rid = i + offset;
 		result_data[rid].offset = total_len;
 		if (state.linked_list.total_capacity == 0) {
@@ -123,7 +123,7 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 	ListVector::Reserve(result, total_len);
 	auto &result_child = ListVector::GetEntry(result);
 	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].value;
+		auto &state = *states[i].GetValue();
 		const auto rid = i + offset;
 		if (state.linked_list.total_capacity == 0) {
 			continue;
@@ -150,7 +150,7 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 	auto result_type = ListType::GetChildType(list_bind_data.stype);
 
 	for (idx_t i = 0; i < count; i++) {
-		auto &source = *states[i].value;
+		auto &source = *states[i].GetValue();
 		auto &target = *combined_ptr[i];
 
 		const auto entry_count = source.linked_list.total_capacity;

--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -116,8 +116,8 @@ struct ListFilterFunctor {
 			}
 
 			// found a true value
-			if (entry.is_valid && entry.value) {
-				sel.set_index(count++, entry.index);
+			if (entry.IsValid() && entry.GetValue()) {
+				sel.set_index(count++, entry.GetIndex());
 				info.length++;
 			}
 

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2075,8 +2075,9 @@ struct StructDatePart {
 			for (idx_t i = 0; i < count; ++i) {
 				auto entry = entries[i];
 				if (entry.IsValid()) {
-					if (Value::IsFinite(entry.value)) {
-						DatePart::StructOperator::Operation(bigint_values, double_values, entry.value, i, part_mask);
+					if (Value::IsFinite(entry.GetValue())) {
+						DatePart::StructOperator::Operation(bigint_values, double_values, entry.GetValue(), i,
+						                                    part_mask);
 					} else {
 						for (auto &child_entry : child_entries) {
 							FlatVector::Validity(child_entry).SetInvalid(i);

--- a/extension/core_functions/scalar/generic/least.cpp
+++ b/extension/core_functions/scalar/generic/least.cpp
@@ -148,7 +148,7 @@ void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &resu
 				auto entry = entries[i];
 				if (entry.IsValid()) {
 					// not a null entry: perform the operation and add to new set
-					auto ivalue = entry.value;
+					auto ivalue = entry.GetValue();
 					if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
 						result_has_value[i] = true;
 						result_data[i] = ivalue;

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -154,7 +154,7 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 			continue;
 		}
 
-		const auto &list_entry = entry.value;
+		const auto &list_entry = entry.GetValue();
 
 		// empty list, no sorting required
 		if (list_entry.length == 0) {

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -424,8 +424,8 @@ struct ICUDatePart : public ICUDateFunc {
 				auto entry = entries[i];
 				if (entry.IsValid()) {
 					res_valid.SetValid(i);
-					auto micros = SetTime(calendar, entry.value);
-					const auto is_finite = Timestamp::IsFinite(entry.value);
+					auto micros = SetTime(calendar, entry.GetValue());
+					const auto is_finite = Timestamp::IsFinite(entry.GetValue());
 					for (size_t col = 0; col < child_entries.size(); ++col) {
 						auto &child_entry = child_entries[col];
 						if (is_finite) {

--- a/extension/json/json_functions/json_merge_patch.cpp
+++ b/extension/json/json_functions/json_merge_patch.cpp
@@ -23,8 +23,8 @@ static inline void ReadObjects(yyjson_mut_doc *doc, Vector &input, yyjson_mut_va
 		if (!entry.IsValid()) {
 			objs[i] = nullptr;
 		} else {
-			objs[i] =
-			    yyjson_val_mut_copy(doc, JSONCommon::ReadDocument(entry.value, JSONCommon::READ_FLAG, &doc->alc)->root);
+			objs[i] = yyjson_val_mut_copy(
+			    doc, JSONCommon::ReadDocument(entry.GetValue(), JSONCommon::READ_FLAG, &doc->alc)->root);
 		}
 	}
 }

--- a/src/common/arrow/appender/bool_data.cpp
+++ b/src/common/arrow/appender/bool_data.cpp
@@ -25,9 +25,9 @@ void ArrowBoolData::Append(ArrowAppendData &append_data, Vector &input, idx_t fr
 	for (idx_t i = from; i < to; i++) {
 		auto entry = data[i];
 		// append the validity mask
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			append_data.SetNull(validity_data, current_byte, current_bit);
-		} else if (!entry.value) {
+		} else if (!entry.GetValue()) {
 			ArrowAppendData::UnsetBit(result_data, current_byte, current_bit);
 		}
 		ArrowAppendData::NextBit(current_byte, current_bit);

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -364,7 +364,7 @@ struct ArrowBool8 {
 		for (idx_t i = 0; i < count; i++) {
 			auto entry = entries[i];
 			if (entry.IsValid()) {
-				result_ptr[i] = static_cast<int8_t>(entry.value);
+				result_ptr[i] = static_cast<int8_t>(entry.GetValue());
 			} else {
 				result_validity.SetInvalid(i);
 			}

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -247,7 +247,7 @@ static void TemplatedGetHivePartitionValues(Vector &input, vector<HivePartitionK
 		auto &key = keys[i];
 		auto entry = entries[i];
 		if (entry.IsValid()) {
-			key.values[col_idx] = GetHiveKeyValue(entry.value, type);
+			key.values[col_idx] = GetHiveKeyValue(entry.GetValue(), type);
 		} else {
 			key.values[col_idx] = GetHiveKeyNullValue(type);
 		}

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -2501,7 +2501,7 @@ void Geometry::FromSpatialGeometry(Vector &source_vec, Vector &target_vec, idx_t
 			continue;
 		}
 
-		const auto &source = entry.value;
+		const auto &source = entry.GetValue();
 		BlobReader reader(source.GetData(), static_cast<uint32_t>(source.GetSize()));
 		const auto required_size = FromLegacyGeometryRequiredSize(reader);
 

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -91,7 +91,7 @@ void ConstantVector::Reference(Vector &vector, const Vector &source, idx_t posit
 			break;
 		}
 
-		auto list_entry = entry.value;
+		auto list_entry = entry.GetValue();
 
 		// add the list entry as the first element of "vector"
 		// FIXME: we only need to allocate space for 1 tuple here

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -319,7 +319,7 @@ idx_t ListVector::GetConsecutiveChildList(Vector &list, Vector &result, idx_t of
 idx_t ListVector::GetTotalEntryCount(Vector &list, idx_t count) {
 	idx_t total_count = 0;
 	for (auto entry : list.ValidValues<list_entry_t>(count)) {
-		total_count += entry.value.length;
+		total_count += entry.GetValue().length;
 	}
 	return total_count;
 }
@@ -332,10 +332,10 @@ ConsecutiveChildListInfo ListVector::GetConsecutiveChildListInfo(Vector &list, i
 	idx_t first_length = 0;
 	for (idx_t i = offset; i < offset + count; i++) {
 		auto entry = list_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			continue;
 		}
-		auto &list_val = entry.value;
+		auto &list_val = entry.GetValue();
 		info.child_list_info.offset = list_val.offset;
 		first_length = list_val.length;
 		break;
@@ -354,10 +354,10 @@ ConsecutiveChildListInfo ListVector::GetConsecutiveChildListInfo(Vector &list, i
 	bool is_consecutive = true;
 	for (idx_t i = offset; i < offset + count; i++) {
 		auto entry = list_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			continue;
 		}
-		auto &list_val = entry.value;
+		auto &list_val = entry.GetValue();
 		if (list_val.offset != info.child_list_info.offset || list_val.length != first_length) {
 			info.is_constant = false;
 		}
@@ -384,10 +384,10 @@ void ListVector::GetConsecutiveChildSelVector(Vector &list, SelectionVector &sel
 	idx_t entry = 0;
 	for (idx_t i = offset; i < offset + count; i++) {
 		auto list_entry = list_data[i];
-		if (!list_entry.is_valid) {
+		if (!list_entry.IsValid()) {
 			continue;
 		}
-		auto &list_val = list_entry.value;
+		auto &list_val = list_entry.GetValue();
 		for (idx_t k = 0; k < list_val.length; k++) {
 			//			child_sel.set_index(entry++, list_data[idx].offset + k);
 			sel.set_index(entry++, list_val.offset + k);

--- a/src/common/vector/map_vector.cpp
+++ b/src/common/vector/map_vector.cpp
@@ -37,10 +37,10 @@ MapInvalidReason MapVector::CheckMapValidity(Vector &map, idx_t count, const Sel
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 		auto mapped_row = sel.get_index(row_idx);
 		auto map_entry = map_entries[mapped_row];
-		if (!map_entry.is_valid) {
+		if (!map_entry.IsValid()) {
 			continue;
 		}
-		auto &map_list = map_entry.value;
+		auto &map_list = map_entry.GetValue();
 
 		value_set_t unique_keys;
 		auto length = map_list.length;

--- a/src/common/vector/union_vector.cpp
+++ b/src/common/vector/union_vector.cpp
@@ -140,11 +140,11 @@ UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector, idx_t count, 
 		}
 
 		auto tag_entry = tag_data[mapped_idx];
-		if (!tag_entry.is_valid) {
+		if (!tag_entry.IsValid()) {
 			// we can't have NULL tags!
 			return UnionInvalidReason::NULL_TAG;
 		}
-		auto tag = tag_entry.value;
+		auto tag = tag_entry.GetValue();
 		if (tag >= member_count) {
 			return UnionInvalidReason::TAG_OUT_OF_RANGE;
 		}

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -44,7 +44,7 @@ void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t
 		for (idx_t i = 0; i < count; i++) {
 			auto left_entry = left_data[i];
 			auto right_entry = right_data[i];
-			bool is_null = OP::Operation(left_entry.value > 0, right_entry.value > 0, !left_entry.IsValid(),
+			bool is_null = OP::Operation(left_entry.GetValue() > 0, right_entry.GetValue() > 0, !left_entry.IsValid(),
 			                             !right_entry.IsValid(), result_data[i]);
 			if (is_null) {
 				result_data.SetInvalid(i);

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -197,7 +197,7 @@ static void ComparatorToBoolean(Vector &left, Vector &right, Vector &result, idx
 		if (!entry.IsValid()) {
 			result_data.SetInvalid(i);
 		} else {
-			result_data[i] = predicate(entry.value);
+			result_data[i] = predicate(entry.GetValue());
 		}
 	}
 }

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -12,7 +12,7 @@ void VectorOperations::DistinctFrom(Vector &left, Vector &right, Vector &result,
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::Writer<bool>(result);
 	for (idx_t i = 0; i < count; i++) {
-		result_data[i] = cmp_data[i].value != 0;
+		result_data[i] = cmp_data[i].GetValue() != 0;
 	}
 }
 
@@ -24,7 +24,7 @@ void VectorOperations::NotDistinctFrom(Vector &left, Vector &right, Vector &resu
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::Writer<bool>(result);
 	for (idx_t i = 0; i < count; i++) {
-		result_data[i] = cmp_data[i].value == 0;
+		result_data[i] = cmp_data[i].GetValue() == 0;
 	}
 }
 
@@ -40,7 +40,7 @@ static idx_t DistinctComparatorSelect(Vector &left, Vector &right, optional_ptr<
 	idx_t false_count = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto result_idx = sel ? sel->get_index(i) : i;
-		if (predicate(cmp_data[i].value)) {
+		if (predicate(cmp_data[i].GetValue())) {
 			if (true_sel) {
 				true_sel->set_index(true_count, result_idx);
 			}

--- a/src/common/vector_operations/vector_storage.cpp
+++ b/src/common/vector_operations/vector_storage.cpp
@@ -13,9 +13,9 @@ void CopyToStorageLoop(Vector &source, idx_t count, data_ptr_t target) {
 	auto result_data = (T *)target;
 	for (auto entry : source.Values<T>(count)) {
 		if (!entry.IsValid()) {
-			result_data[entry.index] = NullValue<T>();
+			result_data[entry.GetIndex()] = NullValue<T>();
 		} else {
-			result_data[entry.index] = entry.value;
+			result_data[entry.GetIndex()] = entry.GetValue();
 		}
 	}
 }

--- a/src/execution/expression_executor/execute_case.cpp
+++ b/src/execution/expression_executor/execute_case.cpp
@@ -114,7 +114,7 @@ void TemplatedFillLoop(Vector &vector, Vector &result, const SelectionVector &se
 			auto entry = entries[i];
 			auto res_idx = sel.get_index(i);
 			if (entry.IsValid()) {
-				res[res_idx] = entry.value;
+				res[res_idx] = entry.GetValue();
 			} else {
 				result_mask.SetInvalid(res_idx);
 			}

--- a/src/execution/expression_executor/execute_comparison.cpp
+++ b/src/execution/expression_executor/execute_comparison.cpp
@@ -182,7 +182,7 @@ static idx_t ComparatorSelectOperation(Vector &left, Vector &right, optional_ptr
 				false_sel->set_index(false_count, result_idx);
 			}
 			false_count++;
-		} else if (predicate(entry.value)) {
+		} else if (predicate(entry.GetValue())) {
 			if (true_sel) {
 				true_sel->set_index(true_count, result_idx);
 			}

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -380,7 +380,7 @@ void PerfectHashJoinExecutor::TemplatedFillSelectionVectorProbe(Vector &source, 
 		if (!entry.IsValid()) {
 			continue;
 		}
-		const auto &input_value = entry.value;
+		const auto &input_value = entry.GetValue();
 		// add index to selection vector if value in the range
 		if (min_value <= input_value && input_value <= max_value) {
 			// subtract min value to get the idx

--- a/src/execution/operator/schema/physical_create_type.cpp
+++ b/src/execution/operator/schema/physical_create_type.cpp
@@ -53,7 +53,7 @@ SinkResultType PhysicalCreateType::Sink(ExecutionContext &context, DataChunk &ch
 		if (!vec_entry.IsValid()) {
 			continue;
 		}
-		auto str = vec_entry.value;
+		auto str = vec_entry.GetValue();
 		auto found = gstate.found_strings.find(str);
 		if (found != gstate.found_strings.end()) {
 			// entry was already found - skip

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -278,7 +278,7 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 			auto entry = source_tag_entries[row_idx];
 			if (entry.IsValid()) {
 				// map the tag
-				auto target_tag = cast_data.tag_map[entry.value];
+				auto target_tag = cast_data.tag_map[entry.GetValue()];
 				FlatVector::GetDataMutable<union_tag_t>(result_tag_vector)[row_idx] =
 				    UnsafeNumericCast<union_tag_t>(target_tag);
 			} else {
@@ -315,12 +315,12 @@ static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, Cast
 			continue;
 		}
 
-		auto tag = tag_entry.value;
+		auto tag = tag_entry.GetValue();
 		auto &member = UnionVector::GetMember(varchar_union, tag);
 		auto member_entries = member.Values<string_t>(count);
 		auto member_entry = member_entries[i];
 		if (member_entry.IsValid()) {
-			result_data[i] = member_entry.value;
+			result_data[i] = member_entry.GetValue();
 		} else {
 			result_data[i] = "NULL";
 		}

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -99,7 +99,7 @@ void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFun
 
 	for (auto entry : input.data[0].Values<string_t>(input.size())) {
 		if (entry.IsValid()) {
-			auto &blob = entry.value;
+			auto &blob = entry.GetValue();
 			auto blob_len = blob.GetSize();
 			auto blob_ptr = blob.GetDataWriteable();
 			auto blob_end = blob_ptr + blob_len;

--- a/src/function/scalar/generic/error.cpp
+++ b/src/function/scalar/generic/error.cpp
@@ -9,10 +9,10 @@ namespace {
 static void ErrorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	for (auto entry : args.data[0].Values<string_t>(args.size())) {
 		if (!entry.IsValid()) {
-			FlatVector::SetNull(result, entry.index, true);
+			FlatVector::SetNull(result, entry.GetIndex(), true);
 			continue;
 		}
-		throw InvalidInputException(entry.value.GetString());
+		throw InvalidInputException(entry.GetValue().GetString());
 	}
 }
 

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -62,7 +62,7 @@ static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, co
 			continue;
 		}
 
-		const auto child_offset = TryGetChildOffset(list_entry.value, offsets_entry.value);
+		const auto child_offset = TryGetChildOffset(list_entry.GetValue(), offsets_entry.GetValue());
 
 		if (!child_offset.IsValid()) {
 			invalid_offsets.push_back(i);

--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -16,10 +16,10 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &result_validity = FlatVector::Validity(result);
 	for (auto entry : input.Values<list_entry_t>(count)) {
 		if (!entry.IsValid()) {
-			result_validity.SetInvalid(entry.index);
+			result_validity.SetInvalid(entry.GetIndex());
 			continue;
 		}
-		result_data[entry.index] = entry.value;
+		result_data[entry.GetIndex()] = entry.GetValue();
 	}
 	ListVector::SetListSize(result, ListVector::GetListSize(input));
 

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -56,7 +56,7 @@ void StringConcatFunction(DataChunk &args, ExpressionState &state, Vector &resul
 				if (!entry.IsValid()) {
 					continue;
 				}
-				result_lengths[entry.index] += entry.value.GetSize();
+				result_lengths[entry.GetIndex()] += entry.GetValue().GetSize();
 			}
 		}
 	}
@@ -95,8 +95,8 @@ void StringConcatFunction(DataChunk &args, ExpressionState &state, Vector &resul
 				if (!entry.IsValid()) {
 					continue;
 				}
-				auto &input_str = entry.value;
-				auto i = entry.index;
+				auto &input_str = entry.GetValue();
+				auto i = entry.GetIndex();
 				auto input_ptr = input_str.GetData();
 				auto input_len = input_str.GetSize();
 				memcpy(result_data[i].GetDataWriteable() + result_lengths[i], input_ptr, input_len);

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -309,17 +309,17 @@ static void RegexExtractStructFunction(DataChunk &args, ExpressionState &state, 
 
 		for (auto entry : input.Values<string_t>(count)) {
 			if (!entry.IsValid()) {
-				FlatVector::SetNull(result, entry.index, true);
+				FlatVector::SetNull(result, entry.GetIndex(), true);
 				continue;
 			}
-			auto str = CreateStringPiece(entry.value);
+			auto str = CreateStringPiece(entry.GetValue());
 			auto match = duckdb_re2::RE2::PartialMatchN(str, lstate.constant_pattern, groups.data(),
 			                                            UnsafeNumericCast<int>(groups.size()));
 			for (size_t col = 0; col < child_entries.size(); ++col) {
 				auto &child_entry = child_entries[col];
 				auto cdata = FlatVector::GetDataMutable<string_t>(child_entry);
 				auto &extracted = ws[col];
-				cdata[entry.index] =
+				cdata[entry.GetIndex()] =
 				    string_t(extracted.data(), UnsafeNumericCast<uint32_t>(match ? extracted.size() : 0));
 			}
 		}

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -129,7 +129,7 @@ int32_t GetGroupIndex(DataChunk &args, idx_t row, int32_t &result) {
 	if (!entry.IsValid()) {
 		return false;
 	}
-	result = entry.value;
+	result = entry.GetValue();
 	return true;
 }
 
@@ -192,7 +192,7 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 			if (!pattern_entry.IsValid()) {
 				pattern_valid = false;
 			} else {
-				auto &pattern_p = pattern_entry.value;
+				auto &pattern_p = pattern_entry.GetValue();
 				auto pattern_strpiece = CreateStringPiece(pattern_p);
 				stored_re = make_uniq<duckdb_re2::RE2>(pattern_strpiece, info.options);
 
@@ -220,7 +220,7 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 
 		auto &re = GetPattern(info, state, stored_re);
 		auto &groups = GetGroupsBuffer(info, state, non_const_args);
-		auto &string = string_entry.value;
+		auto &string = string_entry.GetValue();
 		ExtractSingleTuple(string, re, group_index, groups, result, row);
 	}
 }
@@ -321,7 +321,7 @@ void RegexpExtractAllStruct::Execute(DataChunk &args, ExpressionState &state, Ve
 			list_entries.SetInvalid(row);
 			continue;
 		}
-		auto &string_val = string_entry.value;
+		auto &string_val = string_entry.GetValue();
 		ExtractStructAllSingleTuple(string_val, lstate.constant_pattern, group_spans, child_entries, result, row);
 	}
 }

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -135,13 +135,13 @@ void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result
 		StringSplitInput split_input(result, child_entry, total_splits);
 		if (!delim_entry.IsValid()) {
 			// delim is NULL: copy the complete entry
-			split_input.AddSplit(input_entry.value.GetData(), input_entry.value.GetSize(), 0);
+			split_input.AddSplit(input_entry.GetValue().GetData(), input_entry.GetValue().GetSize(), 0);
 			list_struct_data[i].length = 1;
 			list_struct_data[i].offset = total_splits;
 			total_splits++;
 			continue;
 		}
-		auto list_length = StringSplitter::Split<OP>(input_entry.value, delim_entry.value, split_input, data);
+		auto list_length = StringSplitter::Split<OP>(input_entry.GetValue(), delim_entry.GetValue(), split_input, data);
 		list_struct_data[i].length = list_length;
 		list_struct_data[i].offset = total_splits;
 		total_splits += list_length;

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -544,7 +544,7 @@ static idx_t FindRunIndex(const VectorValueIterator<RUN_END_TYPE> &run_ends, idx
 	while (begin < end) {
 		idx_t middle = (begin + end) / 2;
 		// begin < end implies middle < end
-		if (offset >= static_cast<idx_t>(run_ends[middle].value)) {
+		if (offset >= static_cast<idx_t>(run_ends[middle].GetValue())) {
 			// keep searching in [middle + 1, end)
 			begin = middle + 1;
 		} else {
@@ -579,8 +579,8 @@ static void FlattenRunEnds(Vector &result, ArrowRunEndEncodingState &run_end_enc
 		for (; run < compressed_size; ++run) {
 			auto run_end_entry = run_ends_data[run];
 			auto value_entry = values_data[run];
-			auto &value = value_entry.value;
-			auto run_end = static_cast<idx_t>(run_end_entry.value);
+			auto &value = value_entry.GetValue();
+			auto run_end = static_cast<idx_t>(run_end_entry.GetValue());
 
 			D_ASSERT(run_end > (logical_index + index));
 			auto to_scan = run_end - (logical_index + index);
@@ -603,15 +603,15 @@ static void FlattenRunEnds(Vector &result, ArrowRunEndEncodingState &run_end_enc
 		for (; run < compressed_size; ++run) {
 			auto run_end_entry = run_ends_data[run];
 			auto value_entry = values_data[run];
-			auto run_end = static_cast<idx_t>(run_end_entry.value);
+			auto run_end = static_cast<idx_t>(run_end_entry.GetValue());
 
 			D_ASSERT(run_end > (logical_index + index));
 			auto to_scan = run_end - (logical_index + index);
 			// Cap the amount to scan so we don't go over size
 			to_scan = MinValue<idx_t>(to_scan, (count - index));
 
-			if (value_entry.is_valid) {
-				auto &value = value_entry.value;
+			if (value_entry.IsValid()) {
+				auto &value = value_entry.GetValue();
 				for (idx_t i = 0; i < to_scan; i++) {
 					result_data[index + i] = value;
 					validity.SetValid(index + i);

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -454,20 +454,20 @@ void WindowDistinctAggregatorLocalState::Sorted() {
 		                   //	10:		prevIdcs[i] ← sorted[i-1].second
 		                   for (idx_t j = 0; j < nmatch; ++j) {
 			                   auto scan_idx = matching.get_index(j);
-			                   auto i = input_idx[scan_idx].value;
-			                   auto second = scan_idx ? input_idx[scan_idx - 1].value : prev_i;
+			                   auto i = input_idx[scan_idx].GetValue();
+			                   auto second = scan_idx ? input_idx[scan_idx - 1].GetValue() : prev_i;
 			                   prev_idcs[i] = ZippedTuple(second + 1, i);
 		                   }
 		                   //	11:	else
 		                   //	12:		prevIdcs[i] ← “-”
 		                   for (idx_t j = 0; j < ndistinct; ++j) {
 			                   auto scan_idx = distinct.get_index(j);
-			                   auto i = input_idx[scan_idx].value;
+			                   auto i = input_idx[scan_idx].GetValue();
 			                   prev_idcs[i] = ZippedTuple(0, i);
 		                   }
 
 		                   //	Remember the last input_idx of this chunk.
-		                   prev_i = input_idx[count - 1].value;
+		                   prev_i = input_idx[count - 1].GetValue();
 	                   });
 
 	//	13:	return prevIdcs

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -43,13 +43,25 @@ public:
 
 public:
 	struct VectorValueEntry {
-		idx_t index;
-		T value;
-		bool is_valid;
-
-		bool IsValid() const {
-			return is_valid;
+		VectorValueEntry(UnifiedVectorFormat &format, const T *data, idx_t index) : format(format), data(data), index(index) {
+			sel_index = format.sel->get_index(index);
 		}
+
+		const T &GetValue() const {
+			return data[sel_index];
+		}
+		bool IsValid() const {
+			return format.validity.RowIsValid(sel_index);
+		}
+		idx_t GetIndex() const {
+			return index;
+		}
+
+	private:
+		UnifiedVectorFormat &format;
+		const T *data;
+		idx_t sel_index;
+		idx_t index;
 	};
 
 private:
@@ -117,14 +129,7 @@ private:
 
 	private:
 		VectorValueEntry GetEntry(idx_t i) const {
-			VectorValueEntry result;
-			result.index = i;
-			auto sel_idx = format.sel->get_index(i);
-			result.is_valid = format.validity.RowIsValid(sel_idx);
-			if (result.is_valid) {
-				result.value = data[sel_idx];
-			}
-			return result;
+			return VectorValueEntry(format, data, i);
 		}
 
 	private:

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -43,7 +43,8 @@ public:
 
 public:
 	struct VectorValueEntry {
-		VectorValueEntry(UnifiedVectorFormat &format, const T *data, idx_t index) : format(format), data(data), index(index) {
+		VectorValueEntry(const UnifiedVectorFormat &format, const T *data, idx_t index)
+		    : format(format), data(data), index(index) {
 			sel_index = format.sel->get_index(index);
 		}
 
@@ -58,7 +59,7 @@ public:
 		}
 
 	private:
-		UnifiedVectorFormat &format;
+		const UnifiedVectorFormat &format;
 		const T *data;
 		idx_t sel_index;
 		idx_t index;
@@ -149,14 +150,7 @@ public:
 		return count;
 	}
 	VectorValueEntry operator[](idx_t i) const {
-		VectorValueEntry result;
-		result.index = i;
-		const auto sel_idx = format.sel->get_index(i);
-		result.is_valid = format.validity.RowIsValid(sel_idx);
-		if (result.is_valid) {
-			result.value = data[sel_idx];
-		}
-		return result;
+		return VectorValueEntry(format, data, i);
 	}
 	//! Returns the value at the specified location without checking the NULL mask
 	T GetValueUnsafe(idx_t i) const {
@@ -180,10 +174,22 @@ public:
 		data = UnifiedVectorFormat::GetData<T>(format);
 	}
 
+private:
+	class VectorScanIterator;
+
 public:
 	struct VectorValueEntry {
+		const T &GetValue() const {
+			return value;
+		}
+		idx_t GetIndex() const {
+			return index;
+		}
+
+	private:
 		idx_t index;
 		T value;
+		friend class VectorScanIterator;
 	};
 
 private:

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -76,7 +76,7 @@ public:
 	template <typename T, typename CONVERTER>
 	void InsertKeys(Vector &keys, idx_t count, uint64_t *state_bitmap) const {
 		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			const U y = CONVERTER::Convert(entry.value) - min;
+			const U y = CONVERTER::Convert(entry.GetValue()) - min;
 			// All keys are in-range by construction, so the range check can be omitted here.
 			const U idx = y >> shift;
 			state_bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
@@ -109,14 +109,14 @@ public:
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const {
 		idx_t found_count = 0;
 		for (const auto &entry : keys.template ValidValues<T>(count)) {
-			const U comparable = CONVERTER::Convert(entry.value);
+			const U comparable = CONVERTER::Convert(entry.GetValue());
 			const U y = comparable - min;
 			const U bit_idx = y >> shift;
 			const uint8_t in_range = y <= span;
 			const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
 			const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 
-			result_sel.set_index(found_count, entry.index);
+			result_sel.set_index(found_count, entry.GetIndex());
 			found_count += bit & in_range;
 		}
 		return found_count;

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -324,7 +324,7 @@ bool BitpackingAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 
 	auto &analyze_state = state.Cast<BitpackingAnalyzeState<T>>();
 	for (auto entry : input.Values<T>(count)) {
-		if (!analyze_state.state.template Update<EmptyBitpackingWriter>(entry.value, entry.is_valid)) {
+		if (!analyze_state.state.template Update<EmptyBitpackingWriter>(entry.GetValue(), entry.IsValid())) {
 			return false;
 		}
 	}

--- a/src/storage/compression/dict_fsst/analyze.cpp
+++ b/src/storage/compression/dict_fsst/analyze.cpp
@@ -8,11 +8,11 @@ DictFSSTAnalyzeState::DictFSSTAnalyzeState(const CompressionInfo &info) : Analyz
 
 bool DictFSSTAnalyzeState::Analyze(Vector &input, idx_t count) {
 	for (auto entry : input.Values<string_t>(count)) {
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			contains_nulls = true;
 			continue;
 		}
-		auto &str = entry.value;
+		auto &str = entry.GetValue();
 		auto str_len = str.GetSize();
 		total_string_length += str_len;
 		if (str_len > max_string_length) {

--- a/src/storage/compression/dictionary/common.cpp
+++ b/src/storage/compression/dictionary/common.cpp
@@ -47,10 +47,10 @@ bool DictionaryCompressionState::UpdateState(Vector &scan_vector, idx_t count) {
 	for (auto entry : scan_vector.Values<string_t>(count)) {
 		idx_t string_size = 0;
 		bool new_string = false;
-		auto row_is_valid = entry.is_valid;
+		auto row_is_valid = entry.IsValid();
 
 		if (row_is_valid) {
-			auto &str = entry.value;
+			auto &str = entry.GetValue();
 			string_size = str.GetSize();
 			if (string_size >= StringUncompressed::GetStringBlockLimit(info.GetBlockSize())) {
 				// Big strings not implemented for dictionary compression
@@ -73,7 +73,7 @@ bool DictionaryCompressionState::UpdateState(Vector &scan_vector, idx_t count) {
 		if (!row_is_valid) {
 			AddNull();
 		} else if (new_string) {
-			AddNewString(entry.value);
+			AddNewString(entry.GetValue());
 		} else {
 			AddLastLookup();
 		}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -486,7 +486,7 @@ static void VerifyCheckConstraint(ClientContext &context, TableCatalogEntry &tab
 		                          check.ToString());
 	} // LCOV_EXCL_STOP
 	for (auto entry : result.Values<int32_t>(chunk.size())) {
-		if (entry.IsValid() && entry.value == 0) {
+		if (entry.IsValid() && entry.GetValue() == 0) {
 			throw ConstraintException("CHECK constraint failed on table %s with expression %s", table.name,
 			                          check.ToString());
 		}

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -102,7 +102,7 @@ void ListStats::Verify(const BaseStatistics &stats, Vector &vector, const Select
 		auto idx = sel.get_index(i);
 		auto entry = entries[idx];
 		if (entry.IsValid()) {
-			total_list_count += entry.value.length;
+			total_list_count += entry.GetValue().length;
 		}
 	}
 	SelectionVector list_sel(total_list_count);
@@ -111,7 +111,7 @@ void ListStats::Verify(const BaseStatistics &stats, Vector &vector, const Select
 		auto idx = sel.get_index(i);
 		auto entry = entries[idx];
 		if (entry.IsValid()) {
-			auto list = entry.value;
+			auto list = entry.GetValue();
 			for (idx_t list_idx = 0; list_idx < list.length; list_idx++) {
 				list_sel.set_index(list_count++, list.offset + list_idx);
 			}

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -568,11 +568,12 @@ void NumericStats::TemplatedVerify(const BaseStatistics &stats, Vector &vector, 
 		if (!entry.IsValid()) {
 			continue;
 		}
-		if (!min_value.IsNull() && LessThan::Operation(entry.value, min_value.GetValueUnsafe<T>())) { // LCOV_EXCL_START
+		if (!min_value.IsNull() &&
+		    LessThan::Operation(entry.GetValue(), min_value.GetValueUnsafe<T>())) { // LCOV_EXCL_START
 			throw InternalException("Statistics mismatch: value is smaller than min.\nStatistics: %s\nVector: %s",
 			                        stats.ToString(), vector.ToString(count));
 		} // LCOV_EXCL_STOP
-		if (!max_value.IsNull() && GreaterThan::Operation(entry.value, max_value.GetValueUnsafe<T>())) {
+		if (!max_value.IsNull() && GreaterThan::Operation(entry.GetValue(), max_value.GetValueUnsafe<T>())) {
 			throw InternalException("Statistics mismatch: value is bigger than max.\nStatistics: %s\nVector: %s",
 			                        stats.ToString(), vector.ToString(count));
 		}

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -325,7 +325,7 @@ void StringStats::Verify(const BaseStatistics &stats, Vector &vector, const Sele
 		if (!entry.IsValid()) {
 			continue;
 		}
-		auto value = entry.value;
+		auto value = entry.GetValue();
 		auto data = value.GetData();
 		auto len = value.GetSize();
 		// LCOV_EXCL_START

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -109,14 +109,14 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	validity->ScanCount(state.child_states[0], result, count);
 
 	auto data = offset_vector.Values<uint64_t>(scan_count);
-	auto last_entry = data[scan_count - 1].value;
+	auto last_entry = data[scan_count - 1].GetValue();
 
 	// shift all offsets so they are 0 at the first entry
 	auto result_data = FlatVector::Writer<list_entry_t>(result, scan_count);
 	auto base_offset = state.last_offset;
 	idx_t current_offset = 0;
 	for (idx_t i = 0; i < scan_count; i++) {
-		auto offset = data[i].value;
+		auto offset = data[i].GetValue();
 		result_data[i].offset = current_offset;
 		result_data[i].length = offset - current_offset - base_offset;
 		current_offset += result_data[i].length;
@@ -194,12 +194,12 @@ void ListColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vec
 	bool child_contiguous = true;
 	for (idx_t i = 0; i < count; i++) {
 		auto list_entry = input_offsets[i];
-		if (!list_entry.is_valid) {
+		if (!list_entry.IsValid()) {
 			append_mask.SetInvalid(i);
 			append_offsets[i] = start_offset + child_count;
 			continue;
 		}
-		auto &input_list = list_entry.value;
+		auto &input_list = list_entry.GetValue();
 		if (input_list.offset != child_count) {
 			child_contiguous = false;
 		}
@@ -215,10 +215,10 @@ void ListColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vec
 		idx_t current_count = 0;
 		for (idx_t i = 0; i < count; i++) {
 			auto list_entry = input_offsets[i];
-			if (!list_entry.is_valid) {
+			if (!list_entry.IsValid()) {
 				continue;
 			}
-			auto &input_list = list_entry.value;
+			auto &input_list = list_entry.GetValue();
 			for (idx_t list_idx = 0; list_idx < input_list.length; list_idx++) {
 				child_sel.set_index(current_count++, input_list.offset + list_idx);
 			}

--- a/src/storage/table/variant/variant_unshredding.cpp
+++ b/src/storage/table/variant/variant_unshredding.cpp
@@ -130,10 +130,10 @@ static vector<VariantValue> UnshredTypedArray(UnifiedVariantVectorData &variant,
 	idx_t child_size = 0;
 	for (uint32_t i = 0; i < count; i++) {
 		auto entry = list_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			continue;
 		}
-		auto &list_entry = entry.value;
+		auto &list_entry = entry.GetValue();
 		child_size += list_entry.length;
 	}
 	idx_t current_offset = 0;
@@ -141,12 +141,12 @@ static vector<VariantValue> UnshredTypedArray(UnifiedVariantVectorData &variant,
 	vector<VariantValue> res(count);
 	for (uint32_t i = 0; i < count; i++) {
 		auto entry = list_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			res[i] = VariantValue(Value(LogicalType::SQLNULL));
 			continue;
 		}
 		auto row = row_sel ? static_cast<uint32_t>(row_sel->get_index(i)) : i;
-		auto &list_entry = entry.value;
+		auto &list_entry = entry.GetValue();
 		for (idx_t j = 0; j < list_entry.length; j++) {
 			child_sel[current_offset++] = row;
 		}
@@ -156,10 +156,10 @@ static vector<VariantValue> UnshredTypedArray(UnifiedVariantVectorData &variant,
 	current_offset = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto entry = list_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			continue;
 		}
-		auto &list_entry = entry.value;
+		auto &list_entry = entry.GetValue();
 
 		auto &list_val = res[i];
 		list_val = VariantValue(VariantValueType::ARRAY);
@@ -214,11 +214,11 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
 	auto untyped_data = untyped_value_index->Values<uint32_t>(count);
 	for (uint32_t i = 0; i < count; i++) {
 		auto entry = untyped_data[i];
-		if (!entry.is_valid) {
+		if (!entry.IsValid()) {
 			//! NULL untyped_value_index indicates a fully shredded variant
 			continue;
 		}
-		auto value_index = entry.value;
+		auto value_index = entry.GetValue();
 		if (value_index == 0) {
 			// untyped value index of 0 indicates missing
 			res[i] = VariantValue(VariantValueType::MISSING);


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/21666, we should now call `entry.GetValue()` instead of `entry.value`. We also now return a `const &` to the member instead of a copy (`string_t`), which fixes a number of edge cases that could be introduced w.r.t. inlined `string_t` pointers not being stable across iterations.