### PR TITLE
Add shell extension hooks for registering custom dot-commands

### DIFF
--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -22,6 +22,7 @@ class OperatorExtension;
 class OptimizerExtension;
 class ParserExtension;
 class PlannerExtension;
+class ShellExtensionRegistration;
 class StorageExtension;
 struct ExtensionCallbackRegistry;
 
@@ -43,12 +44,14 @@ public:
 	void Register(shared_ptr<OperatorExtension> extension);
 	void Register(const string &name, shared_ptr<StorageExtension> extension);
 	void Register(shared_ptr<ExtensionCallback> extension);
+	void Register(shared_ptr<ShellExtensionRegistration> extension);
 
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
 	ExtensionCallbackIteratorHelper<ParserExtension> ParserExtensions() const;
 	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
+	ExtensionCallbackIteratorHelper<shared_ptr<ShellExtensionRegistration>> ShellExtensions() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
 	bool HasParserExtensions() const;
 

--- a/src/include/duckdb/main/shell_extension.hpp
+++ b/src/include/duckdb/main/shell_extension.hpp
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/shell_extension.hpp
+//
+// Types for registering shell-level extension commands (dot-commands in the
+// DuckDB CLI). Extensions include this header and register their commands
+// via ShellExtensionRegistration::Register(). The CLI shell queries the
+// ExtensionCallbackManager at command-dispatch time.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+
+namespace duckdb {
+
+class Connection;
+class DatabaseInstance;
+class QueryResult;
+struct DBConfig;
+
+//===--------------------------------------------------------------------===//
+// ShellExtensionData -- base class for extension-stored data
+//===--------------------------------------------------------------------===//
+//! Base class for data stored via ShellContext::SetExtensionData/GetExtensionData.
+//! Extensions subclass this and cast back to their type on retrieval.
+struct ShellExtensionData {
+	virtual ~ShellExtensionData() = default;
+};
+
+//===--------------------------------------------------------------------===//
+// ShellContext -- abstract interface to the shell environment
+//===--------------------------------------------------------------------===//
+//! ShellContext provides the abstract interface that shell extension commands
+//! use to interact with the CLI shell. The concrete implementation lives in
+//! tools/shell/ and wraps ShellState. Extensions never see ShellState directly.
+class ShellContext {
+public:
+	virtual ~ShellContext() = default;
+
+	//===--------------------------------------------------------------------===//
+	// Output
+	//===--------------------------------------------------------------------===//
+	//! Print text to stdout
+	virtual void Print(const string &text) = 0;
+	//! Print text to stderr
+	virtual void PrintError(const string &text) = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Database access
+	//===--------------------------------------------------------------------===//
+	//! Get the active database connection
+	virtual Connection &GetConnection() = 0;
+	//! Get the database instance
+	virtual DatabaseInstance &GetDatabaseInstance() = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Shell state queries
+	//===--------------------------------------------------------------------===//
+	//! Whether the shell is in safe mode (external access disabled)
+	virtual bool IsSafeMode() const = 0;
+	//! Check if an interrupt has been received (Ctrl-C / Escape)
+	virtual bool IsInterrupted() const = 0;
+	//! Clear the interrupt flag
+	virtual void ClearInterrupt() = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Terminal
+	//===--------------------------------------------------------------------===//
+	//! Get the terminal width in columns (0 if unknown)
+	virtual idx_t GetTerminalWidth() = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Rendering
+	//===--------------------------------------------------------------------===//
+	//! Render a query result using the shell's current output mode and renderer
+	virtual void RenderQueryResult(QueryResult &result) = 0;
+	//! Apply syntax highlighting to a SQL string (in-place)
+	virtual void HighlightSQL(string &sql) = 0;
+	//! Whether syntax highlighting is currently enabled
+	virtual bool IsHighlightingEnabled() const = 0;
+	//! Enable or disable syntax highlighting
+	virtual void SetHighlightingEnabled(bool enabled) = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Interactive input (for extensions that run their own REPL sub-loops)
+	//===--------------------------------------------------------------------===//
+	//! Enter extension input mode: saves and disables all SQL-specific
+	//! linenoise configuration (completion, formatting, error rendering,
+	//! ForceSubmitOnEnter, highlighting). Returns a token to pass to
+	//! LeaveExtensionInputMode for correct restoration.
+	virtual idx_t EnterExtensionInputMode() = 0;
+	//! Leave extension input mode: restores all saved linenoise configuration
+	virtual void LeaveExtensionInputMode(idx_t token) = 0;
+	//! Read a line of interactive input with the given prompt.
+	//! Returns the input string, or an empty string if EOF/Ctrl-D was received.
+	//! The caller should check for empty return to detect exit.
+	virtual string ReadLine(const string &prompt) = 0;
+	//! Returns true if the last ReadLine() returned due to EOF (Ctrl-D)
+	virtual bool ReadLineEOF() const = 0;
+
+	//===--------------------------------------------------------------------===//
+	// History management (for custom REPL sub-loops)
+	//===--------------------------------------------------------------------===//
+	//! Add a line to the current input history
+	virtual void AddHistory(const string &line) = 0;
+	//! Clear the current history buffer
+	virtual void ClearHistory() = 0;
+	//! Load raw history entries from a file (each line = one entry, no SQL joining)
+	virtual void LoadRawHistory(const string &path) = 0;
+	//! Save the current history to a file
+	virtual void SaveHistoryToFile(const string &path) = 0;
+	//! Save the shell's SQL history to a file (call before clearing)
+	virtual void SaveShellHistory(const string &path) = 0;
+	//! Load the shell's SQL history from a file (call after restoring)
+	virtual void LoadShellHistory(const string &path) = 0;
+
+	//===--------------------------------------------------------------------===//
+	// Extension data storage
+	//===--------------------------------------------------------------------===//
+	//! Store opaque extension data keyed by name. The data persists for the
+	//! lifetime of the shell session. Extensions subclass ShellExtensionData
+	//! for their state and are responsible for casting back to the correct type.
+	virtual void SetExtensionData(const string &key, shared_ptr<ShellExtensionData> data) = 0;
+	//! Retrieve previously stored extension data (nullptr if not found)
+	virtual shared_ptr<ShellExtensionData> GetExtensionData(const string &key) = 0;
+};
+
+//===--------------------------------------------------------------------===//
+// ShellCommandResult
+//===--------------------------------------------------------------------===//
+//! Result codes for shell extension commands. Values match the shell's
+//! internal MetadataResult enum so they can be cast directly.
+enum class ShellCommandResult : uint8_t { SUCCESS = 0, FAIL = 1, EXIT = 2, PRINT_USAGE = 3 };
+
+//===--------------------------------------------------------------------===//
+// ShellExtensionCommand
+//===--------------------------------------------------------------------===//
+//! Callback signature for shell extension commands
+typedef ShellCommandResult (*shell_command_callback_t)(ShellContext &context, const vector<string> &args);
+
+//! Describes a single dot-command provided by an extension. Mirrors the
+//! shell's internal MetadataCommand struct but uses string members since
+//! these are dynamically allocated.
+struct ShellExtensionCommand {
+	//! The command name (without the leading dot, e.g. "ask" for ".ask")
+	string command;
+	//! Number of required arguments (0 = variadic / flexible)
+	idx_t argument_count = 0;
+	//! The callback function invoked when the command is executed
+	shell_command_callback_t callback = nullptr;
+	//! Usage string shown in .help (e.g. "?MESSAGE?")
+	string usage;
+	//! Short description shown in .help listing
+	string description;
+	//! Minimum prefix length for abbreviated matching (0 = must match full name)
+	idx_t match_size = 0;
+	//! Extended description shown by .help --all or .help <command>
+	string extra_description;
+};
+
+//===--------------------------------------------------------------------===//
+// ShellExtensionRegistration
+//===--------------------------------------------------------------------===//
+//! Optional info struct that extensions can subclass to store static data
+//! associated with their shell extension registration.
+struct ShellExtensionInfo {
+	virtual ~ShellExtensionInfo() = default;
+};
+
+//! Registered with ExtensionCallbackManager during extension Load().
+//! Contains the set of dot-commands the extension provides.
+class ShellExtensionRegistration {
+public:
+	virtual ~ShellExtensionRegistration() = default;
+
+	//! The commands this extension provides
+	vector<ShellExtensionCommand> commands;
+	//! Optional extension info
+	shared_ptr<ShellExtensionInfo> info;
+
+	//! Register this shell extension with the given database config
+	static void Register(DBConfig &config, shared_ptr<ShellExtensionRegistration> extension);
+	//! Iterate all registered shell extensions
+	static ExtensionCallbackIteratorHelper<shared_ptr<ShellExtensionRegistration>> Iterate(DatabaseInstance &db) {
+		return ExtensionCallbackManager::Get(db).ShellExtensions();
+	}
+};
+
+} // namespace duckdb

