### PR TITLE
Add support for octal and hexadecimal sequences in peg parser

### DIFF
--- a/extension/autocomplete/include/transformer/parse_result.hpp
+++ b/extension/autocomplete/include/transformer/parse_result.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "utf8proc_wrapper.hpp"
 #include "duckdb/common/arena_linked_list.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_ptr.hpp"
@@ -424,6 +425,47 @@ public:
 				if (result[i] == '\\' && i + 1 < result.size()) {
 					i++;
 					switch (result[i]) {
+					case 'b':
+						escaped_result += '\b';
+						break;
+					case 'f':
+						escaped_result += '\f';
+						break;
+					case '0':
+					case '1':
+					case '2':
+					case '3':
+					case '4':
+					case '5':
+					case '6':
+					case '7': {
+						size_t oct_start = i;
+						size_t oct_end = oct_start + 1;
+						while (oct_end < result.size() && oct_end - oct_start < 3 && result[oct_end] >= '0' &&
+						       result[oct_end] <= '7') {
+							oct_end++;
+						}
+						string oct_str = result.substr(oct_start, oct_end - oct_start);
+						escaped_result += static_cast<char>(strtoul(oct_str.c_str(), nullptr, 8));
+						i = oct_end - 1;
+						break;
+					}
+					case 'x': {
+						size_t hex_start = i + 1;
+						size_t hex_end = hex_start;
+						while (hex_end < result.size() && hex_end - hex_start < 2 &&
+						       StringUtil::CharacterIsHex(result[hex_end])) {
+							hex_end++;
+						}
+						if (hex_end > hex_start) {
+							string hex_str = result.substr(hex_start, hex_end - hex_start);
+							escaped_result += static_cast<char>(strtoul(hex_str.c_str(), nullptr, 16));
+							i = hex_end - 1;
+						} else {
+							escaped_result += 'x';
+						}
+						break;
+					}
 					case 'n':
 						escaped_result += '\n';
 						break;
@@ -446,6 +488,14 @@ public:
 				} else {
 					escaped_result += result[i];
 				}
+			}
+			UnicodeInvalidReason reason;
+			size_t pos;
+			auto utf_validity = Utf8Proc::Analyze(escaped_result.c_str(), escaped_result.size(), &reason, &pos);
+			if (utf_validity == UnicodeType::INVALID) {
+				const char *reason_str =
+				    reason == UnicodeInvalidReason::BYTE_MISMATCH ? "byte mismatch" : "invalid unicode codepoint";
+				throw ParserException("Invalid UTF-8 in escape string literal at byte offset %d: %s", pos, reason_str);
 			}
 			return make_uniq<ConstantExpression>(Value(escaped_result));
 		}

--- a/extension/autocomplete/include/transformer/parse_result.hpp
+++ b/extension/autocomplete/include/transformer/parse_result.hpp
@@ -489,6 +489,9 @@ public:
 					escaped_result += result[i];
 				}
 			}
+			if (escaped_result.find('\0') != string::npos) {
+				throw ParserException("Null character not permitted in escape string literal");
+			}
 			UnicodeInvalidReason reason;
 			size_t pos;
 			auto utf_validity = Utf8Proc::Analyze(escaped_result.c_str(), escaped_result.size(), &reason, &pos);

--- a/test/sql/peg_parser/escape_string.test
+++ b/test/sql/peg_parser/escape_string.test
@@ -1,0 +1,58 @@
+# name: test/sql/peg_parser/escape_string.test
+# description: Test escape string capability in PEG parser
+# group: [peg_parser]
+
+require autocomplete
+
+statement ok
+call enable_peg_parser();
+
+query I
+SELECT e'\033' = chr(27);
+----
+true
+
+query I
+SELECT e'\7' = chr(7);
+----
+true
+
+statement error
+SELECT e'\xFF' = chr(255);
+----
+Parser Error: Invalid UTF-8 in escape string literal at byte offset 0: byte mismatch
+
+query I
+SELECT e'\x41' = 'A';
+----
+true
+
+query I
+SELECT e'\101' = 'A';
+----
+true
+
+query I
+SELECT e'\x' = 'x';
+----
+true
+
+query I
+SELECT e'\b' = chr(8);
+----
+true
+
+query I
+SELECT e'\f' = chr(12);
+----
+true
+
+query I
+SELECT e'\n' = chr(10);
+----
+true
+
+query I
+SELECT e'\1012' = 'A2';
+----
+true

--- a/test/sql/peg_parser/escape_string.test
+++ b/test/sql/peg_parser/escape_string.test
@@ -56,3 +56,14 @@ query I
 SELECT e'\1012' = 'A2';
 ----
 true
+
+statement error
+SELECT e'\400';
+----
+Parser Error: Null character not permitted in escape string literal
+
+statement error
+SELECT e'\000';
+----
+Parser Error: Null character not permitted in escape string literal
+


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/22139

We already added support for some of the escape string features in the PEG parser, but did not properly add support for octal or hex escape sequences in `e''` style strings. 
- octal escape handling: 1 to 3 octal digits (`\0` - `\777`)
- Hex escape handling: `\xhh` or `\xh`
- Added missing `\b` and `\f` cases 

I also added a check for the UTF-8 validation check. 

Unicode escape sequences (`\uHHHH`) are not yet supported and will be a follow-up PR. For reference, this is the current (incorrect) behaviour for both parsers: 
```sql
-- PEG Parser
memory D select e'\u011Bno';
u011Bno
-- PostgreSQL parser
memory D select e'\u011Bno';
Parser Error:
unicode_to_utf8 NOT IMPLEMENTED
```

PostgreSQL behaviour for reference: 
```sql
postgres=# select e'\u011Bno';
 ?column? 
----------
 ěno
(1 row)
```