### PR TITLE
Move function callbacks/properties into separate structs

### DIFF
--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -242,6 +242,7 @@ AggregateFunction CountFunctionBase::GetFunction() {
 	fun.name = "count";
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetStructStateExport(GetCountStateType);
+	fun.SetStatisticsCallback(CountPropagateStats);
 	return fun;
 }
 
@@ -257,7 +258,6 @@ AggregateFunction CountStarFun::GetFunction() {
 
 AggregateFunctionSet CountFun::GetFunctions() {
 	AggregateFunction count_function = CountFunctionBase::GetFunction();
-	count_function.SetStatisticsCallback(CountPropagateStats);
 	AggregateFunctionSet count("count");
 	count.AddFunction(count_function);
 	// the count function can also be called without arguments

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -2,6 +2,18 @@
 
 namespace duckdb {
 
+bool AggregateFunctionCallbacks::operator==(const AggregateFunctionCallbacks &rhs) const {
+	return state_size == rhs.state_size && initialize == rhs.initialize && update == rhs.update &&
+	       combine == rhs.combine && finalize == rhs.finalize && simple_update == rhs.simple_update &&
+	       window == rhs.window && window_init == rhs.window_init && window_batch == rhs.window_batch &&
+	       bind == rhs.bind && destructor == rhs.destructor && statistics == rhs.statistics &&
+	       serialize == rhs.serialize && deserialize == rhs.deserialize;
+}
+
+bool AggregateFunctionCallbacks::operator!=(const AggregateFunctionCallbacks &rhs) const {
+	return !(*this == rhs);
+}
+
 AggregateFunctionInfo::~AggregateFunctionInfo() {
 }
 

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -2,6 +2,14 @@
 
 namespace duckdb {
 
+bool AggregateFunctionProperties::operator==(const AggregateFunctionProperties &rhs) const {
+	return FunctionProperties::operator==(rhs) && order_dependent == rhs.order_dependent &&
+	       distinct_dependent == rhs.distinct_dependent;
+}
+bool AggregateFunctionProperties::operator!=(const AggregateFunctionProperties &rhs) const {
+	return !(*this == rhs);
+}
+
 bool AggregateFunctionCallbacks::operator==(const AggregateFunctionCallbacks &rhs) const {
 	return state_size == rhs.state_size && initialize == rhs.initialize && update == rhs.update &&
 	       combine == rhs.combine && finalize == rhs.finalize && simple_update == rhs.simple_update &&

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -8,6 +8,11 @@
 
 namespace duckdb {
 
+bool FunctionProperties::operator==(const FunctionProperties &rhs) const {
+	return stability == rhs.stability && null_handling == rhs.null_handling && errors == rhs.errors &&
+	       collation_handling == rhs.collation_handling;
+}
+
 FunctionData::~FunctionData() {
 }
 
@@ -73,11 +78,9 @@ bool SimpleNamedParameterFunction::HasNamedParameters() const {
 }
 
 BaseScalarFunction::BaseScalarFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type_p,
-                                       FunctionStability stability, LogicalType varargs_p,
-                                       FunctionNullHandling null_handling, FunctionErrors errors)
+                                       LogicalType varargs_p)
     : SimpleFunction(std::move(name_p), std::move(arguments_p), std::move(varargs_p)),
-      return_type(std::move(return_type_p)), stability(stability), null_handling(null_handling), errors(errors),
-      collation_handling(FunctionCollationHandling::PROPAGATE_COLLATIONS) {
+      return_type(std::move(return_type_p)) {
 }
 
 BaseScalarFunction::~BaseScalarFunction() {

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -24,8 +24,10 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
                                function_statistics_t statistics, init_local_state_t init_local_state,
                                LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
-                         std::move(varargs), null_handling) {
+    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type)) {
+	properties.stability = side_effects;
+	properties.null_handling = null_handling;
+
 	callbacks.function = std::move(function);
 	callbacks.bind = std::move(bind);
 	callbacks.init_local_state = init_local_state;

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -2,6 +2,17 @@
 
 namespace duckdb {
 
+bool ScalarFunctionCallbacks::operator==(const ScalarFunctionCallbacks &rhs) const {
+	return bind == rhs.bind && init_local_state == rhs.init_local_state && statistics == rhs.statistics &&
+	       bind_lambda == rhs.bind_lambda && bind_expression == rhs.bind_expression &&
+	       get_modified_databases == rhs.get_modified_databases && serialize == rhs.serialize &&
+	       deserialize == rhs.deserialize && filter_prune == rhs.filter_prune;
+}
+
+bool ScalarFunctionCallbacks::operator!=(const ScalarFunctionCallbacks &rhs) const {
+	return !(*this == rhs);
+}
+
 FunctionLocalState::~FunctionLocalState() {
 }
 
@@ -14,10 +25,12 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
                                LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
     : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
-                         std::move(varargs), null_handling),
-      function(std::move(function)), bind(bind), init_local_state(init_local_state), statistics(statistics),
-      bind_lambda(bind_lambda), bind_expression(nullptr), get_modified_databases(nullptr), serialize(nullptr),
-      deserialize(nullptr) {
+                         std::move(varargs), null_handling) {
+	callbacks.function = std::move(function);
+	callbacks.bind = std::move(bind);
+	callbacks.init_local_state = init_local_state;
+	callbacks.statistics = statistics;
+	callbacks.bind_lambda = bind_lambda;
 }
 
 ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
@@ -30,8 +43,7 @@ ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
 	return name == rhs.name && arguments == rhs.GetArguments() && return_type == rhs.return_type &&
-	       varargs == rhs.GetVarArgs() && bind == rhs.bind && statistics == rhs.statistics &&
-	       bind_lambda == rhs.bind_lambda;
+	       varargs == rhs.GetVarArgs() && callbacks == rhs.callbacks;
 }
 
 bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -24,12 +24,12 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
                                function_statistics_t statistics, init_local_state_t init_local_state,
                                LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type)) {
+    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), std::move(varargs)) {
 	properties.stability = side_effects;
 	properties.null_handling = null_handling;
 
 	callbacks.function = std::move(function);
-	callbacks.bind = std::move(bind);
+	callbacks.bind = bind;
 	callbacks.init_local_state = init_local_state;
 	callbacks.statistics = statistics;
 	callbacks.bind_lambda = bind_lambda;
@@ -45,7 +45,7 @@ ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
 	return name == rhs.name && arguments == rhs.GetArguments() && return_type == rhs.return_type &&
-	       varargs == rhs.GetVarArgs() && callbacks == rhs.callbacks;
+	       varargs == rhs.GetVarArgs() && callbacks == rhs.callbacks && properties == rhs.properties;
 }
 
 bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -147,6 +147,46 @@ enum class AggregateDestructorType {
 	LEGACY
 };
 
+class AggregateFunctionCallbacks {
+public:
+	//! The hashed aggregate state sizing function
+	aggregate_size_t state_size = nullptr;
+	//! The hashed aggregate state initialization function
+	aggregate_initialize_t initialize = nullptr;
+	//! The hashed aggregate update state function (may be null, if window is set)
+	aggregate_update_t update = nullptr;
+	//! The hashed aggregate combine states function (may be null, if window is set)
+	aggregate_combine_t combine = nullptr;
+	//! The hashed aggregate finalization function (may be null, if window is set)
+	aggregate_finalize_t finalize = nullptr;
+	//! The simple aggregate update function (may be null)
+	aggregate_simple_update_t simple_update = nullptr;
+	//! The windowed aggregate custom function (may be null)
+	aggregate_window_t window = nullptr;
+	//! The windowed aggregate custom initialization function (may be null)
+	aggregate_wininit_t window_init = nullptr;
+	//! Batched windowed aggregate function (may be null; preferred when set)
+	aggregate_window_batch_t window_batch = nullptr;
+
+	//! The bind function (may be null)
+	bind_aggregate_function_t bind = nullptr;
+
+	//! The destructor method (may be null)
+	aggregate_destructor_t destructor = nullptr;
+
+	//! The statistics propagation function (may be null)
+	aggregate_statistics_t statistics = nullptr;
+
+	aggregate_serialize_t serialize = nullptr;
+
+	aggregate_deserialize_t deserialize = nullptr;
+
+	aggregate_get_state_type_t get_state_type = nullptr;
+
+	bool operator==(const AggregateFunctionCallbacks &rhs) const;
+	bool operator!=(const AggregateFunctionCallbacks &rhs) const;
+};
+
 class AggregateFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
@@ -159,10 +199,20 @@ public:
 	                  aggregate_deserialize_t deserialize = nullptr)
 	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
 	                         LogicalType(LogicalTypeId::INVALID), null_handling),
