### PR TITLE
feat: GeoParquet 1.1 write support and read-side row group pruning

### DIFF
--- a/extension/parquet/include/parquet_geometry.hpp
+++ b/extension/parquet/include/parquet_geometry.hpp
@@ -93,6 +93,9 @@ struct GeoParquetColumnMetadata {
 	// The crs of the geometry column (if any) in PROJJSON format
 	string projjson;
 
+	// Name of the bbox struct column used for GeoParquet 1.1 covering (empty = no covering)
+	string bbox_column_name;
+
 	// Used to track the "primary" geometry column (if any)
 	idx_t insertion_index = 0;
 
@@ -119,11 +122,17 @@ public:
 
 	bool IsGeometryColumn(const string &column_name) const;
 
+	// Register a bbox struct column name as the covering source for a geometry column.
+	// Must be called before Write(). Safe to call before AddGeoParquetStats().
+	void RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name);
+
 	static bool IsGeoParquetConversionEnabled(const ClientContext &context);
 
 private:
 	mutex write_lock;
 	unordered_map<string, GeoParquetColumnMetadata> geometry_columns;
+	// Pending bbox column registrations (geom_col -> bbox_col) set before AddGeoParquetStats runs
+	unordered_map<string, string> pending_bbox_columns;
 	GeoParquetVersion version;
 };
 

--- a/extension/parquet/include/parquet_geometry.hpp
+++ b/extension/parquet/include/parquet_geometry.hpp
@@ -56,6 +56,13 @@ enum class GeoParquetVersion : uint8_t {
 	// GeoParquet 1.0 has the widest support among readers and writers
 	V1,
 
+	// Write GeoParquet 1.1 metadata
+	// Identical to V1 (WKB encoding) but writes "1.1.0" as the version string.
+	// GeoParquet 1.1 is the current stable specification, required by modern tools
+	// (GDAL 3.9+, geopandas 1.0+, gpq). The optional 'covering' bbox struct column
+	// introduced in 1.1 is not yet written; this is a separate enhancement.
+	V1_1,
+
 	// Write GeoParquet 2.0
 	// The GeoParquet 2.0 options is identical to GeoParquet 1.0 except the underlying storage
 	// of spatial columns is Parquet native geometry, where the Parquet writer will include

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -225,6 +225,7 @@ public:
 	uint32_t WriteData(const const_data_ptr_t buffer, const uint32_t buffer_size);
 
 	GeoParquetFileMetadata &GetGeoParquetData();
+	void RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name);
 
 	static bool TryGetParquetType(const LogicalType &duckdb_type,
 	                              optional_ptr<duckdb_parquet::Type::type> type = nullptr,

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -267,6 +267,7 @@ public:
 	uint32_t WriteData(unique_ptr<AsyncWriteBuffer> buffer);
 
 	GeoParquetFileMetadata &GetGeoParquetData();
+	void RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name);
 
 	static bool TryGetParquetType(const LogicalType &duckdb_type,
 	                              optional_ptr<duckdb_parquet::Type::type> type = nullptr,

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -477,7 +477,7 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 			}
 			continue;
 		}
-		GeometryExtent extent;
+		GeometryExtent extent = GeometryExtent::Empty();
 		bool has_empty = false;
 		Geometry::GetExtent(geom_values[geom_idx], extent, has_empty);
 		if (extent.HasXY()) {
@@ -861,13 +861,39 @@ struct ParquetWriteBatchData : public PreparedBatchData {
 	PreparedRowGroup prepared_row_group;
 };
 
-static unique_ptr<PreparedBatchData> ParquetWritePrepareBatch(ClientContext &context, FunctionData &bind_data,
+static unique_ptr<PreparedBatchData> ParquetWritePrepareBatch(ClientContext &context, FunctionData &bind_data_p,
                                                               GlobalFunctionData &gstate,
                                                               unique_ptr<ColumnDataCollection> collection) {
+	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto result = make_uniq<ParquetWriteBatchData>();
 	unique_ptr<ParquetWriteTransformData> transform_data;
-	global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group, transform_data);
+
+	// In batch execution mode, ParquetWriteSink is not called, so bbox columns must be injected here.
+	if (!bind_data.geo_bbox_infos.empty()) {
+		auto augmented = make_uniq<ColumnDataCollection>(context, bind_data.sql_types);
+		ColumnDataAppendState append_state;
+		augmented->InitializeAppend(append_state);
+		for (auto &input_chunk : collection->Chunks()) {
+			// Allocate a fresh chunk for each batch to ensure struct child buffers are clean.
+			DataChunk chunk;
+			chunk.Initialize(Allocator::DefaultAllocator(), bind_data.sql_types, input_chunk.size());
+			// Reference original columns (zero-copy)
+			for (idx_t i = 0; i < input_chunk.ColumnCount(); i++) {
+				chunk.data[i].Reference(input_chunk.data[i]);
+			}
+			// Compute bbox struct columns
+			for (const auto &info : bind_data.geo_bbox_infos) {
+				ComputeBBoxColumn(input_chunk.data[info.geom_col_idx], chunk.data[info.bbox_col_idx],
+				                  input_chunk.size());
+			}
+			chunk.SetCardinality(input_chunk.size());
+			augmented->Append(append_state, chunk);
+		}
+		global_state.writer->PrepareRowGroup(*augmented, result->prepared_row_group, transform_data);
+	} else {
+		global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group, transform_data);
+	}
 	return std::move(result);
 }
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -10,6 +10,9 @@
 
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "parquet_geometry.hpp"
+#include "duckdb/common/types/geometry.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "parquet_crypto.hpp"
 #include "parquet_metadata.hpp"
 #include "parquet_writer.hpp"
@@ -76,9 +79,20 @@ class ClientContext;
 class DataChunk;
 class PhysicalOperator;
 
+struct GeoBBoxInfo {
+	idx_t geom_col_idx;   // index in the original input schema
+	idx_t bbox_col_idx;   // index in the augmented output schema
+	string geom_col_name; // geometry column name (for geo metadata registration)
+	string bbox_col_name; // injected bbox struct column name
+};
+
 struct ParquetWriteBindData : public TableFunctionData {
 	vector<LogicalType> sql_types;
 	vector<string> column_names;
+	// Bbox columns auto-injected for GeoParquet 1.1 covering (empty for other versions)
+	vector<GeoBBoxInfo> geo_bbox_infos;
+	// Geometry->bbox column pairs where the bbox column already exists in the input schema
+	vector<pair<string, string>> existing_bbox_coverings;
 	duckdb_parquet::CompressionCodec::type codec = duckdb_parquet::CompressionCodec::SNAPPY;
 	vector<pair<string, string>> kv_metadata;
 	idx_t row_group_size = DEFAULT_ROW_GROUP_SIZE;
@@ -350,6 +364,51 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 
 	bind_data->sql_types = sql_types;
 	bind_data->column_names = names;
+
+	// For GeoParquet 1.1, auto-inject a per-row bbox struct column for each geometry column.
+	// The bbox column enables the 'covering' metadata field, which accelerates spatial queries.
+	if (bind_data->geoparquet_version == GeoParquetVersion::V1_1) {
+		idx_t geom_count = 0;
+		for (auto &t : sql_types) {
+			if (t.id() == LogicalTypeId::GEOMETRY) {
+				geom_count++;
+			}
+		}
+		for (idx_t i = 0; i < sql_types.size(); i++) {
+			if (sql_types[i].id() != LogicalTypeId::GEOMETRY) {
+				continue;
+			}
+			// Naming: "bbox" for single-geometry files, "{col_name}_bbox" for multi-geometry
+			string bbox_col_name = (geom_count == 1) ? "bbox" : (names[i] + "_bbox");
+			// Skip if the user already provided a column with this name
+			bool already_present = false;
+			for (const auto &n : names) {
+				if (StringUtil::CIEquals(n, bbox_col_name)) {
+					already_present = true;
+					break;
+				}
+			}
+			if (already_present) {
+				// bbox column is already in the schema: register covering without injecting a new column
+				bind_data->existing_bbox_coverings.emplace_back(names[i], bbox_col_name);
+				continue;
+			}
+			GeoBBoxInfo info;
+			info.geom_col_idx = i;
+			info.bbox_col_idx = bind_data->sql_types.size();
+			info.geom_col_name = names[i];
+			info.bbox_col_name = bbox_col_name;
+			bind_data->geo_bbox_infos.push_back(info);
+
+			child_list_t<LogicalType> bbox_children = {{"xmin", LogicalType::FLOAT},
+			                                           {"ymin", LogicalType::FLOAT},
+			                                           {"xmax", LogicalType::FLOAT},
+			                                           {"ymax", LogicalType::FLOAT}};
+			bind_data->sql_types.push_back(LogicalType::STRUCT(std::move(bbox_children)));
+			bind_data->column_names.push_back(bbox_col_name);
+		}
+	}
+
 	return std::move(bind_data);
 }
 
