### PR TITLE
Unify struct filter with expression filter

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -804,33 +804,6 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 		}
 		return true;
 	}
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = filter.Cast<StructFilter>();
-		auto &child_filter = struct_filter.child_filter;
-
-		if (constant.IsNull()) {
-			// NULL struct - filter cannot match (NULL propagation)
-			return false;
-		}
-		if (constant.type().id() != LogicalTypeId::STRUCT) {
-			throw InternalException(
-			    "Constant for this column is not of type struct, but used in a STRUCT_EXTRACT TableFilter");
-		}
-		auto &struct_fields = StructValue::GetChildren(constant);
-		auto field_index = struct_filter.child_idx;
-		if (field_index >= struct_fields.size()) {
-			throw InternalException("STRUCT_EXTRACT looks for child_idx %d, but constant only has %d children",
-			                        field_index, struct_fields.size());
-		}
-		auto &field_name = StructType::GetChildName(constant.type(), field_index);
-		if (!StringUtil::CIEquals(field_name, struct_filter.child_name)) {
-			throw InternalException("STRUCT_EXTRACT looks for a child with name '%s' at index %d, but constant has a "
-			                        "field with '%s' as the name for that index",
-			                        struct_filter.child_name, field_index, field_name);
-		}
-		auto &child_constant = struct_fields[field_index];
-		return EvaluateFilterAgainstConstant(*child_filter, child_constant);
-	}
 	case TableFilterType::OPTIONAL_FILTER: {
 		auto &optional_filter = filter.Cast<OptionalFilter>();
 		if (optional_filter.child_filter) {
@@ -922,6 +895,16 @@ static unique_ptr<Expression> CreateReferenceExpression(const LogicalType &type)
 	return make_uniq<BoundReferenceExpression>(type, storage_t(0));
 }
 
+static unique_ptr<Expression> CreateStructExtractExpression(unique_ptr<Expression> source_expr,
+                                                            const LogicalType &source_type, idx_t child_idx) {
+	auto &child_type = StructType::GetChildType(source_type, child_idx);
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(std::move(source_expr));
+	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(static_cast<int64_t>(child_idx + 1))));
+	return make_uniq<BoundFunctionExpression>(child_type, GetExtractAtFunction(), std::move(arguments),
+	                                          StructExtractAtFun::GetBindData(child_idx));
+}
+
 static bool TryCastConstant(Value &constant, const LogicalType &target_type) {
 	if (!StatisticsPropagator::CanPropagateCast(constant.type(), target_type)) {
 		return false;
@@ -945,6 +928,28 @@ static RewrittenMappedExpression RewriteMappedValueExpression(const Expression &
 		result.mapping = &mapping;
 		result.type = &target_type;
 		return result;
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		idx_t child_idx;
+		if (!TryGetStructExtractChildIndex(func, child_idx)) {
+			return result;
+		}
+		auto child_result = RewriteMappedValueExpression(*func.children[0], mapping, target_type);
+		if (!child_result.expr || !child_result.mapping || !child_result.type ||
+		    child_result.type->id() != LogicalTypeId::STRUCT) {
+			return result;
+		}
+		auto entry = child_result.mapping->child_mapping.find(MultiFileGlobalIndex(child_idx));
+		if (entry == child_result.mapping->child_mapping.end()) {
+			return result;
+		}
+		auto &local_mapping = *entry->second;
+		auto local_child_idx = local_mapping.index.GetIndex();
+		result.expr = CreateStructExtractExpression(std::move(child_result.expr), *child_result.type, local_child_idx);
+		result.mapping = &local_mapping;
+		result.type = &StructType::GetChildType(*child_result.type, local_child_idx);
+		return result;
+	}
 	default:
 		return result;
 	}
@@ -1066,27 +1071,6 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 			res->child_filters.push_back(std::move(child_filter));
 		}
 		return std::move(res);
