### PR TITLE
Remove dictionary size in VectorBuffer, instead use child-vector size

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -160,11 +160,6 @@ void Vector::Reinterpret(const Vector &other) {
 		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
 		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), old_dict.Capacity(), std::move(new_entry));
-		auto dict_size = old_dict.GetDictionarySize();
-		if (dict_size.IsValid()) {
-			buffer->Cast<DictionaryBuffer>().SetDictionarySize(dict_size.GetIndex());
-		}
-		buffer->Cast<DictionaryBuffer>().SetDictionaryId(old_dict.GetDictionaryId());
 	}
 }
 
@@ -209,13 +204,16 @@ void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
 }
 
 void Vector::Dictionary(idx_t dictionary_size, const SelectionVector &sel, idx_t count) {
-	Slice(sel, count);
-	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		buffer->Cast<DictionaryBuffer>().SetDictionarySize(dictionary_size);
+	if (!HasSize() || dictionary_size != size()) {
+		throw InternalException("Vector::Dictionary called with mismatching dictionary size");
 	}
+	Slice(sel, count);
 }
 
 void Vector::Dictionary(const Vector &dict, idx_t dictionary_size, const SelectionVector &sel, idx_t count) {
+	if (!dict.HasSize() || dict.size() != dictionary_size) {
+		throw InternalException("Vector::Dictionary called with mismatching dictionary size");
+	}
 	Reference(dict);
 	Dictionary(dictionary_size, sel, count);
 }

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -89,11 +89,6 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::SliceWithCache(SelCache &cache, const
 		result = Slice(type, sel, count);
 		cache.cache[target_data] = result;
 	}
-	if (dictionary_size.IsValid()) {
-		auto &dict_buffer = result->Cast<DictionaryBuffer>();
-		dict_buffer.SetDictionarySize(dictionary_size.GetIndex());
-		dict_buffer.SetDictionaryId(std::move(dictionary_id));
-	}
 	return result;
 }
 
@@ -103,16 +98,8 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::SliceInternal(const LogicalType &type
 	if (type.InternalType() == PhysicalType::STRUCT) {
 		throw InternalException("Struct vectors cannot be dictionary vectors");
 	}
-	auto dictionary_size = GetDictionarySize();
-	auto dictionary_id = GetDictionaryId();
 	auto sliced_dictionary = GetSelVector().Slice(sel, count);
-	auto entry = GetEntryPtr();
-	auto new_buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary), count, std::move(entry));
-	if (dictionary_size.IsValid()) {
-		auto &dict_buffer = new_buffer->Cast<DictionaryBuffer>();
-		dict_buffer.SetDictionarySize(dictionary_size.GetIndex());
-		dict_buffer.SetDictionaryId(std::move(dictionary_id));
-	}
+	auto new_buffer = make_buffer<DictionaryBuffer>(std::move(sliced_dictionary), count, entry);
 	return new_buffer;
 }
 
@@ -151,7 +138,7 @@ buffer_ptr<VectorBuffer> DictionaryBuffer::FlattenSliceInternal(const LogicalTyp
 
 buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const LogicalType &type, const idx_t &size) {
 	auto entry = make_buffer<DictionaryEntry>(Vector(type, size));
-	entry->size = size;
+	FlatVector::SetSize(entry->data, size);
 	entry->id = UUID::ToString(UUID::GenerateRandomUUID());
 	return entry;
 }