@@ -367,6 +426,15 @@ static unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext
 	    parquet_bind.bloom_filter_false_positive_ratio, parquet_bind.compression_level, parquet_bind.parquet_version,
 	    parquet_bind.geoparquet_version, parquet_bind.write_timestamp_as_int96,
 	    parquet_bind.timestamp_is_adjusted_to_utc);
+
+	// Register bbox covering columns with the geo metadata writer
+	for (const auto &info : parquet_bind.geo_bbox_infos) {
+		global_state->writer->RegisterBBoxCovering(info.geom_col_name, info.bbox_col_name);
+	}
+	// Register pre-existing bbox columns (already in the input schema, no injection needed)
+	for (const auto &pair : parquet_bind.existing_bbox_coverings) {
+		global_state->writer->RegisterBBoxCovering(pair.first, pair.second);
+	}
 	return std::move(global_state);
 }
 
@@ -376,14 +444,81 @@ static void ParquetWriteGetWrittenStatistics(ClientContext &context, FunctionDat
 	global_state.writer->SetWrittenStatistics(statistics);
 }
 
+// Compute per-row bounding boxes from a WKB geometry column and write them into
+// a pre-allocated STRUCT(xmin FLOAT, ymin FLOAT, xmax FLOAT, ymax FLOAT) vector.
+static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
+	UnifiedVectorFormat geom_udata;
+	geom_col.ToUnifiedFormat(count, geom_udata);
+	const auto *geom_values = UnifiedVectorFormat::GetData<string_t>(geom_udata);
+
+	bbox_col.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &struct_entries = StructVector::GetEntries(bbox_col);
+	D_ASSERT(struct_entries.size() == 4);
+	for (auto &child : struct_entries) {
+		child.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	auto *xmin_data = FlatVector::GetData<float>(struct_entries[0]);
+	auto *ymin_data = FlatVector::GetData<float>(struct_entries[1]);
+	auto *xmax_data = FlatVector::GetData<float>(struct_entries[2]);
+	auto *ymax_data = FlatVector::GetData<float>(struct_entries[3]);
+
+	auto &struct_validity = FlatVector::Validity(bbox_col);
+	// Propagate struct validity into children too
+	for (auto &child : struct_entries) {
+		FlatVector::Validity(child).Initialize(count);
+	}
+
+	for (idx_t i = 0; i < count; i++) {
+		auto geom_idx = geom_udata.sel->get_index(i);
+		if (!geom_udata.validity.RowIsValid(geom_idx)) {
+			struct_validity.SetInvalid(i);
+			for (auto &child : struct_entries) {
+				FlatVector::Validity(child).SetInvalid(i);
+			}
+			continue;
+		}
+		GeometryExtent extent;
+		bool has_empty = false;
+		Geometry::GetExtent(geom_values[geom_idx], extent, has_empty);
+		if (extent.HasXY()) {
+			xmin_data[i] = static_cast<float>(extent.x_min);
+			ymin_data[i] = static_cast<float>(extent.y_min);
+			xmax_data[i] = static_cast<float>(extent.x_max);
+			ymax_data[i] = static_cast<float>(extent.y_max);
+		} else {
+			struct_validity.SetInvalid(i);
+			for (auto &child : struct_entries) {
+				FlatVector::Validity(child).SetInvalid(i);
+			}
+		}
+	}
+}
+
 static void ParquetWriteSink(ExecutionContext &context, FunctionData &bind_data_p, GlobalFunctionData &gstate,
                              LocalFunctionData &lstate, DataChunk &input) {
 	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto &local_state = lstate.Cast<ParquetWriteLocalState>();
 
-	// append data to the local (buffered) chunk collection
-	local_state.buffer.Append(local_state.append_state, input);
+	if (!bind_data.geo_bbox_infos.empty()) {
+		// Augment the input chunk with auto-computed bbox struct columns.
+		// Use Initialize (not InitializeEmpty) to ensure struct child buffers are allocated.
+		DataChunk augmented;
+		augmented.Initialize(Allocator::DefaultAllocator(), bind_data.sql_types, input.size());
+		// Reference all original columns (zero-copy, replaces the pre-allocated flat vectors)
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			augmented.data[i].Reference(input.data[i]);
+		}
+		// Compute bbox for each geometry column into the pre-allocated struct columns
+		for (const auto &info : bind_data.geo_bbox_infos) {
+			ComputeBBoxColumn(input.data[info.geom_col_idx], augmented.data[info.bbox_col_idx], input.size());
+		}
+		augmented.SetCardinality(input.size());
+		local_state.buffer.Append(local_state.append_state, augmented);
+	} else {
+		// append data to the local (buffered) chunk collection
+		local_state.buffer.Append(local_state.append_state, input);
+	}
 
 	if (local_state.buffer.Count() >= bind_data.row_group_size ||
 	    local_state.buffer.SizeInBytes() >= bind_data.row_group_size_bytes) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -457,10 +457,10 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 	for (auto &child : struct_entries) {
 		child.SetVectorType(VectorType::FLAT_VECTOR);
 	}
-	auto *xmin_data = FlatVector::GetData<float>(struct_entries[0]);
-	auto *ymin_data = FlatVector::GetData<float>(struct_entries[1]);
-	auto *xmax_data = FlatVector::GetData<float>(struct_entries[2]);
-	auto *ymax_data = FlatVector::GetData<float>(struct_entries[3]);
+	auto *xmin_data = FlatVector::GetDataMutable<float>(struct_entries[0]);
+	auto *ymin_data = FlatVector::GetDataMutable<float>(struct_entries[1]);
+	auto *xmax_data = FlatVector::GetDataMutable<float>(struct_entries[2]);
+	auto *ymax_data = FlatVector::GetDataMutable<float>(struct_entries[3]);
 
 	auto &struct_validity = FlatVector::Validity(bbox_col);
 	// Propagate struct validity into children too

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -324,12 +324,14 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				bind_data->geoparquet_version = GeoParquetVersion::NONE;
 			} else if (roption == "V1") {
 				bind_data->geoparquet_version = GeoParquetVersion::V1;
+			} else if (roption == "V1_1") {
+				bind_data->geoparquet_version = GeoParquetVersion::V1_1;
 			} else if (roption == "V2") {
 				bind_data->geoparquet_version = GeoParquetVersion::V2;
 			} else if (roption == "BOTH") {
 				bind_data->geoparquet_version = GeoParquetVersion::BOTH;
 			} else {
-				throw BinderException("Expected geoparquet_version 'NONE', 'V1' or 'BOTH'");
+				throw BinderException("Expected geoparquet_version 'NONE', 'V1', 'V1_1', 'V2' or 'BOTH'");
 			}
 		} else if (loption == "write_timestamp_as_int96") {
 			bind_data->write_timestamp_as_int96 =
@@ -534,6 +536,8 @@ const char *EnumUtil::ToChars<GeoParquetVersion>(GeoParquetVersion value) {
 		return "NONE";
 	case GeoParquetVersion::V1:
 		return "V1";
+	case GeoParquetVersion::V1_1:
+		return "V1_1";
 	case GeoParquetVersion::V2:
 		return "V2";
 	case GeoParquetVersion::BOTH:
@@ -550,6 +554,9 @@ GeoParquetVersion EnumUtil::FromString<GeoParquetVersion>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "V1")) {
 		return GeoParquetVersion::V1;
+	}
+	if (StringUtil::Equals(value, "V1_1")) {
+		return GeoParquetVersion::V1_1;
 	}
 	if (StringUtil::Equals(value, "V2")) {
 		return GeoParquetVersion::V2;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -519,7 +519,7 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 			}
 			continue;
 		}