-	      state_size(state_size), initialize(initialize), update(update), combine(combine), finalize(finalize),
-	      simple_update(simple_update), window(window), bind(bind), destructor(destructor), statistics(statistics),
-	      serialize(serialize), deserialize(deserialize), order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
+	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
 	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+		callbacks.state_size = state_size;
+		callbacks.initialize = initialize;
+		callbacks.update = update;
+		callbacks.combine = combine;
+		callbacks.finalize = finalize;
+		callbacks.simple_update = simple_update;
+		callbacks.window = window;
+		callbacks.bind = bind;
+		callbacks.destructor = destructor;
+		callbacks.statistics = statistics;
+		callbacks.serialize = serialize;
+		callbacks.deserialize = deserialize;
 	}
 
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
@@ -174,10 +224,20 @@ public:
 	                  aggregate_deserialize_t deserialize = nullptr)
 	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
 	                         LogicalType(LogicalTypeId::INVALID)),
-	      state_size(state_size), initialize(initialize), update(update), combine(combine), finalize(finalize),
-	      simple_update(simple_update), window(window), bind(bind), destructor(destructor), statistics(statistics),
-	      serialize(serialize), deserialize(deserialize), order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
+	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
 	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+		callbacks.state_size = state_size;
+		callbacks.initialize = initialize;
+		callbacks.update = update;
+		callbacks.combine = combine;
+		callbacks.finalize = finalize;
+		callbacks.simple_update = simple_update;
+		callbacks.bind = bind;
+		callbacks.destructor = destructor;
+		callbacks.statistics = statistics;
+		callbacks.window = window;
+		callbacks.serialize = serialize;
+		callbacks.deserialize = deserialize;
 	}
 
 	AggregateFunction(const vector<LogicalType> &arguments, const LogicalType &return_type, aggregate_size_t state_size,
@@ -212,113 +272,89 @@ public:
 	                  aggregate_deserialize_t deserialize = nullptr)
 	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
 	                         LogicalType(LogicalTypeId::INVALID)),
-	      state_size(state_size), initialize(initialize), update(nullptr), combine(nullptr), finalize(nullptr),
-	      simple_update(nullptr), window(window), window_init(window_init), bind(bind), destructor(destructor),
-	      statistics(statistics), serialize(serialize), deserialize(deserialize),
 	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
 	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+		callbacks.state_size = state_size;
+		callbacks.initialize = initialize;
+		callbacks.window = window;
+		callbacks.window_init = window_init;
+		callbacks.bind = bind;
+		callbacks.destructor = destructor;
+		callbacks.statistics = statistics;
+		callbacks.serialize = serialize;
+		callbacks.deserialize = deserialize;
 	}
 
 	// clang-format off
-	bool HasBindCallback() const { return bind != nullptr; }
-	bind_aggregate_function_t GetBindCallback() const { return bind; }
-	void SetBindCallback(bind_aggregate_function_t callback) { bind = callback; }
+	bool HasBindCallback() const { return callbacks.bind != nullptr; }
+	bind_aggregate_function_t GetBindCallback() const { return callbacks.bind; }
+	void SetBindCallback(bind_aggregate_function_t callback) { callbacks.bind = callback; }
 	unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
 	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments) {
 		BindAggregateFunctionInput bind_input(context, *this, arguments);
 		return Bind(bind_input);
 	}
 
-	bool HasStateInitCallback() const { return initialize != nullptr; }
-	aggregate_initialize_t GetStateInitCallback() const { return initialize; }
-	void SetStateInitCallback(aggregate_initialize_t callback) { initialize = callback; }
+	bool HasStateInitCallback() const { return callbacks.initialize != nullptr; }
+	aggregate_initialize_t GetStateInitCallback() const { return callbacks.initialize; }
+	void SetStateInitCallback(aggregate_initialize_t callback) { callbacks.initialize = callback; }
 
-	bool HasStateSizeCallback() const { return state_size != nullptr; }
-	aggregate_size_t GetStateSizeCallback() const { return state_size; }
-	void SetStateSizeCallback(aggregate_size_t callback) { state_size = callback; }
+	bool HasStateSizeCallback() const { return callbacks.state_size != nullptr; }
+	aggregate_size_t GetStateSizeCallback() const { return callbacks.state_size; }
+	void SetStateSizeCallback(aggregate_size_t callback) { callbacks.state_size = callback; }
 
-	bool HasStateDestructorCallback() const { return destructor != nullptr; }
-	aggregate_destructor_t GetStateDestructorCallback() const { return destructor; }
-	void SetStateDestructorCallback(aggregate_destructor_t callback) { destructor = callback; }
+	bool HasStateDestructorCallback() const { return callbacks.destructor != nullptr; }
+	aggregate_destructor_t GetStateDestructorCallback() const { return callbacks.destructor; }
+	void SetStateDestructorCallback(aggregate_destructor_t callback) { callbacks.destructor = callback; }
 
-	bool HasStateUpdateCallback() const { return update != nullptr; }
-	aggregate_update_t GetStateUpdateCallback() const { return update; }
-	void SetStateUpdateCallback(aggregate_update_t callback) { update = callback; }
+	bool HasStateUpdateCallback() const { return callbacks.update != nullptr; }
+	aggregate_update_t GetStateUpdateCallback() const { return callbacks.update; }
+	void SetStateUpdateCallback(aggregate_update_t callback) { callbacks.update = callback; }
 
