### PR TITLE
Fix several warnings that pop up with newer clang version

### DIFF
--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -25,7 +25,6 @@ Value VectorFSSTStringBuffer::GetValue(const LogicalType &type, idx_t index) con
 	}
 	auto str_compressed = reinterpret_cast<const string_t *>(data_ptr)[index];
 	auto decoder = GetDecoder();
-	auto &decompress_buffer = GetDecompressBuffer();
 	auto string_val =
 	    FSSTPrimitives::DecompressValue(decoder, str_compressed.GetData(), str_compressed.GetSize(), decompress_buffer);
 	switch (type.id()) {

--- a/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
+++ b/src/include/duckdb/storage/checkpoint/checkpoint_options.hpp
@@ -26,7 +26,7 @@ struct CheckpointOptions {
 	transaction_t transaction_id;
 	//! The WAL lock - in case we are holding it during the entire checkpoint.
 	//! This is only required if we are doing a checkpoint instead of writing to the WAL
-	optional_ptr<lock_guard<mutex>> wal_lock;
+	optional_ptr<unique_lock<mutex>> wal_lock;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -82,9 +82,9 @@ public:
 	bool WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
 	                        ActiveCheckpointWrapper &active_checkpoint);
 	//! Finishes a checkpoint
-	void WALFinishCheckpoint(lock_guard<mutex> &wal_lock);
+	void WALFinishCheckpoint(unique_lock<mutex> &wal_lock);
 	// Get the WAL lock
-	unique_ptr<lock_guard<mutex>> GetWALLock();
+	unique_lock<mutex> GetWALLock();
 
 	//! Returns the database file path
 	string GetDBPath() const {

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -333,12 +333,12 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 
 		// truncate the WAL
 		if (has_wal) {
-			unique_ptr<lock_guard<mutex>> owned_wal_lock;
-			optional_ptr<lock_guard<mutex>> wal_lock;
+			unique_lock<mutex> owned_wal_lock;
+			optional_ptr<unique_lock<mutex>> wal_lock;
 			if (!options.wal_lock) {
 				// not holding the WAL lock yet - grab it
 				owned_wal_lock = storage_manager.GetWALLock();
-				wal_lock = *owned_wal_lock;
+				wal_lock = owned_wal_lock;
 			} else {
 				// we already have the WAL lock - just refer to it
 				wal_lock = options.wal_lock;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -206,7 +206,7 @@ bool StorageManager::HasWAL() const {
 
 bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointOptions &options,
                                         ActiveCheckpointWrapper &active_checkpoint) {
-	unique_ptr<lock_guard<mutex>> guard;
+	unique_lock<mutex> guard;
 	// Lock ordering: WAL lock -> transaction lock (in GetCheckpointTransaction)
 	if (!options.wal_lock) {
 		// not holding the WAL lock yet - grab it
@@ -258,7 +258,7 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	return true;
 }
 
-void StorageManager::WALFinishCheckpoint(lock_guard<mutex> &) {
+void StorageManager::WALFinishCheckpoint(unique_lock<mutex> &) {
 	D_ASSERT(wal.get());
 
 	// "wal" points to the checkpoint WAL
@@ -289,8 +289,8 @@ void StorageManager::WALFinishCheckpoint(lock_guard<mutex> &) {
 	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Finish Checkpoint");
 }
 
-unique_ptr<lock_guard<mutex>> StorageManager::GetWALLock() {
-	return make_uniq<lock_guard<mutex>>(wal_lock);
+unique_lock<mutex> StorageManager::GetWALLock() {
+	return unique_lock<mutex>(wal_lock);
 }
 
 string StorageManager::GetWALPath(const string &suffix) {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -419,7 +419,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	t_lock.unlock();
 	// if we have skipped the WAL write due to checkpoint, we keep the WAL lock while checkpointing
 	// this prevents any concurrent transactions from happening during this time
-	if (!skip_wal_write_due_to_checkpoint) {
+	if (!skip_wal_write_due_to_checkpoint && held_wal_lock.owns_lock()) {
 		held_wal_lock.unlock();
 	}
 

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -64,9 +64,9 @@ DuckTransactionManager &DuckTransactionManager::Get(AttachedDatabase &db) {
 Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	// obtain the transaction lock during this function
 	auto &meta_transaction = MetaTransaction::Get(context);
-	unique_ptr<lock_guard<mutex>> start_lock;
+	unique_lock<mutex> start_lock(start_transaction_lock, std::defer_lock);
 	if (!meta_transaction.IsReadOnly()) {
-		start_lock = make_uniq<lock_guard<mutex>>(start_transaction_lock);
+		start_lock.lock();
 	}
 	lock_guard<mutex> lock(transaction_lock);
 	if (current_start_timestamp >= TRANSACTION_ID_START) { // LCOV_EXCL_START
@@ -298,7 +298,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	auto undo_properties = transaction.GetUndoProperties();
 	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties);
 	ErrorData error;
-	unique_ptr<lock_guard<mutex>> held_wal_lock;
+	unique_lock<mutex> held_wal_lock;
 	unique_ptr<StorageCommitState> commit_state;
 	bool skip_wal_write_due_to_checkpoint = false;
 	if (checkpoint_decision.can_checkpoint) {
@@ -343,7 +343,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		if (should_write_to_wal && skip_wal_write_due_to_checkpoint && !checkpoint_decision.can_checkpoint) {
 			// we have not written to the WAL but we have now realized we can't checkpoint after all
 			// in order to commit we need backpeddle and write to the WAL after all
-			D_ASSERT(held_wal_lock);
+			D_ASSERT(held_wal_lock.owns_lock());
 			// unlock the transaction lock while we are writing to the WAL
 			t_lock.unlock();
 			error = transaction.WriteToWAL(context, db, commit_state);
@@ -420,7 +420,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// if we have skipped the WAL write due to checkpoint, we keep the WAL lock while checkpointing
 	// this prevents any concurrent transactions from happening during this time
 	if (!skip_wal_write_due_to_checkpoint) {
-		held_wal_lock.reset();
+		held_wal_lock.unlock();
 	}
 
 	CleanupTransactions();
@@ -436,7 +436,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		CheckpointOptions options;
 		options.action = CheckpointAction::ALWAYS_CHECKPOINT;
 		options.type = checkpoint_decision.type;
-		options.wal_lock = held_wal_lock.get();
+		options.wal_lock = held_wal_lock.owns_lock() ? &held_wal_lock : nullptr;
 		auto &storage_manager = db.GetStorageManager();
 		try {
 			storage_manager.CreateCheckpoint(context, options);

--- a/third_party/fmt/include/fmt/core.h
+++ b/third_party/fmt/include/fmt/core.h
@@ -226,8 +226,10 @@ template <typename... Ts> struct void_t_impl { using type = void; };
 #endif
 
 #if defined(FMT_USE_STRING_VIEW)
-template <typename Char> using std_string_view = std::basic_string_view<Char>;
-#elif defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
+// Undefine to avoid deprecation warnings from libc++ for non-standard char types
+#undef FMT_USE_STRING_VIEW
+#endif
+#if defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
 template <typename Char>
 using std_string_view = std::experimental::basic_string_view<Char>;
 #else


### PR DESCRIPTION
* Use `unique_lock<mutex>` instead of `unique_ptr<lock_guard<mutex>>`. These behave the same, but the latter causes warnings when used with clang's thread safety analysis.
* Disable `string_view` in fmt