-		GeometryExtent extent;
+		GeometryExtent extent = GeometryExtent::Empty();
 		bool has_empty = false;
 		Geometry::GetExtent(geom_values[geom_idx], extent, has_empty);
 		if (extent.HasXY()) {
@@ -930,13 +930,39 @@ struct ParquetWriteBatchData : public PreparedBatchData {
 	PreparedRowGroup prepared_row_group;
 };
 
-static unique_ptr<PreparedBatchData> ParquetWritePrepareBatch(ClientContext &context, FunctionData &bind_data,
+static unique_ptr<PreparedBatchData> ParquetWritePrepareBatch(ClientContext &context, FunctionData &bind_data_p,
                                                               GlobalFunctionData &gstate,
                                                               unique_ptr<ColumnDataCollection> collection) {
+	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto result = make_uniq<ParquetWriteBatchData>();
 	unique_ptr<ParquetWriteTransformData> transform_data;
-	global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group, transform_data);
+
+	// In batch execution mode, ParquetWriteSink is not called, so bbox columns must be injected here.
+	if (!bind_data.geo_bbox_infos.empty()) {
+		auto augmented = make_uniq<ColumnDataCollection>(context, bind_data.sql_types);
+		ColumnDataAppendState append_state;
+		augmented->InitializeAppend(append_state);
+		for (auto &input_chunk : collection->Chunks()) {
+			// Allocate a fresh chunk for each batch to ensure struct child buffers are clean.
+			DataChunk chunk;
+			chunk.Initialize(Allocator::DefaultAllocator(), bind_data.sql_types, input_chunk.size());
+			// Reference original columns (zero-copy)
+			for (idx_t i = 0; i < input_chunk.ColumnCount(); i++) {
+				chunk.data[i].Reference(input_chunk.data[i]);
+			}
+			// Compute bbox struct columns
+			for (const auto &info : bind_data.geo_bbox_infos) {
+				ComputeBBoxColumn(input_chunk.data[info.geom_col_idx], chunk.data[info.bbox_col_idx],
+				                  input_chunk.size());
+			}
+			chunk.SetCardinality(input_chunk.size());
+			augmented->Append(append_state, chunk);
+		}
+		global_state.writer->PrepareRowGroup(*augmented, result->prepared_row_group, transform_data);
+	} else {
+		global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group, transform_data);
+	}
 	return std::move(result);
 }
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -10,6 +10,9 @@
 
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "parquet_geometry.hpp"
+#include "duckdb/common/types/geometry.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "parquet_crypto.hpp"
 #include "parquet_metadata.hpp"
 #include "parquet_writer.hpp"
@@ -87,9 +90,20 @@ class ClientContext;
 class DataChunk;
 class PhysicalOperator;
 
+struct GeoBBoxInfo {
+	idx_t geom_col_idx;   // index in the original input schema
+	idx_t bbox_col_idx;   // index in the augmented output schema
+	string geom_col_name; // geometry column name (for geo metadata registration)
+	string bbox_col_name; // injected bbox struct column name
+};
+
 struct ParquetWriteBindData : public TableFunctionData {
 	vector<LogicalType> sql_types;
 	vector<string> column_names;
+	// Bbox columns auto-injected for GeoParquet 1.1 covering (empty for other versions)
+	vector<GeoBBoxInfo> geo_bbox_infos;
+	// Geometry->bbox column pairs where the bbox column already exists in the input schema
+	vector<pair<string, string>> existing_bbox_coverings;
 	duckdb_parquet::CompressionCodec::type codec = duckdb_parquet::CompressionCodec::SNAPPY;
 	vector<pair<string, string>> kv_metadata;
 	idx_t row_group_size = DEFAULT_ROW_GROUP_SIZE;
@@ -366,6 +380,51 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 	bind_data->sql_types = sql_types;
 	bind_data->column_names = IdentifiersToStrings(names);
 
+	// For GeoParquet 1.1, auto-inject a per-row bbox struct column for each geometry column.
+	// The bbox column enables the 'covering' metadata field, which accelerates spatial queries.
+	if (bind_data->geoparquet_version == GeoParquetVersion::V1_1) {
+		idx_t geom_count = 0;
+		for (auto &t : sql_types) {
+			if (t.id() == LogicalTypeId::GEOMETRY) {
+				geom_count++;
+			}
+		}
+		for (idx_t i = 0; i < sql_types.size(); i++) {
+			if (sql_types[i].id() != LogicalTypeId::GEOMETRY) {
+				continue;
+			}
+			const auto &geom_col_name = names[i].GetIdentifierName();
+			// Naming: "bbox" for single-geometry files, "{col_name}_bbox" for multi-geometry
+			string bbox_col_name = (geom_count == 1) ? string("bbox") : (geom_col_name + "_bbox");
+			// Skip if the user already provided a column with this name
+			bool already_present = false;
+			for (const auto &n : names) {
+				if (StringUtil::CIEquals(n.GetIdentifierName(), bbox_col_name)) {
+					already_present = true;
+					break;
+				}
+			}
+			if (already_present) {
+				// bbox column is already in the schema: register covering without injecting a new column
+				bind_data->existing_bbox_coverings.emplace_back(geom_col_name, bbox_col_name);
+				continue;
+			}
+			GeoBBoxInfo info;
+			info.geom_col_idx = i;
+			info.bbox_col_idx = bind_data->sql_types.size();
+			info.geom_col_name = geom_col_name;
+			info.bbox_col_name = bbox_col_name;
+			bind_data->geo_bbox_infos.push_back(info);
+
+			child_list_t<LogicalType> bbox_children = {{"xmin", LogicalType::FLOAT},
+			                                           {"ymin", LogicalType::FLOAT},
+			                                           {"xmax", LogicalType::FLOAT},
+			                                           {"ymax", LogicalType::FLOAT}};
+			bind_data->sql_types.push_back(LogicalType::STRUCT(std::move(bbox_children)));
+			bind_data->column_names.push_back(bbox_col_name);
+		}
+	}
+
 	return std::move(bind_data);
 }
 
@@ -409,6 +468,15 @@ static unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext
 	options.not_null_columns = parquet_bind.not_null_columns;
 
 	global_state->writer = make_uniq<ParquetWriter>(context, fs, std::move(options), parquet_bind.kv_metadata);
+
+	// Register bbox covering columns with the geo metadata writer
+	for (const auto &info : parquet_bind.geo_bbox_infos) {
+		global_state->writer->RegisterBBoxCovering(info.geom_col_name, info.bbox_col_name);
+	}
+	// Register pre-existing bbox columns (already in the input schema, no injection needed)
+	for (const auto &pair : parquet_bind.existing_bbox_coverings) {
+		global_state->writer->RegisterBBoxCovering(pair.first, pair.second);
+	}
 	return std::move(global_state);
 }
 
@@ -418,14 +486,81 @@ static void ParquetWriteGetWrittenStatistics(ClientContext &context, FunctionDat
 	global_state.writer->SetWrittenStatistics(statistics);
 }
 
