### PR TITLE
Remove friend classes from `Vector`

### DIFF
--- a/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/extension/core_functions/scalar/struct/struct_values.cpp
@@ -35,7 +35,7 @@ static void StructValuesFunction(DataChunk &args, ExpressionState &state, Vector
 	} else {
 		// set only the struct buffer's type - do not propagate to children
 		// since children reference external vectors (input children) that may have incompatible buffer types
-		result.GetBuffer()->SetVectorTypeOnly(VectorType::FLAT_VECTOR);
+		result.BufferMutable().SetVectorTypeOnly(VectorType::FLAT_VECTOR);
 
 		// Make result validity to mirror input's nulls
 		auto validity_entries = input.Validity(count);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -304,7 +304,7 @@ Value Vector::GetValue(idx_t index) const {
 	return GetValue(*this, index);
 }
 
-VectorBuffer &Vector::Buffer() {
+VectorBuffer &Vector::BufferMutable() {
 	return *buffer;
 }
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -817,7 +817,7 @@ void Vector::SetVectorType(VectorType new_vector_type) {
 	}
 	if (buffer) {
 		// FIXME: should we allow vectors without a buffer?
-		Buffer().SetVectorType(new_vector_type);
+		BufferMutable().SetVectorType(new_vector_type);
 	}
 }
 

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -52,18 +52,18 @@ public:
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();
 		buffer->ClearAuxiliaryData();
-		AssignSharedPointer(result.buffer, buffer);
-		result.buffer->ResetCapacity(capacity);
+		result.SetBuffer(buffer_ptr<VectorBuffer>(buffer));
+		result.BufferMutable().ResetCapacity(capacity);
 		// use SetVectorTypeOnly to avoid propagating to children
 		// for nested types (struct/array/list) children may have stale incompatible buffers
 		// from a previous execution - they will be reset individually below
-		result.buffer->SetVectorTypeOnly(VectorType::FLAT_VECTOR);
+		result.BufferMutable().SetVectorTypeOnly(VectorType::FLAT_VECTOR);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			// reinitialize the VectorListBuffer
 			// propagate through child
 			auto &child_cache = *child_caches[0];
-			auto &list_buffer = result.buffer->Cast<VectorListBuffer>();
+			auto &list_buffer = result.BufferMutable().Cast<VectorListBuffer>();
 			list_buffer.SetSize(0);
 
 			auto &list_child = list_buffer.GetChild();
@@ -74,14 +74,14 @@ public:
 			// reinitialize the VectorArrayBuffer
 			// propagate through child
 			auto &child_cache = *child_caches[0];
-			auto &array_child = result.buffer->Cast<VectorArrayBuffer>().GetChild();
+			auto &array_child = result.BufferMutable().Cast<VectorArrayBuffer>().GetChild();
 			child_cache.ResetFromCache(array_child);
 			break;
 		}
 		case PhysicalType::STRUCT: {
 			// reinitialize the VectorStructBuffer
 			// propagate through children
-			auto &children = result.buffer->Cast<VectorStructBuffer>().GetChildren();
+			auto &children = result.BufferMutable().Cast<VectorStructBuffer>().GetChildren();
 			for (idx_t i = 0; i < children.size(); i++) {
 				auto &child_cache = *child_caches[i];
 				child_cache.ResetFromCache(children[i]);

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -206,9 +206,9 @@ T &ArrayVector::GetEntryInternal(T &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.buffer);
-	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::ARRAY_BUFFER);
-	return vector.buffer->template Cast<VectorArrayBuffer>().GetChild();
+	D_ASSERT(vector.GetBufferRef());
+	D_ASSERT(vector.Buffer().GetBufferType() == VectorBufferType::ARRAY_BUFFER);
+	return vector.GetBufferRef()->template Cast<VectorArrayBuffer>().GetChild();
 }
 
 const Vector &ArrayVector::GetEntry(const Vector &vector) {
@@ -225,7 +225,7 @@ idx_t ArrayVector::GetTotalSize(const Vector &vector) {
 		auto &child = DictionaryVector::Child(vector);
 		return ArrayVector::GetTotalSize(child);
 	}
-	return vector.buffer->Cast<VectorArrayBuffer>().GetChildSize();
+	return vector.Buffer().Cast<VectorArrayBuffer>().GetChildSize();
 }
 
 } // namespace duckdb

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -11,9 +11,9 @@ void ConstantVector::SetNull(Vector &vector) {
 	auto internal_type = type.InternalType();
 	// ensure the buffer supports validity masks
 	// buffers like SequenceBuffer/DictionaryBuffer do not have validity masks
-	bool needs_new_buffer = !vector.buffer;
+	bool needs_new_buffer = !vector.GetBufferRef();
 	if (!needs_new_buffer) {
-		auto buffer_type = vector.buffer->GetBufferType();
+		auto buffer_type = vector.Buffer().GetBufferType();
 		needs_new_buffer =
 		    (buffer_type != VectorBufferType::STANDARD_BUFFER && buffer_type != VectorBufferType::STRUCT_BUFFER &&
 		     buffer_type != VectorBufferType::ARRAY_BUFFER && buffer_type != VectorBufferType::LIST_BUFFER &&
@@ -21,13 +21,13 @@ void ConstantVector::SetNull(Vector &vector) {
 	}
 	if (needs_new_buffer) {
 		if (internal_type == PhysicalType::STRUCT) {
-			vector.buffer = make_buffer<VectorStructBuffer>(type, 1);
+			vector.SetBuffer(make_buffer<VectorStructBuffer>(type, 1));
 		} else if (internal_type == PhysicalType::ARRAY) {
-			vector.buffer = make_buffer<VectorArrayBuffer>(type, 1);
+			vector.SetBuffer(make_buffer<VectorArrayBuffer>(type, 1));
 		} else if (internal_type == PhysicalType::LIST) {
-			vector.buffer = VectorBuffer::CreateConstantVector(type);
+			vector.SetBuffer(VectorBuffer::CreateConstantVector(type));
 		} else {
-			vector.buffer = VectorBuffer::CreateConstantVector(internal_type);
+			vector.SetBuffer(VectorBuffer::CreateConstantVector(internal_type));
 		}
 	}
 	vector.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -36,7 +36,7 @@ void ConstantVector::SetNull(Vector &vector) {
 
 void ConstantVector::SetNull(Vector &vector, bool is_null) {
 	D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	auto &validity = vector.buffer->GetValidityMask();
+	auto &validity = vector.BufferMutable().GetValidityMask();
 	validity.Set(0, !is_null);
 	if (is_null) {
 		auto &type = vector.GetType();
@@ -132,7 +132,7 @@ void ConstantVector::Reference(Vector &vector, const Vector &source, idx_t posit
 		target_child.Flatten(array_size); // since its constant we only have to flatten this much
 
 		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.BufferMutable().GetValidityMask();
 		validity.Set(0, true);
 		break;
 	}
@@ -155,7 +155,7 @@ void ConstantVector::Reference(Vector &vector, const Vector &source, idx_t posit
 			ConstantVector::Reference(target_entries[i], source_entries[i], position, count);
 		}
 		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.BufferMutable().GetValidityMask();
 		validity.Set(0, true);
 		break;
 	}

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -132,7 +132,7 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::Flatten(const LogicalType &type, cons
 	auto &sel = sel_ref.get();
 
 	// flatten the child using the selection vector
-	return entry->data.buffer->Flatten(type, sel, count);
+	return entry->data.BufferMutable().Flatten(type, sel, count);
 }
 
 buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const LogicalType &type, const idx_t &size) {
@@ -145,7 +145,7 @@ buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const Log
 const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	D_ASSERT(CanCacheHashes(input));
 
-	auto &entry = input.buffer->Cast<DictionaryBuffer>().GetEntry();
+	auto &entry = input.BufferMutable().Cast<DictionaryBuffer>().GetEntry();
 	lock_guard<mutex> guard(entry.cached_hashes_lock);
 
 	if (!entry.cached_hashes) {

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -379,22 +379,22 @@ void FlatVector::SetData(Vector &vector, data_ptr_t data, idx_t capacity) {
 	}
 	// Preserve the validity mask from the old buffer before replacing it.
 	// FIXME: this can maybe be removed in the future - it seems only the Arrow conversion code relies on this behavior
-	auto old_validity = std::move(vector.buffer->GetValidityMask());
+	auto old_validity = std::move(vector.BufferMutable().GetValidityMask());
 	if (vector.GetType().InternalType() == PhysicalType::LIST) {
-		auto &current_buffer = vector.buffer->Cast<VectorListBuffer>();
-		vector.buffer =
-		    make_buffer<VectorListBuffer>(data, capacity, current_buffer.GetChild(), current_buffer.GetSize());
+		auto &current_buffer = vector.BufferMutable().Cast<VectorListBuffer>();
+		vector.SetBuffer(
+		    make_buffer<VectorListBuffer>(data, capacity, current_buffer.GetChild(), current_buffer.GetSize()));
 	} else if (vector.GetType().InternalType() == PhysicalType::VARCHAR) {
-		vector.buffer = make_buffer<VectorStringBuffer>(data, capacity);
+		vector.SetBuffer(make_buffer<VectorStringBuffer>(data, capacity));
 	} else {
-		vector.buffer = make_buffer<StandardVectorBuffer>(data, capacity);
+		vector.SetBuffer(make_buffer<StandardVectorBuffer>(data, capacity));
 	}
-	vector.buffer->GetValidityMask() = std::move(old_validity);
+	vector.BufferMutable().GetValidityMask() = std::move(old_validity);
 }
 
 void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
-	vector.buffer->GetValidityMask().Set(idx, !is_null);
+	vector.BufferMutable().GetValidityMask().Set(idx, !is_null);
 	if (!is_null) {
 		return;
 	}

--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -72,10 +72,10 @@ VectorFSSTStringBuffer &FSSTVector::GetFSSTBuffer(const Vector &vector) {
 	if (vector.GetVectorType() != VectorType::FSST_VECTOR) {
 		throw InternalException("FSSTVector::GetFSSTBuffer called on a non-FSST vector");
 	}
-	if (!vector.buffer || vector.buffer->GetBufferType() != VectorBufferType::FSST_BUFFER) {
+	if (!vector.GetBufferRef() || vector.Buffer().GetBufferType() != VectorBufferType::FSST_BUFFER) {
 		throw InternalException("FSSTVector has a non-FSST buffer");
 	}
-	return vector.buffer->Cast<VectorFSSTStringBuffer>();
+	return vector.GetBufferRef()->Cast<VectorFSSTStringBuffer>();
 }
 
 StringHeap &FSSTVector::GetStringHeap(const Vector &vector) {
@@ -105,8 +105,8 @@ vector<unsigned char> &FSSTVector::GetDecompressBuffer(const Vector &vector) {
 
 void FSSTVector::Create(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder, const idx_t string_block_limit,
                         idx_t capacity) {
-	vector.buffer = make_buffer<VectorFSSTStringBuffer>(capacity);
-	auto &fsst_string_buffer = vector.buffer->Cast<VectorFSSTStringBuffer>();
+	vector.SetBuffer(make_buffer<VectorFSSTStringBuffer>(capacity));
+	auto &fsst_string_buffer = vector.BufferMutable().Cast<VectorFSSTStringBuffer>();
 	fsst_string_buffer.AddDecoder(duckdb_fsst_decoder, string_block_limit);
 }
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -230,9 +230,9 @@ T &ListVector::GetEntryInternal(T &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.buffer);
-	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::LIST_BUFFER);
-	return vector.buffer->template Cast<VectorListBuffer>().GetChild();
+	D_ASSERT(vector.GetBufferRef());
+	D_ASSERT(vector.Buffer().GetBufferType() == VectorBufferType::LIST_BUFFER);
+	return vector.GetBufferRef()->template Cast<VectorListBuffer>().GetChild();
 }
 
 const Vector &ListVector::GetEntry(const Vector &vector) {
@@ -247,9 +247,9 @@ void ListVector::Reserve(Vector &vector, idx_t required_capacity) {
 	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST || vector.GetType().id() == LogicalTypeId::MAP);
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.buffer);
-	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::LIST_BUFFER);
-	auto &child_buffer = vector.buffer->Cast<VectorListBuffer>();
+	D_ASSERT(vector.GetBufferRef());
+	D_ASSERT(vector.Buffer().GetBufferType() == VectorBufferType::LIST_BUFFER);
+	auto &child_buffer = vector.BufferMutable().Cast<VectorListBuffer>();
 	child_buffer.Reserve(required_capacity);
 }
 
@@ -258,23 +258,23 @@ idx_t ListVector::GetListSize(const Vector &vec) {
 		auto &child = DictionaryVector::Child(vec);
 		return ListVector::GetListSize(child);
 	}
-	D_ASSERT(vec.buffer);
-	return vec.buffer->Cast<VectorListBuffer>().GetSize();
+	D_ASSERT(vec.GetBufferRef());
+	return vec.Buffer().Cast<VectorListBuffer>().GetSize();
 }
 
 idx_t ListVector::GetListCapacity(const Vector &vec) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("ListVector::GetListCapacity called on dictionary vector");
 	}
-	D_ASSERT(vec.buffer);
-	return vec.buffer->Cast<VectorListBuffer>().GetChildCapacity();
+	D_ASSERT(vec.GetBufferRef());
+	return vec.Buffer().Cast<VectorListBuffer>().GetChildCapacity();
 }
 
 void ListVector::SetListSize(Vector &vec, idx_t size) {
 	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("ListVector::SetListSize called on dictionary vector");
 	}
-	vec.buffer->Cast<VectorListBuffer>().SetSize(size);
+	vec.BufferMutable().Cast<VectorListBuffer>().SetSize(size);
 }
 
 void ListVector::Append(Vector &target, const Vector &source, idx_t source_size, idx_t source_offset) {
@@ -282,7 +282,7 @@ void ListVector::Append(Vector &target, const Vector &source, idx_t source_size,
 		//! Nothing to add
 		return;
 	}
-	auto &target_buffer = target.buffer->Cast<VectorListBuffer>();
+	auto &target_buffer = target.BufferMutable().Cast<VectorListBuffer>();
 	target_buffer.Append(source, source_size, source_offset);
 }
 
