### PR TITLE
CLI: disable 'FROM _' style queryies by default

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -205,6 +205,8 @@ public:
 	string initFile;
 	bool run_init = true;
 	unique_ptr<duckdb::MaterializedQueryResult> last_result;
+	//! Is previous result (_) available via SQL
+	bool queryable_underscore = false;
 	//! If the following flag is set, then command execution stops at an error
 	BailOnError bail = BailOnError::AUTOMATIC;
 	//! Table name when rendering a DESCRIBE statement
@@ -428,6 +430,7 @@ public:
 	static MetadataResult SetSeparator(ShellState &state, const vector<string> &args);
 	static MetadataResult EnableSafeMode(ShellState &state, const vector<string> &args);
 	static MetadataResult ToggleTimer(ShellState &state, const vector<string> &args);
+	static MetadataResult ToggleQueryableUnderscore(ShellState &state, const vector<string> &args);
 	SuccessState ChangeDirectory(const string &path);
 	SuccessState ShowDatabases();
 	void CloseOutputFile(FILE *file);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1014,6 +1014,12 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 				cMode = RenderMode::DESCRIBE;
 			}
 
+			if (!queryable_underscore) {
+				// Release the previous result before next statement to avoid memory doubling.
+				// `_` SQL reference is therefore unavailable in default mode; opt in via
+				// `.queryable_underscore on`. `.last` still works between prompts.
+				last_result.reset();
+			}
 			auto rc = ExecuteStatement(std::move(statement));
 			if (rc != SuccessState::SUCCESS) {
 				return rc;
@@ -2387,6 +2393,11 @@ MetadataResult ShellState::ToggleTimer(ShellState &state, const vector<string> &
 		state.PrintF(PrintOutput::STDERR, "Error: timer not available on this system.\n");
 		enableTimer = false;
 	}
+	return MetadataResult::SUCCESS;
+}
+
+MetadataResult ShellState::ToggleQueryableUnderscore(ShellState &state, const vector<string> &args) {
+	state.queryable_underscore = state.StringToBool(args[1]);
 	return MetadataResult::SUCCESS;
 }
 

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -42,6 +42,10 @@ unique_ptr<TableRef> ShellScanLastResult(ClientContext &context, ReplacementScan
 	}
 	auto &state = duckdb_shell::ShellState::Get();
 	if (!state.last_result) {
+		if (!state.queryable_underscore) {
+			throw BinderException("`_` is not available: queryable underscore is disabled by default.\n"
+			                      "Run `.queryable_underscore on`, then re-run your query, to make `_` available.");
+		}
 		throw BinderException("Failed to query last result \"_\": no result available");
 	}
 	return make_uniq<ColumnDataRef>(state.last_result->Collection(), state.last_result->names);

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -920,6 +920,8 @@ static const MetadataCommand metadata_commands[] = {
     {"tables", 0, ShowTables, "?TABLE?", "List names of tables matching LIKE pattern TABLE", 2, ""},
     {"thousand_sep", 0, SetThousandSep, "SEP",
      "Sets the thousand separator used when rendering numbers. Only for duckbox mode.", 4, ""},
+    {"queryable_underscore", 2, ShellState::ToggleQueryableUnderscore, "on|off",
+     "Toggle whether `_` SQL replacement is available", 0, ""},
     {"timer", 2, ShellState::ToggleTimer, "on|off", "Turn SQL timer on or off", 0, ""},
     {"ui_command", 0, SetUICommand, "[command]", "Set the UI command", 0, ""},
     {"version", 1, ShowVersion, "", "Show the version", 0, ""},


### PR DESCRIPTION
Saving previous result until completion can have a significant memory impact, that might translate to unpredicatable timings when memory pressure is an issues. Let's avoid worst case of possibly doubling working memory size, with a perf concious default. .last keeps working, and if an users does  the bind time error points to ".queryable_underscore on"

Funny reproducer is:
```sql
CREATE TABLE T AS FROM range(2000000000);
.timer on
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
```
that is somewhat (on my machine) 2x slower and way more jittery than the following variant than on paper perform strictly more work:
```sql
CREATE TABLE T AS FROM range(2000000000);
.timer on
SELECT 'quack'; SELECT random() FROM T;
SELECT 'quack'; SELECT random() FROM T;
SELECT 'quack'; SELECT random() FROM T;
SELECT 'quack'; SELECT random() FROM T;
SELECT 'quack'; SELECT random() FROM T;
SELECT 'quack'; SELECT random() FROM T;
```

Both script were run like:
```
./build/release/duckdb -f file.sql
```