### PR TITLE
Trim ccache on ccache v3 (used in manylinux image)

### DIFF
--- a/.github/actions/trim-ccache/action.yml
+++ b/.github/actions/trim-ccache/action.yml
@@ -1,0 +1,25 @@
+name: 'Trim ccache'
+description: 'Trim old ccache entries on older ccache versions before post-job cache save'
+inputs:
+  older-than:
+    description: 'Age threshold passed to find -newermt (for example: 2 hours ago)'
+    required: false
+    default: '2 hours ago'
+runs:
+  using: "composite"
+  steps:
+    - name: Trim ccache
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ccache --help 2>&1 | grep -q "evict-older-than"; then
+          exit 0
+        fi
+
+        cache_dir="$(ccache --get-config=cache_dir 2>/dev/null || true)"
+        if [[ -z "${cache_dir}" || ! -d "${cache_dir}" ]]; then
+          exit 0
+        fi
+
+        find "${cache_dir}" -type f ! -newermt "${{ inputs.older-than }}" -delete

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -975,6 +975,10 @@ jobs:
           path: |
             static-libs-linux-${{ matrix.config.arch }}.zip
 
+      - name: Trim ccache
+        if: ${{ always() }}
+        uses: ./.github/actions/trim-ccache
+
  static-libs-osx:
     name: Static Libs OSX (${{ matrix.architecture }})
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'static-libs-osx') }}


### PR DESCRIPTION
ccache v3 does not support `--evict-older-than` so the ccache action skips evicting old cache entries.

This means that the manylinux CI jobs can create cache entries up to 5 GiB over time.

I'll look into sending a PR to https://github.com/hendrikmuhs/ccache-action/, but that could take more time to merge, so I added this as a short term fix.