### PR TITLE
Don't use blobs as keys in delim joins

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -237,7 +237,7 @@ static unique_ptr<LogicalDependentJoin> CreateDuplicateEliminatedJoin(const Corr
 }
 
 static bool PerformDelimOnType(const LogicalType &type) {
-	if (type.InternalType() == PhysicalType::LIST) {
+	if (type.InternalType() == PhysicalType::LIST || type.id() == LogicalTypeId::BLOB) {
 		return false;
 	}
 	if (type.InternalType() == PhysicalType::STRUCT) {


### PR DESCRIPTION
Blobs are large objects by definition and can be extremely expensive when used as keys in delim joins.
The PR eliminates such usage.

### Illustration

We have a table with blobs and use table functions to unpack the blobs in lateral joins.
Even relatively small chunks of data cause enormous memory pressure and degrade performance significantly.

```sql
CREATE TABLE blobs (
    id   INTEGER,
    data BLOB
);
INSERT INTO blobs VALUES (
    0,
    -- 96Kb (goes out of memory on my machine with even slightly bigger sizes)
    repeat(chr(42), 98304)::BLOB
);
CREATE OR REPLACE MACRO unpack_blob(b) AS TABLE
    SELECT i FROM generate_series(0, octet_length(b)) t(i);   -- simulate real blob unpacking

-- ~1-2 seconds on Mac Pro M2 (and tons of RAM)
SELECT x.i
FROM blobs as b, unpack_blob(b.data) as x
WHERE b.id = 0;

-- Baseline: a couple of milliseconds with the same query results
FROM unpack_blob((SELECT data FROM blobs where id = 0));
```