### PR TITLE
CompressedFile::Close -> calls Close on its child_handle

### DIFF
--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -45,7 +45,7 @@ ZstdStreamWrapper::~ZstdStreamWrapper() {
 }
 
 void ZstdStreamWrapper::Initialize(QueryContext context, CompressedFile &file, bool write) {
-	Close();
+	D_ASSERT(!zstd_stream_ptr && !zstd_compress_ptr);
 	this->file = &file;
 	this->writing = write;
 	if (write) {

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -13,8 +13,7 @@ CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> 
 
 CompressedFile::~CompressedFile() {
 	try {
-		// stream_wrapper->Close() might throw
-		CompressedFile::Close();
+		Close();
 	} catch (std::exception &ex) {
 		if (child_handle) {
 			// FIXME: Make any log context available here.
@@ -32,7 +31,7 @@ CompressedFile::~CompressedFile() {
 }
 
 void CompressedFile::Initialize(QueryContext context, bool write) {
-	Close();
+	Clear();
 
 	this->write = write;
 	stream_data.in_buf_size = compressed_fs.InBufferSize();
@@ -126,11 +125,15 @@ int64_t CompressedFile::WriteData(data_ptr_t buffer, int64_t nr_bytes) {
 	return nr_bytes;
 }
 
-void CompressedFile::Close() {
+// Clear does most of the heavy lifting of a close, but leaves the child_handle intact. Specifically it is separated out
+// to support upstream Reset() calls from the FileSystem, which should tear down / reset ephemeral state but leave
+// persisent state (child_handle) intact.
+void CompressedFile::Clear() {
 	if (stream_wrapper) {
 		stream_wrapper->Close();
 		stream_wrapper.reset();
 	}
+
 	stream_data.in_buff.reset();
 	stream_data.out_buff.reset();
 	stream_data.out_buff_start = nullptr;
@@ -140,6 +143,18 @@ void CompressedFile::Close() {
 	stream_data.in_buf_size = 0;
 	stream_data.out_buf_size = 0;
 	stream_data.refresh = false;
+}
+
+void CompressedFile::Close() {
+	// This can throw and halt close leaving child_handle dangling until destruction. Given the alternative of writing
+	// corrupted data that seems better than flushing data in an unknown state.
+	Clear();
+
+	// Then close out child_handle itself.
+	if (child_handle) {
+		child_handle->Close();
+		child_handle.reset();
+	}
 }
 
 int64_t CompressedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -110,7 +110,7 @@ MiniZStreamWrapper::~MiniZStreamWrapper() {
 }
 
 void MiniZStreamWrapper::Initialize(QueryContext context, CompressedFile &file, bool write) {
-	Close();
+	D_ASSERT(mz_stream_ptr == nullptr);
 	this->file = &file;
 	mz_stream_ptr = make_uniq<duckdb_miniz::mz_stream>();
 	memset(mz_stream_ptr.get(), 0, sizeof(duckdb_miniz::mz_stream));

--- a/src/include/duckdb/common/compressed_file_system.hpp
+++ b/src/include/duckdb/common/compressed_file_system.hpp
@@ -76,6 +76,8 @@ public:
 	DUCKDB_API void Close() override;
 
 private:
+	void Clear(); // for Initialize re-use to support FS.Reset()
+
 	idx_t current_position = 0;
 	unique_ptr<StreamWrapper> stream_wrapper;
 };


### PR DESCRIPTION
This fixes duckdb/duckdb-azure#157 which demonstrated that CompressedFile did not call Close on its child/underlying file handle.

- move Compressed::Close functionality -> ::Clear (for re-use in FileSystem::Reset)
- Compressed::Close now calls Clear(), then closes and reset child file handle
- fixes https://github.com/duckdb/duckdb-azure/issues/157
- Additionally remove defensive Close() calls to gzip and zstd files, replacing those with asserts

Local testing of this is tricky; however its correctness for this bug is confirmed by [a] local tests, and will be confirmed by [b] [updated Azure tests](https://github.com/duckdb/duckdb-azure/pull/158) which exercise the bug, but must land afterward.