### PR TITLE
Rewrite GLOB matcher from recursive matching to iterative one

### DIFF
--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -9,82 +9,15 @@
 
 namespace duckdb {
 
-bool Glob(const char *string, idx_t slen, const char *pattern, idx_t plen, bool allow_question_mark) {
-	idx_t sidx = 0;
-	idx_t pidx = 0;
-main_loop : {
-	// main matching loop
-	while (sidx < slen && pidx < plen) {
-		char s = string[sidx];
-		char p = pattern[pidx];
-		switch (p) {
-		case '*': {
-			// asterisk: match any set of characters
-			// skip any subsequent asterisks
-			pidx++;
-			while (pidx < plen && pattern[pidx] == '*') {
-				pidx++;
-			}
-			// if the asterisk is the last character, the pattern always matches
-			if (pidx == plen) {
-				return true;
-			}
-			// recursively match the remainder of the pattern
-			for (; sidx < slen; sidx++) {
-				if (Glob(string + sidx, slen - sidx, pattern + pidx, plen - pidx)) {
-					return true;
-				}
-			}
-			return false;
-		}
-		case '?':
-			// when enabled: matches anything but null
-			if (allow_question_mark) {
-				break;
-			}
-			DUCKDB_EXPLICIT_FALLTHROUGH;
-		case '[':
-			pidx++;
-			goto parse_bracket;
-		case '\\':
-			// escape character, next character needs to match literally
-			pidx++;
-			// check that we still have a character remaining
-			if (pidx == plen) {
-				return false;
-			}
-			p = pattern[pidx];
-			if (s != p) {
-				return false;
-			}
-			break;
-		default:
-			// not a control character: characters need to match literally
-			if (s != p) {
-				return false;
-			}
-			break;
-		}
-		sidx++;
-		pidx++;
-	}
-	while (pidx < plen && pattern[pidx] == '*') {
-		pidx++;
-	}
-	// we are finished only if we have consumed the full pattern
-	return pidx == plen && sidx == slen;
-}
-parse_bracket : {
-	// inside a bracket
+static bool GlobMatchesBracket(char s, const char *pattern, idx_t plen, idx_t &pidx, bool &valid_pattern) {
 	if (pidx == plen) {
+		valid_pattern = false;
 		return false;
 	}
 	// check the first character
 	// if it is an exclamation mark we need to invert our logic
-	char p = pattern[pidx];
-	char s = string[sidx];
 	bool invert = false;
-	if (p == '!') {
+	if (pattern[pidx] == '!') {
 		invert = true;
 		pidx++;
 	}
@@ -93,7 +26,7 @@ parse_bracket : {
 	bool found_closing_bracket = false;
 	// now check the remainder of the pattern
 	while (pidx < plen) {
-		p = pattern[pidx];
+		auto p = pattern[pidx];
 		// if the first character is a closing bracket, we match it literally
 		// otherwise it indicates an end of bracket
 		if (p == ']' && pidx > start_pos) {
@@ -102,8 +35,6 @@ parse_bracket : {
 			pidx++;
 			break;
 		}
-		// we either match a range (a-b) or a single character (a)
-		// check if the next character is a dash
 		if (pidx + 1 == plen) {
 			// no next character!
 			break;
@@ -114,7 +45,7 @@ parse_bracket : {
 			if (pidx + 2 == plen) {
 				break;
 			}
-			char next_char = pattern[pidx + 2];
+			auto next_char = pattern[pidx + 2];
 			// check if the current character is within the range
 			matches = s >= p && s <= next_char;
 			// shift the pattern forward past the range
@@ -134,16 +65,96 @@ parse_bracket : {
 	}
 	if (!found_closing_bracket) {
 		// no end of bracket: invalid pattern
+		valid_pattern = false;
 		return false;
 	}
-	if (!found_match) {
-		// did not match the bracket: return false;
-		return false;
-	}
-	// finished the bracket matching: move forward
-	sidx++;
-	goto main_loop;
+	valid_pattern = true;
+	return found_match;
 }
+
+bool Glob(const char *string, idx_t slen, const char *pattern, idx_t plen, bool allow_question_mark) {
+	idx_t sidx = 0;
+	idx_t pidx = 0;
+	idx_t star_pidx = 0;
+	idx_t star_sidx = 0;
+	bool has_star = false;
+	// main matching loop
+	while (sidx < slen) {
+		bool matched = false;
+		idx_t next_pidx = pidx;
+		if (pidx < plen) {
+			auto p = pattern[pidx];
+			switch (p) {
+			case '*': {
+				// asterisk: match any set of characters
+				pidx++;
+				// skip any subsequent asterisks
+				while (pidx < plen && pattern[pidx] == '*') {
+					pidx++;
+				}
+				// if the asterisk is the last character, the pattern always matches
+				if (pidx == plen) {
+					return true;
+				}
+				has_star = true;
+				// remember the pattern position right after '*', and the current string position
+				star_pidx = pidx;
+				star_sidx = sidx;
+				continue;
+			}
+			case '?':
+				// when enabled: matches anything but null
+				if (allow_question_mark) {
+					matched = true;
+				} else {
+					matched = string[sidx] == p;
+				}
+				next_pidx = pidx + 1;
+				break;
+			case '[': {
+				next_pidx = pidx + 1;
+				bool valid_pattern;
+				matched = GlobMatchesBracket(string[sidx], pattern, plen, next_pidx, valid_pattern);
+				if (!valid_pattern) {
+					return false;
+				}
+				break;
+			}
+			case '\\':
+				// escape character, next character needs to match literally
+				pidx++;
+				// check that we still have a character remaining
+				if (pidx == plen) {
+					return false;
+				}
+				matched = string[sidx] == pattern[pidx];
+				next_pidx = pidx + 1;
+				break;
+			default:
+				// not a control character: characters need to match literally
+				matched = string[sidx] == p;
+				next_pidx = pidx + 1;
+				break;
+			}
+		}
+		if (matched) {
+			sidx++;
+			pidx = next_pidx;
+			continue;
+		}
+		if (!has_star) {
+			return false;
+		}
+		// backtrack: the last '*' consumes one more character and we retry from there
+		star_sidx++;
+		sidx = star_sidx;
+		pidx = star_pidx;
+	}
+	while (pidx < plen && pattern[pidx] == '*') {
+		pidx++;
+	}
+	// we are finished only if we have consumed the full pattern
+	return pidx == plen;
 }
 
 namespace {

--- a/test/sql/function/string/test_glob.test
+++ b/test/sql/function/string/test_glob.test
@@ -229,6 +229,46 @@ SELECT '4' GLOB '['
 ----
 0
 
+# star backtracking against bracket with end of string constraint
+query T
+SELECT 'abac' GLOB '*a[bc]'
+----
+1
+
+query T
+SELECT 'abad' GLOB '*a[bc]'
+----
+0
+
+# star backtracking against escaped literal
+query T
+SELECT 'xx*' GLOB '*\*'
+----
+1
+
+query T
+SELECT 'xxa' GLOB '*\*'
+----
+0
+
+# star backtracking against question mark with end of string constraint
+query T
+SELECT 'ab' GLOB '*?'
+----
+1
+
+# invalid bracket after star
+query T
+SELECT 'abc' GLOB '*['
+----
+0
+
+# many-star glob should complete quickly and return false
+query T
+SELECT repeat('a', 35) || 'c' GLOB '*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b'
+----
+0
+
 # like with table
 statement ok
 CREATE TABLE strings(s STRING, pat STRING);


### PR DESCRIPTION
Fixes #22050

GLOB matcher used naive recursion before, it was rewritten to use iterative approach, also some tests were added for couple corner cases. Also fixes the recursive calls not forwarding the `allow_question_mark`.

Before this query:
```
SELECT repeat('a', 35) || 'c' GLOB '*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b';
```
Was taking 30+seconds to complete.

With the new matcher:
```
Run Time (s): real 0.001 user 0.000677 sys 0.000000
```