--- a/src/main/extension_callback_manager.cpp
+++ b/src/main/extension_callback_manager.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/shell_extension.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/operator_extension.hpp"
@@ -21,6 +22,8 @@ struct ExtensionCallbackRegistry {
 	case_insensitive_map_t<shared_ptr<StorageExtension>> storage_extensions;
 	//! Set of callbacks that can be installed by extensions
 	vector<shared_ptr<ExtensionCallback>> extension_callbacks;
+	//! Shell-level extension commands (dot-commands for the CLI)
+	vector<shared_ptr<ShellExtensionRegistration>> shell_extensions;
 };
 
 ExtensionCallbackManager &ExtensionCallbackManager::Get(ClientContext &context) {
@@ -82,6 +85,13 @@ void ExtensionCallbackManager::Register(shared_ptr<ExtensionCallback> extension)
 	callback_registry.atomic_store(new_registry);
 }
 
+void ExtensionCallbackManager::Register(shared_ptr<ShellExtensionRegistration> extension) {
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
+	new_registry->shell_extensions.push_back(std::move(extension));
+	callback_registry.atomic_store(new_registry);
+}
+
 template <class T>
 ExtensionCallbackIteratorHelper<T>::ExtensionCallbackIteratorHelper(
     const vector<T> &vec, shared_ptr<ExtensionCallbackRegistry> callback_registry)
@@ -120,6 +130,14 @@ ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallback
 	auto registry = callback_registry.atomic_load();
 	auto &extension_callbacks = registry->extension_callbacks;
 	return ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>(extension_callbacks, std::move(registry));