@@ -292,12 +292,12 @@ void ListVector::Append(Vector &target, const Vector &source, const SelectionVec
 		//! Nothing to add
 		return;
 	}
-	auto &target_buffer = target.buffer->Cast<VectorListBuffer>();
+	auto &target_buffer = target.BufferMutable().Cast<VectorListBuffer>();
 	target_buffer.Append(source, sel, source_size, source_offset);
 }
 
 void ListVector::PushBack(Vector &target, const Value &insert) {
-	auto &target_buffer = target.buffer.get()->Cast<VectorListBuffer>();
+	auto &target_buffer = target.BufferMutable().Cast<VectorListBuffer>();
 	target_buffer.PushBack(insert);
 }
 

--- a/src/common/vector/sequence_vector.cpp
+++ b/src/common/vector/sequence_vector.cpp
@@ -48,12 +48,12 @@ buffer_ptr<VectorBuffer> SequenceBuffer::Flatten(const LogicalType &type, const 
 	}
 	Vector flattened_vector(type, count);
 	VectorOperations::GenerateSequence(flattened_vector, count, sel, start, increment);
-	return flattened_vector.GetBuffer();
+	return flattened_vector.GetBufferRef();
 }
 
 void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count) {
 	D_ASSERT(vector.GetVectorType() == VectorType::SEQUENCE_VECTOR);
-	auto &data = vector.buffer->Cast<SequenceBuffer>();
+	auto &data = vector.Buffer().Cast<SequenceBuffer>();
 	start = data.start;
 	increment = data.increment;
 	sequence_count = data.count;

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -68,32 +68,32 @@ buffer_ptr<VectorBuffer> ShreddedVectorBuffer::Flatten(const LogicalType &type, 
 	VariantUtils::UnshredVariantData(*source, unshredded_vector, count);
 	// now flatten the unshredded vector
 	unshredded_vector.Flatten(count);
-	return unshredded_vector.GetBuffer();
+	return unshredded_vector.GetBufferRef();
 }
 
 const Vector &ShreddedVector::GetUnshreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.GetBufferRef()->Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 Vector &ShreddedVector::GetUnshreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[0];
+	return StructVector::GetEntries(vec.BufferMutable().Cast<ShreddedVectorBuffer>().GetChild())[0];
 }
 
 const Vector &ShreddedVector::GetShreddedVector(const Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.GetBufferRef()->Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 Vector &ShreddedVector::GetShreddedVector(Vector &vec) {
 	VerifyShreddedVector(vec);
-	return StructVector::GetEntries(vec.buffer->Cast<ShreddedVectorBuffer>().GetChild())[1];
+	return StructVector::GetEntries(vec.BufferMutable().Cast<ShreddedVectorBuffer>().GetChild())[1];
 }
 
 void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 	Vector unshredded_vector(LogicalType::VARIANT(), MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
-	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.GetBufferRef()->Cast<ShreddedVectorBuffer>();
 	VariantUtils::UnshredVariantData(shredded_buffer.GetChild(), unshredded_vector, count);
 	vec.ConstReference(unshredded_vector);
 }
@@ -101,7 +101,7 @@ void ShreddedVector::Unshred(const Vector &vec, idx_t count) {
 void ShreddedVector::Unshred(const Vector &vec, const SelectionVector &sel, idx_t count) {
 	VerifyShreddedVector(vec);
 	// slice the underlying shredded buffer
-	auto &shredded_buffer = vec.buffer->Cast<ShreddedVectorBuffer>();
+	auto &shredded_buffer = vec.GetBufferRef()->Cast<ShreddedVectorBuffer>();
 	Vector sliced_shredded_buffer(shredded_buffer.GetChild(), sel, count);
 	// unshred the vector
 	Vector unshredded_vector(LogicalType::VARIANT());

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -163,14 +163,14 @@ VectorStringBuffer &StringVector::GetStringBuffer(Vector &vector) {
 		                        vector.GetType());
 	}
 	// check if the main buffer is a VectorStringBuffer
-	if (!vector.buffer) {
-		vector.buffer = make_buffer<VectorStringBuffer>(nullptr, 0);
+	if (!vector.GetBufferRef()) {
+		vector.SetBuffer(make_buffer<VectorStringBuffer>(nullptr, 0));
 	}
-	if (vector.buffer->GetBufferType() != VectorBufferType::STRING_BUFFER) {
+	if (vector.Buffer().GetBufferType() != VectorBufferType::STRING_BUFFER) {
 		throw InternalException(
 		    "StringVector::GetStringBuffer called on a vector - but that vector does NOT have a string buffer");
 	}
-	return vector.buffer->Cast<VectorStringBuffer>();
+	return vector.BufferMutable().Cast<VectorStringBuffer>();
 }
 
 ArenaAllocator &StringVector::GetStringAllocator(Vector &vector) {

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -236,9 +236,9 @@ vector<Vector> &StructVector::GetEntries(Vector &vector) {
 	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(vector.buffer);
-	D_ASSERT(vector.buffer->GetBufferType() == VectorBufferType::STRUCT_BUFFER);
-	return vector.buffer->Cast<VectorStructBuffer>().GetChildren();
+	D_ASSERT(vector.GetBufferRef());
+	D_ASSERT(vector.Buffer().GetBufferType() == VectorBufferType::STRUCT_BUFFER);
+	return vector.BufferMutable().Cast<VectorStructBuffer>().GetChildren();
 }
 
 const vector<Vector> &StructVector::GetEntries(const Vector &vector) {

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -29,7 +29,7 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 	}
 	// set only the struct buffer's type - do not propagate to children
 	// since children reference external vectors (args) that may have incompatible buffer types
-	result.GetBuffer()->SetVectorTypeOnly(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+	result.BufferMutable().SetVectorTypeOnly(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
 	result.Verify(args.size());
 }
 

--- a/src/function/table/arrow/arrow_array_scan_state.cpp
+++ b/src/function/table/arrow/arrow_array_scan_state.cpp
@@ -31,7 +31,7 @@ void ArrowArrayScanState::AddDictionary(unique_ptr<Vector> dictionary_p, ArrowAr
 	D_ASSERT(arrow_dict);
 	arrow_dictionary = arrow_dict;
 	// Make sure the data referenced by the dictionary stays alive
-	dictionary->GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
+	dictionary->BufferMutable().AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
 }
 
 bool ArrowArrayScanState::HasDictionary() const {

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -705,8 +705,8 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(Vector &vector, c
 	auto &values_type = struct_info.GetChild(1);
 	D_ASSERT(vector.GetType() == values_type.GetDuckType());
 
-	if (vector.GetBuffer()) {
-		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+	if (vector.GetBufferRef()) {
+		vector.BufferMutable().AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 
 	D_ASSERT(run_ends_array.length == values_array.length);
@@ -1253,8 +1253,8 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 	default:
 		throw NotImplementedException("Unsupported type for arrow conversion: %s", vector.GetType().ToString());
 	}
-	if (vector.GetBuffer()) {
-		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+	if (vector.GetBufferRef()) {
+		vector.BufferMutable().AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 }
 
@@ -1394,8 +1394,8 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
                                                             ArrowArrayScanState &array_state, idx_t size,
                                                             const ArrowType &arrow_type, int64_t nested_offset,
                                                             const ValidityMask *parent_mask, uint64_t parent_offset) {
-	if (vector.GetBuffer()) {
-		vector.GetBuffer()->AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
+	if (vector.GetBufferRef()) {
+		vector.BufferMutable().AddAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 	D_ASSERT(arrow_type.HasDictionary());
 	const bool has_nulls = CanContainNull(array, parent_mask);

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -155,7 +155,9 @@ public:
 		return type;
 	}
 
-	inline const buffer_ptr<VectorBuffer> &GetBuffer() const {
+	VectorBuffer &BufferMutable();
+	const VectorBuffer &Buffer() const;
+	inline const buffer_ptr<VectorBuffer> &GetBufferRef() const {
 		return buffer;
 	}
 	void SetBuffer(buffer_ptr<VectorBuffer> buffer_p) {
@@ -177,10 +179,6 @@ public:
 	VectorValidValueIterator<T> ValidValues(idx_t count) const;
 
 	VectorValidityIterator Validity(idx_t count) const;
-
-protected:
-	VectorBuffer &Buffer();
-	const VectorBuffer &Buffer() const;
 
 private:
 	//! Returns the [index] element of the Vector as a Value.

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -33,24 +33,6 @@ enum class VectorDataInitialization { UNINITIALIZED, ZERO_INITIALIZE };
 
 //! Vector of values of a specified PhysicalType.
 class Vector {
-	friend struct ConstantVector;
-	friend struct DictionaryVector;
-	friend struct FlatVector;
-	friend struct ListVector;
-	friend struct StringVector;
-	friend struct FSSTVector;
-	friend struct StructVector;
-	friend struct UnionVector;
-	friend struct SequenceVector;
-	friend struct ArrayVector;
-	friend struct ShreddedVector;
-
-	friend class DataChunk;
-	friend class VectorBuffer;
-	friend class DictionaryBuffer;
-	friend class VectorStructBuffer;
-	friend class VectorCacheEntry;
-
 public:
 	//! Create a vector that slices another vector
 	DUCKDB_API explicit Vector(const Vector &other, const SelectionVector &sel, idx_t count);
@@ -153,10 +135,6 @@ public:
 	void AddAuxiliaryData(unique_ptr<AuxiliaryDataHolder> data);
 	void AddHeapReference(const Vector &other);
 
-	inline void CopyBuffer(Vector &other) {
-		buffer = other.buffer;
-	}
-
 	//! Resizes the vector.
 	DUCKDB_API void Resize(idx_t cur_size, idx_t new_size);
 
@@ -177,8 +155,11 @@ public:
 		return type;
 	}
 
-	inline buffer_ptr<VectorBuffer> GetBuffer() {
+	inline const buffer_ptr<VectorBuffer> &GetBuffer() const {
 		return buffer;
+	}
+	void SetBuffer(buffer_ptr<VectorBuffer> buffer_p) {
+		buffer = std::move(buffer_p);
 	}
 
 	// Setters

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -180,16 +180,16 @@ public:
 
 	VectorValidityIterator Validity(idx_t count) const;
 
+	//! This allows a vector to reference another vector while const
+	//! This is only used internally in `Flatten` - since referencing
+	// an arbitrary other vector could change the logical data contained in the vector (and not be const)
+	void ConstReference(const Vector &other) const;
+
 private:
 	//! Returns the [index] element of the Vector as a Value.
 	static Value GetValue(const Vector &v, idx_t index);
 	//! Returns the [index] element of the Vector as a Value.
 	static Value GetValueInternal(const Vector &v, idx_t index);
-
-	//! This allows a vector to reference another vector while const
-	//! This is only used internally in `Flatten` - since referencing
-	// an arbitrary other vector could change the logical data contained in the vector (and not be const)
-	void ConstReference(const Vector &other) const;
 
 	//! Create a vector that references the other vector
 	Vector(const Vector &other, VectorConstructorAction action);

--- a/src/include/duckdb/common/vector/constant_vector.hpp
+++ b/src/include/duckdb/common/vector/constant_vector.hpp
@@ -37,11 +37,11 @@ struct ConstantVector {
 
 	static inline const_data_ptr_t GetData(const Vector &vector) {
 		VerifyConstantVector(vector);
-		return vector.buffer ? vector.buffer->GetData() : nullptr;
+		return vector.GetBufferRef() ? vector.GetBufferRef()->GetData() : nullptr;
 	}
 	static inline data_ptr_t GetData(Vector &vector) {
 		VerifyConstantVector(vector);
-		return vector.buffer ? vector.buffer->GetData() : nullptr;
+		return vector.GetBufferRef() ? vector.BufferMutable().GetData() : nullptr;
 	}
 	template <class T>
 	static inline const T *GetDataUnsafe(const Vector &vector) {
@@ -63,7 +63,7 @@ struct ConstantVector {
 	}
 	static inline bool IsNull(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.Buffer().GetValidityMask();
 		return !validity.RowIsValid(0);
 	}
 	//! Sets a vector to be a constant NULL vector
@@ -71,12 +71,12 @@ struct ConstantVector {
 	DUCKDB_API static void SetNull(Vector &vector, bool is_null);
 	static inline ValidityMask &Validity(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.BufferMutable().GetValidityMask();
 		return validity;
 	}
 	static inline const ValidityMask &Validity(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.Buffer().GetValidityMask();
 		return validity;
 	}
 	DUCKDB_API static const SelectionVector *ZeroSelectionVector(idx_t count, SelectionVector &owned_sel);

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -107,23 +107,23 @@ struct DictionaryVector {
 	}
 	static inline const SelectionVector &SelVector(const Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.buffer->Cast<DictionaryBuffer>().GetSelVector();
+		return vector.Buffer().Cast<DictionaryBuffer>().GetSelVector();
 	}
 	static inline SelectionVector &SelVector(Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.buffer->Cast<DictionaryBuffer>().GetSelVector();
+		return vector.BufferMutable().Cast<DictionaryBuffer>().GetSelVector();
 	}
 	static inline const Vector &Child(const Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.buffer->Cast<DictionaryBuffer>().GetEntry().data;
+		return vector.Buffer().Cast<DictionaryBuffer>().GetEntry().data;
 	}
 	static inline Vector &Child(Vector &vector) {
 		VerifyDictionary(vector);
-		return vector.buffer->Cast<DictionaryBuffer>().GetEntry().data;
+		return vector.BufferMutable().Cast<DictionaryBuffer>().GetEntry().data;
 	}
 	static inline optional_idx DictionarySize(const Vector &vector) {
 		VerifyDictionary(vector);
-		const auto &dict_buffer = vector.buffer->Cast<DictionaryBuffer>();
+		const auto &dict_buffer = vector.Buffer().Cast<DictionaryBuffer>();
 		const auto &entry = dict_buffer.GetEntry();
 		if (entry.size.IsValid()) {
 			return entry.size;
@@ -132,7 +132,7 @@ struct DictionaryVector {
 	}
 	static inline const string &DictionaryId(const Vector &vector) {
 		VerifyDictionary(vector);
-		const auto &dict_buffer = vector.buffer->Cast<DictionaryBuffer>();
+		const auto &dict_buffer = vector.Buffer().Cast<DictionaryBuffer>();
 		const auto &entry = dict_buffer.GetEntry();
 		if (!entry.id.empty()) {
 			return entry.id;

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -100,10 +100,10 @@ struct FlatVector {
 		return GetDataMutableUnsafe(vector);
 	}
 	static inline const_data_ptr_t GetDataUnsafe(const Vector &vector) {
-		return vector.buffer ? vector.buffer->GetData() : nullptr;
+		return vector.GetBufferRef() ? vector.GetBufferRef()->GetData() : nullptr;
 	}
 	static inline data_ptr_t GetDataMutableUnsafe(Vector &vector) {
-		return vector.buffer ? vector.buffer->GetData() : nullptr;
+		return vector.GetBufferRef() ? vector.BufferMutable().GetData() : nullptr;
 	}
 	template <class T>
 	static inline const T *GetData(const Vector &vector) {
@@ -122,7 +122,7 @@ struct FlatVector {
 	}
 	static inline idx_t GetCapacity(const Vector &vector) {
 		VerifyFlatVector(vector);
-		return vector.buffer ? vector.buffer->Capacity() : 0;
+		return vector.GetBufferRef() ? vector.Buffer().Capacity() : 0;
 	}
 	template <class T>
 	static inline const T *GetDataUnsafe(const Vector &vector) {
@@ -144,21 +144,21 @@ struct FlatVector {
 	}
 	static inline const ValidityMask &Validity(const Vector &vector) {
 		VerifyFlatVector(vector);
-		return vector.buffer->GetValidityMask();
+		return vector.Buffer().GetValidityMask();
 	}
 	static inline ValidityMask &Validity(Vector &vector) {
 		VerifyFlatVector(vector);
-		return vector.buffer->GetValidityMask();
+		return vector.BufferMutable().GetValidityMask();
 	}
 	static inline void SetValidity(Vector &vector, const ValidityMask &new_validity) {
 		VerifyFlatVector(vector);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.BufferMutable().GetValidityMask();
 		validity.Initialize(new_validity);
 	}
 	DUCKDB_API static void SetNull(Vector &vector, idx_t idx, bool is_null);
 	static inline bool IsNull(const Vector &vector, idx_t idx) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.Buffer().GetValidityMask();
 		return !validity.RowIsValid(idx);
 	}
 	DUCKDB_API static const SelectionVector *IncrementalSelectionVector();

--- a/src/include/duckdb/common/vector/fsst_vector.hpp
+++ b/src/include/duckdb/common/vector/fsst_vector.hpp
@@ -49,24 +49,24 @@ private:
 struct FSSTVector {
 	static inline const ValidityMask &Validity(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return vector.buffer->GetValidityMask();
+		return vector.Buffer().GetValidityMask();
 	}
 	static inline ValidityMask &Validity(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return vector.buffer->GetValidityMask();
+		return vector.BufferMutable().GetValidityMask();
 	}
 	static inline void SetValidity(Vector &vector, ValidityMask &new_validity) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		auto &validity = vector.buffer->GetValidityMask();
+		auto &validity = vector.BufferMutable().GetValidityMask();
 		validity.Initialize(new_validity);
 	}
 	static inline const string_t *GetCompressedData(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return reinterpret_cast<string_t *>(vector.buffer->GetData());
+		return reinterpret_cast<const string_t *>(vector.GetBufferRef()->GetData());
 	}
 	static inline string_t *GetCompressedData(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::FSST_VECTOR);
-		return reinterpret_cast<string_t *>(vector.buffer->GetData());
+		return reinterpret_cast<string_t *>(vector.BufferMutable().GetData());
 	}
 
 	DUCKDB_API static string_t AddCompressedString(Vector &vector, string_t data);


### PR DESCRIPTION
Instead use public `Buffer` methods to operate on the buffer in the various vector helpers in which this is required.