### PR TITLE
fix failures summary in test runner

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -213,21 +213,14 @@ def launch_test(test, list_of_tests=False):
         fail()
         return
 
-    stdout = res.stdout.decode('utf8') if not list_of_tests else ''
-    stderr = res.stderr.decode('utf8')
-
-    if len(stderr) > 0:
-        # when list_of_tests test name gets transformed, but we can get it from stderr
-        test_name = test[0] if not list_of_tests else get_test_name_from(stderr)
-        error_message = get_clean_error_message_from(stderr)
-        new_data = {"test": test_name, "return_code": res.returncode, "stdout": stdout, "stderr": error_message}
-        error_container.append(new_data)
-
     end = time.time()
 
     # join the background print thread
     is_active = False
     background_print_thread.join()
+
+    stdout = res.stdout.decode('utf8') if not list_of_tests else ''
+    stderr = res.stderr.decode('utf8')
 
     additional_data = ""
     if assertions:
@@ -239,6 +232,13 @@ def launch_test(test, list_of_tests=False):
         print(f'{test_case}	{end - start}')
     if res.returncode is None or res.returncode == 0:
         return
+
+    if len(stderr) > 0:
+        # when list_of_tests test name gets transformed, but we can get it from stderr
+        test_name = test[0] if not list_of_tests else get_test_name_from(stderr)
+        error_message = get_clean_error_message_from(stderr)
+        new_data = {"test": test_name, "return_code": res.returncode, "stdout": stdout, "stderr": error_message}
+        error_container.append(new_data)
 
     print("FAILURE IN RUNNING TEST")
     print(


### PR DESCRIPTION
only add to failures summary if the test failed, i.e. returncode != 0 
tests that succeed but emit warnings to stderr are excluded from the summary

Note: 
- function `launch_test` returns early if tests succeed, so the code to append to the error summary could just be moved to after that point.
- `len(stderr) > 0` is not a good proxy to determine if a test failed, because warnings also write to stderr

