### PR TITLE
Fix memory limit reset

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1301,6 +1301,9 @@ void MaxMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const V
 
 void MaxMemorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.SetDefaultMaxMemory();
+	if (db) {
+		BufferManager::GetBufferManager(*db).SetMemoryLimit(config.options.maximum_memory);
+	}
 }
 
 Value MaxMemorySetting::GetSetting(const ClientContext &context) {

--- a/test/sql/settings/reset/reset_memory_limit.test
+++ b/test/sql/settings/reset/reset_memory_limit.test
@@ -1,0 +1,23 @@
+# name: test/sql/settings/reset/reset_memory_limit.test
+# description: Test that RESET memory_limit actually applies to the buffer manager
+# group: [reset]
+
+# Disable temp directory so the buffer manager cannot spill to disk
+statement ok
+PRAGMA temp_directory='';
+
+# Set an impossibly low limit
+statement ok
+SET memory_limit='2MB';
+
+# Takes ~8MiB
+statement error
+CREATE TABLE t1 AS SELECT * FROM range(1000000);
+----
+
+statement ok
+RESET memory_limit;
+
+# After reset, the buffer manager should allow the allocation
+statement ok
+CREATE TABLE t1 AS SELECT * FROM range(1000000);


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22203
The issue is straightforward, on memory limit set or reset, we should both update buffer manager accordingly.
I have ran CI in my own fork: https://github.com/dentiny/duckdb/pull/92, failed CI unrelated
