### PR TITLE
Use the latest storage version for temp storage

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -101,6 +101,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 	if (type == AttachedDatabaseType::TEMP_DATABASE) {
 		unordered_map<string, Value> options;
 		AttachOptions attach_options(options, AccessMode::READ_WRITE);
+		options["storage_version"] = "latest";
 		storage = make_uniq<SingleFileStorageManager>(*this, string(IN_MEMORY_PATH), attach_options);
 	}
 


### PR DESCRIPTION
The latest storage version is generally more efficient and we're already using it for in-memory databases. We should also use it for temporary storage.