### PR TITLE
Don't copy input parameters for StartsWith

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -138,7 +138,7 @@ void StringUtil::Trim(string &str) {
 	StringUtil::RTrim(str);
 }
 
-bool StringUtil::StartsWith(string str, string prefix) {
+bool StringUtil::StartsWith(const string &str, const string &prefix) {
 	if (prefix.size() > str.size()) {
 		return false;
 	}

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -122,8 +122,8 @@ public:
 	//! Returns the position of needle string within the haystack
 	DUCKDB_API static optional_idx Find(const string &haystack, const string &needle);
 
-	//! Returns true if the target string starts with the given prefix
-	DUCKDB_API static bool StartsWith(string str, string prefix);
+	//! Returns true if the target string <b>starts</b> with the given prefix
+	DUCKDB_API static bool StartsWith(const string &str, const string &prefix);
 
 	//! Returns true if the target string <b>ends</b> with the given suffix.
 	DUCKDB_API static bool EndsWith(const string &str, const string &suffix);

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -122,10 +122,10 @@ public:
 	//! Returns the position of needle string within the haystack
 	DUCKDB_API static optional_idx Find(const string &haystack, const string &needle);
 
-	//! Returns true if the target string <b>starts</b> with the given prefix
+	//! Returns true if the target string starts with the given prefix
 	DUCKDB_API static bool StartsWith(const string &str, const string &prefix);
 
-	//! Returns true if the target string <b>ends</b> with the given suffix.
+	//! Returns true if the target string ends with the given suffix
 	DUCKDB_API static bool EndsWith(const string &str, const string &suffix);
 
 	//! Repeat a string multiple times


### PR DESCRIPTION
Also I'm interested why DuckDB doesn't use string_view? Because c-strings? Maybe something like zstring_view(zero-terminated string_view or sometimes named cstring_view) makes sense?