### PR TITLE
Coorporative tasks might lead to busy spinning in `TaskExecutor::WorkOnTasks`

### DIFF
--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/parallel/task_notifier.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 
+#include <thread>
+
 namespace duckdb {
 
 TaskExecutor::TaskExecutor(TaskScheduler &scheduler)
@@ -38,14 +40,16 @@ void TaskExecutor::FinishTask() {
 void TaskExecutor::WorkOnTasks() {
 	// repeatedly execute tasks until we are finished
 	shared_ptr<Task> task_from_producer;
-	while (scheduler.GetTaskFromProducer(*token, task_from_producer)) {
-		auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
-		(void)res;
-		D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);
-		task_from_producer.reset();
-	}
 	// wait for all active tasks to finish
 	while (completed_tasks != total_tasks) {
+		if (scheduler.GetTaskFromProducer(*token, task_from_producer)) {
+			const auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
+			std::ignore = res;
+			D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);
+			task_from_producer.reset();
+		} else {
+			std::this_thread::yield();
+		}
 	}
 
 	// check if we ran into any errors while checkpointing

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_API_OBJECTS
     test_windows_header_compatibility.cpp
     test_windows_unicode_path.cpp
     test_object_cache.cpp
+    test_partial_executor.cpp
     test_buffer_pool_eviction.cpp)
 
 if(NOT WIN32)

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -3,14 +3,15 @@
 #include "duckdb/parallel/task_executor.hpp"
 
 #include <chrono>