+}
+
+ExtensionCallbackIteratorHelper<shared_ptr<ShellExtensionRegistration>>
+ExtensionCallbackManager::ShellExtensions() const {
+	auto registry = callback_registry.atomic_load();
+	auto &shell_extensions = registry->shell_extensions;
+	return ExtensionCallbackIteratorHelper<shared_ptr<ShellExtensionRegistration>>(shell_extensions,
+	                                                                               std::move(registry));
 }
 
 optional_ptr<StorageExtension> ExtensionCallbackManager::FindStorageExtension(const string &name) const {
@@ -165,8 +183,13 @@ void StorageExtension::Register(DBConfig &config, const string &extension_name,
 	config.GetCallbackManager().Register(extension_name, std::move(extension));
 }
 
+void ShellExtensionRegistration::Register(DBConfig &config, shared_ptr<ShellExtensionRegistration> extension) {
+	config.GetCallbackManager().Register(std::move(extension));
+}
+
 template class ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>;
 template class ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>>;
+template class ExtensionCallbackIteratorHelper<shared_ptr<ShellExtensionRegistration>>;
 template class ExtensionCallbackIteratorHelper<OptimizerExtension>;
 template class ExtensionCallbackIteratorHelper<ParserExtension>;
 template class ExtensionCallbackIteratorHelper<PlannerExtension>;

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(../../third_party/utf8proc/include)
 set(SHELL_SOURCES
     ${SHELL_SOURCES}
     shell_command_line_option.cpp
+    shell_context_impl.cpp
     shell_extension.cpp
     shell.cpp
     shell_helpers.cpp

--- a/tools/shell/include/shell_context_impl.hpp
+++ b/tools/shell/include/shell_context_impl.hpp
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// shell_context_impl.hpp
+//
+// Concrete implementation of ShellContext that wraps ShellState.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/shell_extension.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+
+namespace duckdb_shell {
+
+struct ShellState;
+
+//! Saved linenoise/shell input state for EnterExtensionInputMode/LeaveExtensionInputMode
+struct SavedInputMode {
+	void *completion_cb = nullptr;
+	void *format_cb = nullptr;
+	bool highlighting_enabled = true;
+	bool force_submit_on_enter = false;
+	int error_rendering = 1;
+	int completion_rendering = 1;
+};
+
+//! Concrete implementation of ShellContext that delegates to ShellState.
+//! One instance is lazily created per ShellState and persists for the
+//! lifetime of the shell session (so extension data survives across
+//! dot-command invocations).
+class ShellContextImpl : public duckdb::ShellContext {
+public:
+	explicit ShellContextImpl(ShellState &state);
+	~ShellContextImpl() override;
+
+	// Output
+	void Print(const duckdb::string &text) override;
+	void PrintError(const duckdb::string &text) override;
+
+	// Database access
+	duckdb::Connection &GetConnection() override;
+	duckdb::DatabaseInstance &GetDatabaseInstance() override;
+
+	// Shell state queries
+	bool IsSafeMode() const override;
+	bool IsInterrupted() const override;
+	void ClearInterrupt() override;
+
+	// Terminal
+	duckdb::idx_t GetTerminalWidth() override;
+
+	// Rendering
+	void RenderQueryResult(duckdb::QueryResult &result) override;
+	void HighlightSQL(duckdb::string &sql) override;
+	bool IsHighlightingEnabled() const override;
+	void SetHighlightingEnabled(bool enabled) override;
+
+	// Interactive input
+	duckdb::idx_t EnterExtensionInputMode() override;
+	void LeaveExtensionInputMode(duckdb::idx_t token) override;
+	duckdb::string ReadLine(const duckdb::string &prompt) override;
+	bool ReadLineEOF() const override;
+
+	// History
+	void AddHistory(const duckdb::string &line) override;
+	void ClearHistory() override;
+	void LoadRawHistory(const duckdb::string &path) override;
+	void SaveHistoryToFile(const duckdb::string &path) override;
+	void SaveShellHistory(const duckdb::string &path) override;
+	void LoadShellHistory(const duckdb::string &path) override;
+
+	// Extension data storage
+	void SetExtensionData(const duckdb::string &key, duckdb::shared_ptr<duckdb::ShellExtensionData> data) override;
+	duckdb::shared_ptr<duckdb::ShellExtensionData> GetExtensionData(const duckdb::string &key) override;
+
+private:
+	ShellState &state;
+	//! Extension data, keyed by extension name
+	duckdb::case_insensitive_map_t<duckdb::shared_ptr<duckdb::ShellExtensionData>> extension_data;
+	//! Stack of saved input modes for nested EnterExtensionInputMode calls
+	duckdb::vector<SavedInputMode> saved_input_modes;
+	//! Whether the last ReadLine returned due to EOF
+	bool last_readline_eof = false;
+};
+
+} // namespace duckdb_shell

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -42,6 +42,7 @@ struct ShellState;
 using duckdb::InternalException;
 using duckdb::InvalidInputException;
 using duckdb::to_string;
+class ShellContextImpl;
 struct Prompt;
 struct ShellProgressBar;
 struct PagerState;
@@ -282,6 +283,8 @@ public:
 	bool pager_is_active = false;
 	//! Shell highlighting mode
 	HighlightMode highlight_mode = HighlightMode::AUTOMATIC;
+	//! Shell context for extension commands (lazily created, persists for session)
+	unique_ptr<ShellContextImpl> shell_context;
 
 public:
 	ShellState();
@@ -411,6 +414,8 @@ public:
 #endif
 	optional_ptr<const CommandLineOption> FindCommandLineOption(const string &option, string &error_msg) const;
 	optional_ptr<const MetadataCommand> FindMetadataCommand(const string &option, string &error_msg) const;
+	//! Try to dispatch an extension-registered shell command. Returns -1 if no match, otherwise the MetadataResult.
+	int TryExtensionCommand(const vector<string> &args);
 	static vector<string> GetMetadataCompletions(const char *zLine, idx_t nLine);
 
 	//! Execute a SQL query

--- a/tools/shell/linenoise/history.cpp
+++ b/tools/shell/linenoise/history.cpp
@@ -23,6 +23,21 @@ void History::Free() {
 	}
 }
 
+void History::Clear() {
+	if (history) {
+		for (idx_t j = 0; j < history_len; j++) {
+			free(history[j]);
+		}
+		free(history);
+		history = nullptr;
+	}
+	history_len = 0;
+	if (history_file) {
+		free(history_file);
+		history_file = nullptr;
+	}
+}
+
 idx_t History::GetLength() {
 	return history_len;
 }
@@ -362,6 +377,22 @@ int History::Load(const char *filename) {
 		}
 		// the result does not contain a full SQL statement - add a newline deliminator and move on to the next line
 		result += "\r\n";
+	}
+	reader.Close();
+
+	history_file = strdup(filename);
+	return 0;
+}
+
+int History::LoadRaw(const char *filename) {
+	LineReader reader;
+	if (!reader.Init(filename)) {
+		return -1;
+	}
+
+	while (reader.NextLine()) {
+		auto buf = reader.GetLine();
+		History::Add(buf);
 	}
 	reader.Close();
 

--- a/tools/shell/linenoise/include/history.hpp
+++ b/tools/shell/linenoise/include/history.hpp
@@ -15,6 +15,7 @@ namespace duckdb {
 class History {
 public:
 	static void Free();
+	static void Clear();
 	static idx_t GetLength();
 	static const char *GetEntry(idx_t index);
 	static void Overwrite(idx_t index, const char *new_entry);
@@ -24,6 +25,8 @@ public:
 	static int SetMaxLength(idx_t len);
 	static int Save(const char *filename);
 	static int Load(const char *filename);
+	//! Load history treating each line as a separate entry (no SQL multi-line joining)
+	static int LoadRaw(const char *filename);
 };
 
 } // namespace duckdb

--- a/tools/shell/linenoise/include/linenoise.h
+++ b/tools/shell/linenoise/include/linenoise.h
@@ -59,9 +59,11 @@ typedef char *(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);
 typedef char *(linenoiseFormatCallback)(const char *);
 void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
+linenoiseCompletionCallback *linenoiseGetCompletionCallback(void);
 void linenoiseSetHintsCallback(linenoiseHintsCallback *);
 void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseSetFormatCallback(linenoiseFormatCallback *);
+linenoiseFormatCallback *linenoiseGetFormatCallback(void);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *line, const char *completion, size_t nCompletion,
                             size_t completion_start, const char *completion_type, size_t score, char extra_char);
 

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -94,7 +94,9 @@ public:
 	int Edit();
 
 	static void SetCompletionCallback(linenoiseCompletionCallback *fn);
