### PR TITLE
Fix GCC-12 build and notify external repo CI jobs

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -57,7 +57,7 @@ jobs:
       skip_tests: ${{ inputs.skip_tests }}
 
   prepare-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     needs:
       - extensions

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -69,7 +69,7 @@ env:
 jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
     steps:
       - name: Run ODBC Vendor
@@ -81,7 +81,7 @@ jobs:
 
   notify-jdbc-run:
     name: Run JDBC Vendor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
     steps:
       - name: Run JDBC Vendor
@@ -93,18 +93,18 @@ jobs:
 
   notify-nightly-build-status:
     name: Run Nightly build status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Run Nightly build status
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": ${{ inputs.should-publish }}}}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
   notify-python-nightly:
     name: Dispatch Python nightly build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Call /dispatch
         if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -73,27 +73,28 @@ jobs:
     if: ${{ github.repository == 'duckdb/duckdb' }}
     steps:
       - name: Run ODBC Vendor
-        if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
+        if: ${{ always() && inputs.is-success && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-odbc/actions/workflows/Vendor.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
       - name: Run JDBC Vendor
-        if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
+        if: ${{ always() && inputs.is-success && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
       - name: Run Nightly build status
+        if: ${{ always() }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
       - name: Call /dispatch
-        if: ${{ inputs.override-git-describe == '' }}
+        if: ${{ always() && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/release.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "pypi-index": "prod" }}'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -67,48 +67,34 @@ env:
   PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
 jobs:
-  notify-odbc-run:
-    name: Run ODBC Vendor
+  notify-external-repositories:
+    name: Notify External Repositories
     runs-on: ubuntu-slim
-    if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
+    if: ${{ github.repository == 'duckdb/duckdb' }}
     steps:
       - name: Run ODBC Vendor
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-odbc/actions/workflows/Vendor.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
-  notify-jdbc-run:
-    name: Run JDBC Vendor
-    runs-on: ubuntu-slim
-    if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
-    steps:
       - name: Run JDBC Vendor
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ inputs.is-success && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
-  notify-nightly-build-status:
-    name: Run Nightly build status
-    runs-on: ubuntu-slim
-    steps:
       - name: Run Nightly build status
-        if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
+          curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"
 
-  notify-python-nightly:
-    name: Dispatch Python nightly build
-    runs-on: ubuntu-slim
-    steps:
       - name: Call /dispatch
-        if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}
+        if: ${{ inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/release.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "pypi-index": "prod" }}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          curl -v --fail-with-body --retry 5 --retry-all-errors -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" "$URL" --data "$DATA"

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -40,7 +40,7 @@ unique_ptr<Expression> ExpressionFilter::CreateInExpression(unique_ptr<Expressio
 	for (auto &value : values) {
 		result->children.push_back(make_uniq<BoundConstantExpression>(std::move(value)));
 	}
-	return unique_ptr_cast<BoundOperatorExpression, Expression>(std::move(result));
+	return std::move(result);
 }
 
 bool ExpressionFilter::EvaluateWithConstant(ClientContext &context, const Value &val) const {

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -40,7 +40,7 @@ unique_ptr<Expression> ExpressionFilter::CreateInExpression(unique_ptr<Expressio
 	for (auto &value : values) {
 		result->children.push_back(make_uniq<BoundConstantExpression>(std::move(value)));
 	}
-	return result;
+	return unique_ptr_cast<BoundOperatorExpression, Expression>(std::move(result));
 }
 
 bool ExpressionFilter::EvaluateWithConstant(ClientContext &context, const Value &val) const {


### PR DESCRIPTION
The CI job `Linux static libraries (amd64)` uses GCC-12 and reported an [error](https://github.com/duckdb/duckdb/actions/runs/24698539753/job/72236578826#step:3:512) in CI:
```c++
In file included from build/release/src/planner/filter/ub_duckdb_planner_filter.cpp:6:
src/planner/filter/expression_filter.cpp: In static member function ‘static duckdb::unique_ptr<duckdb::Expression> duckdb::ExpressionFilter::CreateInExpression(duckdb::unique_ptr<duckdb::Expression>, duckdb::vector<duckdb::Value>)’:
src/planner/filter/expression_filter.cpp:43:16: error: could not convert ‘result’ from ‘unique_ptr<duckdb::BoundOperatorExpression,default_delete<duckdb::BoundOperatorExpression>,[...]>’ to ‘unique_ptr<duckdb::Expression,default_delete<duckdb::Expression>,[...]>’
   43 |         return result;
      |                ^~~~~~
      |                |
      |                unique_ptr<duckdb::BoundOperatorExpression,default_delete<duckdb::BoundOperatorExpression>,[...]>
```

The nightly build status workflow did not receive the dispatch call due to a type [error](https://github.com/duckdb/duckdb/actions/runs/24698539753/job/72270710106#step:2:111) (expected string instead of a bool):
```json
* Connection #0 to host api.github.com left intact
{
  "message": "Invalid value for input 'should_publish'",
  "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event",
  "status": "422"
}
```

I've also added curl retry logic (for robustness), and let an HTTP response failure also mark the CI job as failed.