### PR TITLE
backport 22094

### DIFF
--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -45,13 +45,13 @@ void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, T &&callback) 
 		state.start = state.handle.Ptr();
 		state.end = state.start + state.current->position;
 		while (state.start < state.end) {
+			auto len_position = state.start + sizeof(UndoFlags);
+			auto payload_position = len_position + sizeof(uint32_t);
 			UndoFlags type = Load<UndoFlags>(state.start);
-			state.start += sizeof(UndoFlags);
+			uint32_t len = Load<uint32_t>(len_position);
 
-			uint32_t len = Load<uint32_t>(state.start);
-			state.start += sizeof(uint32_t);
-			callback(type, state.start);
-			state.start += len;
+			callback(type, payload_position);
+			state.start = payload_position + len;
 		}
 		state.current = state.current->prev;
 	}


### PR DESCRIPTION
I'm not backporting the relaxed assertion or the reproducer, just the commit iteration bugfix. The reason is we can't relax the assert in the same way due to a lack of delta indexes, and the reproducer could still fail on relassert or debug with the assert (For 1.4 it makes more sense to keep the assert in and look out for errors there, than to have the specific reproducer). 