### PR TITLE
fix: only set chains_longer_than_one when extending chains

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -565,12 +565,11 @@ static inline void InsertMatchesAndIncrementMisses(atomic<ht_entry_t> entries[],
                                                    idx_t ht_offsets[], const hash_t hash_salts[],
                                                    const idx_t capacity_mask, const idx_t key_match_count,
                                                    const idx_t key_no_match_count) {
-	if (key_match_count != 0) {
-		ht.chains_longer_than_one = true;
-	}
-
 	// Insert the rows that match
 	if (ht.insert_duplicate_keys) {
+		if (key_match_count != 0) {
+			ht.chains_longer_than_one = true;
+		}
 		for (idx_t i = 0; i < key_match_count; i++) {
 			const auto need_compare_idx = state.key_match_sel.get_index(i);
 			const auto entry_index = state.keys_to_compare_sel.get_index(need_compare_idx);


### PR DESCRIPTION
## Summary

- Guard the `chains_longer_than_one = true` assignment in `InsertMatchesAndIncrementMisses` with `ht.insert_duplicate_keys`, so it is only set when duplicate keys are actually chained together.
- When `insert_duplicate_keys` is false (SEMI/ANTI/MARK joins), matched rows are dropped rather than inserted into the chain, so chains remain length 1. The previous unconditional assignment forced the probe path to take the slower chain-following codepath unnecessarily.

## Test plan

- [x] Existing join tests (SEMI, ANTI, MARK, INNER, LEFT, RIGHT, FULL) continue to pass.

This PR was split out from #22013 by @lnkuiper's suggestion.


🤖 Generated with [Claude Code](https://claude.com/claude-code)