### PR TITLE
CLI: when tab completing, complete until the longest prefix of all matches in case of conflicts

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -167,6 +167,26 @@ bool Linenoise::CompleteLine(KeyPress &next_key) {
 		if (has_ties) {
 			// if there are ties we don't auto-complete immediately
 			// instead we display the list of suggestions
+			// but first, complete up to the longest common prefix (like shell behavior)
+			auto &first = completions[0].completion;
+			idx_t common_len = first.size();
+			for (idx_t i = 1; i < completions.size(); i++) {
+				auto &other = completions[i].completion;
+				idx_t min_len = MinValue<idx_t>(common_len, other.size());
+				idx_t j;
+				for (j = 0; j < min_len; j++) {
+					if (first[j] != other[j]) {
+						break;
+					}
+				}
+				common_len = j;
+			}
+			if (common_len > (idx_t)len) {
+				// there is a common prefix longer than the current input - apply it
+				int nwritten = snprintf(buf, buflen, "%.*s", (int)common_len, first.c_str());
+				pos = nwritten;
+				len = nwritten;
+			}
 			completion_idx = optional_idx();
 			render_completion_suggestion = true;
 		} else {


### PR DESCRIPTION
Currently when tab completing, if there are conflicts, we skip tab completion entirely. For example:

```
data/csv/issue_8320_1.csv.gz
data/csv/issue_8320_2.csv.gz
data/csv/issue_8320_3.csv.gz
```

```sql
SELECT * FROM 'data/csv/issue_8[TAB]
```

This would result in displaying the three files, but not doing any completion, ending in this state:

```sql
memory D SELECT * FROM 'data/csv/issue_8
issue_8320_1.csv.gz' issue_8320_2.csv.gz' issue_8320_3.csv.gz'
```


Shells will instead auto-complete until the first ambiguous character, i.e. they auto-complete to `data/csv/issue_8320_`. This is nice because we can then disambiguate with a single character press. This PR makes our auto-complete behave like that, i.e. we end up in this state:

```sql
memory D SELECT * FROM 'data/csv/issue_8320_
issue_8320_1.csv.gz' issue_8320_2.csv.gz' issue_8320_3.csv.gz'
```
