### PR TITLE
When resizing a list vector, keep the original child Vector in the new buffer

### DIFF
--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -75,8 +75,12 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &
 	return make_buffer<DictionaryBuffer>(sel, count, std::move(entry));
 }
 
-buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateBuffer(AllocatedData &&new_data, idx_t capacity) const {
-	return make_buffer<StandardVectorBuffer>(std::move(new_data), capacity);
+buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateBuffer(AllocatedData &&new_data, idx_t new_capacity) const {
+	return make_buffer<StandardVectorBuffer>(std::move(new_data), new_capacity);
+}
+
+buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateResizeBuffer(AllocatedData &&new_data, idx_t new_capacity) {
+	return CreateBuffer(std::move(new_data), new_capacity);
 }
 
 buffer_ptr<VectorBuffer> StandardVectorBuffer::Resize(const LogicalType &type, idx_t current_size, idx_t new_size) {
@@ -98,7 +102,7 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::Resize(const LogicalType &type, i
 	memcpy(new_data.get(), data_ptr, old_byte_count);
 
 	// create the new buffer
-	auto result = CreateBuffer(std::move(new_data), new_size);
+	auto result = CreateResizeBuffer(std::move(new_data), new_size);
 	// copy over the validity mask
 	auto &new_validity = result->GetValidityMask();
 	new_validity.Resize(new_size);

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -35,6 +35,14 @@ VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, idx_t capacit
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
 }
 
+VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, idx_t capacity, VectorListBuffer &parent)
+    : StandardVectorBuffer(std::move(allocated_data_p), capacity), size(parent.size) {
+	buffer_type = VectorBufferType::LIST_BUFFER;
+	auto &parent_child = parent.GetChildMutable();
+	child = std::move(parent_child);
+	parent_child = make_uniq<Vector>(Vector::Ref(*child));
+}
+
 void VectorListBuffer::Reserve(idx_t to_reserve) {
 	idx_t child_capacity = GetChildCapacity();
 	if (to_reserve > child_capacity) {
@@ -162,6 +170,10 @@ void VectorListBuffer::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format)
 }
 
 buffer_ptr<VectorBuffer> VectorListBuffer::CreateBuffer(AllocatedData &&new_data, idx_t capacity) const {
+	return make_buffer<VectorListBuffer>(std::move(new_data), capacity, *this);
+}
+
+buffer_ptr<VectorBuffer> VectorListBuffer::CreateResizeBuffer(AllocatedData &&new_data, idx_t capacity) {
 	return make_buffer<VectorListBuffer>(std::move(new_data), capacity, *this);
 }
 

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -54,6 +54,7 @@ protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) override;
 
 	virtual buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, idx_t capacity) const;
+	virtual buffer_ptr<VectorBuffer> CreateResizeBuffer(AllocatedData &&new_data, idx_t capacity);
 
 protected:
 	ValidityMask validity;

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -24,6 +24,7 @@ public:
 	explicit VectorListBuffer(data_ptr_t data, idx_t capacity, const Vector &vector, idx_t child_size);
 	explicit VectorListBuffer(data_ptr_t data, idx_t capacity, const VectorListBuffer &parent);
 	explicit VectorListBuffer(AllocatedData allocated_data, idx_t capacity, const VectorListBuffer &parent);
+	explicit VectorListBuffer(AllocatedData allocated_data, idx_t capacity, VectorListBuffer &parent);
 	~VectorListBuffer() override;
 
 public:
@@ -32,6 +33,9 @@ public:
 	}
 	const Vector &GetChild() const {
 		return *child;
+	}
+	unique_ptr<Vector> &GetChildMutable() {
+		return child;
 	}
 	void Reserve(idx_t to_reserve);
 
@@ -60,6 +64,7 @@ public:
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
 	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, idx_t capacity) const override;
