### PR TITLE
Allow extending format checks for downstream extension usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -677,13 +677,13 @@ test_compile: # test compilation of individual cpp files
 	$(PYTHON) scripts/test_compile.py
 
 format-check: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py --all --check
+	$(FORMAT_PYTHON) scripts/format.py --all --check $(T)
 
 format-check-silent: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py --all --check --silent
+	$(FORMAT_PYTHON) scripts/format.py --all --check --silent $(T)
 
 format-fix: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py --all --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py --all --fix --noconfirm $(T)
 
 .PHONY: check-extension-entries
 check-extension-entries: extension_configuration $(FORMAT_SETUP_DEPS)
@@ -700,16 +700,16 @@ check-extension-entries: extension_configuration $(FORMAT_SETUP_DEPS)
 	fi
 
 format-head: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm $(T)
 
 format-changes: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py HEAD --fix --noconfirm $(T)
 
 format-main: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py main --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py main --fix --noconfirm $(T)
 
 format-feature: $(FORMAT_SETUP_DEPS)
-	$(FORMAT_PYTHON) scripts/format.py feature --fix --noconfirm
+	$(FORMAT_PYTHON) scripts/format.py feature --fix --noconfirm $(T)
 
 format-configs:
 	$(foreach file, $(wildcard $(CONFIGS_DIR)/*), jq . < "$(file)" > "$(file).tmp" && mv "$(file).tmp" "$(file)" ;)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -139,6 +139,7 @@ parser.add_argument('--check', action='store_true', help='Only print differences
 parser.add_argument('--fix', action='store_true', help='Fix the files')
 parser.add_argument('-a', '--all', action='store_true', help='Format all files')
 parser.add_argument('-d', '--directories', nargs='*', default=[], help='Format specified directories')
+parser.add_argument('-C', '--workdir', type=str, help='Change work directory')
 parser.add_argument('-y', '--noconfirm', action='store_true', help='Skip confirmation prompt')
 parser.add_argument('-q', '--silent', action='store_true', help='Suppress output')
 parser.add_argument('-f', '--force', action='store_true', help='Force formatting')
@@ -148,6 +149,10 @@ revision = args.revision
 if args.check and args.fix:
     parser.print_usage()
     exit(1)
+
+if args.workdir:
+    os.chdir(args.workdir)
+
 check_only = not args.fix
 confirm = not args.noconfirm
 silent = args.silent
@@ -166,6 +171,9 @@ def get_typos_targets():
 def run_typos_check():
     typos_targets = get_typos_targets()
     if not typos_targets:
+        return 0
+    # Ignore typos check for non-duckdb code.
+    if not os.path.isfile('scripts/typos.toml'):
         return 0
     typos_command = ['typos', '--force-exclude']
     if not check_only:


### PR DESCRIPTION
Adding `typos-cli` and creating the venv inside the `format.py` script [broke](https://github.com/duckdb/duckdb-azure/actions/runs/24882251312/job/72853403255?pr=159#step:7:167) format checks in downstream extensions.

This PR allows extending the format checks without copying the `Makefile` from duckdb in `extension-ci-tools`.

In `extension-ci-tools` we can now use:
```diff
--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -258,16 +258,15 @@ build/extension_configuration/vcpkg.json: ${EXTENSION_CONFIG_TARGET}
 
 #### Misc
 format-check:
-       python3 duckdb/scripts/format.py --all --check --directories src test
+       $(MAKE) -C duckdb format-check T="--workdir $$PWD --directories src test"
 
-format:
-       python3 duckdb/scripts/format.py --all --fix --noconfirm --directories src test
+format: format-check
 
 format-fix:
-       python3 duckdb/scripts/format.py --all --fix --noconfirm --directories src test
+       $(MAKE) -C duckdb format-fix T="--workdir $$PWD --directories src test"
 
 format-main:
-       python3 duckdb/scripts/format.py main --fix --noconfirm --directories src test
+       $(MAKE) -C duckdb format-main T="--workdir $$PWD --directories src test"
 
 tidy-check:
        mkdir -p ./build/tidy
```

Related PR: https://github.com/duckdb/extension-ci-tools/pull/358