### PR TITLE
If the input to a function or cast is NULL, automatically emit a constant NULL instead of calling the function - as long as the function has `DEFAULT_NULL_HANDLING`

### DIFF
--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -431,11 +431,10 @@ void DateDiffFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
-			DateDiffBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+			throw InternalException("DateDiff called with constant NULL part");
 		}
+		const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+		DateDiffBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
 	} else {
 		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
 		    part_arg, start_arg, end_arg, result, args.size(),

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2016,82 +2016,51 @@ struct StructDatePart {
 			}
 		}
 
-		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto entries = input.Values<INPUT_TYPE>(count);
 
-			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result);
-			} else {
-				for (size_t col = 0; col < child_entries.size(); ++col) {
-					auto &child_entry = child_entries[col];
-					const auto part_index = size_t(info.part_codes[col]);
-					if (owners[part_index] == col) {
-						if (IsBigintDatepart(info.part_codes[col])) {
-							bigint_values[part_index - size_t(DatePartSpecifier::BEGIN_BIGINT)] =
-							    ConstantVector::GetData<int64_t>(child_entry);
-						} else {
-							double_values[part_index - size_t(DatePartSpecifier::BEGIN_DOUBLE)] =
-							    ConstantVector::GetData<double>(child_entry);
-						}
-					}
-				}
-				auto tdata = ConstantVector::GetData<INPUT_TYPE>(input);
-				if (Value::IsFinite(tdata[0])) {
-					DatePart::StructOperator::Operation(bigint_values, double_values, tdata[0], 0, part_mask);
+		// Start with a valid flat vector
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto &res_valid = FlatVector::Validity(result);
+		if (res_valid.GetData()) {
+			res_valid.SetAllValid(count);
+		}
+
+		// Start with valid children
+		for (size_t col = 0; col < child_entries.size(); ++col) {
+			auto &child_entry = child_entries[col];
+			child_entry.SetVectorType(VectorType::FLAT_VECTOR);
+			auto &child_validity = FlatVector::Validity(child_entry);
+			if (child_validity.GetData()) {
+				child_validity.SetAllValid(count);
+			}
+
+			// Pre-multiplex
+			const auto part_index = size_t(info.part_codes[col]);
+			if (owners[part_index] == col) {
+				if (IsBigintDatepart(info.part_codes[col])) {
+					bigint_values[part_index - size_t(DatePartSpecifier::BEGIN_BIGINT)] =
+					    FlatVector::GetDataMutable<int64_t>(child_entry);
 				} else {
-					for (auto &child_entry : child_entries) {
-						ConstantVector::SetNull(child_entry);
-					}
+					double_values[part_index - size_t(DatePartSpecifier::BEGIN_DOUBLE)] =
+					    FlatVector::GetDataMutable<double>(child_entry);
 				}
 			}
-		} else {
-			auto entries = input.template Values<INPUT_TYPE>(count);
+		}
 
-			// Start with a valid flat vector
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			auto &res_valid = FlatVector::Validity(result);
-			if (res_valid.GetData()) {
-				res_valid.SetAllValid(count);
-			}
-
-			// Start with valid children
-			for (size_t col = 0; col < child_entries.size(); ++col) {
-				auto &child_entry = child_entries[col];
-				child_entry.SetVectorType(VectorType::FLAT_VECTOR);
-				auto &child_validity = FlatVector::Validity(child_entry);
-				if (child_validity.GetData()) {
-					child_validity.SetAllValid(count);
-				}
-
-				// Pre-multiplex
-				const auto part_index = size_t(info.part_codes[col]);
-				if (owners[part_index] == col) {
-					if (IsBigintDatepart(info.part_codes[col])) {
-						bigint_values[part_index - size_t(DatePartSpecifier::BEGIN_BIGINT)] =
-						    FlatVector::GetDataMutable<int64_t>(child_entry);
-					} else {
-						double_values[part_index - size_t(DatePartSpecifier::BEGIN_DOUBLE)] =
-						    FlatVector::GetDataMutable<double>(child_entry);
-					}
-				}
-			}
-
-			for (idx_t i = 0; i < count; ++i) {
-				auto entry = entries[i];
-				if (entry.IsValid()) {
-					if (Value::IsFinite(entry.GetValue())) {
-						DatePart::StructOperator::Operation(bigint_values, double_values, entry.GetValue(), i,
-						                                    part_mask);
-					} else {
-						for (auto &child_entry : child_entries) {
-							FlatVector::Validity(child_entry).SetInvalid(i);
-						}
-					}
+		for (idx_t i = 0; i < count; ++i) {
+			auto entry = entries[i];
+			if (entry.IsValid()) {
+				if (Value::IsFinite(entry.GetValue())) {
+					DatePart::StructOperator::Operation(bigint_values, double_values, entry.GetValue(), i, part_mask);
 				} else {
-					res_valid.SetInvalid(i);
 					for (auto &child_entry : child_entries) {
 						FlatVector::Validity(child_entry).SetInvalid(i);
 					}
+				}
+			} else {
+				res_valid.SetInvalid(i);
+				for (auto &child_entry : child_entries) {
+					FlatVector::Validity(child_entry).SetInvalid(i);
 				}
 			}
 		}

--- a/extension/core_functions/scalar/date/date_sub.cpp
+++ b/extension/core_functions/scalar/date/date_sub.cpp
@@ -428,11 +428,10 @@ void DateSubFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
-			DateSubBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+			throw InternalException("DateSub called with constant NULL part");
 		}
+		const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+		DateSubBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
 	} else {
 		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
 		    part_arg, start_arg, end_arg, result, args.size(),

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -482,11 +482,10 @@ void DateTruncFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Common case of constant part.
 		if (ConstantVector::IsNull(part_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
-			DateTruncUnaryExecutor<TA, TR>(type, date_arg, result, args.size());
+			throw InternalException("DateTrunc called with constant NULL part");
 		}
+		const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+		DateTruncUnaryExecutor<TA, TR>(type, date_arg, result, args.size());
 	} else {
 		BinaryExecutor::ExecuteStandard<string_t, TA, TR, DateTruncBinaryOperator>(part_arg, date_arg, result,
 		                                                                           args.size());

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -235,28 +235,27 @@ void TimeBucketFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 	if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(bucket_width_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-			TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
-			switch (bucket_width_type) {
-			case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MICROS:
-				BinaryExecutor::Execute<interval_t, T, T>(
-				    bucket_width_arg, ts_arg, result, args.size(),
-				    TimeBucket::WidthConvertibleToMicrosBinaryOperator::Operation<interval_t, T, T>);
-				break;
-			case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MONTHS:
-				BinaryExecutor::Execute<interval_t, T, T>(
-				    bucket_width_arg, ts_arg, result, args.size(),
-				    TimeBucket::WidthConvertibleToMonthsBinaryOperator::Operation<interval_t, T, T>);
-				break;
-			case TimeBucket::BucketWidthType::UNCLASSIFIED:
-				BinaryExecutor::Execute<interval_t, T, T>(bucket_width_arg, ts_arg, result, args.size(),
-				                                          TimeBucket::BinaryOperator::Operation<interval_t, T, T>);
-				break;
-			default:
-				throw NotImplementedException("Bucket type not implemented for TIME_BUCKET");
-			}
+			throw InternalException("DateSub called with constant NULL part");
+		}
+		interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
+		TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
+		switch (bucket_width_type) {
+		case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MICROS:
+			BinaryExecutor::Execute<interval_t, T, T>(
+			    bucket_width_arg, ts_arg, result, args.size(),
+			    TimeBucket::WidthConvertibleToMicrosBinaryOperator::Operation<interval_t, T, T>);
+			break;
+		case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MONTHS:
+			BinaryExecutor::Execute<interval_t, T, T>(
+			    bucket_width_arg, ts_arg, result, args.size(),
+			    TimeBucket::WidthConvertibleToMonthsBinaryOperator::Operation<interval_t, T, T>);
+			break;
+		case TimeBucket::BucketWidthType::UNCLASSIFIED:
+			BinaryExecutor::Execute<interval_t, T, T>(bucket_width_arg, ts_arg, result, args.size(),
+			                                          TimeBucket::BinaryOperator::Operation<interval_t, T, T>);
+			break;
+		default:
+			throw NotImplementedException("Bucket type not implemented for TIME_BUCKET");
 		}
 	} else {
 		BinaryExecutor::Execute<interval_t, T, T>(bucket_width_arg, ts_arg, result, args.size(),
@@ -274,29 +273,28 @@ void TimeBucketOffsetFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 	if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(bucket_width_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-			TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
-			switch (bucket_width_type) {
-			case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MICROS:
-				TernaryExecutor::Execute<interval_t, T, interval_t, T>(
-				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-				    TimeBucket::OffsetWidthConvertibleToMicrosTernaryOperator::Operation<interval_t, T, interval_t, T>);
-				break;
-			case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MONTHS:
-				TernaryExecutor::Execute<interval_t, T, interval_t, T>(
-				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-				    TimeBucket::OffsetWidthConvertibleToMonthsTernaryOperator::Operation<interval_t, T, interval_t, T>);
-				break;
-			case TimeBucket::BucketWidthType::UNCLASSIFIED:
-				TernaryExecutor::Execute<interval_t, T, interval_t, T>(
-				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-				    TimeBucket::OffsetTernaryOperator::Operation<interval_t, T, interval_t, T>);
-				break;
-			default:
-				throw NotImplementedException("Bucket type not implemented for TIME_BUCKET");
-			}
+			throw InternalException("TimeBucketOffset called with constant NULL bucket width");
+		}
+		interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
+		TimeBucket::BucketWidthType bucket_width_type = TimeBucket::ClassifyBucketWidth(bucket_width);
+		switch (bucket_width_type) {
+		case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MICROS:
+			TernaryExecutor::Execute<interval_t, T, interval_t, T>(
+			    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+			    TimeBucket::OffsetWidthConvertibleToMicrosTernaryOperator::Operation<interval_t, T, interval_t, T>);
+			break;
+		case TimeBucket::BucketWidthType::CONVERTIBLE_TO_MONTHS:
+			TernaryExecutor::Execute<interval_t, T, interval_t, T>(
+			    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+			    TimeBucket::OffsetWidthConvertibleToMonthsTernaryOperator::Operation<interval_t, T, interval_t, T>);
+			break;
+		case TimeBucket::BucketWidthType::UNCLASSIFIED:
+			TernaryExecutor::Execute<interval_t, T, interval_t, T>(
+			    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+			    TimeBucket::OffsetTernaryOperator::Operation<interval_t, T, interval_t, T>);
+			break;
+		default:
+			throw NotImplementedException("Bucket type not implemented for TIME_BUCKET");
 		}
 	} else {
 		TernaryExecutor::Execute<interval_t, T, interval_t, T>(

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -158,76 +158,6 @@ bool ClampSlice(const INPUT_TYPE &value, INDEX_TYPE &begin, INDEX_TYPE &end) {
 }
 
 template <typename INPUT_TYPE, typename INDEX_TYPE, typename OP>
-void ExecuteConstantSlice(Vector &result, Vector &str_vector, Vector &begin_vector, Vector &end_vector,
-                          optional_ptr<Vector> step_vector, const idx_t count, SelectionVector &sel, idx_t &sel_idx,
-                          optional_ptr<Vector> result_child_vector, bool begin_is_empty, bool end_is_empty) {
-	// check all this nullness early
-	auto str_valid = !ConstantVector::IsNull(str_vector);
-	auto begin_valid = !ConstantVector::IsNull(begin_vector);
-	auto end_valid = !ConstantVector::IsNull(end_vector);
-	auto step_valid = step_vector && !ConstantVector::IsNull(*step_vector);
-
-	if (!str_valid || !begin_valid || !end_valid || (step_vector && !step_valid)) {
-		ConstantVector::SetNull(result);
-		return;
-	}
-
-	auto result_data = ConstantVector::GetData<INPUT_TYPE>(result);
-	auto str_data = ConstantVector::GetData<INPUT_TYPE>(str_vector);
-	auto step_data = step_vector ? ConstantVector::GetData<INDEX_TYPE>(*step_vector) : nullptr;
-
-	auto str = str_data[0];
-	INDEX_TYPE begin, end;
-	if (begin_is_empty) {
-		begin = 0;
-	} else {
-		begin = *ConstantVector::GetData<INDEX_TYPE>(begin_vector);
-	}
-	if (end_is_empty) {
-		end = OP::ValueLength(str);
-	} else {
-		end = *ConstantVector::GetData<INDEX_TYPE>(end_vector);
-	}
-	auto step = step_data ? step_data[0] : 1;
-
-	if (step < 0) {
-		swap(begin, end);
-		begin = end_is_empty ? 0 : begin;
-		end = begin_is_empty ? OP::ValueLength(str) : end;
-	}
-
-	// Clamp offsets
-	bool clamp_result = false;
-	if (step_valid || step == 1) {
-		clamp_result = ClampSlice<INPUT_TYPE, INDEX_TYPE, OP>(str, begin, end);
-	}
-
-	idx_t sel_length = 0;
-	bool sel_valid = false;
-	if (step_valid && step != 1 && end - begin > 0) {
-		sel_length =
-		    CalculateSliceLength(UnsafeNumericCast<idx_t>(begin), UnsafeNumericCast<idx_t>(end), step, step_valid);
-		sel.Initialize(sel_length);
-		sel_valid = true;
-	}
-
-	// Try to slice
-	if (!clamp_result) {
-		ConstantVector::SetNull(result);
-	} else if (step == 1) {
-		result_data[0] = OP::SliceValue(result, str, begin, end);
-	} else {
-		result_data[0] = OP::SliceValueWithSteps(result, sel, str, begin, end, step, sel_idx);
-	}
-
-	if (sel_valid) {
-		result_child_vector->Slice(sel, sel_length);
-		result_child_vector->Flatten(sel_length);
-		ListVector::SetListSize(result, sel_length);
-	}
-}
-
-template <typename INPUT_TYPE, typename INDEX_TYPE, typename OP>
 void ExecuteFlatSlice(Vector &result, Vector &list_vector, Vector &begin_vector, Vector &end_vector,
                       optional_ptr<Vector> step_vector, const idx_t count, SelectionVector &sel, idx_t &sel_idx,
                       optional_ptr<Vector> result_child_vector, bool begin_is_empty, bool end_is_empty) {
@@ -312,15 +242,9 @@ void ExecuteSlice(Vector &result, Vector &list_or_str_vector, Vector &begin_vect
 	SelectionVector sel;
 	idx_t sel_idx = 0;
 
-	if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		ExecuteConstantSlice<INPUT_TYPE, INDEX_TYPE, OP>(result, list_or_str_vector, begin_vector, end_vector,
-		                                                 step_vector, count, sel, sel_idx, result_child_vector,
-		                                                 begin_is_empty, end_is_empty);
-	} else {
-		ExecuteFlatSlice<INPUT_TYPE, INDEX_TYPE, OP>(result, list_or_str_vector, begin_vector, end_vector, step_vector,
-		                                             count, sel, sel_idx, result_child_vector, begin_is_empty,
-		                                             end_is_empty);
-	}
+	ExecuteFlatSlice<INPUT_TYPE, INDEX_TYPE, OP>(result, list_or_str_vector, begin_vector, end_vector, step_vector,
+	                                             count, sel, sel_idx, result_child_vector, begin_is_empty,
+	                                             end_is_empty);
 	result.Verify(count);
 }
 

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -48,10 +48,6 @@ static void StructKeysFunction(DataChunk &args, ExpressionState &state, Vector &
 
 	// If the input is a constant, we must return a CONSTANT_VECTOR
 	if (args.AllConstant()) {
-		if (ConstantVector::IsNull(input)) {
-			ConstantVector::SetNull(result);
-			return;
-		}
 		ConstantVector::Reference(result, keys_vector, 0, count);
 		return;
 	}

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -382,72 +382,42 @@ struct ICUDatePart : public ICUDateFunc {
 		D_ASSERT(args.ColumnCount() == 1);
 		const auto count = args.size();
 		Vector &input = args.data[0];
+		auto entries = input.Values<INPUT_TYPE>(count);
 
-		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto &child_entries = StructVector::GetEntries(result);
+		for (auto &child_entry : child_entries) {
+			child_entry.SetVectorType(VectorType::FLAT_VECTOR);
+		}
 
-			if (ConstantVector::IsNull(input)) {
-				ConstantVector::SetNull(result);
-			} else {
-				auto tdata = ConstantVector::GetData<INPUT_TYPE>(input);
-				auto micros = SetTime(calendar, tdata[0]);
-				const auto is_finite = Timestamp::IsFinite(*tdata);
-				auto &child_entries = StructVector::GetEntries(result);
+		auto &res_valid = FlatVector::Validity(result);
+		for (idx_t i = 0; i < count; ++i) {
+			auto entry = entries[i];
+			if (entry.IsValid()) {
+				res_valid.SetValid(i);
+				auto micros = SetTime(calendar, entry.GetValue());
+				const auto is_finite = Timestamp::IsFinite(entry.GetValue());
 				for (size_t col = 0; col < child_entries.size(); ++col) {
 					auto &child_entry = child_entries[col];
 					if (is_finite) {
+						FlatVector::Validity(child_entry).SetValid(i);
 						if (IsBigintDatepart(info.part_codes[col])) {
-							auto pdata = ConstantVector::GetData<int64_t>(child_entry);
+							auto pdata = FlatVector::GetDataMutable<int64_t>(child_entry);
 							auto adapter = info.bigints[col];
-							pdata[0] = adapter(calendar, micros);
+							pdata[i] = adapter(calendar, micros);
 						} else {
-							auto pdata = ConstantVector::GetData<double>(child_entry);
+							auto pdata = FlatVector::GetDataMutable<double>(child_entry);
 							auto adapter = info.doubles[col];
-							pdata[0] = adapter(calendar, micros);
+							pdata[i] = adapter(calendar, micros);
 						}
 					} else {
-						ConstantVector::SetNull(child_entry);
-					}
-				}
-			}
-		} else {
-			auto entries = input.template Values<INPUT_TYPE>(count);
-
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-			auto &child_entries = StructVector::GetEntries(result);
-			for (auto &child_entry : child_entries) {
-				child_entry.SetVectorType(VectorType::FLAT_VECTOR);
-			}
-
-			auto &res_valid = FlatVector::Validity(result);
-			for (idx_t i = 0; i < count; ++i) {
-				auto entry = entries[i];
-				if (entry.IsValid()) {
-					res_valid.SetValid(i);
-					auto micros = SetTime(calendar, entry.GetValue());
-					const auto is_finite = Timestamp::IsFinite(entry.GetValue());
-					for (size_t col = 0; col < child_entries.size(); ++col) {
-						auto &child_entry = child_entries[col];
-						if (is_finite) {
-							FlatVector::Validity(child_entry).SetValid(i);
-							if (IsBigintDatepart(info.part_codes[col])) {
-								auto pdata = FlatVector::GetDataMutable<int64_t>(child_entry);
-								auto adapter = info.bigints[col];
-								pdata[i] = adapter(calendar, micros);
-							} else {
-								auto pdata = FlatVector::GetDataMutable<double>(child_entry);
-								auto adapter = info.doubles[col];
-								pdata[i] = adapter(calendar, micros);
-							}
-						} else {
-							FlatVector::Validity(child_entry).SetInvalid(i);
-						}
-					}
-				} else {
-					res_valid.SetInvalid(i);
-					for (auto &child_entry : child_entries) {
 						FlatVector::Validity(child_entry).SetInvalid(i);
 					}
+				}
+			} else {
+				res_valid.SetInvalid(i);
+				for (auto &child_entry : child_entries) {
+					FlatVector::Validity(child_entry).SetInvalid(i);
 				}
 			}
 		}

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -102,21 +102,20 @@ struct ICUCalendarSub : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
-				auto part_func = SubtractFactory(GetDatePartSpecifier(specifier));
-				BinaryExecutor::ExecuteWithNulls<T, T, int64_t>(
-				    startdate_arg, enddate_arg, result, args.size(),
-				    [&](T start_date, T end_date, ValidityMask &mask, idx_t idx) {
-					    if (Timestamp::IsFinite(start_date) && Timestamp::IsFinite(end_date)) {
-						    return part_func(calendar.get(), start_date, end_date);
-					    } else {
-						    mask.SetInvalid(idx);
-						    return int64_t(0);
-					    }
-				    });
+				throw InternalException("ICUDateSub called with constant NULL bucket width");
 			}
+			const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
+			auto part_func = SubtractFactory(GetDatePartSpecifier(specifier));
+			BinaryExecutor::ExecuteWithNulls<T, T, int64_t>(
+			    startdate_arg, enddate_arg, result, args.size(),
+			    [&](T start_date, T end_date, ValidityMask &mask, idx_t idx) {
+				    if (Timestamp::IsFinite(start_date) && Timestamp::IsFinite(end_date)) {
+					    return part_func(calendar.get(), start_date, end_date);
+				    } else {
+					    mask.SetInvalid(idx);
+					    return int64_t(0);
+				    }
+			    });
 		} else {
 			TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
 			    part_arg, startdate_arg, enddate_arg, result, args.size(),
@@ -232,23 +231,22 @@ struct ICUCalendarDiff : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
-				const auto part = GetDatePartSpecifier(specifier);
-				auto trunc_func = DiffTruncationFactory(part);
-				auto sub_func = SubtractFactory(part);
-				BinaryExecutor::ExecuteWithNulls<T, T, int64_t>(
-				    startdate_arg, enddate_arg, result, args.size(),
-				    [&](T start_date, T end_date, ValidityMask &mask, idx_t idx) {
-					    if (Timestamp::IsFinite(start_date) && Timestamp::IsFinite(end_date)) {
-						    return DifferenceFunc<T>(calendar, start_date, end_date, trunc_func, sub_func);
-					    } else {
-						    mask.SetInvalid(idx);
-						    return int64_t(0);
-					    }
-				    });
+				throw InternalException("ICUDateSub called with constant NULL bucket width");
 			}
+			const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
+			const auto part = GetDatePartSpecifier(specifier);
+			auto trunc_func = DiffTruncationFactory(part);
+			auto sub_func = SubtractFactory(part);
+			BinaryExecutor::ExecuteWithNulls<T, T, int64_t>(
+			    startdate_arg, enddate_arg, result, args.size(),
+			    [&](T start_date, T end_date, ValidityMask &mask, idx_t idx) {
+				    if (Timestamp::IsFinite(start_date) && Timestamp::IsFinite(end_date)) {
+					    return DifferenceFunc<T>(calendar, start_date, end_date, trunc_func, sub_func);
+				    } else {
+					    mask.SetInvalid(idx);
+					    return int64_t(0);
+				    }
+			    });
 		} else {
 			TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
 			    part_arg, startdate_arg, enddate_arg, result, args.size(),

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -136,20 +136,19 @@ struct ICUDateTrunc : public ICUDateFunc {
 		if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(part_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
-				auto truncator = TruncationFactory(GetDatePartSpecifier(specifier));
-				UnaryExecutor::Execute<T, timestamp_t>(date_arg, result, args.size(), [&](T input) {
-					if (Timestamp::IsFinite(input)) {
-						auto micros = SetTime(calendar.get(), input);
-						truncator(calendar.get(), micros);
-						return GetTimeUnsafe(calendar.get(), micros);
-					} else {
-						return input;
-					}
-				});
+				throw InternalException("ICUDateTrunc called with constant NULL bucket width");
 			}
+			const auto specifier = ConstantVector::GetData<string_t>(part_arg)->GetString();
+			auto truncator = TruncationFactory(GetDatePartSpecifier(specifier));
+			UnaryExecutor::Execute<T, timestamp_t>(date_arg, result, args.size(), [&](T input) {
+				if (Timestamp::IsFinite(input)) {
+					auto micros = SetTime(calendar.get(), input);
+					truncator(calendar.get(), micros);
+					return GetTimeUnsafe(calendar.get(), micros);
+				} else {
+					return input;
+				}
+			});
 		} else {
 			BinaryExecutor::Execute<string_t, T, timestamp_t>(
 			    part_arg, date_arg, result, args.size(), [&](string_t specifier, T input) {

--- a/extension/icu/icu-makedate.cpp
+++ b/extension/icu/icu-makedate.cpp
@@ -125,14 +125,13 @@ struct ICUMakeTimestampTZFunc : public ICUDateFunc {
 			auto &tz_vec = input.data.back();
 			if (tz_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 				if (ConstantVector::IsNull(tz_vec)) {
-					ConstantVector::SetNull(result);
-				} else {
-					SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
-					SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(
-					    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss) {
-						    return Operation<T>(calendar, yyyy, mm, dd, hr, mn, ss);
-					    });
+					throw InternalException("ICUMakeTimestamp called with constant NULL tz");
 				}
+				SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
+				SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(
+				    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss) {
+					    return Operation<T>(calendar, yyyy, mm, dd, hr, mn, ss);
+				    });
 			} else {
 				SeptenaryExecutor::Execute<T, T, T, T, T, double, string_t, timestamp_t>(
 				    input, result, [&](T yyyy, T mm, T dd, T hr, T mn, double ss, string_t tz_id) {

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -112,30 +112,25 @@ struct ICUStrptime : public ICUDateFunc {
 		auto calendar = calendar_ptr.get();
 
 		D_ASSERT(fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR);
-
-		if (ConstantVector::IsNull(fmt_arg)) {
-			ConstantVector::SetNull(result);
-		} else {
-			UnaryExecutor::Execute<string_t, timestamp_t>(str_arg, result, args.size(), [&](string_t input) {
-				ParseResult parsed;
-				for (auto &format : info.formats) {
-					if (format.Parse(input, parsed)) {
-						if (parsed.is_special) {
-							return parsed.ToTimestamp();
-						} else {
-							// Set TZ first, if any.
-							if (!parsed.tz.empty()) {
-								SetTimeZone(calendar, parsed.tz);
-							}
-
-							return GetTime(calendar, ToMicros(calendar, parsed, format));
+		UnaryExecutor::Execute<string_t, timestamp_t>(str_arg, result, args.size(), [&](string_t input) {
+			ParseResult parsed;
+			for (auto &format : info.formats) {
+				if (format.Parse(input, parsed)) {
+					if (parsed.is_special) {
+						return parsed.ToTimestamp();
+					} else {
+						// Set TZ first, if any.
+						if (!parsed.tz.empty()) {
+							SetTimeZone(calendar, parsed.tz);
 						}
+
+						return GetTime(calendar, ToMicros(calendar, parsed, format));
 					}
 				}
+			}
 
-				throw InvalidInputException(parsed.FormatError(input, info.formats[0].format_specifier));
-			});
-		}
+			throw InvalidInputException(parsed.FormatError(input, info.formats[0].format_specifier));
+		});
 	}
 
 	static void TryParse(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -428,20 +423,19 @@ struct ICUStrftime : public ICUDateFunc {
 		if (fmt_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// Common case of constant part.
 			if (ConstantVector::IsNull(fmt_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				StrfTimeFormat format;
-				ParseFormatSpecifier(*ConstantVector::GetData<string_t>(fmt_arg), format);
-
-				UnaryExecutor::ExecuteWithNulls<timestamp_t, string_t>(
-				    src_arg, result, args.size(), [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
-					    if (Timestamp::IsFinite(input)) {
-						    return Operation(calendar.get(), input, tz_name, format, result);
-					    } else {
-						    return StringVector::AddString(result, Timestamp::ToString(input));
-					    }
-				    });
+				throw InternalException("ICUStrfTime called with constant NULL format");
 			}
+			StrfTimeFormat format;
+			ParseFormatSpecifier(*ConstantVector::GetData<string_t>(fmt_arg), format);
+
+			UnaryExecutor::ExecuteWithNulls<timestamp_t, string_t>(
+			    src_arg, result, args.size(), [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
+				    if (Timestamp::IsFinite(input)) {
+					    return Operation(calendar.get(), input, tz_name, format, result);
+				    } else {
+					    return StringVector::AddString(result, Timestamp::ToString(input));
+				    }
+			    });
 		} else {
 			BinaryExecutor::ExecuteWithNulls<timestamp_t, string_t, string_t>(
 			    src_arg, fmt_arg, result, args.size(),

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -376,38 +376,37 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
-				switch (bucket_width_type) {
-				case BucketWidthType::CONVERTIBLE_TO_MICROS:
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return WidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_DAYS:
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return WidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_MONTHS:
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return WidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, calendar);
-					    });
-					break;
-				case BucketWidthType::UNCLASSIFIED:
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return BinaryOperator::Operation(bucket_width, ts, calendar);
-					    });
-					break;
-				default:
-					throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
-				}
+				throw InternalException("ICUTimeBucket called with constant NULL bucket");
+			}
+			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
+			BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
+			switch (bucket_width_type) {
+			case BucketWidthType::CONVERTIBLE_TO_MICROS:
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return WidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_DAYS:
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return WidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_MONTHS:
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return WidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, calendar);
+				    });
+				break;
+			case BucketWidthType::UNCLASSIFIED:
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return BinaryOperator::Operation(bucket_width, ts, calendar);
+				    });
+				break;
+			default:
+				throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
 			}
 		} else {
 			BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
@@ -431,45 +430,44 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
-				switch (bucket_width_type) {
-				case BucketWidthType::CONVERTIBLE_TO_MICROS:
-					TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-					    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
-						    return OffsetWidthConvertibleToMicrosTernaryOperator::Operation(bucket_width, ts, offset,
-						                                                                    calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_DAYS:
-					TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-					    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
-						    return OffsetWidthConvertibleToDaysTernaryOperator::Operation(bucket_width, ts, offset,
-						                                                                  calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_MONTHS:
-					TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-					    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
-						    return OffsetWidthConvertibleToMonthsTernaryOperator::Operation(bucket_width, ts, offset,
-						                                                                    calendar);
-					    });
-					break;
-				case BucketWidthType::UNCLASSIFIED:
-					TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
-					    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
-						    return OffsetTernaryOperator::Operation(bucket_width, ts, offset, calendar);
-					    });
-					break;
-				default:
-					throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
-				}
+				throw InternalException("ICUTimeBucketOffset called with constant NULL bucket");
+			}
+			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
+			BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
+			switch (bucket_width_type) {
+			case BucketWidthType::CONVERTIBLE_TO_MICROS:
+				TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+				    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
+					    return OffsetWidthConvertibleToMicrosTernaryOperator::Operation(bucket_width, ts, offset,
+					                                                                    calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_DAYS:
+				TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+				    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
+					    return OffsetWidthConvertibleToDaysTernaryOperator::Operation(bucket_width, ts, offset,
+					                                                                  calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_MONTHS:
+				TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+				    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
+					    return OffsetWidthConvertibleToMonthsTernaryOperator::Operation(bucket_width, ts, offset,
+					                                                                    calendar);
+				    });
+				break;
+			case BucketWidthType::UNCLASSIFIED:
+				TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, offset_arg, result, args.size(),
+				    [&](interval_t bucket_width, timestamp_t ts, interval_t offset) {
+					    return OffsetTernaryOperator::Operation(bucket_width, ts, offset, calendar);
+				    });
+				break;
+			default:
+				throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
 			}
 		} else {
 			TernaryExecutor::Execute<interval_t, timestamp_t, interval_t, timestamp_t>(
@@ -560,50 +558,49 @@ struct ICUTimeBucket : public ICUDateFunc {
 		if (bucket_width_arg.GetVectorType() == VectorType::CONSTANT_VECTOR &&
 		    tz_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(bucket_width_arg) || ConstantVector::IsNull(tz_arg)) {
-				ConstantVector::SetNull(result);
-			} else {
-				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-				SetTimeZone(calendar.GetICUCalendar(), *ConstantVector::GetData<string_t>(tz_arg));
-				timestamp_t origin;
-				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
-				switch (bucket_width_type) {
-				case BucketWidthType::CONVERTIBLE_TO_MICROS:
-					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
-					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return TimeZoneWidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, origin,
-						                                                                     calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_DAYS:
-					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
-					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return TimeZoneWidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, origin,
-						                                                                   calendar);
-					    });
-					break;
-				case BucketWidthType::CONVERTIBLE_TO_MONTHS:
-					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
-					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_2));
-					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
-						    return TimeZoneWidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, origin,
-						                                                                     calendar);
-					    });
-					break;
-				case BucketWidthType::UNCLASSIFIED:
-					TernaryExecutor::Execute<interval_t, timestamp_t, string_t, timestamp_t>(
-					    bucket_width_arg, ts_arg, tz_arg, result, args.size(),
-					    [&](interval_t bucket_width, timestamp_t ts, string_t tz) {
-						    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar);
-					    });
-					break;
-				default:
-					throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
-				}
+				throw InternalException("ICUTimeBucketTimeZone called with constant NULL bucket width or tz");
+			}
+			interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
+			SetTimeZone(calendar.GetICUCalendar(), *ConstantVector::GetData<string_t>(tz_arg));
+			timestamp_t origin;
+			BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
+			switch (bucket_width_type) {
+			case BucketWidthType::CONVERTIBLE_TO_MICROS:
+				origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+				                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return TimeZoneWidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, origin,
+					                                                                     calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_DAYS:
+				origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+				                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return TimeZoneWidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, origin,
+					                                                                   calendar);
+				    });
+				break;
+			case BucketWidthType::CONVERTIBLE_TO_MONTHS:
+				origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+				                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_2));
+				BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
+					    return TimeZoneWidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, origin,
+					                                                                     calendar);
+				    });
+				break;
+			case BucketWidthType::UNCLASSIFIED:
+				TernaryExecutor::Execute<interval_t, timestamp_t, string_t, timestamp_t>(
+				    bucket_width_arg, ts_arg, tz_arg, result, args.size(),
+				    [&](interval_t bucket_width, timestamp_t ts, string_t tz) {
+					    return TimeZoneTernaryOperator::Operation(bucket_width, ts, tz, calendar);
+				    });
+				break;
+			default:
+				throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
 			}
 		} else {
 			TernaryExecutor::Execute<interval_t, timestamp_t, string_t, timestamp_t>(

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -422,12 +422,11 @@ struct ICUTimeZoneFunc : public ICUDateFunc {
 		auto &ts_vec = input.data[1];
 		if (tz_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			if (ConstantVector::IsNull(tz_vec)) {
-				ConstantVector::SetNull(result);
-			} else {
-				SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
-				UnaryExecutor::Execute<T, T>(ts_vec, result, input.size(),
-				                             [&](T ts) { return OP::Operation(calendar, ts); });
+				throw InternalException("ICUTimeZone called with constant NULL tz");
 			}
+			SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_vec));
+			UnaryExecutor::Execute<T, T>(ts_vec, result, input.size(),
+			                             [&](T ts) { return OP::Operation(calendar, ts); });
 		} else {
 			BinaryExecutor::Execute<string_t, T, T>(tz_vec, ts_vec, result, input.size(), [&](string_t tz_id, T ts) {
 				if (ICUIsFinite(ts)) {

--- a/extension/json/json_functions/json_contains.cpp
+++ b/extension/json/json_functions/json_contains.cpp
@@ -116,8 +116,7 @@ static void JSONContainsFunction(DataChunk &args, ExpressionState &state, Vector
 
 	if (needles.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(needles)) {
-			ConstantVector::SetNull(result);
-			return;
+			throw InternalException("JSON Contains called with constant NULL needles");
 		}
 		auto &needle_str = *ConstantVector::GetData<string_t>(needles);
 		auto needle_doc = JSONCommon::ReadDocument(needle_str, JSONCommon::READ_FLAG, alc);

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -40,6 +40,12 @@ void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionStat
 	bool all_constant = child.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	if (all_constant) {
 		// if the input is constant we only need to cast one value
+		if (ConstantVector::IsNull(child) && result.GetType().id() != LogicalTypeId::UNION) {
+			// if the input is constant NULL the output is always constant NULL
+			// ... except for unions, that are special
+			ConstantVector::SetNull(result);
+			return;
+		}
 		count = 1;
 	}
 	expr.bound_cast.function(child, result, count, parameters);

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -222,12 +222,17 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 		// we cannot optimize away constant vectors for volatile functions
 		all_constant = false;
 	}
+	auto default_null_handling = expr.function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING;
 	if (!state->types.empty()) {
 		for (idx_t i = 0; i < expr.children.size(); i++) {
 			D_ASSERT(state->types[i] == expr.children[i]->return_type);
 			Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
 			if (arguments.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 				all_constant = false;
+			} else if (default_null_handling && ConstantVector::IsNull(arguments.data[i])) {
+				// constant NULL input: result is NULL
+				ConstantVector::SetNull(result);
+				return;
 			}
 		}
 	}
@@ -278,7 +283,7 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 	if (!expr.function.HasSelectCallback()) {
 		return DefaultSelect(expr, state, sel, count, true_sel, false_sel);
 	}
-
+	// FIXME: push constant handling in here
 	state->intermediate_chunk.Reset();
 	auto &arguments = state->intermediate_chunk;
 	for (idx_t i = 0; i < expr.children.size(); i++) {


### PR DESCRIPTION
This simplifies constant handling in functions, as we can no longer get any constant `NULL` inputs for functions that have default null handling.