### PR TITLE
Add support for static linking C-API extensions

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -24,11 +24,17 @@ get_statically_linked_extensions("${DUCKDB_EXTENSION_NAMES}"
 foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
   string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
   if(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})
-    set(DUCKDB_EXTENSION_HEADER "${EXT_NAME}_extension.hpp")
-    file(
-      APPEND
-      "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp.cand"
-      "#include \"${DUCKDB_EXTENSION_HEADER}\"\n")
+    get_property(
+      EXT_KIND
+      TARGET ${EXT_NAME}_extension
+      PROPERTY DUCKDB_EXTENSION_KIND)
+    if(NOT "${EXT_KIND}" STREQUAL "CAPI")
+      set(DUCKDB_EXTENSION_HEADER "${EXT_NAME}_extension.hpp")
+      file(
+        APPEND
+        "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp.cand"
+        "#include \"${DUCKDB_EXTENSION_HEADER}\"\n")
+    endif()
   endif()
 endforeach()
 
@@ -39,6 +45,7 @@ configure_file(
 # generated_extension_loader.hpp
 set(EXT_LOADER_NAME_LIST "")
 set(EXT_LOADER_BODY "")
+set(EXT_CAPI_DECLARATIONS "")
 foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
   string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
   if(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})
@@ -53,14 +60,31 @@ foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
       set(EXT_NAME_CAMELCASE "${EXT_NAME_CAMELCASE}${FIRST_LETTER}${REMAINDER}")
     endforeach()
 
+    get_property(
+      EXT_KIND
+      TARGET ${EXT_NAME}_extension
+      PROPERTY DUCKDB_EXTENSION_KIND)
     set(EXT_LOADER_NAME_LIST "${EXT_LOADER_NAME_LIST},\n\t\"${EXT_NAME}\"")
-    set(EXT_LOADER_BODY
-        "${EXT_LOADER_BODY}\
+    if("${EXT_KIND}" STREQUAL "CAPI")
+      set(EXT_CAPI_DECLARATIONS
+          "${EXT_CAPI_DECLARATIONS}extern \"C\" bool ${EXT_NAME}_init_c_api(duckdb_extension_info, duckdb_extension_access *);\n"
+      )
+      set(EXT_LOADER_BODY
+          "${EXT_LOADER_BODY}\
+    if (extension==\"${EXT_NAME}\") {
+        db.LoadStaticCAPIExtension(\"${EXT_NAME}\", ${EXT_NAME}_init_c_api);
+        return ExtensionLoadResult::LOADED_EXTENSION;
+    }
+")
+    else()
+      set(EXT_LOADER_BODY
+          "${EXT_LOADER_BODY}\
     if (extension==\"${EXT_NAME}\") {
         db.LoadStaticExtension<${EXT_NAME_CAMELCASE}Extension>();
         return ExtensionLoadResult::LOADED_EXTENSION;
     }
 ")
+    endif()
   endif()
 endforeach()
 

--- a/extension/demo_capi/CMakeLists.txt
+++ b/extension/demo_capi/CMakeLists.txt
@@ -17,6 +17,7 @@ option(
 
 if(USE_UNSTABLE_C_API)
   build_loadable_extension_capi_unstable(${EXTENSION_NAME} ${EXTENSION_FILES})
+  build_static_extension_capi_unstable(${EXTENSION_NAME} ${EXTENSION_FILES})
 else()
   # Minimum supported DuckDB version
   set(CAPI_MAJOR 1)
@@ -24,4 +25,6 @@ else()
   set(CAPI_PATCH 0)
   build_loadable_extension_capi(${EXTENSION_NAME} ${CAPI_MAJOR} ${CAPI_MINOR}
                                 ${CAPI_PATCH} ${EXTENSION_FILES})
+  build_static_extension_capi(${EXTENSION_NAME} ${CAPI_MAJOR} ${CAPI_MINOR}
+                              ${CAPI_PATCH} ${EXTENSION_FILES})
 endif()

--- a/extension/demo_capi/demo_capi_config.py
+++ b/extension/demo_capi/demo_capi_config.py
@@ -1,0 +1,18 @@
+import os
+
+extension_kind = 'CAPI'
+
+# list all include directories
+include_directories = [os.path.sep.join(x.split('/')) for x in ['extension/demo_capi/include']]
+
+
+# source files
+def list_files_recursive(rootdir, suffix):
+    file_list = []
+    for root, _, files in os.walk(rootdir):
+        file_list += [os.path.join(root, f) for f in files if f.endswith(suffix)]
+    return file_list
+
+
+prefix = os.path.join('extension', 'demo_capi')
+source_files = list_files_recursive(prefix, '.cpp')

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -260,6 +260,31 @@ function(build_static_extension NAME PARAMETERS)
     list(REMOVE_AT FILES 0)
     add_library(${NAME}_extension STATIC ${FILES})
     target_link_libraries(${NAME}_extension duckdb_static)
+    set_property(TARGET ${NAME}_extension PROPERTY DUCKDB_EXTENSION_KIND "CPP")
+endfunction()
+
+function(build_static_extension_capi NAME CAPI_VERSION_MAJOR CAPI_VERSION_MINOR CAPI_VERSION_PATCH PARAMETERS)
+    set(FILES "${ARGV}")
+    list(REMOVE_AT FILES 0 1 2 3)
+    add_library(${NAME}_extension STATIC ${FILES})
+    target_link_libraries(${NAME}_extension duckdb_static)
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_BUILD_STATIC_EXTENSION)
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_API_VERSION_MAJOR=${CAPI_VERSION_MAJOR})
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_API_VERSION_MINOR=${CAPI_VERSION_MINOR})
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_API_VERSION_PATCH=${CAPI_VERSION_PATCH})
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_NAME=${NAME})
+    set_property(TARGET ${NAME}_extension PROPERTY DUCKDB_EXTENSION_KIND "CAPI")
+endfunction()
+
+function(build_static_extension_capi_unstable NAME PARAMETERS)
+    set(FILES "${ARGV}")
+    list(REMOVE_AT FILES 0)
+    add_library(${NAME}_extension STATIC ${FILES})
+    target_link_libraries(${NAME}_extension duckdb_static)
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_BUILD_STATIC_EXTENSION)
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_API_VERSION_UNSTABLE=${DUCKDB_NORMALIZED_VERSION})
+    target_compile_definitions(${NAME}_extension PRIVATE DUCKDB_EXTENSION_NAME=${NAME})
+    set_property(TARGET ${NAME}_extension PROPERTY DUCKDB_EXTENSION_KIND "CAPI")
 endfunction()
 
 # Internal extension register function