-	bool HasStateSimpleUpdateCallback() const { return simple_update != nullptr; }
-	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return simple_update; }
-	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { simple_update = callback; }
+	bool HasStateSimpleUpdateCallback() const { return callbacks.simple_update != nullptr; }
+	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return callbacks.simple_update; }
+	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { callbacks.simple_update = callback; }
 
-	void SetStateCombineCallback(aggregate_combine_t callback) { combine = callback; }
-	aggregate_combine_t GetStateCombineCallback() const { return combine; }
-	bool HasStateCombineCallback() const { return combine != nullptr; }
+	void SetStateCombineCallback(aggregate_combine_t callback) { callbacks.combine = callback; }
+	aggregate_combine_t GetStateCombineCallback() const { return callbacks.combine; }
+	bool HasStateCombineCallback() const { return callbacks.combine != nullptr; }
 
-	void SetStateFinalizeCallback(aggregate_finalize_t callback) { finalize = callback; }
-	aggregate_finalize_t GetStateFinalizeCallback() const { return finalize; }
-	bool HasStateFinalizeCallback() const { return finalize != nullptr; }
+	void SetStateFinalizeCallback(aggregate_finalize_t callback) { callbacks.finalize = callback; }
+	aggregate_finalize_t GetStateFinalizeCallback() const { return callbacks.finalize; }
+	bool HasStateFinalizeCallback() const { return callbacks.finalize != nullptr; }
 
-	bool HasWindowCallback() const { return window != nullptr; }
-	aggregate_window_t GetWindowCallback() const { return window; }
-	void SetWindowCallback(aggregate_window_t callback) { window = callback; }
+	bool HasWindowCallback() const { return callbacks.window != nullptr; }
+	aggregate_window_t GetWindowCallback() const { return callbacks.window; }
+	void SetWindowCallback(aggregate_window_t callback) { callbacks.window = callback; }
 
-	void SetWindowInitCallback(aggregate_wininit_t callback) { window_init = callback; }
-	aggregate_wininit_t GetWindowInitCallback() const { return window_init; }
-	bool HasWindowInitCallback() const { return window_init != nullptr; }
+	void SetWindowInitCallback(aggregate_wininit_t callback) { callbacks.window_init = callback; }
+	aggregate_wininit_t GetWindowInitCallback() const { return callbacks.window_init; }
+	bool HasWindowInitCallback() const { return callbacks.window_init != nullptr; }
 
 	//! Batched window callback — takes precedence over the per-row window
 	//! callback when set. See aggregate_window_batch_t for semantics.
-	bool HasWindowBatchCallback() const { return window_batch != nullptr; }
-	aggregate_window_batch_t GetWindowBatchCallback() const { return window_batch; }
-	void SetWindowBatchCallback(aggregate_window_batch_t callback) { window_batch = callback; }
+	bool HasWindowBatchCallback() const { return callbacks.window_batch != nullptr; }
+	aggregate_window_batch_t GetWindowBatchCallback() const { return callbacks.window_batch; }
+	void SetWindowBatchCallback(aggregate_window_batch_t callback) { callbacks.window_batch = callback; }
 
-	bool HasStatisticsCallback() const { return statistics != nullptr; }
-	aggregate_statistics_t GetStatisticsCallback() const { return statistics; }
-	void SetStatisticsCallback(aggregate_statistics_t callback) { statistics = callback; }
+	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
+	aggregate_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
+	void SetStatisticsCallback(aggregate_statistics_t callback) { callbacks.statistics = callback; }
 
-	bool HasSerializationCallbacks() const { return serialize != nullptr && deserialize != nullptr; }
-	void SetSerializeCallback(aggregate_serialize_t callback) { serialize = callback; }
-	void SetDeserializeCallback(aggregate_deserialize_t callback) { deserialize = callback; }
-	aggregate_serialize_t GetSerializeCallback() const { return serialize; }
-	aggregate_deserialize_t GetDeserializeCallback() const { return deserialize; }
+	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
+	void SetSerializeCallback(aggregate_serialize_t callback) { callbacks.serialize = callback; }
+	void SetDeserializeCallback(aggregate_deserialize_t callback) { callbacks.deserialize = callback; }
+	aggregate_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
+	aggregate_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
 	// clang-format on
 
 protected:
-	//! The hashed aggregate state sizing function
-	aggregate_size_t state_size;
-	//! The hashed aggregate state initialization function
-	aggregate_initialize_t initialize;
-	//! The hashed aggregate update state function (may be null, if window is set)
-	aggregate_update_t update;
-	//! The hashed aggregate combine states function (may be null, if window is set)
-	aggregate_combine_t combine;
-	//! The hashed aggregate finalization function (may be null, if window is set)
-	aggregate_finalize_t finalize;
-	//! The simple aggregate update function (may be null)
-	aggregate_simple_update_t simple_update;
-	//! The windowed aggregate custom function (may be null)
-	aggregate_window_t window;
-	//! The windowed aggregate custom initialization function (may be null)
-	aggregate_wininit_t window_init = nullptr;
-	//! Batched windowed aggregate function (may be null; preferred when set)
-	aggregate_window_batch_t window_batch = nullptr;
-
-	//! The bind function (may be null)
-	bind_aggregate_function_t bind;
-	//! The destructor method (may be null)
-	aggregate_destructor_t destructor;
-
-	//! The statistics propagation function (may be null)
-	aggregate_statistics_t statistics;
-
-	aggregate_serialize_t serialize;
-	aggregate_deserialize_t deserialize;
+	AggregateFunctionCallbacks callbacks;
 
 	//! Whether or not the aggregate is order dependent
 	AggregateOrderDependent order_dependent;
 	//! Whether or not the aggregate is affect by distinct modifiers
 	AggregateDistinctDependent distinct_dependent;
-
-	aggregate_get_state_type_t get_state_type = nullptr;
 
 	//! Additional function info, passed to the bind
 	shared_ptr<AggregateFunctionInfo> function_info;
@@ -356,20 +392,20 @@ public:
 	}
 
 	bool HasGetStateTypeCallback() const {
-		return get_state_type != nullptr;
+		return callbacks.get_state_type != nullptr;
 	}
 	aggregate_get_state_type_t GetStateTypeCallback() const {
-		return get_state_type;
+		return callbacks.get_state_type;
 	}
 
 	AggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
