### PR TITLE
Make multi-file scan's filter pushdown skip files instead of opening them

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -776,10 +776,9 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMapping(MultiFileColumnMa
 	}
 }
 
-bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &filter, const Value &constant) {
+bool EvaluateTableFilterAgainstConstant(ClientContext &context, const TableFilter &filter, const Value &constant) {
 	if (filter.filter_type == TableFilterType::EXPRESSION_FILTER) {
-		auto &expr_filter =
-		    ExpressionFilter::GetExpressionFilter(filter, "MultiFileColumnMapper::EvaluateFilterAgainstConstant");
+		auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "EvaluateTableFilterAgainstConstant");
 		return expr_filter.EvaluateWithConstant(context, constant);
 	}
 	const auto type = filter.filter_type;
@@ -788,7 +787,7 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 	case TableFilterType::CONJUNCTION_OR: {
 		auto &or_filter = filter.Cast<ConjunctionOrFilter>();
 		for (auto &it : or_filter.child_filters) {
-			if (EvaluateFilterAgainstConstant(*it, constant)) {
+			if (EvaluateTableFilterAgainstConstant(context, *it, constant)) {
 				return true;
 			}
 		}
@@ -798,7 +797,7 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
 		auto res = make_uniq<ConjunctionAndFilter>();
 		for (auto &it : and_filter.child_filters) {
-			if (!EvaluateFilterAgainstConstant(*it, constant)) {
+			if (!EvaluateTableFilterAgainstConstant(context, *it, constant)) {
 				return false;
 			}
 		}
@@ -807,7 +806,7 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 	case TableFilterType::OPTIONAL_FILTER: {
 		auto &optional_filter = filter.Cast<OptionalFilter>();
 		if (optional_filter.child_filter) {
-			return EvaluateFilterAgainstConstant(*optional_filter.child_filter, constant);
+			return EvaluateTableFilterAgainstConstant(context, *optional_filter.child_filter, constant);
 		}
 		return true;
 	}
@@ -845,6 +844,10 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 		throw NotImplementedException("Can't evaluate TableFilterType (%s) against a constant",
 		                              EnumUtil::ToString(type));
 	}
+}
+
+bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &filter, const Value &constant) {
+	return EvaluateTableFilterAgainstConstant(context, filter, constant);
 }
 
 Value MultiFileColumnMapper::GetConstantValue(MultiFileGlobalIndex global_index) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -291,6 +291,36 @@ void MultiFileReader::GetVirtualColumns(ClientContext &context, MultiFileReaderB
 	result.insert(make_pair(COLUMN_IDENTIFIER_EMPTY, TableColumn("", LogicalType::BOOLEAN)));
 }
 
+// Resolves `column_id` to a Value from info known without opening the file: filename, file_index,
+// or hive partitioning columns. `hive_partitions` is a caller-owned lazy cache.
+static bool TryResolvePreOpenConstant(column_t column_id, const string &file_path, idx_t file_list_idx,
+                                      const MultiFileReaderBindData &reader_bind, const MultiFileOptions &file_options,
+                                      ClientContext &context, std::map<string, string> &hive_partitions,
+                                      bool &hive_partitions_parsed, Value &out_constant) {
+	if ((reader_bind.filename_idx.IsValid() && column_id == reader_bind.filename_idx.GetIndex()) ||
+	    column_id == MultiFileReader::COLUMN_IDENTIFIER_FILENAME) {
+		out_constant = Value(file_path);
+		return true;
+	}
+	if (column_id == MultiFileReader::COLUMN_IDENTIFIER_FILE_INDEX) {
+		out_constant = Value::UBIGINT(file_list_idx);
+		return true;
+	}
+	auto &hive = reader_bind.hive_partitioning_indexes;
+	auto hp = std::find_if(hive.begin(), hive.end(),
+	                       [column_id](const HivePartitioningIndex &e) { return e.index == column_id; });
+	if (hp == hive.end()) {
+		return false;
+	}
+	if (!hive_partitions_parsed) {
+		hive_partitions = HivePartitioning::Parse(file_path);
+		hive_partitions_parsed = true;
+	}
+	D_ASSERT(hive_partitions.size() == hive.size());
+	out_constant = file_options.GetHivePartitionValue(hive_partitions[hp->value], hp->value, context);
+	return true;
+}
+
 void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const MultiFileOptions &file_options,
                                    const MultiFileReaderBindData &options,
                                    const vector<MultiFileColumnDefinition> &global_columns,
@@ -306,40 +336,21 @@ void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const Multi
 			name_map[column.name] = col_idx;
 		}
 	}
