### PR TITLE
[Bugfix] Reset pg_err_pos in pg_parser_init to prevent stale error position leaking

### DIFF
--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -2,5 +2,13 @@
   "description": "Test PEG Parser + transformer in strict mode",
   "skip_compiled": "true",
   "on_init": "set allow_parser_override_extension=strict;",
-  "statically_loaded_extensions": ["core_functions", "autocomplete"]
+  "statically_loaded_extensions": ["core_functions", "autocomplete"],
+  "skip_tests": [
+    {
+      "reason": "This test verifies pg_err_pos reset behavior specific to the Postgres parser internals (errhint from LIMIT #,# grammar rule), which does not apply to the PEG parser",
+      "paths": [
+        "test/sql/parser/pg_err_pos_reset.test"
+      ]
+    }
+  ]
 }

--- a/test/sql/parser/pg_err_pos_reset.test
+++ b/test/sql/parser/pg_err_pos_reset.test
@@ -1,0 +1,34 @@
+# name: test/sql/parser/pg_err_pos_reset.test
+# description: Verify pg_err_pos is reset between parses so stale position
+# group: [parser]
+
+#              does not leak into unrelated error messages
+
+# Step 1: A syntax error that sets pg_err_pos via errposition().
+# Any normal parse error (e.g., a misspelled keyword) triggers
+# scanner_yyerror -> errposition(), leaving pg_err_pos non-zero.
+statement error
+SELECT 1 AS foo frommmm bar;
+----
+syntax error
+
+# Step 2: A parse error that throws via errhint() BEFORE
+# errposition() is reached.  The LIMIT #,# syntax triggers
+# the grammar rule that calls errhint("Use separate LIMIT and
+# OFFSET clauses."), which throws immediately — so
+# parser_errposition in the same ereport() comma-expression
+# is never evaluated.
+# Without the fix, the stale pg_err_pos from Step 1 causes a
+# spurious "LINE 1:" indicator in this error message.
+# With the fix (pg_err_pos = 0 in pg_parser_init), no position
+# is emitted and LINE 1: must not appear.
+statement error
+SELECT 1 LIMIT 5,10;
+----
+errhint NOT IMPLEMENTED
+
+# Verify LINE 1: does not appear in the errhint error
+statement error
+SELECT 1 LIMIT 5,10;
+----
+<!REGEX>:(?s).*LINE 1:.*

--- a/third_party/libpg_query/pg_functions.cpp
+++ b/third_party/libpg_query/pg_functions.cpp
@@ -85,6 +85,7 @@ void *palloc(size_t n) {
 
 void pg_parser_init() {
 	pg_parser_state.pg_err_code = PGUNDEFINED;
+	pg_parser_state.pg_err_pos = 0;
 	pg_parser_state.pg_err_msg[0] = '\0';
 
 	pg_parser_state.malloc_ptr_size = 4;


### PR DESCRIPTION
pg_parser_init() resets pg_err_code and pg_err_msg but not pg_err_pos. When a parse error sets pg_err_pos via errposition(), and the next parse fails through a path that never calls errposition() (e.g. errhint() which throws before parser_errposition() is evaluated in the ereport comma-expression), the stale pg_err_pos from the previous parse leaks into the new error message, producing a spurious "LINE 1: ..." indicator that points to the wrong query.

Fix: add pg_parser_state.pg_err_pos = 0 in pg_parser_init().
Test: test/sql/parser/pg_err_pos_reset.test