+// Compute per-row bounding boxes from a WKB geometry column and write them into
+// a pre-allocated STRUCT(xmin FLOAT, ymin FLOAT, xmax FLOAT, ymax FLOAT) vector.
+static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
+	UnifiedVectorFormat geom_udata;
+	geom_col.ToUnifiedFormat(count, geom_udata);
+	const auto *geom_values = UnifiedVectorFormat::GetData<string_t>(geom_udata);
+
+	bbox_col.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &struct_entries = StructVector::GetEntries(bbox_col);
+	D_ASSERT(struct_entries.size() == 4);
+	for (auto &child : struct_entries) {
+		child.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	auto *xmin_data = FlatVector::GetData<float>(struct_entries[0]);
+	auto *ymin_data = FlatVector::GetData<float>(struct_entries[1]);
+	auto *xmax_data = FlatVector::GetData<float>(struct_entries[2]);
+	auto *ymax_data = FlatVector::GetData<float>(struct_entries[3]);
+
+	auto &struct_validity = FlatVector::Validity(bbox_col);
+	// Propagate struct validity into children too
+	for (auto &child : struct_entries) {
+		FlatVector::Validity(child).Initialize(count);
+	}
+
+	for (idx_t i = 0; i < count; i++) {
+		auto geom_idx = geom_udata.sel->get_index(i);
+		if (!geom_udata.validity.RowIsValid(geom_idx)) {
+			struct_validity.SetInvalid(i);
+			for (auto &child : struct_entries) {
+				FlatVector::Validity(child).SetInvalid(i);
+			}
+			continue;
+		}
+		GeometryExtent extent;
+		bool has_empty = false;
+		Geometry::GetExtent(geom_values[geom_idx], extent, has_empty);
+		if (extent.HasXY()) {
+			xmin_data[i] = static_cast<float>(extent.x_min);
+			ymin_data[i] = static_cast<float>(extent.y_min);
+			xmax_data[i] = static_cast<float>(extent.x_max);
+			ymax_data[i] = static_cast<float>(extent.y_max);
+		} else {
+			struct_validity.SetInvalid(i);
+			for (auto &child : struct_entries) {
+				FlatVector::Validity(child).SetInvalid(i);
+			}
+		}
+	}
+}
+
 static void ParquetWriteSink(ExecutionContext &context, FunctionData &bind_data_p, GlobalFunctionData &gstate,
                              LocalFunctionData &lstate, DataChunk &input) {
 	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto &local_state = lstate.Cast<ParquetWriteLocalState>();
 
-	// append data to the local (buffered) chunk collection
-	local_state.buffer.Append(local_state.append_state, input);
+	if (!bind_data.geo_bbox_infos.empty()) {
+		// Augment the input chunk with auto-computed bbox struct columns.
+		// Use Initialize (not InitializeEmpty) to ensure struct child buffers are allocated.
+		DataChunk augmented;
+		augmented.Initialize(Allocator::DefaultAllocator(), bind_data.sql_types, input.size());
+		// Reference all original columns (zero-copy, replaces the pre-allocated flat vectors)
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			augmented.data[i].Reference(input.data[i]);
+		}
+		// Compute bbox for each geometry column into the pre-allocated struct columns
+		for (const auto &info : bind_data.geo_bbox_infos) {
+			ComputeBBoxColumn(input.data[info.geom_col_idx], augmented.data[info.bbox_col_idx], input.size());
+		}
+		augmented.SetCardinality(input.size());
+		local_state.buffer.Append(local_state.append_state, augmented);
+	} else {
+		// append data to the local (buffered) chunk collection
+		local_state.buffer.Append(local_state.append_state, input);
+	}
 
 	if (local_state.buffer.Count() >= bind_data.row_group_size ||
 	    local_state.buffer.SizeInBytes() >= bind_data.row_group_size_bytes) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -490,7 +490,7 @@ static void ParquetWriteGetWrittenStatistics(ClientContext &context, FunctionDat
 // a pre-allocated STRUCT(xmin FLOAT, ymin FLOAT, xmax FLOAT, ymax FLOAT) vector.
 static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 	UnifiedVectorFormat geom_udata;
-	geom_col.ToUnifiedFormat(count, geom_udata);
+	geom_col.ToUnifiedFormat(geom_udata);
 	const auto *geom_values = UnifiedVectorFormat::GetData<string_t>(geom_udata);
 
 	bbox_col.SetVectorType(VectorType::FLAT_VECTOR);
@@ -499,15 +499,15 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 	for (auto &child : struct_entries) {
 		child.SetVectorType(VectorType::FLAT_VECTOR);
 	}
-	auto *xmin_data = FlatVector::GetData<float>(struct_entries[0]);
-	auto *ymin_data = FlatVector::GetData<float>(struct_entries[1]);
-	auto *xmax_data = FlatVector::GetData<float>(struct_entries[2]);
-	auto *ymax_data = FlatVector::GetData<float>(struct_entries[3]);
+	auto *xmin_data = FlatVector::GetDataMutable<float>(struct_entries[0]);
+	auto *ymin_data = FlatVector::GetDataMutable<float>(struct_entries[1]);
+	auto *xmax_data = FlatVector::GetDataMutable<float>(struct_entries[2]);
+	auto *ymax_data = FlatVector::GetDataMutable<float>(struct_entries[3]);
 
-	auto &struct_validity = FlatVector::Validity(bbox_col);
+	auto &struct_validity = FlatVector::ValidityMutable(bbox_col);
 	// Propagate struct validity into children too
 	for (auto &child : struct_entries) {
-		FlatVector::Validity(child).Initialize(count);
+		FlatVector::ValidityMutable(child).Initialize(count);
 	}
 
 	for (idx_t i = 0; i < count; i++) {
@@ -515,7 +515,7 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 		if (!geom_udata.validity.RowIsValid(geom_idx)) {
 			struct_validity.SetInvalid(i);
 			for (auto &child : struct_entries) {
-				FlatVector::Validity(child).SetInvalid(i);
+				FlatVector::ValidityMutable(child).SetInvalid(i);
 			}
 			continue;
 		}
@@ -530,7 +530,7 @@ static void ComputeBBoxColumn(Vector &geom_col, Vector &bbox_col, idx_t count) {
 		} else {
 			struct_validity.SetInvalid(i);
 			for (auto &child : struct_entries) {
-				FlatVector::Validity(child).SetInvalid(i);
+				FlatVector::ValidityMutable(child).SetInvalid(i);
 			}
 		}
 	}

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -339,12 +339,14 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				bind_data->geoparquet_version = GeoParquetVersion::NONE;
 			} else if (roption == "V1") {
 				bind_data->geoparquet_version = GeoParquetVersion::V1;
+			} else if (roption == "V1_1") {
+				bind_data->geoparquet_version = GeoParquetVersion::V1_1;
 			} else if (roption == "V2") {
 				bind_data->geoparquet_version = GeoParquetVersion::V2;
 			} else if (roption == "BOTH") {
 				bind_data->geoparquet_version = GeoParquetVersion::BOTH;
 			} else {
-				throw BinderException("Expected geoparquet_version 'NONE', 'V1' or 'BOTH'");
+				throw BinderException("Expected geoparquet_version 'NONE', 'V1', 'V1_1', 'V2' or 'BOTH'");
 			}
 		} else if (loption == "write_timestamp_as_int96") {
 			bind_data->write_timestamp_as_int96 =
@@ -599,6 +601,8 @@ const char *EnumUtil::ToChars<GeoParquetVersion>(GeoParquetVersion value) {
 		return "NONE";
 	case GeoParquetVersion::V1:
 		return "V1";
+	case GeoParquetVersion::V1_1:
+		return "V1_1";
 	case GeoParquetVersion::V2:
 		return "V2";
 	case GeoParquetVersion::BOTH:
@@ -615,6 +619,9 @@ GeoParquetVersion EnumUtil::FromString<GeoParquetVersion>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "V1")) {
 		return GeoParquetVersion::V1;
+	}
+	if (StringUtil::Equals(value, "V1_1")) {
+		return GeoParquetVersion::V1_1;
 	}
 	if (StringUtil::Equals(value, "V2")) {
 		return GeoParquetVersion::V2;

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -150,7 +150,25 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 						}
 					}
 
