### PR TITLE
Set `temp_file_encryption` setting outside of loop

### DIFF
--- a/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
+++ b/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
@@ -5,11 +5,6 @@
 # We need httpfs to do encrypted writes
 require httpfs
 
-foreach cipher GCM CTR
-
-statement ok
-ATTACH '{TEST_DIR}/encrypted_temp_files_{cipher}.db' AS enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '{cipher}');
-
 statement ok
 SET temp_file_encryption=true;
 
@@ -25,6 +20,11 @@ SET temp_directory='{TEST_DIR}/temp.tmp'
 # Force PhysicalAsOfJoin
 statement ok
 PRAGMA asof_loop_join_threshold = 0;
+
+foreach cipher GCM CTR
+
+statement ok
+ATTACH '{TEST_DIR}/encrypted_temp_files_{cipher}.db' AS enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '{cipher}');
 
 query II
 WITH build AS (


### PR DESCRIPTION
Fixes an issue with `temp_file_encryption` being set with an active temp directory in a test