### PR TITLE
Only build plan_serializer when building the main DuckDB library

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,9 @@ if(NOT SUN AND BUILD_SHELL)
   add_subdirectory(shell)
 endif()
 
-add_executable(plan_serializer utils/plan_serializer.cpp)
-target_link_libraries(plan_serializer duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
-link_extension_libraries(plan_serializer "")
+if(BUILD_SHELL)
+  add_executable(plan_serializer utils/plan_serializer.cpp)
+  target_link_libraries(plan_serializer duckdb_static
+                        ${DUCKDB_EXTRA_LINK_FLAGS})
+  link_extension_libraries(plan_serializer "")
+endif()


### PR DESCRIPTION
## Problem

The `plan_serializer` tool added in v1.5.2 causes a linker error on ARM64 Linux (GCC 14) during community extension builds:

```
ld: src/libduckdb_static.a(ub_duckdb_common_serializer.cpp.o):
  multiple definition of `duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS';
  tools/CMakeFiles/plan_serializer.dir/utils/plan_serializer.cpp.o:
  first defined here
```

`plan_serializer.cpp` and the unity-built `ub_duckdb_common_serializer.cpp.o` both define `BufferedFileWriter::DEFAULT_OPEN_FLAGS`. DuckDB builds with C++11, where `static constexpr` class-type members are not implicitly `inline`, so GCC emits them with incompatible linkage (COMDAT vs non-COMDAT) and the linker rejects the duplicate.

This is currently breaking community extension CI for extensions like `jsonata`, `crypto`, and `adbc_scanner` on `linux_arm64`.

## Fix

Guard `plan_serializer` with `BUILD_SHELL`, matching the existing convention for the shell tool in the same file. `BUILD_SHELL` is `FALSE` when `BUILD_MAIN_DUCKDB_LIBRARY` is `FALSE` (i.e. extension-only builds where `plan_serializer` isn't needed).

Fixes #22097