### PR TITLE
Fix duckdb_param_type returning INVALID for nested casts

### DIFF
--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -76,6 +76,13 @@ static unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr,
 			parameter.return_type = parameter.parameter_data->return_type;
 			return expr;
 		}
+		// If this occurrence's own return_type still matches parameter_data->return_type, the
+		// parameter was pinned by an inner cast on this same occurrence (e.g. CAST(CAST($1 AS A) AS B)).
+		// Add a regular cast on top instead of invalidating.
+		if (parameter.return_type == parameter.parameter_data->return_type) {
+			auto cast_function = cast_functions.GetCastFunction(parameter.return_type, target_type, get_input);
+			return AddCastExpressionInternal(std::move(expr), target_type, std::move(cast_function), try_cast);
+		}
 		// invalidate the type
 		parameter.parameter_data->return_type = LogicalType::INVALID;
 		parameter.return_type = target_type;

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -398,6 +398,43 @@ TEST_CASE("Test duckdb_param_type and duckdb_param_logical_type", "[capi]") {
 	duckdb_close(&db);
 }
 
+TEST_CASE("Test duckdb_param_type with nested casts", "[capi]") {
+	duckdb_database db;
+	duckdb_connection conn;
+	duckdb_prepared_statement stmt;
+
+	REQUIRE(duckdb_open("", &db) == DuckDBSuccess);
+	REQUIRE(duckdb_connect(db, &conn) == DuckDBSuccess);
+
+	// Single cast: parameter type is the inner cast target.
+	REQUIRE(duckdb_prepare(conn, "SELECT CAST($1 AS INTEGER)", &stmt) == DuckDBSuccess);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INTEGER);
+	duckdb_destroy_prepare(&stmt);
+
+	// Nested cast: parameter type should still be the innermost cast target.
+	REQUIRE(duckdb_prepare(conn, "SELECT CAST(CAST($1 AS INTEGER) AS VARCHAR)", &stmt) == DuckDBSuccess);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INTEGER);
+	duckdb_destroy_prepare(&stmt);
+
+	REQUIRE(duckdb_prepare(conn, "SELECT CAST(CAST($1 AS TIMESTAMPTZ) AS VARCHAR)", &stmt) == DuckDBSuccess);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_TIMESTAMP_TZ);
+	duckdb_destroy_prepare(&stmt);
+
+	// Triple-nested cast: still pinned by the innermost target.
+	REQUIRE(duckdb_prepare(conn, "SELECT CAST(CAST(CAST($1 AS INTEGER) AS BIGINT) AS VARCHAR)", &stmt) ==
+	        DuckDBSuccess);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INTEGER);
+	duckdb_destroy_prepare(&stmt);
+
+	// Multiple independent casts on the same parameter remain ambiguous and invalidate.
+	REQUIRE(duckdb_prepare(conn, "SELECT $1::INTEGER + $1::BIGINT", &stmt) == DuckDBSuccess);
+	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_INVALID);
+	duckdb_destroy_prepare(&stmt);
+
+	duckdb_disconnect(&conn);
+	duckdb_close(&db);
+}
+
 TEST_CASE("Test prepared statements with named parameters in C API", "[capi]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;


### PR DESCRIPTION
Closes #22187

## Summary

For prepared statements like `CAST(CAST($1 AS A) AS B)`, the outer cast was hitting the same `BoundParameterExpression` already pinned by the inner cast and treating the outer `target_type` as a conflicting second opinion, so the parameter ended up invalidated:

| SQL | `duckdb_param_type($1)` (before / after) |
|---|---|
| `SELECT CAST($1 AS INTEGER)` | `INTEGER` / `INTEGER` |
| `SELECT CAST(CAST($1 AS INTEGER) AS VARCHAR)` | **`INVALID`** / `INTEGER` |
| `SELECT CAST(CAST($1 AS TIMESTAMPTZ) AS VARCHAR)` | **`INVALID`** / `TIMESTAMPTZ` |
| `SELECT $1::INTEGER + $1::BIGINT` | `INVALID` / `INVALID` (unchanged) |

The fix follows the approach proposed by @MBkkt in the issue: distinguish nested-cast from genuine ambiguity by checking whether this occurrence's `return_type` still matches `parameter_data->return_type`. If it does, the inner cast pinned this same occurrence — add a regular A→B cast on top. If not (separate occurrence sharing the same `parameter_data`), invalidate as before.

## Test plan

- [x] New `[capi]` test case covering single, double, and triple nested casts plus the existing `$1::A + $1::B` ambiguity case
- [x] All `[capi]` tests pass (704432 assertions / 154 cases)
- [x] All `test/sql/prepared/*` tests pass (1490 assertions / 37 cases)