### PR TITLE
Detect typos in code using typos-cli

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Install format tools
         if: ${{ !inputs.skip_tests }}
-        run: python3 scripts/ci/retry.py -- make format_tools
+        run: python3 scripts/ci/retry.py -- make -j4 format_tools
 
       - name: Check if extension_entries.hpp is up to date
         if: ${{ !inputs.skip_tests }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Check format
         run: |
-          make format-check-silent enum-integrity-check check-typos -j -Otarget
+          make format-check-silent enum-integrity-check -j -Otarget
           echo "::group::Check generated files"
           make generate-files
           git diff --exit-code

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Check format
         run: |
-          make format-check-silent enum-integrity-check
+          make format-check-silent enum-integrity-check check-typos -j -Otarget
           echo "::group::Check generated files"
           make generate-files
           git diff --exit-code

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -221,8 +221,8 @@ jobs:
         with:
           save: ${{ fromJson(steps.config.outputs.save_cache) }}
 
-      - name: Install format tools
-        run: python3 scripts/ci/retry.py -- make format_tools
+      - name: Install tools
+        run: python3 scripts/ci/retry.py -- make -j format_tools spell_tools
 
       - name: Check format
         run: |

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -222,7 +222,7 @@ jobs:
           save: ${{ fromJson(steps.config.outputs.save_cache) }}
 
       - name: Install tools
-        run: python3 scripts/ci/retry.py -- make -j format_tools spell_tools
+        run: python3 scripts/ci/retry.py -- make -j4 format_tools
 
       - name: Check format
         run: |

--- a/Doxyfile
+++ b/Doxyfile
@@ -1418,7 +1418,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/Makefile
+++ b/Makefile
@@ -574,7 +574,6 @@ toolsci:
 		sudo apt-get update -y -qq; \
 		sudo apt-get install -y -qq libcurl4-openssl-dev; \
 	}
-	command -v typos >/dev/null 2>&1 || cargo install --locked typos-cli
 	ls -lh /usr/bin/gcc* /usr/bin/g++*
 	gcc --version
 	g++ --version

--- a/Makefile
+++ b/Makefile
@@ -689,9 +689,9 @@ format-fix: $(FORMAT_SETUP_DEPS)
 	$(FORMAT_PYTHON) scripts/format.py --all --fix --noconfirm
 
 .PHONY: check-extension-entries
-check-extension-entries: extension_configuration
+check-extension-entries: extension_configuration $(FORMAT_SETUP_DEPS)
 	$(PYTHON) scripts/generate_extensions_function.py
-	$(PYTHON) scripts/format.py src/include/duckdb/main/extension_entries.hpp --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py src/include/duckdb/main/extension_entries.hpp --fix --noconfirm
 	@git diff -- src/include/duckdb/main/extension_entries.hpp > extension_entries.hpp.diff
 	@if [ -s extension_entries.hpp.diff ]; then \
 		cat extension_entries.hpp.diff; \

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ PROJ_DIR := $(dir $(MKFILE_PATH))
 
 PYTHON ?= python3
 FORMAT_VENV ?= build/format-venv
-FORMAT_VENV_PYTHON := $(FORMAT_VENV)/bin/python
-FORMAT_PYTHON := $(FORMAT_VENV_PYTHON)
-FORMAT_SETUP_DEPS := format-venv-tools
+FORMAT_PYTHON := $(FORMAT_VENV)/bin/python
+FORMAT_SETUP_DEPS := format_venv
 
 EXE_SUFFIX :=
 ifeq ($(OS),Windows_NT)
@@ -571,7 +570,7 @@ define ensure_apt_commands
 	fi
 endef
 
-.PHONY: toolsci format_tools spell_tools enum-integrity-check format-venv-tools
+.PHONY: toolsci
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
@@ -586,7 +585,10 @@ toolsci:
 test_ci:
 	python3 -m unittest discover --buffer --start-directory scripts/ci $(T)
 
-format_tools:
+.PHONY: format_tools parser_tools spell_tools
+format_tools: parser_tools spell_tools
+
+parser_tools:
 	$(call ensure_apt_commands,ninja,ninja-build)
 	sudo pip3 install --break-system-packages cxxheaderparser pcpp
 	@echo "::group::Installed Python packages"
@@ -619,17 +621,19 @@ spell_tools:
 	fi; \
 	typos --version
 
+.PHONY: enum-integrity-check
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h
 
-format-venv-tools:
-	@if [ ! -x "$(FORMAT_VENV_PYTHON)" ]; then \
+.PHONY: format_venv
+format_venv:
+	@if [ ! -x "$(FORMAT_PYTHON)" ]; then \
 		mkdir -p "$(dir $(FORMAT_VENV))" && \
 		$(PYTHON) -m venv "$(FORMAT_VENV)"; \
 	fi
-	@$(FORMAT_VENV_PYTHON) -m pip show black >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install black==24.*
-	@$(FORMAT_VENV_PYTHON) -m pip show cmake-format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install cmake-format
-	@$(FORMAT_VENV_PYTHON) -m pip show clang_format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install clang_format==11.0.1
+	@$(FORMAT_PYTHON) -m pip show black >/dev/null 2>&1 || $(FORMAT_PYTHON) -m pip install black==24.*
+	@$(FORMAT_PYTHON) -m pip show cmake-format >/dev/null 2>&1 || $(FORMAT_PYTHON) -m pip install cmake-format
+	@$(FORMAT_PYTHON) -m pip show clang_format >/dev/null 2>&1 || $(FORMAT_PYTHON) -m pip install clang_format==11.0.1
 
 benchmark:
 	mkdir -p ./build/release && \

--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ define ensure_apt_commands
 	fi
 endef
 
-.PHONY: toolsci format_tools enum-integrity-check check-typos
+.PHONY: toolsci format_tools spell_tools enum-integrity-check check-typos
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
@@ -593,6 +593,32 @@ format_tools:
 	clang-format --dump-config
 	black --version
 	@echo "::endgroup::"
+
+spell_tools:
+	@if [ "$$(uname -s)" != "Linux" ]; then \
+		echo "Skipping spell_tools on non-Linux"; \
+		exit 0; \
+	fi
+	@set -eu; \
+	VERSION=1.45.1; \
+	if [ "$$(uname -m)" = "arm64" ] || [ "$$(uname -m)" = "aarch64" ]; then \
+		ARCH="aarch64"; \
+	else \
+		ARCH="x86_64"; \
+	fi; \
+	TARGET_FILE="$${ARCH}-unknown-linux-musl"; \
+	FILE_NAME="typos-v$${VERSION}-$${TARGET_FILE}.tar.gz"; \
+	DOWNLOAD_URL="https://github.com/crate-ci/typos/releases/download/v$${VERSION}/$${FILE_NAME}"; \
+	$(PYTHON) scripts/ci/retry.py -- curl --fail --location --silent --show-error --output "/tmp/$${FILE_NAME}" "$${DOWNLOAD_URL}"; \
+	TMP_DIR="$$(mktemp -d)"; \
+	tar -xzf "/tmp/$${FILE_NAME}" -C "$${TMP_DIR}"; \
+	TYPOS_BIN="$$(find "$${TMP_DIR}" -type f -name typos | head -n 1)"; \
+	if [ -w /usr/local/bin ]; then \
+		install -m 0755 "$${TYPOS_BIN}" /usr/local/bin/typos; \
+	else \
+		sudo install -m 0755 "$${TYPOS_BIN}" /usr/local/bin/typos; \
+	fi; \
+	typos --version
 
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
 
 PYTHON ?= python3
+FORMAT_VENV ?= build/format-venv
+FORMAT_VENV_PYTHON := $(FORMAT_VENV)/bin/python
+ifdef CI
+FORMAT_PYTHON := $(PYTHON)
+FORMAT_SETUP_DEPS :=
+else
+FORMAT_PYTHON := $(FORMAT_VENV_PYTHON)
+FORMAT_SETUP_DEPS := format-venv-tools
+endif
+
 EXE_SUFFIX :=
 ifeq ($(OS),Windows_NT)
 EXE_SUFFIX := .exe
@@ -566,7 +576,7 @@ define ensure_apt_commands
 	fi
 endef
 
-.PHONY: toolsci format_tools spell_tools enum-integrity-check
+.PHONY: toolsci format_tools spell_tools enum-integrity-check format-venv-tools
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
@@ -622,6 +632,15 @@ spell_tools:
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h
 
+format-venv-tools:
+	@if [ ! -x "$(FORMAT_VENV_PYTHON)" ]; then \
+		mkdir -p "$(dir $(FORMAT_VENV))" && \
+		$(PYTHON) -m venv "$(FORMAT_VENV)"; \
+	fi
+	@$(FORMAT_VENV_PYTHON) -m pip show black >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install black
+	@$(FORMAT_VENV_PYTHON) -m pip show cmake-format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install cmake-format
+	@$(FORMAT_VENV_PYTHON) -m pip show clang_format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install clang_format==11.0.1
+
 benchmark:
 	mkdir -p ./build/release && \
 	cd build/release && \
@@ -669,15 +688,15 @@ tidy-fix:
 test_compile: # test compilation of individual cpp files
 	$(PYTHON) scripts/amalgamation.py --compile
 
-format-check:
-	$(PYTHON) scripts/format.py --all --check
+format-check: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py --all --check
 
-format-check-silent:
-	$(PYTHON) scripts/format.py --all --check --silent
+format-check-silent: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py --all --check --silent
 
