### PR TITLE
Rename `VectorValueIterator` to `VectorIterator`, add assert when `GetValue()` is used on a value that is `NULL`, and add `GetValueUnsafe()`

### DIFF
--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -44,7 +44,7 @@ void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t
 		for (idx_t i = 0; i < count; i++) {
 			auto left_entry = left_data[i];
 			auto right_entry = right_data[i];
-			bool is_null = OP::Operation(left_entry.GetValue() > 0, right_entry.GetValue() > 0, !left_entry.IsValid(),
+			bool is_null = OP::Operation(left_entry.GetValueUnsafe() > 0, right_entry.GetValueUnsafe() > 0, !left_entry.IsValid(),
 			                             !right_entry.IsValid(), result_data[i]);
 			if (is_null) {
 				result_data.SetInvalid(i);

--- a/src/common/vector_operations/boolean_operators.cpp
+++ b/src/common/vector_operations/boolean_operators.cpp
@@ -44,8 +44,8 @@ void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t
 		for (idx_t i = 0; i < count; i++) {
 			auto left_entry = left_data[i];
 			auto right_entry = right_data[i];
-			bool is_null = OP::Operation(left_entry.GetValueUnsafe() > 0, right_entry.GetValueUnsafe() > 0, !left_entry.IsValid(),
-			                             !right_entry.IsValid(), result_data[i]);
+			bool is_null = OP::Operation(left_entry.GetValueUnsafe() > 0, right_entry.GetValueUnsafe() > 0,
+			                             !left_entry.IsValid(), !right_entry.IsValid(), result_data[i]);
 			if (is_null) {
 				result_data.SetInvalid(i);
 			}

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -12,7 +12,7 @@ void VectorOperations::DistinctFrom(Vector &left, Vector &right, Vector &result,
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::Writer<bool>(result);
 	for (idx_t i = 0; i < count; i++) {
-		result_data[i] = cmp_data[i].GetValue() != 0;
+		result_data[i] = cmp_data[i].GetValueUnsafe() != 0;
 	}
 }
 
@@ -24,7 +24,7 @@ void VectorOperations::NotDistinctFrom(Vector &left, Vector &right, Vector &resu
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::Writer<bool>(result);
 	for (idx_t i = 0; i < count; i++) {
-		result_data[i] = cmp_data[i].GetValue() == 0;
+		result_data[i] = cmp_data[i].GetValueUnsafe() == 0;
 	}
 }
 
@@ -40,7 +40,7 @@ static idx_t DistinctComparatorSelect(Vector &left, Vector &right, optional_ptr<
 	idx_t false_count = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto result_idx = sel ? sel->get_index(i) : i;
-		if (predicate(cmp_data[i].GetValue())) {
+		if (predicate(cmp_data[i].GetValueUnsafe())) {
 			if (true_sel) {
 				true_sel->set_index(true_count, result_idx);
 			}

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -548,7 +548,7 @@ struct SortedAggregateFunction {
 
 		vector<idx_t> state_unprocessed(count, 0);
 		for (idx_t i = 0; i < count; ++i) {
-			state_unprocessed[i] = sdata[i].GetValue()->count;
+			state_unprocessed[i] = sdata[i].GetValueUnsafe()->count;
 		}
 
 		ThreadContext thread(client);
@@ -566,7 +566,7 @@ struct SortedAggregateFunction {
 		idx_t sorted = 0;
 		for (idx_t finalized = 0; finalized < count;) {
 			if (unsorted_count < order_bind.threshold) {
-				auto state = sdata[finalized].GetValue();
+				auto state = sdata[finalized].GetValueUnsafe();
 				prefixed.Reset();
 				prefixed.data[0].Reference(Value::USMALLINT(UnsafeNumericCast<uint16_t>(finalized)));
 				OperatorSinkInput sink {*global_sink, *local_sink, interrupt};

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -580,7 +580,7 @@ static void FlattenRunEnds(Vector &result, ArrowRunEndEncodingState &run_end_enc
 			auto run_end_entry = run_ends_data[run];
 			auto value_entry = values_data[run];
 			auto &value = value_entry.GetValue();
-			auto run_end = static_cast<idx_t>(run_end_entry.GetValue());
+			auto run_end = static_cast<idx_t>(run_end_entry.GetValueUnsafe());
 
 			D_ASSERT(run_end > (logical_index + index));
 			auto to_scan = run_end - (logical_index + index);
@@ -603,7 +603,7 @@ static void FlattenRunEnds(Vector &result, ArrowRunEndEncodingState &run_end_enc
 		for (; run < compressed_size; ++run) {
 			auto run_end_entry = run_ends_data[run];
 			auto value_entry = values_data[run];
-			auto run_end = static_cast<idx_t>(run_end_entry.GetValue());
+			auto run_end = static_cast<idx_t>(run_end_entry.GetValueUnsafe());
 
 			D_ASSERT(run_end > (logical_index + index));
 			auto to_scan = run_end - (logical_index + index);

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -531,7 +531,7 @@ static void IntervalConversionMonthDayNanos(Vector &vector, ArrowArray &array, i
 // Find the index of the first run-end that is strictly greater than the offset.
 // count is returned if no such run-end is found.
 template <class RUN_END_TYPE>
-static idx_t FindRunIndex(const VectorValueIterator<RUN_END_TYPE> &run_ends, idx_t count, idx_t offset) {
+static idx_t FindRunIndex(const VectorIterator<RUN_END_TYPE> &run_ends, idx_t count, idx_t offset) {
 	// Binary-search within the [0, count) range. For example:
 	// [0, 0, 0, 1, 1, 2] encoded as
 	// run_ends: [3, 5, 6]:

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -454,20 +454,20 @@ void WindowDistinctAggregatorLocalState::Sorted() {
 		                   //	10:		prevIdcs[i] ← sorted[i-1].second
 		                   for (idx_t j = 0; j < nmatch; ++j) {
 			                   auto scan_idx = matching.get_index(j);
-			                   auto i = input_idx[scan_idx].GetValue();
-			                   auto second = scan_idx ? input_idx[scan_idx - 1].GetValue() : prev_i;
+			                   auto i = input_idx[scan_idx].GetValueUnsafe();
+			                   auto second = scan_idx ? input_idx[scan_idx - 1].GetValueUnsafe() : prev_i;
 			                   prev_idcs[i] = ZippedTuple(second + 1, i);
 		                   }
 		                   //	11:	else
 		                   //	12:		prevIdcs[i] ← “-”
 		                   for (idx_t j = 0; j < ndistinct; ++j) {
 			                   auto scan_idx = distinct.get_index(j);
-			                   auto i = input_idx[scan_idx].GetValue();
+			                   auto i = input_idx[scan_idx].GetValueUnsafe();
 			                   prev_idcs[i] = ZippedTuple(0, i);
 		                   }
 
 		                   //	Remember the last input_idx of this chunk.
-		                   prev_i = input_idx[count - 1].GetValue();
+		                   prev_i = input_idx[count - 1].GetValueUnsafe();
 	                   });
 
 	//	13:	return prevIdcs

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -24,7 +24,7 @@ struct SelCache;
 enum class VectorConstructorAction;
 
 template <class T>
-class VectorValueIterator;
+class VectorIterator;
 template <class T>
 class VectorValidValueIterator;
 class VectorValidityIterator;
@@ -190,7 +190,7 @@ public:
 	static void DebugShuffleNestedVector(Vector &vector, idx_t count);
 
 	template <class T>
-	VectorValueIterator<T> Values(idx_t count) const;
+	VectorIterator<T> Values(idx_t count) const;
 
 	template <class T>
 	VectorValidValueIterator<T> ValidValues(idx_t count) const;

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -49,6 +49,7 @@ public:
 		}
 
 		const T &GetValue() const {
+			D_ASSERT(IsValid());
 			return data[sel_index];
 		}
 		bool IsValid() const {

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -34,22 +34,27 @@ private:
 };
 
 template <class T>
-class VectorValueIterator {
+class VectorIterator {
 public:
-	VectorValueIterator(const Vector &vector, idx_t count) : count(count) {
+	VectorIterator(const Vector &vector, idx_t count) : count(count) {
 		vector.ToUnifiedFormat(count, format);
 		data = UnifiedVectorFormat::GetData<T>(format);
 	}
 
 public:
-	struct VectorValueEntry {
-		VectorValueEntry(const UnifiedVectorFormat &format, const T *data, idx_t index)
+	struct ValueEntry {
+		ValueEntry(const UnifiedVectorFormat &format, const T *data, idx_t index)
 		    : format(format), data(data), index(index) {
 			sel_index = format.sel->get_index(index);
 		}
 
+		//! Return the data - the value must be valid
 		const T &GetValue() const {
 			D_ASSERT(IsValid());
+			return GetValueUnsafe();
+		}
+		//! Return the underlying data. If the data is not valid then uninitialized memory is returned.
+		const T &GetValueUnsafe() const {
 			return data[sel_index];
 		}
 		bool IsValid() const {
@@ -67,71 +72,71 @@ public:
 	};
 
 private:
-	class VectorIterator {
+	class Iterator {
 	public:
-		explicit VectorIterator(UnifiedVectorFormat &format, const T *data, idx_t index)
+		explicit Iterator(UnifiedVectorFormat &format, const T *data, idx_t index)
 		    : format(format), data(data), index(index) {
 		}
 
 	public:
-		VectorIterator &operator++() { // NOLINT: match stl API
+		Iterator &operator++() { // NOLINT: match stl API
 			++index;
 			return *this;
 		}
-		VectorIterator operator++(int) { // NOLINT: match stl API
+		Iterator operator++(int) { // NOLINT: match stl API
 			auto tmp = *this;
 			++index;
 			return tmp;
 		}
-		VectorIterator &operator--() { // NOLINT: match stl API
+		Iterator &operator--() { // NOLINT: match stl API
 			--index;
 			return *this;
 		}
-		VectorIterator &operator+=(idx_t n) {
+		Iterator &operator+=(idx_t n) {
 			index += n;
 			return *this;
 		}
-		VectorIterator &operator-=(idx_t n) {
+		Iterator &operator-=(idx_t n) {
 			index -= n;
 			return *this;
 		}
-		VectorIterator operator+(idx_t n) const {
-			return VectorIterator(format, data, index + n);
+		Iterator operator+(idx_t n) const {
+			return Iterator(format, data, index + n);
 		}
-		VectorIterator operator-(idx_t n) const {
-			return VectorIterator(format, data, index - n);
+		Iterator operator-(idx_t n) const {
+			return Iterator(format, data, index - n);
 		}
-		int64_t operator-(const VectorIterator &other) const {
+		int64_t operator-(const Iterator &other) const {
 			return static_cast<int64_t>(index) - static_cast<int64_t>(other.index);
 		}
-		bool operator==(const VectorIterator &other) const {
+		bool operator==(const Iterator &other) const {
 			return index == other.index;
 		}
-		bool operator!=(const VectorIterator &other) const {
+		bool operator!=(const Iterator &other) const {
 			return index != other.index;
 		}
-		bool operator<(const VectorIterator &other) const {
+		bool operator<(const Iterator &other) const {
 			return index < other.index;
 		}
-		bool operator<=(const VectorIterator &other) const {
+		bool operator<=(const Iterator &other) const {
 			return index <= other.index;
 		}
-		bool operator>(const VectorIterator &other) const {
+		bool operator>(const Iterator &other) const {
 			return index > other.index;
 		}
-		bool operator>=(const VectorIterator &other) const {
+		bool operator>=(const Iterator &other) const {
 			return index >= other.index;
 		}
-		VectorValueEntry operator*() const {
+		ValueEntry operator*() const {
 			return GetEntry(index);
 		}
-		VectorValueEntry operator[](idx_t n) const {
+		ValueEntry operator[](idx_t n) const {
 			return GetEntry(index + n);
 		}
 
 	private:
-		VectorValueEntry GetEntry(idx_t i) const {
-			return VectorValueEntry(format, data, i);
+		ValueEntry GetEntry(idx_t i) const {
+			return ValueEntry(format, data, i);
 		}
 
 	private:
@@ -141,17 +146,17 @@ private:
 	};
 
 public:
-	VectorIterator begin() { // NOLINT: match stl API
-		return VectorIterator(format, data, 0);
+	Iterator begin() { // NOLINT: match stl API
+		return Iterator(format, data, 0);
 	}
-	VectorIterator end() { // NOLINT: match stl API
-		return VectorIterator(format, data, count);
+	Iterator end() { // NOLINT: match stl API
+		return Iterator(format, data, count);
 	}
 	idx_t size() const {
 		return count;
 	}
-	VectorValueEntry operator[](idx_t i) const {
-		return VectorValueEntry(format, data, i);
+	ValueEntry operator[](idx_t i) const {
+		return ValueEntry(format, data, i);
 	}
 	//! Returns the value at the specified location without checking the NULL mask
 	T GetValueUnsafe(idx_t i) const {
@@ -265,8 +270,8 @@ private:
 };
 
 template <class T>
-inline VectorValueIterator<T> Vector::Values(idx_t count) const {
-	return VectorValueIterator<T>(*this, count);
+inline VectorIterator<T> Vector::Values(idx_t count) const {
+	return VectorIterator<T>(*this, count);
 }
 
 template <class T>

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -389,7 +389,7 @@ public:
 		auto tdata = target.Values<STATE_TYPE *>(count);
 
 		for (idx_t i = 0; i < count; i++) {
-			OP::template Combine<STATE_TYPE, OP>(*sdata[i].GetValue(), *tdata[i].GetValue(), aggr_input_data);
+			OP::template Combine<STATE_TYPE, OP>(*sdata[i].GetValueUnsafe(), *tdata[i].GetValueUnsafe(), aggr_input_data);
 		}
 	}
 
@@ -504,7 +504,7 @@ public:
 		auto sdata = states.Values<STATE_TYPE *>(count);
 		;
 		for (idx_t i = 0; i < count; i++) {
-			OP::template Destroy<STATE_TYPE>(*sdata[i].GetValue(), aggr_input_data);
+			OP::template Destroy<STATE_TYPE>(*sdata[i].GetValueUnsafe(), aggr_input_data);
 		}
 	}
 };

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -389,7 +389,8 @@ public:
 		auto tdata = target.Values<STATE_TYPE *>(count);
 
 		for (idx_t i = 0; i < count; i++) {
-			OP::template Combine<STATE_TYPE, OP>(*sdata[i].GetValueUnsafe(), *tdata[i].GetValueUnsafe(), aggr_input_data);
+			OP::template Combine<STATE_TYPE, OP>(*sdata[i].GetValueUnsafe(), *tdata[i].GetValueUnsafe(),
+			                                     aggr_input_data);
 		}
 	}
 

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -489,7 +489,7 @@ public:
 	}
 
 	void Append(Vector &input, idx_t count) {
-		for(auto entry : input.Values<T>(count)) {
+		for (auto entry : input.Values<T>(count)) {
 			state.template Update<BitpackingWriter>(entry);
 		}
 	}

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -270,7 +270,8 @@ public:
 	}
 
 	template <class OP = EmptyBitpackingWriter>
-	bool Update(T value, bool is_valid) {
+	bool Update(typename VectorIterator<T>::ValueEntry val) {
+		auto is_valid = val.IsValid();
 		compression_buffer_validity[compression_buffer_idx] = is_valid;
 		has_valid = has_valid || is_valid;
 		has_invalid = has_invalid || !is_valid;
@@ -278,6 +279,7 @@ public:
 		all_invalid = all_invalid && !is_valid;
 
 		if (is_valid) {
+			auto value = val.GetValue();
 			compression_buffer[compression_buffer_idx] = value;
 			minimum = MinValue<T>(minimum, value);
 			maximum = MaxValue<T>(maximum, value);
@@ -324,7 +326,7 @@ bool BitpackingAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 
 	auto &analyze_state = state.Cast<BitpackingAnalyzeState<T>>();
 	for (auto entry : input.Values<T>(count)) {
-		if (!analyze_state.state.template Update<EmptyBitpackingWriter>(entry.GetValue(), entry.IsValid())) {
+		if (!analyze_state.state.template Update<EmptyBitpackingWriter>(entry)) {
 			return false;
 		}
 	}
@@ -486,13 +488,9 @@ public:
 		metadata_ptr = handle.Ptr() + info.GetBlockSize();
 	}
 
-	void Append(UnifiedVectorFormat &vdata, idx_t count) {
-		auto data = UnifiedVectorFormat::GetData<T>(vdata);
-
-		for (idx_t i = 0; i < count; i++) {
-			idx_t idx = vdata.sel->get_index(i);
-			state.template Update<BitpackingCompressionState<T, WRITE_STATISTICS, T_S>::BitpackingWriter>(
-			    data[idx], vdata.validity.RowIsValid(idx));
+	void Append(Vector &input, idx_t count) {
+		for(auto entry : input.Values<T>(count)) {
+			state.template Update<BitpackingWriter>(entry);
 		}
 	}
 
@@ -547,9 +545,7 @@ unique_ptr<CompressionState> BitpackingInitCompression(ColumnDataCheckpointData 
 template <class T, bool WRITE_STATISTICS>
 void BitpackingCompress(CompressionState &state_p, Vector &scan_vector, idx_t count) {
 	auto &state = state_p.Cast<BitpackingCompressionState<T, WRITE_STATISTICS>>();
-	UnifiedVectorFormat vdata;
-	scan_vector.ToUnifiedFormat(count, vdata);
-	state.Append(vdata, count);
+	state.Append(scan_vector, count);
 }
 
 template <class T, bool WRITE_STATISTICS>

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -109,14 +109,14 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	validity->ScanCount(state.child_states[0], result, count);
 
 	auto data = offset_vector.Values<uint64_t>(scan_count);
-	auto last_entry = data[scan_count - 1].GetValue();
+	auto last_entry = data[scan_count - 1].GetValueUnsafe();
 
 	// shift all offsets so they are 0 at the first entry
 	auto result_data = FlatVector::Writer<list_entry_t>(result, scan_count);
 	auto base_offset = state.last_offset;
 	idx_t current_offset = 0;
 	for (idx_t i = 0; i < scan_count; i++) {
-		auto offset = data[i].GetValue();
+		auto offset = data[i].GetValueUnsafe();
 		result_data[i].offset = current_offset;
 		result_data[i].length = offset - current_offset - base_offset;
 		current_offset += result_data[i].length;


### PR DESCRIPTION
Several vector iterator improvements: we should be careful with using `GetValue()` on a value that is `NULL` since we will be accessing uninitialized memory. In some situations that is not a problem, but it can lead to issues. This PR adds an assertion so this situation is flagged, and adds an alternative method `GetValueUnsafe()` that skips this check. 