### PR TITLE
Add a sel_count and capacity to the DictionaryBuffer

### DIFF
--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -135,7 +135,7 @@ idx_t DictionaryDecoder::Read(uint8_t *defines, idx_t read_count, Vector &result
 	dictionary_selection_vector.Verify(read_count, dictionary_size + can_have_nulls);
 #endif
 	if (result_offset == 0) {
-		result.Dictionary(dictionary, dictionary_selection_vector);
+		result.Dictionary(dictionary, dictionary_selection_vector, read_count);
 		D_ASSERT(result.GetVectorType() == VectorType::DICTIONARY_VECTOR);
 	} else {
 		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -152,7 +152,7 @@ void Vector::Reinterpret(const Vector &other) {
 		new_vector.Reinterpret(DictionaryVector::Child(other));
 		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
-		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), std::move(new_entry));
+		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), old_dict.Capacity(), std::move(new_entry));
 		auto dict_size = old_dict.GetDictionarySize();
 		if (dict_size.IsValid()) {
 			buffer->Cast<DictionaryBuffer>().SetDictionarySize(dict_size.GetIndex());
@@ -213,12 +213,12 @@ void Vector::Dictionary(const Vector &dict, idx_t dictionary_size, const Selecti
 	Dictionary(dictionary_size, sel, count);
 }
 
-void Vector::Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel) {
+void Vector::Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel, idx_t sel_count) {
 	if (type.InternalType() == PhysicalType::STRUCT) {
 		throw InternalException("Struct vectors cannot be dictionaries");
 	}
 	D_ASSERT(type == reusable_dict->data.GetType());
-	buffer = make_buffer<DictionaryBuffer>(sel, std::move(reusable_dict));
+	buffer = make_buffer<DictionaryBuffer>(sel, sel_count, std::move(reusable_dict));
 }
 
 void Vector::Initialize(VectorDataInitialization data_initialize, idx_t capacity) {
@@ -889,7 +889,7 @@ void Vector::DebugTransformToDictionary(Vector &vector, idx_t count) {
 		// Reusable dictionary API does not work for STRUCT
 		vector.Dictionary(inverted_vector, verify_count, original_sel, count);
 	} else {
-		vector.Dictionary(reusable_dict, original_sel);
+		vector.Dictionary(reusable_dict, original_sel, count);
 	}
 	vector.Verify(count);
 }

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -6,22 +6,26 @@
 
 namespace duckdb {
 
-DictionaryBuffer::DictionaryBuffer(const SelectionVector &sel, buffer_ptr<DictionaryEntry> entry_p)
+DictionaryBuffer::DictionaryBuffer(const SelectionVector &sel, idx_t sel_count_p, buffer_ptr<DictionaryEntry> entry_p)
     : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(sel),
-      entry(std::move(entry_p)) {
+      sel_count(sel_count_p), entry(std::move(entry_p)) {
 }
-DictionaryBuffer::DictionaryBuffer(buffer_ptr<SelectionData> data, buffer_ptr<DictionaryEntry> entry_p)
+DictionaryBuffer::DictionaryBuffer(buffer_ptr<SelectionData> data, idx_t sel_count_p,
+                                   buffer_ptr<DictionaryEntry> entry_p)
     : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(std::move(data)),
-      entry(std::move(entry_p)) {
+      sel_count(sel_count_p), entry(std::move(entry_p)) {
 }
-DictionaryBuffer::DictionaryBuffer(const SelectionVector &sel)
-    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(sel) {
+DictionaryBuffer::DictionaryBuffer(const SelectionVector &sel, idx_t sel_count_p)
+    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(sel),
+      sel_count(sel_count_p) {
 }
-DictionaryBuffer::DictionaryBuffer(buffer_ptr<SelectionData> data)
-    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(std::move(data)) {
+DictionaryBuffer::DictionaryBuffer(buffer_ptr<SelectionData> data, idx_t sel_count_p)
+    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(std::move(data)),
+      sel_count(sel_count_p) {
 }
 DictionaryBuffer::DictionaryBuffer(idx_t count)
-    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(count) {
+    : VectorBuffer(VectorType::DICTIONARY_VECTOR, VectorBufferType::DICTIONARY_BUFFER), sel_vector(count),
+      sel_count(count) {
 }
 
 idx_t DictionaryBuffer::GetDataSize(const LogicalType &type, idx_t count) const {
@@ -77,7 +81,7 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::SliceWithCache(SelCache &cache, const
 	if (cache_entry != cache.cache.end()) {
 		// cached entry exists: use the cached selection vector with our dictionary entry
 		auto &cached_dict = cache_entry->second->Cast<DictionaryBuffer>();
-		result = make_buffer<DictionaryBuffer>(cached_dict.GetSelVector(), entry);
+		result = make_buffer<DictionaryBuffer>(cached_dict.GetSelVector(), count, entry);
 	} else {
 		// no cached entry - perform the slice and store the result
 		result = Slice(type, sel, count);
@@ -101,7 +105,7 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::SliceInternal(const LogicalType &type
 	auto dictionary_id = GetDictionaryId();
 	auto sliced_dictionary = GetSelVector().Slice(sel, count);
 	auto entry = GetEntryPtr();
-	auto new_buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary), std::move(entry));
+	auto new_buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary), count, std::move(entry));
 	if (dictionary_size.IsValid()) {
 		auto &dict_buffer = new_buffer->Cast<DictionaryBuffer>();
 		dict_buffer.SetDictionarySize(dictionary_size.GetIndex());
@@ -111,6 +115,9 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::SliceInternal(const LogicalType &type
 }
 
 Value DictionaryBuffer::GetValue(const LogicalType &type, idx_t index) const {
+	if (index >= sel_count) {
+		throw InternalException("DictionaryBuffer::GetValue out of range for selection vector");
+	}
 	auto resolved_index = sel_vector.get_index(index);
 	return entry->data.GetValue(resolved_index);
 }

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -72,7 +72,7 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &
                                                              idx_t count) {
 	Vector child_vector(type, shared_from_this());
 	auto entry = make_shared_ptr<DictionaryEntry>(std::move(child_vector));
-	return make_buffer<DictionaryBuffer>(sel, std::move(entry));
+	return make_buffer<DictionaryBuffer>(sel, count, std::move(entry));
 }
 
 buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateBuffer(AllocatedData &&new_data, idx_t capacity) const {

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -111,7 +111,7 @@ bool ExecuteFunctionState::TryExecuteDictionaryExpression(const BoundFunctionExp
 	}
 
 	// Result references the dictionary
-	result.Dictionary(output_dictionary, DictionaryVector::SelVector(unary_input));
+	result.Dictionary(output_dictionary, DictionaryVector::SelVector(unary_input), args.size());
 
 	return true;
 }

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -299,7 +299,7 @@ OperatorResultType PerfectHashJoinExecutor::ProbePerfectHashTable(ExecutionConte
 	for (idx_t i = 0; i < join.rhs_output_columns.col_types.size(); i++) {
 		auto &result_vector = result.data[lhs_output_columns.ColumnCount() + i];
 		D_ASSERT(result_vector.GetType() == ht.layout_ptr->GetTypes()[ht.output_columns[i]]);
-		result_vector.Dictionary(perfect_hash_table[i], state.build_sel_vec);
+		result_vector.Dictionary(perfect_hash_table[i], state.build_sel_vec, probe_sel_count);
 	}
 	return OperatorResultType::NEED_MORE_INPUT;
 }

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -105,7 +105,7 @@ public:
 	//! Creates a reference to a dictionary of the other vector
 	DUCKDB_API void Dictionary(const Vector &dict, idx_t dictionary_size, const SelectionVector &sel, idx_t count);
 	//! Creates a dictionary on the reusable dict
-	DUCKDB_API void Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel);
+	DUCKDB_API void Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const SelectionVector &sel, idx_t sel_count);
 
 	//! Creates the data of this vector with the specified type. Any data that
 	//! is currently in the vector is destroyed.

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -31,13 +31,16 @@ public:
 //! The DictionaryBuffer holds a selection vector and a reference to a DictionaryEntry
 class DictionaryBuffer : public VectorBuffer {
 public:
-	explicit DictionaryBuffer(const SelectionVector &sel, buffer_ptr<DictionaryEntry> entry_p);
-	explicit DictionaryBuffer(buffer_ptr<SelectionData> data, buffer_ptr<DictionaryEntry> entry_p);
-	explicit DictionaryBuffer(const SelectionVector &sel);
-	explicit DictionaryBuffer(buffer_ptr<SelectionData> data);
+	explicit DictionaryBuffer(const SelectionVector &sel, idx_t sel_count, buffer_ptr<DictionaryEntry> entry_p);
+	explicit DictionaryBuffer(buffer_ptr<SelectionData> data, idx_t sel_count, buffer_ptr<DictionaryEntry> entry_p);
+	explicit DictionaryBuffer(const SelectionVector &sel, idx_t sel_count);
+	explicit DictionaryBuffer(buffer_ptr<SelectionData> data, idx_t sel_count);
 	explicit DictionaryBuffer(idx_t count = STANDARD_VECTOR_SIZE);
 
 public:
+	idx_t Capacity() const override {
+		return sel_count;
+	}
 	const SelectionVector &GetSelVector() const {
 		return sel_vector;
 	}
@@ -88,6 +91,7 @@ protected:
 
 private:
 	SelectionVector sel_vector;
+	idx_t sel_count;
 	buffer_ptr<DictionaryEntry> entry;
 	optional_idx dictionary_size;
 	//! A unique identifier for the dictionary that can be used to check if two dictionaries are equivalent

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -221,7 +221,7 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 		}
 		sel_count = approved_tuple_count;
 
-		result.Dictionary(scan_state.dictionary, dict_sel);
+		result.Dictionary(scan_state.dictionary, dict_sel, vector_count);
 		return;
 	}
 	// fallback: scan + filter

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -226,7 +226,7 @@ void CompressedStringScanState::ScanToDictionaryVector(ColumnSegment &segment, V
 	D_ASSERT(result_offset == 0);
 
 	auto &selvec = GetSelVec(start, scan_count);
-	result.Dictionary(dictionary, selvec);
+	result.Dictionary(dictionary, selvec, scan_count);
 	result.Verify(result_offset + scan_count);
 }
 

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -114,7 +114,7 @@ void CompressedStringScanState::ScanToDictionaryVector(ColumnSegment &segment, V
 		}
 	}
 
-	result.Dictionary(dictionary, *sel_vec);
+	result.Dictionary(dictionary, *sel_vec, scan_count);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Rather than the `DictionaryBuffer` getting only a `SelectionVector`, it now also gets a `sel_count` with how many elements are in the selection vector.