### PR TITLE
Improve error message with mismatching VALUES lists

### DIFF
--- a/extension/autocomplete/transformer/transform_select.cpp
+++ b/extension/autocomplete/transformer/transform_select.cpp
@@ -1131,7 +1131,11 @@ unique_ptr<SelectStatement> PEGTransformerFactory::TransformValuesClause(PEGTran
 		const auto expected_size = values_list[0].size();
 		for (idx_t i = 1; i < values_list.size(); i++) {
 			if (values_list[i].size() != expected_size) {
-				throw ParserException("VALUES lists must all be the same length");
+				throw ParserException(
+				    *values_list[i][0],
+				    "VALUES lists must all be the same length, expected %d %s but found a list with %d %s",
+				    expected_size, expected_size == 1 ? "entry" : "entries", values_list[i].size(),
+				    values_list[i].size() == 1 ? "entry" : "entries");
 			}
 		}
 	}

--- a/test/sql/parser/values_list_error.test
+++ b/test/sql/parser/values_list_error.test
@@ -1,0 +1,24 @@
+# name: test/sql/parser/values_list_error.test
+# description: Test values list mismatch error
+# group: [parser]
+
+require autocomplete
+
+statement ok
+CALL enable_peg_parser();
+
+statement error
+FROM (VALUES ('1', '2'), ('1'))
+----
+<REGEX>:.*2 entries.*1 entry.*
+
+# we should have a marker
+statement error
+FROM (VALUES ('1', '2'), ('1'))
+----
+^
+
+statement error
+FROM (VALUES ('1'), ('1', '2'))
+----
+<REGEX>:.*1 entry.*2 entries.*


### PR DESCRIPTION
Currently we show a poor error (`VALUES lists must all be the same length`). This PR makes us show an actually helpful error in resolving the issue:

```sql
from (values ('1', '2'), ('1'));
Parser Error:
VALUES lists must all be the same length, expected 2 entries but found a list with 1 entry

LINE 1: from (values ('1', '2'), ('1'));
                                  ^
```