-	}
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = global_filter.Cast<StructFilter>();
-		auto &child_filter = struct_filter.child_filter;
-
-		// find the corresponding local entry
-		auto entry = mapping.child_mapping.find(MultiFileGlobalIndex(struct_filter.child_idx));
-		if (entry == mapping.child_mapping.end()) {
-			// this is constant for this file - abort
-			// FIXME: should be handled before
-			return nullptr;
-		}
-		auto &struct_mapping = *entry->second;
-		auto &struct_type = StructType::GetChildTypes(target_type);
-		auto &child_type = struct_type[struct_mapping.index].second;
-		auto new_child_filter = TryCastTableFilter(*child_filter, struct_mapping, child_type);
-		if (!new_child_filter) {
-			return nullptr;
-		}
-		auto child_name = struct_type[struct_mapping.index].first;
-		return make_uniq<StructFilter>(struct_mapping.index, std::move(child_name), std::move(new_child_filter));
 	}
 	case TableFilterType::OPTIONAL_FILTER: {
 		auto &optional_filter = global_filter.Cast<OptionalFilter>();

--- a/src/include/duckdb/planner/filter/struct_filter.hpp
+++ b/src/include/duckdb/planner/filter/struct_filter.hpp
@@ -9,11 +9,10 @@
 #pragma once
 
 #include "duckdb/planner/table_filter.hpp"
-#include "duckdb/common/types/value.hpp"
-#include "duckdb/common/enums/expression_type.hpp"
 
 namespace duckdb {
 
+//! DEPRECATED - only preserved for backwards-compatible deserialization and expression conversion
 class StructFilter : public TableFilter {
 public:
 	static constexpr const TableFilterType TYPE = TableFilterType::STRUCT_EXTRACT;

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -248,10 +248,6 @@ idx_t ExpressionHeuristics::Cost(const TableFilter &filter) {
 		}
 		return cost;
 	}
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = filter.Cast<StructFilter>();
-		return Cost(*struct_filter.child_filter);
-	}
 	default:
 		return 1000;
 	}

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
 
@@ -76,11 +77,7 @@ FilterPropagateResult ExpressionFilter::CheckStatistics(BaseStatistics &stats) c
 	return CheckExpressionStatistics(*expr, stats);
 }
 
