### PR TITLE
Unify null filter with expression filter

### DIFF
--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -179,16 +179,14 @@ bool DictionaryDecoder::DictionarySupportsFilter(const TableFilter &filter, Tabl
 		}
 		return true;
 	}
-	case TableFilterType::IS_NOT_NULL:
-		return true;
 	case TableFilterType::EXPRESSION_FILTER: {
 		// expression filters can only be pushed into the dictionary if they filter out NULL values
-		auto &expr_filter = filter.Cast<ExpressionFilter>();
+		auto &expr_filter =
+		    ExpressionFilter::GetExpressionFilter(filter, "DictionaryDecoder::DictionarySupportsFilter");
 		auto &state = filter_state.Cast<ExpressionFilterState>();
 		auto emits_nulls = expr_filter.EvaluateWithConstant(*state.executor, Value(reader.Type()));
 		return !emits_nulls;
 	}
-	case TableFilterType::IS_NULL:
 	case TableFilterType::DYNAMIC_FILTER:
 	case TableFilterType::OPTIONAL_FILTER:
 	case TableFilterType::STRUCT_EXTRACT:

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -785,12 +785,6 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 	const auto type = filter.filter_type;
 
 	switch (type) {
-	case TableFilterType::IS_NULL: {
-		return constant.IsNull();
-	}
-	case TableFilterType::IS_NOT_NULL: {
-		return !constant.IsNull();
-	}
 	case TableFilterType::CONJUNCTION_OR: {
 		auto &or_filter = filter.Cast<ConjunctionOrFilter>();
 		for (auto &it : or_filter.child_filters) {
@@ -1127,10 +1121,6 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 		return make_uniq<ExpressionFilter>(make_uniq<BoundComparisonExpression>(
 		    dynamic_filter.filter_data->comparison_type, std::move(lhs), std::move(rhs)));
 	}
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-		// these filters can just be copied as they don't depend on type
-		return global_filter.Copy();
 	default:
 		throw NotImplementedException("Can't convert TableFilterType (%s) from global to local indexes",
 		                              EnumUtil::ToString(type));

--- a/src/include/duckdb/planner/filter/expression_filter.hpp
+++ b/src/include/duckdb/planner/filter/expression_filter.hpp
@@ -41,6 +41,9 @@ public:
 	static ExpressionFilter &GetExpressionFilter(TableFilter &filter, const char *context);
 	//! Build a COMPARE_IN expression over a single-column filter subject.
 	static unique_ptr<Expression> CreateInExpression(unique_ptr<Expression> column, vector<Value> values);
+	//! Build an IS NULL/IS NOT NULL expression over a single-column filter subject.
+	static unique_ptr<Expression> CreateNullCheckExpression(unique_ptr<Expression> column,
+	                                                        ExpressionType expression_type);
 
 	//! Enhanced CheckStatistics that recognizes standard expression patterns
 	static FilterPropagateResult CheckExpressionStatistics(const Expression &expr, BaseStatistics &stats);

--- a/src/include/duckdb/planner/filter/null_filter.hpp
+++ b/src/include/duckdb/planner/filter/null_filter.hpp
@@ -12,6 +12,7 @@
 
 namespace duckdb {
 
+//! DEPRECATED - only preserved for backwards-compatible deserialization and expression conversion
 class IsNullFilter : public TableFilter {
 public:
 	static constexpr const TableFilterType TYPE = TableFilterType::IS_NULL;
@@ -22,12 +23,14 @@ public:
 public:
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
 	string ToString(const string &column_name) const override;
+	bool Equals(const TableFilter &other) const override;
 	unique_ptr<TableFilter> Copy() const override;
 	unique_ptr<Expression> ToExpression(const Expression &column) const override;
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<TableFilter> Deserialize(Deserializer &deserializer);
 };
 
+//! DEPRECATED - only preserved for backwards-compatible deserialization and expression conversion
 class IsNotNullFilter : public TableFilter {
 public:
 	static constexpr const TableFilterType TYPE = TableFilterType::IS_NOT_NULL;
@@ -38,6 +41,7 @@ public:
 public:
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
 	string ToString(const string &column_name) const override;
+	bool Equals(const TableFilter &other) const override;
 	unique_ptr<TableFilter> Copy() const override;
 	unique_ptr<Expression> ToExpression(const Expression &column) const override;
 	void Serialize(Serializer &serializer) const override;

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_delim_get.hpp"
@@ -118,7 +119,14 @@ bool Deliminator::HasSelection(const LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_GET: {
 		auto &get = op.Cast<LogicalGet>();
 		for (const auto &entry : get.table_filters) {
-			if (entry.Filter().filter_type != TableFilterType::IS_NOT_NULL) {
+			auto &filter = entry.Filter();
+			if (filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
+				return true;
+			}
+			auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "Deliminator::HasSelection");
+			auto &expr = *expr_filter.expr;
+			if (expr.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR ||
+			    expr.type != ExpressionType::OPERATOR_IS_NOT_NULL) {
 				return true;
 			}
 		}

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -248,9 +248,6 @@ idx_t ExpressionHeuristics::Cost(const TableFilter &filter) {
 		}
 		return cost;
 	}
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-		return 5;
 	case TableFilterType::STRUCT_EXTRACT: {
 		auto &struct_filter = filter.Cast<StructFilter>();
 		return Cost(*struct_filter.child_filter);

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -15,7 +15,6 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -457,8 +456,9 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	// constant value expr can sometimes be null. if so, push is not null filter, which will
 	// make the filter unsatisfiable and return no results.
 	if (constant_value_expr.value.IsNull()) {
-		auto is_not_null = make_uniq<IsNotNullFilter>();
-		table_filters.PushFilter(proj_index, std::move(is_not_null));
+		auto is_not_null = ExpressionFilter::CreateNullCheckExpression(CreateFilterTargetExpression(*func.children[0]),
+		                                                               ExpressionType::OPERATOR_IS_NOT_NULL);
+		table_filters.PushFilter(proj_index, make_uniq<ExpressionFilter>(std::move(is_not_null)));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	auto &like_string = StringValue::Get(constant_value_expr.value);
@@ -609,13 +609,15 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		if (const_val->value.IsNull()) {
 			switch (comparison_type) {
 			case ExpressionType::COMPARE_DISTINCT_FROM: {
-				auto null_filter = make_uniq<IsNotNullFilter>();
-				conj_filter->child_filters.push_back(std::move(null_filter));
+				auto null_expr = ExpressionFilter::CreateNullCheckExpression(CreateFilterTargetExpression(*column_ref),
+				                                                             ExpressionType::OPERATOR_IS_NOT_NULL);
+				conj_filter->child_filters.push_back(make_uniq<ExpressionFilter>(std::move(null_expr)));
 				break;
 			}
 			case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
-				auto null_filter = make_uniq<IsNullFilter>();
-				conj_filter->child_filters.push_back(std::move(null_filter));
+				auto null_expr = ExpressionFilter::CreateNullCheckExpression(CreateFilterTargetExpression(*column_ref),
+				                                                             ExpressionType::OPERATOR_IS_NULL);
+				conj_filter->child_filters.push_back(make_uniq<ExpressionFilter>(std::move(null_expr)));
 				break;
 			}
 			default:

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/function/scalar/generic_common.hpp"
@@ -222,7 +221,10 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 				break;
 			}
 			// filter is true or null; we can replace this with a not null filter
-			get.table_filters.SetFilterByColumnIndex(table_filter_column, make_uniq<IsNotNullFilter>());
+			auto not_null = ExpressionFilter::CreateNullCheckExpression(
+			    make_uniq<BoundReferenceExpression>(stats.GetType(), 0), ExpressionType::OPERATOR_IS_NOT_NULL);
+			get.table_filters.SetFilterByColumnIndex(table_filter_column,
+			                                         make_uniq<ExpressionFilter>(std::move(not_null)));
 			break;
 		}
 		case FilterPropagateResult::FILTER_FALSE_OR_NULL:

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -7,11 +7,12 @@
 #include "duckdb/planner/operator/logical_top_n.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
-#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 
 namespace duckdb {
@@ -119,7 +120,9 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		unique_ptr<TableFilter> pushed_filter = std::move(dynamic_filter);
 		if (nulls_first) {
 			auto or_filter = make_uniq<ConjunctionOrFilter>();
-			or_filter->child_filters.push_back(make_uniq<IsNullFilter>());
+			auto is_null = ExpressionFilter::CreateNullCheckExpression(
+			    make_uniq<BoundReferenceExpression>(type, idx_t(0)), ExpressionType::OPERATOR_IS_NULL);
+			or_filter->child_filters.push_back(make_uniq<ExpressionFilter>(std::move(is_null)));
 			or_filter->child_filters.push_back(std::move(pushed_filter));
 			pushed_filter = std::move(or_filter);
 		}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -43,6 +43,15 @@ unique_ptr<Expression> ExpressionFilter::CreateInExpression(unique_ptr<Expressio
 	return result;
 }
 
+unique_ptr<Expression> ExpressionFilter::CreateNullCheckExpression(unique_ptr<Expression> column,
+                                                                   ExpressionType expression_type) {
+	D_ASSERT(expression_type == ExpressionType::OPERATOR_IS_NULL ||
+	         expression_type == ExpressionType::OPERATOR_IS_NOT_NULL);
+	auto result = make_uniq<BoundOperatorExpression>(expression_type, LogicalType::BOOLEAN);
+	result->children.push_back(std::move(column));
+	return result;
+}
+
 bool ExpressionFilter::EvaluateWithConstant(ClientContext &context, const Value &val) const {
 	ExpressionExecutor executor(context, *expr);
 	return EvaluateWithConstant(executor, val);

--- a/src/planner/filter/null_filter.cpp
+++ b/src/planner/filter/null_filter.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/planner/filter/null_filter.hpp"
-#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
@@ -8,58 +8,54 @@ IsNullFilter::IsNullFilter() : TableFilter(TableFilterType::IS_NULL) {
 }
 
 FilterPropagateResult IsNullFilter::CheckStatistics(BaseStatistics &stats) const {
-	if (!stats.CanHaveNull()) {
-		// no null values are possible: always false
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	if (!stats.CanHaveNoNull()) {
-		// no non-null values are possible: always true
-		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
-	}
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	throw InternalException("IsNullFilter::CheckStatistics should not be called: IsNullFilters should be converted "
+	                        "to ExpressionFilters before statistics checking");
 }
 
 string IsNullFilter::ToString(const string &column_name) const {
-	return column_name + " IS NULL";
+	throw InternalException("IsNullFilter::ToString should not be called: IsNullFilters should be converted to "
+	                        "ExpressionFilters before rendering");
+}
+
+bool IsNullFilter::Equals(const TableFilter &other_p) const {
+	throw InternalException("IsNullFilter::Equals should not be called: IsNullFilters should be converted to "
+	                        "ExpressionFilters before equality checking");
 }
 
 unique_ptr<TableFilter> IsNullFilter::Copy() const {
-	return make_uniq<IsNullFilter>();
+	throw InternalException("IsNullFilter::Copy should not be called: IsNullFilters should be converted to "
+	                        "ExpressionFilters before copying");
 }
 
 unique_ptr<Expression> IsNullFilter::ToExpression(const Expression &column) const {
-	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
-	result->children.push_back(column.Copy());
-	return std::move(result);
+	return ExpressionFilter::CreateNullCheckExpression(column.Copy(), ExpressionType::OPERATOR_IS_NULL);
 }
 
 IsNotNullFilter::IsNotNullFilter() : TableFilter(TableFilterType::IS_NOT_NULL) {
 }
 
 FilterPropagateResult IsNotNullFilter::CheckStatistics(BaseStatistics &stats) const {
-	if (!stats.CanHaveNoNull()) {
-		// no non-null values are possible: always false
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	if (!stats.CanHaveNull()) {
-		// no null values are possible: always true
-		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
-	}
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	throw InternalException("IsNotNullFilter::CheckStatistics should not be called: IsNotNullFilters should be "
+	                        "converted to ExpressionFilters before statistics checking");
 }
 
 string IsNotNullFilter::ToString(const string &column_name) const {
-	return column_name + " IS NOT NULL";
+	throw InternalException("IsNotNullFilter::ToString should not be called: IsNotNullFilters should be converted "
+	                        "to ExpressionFilters before rendering");
+}
+
+bool IsNotNullFilter::Equals(const TableFilter &other_p) const {
+	throw InternalException("IsNotNullFilter::Equals should not be called: IsNotNullFilters should be converted to "
+	                        "ExpressionFilters before equality checking");
 }
 
 unique_ptr<TableFilter> IsNotNullFilter::Copy() const {
-	return make_uniq<IsNotNullFilter>();
+	throw InternalException("IsNotNullFilter::Copy should not be called: IsNotNullFilters should be converted to "
+	                        "ExpressionFilters before copying");
 }
 
 unique_ptr<Expression> IsNotNullFilter::ToExpression(const Expression &column) const {
-	auto result = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
-	result->children.push_back(column.Copy());
-	return std::move(result);
+	return ExpressionFilter::CreateNullCheckExpression(column.Copy(), ExpressionType::OPERATOR_IS_NOT_NULL);
 }
 
 } // namespace duckdb

--- a/src/planner/table_filter_state.cpp
+++ b/src/planner/table_filter_state.cpp
@@ -94,10 +94,6 @@ unique_ptr<TableFilterState> TableFilterState::Initialize(ClientContext &context
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
 		return make_uniq<ExpressionFilterState>(context, *expr_filter.expr);
 	}
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-		// root nodes - create an empty filter state
-		return make_uniq<TableFilterState>();
 	default:
 		throw InternalException("Unsupported filter type for TableFilterState::Initialize");
 	}

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -2,6 +2,10 @@
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/planner/filter/bloom_filter.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/segment/uncompressed.hpp"
@@ -11,6 +15,107 @@
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 
 namespace duckdb {
+
+static bool IsSimpleFilterColumnRef(const Expression &expression) {
+	return expression.type == ExpressionType::BOUND_REF ||
+	       expression.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
+}
+
+static bool TryComparisonFiltersNullValues(const BoundComparisonExpression &comparison, bool &filters_nulls,
+                                           bool &filters_valid_values) {
+	const BoundConstantExpression *constant_expr = nullptr;
+	auto comparison_type = comparison.GetExpressionType();
+	if (IsSimpleFilterColumnRef(*comparison.left) && comparison.right->type == ExpressionType::VALUE_CONSTANT) {
+		constant_expr = &comparison.right->Cast<BoundConstantExpression>();
+	} else if (comparison.left->type == ExpressionType::VALUE_CONSTANT && IsSimpleFilterColumnRef(*comparison.right)) {
+		constant_expr = &comparison.left->Cast<BoundConstantExpression>();
+		comparison_type = FlipComparisonExpression(comparison_type);
+	} else {
+		return false;
+	}
+	if (constant_expr->value.IsNull()) {
+		switch (comparison_type) {
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			filters_valid_values = true;
+			break;
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			filters_nulls = true;
+			break;
+		default:
+			filters_nulls = true;
+			filters_valid_values = true;
+			break;
+		}
+	} else {
+		switch (comparison_type) {
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			filters_nulls = false;
+			break;
+		default:
+			filters_nulls = true;
+			break;
+		}
+	}
+	return true;
+}
+
+static bool TryExpressionFiltersNullValues(const Expression &expression, bool &filters_nulls,
+                                           bool &filters_valid_values) {
+	filters_nulls = false;
+	filters_valid_values = false;
+
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conjunction = expression.Cast<BoundConjunctionExpression>();
+		if (conjunction.type == ExpressionType::CONJUNCTION_AND) {
+			for (auto &child : conjunction.children) {
+				bool child_filters_nulls = false;
+				bool child_filters_valid_values = false;
+				if (!TryExpressionFiltersNullValues(*child, child_filters_nulls, child_filters_valid_values)) {
+					return false;
+				}
+				filters_nulls = filters_nulls || child_filters_nulls;
+				filters_valid_values = filters_valid_values || child_filters_valid_values;
+			}
+			return true;
+		}
+		if (conjunction.type == ExpressionType::CONJUNCTION_OR) {
+			filters_nulls = true;
+			filters_valid_values = true;
+			for (auto &child : conjunction.children) {
+				bool child_filters_nulls = false;
+				bool child_filters_valid_values = false;
+				if (!TryExpressionFiltersNullValues(*child, child_filters_nulls, child_filters_valid_values)) {
+					return false;
+				}
+				filters_nulls = filters_nulls && child_filters_nulls;
+				filters_valid_values = filters_valid_values && child_filters_valid_values;
+			}
+			return true;
+		}
+		return false;
+	}
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+		return TryComparisonFiltersNullValues(expression.Cast<BoundComparisonExpression>(), filters_nulls,
+		                                      filters_valid_values);
+	}
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
+		auto &op = expression.Cast<BoundOperatorExpression>();
+		if (op.children.size() != 1 || !IsSimpleFilterColumnRef(*op.children[0])) {
+			return false;
+		}
+		switch (expression.type) {
+		case ExpressionType::OPERATOR_IS_NULL:
+			filters_valid_values = true;
+			return true;
+		case ExpressionType::OPERATOR_IS_NOT_NULL:
+			filters_nulls = true;
+			return true;
+		default:
+			return false;
+		}
+	}
+	return false;
+}
 
 //===--------------------------------------------------------------------===//
 // Scan
@@ -149,19 +254,14 @@ void ConstantFun::FiltersNullValues(const LogicalType &type, const TableFilter &
 		}
 		break;
 	}
-	case TableFilterType::IS_NULL:
-		filters_valid_values = true;
-		break;
-	case TableFilterType::IS_NOT_NULL:
-		filters_nulls = true;
-		break;
 	case TableFilterType::EXPRESSION_FILTER: {
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
-		auto &state = filter_state.Cast<ExpressionFilterState>();
-		Value val(type);
-		//! If the expression evaluates to true, containing only a NULL vector, it *must* be an IS NULL filter
-		filters_nulls = !expr_filter.EvaluateWithConstant(*state.executor, val);
-		filters_valid_values = false;
+		if (!TryExpressionFiltersNullValues(*expr_filter.expr, filters_nulls, filters_valid_values)) {
+			auto &state = filter_state.Cast<ExpressionFilterState>();
+			Value val(type);
+			filters_nulls = !expr_filter.EvaluateWithConstant(*state.executor, val);
+			filters_valid_values = false;
+		}
 		break;
 	}
 	case TableFilterType::BLOOM_FILTER: {

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -16,107 +16,6 @@
 
 namespace duckdb {
 
-static bool IsSimpleFilterColumnRef(const Expression &expression) {
-	return expression.type == ExpressionType::BOUND_REF ||
-	       expression.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
-}
-
-static bool TryComparisonFiltersNullValues(const BoundComparisonExpression &comparison, bool &filters_nulls,
-                                           bool &filters_valid_values) {
-	const BoundConstantExpression *constant_expr = nullptr;
-	auto comparison_type = comparison.GetExpressionType();
-	if (IsSimpleFilterColumnRef(*comparison.left) && comparison.right->type == ExpressionType::VALUE_CONSTANT) {
-		constant_expr = &comparison.right->Cast<BoundConstantExpression>();
-	} else if (comparison.left->type == ExpressionType::VALUE_CONSTANT && IsSimpleFilterColumnRef(*comparison.right)) {
-		constant_expr = &comparison.left->Cast<BoundConstantExpression>();
-		comparison_type = FlipComparisonExpression(comparison_type);
-	} else {
-		return false;
-	}
-	if (constant_expr->value.IsNull()) {
-		switch (comparison_type) {
-		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
-			filters_valid_values = true;
-			break;
-		case ExpressionType::COMPARE_DISTINCT_FROM:
-			filters_nulls = true;
-			break;
-		default:
-			filters_nulls = true;
-			filters_valid_values = true;
-			break;
-		}
-	} else {
-		switch (comparison_type) {
-		case ExpressionType::COMPARE_DISTINCT_FROM:
-			filters_nulls = false;
-			break;
-		default:
-			filters_nulls = true;
-			break;
-		}
-	}
-	return true;
-}
-
-static bool TryExpressionFiltersNullValues(const Expression &expression, bool &filters_nulls,
-                                           bool &filters_valid_values) {
-	filters_nulls = false;
-	filters_valid_values = false;
-
-	if (expression.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
-		auto &conjunction = expression.Cast<BoundConjunctionExpression>();
-		if (conjunction.type == ExpressionType::CONJUNCTION_AND) {
-			for (auto &child : conjunction.children) {
-				bool child_filters_nulls = false;
-				bool child_filters_valid_values = false;
-				if (!TryExpressionFiltersNullValues(*child, child_filters_nulls, child_filters_valid_values)) {
-					return false;
-				}
-				filters_nulls = filters_nulls || child_filters_nulls;
-				filters_valid_values = filters_valid_values || child_filters_valid_values;
-			}
-			return true;
-		}
-		if (conjunction.type == ExpressionType::CONJUNCTION_OR) {
-			filters_nulls = true;
-			filters_valid_values = true;
-			for (auto &child : conjunction.children) {
-				bool child_filters_nulls = false;
-				bool child_filters_valid_values = false;
-				if (!TryExpressionFiltersNullValues(*child, child_filters_nulls, child_filters_valid_values)) {
-					return false;
-				}
-				filters_nulls = filters_nulls && child_filters_nulls;
-				filters_valid_values = filters_valid_values && child_filters_valid_values;
-			}
-			return true;
-		}
-		return false;
-	}
-	if (expression.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-		return TryComparisonFiltersNullValues(expression.Cast<BoundComparisonExpression>(), filters_nulls,
-		                                      filters_valid_values);
-	}
-	if (expression.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
-		auto &op = expression.Cast<BoundOperatorExpression>();
-		if (op.children.size() != 1 || !IsSimpleFilterColumnRef(*op.children[0])) {
-			return false;
-		}
-		switch (expression.type) {
-		case ExpressionType::OPERATOR_IS_NULL:
-			filters_valid_values = true;
-			return true;
-		case ExpressionType::OPERATOR_IS_NOT_NULL:
-			filters_nulls = true;
-			return true;
-		default:
-			return false;
-		}
-	}
-	return false;
-}
-
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
@@ -256,12 +155,10 @@ void ConstantFun::FiltersNullValues(const LogicalType &type, const TableFilter &
 	}
 	case TableFilterType::EXPRESSION_FILTER: {
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
-		if (!TryExpressionFiltersNullValues(*expr_filter.expr, filters_nulls, filters_valid_values)) {
-			auto &state = filter_state.Cast<ExpressionFilterState>();
-			Value val(type);
-			filters_nulls = !expr_filter.EvaluateWithConstant(*state.executor, val);
-			filters_valid_values = false;
-		}
+		auto &state = filter_state.Cast<ExpressionFilterState>();
+		Value val(type);
+		filters_nulls = !expr_filter.EvaluateWithConstant(*state.executor, val);
+		filters_valid_values = false;
 		break;
 	}
 	case TableFilterType::BLOOM_FILTER: {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -27,9 +27,6 @@ namespace duckdb {
 
 static bool IsDirectNullCheckFilter(const TableFilter &filter) {
 	switch (filter.filter_type) {
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-		return true;
 	case TableFilterType::EXPRESSION_FILTER: {
 		auto &expr = filter.Cast<ExpressionFilter>().expr;
 		if (expr->GetExpressionClass() != ExpressionClass::BOUND_OPERATOR) {

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -462,12 +462,6 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 		}
 		return approved_tuple_count;
 	}
-	case TableFilterType::IS_NULL: {
-		return TemplatedNullSelection<true>(vdata, sel, approved_tuple_count);
-	}
-	case TableFilterType::IS_NOT_NULL: {
-		return TemplatedNullSelection<false>(vdata, sel, approved_tuple_count);
-	}
 	case TableFilterType::STRUCT_EXTRACT: {
 		auto &struct_filter = filter.Cast<StructFilter>();
 		// Apply the filter on the child vector

--- a/test/sql/topn/topn_nulls_first.test
+++ b/test/sql/topn/topn_nulls_first.test
@@ -19,7 +19,7 @@ PRAGMA explain_output='OPTIMIZED_ONLY'
 query II nosort
 EXPLAIN SELECT v FROM topn_nulls ORDER BY v NULLS FIRST LIMIT 6;
 ----
-logical_opt	<REGEX>:.*TOP_N.*optional: v IS NULL.*
+logical_opt	<REGEX>:.*TOP_N.*optional:.*v IS NULL.*
 
 query I
 SELECT v FROM topn_nulls ORDER BY v NULLS FIRST LIMIT 6;


### PR DESCRIPTION
This PR extracts the `ExpressionFilter` unification from https://github.com/duckdb/duckdb/pull/21762. Instead of doing everything at once, this PR only removes `Is[Not]NullFilter` from all code paths except for legacy de/serialization.

There will be a few follow-up PRs regarding:
- [x] `ConstantFilter`
- [ ] `ConjunctionFilter`
- [ ] `DynamicFilter`
- [x] `InFilter`
- [x] `Is[Not]NullFilter`
- [ ] `OptionalFilter`
- [ ] `BloomFilter`
- [ ] `PerfectHashJoinFilter`
- [ ] `PrefixRangeFilter`
- [ ] `SelectivityOptionalFilter`
- [ ] `StructFilter`