### PR TITLE
Use TrySubtract in external file cache timestamp computation

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -41,9 +41,13 @@ timestamp_t timestamp_t::operator+(const double &value) const {
 	return result;
 }
 
+bool timestamp_t::TrySubtract(const timestamp_t &other, int64_t &result) const {
+	return TrySubtractOperator::Operation(value, int64_t(other.value), result);
+}
+
 int64_t timestamp_t::operator-(const timestamp_t &other) const {
 	int64_t result;
-	if (!TrySubtractOperator::Operation(value, int64_t(other.value), result)) {
+	if (!TrySubtract(other, result)) {
 		throw OutOfRangeException("Overflow in timestamp subtraction");
 	}
 	return result;

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -65,6 +65,8 @@ struct timestamp_t { // NOLINT
 	timestamp_t operator+(const double &value) const;
 	int64_t operator-(const timestamp_t &other) const;
 
+	bool TrySubtract(const timestamp_t &other, int64_t &result) const;
+
 	// in-place operators
 	timestamp_t &operator+=(const int64_t &delta);
 	timestamp_t &operator-=(const int64_t &delta);

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -49,6 +49,11 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	if (access_time < current_last_modified) {
 		return false; // Last modified in the future?
 	}
+	int64_t last_modified_time;
+	if (!access_time.TrySubtract(current_last_modified, last_modified_time)) {
+		// ouf ot range
+		return false;
+	}
 	return access_time - current_last_modified > LAST_MODIFIED_THRESHOLD;
 }
 

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -54,7 +54,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 		// ouf ot range
 		return false;
 	}
-	return access_time - current_last_modified > LAST_MODIFIED_THRESHOLD;
+	return last_modified_time > LAST_MODIFIED_THRESHOLD;
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/21681

This fixes a sporadic issue where we would run into `Out of Range Error: Overflow in timestamp subtraction` for certain HTTPFS requests.