### PR TITLE
Remove capacity from `DataChunk`

### DIFF
--- a/.github/patches/extensions/delta/0001-vector-fix.patch
+++ b/.github/patches/extensions/delta/0001-vector-fix.patch
@@ -271,3 +271,134 @@ index de50268..c2bae88 100644
  	physical_copy_ref.return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
  	physical_copy_ref.write_partition_columns = true;
  	physical_copy_ref.children.push_back(*plan);
+diff --git a/src/storage/delta_transaction.cpp b/src/storage/delta_transaction.cpp
+index 9af9de9..1ff75bc 100644
+--- a/src/storage/delta_transaction.cpp
++++ b/src/storage/delta_transaction.cpp
+@@ -34,12 +34,6 @@ static void *allocate_string(const struct ffi::KernelStringSlice slice) {
+ }
+ 
+ struct DeltaCommitInfo {
+-public:
+-	DeltaCommitInfo() {
+-		buffer.Initialize(Allocator::DefaultAllocator(), GetTypes());
+-		buffer.SetCardinality(0);
+-	}
+-
+ public:
+ 	static vector<LogicalType> GetTypes() {
+ 		return {LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)};
+@@ -50,15 +44,7 @@ public:
+ 
+ public:
+ 	void Append(Value commit_info_map) {
+-		idx_t current_size = buffer.size();
+-		idx_t current_capacity = buffer.GetCapacity();
+-
+-		if (current_size == current_capacity) {
+-			buffer.SetCapacity(2 * current_capacity);
+-		}
+-
+-		buffer.SetValue(0, current_size, commit_info_map);
+-		buffer.SetCardinality(current_size + 1);
++		values.push_back(std::move(commit_info_map));
+ 	}
+ 
+ 	void (*release)();
+@@ -70,6 +56,14 @@ public:
+ 	ffi::ArrowFFIData ToArrow(optional_ptr<ClientContext> context) {
+ 		LoggerCallback::TryLog("delta", LogLevel::LOG_TRACE, "Delta ToArrow debug: created CommitInfo");
+ 
++		DataChunk buffer;
++		idx_t capacity = MaxValue<idx_t>(values.size(), STANDARD_VECTOR_SIZE);
++		buffer.Initialize(Allocator::DefaultAllocator(), GetTypes(), capacity);
++		for (idx_t i = 0; i < values.size(); i++) {
++			buffer.SetValue(0, i, values[i]);
++		}
++		buffer.SetCardinality(values.size());
++
+ 		ffi::ArrowFFIData ffi_data;
+ 		unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
+ 		ClientProperties props("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0, context);
+@@ -81,7 +75,7 @@ public:
+ 	}
+ 
+ private:
+-	DataChunk buffer;
++	vector<Value> values;
+ };
+ 
+ struct WriteMetaData {
+@@ -117,8 +111,6 @@ struct WriteMetaData {
+ 	};
+ 
+ 	WriteMetaData() {
+-		buffer = make_uniq<DataChunk>();
+-		buffer->Initialize(Allocator::DefaultAllocator(), GetTypes());
+ 	}
+ 
+ 	WriteMetaData(DeltaMultiFileList &snapshot, vector<DeltaDataFile> &outstanding_appends) : WriteMetaData() {
+@@ -146,19 +138,11 @@ struct WriteMetaData {
+ 	}
+ 
+ 	void Append(const string &path, Value partition_values, idx_t size, idx_t modification_time, bool data_change) {
+-		idx_t current_size = buffer->size();
+-		idx_t current_capacity = buffer->GetCapacity();
+-
+-		if (current_size == current_capacity) {
+-			buffer->SetCapacity(2 * current_capacity);
+-		}
+-
+-		buffer->SetValue(0, current_size, path);
+-		buffer->SetValue(1, current_size, partition_values);
+-		buffer->SetValue(2, current_size, Value::BIGINT(size));
+-		buffer->SetValue(3, current_size, Value::BIGINT(modification_time));
+-		buffer->SetValue(4, current_size, CreateStatsValue(size, true));
+-		buffer->SetCardinality(current_size + 1);
++		paths.push_back(Value(path));
++		partition_values_list.push_back(std::move(partition_values));
++		sizes.push_back(Value::BIGINT(size));
++		modification_times.push_back(Value::BIGINT(modification_time));
++		stats.push_back(CreateStatsValue(size, true));
+ 	}
+ 
+ 	void (*release)();
+@@ -170,10 +154,23 @@ struct WriteMetaData {
+ 	ffi::ArrowFFIData ToArrow(ClientContext &context) {
+ 		LoggerCallback::TryLog("delta", LogLevel::LOG_TRACE, "Delta ToArrow debug: created WriteMetaData");
+ 
++		DataChunk buffer;
++		idx_t n = paths.size();
++		idx_t capacity = MaxValue<idx_t>(n, STANDARD_VECTOR_SIZE);
++		buffer.Initialize(Allocator::DefaultAllocator(), GetTypes(), capacity);
++		for (idx_t i = 0; i < n; i++) {
++			buffer.SetValue(0, i, paths[i]);
++			buffer.SetValue(1, i, partition_values_list[i]);
++			buffer.SetValue(2, i, sizes[i]);
++			buffer.SetValue(3, i, modification_times[i]);
++			buffer.SetValue(4, i, stats[i]);
++		}
++		buffer.SetCardinality(n);
++
+ 		ffi::ArrowFFIData ffi_data;
+ 		unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
+ 		ClientProperties props("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0, context);
+-		ArrowConverter::ToArrowArray(*buffer, (ArrowArray *)(&ffi_data.array), props, extension_types);
++		ArrowConverter::ToArrowArray(buffer, (ArrowArray *)(&ffi_data.array), props, extension_types);
+ 		ArrowConverter::ToArrowSchema((ArrowSchema *)(&ffi_data.schema), GetTypes(), GetNames(), props);
+ 
+ 		ffi_data.array.release = reinterpret_cast<void (*)(ffi::FFI_ArrowArray *)>(InstrumentedRelease);
+@@ -181,7 +178,12 @@ struct WriteMetaData {
+ 		return ffi_data;
+ 	}
+ 
+-	unique_ptr<DataChunk> buffer;
++private:
++	vector<Value> paths;
++	vector<Value> partition_values_list;
++	vector<Value> sizes;
++	vector<Value> modification_times;
++	vector<Value> stats;
+ };
+ 
+ vector<DeltaMultiFileColumnDefinition> DeltaTransaction::GetWriteSchema(ClientContext &context) {

--- a/.github/patches/extensions/excel/0001-vector-fix.patch
+++ b/.github/patches/extensions/excel/0001-vector-fix.patch
@@ -36,3 +36,15 @@ index 685f23c..342c5b8 100644
  	if (files.empty()) {
  		// Use our own error message to be less confusing
  		throw IOException("Cannot open file \"%s\": No such file or directory", file_path);
+diff --git a/src/excel/xlsx/read_xlsx.cpp b/src/excel/xlsx/read_xlsx.cpp
+index 342c5b8..a634e65 100644
+--- a/src/excel/xlsx/read_xlsx.cpp
++++ b/src/excel/xlsx/read_xlsx.cpp
+@@ -708,7 +708,6 @@ static void Execute(ClientContext &context, TableFunctionInput &data, DataChunk
+ 			TryCastFromString(gstate, options.ignore_errors, col_idx, context, target_col);
+ 		}
+ 	}
+-	output.SetCapacity(row_count);
+ 	output.SetCardinality(row_count);
+ 
+ 	output.Verify();

--- a/.github/patches/extensions/spatial/0001-applied-patch-fix-patch.patch
+++ b/.github/patches/extensions/spatial/0001-applied-patch-fix-patch.patch
@@ -2178,3 +2178,16 @@ diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/mo
  			break;
  		case SHPT_POINT:
  			ConvertGeomLoop<ConvertPoint>(result, record_start, count, shp_handle, arena);
+diff --git a/src/spatial/operators/spatial_join_physical.cpp b/src/spatial/operators/spatial_join_physical.cpp
+index 83d4905..bd8b172 100644
+--- a/src/spatial/operators/spatial_join_physical.cpp
++++ b/src/spatial/operators/spatial_join_physical.cpp
+@@ -878,7 +878,7 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
+ 	auto &lstate = lstate_p.Cast<SpatialJoinLocalOperatorState>();
+ 
+ 	idx_t output_index = 0;
+-	idx_t output_count = chunk.GetCapacity();
++	idx_t output_count = STANDARD_VECTOR_SIZE;
+ 
+ 	while (true) {
+ 		switch (lstate.state) {

--- a/src/common/types/column/partitioned_column_data.cpp
+++ b/src/common/types/column/partitioned_column_data.cpp
@@ -178,7 +178,6 @@ void PartitionedColumnData::AppendInternal(PartitionedColumnDataAppendState &sta
 				// Next batch won't fit in the buffer, flush it to the partition
 				partition.Append(partition_append_state, partition_buffer);
 				partition_buffer.Reset();
-				partition_buffer.SetCapacity(BufferSize());
 			}
 		}
 	}

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -20,7 +20,7 @@
 
 namespace duckdb {
 
-DataChunk::DataChunk() : count(0), capacity(STANDARD_VECTOR_SIZE) {
+DataChunk::DataChunk() : count(0) {
 }
 
 DataChunk::~DataChunk() {
@@ -28,7 +28,6 @@ DataChunk::~DataChunk() {
 
 void DataChunk::InitializeEmpty(const vector<LogicalType> &types) {
 	D_ASSERT(data.empty());
-	capacity = STANDARD_VECTOR_SIZE;
 	for (idx_t i = 0; i < types.size(); i++) {
 		data.emplace_back(types[i], nullptr);
 	}
@@ -49,12 +48,10 @@ void DataChunk::Initialize(ClientContext &context, const vector<LogicalType> &ty
 }
 
 void DataChunk::Initialize(Allocator &allocator, const vector<LogicalType> &types, const vector<bool> &initialize,
-                           idx_t capacity_p) {
+                           idx_t capacity) {
 	D_ASSERT(types.size() == initialize.size());
 	D_ASSERT(data.empty());
 
-	capacity = capacity_p;
-	initial_capacity = capacity_p;
 	for (idx_t i = 0; i < types.size(); i++) {
 		// We copy the type here so we don't create another reference to the same shared_ptr<ExtraTypeInfo>
 		// Otherwise, threads will constantly increment/decrement the atomic ref count to the same shared_ptr
@@ -101,13 +98,11 @@ void DataChunk::Reset() {
 	for (idx_t i = 0; i < ColumnCount(); i++) {
 		data[i].ResetFromCache(vector_caches[i]);
 	}
-	capacity = initial_capacity;
 }
 
 void DataChunk::Destroy() {
 	data.clear();
 	vector_caches.clear();
-	capacity = 0;
 	SetCardinality(0);
 }
 
@@ -129,9 +124,19 @@ bool DataChunk::AllConstant() const {
 	return true;
 }
 
+idx_t DataChunk::GetCapacity() const {
+	return FlatVector::GetCapacity(data[0]);
+}
+
+void DataChunk::SetCardinality(idx_t count_p) {
+	this->count = count_p;
+	for(auto &vec : data) {
+		vec.CheckCapacity(count);
+	}
+}
+
 void DataChunk::Reference(DataChunk &chunk) {
 	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
-	SetCapacity(chunk);
 	SetCardinality(chunk);
 	for (idx_t i = 0; i < chunk.ColumnCount(); i++) {
 		data[i].Reference(chunk.data[i]);
@@ -139,7 +144,6 @@ void DataChunk::Reference(DataChunk &chunk) {
 }
 
 void DataChunk::Move(DataChunk &chunk) {
-	SetCapacity(chunk);
 	SetCardinality(chunk);
 	data = std::move(chunk.data);
 	vector_caches = std::move(chunk.vector_caches);
@@ -183,7 +187,6 @@ void DataChunk::Split(DataChunk &other, idx_t split_idx) {
 		data.pop_back();
 		vector_caches.pop_back();
 	}
-	other.SetCapacity(*this);
 	other.SetCardinality(*this);
 }
 
@@ -209,7 +212,7 @@ void DataChunk::ReferenceColumns(DataChunk &other, const vector<column_t> &colum
 	SetCardinality(other.size());
 }
 
-void DataChunk::Append(const DataChunk &other, bool resize, SelectionVector *sel, idx_t sel_count) {
+void DataChunk::Append(const DataChunk &other, bool resize, optional_ptr<SelectionVector> sel, idx_t sel_count) {
 	idx_t new_size = sel ? size() + sel_count : size() + other.size();
 	if (other.size() == 0) {
 		return;
@@ -217,19 +220,17 @@ void DataChunk::Append(const DataChunk &other, bool resize, SelectionVector *sel
 	if (ColumnCount() != other.ColumnCount()) {
 		throw InternalException("Column counts of appending chunk doesn't match!");
 	}
-	if (new_size > capacity) {
-		if (resize) {
-			auto new_capacity = NextPowerOfTwo(new_size);
-			for (idx_t i = 0; i < ColumnCount(); i++) {
-				data[i].Resize(size(), new_capacity);
-			}
-			capacity = new_capacity;
-		} else {
-			throw InternalException("Can't append chunk to other chunk without resizing");
-		}
-	}
 	for (idx_t i = 0; i < ColumnCount(); i++) {
 		D_ASSERT(data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		auto capacity = FlatVector::GetCapacity(data[i]);
+		if (new_size > capacity) {
+			if (resize) {
+				auto new_capacity = NextPowerOfTwo(new_size);
+				data[i].Resize(size(), new_capacity);
+			} else {
+				throw InternalException("Can't append chunk to other chunk without resizing");
+			}
+		}
 		if (sel) {
 			VectorOperations::Copy(other.data[i], data[i], *sel, sel_count, 0, size());
 		} else {
@@ -367,7 +368,6 @@ void DataChunk::Hash(vector<idx_t> &column_ids, Vector &result) {
 
 void DataChunk::Verify(optional_ptr<DatabaseInstance> database_instance) {
 #ifdef DEBUG
-	D_ASSERT(size() <= capacity);
 	// verify that all vectors in this chunk have the chunk selection vector
 	for (idx_t i = 0; i < ColumnCount(); i++) {
 		data[i].Verify(size());

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -124,23 +124,19 @@ bool DataChunk::AllConstant() const {
 	return true;
 }
 
-idx_t DataChunk::GetCapacity() const {
-	return FlatVector::GetCapacity(data[0]);
-}
-
 void DataChunk::SetCardinality(idx_t count_p) {
 	this->count = count_p;
-	for(auto &vec : data) {
-		vec.CheckCapacity(count);
-	}
+	// for(auto &vec : data) {
+	// 	vec.CheckCapacity(count);
+	// }
 }
 
 void DataChunk::Reference(DataChunk &chunk) {
 	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
-	SetCardinality(chunk);
 	for (idx_t i = 0; i < chunk.ColumnCount(); i++) {
 		data[i].Reference(chunk.data[i]);
 	}
+	SetCardinality(chunk);
 }
 
 void DataChunk::Move(DataChunk &chunk) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -85,6 +85,21 @@ Vector::Vector(const Value &value) : type(value.type()) {
 Vector::Vector(Vector &&other) noexcept : type(std::move(other.type)), buffer(std::move(other.buffer)) {
 }
 
+void Vector::CheckCapacity(idx_t capacity) const {
+	if (!buffer) {
+		// no buffer - we accept any capacity
+		return;
+	}
+	if (GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// constant vectors can fit any
+		return;
+	}
+	idx_t buffer_capacity = buffer->Capacity();
+	if (capacity > buffer_capacity) {
+		throw InternalException("Vector::CheckCapacity - capacity %d exceeds buffer capacity %d", capacity, buffer_capacity);
+	}
+}
+
 Vector Vector::Ref(const Vector &other) {
 	return Vector(other, VectorConstructorAction::REFERENCE_VECTOR);
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -320,14 +320,6 @@ Value Vector::GetValue(idx_t index) const {
 	return GetValue(*this, index);
 }
 
-VectorBuffer &Vector::BufferMutable() {
-	return *buffer;
-}
-
-const VectorBuffer &Vector::Buffer() const {
-	return *buffer;
-}
-
 // LCOV_EXCL_START
 string VectorTypeToString(VectorType type) {
 	switch (type) {
@@ -818,13 +810,6 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 			throw InternalException("Unimplemented variable width type for Vector::Deserialize!");
 		}
 	}
-}
-
-VectorType Vector::GetVectorType() const {
-	if (!buffer) {
-		return VectorType::FLAT_VECTOR;
-	}
-	return Buffer().GetVectorType();
 }
 
 void Vector::SetVectorType(VectorType new_vector_type) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -96,7 +96,8 @@ void Vector::CheckCapacity(idx_t capacity) const {
 	}
 	idx_t buffer_capacity = buffer->Capacity();
 	if (capacity > buffer_capacity) {
-		throw InternalException("Vector::CheckCapacity - capacity %d exceeds buffer capacity %d", capacity, buffer_capacity);
+		throw InternalException("Vector::CheckCapacity - capacity %d exceeds buffer capacity %d", capacity,
+		                        buffer_capacity);
 	}
 }
 
@@ -440,7 +441,7 @@ void Vector::Sequence(int64_t start, int64_t increment, idx_t count) {
 	this->buffer = make_buffer<SequenceBuffer>(start, increment, static_cast<int64_t>(count));
 }
 
-void Vector::Shred(Vector &shredded_data) {
+void Vector::Shred(Vector &shredded_data, idx_t capacity) {
 	if (GetType().id() != LogicalTypeId::VARIANT) {
 		throw InternalException("Vector::Shred can only be used on variant vectors");
 	}
@@ -448,7 +449,7 @@ void Vector::Shred(Vector &shredded_data) {
 	if (shredded_type.id() != LogicalTypeId::STRUCT || StructType::GetChildCount(shredded_type) != 2) {
 		throw InternalException("Vector::Shred parameter must be a struct with two children");
 	}
-	this->buffer = make_buffer<ShreddedVectorBuffer>(shredded_data);
+	this->buffer = make_buffer<ShreddedVectorBuffer>(shredded_data, capacity);
 }
 
 // FIXME: This should ideally be const

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -192,6 +192,10 @@ void StandardVectorBuffer::SetValue(const LogicalType &type, idx_t index, const 
 		SetValue(type, index, val.DefaultCastAs(type));
 		return;
 	}
+	if (index >= capacity) {
+		throw InvalidInputException("Vector::SetValue index %d is out of range for vector with capacity %d", index,
+		                            capacity);
+	}
 	validity.Set(index, !val.IsNull());
 	if (val.IsNull()) {
 		return;

--- a/src/common/vector/sequence_vector.cpp
+++ b/src/common/vector/sequence_vector.cpp
@@ -3,9 +3,9 @@
 
 namespace duckdb {
 
-SequenceBuffer::SequenceBuffer(int64_t start_p, int64_t increment_p, int64_t count_p)
+SequenceBuffer::SequenceBuffer(int64_t start_p, int64_t increment_p, idx_t count_p)
     : VectorBuffer(VectorType::SEQUENCE_VECTOR, VectorBufferType::SEQUENCE_BUFFER), start(start_p),
-      increment(increment_p), count(count_p) {
+      increment(increment_p), seq_count(count_p) {
 }
 
 idx_t SequenceBuffer::GetDataSize(const LogicalType &type, idx_t count) const {
@@ -44,24 +44,17 @@ buffer_ptr<VectorBuffer> SequenceBuffer::Flatten(const LogicalType &type, const 
                                                  idx_t count) const {
 	if (!sel.IsSet()) {
 		// FIXME: work-around for Flatten being called multiple times on the same vector with different counts...
-		count = MaxValue<idx_t>(this->count, count);
+		count = MaxValue<idx_t>(seq_count, count);
 	}
 	Vector flattened_vector(type, count);
 	VectorOperations::GenerateSequence(flattened_vector, count, sel, start, increment);
 	return flattened_vector.GetBuffer();
 }
 
-void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count) {
-	D_ASSERT(vector.GetVectorType() == VectorType::SEQUENCE_VECTOR);
+void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment) {
 	auto &data = vector.buffer->Cast<SequenceBuffer>();
 	start = data.start;
 	increment = data.increment;
-	sequence_count = data.count;
-}
-
-void SequenceVector::GetSequence(const Vector &vector, int64_t &start, int64_t &increment) {
-	int64_t sequence_count;
-	GetSequence(vector, start, increment, sequence_count);
 }
 
 } // namespace duckdb

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -4,9 +4,9 @@
 
 namespace duckdb {
 
-ShreddedVectorBuffer::ShreddedVectorBuffer(Vector &shredded_data_p)
+ShreddedVectorBuffer::ShreddedVectorBuffer(Vector &shredded_data_p, idx_t capacity)
     : VectorBuffer(VectorType::SHREDDED_VECTOR, VectorBufferType::SHREDDED_BUFFER),
-      shredded_data(make_uniq<Vector>(Vector::Ref(shredded_data_p))) {
+      shredded_data(make_uniq<Vector>(Vector::Ref(shredded_data_p))), capacity(capacity) {
 }
 
 ShreddedVectorBuffer::~ShreddedVectorBuffer() {

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -166,8 +166,7 @@ public:
 		void Execute(ExecutionContext &context, DataChunk &input, DataChunk &delayed, Vector &result,
 		             idx_t delayed_capacity) {
 			if (!curr_chunk.ColumnCount()) {
-				curr_chunk.Initialize(context.client, {result.GetType()},
-				                      MaxValue<idx_t>(delayed_capacity, STANDARD_VECTOR_SIZE));
+				curr_chunk.Initialize(context.client, {result.GetType()}, delayed_capacity);
 			}
 
 			if (offset >= 0) {
@@ -191,11 +190,11 @@ public:
 				//	Shift down incomplete buffers
 				//	Copy prev[count, buffered] => temp[0, buffered-count]
 				source_count = buffered - count;
-				FlatVector::ValidityMutable(temp).Reset();
+				FlatVector::ValidityMutable(temp).Reset(buffered);
 				VectorOperations::Copy(prev, temp, buffered, count, 0);
 
 				// 	Copy temp[0, buffered-count] => prev[0, buffered-count]
-				FlatVector::ValidityMutable(prev).Reset();
+				FlatVector::ValidityMutable(prev).Reset(buffered);
 				VectorOperations::Copy(temp, prev, source_count, 0, 0);
 				// 	Copy curr[0, count] => prev[buffered-count, buffered]
 				VectorOperations::Copy(curr, prev, count, 0, source_count);
@@ -205,7 +204,7 @@ public:
 				//	Copy curr[0, count-buffered] => result[buffered, count]
 				VectorOperations::Copy(curr, result, source_count, 0, buffered);
 				// 	Copy curr[count-buffered, count] => prev[0, buffered]
-				FlatVector::ValidityMutable(prev).Reset();
+				FlatVector::ValidityMutable(prev).Reset(buffered);
 				VectorOperations::Copy(curr, prev, count, source_count, 0);
 			}
 		}
@@ -320,7 +319,7 @@ public:
 			}
 		}
 		if (lead_count) {
-			delayed_capacity = lead_count = STANDARD_VECTOR_SIZE;
+			delayed_capacity = lead_count + STANDARD_VECTOR_SIZE;
 			delayed.Initialize(context, input.GetTypes(), delayed_capacity);
 			shifted.Initialize(context, input.GetTypes(), delayed_capacity);
 		}
@@ -703,25 +702,13 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
 		state.Reset(delayed);
 	}
 	if (delayed.size() < state.lead_count) {
-		const idx_t need = state.lead_count - delayed.size();
-		if (input.size() <= need) {
-			//	If we don't have enough to produce a single row,
-			//	then just delay more rows, return nothing
-			//	and ask for more data.
-			delayed.Append(input);
-			output.SetCardinality(0);
-			return OperatorResultType::NEED_MORE_INPUT;
-		}
-		// Append only the rows that fit; slice input down to the remaining rows
-		// and fall through to process the now-full delayed buffer.
-		SelectionVector partial_sel(need);
-		for (idx_t i = 0; i < need; i++) {
-			partial_sel.set_index(i, i);
-		}
-		delayed.Append(input, false, &partial_sel, need);
-		input.Slice(need, input.size() - need);
-	}
-	if (input.size() < delayed.size()) {
+		//	If we don't have enough to produce a single row,
+		//	then just delay more rows, return nothing
+		//	and ask for more data.
+		delayed.Append(input);
+		output.SetCardinality(0);
+		return OperatorResultType::NEED_MORE_INPUT;
+	} else if (input.size() < delayed.size()) {
 		// If we can't consume all of the delayed values,
 		// we need to split them instead of referencing them all
 		output.SetCardinality(input.size());

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -166,7 +166,8 @@ public:
 		void Execute(ExecutionContext &context, DataChunk &input, DataChunk &delayed, Vector &result,
 		             idx_t delayed_capacity) {
 			if (!curr_chunk.ColumnCount()) {
-				curr_chunk.Initialize(context.client, {result.GetType()}, delayed_capacity);
+				curr_chunk.Initialize(context.client, {result.GetType()},
+				                      MaxValue<idx_t>(delayed_capacity, STANDARD_VECTOR_SIZE));
 			}
 
 			if (offset >= 0) {
@@ -702,13 +703,25 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
 		state.Reset(delayed);
 	}
 	if (delayed.size() < state.lead_count) {
-		//	If we don't have enough to produce a single row,
-		//	then just delay more rows, return nothing
-		//	and ask for more data.
-		delayed.Append(input);
-		output.SetCardinality(0);
-		return OperatorResultType::NEED_MORE_INPUT;
-	} else if (input.size() < delayed.size()) {
+		const idx_t need = state.lead_count - delayed.size();
+		if (input.size() <= need) {
+			//	If we don't have enough to produce a single row,
+			//	then just delay more rows, return nothing
+			//	and ask for more data.
+			delayed.Append(input);
+			output.SetCardinality(0);
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		// Append only the rows that fit; slice input down to the remaining rows
+		// and fall through to process the now-full delayed buffer.
+		SelectionVector partial_sel(need);
+		for (idx_t i = 0; i < need; i++) {
+			partial_sel.set_index(i, i);
+		}
+		delayed.Append(input, false, &partial_sel, need);
+		input.Slice(need, input.size() - need);
+	}
+	if (input.size() < delayed.size()) {
 		// If we can't consume all of the delayed values,
 		// we need to split them instead of referencing them all
 		output.SetCardinality(input.size());

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -163,9 +163,10 @@ public:
 			temp.Initialize(VectorDataInitialization::UNINITIALIZED, buffered);
 		}
 
-		void Execute(ExecutionContext &context, DataChunk &input, DataChunk &delayed, Vector &result) {
+		void Execute(ExecutionContext &context, DataChunk &input, DataChunk &delayed, Vector &result,
+		             idx_t delayed_capacity) {
 			if (!curr_chunk.ColumnCount()) {
-				curr_chunk.Initialize(context.client, {result.GetType()}, delayed.GetCapacity());
+				curr_chunk.Initialize(context.client, {result.GetType()}, delayed_capacity);
 			}
 
 			if (offset >= 0) {
@@ -318,8 +319,9 @@ public:
 			}
 		}
 		if (lead_count) {
-			delayed.Initialize(context, input.GetTypes(), lead_count + STANDARD_VECTOR_SIZE);
-			shifted.Initialize(context, input.GetTypes(), lead_count + STANDARD_VECTOR_SIZE);
+			delayed_capacity = lead_count = STANDARD_VECTOR_SIZE;
+			delayed.Initialize(context, input.GetTypes(), delayed_capacity);
+			shifted.Initialize(context, input.GetTypes(), delayed_capacity);
 		}
 		initialized = true;
 	}
@@ -340,6 +342,7 @@ public:
 	vector<unique_ptr<LeadLagState>> lead_lag_states;
 	//! The number of rows ahead to buffer for LEAD
 	idx_t lead_count = 0;
+	idx_t delayed_capacity = 0;
 	//! A buffer for delayed input
 	DataChunk delayed;
 	//! A buffer for shifting delayed input
@@ -614,7 +617,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 		}
 		case ExpressionType::WINDOW_LAG:
 		case ExpressionType::WINDOW_LEAD:
-			state.lead_lag_states[expr_idx]->Execute(context, output, delayed, result);
+			state.lead_lag_states[expr_idx]->Execute(context, output, delayed, result, state.delayed_capacity);
 			break;
 		default:
 			throw NotImplementedException("%s for StreamingWindow", ExpressionTypeToString(expr.GetExpressionType()));
@@ -737,9 +740,9 @@ OperatorFinalizeResultType PhysicalStreamingWindow::FinalExecute(ExecutionContex
 		auto &input = state.shifted;
 		state.Reset(input);
 
-		if (output.GetCapacity() < delayed.size()) {
+		if (delayed.size() > STANDARD_VECTOR_SIZE) {
 			//	More than one output buffer was delayed, so shift in what we can
-			output.SetCardinality(output.GetCapacity());
+			output.SetCardinality(STANDARD_VECTOR_SIZE);
 			ExecuteShifted(context, delayed, input, output, gstate_p);
 			return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 		}

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -325,10 +325,7 @@ public:
 	}
 
 	static inline void Reset(DataChunk &chunk) {
-		//	Reset trashes the capacity...
-		const auto capacity = chunk.GetCapacity();
 		chunk.Reset();
-		chunk.SetCapacity(capacity);
 	}
 
 public:

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -166,7 +166,8 @@ public:
 		void Execute(ExecutionContext &context, DataChunk &input, DataChunk &delayed, Vector &result,
 		             idx_t delayed_capacity) {
 			if (!curr_chunk.ColumnCount()) {
-				curr_chunk.Initialize(context.client, {result.GetType()}, delayed_capacity);
+				curr_chunk.Initialize(context.client, {result.GetType()},
+				                      MaxValue<idx_t>(STANDARD_VECTOR_SIZE, delayed_capacity));
 			}
 
 			if (offset >= 0) {

--- a/src/execution/operator/csv_scanner/sniffer/type_refinement.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_refinement.cpp
@@ -86,7 +86,6 @@ void CSVSniffer::RefineTypes() {
 		}
 		// reset parse chunk for the next iteration
 		parse_chunk.Reset();
-		parse_chunk.SetCapacity(CSVReaderOptions::sniff_size);
 	}
 	detected_types.clear();
 	// set sql types

--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -202,7 +202,7 @@ static bool TryToShreddedCast(Vector &source, Vector &result, idx_t count, CastP
 	auto &top_shredded = StructVector::GetEntries(shredded_vector);
 	auto &shredded_child = top_shredded[1];
 	ShreddedVectorReference(source, shredded_child, count);
-	result.Shred(shredded_vector);
+	result.Shred(shredded_vector, count);
 	return true;
 }
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -124,7 +124,7 @@ static bool TryShreddedExtractRecursive(Vector &input, const vector<VariantPathC
 		auto &shredded_child = top_shredded[1];
 		shredded_child.Reference(input);
 
-		result.Shred(shredded_vector);
+		result.Shred(shredded_vector, count);
 		return true;
 	}
 	auto &component = components[path_index];

--- a/src/function/window/window_collection.cpp
+++ b/src/function/window/window_collection.cpp
@@ -129,7 +129,6 @@ WindowCursor::WindowCursor(const WindowCollection &paged, vector<column_t> colum
 		state.current_row_index = 0;
 		state.next_row_index = paged.size();
 		state.properties = ColumnDataScanProperties::ALLOW_ZERO_COPY;
-		chunk.SetCapacity(state.next_row_index);
 		chunk.SetCardinality(state.next_row_index);
 		return;
 	} else if (chunk.data.empty()) {

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -61,7 +61,6 @@ public:
 	inline void SetCardinality(const DataChunk &other) {
 		SetCardinality(other.size());
 	}
-	idx_t GetCapacity() const;
 
 	DUCKDB_API Value GetValue(idx_t col_idx, idx_t index) const;
 	DUCKDB_API void SetValue(idx_t col_idx, idx_t index, const Value &val);

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -57,22 +57,11 @@ public:
 	inline idx_t ColumnCount() const {
 		return data.size();
 	}
-	inline void SetCardinality(idx_t count_p) {
-		D_ASSERT(count_p <= capacity);
-		this->count = count_p;
-	}
+	void SetCardinality(idx_t count_p);
 	inline void SetCardinality(const DataChunk &other) {
 		SetCardinality(other.size());
 	}
-	inline idx_t GetCapacity() const {
-		return capacity;
-	}
-	inline void SetCapacity(idx_t capacity_p) {
-		this->capacity = capacity_p;
-	}
-	inline void SetCapacity(const DataChunk &other) {
-		SetCapacity(other.capacity);
-	}
+	idx_t GetCapacity() const;
 
 	DUCKDB_API Value GetValue(idx_t col_idx, idx_t index) const;
 	DUCKDB_API void SetValue(idx_t col_idx, idx_t index, const Value &val);
@@ -107,7 +96,7 @@ public:
 	//! Append the other DataChunk to this one. The column count and types of
 	//! the two DataChunks have to match exactly. Throws an exception if there
 	//! is not enough space in the chunk and resize is not allowed.
-	DUCKDB_API void Append(const DataChunk &other, bool resize = false, SelectionVector *sel = nullptr,
+	DUCKDB_API void Append(const DataChunk &other, bool resize = false, optional_ptr<SelectionVector> sel = nullptr,
 	                       idx_t count = 0);
 
 	//! Destroy all data and columns owned by this DataChunk
@@ -171,10 +160,6 @@ public:
 private:
 	//! The amount of tuples stored in the data chunk
 	idx_t count;
-	//! The amount of tuples that can be stored in the data chunk
-	idx_t capacity;
-	//! The initial capacity of this chunk set during ::Initialize, used when resetting
-	idx_t initial_capacity;
 	//! Vector caches, used to store data when ::Initialize is called
 	vector<VectorCache> vector_caches;
 };

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -71,6 +71,9 @@ public:
 	DUCKDB_API Vector(Vector &&other) noexcept;
 
 public:
+	//! Checks if a vector has enough space for the given count - throws an internal error otherwise
+	DUCKDB_API void CheckCapacity(idx_t capacity) const;
+
 	//! Create a new vector that references the other vector
 	DUCKDB_API static Vector Ref(const Vector &other);
 

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -154,7 +154,11 @@ public:
 
 	// Getters
 	inline VectorType GetVectorType() const {
-		return Buffer().GetVectorType();
+		auto &buffer_ref = GetBufferRef();
+		if (!buffer_ref) {
+			return VectorType::FLAT_VECTOR;
+		}
+		return buffer_ref->GetVectorType();
 	}
 	inline const LogicalType &GetType() const {
 		return type;

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -141,7 +141,7 @@ public:
 	DUCKDB_API void Sequence(int64_t start, int64_t increment, idx_t count);
 
 	//! Turn the vector into a shredded variant vector
-	DUCKDB_API void Shred(Vector &shredded_data);
+	DUCKDB_API void Shred(Vector &shredded_data, idx_t capacity);
 
 	//! Verify that the Vector is in a consistent, not corrupt state. DEBUG
 	//! FUNCTION ONLY!

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -153,13 +153,18 @@ public:
 	idx_t GetAllocationSize() const;
 
 	// Getters
-	VectorType GetVectorType() const;
+	inline VectorType GetVectorType() const {
+		return Buffer().GetVectorType();
+	}
 	inline const LogicalType &GetType() const {
 		return type;
 	}
-
-	VectorBuffer &BufferMutable();
-	const VectorBuffer &Buffer() const;
+	inline VectorBuffer &BufferMutable() {
+		return *buffer;
+	}
+	inline const VectorBuffer &Buffer() const {
+		return *buffer;
+	}
 	inline const buffer_ptr<VectorBuffer> &GetBufferRef() const {
 		return buffer;
 	}

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -116,8 +116,15 @@ struct FlatVector {
 		return GetDataMutableUnsafe<T>(vector);
 	}
 	static inline idx_t GetCapacity(const Vector &vector) {
-		VerifyFlatVector(vector);
-		return vector.GetBufferRef() ? vector.Buffer().Capacity() : 0;
+		auto &buffer_ref = vector.GetBufferRef();
+		if (!buffer_ref) {
+			return 0;
+		}
+		auto &buffer = *buffer_ref;
+		if (buffer.GetVectorType() != VectorType::FLAT_VECTOR) {
+			throw InternalException("FlatVector::GetCapacity requires a flat vector buffer");
+		}
+		return buffer.Capacity();
 	}
 	template <class T>
 	static inline const T *GetDataUnsafe(const Vector &vector) {

--- a/src/include/duckdb/common/vector/sequence_vector.hpp
+++ b/src/include/duckdb/common/vector/sequence_vector.hpp
@@ -14,16 +14,16 @@ namespace duckdb {
 
 class SequenceBuffer : public VectorBuffer {
 public:
-	explicit SequenceBuffer(int64_t start, int64_t increment, int64_t count);
+	explicit SequenceBuffer(int64_t start, int64_t increment, idx_t seq_count);
 
 	int64_t start;
 	int64_t increment;
 	//! FIXME: should not be necessary once vector has count
-	int64_t count;
+	idx_t seq_count;
 
 public:
 	idx_t Capacity() const override {
-		return count;
+		return seq_count;
 	}
 	idx_t GetDataSize(const LogicalType &type, idx_t count) const override;
 	idx_t GetAllocationSize() const override;
@@ -34,7 +34,6 @@ public:
 };
 
 struct SequenceVector {
-	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count);
 	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment);
 };
 

--- a/src/include/duckdb/common/vector/sequence_vector.hpp
+++ b/src/include/duckdb/common/vector/sequence_vector.hpp
@@ -22,6 +22,9 @@ public:
 	int64_t count;
 
 public:
+	idx_t Capacity() const override {
+		return count;
+	}
 	idx_t GetDataSize(const LogicalType &type, idx_t count) const override;
 	idx_t GetAllocationSize() const override;
 	string ToString(const LogicalType &type, idx_t count) const override;

--- a/src/include/duckdb/common/vector/shredded_vector.hpp
+++ b/src/include/duckdb/common/vector/shredded_vector.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class ShreddedVectorBuffer : public VectorBuffer {
 public:
-	explicit ShreddedVectorBuffer(Vector &shredded_data);
+	explicit ShreddedVectorBuffer(Vector &shredded_data, idx_t capacity);
 	~ShreddedVectorBuffer() override;
 
 public:
@@ -23,6 +23,9 @@ public:
 	}
 
 public:
+	idx_t Capacity() const override {
+		return capacity;
+	}
 	idx_t GetDataSize(const LogicalType &type, idx_t count) const override;
 	idx_t GetAllocationSize() const override;
 	string ToString(const LogicalType &type, idx_t count) const override;
@@ -32,6 +35,7 @@ public:
 
 private:
 	unique_ptr<Vector> shredded_data;
+	idx_t capacity;
 };
 
 struct ShreddedVector {

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -317,10 +317,6 @@ void duckdb::BaseAppender::Append(DataChunk &target, const Value &value, idx_t c
 	if (col >= target.ColumnCount()) {
 		throw InvalidInputException("Too many appends for chunk!");
 	}
-	if (row >= target.GetCapacity()) {
-		throw InvalidInputException("Too many rows for chunk!");
-	}
-
 	if (value.type() == target.GetTypes()[col]) {
 		target.SetValue(col, row, value);
 	} else {

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -258,7 +258,7 @@ idx_t VariantColumnData::ScanWithCallback(
 			callback(*sub_columns[1], state.child_states[2], child_vectors[1], target_count);
 			scan_count = callback(*validity, state.child_states[0], unshredding_intermediate, target_count);
 
-			intermediate.Shred(unshredding_intermediate);
+			intermediate.Shred(unshredding_intermediate, scan_count);
 		} else {
 			scan_count = callback(*validity, state.child_states[0], intermediate, target_count);
 			callback(*sub_columns[0], state.child_states[1], intermediate, target_count);
@@ -304,7 +304,7 @@ idx_t VariantColumnData::ScanWithCallback(
 			callback(*sub_columns[1], state.child_states[2], child_vectors[1], target_count);
 			auto scan_count = callback(*validity, state.child_states[0], intermediate, target_count);
 
-			result.Shred(intermediate);
+			result.Shred(intermediate, scan_count);
 			return scan_count;
 		}
 		auto scan_count = callback(*validity, state.child_states[0], result, target_count);


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/22071 has added a capacity field to individual vector buffers. As such, we no longer need to keep track of a separate capacity field in the `DataChunk`. Instead, when appending to a `DataChunk`, we can use the capacity in the individual `VectorBuffer` to determine when we need to resize.