### PR TITLE
Add `DUCKDB_FORMAT_SKIP_FETCH ` environment variable to skip fetching new changes from main in make format-main

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -214,7 +214,7 @@ elif os.path.isdir(revision):
     for fname in changed_files:
         print(fname)
 elif not format_all:
-    if revision == 'main':
+    if revision == 'main' and os.environ.get('DUCKDB_FORMAT_SKIP_FETCH') != '1':
         # fetch new changes when comparing to the master
         os.system("git fetch origin main:main")
     print(action + " since branch or revision: " + revision)


### PR DESCRIPTION
This allows us to run `make format-main` in environments in which running `git fetch` does not work.