### PR TITLE
Add `count_t` and `capacity_t` types and use in certain Vector interfaces

### DIFF
--- a/.github/patches/extensions/vss/0003-vector-capacity.patch
+++ b/.github/patches/extensions/vss/0003-vector-capacity.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
-index 3e095b2..b85f470 100644
+index 3e095b2..4d16e3d 100644
 --- a/src/hnsw/hnsw_index.cpp
 +++ b/src/hnsw/hnsw_index.cpp
 @@ -399,7 +399,7 @@ idx_t HNSWIndex::ExecuteMultiScan(IndexScanState &state_p, float *query_vector,
@@ -7,7 +7,7 @@ index 3e095b2..b85f470 100644
  const Vector &HNSWIndex::GetMultiScanResult(IndexScanState &state) {
  	auto &scan_state = state.Cast<MultiScanState>();
 -	FlatVector::SetData(scan_state.vec, (data_ptr_t)scan_state.row_ids.data());
-+	FlatVector::SetData(scan_state.vec, (data_ptr_t)scan_state.row_ids.data(), scan_state.row_ids.size());
++	FlatVector::SetData(scan_state.vec, (data_ptr_t)scan_state.row_ids.data(), count_t(scan_state.row_ids.size()));
  	return scan_state.vec;
  }
  

--- a/extension/core_functions/scalar/map/map_keys_values.cpp
+++ b/extension/core_functions/scalar/map/map_keys_values.cpp
@@ -27,7 +27,7 @@ static void MapKeyValueFunction(DataChunk &args, ExpressionState &state, Vector 
 	auto &entries = ListVector::GetChildMutable(result);
 	entries.Reference(child);
 
-	FlatVector::SetData(result, FlatVector::GetDataMutable(map), count);
+	FlatVector::SetData(result, FlatVector::GetDataMutable(map), count_t(count));
 	FlatVector::SetValidity(result, FlatVector::ValidityMutable(map));
 	auto list_size = ListVector::GetListSize(map);
 	ListVector::SetListSize(result, list_size);

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -175,7 +175,7 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 	if (!vdata.next_data.IsValid() && state.properties != ColumnDataScanProperties::DISALLOW_ZERO_COPY) {
 		// no next data, we can do a zero-copy read of this vector
 		if (TypeHasData(result.GetType())) {
-			FlatVector::SetData(result, base_ptr, vdata.count);
+			FlatVector::SetData(result, base_ptr, count_t(vdata.count));
 		}
 		FlatVector::ValidityMutable(result).Initialize(validity_data, STANDARD_VECTOR_SIZE);
 		return vdata.count;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -56,10 +56,10 @@ Vector::Vector(LogicalType type_p, data_ptr_t dataptr, idx_t count) : type(std::
 		throw InternalException("Cannot create a nested vector from a single data pointer");
 	}
 	if (type.InternalType() == PhysicalType::VARCHAR) {
-		buffer = make_buffer<VectorStringBuffer>(dataptr, count);
+		buffer = make_buffer<VectorStringBuffer>(dataptr, count_t(count));
 	} else {
 		auto type_size = GetTypeIdSize(type.InternalType());
-		buffer = make_buffer<StandardVectorBuffer>(dataptr, count, type_size);
+		buffer = make_buffer<StandardVectorBuffer>(dataptr, count_t(count), type_size);
 	}
 }
 
@@ -226,9 +226,9 @@ void Vector::Dictionary(buffer_ptr<DictionaryEntry> reusable_dict, const Selecti
 	buffer = make_buffer<DictionaryBuffer>(sel, sel_count, std::move(reusable_dict));
 }
 
-void Vector::Initialize(VectorDataInitialization data_initialize, idx_t capacity) {
-	auto &type = GetType();
+void Vector::Initialize(VectorDataInitialization data_initialize, idx_t capacity_p) {
 	auto internal_type = type.InternalType();
+	auto capacity = capacity_t(capacity_p);
 	if (internal_type == PhysicalType::STRUCT) {
 		buffer = make_buffer<VectorStructBuffer>(type, capacity);
 	} else if (internal_type == PhysicalType::LIST) {

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, idx_t capacity) {
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, capacity_t capacity) {
 	if (type == PhysicalType::LIST) {
 		throw InternalException("VectorBuffer::CreateStandardVector requires full list type");
 	}
@@ -26,7 +26,7 @@ buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, i
 	return make_buffer<StandardVectorBuffer>(capacity, GetTypeIdSize(type));
 }
 
-buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &type, idx_t capacity) {
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &type, capacity_t capacity) {
 	if (type.InternalType() == PhysicalType::LIST) {
 		throw InternalException("VectorBuffer::CreateStandardVector not supported for list");
 	}

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -105,7 +105,7 @@ private:
 	//! Buffer data for the vector (if any)
 	buffer_ptr<VectorBuffer> buffer;
 	//! Capacity of the vector
-	idx_t capacity;
+	capacity_t capacity;
 };
 
 VectorCache::VectorCache() {

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -6,14 +6,14 @@
 
 namespace duckdb {
 
-VectorArrayBuffer::VectorArrayBuffer(unique_ptr<Vector> child_vector, idx_t array_size, idx_t initial_capacity)
+VectorArrayBuffer::VectorArrayBuffer(unique_ptr<Vector> child_vector, idx_t array_size, capacity_t initial_capacity)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::ARRAY_BUFFER), child(std::move(child_vector)),
       array_size(array_size), capacity(initial_capacity) {
 	D_ASSERT(array_size != 0);
 	validity.Resize(initial_capacity);
 }
 
-VectorArrayBuffer::VectorArrayBuffer(const LogicalType &array, idx_t initial)
+VectorArrayBuffer::VectorArrayBuffer(const LogicalType &array, capacity_t initial)
     : VectorArrayBuffer(make_uniq<Vector>(ArrayType::GetChildType(array), initial * ArrayType::GetSize(array)),
                         ArrayType::GetSize(array), initial) {
 }
@@ -104,13 +104,6 @@ buffer_ptr<VectorBuffer> VectorArrayBuffer::Flatten(const LogicalType &type, idx
 
 buffer_ptr<VectorBuffer> VectorArrayBuffer::FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,
                                                                  idx_t count) const {
-	// now construct the result
-	auto result = make_buffer<VectorArrayBuffer>(nullptr, array_size, count);
-
-	// first copy over the validity
-	auto &result_validity = result->GetValidityMask();
-	result_validity.CopySel(validity, sel, 0, 0, count);
-
 	// now flatten the child vector
 	auto target_child_size = count * array_size;
 	auto child_result = make_uniq<Vector>(Vector::Ref(*child));
@@ -127,17 +120,24 @@ buffer_ptr<VectorBuffer> VectorArrayBuffer::FlattenSliceInternal(const LogicalTy
 	// flatten the child using the child selection vector
 	child_result->Flatten(child_sel, target_child_size);
 
-	result->child = std::move(child_result);
+	// construct the result
+	auto result = make_buffer<VectorArrayBuffer>(std::move(child_result), array_size, capacity_t(count));
+
+	// copy over the validity
+	auto &result_validity = result->GetValidityMask();
+	result_validity.CopySel(validity, sel, 0, 0, count);
+
 	result->SetVectorSize(count);
 	return result;
 }
 
 buffer_ptr<VectorBuffer> VectorArrayBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
-	auto result = make_buffer<VectorArrayBuffer>(type, end - offset);
-	auto &result_child = result->GetChild();
-	result_child.Slice(*child, offset * array_size, end * array_size);
-	result->GetValidityMask().Slice(validity, offset, end - offset);
-	result->SetVectorSize(end - offset);
+	auto count = count_t(end - offset);
+	auto new_child = make_uniq<Vector>(*child, offset * array_size, end * array_size);
+
+	auto result = make_buffer<VectorArrayBuffer>(std::move(new_child), array_size, capacity_t(count));
+	result->GetValidityMask().Slice(validity, offset, count);
+	result->SetVectorSize(count);
 	return result;
 }
 

--- a/src/common/vector/constant_vector.cpp
+++ b/src/common/vector/constant_vector.cpp
@@ -11,16 +11,17 @@ buffer_ptr<VectorBuffer> CreateConstantBuffer(const Value &value) {
 	auto &type = value.type();
 	auto internal_type = type.InternalType();
 	buffer_ptr<VectorBuffer> result;
+	capacity_t capacity(1ULL);
 	if (internal_type == PhysicalType::STRUCT) {
-		result = make_buffer<VectorStructBuffer>(value.type(), 1ULL);
+		result = make_buffer<VectorStructBuffer>(value.type(), capacity);
 	} else if (internal_type == PhysicalType::LIST) {
-		result = make_buffer<VectorListBuffer>(1ULL, value.type());
+		result = make_buffer<VectorListBuffer>(capacity, value.type());
 	} else if (internal_type == PhysicalType::ARRAY) {
-		result = make_buffer<VectorArrayBuffer>(value.type());
+		result = make_buffer<VectorArrayBuffer>(value.type(), capacity);
 	} else if (internal_type == PhysicalType::VARCHAR) {
-		result = make_buffer<VectorStringBuffer>(1);
+		result = make_buffer<VectorStringBuffer>(capacity);
 	} else {
-		result = make_buffer<StandardVectorBuffer>(1ULL, GetTypeIdSize(internal_type));
+		result = make_buffer<StandardVectorBuffer>(capacity, GetTypeIdSize(internal_type));
 	}
 	result->SetValue(type, 0, value);
 	result->SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -6,37 +6,43 @@
 #include "duckdb/common/types/bignum.hpp"
 
 namespace duckdb {
-StandardVectorBuffer::StandardVectorBuffer(Allocator &allocator, idx_t capacity_p, idx_t type_size_p)
+StandardVectorBuffer::StandardVectorBuffer(Allocator &allocator, capacity_t capacity_p, idx_t type_size_p)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::STANDARD_BUFFER), data_ptr(nullptr),
       type_size(type_size_p), capacity(capacity_p) {
 	if (capacity > 0) {
 		if (type_size == 0) {
-			throw InternalException("eek");
+			throw InternalException("StandardVectorBuffer: empty type size");
 		}
 		allocated_data = allocator.Allocate(capacity * type_size);
 		data_ptr = allocated_data.get();
 		// resize the validity
 		validity.Resize(capacity);
 	}
+	v_size = 0ULL;
 }
-StandardVectorBuffer::StandardVectorBuffer(idx_t capacity, idx_t type_size_p)
+StandardVectorBuffer::StandardVectorBuffer(capacity_t capacity, idx_t type_size_p)
     : StandardVectorBuffer(Allocator::DefaultAllocator(), capacity, type_size_p) {
 }
-StandardVectorBuffer::StandardVectorBuffer(data_ptr_t data_ptr_p, idx_t capacity_p, idx_t type_size_p)
+StandardVectorBuffer::StandardVectorBuffer(data_ptr_t data_ptr_p, count_t count, idx_t type_size_p)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::STANDARD_BUFFER), data_ptr(data_ptr_p),
-      type_size(type_size_p), capacity(capacity_p) {
+      type_size(type_size_p), capacity(count) {
+	SetVectorSize(count);
 }
-StandardVectorBuffer::StandardVectorBuffer(AllocatedData &&data_p, idx_t capacity_p, idx_t type_size_p)
+StandardVectorBuffer::StandardVectorBuffer(AllocatedData &&data_p, count_t count, idx_t type_size_p)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::STANDARD_BUFFER), data_ptr(data_p.get()),
-      type_size(type_size_p), capacity(capacity_p), allocated_data(std::move(data_p)) {
+      type_size(type_size_p), capacity(data_p.GetSize() / type_size), allocated_data(std::move(data_p)) {
+	if (count > capacity) {
+		throw InternalException("Count is out of range for capacity");
+	}
+	SetVectorSize(count);
 }
 
 void StandardVectorBuffer::SetVectorType(VectorType new_vector_type) {
 	vector_type = new_vector_type;
 }
 
-void StandardVectorBuffer::ResetCapacity(idx_t capacity) {
-	this->capacity = capacity;
+void StandardVectorBuffer::ResetCapacity(idx_t capacity_p) {
+	capacity = capacity_p;
 	validity.Reset(capacity);
 }
 
@@ -64,10 +70,11 @@ void StandardVectorBuffer::Verify(const LogicalType &type, const SelectionVector
 
 buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
 	D_ASSERT(end <= capacity);
+	auto count = count_t(end - offset);
 	auto offset_ptr = data_ptr + type_size * offset;
-	auto result = make_buffer<StandardVectorBuffer>(offset_ptr, end - offset, type_size);
-	result->GetValidityMask().Slice(validity, offset, end - offset);
-	result->SetVectorSize(end - offset);
+	auto result = make_buffer<StandardVectorBuffer>(offset_ptr, count, type_size);
+	result->GetValidityMask().Slice(validity, offset, count);
+	result->SetVectorSize(count);
 	return result;
 }
 
@@ -78,8 +85,8 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &
 	return make_buffer<DictionaryBuffer>(sel, count, std::move(entry));
 }
 
-buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateBuffer(AllocatedData &&new_data, idx_t new_capacity) const {
-	return make_buffer<StandardVectorBuffer>(std::move(new_data), new_capacity, type_size);
+buffer_ptr<VectorBuffer> StandardVectorBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {
+	return make_buffer<StandardVectorBuffer>(std::move(new_data), count, type_size);
 }
 
 void StandardVectorBuffer::Resize(idx_t current_size, idx_t new_size) {
@@ -162,8 +169,7 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::FlattenSliceInternal(const Logica
 	// copy data using sel
 	FlattenVectorBuffer(new_data.get(), data_ptr, sel, count, type_size);
 
-	auto result = CreateBuffer(std::move(new_data), count);
-	result->SetVectorSize(count);
+	auto result = CreateBuffer(std::move(new_data), count_t(count));
 	// copy validity using sel
 	auto &result_validity = result->GetValidityMask();
 	result_validity.Resize(allocated_count);
@@ -421,7 +427,7 @@ Value StandardVectorBuffer::GetValue(const LogicalType &type, idx_t index) const
 	}
 }
 
-void FlatVector::SetData(Vector &vector, data_ptr_t data, idx_t capacity) {
+void FlatVector::SetData(Vector &vector, data_ptr_t data, count_t count) {
 	VerifyFlatVector(vector);
 	if (vector.GetType().InternalType() == PhysicalType::ARRAY) {
 		throw InternalException("SetData not supported for array");
@@ -434,16 +440,16 @@ void FlatVector::SetData(Vector &vector, data_ptr_t data, idx_t capacity) {
 	auto old_validity = std::move(vector.BufferMutable().GetValidityMask());
 	if (vector.GetType().InternalType() == PhysicalType::LIST) {
 		auto &current_buffer = vector.BufferMutable().Cast<VectorListBuffer>();
-		vector.SetBuffer(make_buffer<VectorListBuffer>(data, capacity, current_buffer.GetChild()));
+		vector.SetBuffer(make_buffer<VectorListBuffer>(data, count, current_buffer.GetChild()));
 	} else if (vector.GetType().InternalType() == PhysicalType::VARCHAR) {
-		vector.SetBuffer(make_buffer<VectorStringBuffer>(data, capacity));
+		vector.SetBuffer(make_buffer<VectorStringBuffer>(data, count));
 	} else {
 		auto type_size = GetTypeIdSize(vector.GetType().InternalType());
-		vector.SetBuffer(make_buffer<StandardVectorBuffer>(data, capacity, type_size));
+		vector.SetBuffer(make_buffer<StandardVectorBuffer>(data, count, type_size));
 	}
 	vector.BufferMutable().GetValidityMask() = std::move(old_validity);
 	// set the size of the new buffer so child->size() works for list parents using GetChildSize()
-	vector.BufferMutable().SetVectorSize(capacity);
+	vector.BufferMutable().SetVectorSize(count);
 }
 
 void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {

--- a/src/common/vector/fsst_vector.cpp
+++ b/src/common/vector/fsst_vector.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-VectorFSSTStringBuffer::VectorFSSTStringBuffer(idx_t capacity) : VectorStringBuffer(capacity) {
+VectorFSSTStringBuffer::VectorFSSTStringBuffer(capacity_t capacity) : VectorStringBuffer(capacity) {
 	buffer_type = VectorBufferType::FSST_BUFFER;
 	vector_type = VectorType::FSST_VECTOR;
 }
@@ -39,7 +39,7 @@ Value VectorFSSTStringBuffer::GetValue(const LogicalType &type, idx_t index) con
 
 buffer_ptr<VectorBuffer> VectorFSSTStringBuffer::FlattenSliceInternal(const LogicalType &type,
                                                                       const SelectionVector &sel, idx_t count) const {
-	auto result = make_buffer<VectorStringBuffer>(count);
+	auto result = make_buffer<VectorStringBuffer>(capacity_t(count));
 
 	auto fsst_data = reinterpret_cast<const string_t *>(data_ptr);
 	auto result_data = reinterpret_cast<string_t *>(result->GetData());
@@ -105,7 +105,7 @@ vector<unsigned char> &FSSTVector::GetDecompressBuffer(const Vector &vector) {
 
 void FSSTVector::Create(Vector &vector, buffer_ptr<void> &duckdb_fsst_decoder, const idx_t string_block_limit,
                         idx_t capacity) {
-	vector.SetBuffer(make_buffer<VectorFSSTStringBuffer>(capacity));
+	vector.SetBuffer(make_buffer<VectorFSSTStringBuffer>(capacity_t(capacity)));
 	auto &fsst_string_buffer = vector.BufferMutable().Cast<VectorFSSTStringBuffer>();
 	fsst_string_buffer.AddDecoder(duckdb_fsst_decoder, string_block_limit);
 }

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -3,40 +3,40 @@
 
 namespace duckdb {
 
-VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector)
+VectorListBuffer::VectorListBuffer(Allocator &allocator, capacity_t capacity, unique_ptr<Vector> vector)
     : StandardVectorBuffer(allocator, capacity, sizeof(list_entry_t)), child(std::move(vector)) {
 	buffer_type = VectorBufferType::LIST_BUFFER;
 	FlatVector::SetSize(*child, 0ULL);
 }
-VectorListBuffer::VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
-                                   idx_t child_capacity)
+VectorListBuffer::VectorListBuffer(Allocator &allocator, capacity_t capacity, const LogicalType &list_type,
+                                   capacity_t child_capacity)
     : VectorListBuffer(allocator, capacity, make_uniq<Vector>(ListType::GetChildType(list_type), child_capacity)) {
 }
 
-VectorListBuffer::VectorListBuffer(idx_t capacity, const LogicalType &list_type, idx_t child_capacity)
+VectorListBuffer::VectorListBuffer(capacity_t capacity, const LogicalType &list_type, capacity_t child_capacity)
     : VectorListBuffer(Allocator::DefaultAllocator(), capacity, list_type, child_capacity) {
 }
 
-VectorListBuffer::VectorListBuffer(data_ptr_t data, idx_t capacity, const Vector &vector)
-    : StandardVectorBuffer(data, capacity, sizeof(list_entry_t)) {
+VectorListBuffer::VectorListBuffer(data_ptr_t data, count_t count, const Vector &vector)
+    : StandardVectorBuffer(data, count, sizeof(list_entry_t)) {
 	buffer_type = VectorBufferType::LIST_BUFFER;
 	child = make_uniq<Vector>(Vector::Ref(vector));
 }
 
-VectorListBuffer::VectorListBuffer(data_ptr_t data, idx_t capacity, const VectorListBuffer &parent)
-    : StandardVectorBuffer(data, capacity, sizeof(list_entry_t)) {
+VectorListBuffer::VectorListBuffer(data_ptr_t data, count_t count, const VectorListBuffer &parent)
+    : StandardVectorBuffer(data, count, sizeof(list_entry_t)) {
 	buffer_type = VectorBufferType::LIST_BUFFER;
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
 }
 
-VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, idx_t capacity, const VectorListBuffer &parent)
-    : StandardVectorBuffer(std::move(allocated_data_p), capacity, sizeof(list_entry_t)) {
+VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, count_t count, const VectorListBuffer &parent)
+    : StandardVectorBuffer(std::move(allocated_data_p), count, sizeof(list_entry_t)) {
 	buffer_type = VectorBufferType::LIST_BUFFER;
 	child = make_uniq<Vector>(Vector::Ref(parent.GetChild()));
 }
 
-VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, idx_t capacity, VectorListBuffer &parent)
-    : StandardVectorBuffer(std::move(allocated_data_p), capacity, sizeof(list_entry_t)) {
+VectorListBuffer::VectorListBuffer(AllocatedData allocated_data_p, count_t count, VectorListBuffer &parent)
+    : StandardVectorBuffer(std::move(allocated_data_p), count, sizeof(list_entry_t)) {
 	buffer_type = VectorBufferType::LIST_BUFFER;
 	auto &parent_child = parent.GetChildMutable();
 	child = std::move(parent_child);
@@ -133,9 +133,10 @@ void VectorListBuffer::Verify(const LogicalType &type, const SelectionVector &se
 buffer_ptr<VectorBuffer> VectorListBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
 	auto type_size = GetTypeIdSize(type.InternalType());
 	auto offset_ptr = data_ptr + type_size * offset;
-	auto result = make_buffer<VectorListBuffer>(offset_ptr, end - offset, *this);
-	result->GetValidityMask().Slice(validity, offset, end - offset);
-	result->SetVectorSize(end - offset);
+	auto count = count_t(end - offset);
+	auto result = make_buffer<VectorListBuffer>(offset_ptr, count, *this);
+	result->GetValidityMask().Slice(validity, offset, count);
+	result->SetVectorSize(count);
 	return result;
 }
 
@@ -149,8 +150,8 @@ void VectorListBuffer::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format)
 	format.validity = validity;
 }
 
-buffer_ptr<VectorBuffer> VectorListBuffer::CreateBuffer(AllocatedData &&new_data, idx_t capacity) const {
-	return make_buffer<VectorListBuffer>(std::move(new_data), capacity, *this);
+buffer_ptr<VectorBuffer> VectorListBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {
+	return make_buffer<VectorListBuffer>(std::move(new_data), count, *this);
 }
 
 void VectorListBuffer::CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count,

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -23,36 +23,36 @@ void VectorScatterWriter<string_t>::InitializeHeap() {
 	heap = StringVector::GetStringHeap(vector);
 }
 
-VectorStringBuffer::VectorStringBuffer() : StandardVectorBuffer(idx_t(0), sizeof(string_t)) {
+VectorStringBuffer::VectorStringBuffer() : StandardVectorBuffer(capacity_t(0), sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
 VectorStringBuffer::VectorStringBuffer(Allocator &allocator)
-    : StandardVectorBuffer(allocator, 0, sizeof(string_t)), heap(AllocateHeap(allocator)) {
+    : StandardVectorBuffer(allocator, capacity_t(0), sizeof(string_t)), heap(AllocateHeap(allocator)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(Allocator &allocator, idx_t capacity)
+VectorStringBuffer::VectorStringBuffer(Allocator &allocator, capacity_t capacity)
     : StandardVectorBuffer(allocator, capacity, sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(idx_t capacity) : StandardVectorBuffer(capacity, sizeof(string_t)) {
+VectorStringBuffer::VectorStringBuffer(capacity_t capacity) : StandardVectorBuffer(capacity, sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p, idx_t capacity)
-    : StandardVectorBuffer(data_ptr_p, capacity, sizeof(string_t)) {
+VectorStringBuffer::VectorStringBuffer(data_ptr_t data_ptr_p, count_t count)
+    : StandardVectorBuffer(data_ptr_p, count, sizeof(string_t)) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, idx_t capacity)
-    : StandardVectorBuffer(std::move(data_p), capacity, sizeof(string_t)), heap(AllocateHeap()) {
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, count_t count)
+    : StandardVectorBuffer(std::move(data_p), count, sizeof(string_t)), heap(AllocateHeap()) {
 	buffer_type = VectorBufferType::STRING_BUFFER;
 }
 
-VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, idx_t capacity, const VectorStringBuffer &other)
-    : StandardVectorBuffer(std::move(data_p), capacity, sizeof(string_t)) {
+VectorStringBuffer::VectorStringBuffer(AllocatedData &&data_p, count_t count, const VectorStringBuffer &other)
+    : StandardVectorBuffer(std::move(data_p), count, sizeof(string_t)) {
 	auto auxiliary_data = other.GetAuxiliaryData();
 	if (auxiliary_data) {
 		AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(std::move(auxiliary_data)));
@@ -78,13 +78,14 @@ idx_t StringHeapHolder::GetAllocationSize() const {
 buffer_ptr<VectorBuffer> VectorStringBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
 	auto type_size = GetTypeIdSize(type.InternalType());
 	auto offset_ptr = data_ptr + type_size * offset;
-	auto result = make_buffer<VectorStringBuffer>(offset_ptr, end - offset);
-	result->GetValidityMask().Slice(validity, offset, end - offset);
+	auto count = count_t(end - offset);
+	auto result = make_buffer<VectorStringBuffer>(offset_ptr, count);
+	result->GetValidityMask().Slice(validity, offset, count);
 	// keep the heap alive
 	if (auxiliary_data) {
 		result->AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(auxiliary_data));
 	}
-	result->SetVectorSize(end - offset);
+	result->SetVectorSize(count);
 	return result;
 }
 
@@ -148,8 +149,8 @@ void VectorStringBuffer::Verify(const LogicalType &type, const SelectionVector &
 	}
 }
 
-buffer_ptr<VectorBuffer> VectorStringBuffer::CreateBuffer(AllocatedData &&new_data, idx_t capacity) const {
-	return make_buffer<VectorStringBuffer>(std::move(new_data), capacity, *this);
+buffer_ptr<VectorBuffer> VectorStringBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {
+	return make_buffer<VectorStringBuffer>(std::move(new_data), count, *this);
 }
 
 buffer_ptr<VectorBuffer> VectorStringBuffer::FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,
@@ -189,7 +190,7 @@ VectorStringBuffer &StringVector::GetStringBuffer(Vector &vector) {
 	}
 	// check if the main buffer is a VectorStringBuffer
 	if (!vector.GetBufferRef()) {
-		vector.SetBuffer(make_buffer<VectorStringBuffer>(nullptr, 0));
+		vector.SetBuffer(make_buffer<VectorStringBuffer>(nullptr, count_t(0)));
 	}
 	if (vector.Buffer().GetBufferType() != VectorBufferType::STRING_BUFFER) {
 		throw InternalException(

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-VectorStructBuffer::VectorStructBuffer(const LogicalType &type, idx_t capacity)
+VectorStructBuffer::VectorStructBuffer(const LogicalType &type, capacity_t capacity)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::STRUCT_BUFFER), capacity(capacity) {
 	auto &child_types = StructType::GetChildTypes(type);
 	for (auto &child_type : child_types) {
@@ -16,7 +16,7 @@ VectorStructBuffer::VectorStructBuffer(const LogicalType &type, idx_t capacity)
 	validity.Resize(capacity);
 }
 
-VectorStructBuffer::VectorStructBuffer(vector<Vector> children_p, idx_t capacity_p)
+VectorStructBuffer::VectorStructBuffer(vector<Vector> children_p, capacity_t capacity_p)
     : VectorBuffer(VectorType::FLAT_VECTOR, VectorBufferType::STRUCT_BUFFER), children(std::move(children_p)),
       capacity(capacity_p) {
 	validity.Resize(capacity);
@@ -103,9 +103,10 @@ buffer_ptr<VectorBuffer> VectorStructBuffer::SliceInternal(const LogicalType &ty
 	for (idx_t i = 0; i < children.size(); i++) {
 		result_children.emplace_back(children[i], offset, end);
 	}
-	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), end - offset);
-	result->GetValidityMask().Slice(validity, offset, end - offset);
-	result->SetVectorSize(end - offset);
+	auto count = count_t(end - offset);
+	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), capacity_t(count));
+	result->GetValidityMask().Slice(validity, offset, count);
+	result->SetVectorSize(count);
 	return result;
 }
 
@@ -223,7 +224,7 @@ buffer_ptr<VectorBuffer> VectorStructBuffer::FlattenSliceInternal(const LogicalT
 		result_children.emplace_back(Vector::Ref(children[i]));
 		result_children[i].Flatten(sel, count);
 	}
-	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), count);
+	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), capacity_t(count));
 	// copy validity using sel
 	auto &result_validity = result->GetValidityMask();
 	result_validity.CopySel(validity, sel, 0, 0, count);

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -385,7 +385,7 @@ static void DirectConversion(Vector &vector, ArrowArray &array, idx_t chunk_offs
 	auto data_ptr =
 	    ArrowBufferData<data_t>(array, 1) +
 	    internal_type * GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), chunk_offset, nested_offset);
-	FlatVector::SetData(vector, data_ptr, size);
+	FlatVector::SetData(vector, data_ptr, count_t(size));
 }
 
 template <class T>
@@ -765,7 +765,7 @@ void ConvertDecimal(SRC src_ptr, Vector &vector, ArrowArray &array, idx_t size, 
 			auto data = ArrowBufferData<data_t>(array, 1) +
 			            GetTypeIdSize(vector.GetType().InternalType()) *
 			                GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), chunk_offset, nested_offset);
-			FlatVector::SetData(vector, data, size);
+			FlatVector::SetData(vector, data, count_t(size));
 		} else {
 			auto tgt_ptr = FlatVector::GetDataMutable<int32_t>(vector);
 			for (idx_t row = 0; row < size; row++) {
@@ -783,7 +783,7 @@ void ConvertDecimal(SRC src_ptr, Vector &vector, ArrowArray &array, idx_t size, 
 			auto data = ArrowBufferData<data_t>(array, 1) +
 			            GetTypeIdSize(vector.GetType().InternalType()) *
 			                GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), chunk_offset, nested_offset);
-			FlatVector::SetData(vector, data, size);
+			FlatVector::SetData(vector, data, count_t(size));
 		} else {
 			auto tgt_ptr = FlatVector::GetDataMutable<int64_t>(vector);
 			for (idx_t row = 0; row < size; row++) {
@@ -801,7 +801,7 @@ void ConvertDecimal(SRC src_ptr, Vector &vector, ArrowArray &array, idx_t size, 
 			auto data = ArrowBufferData<data_t>(array, 1) +
 			            GetTypeIdSize(vector.GetType().InternalType()) *
 			                GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), chunk_offset, nested_offset);
-			FlatVector::SetData(vector, data, size);
+			FlatVector::SetData(vector, data, count_t(size));
 		} else {
 			auto tgt_ptr = FlatVector::GetDataMutable<hugeint_t>(vector);
 			for (idx_t row = 0; row < size; row++) {

--- a/src/include/duckdb/common/types/size.hpp
+++ b/src/include/duckdb/common/types/size.hpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/size.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+//! capacity_t indicates how many values a structure can hold
+struct capacity_t {
+	explicit capacity_t(idx_t val) : val(val) {
+	}
+
+	operator idx_t() const {
+		return val;
+	} // NOLINT: allow implicit conversion
+
+private:
+	idx_t val;
+};
+
+//! count_t indicates how many values are currently in a structure
+struct count_t {
+	explicit count_t(idx_t val) : val(val) {
+	}
+
+	operator idx_t() const {
+		return val;
+	} // NOLINT: allow implicit conversion
+
+private:
+	idx_t val;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/size.hpp
+++ b/src/include/duckdb/common/types/size.hpp
@@ -17,9 +17,9 @@ struct capacity_t {
 	explicit capacity_t(idx_t val) : val(val) {
 	}
 
-	operator idx_t() const {
+	operator idx_t() const { // NOLINT: allow implicit conversion
 		return val;
-	} // NOLINT: allow implicit conversion
+	}
 
 private:
 	idx_t val;
@@ -30,9 +30,9 @@ struct count_t {
 	explicit count_t(idx_t val) : val(val) {
 	}
 
-	operator idx_t() const {
+	operator idx_t() const { // NOLINT: allow implicit conversion
 		return val;
-	} // NOLINT: allow implicit conversion
+	}
 
 private:
 	idx_t val;

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/common/enums/vector_type.hpp"
+#include "duckdb/common/types/size.hpp"
 
 namespace duckdb {
 
@@ -120,9 +121,10 @@ public:
 		return nullptr;
 	}
 
-	static buffer_ptr<VectorBuffer> CreateStandardVector(PhysicalType type, idx_t capacity = STANDARD_VECTOR_SIZE);
+	static buffer_ptr<VectorBuffer> CreateStandardVector(PhysicalType type,
+	                                                     capacity_t capacity = capacity_t(STANDARD_VECTOR_SIZE));
 	static buffer_ptr<VectorBuffer> CreateStandardVector(const LogicalType &logical_type,
-	                                                     idx_t capacity = STANDARD_VECTOR_SIZE);
+	                                                     capacity_t capacity = capacity_t(STANDARD_VECTOR_SIZE));
 
 	inline VectorType GetVectorType() const {
 		return vector_type;

--- a/src/include/duckdb/common/vector/array_vector.hpp
+++ b/src/include/duckdb/common/vector/array_vector.hpp
@@ -14,8 +14,8 @@ namespace duckdb {
 
 class VectorArrayBuffer : public VectorBuffer {
 public:
-	explicit VectorArrayBuffer(unique_ptr<Vector> child_vector, idx_t array_size, idx_t initial_capacity);
-	explicit VectorArrayBuffer(const LogicalType &array, idx_t initial = STANDARD_VECTOR_SIZE);
+	explicit VectorArrayBuffer(unique_ptr<Vector> child_vector, idx_t array_size, capacity_t initial_capacity);
+	explicit VectorArrayBuffer(const LogicalType &array, capacity_t initial = capacity_t(STANDARD_VECTOR_SIZE));
 	~VectorArrayBuffer() override;
 
 public:

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -50,7 +50,11 @@ public:
 		this->sel_vector.Initialize(vector);
 	}
 	optional_idx GetDictionarySize() const {
-		return entry->data.HasSize() ? entry->data.size() : optional_idx();
+		if (!entry->data.HasSize() || entry->data.size() == 0) {
+			// FIXME: we should be directly returning entry->data.size(), this should not be an optional_idx
+			return optional_idx();
+		}
+		return entry->data.size();
 	}
 	void SetDictionaryId(string id) {
 		entry->id = std::move(id);

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -15,10 +15,10 @@ namespace duckdb {
 
 class StandardVectorBuffer : public VectorBuffer {
 public:
-	StandardVectorBuffer(Allocator &allocator, idx_t capacity, idx_t type_size);
-	explicit StandardVectorBuffer(idx_t capacity, idx_t type_size);
-	explicit StandardVectorBuffer(data_ptr_t data_ptr_p, idx_t capacity, idx_t type_size);
-	explicit StandardVectorBuffer(AllocatedData &&data_p, idx_t capacity, idx_t type_size);
+	StandardVectorBuffer(Allocator &allocator, capacity_t capacity, idx_t type_size);
+	explicit StandardVectorBuffer(capacity_t capacity, idx_t type_size);
+	explicit StandardVectorBuffer(data_ptr_t data_ptr_p, count_t count, idx_t type_size);
+	explicit StandardVectorBuffer(AllocatedData &&data_p, count_t count, idx_t type_size);
 
 public:
 	data_ptr_t GetData() override {
@@ -57,7 +57,7 @@ protected:
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,
 	                                              idx_t count) const override;
 
-	virtual buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, idx_t capacity) const;
+	virtual buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, count_t count) const;
 
 protected:
 	ValidityMask validity;
@@ -151,7 +151,7 @@ struct FlatVector {
 	static inline T *GetDataMutableUnsafe(Vector &vector) {
 		return reinterpret_cast<T *>(GetDataMutableUnsafe(vector));
 	}
-	static void SetData(Vector &vector, data_ptr_t data, idx_t capacity);
+	static void SetData(Vector &vector, data_ptr_t data, count_t count);
 	template <class T>
 	static inline T GetValue(Vector &vector, idx_t idx) {
 		VerifyFlatVector(vector);

--- a/src/include/duckdb/common/vector/fsst_vector.hpp
+++ b/src/include/duckdb/common/vector/fsst_vector.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class VectorFSSTStringBuffer : public VectorStringBuffer {
 public:
-	explicit VectorFSSTStringBuffer(idx_t capacity);
+	explicit VectorFSSTStringBuffer(capacity_t capacity);
 
 public:
 	void AddDecoder(buffer_ptr<void> &duckdb_fsst_decoder_p, const idx_t string_block_limit) {

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -16,15 +16,15 @@ namespace duckdb {
 
 class VectorListBuffer : public StandardVectorBuffer {
 public:
-	explicit VectorListBuffer(Allocator &allocator, idx_t capacity, unique_ptr<Vector> vector);
-	explicit VectorListBuffer(Allocator &allocator, idx_t capacity, const LogicalType &list_type,
-	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
-	explicit VectorListBuffer(idx_t capacity, const LogicalType &list_type,
-	                          idx_t child_capacity = STANDARD_VECTOR_SIZE);
-	explicit VectorListBuffer(data_ptr_t data, idx_t capacity, const Vector &vector);
-	explicit VectorListBuffer(data_ptr_t data, idx_t capacity, const VectorListBuffer &parent);
-	explicit VectorListBuffer(AllocatedData allocated_data, idx_t capacity, const VectorListBuffer &parent);
-	explicit VectorListBuffer(AllocatedData allocated_data, idx_t capacity, VectorListBuffer &parent);
+	explicit VectorListBuffer(Allocator &allocator, capacity_t capacity, unique_ptr<Vector> vector);
+	explicit VectorListBuffer(Allocator &allocator, capacity_t capacity, const LogicalType &list_type,
+	                          capacity_t child_capacity = capacity_t(STANDARD_VECTOR_SIZE));
+	explicit VectorListBuffer(capacity_t capacity, const LogicalType &list_type,
+	                          capacity_t child_capacity = capacity_t(STANDARD_VECTOR_SIZE));
+	explicit VectorListBuffer(data_ptr_t data, count_t count, const Vector &vector);
+	explicit VectorListBuffer(data_ptr_t data, count_t count, const VectorListBuffer &parent);
+	explicit VectorListBuffer(AllocatedData allocated_data, count_t count, const VectorListBuffer &parent);
+	explicit VectorListBuffer(AllocatedData allocated_data, count_t count, VectorListBuffer &parent);
 	~VectorListBuffer() override;
 
 public:
@@ -62,7 +62,7 @@ public:
 
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
-	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, idx_t capacity) const override;
+	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, count_t count) const override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -26,11 +26,11 @@ class VectorStringBuffer : public StandardVectorBuffer {
 public:
 	VectorStringBuffer();
 	explicit VectorStringBuffer(Allocator &allocator);
-	VectorStringBuffer(Allocator &allocator, idx_t capacity);
-	explicit VectorStringBuffer(idx_t capacity);
-	explicit VectorStringBuffer(data_ptr_t data_ptr_p, idx_t capacity);
-	explicit VectorStringBuffer(AllocatedData &&data_p, idx_t capacity);
-	VectorStringBuffer(AllocatedData &&data_p, idx_t capacity, const VectorStringBuffer &other);
+	VectorStringBuffer(Allocator &allocator, capacity_t capacity);
+	explicit VectorStringBuffer(capacity_t capacity);
+	explicit VectorStringBuffer(data_ptr_t data_ptr_p, count_t count);
+	explicit VectorStringBuffer(AllocatedData &&data_p, count_t count);
+	VectorStringBuffer(AllocatedData &&data_p, count_t count, const VectorStringBuffer &other);
 
 public:
 	StringHeap &GetHeap() {
@@ -61,7 +61,7 @@ public:
 
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
-	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, idx_t capacity) const override;
+	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, count_t count) const override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,

--- a/src/include/duckdb/common/vector/struct_vector.hpp
+++ b/src/include/duckdb/common/vector/struct_vector.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 
 class VectorStructBuffer : public VectorBuffer {
 public:
-	explicit VectorStructBuffer(const LogicalType &struct_type, idx_t capacity = STANDARD_VECTOR_SIZE);
-	VectorStructBuffer(vector<Vector> children, idx_t capacity);
+	explicit VectorStructBuffer(const LogicalType &struct_type, capacity_t capacity = capacity_t(STANDARD_VECTOR_SIZE));
+	VectorStructBuffer(vector<Vector> children, capacity_t capacity);
 	VectorStructBuffer(VectorStructBuffer &other, const SelectionVector &sel, idx_t count);
 	~VectorStructBuffer() override;
 

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -175,7 +175,7 @@ void FixedSizeScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_co
 	auto source_data = data + start * sizeof(T);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	FlatVector::SetData(result, source_data, scan_count);
+	FlatVector::SetData(result, source_data, count_t(scan_count));
 }
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
"Count" and "capacity" are subtly different, having them both be an `idx_t` is confusing and can lead to hard to understand behavior. This PR adds dedicated classes that make it clear which is which and uses these in some of the VectorBuffer APIs. 