### PR TITLE
Unify in filter with expression filter

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -791,15 +791,6 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 	case TableFilterType::IS_NOT_NULL: {
 		return !constant.IsNull();
 	}
-	case TableFilterType::IN_FILTER: {
-		auto &in_filter = filter.Cast<InFilter>();
-		for (auto &val : in_filter.values) {
-			if (!constant.IsNull() && val == constant) {
-				return true;
-			}
-		}
-		return false;
-	}
 	case TableFilterType::CONJUNCTION_OR: {
 		auto &or_filter = filter.Cast<ConjunctionOrFilter>();
 		for (auto &it : or_filter.child_filters) {
@@ -1140,20 +1131,6 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 	case TableFilterType::IS_NOT_NULL:
 		// these filters can just be copied as they don't depend on type
 		return global_filter.Copy();
-	case TableFilterType::IN_FILTER: {
-		auto &in_filter = global_filter.Cast<InFilter>();
-		auto in_list = in_filter.values;
-		if (!in_list.empty() && !StatisticsPropagator::CanPropagateCast(in_list[0].type(), target_type)) {
-			// type cannot be converted - abort
-			return nullptr;
-		}
-		for (auto &val : in_list) {
-			if (!val.DefaultTryCastAs(target_type)) {
-				return nullptr;
-			}
-		}
-		return make_uniq<InFilter>(std::move(in_list));
-	}
 	default:
 		throw NotImplementedException("Can't convert TableFilterType (%s) from global to local indexes",
 		                              EnumUtil::ToString(type));

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -25,9 +25,9 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/perfect_hash_join_filter.hpp"
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
@@ -894,6 +894,15 @@ bool JoinFilterPushdownInfo::CanUseInFilter(const ClientContext &context, option
 	return ht && ht->Count() > 1 && ht->Count() <= dynamic_or_filter_threshold && cmp == ExpressionType::COMPARE_EQUAL;
 }
 
+static unique_ptr<Expression> CreateInExpression(const LogicalType &type, vector<Value> values) {
+	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN, LogicalType::BOOLEAN);
+	result->children.push_back(make_uniq<BoundReferenceExpression>(type, idx_t(0)));
+	for (auto &value : values) {
+		result->children.push_back(make_uniq<BoundConstantExpression>(std::move(value)));
+	}
+	return result;
+}
+
 void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, JoinHashTable &ht,
                                           const PhysicalOperator &op, idx_t filter_idx,
                                           ProjectionIndex filter_col_idx) const {
@@ -927,12 +936,10 @@ void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 		return;
 	}
 
-	// generate the OR filter
-	auto in_filter = make_uniq<InFilter>(std::move(in_list));
-
 	// we push the OR filter as an OptionalFilter so that we can use it for zonemap pruning only
 	// the IN-list is expensive to execute otherwise
-	auto filter = make_uniq<OptionalFilter>(std::move(in_filter));
+	auto in_expr = CreateInExpression(info.columns[filter_idx].storage_type, std::move(in_list));
+	auto filter = make_uniq<OptionalFilter>(make_uniq<ExpressionFilter>(std::move(in_expr)));
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -25,7 +25,6 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
@@ -894,15 +893,6 @@ bool JoinFilterPushdownInfo::CanUseInFilter(const ClientContext &context, option
 	return ht && ht->Count() > 1 && ht->Count() <= dynamic_or_filter_threshold && cmp == ExpressionType::COMPARE_EQUAL;
 }
 
-static unique_ptr<Expression> CreateInExpression(const LogicalType &type, vector<Value> values) {
-	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN, LogicalType::BOOLEAN);
-	result->children.push_back(make_uniq<BoundReferenceExpression>(type, idx_t(0)));
-	for (auto &value : values) {
-		result->children.push_back(make_uniq<BoundConstantExpression>(std::move(value)));
-	}
-	return result;
-}
-
 void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, JoinHashTable &ht,
                                           const PhysicalOperator &op, idx_t filter_idx,
                                           ProjectionIndex filter_col_idx) const {
@@ -938,7 +928,8 @@ void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 
 	// we push the OR filter as an OptionalFilter so that we can use it for zonemap pruning only
 	// the IN-list is expensive to execute otherwise
-	auto in_expr = CreateInExpression(info.columns[filter_idx].storage_type, std::move(in_list));
+	auto in_expr = ExpressionFilter::CreateInExpression(
+	    make_uniq<BoundReferenceExpression>(info.columns[filter_idx].storage_type, idx_t(0)), std::move(in_list));
 	auto filter = make_uniq<OptionalFilter>(make_uniq<ExpressionFilter>(std::move(in_expr)));
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 }

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -27,7 +27,6 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
@@ -567,15 +566,6 @@ static bool CollectValuesAndComparisonsFromTableFilter(const TableFilter &filter
 			return true; // No child filters, always OK
 		}
 		return CollectValuesAndComparisonsFromTableFilter(*optional_filter.child_filter, in_values, comparisons);
