### PR TITLE
Avoid handling Ctrl+C during shutdown (state might be already gone)

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3266,6 +3266,11 @@ int RunShell(int argc, const char **argv) {
 			rc = data.ProcessInput(InputMode::STANDARD);
 		}
 	}
+#if !defined(_WIN32) && !defined(WIN32)
+	signal(SIGINT, SIG_IGN);
+#else
+	SetConsoleCtrlHandler(ConsoleCtrlHandler, FALSE);
+#endif
 	data.SetTableName(0);
 	data.last_result.reset();
 	data.db.reset();


### PR DESCRIPTION
This is visible only doing something like:

* duckdb -ui
* Ctrl + D
* Ctrl + C

If you can fire interrupt while Ctrl+D is being processed, it might fire on a state that's being destructed, and a segfault is not unexpected.