### PR TITLE
Inherit initial value for `custom_user_agent` from `DUCKDB_CUSTOM_USER_AGENT` env variable

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -40,6 +40,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  DUCKDB_CUSTOM_USER_AGENT: 'ci/${{ github.repository }}/${{ github.workflow }}'
 
 jobs:
  check-draft:

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -56,6 +56,10 @@ DBConfig::DBConfig() {
 	secret_manager = make_uniq<SecretManager>();
 	http_util = make_shared_ptr<HTTPUtil>();
 	callback_manager = make_uniq<ExtensionCallbackManager>();
+	auto env_user_agent = FileSystem::GetEnvVariable("DUCKDB_CUSTOM_USER_AGENT");
+	if (!env_user_agent.empty()) {
+		options.custom_user_agent = std::move(env_user_agent);
+	}
 }
 
 DBConfig::DBConfig(bool read_only) : DBConfig::DBConfig() {

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -701,10 +701,10 @@ TEST_CASE("Test custom_user_agent config", "[capi]") {
 		REQUIRE(duckdb_row_count(&result_full_user_agent) == 1);
 
 		char *custom_user_agent_value = duckdb_value_varchar(&result_custom_user_agent, 0, 0);
-		REQUIRE(string(custom_user_agent_value) == "CUSTOM_STRING");
+		REQUIRE_THAT(string(custom_user_agent_value), Catch::Matchers::Matches(".*CUSTOM_STRING"));
 
 		char *full_user_agent_value = duckdb_value_varchar(&result_full_user_agent, 0, 0);
-		REQUIRE_THAT(full_user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi CUSTOM_STRING.*"));
+		REQUIRE_THAT(full_user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi .*CUSTOM_STRING.*"));
 
 		duckdb_destroy_config(&config);
 		duckdb_free(custom_user_agent_value);

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -671,7 +671,7 @@ TEST_CASE("Test custom_user_agent config", "[capi]") {
 
 		REQUIRE(duckdb_row_count(&result) == 1);
 		char *user_agent_value = duckdb_value_varchar(&result, 0, 0);
-		REQUIRE_THAT(user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi"));
+		REQUIRE_THAT(user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi.*"));
 
 		duckdb_free(user_agent_value);
 		duckdb_destroy_result(&result);
@@ -704,7 +704,7 @@ TEST_CASE("Test custom_user_agent config", "[capi]") {
 		REQUIRE(string(custom_user_agent_value) == "CUSTOM_STRING");
 
 		char *full_user_agent_value = duckdb_value_varchar(&result_full_user_agent, 0, 0);
-		REQUIRE_THAT(full_user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi CUSTOM_STRING"));
+		REQUIRE_THAT(full_user_agent_value, Catch::Matchers::Matches("duckdb/.*(.*) capi CUSTOM_STRING.*"));
 
 		duckdb_destroy_config(&config);
 		duckdb_free(custom_user_agent_value);

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Test user_agent", "[api]") {
 		DuckDB db(nullptr);
 		Connection con(db);
 		auto res = con.Query("PRAGMA user_agent");
-		REQUIRE_THAT(res->GetValue(0, 0).ToString(), Catch::Matchers::Matches("duckdb/.*(.*) cpp"));
+		REQUIRE_THAT(res->GetValue(0, 0).ToString(), Catch::Matchers::Matches("duckdb/.*(.*) cpp.*"));
 	}
 	{
 		// The latest provided duckdb_api is used
@@ -129,7 +129,7 @@ TEST_CASE("Test user_agent", "[api]") {
 		DuckDB db("", &config);
 		Connection con(db);
 		auto res = con.Query("PRAGMA user_agent");
-		REQUIRE_THAT(res->GetValue(0, 0).ToString(), Catch::Matchers::Matches("duckdb/.*(.*) go"));
+		REQUIRE_THAT(res->GetValue(0, 0).ToString(), Catch::Matchers::Matches("duckdb/.*(.*) go.*"));
 	}
 }
 

--- a/test/sql/settings/user_agent.test
+++ b/test/sql/settings/user_agent.test
@@ -12,11 +12,6 @@ RESET custom_user_agent
 ----
 Cannot change custom_user_agent setting while database is running
 
-query T
-SELECT current_setting('custom_user_agent')
-----
-(empty)
-
 statement error
 SET duckdb_api='something else'
 ----


### PR DESCRIPTION
Idea is as follow: if you define `DUCKDB_CUSTOM_USER_AGENT`, that get's added to `custom_user_agent`, and eventually surfaced to outbound HTTP traffic. This allows an easy to set way to attribute traffic if one decides to do so.

Demo it's like:
```
./build/release/duckdb
```
```sql
CALL enable_logging('HTTP');
FORCE INSTALL spatial;
FROM duckdb_logs_parsed('HTTP') SELECT request.headers;
┌───────────────────────────────────────────────────────────────┐
│                            headers                            │
│                     map(varchar, varchar)                     │
├───────────────────────────────────────────────────────────────┤
│ {User-Agent='duckdb/v1.5.3-dev124(osx_arm64) cli 5f3eef3128'} │
└───────────────────────────────────────────────────────────────┘
```
vs
```
DUCKDB_CUSTOM_USER_AGENT=my_user_agent ./build/release/duckdb
```
```sql
CALL enable_logging('HTTP');
FORCE INSTALL spatial;
FROM duckdb_logs_parsed('HTTP') SELECT request.headers;
┌─────────────────────────────────────────────────────────────────────────────┐
│                                   headers                                   │
│                            map(varchar, varchar)                            │
├─────────────────────────────────────────────────────────────────────────────┤
│ {User-Agent='duckdb/v1.5.3-dev124(osx_arm64) cli my_user_agent 5f3eef3128'} │
└─────────────────────────────────────────────────────────────────────────────┘
```

Added an example of usage in Main.yml.