-	}
-	case TableFilterType::IN_FILTER: {
-		auto &in_filter = filter.Cast<InFilter>();
-		for (auto &value : in_filter.values) {
-			if (!value.IsNull()) {
-				in_values.insert(value);
-			}
-		}
-		return true;
 	}
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &conjunction_and = filter.Cast<ConjunctionAndFilter>();

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -623,8 +623,9 @@ vector<unique_ptr<Expression>> ExtractFilterExpressions(const ColumnDefinition &
 
 	// Attempt matching the top-level filter to the index expression.
 	if (expressions.empty()) {
-		auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ExtractFilterExpressions");
-		auto filter_expr = expr_filter.ToExpression(*bound_ref);
+		auto filter_expr = filter.filter_type == TableFilterType::EXPRESSION_FILTER
+		                       ? filter.Cast<ExpressionFilter>().ToExpression(*bound_ref)
+		                       : filter.ToExpression(*bound_ref);
 		expressions.push_back(std::move(filter_expr));
 	}
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -633,9 +633,8 @@ vector<unique_ptr<Expression>> ExtractFilterExpressions(const ColumnDefinition &
 
 	// Attempt matching the top-level filter to the index expression.
 	if (expressions.empty()) {
-		auto filter_expr = filter.filter_type == TableFilterType::EXPRESSION_FILTER
-		                       ? filter.Cast<ExpressionFilter>().ToExpression(*bound_ref)
-		                       : filter.ToExpression(*bound_ref);
+		auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ExtractFilterExpressions");
+		auto filter_expr = expr_filter.ToExpression(*bound_ref);
 		expressions.push_back(std::move(filter_expr));
 	}
 

--- a/src/include/duckdb/planner/filter/expression_filter.hpp
+++ b/src/include/duckdb/planner/filter/expression_filter.hpp
@@ -39,6 +39,8 @@ public:
 	//! Access a runtime ExpressionFilter, failing fast if a legacy filter somehow reached an active code path.
 	static const ExpressionFilter &GetExpressionFilter(const TableFilter &filter, const char *context);
 	static ExpressionFilter &GetExpressionFilter(TableFilter &filter, const char *context);
+	//! Build a COMPARE_IN expression over a single-column filter subject.
+	static unique_ptr<Expression> CreateInExpression(unique_ptr<Expression> column, vector<Value> values);
 
 	//! Enhanced CheckStatistics that recognizes standard expression patterns
 	static FilterPropagateResult CheckExpressionStatistics(const Expression &expr, BaseStatistics &stats);

--- a/src/include/duckdb/planner/filter/in_filter.hpp
+++ b/src/include/duckdb/planner/filter/in_filter.hpp
@@ -13,6 +13,7 @@
 
 namespace duckdb {
 
+//! DEPRECATED - only preserved for backwards-compatible deserialization and expression conversion
 class InFilter : public TableFilter {
 public:
 	static constexpr const TableFilterType TYPE = TableFilterType::IN_FILTER;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -15,7 +15,6 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
@@ -557,9 +556,9 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	// if this is not a dense range we can push an optional filter for zone-map pruning
-	auto optional_filter = make_uniq<OptionalFilter>();
-	auto in_filter = make_uniq<InFilter>(std::move(in_list));
-	optional_filter->child_filter = std::move(in_filter);
+	auto in_expr = ExpressionFilter::CreateInExpression(CreateFilterTargetExpression(*func.children[0]),
+	                                                   std::move(in_list));
+	auto optional_filter = make_uniq<OptionalFilter>(make_uniq<ExpressionFilter>(std::move(in_expr)));
 	table_filters.PushFilter(proj_index, std::move(optional_filter));
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -556,8 +556,8 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	// if this is not a dense range we can push an optional filter for zone-map pruning
-	auto in_expr = ExpressionFilter::CreateInExpression(CreateFilterTargetExpression(*func.children[0]),
-	                                                   std::move(in_list));
+	auto in_expr =
+	    ExpressionFilter::CreateInExpression(CreateFilterTargetExpression(*func.children[0]), std::move(in_list));
 	auto optional_filter = make_uniq<OptionalFilter>(make_uniq<ExpressionFilter>(std::move(in_expr)));
 	table_filters.PushFilter(proj_index, std::move(optional_filter));
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -34,6 +34,15 @@ ExpressionFilter &ExpressionFilter::GetExpressionFilter(TableFilter &filter, con
 	return filter.Cast<ExpressionFilter>();
 }
 
+unique_ptr<Expression> ExpressionFilter::CreateInExpression(unique_ptr<Expression> column, vector<Value> values) {
+	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN, LogicalType::BOOLEAN);
+	result->children.push_back(std::move(column));
+	for (auto &value : values) {
+		result->children.push_back(make_uniq<BoundConstantExpression>(std::move(value)));
+	}
+	return result;
+}
+
 bool ExpressionFilter::EvaluateWithConstant(ClientContext &context, const Value &val) const {
 	ExpressionExecutor executor(context, *expr);
 	return EvaluateWithConstant(executor, val);

--- a/src/planner/filter/in_filter.cpp
+++ b/src/planner/filter/in_filter.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/planner/filter/in_filter.hpp"
 
-#include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 
@@ -23,42 +22,13 @@ InFilter::InFilter(vector<Value> values_p) : TableFilter(TableFilterType::IN_FIL
 }
 
 FilterPropagateResult InFilter::CheckStatistics(BaseStatistics &stats) const {
-	if (!stats.CanHaveNoNull()) {
-		// no non-null values are possible: always false
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	switch (values[0].type().InternalType()) {
-	case PhysicalType::UINT8:
-	case PhysicalType::UINT16:
-	case PhysicalType::UINT32:
-	case PhysicalType::UINT64:
-	case PhysicalType::UINT128:
-	case PhysicalType::INT8:
-	case PhysicalType::INT16:
-	case PhysicalType::INT32:
-	case PhysicalType::INT64:
-	case PhysicalType::INT128:
-	case PhysicalType::FLOAT:
-	case PhysicalType::DOUBLE:
-		return NumericStats::CheckZonemap(stats, ExpressionType::COMPARE_EQUAL,
-		                                  array_ptr<const Value>(values.data(), values.size()));
-	case PhysicalType::VARCHAR:
-		return StringStats::CheckZonemap(stats, ExpressionType::COMPARE_EQUAL,
-		                                 array_ptr<const Value>(values.data(), values.size()));
-	default:
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
+	throw InternalException("InFilter::CheckStatistics should not be called: InFilters should be converted to "
+	                        "ExpressionFilters before statistics checking");
 }
 
 string InFilter::ToString(const string &column_name) const {
-	string in_list;
-	for (auto &val : values) {
-		if (!in_list.empty()) {
-			in_list += ", ";
-		}
-		in_list += val.ToSQLString();
-	}
-	return column_name + " IN (" + in_list + ")";
+	throw InternalException("InFilter::ToString should not be called: InFilters should be converted to "
+	                        "ExpressionFilters before rendering");
 }
 
 unique_ptr<Expression> InFilter::ToExpression(const Expression &column) const {
@@ -71,15 +41,13 @@ unique_ptr<Expression> InFilter::ToExpression(const Expression &column) const {
 }
 
 bool InFilter::Equals(const TableFilter &other_p) const {
-	if (!TableFilter::Equals(other_p)) {
-		return false;
-	}
-	auto &other = other_p.Cast<InFilter>();
-	return other.values == values;
+	throw InternalException("InFilter::Equals should not be called: InFilters should be converted to "
+	                        "ExpressionFilters before equality checking");
 }
 
 unique_ptr<TableFilter> InFilter::Copy() const {
-	return make_uniq<InFilter>(values);
+	throw InternalException("InFilter::Copy should not be called: InFilters should be converted to "
+	                        "ExpressionFilters before copying");
 }
 
 } // namespace duckdb

--- a/src/planner/filter/in_filter.cpp
+++ b/src/planner/filter/in_filter.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 
 namespace duckdb {
 

--- a/src/planner/filter/in_filter.cpp
+++ b/src/planner/filter/in_filter.cpp
@@ -32,12 +32,7 @@ string InFilter::ToString(const string &column_name) const {
 }
 
 unique_ptr<Expression> InFilter::ToExpression(const Expression &column) const {
-	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN, LogicalType::BOOLEAN);
-	result->children.push_back(column.Copy());
-	for (auto &val : values) {
-		result->children.push_back(make_uniq<BoundConstantExpression>(val));
-	}
-	return std::move(result);
+	return ExpressionFilter::CreateInExpression(column.Copy(), values);
 }
 
 bool InFilter::Equals(const TableFilter &other_p) const {


### PR DESCRIPTION
This PR extracts the `ExpressionFilter` unification from https://github.com/duckdb/duckdb/pull/21762. Instead of doing everything at once, this PR only sets up some common infrastructure required for all TableFilter refactoring (eliminations), and removes `InFilter` from all code paths except for legacy de/serialization.

There will be a few follow-up PRs regarding:
- [x] `ConstantFilter`
- [ ] `ConjunctionFilter`
- [ ] `DynamicFilter`
- [x] `InFilter`
- [ ] `Is[Not]NullFilter`
- [ ] `OptionalFilter`
- [ ] `BloomFilter`
- [ ] `PerfectHashJoinFilter`
- [ ] `PrefixRangeFilter`
- [ ] `SelectivityOptionalFilter`
- [ ] `StructFilter`