-#include <future>
 #include <thread>
 
 using namespace duckdb;
 
 struct WeirdTask : BaseExecutorTask {
-	WeirdTask(TaskExecutor &executor_p, shared_ptr<std::atomic_bool> complete_now_p)
-	    : BaseExecutorTask(executor_p), complete_now(std::move(complete_now_p)) {
+	WeirdTask(TaskExecutor &executor_p, shared_ptr<std::atomic_bool> complete_now_p,
+	          shared_ptr<std::atomic<idx_t>> finished_count_p)
+	    : BaseExecutorTask(executor_p), complete_now(std::move(complete_now_p)),
+	      finished_count(std::move(finished_count_p)) {
 	}
 
 	void ExecuteTask() override {
@@ -25,37 +26,48 @@ struct WeirdTask : BaseExecutorTask {
 		std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
 		if (!*complete_now && mode == TaskExecutionMode::PROCESS_PARTIAL) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 			return TaskExecutionResult::TASK_NOT_FINISHED;
 		}
+		++*finished_count;
 		executor.FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
 private:
 	shared_ptr<std::atomic_bool> complete_now;
+	shared_ptr<std::atomic<idx_t>> finished_count;
 };
 
 TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever") {
 	DuckDB db {};
 	Connection con {db};
-	REQUIRE_NO_FAIL(con.Query("SET threads=40"));
+	REQUIRE_NO_FAIL(con.Query("SET threads=5"));
 	REQUIRE_NO_FAIL(con.Query("SET scheduler_process_partial=true"));
 	TaskExecutor executor {*con.context};
 
-	shared_ptr<std::atomic_bool> complete_now = make_shared_ptr<std::atomic_bool>(false);
-	for (auto i = 0; i < 20; i += 1) {
-		executor.ScheduleTask(make_uniq<WeirdTask>(executor, complete_now));
+	auto complete_now = make_shared_ptr<std::atomic_bool>(false);
+	auto finished_count = make_shared_ptr<std::atomic<idx_t>>(0);
+	constexpr idx_t TASK_COUNT = 20;
+	for (idx_t i = 0; i < TASK_COUNT; i++) {
+		executor.ScheduleTask(make_uniq<WeirdTask>(executor, complete_now, finished_count));
 	}
+
+	// let background workers pick up the tasks and start cycling them in PROCESS_PARTIAL mode
 	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-	auto finished = std::async(std::launch::async, [&] {
-		executor.WorkOnTasks();
-		return true;
-	});
-	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	// shrink the pool to zero background workers (external_threads defaults to 1, so threads=1
+	// means requested_thread_count=0). Any task currently in flight gets re-enqueued as
+	// TASK_NOT_FINISHED before the worker exits, so the queue now holds tasks with nobody to
+	// drive them to completion.
 	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
-	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	complete_now->store(true);
-	REQUIRE(finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+
+	// poll up to 5 seconds for all tasks to complete - without a worker or WorkOnTasks driving
+	// progress, the re-enqueued tasks are stranded and the count never reaches TASK_COUNT
+	auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+	while (std::chrono::steady_clock::now() < deadline && finished_count->load() != TASK_COUNT) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	REQUIRE(finished_count->load() == TASK_COUNT);
 }

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -3,71 +3,53 @@
 #include "duckdb/parallel/task_executor.hpp"
 
 #include <chrono>
+#include <future>
 #include <thread>
 
 using namespace duckdb;
 
 struct WeirdTask : BaseExecutorTask {
-	WeirdTask(TaskExecutor &executor_p, shared_ptr<std::atomic_bool> complete_now_p,
-	          shared_ptr<std::atomic<idx_t>> finished_count_p)
-	    : BaseExecutorTask(executor_p), complete_now(std::move(complete_now_p)),
-	      finished_count(std::move(finished_count_p)) {
-	}
+	using BaseExecutorTask::BaseExecutorTask;
 
 	void ExecuteTask() override {
-		throw InternalException("Simple ExecuteTask should never be called!");
 	}
 
 	TaskExecutionResult Execute(TaskExecutionMode mode) override {
-		if (executor.HasError()) {
-			executor.FinishTask();
-			return TaskExecutionResult::TASK_FINISHED;
-		}
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-		if (!*complete_now && mode == TaskExecutionMode::PROCESS_PARTIAL) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		if (mode == TaskExecutionMode::PROCESS_PARTIAL) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(300));
 			return TaskExecutionResult::TASK_NOT_FINISHED;
 		}
-		++*finished_count;
 		executor.FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
-
-private:
-	shared_ptr<std::atomic_bool> complete_now;
-	shared_ptr<std::atomic<idx_t>> finished_count;
 };
 
 TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever") {
-	DuckDB db {};
+	DuckDB db;
 	Connection con {db};
 	REQUIRE_NO_FAIL(con.Query("SET threads=5"));
 	REQUIRE_NO_FAIL(con.Query("SET scheduler_process_partial=true"));
 	TaskExecutor executor {*con.context};
 
-	auto complete_now = make_shared_ptr<std::atomic_bool>(false);
-	auto finished_count = make_shared_ptr<std::atomic<idx_t>>(0);
-	constexpr idx_t TASK_COUNT = 20;
-	for (idx_t i = 0; i < TASK_COUNT; i++) {
-		executor.ScheduleTask(make_uniq<WeirdTask>(executor, complete_now, finished_count));
+	// One task per background worker (threads=5, external=1 -> 4 workers).
+	for (auto i = 0; i < 4; i++) {
+		executor.ScheduleTask(make_uniq<WeirdTask>(executor));
 	}
 
-	// let background workers pick up the tasks and start cycling them in PROCESS_PARTIAL mode
+	// Let each worker grab a task and enter its PROCESS_PARTIAL sleep.
 	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-	// shrink the pool to zero background workers (external_threads defaults to 1, so threads=1
-	// means requested_thread_count=0). Any task currently in flight gets re-enqueued as
-	// TASK_NOT_FINISHED before the worker exits, so the queue now holds tasks with nobody to
-	// drive them to completion.
-	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
-	complete_now->store(true);
+	// WorkOnTasks finds the producer queue empty (all tasks in worker hands),
+	// exits its first loop, and enters `while (completed_tasks != total_tasks) {}`.
+	auto finished = std::async(std::launch::async, [&] {
+		executor.WorkOnTasks();
+	});
 
-	// poll up to 5 seconds for all tasks to complete - without a worker or WorkOnTasks driving
-	// progress, the re-enqueued tasks are stranded and the count never reaches TASK_COUNT
-	auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-	while (std::chrono::steady_clock::now() < deadline && finished_count->load() != TASK_COUNT) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
-	}
-	REQUIRE(finished_count->load() == TASK_COUNT);
+	// Kill background workers. Their in-flight tasks get re-enqueued as
+	// TASK_NOT_FINISHED and stranded — WorkOnTasks is already busy-spinning
+	// and never re-checks the queue.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+
+	REQUIRE(finished.wait_for(std::chrono::milliseconds(100)) == std::future_status::ready);
 }

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -41,9 +41,7 @@ TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever"
 
 	// WorkOnTasks finds the producer queue empty (all tasks in worker hands),
 	// exits its first loop, and enters `while (completed_tasks != total_tasks) {}`.
-	auto finished = std::async(std::launch::async, [&] {
-		executor.WorkOnTasks();
-	});
+	auto finished = std::async(std::launch::async, [&] { executor.WorkOnTasks(); });
 
 	// Kill background workers. Their in-flight tasks get re-enqueued as
 	// TASK_NOT_FINISHED and stranded — WorkOnTasks is already busy-spinning

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -1,0 +1,61 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace duckdb;
+
+struct WeirdTask : BaseExecutorTask {
+	WeirdTask(TaskExecutor &executor_p, shared_ptr<std::atomic_bool> complete_now_p)
+	    : BaseExecutorTask(executor_p), complete_now(std::move(complete_now_p)) {
+	}
+
+	void ExecuteTask() override {
+		throw InternalException("Simple ExecuteTask should never be called!");
+	}
+
+	TaskExecutionResult Execute(TaskExecutionMode mode) override {
+		if (executor.HasError()) {
+			executor.FinishTask();
+			return TaskExecutionResult::TASK_FINISHED;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+		if (!*complete_now && mode == TaskExecutionMode::PROCESS_PARTIAL) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+			return TaskExecutionResult::TASK_NOT_FINISHED;
+		}
+		executor.FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<std::atomic_bool> complete_now;
+};
+
+TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever") {
+	DuckDB db {};
+	Connection con {db};
+	REQUIRE_NO_FAIL(con.Query("SET threads=40"));
+	REQUIRE_NO_FAIL(con.Query("SET scheduler_process_partial=true"));
+	TaskExecutor executor {*con.context};
+
+	shared_ptr<std::atomic_bool> complete_now = make_shared_ptr<std::atomic_bool>(false);
+	for (auto i = 0; i < 20; i += 1) {
+		executor.ScheduleTask(make_uniq<WeirdTask>(executor, complete_now));
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	auto finished = std::async(std::launch::async, [&] {
+		executor.WorkOnTasks();
+		return true;
+	});
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	complete_now->store(true);
+	REQUIRE(finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+}


### PR DESCRIPTION
It is possible for the `TaskExecutor::WorkOnTasks` to busyspin forever if all tasks are currently executed in the `TaskScheduler`, but only partially. As a result `TaskExecutor::WorkOnTasks` cannot retrieve a task and then waits for `completed_tasks != total_tasks` which might not happen if other tasks are blocking the `TaskScheduler`