### PR TITLE
Fix union_by_name remap for non-nested parquet columns

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -580,13 +580,13 @@ unique_ptr<Expression> ConstructMapExpression(ClientContext &context, idx_t loca
                                               const MultiFileColumnDefinition &global_column,
                                               bool is_trivially_mappable) {
 	auto &local_column = *mapping.local_column;
-	unique_ptr<Expression> expr;
-	expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx);
-	if (!global_column.type.IsNested() ||
-	    (!mapping.column_map.IsNull() && mapping.column_map.type().id() != LogicalTypeId::STRUCT) ||
-	    is_trivially_mappable || !local_column.type.IsNested()) {
-		// non-nested global type, or non-nested local type (remap_struct requires a nested source - see #22147)
-		// potentially add a cast
+	unique_ptr<Expression> expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx);
+	bool can_use_remap_struct =
+	    global_column.type.IsNested() &&
+	    (mapping.column_map.IsNull() || mapping.column_map.type().id() == LogicalTypeId::STRUCT) &&
+	    !is_trivially_mappable && local_column.type.IsNested();
+	if (!can_use_remap_struct) {
+		// use the cast path unless we actually need struct remapping and both source/target sides are nested
 		if (local_column.type != global_column.type) {
 			expr = BoundCastExpression::AddCastToType(context, std::move(expr), global_column.type);
 		}

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -584,8 +584,9 @@ unique_ptr<Expression> ConstructMapExpression(ClientContext &context, idx_t loca
 	expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx);
 	if (!global_column.type.IsNested() ||
 	    (!mapping.column_map.IsNull() && mapping.column_map.type().id() != LogicalTypeId::STRUCT) ||
-	    is_trivially_mappable) {
-		// not a struct - potentially add a cast
+	    is_trivially_mappable || !local_column.type.IsNested()) {
+		// non-nested global type, or non-nested local type (remap_struct requires a nested source - see #22147)
+		// potentially add a cast
 		if (local_column.type != global_column.type) {
 			expr = BoundCastExpression::AddCastToType(context, std::move(expr), global_column.type);
 		}

--- a/test/sql/copy/parquet/parquet_22147_union_by_name_nonnested.test
+++ b/test/sql/copy/parquet/parquet_22147_union_by_name_nonnested.test
@@ -1,0 +1,53 @@
+# name: test/sql/copy/parquet/parquet_22147_union_by_name_nonnested.test
+# description: Issue #22147: read_parquet(union_by_name=true) should not fail when one file has a STRUCT column and another file has a non-nested column with the same name
+# group: [parquet]
+
+require parquet
+
+# file 1: 'x' is a STRUCT
+statement ok
+COPY (SELECT {'a': 1::INTEGER} AS x) TO '{TEST_DIR}/ubn22147_struct.parquet' (FORMAT PARQUET);
+
+# file 2: 'x' is a non-nested column (all-null INTEGER) - mimics what polars writes for a None-valued column
+statement ok
+COPY (SELECT NULL::INTEGER AS x) TO '{TEST_DIR}/ubn22147_int.parquet' (FORMAT PARQUET);
+
+# file 3: 'x' is a SQLNULL column
+statement ok
+COPY (SELECT NULL AS x) TO '{TEST_DIR}/ubn22147_null.parquet' (FORMAT PARQUET);
+
+# union_by_name should succeed: non-nested local columns are treated as NULL of the global STRUCT type
+query I rowsort
+SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_int.parquet'], union_by_name=true);
+----
+NULL
+{'a': 1}
+
+query I rowsort
+SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_null.parquet'], union_by_name=true);
+----
+NULL
+{'a': 1}
+
+# all three together
+query I rowsort
+SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_int.parquet', '{TEST_DIR}/ubn22147_null.parquet'], union_by_name=true);
+----
+NULL
+NULL
+{'a': 1}
+
+# struct child filter should also work when one file contributes a non-nested NULL-like column
+query I
+SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_int.parquet'], union_by_name=true) WHERE x.a = 1;
+----
+{'a': 1}
+
+# real type conflict (non-null INTEGER vs STRUCT) should still raise a clear conversion error
+statement ok
+COPY (SELECT 42::INTEGER AS x) TO '{TEST_DIR}/ubn22147_int_val.parquet' (FORMAT PARQUET);
+
+statement error
+SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_int_val.parquet'], union_by_name=true);
+----
+Unimplemented type for cast

--- a/test/sql/copy/parquet/parquet_22147_union_by_name_nonnested.test
+++ b/test/sql/copy/parquet/parquet_22147_union_by_name_nonnested.test
@@ -50,4 +50,4 @@ COPY (SELECT 42::INTEGER AS x) TO '{TEST_DIR}/ubn22147_int_val.parquet' (FORMAT 
 statement error
 SELECT x FROM read_parquet(['{TEST_DIR}/ubn22147_struct.parquet', '{TEST_DIR}/ubn22147_int_val.parquet'], union_by_name=true);
 ----
-Unimplemented type for cast
+INTEGER -> STRUCT(a INTEGER)


### PR DESCRIPTION
Fixes #22147.

When `union_by_name=true` resolves a global nested type against a local non-nested column, `ConstructMapExpression` could still route the expression through `remap_struct`. That binder only accepts nested sources, which turns NULL-like parquet columns written as scalar types into an unnecessary failure.

This change treats non-nested local columns like the existing cast path instead of trying to remap them as structs. That keeps NULL-like columns readable while preserving a clear cast error for real scalar-vs-struct conflicts.