-					// TODO: Parse the bounding box, other metadata that might be useful.
+					// Parse the covering field (GeoParquet 1.1+)
+					// covering.bbox maps each coordinate (xmin/ymin/xmax/ymax) to
+					// [column_name, field_name]. We only need the column name.
+					const auto covering_val = yyjson_obj_get(column_val, "covering");
+					if (covering_val && yyjson_is_obj(covering_val)) {
+						const auto bbox_covering = yyjson_obj_get(covering_val, "bbox");
+						if (bbox_covering && yyjson_is_obj(bbox_covering)) {
+							// All four coords reference the same column; read from xmin
+							const auto xmin_arr = yyjson_obj_get(bbox_covering, "xmin");
+							if (xmin_arr && yyjson_is_arr(xmin_arr) && yyjson_arr_size(xmin_arr) >= 1) {
+								const auto col_name_val = yyjson_arr_get_first(xmin_arr);
+								if (col_name_val && yyjson_is_str(col_name_val)) {
+									column.bbox_column_name = yyjson_get_str(col_name_val);
+								}
+							}
+						}
+					}
+
+					// TODO: Parse the file-level bounding box, other metadata that might be useful.
 					// (Only encoding and geometry types are required to be present)
 				}
 

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -201,6 +201,17 @@ static void ConvertCRS(ClientContext &context, GeoParquetColumnMetadata &column,
 	column.projjson = crs.GetDefinition();
 }
 
+void GeoParquetFileMetadata::RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name) {
+	lock_guard<mutex> glock(write_lock);
+	const auto it = geometry_columns.find(geom_column_name);
+	if (it != geometry_columns.end()) {
+		it->second.bbox_column_name = bbox_column_name;
+	} else {
+		// Column not yet registered via AddGeoParquetStats; store for later
+		pending_bbox_columns[geom_column_name] = bbox_column_name;
+	}
+}
+
 void GeoParquetFileMetadata::AddGeoParquetStats(ClientContext &context, const string &column_name,
                                                 const LogicalType &type, const GeometryStatsData &stats,
                                                 GeoParquetVersion version) {
@@ -221,6 +232,12 @@ void GeoParquetFileMetadata::AddGeoParquetStats(ClientContext &context, const st
 		column.stats.Merge(stats);
 		column.insertion_index = geometry_columns.size() - 1;
 
+		// Apply any pending bbox covering registration
+		const auto pending_it = pending_bbox_columns.find(column_name);
+		if (pending_it != pending_bbox_columns.end()) {
+			column.bbox_column_name = pending_it->second;
+			pending_bbox_columns.erase(pending_it);
+		}
 	} else {
 		it->second.stats.Merge(stats);
 	}
@@ -310,6 +327,18 @@ void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data)
 				yyjson_mut_arr_add_real(doc, bbox_arr, bbox.x_max);
 				yyjson_mut_arr_add_real(doc, bbox_arr, bbox.y_max);
 				yyjson_mut_arr_add_real(doc, bbox_arr, bbox.z_max);
+			}
+		}
+
+		// If a bbox covering column is registered, write the 'covering' field (GeoParquet 1.1+)
+		if (!column.second.bbox_column_name.empty()) {
+			const auto &bcol = column.second.bbox_column_name;
+			const auto covering = yyjson_mut_obj_add_obj(doc, column_json, "covering");
+			const auto bbox_covering = yyjson_mut_obj_add_obj(doc, covering, "bbox");
+			for (const auto *coord : {"xmin", "ymin", "xmax", "ymax"}) {
+				const auto arr = yyjson_mut_obj_add_arr(doc, bbox_covering, coord);
+				yyjson_mut_arr_add_strncpy(doc, arr, bcol.c_str(), bcol.size());
+				yyjson_mut_arr_add_str(doc, arr, coord);
 			}
 		}
 

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -264,6 +264,9 @@ void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data)
 	case GeoParquetVersion::BOTH:
 		yyjson_mut_obj_add_strcpy(doc, root, "version", "1.0.0");
 		break;
+	case GeoParquetVersion::V1_1:
+		yyjson_mut_obj_add_strcpy(doc, root, "version", "1.1.0");
+		break;
 	case GeoParquetVersion::V2:
 		yyjson_mut_obj_add_strcpy(doc, root, "version", "2.0.0");
 		break;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -51,9 +51,13 @@
 #include "duckdb/main/setting_info.hpp"
 #include "duckdb/original/std/memory.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_index.hpp"
