### PR TITLE
User-facing `enable_caching_operators` setting

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -449,6 +449,12 @@
         "default_value": "50"
     },
     {
+        "name": "enable_caching_operators",
+        "description": "Enables caching operators that cache intermediate results",
+        "type": "BOOLEAN",
+        "scope": "local"
+    },
+    {
         "name": "enable_external_access",
         "description": "Allow the database to access external state (through e.g. loading/installing modules, COPY TO/FROM, CSV \"\n\t    \"readers, pandas replacement scans, etc)",
         "type": "BOOLEAN",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -694,6 +694,16 @@ struct DynamicOrFilterThresholdSetting {
 	static constexpr idx_t SettingIndex = 36;
 };
 
+struct EnableCachingOperatorsSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "enable_caching_operators";
+	static constexpr const char *Description = "Enables caching operators that cache intermediate results";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct EnableExternalAccessSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_external_access";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -120,6 +120,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(DisabledOptimizersSetting),
     DUCKDB_SETTING_CALLBACK(DuckDBAPISetting),
     DUCKDB_SETTING(DynamicOrFilterThresholdSetting),
+    DUCKDB_LOCAL(EnableCachingOperatorsSetting),
     DUCKDB_SETTING_CALLBACK(EnableExternalAccessSetting),
     DUCKDB_SETTING_CALLBACK(EnableExternalFileCacheSetting),
     DUCKDB_SETTING(EnableFSSTVectorsSetting),
@@ -208,12 +209,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 99),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 100),
                                                      DUCKDB_SETTING_ALIAS("null_order", 43),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 118),
-                                                     DUCKDB_SETTING_ALIAS("user", 133),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 119),
+                                                     DUCKDB_SETTING_ALIAS("user", 134),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 25),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 132),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 133),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -116,6 +116,23 @@ void DeprecatedUsingKeySyntaxSetting::OnSet(SettingCallbackInfo &info, Value &pa
 }
 
 //===----------------------------------------------------------------------===//
+// Enable Caching Operators
+//===----------------------------------------------------------------------===//
+void EnableCachingOperatorsSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.enable_caching_operators = input.GetValue<bool>();
+}
+
+void EnableCachingOperatorsSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).enable_caching_operators = ClientConfig().enable_caching_operators;
+}
+
+Value EnableCachingOperatorsSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::BOOLEAN(config.enable_caching_operators);
+}
+
+//===----------------------------------------------------------------------===//
 // Enable Progress Bar
 //===----------------------------------------------------------------------===//
 void EnableProgressBarSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -132,7 +132,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"experimental_metadata_reuse", {false}},
 	    {"storage_block_prefetch", {"always_prefetch"}},
 	    {"pin_threads", {"off"}},
-	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}}};
+	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}},
+	    {"enable_caching_operators", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		switch (type.id()) {

--- a/test/sql/settings/enable_caching_operators.test_slow
+++ b/test/sql/settings/enable_caching_operators.test_slow
@@ -1,0 +1,48 @@
+# name: test/sql/settings/enable_caching_operators.test_slow
+# group: [settings]
+
+require parquet
+
+statement ok
+set threads=1
+
+statement ok
+set preserve_insertion_order=false;
+
+# 8 strings ~8 MB each for a total of ~64 mb per file, 8 files so 512 mb total
+
+loop i 0 8
+
+statement ok
+copy (select range id, {i} || repeat('a', 8e6::int) || range as c from range(8)) to '{TEST_DIR}/enable_caching_operators_input{i}.parquet'
+
+endloop
+
+# create table to join with so that caching physical operator is triggered
+
+statement ok
+create table build as select range id from range(8)
+
+statement ok
+set memory_limit='300mb'
+
+# runs out of memory when caching operators are enabled because strings are accumulated
+statement error
+copy (
+    select c
+    from '{TEST_DIR}/enable_caching_operators_input*.parquet'
+    where id in (from build)
+) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size_bytes '64mb');
+----
+Out of Memory
+
+# runs fine when disabled
+statement ok
+set enable_caching_operators=false;
+
+statement ok
+copy (
+    select c
+    from '{TEST_DIR}/enable_caching_operators_input*.parquet'
+    where id in (from build)
+) to '{TEST_DIR}/enable_caching_operators_output.parquet' (row_group_size_bytes '64mb');


### PR DESCRIPTION
We already have this setting, just not user-facing, which this PR implements.

It's enabled by default, can be disabled like so:
```sql
SET enable_caching_operators=false;
```

Disabling this can be beneficial when processing massive strings, for example, as demonstrated by the added test.