### PR TITLE
Fix CSV escape

### DIFF
--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine_options.hpp
@@ -25,7 +25,7 @@ struct CSVStateMachineOptions {
 	//! Quote used for columns that contain reserved characters, e.g '
 	CSVOption<char> quote = '\"';
 	//! Escape character to escape quote character
-	CSVOption<char> escape = '\0';
+	CSVOption<char> escape = '\"';
 	//! Comment character to skip a line
 	CSVOption<char> comment = '\0';
 	//! New Line separator

--- a/test/sql/copy/csv/issue_22153.test
+++ b/test/sql/copy/csv/issue_22153.test
@@ -1,0 +1,14 @@
+# name: test/sql/copy/csv/issue_22153.test
+# description: Test that escape defaults to quote when auto_detect=false (issue #22153)
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+COPY (SELECT 'hello "world"' AS a, 42 AS b) TO '__TEST_DIR__/test_escape_default.csv' (HEADER false);
+
+query IT
+SELECT * FROM read_csv('__TEST_DIR__/test_escape_default.csv', auto_detect=false, columns={'a':'VARCHAR','b':'INTEGER'})
+----
+hello "world"	42


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22153

According to [doc](https://duckdb.org/docs/current/data/csv/overview#parameters), the default escape should be `"` instead of `\0`.