@@ -165,7 +152,6 @@ const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	if (!entry.cached_hashes) {
 		// Uninitialized: hash the dictionary
 		const auto dictionary_size = DictionarySize(input).GetIndex();
-		D_ASSERT(!entry.size.IsValid() || entry.size.GetIndex() == dictionary_size);
 		entry.cached_hashes = make_uniq<Vector>(LogicalType::HASH, dictionary_size);
 		VectorOperations::Hash(entry.data, *entry.cached_hashes, dictionary_size);
 	}

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -268,9 +268,8 @@ void VariantUtils::VariantExtract(Vector &variant_vec, const vector<VariantPathC
 	auto &result_type_id = VariantVector::GetValuesTypeId(result);
 	auto &result_byte_offset = VariantVector::GetValuesByteOffset(result);
 
-	result_type_id.Dictionary(VariantVector::GetValuesTypeId(variant_vec), values_list_size, new_sel, values_list_size);
-	result_byte_offset.Dictionary(VariantVector::GetValuesByteOffset(variant_vec), values_list_size, new_sel,
-	                              values_list_size);
+	result_type_id.Slice(VariantVector::GetValuesTypeId(variant_vec), new_sel, values_list_size);
+	result_byte_offset.Slice(VariantVector::GetValuesByteOffset(variant_vec), new_sel, values_list_size);
 
 	if (validity.CanHaveNull()) {
 		//! Create a copy of the vector, because we used Reference before, and we now need to adjust the data

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -50,7 +50,11 @@ public:
 		this->sel_vector.Initialize(vector);
 	}
 	optional_idx GetDictionarySize() const {
-		return entry->data.HasSize() ? entry->data.size() : optional_idx();
+		if (!entry->data.HasSize() || entry->data.size() == 0) {
+			// FIXME: we should be directly returning entry->data.size(), this should not be an optional_idx
+			return optional_idx();
+		}
+		return entry->data.size();
 	}
 	void SetDictionaryId(string id) {
 		entry->id = std::move(id);

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -20,8 +20,7 @@ public:
 
 public:
 	Vector data;
-	//! Optional size/id to uniquely identify re-occurring dictionaries
-	optional_idx size;
+	//! Optional id to uniquely identify re-occurring dictionaries
 	string id;
 	//! For caching the hashes of a child buffer
 	mutex cached_hashes_lock;
@@ -50,17 +49,14 @@ public:
 	void SetSelVector(const SelectionVector &vector) {
 		this->sel_vector.Initialize(vector);
 	}
-	void SetDictionarySize(idx_t dict_size) {
-		dictionary_size = dict_size;
-	}
 	optional_idx GetDictionarySize() const {
-		return dictionary_size;
+		return entry->data.HasSize() ? entry->data.size() : optional_idx();
 	}
 	void SetDictionaryId(string id) {
-		dictionary_id = std::move(id);
+		entry->id = std::move(id);
 	}
 	const string &GetDictionaryId() const {
-		return dictionary_id;
+		return entry->id;
 	}
 
 	DictionaryEntry &GetEntry() {
@@ -94,9 +90,6 @@ protected:
 private:
 	SelectionVector sel_vector;
 	buffer_ptr<DictionaryEntry> entry;
-	optional_idx dictionary_size;
-	//! A unique identifier for the dictionary that can be used to check if two dictionaries are equivalent
-	string dictionary_id;
 };
 
 struct DictionaryVector {
@@ -129,19 +122,11 @@ struct DictionaryVector {
 	static inline optional_idx DictionarySize(const Vector &vector) {
 		VerifyDictionary(vector);
 		const auto &dict_buffer = vector.Buffer().Cast<DictionaryBuffer>();
-		const auto &entry = dict_buffer.GetEntry();
-		if (entry.size.IsValid()) {
-			return entry.size;
-		}
 		return dict_buffer.GetDictionarySize();
 	}
 	static inline const string &DictionaryId(const Vector &vector) {
 		VerifyDictionary(vector);
 		const auto &dict_buffer = vector.Buffer().Cast<DictionaryBuffer>();
-		const auto &entry = dict_buffer.GetEntry();
-		if (!entry.id.empty()) {
-			return entry.id;
-		}
 		return dict_buffer.GetDictionaryId();
 	}
 	static inline bool CanCacheHashes(const LogicalType &type) {

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -190,6 +190,7 @@ private:
 						    FlatVector::ValidityMutable(result), data, adds_nulls);
 						// slice the result with the original offsets
 						auto &offsets = DictionaryVector::SelVector(input);
+						FlatVector::SetSize(result, dict_size.GetIndex());
 						result.Dictionary(result, dict_size.GetIndex(), offsets, count);
 						break;
 					}

--- a/src/include/duckdb/function/cast/variant/array_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/array_to_variant.hpp
@@ -50,8 +50,7 @@ bool ConvertArrayToVariant(ToVariantSourceData &source, ToVariantGlobalResultDat
 	//! Now write the child vector of the list
 	auto &entry = ArrayVector::GetChildMutable(source.vec);
 	if (sel.count != list_size) {
-		Vector sliced_entry(entry.GetType(), nullptr);
-		sliced_entry.Dictionary(entry, list_size, sel.non_null_selection, sel.count);
+		Vector sliced_entry(entry, sel.non_null_selection, sel.count);
 		ToVariantSourceData child_source_data(sliced_entry, sel.count);
 		return ConvertToVariant<WRITE_DATA, false>(child_source_data, result, sel.count, &sel.new_selection,
 		                                           &sel.children_selection, false);

--- a/src/include/duckdb/function/cast/variant/list_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/list_to_variant.hpp
@@ -54,8 +54,7 @@ bool ConvertListToVariant(ToVariantSourceData &source, ToVariantGlobalResultData
 	auto &entry = ListVector::GetChildMutable(source.vec);
 	auto child_size = ListVector::GetListSize(source.vec);
 	if (sel.count != list_size) {
-		Vector sliced_entry(entry.GetType(), nullptr);
-		sliced_entry.Dictionary(entry, list_size, sel.non_null_selection, sel.count);
+		Vector sliced_entry(entry, sel.non_null_selection, sel.count);
 		ToVariantSourceData child_source_data(sliced_entry, sel.count);
 		return ConvertToVariant<WRITE_DATA, false>(child_source_data, result, sel.count, &sel.new_selection,
 		                                           &sel.children_selection, false);

--- a/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
@@ -85,8 +85,7 @@ bool ConvertStructToVariant(ToVariantSourceData &source, ToVariantGlobalResultDa
 
 		if (sel.count != count) {
 			//! Some of the STRUCT rows are NULL entirely, we have to filter these rows out of the children
-			Vector new_child(child.GetType(), nullptr);
-			new_child.Dictionary(child, count, sel.non_null_selection, sel.count);
+			Vector new_child(child, sel.non_null_selection, sel.count);
 			ToVariantSourceData child_source_data(new_child, sel.count);
 			if (!ConvertToVariant<WRITE_DATA>(child_source_data, result, sel.count, &sel.new_selection,
 			                                  &sel.children_selection, false)) {


### PR DESCRIPTION
Also remove the duplicated `id` (both the `DictionaryBuffer` and `DictionaryEntry` had an id for some reason - this unifies them).