### PR TITLE
fix commit iteration offset bug + relax RemoveFromIndexes assertion

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1484,7 +1484,8 @@ void DataTable::RevertIndexAppend(TableAppendState &state, DataChunk &chunk, Vec
 
 void DataTable::RemoveFromIndexes(const QueryContext &context, Vector &row_identifiers, idx_t count,
                                   IndexRemovalType removal_type, optional_idx active_checkpoint) {
-	D_ASSERT(IsMainTable());
+	D_ASSERT(IsMainTable() || removal_type == IndexRemovalType::REVERT_MAIN_INDEX ||
+	         removal_type == IndexRemovalType::REVERT_MAIN_INDEX_ONLY);
 	row_groups->RemoveFromIndexes(context, info->indexes, row_identifiers, count, removal_type, active_checkpoint);
 }
 

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -47,9 +47,11 @@ void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, T &&callback) 
 		state.start = state.handle.Ptr();
 		state.end = state.start + state.current->position;
 		while (state.start < state.end) {
+			auto len_position = state.start + sizeof(UndoFlags);
+			auto payload_position = len_position + sizeof(uint32_t);
 			UndoFlags type = Load<UndoFlags>(state.start);
-			uint32_t len = Load<uint32_t>(state.start + sizeof(UndoFlags));
-			auto payload_position = state.start + sizeof(UndoFlags) + sizeof(uint32_t);
+			uint32_t len = Load<uint32_t>(len_position);
+
 			callback(type, payload_position);
 			state.start = payload_position + len;
 		}

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -48,12 +48,10 @@ void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, T &&callback) 
 		state.end = state.start + state.current->position;
 		while (state.start < state.end) {
 			UndoFlags type = Load<UndoFlags>(state.start);
-			state.start += sizeof(UndoFlags);
-
-			uint32_t len = Load<uint32_t>(state.start);
-			state.start += sizeof(uint32_t);
-			callback(type, state.start);
-			state.start += len;
+			uint32_t len = Load<uint32_t>(state.start + sizeof(UndoFlags));
+			auto payload_position = state.start + sizeof(UndoFlags) + sizeof(uint32_t);
+			callback(type, payload_position);
+			state.start = payload_position + len;
 		}
 		state.current = state.current->prev;
 	}

--- a/test/sql/alter/drop_col/test_drop_col_concurrent_dml_conflict.test
+++ b/test/sql/alter/drop_col/test_drop_col_concurrent_dml_conflict.test
@@ -1,0 +1,50 @@
+# name: test/sql/alter/drop_col/test_drop_col_concurrent_dml_conflict.test
+# description: A DML transaction must fail to commit if another connection drops a column concurrently
+# group: [drop_col]
+
+load __TEST_DIR__/reproduce_alter_dupkey.db
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+CREATE TABLE t1 (id INTEGER PRIMARY KEY, val INTEGER, extra INTEGER)
+
+statement ok
+INSERT INTO t1 SELECT i, i * 10, i FROM range(1000) tbl(i)
+
+statement ok con1
+BEGIN
+
+statement ok con1
+DELETE FROM t1 WHERE id < 500
+
+statement ok con2
+ALTER TABLE t1 DROP COLUMN extra
+
+statement error con1
+COMMIT
+----
+another transaction has altered this table
+
+query II
+EXPLAIN ANALYZE SELECT val FROM t1 WHERE id = 5
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I
+SELECT val FROM t1 WHERE id = 5
+----
+50
+
+query II
+EXPLAIN ANALYZE SELECT val FROM t1 WHERE id = 500
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I
+SELECT val FROM t1 WHERE id = 500
+----
+5000
+
+

--- a/test/sql/alter/drop_col/test_drop_col_concurrent_dml_conflict.test
+++ b/test/sql/alter/drop_col/test_drop_col_concurrent_dml_conflict.test
@@ -33,9 +33,9 @@ EXPLAIN ANALYZE SELECT val FROM t1 WHERE id = 5
 analyzed_plan	<REGEX>:.*Index Scan.*
 
 query I
-SELECT val FROM t1 WHERE id = 5
+SELECT val FROM t1 WHERE id = 499
 ----
-50
+4990
 
 query II
 EXPLAIN ANALYZE SELECT val FROM t1 WHERE id = 500


### PR DESCRIPTION
In UndoBuffer::IterateEntries (used along the commit path), we were not adjusting the state.start to point to the beginning of the entry if the callback would throw an exception. This means on RevertCommit we were attempting to revert the entry that the commit path failed on (i.e., we didn't do the commit operations, and in such a case we assume the callback cleaned up after itself). 

This manifested in the reproducer since con1 tries to commit but con2 dropped a column, so we should fail with "another transaction has altered this table". What was happening instead is the RevertCommit would try to insert the delete that didn't happen

I also relaxed the IsMainTable() assertion in DataTable::RemoveFromIndexes, since we can hit this after the table has been altered or dropped on the commit path, and I think it's fine on the revert path for this assertion not to hold. This technically "fixes" this issue: https://github.com/duckdb/duckdb/pull/21006, since the assert there was too strict and should not be failing. But even though the assert shouldn't have been failing, the investigation dug up some related issues which are coming in a separate PR. 