### PR TITLE
Expose query string to the optimizer

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -101,6 +101,26 @@ private:
 	BaseQueryResult *open_result = nullptr;
 };
 
+//! RAII wrapper that ensures the active query is reset if an exception occurs during preparation
+struct ActiveQueryGuard {
+	unique_ptr<ActiveQueryContext> &active_query;
+	bool set_active_query;
+
+	ActiveQueryGuard(unique_ptr<ActiveQueryContext> &active_query_p, const string &query)
+	    : active_query(active_query_p), set_active_query(false) {
+		if (!active_query) {
+			active_query = make_uniq<ActiveQueryContext>();
+			set_active_query = true;
+			active_query->query = query;
+		}
+	}
+	~ActiveQueryGuard() {
+		if (set_active_query) {
+			active_query.reset();
+		}
+	}
+};
+
 #ifdef DEBUG
 struct DebugClientContextState : public ClientContextState {
 	~DebugClientContextState() override {
@@ -779,7 +799,10 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 	PendingQueryParameters parameters;
 	RunFunctionInTransactionInternal(
 	    lock,
-	    [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), parameters); },
+	    [&]() {
+		    ActiveQueryGuard guard(active_query, statement_query);
+		    prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), parameters);
+	    },
 	    false);
 	prepared_data->unbound_statement = std::move(unbound_statement);
 	return make_uniq<PreparedStatement>(shared_from_this(), std::move(prepared_data), std::move(statement_query),


### PR DESCRIPTION
This is a follow-up to PRs https://github.com/duckdb/duckdb/pull/21232 and https://github.com/duckdb/duckdb/pull/20755.

Original issue was that prepared statements do not set `active_query` in the `ClientContext`. Because of that, tools which use the `active_query` (like our [duck_lineage](https://github.com/ilum-cloud/duck_lineage) extension) do not have access to additional information, when used from emedded DuckDB clients.

One possible fix was to simply set the active query, another was to pass the query string as an optional argument to the optimizer.

This PR is a rebase of the original PR with changes to the `active_query`.

We can continue here @lnkuiper, @Mytherin 