### PR TITLE
GCC 12 could not convert unique_ptr result

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -49,7 +49,7 @@ unique_ptr<Expression> ExpressionFilter::CreateNullCheckExpression(unique_ptr<Ex
 	         expression_type == ExpressionType::OPERATOR_IS_NOT_NULL);
 	auto result = make_uniq<BoundOperatorExpression>(expression_type, LogicalType::BOOLEAN);
 	result->children.push_back(std::move(column));
-	return result;
+	return std::move(result);
 }
 
 bool ExpressionFilter::EvaluateWithConstant(ClientContext &context, const Value &val) const {


### PR DESCRIPTION
GCC 12 [failed](https://github.com/duckdb/duckdb/actions/runs/24754571729/job/72424927532#step:3:512) to compile:
```c++
In file included from build/release/src/planner/filter/ub_duckdb_planner_filter.cpp:6:
src/planner/filter/expression_filter.cpp: In static member function ‘static duckdb::unique_ptr<duckdb::Expression> duckdb::ExpressionFilter::CreateNullCheckExpression(duckdb::unique_ptr<duckdb::Expression>, duckdb::ExpressionType)’:
src/planner/filter/expression_filter.cpp:52:16: error: could not convert ‘result’ from ‘unique_ptr<duckdb::BoundOperatorExpression,default_delete<duckdb::BoundOperatorExpression>,[...]>’ to ‘unique_ptr<duckdb::Expression,default_delete<duckdb::Expression>,[...]>’
   52 |         return result;
      |                ^~~~~~
      |                |
      |                unique_ptr<duckdb::BoundOperatorExpression,default_delete<duckdb::BoundOperatorExpression>,[...]>

```