### PR TITLE
PEG parser sample bug

### DIFF
--- a/extension/autocomplete/include/inlined_grammar.gram
+++ b/extension/autocomplete/include/inlined_grammar.gram
@@ -1415,7 +1415,7 @@ SetStatement <- 'SET' (StandardAssignment / SetTimeZone)
 StandardAssignment <- (SetVariable / SetSetting) SetAssignment
 SetTimeZone <- 'TIME' 'ZONE' ZoneValue
 
-ZoneValue <- ZoneIntervalWithPrecision / ZoneIntervalWithInterval / 'LOCAL' / 'DEFAULT' / StringLiteral / Identifier / NumberLiteral / 'DEFAULT' / 'LOCAL'
+ZoneValue <- ZoneIntervalWithPrecision / ZoneIntervalWithInterval / 'LOCAL' / 'DEFAULT' / StringLiteral / Identifier / NumberLiteral
 ZoneIntervalWithInterval <- 'INTERVAL' StringLiteral Interval?
 ZoneIntervalWithPrecision <- 'INTERVAL' Parens(NumberLiteral) StringLiteral
 

--- a/extension/autocomplete/include/inlined_grammar.hpp
+++ b/extension/autocomplete/include/inlined_grammar.hpp
@@ -1296,7 +1296,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"SetStatement <- 'SET' (StandardAssignment / SetTimeZone)\n"
 	"StandardAssignment <- (SetVariable / SetSetting) SetAssignment\n"
 	"SetTimeZone <- 'TIME' 'ZONE' ZoneValue\n"
-	"ZoneValue <- ZoneIntervalWithPrecision / ZoneIntervalWithInterval / 'LOCAL' / 'DEFAULT' / StringLiteral / Identifier / NumberLiteral / 'DEFAULT' / 'LOCAL'\n"
+	"ZoneValue <- ZoneIntervalWithPrecision / ZoneIntervalWithInterval / 'LOCAL' / 'DEFAULT' / StringLiteral / Identifier / NumberLiteral\n"
 	"ZoneIntervalWithInterval <- 'INTERVAL' StringLiteral Interval?\n"
 	"ZoneIntervalWithPrecision <- 'INTERVAL' Parens(NumberLiteral) StringLiteral\n"
 	"SetSetting <- SettingScope? SettingName\n"

--- a/extension/autocomplete/transformer/transform_select.cpp
+++ b/extension/autocomplete/transformer/transform_select.cpp
@@ -1727,6 +1727,9 @@ unique_ptr<SampleOptions> PEGTransformerFactory::TransformSampleEntryCount(PEGTr
 		auto properties = transformer.Transform<pair<SampleMethod, optional_idx>>(extract_parens);
 		sample_count->method = properties.first;
 		sample_count->seed = properties.second;
+		if (sample_count->seed.IsValid()) {
+			sample_count->repeatable = true;
+		}
 	}
 	return sample_count;
 }


### PR DESCRIPTION
Running the slow tests revealed two failing tests: 
- `test/sql/sample/sample_verification.test_slow`
- `test/sql/sample/bernoulli_sampling.test_slow`

This was because I forgot to set the `repeatable` property when the seed is provided for sampling