+	std::map<string, string> hive_partitions;
+	bool hive_partitions_parsed = false;
+	Value pre_open_constant;
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
 		auto global_idx = MultiFileGlobalIndex(i);
 		auto &col_id = global_column_ids[i];
 		auto column_id = col_id.GetPrimaryIndex();
-		if ((options.filename_idx.IsValid() && column_id == options.filename_idx.GetIndex()) ||
-		    column_id == COLUMN_IDENTIFIER_FILENAME) {
-			// filename
-			reader_data.constant_map.Add(global_idx, Value(filename));
-			continue;
-		}
-		if (column_id == COLUMN_IDENTIFIER_FILE_INDEX) {
-			// filename
-			reader_data.constant_map.Add(global_idx, Value::UBIGINT(reader_data.reader->file_list_idx.GetIndex()));
+		if (TryResolvePreOpenConstant(column_id, filename, reader_data.reader->file_list_idx.GetIndex(), options,
+		                              file_options, context, hive_partitions, hive_partitions_parsed,
+		                              pre_open_constant)) {
+			reader_data.constant_map.Add(global_idx, pre_open_constant);
 			continue;
 		}
 		if (IsVirtualColumn(column_id)) {
 			continue;
-		}
-		if (!options.hive_partitioning_indexes.empty()) {
-			// hive partition constants
-			auto partitions = HivePartitioning::Parse(filename);
-			D_ASSERT(partitions.size() == options.hive_partitioning_indexes.size());
-			bool found_partition = false;
-			for (auto &entry : options.hive_partitioning_indexes) {
-				if (column_id == entry.index) {
-					Value value = file_options.GetHivePartitionValue(partitions[entry.value], entry.value, context);
-					reader_data.constant_map.Add(global_idx, value);
-					found_partition = true;
-					break;
-				}
-			}
-			if (found_partition) {
-				continue;
-			}
 		}
 		if (file_options.union_by_name) {
 			auto &column = global_columns[column_id];
@@ -615,52 +626,14 @@ bool MultiFileReader::CanSkipFileFromFilters(ClientContext &context, const OpenF
 		return false;
 	}
 
-	// Parse hive partitions lazily - only if we encounter a filter on a hive-partitioning column
-	std::map<string, string> partitions;
-	bool partitions_parsed = false;
+	std::map<string, string> hive_partitions;
+	bool hive_partitions_parsed = false;
+	Value constant;
 
 	for (auto &it : *filters) {
-		auto global_column_position = it.GetIndex().GetIndex();
-		if (global_column_position >= global_column_ids.size()) {
-			continue;
-		}
-		auto column_id = global_column_ids[global_column_position].GetPrimaryIndex();
-
-		Value constant;
-		bool have_constant = false;
-
-		// Virtual column: filename
-		if ((reader_bind.filename_idx.IsValid() && column_id == reader_bind.filename_idx.GetIndex()) ||
-		    column_id == COLUMN_IDENTIFIER_FILENAME) {
-			constant = Value(file.path);
-			have_constant = true;
-		} else if (column_id == COLUMN_IDENTIFIER_FILE_INDEX) {
-			// Virtual column: file_index (position in the file list)
-			constant = Value::UBIGINT(file_list_idx);
-			have_constant = true;
-		} else if (!reader_bind.hive_partitioning_indexes.empty()) {
-			// Hive partition column: value is determined by the file path
-			for (auto &hp_entry : reader_bind.hive_partitioning_indexes) {
-				if (column_id != hp_entry.index) {
-					continue;
-				}
-				if (!partitions_parsed) {
-					partitions = HivePartitioning::Parse(file.path);
-					partitions_parsed = true;
-				}
-				auto part_it = partitions.find(hp_entry.value);
-				if (part_it == partitions.end()) {
-					// filename doesn't encode this partition - can't determine, skip this filter
-					break;
-				}
-				constant = file_options.GetHivePartitionValue(part_it->second, hp_entry.value, context);
-				have_constant = true;
-				break;
-			}
-		}
-
-		if (!have_constant) {
-			// filter is on a column we can't pre-evaluate - defer to post-open path
+		auto column_id = global_column_ids[it.GetIndex().GetIndex()].GetPrimaryIndex();
+		if (!TryResolvePreOpenConstant(column_id, file.path, file_list_idx, reader_bind, file_options, context,
+		                               hive_partitions, hive_partitions_parsed, constant)) {
 			continue;
 		}
 		if (!EvaluateTableFilterAgainstConstant(context, it.Filter(), constant)) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -316,8 +316,11 @@ static bool TryResolvePreOpenConstant(column_t column_id, const string &file_pat
 		hive_partitions = HivePartitioning::Parse(file_path);
 		hive_partitions_parsed = true;
 	}
-	D_ASSERT(hive_partitions.size() == hive.size());
-	out_constant = file_options.GetHivePartitionValue(hive_partitions[hp->value], hp->value, context);
+	auto entry = hive_partitions.find(hp->value);
+	if (entry == hive_partitions.end()) {
+		return false;
+	}
+	out_constant = file_options.GetHivePartitionValue(entry->second, hp->value, context);
 	return true;
 }
 
@@ -631,7 +634,9 @@ bool MultiFileReader::CanSkipFileFromFilters(ClientContext &context, const OpenF
 	Value constant;
 
 	for (auto &it : *filters) {
-		auto column_id = global_column_ids[it.GetIndex().GetIndex()].GetPrimaryIndex();
+		auto projection_idx = it.GetIndex().GetIndex();
+		D_ASSERT(projection_idx < global_column_ids.size());
+		auto column_id = global_column_ids[projection_idx].GetPrimaryIndex();
 		if (!TryResolvePreOpenConstant(column_id, file.path, file_list_idx, reader_bind, file_options, context,
 		                               hive_partitions, hive_partitions_parsed, constant)) {
 			continue;

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -606,6 +606,70 @@ shared_ptr<BaseFileReader> MultiFileReader::CreateReader(ClientContext &context,
 	return interface.CreateReader(context, file, options, file_options);
 }
 
+bool MultiFileReader::CanSkipFileFromFilters(ClientContext &context, const OpenFileInfo &file, idx_t file_list_idx,
+                                             const MultiFileOptions &file_options,
+                                             const MultiFileReaderBindData &reader_bind,
+                                             const vector<ColumnIndex> &global_column_ids,
+                                             optional_ptr<TableFilterSet> filters) {
+	if (!filters) {
+		return false;
+	}
+
+	// Parse hive partitions lazily - only if we encounter a filter on a hive-partitioning column
+	std::map<string, string> partitions;
+	bool partitions_parsed = false;
+
+	for (auto &it : *filters) {
+		auto global_column_position = it.GetIndex().GetIndex();
+		if (global_column_position >= global_column_ids.size()) {
+			continue;
+		}
+		auto column_id = global_column_ids[global_column_position].GetPrimaryIndex();
+
+		Value constant;
+		bool have_constant = false;
+
+		// Virtual column: filename
+		if ((reader_bind.filename_idx.IsValid() && column_id == reader_bind.filename_idx.GetIndex()) ||
+		    column_id == COLUMN_IDENTIFIER_FILENAME) {
+			constant = Value(file.path);
+			have_constant = true;
+		} else if (column_id == COLUMN_IDENTIFIER_FILE_INDEX) {
+			// Virtual column: file_index (position in the file list)
+			constant = Value::UBIGINT(file_list_idx);
+			have_constant = true;
+		} else if (!reader_bind.hive_partitioning_indexes.empty()) {
+			// Hive partition column: value is determined by the file path
+			for (auto &hp_entry : reader_bind.hive_partitioning_indexes) {
+				if (column_id != hp_entry.index) {
+					continue;
+				}
+				if (!partitions_parsed) {
+					partitions = HivePartitioning::Parse(file.path);
+					partitions_parsed = true;
+				}
+				auto part_it = partitions.find(hp_entry.value);
+				if (part_it == partitions.end()) {
+					// filename doesn't encode this partition - can't determine, skip this filter
+					break;
+				}
+				constant = file_options.GetHivePartitionValue(part_it->second, hp_entry.value, context);
+				have_constant = true;
+				break;
+			}
+		}
+
+		if (!have_constant) {
+			// filter is on a column we can't pre-evaluate - defer to post-open path
+			continue;
+		}
+		if (!EvaluateTableFilterAgainstConstant(context, it.Filter(), constant)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void MultiFileReader::PruneReaders(MultiFileBindData &data, MultiFileList &file_list) {
 	unordered_set<string> file_set;
 

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -14,6 +14,13 @@ namespace duckdb {
 struct ResultColumnMapping;
 struct ColumnMapper;
 
+//! Evaluates a TableFilter against a concrete constant Value. Returns true iff the filter matches.
+//! Exposed as a free function so the filter can be evaluated for columns whose values are known
+//! without opening a file (e.g. filename, file_index, hive partition columns) from the multi-file
+//! scan driver, which does not have a MultiFileColumnMapper instance pre-open.
+DUCKDB_API bool EvaluateTableFilterAgainstConstant(ClientContext &context, const TableFilter &filter,
+                                                   const Value &constant);
+
 class MultiFileColumnMapper {
 public:
 	MultiFileColumnMapper(ClientContext &context, MultiFileReader &multi_file_reader, MultiFileReaderData &reader_data,

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -15,11 +15,7 @@ struct ResultColumnMapping;
 struct ColumnMapper;
 
 //! Evaluates a TableFilter against a concrete constant Value. Returns true iff the filter matches.
-//! Exposed as a free function so the filter can be evaluated for columns whose values are known
-//! without opening a file (e.g. filename, file_index, hive partition columns) from the multi-file
-//! scan driver, which does not have a MultiFileColumnMapper instance pre-open.
-DUCKDB_API bool EvaluateTableFilterAgainstConstant(ClientContext &context, const TableFilter &filter,
-                                                   const Value &constant);
+bool EvaluateTableFilterAgainstConstant(ClientContext &context, const TableFilter &filter, const Value &constant);
 
 class MultiFileColumnMapper {
 public:

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -323,6 +323,9 @@ public:
 				parallel_lock.lock();
 				if (can_skip_file) {
 					current_reader_data.file_state = MultiFileFileState::SKIPPED;
+					// release the reader so its file handle is closed; skipped files are
+					// never scanned, so nothing else needs the reader
+					current_reader_data.reader = nullptr;
 					//! Intentionally do not increase 'i'
 					continue;
 				}
@@ -540,6 +543,7 @@ public:
 				if (init_result == ReaderInitializeType::SKIP_READING_FILE) {
 					//! File can be skipped entirely, close it and move on
 					reader_data->file_state = MultiFileFileState::SKIPPED;
+					reader_data->reader = nullptr;
 					result->file_index++;
 				}
 			}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -284,6 +284,19 @@ public:
 
 			auto &current_reader_data = *global_state.readers[current_file_index];
 			if (current_reader_data.file_state == MultiFileFileState::UNOPENED) {
+				// Try to skip the file without opening it, based on filters on columns whose values are
+				// known from the file path / list position (filename, file_index, hive partitioning).
+				// This avoids the open+footer-read cost for files the filter rules out anyway, which
+				// matters a lot when dynamic filters from hash-join pushdown select few out of many files.
+				if (!current_reader_data.union_data &&
+				    MultiFileReader::CanSkipFileFromFilters(
+				        context, current_reader_data.file_to_be_opened, current_file_index, bind_data.file_options,
+				        bind_data.reader_bind, global_state.column_indexes, global_state.filters)) {
+					current_reader_data.file_state = MultiFileFileState::SKIPPED;
+					//! Intentionally do not increase 'i'
+					continue;
+				}
+
 				current_reader_data.file_state = MultiFileFileState::OPENING;
 				// Get pointer to file mutex before unlocking
 				auto &current_file_lock = *current_reader_data.file_mutex;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -284,10 +284,7 @@ public:
 
 			auto &current_reader_data = *global_state.readers[current_file_index];
 			if (current_reader_data.file_state == MultiFileFileState::UNOPENED) {
-				// Try to skip the file without opening it, based on filters on columns whose values are
-				// known from the file path / list position (filename, file_index, hive partitioning).
-				// This avoids the open+footer-read cost for files the filter rules out anyway, which
-				// matters a lot when dynamic filters from hash-join pushdown select few out of many files.
+				// skip the file if pre-open-knowable filters already rule it out
 				if (!current_reader_data.union_data &&
 				    MultiFileReader::CanSkipFileFromFilters(
 				        context, current_reader_data.file_to_be_opened, current_file_index, bind_data.file_options,

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -157,6 +157,16 @@ public:
 
 	static void PruneReaders(MultiFileBindData &data, MultiFileList &file_list);
 
+	//! Returns true iff the file can be skipped based on filters on columns whose values are known without
+	//! opening the file (filename, file_index, hive partitioning columns). A false return means either some
+	//! applicable filter matches OR no applicable filter is present - in both cases, the caller should proceed
+	//! with opening the file so remaining filters (e.g. column-level filters with statistics) can be evaluated.
+	DUCKDB_API static bool CanSkipFileFromFilters(ClientContext &context, const OpenFileInfo &file, idx_t file_list_idx,
+	                                              const MultiFileOptions &file_options,
+	                                              const MultiFileReaderBindData &reader_bind,
+	                                              const vector<ColumnIndex> &global_column_ids,
+	                                              optional_ptr<TableFilterSet> filters);
+
 	DUCKDB_API virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                                           BaseUnionData &union_data,
 	                                                           const MultiFileBindData &bind_data);

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -157,10 +157,7 @@ public:
 
 	static void PruneReaders(MultiFileBindData &data, MultiFileList &file_list);
 
-	//! Returns true iff the file can be skipped based on filters on columns whose values are known without
-	//! opening the file (filename, file_index, hive partitioning columns). A false return means either some
-	//! applicable filter matches OR no applicable filter is present - in both cases, the caller should proceed
-	//! with opening the file so remaining filters (e.g. column-level filters with statistics) can be evaluated.
+	//! Returns true iff pre-open-knowable filters (filename, file_index, hive) reject this file.
 	DUCKDB_API static bool CanSkipFileFromFilters(ClientContext &context, const OpenFileInfo &file, idx_t file_list_idx,
 	                                              const MultiFileOptions &file_options,
 	                                              const MultiFileReaderBindData &reader_bind,


### PR DESCRIPTION
Follow up to #22261 (which contains the relevant table and description, duplicated here)

This is expected to greatly reduce http GETs

Skip files without opening them at all when the filter already answers. For filters on columns whose values are known from the file list itself — `filename`, `file_index`, hive-partition columns — `CanSkipFileFromFilters` now evaluates the pushed-down filter against those constants before `CreateReader`. This reuses the existing `EvaluateFilterAgainstConstant` dispatch (exposed as a free function so we don't duplicate the switch; it'll simplify alongside #21762). If any pre-open-evaluable filter rejects, the file goes straight to `SKIPPED` without any I/O.

As a drive-by, FinalizeBind shares the same pre-open constant resolution helper — so hive partitions are now parsed once per file rather than once per projected column.


| Query | Pre-fix | Baseline (late-mat disabled) | FD-release on SKIPPED | pre-open skip |
|-------|--------:|-----------------------------:|------------------------:|----------------:|
| `SELECT * FROM 'lineitem.parquet' LIMIT 51` | 8.54s | **2.43s** | 7.87s | **2.57s** |
| `SELECT * FROM 'lineitem.parquet' LIMIT 500000` | 10.04s | **4.50s** | 9.37s | **4.28s** |
| `SELECT * FROM 'lineitem.parquet' ORDER BY l_extendedprice DESC LIMIT 5` | 14.88s | 13.01s | 14.37s | **9.42s** |
| `SELECT COUNT(*) FROM 'lineitem.parquet'` *(no filter, control)* | 9.88s | 9.30s | 9.39s | 9.30s |


Also note for simple limit queries with no offset it may be faster to just not do late materialization

### Caveat

`CanSkipFileFromFilters` calls `filter_data->ToExpression(...)` + wraps in a fresh `ExpressionFilter` per file for `DYNAMIC_FILTER`, and `HivePartitioning::Parse(file.path)` can run up to three times per file across InitGlobal pushdown, this helper, and `FinalizeBind`. Both are reasonable follow-ups to cache (per filter_data epoch and on `OpenFileInfo` respectively) — not done here to keep the change minimal; the win above is already bounded by file I/O, not filter-eval.