-		get_state_type = get_state_type_callback;
+		callbacks.get_state_type = get_state_type_callback;
 		return *this;
 	}
 
 	LogicalType GetStateType() const {
-		D_ASSERT(get_state_type);
-		const auto result = get_state_type(*this);
+		D_ASSERT(callbacks.get_state_type);
+		const auto result = callbacks.get_state_type(*this);
 		// The underlying type of the AggregateState should be a struct
 		D_ASSERT(result.id() == LogicalTypeId::STRUCT);
 		return result;
@@ -377,18 +413,17 @@ public:
 
 public:
 	bool operator==(const AggregateFunction &rhs) const {
-		return state_size == rhs.state_size && initialize == rhs.initialize && update == rhs.update &&
-		       combine == rhs.combine && finalize == rhs.finalize && window == rhs.window;
+		return callbacks == rhs.callbacks;
 	}
 	bool operator!=(const AggregateFunction &rhs) const {
 		return !(*this == rhs);
 	}
 
 	bool CanAggregate() const {
-		return update || combine || finalize;
+		return callbacks.update || callbacks.combine || callbacks.finalize;
 	}
 	bool CanWindow() const {
-		return window;
+		return callbacks.window;
 	}
 
 public:
@@ -417,7 +452,7 @@ public:
 	          AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
 	static AggregateFunction UnaryAggregateDestructor(LogicalType input_type, LogicalType return_type) {
 		auto aggregate = UnaryAggregate<STATE, INPUT_TYPE, RESULT_TYPE, OP, destructor_type>(input_type, return_type);
-		aggregate.destructor = AggregateFunction::StateDestroy<STATE, OP>;
+		aggregate.callbacks.destructor = AggregateFunction::StateDestroy<STATE, OP>;
 		return aggregate;
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -187,6 +187,17 @@ public:
 	bool operator!=(const AggregateFunctionCallbacks &rhs) const;
 };
 
+class AggregateFunctionProperties : public FunctionProperties {
+public:
+	//! Whether or not the aggregate is order dependent
+	AggregateOrderDependent order_dependent = AggregateOrderDependent::ORDER_DEPENDENT;
+	//! Whether or not the aggregate is affect by distinct modifiers
+	AggregateDistinctDependent distinct_dependent = AggregateDistinctDependent::DISTINCT_DEPENDENT;
+
+	bool operator==(const AggregateFunctionProperties &rhs) const;
+	bool operator!=(const AggregateFunctionProperties &rhs) const;
+};
+
 class AggregateFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
@@ -197,10 +208,9 @@ public:
 	                  aggregate_destructor_t destructor = nullptr, aggregate_statistics_t statistics = nullptr,
 	                  aggregate_window_t window = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
-	                         LogicalType(LogicalTypeId::INVALID), null_handling),
-	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
-	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+	    : BaseScalarFunction(name, arguments, return_type) {
+		properties.null_handling = null_handling;
+
 		callbacks.state_size = state_size;
 		callbacks.initialize = initialize;
 		callbacks.update = update;
@@ -222,10 +232,7 @@ public:
 	                  aggregate_destructor_t destructor = nullptr, aggregate_statistics_t statistics = nullptr,
 	                  aggregate_window_t window = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
-	                         LogicalType(LogicalTypeId::INVALID)),
-	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
-	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+	    : BaseScalarFunction(name, arguments, return_type) {
 		callbacks.state_size = state_size;
 		callbacks.initialize = initialize;
 		callbacks.update = update;
@@ -270,10 +277,7 @@ public:
 	                  bind_aggregate_function_t bind = nullptr, aggregate_destructor_t destructor = nullptr,
 	                  aggregate_statistics_t statistics = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
-	                         LogicalType(LogicalTypeId::INVALID)),
-	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
-	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+	    : BaseScalarFunction(name, arguments, return_type) {
 		callbacks.state_size = state_size;
 		callbacks.initialize = initialize;
 		callbacks.window = window;
@@ -350,14 +354,27 @@ public:
 
 protected:
 	AggregateFunctionCallbacks callbacks;
-
-	//! Whether or not the aggregate is order dependent
-	AggregateOrderDependent order_dependent;
-	//! Whether or not the aggregate is affect by distinct modifiers
-	AggregateDistinctDependent distinct_dependent;
+	AggregateFunctionProperties properties;
 
 	//! Additional function info, passed to the bind
 	shared_ptr<AggregateFunctionInfo> function_info;
+
+public:
+	// clang-format off
+	FunctionStability GetStability() const { return properties.stability; }
+	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
+	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
+	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
+	FunctionErrors GetErrorMode() const { return properties.errors; }
+	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
+	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
+	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+	// clang-format on
 
 public:
 	bool HasExtraFunctionInfo() const {
@@ -379,16 +396,16 @@ public:
 	}
 
 	AggregateOrderDependent GetOrderDependent() const {
-		return order_dependent;
+		return properties.order_dependent;
 	}
 	void SetOrderDependent(AggregateOrderDependent value) {
-		order_dependent = value;
+		properties.order_dependent = value;
 	}
 	AggregateDistinctDependent GetDistinctDependent() const {
-		return distinct_dependent;
+		return properties.distinct_dependent;
 	}
 	void SetDistinctDependent(AggregateDistinctDependent value) {
-		distinct_dependent = value;
+		properties.distinct_dependent = value;
 	}
 
 	bool HasGetStateTypeCallback() const {

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -193,13 +193,24 @@ public:
 	DUCKDB_API bool HasNamedParameters() const;
 };
 
+class FunctionProperties {
+public:
+	FunctionStability stability = FunctionStability::CONSISTENT;
+	//! How this function handles NULL values
+	FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING;
+	//! Whether or not this function can throw an error
+	FunctionErrors errors = FunctionErrors::CANNOT_ERROR;
+	//! Collation handling of the function
+	FunctionCollationHandling collation_handling = FunctionCollationHandling::PROPAGATE_COLLATIONS;
+
+	bool operator==(const FunctionProperties &rhs) const;
+	bool operator!=(const FunctionProperties &rhs) const;
+};
+
 class BaseScalarFunction : public SimpleFunction {
 public:
 	DUCKDB_API BaseScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
-	                              FunctionStability stability,
-	                              LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
-	                              FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
-	                              FunctionErrors errors = FunctionErrors::CANNOT_ERROR);
+	                              LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
 	DUCKDB_API ~BaseScalarFunction() override;
 
 public:
@@ -213,59 +224,9 @@ public:
 		return return_type;
 	}
 
-	FunctionStability GetStability() const {
-		return stability;
-	}
-	void SetStability(FunctionStability stability_p) {
-		stability = stability_p;
-	}
-
-	FunctionNullHandling GetNullHandling() const {
-		return null_handling;
-	}
-	void SetNullHandling(FunctionNullHandling null_handling_p) {
-		null_handling = null_handling_p;
-	}
-
-	FunctionErrors GetErrorMode() const {
-		return errors;
-	}
-	void SetErrorMode(FunctionErrors errors_p) {
-		errors = errors_p;
-	}
-
-	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() {
-		errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
-	}
-	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() {
-		stability = FunctionStability::VOLATILE;
-	}
-
-	void SetCollationHandling(FunctionCollationHandling collation_handling_p) {
-		collation_handling = collation_handling_p;
-	}
-	FunctionCollationHandling GetCollationHandling() const {
-		return collation_handling;
-	}
-
 protected:
 	//! Return type of the function
 	LogicalType return_type;
