### PR TITLE
Fix: release ParquetReader when a file is marked SKIPPED in multi-file scan

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -323,6 +323,9 @@ public:
 				parallel_lock.lock();
 				if (can_skip_file) {
 					current_reader_data.file_state = MultiFileFileState::SKIPPED;
+					// release the reader so its file handle is closed; skipped files are
+					// never scanned, so nothing else needs the reader
+					current_reader_data.reader = nullptr;
 					//! Intentionally do not increase 'i'
 					continue;
 				}
@@ -540,6 +543,7 @@ public:
 				if (init_result == ReaderInitializeType::SKIP_READING_FILE) {
 					//! File can be skipped entirely, close it and move on
 					reader_data->file_state = MultiFileFileState::SKIPPED;
+					reader_data->reader = nullptr;
 					result->file_index++;
 				}
 			}


### PR DESCRIPTION
Fixes #18831
Related to: https://github.com/duckdb/duckdb-httpfs/issues/316

When `MultiFileReader::InitializeReader` returns `SKIP_READING_FILE` (i.e. file-level filter pushdown determined the file has no matching rows), `TryOpenNextFile` marks the slot `SKIPPED` but leaves the `shared_ptr<BaseFileReader>` in `MultiFileGlobalState::readers[i]->reader`. That keeps the `ParquetReader` — and its open `CachingFileHandle` — alive for the duration of the whole scan. For scans with many files where most are filter-pruned, this accumulates one open FD per skipped file and eventually hits `EMFILE`.

This comes up naturally when the `LateMaterialization` optimizer rewrites `SELECT * FROM '<partitioned parquet dir>' LIMIT N` (for `50 < N <= 1_000_000`) into a SEMI-JOIN on `(file_index, file_row_number)`. The LHS scan receives a `(file_index, file_row_number) IN (...)` filter from the hash-join build, and every file whose `file_index` doesn't match goes through the SKIPPED path. On the repro below, 50,874 parquet files all get marked SKIPPED (only 1-2 produce rows) and every one of them keeps an FD.

Same pattern exists in `MultiFileInitGlobal` for pre-initialized union readers, so the fix is applied in both places.

### Measurements (sf=10 lineitem, partitioned by `(l_ship_month, l_shipmode)`, 50,874 files)

Peak concurrent `ParquetReader` instances during `SELECT * FROM 'lineitem.parquet' LIMIT 51`, measured by a static atomic counter in the ctor/dtor:

| | Pre-fix | Post-fix |
|---|---|---|
| peak live `ParquetReader` | 50,875 | 32 |

`ulimit -n 1024` + the same query pre-fix produces `IO Error: Cannot open file ...: Too many open files`; post-fix it returns normally. Query wall-time is unchanged to within noise (−8% to +2% across a range of LIMIT/OFFSET/ORDER BY queries on partitioned parquet, native tables, and single-file parquet).

### Repro

```sql
INSTALL tpch; LOAD tpch;
CALL dbgen(sf=10);
COPY (SELECT *, strftime(l_shipdate, '%Y-%m') AS l_ship_month FROM lineitem)
  TO 'lineitem.parquet' (FORMAT parquet, PARTITION_BY (l_ship_month, l_shipmode));
```

Then, with a default-ish FD limit:

```bash
ulimit -n 1024
duckdb -c "SELECT * FROM 'lineitem.parquet' LIMIT 51;"
# pre-fix:  IO Error: Cannot open file "...": Too many open files
# post-fix: returns 51 rows
```


Note: This pattern on partitioned files can benefit from evaluating filters prior to even opening them, however that is more of an optimization rather than a bugfix so it will be a separate PR and will target main

# Follow-up: skip files without opening them when filter can be evaluated from the path alone

The previous change stops leaking file handles, but the scan still **opens** every file (footer read + metadata parse) to discover that the filter rejects it. For filters on columns whose values are determined purely by the file list — `filename`, `file_index`, and hive partitioning columns — we can answer "does this filter reject this file?" before any I/O.

This follow-up will go to main

Added `MultiFileReader::CanSkipFileFromFilters(...)` and call it in `TryOpenNextFile` before `CreateReader`. It evaluates each pushed-down `TableFilter` (including dynamic filters from hash-join pushdown — bloom, IN, min-max) against the pre-known constant for that column. If any filter rejects → mark `SKIPPED` and skip the open.

##### Measurements (same sf=10 lineitem / 50,874 files, `relassert` build)

The "baseline" column is with `SET disabled_optimizers = 'late_materialization'` — i.e. the optimizer never produces the SEMI-JOIN-over-virtual-columns plan in the first place.

| Query | Pre-fix | Baseline (late-mat disabled) | FD-release on SKIPPED | pre-open skip |
|-------|--------:|-----------------------------:|------------------------:|----------------:|
| `SELECT * FROM 'lineitem.parquet' LIMIT 51` | 8.54s | **2.43s** | 7.87s | **2.57s** |
| `SELECT * FROM 'lineitem.parquet' LIMIT 500000` | 10.04s | **4.50s** | 9.37s | **4.28s** |
| `SELECT * FROM 'lineitem.parquet' ORDER BY l_extendedprice DESC LIMIT 5` | 14.88s | 13.01s | 14.37s | **9.42s** |
| `SELECT COUNT(*) FROM 'lineitem.parquet'` *(no filter, control)* | 9.88s | 9.30s | 9.39s | 9.30s |

