### PR TITLE
Fix bignum sum Combine to correctly take over memory ownership of state

### DIFF
--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -247,12 +247,10 @@ struct BignumOperation {
 			return;
 		}
 		if (!target.is_set) {
-			target.value = source.value;
+			target.value.Initialize(input.allocator);
 			target.is_set = true;
-			return;
 		}
 		target.value.AddInPlace(input.allocator, source.value);
-		target.is_set = true;
 	}
 
 	template <class TARGET_TYPE, class STATE>


### PR DESCRIPTION
Fixes a sporadic failure in `test/sql/types/bignum/test_bignum_sum.test_slow`.