### PR TITLE
Make test more flexible

### DIFF
--- a/test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test
+++ b/test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test
@@ -161,11 +161,13 @@ SELECT count(*) FROM read_parquet(['{TEST_DIR}/af_cross_1.parquet', '{TEST_DIR}/
 query II
 SELECT
     (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
-     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'INITIAL') = 2,
+     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'INITIAL') BETWEEN 1 AND 2,
     (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
-     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'SEEDED') = 1
+     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'SEEDED') >= 1,
+    (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
+     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet') = 3
 ----
-true	true
+true	true	true
 
 # A seeded file permutation must be equal to one of the initial sources
 query I

--- a/test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test
+++ b/test/sql/copy/parquet/multi_file/adaptive_filter_carryover.test
@@ -163,11 +163,9 @@ SELECT
     (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
      WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'INITIAL') BETWEEN 1 AND 2,
     (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
-     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'SEEDED') >= 1,
-    (SELECT count(*) FROM duckdb_logs_parsed('AdaptiveFilter')
-     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet') = 3
+     WHERE event = 'INIT' AND file_path LIKE '%af_cross_%.parquet' AND info['source'] = 'SEEDED') >= 1
 ----
-true	true	true
+true	true
 
 # A seeded file permutation must be equal to one of the initial sources
 query I


### PR DESCRIPTION
Since we are running with multiple threads, there is no guarantee of the state of our adaptive filters.