### PR TITLE
Add support for deferred binding of views in the SQL layer

### DIFF
--- a/extension/autocomplete/grammar/statements/create_view.gram
+++ b/extension/autocomplete/grammar/statements/create_view.gram
@@ -1,1 +1,1 @@
-CreateViewStmt <- 'RECURSIVE'? 'VIEW' IfNotExists? QualifiedName InsertColumnList? 'AS' SelectStatementInternal
+CreateViewStmt <- 'RECURSIVE'? 'VIEW' IfNotExists? QualifiedName InsertColumnList? WithList? 'AS' SelectStatementInternal

--- a/extension/autocomplete/include/inlined_grammar.hpp
+++ b/extension/autocomplete/include/inlined_grammar.hpp
@@ -926,7 +926,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"ExecuteStatement <- 'EXECUTE' Identifier TableFunctionArguments?\n"
 	"CreateSecretStmt <- 'SECRET' IfNotExists? SecretName? SecretStorageSpecifier? GenericCopyOptionList\n"
 	"SecretStorageSpecifier <- 'IN' Identifier\n"
-	"CreateViewStmt <- 'RECURSIVE'? 'VIEW' IfNotExists? QualifiedName InsertColumnList? 'AS' SelectStatementInternal\n"
+	"CreateViewStmt <- 'RECURSIVE'? 'VIEW' IfNotExists? QualifiedName InsertColumnList? WithList? 'AS' SelectStatementInternal\n"
 	"DescribeStatement <- ShowTables / ShowSelect / ShowAllTables / ShowQualifiedName\n"
 	"ShowSelect <- ShowOrDescribeOrSummarize SelectStatementInternal\n"
 	"ShowAllTables <- ShowOrDescribe 'ALL' 'TABLES'\n"

--- a/extension/autocomplete/transformer/transform_create_view.cpp
+++ b/extension/autocomplete/transformer/transform_create_view.cpp
@@ -106,7 +106,28 @@ unique_ptr<CreateStatement> PEGTransformerFactory::TransformCreateViewStmt(PEGTr
 	info->schema = qualified_name.schema;
 	info->view_name = qualified_name.name;
 	info->aliases = column_list;
-	auto select_statement = transformer.Transform<unique_ptr<SelectStatement>>(list_pr.Child<ListParseResult>(6));
+	auto &with_list_opt = list_pr.Child<OptionalParseResult>(5);
+	if (with_list_opt.HasResult()) {
+		auto options_expr =
+		    transformer.Transform<case_insensitive_map_t<unique_ptr<ParsedExpression>>>(with_list_opt.GetResult());
+		for (auto &option_entry : options_expr) {
+			if (!StringUtil::CIEquals(option_entry.first, "defer_binding")) {
+				throw ParserException("Only DEFER_BINDING is currently supported as option for CREATE VIEW");
+			}
+			if (option_entry.second->GetExpressionClass() != ExpressionClass::CONSTANT) {
+				throw InvalidInputException("Defer binding option must be a constant value");
+			}
+			auto &val = option_entry.second->Cast<ConstantExpression>().value;
+			if (val.IsNull()) {
+				info->binding_mode = CreateViewBindingMode::SKIP_BINDING;
+			} else if (val.type().id() != LogicalTypeId::BOOLEAN) {
+				throw InvalidInputException("Defer binding option must be a boolean");
+			} else if (BooleanValue::Get(val)) {
+				info->binding_mode = CreateViewBindingMode::SKIP_BINDING;
+			}
+		}
+	}
+	auto select_statement = transformer.Transform<unique_ptr<SelectStatement>>(list_pr.Child<ListParseResult>(7));
 	if (list_pr.Child<OptionalParseResult>(0).HasResult()) {
 		ConvertToRecursiveView(info, select_statement->node);
 	} else {

--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -28,6 +28,9 @@ string CreateViewInfo::ToString() const {
 		                           [](const string &name) { return KeywordHelper::WriteOptionallyQuoted(name); });
 		result += ")";
 	}
+	if (binding_mode == CreateViewBindingMode::SKIP_BINDING) {
+		result += " WITH (DEFER_BINDING)";
+	}
 	result += " AS ";
 	result += query->ToString();
 	result += ";";

--- a/test/sql/catalog/view/deferred_binding.test
+++ b/test/sql/catalog/view/deferred_binding.test
@@ -1,0 +1,27 @@
+# name: test/sql/catalog/view/deferred_binding.test
+# description: Test support for deferred binding of views
+# group: [view]
+
+require autocomplete
+
+statement ok
+CALl enable_peg_parser();
+
+statement ok
+CREATE VIEW v1 WITH (DEFER_BINDING) AS SELECT * FROM tbl;
+
+statement error
+FROM v1
+----
+does not exist
+
+statement ok
+CREATE TABLE tbl(i INTEGER)
+
+statement ok
+INSERT INTO tbl VALUES (42);
+
+query I
+FROM v1
+----
+42


### PR DESCRIPTION
This PR adds support for deferred binding of views through adding `WITH (DEFER_BINDING)` to `CREATE VIEW`, e.g.:

```sql
CREATE VIEW v1 WITH (DEFER_BINDING) AS SELECT * FROM tbl;
```

This follows the way that [Postgres allows options to be passed in during `CREATE VIEW`](https://www.postgresql.org/docs/current/sql-createview.html).

When `DEFER_BINDING` is specified, we do not bind the view during `CREATE VIEW`. That means that only the syntax is verified. This allows us to create views over e.g. tables or files that do not exist. Only when the view is used do we actually bind the view, and would optionally throw an error if the view fails to bind. 

Another benefit of `DEFER_BINDING` is that, if the view requires verifying external state (e.g. the existence of files), we do not need to do this during `CREATE VIEW`. This allows for us to skip e.g. file listings, globs, or other forms of I/O (CSV schema detection, etc) which speeds up `CREATE VIEW`.