### PR TITLE
Internal #8812: Allow prepared TIMESTAMPTZ params in TIMESTAMP_NS comparisons

### DIFF
--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -291,6 +291,17 @@ static int64_t ImplicitCastTimestamp(const LogicalType &to) {
 	}
 }
 
+static int64_t ImplicitCastTimestampTZ(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
 static int64_t ImplicitCastBignum(const LogicalType &to) {
 	switch (to.id()) {
 	case LogicalTypeId::DOUBLE:
@@ -604,6 +615,8 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		return ImplicitCastTimestampNS(to);
 	case LogicalTypeId::TIMESTAMP:
 		return ImplicitCastTimestamp(to);
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return ImplicitCastTimestampTZ(to);
 	case LogicalTypeId::BIGNUM:
 		return ImplicitCastBignum(to);
 	case LogicalTypeId::VARIANT:

--- a/test/sql/prepared/test_prepare_issue_8812.test
+++ b/test/sql/prepared/test_prepare_issue_8812.test
@@ -1,0 +1,31 @@
+# name: test/sql/prepared/test_prepare_issue_8812.test
+# description: Issue #8812 - prepared TIMESTAMPTZ arguments can compare against TIMESTAMP_NS columns
+# group: [prepared]
+
+statement ok
+CREATE OR REPLACE TABLE events_ns(
+	ts TIMESTAMP_NS,
+	category VARCHAR
+);
+
+statement ok
+INSERT INTO events_ns VALUES
+	(TIMESTAMP_NS '2024-04-05 00:00:00.000000001', 'A'),
+	(TIMESTAMP_NS '2024-04-05 01:00:00.000000001', 'A'),
+	(TIMESTAMP_NS '2024-04-05 02:00:00.000000001', 'A'),
+	(TIMESTAMP_NS '2024-04-06 00:00:00.000000001', 'A'),
+	(TIMESTAMP_NS '2024-04-06 01:00:00.000000001', 'A');
+
+statement ok
+PREPARE v1 AS
+SELECT COUNT(*)
+FROM events_ns
+WHERE ts >= ? AND ts < ?;
+
+query I
+EXECUTE v1(
+	TIMESTAMPTZ '2024-04-05 00:00:00+00',
+	TIMESTAMPTZ '2024-04-06 00:00:00+00'
+);
+----
+3


### PR DESCRIPTION
By adding implicit casts from TIMESTAMP_TZ to TIMESTAMP_NS/MS/S.

Follow-up to #22000