-format-fix:
+format-fix: $(FORMAT_SETUP_DEPS)
 	rm -rf src/amalgamation/*
-	$(PYTHON) scripts/format.py --all --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py --all --fix --noconfirm
 
 .PHONY: check-extension-entries
 check-extension-entries: extension_configuration
@@ -693,17 +712,17 @@ check-extension-entries: extension_configuration
 		echo "No differences found"; \
 	fi
 
-format-head:
-	$(PYTHON) scripts/format.py HEAD --fix --noconfirm
+format-head: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm
 
-format-changes:
-	$(PYTHON) scripts/format.py HEAD --fix --noconfirm
+format-changes: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm
 
-format-main:
-	$(PYTHON) scripts/format.py main --fix --noconfirm
+format-main: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py main --fix --noconfirm
 
-format-feature:
-	$(PYTHON) scripts/format.py feature --fix --noconfirm
+format-feature: $(FORMAT_SETUP_DEPS)
+	$(FORMAT_PYTHON) scripts/format.py feature --fix --noconfirm
 
 format-configs:
 	$(foreach file, $(wildcard $(CONFIGS_DIR)/*), jq . < "$(file)" > "$(file).tmp" && mv "$(file).tmp" "$(file)" ;)

--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ define ensure_apt_commands
 	fi
 endef
 
-.PHONY: toolsci format_tools enum-integrity-check
+.PHONY: toolsci format_tools enum-integrity-check check-typos
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
@@ -574,6 +574,7 @@ toolsci:
 		sudo apt-get update -y -qq; \
 		sudo apt-get install -y -qq libcurl4-openssl-dev; \
 	}
+	command -v typos >/dev/null 2>&1 || cargo install --locked typos-cli
 	ls -lh /usr/bin/gcc* /usr/bin/g++*
 	gcc --version
 	g++ --version
@@ -595,6 +596,13 @@ format_tools:
 
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h
+
+check-typos:
+	@if ! command -v typos >/dev/null 2>&1; then \
+		echo 'typos not found. Install it with "brew install typos-cli"'; \
+		exit 1; \
+	fi
+	typos -c scripts/typos.toml
 
 benchmark:
 	mkdir -p ./build/release && \

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,8 @@ PROJ_DIR := $(dir $(MKFILE_PATH))
 PYTHON ?= python3
 FORMAT_VENV ?= build/format-venv
 FORMAT_VENV_PYTHON := $(FORMAT_VENV)/bin/python
-ifdef CI
-FORMAT_PYTHON := $(PYTHON)
-FORMAT_SETUP_DEPS :=
-else
 FORMAT_PYTHON := $(FORMAT_VENV_PYTHON)
 FORMAT_SETUP_DEPS := format-venv-tools
-endif
 
 EXE_SUFFIX :=
 ifeq ($(OS),Windows_NT)
@@ -592,15 +587,10 @@ test_ci:
 	python3 -m unittest discover --buffer --start-directory scripts/ci $(T)
 
 format_tools:
-	$(call ensure_apt_commands,ninja clang-format,ninja-build clang-format-11)
-	sudo pip3 install --break-system-packages cmake-format 'black==24.*' cxxheaderparser pcpp 'clang_format==11.0.1'
+	$(call ensure_apt_commands,ninja,ninja-build)
+	sudo pip3 install --break-system-packages cxxheaderparser pcpp
 	@echo "::group::Installed Python packages"
 	pip3 freeze
-	@echo "::endgroup::"
-	@echo "::group::Formatter versions and config"
-	clang-format --version
-	clang-format --dump-config
-	black --version
 	@echo "::endgroup::"
 
 spell_tools:
@@ -637,7 +627,7 @@ format-venv-tools:
 		mkdir -p "$(dir $(FORMAT_VENV))" && \
 		$(PYTHON) -m venv "$(FORMAT_VENV)"; \
 	fi
-	@$(FORMAT_VENV_PYTHON) -m pip show black >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install black
+	@$(FORMAT_VENV_PYTHON) -m pip show black >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install black==24.*
 	@$(FORMAT_VENV_PYTHON) -m pip show cmake-format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install cmake-format
 	@$(FORMAT_VENV_PYTHON) -m pip show clang_format >/dev/null 2>&1 || $(FORMAT_VENV_PYTHON) -m pip install clang_format==11.0.1
 

--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ define ensure_apt_commands
 	fi
 endef
 
-.PHONY: toolsci format_tools spell_tools enum-integrity-check check-typos
+.PHONY: toolsci format_tools spell_tools enum-integrity-check
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
@@ -621,13 +621,6 @@ spell_tools:
 
 enum-integrity-check:
 	$(PYTHON) scripts/verify_enum_integrity.py src/include/duckdb.h
-
-check-typos:
-	@if ! command -v typos >/dev/null 2>&1; then \
-		echo 'typos not found. Install it with "brew install typos-cli"'; \
-		exit 1; \
-	fi
-	typos -c scripts/typos.toml
 
 benchmark:
 	mkdir -p ./build/release && \

--- a/extension/ExtensionDistribution.md
+++ b/extension/ExtensionDistribution.md
@@ -41,7 +41,7 @@ name                                        The default name of a given extensio
 .duckdb_extension                           Fixed file identifier
 ```
 
-DuckDB-Wasm extensions are are downloaded by the browsers WITHOUT appening .gz, since decompression status is agreed using headers such as `Accept-Encoding: *` and `Content-Encoding: br`.
+DuckDB-Wasm extensions are downloaded by the browsers WITHOUT appending .gz, since decompression status is agreed using headers such as `Accept-Encoding: *` and `Content-Encoding: br`.
 
 ### Version identifier
 

--- a/extension/autocomplete/transformer/transform_pivot.cpp
+++ b/extension/autocomplete/transformer/transform_pivot.cpp
@@ -212,7 +212,8 @@ unique_ptr<SelectStatement> PEGTransformerFactory::TransformUnpivotStatement(PEG
 		name_and_values = transformer.Transform<UnpivotNameValues>(unpivot_names_opt.GetResult());
 		auto unpivot_list_size = name_and_values.column.unpivot_names.size();
 		if (unpivot_list_size != 1) {
-			throw NotImplementedException("Only expectd a single value after NAME, got %d instead.", unpivot_list_size);
+			throw NotImplementedException("Only expected a single value after NAME, got %d instead.",
+			                              unpivot_list_size);
 		}
 		auto &col = name_and_values.column;
 		for (auto &expr : target_list) {

--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -363,7 +363,7 @@ struct QuantileSortTree {
 		//	Thread safe and idempotent.
 		index_tree->Build();
 
-		//	Find the interpolated indicies within the frame
+		//	Find the interpolated indices within the frame
 		QuantileInterpolator<DISCRETE> interp(q, n, false);
 		const auto lo_data = SelectNth(frames, interp.FRN);
 		auto hi_data = lo_data;

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2007,7 +2007,7 @@ struct StructDatePart {
 		auto &child_entries = StructVector::GetEntries(result);
 
 		// The first computer of a part "owns" it
-		// and other requestors just reference the owner
+		// and other requesters just reference the owner
 		vector<size_t> owners(int(DatePartSpecifier::JULIAN_DAY) + 1, child_entries.size());
 		for (size_t col = 0; col < child_entries.size(); ++col) {
 			const auto part_index = size_t(info.part_codes[col]);

--- a/extension/core_functions/scalar/list/flatten.cpp
+++ b/extension/core_functions/scalar/list/flatten.cpp
@@ -124,7 +124,7 @@ void ListFlattenFunction(DataChunk &args, ExpressionState &, Vector &result) {
 		flat_list_data.WriteValue(list_entry);
 	}
 
-	// Now assing the result
+	// Now assign the result
 	ListVector::SetListSize(result, sel_idx);
 
 	auto &result_child_vector = ListVector::GetChildMutable(result);

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1106,7 +1106,7 @@ struct LogBaseOperator {
 	static inline TR Operation(TA b, TB x) {
 		auto divisor = Log10Operator::Operation<TA, TR>(b);
 		if (divisor == 0) {
-			throw OutOfRangeException("divison by zero in based logarithm");
+			throw OutOfRangeException("division by zero in based logarithm");
 		}
 		return Log10Operator::Operation<TB, TR>(x) / divisor;
 	}

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -69,24 +69,24 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	child_list_t<LogicalType> new_children;
 	auto &existing_children = StructType::GetChildTypes(arguments[0]->return_type);
 
-	auto incomming_children = case_insensitive_tree_t<idx_t>();
+	auto incoming_children = case_insensitive_tree_t<idx_t>();
 	auto is_new_field = vector<bool>(arguments.size(), true);
 
-	// Validate incomming arguments and record names
+	// Validate incoming arguments and record names
 	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
 		auto &child = arguments[arg_idx];
 		if (child->alias.empty()) {
 			throw BinderException("Need named argument for struct update, e.g., a := b");
-		} else if (incomming_children.find(child->alias) != incomming_children.end()) {
+		} else if (incoming_children.find(child->alias) != incoming_children.end()) {
 			throw InvalidInputException("Duplicate named argument provided for %s", child->alias.c_str());
 		}
-		incomming_children.emplace(child->alias, arg_idx);
+		incoming_children.emplace(child->alias, arg_idx);
 	}
 
 	for (idx_t field_idx = 0; field_idx < existing_children.size(); field_idx++) {
 		auto &existing_child = existing_children[field_idx];
-		auto update = incomming_children.find(existing_child.first);
-		if (update == incomming_children.end()) {
+		auto update = incoming_children.find(existing_child.first);
+		if (update == incoming_children.end()) {
 			// No update provided for the named value
 			new_children.push_back(make_pair(existing_child.first, existing_child.second));
 		} else {
@@ -114,13 +114,13 @@ unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionSta
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 
-	auto incomming_children = case_insensitive_tree_t<idx_t>();
+	auto incoming_children = case_insensitive_tree_t<idx_t>();
 	auto is_new_field = vector<bool>(expr.children.size(), true);
 	auto new_stats = StructStats::CreateUnknown(expr.return_type);
 
 	for (idx_t arg_idx = 1; arg_idx < expr.children.size(); arg_idx++) {
 		auto &new_child = expr.children[arg_idx];
-		incomming_children.emplace(new_child->alias, arg_idx);
+		incoming_children.emplace(new_child->alias, arg_idx);
 	}
 
 	auto existing_type = child_stats[0].GetType();
@@ -128,8 +128,8 @@ unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionSta
 	auto existing_stats = StructStats::GetChildStats(child_stats[0]);
 	for (idx_t field_idx = 0; field_idx < existing_count; field_idx++) {
 		auto &existing_child = existing_stats[field_idx];
-		auto update = incomming_children.find(StructType::GetChildName(existing_type, field_idx));
-		if (update == incomming_children.end()) {
+		auto update = incoming_children.find(StructType::GetChildName(existing_type, field_idx));
+		if (update == incoming_children.end()) {
 			StructStats::SetChildStats(new_stats, field_idx, existing_child);
 		} else {
 			auto arg_idx = update->second;

--- a/extension/delta/CMakeLists.txt
+++ b/extension/delta/CMakeLists.txt
@@ -104,7 +104,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET
 # Add the default client
 add_compile_definitions(DEFINE_DEFAULT_ENGINE)
 
-# Link delta-kernal-rs to static lib
+# Link delta-kernel-rs to static lib
 target_link_libraries(
   ${EXTENSION_NAME}
   debug
@@ -114,7 +114,7 @@ target_link_libraries(
   ${PLATFORM_LIBS})
 add_dependencies(${EXTENSION_NAME} delta_kernel)
 
-# Link delta-kernal-rs to dynamic lib
+# Link delta-kernel-rs to dynamic lib
 target_link_libraries(
   ${LOADABLE_EXTENSION_NAME}
   debug

--- a/extension/demo_capi/capi_demo.cpp
+++ b/extension/demo_capi/capi_demo.cpp
@@ -18,6 +18,6 @@ DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection, duckdb_extension_info 
 	duckdb_destroy_arrow(&result);
 #endif
 
-	// Return true to indicate succesful initialization
+	// Return true to indicate successful initialization
 	return true;
 }

--- a/extension/json/include/json_transform.hpp
+++ b/extension/json/include/json_transform.hpp
@@ -22,7 +22,7 @@ class JSONReader;
 struct JSONTransformOptions {
 public:
 	JSONTransformOptions();
-	JSONTransformOptions(bool strict_cast, bool error_duplicate_key, bool error_missing_key, bool error_unkown_key);
+	JSONTransformOptions(bool strict_cast, bool error_duplicate_key, bool error_missing_key, bool error_unknown_key);
 
 public:
 	//! Throws an error if the cast doesn't work (instead of NULL-ing it)

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -24,9 +24,9 @@ JSONTransformOptions::JSONTransformOptions() : parameters(false, &error_message)
 }
 
 JSONTransformOptions::JSONTransformOptions(bool strict_cast_p, bool error_duplicate_key_p, bool error_missing_key_p,
-                                           bool error_unkown_key_p)
+                                           bool error_unknown_key_p)
     : strict_cast(strict_cast_p), error_duplicate_key(error_duplicate_key_p), error_missing_key(error_missing_key_p),
-      error_unknown_key(error_unkown_key_p), parameters(false, &error_message) {
+      error_unknown_key(error_unknown_key_p), parameters(false, &error_message) {
 }
 
 //! Forward declaration for recursion

--- a/scripts/append_metadata.cmake
+++ b/scripts/append_metadata.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15...3.29)
 
 # Usage: cmake -DEXTENSION=path/to/extension.duckdb_extension -DPLATFORM_FILE=README.md -DDUCKDB_VERSION=tag1 -DEXTENSION_VERSION=tag2 -P scripts/append_metadata.cmake
 # Currently hardcoded to host up to 8 fields
-# Example: ./scripts/append_metadata.sh file.duckdb_extension git_hash_duckdb_file git_hash_extension_file platfrom_file
+# Example: ./scripts/append_metadata.sh file.duckdb_extension git_hash_duckdb_file git_hash_extension_file platform_file
 
 set(EXTENSION "" CACHE PATH "Path to the extension where to add metadata")
 set(NULL_FILE "" CACHE PATH "Path to file containing a single 0 byte")
@@ -41,7 +41,7 @@ string(APPEND CUSTOM_SECTION "${CUSTOM_SECTION_3}")
 # Second metadata-field is special, since content comes from a file
 file(READ "${PLATFORM_FILE}" META2)
 
-# Build METADATAx variable by appending and then truncating empty strings
+# Build METADATA variables by appending and then truncating empty strings
 string(SUBSTRING "${META1}${EMPTY_32}" 0 32 METADATA1)
 string(SUBSTRING "${META2}${EMPTY_32}" 0 32 METADATA2)
 string(SUBSTRING "${VERSION_FIELD}${EMPTY_32}" 0 32 METADATA3)

--- a/scripts/create_local_extension_repo.py
+++ b/scripts/create_local_extension_repo.py
@@ -1,6 +1,6 @@
 ###
 # This script copies all extensions in a build folder from their cmake-produced structure into the extension repository
-# structure of ./<duckdb_version>/<build_archictecture>/<extension_name>.duckdb_extension
+# structure of ./<duckdb_version>/<build_architecture>/<extension_name>.duckdb_extension
 # Note that it requires duckdb_platofrom_out file to be populated with the platform
 
 import os

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -20,6 +20,11 @@ from python_helpers import open_utf8
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from format_test_benchmark import format_file_content
 
+# Ensure binaries installed into the current Python environment are discoverable.
+# This is required when invoking this script via an explicit venv python path.
+python_bin_dir = os.path.dirname(os.path.abspath(sys.executable))
+os.environ['PATH'] = python_bin_dir + os.pathsep + os.environ.get('PATH', '')
+
 try:
     ver = subprocess.check_output(('black', '--version'), text=True)
     if int(ver.split(' ')[1].split('.')[0]) < 24:

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -152,6 +152,27 @@ if args.directories:
     formatted_directories = args.directories
 
 
+def get_typos_targets():
+    if format_all:
+        return [path for path in formatted_directories if os.path.exists(path)]
+    return sorted(set([f.full_path for f in files if os.path.exists(f.full_path)]))
+
+
+def run_typos_check():
+    typos_targets = get_typos_targets()
+    if not typos_targets:
+        return 0
+    typos_command = ['typos']
+    if not check_only:
+        typos_command.append('-w')
+    typos_command += ['-c', 'scripts/typos.toml'] + typos_targets
+    try:
+        return subprocess.call(typos_command)
+    except FileNotFoundError:
+        print('typos not found. Install it with "brew install typos-cli"')
+        return 1
+
+
 def file_is_ignored(full_path):
     if os.path.basename(full_path) in ignored_files:
         return True
@@ -430,6 +451,8 @@ with concurrent.futures.ThreadPoolExecutor() as executor:
         executor.shutdown(wait=True, cancel_futures=True)
         raise
 
+typos_status = run_typos_check()
+
 if check_only:
     if len(difference_files) > 0:
         print("")
@@ -440,6 +463,10 @@ if check_only:
             print("- " + fname)
         print('Run "make format-fix" to fix these differences automatically')
         exit(1)
+    if typos_status != 0:
+        exit(1)
     else:
         print("Passed format-check")
         exit(0)
+elif typos_status != 0:
+    exit(1)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -167,7 +167,7 @@ def run_typos_check():
     typos_targets = get_typos_targets()
     if not typos_targets:
         return 0
-    typos_command = ['typos']
+    typos_command = ['typos', '--force-exclude']
     if not check_only:
         typos_command.append('-w')
     typos_command += ['-c', 'scripts/typos.toml'] + typos_targets

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -77,7 +77,7 @@ class BenchmarkRunnerConfig:
         )
         parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
         parser.add_argument(
-            "--no-summary", type=str, default=False, help="No failures summary is outputed when passing this flag."
+            "--no-summary", type=str, default=False, help="No failures summary is outputted when passing this flag."
         )
 
         # Parse arguments

--- a/scripts/typos.toml
+++ b/scripts/typos.toml
@@ -1,15 +1,44 @@
 [files]
 extend-exclude = [
-  "*.csv",
-  "/benchmark/clickbench",
+  "/benchmark/",
   "/data/",
-  "/test/ossfuzz",
-  "project.pbxproj",
+  "/extension/icu/",
+  "/extension/jemalloc/",
+  "/extension/tpcds/dsdgen/",
+  "/extension/tpch/dbgen/",
+  "/test/",
+  "/tools/juliapkg/",
+  "/tools/swift/duckdb-swift/",
+  "/tools/shell/tests/test_*.py",
   "third_party",
+]
+
+[default]
+extend-ignore-re = [
+  # Ignore short, intentionally random SQL literals (e.g. 'ABC')
+  "'[A-Z]{2,4}'",
+  "PNGs?",
 ]
 
 [default.extend-words]
 # Legal language
 stichting = "stichting"
+
 # Project-specific acronyms
 nd = "nd"
+eit = "eit"
+ser = "ser"
+siz = "siz"
+cpy = "cpy"
+Cpy = "Cpy"
+acount = "acount"
+
+# API identifiers (to avoid breaking code)
+writeable = "writeable"
+Writeable = "Writeable"
+millenium = "millenium"
+Millenium = "Millenium"
+seeked = "seeked"
+larg = "larg"
+rarg = "rarg"
+deliminated = "deliminated"

--- a/scripts/typos.toml
+++ b/scripts/typos.toml
@@ -1,0 +1,15 @@
+[files]
+extend-exclude = [
+  "*.csv",
+  "/benchmark/clickbench",
+  "/data/",
+  "/test/ossfuzz",
+  "project.pbxproj",
+  "third_party",
+]
+
+[default.extend-words]
+# Legal language
+stichting = "stichting"
+# Project-specific acronyms
+nd = "nd"

--- a/scripts/typos.toml
+++ b/scripts/typos.toml
@@ -17,7 +17,14 @@ extend-exclude = [
 extend-ignore-re = [
   # Ignore short, intentionally random SQL literals (e.g. 'ABC')
   "'[A-Z]{2,4}'",
-  "PNGs?",
+  # Explicitly capitalized words, ending with an optional 's'.
+  "\\b[A-Z]{2,}s?\\b",
+  # Ignore lines that end with `# typos:ignore`
+  "(?Rm)^.*(#|//)\\s*typos:ignore$",
+  # Ignore the line after `# typos:ignore-next-line`
+  "(#|//)\\s*typos:ignore-next-line\\n.*",
+  # Ignore blocks between `# typos:off` and `# typos:on`
+  "(?s)(#|//)\\s*typos:off.*?\\n\\s*(#|//)\\s*typos:on",
 ]
 
 [default.extend-words]

--- a/scripts/typos.toml
+++ b/scripts/typos.toml
@@ -6,10 +6,13 @@ extend-exclude = [
   "/extension/jemalloc/",
   "/extension/tpcds/dsdgen/",
   "/extension/tpch/dbgen/",
+  "/scripts/generate_extensions_function.py",
+  "/src/common/crypto/md5.cpp",
+  "/src/include/duckdb/main/extension_entries.hpp",
   "/test/",
   "/tools/juliapkg/",
-  "/tools/swift/duckdb-swift/",
   "/tools/shell/tests/test_*.py",
+  "/tools/swift/duckdb-swift/",
   "third_party",
 ]
 

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -527,7 +527,7 @@ bool CatalogSet::UseTimestamp(CatalogTransaction transaction, transaction_t time
 		return true;
 	}
 	if (timestamp < transaction.start_time) {
-		// this version was commited before we started the transaction
+		// this version was committed before we started the transaction
 		return true;
 	}
 	return false;
@@ -767,9 +767,9 @@ void CatalogSet::Scan(const std::function<void(CatalogEntry &)> &callback) {
 	lock_guard<mutex> lock(catalog_lock);
 	for (auto &kv : map.Entries()) {
 		auto &entry = *kv.second;
-		auto &commited_entry = GetCommittedEntry(entry);
-		if (!commited_entry.deleted) {
-			callback(commited_entry);
+		auto &committed_entry = GetCommittedEntry(entry);
+		if (!committed_entry.deleted) {
+			callback(committed_entry);
 		}
 	}
 }

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -927,7 +927,7 @@ string BoxRendererImplementation::ConvertRenderValue(const string &input) {
 				result += 'f';
 				break;
 			case 13:
-				// cariage return
+				// carriage return
 				result += 'r';
 				break;
 			case 27:

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -384,7 +384,7 @@ static idx_t GetFileUrlOffset(const string &path) {
 #endif
 	}
 
-	// unkown file:/ url format
+	// unknown file:/ url format
 	return 0;
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -110,7 +110,7 @@ bool LocalFileSystem::FileExists(const string &filename, optional_ptr<FileOpener
 	auto unicode_path = NormalizePathAndConvertToUnicode(*this, filename, opener);
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
-		struct _stati64 status;
+		struct _stati64 status; // typos:ignore
 		_wstati64(wpath, &status);
 		if (status.st_mode & S_IFREG) {
 			return true;
@@ -122,7 +122,7 @@ bool LocalFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> op
 	auto unicode_path = NormalizePathAndConvertToUnicode(*this, filename, opener);
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
-		struct _stati64 status;
+		struct _stati64 status; // typos:ignore
 		_wstati64(wpath, &status);
 		if (status.st_mode & _S_IFCHR) {
 			return true;

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -265,7 +265,7 @@ ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefin
 	if (!selected_children.empty()) {
 		auto entry = selected_children.find(0);
 		if (entry != selected_children.end()) {
-			// the column is relevent - set the child index
+			// the column is relevant - set the child index
 			global_child_index = entry->second;
 		} else {
 			// not relevant - ignore the column
@@ -331,7 +331,7 @@ MapColumnMapComponent(ClientContext &context,
 	if (!selected_children.empty()) {
 		auto entry = selected_children.find(component_idx);
 		if (entry != selected_children.end()) {
-			// the column is relevent - set the child index
+			// the column is relevant - set the child index
 			child_index = entry->second;
 		} else {
 			// not relevant - ignore the column
@@ -463,7 +463,7 @@ ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDef
 		if (!selected_children.empty()) {
 			auto entry = selected_children.find(i);
 			if (entry != selected_children.end()) {
-				// the column is relevent - set the child index
+				// the column is relevant - set the child index
 				global_child_index = entry->second;
 			} else {
 				// not relevant - ignore the column

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -2928,7 +2928,7 @@ void GetDivMod(hugeint_t lhs, hugeint_t rhs, hugeint_t &div, hugeint_t &mod) {
 template <class SRC, class DST>
 bool TryCastDecimalToFloatingPoint(SRC input, DST &result, uint8_t scale) {
 	if (IsRepresentableExactly<SRC, DST>(input, DST(0.0)) || scale == 0) {
-		// Fast path, integer is representable exaclty as a float/double
+		// Fast path, integer is representable exactly as a float/double
 		result = Cast::Operation<SRC, DST>(input) / DST(NumericHelper::DOUBLE_POWERS_OF_TEN[scale]);
 		return true;
 	}

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -19,7 +19,7 @@ void QueryProgress::Restart() {
 double QueryProgress::GetPercentage() {
 	return percentage;
 }
-uint64_t QueryProgress::GetRowsProcesseed() {
+uint64_t QueryProgress::GetRowsProcessed() {
 	return rows_processed;
 }
 uint64_t QueryProgress::GetTotalRowsToProcess() {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -805,7 +805,7 @@ bool LogicalType::GetDecimalProperties(uint8_t &width, uint8_t &scale) const {
 		// Nonsense values to ensure initialization
 		width = 255u;
 		scale = 255u;
-		// FIXME(carlo): This should be probably a throw, requires checkign the various call-sites
+		// FIXME(carlo): This should be probably a throw, requires checking the various call-sites
 		return false;
 	}
 	return true;

--- a/src/common/types/bignum.cpp
+++ b/src/common/types/bignum.cpp
@@ -198,6 +198,7 @@ string Bignum::FromByteArray(uint8_t *data, idx_t size, bool is_negative) {
 	return result;
 }
 
+// typos:ignore-next-line
 // Following CPython and Knuth (TAOCP, Volume 2 (3rd edn), section 4.4, Method 1b).
 string Bignum::BignumToVarchar(const bignum_t &blob) {
 	string decimal_string;

--- a/src/common/types/row/tuple_data_layout.cpp
+++ b/src/common/types/row/tuple_data_layout.cpp
@@ -167,18 +167,18 @@ void TupleDataLayout::Initialize(const vector<BoundOrderByNode> &orders, const L
 
 	// Compute row width
 	sort_width = 0;
-	bool all_valid_and_truely_constant = true;
+	bool all_valid_and_truly_constant = true;
 	for (idx_t order_idx = 0; order_idx < orders.size(); order_idx++) {
 		const auto &order = orders[order_idx];
 		const auto &logical_type = order.expression->return_type;
 		const auto physical_type = logical_type.InternalType();
 
-		if (all_valid_and_truely_constant && order.stats && !order.stats->CanHaveNull() &&
+		if (all_valid_and_truly_constant && order.stats && !order.stats->CanHaveNull() &&
 		    TypeIsConstantSize(physical_type) && sort_width < 7) {
 			// We don't have to sort by this byte, all values are valid
 			sort_skippable_bytes.emplace_back(sort_width);
 		} else {
-			all_valid_and_truely_constant = false;
+			all_valid_and_truly_constant = false;
 		}
 
 		if (TypeIsConstantSize(physical_type)) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -554,11 +554,11 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 				idx_t byte_data_length = 0;
 
 				// write all the lengths
-				auto lenghs_write_ptr = reinterpret_cast<uint32_t *>(length_data.get());
+				auto lengths_write_ptr = reinterpret_cast<uint32_t *>(length_data.get());
 				for (idx_t i = 0; i < count; i++) {
 					auto idx = vdata.sel->get_index(i);
 					auto this_length = vdata.validity.RowIsValid(idx) ? strings[idx].GetSize() : 0;
-					lenghs_write_ptr[i] = UnsafeNumericCast<uint32_t>(this_length);
+					lengths_write_ptr[i] = UnsafeNumericCast<uint32_t>(this_length);
 					byte_data_length += this_length;
 				}
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -218,7 +218,7 @@ static idx_t ProbeForPointersInternal(JoinHashTable::ProbeState &state, JoinHash
 				const hash_t row_salt = ht_entry_t::ExtractSalt(row_hash);
 				const bool salt_match = entry.GetSalt() == row_salt;
 				if (salt_match) {
-					// we know that the enty is occupied and the salt matches -> compare the keys
+					// we know that the entry is occupied and the salt matches -> compare the keys
 					auto row_index = GetOptionalIndex<HAS_SEL>(row_sel, i);
 					AddPointerToCompare(state, entry, pointers_result_v, row_ht_offset, keys_to_compare_count,
 					                    row_index);
@@ -323,7 +323,7 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
 			hashes_dense[i] = ht_offset_and_salt; // populate dense again
 		}
 
-		// in the next interation, we have a selection vector with the keys that do not match
+		// in the next iteration, we have a selection vector with the keys that do not match
 		row_sel = &state.keys_no_match_sel;
 		has_row_sel = true;
 
@@ -493,7 +493,7 @@ static data_ptr_t LoadPointer(const const_data_ptr_t &source) {
 	return cast_uint64_to_pointer(Load<uint64_t>(source));
 }
 
-//! If we consider to insert into an entry we expct to be empty, if it was filled in the meantime the insert will not
+//! If we consider to insert into an entry we expect to be empty, if it was filled in the meantime the insert will not
 //! happen and we need to return the pointer to the to row with which the new entry would have collided. In any other
 //! case we return a nullptr
 template <bool PARALLEL, bool EXPECT_EMPTY>
@@ -1856,7 +1856,7 @@ bool JoinHashTable::PrepareExternalFinalize(const idx_t max_ht_size) {
 	std::stable_sort(partition_indices.begin(), partition_indices.end(), [&](const idx_t &lhs, const idx_t &rhs) {
 		const auto lhs_size = partitions[lhs]->SizeInBytes() + PointerTableSize(partitions[lhs]->Count());
 		const auto rhs_size = partitions[rhs]->SizeInBytes() + PointerTableSize(partitions[rhs]->Count());
-		// We divide by min_partition_size, effectively rouding everything down to a multiple of min_partition_size
+		// We divide by min_partition_size, effectively rounding everything down to a multiple of min_partition_size
 		// Makes it so minor differences in partition sizes don't mess up the original order
 		// Retaining as much of the original order as possible reduces I/O (partition idx determines eviction queue idx)
 		return lhs_size / min_partition_size < rhs_size / min_partition_size;

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -19,7 +19,7 @@ constexpr idx_t StringValueScanner::LINE_FINDER_ID;
 
 StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_machine,
                                      const shared_ptr<CSVBufferHandle> &buffer_handle, Allocator &buffer_allocator,
-                                     idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_hander_p,
+                                     idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_handler_p,
                                      CSVIterator &iterator_p, bool store_line_size_p,
                                      shared_ptr<CSVFileScan> csv_file_scan_p, idx_t &lines_read_p, bool sniffing_p,
                                      const string &path_p, idx_t scan_id, bool &used_unstrictness)
@@ -29,7 +29,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
       extra_delimiter_bytes(state_machine.dialect_options.state_machine_options.delimiter.GetValue().empty()
                                 ? 0
                                 : state_machine.dialect_options.state_machine_options.delimiter.GetValue().size() - 1),
-      error_handler(error_hander_p), iterator(iterator_p), store_line_size(store_line_size_p),
+      error_handler(error_handler_p), iterator(iterator_p), store_line_size(store_line_size_p),
       csv_file_scan(std::move(csv_file_scan_p)), lines_read(lines_read_p), used_unstrictness(used_unstrictness),
       current_errors(scan_id, state_machine.options.IgnoreErrors()), sniffing(sniffing_p), path(path_p) {
 	// Vector information

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -321,7 +321,7 @@ void CSVReaderOptions::SetReadOption(const string &loption, const Value &value, 
 			force_not_null = ParseColumnList(value, expected_names, loption);
 		} else {
 			if (value.IsNull()) {
-				throw BinderException("Invalid value for 'force_not_null' paramenter");
+				throw BinderException("Invalid value for 'force_not_null' parameter");
 			}
 			// Get the list of columns to use as a recovery key
 			auto &children = ListValue::GetChildren(value);

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -198,7 +198,7 @@ SinkFinalizeType PhysicalIEJoin::Finalize(Pipeline &pipeline, Event &event, Clie
 
 	if ((gstate.child == 1 && PropagatesBuildSide(join_type)) || (gstate.child == 0 && IsLeftOuterJoin(join_type))) {
 		// for FULL/LEFT/RIGHT OUTER JOIN, initialize found_match to false for every tuple
-		table.IntializeMatches();
+		table.InitializeMatches();
 	}
 
 	SinkFinalizeType res;
@@ -1233,7 +1233,7 @@ void IEJoinLocalSourceState::ExecuteSinkL1Task(ExecutionContext &context, Interr
 		// RHS has negative rids
 		ExpressionExecutor r_executor(context.client);
 		r_executor.AddExpression(*op.rhs_orders[0].expression);
-		// add const column flase
+		// add const column false
 		auto right_const = make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
 		r_executor.AddExpression(*right_const);
 		r_executor.AddExpression(*op.rhs_orders[1].expression);

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -166,7 +166,7 @@ SinkFinalizeType PhysicalPiecewiseMergeJoin::Finalize(Pipeline &pipeline, Event 
 
 	if (PropagatesBuildSide(join_type)) {
 		// for FULL/RIGHT OUTER JOIN, initialize found_match to false for every tuple
-		gstate.table->IntializeMatches();
+		gstate.table->InitializeMatches();
 	}
 
 	if (gstate.table->Count() == 0 && EmptyResultIfRHSIsEmpty()) {

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -109,7 +109,7 @@ void PhysicalRangeJoin::GlobalSortedTable::Finalize(ClientContext &client, Inter
 	global_source = sort->GetGlobalSourceState(client, *global_sink);
 }
 
-void PhysicalRangeJoin::GlobalSortedTable::IntializeMatches() {
+void PhysicalRangeJoin::GlobalSortedTable::InitializeMatches() {
 	found_match = make_unsafe_uniq_array_uninitialized<bool>(Count());
 	memset(found_match.get(), 0, sizeof(bool) * Count());
 }

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -206,7 +206,7 @@ CopyToFunctionGlobalState::~CopyToFunctionGlobalState() {
 		try {
 			fs.TryRemoveFile(file);
 		} catch (...) {
-			// TryRemoveFile migth fail for a varieaty of reasons, but we can't really propagate error codes here, so
+			// TryRemoveFile might fail for a varieaty of reasons, but we can't really propagate error codes here, so
 			// best effort cleanup
 		}
 	}

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -506,7 +506,7 @@ static idx_t HandleInsertConflicts(DuckTableEntry &table, ExecutionContext &cont
 	auto affected_tuples = PerformOnConflictAction<GLOBAL>(lstate, gstate, context, combined_chunk, table, row_ids, op);
 
 	// Remove the conflicting tuples from the insert chunk
-	// We can use only the primay data because the secondary data has the same indexes in the chunk.
+	// We can use only the primary data because the secondary data has the same indexes in the chunk.
 	SelectionVector sel_vec(tuples.size());
 	auto &inverted_sel = conflict_manager.GetInvertedSel();
 	auto new_size = SelectionVector::Inverted(inverted_sel, sel_vec, conflict_count, tuples.size());

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -35,7 +35,7 @@ PhysicalCreateIndex::PhysicalCreateIndex(PhysicalPlan &physical_plan, LogicalOpe
 		indexed_columns.push_back(i);
 	}
 
-	// Row id is alway last
+	// Row id is always last
 	rowid_column.push_back(unbound_expressions.size());
 }
 

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -388,9 +388,9 @@ static CachingPhysicalOperatorExecuteMode SelectExecutionMode(const DataChunk &c
 		D_ASSERT(state.cached_chunk->size() > 0);
 
 		if (chunk.size() <= CachingPhysicalOperator::CACHE_THRESHOLD) {
-			// We can consider appening
+			// We can consider appending
 			if (chunk.size() + state.cached_chunk->size() <= STANDARD_VECTOR_SIZE) {
-				// Both fit toghether, append then return
+				// Both fit together, append then return
 				return CachingPhysicalOperatorExecuteMode::RETURN_CACHED_PLUS_CHUNK;
 			}
 			if (needs_continuation_chunk) {

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -684,7 +684,7 @@ idx_t RadixPartitionedHashTable::MaxThreads(GlobalSinkState &sink_p) const {
 	// This many partitions will fit given our reservation (at least 1))
 	const auto partitions_fit = MaxValue<idx_t>(usable_memory / sink.max_partition_size, 1);
 
-	// Mininum of the two
+	// Minimum of the two
 	return MinValue<idx_t>(partitions_fit, max_threads);
 }
 

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -113,7 +113,7 @@ unique_ptr<DataChunk> ReservoirSample::GetChunk() {
 	if (destroyed || !reservoir_chunk || Chunk().size() == 0) {
 		return nullptr;
 	}
-	// cannot destory internal samples.
+	// cannot destroy internal samples.
 	auto ret = make_uniq<DataChunk>();
 
 	SelectionVector ret_sel(STANDARD_VECTOR_SIZE);
@@ -327,7 +327,7 @@ void ReservoirSample::SimpleMerge(ReservoirSample &other) {
 	UpdateSampleAppend(reservoir_chunk->chunk, other.reservoir_chunk->chunk, chunk_sel, keep_from_other);
 	base_reservoir_sample->num_entries_seen_total += other.GetTuplesSeen();
 
-	// if THIS has too many samples now, we conver it to a slower sample.
+	// if THIS has too many samples now, we convert it to a slower sample.
 	if (GetTuplesSeen() >= FIXED_SAMPLE_SIZE * FAST_TO_SLOW_THRESHOLD) {
 		ConvertToReservoirSample();
 	}
@@ -352,7 +352,7 @@ void ReservoirSample::WeightedMerge(ReservoirSample &other_sample) {
 	for (idx_t i = num_samples_to_keep; i < total_samples; i++) {
 		auto min_weight_this = base_reservoir_sample->min_weight_threshold;
 		auto min_weight_other = other_sample.base_reservoir_sample->min_weight_threshold;
-		// min weight threshol is always positive
+		// min weight threshold is always positive
 		if (min_weight_this > min_weight_other) {
 			// pop from other
 			other_sample.base_reservoir_sample->reservoir_weights.pop();
@@ -394,7 +394,7 @@ void ReservoirSample::WeightedMerge(ReservoirSample &other_sample) {
 			sel_size += 1;
 		}
 
-		// make sure that the sample indexes are (this.sample_chunk.size() + chunk_offfset)
+		// make sure that the sample indexes are (this.sample_chunk.size() + chunk_offset)
 		base_reservoir_sample->reservoir_weights.push(other_top);
 		chunk_offset += 1;
 		i += 1;
@@ -772,7 +772,7 @@ void ReservoirSample::AddToReservoir(DataChunk &chunk) {
 
 	Verify();
 
-	// if we are over the threshold, we ned to switch to slow sampling.
+	// if we are over the threshold, we need to switch to slow sampling.
 	if (GetSamplingState() == SamplingState::RANDOM && GetTuplesSeen() >= FIXED_SAMPLE_SIZE * FAST_TO_SLOW_THRESHOLD) {
 		ConvertToReservoirSample();
 	}
@@ -909,7 +909,7 @@ unique_ptr<BlockingSample> ReservoirSamplePercentage::Copy() const {
 
 void ReservoirSamplePercentage::Finalize() {
 	// need to finalize the current sample, if any
-	// we are finializing, so we are starting to return chunks. Our last chunk has
+	// we are finalizing, so we are starting to return chunks. Our last chunk has
 	// sample_percentage * RESERVOIR_THRESHOLD entries that hold samples.
 	// if our current count is less than the sample_percentage * RESERVOIR_THRESHOLD
 	// then we have sampled too much for the current_sample and we need to redo the sample

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -615,7 +615,7 @@ void FunctionBinder::ResolveTemplateTypes(BaseScalarFunction &bound_function,
 		to_substitute.emplace_back(bound_function.varargs);
 	}
 
-	// If the return type is templated, we need to subsitute it as well
+	// If the return type is templated, we need to substitute it as well
 	if (bound_function.GetReturnType().IsTemplated()) {
 		to_substitute.emplace_back(bound_function.GetReturnType());
 	}

--- a/src/function/macro_function.cpp
+++ b/src/function/macro_function.cpp
@@ -296,7 +296,7 @@ MacroFunction::GetPositionalParametersForSerialization(Serializer &serializer) c
 		}
 		return result;
 	}
-	// Serializing targeting an older version - delete all named parameters from the list of positional parmaeters
+	// Serializing targeting an older version - delete all named parameters from the list of positional parameters
 	for (auto &param : parameters) {
 		auto &colref = param->Cast<ColumnRefExpression>();
 		if (default_parameters.find(colref.GetName()) != default_parameters.end()) {

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -24,18 +24,18 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 	target.ToUnifiedFormat(count, target_format);
 	const auto target_data = UnifiedVectorFormat::GetData<T>(target_format);
 
-	vector<const T *> member_datas;
+	vector<const T *> member_data_ptrs;
 	vector<UnifiedVectorFormat> member_vectors;
 	idx_t total_matches = 0;
 	for (auto &member : members) {
 		if (member.GetType().InternalType() == target_type.InternalType()) {
 			UnifiedVectorFormat member_format;
 			member.ToUnifiedFormat(count, member_format);
-			member_datas.push_back(UnifiedVectorFormat::GetData<T>(member_format));
+			member_data_ptrs.push_back(UnifiedVectorFormat::GetData<T>(member_format));
 			member_vectors.push_back(std::move(member_format));
 			total_matches++;
 		} else {
-			member_datas.push_back(nullptr);
+			member_data_ptrs.push_back(nullptr);
 			member_vectors.push_back(UnifiedVectorFormat());
 		}
 	}
@@ -75,8 +75,8 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 		RETURN_TYPE found_value {};
 
 		for (idx_t member_idx = 0; member_idx < member_count; member_idx++) {
-			auto &member_data = member_datas[member_idx];
-			if (!member_data) {
+			auto &member_data_ptr = member_data_ptrs[member_idx];
+			if (!member_data_ptr) {
 				continue; // skip if member data is not compatible with the target type
 			}
 			const auto &member_vector = member_vectors[member_idx];
@@ -84,8 +84,9 @@ static void TemplatedStructSearch(Vector &input_vector, vector<Vector> &members,
 			const auto col_valid = member_vector.validity.RowIsValid(member_data_idx);
 
 			auto is_null = FIND_NULLS && !col_valid && !target_valid;
-			auto both_valid_and_match = col_valid && target_valid &&
-			                            Equals::Operation<T>(member_data[member_data_idx], target_data[target_row_idx]);
+			auto both_valid_and_match =
+			    col_valid && target_valid &&
+			    Equals::Operation<T>(member_data_ptr[member_data_idx], target_data[target_row_idx]);
 
 			if (is_null || both_valid_and_match) {
 				found = true;

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -52,7 +52,7 @@ T *ArrowBufferData(ArrowArray &array, idx_t buffer_idx) {
 
 static void GetValidityMask(ValidityMask &mask, ArrowArray &array, idx_t chunk_offset, idx_t size,
                             int64_t parent_offset, int64_t nested_offset = -1, bool add_null = false) {
-	// In certains we don't need to or cannot copy arrow's validity mask to duckdb.
+	// In certain we don't need to or cannot copy arrow's validity mask to duckdb.
 	//
 	// The conditions where we do want to copy arrow's mask to duckdb are:
 	// 1. nulls exist

--- a/src/function/window/README.md
+++ b/src/function/window/README.md
@@ -2,7 +2,7 @@
 
 Starting with V2.0, window functions will no longer be special cased via enums
 but will be stored in the catalog as a new function type.
-They are in the same namepace as macros and as scalar and aggregate functions.
+They are in the same namespace as macros and as scalar and aggregate functions.
 
 Among other things, this means that extensions will be able to register _new_ window functions.
 New window functions should be functions that _cannot_ be implemented as windowed aggregates.

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -125,7 +125,7 @@ WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(ClientC
 	sort_types = aggregator.arg_types;
 	sort_types.emplace_back(LogicalType::UBIGINT);
 
-	//	All expressions will be precomputed for sharing, so we jsut need to reference the arguments
+	//	All expressions will be precomputed for sharing, so we just need to reference the arguments
 	vector<BoundOrderByNode> orders;
 	for (const auto &type : sort_types) {
 		auto expr = make_uniq<BoundReferenceExpression>(type, orders.size());

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -73,7 +73,7 @@ protected:
 	Vector statep;
 	//! Input data chunk, used for leaf segment aggregation
 	DataChunk leaves;
-	//! The rows beging updated.
+	//! The rows beginning updated.
 	SelectionVector update_sel;
 	//! Count of buffered values
 	idx_t flush_count;

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -1575,7 +1575,7 @@ void WindowFillExecutor::GetData(ExecutionContext &context, DataChunk &eval_chun
 				}
 			}
 
-			//	If there is nothing beind us (missing early value) then scan forward
+			//	If there is nothing being us (missing early value) then scan forward
 			if (prev_valid == DConstants::INVALID_INDEX) {
 				for (idx_t n = own_row + 1; n < frame_width; ++n) {
 					auto j = gfstate.value_tree->SelectNth(frames, n).first;

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -358,7 +358,7 @@ public:
 	DUCKDB_API string GetDefaultTable() const;
 	DUCKDB_API string GetDefaultTableSchema() const;
 
-	//! Returns the dependency manager of this catalog - if the catalog has anye
+	//! Returns the dependency manager of this catalog - if the catalog has any
 	virtual optional_ptr<DependencyManager> GetDependencyManager();
 
 	//! Whether attaching a catalog with the given path and attach options would be considered a conflict

--- a/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
@@ -81,7 +81,7 @@ public:
 	                                                        CreatePragmaFunctionInfo &info) = 0;
 	//! Create a collation within the given schema
 	virtual optional_ptr<CatalogEntry> CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) = 0;
-	//! Create a coordiante system within the given schema
+	//! Create a coordinate system within the given schema
 	virtual optional_ptr<CatalogEntry> CreateCoordinateSystem(CatalogTransaction transaction,
 	                                                          CreateCoordinateSystemInfo &info) {
 		throw NotImplementedException("Coordinate systems are not supported in schema '%s'", name);

--- a/src/include/duckdb/common/arrow/nanoarrow/nanoarrow.h
+++ b/src/include/duckdb/common/arrow/nanoarrow/nanoarrow.h
@@ -284,7 +284,7 @@ ArrowErrorCode ArrowMetadataGetValue(const char *metadata, const char *key, cons
 /// Contains more readily extractable values than a raw ArrowSchema.
 /// Clients can stack or statically allocate this structure but are
 /// encouraged to use the provided getters to ensure forward
-/// compatiblity.
+/// compatibility.
 struct ArrowSchemaView {
 	/// \brief A pointer to the schema represented by this view
 	struct ArrowSchema *schema;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -208,7 +208,7 @@ public:
 	DUCKDB_API virtual bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Remove a file from disk
 	DUCKDB_API virtual void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
-	//! Remvoe a file from disk if it exists - if it does not exist, return false
+	//! Remove a file from disk if it exists - if it does not exist, return false
 	DUCKDB_API virtual bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Remove multiple files from disk - does not error if any file does not exist
 	DUCKDB_API virtual void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener = nullptr);
@@ -271,7 +271,7 @@ public:
 	//! Unregister a sub-filesystem by name
 	DUCKDB_API virtual void UnregisterSubSystem(const string &name);
 
-	// !Extract a sub-filesystem by name, with ownership transfered, return nullptr if not registered or the subsystem
+	// !Extract a sub-filesystem by name, with ownership transferred, return nullptr if not registered or the subsystem
 	// has been disabled.
 	DUCKDB_API virtual unique_ptr<FileSystem> ExtractSubSystem(const string &name);
 
@@ -301,7 +301,7 @@ public:
 	//! Create a LocalFileSystem.
 	DUCKDB_API static unique_ptr<FileSystem> CreateLocal();
 
-	//! Return the name of the filesytem. Used for forming diagnosis messages.
+	//! Return the name of the filesystem. Used for forming diagnosis messages.
 	DUCKDB_API virtual std::string GetName() const = 0;
 
 	//! Whether or not a file is remote or local, based only on file path

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -79,7 +79,7 @@ public:
 
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
 	void Seek(FileHandle &handle, idx_t location) override;
-	//! Return the current seek posiiton in the file.
+	//! Return the current seek position in the file.
 	idx_t SeekPosition(FileHandle &handle) override;
 
 	//! Whether or not we can seek into the file

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -342,7 +342,7 @@ public:
 			auto &file_mutex = *global_state.readers[file_index]->file_mutex;
 
 			// To get the file lock, we first need to release the parallel_lock to prevent deadlocking. Note that this
-			// requires getting the ref to the file mutex pointer with the lock stil held: readers get be resized
+			// requires getting the ref to the file mutex pointer with the lock still held: readers get be resized
 			parallel_lock.unlock();
 			unique_lock<mutex> current_file_lock(file_mutex);
 			parallel_lock.lock();

--- a/src/include/duckdb/common/progress_bar/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar.hpp
@@ -27,7 +27,7 @@ public:
 	void Initialize();
 	void Restart();
 	double GetPercentage();
-	uint64_t GetRowsProcesseed();
+	uint64_t GetRowsProcessed();
 	uint64_t GetTotalRowsToProcess();
 	QueryProgress &operator=(const QueryProgress &other);
 	QueryProgress(const QueryProgress &other);

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -23,7 +23,7 @@ namespace duckdb {
 
 #ifndef DUCKDB_QUOTE_DEFINE
 // Preprocessor trick to allow text to be converted to C-string / string
-// Expecte use is:
+// Expected use is:
 //	#ifdef SOME_DEFINE
 //	string str = DUCKDB_QUOTE_DEFINE(SOME_DEFINE)
 //	...do something with str
@@ -138,7 +138,7 @@ public:
 	DUCKDB_API static vector<string> SplitWithParentheses(const string &str, char delimiter = ',', char par_open = '(',
 	                                                      char par_close = ')');
 
-	//! Split the input string allong a quote. Note that any escaping is NOT supported.
+	//! Split the input string along a quote. Note that any escaping is NOT supported.
 	DUCKDB_API static vector<string> SplitWithQuote(const string &str, char delimiter = ',', char quote = '"');
 
 	//! Join multiple strings into one string. Components are concatenated by the given separator

--- a/src/include/duckdb/common/types/bignum.hpp
+++ b/src/include/duckdb/common/types/bignum.hpp
@@ -48,7 +48,7 @@ public:
 	DUCKDB_API static bignum_t InitializeBignumZero(Vector &result);
 	DUCKDB_API static string InitializeBignumZero();
 
-	//! Switch Case of To Bignum Convertion
+	//! Switch Case of To Bignum Conversion
 	DUCKDB_API static BoundCastInfo NumericToBignumCastSwitch(const LogicalType &source);
 
 	//! ----------------------------------- Varchar Cast ----------------------------------- //

--- a/src/include/duckdb/execution/merge_sort_tree.hpp
+++ b/src/include/duckdb/execution/merge_sort_tree.hpp
@@ -462,7 +462,7 @@ pair<idx_t, idx_t> MergeSortTree<E, O, CMP, F, C>::SelectNth(const SubFrames &fr
 	// First, handle levels with cascading pointers
 	const auto min_cascaded = LowestCascadingLevel();
 	if (level_no > min_cascaded) {
-		//	Initialise the cascade indicies from the previous level
+		//	Initialise the cascade indices from the previous level
 		using CascadeRange = pair<idx_t, idx_t>;
 		std::array<CascadeRange, 3> cascades;
 		const auto &level = tree[level_no + 1].first;
@@ -479,7 +479,7 @@ pair<idx_t, idx_t> MergeSortTree<E, O, CMP, F, C>::SelectNth(const SubFrames &fr
 
 		// 	Walk the cascaded levels
 		for (; level_no >= min_cascaded; --level_no) {
-			//	The cascade indicies into this level are in the previous level
+			//	The cascade indices into this level are in the previous level
 			const auto &level_cascades = tree[level_no + 1].second;
 
 			// Go over all children until we found enough in range

--- a/src/include/duckdb/execution/operator/join/physical_range_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_range_join.hpp
@@ -76,7 +76,7 @@ public:
 			return sorted->key_data->GetLayout().GetSortKeyType();
 		}
 
-		void IntializeMatches();
+		void InitializeMatches();
 
 		//! Combine local states
 		void Combine(ExecutionContext &context, LocalSortedTable &ltable);

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -58,7 +58,7 @@ public:
 	const vector<unique_ptr<BoundConstraint>> &bound_constraints;
 	//! The delete state for ON CONFLICT handling that is rewritten into DELETE + INSERT.
 	unique_ptr<TableDeleteState> delete_state;
-	//! The append chunk for ON CONFLICT handling that is rewritting into DELETE + INSERT.
+	//! The append chunk for ON CONFLICT handling that is rewriting into DELETE + INSERT.
 	DataChunk append_chunk;
 };
 

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -45,7 +45,7 @@ public:
 	};
 };
 
-//! Resevoir sampling is based on the 2005 paper "Weighted Random Sampling" by Efraimidis and Spirakis
+//! Reservoir sampling is based on the 2005 paper "Weighted Random Sampling" by Efraimidis and Spirakis
 class BaseReservoirSampling {
 public:
 	explicit BaseReservoirSampling(int64_t seed);
@@ -61,7 +61,7 @@ public:
 	void UpdateMinWeightThreshold();
 
 	//! Go from the naive sampling to the reservoir sampling
-	//! Naive samping will not collect weights, but when we serialize
+	//! Naive sampling will not collect weights, but when we serialize
 	//! we need to serialize weights again.
 	void FillWeights(SelectionVector &sel, idx_t &sel_size);
 
@@ -90,7 +90,7 @@ public:
 
 	// static unordered_map<idx_t, double> tuples_to_min_weight_map;
 	// Blocking sample is a virtual class. It should be allowed to see the weights and
-	// of tuples in the sample. The blocking sample can then easily maintain statisitcal properties
+	// of tuples in the sample. The blocking sample can then easily maintain statistical properties
 	// from the sample point of view.
 	friend class BlockingSample;
 };
@@ -296,7 +296,7 @@ public:
 
 	unique_ptr<BlockingSample> Copy() const override;
 
-	//! Fetches a chunk from the sample. If destory = true this method is descructive
+	//! Fetches a chunk from the sample. If destroy = true this method is descructive
 	unique_ptr<DataChunk> GetChunk() override;
 	void Finalize() override;
 

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -74,7 +74,7 @@ public:
 		return lookup_bytes;
 	}
 
-	//! Optional convertion map, that indicates byte replacements.
+	//! Optional conversion map, that indicates byte replacements.
 	const map_entry_encoding *conversion_map {};
 	size_t map_size {};
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -440,7 +440,7 @@ public:
 	//! (Optional) cardinality function
 	//! Returns the expected cardinality of this scan
 	table_function_cardinality_t cardinality;
-	//! (Optional) returns the number of rows that have benn scanned
+	//! (Optional) returns the number of rows that have been scanned
 	table_function_rows_scanned_t rows_scanned;
 	//! (Optional) pushdown a set of arbitrary filter expressions, rather than only simple comparisons with a constant
 	//! Any functions remaining in the expression list will be pushed as a regular filter after the scan

--- a/src/include/duckdb/function/window/window_aggregator.hpp
+++ b/src/include/duckdb/function/window/window_aggregator.hpp
@@ -116,7 +116,7 @@ public:
 	const idx_t state_size;
 	//! The window exclusion clause
 	const WindowExcludeMode exclude_mode;
-	//! Partition collection column indicies
+	//! Partition collection column indices
 	vector<column_t> child_idx;
 };
 

--- a/src/include/duckdb/logging/log_manager.hpp
+++ b/src/include/duckdb/logging/log_manager.hpp
@@ -39,7 +39,7 @@ public:
 
 	DUCKDB_API bool RegisterLogStorage(const string &name, shared_ptr<LogStorage> &storage);
 
-	//! The global logger can be used whe
+	//! The global logger can be used when
 	DUCKDB_API Logger &GlobalLogger();
 	DUCKDB_API shared_ptr<Logger> GlobalLoggerReference();
 

--- a/src/include/duckdb/logging/log_storage.hpp
+++ b/src/include/duckdb/logging/log_storage.hpp
@@ -148,7 +148,7 @@ protected:
 	//! lock to be used by this class and child classes to ensure thread safety TODO: maybe remove and delegate
 	//! thread-safety to LogManager?
 	mutable mutex lock;
-	//! Switches between using false = use LoggingTargetTable::ALL_LOGS, true = use LoggingTargetTable::LOG_ENTIRES +
+	//! Switches between using false = use LoggingTargetTable::ALL_LOGS, true = use LoggingTargetTable::LOG_ENTRIES +
 	//! LoggingTargetTable::CONTEXTS
 	bool normalize_contexts = true;
 
@@ -278,7 +278,7 @@ protected:
 	void AfterFlush(LoggingTargetTable table, DataChunk &chunk) override;
 
 private:
-	//! Intialize the csv file for `table`
+	//! Initialize the csv file for `table`
 	void InitializeFile(DatabaseInstance &db, LoggingTargetTable table);
 	//! Initialize the filewriter to be passed to the CSVWriter
 	static unique_ptr<BufferedFileWriter> InitializeFileWriter(DatabaseInstance &db, const string &path);

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -57,7 +57,7 @@ protected:
 	AppenderType appender_type;
 	//! The amount of rows after which the appender flushes automatically.
 	idx_t flush_count = DEFAULT_FLUSH_COUNT;
-	//! Peak allocation threshold at which to flush the allocator when appender flushs chunk.
+	//! Peak allocation threshold at which to flush the allocator when appender flushes chunk.
 	optional_idx flush_memory_threshold;
 
 protected:

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -216,7 +216,7 @@ public:
 		                             std::move(varargs));
 	}
 
-	//------------------------------------- Aggreate Functions ----------------------------------------//
+	//------------------------------------- Aggregate Functions ----------------------------------------//
 	template <typename UDF_OP, typename STATE, typename TR, typename TA>
 	void CreateAggregateFunction(const string &name) {
 		AggregateFunction function = UDFWrapper::CreateAggregateFunction<UDF_OP, STATE, TR, TA>(name);

--- a/src/include/duckdb/optimizer/cse_optimizer.hpp
+++ b/src/include/duckdb/optimizer/cse_optimizer.hpp
@@ -33,7 +33,7 @@ private:
 	void PerformCSEReplacement(unique_ptr<Expression> &expr, CSEReplacementState &state);
 
 	//! Main method to extract common subexpressions
-	void ExtractCommonSubExpresions(LogicalOperator &op);
+	void ExtractCommonSubExpressions(LogicalOperator &op);
 
 private:
 	Binder &binder;

--- a/src/include/duckdb/optimizer/matcher/set_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/set_matcher.hpp
@@ -30,7 +30,7 @@ public:
 		INVALID
 	};
 
-	/* The double {{}} in the intializer for excluded_entries is intentional, workaround for bug in gcc-4.9 */
+	/* The double {{}} in the initializer for excluded_entries is intentional, workaround for bug in gcc-4.9 */
 	template <class T, class MATCHER>
 	static bool MatchRecursive(vector<unique_ptr<MATCHER>> &matchers, vector<reference<T>> &entries,
 	                           vector<reference<T>> &bindings, unordered_set<idx_t> excluded_entries, idx_t m_idx = 0) {

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -90,7 +90,7 @@ protected:
 	unique_ptr<Expression> VisitReplace(BoundReferenceExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
 protected:
-	//! Add a reference to the column in its entirey
+	//! Add a reference to the column in its entirety
 	void AddBinding(BoundColumnRefExpression &col);
 	//! Add a reference to a sub-section of the column
 	void AddBinding(BoundColumnRefExpression &col, ColumnIndex child_column);

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -55,7 +55,7 @@ public:
 	// Check whether there are tasks associated
 	bool HasTasks() const;
 	AsyncResultType GetResultType() const;
-	// Extract associated tasks, moving them away, will empty async_tasks and trasnform to INVALID
+	// Extract associated tasks, moving them away, will empty async_tasks and transform to INVALID
 	vector<unique_ptr<AsyncTask>> &&ExtractAsyncTasks();
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -80,7 +80,7 @@ public:
 	static void YieldThread();
 
 	//! Set the allocator flush threshold
-	void SetAllocatorFlushTreshold(idx_t threshold);
+	void SetAllocatorFlushThreshold(idx_t threshold);
 	//! Sets the allocator background thread
 	void SetAllocatorBackgroundThreads(bool enable);
 

--- a/src/include/duckdb/parser/constraint.hpp
+++ b/src/include/duckdb/parser/constraint.hpp
@@ -31,7 +31,7 @@ enum class ConstraintType : uint8_t {
 enum class ForeignKeyType : uint8_t {
 	FK_TYPE_PRIMARY_KEY_TABLE = 0,   // main table
 	FK_TYPE_FOREIGN_KEY_TABLE = 1,   // referencing table
-	FK_TYPE_SELF_REFERENCE_TABLE = 2 // self refrencing table
+	FK_TYPE_SELF_REFERENCE_TABLE = 2 // self referencing table
 };
 
 struct ForeignKeyInfo {

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -52,7 +52,7 @@ public:
 
 	~ActiveCheckpointWrapper();
 
-	//! Begin the transaction withint the newly created connection.
+	//! Begin the transaction within the newly created connection.
 	void GetCheckpointTransaction(CheckpointOptions &options);
 	void Commit();
 	bool HasCheckpointContext() const;

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -345,7 +345,7 @@ struct AlpCompression {
 			compression_data.encoded_integers[null_value_pos] = a_non_exception_value;
 		}
 
-		// Analyze FFOR
+		// Analyze FFOR // typos:ignore
 		auto min_value = NumericLimits<int64_t>::Maximum();
 		auto max_value = NumericLimits<int64_t>::Minimum();
 		for (idx_t i = 0; i < n_values; i++) {

--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -20,7 +20,7 @@ namespace roaring {
 
 //! Used for compressed runs/arrays
 static constexpr uint16_t COMPRESSED_SEGMENT_SIZE = 256;
-//! compresed segment size is 256, instead of division we can make use of shifting
+//! compressed segment size is 256, instead of division we can make use of shifting
 static constexpr uint16_t COMPRESSED_SEGMENT_SHIFT_AMOUNT = 8;
 //! The amount of values that are encoded per container
 static constexpr idx_t ROARING_CONTAINER_SIZE = 2048;
@@ -48,7 +48,7 @@ static_assert(BITSET_CONTAINER_SENTINEL_VALUE < NumericLimits<uint8_t>::Maximum(
               "The array/bitset size is encoded in a maximum of 8 bits");
 
 static_assert(ROARING_CONTAINER_SIZE % COMPRESSED_SEGMENT_SIZE == 0,
-              "The (maximum) container size has to be cleanly divisable by the segment size");
+              "The (maximum) container size has to be cleanly divisible by the segment size");
 
 static_assert((1 << RUN_CONTAINER_SIZE_BITWIDTH) - 1 >= MAX_RUN_IDX,
               "The bitwidth used to store the size of a run container has to be big enough to store the maximum size");

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -45,7 +45,7 @@ private:
 
 //! [CachingFileSystemWrapper] is an adapter class, which wraps [CachingFileSystem] to conform to FileSystem API.
 //! Different from [CachingFileSystem], which owns cache content and returns a [BufferHandle] to achieve zero-copy on
-//! read, the wrapper class always copies requested byted into the provided address.
+//! read, the wrapper class always copies requested bytes into the provided address.
 //!
 //! NOTICE: Currently only read and seek operations are supported, write operations are disabled.
 class CachingFileSystemWrapper : public FileSystem, public enable_shared_from_this<CachingFileSystemWrapper> {

--- a/src/include/duckdb/storage/external_file_cache/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/external_file_cache/file_buffer_handle_group.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 
 // A group of BufferHandles that together represent contiguous file content.
 // For example, ZSTD supports stream-based decompression, which doesn't require to prepare a contiguous buffer;
-// insteads users are able to iterate all handles and decompress them on the fly.
+// instead users are able to iterate all handles and decompress them on the fly.
 class FileBufferHandleGroup {
 public:
 	// A single BufferHandle and its offset/length within the file.

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -64,7 +64,7 @@ public:
 	ErrorData WriteToWAL(ClientContext &context, AttachedDatabase &db,
 	                     unique_ptr<StorageCommitState> &commit_state) noexcept;
 	//! Commit the current transaction with the given commit identifier. Returns an error message if the transaction
-	//! commit failed, or an empty string if the commit was sucessful
+	//! commit failed, or an empty string if the commit was successful
 	ErrorData Commit(AttachedDatabase &db, CommitInfo &commit_info,
 	                 unique_ptr<StorageCommitState> commit_state) noexcept;
 	//! Returns whether or not a commit of this transaction should trigger an automatic checkpoint

--- a/src/main/capi/copy_function-c.cpp
+++ b/src/main/capi/copy_function-c.cpp
@@ -685,7 +685,7 @@ unique_ptr<FunctionData> CCopyFromBind(ClientContext &context, CopyFromFunctionB
 			}
 		}
 
-		// Assing the option as a named parameter
+		// Assign the option as a named parameter
 		named_parameters[opt.first] = param_value;
 	}
 

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -130,7 +130,7 @@ duckdb_query_progress_type duckdb_query_progress(duckdb_connection connection) {
 	Connection *conn = reinterpret_cast<Connection *>(connection);
 	auto query_progress = conn->context->GetQueryProgress();
 	query_progress_type.total_rows_to_process = query_progress.GetTotalRowsToProcess();
-	query_progress_type.rows_processed = query_progress.GetRowsProcesseed();
+	query_progress_type.rows_processed = query_progress.GetRowsProcessed();
 	query_progress_type.percentage = query_progress.GetPercentage();
 	return query_progress_type;
 }

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	auto extension = ExtensionHelper::ExtractExtensionPrefixFromPath(path);
 	if (!extension.empty()) {
-		// path is prefixed with an extension - remove the first occurence of it
+		// path is prefixed with an extension - remove the first occurrence of it
 		path = path.substr(extension.length() + 1);
 		db_type = ExtensionHelper::ApplyExtensionAlias(extension);
 	}

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -421,6 +421,7 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 	}
 }
 
+// typos:off
 static const char *const public_keys[] = {
     R"(
 -----BEGIN PUBLIC KEY-----
@@ -854,6 +855,7 @@ k9EbTcRNnxCvab/oqjvgyRuSmIES00v8jZOGQZQUpw02RN6yCBeX2i8GPsGjj/T9
 -----END PUBLIC KEY-----
 )", nullptr};
 
+// typos:on
 const vector<string> ExtensionHelper::GetPublicKeys(bool allow_community_extensions) {
 	vector<string> keys;
 	for (idx_t i = 0; public_keys[i]; i++) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -120,7 +120,7 @@ struct ExtensionAccess {
 			}
 		} else if (load_state.init_result.abi_type == ExtensionABIType::C_STRUCT_UNSTABLE) {
 			// NOTE: we currently don't check anything here: the version of extensions of ABI type C_STRUCT_UNSTABLE is
-			// ignored because C_STRUCT_UNSTABLE extensions are tied 1:1 to duckdb verions meaning they will always
+			// ignored because C_STRUCT_UNSTABLE extensions are tied 1:1 to duckdb versions meaning they will always
 			// receive the whole function pointer struct
 		} else {
 			load_state.has_error = true;
@@ -190,7 +190,7 @@ static string ComputeFinalHash(const vector<string> &chunks) {
 	return two_level_hash;
 }
 
-static void IntializeAncillaryData(vector<string> &hash_chunks, vector<idx_t> &splits, idx_t length) {
+static void InitializeAncillaryData(vector<string> &hash_chunks, vector<idx_t> &splits, idx_t length) {
 	const idx_t maxLenChunks = 1024ULL * 1024ULL;
 	const idx_t numChunks = (length + maxLenChunks - 1) / maxLenChunks;
 	hash_chunks.resize(numChunks);
@@ -327,7 +327,7 @@ bool ExtensionHelper::CheckExtensionSignature(FileHandle &handle, ParsedExtensio
 
 	vector<string> hash_chunks;
 	vector<idx_t> splits;
-	IntializeAncillaryData(hash_chunks, splits, signature_offset);
+	InitializeAncillaryData(hash_chunks, splits, signature_offset);
 
 	ComputeHashesOnSegments(ComputeSHA256FileSegment, &handle, splits, hash_chunks);
 
@@ -343,7 +343,7 @@ bool ExtensionHelper::CheckExtensionBufferSignature(const char *buffer, idx_t bu
                                                     const bool allow_community_extensions) {
 	vector<string> hash_chunks;
 	vector<idx_t> splits;
-	IntializeAncillaryData(hash_chunks, splits, buffer_length);
+	InitializeAncillaryData(hash_chunks, splits, buffer_length);
 
 	ComputeHashesOnSegments(ComputeSHA256Buffer, buffer, splits, hash_chunks);
 
@@ -509,7 +509,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 #ifdef WASM_LOADABLE_EXTENSIONS
 	EM_ASM(
 	    {
-		    // Next few lines should argubly in separate JavaScript-land function call
+		    // Next few lines should arguably in separate JavaScript-land function call
 		    // TODO: move them out / have them configurable
 		    const xhr = new XMLHttpRequest();
 		    xhr.open("GET", UTF8ToString($0), false);

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -130,14 +130,14 @@ Value DeltaOnlyVariantEncodingEnabledSetting::GetSetting(const ClientContext &co
 void AllocatorFlushThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	config.options.allocator_flush_threshold = DBConfig::ParseMemoryLimit(input.ToString());
 	if (db) {
-		TaskScheduler::GetScheduler(*db).SetAllocatorFlushTreshold(config.options.allocator_flush_threshold);
+		TaskScheduler::GetScheduler(*db).SetAllocatorFlushThreshold(config.options.allocator_flush_threshold);
 	}
 }
 
 void AllocatorFlushThresholdSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.allocator_flush_threshold = DBConfigOptions().allocator_flush_threshold;
 	if (db) {
-		TaskScheduler::GetScheduler(*db).SetAllocatorFlushTreshold(config.options.allocator_flush_threshold);
+		TaskScheduler::GetScheduler(*db).SetAllocatorFlushThreshold(config.options.allocator_flush_threshold);
 	}
 }
 
@@ -1181,7 +1181,7 @@ void EnableHTTPLoggingSetting::SetLocal(ClientContext &context, const Value &inp
 	auto &config = ClientConfig::GetConfig(context);
 	config.enable_http_logging = input.GetValue<bool>();
 
-	// NOTE: this is a deprecated setting: we mimick the old behaviour by setting the log storage output to STDOUT and
+	// NOTE: this is a deprecated setting: we mimic the old behaviour by setting the log storage output to STDOUT and
 	// enabling logging for http only. Note that this behaviour is slightly wonky in that it sets all sorts of logging
 	// config
 	auto &log_manager = LogManager::Get(context);

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -38,7 +38,7 @@ void CommonSubExpressionOptimizer::VisitOperator(LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_PROJECTION:
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
-		ExtractCommonSubExpresions(op);
+		ExtractCommonSubExpressions(op);
 		break;
 	default:
 		break;
@@ -137,7 +137,7 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 	                                      [&](unique_ptr<Expression> &child) { PerformCSEReplacement(child, state); });
 }
 
-void CommonSubExpressionOptimizer::ExtractCommonSubExpresions(LogicalOperator &op) {
+void CommonSubExpressionOptimizer::ExtractCommonSubExpressions(LogicalOperator &op) {
 	D_ASSERT(op.children.size() == 1);
 
 	// first we count for each expression with children how many types it occurs

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -156,7 +156,7 @@ idx_t ExpressionHeuristics::ExpressionCost(BoundOperatorExpression &expr, Expres
 }
 
 idx_t ExpressionHeuristics::ExpressionCost(PhysicalType return_type, idx_t multiplier) {
-	// TODO: ajust values according to benchmark results
+	// TODO: adjust values according to benchmark results
 	switch (return_type) {
 	case PhysicalType::VARCHAR:
 		return 5 * multiplier;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -1209,7 +1209,7 @@ FilterResult FilterCombiner::AddTransitiveFilters(BoundComparisonExpression &com
 			// create filter j [>, >=] 10 and add the filter j [>=, <=] i into the remaining filters
 			info.comparison_type = right_constant.comparison_type; // create filter j [>, >=, <, <=] 10
 			if (!is_inserted) {
-				// Add the filter j >= i in the remaing filters
+				// Add the filter j >= i in the remaining filters
 				auto filter = make_uniq<BoundComparisonExpression>(comparison.GetExpressionType(),
 				                                                   comparison.left->Copy(), comparison.right->Copy());
 				remaining_filters.push_back(std::move(filter));

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -400,7 +400,7 @@ DenomInfo CardinalityEstimator::GetDenominator(JoinRelationSet &set) {
 	return DenomInfo(*subgraphs.at(0).numerator_relations, 1, subgraphs.at(0).denom * denom_multiplier);
 }
 
-// Cardinality is calculatd using logic found in
+// Cardinality is calculated using logic found in
 // https://blobs.duckdb.org/papers/tom-ebergen-msc-thesis-join-order-optimization-with-almost-no-statistics.pdf TL;DR
 // Cardinality is estimated based on cardinality of base tables and the distinct counts of joined columns. If you have
 // two tables A and B joined using A.x = B.y we assume that each tuple in A will match ~ B/(distinct(y)) tuples in B.

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -600,7 +600,7 @@ vector<unique_ptr<FilterInfo>> RelationManager::ExtractEdges(LogicalOperator &op
 				optional_ptr<JoinRelationSet> right_set;
 				optional_ptr<JoinRelationSet> full_set;
 				// here we create a left_set that unions all relations from the left side of
-				// every expression and a right_set that unions all relations frmo the right side of a
+				// every expression and a right_set that unions all relations from the right side of a
 				// every expression (although this should always be 1).
 				for (auto &bound_expr : conjunction_expression->children) {
 					D_ASSERT(bound_expr->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);

--- a/src/optimizer/pushdown/pushdown_window.cpp
+++ b/src/optimizer/pushdown/pushdown_window.cpp
@@ -34,7 +34,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownWindow(unique_ptr<LogicalOpe
 	auto &window = op->Cast<LogicalWindow>();
 	FilterPushdown pushdown(optimizer, convert_mark_joins);
 
-	// 1. Loop throguh the expressions, find the window expressions and investigate the partitions
+	// 1. Loop through the expressions, find the window expressions and investigate the partitions
 	// if a filter applies to a partition in each window expression then you can push the filter
 	// into the children.
 	vector<column_binding_set_t> window_exprs_partition_bindings;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -329,7 +329,7 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 		auto &distinct = op.Cast<LogicalDistinct>();
 		if (distinct.distinct_type == DistinctType::DISTINCT_ON) {
 			// distinct type references columns that need to be distinct on, so no
-			// need to implicity reference everything.
+			// need to implicitly reference everything.
 			break;
 		}
 		// distinct, all projected columns are used for the DISTINCT computation

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -145,7 +145,7 @@ static bool IsConstantOrNullFilter(const TableFilter &table_filter) {
 
 static bool CanReplaceConstantOrNull(const TableFilter &table_filter) {
 	if (!IsConstantOrNullFilter(table_filter)) {
-		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
+		throw InternalException("CanReplaceConstantOrNull() called on unexpected Table Filter");
 	}
 	D_ASSERT(table_filter.filter_type == TableFilterType::EXPRESSION_FILTER);
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(table_filter, "CanReplaceConstantOrNull");

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -138,7 +138,8 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 		// note that it is fine to do this now, even if the same column is used again later
 		// e.g. if we have i=j AND i=k, and the stats for j and k are disjoint, we know there are no results
 		// so if we have e.g. i: [0, 100], j: [0, 25], k: [75, 100]
-		// we can set i: [0, 25] after the first comparison, and statically determine that the second comparison is fals
+		// we can set i: [0, 25] after the first comparison, and statically determine that the second comparison is
+		// false
 
 		// note that we can't update statistics the same for all join types
 		// mark and single joins don't filter any tuples -> so there is no propagation possible

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -438,7 +438,7 @@ void TaskScheduler::SetThreads(idx_t total_threads, idx_t external_threads) {
 	requested_thread_count = NumericCast<int32_t>(total_threads - external_threads);
 }
 
-void TaskScheduler::SetAllocatorFlushTreshold(idx_t threshold) {
+void TaskScheduler::SetAllocatorFlushThreshold(idx_t threshold) {
 	allocator_flush_threshold = threshold;
 }
 

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -38,7 +38,7 @@ string KeywordHelper::EscapeQuotes(const string &text, char quote) {
 }
 
 string KeywordHelper::WriteQuoted(const string &text, char quote) {
-	// 1. Escapes all occurences of 'quote' by doubling them (escape in SQL)
+	// 1. Escapes all occurrences of 'quote' by doubling them (escape in SQL)
 	// 2. Adds quotes around the string
 	return string(1, quote) + EscapeQuotes(text, quote) + string(1, quote);
 }

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -138,7 +138,7 @@ PivotColumnEntry PivotColumnEntry::Copy() const {
 	return result;
 }
 
-static bool TryFoldConstantForBackwardsCompatability(const ParsedExpression &expr, Value &value) {
+static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &expr, Value &value) {
 	switch (expr.GetExpressionType()) {
 	case ExpressionType::FUNCTION: {
 		auto &function = expr.Cast<FunctionExpression>();
@@ -151,7 +151,7 @@ static bool TryFoldConstantForBackwardsCompatability(const ParsedExpression &exp
 					return false;
 				}
 				Value child_value;
-				if (!TryFoldConstantForBackwardsCompatability(*child, child_value)) {
+				if (!TryFoldConstantForBackwardsCompatibility(*child, child_value)) {
 					return false;
 				}
 				values.emplace_back(child->GetAlias(), std::move(child_value));
@@ -163,7 +163,7 @@ static bool TryFoldConstantForBackwardsCompatability(const ParsedExpression &exp
 			values.reserve(function.children.size());
 			for (const auto &child : function.children) {
 				Value child_value;
-				if (!TryFoldConstantForBackwardsCompatability(*child, child_value)) {
+				if (!TryFoldConstantForBackwardsCompatibility(*child, child_value)) {
 					return false;
 				}
 				values.emplace_back(std::move(child_value));
@@ -180,12 +180,12 @@ static bool TryFoldConstantForBackwardsCompatability(const ParsedExpression &exp
 			return true;
 		} else if (function.function_name == "map") {
 			Value keys;
-			if (!TryFoldConstantForBackwardsCompatability(*function.children[0], keys)) {
+			if (!TryFoldConstantForBackwardsCompatibility(*function.children[0], keys)) {
 				return false;
 			}
 
 			Value values;
-			if (!TryFoldConstantForBackwardsCompatability(*function.children[1], values)) {
+			if (!TryFoldConstantForBackwardsCompatibility(*function.children[1], values)) {
 				return false;
 			}
 
@@ -207,7 +207,7 @@ static bool TryFoldConstantForBackwardsCompatability(const ParsedExpression &exp
 	case ExpressionType::OPERATOR_CAST: {
 		auto &cast = expr.Cast<CastExpression>();
 		Value dummy_value;
-		if (!TryFoldConstantForBackwardsCompatability(*cast.child, dummy_value)) {
+		if (!TryFoldConstantForBackwardsCompatibility(*cast.child, dummy_value)) {
 			return false;
 		}
 
@@ -262,7 +262,7 @@ static bool TryFoldForBackwardsCompatibility(const unique_ptr<ParsedExpression> 
 	}
 	default: {
 		Value val;
-		if (!TryFoldConstantForBackwardsCompatability(*expr, val)) {
+		if (!TryFoldConstantForBackwardsCompatibility(*expr, val)) {
 			return false;
 		}
 		values.push_back(std::move(val));

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -94,7 +94,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 	auto result = make_uniq<CreateStatement>();
 	auto info = make_uniq<CreateTableInfo>();
 
-	if (stmt.inhRelations) {
+	if (stmt.inhRelations) { // typos:ignore
 		throw NotImplementedException("inherited relations not implemented");
 	}
 	D_ASSERT(stmt.relation);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -534,7 +534,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 
 	expr->SetQueryLocation(col_ref_p.GetQueryLocation());
 
-	// the above QualifyColumName returns a generated expression for a generated
+	// the above QualifyColumnName returns a generated expression for a generated
 	// column, and struct_extract for a struct, or a lambda reference expression,
 	// all of them are not column reference expressions, so we return here
 	if (expr->GetExpressionType() != ExpressionType::COLUMN_REF) {

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -290,7 +290,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 	result->distinct = window.distinct;
 
 	// Convert RANGE boundary expressions to ORDER +/- expressions.
-	// Note that PRECEEDING and FOLLOWING refer to the sequential order in the frame,
+	// Note that PRECEDING and FOLLOWING refer to the sequential order in the frame,
 	// not the natural ordering of the type. This means that the offset arithmetic must be reversed
 	// for ORDER BY DESC.
 	auto &config = DBConfig::GetConfig(context);

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -161,7 +161,7 @@ BoundCTEData Binder::PrepareCTE(const string &ctename, CommonTableExpressionInfo
 	result.child_binder = Binder::CreateBinder(context, this);
 
 	// Add bindings of left side to temporary CTE bindings context
-	// as we are binding a CTE currently, we take precendence over the existing binding.
+	// as we are binding a CTE currently, we take precedence over the existing binding.
 	// This implements the CTE shadowing behavior.
 	auto cte_binding = make_uniq<CTEBinding>(BindingAlias(ctename), result.cte_bind_state, result.setop_index);
 	result.child_binder->bind_context.AddCTEBinding(std::move(cte_binding));

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -638,11 +638,11 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 					target_col_names.push_back(names[i]);
 				}
 			}
-			ColumnList new_colums;
+			ColumnList new_columns;
 			for (idx_t i = 0; i < target_col_names.size(); i++) {
-				new_colums.AddColumn(ColumnDefinition(target_col_names[i], sql_types[i]));
+				new_columns.AddColumn(ColumnDefinition(target_col_names[i], sql_types[i]));
 			}
-			base.columns = std::move(new_colums);
+			base.columns = std::move(new_columns);
 		} else {
 			for (idx_t i = 0; i < names.size(); i++) {
 				base.columns.AddColumn(ColumnDefinition(names[i], sql_types[i]));

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -233,9 +233,9 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 		child_list_t<LogicalType> select_list;
 		// Let's verify if any on these columns have not null constraints
 		vector<string> not_null_columns;
-		for (auto &constaint : table.GetConstraints()) {
-			if (constaint->type == ConstraintType::NOT_NULL) {
-				auto &not_null_constraint = constaint->Cast<NotNullConstraint>();
+		for (auto &constraint : table.GetConstraints()) {
+			if (constraint->type == ConstraintType::NOT_NULL) {
+				auto &not_null_constraint = constraint->Cast<NotNullConstraint>();
 				not_null_columns.push_back(table.GetColumn(not_null_constraint.index).GetName());
 			}
 		}

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -32,7 +32,7 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 	auto entry = Catalog::GetEntry<PragmaFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, info.name,
 	                                                           OnEntryNotFound::RETURN_NULL);
 	if (!entry) {
-		// try to find whether a table extry might exist
+		// try to find whether a table entry might exist
 		auto table_entry = Catalog::GetEntry<TableFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA,
 		                                                                info.name, OnEntryNotFound::RETURN_NULL);
 		if (table_entry) {

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -99,7 +99,7 @@ void Binder::BindRowIdColumns(TableCatalogEntry &table, LogicalGet &get, vector<
 			throw InternalException(
 			    "BindRowIdColumns could not find the row id column in the virtual columns list of the table");
 		}
-		// check if this column has alraedy been projected
+		// check if this column has already been projected
 		idx_t column_idx;
 		for (column_idx = 0; column_idx < column_ids.size(); ++column_idx) {
 			if (column_ids[column_idx].GetPrimaryIndex() == row_id_column) {

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -125,7 +125,7 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(Deserializer &deseri
 		if (bound_expression) {
 			return bound_expression;
 		}
-		// Otherwise, fall thorugh and continue on normally
+		// Otherwise, fall through and continue on normally
 	}
 	auto result = make_uniq<BoundFunctionExpression>(std::move(function_return_type), std::move(entry.first),
 	                                                 std::move(children), std::move(entry.second));

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -74,7 +74,7 @@ void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 	auto rowid_binding = update_op.children.back()->GetColumnBindings().back();
 
 	// We're looking for the GET operator that produces this rowid, and therefore produce this binding.
-	// There might be projections in betweeen though, so we need to traverse through them.
+	// There might be projections in between though, so we need to traverse through them.
 	auto target_binding = rowid_binding;
 	vector<reference<unique_ptr<LogicalOperator>>> stack;
 

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -125,7 +125,7 @@ public:
 
 	void CalculateDeltaStats() {
 		// TODO: currently we dont support delta compression of values above NumericLimits<T_S>::Maximum(),
-		// 		 we could support this with some clever substract trickery?
+		// 		 we could support this with some clever subtract trickery?
 		if (maximum > static_cast<T>(NumericLimits<T_S>::Maximum())) {
 			return;
 		}

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -51,7 +51,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	}
 	int64_t last_modified_time;
 	if (!access_time.TrySubtract(current_last_modified, last_modified_time)) {
-		// ouf ot range
+		// out of range
 		return false;
 	}
 	return last_modified_time > LAST_MODIFIED_THRESHOLD;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -767,7 +767,7 @@ void SingleFileBlockManager::Initialize(const DatabaseHeader &header, const opti
 	iteration_count = header.iteration;
 	max_block = NumericCast<block_id_t>(header.block_count);
 	if (options.storage_version.IsValid()) {
-		// storage version specified explicity - use requested storage version
+		// storage version specified explicitly - use requested storage version
 		auto requested_compat_version = options.storage_version.GetIndex();
 		if (requested_compat_version < header.serialization_compatibility) {
 			throw InvalidInputException(

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1651,7 +1651,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				throw InternalException("Checkpointing should always remember metadata blocks");
 			}
 			if (metadata_reuse && pointer_copy.data_pointers != row_group.GetColumnStartPointers()) {
-				throw InternalException("Colum start pointers changed during metadata reuse");
+				throw InternalException("Column start pointers changed during metadata reuse");
 			}
 
 			// Capture blocks that have been written

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -144,7 +144,7 @@ void TableStatistics::MergeStats(TableStatistics &other) {
 			D_ASSERT(other.table_sample->type == SampleType::RESERVOIR_SAMPLE);
 			this_reservoir.Merge(std::move(other.table_sample));
 		}
-		// if no other.table sample, do nothig
+		// if no other.table sample, do nothing
 	} else {
 		if (other.table_sample) {
 			auto &other_reservoir = other.table_sample->Cast<ReservoirSample>();

--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -60,7 +60,7 @@ public:
 			if (new_percentage > 100) {
 				error.SetError([new_percentage]() { REQUIRE(new_percentage <= 100); });
 			}
-			cur_rows_read = query_progress.GetRowsProcesseed();
+			cur_rows_read = query_progress.GetRowsProcessed();
 			total_cardinality = query_progress.GetTotalRowsToProcess();
 			if (cur_rows_read > total_cardinality) {
 				error.SetError([cur_rows_read, total_cardinality]() { REQUIRE(cur_rows_read <= total_cardinality); });

--- a/test/sql/function/numeric/test_pg_math.test
+++ b/test/sql/function/numeric/test_pg_math.test
@@ -125,7 +125,7 @@ select log(2, -1)
 statement error
 select log(1, 64)
 ----
-<REGEX>:.*Out of Range Error.*divison by zero.*
+<REGEX>:.*Out of Range Error.*division by zero.*
 
 query I
 select log(2, 1)

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -214,7 +214,7 @@ MetadataResult SetHighlightColors(ShellState &state, const vector<string> &args)
 	return MetadataResult::SUCCESS;
 }
 
-MetadataResult ToggleHighlighErrors(ShellState &state, const vector<string> &args) {
+MetadataResult ToggleHighlightErrors(ShellState &state, const vector<string> &args) {
 	state.highlight_errors = state.StringToBool(args[1]) ? OptionType::ON : OptionType::OFF;
 	return MetadataResult::SUCCESS;
 }
@@ -868,7 +868,7 @@ static const MetadataCommand metadata_commands[] = {
     {"help", 0, ShowHelp, "?-all? ?PATTERN?", "Show help text for PATTERN", 0, ""},
     {"highlight", 2, ToggleHighlighting, "on|off", "Toggle syntax highlighting in the shell on/off", 0, ""},
     {"highlight_colors", 0, SetHighlightColors, "OPTIONS", "Configure highlighting colors", 0, ""},
-    {"highlight_errors", 2, ToggleHighlighErrors, "on|off", "Turn highlighting of errors on or off", 0, ""},
+    {"highlight_errors", 2, ToggleHighlightErrors, "on|off", "Turn highlighting of errors on or off", 0, ""},
     {"highlight_mode", 2, ToggleHighlightMode, "mixed|dark|light", "Toggle the highlight mode to dark or light mode", 0,
      ""},
     {"highlight_results", 2, ToggleHighlightResult, "on|off", "Turn highlighting of results on or off", 0, ""},


### PR DESCRIPTION
Attempt to [fix](https://github.com/duckdblabs/duckdb-internal/issues/6608) typos in duckdb, and integrate the tool into `format.py` (so `make format-fix` works).

Adopt [typos](https://github.com/crate-ci/typos) to find and correct spelling mistakes in source code:
- Fast enough to run on large codebases (takes `0.4s` for all duckdb code).
- Low false positives to enable on PRs.
- Can be installed locally using `brew install typos-cli`.

<img width="761" height="205" alt="Screenshot 2026-04-21 at 14 31 18" src="https://github.com/user-attachments/assets/174b5b97-18c5-4073-8ee8-e239b82df6c7" />


Fixes https://github.com/duckdblabs/duckdb-internal/issues/6608.

### Exceptions

I added some spelling exceptions that seem "good enough" to keep:

```toml
# Legal language
stichting = "stichting"

# Project-specific acronyms
nd = "nd"
eit = "eit"
ser = "ser"
siz = "siz"
cpy = "cpy"
Cpy = "Cpy"
acount = "acount"

# API identifiers (to avoid breaking code)
writeable = "writeable"
Writeable = "Writeable"
millenium = "millenium"
Millenium = "Millenium"
seeked = "seeked"
larg = "larg"
rarg = "rarg"
deliminated = "deliminated"
```

I tried to balance how much code changes were needed with adding an exception, so keep a short list of exceptions while not changing large amounts of code for a potential typo.