### PR TITLE
Account for ROW_GROUP_SIZE when deciding whether to append to an existing row group

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -68,9 +68,7 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 	this->row_groups = make_shared_ptr<RowGroupCollection>(info, io_manager, types, 0);
 	if (data && data->row_group_count > 0) {
 		this->row_groups->Initialize(*data);
-		// We require a new row group after loading from disk because we don't know whether the row group size given on
-		// ATTACH matches that of the loaded file
-		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::REQUIRE_NEW);
+		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	} else {
 		this->row_groups->InitializeEmpty();
 		D_ASSERT(row_groups->GetTotalRows() == 0);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -68,7 +68,9 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 	this->row_groups = make_shared_ptr<RowGroupCollection>(info, io_manager, types, 0);
 	if (data && data->row_group_count > 0) {
 		this->row_groups->Initialize(*data);
-		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
+		// We require a new row group after loading from disk because we don't know whether the row group size given on
+		// ATTACH matches that of the loaded file
+		row_groups->SetRowGroupAppendMode(RowGroupAppendMode::REQUIRE_NEW);
 	} else {
 		this->row_groups->InitializeEmpty();
 		D_ASSERT(row_groups->GetTotalRows() == 0);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -484,9 +484,17 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 	auto l = state.row_groups->Lock();
 	// We need a new row group if there are none yet or the append mode forces us to create a new row group
 	bool needs_new_row_group = state.row_groups->IsEmpty(l) || row_group_append_mode == RowGroupAppendMode::REQUIRE_NEW;
-	// We honor SUGGEST_NEW iff the table has no indexes (because indexed tables aren't vacuumed so row groups might
-	// not be filled if we create a new one on append).
-	needs_new_row_group |= row_group_append_mode == RowGroupAppendMode::SUGGEST_NEW && info->GetIndexes().Empty();
+	// Otherwise we evaluate the row_group_append_mode
+	if (!needs_new_row_group) {
+		if (info->GetIndexes().Empty()) {
+			// We honor SUGGEST_NEW unless the table has indexes because there is no vacuuming for indexed tables...
+			needs_new_row_group = row_group_append_mode == RowGroupAppendMode::SUGGEST_NEW;
+		} else {
+			// ... and if it has indexes we will ignore row_group_append_mode and try to append, unless the last row
+			// group is full already.
+			needs_new_row_group = row_group_size < state.row_groups->GetLastSegment(l)->GetNode().count;
+		}
+	}
 	if (needs_new_row_group) {
 		AppendRowGroup(l, state.row_groups->GetBaseRowId() + total_rows);
 	}

--- a/test/sql/attach/attach_row_group_size_decreasing.test
+++ b/test/sql/attach/attach_row_group_size_decreasing.test
@@ -1,0 +1,41 @@
+# name: test/sql/attach/attach_row_group_size_decreasing.test
+# description: Tests writing to a database file with decreasing row group sizes.
+# group: [attach]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH '__TEST_DIR__/attach_row_group_size_decreasing.db' as test (ROW_GROUP_SIZE 4096);
+
+statement ok
+CREATE TABLE test.data (key BIGINT PRIMARY KEY);
+
+statement ok
+INSERT INTO test.data SELECT * FROM range(8190);
+
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('test.data');
+----
+2
+
+statement ok
+DETACH test;
+
+# Now we re-attach, but with a smaller row group size
+statement ok
+ATTACH '__TEST_DIR__/attach_row_group_size_decreasing.db' as test (ROW_GROUP_SIZE 2048);
+
+# Make sure that a _new_ row group is written (the last row group contains > 2048 rows)
+statement ok
+INSERT INTO test.data VALUES(8190), (8191);
+
+query II
+SELECT row_group_id, count FROM pragma_storage_info('test.data') where segment_type != 'VALIDITY' ORDER BY row_group_id;
+----
+0	4096
+1	4094
+2	2
+
+statement ok
+DETACH test;

--- a/test/sql/attach/attach_row_group_size_decreasing.test
+++ b/test/sql/attach/attach_row_group_size_decreasing.test
@@ -31,7 +31,7 @@ statement ok
 INSERT INTO test.data VALUES(8190), (8191);
 
 query II
-SELECT row_group_id, count FROM pragma_storage_info('test.data') where segment_type != 'VALIDITY' ORDER BY row_group_id;
+SELECT row_group_id, SUM(count) FROM pragma_storage_info('test.data') where segment_type != 'VALIDITY' GROUP BY (row_group_id) ORDER BY row_group_id;
 ----
 0	4096
 1	4094


### PR DESCRIPTION
Follow up on #22060 

After the row group append fix for indexed tables, when we `ATTACH '...' (ROW_GROUP_SIZE <N>)` with a `ROW_GROUP_SIZE` that is smaller than the amount of rows that are stored in the last row group, and we insert a row, we get an error that suggests the row group got truncated to the given `ROW_GROUP_SIZE`.

Example:

```
ATTACH 'test.duckdb' as test (ROW_GROUP_SIZE 4096);
CREATE TABLE test.data (key BIGINT PRIMARY KEY);
INSERT INTO test.data SELECT * FROM range(4000);
DETACH test;
ATTACH 'test.duckdb' as test (ROW_GROUP_SIZE 2048);
INSERT INTO test.data VALUES (4000), (4001);
```

```
FATAL Error:
Failed to rollback transaction. Cannot continue operation.
Original Error: INTERNAL Error: Could not find node in column segment tree!
Attempting to find row number "4000" in 1 nodes
* Node 0: Start 0, Count 2048
```

<details>
<summary>Stack trace:</summary>

```
0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 52
1        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 20
2        duckdb::InternalException::InternalException<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 48
3        duckdb::SegmentTree<duckdb::RowGroup, true>::GetSegmentIndex(duckdb::SegmentLock&, unsigned long long) const + 252
4        duckdb::RowGroupCollection::InitializeScanWithOffset(duckdb::QueryContext const&, duckdb::CollectionScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, unsigned long long, unsigned long long) + 196
5        duckdb::DataTable::InitializeScanWithOffset(duckdb::DuckTransaction&, duckdb::TableScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, unsigned long long, unsigned long long) + 140
6        duckdb::DataTable::ScanTableSegment(duckdb::DuckTransaction&, unsigned long long, unsigned long long, std::__1::function<void (duckdb::DataChunk&)> const&) + 416
7        duckdb::DataTable::WriteToLog(duckdb::DuckTransaction&, duckdb::WriteAheadLog&, unsigned long long, unsigned long long, duckdb::optional_ptr<duckdb::StorageCommitState, true>) + 352
8        duckdb::UndoBuffer::WriteToWAL(duckdb::WriteAheadLog&, duckdb::optional_ptr<duckdb::StorageCommitState, true>) + 228
9        duckdb::DuckTransaction::WriteToWAL(duckdb::ClientContext&, duckdb::AttachedDatabase&, duckdb::unique_ptr<duckdb::StorageCommitState, std::__1::default_delete<duckdb::StorageCommitState>, true>&) + 244
10       duckdb::DuckTransactionManager::CommitTransaction(duckdb::ClientContext&, duckdb::Transaction&) + 556
11       duckdb::MetaTransaction::Commit() + 276
12       duckdb::TransactionContext::Commit() + 64
13       duckdb::ClientContext::EndQueryInternal(duckdb::ClientContextLock&, bool, bool, duckdb::optional_ptr<duckdb::ErrorData, true>) + 216
14       duckdb::ClientContext::CleanupInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult*, bool) + 188
15       duckdb::ClientContext::FetchResultInternal(duckdb::ClientContextLock&, duckdb::PendingQueryResult&) + 144
16       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 180
17       duckdb::ClientContext::Query(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 136
18       duckdb::Connection::SendQuery(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 64
19       duckdb_shell::ShellState::ExecuteStatement(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>) + 272
20       duckdb_shell::ShellState::ExecuteSQL(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 576
21       duckdb_shell::ShellState::RunOneSqlLine(duckdb_shell::InputMode, char*) + 272
22       duckdb_shell::ShellState::ProcessInput(duckdb_shell::InputMode) + 1600
23       RunShell(int, char const**) + 3632
24       main + 56
25       start + 6076

Rollback Error: INTERNAL Error: Could not find node in column segment tree!
Attempting to find row number "4000" in 1 nodes
* Node 0: Start 0, Count 2048

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/stable/dev/internal_errors

Stack Trace:

0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 52
1        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 20
2        duckdb::InternalException::InternalException<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 48
3        duckdb::SegmentTree<duckdb::RowGroup, true>::GetSegmentIndex(duckdb::SegmentLock&, unsigned long long) const + 252
4        duckdb::RowGroupCollection::InitializeScanWithOffset(duckdb::QueryContext const&, duckdb::CollectionScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, unsigned long long, unsigned long long) + 196
5        duckdb::DataTable::InitializeScanWithOffset(duckdb::DuckTransaction&, duckdb::TableScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, unsigned long long, unsigned long long) + 140
6        duckdb::DataTable::ScanTableSegment(duckdb::DuckTransaction&, unsigned long long, unsigned long long, std::__1::function<void (duckdb::DataChunk&)> const&) + 416
7        duckdb::DataTable::RevertAppend(duckdb::DuckTransaction&, unsigned long long, unsigned long long) + 296
8        duckdb::UndoBuffer::Rollback() + 608
9        duckdb::DuckTransaction::Rollback() + 52
10       duckdb::DuckTransactionManager::CommitTransaction(duckdb::ClientContext&, duckdb::Transaction&) + 2772
11       duckdb::MetaTransaction::Commit() + 276
12       duckdb::TransactionContext::Commit() + 64
13       duckdb::ClientContext::EndQueryInternal(duckdb::ClientContextLock&, bool, bool, duckdb::optional_ptr<duckdb::ErrorData, true>) + 216
14       duckdb::ClientContext::CleanupInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult*, bool) + 188
15       duckdb::ClientContext::FetchResultInternal(duckdb::ClientContextLock&, duckdb::PendingQueryResult&) + 144
16       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 180
17       duckdb::ClientContext::Query(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 136
18       duckdb::Connection::SendQuery(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 64
19       duckdb_shell::ShellState::ExecuteStatement(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>) + 272
20       duckdb_shell::ShellState::ExecuteSQL(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 576
21       duckdb_shell::ShellState::RunOneSqlLine(duckdb_shell::InputMode, char*) + 272
22       duckdb_shell::ShellState::ProcessInput(duckdb_shell::InputMode) + 1600
23       RunShell(int, char const**) + 3632
24       main + 56
25       start + 6076
```

</details>

This PR makes sure that we require a new rowgroup for indexed tables if the current rowgroup is larger than the configured row_group_size - which can only happen when the last rowgroup was written with a `ROW_GROUP_SIZE` attach-setting that is larger than the ROW_GROUP_SIZE that is currently configured...