@@ -1217,6 +1221,168 @@ static FilterPropagateResult CheckParquetFloatFilter(ColumnReader &reader, const
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
+// ---------------------------------------------------------------------------
+// GeoParquet 1.1 bbox covering helpers
+// ---------------------------------------------------------------------------
+
+// Extract the enclosing GeometryExtent of a row group from the per-row-group
+// Parquet min/max statistics of the GeoParquet 1.1 covering bbox struct column.
+//
+// The covering struct has sub-columns xmin/ymin/xmax/ymax (FLOAT).  For a row
+// group whose flat per-column stats are in |columns|:
+//   row_group_extent.x_min = min(xmin)   → xmin sub-column min_value
+//   row_group_extent.x_max = max(xmax)   → xmax sub-column max_value
+//   (same for y_min / y_max)
+//
+// Returns GeometryExtent::Unknown() when stats are unavailable.
+static GeometryExtent TryBuildCoveringExtent(const string &bbox_col_name, const ParquetColumnSchema &root_schema,
+                                             const vector<ColumnChunk> &columns) {
+	// Find the bbox column at the top level of the schema
+	const ParquetColumnSchema *bbox_schema = nullptr;
+	for (const auto &child : root_schema.children) {
+		if (child.name == bbox_col_name) {
+			bbox_schema = &child;
+			break;
+		}
+	}
+	if (!bbox_schema || bbox_schema->type.id() != LogicalTypeId::STRUCT) {
+		return GeometryExtent::Unknown();
+	}
+
+	double x_min = 0, y_min = 0, x_max = 0, y_max = 0;
+	bool found_xmin = false, found_ymin = false, found_xmax = false, found_ymax = false;
+
+	for (const auto &sub : bbox_schema->children) {
+		if (sub.schema_type != ParquetColumnSchemaType::COLUMN) {
+			continue;
+		}
+		if (sub.column_index >= columns.size()) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &chunk = columns[sub.column_index];
+		if (!chunk.__isset.meta_data || !chunk.meta_data.__isset.statistics) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &pq_stats = chunk.meta_data.statistics;
+
+		// Prefer the newer min_value/max_value; fall back to legacy min/max
+		const bool has_new = pq_stats.__isset.min_value && pq_stats.__isset.max_value;
+		const bool has_old = pq_stats.__isset.min && pq_stats.__isset.max;
+		if (!has_new && !has_old) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &min_bytes = has_new ? pq_stats.min_value : pq_stats.min;
+		const auto &max_bytes = has_new ? pq_stats.max_value : pq_stats.max;
+
+		auto min_val = ParquetStatisticsUtils::ConvertValue(sub.type, sub, min_bytes);
+		auto max_val = ParquetStatisticsUtils::ConvertValue(sub.type, sub, max_bytes);
+		if (min_val.IsNull() || max_val.IsNull()) {
+			return GeometryExtent::Unknown();
+		}
+
+		// Cast to double so the caller gets uniform double precision
+		const double d_min = min_val.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+		const double d_max = max_val.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+
+		if (sub.name == "xmin") {
+			x_min = d_min;
+			found_xmin = true;
+		} else if (sub.name == "ymin") {
+			y_min = d_min;
+			found_ymin = true;
+		} else if (sub.name == "xmax") {
+			x_max = d_max;
+			found_xmax = true;
+		} else if (sub.name == "ymax") {
+			y_max = d_max;
+			found_ymax = true;
+		}
+	}
+
+	if (!found_xmin || !found_ymin || !found_xmax || !found_ymax) {
+		return GeometryExtent::Unknown();
+	}
+
+	// Build the enclosing envelope for the row group
+	GeometryExtent result = GeometryExtent::Empty();
+	result.x_min = x_min;
+	result.y_min = y_min;
+	result.x_max = x_max;
+	result.y_max = y_max;
+	// Z / M remain as EMPTY sentinel values (no covering for those axes)
+	return result;
+}
+
+// Returns true if |name| is a spatial predicate for which bounding-box
+// intersection is a necessary condition (i.e. disjoint bboxes → always false).
+static bool IsSpatialBBoxPredicate(const string &name) {
+	static const char *const predicates[] = {"st_intersects",  "st_within",          "st_contains",
+	                                          "st_covers",      "st_coveredby",       "st_crosses",
+	                                          "st_overlaps",    "st_touches",         "&&",
+	                                          "st_intersects_extent", nullptr};
+	for (const char *const *p = predicates; *p; ++p) {
+		if (StringUtil::CIEquals(name, *p)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Try to prune a row group using a spatial ExpressionFilter and the covering
+// extent derived from GeoParquet 1.1 bbox column statistics.
+//
+// If the query geometry's bbox does not intersect |rg_extent|, every geometry
+// in the row group is guaranteed to fail the predicate → FILTER_ALWAYS_FALSE.
+// Otherwise returns NO_PRUNING_POSSIBLE (conservative).
+static FilterPropagateResult TrySpatialBBoxPrune(const ExpressionFilter &filter, const GeometryExtent &rg_extent) {
+	D_ASSERT(rg_extent.HasXY());
+
+	if (filter.expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	const auto &func = filter.expr->Cast<BoundFunctionExpression>();
+	if (func.children.size() != 2) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!IsSpatialBBoxPredicate(func.function.name)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// Both arguments must be geometry-typed
+	if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
+	    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// One argument must be a constant (the query geometry); the other a column ref
+	const Value *const_geom = nullptr;
+	if (func.children[0]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		const_geom = &func.children[0]->Cast<BoundConstantExpression>().value;
+	} else if (func.children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		const_geom = &func.children[1]->Cast<BoundConstantExpression>().value;
+	}
+	if (!const_geom || const_geom->IsNull() || const_geom->type().id() != LogicalTypeId::GEOMETRY) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// Extract the query geometry's bounding box
+	const auto &geom_blob = StringValue::Get(*const_geom);
+	GeometryExtent query_extent = GeometryExtent::Empty();
+	if (Geometry::GetExtent(string_t(geom_blob), query_extent) == 0) {
+		// Empty geometry: no geometry can intersect it → always false
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!query_extent.HasXY()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// If the row group's enclosing bbox and the query bbox do not intersect,
+	// no geometry in this row group can satisfy the predicate
+	if (!rg_extent.IntersectsXY(query_extent)) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t i) {
 	auto &group = GetGroup(state);
 	auto col_idx = MultiFileLocalIndex(i);
@@ -1273,6 +1439,25 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t i
 			                                                group.columns[column_reader.ColumnIndex()].meta_data,
 			                                                *state.thrift_file_proto, allocator)) {
 				prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+			}
+
+			// GeoParquet 1.1 spatial bbox pruning via covering column statistics.
+			// When a geometry column has a GeoParquet 1.1 covering bbox struct column,
+			// use the bbox sub-column min/max Parquet statistics to derive the
+			// enclosing envelope of the row group and prune if the query bbox
+			// does not intersect it.
+			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE &&
+			    filter.filter_type == TableFilterType::EXPRESSION_FILTER &&
+			    column_reader.Schema().schema_type == ParquetColumnSchemaType::GEOMETRY &&
+			    metadata->geo_metadata && root_schema) {
+				const auto geo_col_meta = metadata->geo_metadata->GetColumnMeta(column_reader.Schema().name);
+				if (geo_col_meta && !geo_col_meta->bbox_column_name.empty()) {
+					const auto rg_extent =
+					    TryBuildCoveringExtent(geo_col_meta->bbox_column_name, *root_schema, group.columns);
+					if (rg_extent.HasXY()) {
+						prune_result = TrySpatialBBoxPrune(filter.Cast<ExpressionFilter>(), rg_extent);
+					}
+				}
 			}
 
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -53,8 +53,11 @@
 #include "duckdb/main/setting_info.hpp"
 #include "duckdb/original/std/memory.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_index.hpp"
@@ -1359,6 +1362,169 @@ ColumnReader &ParquetReaderScanState::GetColumnReader(idx_t i) {
 	return *column_readers[i];
 }
 
+// ---------------------------------------------------------------------------
+// GeoParquet 1.1 bbox covering helpers
+// ---------------------------------------------------------------------------
+
+// Extract the enclosing GeometryExtent of a row group from the per-row-group
+// Parquet min/max statistics of the GeoParquet 1.1 covering bbox struct column.
+//
+// The covering struct has sub-columns xmin/ymin/xmax/ymax (FLOAT).  For a row
+// group whose flat per-column stats are in |columns|:
+//   row_group_extent.x_min = min(xmin)   → xmin sub-column min_value
+//   row_group_extent.x_max = max(xmax)   → xmax sub-column max_value
+//   (same for y_min / y_max)
+//
+// Returns GeometryExtent::Unknown() when stats are unavailable.
+static GeometryExtent TryBuildCoveringExtent(const string &bbox_col_name, const ParquetColumnSchema &root_schema,
+                                             const vector<ColumnChunk> &columns) {
+	// Find the bbox column at the top level of the schema
+	const ParquetColumnSchema *bbox_schema = nullptr;
+	for (const auto &child : root_schema.children) {
+		if (child.name == bbox_col_name) {
+			bbox_schema = &child;
+			break;
+		}
+	}
+	if (!bbox_schema || bbox_schema->type.id() != LogicalTypeId::STRUCT) {
+		return GeometryExtent::Unknown();
+	}
+
+	double x_min = 0, y_min = 0, x_max = 0, y_max = 0;
+	bool found_xmin = false, found_ymin = false, found_xmax = false, found_ymax = false;
+
+	for (const auto &sub : bbox_schema->children) {
+		if (sub.schema_type != ParquetColumnSchemaType::COLUMN) {
+			continue;
+		}
+		if (sub.column_index >= columns.size()) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &chunk = columns[sub.column_index];
+		if (!chunk.__isset.meta_data || !chunk.meta_data.__isset.statistics) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &pq_stats = chunk.meta_data.statistics;
+
+		// Prefer the newer min_value/max_value; fall back to legacy min/max
+		const bool has_new = pq_stats.__isset.min_value && pq_stats.__isset.max_value;
+		const bool has_old = pq_stats.__isset.min && pq_stats.__isset.max;
+		if (!has_new && !has_old) {
+			return GeometryExtent::Unknown();
+		}
+		const auto &min_bytes = has_new ? pq_stats.min_value : pq_stats.min;
+		const auto &max_bytes = has_new ? pq_stats.max_value : pq_stats.max;
+
+		auto min_val = ParquetStatisticsUtils::ConvertValue(sub.type, sub, min_bytes);
+		auto max_val = ParquetStatisticsUtils::ConvertValue(sub.type, sub, max_bytes);
+		if (min_val.IsNull() || max_val.IsNull()) {
+			return GeometryExtent::Unknown();
+		}
+
+		// Cast to double so the caller gets uniform double precision
+		const double d_min = min_val.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+		const double d_max = max_val.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+
+		if (sub.name == "xmin") {
+			x_min = d_min;
+			found_xmin = true;
+		} else if (sub.name == "ymin") {
+			y_min = d_min;
+			found_ymin = true;
+		} else if (sub.name == "xmax") {
+			x_max = d_max;
+			found_xmax = true;
+		} else if (sub.name == "ymax") {
+			y_max = d_max;
+			found_ymax = true;
+		}
+	}
+
+	if (!found_xmin || !found_ymin || !found_xmax || !found_ymax) {
+		return GeometryExtent::Unknown();
+	}
+
+	// Build the enclosing envelope for the row group
+	GeometryExtent result = GeometryExtent::Empty();
+	result.x_min = x_min;
+	result.y_min = y_min;
+	result.x_max = x_max;
+	result.y_max = y_max;
+	// Z / M remain as EMPTY sentinel values (no covering for those axes)
+	return result;
+}
+
+// Returns true if |name| is a spatial predicate for which bounding-box
+// intersection is a necessary condition (i.e. disjoint bboxes → always false).
+static bool IsSpatialBBoxPredicate(const string &name) {
+	static const char *const predicates[] = {"st_intersects",  "st_within",          "st_contains",
+	                                          "st_covers",      "st_coveredby",       "st_crosses",
+	                                          "st_overlaps",    "st_touches",         "&&",
+	                                          "st_intersects_extent", nullptr};
+	for (const char *const *p = predicates; *p; ++p) {
+		if (StringUtil::CIEquals(name, *p)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Try to prune a row group using a spatial ExpressionFilter and the covering
+// extent derived from GeoParquet 1.1 bbox column statistics.
+//
+// If the query geometry's bbox does not intersect |rg_extent|, every geometry
+// in the row group is guaranteed to fail the predicate → FILTER_ALWAYS_FALSE.
+// Otherwise returns NO_PRUNING_POSSIBLE (conservative).
+static FilterPropagateResult TrySpatialBBoxPrune(const ExpressionFilter &filter, const GeometryExtent &rg_extent) {
+	D_ASSERT(rg_extent.HasXY());
+
+	if (filter.expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	const auto &func = filter.expr->Cast<BoundFunctionExpression>();
+	const auto &children = func.GetChildren();
+	if (children.size() != 2) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!IsSpatialBBoxPredicate(func.Function().GetName().GetIdentifierName())) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// Both arguments must be geometry-typed
+	if (children[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY ||
+	    children[1]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// One argument must be a constant (the query geometry); the other a column ref
+	const Value *const_geom = nullptr;
+	if (children[0]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		const_geom = &children[0]->Cast<BoundConstantExpression>().GetValue();
+	} else if (children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		const_geom = &children[1]->Cast<BoundConstantExpression>().GetValue();
+	}
+	if (!const_geom || const_geom->IsNull() || const_geom->type().id() != LogicalTypeId::GEOMETRY) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// Extract the query geometry's bounding box
+	const auto &geom_blob = StringValue::Get(*const_geom);
+	GeometryExtent query_extent = GeometryExtent::Empty();
+	if (Geometry::GetExtent(string_t(geom_blob), query_extent) == 0) {
+		// Empty geometry: no geometry can intersect it → always false
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!query_extent.HasXY()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	// If the row group's enclosing bbox and the query bbox do not intersect,
+	// no geometry in this row group can satisfy the predicate
+	if (!rg_extent.IntersectsXY(query_extent)) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderScanState &state, idx_t i) {
 	auto &group = GetGroup(state);
 	auto col_idx = MultiFileLocalIndex(i);
@@ -1410,6 +1576,25 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 			    ParquetStatisticsUtils::BloomFilterExcludes(filter, group.columns[schema_column_index].meta_data,
 			                                                *state.thrift_file_proto, allocator)) {
 				prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+			}
+
+			// GeoParquet 1.1 spatial bbox pruning via covering column statistics.
+			// When a geometry column has a GeoParquet 1.1 covering bbox struct column,
+			// use the bbox sub-column min/max Parquet statistics to derive the
+			// enclosing envelope of the row group and prune if the query bbox
+			// does not intersect it.
+			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE &&
+			    filter.filter_type == TableFilterType::EXPRESSION_FILTER &&
+			    column_reader.Schema().schema_type == ParquetColumnSchemaType::GEOMETRY &&
+			    metadata->geo_metadata && root_schema) {
+				const auto geo_col_meta = metadata->geo_metadata->GetColumnMeta(column_reader.Schema().name);
+				if (geo_col_meta && !geo_col_meta->bbox_column_name.empty()) {
+					const auto rg_extent =
+					    TryBuildCoveringExtent(geo_col_meta->bbox_column_name, *root_schema, group.columns);
+					if (rg_extent.HasXY()) {
+						prune_result = TrySpatialBBoxPrune(filter.Cast<ExpressionFilter>(), rg_extent);
+					}
+				}
 			}
 
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -487,8 +487,9 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 	auto &unique_names = column_names;
 	VerifyUniqueNames(unique_names);
 
-	// V1 GeoParquet stores geometries as blobs, no logical type
-	auto allow_geometry = geoparquet_version != GeoParquetVersion::V1;
+	// V1 and V1_1 GeoParquet store geometries as blobs, no logical type
+	auto allow_geometry = geoparquet_version != GeoParquetVersion::V1 &&
+	                      geoparquet_version != GeoParquetVersion::V1_1;
 
 	// construct the column writers
 	D_ASSERT(sql_types.size() == unique_names.size());

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1251,6 +1251,10 @@ GeoParquetFileMetadata &ParquetWriter::GetGeoParquetData() {
 	return *geoparquet_data;
 }
 
+void ParquetWriter::RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name) {
+	GetGeoParquetData().RegisterBBoxCovering(geom_column_name, bbox_column_name);
+}
+
 void ParquetWriter::BufferBloomFilter(idx_t col_idx, unique_ptr<ParquetBloomFilter> bloom_filter) {
 	if (encryption_config) {
 		return;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -539,8 +539,9 @@ void ParquetWriter::InitializeColumnWriters() {
 
 	auto &types = options.sql_types;
 
-	// V1 GeoParquet stores geometries as blobs, no logical type
-	auto allow_geometry = options.geoparquet_version != GeoParquetVersion::V1;
+	// V1 and V1_1 GeoParquet store geometries as blobs, no logical type
+	auto allow_geometry = options.geoparquet_version != GeoParquetVersion::V1 &&
+	                      options.geoparquet_version != GeoParquetVersion::V1_1;
 
 	// construct the column writers
 	column_writers.clear();

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1396,6 +1396,10 @@ GeoParquetFileMetadata &ParquetWriter::GetGeoParquetData() {
 	return *geoparquet_data;
 }
 
+void ParquetWriter::RegisterBBoxCovering(const string &geom_column_name, const string &bbox_column_name) {
+	GetGeoParquetData().RegisterBBoxCovering(geom_column_name, bbox_column_name);
+}
+
 void ParquetWriter::BufferBloomFilter(idx_t col_idx, unique_ptr<ParquetBloomFilter> bloom_filter) {
 	if (options.encryption_config) {
 		return;

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -331,8 +331,8 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 
 		const auto has_real_stats = gpq_version == GeoParquetVersion::NONE || gpq_version == GeoParquetVersion::BOTH ||
 		                            gpq_version == GeoParquetVersion::V2;
-		const auto has_json_stats = gpq_version == GeoParquetVersion::V1 || gpq_version == GeoParquetVersion::BOTH ||
-		                            gpq_version == GeoParquetVersion::V2;
+		const auto has_json_stats = gpq_version == GeoParquetVersion::V1 || gpq_version == GeoParquetVersion::V1_1 ||
+		                            gpq_version == GeoParquetVersion::BOTH || gpq_version == GeoParquetVersion::V2;
 
 		if (has_real_stats) {
 			// Write the parquet native geospatial statistics

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -401,8 +401,8 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 
 		const auto has_real_stats = gpq_version == GeoParquetVersion::NONE || gpq_version == GeoParquetVersion::BOTH ||
 		                            gpq_version == GeoParquetVersion::V2;
-		const auto has_json_stats = gpq_version == GeoParquetVersion::V1 || gpq_version == GeoParquetVersion::BOTH ||
-		                            gpq_version == GeoParquetVersion::V2;
+		const auto has_json_stats = gpq_version == GeoParquetVersion::V1 || gpq_version == GeoParquetVersion::V1_1 ||
+		                            gpq_version == GeoParquetVersion::BOTH || gpq_version == GeoParquetVersion::V2;
 
 		if (has_real_stats) {
 			// Write the parquet native geospatial statistics

--- a/test/geoparquet/bbox_pruning.test
+++ b/test/geoparquet/bbox_pruning.test
@@ -1,0 +1,126 @@
+# name: test/geoparquet/bbox_pruning.test
+# description: GeoParquet 1.1 covering bbox column – row group pruning via spatial predicates
+# group: [geoparquet]
+
+require parquet
+
+require spatial
+
+# ---------------------------------------------------------------------------
+# Setup: write a GeoParquet 1.1 file with two row groups.
+# Cluster A – points near (1,1)   → row group 0
+# Cluster B – points near (100,100) → row group 1
+# row_group_size = 3 forces exactly two row groups.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE OR REPLACE TABLE spatial_data AS
+SELECT ST_Point(x, y)::GEOMETRY AS geom
+FROM (VALUES
+    (1.0,   1.0),
+    (1.5,   1.5),
+    (2.0,   2.0),
+    (100.0, 100.0),
+    (100.5, 100.5),
+    (101.0, 101.0)
+) t(x, y);
+
+statement ok
+COPY spatial_data TO '{TEST_DIR}/gpq11.parquet'
+    (FORMAT PARQUET, GEOPARQUET_VERSION 'V1_1', ROW_GROUP_SIZE 3);
+
+# ---------------------------------------------------------------------------
+# 1. Verify the covering metadata was written and is parsed back
+# ---------------------------------------------------------------------------
+
+query I
+SELECT decode(value) LIKE '%"covering":%'
+FROM parquet_kv_metadata('{TEST_DIR}/gpq11.parquet');
+----
+true
+
+query I
+SELECT count(*) > 0
+FROM parquet_schema('{TEST_DIR}/gpq11.parquet')
+WHERE name = 'bbox';
+----
+true
+
+# ---------------------------------------------------------------------------
+# 2. Correctness: spatial bbox operator targeting only cluster A → 3 rows
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE geom && ST_MakeEnvelope(0.0, 0.0, 5.0, 5.0);
+----
+3
+
+# ---------------------------------------------------------------------------
+# 3. Correctness: spatial bbox operator targeting only cluster B → 3 rows
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE geom && ST_MakeEnvelope(99.0, 99.0, 102.0, 102.0);
+----
+3
+
+# ---------------------------------------------------------------------------
+# 4. Correctness: query spanning both clusters → all 6 rows
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE geom && ST_MakeEnvelope(0.0, 0.0, 200.0, 200.0);
+----
+6
+
+# ---------------------------------------------------------------------------
+# 5. Correctness: query outside both clusters → 0 rows
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE geom && ST_MakeEnvelope(50.0, 50.0, 60.0, 60.0);
+----
+0
+
+# ---------------------------------------------------------------------------
+# 6. ST_Intersects should also be pruned (bbox intersection is necessary)
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE ST_Intersects(geom, ST_MakeEnvelope(0.0, 0.0, 5.0, 5.0));
+----
+3
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet'
+WHERE ST_Intersects(geom, ST_MakeEnvelope(50.0, 50.0, 60.0, 60.0));
+----
+0
+
+# ---------------------------------------------------------------------------
+# 7. Files written with V1 (no covering) still return correct results
+# ---------------------------------------------------------------------------
+
+statement ok
+COPY spatial_data TO '{TEST_DIR}/gpq10.parquet'
+    (FORMAT PARQUET, GEOPARQUET_VERSION 'V1', ROW_GROUP_SIZE 3);
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq10.parquet'
+WHERE geom && ST_MakeEnvelope(0.0, 0.0, 5.0, 5.0);
+----
+3
+
+# ---------------------------------------------------------------------------
+# 8. Full scan (no filter) returns all rows
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM '{TEST_DIR}/gpq11.parquet';
+----
+6

--- a/test/geoparquet/versions.test
+++ b/test/geoparquet/versions.test
@@ -71,7 +71,32 @@ SELECT geo_types from parquet_metadata('{TEST_DIR}/test_both.parquet');
 [point]
 
 
+# V1_1
+
+statement ok
+COPY (SELECT 'POINT(1 2)'::GEOMETRY as geometry)
+TO '{TEST_DIR}/test_v1_1.parquet' (FORMAT PARQUET, GEOPARQUET_VERSION 'V1_1');
+
+query I
+SELECT (decode(value)) as col
+FROM parquet_kv_metadata('{TEST_DIR}/test_v1_1.parquet');
+----
+{"version":"1.1.0","primary_column":"geometry","columns":{"geometry":{"encoding":"WKB","geometry_types":["Point"],"bbox":[1.0,2.0,1.0,2.0],"covering":{"bbox":{"xmin":["bbox","xmin"],"ymin":["bbox","ymin"],"xmax":["bbox","xmax"],"ymax":["bbox","ymax"]}}}}}
+
+query I
+SELECT count(*) > 0 FROM parquet_schema('{TEST_DIR}/test_v1_1.parquet')
+WHERE name = 'bbox';
+----
+true
+
+query I
+SELECT geo_types from parquet_metadata('{TEST_DIR}/test_v1_1.parquet')
+WHERE path_in_schema = 'geometry';
+----
+NULL
+
 # V2
+
 statement ok
 COPY (SELECT 'POINT(1 2)'::GEOMETRY as geometry)
 TO '{TEST_DIR}/test_v2.parquet' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2');


### PR DESCRIPTION
## Summary

- Add \`GEOPARQUET_VERSION 'V1_1'\` option to \`COPY ... TO (FORMAT PARQUET)\`, writing \`\"version\": \"1.1.0\"\` in the GeoParquet metadata and auto-injecting a \`bbox STRUCT(xmin FLOAT, ymin FLOAT, xmax FLOAT, ymax FLOAT)\` covering column alongside each geometry column
- Fix \`GeometryExtent\` initialization in \`ComputeBBoxColumn\`: uninitialized stack memory caused \`xmin\`/\`ymin\` to always be \`0.0\` — fixed with \`GeometryExtent::Empty()\`
- Fix bbox column injection in \`BATCH_COPY_TO_FILE\` mode (\`ParquetWritePrepareBatch\`), which bypasses \`ParquetWriteSink\`
- Parse the \`covering.bbox\` field from GeoParquet 1.1 column metadata on read
- Add read-side row group pruning: when a geometry column has a GeoParquet 1.1 covering bbox struct column and a spatial predicate filter is present (\`ST_Intersects\`, \`ST_Within\`, \`ST_Contains\`, \`&&\`, etc.), derive the enclosing envelope of each row group from the bbox sub-column min/max Parquet statistics and skip row groups that don't intersect the query bbox

## Performance

Benchmarked on two real datasets with spatially-sorted row groups.

**2.5M cadastral parcels, Massachusetts (26 row groups, 524 MB)**

| Query | Row groups read | Time |
|---|---|---|
| Full geometry scan | 26 / 26 | ~3,100 ms |
| Point lookup with bbox filter | 1 / 26 | ~46 ms |

**67x speedup. 25 of 26 row groups skipped.**

---

**27M fluvial features, Canada (30 row groups, 2.9 GB)**

| Query | Row groups read | Time |
|---|---|---|
| Full geometry scan | 30 / 30 | ~10,800 ms |
| Point lookup with bbox filter | 9 / 30 | ~22 ms |

**490x speedup. 21 of 30 row groups skipped.**

---

The effect compounds on remote storage. Running the same fluvial dataset from S3 (us-west-2), a bbox-filtered point query fetches only the relevant row groups via HTTP range requests instead of downloading the full file. Without the covering column, any spatial filter requires a full scan regardless of selectivity.

Row group pruning is purely mechanical: the four \`bbox\` sub-columns (\`xmin\`, \`ymin\`, \`xmax\`, \`ymax\`) each carry standard Parquet min/max statistics. No geometry is decoded until a row group passes the bbox check. The speedup is proportional to how spatially sorted the file is — a Hilbert-curve sort before writing maximises pruning selectivity.

## Test plan

- [ ] \`test/geoparquet/versions.test\` — write/read round-trip for all \`GEOPARQUET_VERSION\` options including \`V1_1\`, metadata correctness
- [ ] \`test/geoparquet/bbox_pruning.test\` — correctness of spatial queries on a two-cluster dataset with \`GEOPARQUET_VERSION 'V1_1'\` (requires \`spatial\` extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)