-static bool IsDirectColumnRef(const Expression &expr) {
-	return expr.GetExpressionClass() == ExpressionClass::BOUND_REF;
-}
-
-static FilterPropagateResult CheckZonemapAgainstConstants(BaseStatistics &stats, ExpressionType comparison_type,
+static FilterPropagateResult CheckZonemapAgainstConstants(const BaseStatistics &stats, ExpressionType comparison_type,
                                                           array_ptr<const Value> values) {
 	D_ASSERT(values.size() > 0);
 	switch (values[0].type().InternalType()) {
@@ -115,20 +112,57 @@ static FilterPropagateResult CheckFunctionStatistics(const BoundFunctionExpressi
 	return func_expr.function.GetFilterPruneCallback()(input);
 }
 
+static optional_ptr<const BaseStatistics> TryGetFilterStats(const Expression &expr, const BaseStatistics &stats,
+                                                            vector<unique_ptr<BaseStatistics>> &owned_stats) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_REF:
+		return &stats;
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		idx_t child_idx;
+		if (!TryGetStructExtractChildIndex(func, child_idx) || func.children.empty()) {
+			return nullptr;
+		}
+		auto child_stats = TryGetFilterStats(*func.children[0], stats, owned_stats);
+		if (!child_stats || child_stats->GetType().id() != LogicalTypeId::STRUCT) {
+			return nullptr;
+		}
+		owned_stats.push_back(StructStats::GetChildStats(*child_stats, child_idx).ToUnique());
+		return owned_stats.back().get();
+	}
+	default:
+		return nullptr;
+	}
+}
+
 static FilterPropagateResult CheckComparisonStatistics(const BoundComparisonExpression &comp_expr,
                                                        BaseStatistics &stats) {
-	if (!IsDirectColumnRef(*comp_expr.left) || comp_expr.right->type != ExpressionType::VALUE_CONSTANT) {
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	optional_ptr<const BaseStatistics> filter_stats;
+	optional_ptr<const BoundConstantExpression> constant_expr;
+	auto comparison_type = comp_expr.type;
+	if (comp_expr.right->type == ExpressionType::VALUE_CONSTANT) {
+		filter_stats = TryGetFilterStats(*comp_expr.left, stats, owned_stats);
+		constant_expr = &comp_expr.right->Cast<BoundConstantExpression>();
+	} else if (comp_expr.left->type == ExpressionType::VALUE_CONSTANT) {
+		filter_stats = TryGetFilterStats(*comp_expr.right, stats, owned_stats);
+		constant_expr = &comp_expr.left->Cast<BoundConstantExpression>();
+		comparison_type = FlipComparisonExpression(comparison_type);
+	} else {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	auto &constant = comp_expr.right->Cast<BoundConstantExpression>().value;
+	if (!filter_stats || !constant_expr) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &constant = constant_expr->value;
 	if (constant.IsNull()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	if (!stats.CanHaveNoNull()) {
+	if (!filter_stats->CanHaveNoNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	auto result = CheckZonemapAgainstConstants(stats, comp_expr.type, array_ptr<const Value>(&constant, 1));
-	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && stats.CanHaveNull()) {
+	auto result = CheckZonemapAgainstConstants(*filter_stats, comparison_type, array_ptr<const Value>(&constant, 1));
+	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && filter_stats->CanHaveNull()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	return result;
@@ -136,21 +170,26 @@ static FilterPropagateResult CheckComparisonStatistics(const BoundComparisonExpr
 
 static FilterPropagateResult CheckNullOperatorStatistics(const BoundOperatorExpression &op_expr, BaseStatistics &stats,
                                                          ExpressionType operator_type) {
-	if (op_expr.children.empty() || !IsDirectColumnRef(*op_expr.children[0])) {
+	if (op_expr.children.empty()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	auto filter_stats = TryGetFilterStats(*op_expr.children[0], stats, owned_stats);
+	if (!filter_stats) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	if (operator_type == ExpressionType::OPERATOR_IS_NULL) {
-		if (!stats.CanHaveNull()) {
+		if (!filter_stats->CanHaveNull()) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
-		if (!stats.CanHaveNoNull()) {
+		if (!filter_stats->CanHaveNoNull()) {
 			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 		}
 	} else {
-		if (!stats.CanHaveNoNull()) {
+		if (!filter_stats->CanHaveNoNull()) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
-		if (!stats.CanHaveNull()) {
+		if (!filter_stats->CanHaveNull()) {
 			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 		}
 	}
@@ -158,7 +197,12 @@ static FilterPropagateResult CheckNullOperatorStatistics(const BoundOperatorExpr
 }
 
 static FilterPropagateResult CheckInOperatorStatistics(const BoundOperatorExpression &op_expr, BaseStatistics &stats) {
-	if (op_expr.children.size() <= 1 || !IsDirectColumnRef(*op_expr.children[0])) {
+	if (op_expr.children.size() <= 1) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	vector<unique_ptr<BaseStatistics>> owned_stats;
+	auto filter_stats = TryGetFilterStats(*op_expr.children[0], stats, owned_stats);
+	if (!filter_stats) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	vector<Value> values;
@@ -175,12 +219,12 @@ static FilterPropagateResult CheckInOperatorStatistics(const BoundOperatorExpres
 	if (values.empty()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	if (!stats.CanHaveNoNull()) {
+	if (!filter_stats->CanHaveNoNull()) {
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
-	auto result = CheckZonemapAgainstConstants(stats, ExpressionType::COMPARE_EQUAL,
+	auto result = CheckZonemapAgainstConstants(*filter_stats, ExpressionType::COMPARE_EQUAL,
 	                                           array_ptr<const Value>(values.data(), values.size()));
-	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && stats.CanHaveNull()) {
+	if (result == FilterPropagateResult::FILTER_ALWAYS_TRUE && filter_stats->CanHaveNull()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	return result;

--- a/src/planner/filter/struct_filter.cpp
+++ b/src/planner/filter/struct_filter.cpp
@@ -1,7 +1,5 @@
 #include "duckdb/planner/filter/struct_filter.hpp"
-#include "duckdb/storage/statistics/base_statistics.hpp"
-#include "duckdb/storage/statistics/struct_stats.hpp"
-#include "duckdb/common/string_util.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
@@ -15,32 +13,23 @@ StructFilter::StructFilter(idx_t child_idx_p, string child_name_p, unique_ptr<Ta
 }
 
 FilterPropagateResult StructFilter::CheckStatistics(BaseStatistics &stats) const {
-	D_ASSERT(stats.GetType().id() == LogicalTypeId::STRUCT);
-	// Check the child statistics
-	auto &child_stats = StructStats::GetChildStats(stats, child_idx);
-	return child_filter->CheckStatistics(child_stats);
+	throw InternalException("StructFilter::CheckStatistics should not be called: StructFilters should be converted "
+	                        "to ExpressionFilters before statistics checking");
 }
 
 string StructFilter::ToString(const string &column_name) const {
-	if (!child_name.empty()) {
-		return child_filter->ToString(column_name + "." + child_name);
-	}
-	return child_filter->ToString("struct_extract_at(" + column_name + "," + std::to_string(child_idx + 1) + ")");
+	throw InternalException("StructFilter::ToString should not be called: StructFilters should be converted to "
+	                        "ExpressionFilters before rendering");
 }
 
 bool StructFilter::Equals(const TableFilter &other_p) const {
-	if (!TableFilter::Equals(other_p)) {
-		return false;
-	}
-	auto &other = other_p.Cast<StructFilter>();
-	if ((!child_name.empty()) && (!other.child_name.empty())) { // if both child_names are known, sanity check
-		D_ASSERT((other.child_idx == child_idx) == StringUtil::CIEquals(other.child_name, child_name));
-	}
-	return other.child_idx == child_idx && other.child_filter->Equals(*child_filter);
+	throw InternalException("StructFilter::Equals should not be called: StructFilters should be converted to "
+	                        "ExpressionFilters before equality checking");
 }
 
 unique_ptr<TableFilter> StructFilter::Copy() const {
-	return make_uniq<StructFilter>(child_idx, child_name, child_filter->Copy());
+	throw InternalException("StructFilter::Copy should not be called: StructFilters should be converted to "
+	                        "ExpressionFilters before copying");
 }
 
 unique_ptr<Expression> StructFilter::ToExpression(const Expression &column) const {

--- a/src/planner/table_filter_state.cpp
+++ b/src/planner/table_filter_state.cpp
@@ -69,11 +69,6 @@ unique_ptr<TableFilterState> TableFilterState::Initialize(ClientContext &context
 		auto &optional_filter = filter.Cast<OptionalFilter>();
 		return optional_filter.InitializeState(context);
 	}
-
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = filter.Cast<StructFilter>();
-		return Initialize(context, *struct_filter.child_filter);
-	}
 	case TableFilterType::CONJUNCTION_OR: {
 		auto &conj_filter = filter.Cast<ConjunctionOrFilter>();
 		auto result = make_uniq<ConjunctionOrFilterState>();

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -462,15 +462,6 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 		}
 		return approved_tuple_count;
 	}
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = filter.Cast<StructFilter>();
-		// Apply the filter on the child vector
-		auto &child_vec = StructVector::GetEntries(vector)[struct_filter.child_idx];
-		UnifiedVectorFormat child_data;
-		child_vec.ToUnifiedFormat(scan_count, child_data);
-		return FilterSelection(sel, child_vec, child_data, *struct_filter.child_filter, filter_state, scan_count,
-		                       approved_tuple_count);
-	}
 	case TableFilterType::BLOOM_FILTER: {
 		auto &bloom_filter = filter.Cast<BFTableFilter>();
 		auto &state = filter_state.Cast<JoinFilterTableFilterState>();


### PR DESCRIPTION
This PR extracts the `ExpressionFilter` unification from https://github.com/duckdb/duckdb/pull/21762. Instead of doing everything at once, this PR only removes `StructFilter` from all code paths except for legacy de/serialization.

There will be a few follow-up PRs regarding:
- [x] `ConstantFilter`
- [ ] `ConjunctionFilter`
- [ ] `DynamicFilter`
- [x] `InFilter`
- [x] `Is[Not]NullFilter`
- [ ] `OptionalFilter`
- [ ] `BloomFilter`
- [ ] `PerfectHashJoinFilter`
- [ ] `PrefixRangeFilter`
- [ ] `SelectivityOptionalFilter`
- [x] `StructFilter`