-	//! The stability of the function (see FunctionStability enum for more info)
-	FunctionStability stability;
-	//! How this function handles NULL values
-	FunctionNullHandling null_handling;
-	//! Whether or not this function can throw an error
-	FunctionErrors errors;
-	//! Collation handling of the function
-	FunctionCollationHandling collation_handling;
-
-	static BaseScalarFunction SetReturnsError(BaseScalarFunction &function) {
-		function.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
-		return function;
-	}
 
 public:
 	DUCKDB_API hash_t Hash() const;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -145,88 +145,8 @@ typedef FilterPropagateResult (*propagate_filter_t)(const FunctionStatisticsPrun
 //! The type to bind lambda-specific parameter types
 typedef unique_ptr<Expression> (*function_bind_expression_t)(FunctionBindExpressionInput &input);
 
-class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
+class ScalarFunctionCallbacks {
 public:
-	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
-	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
-	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
-	                          FunctionStability stability = FunctionStability::CONSISTENT,
-	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
-	                          bind_lambda_function_t bind_lambda = nullptr);
-
-	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
-	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
-	                          init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
-	                          FunctionStability stability = FunctionStability::CONSISTENT,
-	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
-	                          bind_lambda_function_t bind_lambda = nullptr);
-
-	// clang-format off
-	// Keep these on one-line for readability
-	bool HasFunctionCallback() const { return function != nullptr; }
-	scalar_function_t GetFunctionCallback() const { return function; }
-	void SetFunctionCallback(scalar_function_t callback) { function = std::move(callback); }
-
-	bool HasSelectCallback() const { return select_function != nullptr; }
-	scalar_function_select_t GetSelectCallback() const { return select_function; }
-	void SetSelectCallback(scalar_function_select_t callback) { select_function = callback; }
-
-	bool HasBindCallback() const { return bind != nullptr; };
-	bind_scalar_function_t GetBindCallback() const { return bind; };
-	void SetBindCallback(bind_scalar_function_t callback) { bind = callback; }
-	unique_ptr<FunctionData> Bind(BindScalarFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
-	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments,
-		optional_ptr<Binder> binder = nullptr);
-
-	bool HasBindLambdaCallback() const { return bind_lambda != nullptr; }
-	bind_lambda_function_t GetBindLambdaCallback() const { return bind_lambda; }
-	void SetBindLambdaCallback(bind_lambda_function_t callback) { bind_lambda = callback; }
-
-	bool HasBindExpressionCallback() const { return bind_expression != nullptr; }
-	function_bind_expression_t GetBindExpressionCallback() const { return bind_expression; }
-	void SetBindExpressionCallback(function_bind_expression_t callback) { bind_expression = callback; }
-
-	bool HasInitStateCallback() const { return init_local_state != nullptr; }
-	init_local_state_t GetInitStateCallback() const { return init_local_state; }
-	void SetInitStateCallback(init_local_state_t callback) { init_local_state = callback; }
-
-	bool HasStatisticsCallback() const { return statistics != nullptr; }
-	function_statistics_t GetStatisticsCallback() const { return statistics; }
-	void SetStatisticsCallback(function_statistics_t callback) { statistics = callback; }
-
-	bool HasModifiedDatabasesCallback() const { return get_modified_databases != nullptr; }
-	get_modified_databases_t GetModifiedDatabasesCallback() const { return get_modified_databases; }
-	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { get_modified_databases = callback; }
-
-	bool HasSerializationCallbacks() const { return serialize != nullptr && deserialize != nullptr; }
-	void SetSerializeCallback(function_serialize_t callback) { serialize = callback; }
-	void SetDeserializeCallback(function_deserialize_t callback) { deserialize = callback; }
-	function_serialize_t GetSerializeCallback() const { return serialize; }
-	function_deserialize_t GetDeserializeCallback() const { return deserialize; }
-
-	bool HasFilterPruneCallback() const {return filter_prune != nullptr; }
-	void SetFilterPruneCallback(propagate_filter_t callback) { filter_prune = callback; }
-	propagate_filter_t GetFilterPruneCallback() const { return filter_prune; }
-	// clang-format on
-
-	bool HasExtraFunctionInfo() const {
-		return function_info != nullptr;
-	}
-	ScalarFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-
-protected:
 	//! The main scalar function to execute
 	scalar_function_t function;
 	//! Direct selection callback (if any)
@@ -249,6 +169,95 @@ protected:
 
 	//! The filter prune function (if any)
 	propagate_filter_t filter_prune = nullptr;
