### PR TITLE
fix: shredded variant int16 decimal conversion

### DIFF
--- a/extension/parquet/reader/variant/variant_shredded_conversion.cpp
+++ b/extension/parquet/reader/variant/variant_shredded_conversion.cpp
@@ -77,7 +77,11 @@ template <>
 VariantValue ConvertShreddedValue<double>::Convert(double val) {
 	return VariantValue(Value::DOUBLE(val));
 }
-//! decimal4/decimal8/decimal16
+//! decimal2/decimal4/decimal8/decimal16
+template <>
+VariantValue ConvertShreddedValue<int16_t>::ConvertDecimal(int16_t val, uint8_t width, uint8_t scale) {
+	return VariantValue(Value::DECIMAL(val, width, scale));
+}
 template <>
 VariantValue ConvertShreddedValue<int32_t>::ConvertDecimal(int32_t val, uint8_t width, uint8_t scale) {
 	return VariantValue(Value::DECIMAL(val, width, scale));
@@ -250,10 +254,14 @@ vector<VariantValue> VariantShreddedConversion::ConvertShreddedLeaf(Vector &meta
 		return ConvertTypedValues<double, ConvertShreddedValue<double>, LogicalTypeId::DOUBLE>(
 		    typed_value, metadata, value, offset, length, total_size, is_field);
 	}
-	//! decimal4/decimal8/decimal16
+	//! decimal2/decimal4/decimal8/decimal16
 	case LogicalTypeId::DECIMAL: {
 		auto physical_type = type.InternalType();
 		switch (physical_type) {
+		case PhysicalType::INT16: {
+			return ConvertTypedValues<int16_t, ConvertShreddedValue<int16_t>, LogicalTypeId::DECIMAL>(
+			    typed_value, metadata, value, offset, length, total_size, is_field);
+		}
 		case PhysicalType::INT32: {
 			return ConvertTypedValues<int32_t, ConvertShreddedValue<int32_t>, LogicalTypeId::DECIMAL>(
 			    typed_value, metadata, value, offset, length, total_size, is_field);

--- a/test/parquet/variant/variant_all_types_shredded.test
+++ b/test/parquet/variant/variant_all_types_shredded.test
@@ -21,8 +21,6 @@ create macro data() as table (
 			'time_tz',
 			'interval',
 			'bit',
-			'dec_4_1', -- Parquet VARIANT doesn't have int16_t DECIMAL
--- Conversion isn't 1-to-1
 			'blob' -- data is base64-encoded in parquet read
 		]
 	])::VARIANT var from test_all_types()
@@ -32,7 +30,7 @@ query I nosort expected_res
 select * from data();
 ----
 
-foreach type bool tinyint smallint int bigint date time timestamp timestamp_ns timestamp_tz float double dec_9_4 dec_18_6 dec38_10 uuid varchar blob small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs
+foreach type bool tinyint smallint int bigint date time timestamp timestamp_ns timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid varchar blob small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs
 
 statement ok
 SET VARIABLE type_str = (SELECT $$STRUCT("{type}" $$ || typeof("{type}") || ')' from test_all_types() limit 1);

--- a/test/parquet/variant/variant_shredded_decimal_int16.test
+++ b/test/parquet/variant/variant_shredded_decimal_int16.test
@@ -1,0 +1,30 @@
+# name: test/parquet/variant/variant_shredded_decimal_int16.test
+# group: [variant]
+
+require parquet
+
+# DECIMAL width ≤ 4 uses PhysicalType::INT16 (see DecimalWidth<int16_t>).
+# Shredded Variant parquet must materialize typed_value leaves via
+# ConvertShreddedValue<int16_t>::ConvertDecimal (not Convert, which would yield SMALLINT).
+
+statement ok
+COPY (
+	SELECT * FROM (VALUES
+		({'d': 42.5::DECIMAL(4, 1)}::VARIANT),
+		({'d': -12.3::DECIMAL(4, 1)}::VARIANT),
+		({'d': 999.9::DECIMAL(4, 1)}::VARIANT),
+		({'d': -999.9::DECIMAL(4, 1)}::VARIANT)
+	) AS t(var)
+) TO '__TEST_DIR__/shredded_variant_dec_int16.parquet' (
+	SHREDDING {
+		'var': 'STRUCT(d DECIMAL(4,1))'
+	}
+)
+
+query I nosort
+SELECT * FROM '__TEST_DIR__/shredded_variant_dec_int16.parquet';
+----
+{'d': 42.5}
+{'d': -12.3}
+{'d': 999.9}
+{'d': -999.9}


### PR DESCRIPTION
The parquet reader deserializes shredded decimals to int16 if they can fit (I believe controlled by [this](https://github.com/duckdb/duckdb/blob/27f53474b36204d4be4d4bb6a9039fa2461e507c/src/function/scalar/variant/variant_utils.cpp#L24-L26)). However downstream consumers were not handling int16 sized decimals, causing `Not implemented Error: Decimal with PhysicalType (INT16) not implemented for shredded Variant`. 

Added a reproducing testcase and a fix.

Apologies if this should go on `v1.5-variegata` instead.