### PR TITLE
[Fix] Allow DDL after DML within the same transaction

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -334,14 +334,16 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const string &name, 
 	}
 
 	// If this ALTER produced a new DuckTableEntry, refresh the LocalTableStorage's table_entry
-	// pointer for this transaction so that a later commit-time LocalStorage::Flush pushes an
-	// AppendInfo referencing the current DuckTableEntry (not the pre-ALTER one).
+	// pointer so that commit-time Flush pushes an AppendInfo referencing the current DuckTableEntry.
 	if (transaction.context && value->type == CatalogType::TABLE_ENTRY) {
 		auto &tce = value->Cast<TableCatalogEntry>();
 		if (tce.IsDuckTable()) {
 			auto &new_entry = tce.Cast<DuckTableEntry>();
 			auto &new_storage = new_entry.GetStorage();
-			LocalStorage::Get(*transaction.context, new_storage.db).RegisterTableEntry(new_storage, new_entry);
+			auto lstorage = LocalStorage::Get(*transaction.context, new_storage.db).GetStorage(new_storage);
+			if (lstorage) {
+				lstorage->table_entry = &new_entry;
+			}
 		}
 	}
 

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -1,6 +1,9 @@
 #include "duckdb/catalog/catalog_set.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
@@ -327,6 +330,18 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const string &name, 
 		if (!value) {
 			// alter failed, but did not result in an error
 			return true;
+		}
+	}
+
+	// If this ALTER produced a new DuckTableEntry, refresh the LocalTableStorage's table_entry
+	// pointer for this transaction so that a later commit-time LocalStorage::Flush pushes an
+	// AppendInfo referencing the current DuckTableEntry (not the pre-ALTER one).
+	if (transaction.context && value->type == CatalogType::TABLE_ENTRY) {
+		auto &tce = value->Cast<TableCatalogEntry>();
+		if (tce.IsDuckTable()) {
+			auto &new_entry = tce.Cast<DuckTableEntry>();
+			auto &new_storage = new_entry.GetStorage();
+			LocalStorage::Get(*transaction.context, new_storage.db).RegisterTableEntry(new_storage, new_entry);
 		}
 	}
 

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -15,8 +15,7 @@
 namespace duckdb {
 
 PhysicalBatchInsert::PhysicalBatchInsert(PhysicalPlan &physical_plan, vector<LogicalType> types_p,
-                                         TableCatalogEntry &table,
-                                         vector<unique_ptr<BoundConstraint>> bound_constraints_p,
+                                         DuckTableEntry &table, vector<unique_ptr<BoundConstraint>> bound_constraints_p,
                                          idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::BATCH_INSERT, std::move(types_p), estimated_cardinality),
       insert_table(&table), insert_types(table.GetTypes()), bound_constraints(std::move(bound_constraints_p)) {
@@ -409,13 +408,13 @@ void BatchInsertGlobalState::AddCollection(ClientContext &context, const idx_t b
 // States
 //===--------------------------------------------------------------------===//
 unique_ptr<GlobalSinkState> PhysicalBatchInsert::GetGlobalSinkState(ClientContext &context) const {
-	optional_ptr<TableCatalogEntry> table;
+	optional_ptr<DuckTableEntry> table;
 	if (info) {
 		// CREATE TABLE AS
 		D_ASSERT(!insert_table);
 		auto &catalog = schema->catalog;
 		auto created_table = catalog.CreateTable(catalog.GetCatalogTransaction(context), *schema.get_mutable(), *info);
-		table = &created_table->Cast<TableCatalogEntry>();
+		table = &created_table->Cast<DuckTableEntry>();
 	} else {
 		D_ASSERT(insert_table);
 		D_ASSERT(insert_table->IsDuckTable());
@@ -424,7 +423,7 @@ unique_ptr<GlobalSinkState> PhysicalBatchInsert::GetGlobalSinkState(ClientContex
 	// heuristic - we start off by allocating 4MB of cache space per column
 	static constexpr const idx_t MINIMUM_MEMORY_PER_COLUMN = 4ULL * 1024ULL * 1024ULL;
 	auto minimum_memory_per_thread = table->GetColumns().PhysicalColumnCount() * MINIMUM_MEMORY_PER_COLUMN;
-	auto result = make_uniq<BatchInsertGlobalState>(context, table->Cast<DuckTableEntry>(), minimum_memory_per_thread);
+	auto result = make_uniq<BatchInsertGlobalState>(context, *table, minimum_memory_per_thread);
 	return std::move(result);
 }
 
@@ -648,7 +647,7 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 		// finally, merge the row groups into the local storage
 		for (const auto collection_index : final_collections) {
 			auto &collection = data_table.GetOptimisticCollection(context, collection_index);
-			data_table.LocalMerge(context, collection);
+			data_table.LocalMerge(context, table, collection);
 			data_table.ResetOptimisticCollection(context, collection_index);
 		}
 

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -672,7 +672,7 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 		auto &optimistic_collection = data_table.GetOptimisticCollection(context, entry.collection_index);
 		auto &collection = *optimistic_collection.collection;
 		for (auto &insert_chunk : collection.Chunks(transaction)) {
-			data_table.LocalAppend(append_state, context, insert_chunk, false);
+			data_table.LocalAppend(append_state, table, context, insert_chunk, false);
 		}
 		data_table.ResetOptimisticCollection(context, entry.collection_index);
 	}

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -25,8 +25,8 @@ PhysicalDelete::PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> 
 //===--------------------------------------------------------------------===//
 class DeleteGlobalState : public GlobalSinkState {
 public:
-	explicit DeleteGlobalState(ClientContext &context, const vector<LogicalType> &return_types,
-	                           TableCatalogEntry &table, const vector<unique_ptr<BoundConstraint>> &bound_constraints)
+	explicit DeleteGlobalState(ClientContext &context, const vector<LogicalType> &return_types, DuckTableEntry &table,
+	                           const vector<unique_ptr<BoundConstraint>> &bound_constraints)
 	    : deleted_count(0), return_collection(context, return_types), has_unique_indexes(false) {
 		// We need to append deletes to the local delete-ART.
 		auto &storage = table.GetStorage();

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/operator/persistent/physical_delete.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -11,7 +12,7 @@
 
 namespace duckdb {
 
-PhysicalDelete::PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &tableref,
+PhysicalDelete::PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref,
                                DataTable &table, vector<unique_ptr<BoundConstraint>> bound_constraints,
                                idx_t row_id_index, idx_t estimated_cardinality, bool return_chunk,
                                vector<idx_t> return_columns)
@@ -90,7 +91,7 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	// Fast path: no RETURNING and no unique indexes
 	if (!return_chunk && !g_state.has_unique_indexes) {
-		auto deleted = table.Delete(*l_state.delete_state, context.client, row_ids, chunk.size());
+		auto deleted = table.Delete(*l_state.delete_state, context.client, tableref, row_ids, chunk.size());
 		g_state.deleted_count.fetch_add(deleted);
 		return SinkResultType::NEED_MORE_INPUT;
 	}
@@ -191,7 +192,7 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 		}
 	}
 
-	auto deleted = table.Delete(*l_state.delete_state, context.client, delete_row_ids, delete_count);
+	auto deleted = table.Delete(*l_state.delete_state, context.client, tableref, delete_row_ids, delete_count);
 	g_state.deleted_count.fetch_add(deleted);
 
 	// Collect RETURNING rows per-thread; merge into global in Combine()

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -24,7 +24,7 @@
 
 namespace duckdb {
 
-PhysicalInsert::PhysicalInsert(PhysicalPlan &physical_plan, vector<LogicalType> types_p, TableCatalogEntry &table,
+PhysicalInsert::PhysicalInsert(PhysicalPlan &physical_plan, vector<LogicalType> types_p, DuckTableEntry &table,
                                vector<unique_ptr<BoundConstraint>> bound_constraints_p,
                                vector<unique_ptr<Expression>> set_expressions, vector<PhysicalIndex> set_columns,
                                vector<LogicalType> set_types, idx_t estimated_cardinality, bool return_chunk,
@@ -104,19 +104,19 @@ TableDeleteState &InsertLocalState::GetDeleteState(DataTable &table, TableCatalo
 }
 
 unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &context) const {
-	optional_ptr<TableCatalogEntry> table;
+	optional_ptr<DuckTableEntry> table;
 	if (info) {
 		// CREATE TABLE AS
 		D_ASSERT(!insert_table);
 		auto &catalog = schema->catalog;
 		table = &catalog.CreateTable(catalog.GetCatalogTransaction(context), *schema.get_mutable(), *info)
-		             ->Cast<TableCatalogEntry>();
+		             ->Cast<DuckTableEntry>();
 	} else {
 		D_ASSERT(insert_table);
 		D_ASSERT(insert_table->IsDuckTable());
 		table = insert_table.get_mutable();
 	}
-	auto result = make_uniq<InsertGlobalState>(context, GetTypes(), table->Cast<DuckTableEntry>());
+	auto result = make_uniq<InsertGlobalState>(context, GetTypes(), *table);
 	return std::move(result);
 }
 
@@ -187,7 +187,7 @@ static void CombineExistingAndInsertTuples(DataChunk &result, DataChunk &scan_ch
 	result.SetCardinality(input_chunk.size());
 }
 
-static void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, TableCatalogEntry &table, Vector &row_ids,
+static void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, DuckTableEntry &table, Vector &row_ids,
                               DataChunk &update_chunk, const PhysicalInsert &op) {
 	auto &do_update_condition = op.do_update_condition;
 	auto &set_types = op.set_types;
@@ -237,7 +237,7 @@ static void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, Table
 
 template <bool GLOBAL>
 static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState &gstate, ExecutionContext &context,
-                                     DataChunk &chunk, TableCatalogEntry &table, Vector &row_ids,
+                                     DataChunk &chunk, DuckTableEntry &table, Vector &row_ids,
                                      const PhysicalInsert &op) {
 	// Early-out, if we do nothing on conflicting rows.
 	if (op.action_type == OnConflictAction::NOTHING) {
@@ -272,20 +272,20 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 
 		if (GLOBAL) {
 			auto update_state = data_table.InitializeUpdate(table, context.client, op.bound_constraints);
-			data_table.Update(*update_state, context.client, row_ids, set_columns, update_chunk);
+			data_table.Update(*update_state, context.client, table, row_ids, set_columns, update_chunk);
 			return update_chunk.size();
 		}
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);
-		local_storage.Update(data_table, row_ids, set_columns, update_chunk);
+		local_storage.Update(data_table, table, row_ids, set_columns, update_chunk);
 		return update_chunk.size();
 	}
 
 	if (GLOBAL) {
 		auto &delete_state = lstate.GetDeleteState(data_table, table, context.client);
-		data_table.Delete(delete_state, context.client, row_ids, update_chunk.size());
+		data_table.Delete(delete_state, context.client, table, row_ids, update_chunk.size());
 	} else {
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);
-		local_storage.Delete(data_table, row_ids, update_chunk.size());
+		local_storage.Delete(data_table, table, row_ids, update_chunk.size());
 	}
 
 	if (!op.parallel && op.return_chunk) {
@@ -428,7 +428,7 @@ static void VerifyOnConflictCondition(ExecutionContext &context, DataChunk &comb
 }
 
 template <bool GLOBAL>
-static idx_t HandleInsertConflicts(TableCatalogEntry &table, ExecutionContext &context, InsertLocalState &lstate,
+static idx_t HandleInsertConflicts(DuckTableEntry &table, ExecutionContext &context, InsertLocalState &lstate,
                                    InsertGlobalState &gstate, DataChunk &tuples, const PhysicalInsert &op) {
 	auto &types_to_fetch = op.types_to_fetch;
 	auto &on_conflict_condition = op.on_conflict_condition;
@@ -516,7 +516,7 @@ static idx_t HandleInsertConflicts(TableCatalogEntry &table, ExecutionContext &c
 	return affected_tuples;
 }
 
-idx_t PhysicalInsert::OnConflictHandling(TableCatalogEntry &table, ExecutionContext &context, InsertGlobalState &gstate,
+idx_t PhysicalInsert::OnConflictHandling(DuckTableEntry &table, ExecutionContext &context, InsertGlobalState &gstate,
                                          InsertLocalState &lstate, DataChunk &insert_chunk) const {
 	auto &data_table = table.GetStorage();
 	auto &local_storage = LocalStorage::Get(context.client, data_table.db);
@@ -713,7 +713,7 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
 		lstate.optimistic_writer->WriteUnflushedRowGroups(optimistic_collection);
 		lstate.optimistic_writer->FinalFlush();
-		gstate.table.GetStorage().LocalMerge(context.client, optimistic_collection);
+		gstate.table.GetStorage().LocalMerge(context.client, gstate.table, optimistic_collection);
 		auto &optimistic_writer = gstate.table.GetStorage().GetOptimisticWriter(context.client);
 		optimistic_writer.Merge(*lstate.optimistic_writer);
 	}

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -706,7 +706,7 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		storage.InitializeLocalAppend(append_state, table, context.client, bound_constraints);
 		auto &transaction = DuckTransaction::Get(context.client, table.catalog);
 		for (auto &insert_chunk : collection.Chunks(transaction)) {
-			storage.LocalAppend(append_state, context.client, insert_chunk, false);
+			storage.LocalAppend(append_state, table, context.client, insert_chunk, false);
 		}
 		storage.FinalizeLocalAppend(append_state);
 	} else {

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/operator/persistent/physical_update.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -16,7 +17,7 @@
 
 namespace duckdb {
 
-PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &tableref,
+PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref,
                                DataTable &table, vector<PhysicalIndex> columns,
                                vector<unique_ptr<Expression>> expressions,
                                vector<unique_ptr<Expression>> bound_defaults,
@@ -139,7 +140,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 			}
 		}
 		auto &update_state = l_state.GetUpdateState(table, tableref, context.client);
-		table.Update(update_state, context.client, row_ids, columns, update_chunk);
+		table.Update(update_state, context.client, tableref, row_ids, columns, update_chunk);
 
 		if (return_chunk) {
 			lock_guard<mutex> glock(g_state.lock);
@@ -190,7 +191,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	}
 
 	auto &delete_state = l_state.GetDeleteState(table, tableref, context.client);
-	table.Delete(delete_state, context.client, del_row_ids, update_count);
+	table.Delete(delete_state, context.client, tableref, del_row_ids, update_count);
 
 	// Arrange the columns in the standard table order.
 	mock_chunk.SetCardinality(update_count);

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -11,9 +11,9 @@ PhysicalOperator &DuckCatalog::PlanDelete(ClientContext &context, PhysicalPlanGe
                                           PhysicalOperator &plan) {
 	// Get the row_id column index.
 	auto &bound_ref = op.expressions[0]->Cast<BoundReferenceExpression>();
-	auto &del = planner.Make<PhysicalDelete>(op.types, op.table, op.table.GetStorage(), std::move(op.bound_constraints),
-	                                         bound_ref.index, op.estimated_cardinality, op.return_chunk,
-	                                         std::move(op.return_columns));
+	auto &del = planner.Make<PhysicalDelete>(op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
+	                                         std::move(op.bound_constraints), bound_ref.index, op.estimated_cardinality,
+	                                         op.return_chunk, std::move(op.return_columns));
 	del.children.push_back(plan);
 	return del;
 }

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/execution/operator/persistent/physical_insert.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
@@ -120,14 +121,14 @@ PhysicalOperator &DuckCatalog::PlanInsert(ClientContext &context, PhysicalPlanGe
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 	if (use_batch_index && !parallel_streaming_insert) {
-		auto &insert = planner.Make<PhysicalBatchInsert>(op.types, op.table, std::move(op.bound_constraints),
-		                                                 op.estimated_cardinality);
+		auto &insert = planner.Make<PhysicalBatchInsert>(op.types, op.table.Cast<DuckTableEntry>(),
+		                                                 std::move(op.bound_constraints), op.estimated_cardinality);
 		insert.children.push_back(*plan);
 		return insert;
 	}
 
 	auto &insert = planner.Make<PhysicalInsert>(
-	    op.types, op.table, std::move(op.bound_constraints), std::move(op.expressions),
+	    op.types, op.table.Cast<DuckTableEntry>(), std::move(op.bound_constraints), std::move(op.expressions),
 	    std::move(op.on_conflict_info.set_columns), std::move(op.on_conflict_info.set_types), op.estimated_cardinality,
 	    op.return_chunk, parallel_streaming_insert && num_threads > 1, op.on_conflict_info.action_type,
 	    std::move(op.on_conflict_info.on_conflict_condition), std::move(op.on_conflict_info.do_update_condition),

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/execution/operator/persistent/physical_merge_into.hpp"
 #include "duckdb/execution/operator/persistent/physical_delete.hpp"
@@ -32,10 +33,10 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		for (auto &def : op.bound_defaults) {
 			defaults.push_back(def->Copy());
 		}
-		result->op =
-		    planner.Make<PhysicalUpdate>(std::move(return_types), op.table, op.table.GetStorage(),
-		                                 std::move(action.columns), std::move(action.expressions), std::move(defaults),
-		                                 std::move(bound_constraints), cardinality, op.return_chunk);
+		result->op = planner.Make<PhysicalUpdate>(std::move(return_types), op.table.Cast<DuckTableEntry>(),
+		                                          op.table.GetStorage(), std::move(action.columns),
+		                                          std::move(action.expressions), std::move(defaults),
+		                                          std::move(bound_constraints), cardinality, op.return_chunk);
 		auto &cast_update = result->op->Cast<PhysicalUpdate>();
 		cast_update.update_is_del_and_insert = action.update_is_del_and_insert;
 		break;
@@ -43,9 +44,9 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 	case MergeActionType::MERGE_DELETE: {
 		// Use delete_return_columns if available (for optimized RETURNING path)
 		vector<idx_t> return_columns = op.delete_return_columns;
-		result->op = planner.Make<PhysicalDelete>(std::move(return_types), op.table, op.table.GetStorage(),
-		                                          std::move(bound_constraints), op.row_id_start, cardinality,
-		                                          op.return_chunk, std::move(return_columns));
+		result->op = planner.Make<PhysicalDelete>(std::move(return_types), op.table.Cast<DuckTableEntry>(),
+		                                          op.table.GetStorage(), std::move(bound_constraints), op.row_id_start,
+		                                          cardinality, op.return_chunk, std::move(return_columns));
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {
@@ -55,11 +56,11 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		unordered_set<column_t> on_conflict_filter;
 		vector<column_t> columns_to_fetch;
 
-		result->op = planner.Make<PhysicalInsert>(std::move(return_types), op.table, std::move(bound_constraints),
-		                                          std::move(set_expressions), std::move(set_columns),
-		                                          std::move(set_types), cardinality, op.return_chunk, !op.return_chunk,
-		                                          OnConflictAction::THROW, nullptr, nullptr,
-		                                          std::move(on_conflict_filter), std::move(columns_to_fetch), false);
+		result->op = planner.Make<PhysicalInsert>(
+		    std::move(return_types), op.table.Cast<DuckTableEntry>(), std::move(bound_constraints),
+		    std::move(set_expressions), std::move(set_columns), std::move(set_types), cardinality, op.return_chunk,
+		    !op.return_chunk, OnConflictAction::THROW, nullptr, nullptr, std::move(on_conflict_filter),
+		    std::move(columns_to_fetch), false);
 		// transform expressions if required
 		if (!action.column_index_map.empty()) {
 			vector<unique_ptr<Expression>> new_expressions;

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/execution/operator/persistent/physical_update.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
@@ -9,8 +10,8 @@ namespace duckdb {
 PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                           PhysicalOperator &plan) {
 	auto &update = planner.Make<PhysicalUpdate>(
-	    op.types, op.table, op.table.GetStorage(), op.columns, std::move(op.expressions), std::move(op.bound_defaults),
-	    std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk);
+	    op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(), op.columns, std::move(op.expressions),
+	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
 	cast_update.children.push_back(plan);

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/execution/operator/persistent/physical_insert.hpp"
 
 namespace duckdb {
+class DuckTableEntry;
 
 class PhysicalBatchInsert : public PhysicalOperator {
 public:
@@ -18,14 +19,14 @@ public:
 
 public:
 	//! INSERT INTO
-	PhysicalBatchInsert(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &table,
+	PhysicalBatchInsert(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &table,
 	                    vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality);
 	//! CREATE TABLE AS
 	PhysicalBatchInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
 	                    unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
 
 	//! The table to insert into
-	optional_ptr<TableCatalogEntry> insert_table;
+	optional_ptr<DuckTableEntry> insert_table;
 	//! The insert types
 	vector<LogicalType> insert_types;
 	//! The bound constraints for the table

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -13,6 +13,7 @@
 
 namespace duckdb {
 class DataTable;
+class DuckTableEntry;
 
 //! Physically delete data from a table
 class PhysicalDelete : public PhysicalOperator {
@@ -20,11 +21,11 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::DELETE_OPERATOR;
 
 public:
-	PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &tableref,
-	               DataTable &table, vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t row_id_index,
+	PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref, DataTable &table,
+	               vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t row_id_index,
 	               idx_t estimated_cardinality, bool return_chunk, vector<idx_t> return_columns);
 
-	TableCatalogEntry &tableref;
+	DuckTableEntry &tableref;
 	DataTable &table;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	idx_t row_id_index;

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -69,7 +69,7 @@ public:
 
 public:
 	//! INSERT INTO
-	PhysicalInsert(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &table,
+	PhysicalInsert(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &table,
 	               vector<unique_ptr<BoundConstraint>> bound_constraints,
 	               vector<unique_ptr<Expression>> set_expressions, vector<PhysicalIndex> set_columns,
 	               vector<LogicalType> set_types, idx_t estimated_cardinality, bool return_chunk, bool parallel,
@@ -81,7 +81,7 @@ public:
 	               unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality, bool parallel);
 
 	//! The table to insert into
-	optional_ptr<TableCatalogEntry> insert_table;
+	optional_ptr<DuckTableEntry> insert_table;
 	//! The insert types
 	vector<LogicalType> insert_types;
 	//! The bound constraints for the table
@@ -157,9 +157,9 @@ protected:
 	void CombineExistingAndInsertTuples(DataChunk &result, DataChunk &scan_chunk, DataChunk &input_chunk,
 	                                    ClientContext &client) const;
 	//! Returns the amount of updated tuples
-	void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, TableCatalogEntry &table, Vector &row_ids,
+	void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, DuckTableEntry &table, Vector &row_ids,
 	                       DataChunk &result) const;
-	idx_t OnConflictHandling(TableCatalogEntry &table, ExecutionContext &context, InsertGlobalState &gstate,
+	idx_t OnConflictHandling(DuckTableEntry &table, ExecutionContext &context, InsertGlobalState &gstate,
 	                         InsertLocalState &lstate, DataChunk &insert_chunk) const;
 };
 

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 class DataTable;
+class DuckTableEntry;
 
 //! Physically update data in a table
 class PhysicalUpdate : public PhysicalOperator {
@@ -21,12 +22,12 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UPDATE;
 
 public:
-	PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &tableref,
-	               DataTable &table, vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
+	PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref, DataTable &table,
+	               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
 	               vector<unique_ptr<Expression>> bound_defaults, vector<unique_ptr<BoundConstraint>> bound_constraints,
 	               idx_t estimated_cardinality, bool return_chunk);
 
-	TableCatalogEntry &tableref;
+	DuckTableEntry &tableref;
 	DataTable &table;
 	vector<PhysicalIndex> columns;
 	vector<unique_ptr<Expression>> expressions;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -134,7 +134,7 @@ public:
 	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints,
 	                 optional_ptr<const vector<LogicalIndex>> column_ids);
 	//! Merge a row group collection into the transaction-local storage
-	void LocalMerge(ClientContext &context, OptimisticWriteCollection &collection);
+	void LocalMerge(ClientContext &context, DuckTableEntry &table_entry, OptimisticWriteCollection &collection);
 	//! Create an optimistic row group collection for this table. Used for optimistically writing parallel appends.
 	//! Returns the index into the optimistic_collections vector for newly created collection.
 	PhysicalIndex CreateOptimisticCollection(ClientContext &context, unique_ptr<OptimisticWriteCollection> collection);
@@ -148,12 +148,13 @@ public:
 	unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry &table, ClientContext &context,
 	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 	//! Delete the entries with the specified row identifier from the table
-	idx_t Delete(TableDeleteState &state, ClientContext &context, Vector &row_ids, idx_t count);
+	idx_t Delete(TableDeleteState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
+	             idx_t count);
 
 	unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
 	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 	//! Update the entries with the specified row identifier from the table
-	void Update(TableUpdateState &state, ClientContext &context, Vector &row_ids,
+	void Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
 	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
 	//! Update a single (sub-)column along a column path
 	//! The column_path vector is a *path* towards a column within the table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -110,27 +110,28 @@ public:
 	bool CanFetch(DuckTransaction &transaction, const row_t row_id);
 
 	//! Initializes appending to transaction-local storage
-	void InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+	void InitializeLocalAppend(LocalAppendState &state, DuckTableEntry &table, ClientContext &context,
 	                           const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 	//! Initializes only the delete-indexes of the transaction-local storage
-	void InitializeLocalStorage(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+	void InitializeLocalStorage(LocalAppendState &state, DuckTableEntry &table, ClientContext &context,
 	                            const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 	//! Append a DataChunk to the transaction-local storage of the table.
-	void LocalAppend(LocalAppendState &state, ClientContext &context, DataChunk &chunk, bool unsafe);
+	void LocalAppend(LocalAppendState &state, DuckTableEntry &table_entry, ClientContext &context, DataChunk &chunk,
+	                 bool unsafe);
 	//! Finalizes a transaction-local append
 	void FinalizeLocalAppend(LocalAppendState &state);
 	//! Append a chunk to the transaction-local storage of this table and update the delete indexes.
-	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	void LocalAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
 	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, Vector &row_ids,
 	                 DataChunk &delete_chunk);
 	//! Appends to the transaction-local storage of this table
-	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	void LocalAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
 	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool unsafe = false);
 	//! Append a chunk to the transaction-local storage of this table.
-	void LocalWALAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	void LocalWALAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
 	                    const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 	//! Append a column data collection with default values to the transaction-local storage of this table.
-	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
+	void LocalAppend(DuckTableEntry &table, ClientContext &context, ColumnDataCollection &collection,
 	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints,
 	                 optional_ptr<const vector<LogicalIndex>> column_ids);
 	//! Merge a row group collection into the transaction-local storage
@@ -165,7 +166,7 @@ public:
 	//! -> 1 (second subcolumn of struct)
 	//! -> 0 (first subcolumn of INT)
 	//! This method should only be used from the WAL replay. It does not verify update constraints.
-	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+	void UpdateColumn(DuckTableEntry &table, ClientContext &context, Vector &row_ids,
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
 	//! Fetches an append lock

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -41,9 +41,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -167,11 +167,11 @@ public:
 	virtual void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index,
 	                      row_t row_id, Vector &result, idx_t result_idx);
 
-	virtual void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
-	                    row_t *row_ids, idx_t update_count, idx_t row_group_start);
-	virtual void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
-	                          Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
-	                          idx_t row_group_start);
+	virtual void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
+	                    Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start);
+	virtual void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
+	                          const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
+	                          idx_t update_count, idx_t depth, idx_t row_group_start);
 	virtual unique_ptr<BaseStatistics> GetUpdateStatistics();
 
 	virtual void VisitBlockIds(BlockIdVisitor &visitor) const;
@@ -233,8 +233,9 @@ protected:
 	void FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result, idx_t scan_count,
 	                  UpdateScanType update_type);
 	void FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx);
-	void UpdateInternal(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
-	                    row_t *row_ids, idx_t update_count, Vector &base_vector, idx_t row_group_start);
+	void UpdateInternal(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
+	                    Vector &update_vector, row_t *row_ids, idx_t update_count, Vector &base_vector,
+	                    idx_t row_group_start);
 	idx_t FetchUpdateData(ColumnScanState &state, row_t *row_ids, Vector &base_vector, idx_t row_group_start);
 
 	idx_t GetVectorCount(idx_t vector_index) const;

--- a/src/include/duckdb/storage/table/geo_column_data.hpp
+++ b/src/include/duckdb/storage/table/geo_column_data.hpp
@@ -47,9 +47,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -39,9 +39,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -25,6 +25,7 @@ class BlockManager;
 class ColumnData;
 class DatabaseInstance;
 class DataTable;
+class DuckTableEntry;
 class PartialBlockManager;
 struct DataTableInfo;
 class ExpressionExecutor;
@@ -158,7 +159,8 @@ public:
 	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
 
 	//! Delete the given set of rows in the version manager
-	idx_t Delete(TransactionData transaction, DataTable &table, row_t *row_ids, idx_t count, idx_t row_group_start);
+	idx_t Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *row_ids, idx_t count,
+	             idx_t row_group_start);
 
 	static vector<RowGroupWriteData> WriteToDisk(RowGroupWriteInfo &info,
 	                                             const vector<const_reference<RowGroup>> &row_groups);
@@ -178,11 +180,11 @@ public:
 	void InitializeAppend(RowGroupAppendState &append_state);
 	void Append(RowGroupAppendState &append_state, DataChunk &chunk, idx_t append_count);
 
-	void Update(TransactionData transaction, DataTable &data_table, DataChunk &updates, row_t *ids, idx_t offset,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &updates, row_t *ids, idx_t offset,
 	            idx_t count, const vector<PhysicalIndex> &column_ids, idx_t row_group_start);
 	//! Update a single column; corresponds to DataTable::UpdateColumn
 	//! This method should only be called from the WAL
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, DataChunk &updates, Vector &row_ids,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &updates, Vector &row_ids,
 	                  idx_t offset, idx_t count, const vector<column_t> &column_path, idx_t row_group_start);
 
 	void MergeStatistics(idx_t column_idx, const BaseStatistics &other);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -38,6 +38,7 @@ struct PersistentCollectionData;
 class CheckpointTask;
 class TableIOManager;
 class DataTable;
+class DuckTableEntry;
 class RowGroupIterationHelper;
 class TableScanState;
 
@@ -108,10 +109,10 @@ public:
 	void RemoveFromIndexes(const QueryContext &context, TableIndexList &indexes, Vector &row_identifiers, idx_t count,
 	                       IndexRemovalType removal_type, optional_idx active_checkpoint = optional_idx());
 
-	idx_t Delete(TransactionData transaction, DataTable &table, row_t *ids, idx_t count);
-	void Update(TransactionData transaction, DataTable &table, row_t *ids, const vector<PhysicalIndex> &column_ids,
-	            DataChunk &updates);
-	void UpdateColumn(TransactionData transaction, DataTable &table, Vector &row_ids,
+	idx_t Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *ids, idx_t count);
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, row_t *ids,
+	            const vector<PhysicalIndex> &column_ids, DataChunk &updates);
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, Vector &row_ids,
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
 	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -44,9 +44,9 @@ public:
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
 	void RevertAppend(row_t new_count) override;
 
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 

--- a/src/include/duckdb/storage/table/row_number_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_number_column_data.hpp
@@ -42,9 +42,9 @@ public:
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
 	void RevertAppend(row_t new_count) override;
 
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -42,9 +42,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -55,9 +55,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -17,6 +17,7 @@
 namespace duckdb {
 class ColumnData;
 class DataTable;
+class DuckTableEntry;
 class Vector;
 struct UpdateInfo;
 struct UpdateNode;
@@ -38,8 +39,8 @@ public:
 	void FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result);
 	void FetchCommitted(idx_t vector_index, Vector &result);
 	void FetchCommittedRange(idx_t start_row, idx_t count, Vector &result);
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update, row_t *ids,
-	            idx_t count, Vector &base_data, idx_t row_group_start);
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update,
+	            row_t *ids, idx_t count, Vector &base_data, idx_t row_group_start);
 	void FetchRow(TransactionData transaction, idx_t row_id, Vector &result, idx_t result_idx);
 
 	void RollbackUpdate(UpdateInfo &info);

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -28,8 +28,9 @@ public:
 	                                                        PartialBlockManager &partial_block_manager) override;
 
 	void Verify(RowGroup &parent) override;
-	void UpdateWithBase(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
-	                    row_t *row_ids, idx_t update_count, ColumnData &base, idx_t row_group_start);
+	void UpdateWithBase(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
+	                    Vector &update_vector, row_t *row_ids, idx_t update_count, ColumnData &base,
+	                    idx_t row_group_start);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -50,9 +50,9 @@ public:
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,
 	              Vector &result, idx_t result_idx) override;
-	void Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	void Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index, Vector &update_vector,
 	            row_t *row_ids, idx_t update_count, idx_t row_group_start) override;
-	void UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
+	void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, const vector<column_t> &column_path,
 	                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
 	                  idx_t row_group_start) override;
 	unique_ptr<BaseStatistics> GetUpdateStatistics() override;

--- a/src/include/duckdb/transaction/append_info.hpp
+++ b/src/include/duckdb/transaction/append_info.hpp
@@ -11,10 +11,10 @@
 #include "duckdb/common/constants.hpp"
 
 namespace duckdb {
-class DataTable;
+class DuckTableEntry;
 
 struct AppendInfo {
-	DataTable *table;
+	DuckTableEntry *table;
 	idx_t start_row;
 	idx_t count;
 };

--- a/src/include/duckdb/transaction/delete_info.hpp
+++ b/src/include/duckdb/transaction/delete_info.hpp
@@ -11,11 +11,11 @@
 #include "duckdb/common/constants.hpp"
 
 namespace duckdb {
-class DataTable;
+class DuckTableEntry;
 class RowVersionManager;
 
 struct DeleteInfo {
-	DataTable *table;
+	DuckTableEntry *table;
 	RowVersionManager *version_info;
 	idx_t vector_idx;
 	idx_t count;

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -16,6 +16,7 @@
 
 namespace duckdb {
 class CheckpointLock;
+class DuckTableEntry;
 class RowGroupCollection;
 class RowVersionManager;
 class DuckTransactionManager;
@@ -77,11 +78,12 @@ public:
 	bool ChangesMade();
 	UndoBufferProperties GetUndoProperties();
 
-	void PushDelete(DataTable &table, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
+	void PushDelete(DuckTableEntry &table_entry, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
 	                idx_t base_row);
 	void PushSequenceUsage(SequenceCatalogEntry &entry, const SequenceData &data);
-	void PushAppend(DataTable &table, idx_t row_start, idx_t row_count);
-	UndoBufferReference CreateUpdateInfo(idx_t type_size, DataTable &data_table, idx_t entries, idx_t row_group_start);
+	void PushAppend(DuckTableEntry &table_entry, idx_t row_start, idx_t row_count);
+	UndoBufferReference CreateUpdateInfo(DuckTableEntry &table_entry, idx_t type_size, idx_t entries,
+	                                     idx_t row_group_start);
 
 	DuckTransactionManager &GetTransactionManager();
 	bool IsDuckTransaction() const override {
@@ -92,9 +94,6 @@ public:
 
 	//! Get a shared lock on a table
 	shared_ptr<CheckpointLock> SharedLockTable(DataTableInfo &info);
-
-	//! Hold an owning reference of the table, needed to safely reference it inside the transaction commit/undo logic
-	void ModifyTable(DataTable &tbl);
 
 	void SetIsCheckpointTransaction() {
 		is_checkpoint_transaction = true;
@@ -114,10 +113,6 @@ private:
 	mutex sequence_lock;
 	//! Map of all sequences that were used during the transaction and the value they had in this transaction
 	reference_map_t<SequenceCatalogEntry, reference<SequenceValue>> sequence_usage;
-	//! Lock for modified_tables
-	mutex modified_tables_lock;
-	//! Tables that are modified by this transaction
-	reference_map_t<DataTable, shared_ptr<DataTable>> modified_tables;
 	//! Lock for the active_locks map
 	mutex active_locks_lock;
 	struct ActiveTableLock {

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -22,6 +22,7 @@ class CollectionScanState;
 class ColumnDefinition;
 class DataChunk;
 class DataTable;
+class DuckTableEntry;
 class DuckTransaction;
 class Expression;
 class ExpressionExecutor;
@@ -54,6 +55,10 @@ public:
 	QueryContext context;
 
 	reference<DataTable> table_ref;
+	//! The DuckTableEntry visible to this transaction that references table_ref.
+	//! Set when InitializeAppend/InitializeStorage is called and refreshed when ALTER within this
+	//! transaction produces a new DuckTableEntry via DuckTableEntry::AlterEntry.
+	optional_ptr<DuckTableEntry> table_entry;
 
 	Allocator &allocator;
 	//! The main row group collection.
@@ -148,15 +153,20 @@ public:
 	                      CollectionScanState &scan_state);
 
 	//! Begin appending to the local storage
-	void InitializeAppend(LocalAppendState &state, DataTable &table);
+	void InitializeAppend(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry);
 	//! Initialize the storage and its indexes, but no row groups.
-	void InitializeStorage(LocalAppendState &state, DataTable &table);
+	void InitializeStorage(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry);
+
+	//! Update the DuckTableEntry associated with a DataTable in this transaction's local storage.
+	//! Called after DuckTableEntry::AlterEntry produces a new DuckTableEntry so that a subsequent
+	//! LocalStorage::Flush can push the AppendInfo with the current DuckTableEntry.
+	void RegisterTableEntry(DataTable &table, DuckTableEntry &table_entry);
 	//! Append a chunk to the local storage
 	static void Append(LocalAppendState &state, DataChunk &table_chunk, DataTableInfo &data_table_info);
 	//! Finish appending to the local storage
 	static void FinalizeAppend(LocalAppendState &state);
 	//! Merge a row group collection into the transaction-local storage
-	void LocalMerge(DataTable &table, OptimisticWriteCollection &collection);
+	void LocalMerge(DataTable &table, DuckTableEntry &table_entry, OptimisticWriteCollection &collection);
 	//! Create an optimistic row group collection for this table.
 	//! Returns the index into the optimistic_collections vector for newly created collection.
 	PhysicalIndex CreateOptimisticCollection(DataTable &table, unique_ptr<OptimisticWriteCollection> collection);
@@ -168,9 +178,10 @@ public:
 	OptimisticDataWriter &GetOptimisticWriter(DataTable &table);
 
 	//! Delete a set of rows from the local storage
-	idx_t Delete(DataTable &table, Vector &row_ids, idx_t count);
+	idx_t Delete(DataTable &table, DuckTableEntry &table_entry, Vector &row_ids, idx_t count);
 	//! Update a set of rows in the local storage
-	void Update(DataTable &table, Vector &row_ids, const vector<PhysicalIndex> &column_ids, DataChunk &data);
+	void Update(DataTable &table, DuckTableEntry &table_entry, Vector &row_ids, const vector<PhysicalIndex> &column_ids,
+	            DataChunk &data);
 
 	//! Commits the local storage, writing it to the WAL and completing the commit
 	void Commit(optional_ptr<StorageCommitState> commit_state);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -56,8 +56,8 @@ public:
 
 	reference<DataTable> table_ref;
 	//! The DuckTableEntry visible to this transaction that references table_ref.
-	//! Set when InitializeAppend/InitializeStorage is called and refreshed when ALTER within this
-	//! transaction produces a new DuckTableEntry via DuckTableEntry::AlterEntry.
+	//! Updated through the append path (InitializeAppend, Append, LocalMerge) and
+	//! propagated from parent storage on ALTER operations.
 	optional_ptr<DuckTableEntry> table_entry;
 
 	Allocator &allocator;
@@ -157,12 +157,9 @@ public:
 	//! Initialize the storage and its indexes, but no row groups.
 	void InitializeStorage(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry);
 
-	//! Update the DuckTableEntry associated with a DataTable in this transaction's local storage.
-	//! Called after DuckTableEntry::AlterEntry produces a new DuckTableEntry so that a subsequent
-	//! LocalStorage::Flush can push the AppendInfo with the current DuckTableEntry.
-	void RegisterTableEntry(DataTable &table, DuckTableEntry &table_entry);
 	//! Append a chunk to the local storage
-	static void Append(LocalAppendState &state, DataChunk &table_chunk, DataTableInfo &data_table_info);
+	static void Append(LocalAppendState &state, DuckTableEntry &table_entry, DataChunk &table_chunk,
+	                   DataTableInfo &data_table_info);
 	//! Finish appending to the local storage
 	static void FinalizeAppend(LocalAppendState &state);
 	//! Merge a row group collection into the transaction-local storage

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 class UpdateSegment;
 struct DataTableInfo;
-class DataTable;
+class DuckTableEntry;
 
 //! UpdateInfo is a class that represents a set of updates applied to a single vector.
 //! The UpdateInfo struct contains metadata associated with the update.
@@ -28,7 +28,7 @@ struct UpdateInfo {
 	//! The update segment that this update info affects
 	UpdateSegment *segment;
 	//! The table this was update was made on
-	DataTable *table;
+	DuckTableEntry *table;
 	//! The column index of which column we are updating
 	idx_t column_index;
 	//! The start index of the row group
@@ -96,7 +96,7 @@ struct UpdateInfo {
 	//! Returns the total allocation size for an UpdateInfo entry, together with space for the tuple data
 	static idx_t GetAllocSize(idx_t type_size);
 	//! Initialize an UpdateInfo struct that has been allocated using GetAllocSize (i.e. has extra space after it)
-	static void Initialize(UpdateInfo &info, DataTable &data_table, transaction_t transaction_id,
+	static void Initialize(UpdateInfo &info, DuckTableEntry &table_entry, transaction_t transaction_id,
 	                       idx_t row_group_start);
 };
 

--- a/src/include/duckdb/transaction/wal_write_state.hpp
+++ b/src/include/duckdb/transaction/wal_write_state.hpp
@@ -14,11 +14,11 @@
 namespace duckdb {
 class CatalogEntry;
 class DataChunk;
+class DuckTableEntry;
 class DuckTransaction;
 class WriteAheadLog;
 class ClientContext;
 
-struct DataTableInfo;
 struct DeleteInfo;
 struct UpdateInfo;
 
@@ -31,7 +31,7 @@ public:
 	void CommitEntry(UndoFlags type, data_ptr_t data);
 
 private:
-	void SwitchTable(DataTableInfo &table, UndoFlags new_op);
+	void SwitchTable(DuckTableEntry &table_entry, UndoFlags new_op);
 
 	void WriteCatalogEntry(CatalogEntry &entry, data_ptr_t extra_data);
 	void WriteDelete(DeleteInfo &info);
@@ -42,7 +42,7 @@ private:
 	WriteAheadLog &log;
 	optional_ptr<StorageCommitState> commit_state;
 
-	optional_ptr<DataTableInfo> current_table_info;
+	optional_ptr<DuckTableEntry> current_table_entry;
 
 	unique_ptr<DataChunk> delete_chunk;
 	unique_ptr<DataChunk> update_chunk;

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -742,7 +742,7 @@ InternalAppender::~InternalAppender() {
 void InternalAppender::FlushInternal(ColumnDataCollection &collection) {
 	auto binder = Binder::CreateBinder(context);
 	auto bound_constraints = binder->BindConstraints(table);
-	table.GetStorage().LocalAppend(table, context, collection, bound_constraints, nullptr);
+	table.GetStorage().LocalAppend(table.Cast<DuckTableEntry>(), context, collection, bound_constraints, nullptr);
 }
 
 void BaseAppender::Close() {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
@@ -854,7 +855,7 @@ void DataTable::InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry
 		                           GetTableName(), TableModification());
 	}
 	auto &local_storage = LocalStorage::Get(context, db);
-	local_storage.InitializeAppend(state, *this);
+	local_storage.InitializeAppend(state, *this, table.Cast<DuckTableEntry>());
 	state.constraint_state = InitializeConstraintState(table, bound_constraints);
 }
 
@@ -867,7 +868,7 @@ void DataTable::InitializeLocalStorage(LocalAppendState &state, TableCatalogEntr
 	}
 
 	auto &local_storage = LocalStorage::Get(context, db);
-	local_storage.InitializeStorage(state, *this);
+	local_storage.InitializeStorage(state, *this, table.Cast<DuckTableEntry>());
 	state.constraint_state = InitializeConstraintState(table, bound_constraints);
 }
 
@@ -928,9 +929,9 @@ OptimisticDataWriter &DataTable::GetOptimisticWriter(ClientContext &context) {
 	return local_storage.GetOptimisticWriter(*this);
 }
 
-void DataTable::LocalMerge(ClientContext &context, OptimisticWriteCollection &collection) {
+void DataTable::LocalMerge(ClientContext &context, DuckTableEntry &table_entry, OptimisticWriteCollection &collection) {
 	auto &local_storage = LocalStorage::Get(context, db);
-	local_storage.LocalMerge(*this, collection);
+	local_storage.LocalMerge(*this, table_entry, collection);
 }
 
 void DataTable::LocalWALAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
@@ -1430,7 +1431,8 @@ unique_ptr<TableDeleteState> DataTable::InitializeDelete(TableCatalogEntry &tabl
 	return result;
 }
 
-idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector &row_identifiers, idx_t count) {
+idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, DuckTableEntry &table_entry,
+                        Vector &row_identifiers, idx_t count) {
 	D_ASSERT(row_identifiers.GetType().InternalType() == ROW_TYPE);
 	if (count == 0) {
 		return 0;
@@ -1469,7 +1471,7 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector 
 				                         fetch_state);
 				VerifyDeleteConstraints(storage, state, context, state.verify_chunk);
 			}
-			delete_count += local_storage.Delete(*this, offset_ids, current_count);
+			delete_count += local_storage.Delete(*this, table_entry, offset_ids, current_count);
 			continue;
 		}
 
@@ -1480,7 +1482,7 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector 
 			Fetch(transaction, state.verify_chunk, state.col_ids, offset_ids, current_count, fetch_state);
 			VerifyDeleteConstraints(storage, state, context, state.verify_chunk);
 		}
-		delete_count += row_groups->Delete(transaction, *this, ids + current_offset, current_count);
+		delete_count += row_groups->Delete(transaction, table_entry, ids + current_offset, current_count);
 	}
 	return delete_count;
 }
@@ -1582,7 +1584,7 @@ unique_ptr<TableUpdateState> DataTable::InitializeUpdate(TableCatalogEntry &tabl
 	return result;
 }
 
-void DataTable::Update(TableUpdateState &state, ClientContext &context, Vector &row_ids,
+void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
                        const vector<PhysicalIndex> &column_ids, DataChunk &updates) {
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	D_ASSERT(column_ids.size() == updates.ColumnCount());
@@ -1620,19 +1622,18 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, Vector &
 		row_ids_slice.Slice(row_ids, sel_local_update, n_local_update);
 		row_ids_slice.Flatten(n_local_update);
 
-		LocalStorage::Get(context, db).Update(*this, row_ids_slice, column_ids, updates_slice);
+		LocalStorage::Get(context, db).Update(*this, table_entry, row_ids_slice, column_ids, updates_slice);
 	}
 
 	// otherwise global storage
 	if (n_global_update > 0) {
 		auto &transaction = DuckTransaction::Get(context, db);
-		transaction.ModifyTable(*this);
 		updates_slice.Slice(updates, sel_global_update, n_global_update);
 		updates_slice.Flatten();
 		row_ids_slice.Slice(row_ids, sel_global_update, n_global_update);
 		row_ids_slice.Flatten(n_global_update);
 
-		row_groups->Update(transaction, *this, FlatVector::GetDataMutable<row_t>(row_ids_slice), column_ids,
+		row_groups->Update(transaction, table_entry, FlatVector::GetDataMutable<row_t>(row_ids_slice), column_ids,
 		                   updates_slice);
 	}
 }
@@ -1657,7 +1658,7 @@ void DataTable::UpdateColumn(TableCatalogEntry &table, ClientContext &context, V
 
 	updates.Flatten();
 	row_ids.Flatten(updates.size());
-	row_groups->UpdateColumn(transaction, *this, row_ids, column_path, updates);
+	row_groups->UpdateColumn(transaction, table.Cast<DuckTableEntry>(), row_ids, column_path, updates);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -847,7 +847,7 @@ string DataTable::TableModification() const {
 	}
 }
 
-void DataTable::InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+void DataTable::InitializeLocalAppend(LocalAppendState &state, DuckTableEntry &table, ClientContext &context,
                                       const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
@@ -855,11 +855,11 @@ void DataTable::InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry
 		                           GetTableName(), TableModification());
 	}
 	auto &local_storage = LocalStorage::Get(context, db);
-	local_storage.InitializeAppend(state, *this, table.Cast<DuckTableEntry>());
+	local_storage.InitializeAppend(state, *this, table);
 	state.constraint_state = InitializeConstraintState(table, bound_constraints);
 }
 
-void DataTable::InitializeLocalStorage(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+void DataTable::InitializeLocalStorage(LocalAppendState &state, DuckTableEntry &table, ClientContext &context,
                                        const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
@@ -868,11 +868,12 @@ void DataTable::InitializeLocalStorage(LocalAppendState &state, TableCatalogEntr
 	}
 
 	auto &local_storage = LocalStorage::Get(context, db);
-	local_storage.InitializeStorage(state, *this, table.Cast<DuckTableEntry>());
+	local_storage.InitializeStorage(state, *this, table);
 	state.constraint_state = InitializeConstraintState(table, bound_constraints);
 }
 
-void DataTable::LocalAppend(LocalAppendState &state, ClientContext &context, DataChunk &chunk, bool unsafe) {
+void DataTable::LocalAppend(LocalAppendState &state, DuckTableEntry &table_entry, ClientContext &context,
+                            DataChunk &chunk, bool unsafe) {
 	if (chunk.size() == 0) {
 		return;
 	}
@@ -892,14 +893,14 @@ void DataTable::LocalAppend(LocalAppendState &state, ClientContext &context, Dat
 
 	// Append to the transaction-local data.
 	auto data_table_info = GetDataTableInfo();
-	LocalStorage::Append(state, chunk, *data_table_info);
+	LocalStorage::Append(state, table_entry, chunk, *data_table_info);
 }
 
-void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+void DataTable::LocalAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
                             const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool unsafe) {
 	LocalAppendState append_state;
 	InitializeLocalAppend(append_state, table, context, bound_constraints);
-	LocalAppend(append_state, context, chunk, unsafe);
+	LocalAppend(append_state, table, context, chunk, unsafe);
 	FinalizeLocalAppend(append_state);
 }
 
@@ -934,18 +935,18 @@ void DataTable::LocalMerge(ClientContext &context, DuckTableEntry &table_entry, 
 	local_storage.LocalMerge(*this, table_entry, collection);
 }
 
-void DataTable::LocalWALAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+void DataTable::LocalWALAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
                                const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
 	LocalAppendState append_state;
 	auto &storage = table.GetStorage();
 	storage.InitializeLocalAppend(append_state, table, context, bound_constraints);
 
-	storage.LocalAppend(append_state, context, chunk, true);
+	storage.LocalAppend(append_state, table, context, chunk, true);
 	append_state.storage->index_append_mode = IndexAppendMode::INSERT_DUPLICATES;
 	storage.FinalizeLocalAppend(append_state);
 }
 
-void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+void DataTable::LocalAppend(DuckTableEntry &table, ClientContext &context, DataChunk &chunk,
                             const vector<unique_ptr<BoundConstraint>> &bound_constraints, Vector &row_ids,
                             DataChunk &delete_chunk) {
 	LocalAppendState append_state;
@@ -953,11 +954,11 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Da
 	storage.InitializeLocalAppend(append_state, table, context, bound_constraints);
 	append_state.storage->AppendToDeleteIndexes(row_ids, delete_chunk);
 
-	storage.LocalAppend(append_state, context, chunk, false);
+	storage.LocalAppend(append_state, table, context, chunk, false);
 	storage.FinalizeLocalAppend(append_state);
 }
 
-void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
+void DataTable::LocalAppend(DuckTableEntry &table, ClientContext &context, ColumnDataCollection &collection,
                             const vector<unique_ptr<BoundConstraint>> &bound_constraints,
                             optional_ptr<const vector<LogicalIndex>> column_ids) {
 	LocalAppendState append_state;
@@ -966,7 +967,7 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Co
 
 	if (!column_ids || column_ids->empty()) {
 		for (auto &chunk : collection.Chunks()) {
-			storage.LocalAppend(append_state, context, chunk, false);
+			storage.LocalAppend(append_state, table, context, chunk, false);
 		}
 		storage.FinalizeLocalAppend(append_state);
 		return;
@@ -1009,7 +1010,7 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Co
 
 	for (auto &chunk : collection.Chunks()) {
 		expression_executor.Execute(chunk, result);
-		storage.LocalAppend(append_state, context, result, false);
+		storage.LocalAppend(append_state, table, context, result, false);
 		result.Reset();
 	}
 	storage.FinalizeLocalAppend(append_state);
@@ -1638,7 +1639,7 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTabl
 	}
 }
 
-void DataTable::UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+void DataTable::UpdateColumn(DuckTableEntry &table, ClientContext &context, Vector &row_ids,
                              const vector<column_t> &column_path, DataChunk &updates) {
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	D_ASSERT(updates.ColumnCount() == 1);
@@ -1658,7 +1659,7 @@ void DataTable::UpdateColumn(TableCatalogEntry &table, ClientContext &context, V
 
 	updates.Flatten();
 	row_ids.Flatten(updates.size());
-	row_groups->UpdateColumn(transaction, table.Cast<DuckTableEntry>(), row_ids, column_path, updates);
+	row_groups->UpdateColumn(transaction, table, row_ids, column_path, updates);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -431,16 +431,6 @@ void LocalStorage::InitializeStorage(LocalAppendState &state, DataTable &table, 
 	state.storage->table_entry = &table_entry;
 }
 
-void LocalStorage::RegisterTableEntry(DataTable &table, DuckTableEntry &table_entry) {
-	// If this transaction already has local storage for `table`, refresh its table_entry.
-	// No entry means this transaction has no local data for the table - nothing to update.
-	auto storage = table_manager.GetStorage(table);
-	if (!storage) {
-		return;
-	}
-	storage->table_entry = &table_entry;
-}
-
 void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete_chunk) {
 	if (delete_chunk.size() == 0) {
 		return;
@@ -459,9 +449,10 @@ void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete
 	}
 }
 
-void LocalStorage::Append(LocalAppendState &state, DataChunk &table_chunk, DataTableInfo &data_table_info) {
-	// Append to any unique indexes.
+void LocalStorage::Append(LocalAppendState &state, DuckTableEntry &table_entry, DataChunk &table_chunk,
+                          DataTableInfo &data_table_info) {
 	auto storage = state.storage;
+	storage->table_entry = &table_entry;
 	auto offset = NumericCast<idx_t>(MAX_ROW_ID) + storage->GetCollection().GetTotalRows();
 	idx_t base_id = offset + state.append_state.total_append_count;
 
@@ -608,8 +599,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 		// after that is successful - append to the table
 		storage.AppendToTable(transaction, append_state);
 	}
-	// table_entry is set by InitializeAppend/InitializeStorage and is refreshed by
-	// DuckTableEntry::AlterEntry -> LocalStorage::RegisterTableEntry whenever ALTER produces a new entry.
+	// table_entry is set through the append path (InitializeAppend/Append/LocalMerge/Alter)
 	D_ASSERT(storage.table_entry);
 	transaction.PushAppend(*storage.table_entry, NumericCast<idx_t>(append_state.row_start), append_count);
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/transaction/local_storage.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/partial_block_manager.hpp"
@@ -419,13 +420,25 @@ bool LocalStorage::NextParallelScan(ClientContext &context, DataTable &table, Pa
 	return storage->GetCollection().NextParallelScan(context, state, scan_state);
 }
 
-void LocalStorage::InitializeAppend(LocalAppendState &state, DataTable &table) {
+void LocalStorage::InitializeAppend(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry) {
 	state.storage = &table_manager.GetOrCreateStorage(context, table);
+	state.storage->table_entry = &table_entry;
 	state.storage->GetCollection().InitializeAppend(TransactionData(transaction), state.append_state);
 }
 
-void LocalStorage::InitializeStorage(LocalAppendState &state, DataTable &table) {
+void LocalStorage::InitializeStorage(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry) {
 	state.storage = &table_manager.GetOrCreateStorage(context, table);
+	state.storage->table_entry = &table_entry;
+}
+
+void LocalStorage::RegisterTableEntry(DataTable &table, DuckTableEntry &table_entry) {
+	// If this transaction already has local storage for `table`, refresh its table_entry.
+	// No entry means this transaction has no local data for the table - nothing to update.
+	auto storage = table_manager.GetStorage(table);
+	if (!storage) {
+		return;
+	}
+	storage->table_entry = &table_entry;
 }
 
 void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete_chunk) {
@@ -484,8 +497,9 @@ void LocalStorage::FinalizeAppend(LocalAppendState &state) {
 	state.storage->GetCollection().FinalizeAppend(state.append_state.transaction, state.append_state);
 }
 
-void LocalStorage::LocalMerge(DataTable &table, OptimisticWriteCollection &collection) {
+void LocalStorage::LocalMerge(DataTable &table, DuckTableEntry &table_entry, OptimisticWriteCollection &collection) {
 	auto &storage = table_manager.GetOrCreateStorage(context, table);
+	storage.table_entry = &table_entry;
 	if (!storage.append_indexes.Empty()) {
 		// append data to indexes if required
 		row_t base_id = MAX_ROW_ID + NumericCast<row_t>(storage.GetCollection().GetTotalRows());
@@ -533,7 +547,7 @@ idx_t LocalStorage::EstimatedSize() {
 	return table_manager.EstimatedSize();
 }
 
-idx_t LocalStorage::Delete(DataTable &table, Vector &row_ids, idx_t count) {
+idx_t LocalStorage::Delete(DataTable &table, DuckTableEntry &table_entry, Vector &row_ids, idx_t count) {
 	auto storage = table_manager.GetStorage(table);
 	D_ASSERT(storage);
 
@@ -544,19 +558,19 @@ idx_t LocalStorage::Delete(DataTable &table, Vector &row_ids, idx_t count) {
 	}
 
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
-	idx_t delete_count = storage->GetCollection().Delete(TransactionData(0, 0), table, ids, count);
+	idx_t delete_count = storage->GetCollection().Delete(TransactionData(0, 0), table_entry, ids, count);
 	storage->deleted_rows += delete_count;
 	return delete_count;
 }
 
-void LocalStorage::Update(DataTable &table, Vector &row_ids, const vector<PhysicalIndex> &column_ids,
-                          DataChunk &updates) {
+void LocalStorage::Update(DataTable &table, DuckTableEntry &table_entry, Vector &row_ids,
+                          const vector<PhysicalIndex> &column_ids, DataChunk &updates) {
 	D_ASSERT(updates.size() >= 1);
 	auto storage = table_manager.GetStorage(table);
 	D_ASSERT(storage);
 
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
-	storage->GetCollection().Update(TransactionData(0, 0), table, ids, column_ids, updates);
+	storage->GetCollection().Update(TransactionData(0, 0), table_entry, ids, column_ids, updates);
 }
 
 void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_ptr<StorageCommitState> commit_state) {
@@ -594,7 +608,10 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 		// after that is successful - append to the table
 		storage.AppendToTable(transaction, append_state);
 	}
-	transaction.PushAppend(table, NumericCast<idx_t>(append_state.row_start), append_count);
+	// table_entry is set by InitializeAppend/InitializeStorage and is refreshed by
+	// DuckTableEntry::AlterEntry -> LocalStorage::RegisterTableEntry whenever ALTER produces a new entry.
+	D_ASSERT(storage.table_entry);
+	transaction.PushAppend(*storage.table_entry, NumericCast<idx_t>(append_state.row_start), append_count);
 
 #ifdef DEBUG
 	// Verify that our index memory is stable.

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -222,12 +222,12 @@ idx_t ArrayColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &resul
 	throw NotImplementedException("Array Fetch");
 }
 
-void ArrayColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void ArrayColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                              Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw NotImplementedException("Array Update is not supported.");
 }
 
-void ArrayColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void ArrayColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                    const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                    idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw NotImplementedException("Array Update Column is not supported");

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -284,14 +284,14 @@ void ColumnData::FetchUpdateRow(TransactionData transaction, row_t row_id, Vecto
 	updates->FetchRow(transaction, NumericCast<idx_t>(row_id), result, result_idx);
 }
 
-void ColumnData::UpdateInternal(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void ColumnData::UpdateInternal(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                 Vector &update_vector, row_t *row_ids, idx_t update_count, Vector &base_vector,
                                 idx_t row_group_start) {
 	lock_guard<mutex> update_guard(update_lock);
 	if (!updates) {
 		updates = make_uniq<UpdateSegment>(*this);
 	}
-	updates->Update(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector,
+	updates->Update(transaction, table_entry, column_index, update_vector, row_ids, update_count, base_vector,
 	                row_group_start);
 }
 
@@ -587,22 +587,22 @@ idx_t ColumnData::FetchUpdateData(ColumnScanState &state, row_t *row_ids, Vector
 	return fetch_count;
 }
 
-void ColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
-                        row_t *row_ids, idx_t update_count, idx_t row_group_start) {
+void ColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
+                        Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	Vector base_vector(type);
 	ColumnScanState state(nullptr);
 	FetchUpdateData(state, row_ids, base_vector, row_group_start);
 
-	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector,
+	UpdateInternal(transaction, table_entry, column_index, update_vector, row_ids, update_count, base_vector,
 	               row_group_start);
 }
 
-void ColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table, const vector<column_t> &column_path,
-                              Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth,
-                              idx_t row_group_start) {
+void ColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
+                              const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
+                              idx_t update_count, idx_t depth, idx_t row_group_start) {
 	// this method should only be called at the end of the path in the base column case
 	D_ASSERT(depth >= column_path.size());
-	ColumnData::Update(transaction, data_table, column_path[0], update_vector, row_ids, update_count, row_group_start);
+	ColumnData::Update(transaction, table_entry, column_path[0], update_vector, row_ids, update_count, row_group_start);
 }
 
 void ColumnData::AppendTransientSegment(SegmentLock &l, idx_t start_row) {

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -153,12 +153,12 @@ void GeoColumnData::FetchRow(TransactionData transaction, ColumnFetchState &stat
 // Update
 //----------------------------------------------------------------------------------------------------------------------
 
-void GeoColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void GeoColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                            Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw NotImplementedException("GEOMETRY Update is not supported");
 }
 
-void GeoColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void GeoColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                  const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                  idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw NotImplementedException("GEOMETRY Update is not supported");

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -258,12 +258,12 @@ idx_t ListColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result
 	throw NotImplementedException("List Fetch");
 }
 
-void ListColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void ListColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                             Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw NotImplementedException("List Update is not supported.");
 }
 
-void ListColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void ListColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                   const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                   idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw NotImplementedException("List Update Column is not supported");

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -957,7 +957,7 @@ void RowGroup::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_
 	vinfo.CleanupAppend(lowest_transaction, start, count);
 }
 
-void RowGroup::Update(TransactionData transaction, DataTable &data_table, DataChunk &update_chunk, row_t *ids,
+void RowGroup::Update(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &update_chunk, row_t *ids,
                       idx_t offset, idx_t count, const vector<PhysicalIndex> &column_ids, idx_t row_group_start) {
 #ifdef DEBUG
 	for (size_t i = offset; i < offset + count; i++) {
@@ -971,16 +971,18 @@ void RowGroup::Update(TransactionData transaction, DataTable &data_table, DataCh
 		if (offset > 0) {
 			Vector sliced_vector(update_chunk.data[i], offset, offset + count);
 			sliced_vector.Flatten(count);
-			col_data.Update(transaction, data_table, column.index, sliced_vector, ids + offset, count, row_group_start);
+			col_data.Update(transaction, table_entry, column.index, sliced_vector, ids + offset, count,
+			                row_group_start);
 		} else {
-			col_data.Update(transaction, data_table, column.index, update_chunk.data[i], ids, count, row_group_start);
+			col_data.Update(transaction, table_entry, column.index, update_chunk.data[i], ids, count, row_group_start);
 		}
 		MergeStatistics(column.index, *col_data.GetUpdateStatistics());
 	}
 }
 
-void RowGroup::UpdateColumn(TransactionData transaction, DataTable &data_table, DataChunk &updates, Vector &row_ids,
-                            idx_t offset, idx_t count, const vector<column_t> &column_path, idx_t row_group_start) {
+void RowGroup::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, DataChunk &updates,
+                            Vector &row_ids, idx_t offset, idx_t count, const vector<column_t> &column_path,
+                            idx_t row_group_start) {
 	D_ASSERT(updates.ColumnCount() == 1);
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
 
@@ -991,10 +993,10 @@ void RowGroup::UpdateColumn(TransactionData transaction, DataTable &data_table, 
 	if (offset > 0) {
 		Vector sliced_vector(updates.data[0], offset, offset + count);
 		sliced_vector.Flatten(count);
-		col_data.UpdateColumn(transaction, data_table, column_path, sliced_vector, ids + offset, count, depth,
+		col_data.UpdateColumn(transaction, table_entry, column_path, sliced_vector, ids + offset, count, depth,
 		                      row_group_start);
 	} else {
-		col_data.UpdateColumn(transaction, data_table, column_path, updates.data[0], ids, count, depth,
+		col_data.UpdateColumn(transaction, table_entry, column_path, updates.data[0], ids, count, depth,
 		                      row_group_start);
 	}
 	MergeStatistics(primary_column_idx, *col_data.GetUpdateStatistics());
@@ -1482,14 +1484,14 @@ void RowGroup::GetColumnSegmentInfo(const QueryContext &context, idx_t row_group
 //===--------------------------------------------------------------------===//
 class VersionDeleteState {
 public:
-	VersionDeleteState(RowGroup &info, TransactionData transaction, DataTable &table, idx_t base_row)
-	    : info(info), transaction(transaction), table(table), current_chunk(DConstants::INVALID_INDEX), count(0),
-	      base_row(base_row), delete_count(0) {
+	VersionDeleteState(RowGroup &info, TransactionData transaction, DuckTableEntry &table_entry, idx_t base_row)
+	    : info(info), transaction(transaction), table_entry(table_entry), current_chunk(DConstants::INVALID_INDEX),
+	      count(0), base_row(base_row), delete_count(0) {
 	}
 
 	RowGroup &info;
 	TransactionData transaction;
-	DataTable &table;
+	DuckTableEntry &table_entry;
 	idx_t current_chunk;
 	row_t rows[STANDARD_VECTOR_SIZE];
 	idx_t count;
@@ -1502,8 +1504,9 @@ public:
 	void Flush();
 };
 
-idx_t RowGroup::Delete(TransactionData transaction, DataTable &table, row_t *ids, idx_t count, idx_t row_group_start) {
-	VersionDeleteState del_state(*this, transaction, table, row_group_start);
+idx_t RowGroup::Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *ids, idx_t count,
+                       idx_t row_group_start) {
+	VersionDeleteState del_state(*this, transaction, table_entry, row_group_start);
 
 	// obtain a write lock
 	for (idx_t i = 0; i < count; i++) {
@@ -1558,7 +1561,7 @@ void VersionDeleteState::Flush() {
 	delete_count += actual_delete_count;
 	if (transaction.transaction && actual_delete_count > 0) {
 		// now push the delete into the undo buffer, but only if any deletes were actually performed
-		transaction.transaction->PushDelete(table, info.GetOrCreateVersionInfo(), current_chunk, rows,
+		transaction.transaction->PushDelete(table_entry, info.GetOrCreateVersionInfo(), current_chunk, rows,
 		                                    actual_delete_count, base_row + chunk_row);
 	}
 	count = 0;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -737,7 +737,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 //===--------------------------------------------------------------------===//
 // Delete
 //===--------------------------------------------------------------------===//
-idx_t RowGroupCollection::Delete(TransactionData transaction, DataTable &table, row_t *ids, idx_t count) {
+idx_t RowGroupCollection::Delete(TransactionData transaction, DuckTableEntry &table_entry, row_t *ids, idx_t count) {
 	idx_t delete_count = 0;
 	// delete is in the row groups
 	// we need to figure out for each id to which row group it belongs
@@ -764,7 +764,7 @@ idx_t RowGroupCollection::Delete(TransactionData transaction, DataTable &table, 
 				break;
 			}
 		}
-		delete_count += current_row_group.Delete(transaction, table, ids + start, pos - start, row_start);
+		delete_count += current_row_group.Delete(transaction, table_entry, ids + start, pos - start, row_start);
 	} while (pos < count);
 
 	return delete_count;
@@ -798,7 +798,7 @@ optional_ptr<SegmentNode<RowGroup>> RowGroupCollection::NextUpdateRowGroup(RowGr
 	return row_group;
 }
 
-void RowGroupCollection::Update(TransactionData transaction, DataTable &data_table, row_t *ids,
+void RowGroupCollection::Update(TransactionData transaction, DuckTableEntry &table_entry, row_t *ids,
                                 const vector<PhysicalIndex> &column_ids, DataChunk &updates) {
 	D_ASSERT(updates.size() >= 1);
 	idx_t pos = 0;
@@ -808,7 +808,7 @@ void RowGroupCollection::Update(TransactionData transaction, DataTable &data_tab
 		auto row_group = NextUpdateRowGroup(*row_groups, ids, pos, updates.size());
 
 		auto &current_row_group = row_group->GetNode();
-		current_row_group.Update(transaction, data_table, updates, ids, start, pos - start, column_ids,
+		current_row_group.Update(transaction, table_entry, updates, ids, start, pos - start, column_ids,
 		                         row_group->GetRowStart());
 
 		auto l = stats.GetLock();
@@ -1056,7 +1056,7 @@ void RowGroupCollection::RemoveFromIndexes(const QueryContext &context, TableInd
 	}
 }
 
-void RowGroupCollection::UpdateColumn(TransactionData transaction, DataTable &data_table, Vector &row_ids,
+void RowGroupCollection::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry, Vector &row_ids,
                                       const vector<column_t> &column_path, DataChunk &updates) {
 	D_ASSERT(updates.size() >= 1);
 	auto ids = FlatVector::GetDataMutable<row_t>(row_ids);
@@ -1066,7 +1066,7 @@ void RowGroupCollection::UpdateColumn(TransactionData transaction, DataTable &da
 		idx_t start = pos;
 		auto row_group = NextUpdateRowGroup(*row_groups, ids, pos, updates.size());
 		auto &current_row_group = row_group->GetNode();
-		current_row_group.UpdateColumn(transaction, data_table, updates, row_ids, start, pos - start, column_path,
+		current_row_group.UpdateColumn(transaction, table_entry, updates, row_ids, start, pos - start, column_path,
 		                               row_group->GetRowStart());
 
 		auto lock = stats.GetLock();

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -139,12 +139,12 @@ void RowIdColumnData::RevertAppend(row_t new_count) {
 	throw InternalException("RowIdColumnData cannot be appended to");
 }
 
-void RowIdColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void RowIdColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                              Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw InternalException("RowIdColumnData cannot be updated");
 }
 
-void RowIdColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void RowIdColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                    const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                    idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw InternalException("RowIdColumnData cannot be updated");

--- a/src/storage/table/row_number_column_data.cpp
+++ b/src/storage/table/row_number_column_data.cpp
@@ -99,12 +99,12 @@ void RowNumberColumnData::RevertAppend(row_t new_count) {
 	throw InternalException("RowNumberColumnData cannot be appended to");
 }
 
-void RowNumberColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void RowNumberColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                  Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw InternalException("RowNumberColumnData cannot be updated");
 }
 
-void RowNumberColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void RowNumberColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                        const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                        idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw InternalException("RowNumberColumnData cannot be updated");

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -145,7 +145,7 @@ idx_t StandardColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &re
 	return scan_count;
 }
 
-void StandardColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void StandardColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                 Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	ColumnScanState standard_state(nullptr);
 	ColumnScanState validity_state(nullptr);
@@ -154,24 +154,24 @@ void StandardColumnData::Update(TransactionData transaction, DataTable &data_tab
 	FetchUpdateData(standard_state, row_ids, base_vector, row_group_start);
 	validity->FetchUpdateData(validity_state, row_ids, base_vector, row_group_start);
 
-	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector,
+	UpdateInternal(transaction, table_entry, column_index, update_vector, row_ids, update_count, base_vector,
 	               row_group_start);
-	validity->UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector,
+	validity->UpdateInternal(transaction, table_entry, column_index, update_vector, row_ids, update_count, base_vector,
 	                         row_group_start);
 }
 
-void StandardColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void StandardColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                       const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                       idx_t update_count, idx_t depth, idx_t row_group_start) {
 	if (depth >= column_path.size()) {
 		// update this column
-		ColumnData::Update(transaction, data_table, column_path[0], update_vector, row_ids, update_count,
+		ColumnData::Update(transaction, table_entry, column_path[0], update_vector, row_ids, update_count,
 		                   row_group_start);
 	} else {
 		// update the child column (i.e. the validity column)
-		validity->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1,
+		validity->UpdateColumn(transaction, table_entry, column_path, update_vector, row_ids, update_count, depth + 1,
 		                       row_group_start);
-		validity->UpdateWithBase(transaction, data_table, column_path[0], update_vector, row_ids, update_count, *this,
+		validity->UpdateWithBase(transaction, table_entry, column_path[0], update_vector, row_ids, update_count, *this,
 		                         row_group_start);
 	}
 }

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -266,17 +266,17 @@ idx_t StructColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &resu
 	return scan_count;
 }
 
-void StructColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void StructColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                               Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
-	validity->Update(transaction, data_table, column_index, update_vector, row_ids, update_count, row_group_start);
+	validity->Update(transaction, table_entry, column_index, update_vector, row_ids, update_count, row_group_start);
 	auto &child_entries = StructVector::GetEntries(update_vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		sub_columns[i]->Update(transaction, data_table, column_index, child_entries[i], row_ids, update_count,
+		sub_columns[i]->Update(transaction, table_entry, column_index, child_entries[i], row_ids, update_count,
 		                       row_group_start);
 	}
 }
 
-void StructColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void StructColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                     const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                     idx_t update_count, idx_t depth, idx_t row_group_start) {
 	// we can never DIRECTLY update a struct column
@@ -286,13 +286,13 @@ void StructColumnData::UpdateColumn(TransactionData transaction, DataTable &data
 	auto update_column = column_path[depth];
 	if (update_column == 0) {
 		// update the validity column
-		validity->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1,
+		validity->UpdateColumn(transaction, table_entry, column_path, update_vector, row_ids, update_count, depth + 1,
 		                       row_group_start);
 	} else {
 		if (update_column > sub_columns.size()) {
 			throw InternalException("Update column_path out of range");
 		}
-		sub_columns[update_column - 1]->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids,
+		sub_columns[update_column - 1]->UpdateColumn(transaction, table_entry, column_path, update_vector, row_ids,
 		                                             update_count, depth + 1, row_group_start);
 	}
 }

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -102,12 +102,12 @@ idx_t UpdateInfo::GetAllocSize(idx_t type_size) {
 	return AlignValue<idx_t>(sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
 }
 
-void UpdateInfo::Initialize(UpdateInfo &info, DataTable &data_table, transaction_t transaction_id,
+void UpdateInfo::Initialize(UpdateInfo &info, DuckTableEntry &table_entry, transaction_t transaction_id,
                             idx_t row_group_start) {
 	info.max = STANDARD_VECTOR_SIZE;
 	info.row_group_start = row_group_start;
 	info.version_number = transaction_id;
-	info.table = &data_table;
+	info.table = &table_entry;
 	info.segment = nullptr;
 	info.prev.entry = nullptr;
 	info.next.entry = nullptr;
@@ -1256,11 +1256,11 @@ static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids) 
 	return pos;
 }
 
-UpdateInfo *CreateEmptyUpdateInfo(TransactionData transaction, DataTable &data_table, idx_t type_size, idx_t count,
-                                  unsafe_unique_array<char> &data, idx_t row_group_start) {
+UpdateInfo *CreateEmptyUpdateInfo(TransactionData transaction, DuckTableEntry &table_entry, idx_t type_size,
+                                  idx_t count, unsafe_unique_array<char> &data, idx_t row_group_start) {
 	data = make_unsafe_uniq_array_uninitialized<char>(UpdateInfo::GetAllocSize(type_size));
 	auto update_info = reinterpret_cast<UpdateInfo *>(data.get());
-	UpdateInfo::Initialize(*update_info, data_table, transaction.transaction_id, row_group_start);
+	UpdateInfo::Initialize(*update_info, table_entry, transaction.transaction_id, row_group_start);
 	return update_info;
 }
 
@@ -1278,8 +1278,8 @@ void UpdateSegment::InitializeUpdateInfo(idx_t vector_idx) {
 	}
 }
 
-void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_p,
-                           row_t *ids, idx_t count, Vector &base_data, idx_t row_group_start) {
+void UpdateSegment::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
+                           Vector &update_p, row_t *ids, idx_t count, Vector &base_data, idx_t row_group_start) {
 	// obtain an exclusive lock
 	auto write_lock = lock.GetExclusiveLock();
 
@@ -1354,11 +1354,11 @@ void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, i
 			// no updates made yet by this transaction: initially the update info to empty
 			if (transaction.transaction) {
 				auto &dtransaction = transaction.transaction->Cast<DuckTransaction>();
-				node_ref = dtransaction.CreateUpdateInfo(type_size, data_table, count, row_group_start);
+				node_ref = dtransaction.CreateUpdateInfo(table_entry, type_size, count, row_group_start);
 				node = &UpdateInfo::Get(node_ref);
 			} else {
-				node =
-				    CreateEmptyUpdateInfo(transaction, data_table, type_size, count, update_info_data, row_group_start);
+				node = CreateEmptyUpdateInfo(transaction, table_entry, type_size, count, update_info_data,
+				                             row_group_start);
 			}
 			node->segment = this;
 			node->vector_index = vector_index;
@@ -1392,7 +1392,7 @@ void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, i
 		idx_t alloc_size = UpdateInfo::GetAllocSize(type_size);
 		auto handle = root->allocator.Allocate(alloc_size);
 		auto &update_info = UpdateInfo::Get(handle);
-		UpdateInfo::Initialize(update_info, data_table, TRANSACTION_ID_START - 1, row_group_start);
+		UpdateInfo::Initialize(update_info, table_entry, TRANSACTION_ID_START - 1, row_group_start);
 		update_info.column_index = column_index;
 
 		InitializeUpdateInfo(update_info, ids, sel, count, vector_index, vector_offset);
@@ -1402,11 +1402,11 @@ void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, i
 		UndoBufferReference node_ref;
 		optional_ptr<UpdateInfo> transaction_node;
 		if (transaction.transaction) {
-			node_ref = transaction.transaction->CreateUpdateInfo(type_size, data_table, count, row_group_start);
+			node_ref = transaction.transaction->CreateUpdateInfo(table_entry, type_size, count, row_group_start);
 			transaction_node = &UpdateInfo::Get(node_ref);
 		} else {
 			transaction_node =
-			    CreateEmptyUpdateInfo(transaction, data_table, type_size, count, update_info_data, row_group_start);
+			    CreateEmptyUpdateInfo(transaction, table_entry, type_size, count, update_info_data, row_group_start);
 		}
 
 		InitializeUpdateInfo(*transaction_node, ids, sel, count, vector_index, vector_offset);

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -18,7 +18,7 @@ FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, T
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
-void ValidityColumnData::UpdateWithBase(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void ValidityColumnData::UpdateWithBase(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                         Vector &update_vector, row_t *row_ids, idx_t update_count, ColumnData &base,
                                         idx_t row_group_start) {
 	Vector base_vector(base.type);
@@ -33,7 +33,7 @@ void ValidityColumnData::UpdateWithBase(TransactionData transaction, DataTable &
 		base_vector.Flatten(fetch_count);
 	}
 
-	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector,
+	UpdateInternal(transaction, table_entry, column_index, update_vector, row_ids, update_count, base_vector,
 	               row_group_start);
 }
 

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -426,12 +426,12 @@ idx_t VariantColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &res
 	throw NotImplementedException("VARIANT Fetch");
 }
 
-void VariantColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
+void VariantColumnData::Update(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
 	throw NotImplementedException("VARIANT Update is not supported.");
 }
 
-void VariantColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table,
+void VariantColumnData::UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
                                      const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                      idx_t update_count, idx_t depth, idx_t row_group_start) {
 	throw NotImplementedException("VARIANT Update Column is not supported");

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -48,7 +48,7 @@ public:
 	AttachedDatabase &db;
 	ClientContext &context;
 	Catalog &catalog;
-	optional_ptr<TableCatalogEntry> current_table;
+	optional_ptr<DuckTableEntry> current_table;
 	MetaBlockPointer checkpoint_id;
 	idx_t wal_version = 1;
 	optional_idx current_position;
@@ -1105,7 +1105,7 @@ void WriteAheadLogDeserializer::ReplayUseTable() {
 	if (DeserializeOnly()) {
 		return;
 	}
-	state.current_table = &catalog.GetEntry<TableCatalogEntry>(context, schema_name, table_name);
+	state.current_table = &catalog.GetEntry<DuckTableEntry>(context, schema_name, table_name);
 }
 
 void WriteAheadLogDeserializer::ReplayInsert() {
@@ -1206,7 +1206,7 @@ void WriteAheadLogDeserializer::ReplayDelete() {
 		}
 	}
 	TableDeleteState delete_state;
-	storage.Delete(delete_state, context, state.current_table->Cast<DuckTableEntry>(), row_identifiers, chunk.size());
+	storage.Delete(delete_state, context, *state.current_table, row_identifiers, chunk.size());
 }
 
 void WriteAheadLogDeserializer::ReplayUpdate() {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1206,7 +1206,7 @@ void WriteAheadLogDeserializer::ReplayDelete() {
 		}
 	}
 	TableDeleteState delete_state;
-	storage.Delete(delete_state, context, row_identifiers, chunk.size());
+	storage.Delete(delete_state, context, state.current_table->Cast<DuckTableEntry>(), row_identifiers, chunk.size());
 }
 
 void WriteAheadLogDeserializer::ReplayUpdate() {

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/data_table.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
 #include "duckdb/storage/table/chunk_info.hpp"
 #include "duckdb/storage/table/update_segment.hpp"
@@ -33,7 +34,7 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// mark the tuples as committed
-		info->table->CleanupAppend(lowest_active_transaction, info->start_row, info->count);
+		info->table->GetStorage().CleanupAppend(lowest_active_transaction, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -31,7 +31,7 @@ IndexDataRemover::IndexDataRemover(DuckTransaction &transaction_p, QueryContext 
 }
 
 void IndexDataRemover::PushDelete(DeleteInfo &info) {
-	auto &version_table = *info.table;
+	auto &version_table = info.table->GetStorage();
 	if (!version_table.HasIndexes()) {
 		// this table has no indexes: no cleanup to be done
 		return;
@@ -261,22 +261,24 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		// append:
 		auto info = reinterpret_cast<AppendInfo *>(data);
-		if (!info->table->IsMainTable()) {
-			auto table_name = info->table->GetTableName();
-			auto table_modification = info->table->TableModification();
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+			auto &storage = info->table->GetStorage();
+			auto table_name = storage.GetTableName();
+			auto table_modification = storage.TableModification();
 			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
 			                           table_name, table_modification);
 		}
 		// mark the tuples as committed
-		info->table->CommitAppend(commit_id, info->start_row, info->count);
+		info->table->GetStorage().CommitAppend(commit_id, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {
 		// deletion:
 		auto info = reinterpret_cast<DeleteInfo *>(data);
-		if (!info->table->IsMainTable()) {
-			auto table_name = info->table->GetTableName();
-			auto table_modification = info->table->TableModification();
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+			auto &storage = info->table->GetStorage();
+			auto table_name = storage.GetTableName();
+			auto table_modification = storage.TableModification();
 			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
 			                           table_name, table_modification);
 		}
@@ -286,9 +288,10 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::UPDATE_TUPLE: {
 		// update:
 		auto info = reinterpret_cast<UpdateInfo *>(data);
-		if (!info->table->IsMainTable()) {
-			auto table_name = info->table->GetTableName();
-			auto table_modification = info->table->TableModification();
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+			auto &storage = info->table->GetStorage();
+			auto table_name = storage.GetTableName();
+			auto table_modification = storage.TableModification();
 			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
 			                           table_name, table_modification);
 		}
@@ -327,7 +330,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// revert this append
-		info->table->RevertAppend(transaction, info->start_row, info->count);
+		info->table->GetStorage().RevertAppend(transaction, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/column_definition.hpp"
@@ -87,9 +88,8 @@ void DuckTransaction::PushAttach(AttachedDatabase &db) {
 	Store<CatalogEntry *>(&db, ptr);
 }
 
-void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
-                                 idx_t base_row) {
-	ModifyTable(table);
+void DuckTransaction::PushDelete(DuckTableEntry &table_entry, RowVersionManager &info, idx_t vector_idx, row_t rows[],
+                                 idx_t count, idx_t base_row) {
 	bool is_consecutive = true;
 	// check if the rows are consecutive
 	for (idx_t i = 0; i < count; i++) {
@@ -108,7 +108,7 @@ void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_
 	auto delete_info = reinterpret_cast<DeleteInfo *>(undo_entry.Ptr());
 	delete_info->version_info = &info;
 	delete_info->vector_idx = vector_idx;
-	delete_info->table = &table;
+	delete_info->table = &table_entry;
 	delete_info->count = count;
 	delete_info->base_row = base_row;
 	delete_info->is_consecutive = is_consecutive;
@@ -121,21 +121,20 @@ void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_
 	}
 }
 
-void DuckTransaction::PushAppend(DataTable &table, idx_t start_row, idx_t row_count) {
-	ModifyTable(table);
+void DuckTransaction::PushAppend(DuckTableEntry &table_entry, idx_t start_row, idx_t row_count) {
 	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::INSERT_TUPLE, sizeof(AppendInfo));
 	auto append_info = reinterpret_cast<AppendInfo *>(undo_entry.Ptr());
-	append_info->table = &table;
+	append_info->table = &table_entry;
 	append_info->start_row = start_row;
 	append_info->count = row_count;
 }
 
-UndoBufferReference DuckTransaction::CreateUpdateInfo(idx_t type_size, DataTable &data_table, idx_t entries,
+UndoBufferReference DuckTransaction::CreateUpdateInfo(DuckTableEntry &table_entry, idx_t type_size, idx_t entries,
                                                       idx_t row_group_start) {
 	idx_t alloc_size = UpdateInfo::GetAllocSize(type_size);
 	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::UPDATE_TUPLE, alloc_size);
 	auto &update_info = UpdateInfo::Get(undo_entry);
-	UpdateInfo::Initialize(update_info, data_table, transaction_id, row_group_start);
+	UpdateInfo::Initialize(update_info, table_entry, transaction_id, row_group_start);
 	return undo_entry;
 }
 
@@ -155,17 +154,6 @@ void DuckTransaction::PushSequenceUsage(SequenceCatalogEntry &sequence, const Se
 		sequence_info.usage_count = data.usage_count;
 		sequence_info.counter = data.counter;
 	}
-}
-
-void DuckTransaction::ModifyTable(DataTable &tbl) {
-	lock_guard<mutex> guard(modified_tables_lock);
-	auto table_ref = reference<DataTable>(tbl);
-	auto entry = modified_tables.find(table_ref);
-	if (entry != modified_tables.end()) {
-		// already exists
-		return;
-	}
-	modified_tables.insert(make_pair(table_ref, tbl.shared_from_this()));
 }
 
 bool DuckTransaction::ChangesMade() {

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/table/chunk_info.hpp"
 
 #include "duckdb/catalog/catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/table/update_segment.hpp"
@@ -29,7 +30,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// revert the append in the base table
-		info->table->RevertAppend(transaction, info->start_row, info->count);
+		info->table->GetStorage().RevertAppend(transaction, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/list.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/pair.hpp"
@@ -140,7 +141,7 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 			if (info->is_consecutive) {
 				properties.estimated_size += sizeof(row_t) * info->count;
 			}
-			if (info->table->HasIndexes()) {
+			if (info->table->GetStorage().HasIndexes()) {
 				properties.has_index_deletes = true;
 			}
 			properties.has_deletes = true;

--- a/src/transaction/wal_write_state.cpp
+++ b/src/transaction/wal_write_state.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/trigger_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
@@ -26,14 +27,14 @@ namespace duckdb {
 
 WALWriteState::WALWriteState(DuckTransaction &transaction_p, WriteAheadLog &log,
                              optional_ptr<StorageCommitState> commit_state)
-    : transaction(transaction_p), log(log), commit_state(commit_state), current_table_info(nullptr) {
+    : transaction(transaction_p), log(log), commit_state(commit_state), current_table_entry(nullptr) {
 }
 
-void WALWriteState::SwitchTable(DataTableInfo &table_info, UndoFlags new_op) {
-	if (current_table_info != &table_info) {
+void WALWriteState::SwitchTable(DuckTableEntry &table_entry, UndoFlags new_op) {
+	if (current_table_entry.get() != &table_entry) {
 		// write the current table to the log
-		log.WriteSetTable(table_info.GetSchemaName(), table_info.GetTableName());
-		current_table_info = table_info;
+		log.WriteSetTable(table_entry.schema.name, table_entry.name);
+		current_table_entry = table_entry;
 	}
 }
 
@@ -182,7 +183,7 @@ void WALWriteState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 
 void WALWriteState::WriteDelete(DeleteInfo &info) {
 	// switch to the current table, if necessary
-	SwitchTable(*info.table->GetDataTableInfo(), UndoFlags::DELETE_TUPLE);
+	SwitchTable(*info.table, UndoFlags::DELETE_TUPLE);
 
 	if (!delete_chunk) {
 		delete_chunk = make_uniq<DataChunk>();
@@ -207,9 +208,8 @@ void WALWriteState::WriteDelete(DeleteInfo &info) {
 void WALWriteState::WriteUpdate(UpdateInfo &info) {
 	// switch to the current table, if necessary
 	auto &column_data = info.segment->column_data;
-	auto &table_info = column_data.GetTableInfo();
 
-	SwitchTable(table_info, UndoFlags::UPDATE_TUPLE);
+	SwitchTable(*info.table, UndoFlags::UPDATE_TUPLE);
 
 	// initialize the update chunk
 	vector<LogicalType> update_types;
@@ -271,15 +271,15 @@ void WALWriteState::CommitEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		// append:
 		auto info = reinterpret_cast<AppendInfo *>(data);
-		if (!info->table->IsTemporary()) {
-			info->table->WriteToLog(transaction, log, info->start_row, info->count, commit_state.get());
+		if (!info->table->GetStorage().IsTemporary()) {
+			info->table->GetStorage().WriteToLog(transaction, log, info->start_row, info->count, commit_state.get());
 		}
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {
 		// deletion:
 		auto info = reinterpret_cast<DeleteInfo *>(data);
-		if (!info->table->IsTemporary()) {
+		if (!info->table->GetStorage().IsTemporary()) {
 			WriteDelete(*info);
 		}
 		break;

--- a/test/sql/transactions/test_ddl_after_dml.test
+++ b/test/sql/transactions/test_ddl_after_dml.test
@@ -1,0 +1,74 @@
+# name: test/sql/transactions/test_ddl_after_dml.test
+# description: Within the same transaction, DDL is allowed to be executed after DML
+# group: [transactions]
+
+load {TEST_DIR}/test_ddl_after_dml.db
+
+statement ok
+CREATE TABLE t1 (id INT)
+
+statement ok
+INSERT INTO t1 (id) VALUES (1)
+
+# Test 1: UPDATE followed by ADD COLUMN in the same transaction.
+statement ok
+BEGIN
+
+statement ok
+UPDATE t1 SET id = 2 WHERE id = 1
+
+statement ok
+ALTER TABLE t1 ADD COLUMN c0 INT DEFAULT 0
+
+statement ok
+COMMIT
+
+query II
+select * from t1
+----
+2	0
+
+# Test 2: Two ALTERs one transaction
+# The ADD COLUMN DEFAULT FUNCTION() is internally expanded into
+# ADD + UPDATE + SET DEFAULT (see PR #20224).
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t1 ADD COLUMN c1 VARCHAR DEFAULT repeat('a', 5)
+
+statement ok
+ALTER TABLE t1 DROP COLUMN c0
+
+statement ok
+COMMIT
+
+query II
+select * from t1;
+----
+2	aaaaa
+
+# Test 3: INSERT followed by ADD COLUMN in the same transaction.
+# This test the LocalStorage Flush path: the new LocalTableStorage created
+# by ALTER must still be able to find the post-ALTER DuckTableEntry at commit.
+statement ok
+CREATE TABLE t2 (id INT)
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO t2 (id) VALUES (10), (20), (30)
+
+statement ok
+ALTER TABLE t2 ADD COLUMN c0 INT DEFAULT 7
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM t2 ORDER BY id
+----
+10	7
+20	7
+30	7

--- a/test/sql/transactions/test_ddl_after_dml.test
+++ b/test/sql/transactions/test_ddl_after_dml.test
@@ -52,6 +52,12 @@ select * from t1;
 # This test the LocalStorage Flush path: the new LocalTableStorage created
 # by ALTER must still be able to find the post-ALTER DuckTableEntry at commit.
 statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB'
+
+statement ok
 CREATE TABLE t2 (id INT)
 
 statement ok
@@ -64,10 +70,15 @@ statement ok
 ALTER TABLE t2 ADD COLUMN c0 INT DEFAULT 7
 
 statement ok
+ALTER TABLE t2 RENAME TO t3
+
+statement ok
 COMMIT
 
+restart
+
 query II
-SELECT * FROM t2 ORDER BY id
+SELECT * FROM t3 ORDER BY id
 ----
 10	7
 20	7


### PR DESCRIPTION
## What Happened?

After https://github.com/duckdb/duckdb/pull/20224, the `ALTER TABLE ADD COLUMN col DEFAULT VALUE FUNCTION()` is expanded to:
1. `ALTER ... DEFAULT VALUE NULL`
2. `UPDATE ... SET col = FUNCTION()`
3. `ALTER ... SET DEFAULT`

However, there will be an issue. If we execute two DDLs in one transaction, we will get an error when we commit:
```shell
DuckDB v1.6.0-dev3507 (Development Version, b3f65d8dbb)
Enter ".help" for usage hints.
memory D CREATE TABLE t1 (id INT);
memory D INSERT INTO t1 (id) VALUES (1);
memory D BEGIN;
memory D ALTER TABLE t1 ADD COLUMN c1 VARCHAR DEFAULT repeat('a', 5);
memory D ALTER TABLE t1 ADD COLUMN c2 INT DEFAULT 0;
memory D COMMIT;
TransactionContext Error:
Failed to commit: Attempting to modify table t1 but another transaction has altered this table
```

After analysis, I found that this is because if a DDL is executed after a DML, it will cause the transaction to fail, even if they are both within the same transaction:
```shell
DuckDB v1.6.0-dev3507 (Development Version, b3f65d8dbb)
Enter ".help" for usage hints.
memory D CREATE TABLE t1 (id INT);
memory D INSERT INTO t1 (id) VALUES (1);
memory D BEGIN;
memory D UPDATE t1 SET id = 2 WHERE id = 1;
memory D ALTER TABLE t1 ADD COLUMN c2 INT DEFAULT 0;
memory D COMMIT;
TransactionContext Error:
Failed to commit: Attempting to modify table t1 but another transaction has altered this table
```

The COMMIT failed because of a check that requires `UpdateInfo` to point to the latest `DataTable`, as shown in the code below:

```cpp
void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
	...
	case UndoFlags::UPDATE_TUPLE: {
		auto info = reinterpret_cast<UpdateInfo *>(data);
		if (!info->table->IsMainTable()) { // Must be the latest!
			auto table_name = info->table->GetTableName();
			auto table_modification = info->table->TableModification();
			throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
			                           table_name, table_modification);
		}
		info->version_number = commit_id;
		break;
	}
	...
}
```

## How to fix?

I think that during the `CommitState::CommitEntry` check, the requirement that `DataTable` must be latest could be relaxed to allow DDL within the same transaction. Therefore, while setting `parent.version`, I also added the setting for `parent.altered_by_transaction`. Then when we COMMIT, we can check if the ALTER statement is within the same transaction, as shown in the following code:

```cpp
diff --git a/src/transaction/commit_state.cpp b/src/transaction/commit_state.cpp
index 88d492cc19..7a1967f218 100644
--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -286,7 +286,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
        case UndoFlags::UPDATE_TUPLE: {
                // update:
                auto info = reinterpret_cast<UpdateInfo *>(data);
-               if (!info->table->IsMainTable()) {
+               if (!info->table->IsMainTable() && info->table->GetAlteredByTransaction() != transaction.transaction_id) {
                        auto table_name = info->table->GetTableName();
                        auto table_modification = info->table->TableModification();
                        throw TransactionException("Attempting to modify table %s but another transaction has %s this table",
```

I think this is safe because if there is a DDL being executed in this transaction on the table, other Connections cannot execute DDL.