+
+	bool operator==(const ScalarFunctionCallbacks &rhs) const;
+	bool operator!=(const ScalarFunctionCallbacks &rhs) const;
+};
+
+class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
+public:
+	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
+	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
+	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
+	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
+	                          FunctionStability stability = FunctionStability::CONSISTENT,
+	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
+	                          bind_lambda_function_t bind_lambda = nullptr);
+
+	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
+	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
+	                          init_local_state_t init_local_state = nullptr,
+	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
+	                          FunctionStability stability = FunctionStability::CONSISTENT,
+	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
+	                          bind_lambda_function_t bind_lambda = nullptr);
+
+	// clang-format off
+	// Keep these on one-line for readability
+	bool HasFunctionCallback() const { return callbacks.function != nullptr; }
+	scalar_function_t GetFunctionCallback() const { return callbacks.function; }
+	void SetFunctionCallback(scalar_function_t callback) { callbacks.function = std::move(callback); }
+
+	bool HasSelectCallback() const { return callbacks.select_function != nullptr; }
+	scalar_function_select_t GetSelectCallback() const { return callbacks.select_function; }
+	void SetSelectCallback(scalar_function_select_t callback) { callbacks.select_function = callback; }
+
+	bool HasBindCallback() const { return callbacks.bind != nullptr; };
+	bind_scalar_function_t GetBindCallback() const { return callbacks.bind; };
+	void SetBindCallback(bind_scalar_function_t callback) { callbacks.bind = callback; }
+	unique_ptr<FunctionData> Bind(BindScalarFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
+	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments,
+		optional_ptr<Binder> binder = nullptr);
+
+	bool HasBindLambdaCallback() const { return callbacks.bind_lambda != nullptr; }
+	bind_lambda_function_t GetBindLambdaCallback() const { return callbacks.bind_lambda; }
+	void SetBindLambdaCallback(bind_lambda_function_t callback) { callbacks.bind_lambda = callback; }
+
+	bool HasBindExpressionCallback() const { return callbacks.bind_expression != nullptr; }
+	function_bind_expression_t GetBindExpressionCallback() const { return callbacks.bind_expression; }
+	void SetBindExpressionCallback(function_bind_expression_t callback) { callbacks.bind_expression = callback; }
+
+	bool HasInitStateCallback() const { return callbacks.init_local_state != nullptr; }
+	init_local_state_t GetInitStateCallback() const { return callbacks.init_local_state; }
+	void SetInitStateCallback(init_local_state_t callback) { callbacks.init_local_state = callback; }
+
+	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
+	function_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
+	void SetStatisticsCallback(function_statistics_t callback) { callbacks.statistics = callback; }
+
+	bool HasModifiedDatabasesCallback() const { return callbacks.get_modified_databases != nullptr; }
+	get_modified_databases_t GetModifiedDatabasesCallback() const { return callbacks.get_modified_databases; }
+	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { callbacks.get_modified_databases = callback; }
+
+	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
+	void SetSerializeCallback(function_serialize_t callback) { callbacks.serialize = callback; }
+	void SetDeserializeCallback(function_deserialize_t callback) { callbacks.deserialize = callback; }
+	function_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
+	function_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
+
+	bool HasFilterPruneCallback() const {return callbacks.filter_prune != nullptr; }
+	void SetFilterPruneCallback(propagate_filter_t callback) { callbacks.filter_prune = callback; }
+	propagate_filter_t GetFilterPruneCallback() const { return callbacks.filter_prune; }
+	// clang-format on
+
+	bool HasExtraFunctionInfo() const {
+		return function_info != nullptr;
+	}
+	ScalarFunctionInfo &GetExtraFunctionInfo() const {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
+		function_info = std::move(info);
+	}
+	template <class T, class... ARGS>
+	void SetExtraFunctionInfo(ARGS &&... args) {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+	}
+
+protected:
+	ScalarFunctionCallbacks callbacks;
+
 	//! Additional function info, passed to the bind
 	shared_ptr<ScalarFunctionInfo> function_info;
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -148,24 +148,24 @@ typedef unique_ptr<Expression> (*function_bind_expression_t)(FunctionBindExpress
 class ScalarFunctionCallbacks {
 public:
 	//! The main scalar function to execute
-	scalar_function_t function;
+	scalar_function_t function = nullptr;
 	//! Direct selection callback (if any)
 	scalar_function_select_t select_function = nullptr;
 	//! The bind function (if any)
-	bind_scalar_function_t bind;
+	bind_scalar_function_t bind = nullptr;
 	//! Init thread local state for the function (if any)
-	init_local_state_t init_local_state;
+	init_local_state_t init_local_state = nullptr;
 	//! The statistics propagation function (if any)
-	function_statistics_t statistics;
+	function_statistics_t statistics = nullptr;
 	//! The lambda bind function (if any)
-	bind_lambda_function_t bind_lambda;
+	bind_lambda_function_t bind_lambda = nullptr;
 	//! Function to bind the result function expression directly (if any)
-	function_bind_expression_t bind_expression;
+	function_bind_expression_t bind_expression = nullptr;
 	//! Gets the modified databases (if any)
-	get_modified_databases_t get_modified_databases;
+	get_modified_databases_t get_modified_databases = nullptr;
 
-	function_serialize_t serialize;
-	function_deserialize_t deserialize;
+	function_serialize_t serialize = nullptr;
+	function_deserialize_t deserialize = nullptr;
 
 	//! The filter prune function (if any)
 	propagate_filter_t filter_prune = nullptr;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -256,10 +256,28 @@ public:
 	}
 
 protected:
+	FunctionProperties properties;
 	ScalarFunctionCallbacks callbacks;
 
 	//! Additional function info, passed to the bind
 	shared_ptr<ScalarFunctionInfo> function_info;
+
+public:
+	// clang-format off
+	FunctionStability GetStability() const { return properties.stability; }
+	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
+	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
+	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
+	FunctionErrors GetErrorMode() const { return properties.errors; }
+	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
+	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
+	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+	// clang-format on
 
 public:
 	DUCKDB_API bool operator==(const ScalarFunction &rhs) const;

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -146,6 +146,38 @@ typedef void (*window_serialize_t)(Serializer &serializer, const optional_ptr<Fu
                                    const WindowFunction &function);
 typedef unique_ptr<FunctionData> (*window_deserialize_t)(Deserializer &deserializer, WindowFunction &function);
 
+class WindowFunctionCallbacks {
+public:
+	//! The bind function (may be null)
+	window_bind_function_t bind = nullptr;
+
+	//! The framing bounds lists
+	window_bounds_function_t bounds = nullptr;
+	//! The children sharing requirements
+	window_sharing_function_t sharing = nullptr;
+	//! The global state constructor
+	window_global_function_t global = nullptr;
+	//! The local state constructor
+	window_local_function_t local = nullptr;
+	//! The local state data sink
+	window_sink_function_t sink = nullptr;
+	//! The local state finalize operation
+	window_finalize_function_t finalize = nullptr;
+	//! The thread-local evaluation function
+	window_evaluate_function_t evaluate = nullptr;
+
+	//! Can the function stream?
+	window_canstream_function_t can_stream = nullptr;
+	//! Get the streaming state object
+	window_streaming_state_function_t streaming_state = nullptr;
+	//! The streaming evaluation function
+	window_stream_function_t stream = nullptr;
+
+	//! Serialization specialization. Not yet implemented
+	window_serialize_t serialize = nullptr;
+	window_deserialize_t deserialize = nullptr;
+};
+
 class WindowFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	WindowFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
@@ -156,8 +188,15 @@ public:
 	               window_evaluate_function_t evaluate = nullptr)
 	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
 	                         LogicalType(LogicalTypeId::INVALID), FunctionNullHandling::DEFAULT_NULL_HANDLING),
