### PR TITLE
Add aggregate_window_batch_t — batched variant of the window callback

### DIFF
--- a/src/function/window/window_custom_aggregator.cpp
+++ b/src/function/window/window_custom_aggregator.cpp
@@ -150,6 +150,24 @@ void WindowCustomAggregator::Evaluate(ExecutionContext &context, const DataChunk
 	auto &stats = gcsink.stats;
 	WindowPartitionInput partition(context, inputs, collection->size(), child_idx, all_valids, filter_packed, stats,
 	                               sink.interrupt_state);
+
+	// Batched window callback path: if the aggregate installs a batch callback,
+	// collect all `count` rows' subframes into a contiguous array and hand them
+	// off in a single call. This lets implementations amortise per-call
+	// overhead (e.g., RPC extensions that would otherwise fire one call per
+	// output row).
+	if (aggr.function.HasWindowBatchCallback()) {
+		vector<SubFrames> all_frames;
+		all_frames.reserve(count);
+		EvaluateSubFrames(bounds, exclude_mode, count, row_idx, frames, [&](idx_t i) {
+			all_frames.push_back(frames);
+		});
+		AggregateInputData aggr_input_data(aggr.GetFunctionData(), lcstate.allocator);
+		aggr.function.GetWindowBatchCallback()(aggr_input_data, partition, gstate_p, lcstate.state.data(),
+		                                        all_frames.data(), count, result, row_idx);
+		return;
+	}
+
 	EvaluateSubFrames(bounds, exclude_mode, count, row_idx, frames, [&](idx_t i) {
 		// Extract the range
 		AggregateInputData aggr_input_data(aggr.GetFunctionData(), lcstate.allocator);

--- a/src/function/window/window_custom_aggregator.cpp
+++ b/src/function/window/window_custom_aggregator.cpp
@@ -159,12 +159,10 @@ void WindowCustomAggregator::Evaluate(ExecutionContext &context, const DataChunk
 	if (aggr.function.HasWindowBatchCallback()) {
 		vector<SubFrames> all_frames;
 		all_frames.reserve(count);
-		EvaluateSubFrames(bounds, exclude_mode, count, row_idx, frames, [&](idx_t i) {
-			all_frames.push_back(frames);
-		});
+		EvaluateSubFrames(bounds, exclude_mode, count, row_idx, frames, [&](idx_t i) { all_frames.push_back(frames); });
 		AggregateInputData aggr_input_data(aggr.GetFunctionData(), lcstate.allocator);
 		aggr.function.GetWindowBatchCallback()(aggr_input_data, partition, gstate_p, lcstate.state.data(),
-		                                        all_frames.data(), count, result, row_idx);
+		                                       all_frames.data(), count, result, row_idx);
 		return;
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -89,9 +89,9 @@ typedef void (*aggregate_window_t)(AggregateInputData &aggr_input_data, const Wi
 //! callback, letting implementations issue a single batched call (e.g., one
 //! RPC for the whole Evaluate chunk instead of count separate calls).
 typedef void (*aggregate_window_batch_t)(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,
-                                          const_data_ptr_t g_state, data_ptr_t l_state,
-                                          const SubFrames *subframes_per_row, idx_t count,
-                                          Vector &result, idx_t row_idx);
+                                         const_data_ptr_t g_state, data_ptr_t l_state,
+                                         const SubFrames *subframes_per_row, idx_t count, Vector &result,
+                                         idx_t row_idx);
 
 //! The type used for initializing shared complex/custom windowed aggregate state (optional)
 typedef void (*aggregate_wininit_t)(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -82,6 +82,17 @@ typedef void (*aggregate_window_t)(AggregateInputData &aggr_input_data, const Wi
                                    const_data_ptr_t g_state, data_ptr_t l_state, const SubFrames &subframes,
                                    Vector &result, idx_t rid);
 
+//! Batched variant of aggregate_window_t — called once per Evaluate() with frame
+//! bounds for all `count` output rows pre-computed. `subframes_per_row` points
+//! to `count` SubFrames entries (each 1-3 FrameBounds depending on EXCLUDE
+//! clause). When set, the window executor prefers this over the per-row
+//! callback, letting implementations issue a single batched call (e.g., one
+//! RPC for the whole Evaluate chunk instead of count separate calls).
+typedef void (*aggregate_window_batch_t)(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,
+                                          const_data_ptr_t g_state, data_ptr_t l_state,
+                                          const SubFrames *subframes_per_row, idx_t count,
+                                          Vector &result, idx_t row_idx);
+
 //! The type used for initializing shared complex/custom windowed aggregate state (optional)
 typedef void (*aggregate_wininit_t)(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,
                                     data_ptr_t g_state);
@@ -225,6 +236,12 @@ public:
 	aggregate_wininit_t GetWindowInitCallback() const { return window_init; }
 	bool HasWindowInitCallback() const { return window_init != nullptr; }
 
+	//! Batched window callback — takes precedence over the per-row window
+	//! callback when set. See aggregate_window_batch_t for semantics.
+	bool HasWindowBatchCallback() const { return window_batch != nullptr; }
+	aggregate_window_batch_t GetWindowBatchCallback() const { return window_batch; }
+	void SetWindowBatchCallback(aggregate_window_batch_t callback) { window_batch = callback; }
+
 	bool HasStatisticsCallback() const { return statistics != nullptr; }
 	aggregate_statistics_t GetStatisticsCallback() const { return statistics; }
 	void SetStatisticsCallback(aggregate_statistics_t callback) { statistics = callback; }
@@ -253,6 +270,8 @@ public:
 	aggregate_window_t window;
 	//! The windowed aggregate custom initialization function (may be null)
 	aggregate_wininit_t window_init = nullptr;
+	//! Batched windowed aggregate function (may be null; preferred when set)
+	aggregate_window_batch_t window_batch = nullptr;
 
 	//! The bind function (may be null)
 	bind_aggregate_function_t bind;


### PR DESCRIPTION
## What

Adds an optional batched counterpart to `aggregate_window_t`. When set,
`WindowCustomAggregator::Evaluate` pre-collects subframes for all `count`
output rows and invokes the batch callback once instead of looping the
per-row callback.

```cpp
typedef void (*aggregate_window_batch_t)(
    AggregateInputData &, const WindowPartitionInput &,
    const_data_ptr_t g_state, data_ptr_t l_state,
    const SubFrames *subframes_per_row, idx_t count,
    Vector &result, idx_t row_idx);
```

The existing per-row path is untouched; aggregates that don't install
`window_batch` behave identically.

## Why

Some aggregate implementations have meaningful per-call overhead the
per-row loop amplifies — data marshalling, cross-language bridges,
network hops, etc. A batched entry point lets those implementations
amortise it across an Evaluate chunk. For aggregates with no such
overhead, the existing callback remains optimal and is still the
default.

## Change

+37 lines, two files, purely additive: the new typedef, a nullable
`window_batch` field on `AggregateFunction`, three accessors, and the
branch in `Evaluate` that pre-collects subframes and dispatches.