### PR TITLE
 Row group append

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -60,6 +60,7 @@
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/quantile_enum.hpp"
 #include "duckdb/common/enums/relation_type.hpp"
+#include "duckdb/common/enums/row_group_append_mode.hpp"
 #include "duckdb/common/enums/set_operation_type.hpp"
 #include "duckdb/common/enums/set_scope.hpp"
 #include "duckdb/common/enums/set_type.hpp"
@@ -4253,6 +4254,25 @@ const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value) {
 template<>
 ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value) {
 	return static_cast<ResultModifierType>(StringUtil::StringToEnum(GetResultModifierTypeValues(), 4, "ResultModifierType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetRowGroupAppendModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(RowGroupAppendMode::APPEND_TO_EXISTING), "APPEND_TO_EXISTING" },
+		{ static_cast<uint32_t>(RowGroupAppendMode::SUGGEST_NEW), "SUGGEST_NEW" },
+		{ static_cast<uint32_t>(RowGroupAppendMode::REQUIRE_NEW), "REQUIRE_NEW" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<RowGroupAppendMode>(RowGroupAppendMode value) {
+	return StringUtil::EnumToString(GetRowGroupAppendModeValues(), 3, "RowGroupAppendMode", static_cast<uint32_t>(value));
+}
+
+template<>
+RowGroupAppendMode EnumUtil::FromString<RowGroupAppendMode>(const char *value) {
+	return static_cast<RowGroupAppendMode>(StringUtil::StringToEnum(GetRowGroupAppendModeValues(), 3, "RowGroupAppendMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSampleMethodValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -378,6 +378,8 @@ enum class RequestType : uint8_t;
 
 enum class ResultModifierType : uint8_t;
 
+enum class RowGroupAppendMode : uint8_t;
+
 enum class SampleMethod : uint8_t;
 
 enum class SampleType : uint8_t;
@@ -1023,6 +1025,9 @@ const char* EnumUtil::ToChars<RequestType>(RequestType value);
 
 template<>
 const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
+
+template<>
+const char* EnumUtil::ToChars<RowGroupAppendMode>(RowGroupAppendMode value);
 
 template<>
 const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
@@ -1732,6 +1737,9 @@ RequestType EnumUtil::FromString<RequestType>(const char *value);
 
 template<>
 ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
+
+template<>
+RowGroupAppendMode EnumUtil::FromString<RowGroupAppendMode>(const char *value);
 
 template<>
 SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);

--- a/src/include/duckdb/common/enums/row_group_append_mode.hpp
+++ b/src/include/duckdb/common/enums/row_group_append_mode.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/row_group_append_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+
+namespace duckdb {
+
+//! Controls whether an append creates a new row group or reuses an existing one.
+//! Values are ordered so that higher values take priority (ratchet semantics).
+enum class RowGroupAppendMode : uint8_t {
+	//! Append to the last existing row group if possible (default)
+	APPEND_TO_EXISTING = 0,
+	//! Suggest creating a new row group — may be ignored for tables with indexes
+	SUGGEST_NEW = 1,
+	//! Require creating a new row group — cannot be ignored
+	REQUIRE_NEW = 2
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/common/enums/index_removal_type.hpp"
+#include "duckdb/common/enums/row_group_append_mode.hpp"
 
 namespace duckdb {
 
@@ -158,7 +159,7 @@ public:
 	idx_t GetRowGroupSize() const {
 		return row_group_size;
 	}
-	void SetAppendRequiresNewRowGroup();
+	void SetRowGroupAppendMode(RowGroupAppendMode mode);
 	//! Returns the total amount of segments - use sparingly, as this forces all segments to be loaded
 	idx_t GetSegmentCount();
 
@@ -192,8 +193,8 @@ private:
 	MetaBlockPointer metadata_pointer;
 	//! Other metadata pointers
 	vector<MetaBlockPointer> metadata_pointers;
-	//! Whether or not we need to append a new row group prior to appending
-	bool requires_new_row_group;
+	//! Controls whether the next append creates a new row group or reuses the existing one
+	RowGroupAppendMode row_group_append_mode;
 };
 
 class RowGroupIterationHelper {

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -195,8 +195,6 @@ private:
 	vector<MetaBlockPointer> metadata_pointers;
 	//! Controls whether the next append creates a new row group or reuses the existing one
 	RowGroupAppendMode row_group_append_mode;
-	//! The default append mode, determined by column types (e.g. REQUIRE_NEW for VARIANT columns)
-	RowGroupAppendMode default_row_group_append_mode;
 };
 
 class RowGroupIterationHelper {

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -195,6 +195,8 @@ private:
 	vector<MetaBlockPointer> metadata_pointers;
 	//! Controls whether the next append creates a new row group or reuses the existing one
 	RowGroupAppendMode row_group_append_mode;
+	//! The default append mode, determined by column types (e.g. REQUIRE_NEW for VARIANT columns)
+	RowGroupAppendMode default_row_group_append_mode;
 };
 
 class RowGroupIterationHelper {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -68,7 +68,7 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 	this->row_groups = make_shared_ptr<RowGroupCollection>(info, io_manager, types, 0);
 	if (data && data->row_group_count > 0) {
 		this->row_groups->Initialize(*data);
-		row_groups->SetAppendRequiresNewRowGroup();
+		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	} else {
 		this->row_groups->InitializeEmpty();
 		D_ASSERT(row_groups->GetTotalRows() == 0);
@@ -1156,7 +1156,7 @@ void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state
 		// there is a checkpoint active while we are appending
 		// in this case we cannot just blindly append to the last row group, because we need to checkpoint that
 		// always start a new row group in this case
-		row_groups->SetAppendRequiresNewRowGroup();
+		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::REQUIRE_NEW);
 	}
 }
 
@@ -1816,7 +1816,7 @@ void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 	// checkpoint each individual row group
 	TableStatistics global_stats;
 	row_groups->Checkpoint(writer, global_stats);
-	row_groups->SetAppendRequiresNewRowGroup();
+	row_groups->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	if (writer.GetRebuildIndexes()) {
 		RebuildIndexes();
 	}

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -145,7 +145,7 @@ void OptimisticWriteCollection::MergeStorage(OptimisticWriteCollection &merge_co
 	// we cannot append into a row group that has been flushed
 	if (complete_row_groups == collection->GetRowGroupCount()) {
 		// if the last row group has been flushed move any new appends to a new row group
-		collection->SetAppendRequiresNewRowGroup();
+		collection->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	}
 }
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -68,16 +68,15 @@ RowGroupCollection::RowGroupCollection(shared_ptr<DataTableInfo> info_p, BlockMa
                                        idx_t row_group_size_p)
     : block_manager(block_manager), row_group_size(row_group_size_p), total_rows(total_rows_p), info(std::move(info_p)),
       types(std::move(types_p)), owned_row_groups(make_shared_ptr<RowGroupSegmentTree>(*this, row_start)),
-      allocation_size(0), default_row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
+      allocation_size(0), row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
 	// If the table contains shredded types (variant / geometry) then we can't append to an existing row group
 	for (auto &type : types) {
 		if (TypeVisitor::Contains(type, LogicalTypeId::VARIANT) ||
 		    TypeVisitor::Contains(type, LogicalTypeId::GEOMETRY)) {
-			default_row_group_append_mode = RowGroupAppendMode::REQUIRE_NEW;
+			row_group_append_mode = RowGroupAppendMode::REQUIRE_NEW;
 			break;
 		}
 	}
-	row_group_append_mode = default_row_group_append_mode;
 }
 
 idx_t RowGroupCollection::GetTotalRows() const {
@@ -170,7 +169,7 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
-	row_group_append_mode = default_row_group_append_mode;
+	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -69,8 +69,10 @@ RowGroupCollection::RowGroupCollection(shared_ptr<DataTableInfo> info_p, BlockMa
     : block_manager(block_manager), row_group_size(row_group_size_p), total_rows(total_rows_p), info(std::move(info_p)),
       types(std::move(types_p)), owned_row_groups(make_shared_ptr<RowGroupSegmentTree>(*this, row_start)),
       allocation_size(0), default_row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
+	// If the table contains shredded types (variant / geometry) then we can't append to an existing row group
 	for (auto &type : types) {
-		if (TypeVisitor::Contains(type, LogicalTypeId::VARIANT)) {
+		if (TypeVisitor::Contains(type, LogicalTypeId::VARIANT) ||
+		    TypeVisitor::Contains(type, LogicalTypeId::GEOMETRY)) {
 			default_row_group_append_mode = RowGroupAppendMode::REQUIRE_NEW;
 			break;
 		}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -67,7 +67,7 @@ RowGroupCollection::RowGroupCollection(shared_ptr<DataTableInfo> info_p, BlockMa
                                        idx_t row_group_size_p)
     : block_manager(block_manager), row_group_size(row_group_size_p), total_rows(total_rows_p), info(std::move(info_p)),
       types(std::move(types_p)), owned_row_groups(make_shared_ptr<RowGroupSegmentTree>(*this, row_start)),
-      allocation_size(0), requires_new_row_group(false) {
+      allocation_size(0), row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
 }
 
 idx_t RowGroupCollection::GetTotalRows() const {
@@ -135,8 +135,11 @@ void RowGroupCollection::Initialize(PersistentCollectionData &data) {
 	}
 }
 
-void RowGroupCollection::SetAppendRequiresNewRowGroup() {
-	requires_new_row_group = true;
+void RowGroupCollection::SetRowGroupAppendMode(RowGroupAppendMode mode) {
+	if (mode > row_group_append_mode) {
+		// We never downgrade the mode, i.e. if REQUIRE_NEW was already set then we do not set it back to SUGGEST_NEW
+		row_group_append_mode = mode;
+	}
 }
 
 void RowGroupCollection::InitializeEmpty() {
@@ -157,7 +160,7 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
-	requires_new_row_group = false;
+	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {
@@ -470,8 +473,12 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 	// start writing to the row_groups
 	state.row_groups = GetRowGroups();
 	auto l = state.row_groups->Lock();
-	if (state.row_groups->IsEmpty(l) || requires_new_row_group) {
-		// empty row group collection: empty first row group
+	// We need a new row group if there are none yet or the append mode forces us to create a new row group
+	bool needs_new_row_group = state.row_groups->IsEmpty(l) || row_group_append_mode == RowGroupAppendMode::REQUIRE_NEW;
+	// We honor SUGGEST_NEW iff the table has no indexes (because indexed tables aren't vacuumed so row groups might
+	// not be filled if we create a new one on append).
+	needs_new_row_group |= row_group_append_mode == RowGroupAppendMode::SUGGEST_NEW && info->GetIndexes().Empty();
+	if (needs_new_row_group) {
 		AppendRowGroup(l, state.row_groups->GetBaseRowId() + total_rows);
 	}
 	state.start_row_group = state.row_groups->GetLastSegment(l);
@@ -718,7 +725,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 	stats.MergeStats(data.stats);
 	total_rows += data.total_rows.load();
 	if (is_persistent) {
-		SetAppendRequiresNewRowGroup();
+		SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	}
 }
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/execution/index/art/art.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 
@@ -67,7 +68,14 @@ RowGroupCollection::RowGroupCollection(shared_ptr<DataTableInfo> info_p, BlockMa
                                        idx_t row_group_size_p)
     : block_manager(block_manager), row_group_size(row_group_size_p), total_rows(total_rows_p), info(std::move(info_p)),
       types(std::move(types_p)), owned_row_groups(make_shared_ptr<RowGroupSegmentTree>(*this, row_start)),
-      allocation_size(0), row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
+      allocation_size(0), default_row_group_append_mode(RowGroupAppendMode::APPEND_TO_EXISTING) {
+	for (auto &type : types) {
+		if (TypeVisitor::Contains(type, LogicalTypeId::VARIANT)) {
+			default_row_group_append_mode = RowGroupAppendMode::REQUIRE_NEW;
+			break;
+		}
+	}
+	row_group_append_mode = default_row_group_append_mode;
 }
 
 idx_t RowGroupCollection::GetTotalRows() const {
@@ -160,7 +168,7 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
 	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
-	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
+	row_group_append_mode = default_row_group_append_mode;
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {

--- a/test/sql/storage/checkpoint/indexed_table_delete_insert_fragmentation.test
+++ b/test/sql/storage/checkpoint/indexed_table_delete_insert_fragmentation.test
@@ -1,0 +1,93 @@
+# name: test/sql/storage/checkpoint/indexed_table_delete_insert_fragmentation.test
+# description: Test that delete+insert cycles on indexed tables do not create new row groups excessively.
+# group: [checkpoint]
+
+# We want to manage our own database files
+require noforcestorage
+# No restarts between statements
+require skip_reload
+# If we enable alternative verification then checkpointing on shutdown is disabled, which we don't want
+require no_alternative_verify
+
+# run twice with different multipliers for novelty sizes (8 * novelty_size will be updates, 2 * novelty_size will be
+# inserts)
+foreach novelty_multiplier 10 1024
+
+# Setup: create a snapshot with exactly 2 row groups (row group size = 2048, amount of rows = 4096)
+statement ok
+ATTACH '__TEST_DIR__/test_rowgroup_append_mode_on_fragmented_tables.db' as snap (READ_WRITE, STORAGE_VERSION 'v1.5.0', ROW_GROUP_SIZE 2048);
+
+statement ok
+CREATE OR REPLACE TABLE snap.snapshot(pk BIGINT PRIMARY KEY, val1 VARCHAR, val2 VARCHAR);
+
+statement ok
+INSERT INTO snap.snapshot SELECT pk, uuid()::VARCHAR as val1, uuid()::VARCHAR as val2 FROM generate_series(1, 4096) t(pk);
+
+statement ok
+CHECKPOINT snap;
+
+statement ok
+DETACH snap;
+
+# Now update (DELETE + INSERT) 8 * novelty_multiplier rows and INSERT 2 * novelty_multiplier rows, ten times, as
+# follows:
+# 1. create a new in-memory table valled "novelty_deletes" with 8 * novelty_multiplier rows with bigint PKs only, set to
+#    a random seletion from the range [1, 2m + iteration * 2 * novelty_multiplier].
+# 2. create a new in-memory table called "novelty_inserts" with 8 * novelty_multiplier rows (same structure as
+#    "snapshot") with PKs set to the same PKs as in "novelty_deletes" and random values, and 2 * novelty_multiplier rows
+#    with monotonicallly increasing PKs starting at 2000001 + iteration * 2 * novelty_multiplier.
+# 3. ATTACH to <filename>.duckdb - this should really be as if we are attaching to a new file for the first time - in
+#    read / write mode, with RECOVERY_MODE set to NO_WAL_WRITES.
+# 4. run DELETE FROM snapshot WHERE pk IN (SELECT pk FROM novelty_deletes) - this should be an in-memory operation and
+#    NOT be checkpointed at all, we do not want any vacuuming or compacting to occur.
+# 5. run INSERT INTO snapshot SELECT * FROM novelty_inserts - this should also be in-memory only!
+# 6. run a CHECKPOINT on the snapshot
+# 7. completely detach from <filename>.duckdb
+loop i 0 10
+
+# 1. create novelty_deletes
+statement ok
+CREATE OR REPLACE TABLE novelty_deletes AS SELECT pk FROM generate_series(1, 4096 + ${i} * 2 * ${novelty_multiplier}) t(pk) ORDER BY random() LIMIT 8 * ${novelty_multiplier};
+
+# 2. create novelty_inserts
+statement ok
+CREATE OR REPLACE TABLE novelty_inserts AS SELECT pk, uuid()::VARCHAR as val1, uuid()::VARCHAR as val2 FROM novelty_deletes;
+
+statement ok
+INSERT INTO novelty_inserts SELECT pk, uuid()::VARCHAR, uuid()::VARCHAR FROM generate_series(4096 + ${i} * 2 * ${novelty_multiplier} + 1, 4096 + ${i} * 2 * ${novelty_multiplier} + 2 * ${novelty_multiplier}) t(pk)
+
+# 3. attach snapshot
+statement ok
+ATTACH '__TEST_DIR__/test_rowgroup_append_mode_on_fragmented_tables.db' as snap (READ_WRITE, RECOVERY_MODE NO_WAL_WRITES, STORAGE_VERSION 'v1.5.0', ROW_GROUP_SIZE 2048);
+
+# 4. process novelty_deletes
+statement ok
+DELETE FROM snap.snapshot WHERE pk IN (SELECT pk FROM novelty_deletes);
+
+# 5. process novelty_inserts
+statement ok
+INSERT INTO snap.snapshot SELECT * FROM novelty_inserts;
+
+# 6. checkpoint the snapshot
+statement ok
+CHECKPOINT snap;
+
+# 7. detach from snap
+statement ok
+DETACH snap;
+
+endloop # loop i 0 10
+
+# Now we verify that the amount of row groups created is what we expect
+statement ok
+ATTACH '__TEST_DIR__/test_rowgroup_append_mode_on_fragmented_tables.db' as snap;
+
+query I
+SELECT COUNT(DISTINCT row_group_id) <= CEIL((4096 + 100 * ${novelty_multiplier}) / 2048) FROM pragma_storage_info('snap.snapshot');
+----
+1
+
+statement ok
+DETACH snap;
+
+endloop # foreach val 1000 100000


### PR DESCRIPTION
Related to:
- https://github.com/duckdblabs/appian/issues/84
- https://github.com/duckdblabs/appian/issues/81

This introduces an enum to control the ros group append mode, as [suggested](https://github.com/duckdblabs/appian/issues/81#issuecomment-4045743803) by @Mytherin.

cc @taniabogatsch @Dtenwolde