### PR TITLE
Fix `INSERT OR REPLACE BY NAME` regression by excluding conflict columns from `SET` list

### DIFF
--- a/benchmark/micro/update/insert_or_replace_by_name.benchmark
+++ b/benchmark/micro/update/insert_or_replace_by_name.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/update/insert_or_replace_by_name.benchmark
+# description: Check INSERT OR REPLACE BY NAME performance
+# group: [update]
+
+load
+CREATE TABLE t1 (col1 INT PRIMARY KEY);
+CREATE TABLE t2 (col1 INT);
+INSERT INTO t1 SELECT * FROM range(1000000);
+INSERT INTO t2 SELECT * FROM range(1000000);
+
+run
+INSERT OR REPLACE INTO t1 BY NAME SELECT * FROM t2;

--- a/src/include/duckdb/parser/statement/merge_into_statement.hpp
+++ b/src/include/duckdb/parser/statement/merge_into_statement.hpp
@@ -34,6 +34,8 @@ public:
 	InsertColumnOrder column_order = InsertColumnOrder::INSERT_BY_POSITION;
 	//! Whether or not this is a INSERT DEFAULT VALUES
 	bool default_values = false;
+	//! INSERT_BY_NAME exclude column list - columns to skip when generating the SET list
+	unordered_set<string> exclude_columns;
 
 	string ToString() const;
 	unique_ptr<MergeIntoAction> Copy() const;

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -262,6 +262,25 @@ void Binder::BindInsertColumnList(TableCatalogEntry &table, vector<string> &colu
 	}
 }
 
+static unordered_set<string> GetConflictColumnNames(const TableStorageInfo &storage_info, TableCatalogEntry &table) {
+	unordered_set<column_t> conflict_column_ids;
+	for (auto &index : storage_info.index_info) {
+		if (!index.is_unique) {
+			continue;
+		}
+		for (auto &col_id : index.column_set) {
+			conflict_column_ids.insert(col_id);
+		}
+	}
+	unordered_set<string> conflict_column_names;
+	for (auto &col : table.GetColumns().Physical()) {
+		if (conflict_column_ids.count(col.Physical().index)) {
+			conflict_column_names.insert(col.Name());
+		}
+	}
+	return conflict_column_names;
+}
+
 unique_ptr<MergeIntoStatement> Binder::GenerateMergeInto(InsertStatement &stmt, TableCatalogEntry &table) {
 	D_ASSERT(stmt.on_conflict_info);
 
@@ -485,6 +504,7 @@ unique_ptr<MergeIntoStatement> Binder::GenerateMergeInto(InsertStatement &stmt, 
 	if (on_conflict_info.action_type == OnConflictAction::UPDATE) {
 		// when doing UPDATE set up the when matched action
 		auto update_action = make_uniq<MergeIntoAction>();
+		update_action->exclude_columns = GetConflictColumnNames(storage_info, table);
 		update_action->action_type = MergeActionType::MERGE_UPDATE;
 		update_action->column_order = stmt.column_order;
 		if (on_conflict_info.set_info) {

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -61,20 +61,26 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 			// empty update list - generate it
 			action.update_info = make_uniq<UpdateSetInfo>();
 			if (action.column_order == InsertColumnOrder::INSERT_BY_NAME) {
-				// UPDATE BY NAME - get the name list from the source binder
-				action.update_info->columns = source_names;
+				for (idx_t i = 0; i < source_names.size(); i++) {
+					if (action.exclude_columns.count(source_names[i])) {
+						continue;
+					}
+					action.update_info->columns.push_back(source_names[i]);
+					action.update_info->expressions.push_back(bind_context.CreateColumnReference(
+					    source_aliases[i], source_names[i], ColumnBindType::DO_NOT_EXPAND_GENERATED_COLUMNS));
+				}
 			} else {
 				// UPDATE BY POSITION - get the name list from the table
 				for (auto &col : table.GetColumns().Physical()) {
 					action.update_info->columns.push_back(col.Name());
 				}
+				if (source_names.size() != action.update_info->columns.size()) {
+					throw BinderException(
+					    "Data provided for UPDATE did not match column count in table - expected %d columns but got %d",
+					    action.update_info->columns.size(), source_names.size());
+				}
+				action.update_info->expressions = GenerateColumnReferences(*this, source_aliases, source_names);
 			}
-			if (source_names.size() != action.update_info->columns.size()) {
-				throw BinderException(
-				    "Data provided for UPDATE did not match column count in table - expected %d columns but got %d",
-				    action.update_info->columns.size(), source_names.size());
-			}
-			action.update_info->expressions = GenerateColumnReferences(*this, source_aliases, source_names);
 		}
 		BindUpdateSet(proj_index, root, *action.update_info, table, result->columns, result->expressions, expressions);
 

--- a/test/sql/insert/insert_by_name.test
+++ b/test/sql/insert/insert_by_name.test
@@ -124,3 +124,19 @@ query II
 FROM tbl2
 ----
 1	22
+
+
+# INSERT OR REPLACE BY NAME on a table with only a PK column (no columns to update)
+statement ok
+CREATE TABLE tbl3 (id INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO tbl3 SELECT * FROM range(1000000) t(id);
+
+statement ok
+INSERT OR REPLACE INTO tbl3 BY NAME SELECT * FROM range(1000000) t(id);
+
+query I
+SELECT COUNT(*) FROM tbl3;
+----
+1000000


### PR DESCRIPTION
When doing `INSERT OR REPLACE BY NAME` the update action's `SET` list was auto-generated in `BindMergeAction` without filtering out conflict columns. This caused `BindUpdateConstraints` to set `update_is_del_and_insert=true`, turning every matched row into a `DELETE` + reinsert instead of an in-place update.

This PR fixes that by creating an exclusion list for conflict columns, which is used to filter them out when auto-generating the `SET` list for `BY NAME`.

Correctness is covered by `insert_by_name.test`. Since it's a performance issue, I am adding a benchmark.

Before 
```
benchmark/micro/update/insert_or_replace_by_name.benchmark      1       1.326579
benchmark/micro/update/insert_or_replace_by_name.benchmark      2       1.335533
benchmark/micro/update/insert_or_replace_by_name.benchmark      3       1.329612
benchmark/micro/update/insert_or_replace_by_name.benchmark      4       1.303654
benchmark/micro/update/insert_or_replace_by_name.benchmark      5       1.313185
```

After
```
benchmark/micro/update/insert_or_replace_by_name.benchmark      1       0.036045
benchmark/micro/update/insert_or_replace_by_name.benchmark      2       0.036933
benchmark/micro/update/insert_or_replace_by_name.benchmark      3       0.039216
benchmark/micro/update/insert_or_replace_by_name.benchmark      4       0.038530
benchmark/micro/update/insert_or_replace_by_name.benchmark      5       0.038366
```

Fixes: https://github.com/duckdb/duckdb/issues/21925
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/8817