+	static linenoiseCompletionCallback *GetCompletionCallback();
 	static void SetFormatCallback(linenoiseFormatCallback *fn);
+	static linenoiseFormatCallback *GetFormatCallback();
 
 	static void SetPrompt(const char *continuation, const char *continuationSelected, const char *scrollUpPrompt,
 	                      const char *scrollDownPrompt);

--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -130,6 +130,8 @@ public:
 	static void DisableMouseTracking();
 	static bool IsMultiline();
 	static void SetMultiLine(int ml);
+	static bool ForceSubmitOnEnter();
+	static void SetForceSubmitOnEnter(bool force);
 
 	static void ClearScreen();
 	static void Beep();

--- a/tools/shell/linenoise/linenoise-c.cpp
+++ b/tools/shell/linenoise/linenoise-c.cpp
@@ -100,9 +100,17 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *fn) {
 	Linenoise::SetCompletionCallback(fn);
 }
 
+linenoiseCompletionCallback *linenoiseGetCompletionCallback(void) {
+	return Linenoise::GetCompletionCallback();
+}
+
 /* Register a callback function to be called to format the input before returning it to the shell. */
 void linenoiseSetFormatCallback(linenoiseFormatCallback *fn) {
 	Linenoise::SetFormatCallback(fn);
+}
+
+linenoiseFormatCallback *linenoiseGetFormatCallback(void) {
+	return Linenoise::GetFormatCallback();
 }
 
 void linenoiseSetMultiLine(int ml) {

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -46,9 +46,17 @@ void Linenoise::SetCompletionCallback(linenoiseCompletionCallback *fn) {
 	completionCallback = fn;
 }
 
+linenoiseCompletionCallback *Linenoise::GetCompletionCallback() {
+	return completionCallback;
+}
+
 /* Register a callback function to be called to format the input before returning it to the shell. */
 void Linenoise::SetFormatCallback(linenoiseFormatCallback *fn) {
 	formatCallback = fn;
+}
+
+linenoiseFormatCallback *Linenoise::GetFormatCallback() {
+	return formatCallback;
 }
 
 void Linenoise::Format() {
@@ -1607,7 +1615,7 @@ int Linenoise::Edit() {
 				}
 			}
 #endif
-			if (Terminal::IsMultiline() && len > 0) {
+			if (Terminal::IsMultiline() && len > 0 && !Terminal::ForceSubmitOnEnter()) {
 				// check if this forms a complete SQL statement or not
 				buf[len] = '\0';
 				if (buf[0] != '.' && !AllWhitespace(buf) && !duckdb_shell::ShellState::SQLIsComplete(buf)) {

--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -263,6 +263,16 @@ void Terminal::SetMultiLine(int ml) {
 	mlmode = ml;
 }
 
+static bool force_submit_on_enter = false;
+
+bool Terminal::ForceSubmitOnEnter() {
+	return force_submit_on_enter;
+}
+
+void Terminal::SetForceSubmitOnEnter(bool force) {
+	force_submit_on_enter = force;
+}
+
 static int parseInt(const char *s, int *offset = nullptr) {
 	int result = 0;
 	int idx;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -85,11 +85,15 @@
 #endif
 
 #include "duckdb.hpp"
+#include "shell_context_impl.hpp"
 #include "shell_renderer.hpp"
 #include "shell_highlight.hpp"
 #include "shell_state.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/main/client_config.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/shell_extension.hpp"
 
 using namespace duckdb_shell;
 
@@ -2448,9 +2452,15 @@ int ShellState::DoMetaCommand(const string &zLine) {
 	string error_msg;
 	auto metadata_command = FindMetadataCommand(args[0], error_msg);
 	if (!metadata_command) {
-		// command not found
-		PrintDatabaseError(error_msg);
-		rc = 1;
+		// Try extension-registered commands before giving up
+		int ext_rc = TryExtensionCommand(args);
+		if (ext_rc >= 0) {
+			rc = ext_rc;
+		} else {
+			// command not found
+			PrintDatabaseError(error_msg);
+			rc = 1;
+		}
 	} else {
 		auto &command = *metadata_command;
 		MetadataResult result = MetadataResult::PRINT_USAGE;
@@ -2484,6 +2494,55 @@ int ShellState::DoMetaCommand(const string &zLine) {
 		}
 	}
 	return rc;
+}
+
+int ShellState::TryExtensionCommand(const vector<string> &args) {
+	if (!db || !db->instance) {
+		return -1;
+	}
+	auto &callback_mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+	for (auto &ext : callback_mgr.ShellExtensions()) {
+		for (auto &cmd : ext->commands) {
+			idx_t n = args[0].size();
+			idx_t match_size = cmd.match_size ? cmd.match_size : n;
+			if (n < match_size || strncmp(args[0].c_str(), cmd.command.c_str(), n) != 0) {
+				continue;
+			}
+			// Found a match
+			if (safe_mode) {
+				PrintF(PrintOutput::STDERR, ".%s cannot be used in -safe mode\n", cmd.command.c_str());
+				return int(MetadataResult::FAIL);
+			}
+			if (!cmd.callback) {
+				PrintF(PrintOutput::STDERR, "Command \".%s\" has no callback\n", cmd.command.c_str());
+				return int(MetadataResult::FAIL);
+			}
+			// Lazily create the shell context
+			if (!shell_context) {
+				shell_context = make_uniq<ShellContextImpl>(*this);
+			}
+			MetadataResult result = MetadataResult::PRINT_USAGE;
+			try {
+				if (cmd.argument_count == 0 || cmd.argument_count == args.size()) {
+					auto shell_result = cmd.callback(*shell_context, args);
+					result = static_cast<MetadataResult>(static_cast<uint8_t>(shell_result));
+				}
+				if (result == MetadataResult::PRINT_USAGE) {
+					string error =
+					    StringUtil::Format("Invalid Command Error: Invalid usage of command '.%s'\n\n", args[0]);
+					error += StringUtil::Format("Usage: '.%s %s'", cmd.command.c_str(), cmd.usage.c_str());
+					PrintDatabaseError(error);
+					result = MetadataResult::FAIL;
+				}
+			} catch (std::exception &ex) {
+				ErrorData error(ex);
+				PrintDatabaseError(error.Message());
+				result = MetadataResult::FAIL;
+			}
+			return int(result);
+		}
+	}
+	return -1; // no match
 }
 
 /*

--- a/tools/shell/shell_context_impl.cpp
+++ b/tools/shell/shell_context_impl.cpp
@@ -1,0 +1,237 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// shell_context_impl.cpp
+//
+// Concrete implementation of ShellContext wrapping ShellState.
+//
+//===----------------------------------------------------------------------===//
+
+#include "shell_context_impl.hpp"
+#include "shell_state.hpp"
+#include "shell_renderer.hpp"
+
+#ifdef HAVE_LINENOISE
+#include "linenoise.h"
+#include "history.hpp"
+#include "terminal.hpp"
+#endif
+
+#include "duckdb.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
+
+namespace duckdb_shell {
+
+ShellContextImpl::ShellContextImpl(ShellState &state) : state(state) {
+}
+
+ShellContextImpl::~ShellContextImpl() {
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+void ShellContextImpl::Print(const duckdb::string &text) {
+	state.Print(text);
+}
+
+void ShellContextImpl::PrintError(const duckdb::string &text) {
+	state.Print(PrintOutput::STDERR, text);
+}
+
+// ---------------------------------------------------------------------------
+// Database access
+// ---------------------------------------------------------------------------
+
+duckdb::Connection &ShellContextImpl::GetConnection() {
+	return *state.conn;
+}
+
+duckdb::DatabaseInstance &ShellContextImpl::GetDatabaseInstance() {
+	return *state.db->instance;
+}
+
+// ---------------------------------------------------------------------------
+// Shell state queries
+// ---------------------------------------------------------------------------
+
+bool ShellContextImpl::IsSafeMode() const {
+	return state.safe_mode;
+}
+
+bool ShellContextImpl::IsInterrupted() const {
+	return state.seenInterrupt != 0;
+}
+
+void ShellContextImpl::ClearInterrupt() {
+	state.ClearInterrupt();
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+duckdb::idx_t ShellContextImpl::GetTerminalWidth() {
+#ifdef HAVE_LINENOISE
+	auto term_size = duckdb::Terminal::GetTerminalSize();
+	if (term_size.ws_col > 0) {
+		return static_cast<duckdb::idx_t>(term_size.ws_col);
+	}
+#endif
+	return 0;
+}
+
+void ShellContextImpl::RenderQueryResult(duckdb::QueryResult &result) {
+	auto renderer = state.GetRenderer();
+	state.RenderQueryResult(*renderer, result);
+}
+
+void ShellContextImpl::HighlightSQL(duckdb::string &sql) {
+	state.HighlightSQL(sql);
+}
+
+bool ShellContextImpl::IsHighlightingEnabled() const {
+	return state.highlighting_enabled;
+}
+
+void ShellContextImpl::SetHighlightingEnabled(bool enabled) {
+	state.highlighting_enabled = enabled;
+}
+
+// ---------------------------------------------------------------------------
+// Interactive input
+// ---------------------------------------------------------------------------
+
+duckdb::idx_t ShellContextImpl::EnterExtensionInputMode() {
+	SavedInputMode saved;
+
+#ifdef HAVE_LINENOISE
+	// Save current linenoise configuration
+	saved.completion_cb = reinterpret_cast<void *>(linenoiseGetCompletionCallback());
+	saved.format_cb = reinterpret_cast<void *>(linenoiseGetFormatCallback());
+	saved.force_submit_on_enter = duckdb::Terminal::ForceSubmitOnEnter();
+	// Note: error_rendering and completion_rendering don't have getters,
+	// so we assume the default (enabled=1) unless we know otherwise
+	saved.error_rendering = 1;
+	saved.completion_rendering = 1;
+#endif
+	saved.highlighting_enabled = state.highlighting_enabled;
+
+#ifdef HAVE_LINENOISE
+	// Disable all SQL-specific input features
+	duckdb::Terminal::SetForceSubmitOnEnter(true);
+	linenoiseSetCompletionCallback(nullptr);
+	linenoiseSetFormatCallback(nullptr);
+	linenoiseSetErrorRendering(0);
+	linenoiseSetCompletionRendering(0);
+#endif
+	state.highlighting_enabled = false;
+
+	duckdb::idx_t token = saved_input_modes.size();
+	saved_input_modes.push_back(std::move(saved));
+	return token;
+}
+
+void ShellContextImpl::LeaveExtensionInputMode(duckdb::idx_t token) {
+	if (token >= saved_input_modes.size()) {
+		return;
+	}
+	auto &saved = saved_input_modes[token];
+
+#ifdef HAVE_LINENOISE
+	duckdb::Terminal::SetForceSubmitOnEnter(saved.force_submit_on_enter);
+	linenoiseSetCompletionCallback(reinterpret_cast<linenoiseCompletionCallback *>(saved.completion_cb));
+	linenoiseSetFormatCallback(reinterpret_cast<linenoiseFormatCallback *>(saved.format_cb));
+	linenoiseSetErrorRendering(saved.error_rendering);
+	linenoiseSetCompletionRendering(saved.completion_rendering);
+#endif
+	state.highlighting_enabled = saved.highlighting_enabled;
+
+	// Pop all modes from token onwards (handles nested calls correctly)
+	saved_input_modes.resize(token);
+}
+
+duckdb::string ShellContextImpl::ReadLine(const duckdb::string &prompt) {
+	last_readline_eof = false;
+#ifdef HAVE_LINENOISE
+	char *line = linenoise(prompt.c_str());
+	if (!line) {
+		last_readline_eof = true;
+		return duckdb::string();
+	}
+	duckdb::string result(line);
+	free(line);
+	return result;
+#else
+	state.Print(prompt);
+	fflush(stdout);
+	char buf[4096];
+	if (fgets(buf, sizeof(buf), stdin)) {
+		return duckdb::string(buf);
+	}
+	last_readline_eof = true;
+	return duckdb::string();
+#endif
+}
+
+bool ShellContextImpl::ReadLineEOF() const {
+	return last_readline_eof;
+}
+
+// ---------------------------------------------------------------------------
+// History management
+// ---------------------------------------------------------------------------
+
+void ShellContextImpl::AddHistory(const duckdb::string &line) {
+#ifdef HAVE_LINENOISE
+	linenoiseHistoryAdd(line.c_str());
+#endif
+}
+
+void ShellContextImpl::ClearHistory() {
+#ifdef HAVE_LINENOISE
+	duckdb::History::Clear();
+#endif
+}
+
+void ShellContextImpl::LoadRawHistory(const duckdb::string &path) {
+#ifdef HAVE_LINENOISE
+	duckdb::History::LoadRaw(path.c_str());
+#endif
+}
+
+void ShellContextImpl::SaveHistoryToFile(const duckdb::string &path) {
+#ifdef HAVE_LINENOISE
+	linenoiseHistorySave(path.c_str());
+#endif
+}
+
+void ShellContextImpl::SaveShellHistory(const duckdb::string &path) {
+	state.ShellSaveHistory(path.c_str());
+}
+
+void ShellContextImpl::LoadShellHistory(const duckdb::string &path) {
+	state.ShellLoadHistory(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Extension data storage
+// ---------------------------------------------------------------------------
+
+void ShellContextImpl::SetExtensionData(const duckdb::string &key,
+                                        duckdb::shared_ptr<duckdb::ShellExtensionData> data) {
+	extension_data[key] = std::move(data);
+}
+
+duckdb::shared_ptr<duckdb::ShellExtensionData> ShellContextImpl::GetExtensionData(const duckdb::string &key) {
+	auto it = extension_data.find(key);
+	if (it == extension_data.end()) {
+		return nullptr;
+	}
+	return it->second;
+}
+
+} // namespace duckdb_shell

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -3,6 +3,9 @@
 #include "shell_prompt.hpp"
 #include "shell_progress_bar.hpp"
 #include "shell_renderer.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/shell_extension.hpp"
 
 #ifdef HAVE_LINENOISE
 #include "linenoise.h"
@@ -1063,6 +1066,65 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 			}
 		}
 	}
+	// Also include extension-registered commands
+	if (db && db->instance) {
+		auto &callback_mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext : callback_mgr.ShellExtensions()) {
+			for (auto &cmd : ext->commands) {
+				// Check glob pattern match (same logic as ShouldPrintCommand)
+				if (cmd.description.empty()) {
+					continue;
+				}
+				if (!glob_pattern.empty() && !StringGlob(glob_pattern.c_str(), cmd.command.c_str())) {
+					continue;
+				}
+				PrintCommandInfo print_info;
+				print_info.command_name = StringUtil::Format(".%s", cmd.command);
+				print_info.first_part = StringUtil::Format(" %s", cmd.usage);
+				print_info.second_part = cmd.description;
+				print_info.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+				print_info_list.push_back(std::move(print_info));
+
+				if (print_extended && !cmd.extra_description.empty()) {
+					// Process extended description with same tab/newline logic
+					PrintCommandInfo current_command;
+					bool first_part = true;
+					bool after_newline = true;
+					for (auto c : cmd.extra_description) {
+						if (c == '\n') {
+							print_info_list.push_back(std::move(current_command));
+							current_command = PrintCommandInfo();
+							first_part = true;
+							after_newline = true;
+						} else if (c == '\t') {
+							if (after_newline) {
+								current_command.first_part += string(SPACING_PER_LAYER, ' ');
+							} else {
+								first_part = false;
+							}
+						} else {
+							if (after_newline) {
+								current_command.first_part += string(SPACING_PER_LAYER, ' ');
+								if (c == '-') {
+									current_command.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+								}
+							}
+							after_newline = false;
+							if (first_part) {
+								current_command.first_part += c;
+							} else {
+								current_command.second_part += c;
+							}
+						}
+					}
+					if (!current_command.first_part.empty()) {
+						print_info_list.push_back(std::move(current_command));
+					}
+				}
+			}
+		}
+	}
+
 	// figure out alignment based on the total first part print size
 	idx_t max_lhs_size = 0;
 	for (auto &print_info : print_info_list) {
@@ -1122,6 +1184,31 @@ vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine
 			result.push_back(zBuf);
 		}
 	}
+	// Also include extension-registered commands
+	auto &state = ShellState::Get();
+	if (state.db && state.db->instance) {
+		auto &callback_mgr = duckdb::ExtensionCallbackManager::Get(*state.db->instance);
+		for (auto &ext : callback_mgr.ShellExtensions()) {
+			for (auto &cmd : ext->commands) {
+				auto &line = cmd.command;
+				bool found_match = true;
+				idx_t line_pos;
+				zBuf[0] = '.';
+				for (line_pos = 0; line_pos < line.size() && !IsSpace(line[line_pos]) && line_pos + 2 < sizeof(zBuf);
+				     line_pos++) {
+					zBuf[line_pos + 1] = line[line_pos];
+					if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {
+						found_match = false;
+						break;
+					}
+				}
+				zBuf[line_pos + 1] = '\0';
+				if (found_match && line_pos + 1 >= nLine) {
+					result.push_back(zBuf);
+				}
+			}
+		}
+	}
 	return result;
 }
 
@@ -1142,6 +1229,15 @@ optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string
 	for (idx_t command_idx = 0; metadata_commands[command_idx].command; command_idx++) {
 		auto &command = metadata_commands[command_idx];
 		command_names.push_back(string(".") + command.command);
+	}
+	// Also include extension-registered commands in suggestions
+	if (db && db->instance) {
+		auto &callback_mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext : callback_mgr.ShellExtensions()) {
+			for (auto &cmd : ext->commands) {
+				command_names.push_back(string(".") + cmd.command);
+			}
+		}
 	}
 	auto candidates_msg = StringUtil::CandidatesErrorMessage(command_names, option, "Did you mean");
 	error_msg += candidates_msg + "\n";


### PR DESCRIPTION
## Motivation

I spent some time adding a .ask mode to DuckDB that integrates with an LLM agent demo:

https://github.com/user-attachments/assets/e17a8dca-1dc4-4a66-b5c3-3d22fae2098d


To make that work well, I needed changes to the shell's APIs that go beyond what a SQL function integration can provide — as @Mytherin noted in [#21197](https://github.com/duckdb/duckdb/pull/21197#issuecomment-4242225953).

This PR is a prototype for shell extension infrastructure: a way for loadable extensions to register their own .dot commands with full shell integration (help, tab completion, error suggestions, REPL sub-loops). The `.ask` use case drove the design, but the same primitives would unlock things like a reporting extension backed by Typst — or anything else that wants interactive shell UI without requiring core changes.

I'm not proposing this merges as-is, but I wanted to surface the API surface I think is necessary for a good UX before the design hardens.Related prior work with @carlopi: [#21197](https://github.com/duckdb/duckdb/pull/21197) [#21201](https://github.com/duckdb/duckdb/pull/21201) [#21041](https://github.com/duckdb/duckdb/pull/21041)

## Changes

- Adds infrastructure allowing DuckDB extensions to register their own dot-commands in the CLI shell, following the existing `ExtensionCallbackManager` pattern used by `ParserExtension`, `OptimizerExtension`, etc.
- Defines `ShellContext` (abstract shell interface), `ShellExtensionCommand` (command descriptor), and `ShellExtensionRegistration` (registered via callback manager) in a new core header
- Shell dispatch (`DoMetaCommand`, `FindMetadataCommand`, `PrintHelp`, `GetMetadataCompletions`) queries the callback registry so extension commands appear in help, tab-completion, and error suggestions
- Includes linenoise additions (`History::Clear`, `History::LoadRaw`, `Terminal::ForceSubmitOnEnter`, callback getters) needed for extensions that run custom REPL sub-loops

## State of things right now. 

There's currently no way for a DuckDB extension to add a dot-command to the CLI shell. The metadata command table is a hardcoded static array, and extensions can't interact with the shell's UI layer. This blocks use cases like AI assistants, data visualization tools, or interactive workflows that want to ship as loadable extensions rather than requiring core shell changes.

## Registration

An extension registers commands during `Load()`:

```cpp
void MyExtension::Load(ExtensionLoader &loader) {
    auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
    auto reg = make_shared_ptr<ShellExtensionRegistration>();

    ShellExtensionCommand cmd;
    cmd.command = "mycommand";
    cmd.callback = MyCallback;  // ShellCommandResult (*)(ShellContext&, const vector<string>&)
    cmd.description = "Does something useful";
    cmd.usage = "?ARG?";
    cmd.extra_description = "Extended help text shown by .help --all";
    reg->commands.push_back(std::move(cmd));

    ShellExtensionRegistration::Register(config, std::move(reg));
}
```

Registration uses the existing `ExtensionCallbackManager` copy-on-write pattern, so it's thread-safe and follows the same lifecycle as `ParserExtension`, `OptimizerExtension`, etc.

## ShellContext API

The callback receives a `ShellContext&` -- an abstract interface that wraps `ShellState` without exposing it. Extensions never see `ShellState` directly. The full API surface:

### Output
| Method | Description |
|--------|-------------|
| `Print(const string &text)` | Print to stdout |
| `PrintError(const string &text)` | Print to stderr |

### Database Access
| Method | Description |
|--------|-------------|
| `GetConnection()` | Returns the active `Connection&` for running queries |
| `GetDatabaseInstance()` | Returns the `DatabaseInstance&` for accessing config, HTTP utilities, etc. |

### Shell State
| Method | Description |
|--------|-------------|
| `IsSafeMode()` | Whether `--safe` mode is active (extension commands are automatically blocked by the dispatcher, but extensions can also check this themselves) |
| `IsInterrupted()` | Whether Ctrl-C or Escape has been received |
| `ClearInterrupt()` | Reset the interrupt flag |

### Terminal
| Method | Description |
|--------|-------------|
| `GetTerminalWidth()` | Terminal width in columns (0 if unknown) |

### Rendering
| Method | Description |
|--------|-------------|
| `RenderQueryResult(QueryResult &result)` | Render a query result using the shell's current output mode (duckbox, csv, json, etc.) and pager settings |
| `HighlightSQL(string &sql)` | Apply syntax highlighting to a SQL string in-place |
| `IsHighlightingEnabled()` | Whether highlighting is currently on |
| `SetHighlightingEnabled(bool)` | Toggle highlighting (e.g., disable during natural-language input) |

### Interactive Input (for extensions that run their own REPL sub-loops)
| Method | Description |
|--------|-------------|
| `EnterExtensionInputMode()` | Saves and disables all SQL-specific linenoise config (completion, formatting, error rendering, `ForceSubmitOnEnter`, highlighting). Returns a token for `LeaveExtensionInputMode`. |
| `LeaveExtensionInputMode(idx_t token)` | Restores all saved linenoise config from the token |
| `ReadLine(const string &prompt)` | Read one line of interactive input. Returns empty string on EOF. |
| `ReadLineEOF()` | Whether the last `ReadLine` returned due to EOF (Ctrl-D) |

### History Management (for custom REPL sub-loops)
| Method | Description |
|--------|-------------|
| `AddHistory(const string &line)` | Add a line to the current history |
| `ClearHistory()` | Clear the current history buffer |
| `LoadRawHistory(const string &path)` | Load history from file (each line = one entry, no SQL multi-line joining) |
| `SaveHistoryToFile(const string &path)` | Save the current history to a file |
| `SaveShellHistory(const string &path)` | Save the shell's SQL history (call before clearing to swap histories) |
| `LoadShellHistory(const string &path)` | Load the shell's SQL history (call after restoring) |

### Extension Data Storage
| Method | Description |
|--------|-------------|
| `SetExtensionData(const string &key, shared_ptr<ShellExtensionData> data)` | Store persistent data keyed by name. Survives across command invocations for the lifetime of the shell session. Extensions subclass `ShellExtensionData` and `dynamic_cast` on retrieval. |
| `GetExtensionData(const string &key)` | Retrieve previously stored data (nullptr if not found) |

## Shell Integration

Extension commands are integrated into all the standard shell affordances:

- **`.help`** -- extension commands appear in the help listing with description and usage
- **`.help --all`** -- extended descriptions are shown
- **Tab completion** -- typing `.my` and pressing Tab will complete to `.mycommand`
- **Error suggestions** -- typing `.mycomand` (misspelled) will suggest `.mycommand` in "Did you mean"
- **Safe mode** -- all extension commands are automatically blocked in `--safe` mode

## Linenoise Additions

These are general-purpose additions to the linenoise library that support the input mode switching needed by extension REPL sub-loops:

- `History::Clear()` -- clear all history entries (for swapping between SQL and extension-specific history)
- `History::LoadRaw(filename)` -- load history treating each line as a separate entry (no SQL multi-line joining)
- `Terminal::ForceSubmitOnEnter()` / `SetForceSubmitOnEnter(bool)` -- bypass the `SQLIsComplete` check so Enter always submits (used when collecting natural language input, not SQL)
- `linenoiseGetCompletionCallback()` / `linenoiseGetFormatCallback()` -- getter functions to save/restore callbacks during mode switches


🤖 Generated with [Claude Code](https://claude.com/claude-code)