+	buffer_ptr<VectorBuffer> CreateResizeBuffer(AllocatedData &&new_data, idx_t capacity) override;
 
 private:
 	//! child vectors used for nested data

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -847,3 +847,79 @@ TEST_CASE("Test unsafe string assignment to VARCHAR vector", "[capi]") {
 
 	duckdb_destroy_data_chunk(&chunk);
 }
+
+TEST_CASE("Test appending to a nested list vector", "[capi]") {
+	duckdb_database db;
+	duckdb_connection con;
+	duckdb_open(nullptr, &db);
+	duckdb_connect(db, &con);
+	duckdb_query(con, "CREATE TABLE test (col INTEGER[][])", nullptr);
+
+	// Schema: INTEGER[][]
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto inner_list = duckdb_create_list_type(int_type);
+	auto outer_list = duckdb_create_list_type(inner_list);
+
+	duckdb_logical_type schema[] = {outer_list};
+	auto chunk = duckdb_create_data_chunk(schema, 1);
+
+	// Get the full vector chain up front, before any reserve calls.
+	auto outer_vec = duckdb_data_chunk_get_vector(chunk, 0);
+	auto inner_vec = duckdb_list_vector_get_child(outer_vec);
+	auto data_vec = duckdb_list_vector_get_child(inner_vec);
+
+	// 1 row containing 2100 inner lists, each with 1 element.
+	// The 2100 inner lists exceed STANDARD_VECTOR_SIZE (2048),
+	// so the outer reserve triggers child->Resize() on inner_vec.
+	const int NUM_INNER_LISTS = 2100;
+
+	duckdb_list_vector_reserve(outer_vec, NUM_INNER_LISTS);
+	duckdb_list_vector_reserve(inner_vec, NUM_INNER_LISTS);
+
+	// Write one integer per inner list through the pre-cached data_vec.
+	auto data_ptr = (int32_t *)duckdb_vector_get_data(data_vec);
+	for (int i = 0; i < NUM_INNER_LISTS; i++) {
+		data_ptr[i] = i;
+	}
+	duckdb_list_vector_set_size(inner_vec, NUM_INNER_LISTS);
+
+	// Each inner list: single element
+	auto inner_entries = (duckdb_list_entry *)duckdb_vector_get_data(inner_vec);
+	for (int i = 0; i < NUM_INNER_LISTS; i++) {
+		inner_entries[i] = {(uint64_t)i, 1};
+	}
+	duckdb_list_vector_set_size(outer_vec, NUM_INNER_LISTS);
+
+	// 1 outer row containing all 2100 inner lists
+	auto outer_entries = (duckdb_list_entry *)duckdb_vector_get_data(outer_vec);
+	outer_entries[0] = {0, NUM_INNER_LISTS};
+
+	duckdb_data_chunk_set_size(chunk, 1);
+
+	// Append and read back
+	duckdb_appender appender;
+	duckdb_appender_create(con, nullptr, "test", &appender);
+	duckdb_append_data_chunk(appender, chunk);
+	duckdb_appender_close(appender);
+	duckdb_appender_destroy(&appender);
+
+	// Verify: col[1][1] should be 0, col[2100][1] should be 2099
+	duckdb_result result;
+	duckdb_query(con, "SELECT col[1][1], col[2100][1] FROM test", &result);
+
+	int64_t first = duckdb_value_int64(&result, 0, 0);
+	int64_t last = duckdb_value_int64(&result, 1, 0);
+	REQUIRE(first == 0);
+	REQUIRE(last == 2099);
+
+	bool ok = (first == 0 && last == 2099);
+	REQUIRE(ok);
+
+	duckdb_destroy_result(&result);
+	duckdb_destroy_data_chunk(&chunk);
+	duckdb_destroy_logical_type(&int_type);
+	duckdb_destroy_logical_type(&inner_list);
+	duckdb_destroy_logical_type(&outer_list);
+	duckdb_disconnect(&con);
+	duckdb_close(&db);
+}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21869

Otherwise we will resize a new vector instead of the original vector, which will cause old vectors to still refer to the old (pre-resize) vector.