### PR TITLE
Fix VARIANT + ART-index pushdown-extract: uninitialized memory read in FetchRow

### DIFF
--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -472,7 +472,11 @@ void VariantColumnData::FetchRow(TransactionData transaction, ColumnFetchState &
 		VariantUtils::UnshredVariantData(intermediate, unshredded, 1);
 		variant_vec.SetValue(0, unshredded.GetValue(0));
 	} else {
-		sub_columns[0]->FetchRow(transaction, state, storage_index, row_id, variant_vec, result_idx);
+		//! The storage_index may be a VARIANT-extract (pushdown) with field-name children that don't
+		//! match the underlying unshredded struct's field layout. We still need the full VARIANT
+		//! to run VariantExtract below, so fetch with a fresh StorageIndex.
+		StorageIndex full_fetch(0);
+		sub_columns[0]->FetchRow(transaction, state, full_fetch, row_id, variant_vec, result_idx);
 		if (result_idx) {
 			variant_vec.SetValue(0, variant_vec.GetValue(result_idx));
 		}

--- a/test/sql/storage/types/variant/variant_index_bracket_extract.test
+++ b/test/sql/storage/types/variant/variant_index_bracket_extract.test
@@ -1,0 +1,43 @@
+# name: test/sql/storage/types/variant/variant_index_bracket_extract.test
+# group: [variant]
+
+# Regression test: VARIANT + ART index + pushdown bracket-extract.
+#
+# The unshredded VariantColumnData::FetchRow used to forward the caller's
+# pushdown-extract StorageIndex (whose child is field-based, e.g.
+# "duration_ms") directly to the inner unshredded struct's
+# StructColumnData::FetchRow. The latter treated the child as a numeric
+# index and read past sub_columns, dereferencing uninitialized memory.
+# The failure mode was an INTERNAL Error reporting an out-of-bounds index
+# with a pointer-sized value against a vector of size 4 (the 4 sub-columns
+# of the unshredded struct: keys/children/values/data).
+
+statement ok
+CREATE TABLE events(ts TIMESTAMP, name VARCHAR, attrs VARIANT);
+
+statement ok
+CREATE INDEX idx_events_name ON events(name);
+
+statement ok
+INSERT INTO events VALUES
+  (TIMESTAMP '2024-01-01 00:00:00', 'http.request', CAST({'duration_ms': 100} AS VARIANT)),
+  (TIMESTAMP '2024-01-01 00:00:01', 'http.request', CAST({'duration_ms': 200} AS VARIANT));
+
+# bracket access + equality on indexed column (used to crash)
+query I
+SELECT attrs['duration_ms']::DOUBLE FROM events WHERE name = 'http.request' ORDER BY 1;
+----
+100.0
+200.0
+
+# negative match (used to work, sanity check)
+query I
+SELECT attrs['duration_ms']::DOUBLE FROM events WHERE name = 'no-such-value';
+----
+
+# full VARIANT projection with same filter (sanity check)
+query I
+SELECT attrs FROM events WHERE name = 'http.request' ORDER BY 1;
+----
+{'duration_ms': 100}
+{'duration_ms': 200}


### PR DESCRIPTION
## Summary

`VariantColumnData::FetchRow` (unshredded branch) forwarded the caller's pushdown-extract `StorageIndex` straight to the inner `StructColumnData::FetchRow`. That `StorageIndex`'s child is a VARIANT-extract path (e.g. field-based, `field=\"duration_ms\"`, `has_index=false`, `index` uninitialized). `StructColumnData::FetchRow`'s pushdown branch then called `GetPrimaryIndex()` on that child — which only has `D_ASSERT(has_index)` and returns the uninitialized `index` in release builds — and indexed into its `sub_columns` vector. Since the unshredded struct has 4 sub-columns (keys / children / values / data), the resulting out-of-bounds dereference surfaces as:

```
INTERNAL Error: Attempted to access index <raw-pointer-address> within vector of size 4
```

## Reproduction

```sql
CREATE TABLE events(ts TIMESTAMP, name VARCHAR, attrs VARIANT);
CREATE INDEX idx_events_name ON events(name);
INSERT INTO events VALUES
  (now()::TIMESTAMP, 'http.request', CAST({'duration_ms': 100} AS VARIANT)),
  (now()::TIMESTAMP, 'http.request', CAST({'duration_ms': 200} AS VARIANT));
SELECT attrs['duration_ms']::DOUBLE FROM events WHERE name = 'http.request';
```

Triggered only when the unshredded branch is hit (freshly-inserted rows, no `CHECKPOINT`) and the scan reaches `FetchRow` via the ART-index pushdown path. Existing VARIANT tests checkpoint (triggering shredding), so they miss this path.

## Fix

Pass a fresh full-read `StorageIndex(0)` to the inner `FetchRow`. The outer code already runs `VariantUtils::VariantExtract` against the fully-materialized VARIANT afterward, which is the correct path for the unshredded representation. One-line semantic change.

## Related hardening (not in this PR)

The bug could also be addressed upstream by hardening `StorageIndex::GetPrimaryIndex()` to throw instead of `D_ASSERT`ing when `has_index` is false (matching the behavior of `ColumnIndex::GetPrimaryIndex()` in `common/column_index.hpp`), and/or by initializing `StorageIndex::index = DConstants::INVALID_INDEX` in the field-based constructors. Those hardenings would surface the same class of bug earlier in other pushdown paths that haven't been audited, so the minimal caller-side fix here is what this PR proposes — happy to follow up with a separate PR for the defensive changes if you'd like.

## Test plan

- [x] Added regression test: `test/sql/storage/types/variant/variant_index_bracket_extract.test` covering the failing pattern, a zero-match sanity case, and a full-VARIANT projection
- [x] Existing VARIANT test suites all pass: `test/sql/storage/types/variant/*` (1220 assertions), `test/sql/function/variant/*` (70), `test/sql/types/variant/*` (516)
- [x] Repro verified on release + relassert builds