### PR TITLE
Correctly use new row group when checkpointing, and avoid incorrectly re-using metadata when targeting older storage versions and row ids have changed

### DIFF
--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -23,7 +23,7 @@ class SegmentStatistics;
 // Writes data for an entire row group.
 class RowGroupWriter {
 public:
-	RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager);
+	RowGroupWriter(TableDataWriter &writer, TableCatalogEntry &table, PartialBlockManager &partial_block_manager);
 	virtual ~RowGroupWriter() {
 	}
 
@@ -42,6 +42,9 @@ public:
 
 	DatabaseInstance &GetDatabase();
 	AttachedDatabase &GetAttachedDatabase();
+	TableDataWriter &GetTableWriter() {
+		return writer;
+	}
 	PartialBlockManager &GetPartialBlockManager() {
 		return partial_block_manager;
 	}
@@ -53,6 +56,7 @@ public:
 	}
 
 protected:
+	TableDataWriter &writer;
 	TableCatalogEntry &table;
 	PartialBlockManager &partial_block_manager;
 	vector<CompressionType> compression_types;
@@ -74,8 +78,6 @@ public:
 	void FinishWritingColumns() override;
 
 private:
-	//! Underlying writer object
-	TableDataWriter &writer;
 	//! MetadataWriter is a cursor on a given BlockManager. This returns the
 	//! cursor against which we should write payload data for the specified RowGroup.
 	MetadataWriter &table_data_writer;

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -51,7 +51,17 @@ public:
 	void SetRebuildIndexes() {
 		rebuild_indexes = true;
 	}
+	bool RequireLegacyStartRow() const {
+		return require_legacy_start_row;
+	}
+	void SetRowIdsChanged() {
+		row_ids_changed = true;
+	}
+	bool RowIdsChanged() const {
+		return row_ids_changed;
+	}
 
+	AttachedDatabase &GetAttached();
 	DatabaseInstance &GetDatabase();
 	unique_ptr<TaskExecutor> CreateTaskExecutor();
 
@@ -63,6 +73,8 @@ protected:
 
 	optional_idx row_group_count;
 	bool rebuild_indexes = false;
+	bool require_legacy_start_row = false;
+	atomic<bool> row_ids_changed {false};
 };
 
 class SingleFileTableDataWriter : public TableDataWriter {

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -64,8 +64,8 @@ private:
 
 class InMemoryRowGroupWriter : public RowGroupWriter {
 public:
-	InMemoryRowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager,
-	                       InMemoryCheckpointer &checkpoint_manager);
+	InMemoryRowGroupWriter(TableDataWriter &writer, TableCatalogEntry &table,
+	                       PartialBlockManager &partial_block_manager, InMemoryCheckpointer &checkpoint_manager);
 
 public:
 	CheckpointOptions GetCheckpointOptions() const override;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -167,6 +167,7 @@ public:
 	RowGroupWriteData WriteToDisk(RowGroupWriteInfo &info) const;
 	//! Returns the number of committed rows (count - committed deletes)
 	idx_t GetCommittedRowCount();
+	bool CanReuseMetadata(RowGroupWriter &writer) const;
 	RowGroupWriteData WriteToDisk(RowGroupWriter &writer);
 	RowGroupPointer Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer, TableStatistics &global_stats,
 	                           idx_t row_group_start);