-	      window_enum(window_enum), bind(bind), bounds(bounds), sharing(sharing), global(global), local(local),
-	      sink(sink), finalize(finalize), evaluate(evaluate) {
+	      window_enum(window_enum) {
+		callbacks.bind = bind;
+		callbacks.bounds = bounds;
+		callbacks.sharing = sharing;
+		callbacks.global = global;
+		callbacks.local = local;
+		callbacks.sink = sink;
+		callbacks.finalize = finalize;
+		callbacks.evaluate = evaluate;
 	}
 
 	WindowFunction(const vector<LogicalType> &arguments, const LogicalType &return_type, ExpressionType window_enum,
@@ -170,34 +209,34 @@ public:
 	}
 
 	// clang-format off
-	bool HasBindCallback() const { return bind != nullptr; }
-	window_bind_function_t GetBindCallback() const { return bind; }
-	void SetBindCallback(window_bind_function_t callback) { bind = callback; }
+	bool HasBindCallback() const { return callbacks.bind != nullptr; }
+	window_bind_function_t GetBindCallback() const { return callbacks.bind; }
+	void SetBindCallback(window_bind_function_t callback) { callbacks.bind = callback; }
 	unique_ptr<FunctionData> Bind(BindWindowFunctionInput &bind_input) { return GetBindCallback()(bind_input); }
 	unique_ptr<FunctionData> Bind(ClientContext &context, vector<unique_ptr<Expression>> &arguments) {
 		BindWindowFunctionInput bind_input(context, *this, arguments);
 		return Bind(bind_input);
 	}
 
-	bool HasBoundsCallback() const { return bounds != nullptr; }
-	window_bounds_function_t GetBoundsCallback() const { return bounds; }
-	void SetBoundsCallback(window_bounds_function_t callback) { bounds = callback; }
+	bool HasBoundsCallback() const { return callbacks.bounds != nullptr; }
+	window_bounds_function_t GetBoundsCallback() const { return callbacks.bounds; }
+	void SetBoundsCallback(window_bounds_function_t callback) { callbacks.bounds = callback; }
 	void GetBounds(WindowBoundsSet &bounds, const BoundWindowExpression &wexpr) const {
 		D_ASSERT(HasBoundsCallback());
 		GetBoundsCallback()(bounds, wexpr);
 	}
 
-	bool HasSharingCallback() const { return sharing != nullptr; }
-	window_sharing_function_t GetSharingCallback() const { return sharing; }
-	void SetSharingCallback(window_sharing_function_t callback) { sharing = callback; }
+	bool HasSharingCallback() const { return callbacks.sharing != nullptr; }
+	window_sharing_function_t GetSharingCallback() const { return callbacks.sharing; }
+	void SetSharingCallback(window_sharing_function_t callback) { callbacks.sharing = callback; }
 	void GetSharing(WindowExecutor &executor, WindowSharedExpressions &sharing) const {
 		D_ASSERT(HasSharingCallback());
 		GetSharingCallback()(executor, sharing);
 	}
 
-	bool HasGlobalCallback() const { return global != nullptr; }
-	window_global_function_t GetGlobalCallback() const { return global; }
-	void SetGlobalCallback(window_global_function_t callback) { global = callback; }
+	bool HasGlobalCallback() const { return callbacks.global != nullptr; }
+	window_global_function_t GetGlobalCallback() const { return callbacks.global; }
+	void SetGlobalCallback(window_global_function_t callback) { callbacks.global = callback; }
 	unique_ptr<GlobalSinkState> GetGlobalState(ClientContext &client, const WindowExecutor &executor,
                                                                 const idx_t payload_count,
                                                                 const ValidityMask &partition_mask,
@@ -206,60 +245,60 @@ public:
 		return GetGlobalCallback()(client, executor, payload_count, partition_mask, order_mask);
 	}
 
-	bool HasLocalCallback() const { return local != nullptr; }
-	window_local_function_t GetLocalCallback() const { return local; }
-	void SetLocalCallback(window_local_function_t callback) { local = callback; }
+	bool HasLocalCallback() const { return callbacks.local != nullptr; }
+	window_local_function_t GetLocalCallback() const { return callbacks.local; }
+	void SetLocalCallback(window_local_function_t callback) { callbacks.local = callback; }
 	unique_ptr<LocalSinkState> GetLocalState(ExecutionContext &context, const GlobalSinkState &gstate) const {
 		D_ASSERT(HasLocalCallback());
 		return GetLocalCallback()(context, gstate);
 	}
 
-	bool HasSinkCallback() const { return sink != nullptr; }
-	window_sink_function_t GetSinkCallback() const { return sink; }
-	void SetSinkCallback(window_sink_function_t callback) { sink = callback; }
+	bool HasSinkCallback() const { return callbacks.sink != nullptr; }
+	window_sink_function_t GetSinkCallback() const { return callbacks.sink; }
+	void SetSinkCallback(window_sink_function_t callback) { callbacks.sink = callback; }
 	void Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk,
                                     idx_t input_idx, OperatorSinkInput &sink) const {
 		D_ASSERT(HasSinkCallback());
 		return GetSinkCallback()(context, sink_chunk, coll_chunk, input_idx, sink);
 	}
 
-	bool HasFinalizeCallback() const { return finalize != nullptr; }
-	window_finalize_function_t GetFinalizeCallback() const { return finalize; }
-	void SetFinalizeCallback(window_finalize_function_t callback) { finalize = callback; }
+	bool HasFinalizeCallback() const { return callbacks.finalize != nullptr; }
+	window_finalize_function_t GetFinalizeCallback() const { return callbacks.finalize; }
+	void SetFinalizeCallback(window_finalize_function_t callback) { callbacks.finalize = callback; }
 	void Finalize(ExecutionContext &context, optional_ptr<WindowCollection> collection, OperatorSinkInput &sink) const {
 		D_ASSERT(HasFinalizeCallback());
 		return GetFinalizeCallback()(context, collection, sink);
 	}
 
-	bool HasEvaluateCallback() const { return evaluate != nullptr; }
-	window_evaluate_function_t GetEvaluateCallback() const { return evaluate; }
-	void SetEvaluateCallback(window_evaluate_function_t callback) { evaluate = callback; }
+	bool HasEvaluateCallback() const { return callbacks.evaluate != nullptr; }
+	window_evaluate_function_t GetEvaluateCallback() const { return callbacks.evaluate; }
+	void SetEvaluateCallback(window_evaluate_function_t callback) { callbacks.evaluate = callback; }
 	void Evaluate(ExecutionContext &context, DataChunk &eval_chunk, DataChunk &bounds, Vector &result, idx_t row_idx,
 				  OperatorSinkInput &sink) const {
 		D_ASSERT(HasEvaluateCallback());
 		return GetEvaluateCallback()(context, eval_chunk, bounds, result, row_idx, sink);
 	}
 
-	bool HasCanStreamCallback() const { return can_stream != nullptr; }
-	window_canstream_function_t GetCanStreamCallback() const { return can_stream; }
-	void SetCanStreamCallback(window_canstream_function_t callback) { can_stream = callback; }
+	bool HasCanStreamCallback() const { return callbacks.can_stream != nullptr; }
+	window_canstream_function_t GetCanStreamCallback() const { return callbacks.can_stream; }
+	void SetCanStreamCallback(window_canstream_function_t callback) { callbacks.can_stream = callback; }
 	bool CanStream(ClientContext &client, const BoundWindowExpression &wexpr, idx_t max_delta) const {
 		D_ASSERT(HasCanStreamCallback());
 		return GetCanStreamCallback()(client, wexpr, max_delta);
 	}
 
-	bool HasStreamingStateCallback() const { return streaming_state != nullptr; }
-	window_streaming_state_function_t GetStreamingStateCallback() const { return streaming_state; }
-	void SetStreamingStateCallback(window_streaming_state_function_t callback) { streaming_state = callback; }
+	bool HasStreamingStateCallback() const { return callbacks.streaming_state != nullptr; }
+	window_streaming_state_function_t GetStreamingStateCallback() const { return callbacks.streaming_state; }
+	void SetStreamingStateCallback(window_streaming_state_function_t callback) { callbacks.streaming_state = callback; }
 	unique_ptr<LocalSourceState> GetStreamingState(ClientContext &client, DataChunk &input,
 												   const BoundWindowExpression &wexpr) const {
 		D_ASSERT(HasStreamingStateCallback());
 		return GetStreamingStateCallback()(client, input, wexpr);
 	}
 
