### PR TITLE
Set max cardinality for table functions when provided cardinality is exact

### DIFF
--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -389,9 +389,9 @@ void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool 
 	}
 	auto &bind_info = GetCTableFunctionBindInfo(info);
 	if (is_exact) {
-		bind_info.bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality);
-	} else {
 		bind_info.bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality, cardinality);
+	} else {
+		bind_info.bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality);
 	}
 }
 


### PR DESCRIPTION
The bind step of table function execution is currently bugged. Max cardinality is being set on the node statistics when the provided cardinality estimate is _not_ exact, instead it should be set if it is exact.