--- a/src/storage/checkpoint/row_group_writer.cpp
+++ b/src/storage/checkpoint/row_group_writer.cpp
@@ -5,8 +5,9 @@
 
 namespace duckdb {
 
-RowGroupWriter::RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager)
-    : table(table), partial_block_manager(partial_block_manager) {
+RowGroupWriter::RowGroupWriter(TableDataWriter &writer, TableCatalogEntry &table,
+                               PartialBlockManager &partial_block_manager)
+    : writer(writer), table(table), partial_block_manager(partial_block_manager) {
 	for (auto &col : table.GetColumns().Physical()) {
 		compression_types.push_back(col.CompressionType());
 	}
@@ -22,7 +23,7 @@ AttachedDatabase &RowGroupWriter::GetAttachedDatabase() {
 
 SingleFileRowGroupWriter::SingleFileRowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager,
                                                    TableDataWriter &writer, MetadataWriter &table_data_writer)
-    : RowGroupWriter(table, partial_block_manager), writer(writer), table_data_writer(table_data_writer) {
+    : RowGroupWriter(writer, table, partial_block_manager), table_data_writer(table_data_writer) {
 }
 
 CheckpointOptions SingleFileRowGroupWriter::GetCheckpointOptions() const {

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -18,6 +18,13 @@ namespace duckdb {
 TableDataWriter::TableDataWriter(TableCatalogEntry &table_p, QueryContext context)
     : table(table_p.Cast<DuckTableEntry>()), context(context.GetClientContext()) {
 	D_ASSERT(table_p.IsDuckTable());
+
+	auto serialization_version = SerializationCompatibility::FromDatabase(table_p.ParentCatalog().GetAttached());
+	if (serialization_version.serialization_version <
+	    SerializationCompatibility::FromString("v1.4.4").serialization_version) {
+		// older storage versions require legacy start row to be written
+		require_legacy_start_row = true;
+	}
 }
 
 TableDataWriter::~TableDataWriter() {
@@ -30,6 +37,10 @@ void TableDataWriter::WriteTableData(Serializer &metadata_serializer) {
 
 void TableDataWriter::AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> writer) {
 	row_group_pointers.push_back(std::move(row_group_pointer));
+}
+
+AttachedDatabase &TableDataWriter::GetAttached() {
+	return table.ParentCatalog().GetAttached();
 }
 
 DatabaseInstance &TableDataWriter::GetDatabase() {

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -61,9 +61,10 @@ void InMemoryCheckpointer::WriteTable(TableCatalogEntry &table, Serializer &seri
 	partial_block_manager.FlushPartialBlocks();
 }
 
-InMemoryRowGroupWriter::InMemoryRowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager,
+InMemoryRowGroupWriter::InMemoryRowGroupWriter(TableDataWriter &writer, TableCatalogEntry &table,
+                                               PartialBlockManager &partial_block_manager,
                                                InMemoryCheckpointer &checkpoint_manager)
-    : RowGroupWriter(table, partial_block_manager), checkpoint_manager(checkpoint_manager) {
+    : RowGroupWriter(writer, table, partial_block_manager), checkpoint_manager(checkpoint_manager) {
 }
 
 CheckpointOptions InMemoryRowGroupWriter::GetCheckpointOptions() const {
@@ -96,7 +97,8 @@ void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats,
 }
 
 unique_ptr<RowGroupWriter> InMemoryTableDataWriter::GetRowGroupWriter(RowGroup &row_group) {
-	return make_uniq<InMemoryRowGroupWriter>(table, checkpoint_manager.GetPartialBlockManager(), checkpoint_manager);
+	return make_uniq<InMemoryRowGroupWriter>(*this, table, checkpoint_manager.GetPartialBlockManager(),
+	                                         checkpoint_manager);
 }
 
 void InMemoryTableDataWriter::FlushPartialBlocks() {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1232,8 +1232,9 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		row_group_pointer.data_pointers = column_pointers;
 		row_group_pointer.has_metadata_blocks = true;
 		row_group_pointer.extra_metadata_blocks = write_data.existing_extra_metadata_blocks;
-		row_group_pointer.deletes_pointers = CheckpointDeletes(writer);
 		if (metadata_manager) {
+			row_group_pointer.deletes_pointers = CheckpointDeletes(writer);
+
 			vector<MetaBlockPointer> extra_metadata_block_pointers;
 			extra_metadata_block_pointers.reserve(write_data.existing_extra_metadata_blocks.size());
 			for (auto &block_pointer : write_data.existing_extra_metadata_blocks) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1164,9 +1164,29 @@ const vector<MetaBlockPointer> &RowGroup::GetColumnStartPointers() const {
 	return column_pointers;
 }
 
+bool RowGroup::CanReuseMetadata(RowGroupWriter &writer) const {
+	if (!Settings::Get<ExperimentalMetadataReuseSetting>(writer.GetDatabase())) {
+		// disabled by configuration
+		return false;
+	}
+	if (column_pointers.empty()) {
+		// no existing metadata on disk - cannot re-use
+		return false;
+	}
+	if (HasChanges()) {
+		// we have changes - need to rewrite
+		return false;
+	}
+	auto &table_writer = writer.GetTableWriter();
+	if (table_writer.RequireLegacyStartRow() && table_writer.RowIdsChanged()) {
+		// row-ids changed and we are targeting an old storage version that requires "start_row" - cannot re-use
+		return false;
+	}
+	return true;
+}
+
 RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
-	if (Settings::Get<ExperimentalMetadataReuseSetting>(writer.GetDatabase()) && !column_pointers.empty() &&
-	    !HasChanges()) {
+	if (CanReuseMetadata(writer)) {
 		// we have existing metadata and the row group has not been changed
 		// re-use previous metadata
 		RowGroupWriteData result;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1515,6 +1515,9 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 
 	VacuumState vacuum_state;
 	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
+	if (vacuum_state.row_ids_changed) {
+		writer.SetRowIdsChanged();
+	}
 
 	try {
 		// schedule tasks
@@ -1527,6 +1530,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				// vacuum tasks were scheduled - don't schedule a checkpoint task yet
 				total_vacuum_tasks++;
 				vacuum_state.row_ids_changed = true;
+				writer.SetRowIdsChanged();
 				continue;
 			}
 			if (checkpoint_state.SegmentIsDropped(segment_idx)) {
@@ -1616,16 +1620,18 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			D_ASSERT(checkpoint_state.SegmentIsDropped(segment_idx));
 			continue;
 		}
-		auto &row_group = entry->GetNode();
+		auto &existing_row_group = entry->GetNode();
 		auto &row_group_writer = checkpoint_state.writers[segment_idx];
 		if (!row_group_writer) {
 			// row group was not checkpointed - this can happen if compressing is disabled for in-memory tables
 			new_row_groups->AppendSegment(l, entry->ReferenceNode());
-			new_total_rows += row_group.count;
+			new_total_rows += existing_row_group.count;
 
 			auto lock = global_stats.GetLock();
-			for (idx_t column_idx = 0; column_idx < row_group.GetColumnCount(); column_idx++) {
-				global_stats.GetStats(*lock, column_idx).Statistics().Merge(*row_group.GetStatistics(column_idx));
+			for (idx_t column_idx = 0; column_idx < existing_row_group.GetColumnCount(); column_idx++) {
+				global_stats.GetStats(*lock, column_idx)
+				    .Statistics()
+				    .Merge(*existing_row_group.GetStatistics(column_idx));
 			}
 			continue;
 		}
@@ -1637,6 +1643,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			// row group was unchanged - emit previous row group
 			new_row_group = entry->ReferenceNode();
 		}
+		auto &row_group = *new_row_group;
 		RowGroupPointer pointer_copy;
 		auto debug_verify_blocks = Settings::Get<DebugVerifyBlocksSetting>(GetAttached().GetDatabase()) &&
 		                           dynamic_cast<SingleFileTableDataWriter *>(&checkpoint_state.writer) != nullptr;
@@ -1655,8 +1662,8 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		}
 
 		writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
-		new_row_groups->AppendSegment(l, std::move(new_row_group));
 		new_total_rows += row_group.count;
+		new_row_groups->AppendSegment(l, std::move(new_row_group));
 
 		if (debug_verify_blocks) {
 			if (!pointer_copy.has_metadata_blocks) {
@@ -1717,21 +1724,18 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			if (all_written_block_ids != all_quick_read_block_ids ||
 			    all_quick_read_block_ids != all_full_read_block_ids) {
 				std::stringstream oss;
-				oss << "Written: ";
+				oss << "\nWritten: ";
 				for (auto &block : all_written_blocks) {
 					oss << block << ", ";
 				}
-				oss << "\n";
-				oss << "Quick read: ";
+				oss << "\nQuick read: ";
 				for (auto &block : all_quick_read_blocks) {
 					oss << block << ", ";
 				}
-				oss << "\n";
-				oss << "Full read: ";
+				oss << "\nFull read: ";
 				for (auto &block : all_full_read_blocks) {
 					oss << block << ", ";
 				}
-				oss << "\n";
 
 				throw InternalException("Reloading blocks just written does not yield same blocks: " + oss.str());
 			}


### PR DESCRIPTION
Backport https://github.com/duckdb/duckdb/pull/22249 to `v1.5-variegata`