### PR TITLE
Fix UTC±NN00 cannot be parsed in SQL

### DIFF
--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -215,9 +215,10 @@ unique_ptr<icu::TimeZone> GetKnownTimeZone(const string &tz_str) {
 	return nullptr;
 }
 
-static string NormalizeTimeZone(const string &tz_str) {
-	if (GetKnownTimeZone(tz_str)) {
-		return tz_str;
+unique_ptr<icu::TimeZone> GetNormalizedTimeZone(string &tz_str) {
+	duckdb::unique_ptr<icu::TimeZone> tz;
+	if (tz = GetKnownTimeZone(tz_str)) {
+		return tz;
 	}
 
 	//	Map UTC±NN00 to Etc/UTC±N
@@ -266,16 +267,17 @@ static string NormalizeTimeZone(const string &tz_str) {
 			mapped += '0';
 		}
 		// Final sanity check
-		if (GetKnownTimeZone(mapped)) {
-			return mapped;
+		if (tz = GetKnownTimeZone(mapped)) {
+			tz_str = mapped;
+			return tz;
 		}
 	} while (false);
 
-	return tz_str;
+	return nullptr;
 }
 
 unique_ptr<icu::TimeZone> GetTimeZoneInternal(string &tz_str, vector<string> &candidates) {
-	auto tz = GetKnownTimeZone(tz_str);
+	auto tz = GetNormalizedTimeZone(tz_str);
 	if (tz) {
 		return tz;
 	}
@@ -332,7 +334,6 @@ unique_ptr<icu::TimeZone> ICUHelpers::GetTimeZone(string &tz_str, string *error_
 
 static void SetICUTimeZone(ClientContext &context, SetScope scope, Value &parameter) {
 	auto tz_str = StringValue::Get(parameter);
-	tz_str = NormalizeTimeZone(tz_str);
 	ICUHelpers::GetTimeZone(tz_str);
 	parameter = Value(tz_str);
 }
@@ -470,8 +471,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	std::string tz_string;
 	tz->getID(tz_id).toUTF8String(tz_string);
 	// If the environment TZ is invalid, look for some alternatives
-	tz_string = NormalizeTimeZone(tz_string);
-	if (!GetKnownTimeZone(tz_string)) {
+	tz = GetNormalizedTimeZone(tz_string);
+	if (!tz) {
 		tz_string = "UTC";
 	}
 	config.AddExtensionOption("TimeZone", "The current time zone", LogicalType::VARCHAR, Value(tz_string),

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -173,7 +173,7 @@ public:
 	//! Is the character a valid part of a time zone name?
 	static inline bool CharacterIsTimeZone(char c) {
 		return StringUtil::CharacterIsAlpha(c) || StringUtil::CharacterIsDigit(c) || c == '_' || c == '/' || c == '+' ||
-		       c == '-';
+		       c == '-' || c == ':';
 	}
 
 	//! True, if the timestamp is finite, else false.

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -210,6 +210,16 @@ select value from duckdb_settings() where name = 'TimeZone';
 ----
 Etc/GMT+8
 
+query I
+SELECT '2026-04-23 19:26:40 ${utc}'::TIMESTAMPTZ;
+----
+2026-04-23 19:26:40-08
+
+query I
+SELECT TIMESTAMP '2026-04-23 19:26:40' AT TIME ZONE '${utc}'
+----
+2026-04-23 19:26:40-08
+
 endloop
 
 foreach utc UTC+0500 UTC+05 UTC+5 UTC+05:00
@@ -221,6 +231,16 @@ query I
 select value from duckdb_settings() where name = 'TimeZone';
 ----
 Etc/GMT-5
+
+query I
+SELECT '2026-04-23 19:26:40 ${utc}'::TIMESTAMPTZ;
+----
+2026-04-23 19:26:40+05
+
+query I
+SELECT TIMESTAMP '2026-04-23 19:26:40' AT TIME ZONE '${utc}'
+----
+2026-04-23 19:26:40+05
 
 endloop
 
@@ -234,6 +254,16 @@ select value from duckdb_settings() where name = 'TimeZone';
 ----
 Etc/GMT-14
 
+query I
+SELECT '2026-04-23 19:26:40 ${utc}'::TIMESTAMPTZ;
+----
+2026-04-23 19:26:40+14
+
+query I
+SELECT TIMESTAMP '2026-04-23 19:26:40' AT TIME ZONE '${utc}'
+----
+2026-04-23 19:26:40+14
+
 endloop
 
 foreach utc UTC-0 UTC-00 UTC-000 UTC-0000 UTC+0 UTC+00 UTC+000 UTC+0000
@@ -245,6 +275,16 @@ query I
 select value from duckdb_settings() where name = 'TimeZone';
 ----
 Etc/GMT+0
+
+query I
+SELECT '2026-04-23 19:26:40 ${utc}'::TIMESTAMPTZ;
+----
+2026-04-23 19:26:40+00
+
+query I
+SELECT TIMESTAMP '2026-04-23 19:26:40' AT TIME ZONE '${utc}'
+----
+2026-04-23 19:26:40+00
 
 endloop
 


### PR DESCRIPTION
I noticed that DuckDB now supports timezones in the `UTC±NN00` format; however, this format can currently only be used within the `SET TIMEZONE= ` statement and cannot be used directly within queries. Therefore, I submit this patch to fix this issue.