@@ -316,6 +341,7 @@ function(register_extension NAME DONT_LINK DONT_BUILD LOAD_TESTS PATH INCLUDE_PA
     set(DUCKDB_EXTENSION_${EXTENSION_NAME_UPPERCASE}_INCLUDE_PATH ${INCLUDE_PATH} PARENT_SCOPE)
     set(DUCKDB_EXTENSION_${EXTENSION_NAME_UPPERCASE}_TEST_PATH ${TEST_PATH} PARENT_SCOPE)
     set(DUCKDB_EXTENSION_${EXTENSION_NAME_UPPERCASE}_EXT_VERSION ${EXTENSION_VERSION} PARENT_SCOPE)
+
 endfunction()
 
 # Downloads the external extension repo at the specified commit and calls register_extension

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -10,3 +10,4 @@
 # these extensions are loaded by default on every build as they are an essential part of DuckDB
 duckdb_extension_load(core_functions)
 duckdb_extension_load(parquet)
+

--- a/extension/generated_extension_loader.cpp.in
+++ b/extension/generated_extension_loader.cpp.in
@@ -1,6 +1,7 @@
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/main/extension_helper.hpp"
 
+${EXT_CAPI_DECLARATIONS}
 namespace duckdb {
 
 //! Looks through the CMake-generated list of extensions that are linked into DuckDB currently to try load <extension>

--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -841,15 +841,25 @@ def create_duckdb_c_ext_h(file, ext_api_version, function_groups, api_struct_def
         typedefs += '\n'
 
     duckdb_ext_h += COMMENT_HEADER("Typedefs mapping functions to struct entries")
+    duckdb_ext_h += "// When building as a static extension, DuckDB symbols are resolved directly at link time.\n"
+    duckdb_ext_h += "// The vtable (duckdb_ext_api) is not used - skip these macro redirections.\n"
+    duckdb_ext_h += "#ifndef DUCKDB_BUILD_STATIC_EXTENSION\n"
     duckdb_ext_h += typedefs
+    duckdb_ext_h += "#endif // DUCKDB_BUILD_STATIC_EXTENSION\n"
     duckdb_ext_h += "\n"
 
     # Add The struct global macros
     duckdb_ext_h += COMMENT_HEADER("Struct Global Macros")
-    duckdb_ext_h += f"""// This goes in the c/c++ file containing the entrypoint (handle
+    duckdb_ext_h += f"""#ifdef DUCKDB_BUILD_STATIC_EXTENSION
+// No vtable global needed for static builds - DuckDB symbols are resolved directly at link time
+#define DUCKDB_EXTENSION_GLOBAL
+#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)
+#else
+// This goes in the c/c++ file containing the entrypoint (handle
 #define DUCKDB_EXTENSION_GLOBAL {DUCKDB_EXT_API_STRUCT_TYPENAME} {DUCKDB_EXT_API_VAR_NAME} = {{0}};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
 #define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version) {DUCKDB_EXT_API_STRUCT_TYPENAME} * res = ({DUCKDB_EXT_API_STRUCT_TYPENAME} *)access->get_api(info, minimum_api_version); if (!res) {{return false;}}; {DUCKDB_EXT_API_VAR_NAME} = *res;
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
 """
     duckdb_ext_h += f"""
 // Place in global scope of any C/C++ file that needs to access the extension API

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -238,12 +238,15 @@ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list)
 
     ext_include_dirs = ext_pkg.include_directories
     ext_source_files = ext_pkg.source_files
+    ext_kind = getattr(ext_pkg, 'extension_kind', 'CPP').upper()
 
     include_files += amalgamation.list_includes_files(ext_include_dirs)
     include_list += ext_include_dirs
     source_list += ext_source_files
 
     sys.path = original_path
+
+    return ext_kind
 
 
 def get_extension_linked_define(extension):
@@ -309,9 +312,10 @@ def build_package(
     ext_loader_defines = ''
     ext_headers = ''
     ext_name_vector_initializer = ''
+    ext_capi_declarations = ''
     for ext in extensions:
         ext_path = os.path.join(scripts_dir, '..', 'extension', ext)
-        include_package(ext, ext_path, include_files, include_list, source_list)
+        ext_kind = include_package(ext, ext_path, include_files, include_list, source_list)
 
         ext_linked_define = get_extension_linked_define(ext)
         ext_linked_default = 1 if ext in default_linked_extensions else 0
@@ -320,26 +324,40 @@ def build_package(
             f"#ifndef {ext_linked_define}\n" f"#define {ext_linked_define} {ext_linked_default}\n" "#endif\n\n"
         )
 
-        ext_headers += f'#if {ext_linked_define}\n#include "{ext}_extension.hpp"\n#endif\n'
-
         # handle generated_extension_loader
         # this - beautifully - approximates code in extension/CMakeLists.txt
-        ext_name_camelcase = ext.replace('_', ' ').title().replace(' ', '')
-
-        ext_loader_body += (
-            f"#if {ext_linked_define}\n"
-            f"    if (extension==\"{ext}\") {{\n"
-            f"        db.LoadStaticExtension<{ext_name_camelcase}Extension>();\n"
-            "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
-            "    }\n"
-            "#endif\n"
-        )
+        if ext_kind == 'CAPI':
+            ext_capi_declarations += (
+                f'#if {ext_linked_define}\n'
+                f'extern "C" bool {ext}_init_c_api(duckdb_extension_info, duckdb_extension_access *);\n'
+                "#endif\n"
+            )
+            ext_loader_body += (
+                f"#if {ext_linked_define}\n"
+                f"    if (extension==\"{ext}\") {{\n"
+                f"        db.LoadStaticCAPIExtension(\"{ext}\", {ext}_init_c_api);\n"
+                "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
+                "    }\n"
+                "#endif\n"
+            )
+        else:
+            ext_headers += f'#if {ext_linked_define}\n#include "{ext}_extension.hpp"\n#endif\n'
+            ext_name_camelcase = ext.replace('_', ' ').title().replace(' ', '')
+            ext_loader_body += (
+                f"#if {ext_linked_define}\n"
+                f"    if (extension==\"{ext}\") {{\n"
+                f"        db.LoadStaticExtension<{ext_name_camelcase}Extension>();\n"
+                "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
+                "    }\n"
+                "#endif\n"
+            )
 
         ext_name_vector_initializer += f"\n#if {ext_linked_define}\n" f"        \"{ext}\",\n" "#endif"
 
     loader_code = open(os.path.join('extension', 'generated_extension_loader.cpp.in'), 'rb').read().decode('utf8')
     loader_code = (
         loader_code.replace('${EXT_LOADER_BODY}', ext_loader_body)
+        .replace('${EXT_CAPI_DECLARATIONS}', ext_capi_declarations)
         .replace('${EXT_NAME_VECTOR_INITIALIZER}', ext_name_vector_initializer)
         .replace('${EXT_TEST_PATH_INITIALIZER}', '')
         .replace('CMake', 'package_build.py')

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -150,6 +150,11 @@ public:
 		load_info->FinishLoad(install_info);
 	}
 
+	// Function pointer type for the C API extension init function
+	typedef bool (*ext_init_c_api_fun_t)(duckdb_extension_info info, duckdb_extension_access *access);
+	// Load a statically compiled C API extension by calling its init function directly (no vtable needed)
+	DUCKDB_API void LoadStaticCAPIExtension(const string &name, ext_init_c_api_fun_t init_fun);
+
 	DUCKDB_API FileSystem &GetFileSystem();
 
 	DUCKDB_API idx_t NumberOfThreads();

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -793,6 +793,9 @@ typedef struct {
 //===--------------------------------------------------------------------===//
 // Typedefs mapping functions to struct entries
 //===--------------------------------------------------------------------===//
+// When building as a static extension, DuckDB symbols are resolved directly at link time.
+// The vtable (duckdb_ext_api) is not used — skip these macro redirections.
+#ifndef DUCKDB_BUILD_STATIC_EXTENSION
 // Version v1.2.0
 #define duckdb_open                                    duckdb_ext_api.duckdb_open
 #define duckdb_open_ext                                duckdb_ext_api.duckdb_open_ext
@@ -1392,11 +1395,17 @@ typedef struct {
 #define duckdb_create_selection_vector                 duckdb_ext_api.duckdb_create_selection_vector
 #define duckdb_destroy_selection_vector                duckdb_ext_api.duckdb_destroy_selection_vector
 #define duckdb_selection_vector_get_data_ptr           duckdb_ext_api.duckdb_selection_vector_get_data_ptr
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros
 //===--------------------------------------------------------------------===//
 // This goes in the c/c++ file containing the entrypoint (handle
+#ifdef DUCKDB_BUILD_STATIC_EXTENSION
+// No vtable global needed for static builds — DuckDB symbols are resolved directly at link time
+#define DUCKDB_EXTENSION_GLOBAL
+#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)
+#else
 #define DUCKDB_EXTENSION_GLOBAL duckdb_ext_api_v1 duckdb_ext_api = {0};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
 #define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)                                                   \
@@ -1405,6 +1414,7 @@ typedef struct {
 		return false;                                                                                                  \
 	};                                                                                                                 \
 	duckdb_ext_api = *res;
+#endif // DUCKDB_BUILD_STATIC_EXTENSION
 
 // Place in global scope of any C/C++ file that needs to access the extension API
 #define DUCKDB_EXTENSION_EXTERN extern duckdb_ext_api_v1 duckdb_ext_api;
@@ -1424,7 +1434,7 @@ typedef struct {
 #ifdef DUCKDB_EXTENSION_NAME
 
 // Main entrypoint: opens (and closes) a connection automatically for the extension to register its functionality
-// through
+// through. DUCKDB_EXTENSION_API_INIT is a no-op when DUCKDB_BUILD_STATIC_EXTENSION is defined.
 #define DUCKDB_EXTENSION_ENTRYPOINT                                                                                    \
 	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_connection connection, duckdb_extension_info info, struct duckdb_extension_access * access);            \
@@ -1453,4 +1463,5 @@ typedef struct {
 		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(info, access);                       \
 	}                                                                                                                  \
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
-#endif
+
+#endif // DUCKDB_EXTENSION_NAME

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -794,7 +794,7 @@ typedef struct {
 // Typedefs mapping functions to struct entries
 //===--------------------------------------------------------------------===//
 // When building as a static extension, DuckDB symbols are resolved directly at link time.
-// The vtable (duckdb_ext_api) is not used — skip these macro redirections.
+// The vtable (duckdb_ext_api) is not used - skip these macro redirections.
 #ifndef DUCKDB_BUILD_STATIC_EXTENSION
 // Version v1.2.0
 #define duckdb_open                                    duckdb_ext_api.duckdb_open
@@ -1395,17 +1395,18 @@ typedef struct {
 #define duckdb_create_selection_vector                 duckdb_ext_api.duckdb_create_selection_vector
 #define duckdb_destroy_selection_vector                duckdb_ext_api.duckdb_destroy_selection_vector
 #define duckdb_selection_vector_get_data_ptr           duckdb_ext_api.duckdb_selection_vector_get_data_ptr
+
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros
 //===--------------------------------------------------------------------===//
-// This goes in the c/c++ file containing the entrypoint (handle
 #ifdef DUCKDB_BUILD_STATIC_EXTENSION
-// No vtable global needed for static builds — DuckDB symbols are resolved directly at link time
+// No vtable global needed for static builds - DuckDB symbols are resolved directly at link time
 #define DUCKDB_EXTENSION_GLOBAL
 #define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)
 #else
+// This goes in the c/c++ file containing the entrypoint (handle
 #define DUCKDB_EXTENSION_GLOBAL duckdb_ext_api_v1 duckdb_ext_api = {0};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
 #define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)                                                   \
@@ -1434,7 +1435,7 @@ typedef struct {
 #ifdef DUCKDB_EXTENSION_NAME
 
 // Main entrypoint: opens (and closes) a connection automatically for the extension to register its functionality
-// through. DUCKDB_EXTENSION_API_INIT is a no-op when DUCKDB_BUILD_STATIC_EXTENSION is defined.
+// through
 #define DUCKDB_EXTENSION_ENTRYPOINT                                                                                    \
 	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_connection connection, duckdb_extension_info info, struct duckdb_extension_access * access);            \
@@ -1463,5 +1464,4 @@ typedef struct {
 		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(info, access);                       \
 	}                                                                                                                  \
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
-
-#endif // DUCKDB_EXTENSION_NAME
+#endif

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -138,6 +138,43 @@ struct ExtensionAccess {
 };
 
 //===--------------------------------------------------------------------===//
+// Static C API Extension Loading
+//===--------------------------------------------------------------------===//
+void DuckDB::LoadStaticCAPIExtension(const string &name, ext_init_c_api_fun_t init_fun) {
+	auto &manager = ExtensionManager::Get(*instance);
+	auto load_info = manager.BeginLoad(name);
+	if (!load_info) {
+		// already loaded
+		return;
+	}
+
+	ExtensionInitResult init_result;
+	init_result.filename = name;
+	init_result.filebase = name;
+	// Statically compiled extensions are always tied to the exact DuckDB version
+	init_result.abi_type = ExtensionABIType::C_STRUCT_UNSTABLE;
+	init_result.lib_hdl = nullptr;
+
+	DuckDBExtensionLoadState load_state(*instance, init_result);
+
+	// For static loading, get_api is null - the extension uses direct DuckDB symbols (no vtable needed)
+	duckdb_extension_access access;
+	access.set_error = ExtensionAccess::SetError;
+	access.get_database = ExtensionAccess::GetDatabase;
+	access.get_api = nullptr;
+
+	if (!(*init_fun)(load_state.ToCStruct(), &access)) {
+		string msg = load_state.has_error ? load_state.error_data.Message() : "unknown error";
+		load_info->LoadFail(ErrorData(msg));
+		throw IOException("Failed to load static C API extension '%s': %s", name, msg);
+	}
+
+	ExtensionInstallInfo install_info;
+	install_info.mode = ExtensionInstallMode::STATICALLY_LINKED;
+	load_info->FinishLoad(install_info);
+}
+
+//===--------------------------------------------------------------------===//
 // Load External Extension
 //===--------------------------------------------------------------------===//
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -142,7 +142,7 @@ struct ExtensionAccess {
 //===--------------------------------------------------------------------===//
 void DuckDB::LoadStaticCAPIExtension(const string &name, ext_init_c_api_fun_t init_fun) {
 	auto &manager = ExtensionManager::Get(*instance);
-	auto load_info = manager.BeginLoad(name);
+	auto load_info = manager.BeginLoad({name});
 	if (!load_info) {
 		// already loaded
 		return;


### PR DESCRIPTION
This PR adds support for statically linking C-API extensions using the same cmake configuration setup that DuckDB uses for C++ extensions.

Instead of adding an include like we do for C++ extensions in the generated extension loader, we instead forward declare the extern C function entry-point and invoke it during loading.

To track which loader stub to generate, I've added a `DUCKDB_EXTENSION_KIND` target property to each extension build target which marks it as a C-API or C++ extension.

The `duckdb_extension.h` header has also been changed to conditionally setup the vtable/define the indirection macros depending on if `DUCKDB_BUILD_STATIC_EXTENSION` is defined or not.

Im not sure how to make a test for this. I've tested locally by just adding `duckdb_extension_load(demo_capi)` in `extension/extension_config.cmake`, with and without `DONT_LINK` and that seems to work. Maybe we should just always do this for DEBUG builds or is there some other way to detect that we are running in CI/test environment from cmake?