-	bool HasStreamingDataCallback() const { return stream != nullptr; }
-	window_stream_function_t GetStreamingDataCallback() const { return stream; }
-	void SetStreamingDataCallback(window_stream_function_t callback) { stream = callback; }
+	bool HasStreamingDataCallback() const { return callbacks.stream != nullptr; }
+	window_stream_function_t GetStreamingDataCallback() const { return callbacks.stream; }
+	void SetStreamingDataCallback(window_stream_function_t callback) { callbacks.stream = callback; }
 	void GetStreamingData(ExecutionContext &context, DataChunk &input, DataChunk &delayed, idx_t delayed_capacity,
 	 					  Vector &result, LocalSourceState &lstate) const {
 		D_ASSERT(HasStreamingDataCallback());
@@ -267,10 +306,10 @@ public:
 	}
 
 	bool HasSerializationCallbacks() const { return false; }
-	void SetSerializeCallback(window_serialize_t callback) { serialize = callback; }
-	void SetDeserializeCallback(window_deserialize_t callback) { deserialize = callback; }
-	window_serialize_t GetSerializeCallback() const { return serialize; }
-	window_deserialize_t GetDeserializeCallback() const { return deserialize; }
+	void SetSerializeCallback(window_serialize_t callback) { callbacks.serialize = callback; }
+	void SetDeserializeCallback(window_deserialize_t callback) { callbacks.deserialize = callback; }
+	window_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
+	window_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
 	// clang-format on
 
 	//! The expression enum for the window function
@@ -321,34 +360,7 @@ protected:
 	//! Does the window function support RESPECT/IGNORE NULLS?
 	bool can_ignore_nulls = true;
 
-	//! The bind function (may be null)
-	window_bind_function_t bind = nullptr;
-
-	//! The framing bounds lists
-	window_bounds_function_t bounds = nullptr;
-	//! The children sharing requirements
-	window_sharing_function_t sharing = nullptr;
-	//! The global state constructor
-	window_global_function_t global = nullptr;
-	//! The local state constructor
-	window_local_function_t local = nullptr;
-	//! The local state data sink
-	window_sink_function_t sink = nullptr;
-	//! The local state finalize operation
-	window_finalize_function_t finalize = nullptr;
-	//! The thread-local evaluation function
-	window_evaluate_function_t evaluate = nullptr;
-
-	//! Can the function stream?
-	window_canstream_function_t can_stream = nullptr;
-	//! Get the streaming state object
-	window_streaming_state_function_t streaming_state = nullptr;
-	//! The streaming evaluation function
-	window_stream_function_t stream = nullptr;
-
-	//! Serialization specialization. Not yet implemented
-	window_serialize_t serialize = nullptr;
-	window_deserialize_t deserialize = nullptr;
+	WindowFunctionCallbacks callbacks;
 
 	//! Additional function info, passed to the bind
 	shared_ptr<WindowFunctionInfo> function_info;

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -178,6 +178,20 @@ public:
 	window_deserialize_t deserialize = nullptr;
 };
 
+class WindowFunctionProperties : public FunctionProperties {
+public:
+	//! Does the window function support DISTINCT?
+	bool can_distinct = false;
+	//! Does the window function support FILTER?
+	bool can_filter = false;
+	//! Does the window function support ORDER BY arguments?
+	bool can_order_by = true;
+	//! Does the window function support EXCLUDE?
+	bool can_exclude = false;
+	//! Does the window function support RESPECT/IGNORE NULLS?
+	bool can_ignore_nulls = true;
+};
+
 class WindowFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	WindowFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
@@ -186,9 +200,7 @@ public:
 	               window_global_function_t global = nullptr, window_local_function_t local = nullptr,
 	               window_sink_function_t sink = nullptr, window_finalize_function_t finalize = nullptr,
 	               window_evaluate_function_t evaluate = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
-	                         LogicalType(LogicalTypeId::INVALID), FunctionNullHandling::DEFAULT_NULL_HANDLING),
-	      window_enum(window_enum) {
+	    : BaseScalarFunction(name, arguments, return_type), window_enum(window_enum) {
 		callbacks.bind = bind;
 		callbacks.bounds = bounds;
 		callbacks.sharing = sharing;
@@ -317,54 +329,59 @@ public:
 
 public:
 	bool CanDistinct() const {
-		return can_distinct;
+		return properties.can_distinct;
 	}
 	bool CanFilter() const {
-		return can_filter;
+		return properties.can_filter;
 	}
 	bool CanOrderBy() const {
-		return can_order_by;
+		return properties.can_order_by;
 	}
 	bool CanExclude() const {
-		return can_exclude;
+		return properties.can_exclude;
 	}
 	bool CanIgnoreNulls() const {
-		return can_ignore_nulls;
+		return properties.can_ignore_nulls;
 	}
-
 	void SetCanDistinct(bool value) {
-		can_distinct = value;
+		properties.can_distinct = value;
 	}
 	void SetCanFilter(bool value) {
-		can_filter = value;
+		properties.can_filter = value;
 	}
 	void SetCanOrderBy(bool value) {
-		can_order_by = value;
+		properties.can_order_by = value;
 	}
 	void SetCanExclude(bool value) {
-		can_exclude = value;
+		properties.can_exclude = value;
 	}
 	void SetCanIgnoreNulls(bool value) {
-		can_ignore_nulls = value;
+		properties.can_ignore_nulls = value;
 	}
 
 protected:
-	//! Does the window function support DISTINCT?
-	bool can_distinct = false;
-	//! Does the window function support FILTER?
-	bool can_filter = false;
-	//! Does the window function support ORDER BY arguments?
-	bool can_order_by = true;
-	//! Does the window function support EXCLUDE?
-	bool can_exclude = false;
-	//! Does the window function support RESPECT/IGNORE NULLS?
-	bool can_ignore_nulls = true;
-
+	WindowFunctionProperties properties;
 	WindowFunctionCallbacks callbacks;
 
 	//! Additional function info, passed to the bind
 	shared_ptr<WindowFunctionInfo> function_info;
 
+public:
+	// clang-format off
+	FunctionStability GetStability() const { return properties.stability; }
+	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
+	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
+	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
+	FunctionErrors GetErrorMode() const { return properties.errors; }
+	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
+	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
+	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+	// clang-format on
 public:
 	bool HasExtraFunctionInfo() const {
 		return function_info != nullptr;

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -218,9 +218,9 @@ public:
 	    : WindowFunction("duckweed", {LogicalType::ANY}, LogicalType::ANY, ExpressionType::WINDOW_FUNCTION, Bind,
 	                     GetBounds, GetSharing, GetGlobal, GetLocal, nullptr, Finalizer, GetData) {
 		//	Not implemented
-		can_order_by = false;
+		SetCanOrderBy(false);
 		//	We are filling in NULLs
-		can_ignore_nulls = false;
+		SetCanIgnoreNulls(false);
 
 		SetCanStreamCallback(CanStream);
 		SetStreamingStateCallback(GetStreamingState);


### PR DESCRIPTION
Followup from #22219, this PR moves the callbacks and "properties" into separate structs so that they can easily be passed into future "Bound(Scalar/Aggregate/Window)" function objects.