### PR TITLE
Fix typos in source comments (sucessful, occurence)

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -63,7 +63,7 @@ public:
 	ErrorData WriteToWAL(ClientContext &context, AttachedDatabase &db,
 	                     unique_ptr<StorageCommitState> &commit_state) noexcept;
 	//! Commit the current transaction with the given commit identifier. Returns an error message if the transaction
-	//! commit failed, or an empty string if the commit was sucessful
+	//! commit failed, or an empty string if the commit was successful
 	ErrorData Commit(AttachedDatabase &db, CommitInfo &commit_info,
 	                 unique_ptr<StorageCommitState> commit_state) noexcept;
 	//! Returns whether or not a commit of this transaction should trigger an automatic checkpoint

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	auto extension = ExtensionHelper::ExtractExtensionPrefixFromPath(path);
 	if (!extension.empty()) {
-		// path is prefixed with an extension - remove the first occurence of it
+		// path is prefixed with an extension - remove the first occurrence of it
 		path = path.substr(extension.length() + 1);
 		db_type = ExtensionHelper::ApplyExtensionAlias(extension);
 	}


### PR DESCRIPTION

**Repo:** duckdb/duckdb (⭐ 22000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two spelling typos in comments inside core source files:
- `sucessful` → `successful` in `src/include/duckdb/transaction/duck_transaction.hpp`
- `occurence` → `occurrence` in `src/main/database_path_and_type.cpp`

## Why
Comment-only correctness/readability fix. The misspellings are visible in a
public header (`duck_transaction.hpp`) that downstream consumers may read while
integrating with DuckDB's transaction APIs, so the polish has minor outward
value beyond hygiene.

## Testing
Comment-only changes — no behavior change. No build or tests required to
validate; a recompile would yield byte-identical object code aside from the
embedded comment text (and comments are stripped). Verified by inspection that
no identifiers were altered.

## Risk
Low — comment-only edits in two files, no API or behavior impact.
