### PR TITLE
Fix window self join optimizer

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -4,139 +4,52 @@
 #include "duckdb/planner/operator/logical_window.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
-#include "duckdb/planner/operator/logical_dummy_scan.hpp"
-#include "duckdb/planner/operator/logical_expression_get.hpp"
-#include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
-#include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/logical_operator_deep_copy.hpp"
 
 namespace duckdb {
 
-class WindowSelfJoinTableRebinder : public LogicalOperatorVisitor {
-public:
-	static bool CanRebind(const LogicalOperator &op) {
-		switch (op.type) {
-		case LogicalOperatorType::LOGICAL_GET:
-		case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
-		case LogicalOperatorType::LOGICAL_PROJECTION:
-		case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
-		case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
-		case LogicalOperatorType::LOGICAL_FILTER:
-			if (!op.children.empty()) {
-				return CanRebind(*op.children[0]);
-			}
-			return true;
-		default:
-			break;
-		}
-		return false;
+static unique_ptr<Expression> TranslateAggregate(const BoundWindowExpression &w_expr) {
+	auto agg_func = *w_expr.aggregate;
+	unique_ptr<FunctionData> bind_info;
+	if (w_expr.bind_info) {
+		bind_info = w_expr.bind_info->Copy();
+	} else {
+		bind_info = nullptr;
 	}
 
-	explicit WindowSelfJoinTableRebinder(Optimizer &optimizer) : optimizer(optimizer) {
+	vector<unique_ptr<Expression>> children;
+	for (auto &child : w_expr.children) {
+		auto child_copy = child->Copy();
+		children.push_back(std::move(child_copy));
 	}
 
-	unordered_map<idx_t, idx_t> table_map;
-	Optimizer &optimizer;
-
-	void VisitOperator(LogicalOperator &op) override {
-		// Rebind definitions
-		if (op.type == LogicalOperatorType::LOGICAL_GET) {
-			auto &get = op.Cast<LogicalGet>();
-			auto new_idx = optimizer.binder.GenerateTableIndex();
-			table_map[get.table_index] = new_idx;
-			get.table_index = new_idx;
-		}
-		if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
-			auto &proj = op.Cast<LogicalProjection>();
-			auto new_idx = optimizer.binder.GenerateTableIndex();
-			table_map[proj.table_index] = new_idx;
-			proj.table_index = new_idx;
-		}
-		if (op.type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-			auto &agg = op.Cast<LogicalAggregate>();
-			auto new_agg_idx = optimizer.binder.GenerateTableIndex();
-			auto new_grp_idx = optimizer.binder.GenerateTableIndex();
-			table_map[agg.aggregate_index] = new_agg_idx;
-			table_map[agg.group_index] = new_grp_idx;
-			agg.aggregate_index = new_agg_idx;
-			agg.group_index = new_grp_idx;
-		}
-		if (op.type == LogicalOperatorType::LOGICAL_EXPRESSION_GET) {
-			auto &get = op.Cast<LogicalExpressionGet>();
-			auto new_idx = optimizer.binder.GenerateTableIndex();
-			table_map[get.table_index] = new_idx;
-			get.table_index = new_idx;
-		}
-		if (op.type == LogicalOperatorType::LOGICAL_DUMMY_SCAN) {
-			auto &dummy = op.Cast<LogicalDummyScan>();
-			auto new_idx = optimizer.binder.GenerateTableIndex();
-			table_map[dummy.table_index] = new_idx;
-			dummy.table_index = new_idx;
-		}
-
-		// TODO: Handle other operators defining tables if needed
-		// But Get/Projection/Aggregate are most common in subplans.
-
-		VisitOperatorChildren(op);
-		VisitOperatorExpressions(op);
+	unique_ptr<Expression> filter;
+	if (w_expr.filter_expr) {
+		filter = w_expr.filter_expr->Copy();
 	}
 
-	void VisitExpression(unique_ptr<Expression> *expression) override {
-		auto &expr = *expression;
-		if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-			auto &bound = expr->Cast<BoundColumnRefExpression>();
-			if (table_map.count(bound.binding.table_index)) {
-				bound.binding.table_index = table_map[bound.binding.table_index];
-			}
+	auto aggr_type = w_expr.distinct ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT;
+
+	auto result = make_uniq<BoundAggregateExpression>(std::move(agg_func), std::move(children), std::move(filter),
+	                                                  std::move(bind_info), aggr_type);
+
+	if (!w_expr.arg_orders.empty()) {
+		result->order_bys = make_uniq<BoundOrderModifier>();
+		auto &orders = result->order_bys->orders;
+		for (auto &order : w_expr.arg_orders) {
+			auto order_copy = order.Copy();
+			orders.emplace_back(std::move(order_copy));
 		}
-		VisitExpressionChildren(**expression);
 	}
 
-	unique_ptr<Expression> TranslateAggregate(const BoundWindowExpression &w_expr) {
-		auto agg_func = *w_expr.aggregate;
-		unique_ptr<FunctionData> bind_info;
-		if (w_expr.bind_info) {
-			bind_info = w_expr.bind_info->Copy();
-		} else {
-			bind_info = nullptr;
-		}
-
-		vector<unique_ptr<Expression>> children;
-		for (auto &child : w_expr.children) {
-			auto child_copy = child->Copy();
-			VisitExpression(&child_copy); // Update bindings
-			children.push_back(std::move(child_copy));
-		}
-
-		unique_ptr<Expression> filter;
-		if (w_expr.filter_expr) {
-			filter = w_expr.filter_expr->Copy();
-			VisitExpression(&filter); // Update bindings
-		}
-
-		auto aggr_type = w_expr.distinct ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT;
-
-		auto result = make_uniq<BoundAggregateExpression>(std::move(agg_func), std::move(children), std::move(filter),
-		                                                  std::move(bind_info), aggr_type);
-
-		if (!w_expr.arg_orders.empty()) {
-			result->order_bys = make_uniq<BoundOrderModifier>();
-			auto &orders = result->order_bys->orders;
-			for (auto &order : w_expr.arg_orders) {
-				auto order_copy = order.Copy();
-				VisitExpression(&order_copy.expression); // Update bindings
-				orders.emplace_back(std::move(order_copy));
-			}
-		}
-
-		return std::move(result);
-	}
-};
+	return std::move(result);
+}
 
 WindowSelfJoinOptimizer::WindowSelfJoinOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
 }
@@ -198,10 +111,6 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		// Check recursively
 		window.children[0] = OptimizeInternal(std::move(window.children[0]), replacer);
 
-		if (!WindowSelfJoinTableRebinder::CanRebind(*window.children[0])) {
-			return op;
-		}
-
 		auto &w_expr0 = window.expressions[0]->Cast<BoundWindowExpression>();
 		for (auto &expr : window.expressions) {
 			auto &w_expr = expr->Cast<BoundWindowExpression>();
@@ -214,17 +123,29 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		// --- Transformation ---
 		// try to copy the LHS
 		unique_ptr<LogicalOperator> copy_child;
+		// Reuse the LogicalOperatorDeepCopy from CTE inlining, as the copying requirements are similar (copying an
+		// operator subtree and replacing table indices)
+		LogicalOperatorDeepCopy deep_copy(optimizer.binder, nullptr);
 		try {
-			copy_child = window.children[0]->Copy(optimizer.context);
-		} catch (...) {
+			copy_child = deep_copy.DeepCopy(window.children[0]);
+		} catch (NotImplementedException &ex) {
 			// failed to copy the LHS - cannot run this optimizer
 			return op;
 		}
-		auto original_child = std::move(window.children[0]);
 
-		// Rebind copy_child to avoid duplicate table indices
-		WindowSelfJoinTableRebinder rebinder(optimizer);
-		rebinder.VisitOperator(*copy_child);
+		// We statically know that the copy child has the same column bindings as the original child,
+		// just with different table indices. So we can prepare a replacer with the correct binding
+		// replacements to avoid having to resolve anything again later on.
+		ColumnBindingReplacer local_replacer;
+		auto old_bindings = window.children[0]->GetColumnBindings();
+		auto new_bindings = copy_child->GetColumnBindings();
+		vector<ReplacementBinding> binding_replacements;
+		for (idx_t i = 0; i < old_bindings.size(); ++i) {
+			binding_replacements.emplace_back(old_bindings[i], new_bindings[i]);
+		}
+		local_replacer.replacement_bindings = std::move(binding_replacements);
+
+		auto original_child = std::move(window.children[0]);
 
 		auto aggregate_index = optimizer.binder.GenerateTableIndex();
 		auto group_index = optimizer.binder.GenerateTableIndex();
@@ -235,13 +156,12 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		// Create Aggregate Operator
 		for (auto &part : partitions) {
 			auto part_copy = part->Copy();
-			rebinder.VisitExpression(&part_copy); // Update bindings
 			groups.push_back(std::move(part_copy));
 		}
 
 		for (auto &expr : window.expressions) {
 			auto &w_expr = expr->Cast<BoundWindowExpression>();
-			aggregates.emplace_back(rebinder.TranslateAggregate(w_expr));
+			aggregates.emplace_back(TranslateAggregate(w_expr));
 		}
 
 		// args: group_index, aggregate_index, ...
@@ -249,6 +169,7 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 
 		agg_op->groups = std::move(groups);
 		agg_op->children.push_back(std::move(copy_child));
+		local_replacer.VisitOperator(*agg_op);
 		agg_op->ResolveOperatorTypes();
 
 		if (agg_op->types.size() <= agg_op->groups.size()) {

--- a/test/sql/optimizer/test_window_self_join.test
+++ b/test/sql/optimizer/test_window_self_join.test
@@ -173,3 +173,37 @@ ORDER BY grp, seq;
 physical_plan	<REGEX>:.*Join Type: INNER.*
 
 endloop
+
+statement ok
+CREATE
+OR REPLACE TABLE foo (
+  emp_name VARCHAR,
+  dept_name VARCHAR,
+  base_salary FLOAT
+);
+
+statement ok
+INSERT INTO
+  foo
+VALUES
+  ('a', 'x', 1.0),
+  ('b', 'x', 2.0),
+  ('c', 'x', 3.0),
+  ('d', 'y', 4.0),
+  ('e', 'y', 5.0),
+  ('f', 'y', 6.0);
+
+query I
+select
+  avg(avg(base_salary)) over (
+    partition by
+      dept_name
+  )
+from
+  foo
+group by
+  dept_name
+order by all;
+----
+2.0
+5.0

--- a/test/sql/optimizer/test_window_self_join.test
+++ b/test/sql/optimizer/test_window_self_join.test
@@ -207,3 +207,18 @@ order by all;
 ----
 2.0
 5.0
+
+query II
+explain
+select
+  avg(avg(base_salary)) over (
+    partition by
+      dept_name
+  )
+from
+  foo
+group by
+  dept_name
+order by all;
+----
+physical_plan	<REGEX>:.*Join Type: INNER.*


### PR DESCRIPTION
The`WindowSelfJoinOptimizer` used a home grown re-implementation of a `LogicalOperator` copy + table index remapping. However, we already have that functionality as `LogicalOperatorDeepCopy` for CTE inlining. This PR therefore removes all the duplication and changes the optimizer to use the existing DeepCopy framework instead. This fixes a bug where a table index could still be duplicated, but more importantly, significantly simplifies the code.

fix: https://github.com/duckdb/duckdb/issues/22133