### PR TITLE
Fix ExtractPlan crash in release builds

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -788,11 +788,11 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 			plan = optimizer.Optimize(std::move(plan));
 		}
 
+		plan->ResolveOperatorTypes();
+
 		ColumnBindingResolver resolver;
 		resolver.Verify(*plan);
 		resolver.VisitOperator(*plan);
-
-		plan->ResolveOperatorTypes();
 	});
 	return plan;
 }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -761,11 +761,11 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 			plan = optimizer.Optimize(std::move(plan));
 		}
 
+		plan->ResolveOperatorTypes();
+
 		ColumnBindingResolver resolver;
 		resolver.Verify(*plan);
 		resolver.VisitOperator(*plan);
-
-		plan->ResolveOperatorTypes();
 	});
 	return plan;
 }

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -736,6 +736,15 @@ TEST_CASE("Test a logical execute still has types after an optimization pass", "
 	REQUIRE((query_plan->types[0].id() == LogicalTypeId::INTEGER));
 }
 
+TEST_CASE("Test ExtractPlan type resolution with projections", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.Query("CREATE TABLE t (a INTEGER, b INTEGER)");
+	con.Query("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)");
+
+	REQUIRE_NOTHROW(con.ExtractPlan("SELECT a FROM t WHERE a <> b ORDER BY a LIMIT 1"));
+}
+
 TEST_CASE("Test SqlStatement::ToString for UPDATE, INSERT, DELETE statements with alias of RETURNING clause", "[api]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -743,6 +743,15 @@ TEST_CASE("Test a logical execute still has types after an optimization pass", "
 	REQUIRE((query_plan->types[0].id() == LogicalTypeId::INTEGER));
 }
 
+TEST_CASE("Test ExtractPlan type resolution with projections", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.Query("CREATE TABLE t (a INTEGER, b INTEGER)");
+	con.Query("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)");
+
+	REQUIRE_NOTHROW(con.ExtractPlan("SELECT a FROM t WHERE a <> b ORDER BY a LIMIT 1"));
+}
+
 TEST_CASE("Test SqlStatement::ToString for UPDATE, INSERT, DELETE statements with alias of RETURNING clause", "[api]") {
 	DuckDB db(nullptr);
 	Connection con(db);


### PR DESCRIPTION
## Summary
- `ExtractPlan` called `ResolveOperatorTypes` **after** `ColumnBindingResolver`, but the resolver reads `op.types` for validation
- In debug builds this worked by accident because `ColumnBindingResolver::Verify()` calls `ResolveOperatorTypes` as a side effect (behind `#ifdef DEBUG`)
- In release builds `Verify()` is a no-op, leaving types unpopulated and causing `"inequal num bindings/types"` errors for queries where the filter references columns not in the SELECT list combined with ORDER BY + LIMIT (e.g. `SELECT a FROM t WHERE a <> b ORDER BY a LIMIT 1`)
- Fix: move `ResolveOperatorTypes` before the resolver, matching the order in `PhysicalPlanGenerator::ResolveAndPlan`

## Test plan
- [x] Added `"Test ExtractPlan type resolution with projections"` test in `test/api/test_api.cpp`
- [x] Verified test fails in release before fix, passes after
- [x] Verified test passes in debug both before and after