### PR TITLE
Optimize regexp_replace for anchored capture-then-truncate patterns

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "utf8proc_wrapper.hpp"
@@ -150,16 +152,12 @@ RegexpReplaceBindData::RegexpReplaceBindData(duckdb_re2::RE2::Options options, s
 
 unique_ptr<FunctionData> RegexpReplaceBindData::Copy() const {
 	auto copy = make_uniq<RegexpReplaceBindData>(options, constant_string, constant_pattern, global_replace);
-	copy->short_extract_candidate = short_extract_candidate;
-	copy->short_pattern_string = short_pattern_string;
 	return std::move(copy);
 }
 
 bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
 	auto &other = other_p.Cast<RegexpReplaceBindData>();
-	return RegexpBaseBindData::Equals(other) && global_replace == other.global_replace &&
-	       short_extract_candidate == other.short_extract_candidate &&
-	       short_pattern_string == other.short_pattern_string;
+	return RegexpBaseBindData::Equals(other) && global_replace == other.global_replace;
 }
 
 static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input) {
@@ -175,15 +173,6 @@ static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input)
 	return std::move(data);
 }
 
-static unique_ptr<FunctionLocalState>
-RegexReplaceInitLocalState(ExpressionState &state, const BoundFunctionExpression &expr, FunctionData *bind_data) {
-	auto &info = bind_data->Cast<RegexpReplaceBindData>();
-	if (info.constant_pattern) {
-		return make_uniq<RegexReplaceLocalState>(info);
-	}
-	return nullptr;
-}
-
 static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &info = func_expr.bind_info->Cast<RegexpReplaceBindData>();
@@ -194,34 +183,14 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 
 	auto &heap = StringVector::GetStringHeap(result);
 	if (info.constant_pattern) {
-		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexReplaceLocalState>();
-		if (lstate.fast_path) {
-			// Slice capture group 1 directly out of the input vector via the trimmed pattern.
-			StringVector::AddHeapReference(result, strings);
-			const auto &re = *lstate.pattern;
-			UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-				duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
-				duckdb_re2::StringPiece submatch[2];
-				bool matched = re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::ANCHOR_START, submatch, 2);
-				if (matched) {
-					const char *match_end = submatch[0].data() + submatch[0].size();
-					const char *input_end = in_piece.data() + in_piece.size();
-					auto remainder = static_cast<size_t>(input_end - match_end);
-					if (std::memchr(match_end, '\n', remainder) == nullptr) {
-						return string_t(submatch[1].data(), UnsafeNumericCast<uint32_t>(submatch[1].size()));
-					}
-				}
-				return input;
-			});
-			return;
-		}
+		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, replaces, result, args.size(), [&](string_t input, string_t replace) {
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, *lstate.pattern, CreateStringPiece(replace));
+				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
 			    } else {
-				    RE2::Replace(&sstring, *lstate.pattern, CreateStringPiece(replace));
+				    RE2::Replace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
 			    }
 			    return heap.AddString(sstring);
 		    });
@@ -250,18 +219,31 @@ RegexpExtractBindData::RegexpExtractBindData() {
 }
 
 RegexpExtractBindData::RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string_p,
-                                             bool constant_pattern, string group_string_p)
+                                             bool constant_pattern, string group_string_p, bool no_match_returns_input,
+                                             bool trim_dotstar_dollar)
     : RegexpBaseBindData(options, std::move(constant_string_p), constant_pattern),
-      group_string(std::move(group_string_p)), rewrite(group_string) {
+      group_string(std::move(group_string_p)), rewrite(group_string), no_match_returns_input(no_match_returns_input),
+      trim_dotstar_dollar(trim_dotstar_dollar) {
 }
 
 unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
-	return make_uniq<RegexpExtractBindData>(options, constant_string, constant_pattern, group_string);
+	return make_uniq<RegexpExtractBindData>(options, constant_string, constant_pattern, group_string,
+	                                        no_match_returns_input, trim_dotstar_dollar);
 }
 
 bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
 	auto &other = other_p.Cast<RegexpExtractBindData>();
-	return RegexpBaseBindData::Equals(other) && group_string == other.group_string;
+	return RegexpBaseBindData::Equals(other) && group_string == other.group_string &&
+	       no_match_returns_input == other.no_match_returns_input && trim_dotstar_dollar == other.trim_dotstar_dollar;
+}
+
+// Returns the index of the requested capture group when the rewrite is a single backreference
+// (e.g. `\1`), or -1 otherwise. Single-backref rewrites permit a zero-copy slice of the input.
+static int8_t GetSingleBackrefGroup(const string &group_string) {
+	if (group_string.size() != 2 || group_string[0] != '\\' || group_string[1] < '0' || group_string[1] > '9') {
+		return -1;
+	}
+	return static_cast<int8_t>(group_string[1] - '0');
 }
 
 static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -271,17 +253,45 @@ static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector
 	auto &strings = args.data[0];
 	auto &patterns = args.data[1];
 	auto &heap = StringVector::GetStringHeap(result);
+	const int8_t backref_group = GetSingleBackrefGroup(info.group_string);
+	const bool reference_input = backref_group >= 0 || info.no_match_returns_input;
+	if (reference_input) {
+		StringVector::AddHeapReference(result, strings);
+	}
 	if (info.constant_pattern) {
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
+		const auto &re = lstate.constant_pattern;
+		if (backref_group >= 0 && backref_group <= re.NumberOfCapturingGroups()) {
+			const int nsubmatch = backref_group + 1;
+			const bool check_remainder_newline = info.trim_dotstar_dollar;
+			UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
+				duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
+				duckdb_re2::StringPiece submatch[10];
+				if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
+					if (check_remainder_newline) {
+						const char *match_end = submatch[0].data() + submatch[0].size();
+						const char *input_end = in_piece.data() + in_piece.size();
+						auto remainder = static_cast<size_t>(input_end - match_end);
+						if (std::memchr(match_end, '\n', remainder) != nullptr) {
+							return info.no_match_returns_input ? input : string_t(nullptr, 0);
+						}
+					}
+					return string_t(submatch[backref_group].data(),
+					                UnsafeNumericCast<uint32_t>(submatch[backref_group].size()));
+				}
+				return info.no_match_returns_input ? input : string_t(nullptr, 0);
+			});
+			return;
+		}
 		UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-			return Extract(input, heap, lstate.constant_pattern, info.rewrite);
+			return Extract(input, heap, re, info.rewrite, info.no_match_returns_input);
 		});
 	} else {
-		BinaryExecutor::Execute<string_t, string_t, string_t>(strings, patterns, result, args.size(),
-		                                                      [&](string_t input, string_t pattern) {
-			                                                      RE2 re(CreateStringPiece(pattern), info.options);
-			                                                      return Extract(input, heap, re, info.rewrite);
-		                                                      });
+		BinaryExecutor::Execute<string_t, string_t, string_t>(
+		    strings, patterns, result, args.size(), [&](string_t input, string_t pattern) {
+			    RE2 re(CreateStringPiece(pattern), info.options);
+			    return Extract(input, heap, re, info.rewrite, info.no_match_returns_input);
+		    });
 	}
 }
 
@@ -374,8 +384,9 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 	string constant_string;
 	bool constant_pattern = TryParseConstantPattern(context, *arguments[1], constant_string);
 
+	bool no_match_returns_input = false;
 	if (arguments.size() >= 4) {
-		ParseRegexOptions(context, *arguments[3], options);
+		ParseRegexOptions(context, *arguments[3], options, nullptr, &no_match_returns_input);
 	}
 
 	string group_string = "\\0";
@@ -399,7 +410,7 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 			                                constant_pattern, dummy_names, struct_children);
 			bound_function.SetReturnType(LogicalType::STRUCT(struct_children));
 		} else {
-			auto group_idx = group.GetValue<int32_t>();
+			int32_t group_idx = group.GetValue<int32_t>();
 			if (group_idx < 0 || group_idx > 9) {
 				throw InvalidInputException("Group index must be between 0 and 9!");
 			}
@@ -407,8 +418,40 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 		}
 	}
 
+	// trim_dotstar_dollar is set only by the regexp_replace -> regexp_extract optimizer rewrite.
 	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern,
-	                                        std::move(group_string));
+	                                        std::move(group_string), no_match_returns_input, false);
+}
+
+// Custom serialize/deserialize: the optimizer rewrite trims the pattern in the children and sets
+// trim_dotstar_dollar on the bind data. After the trim the bind callback can no longer detect the
+// pre-trim shape, so we round-trip the full bind data here instead of re-running the bind callback.
+static void RegexExtractSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
+                                  const ScalarFunction &) {
+	auto &info = bind_data->Cast<RegexpExtractBindData>();
+	serializer.WriteProperty(100, "case_sensitive", info.options.case_sensitive());
+	serializer.WriteProperty(101, "dot_nl", info.options.dot_nl());
+	serializer.WriteProperty(102, "literal", info.options.literal());
+	serializer.WriteProperty(103, "constant_string", info.constant_string);
+	serializer.WriteProperty(104, "constant_pattern", info.constant_pattern);
+	serializer.WriteProperty(105, "group_string", info.group_string);
+	serializer.WriteProperty(106, "no_match_returns_input", info.no_match_returns_input);
+	serializer.WriteProperty(107, "trim_dotstar_dollar", info.trim_dotstar_dollar);
+}
+
+static unique_ptr<FunctionData> RegexExtractDeserialize(Deserializer &deserializer, ScalarFunction &) {
+	duckdb_re2::RE2::Options options;
+	options.set_case_sensitive(deserializer.ReadProperty<bool>(100, "case_sensitive"));
+	options.set_dot_nl(deserializer.ReadProperty<bool>(101, "dot_nl"));
+	options.set_literal(deserializer.ReadProperty<bool>(102, "literal"));
+	options.set_log_errors(false);
+	auto constant_string = deserializer.ReadProperty<string>(103, "constant_string");
+	auto constant_pattern = deserializer.ReadProperty<bool>(104, "constant_pattern");
+	auto group_string = deserializer.ReadProperty<string>(105, "group_string");
+	auto no_match_returns_input = deserializer.ReadProperty<bool>(106, "no_match_returns_input");
+	auto trim_dotstar_dollar = deserializer.ReadProperty<bool>(107, "trim_dotstar_dollar");
+	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern,
+	                                        std::move(group_string), no_match_returns_input, trim_dotstar_dollar);
 }
 
 ScalarFunctionSet RegexpFun::GetFunctions() {
@@ -444,28 +487,38 @@ ScalarFunctionSet RegexpReplaceFun::GetFunctions() {
 	ScalarFunctionSet regexp_replace("regexp_replace");
 	regexp_replace.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                          LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr,
-	                                          RegexReplaceInitLocalState));
-	regexp_replace.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	    RegexReplaceFunction, RegexReplaceBind, nullptr, RegexReplaceInitLocalState));
+	                                          RegexInitLocalState));
+	regexp_replace.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr, RegexInitLocalState));
 	return (regexp_replace);
 }
 
 ScalarFunctionSet RegexpExtractFun::GetFunctions() {
 	ScalarFunctionSet regexp_extract("regexp_extract");
-	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                          RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
-	                                          LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                                          FunctionNullHandling::SPECIAL_HANDLING));
-	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
-	                                          LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr,
-	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                                          FunctionNullHandling::SPECIAL_HANDLING));
-	regexp_extract.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
-	                   LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
-	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
+	// Scalar (non-struct) variants share a fixed VARCHAR return type, so it is safe to bypass the
+	// bind callback on deserialize. The custom serialize callbacks below round-trip the
+	// trim_dotstar_dollar flag set by the regexp_replace -> regexp_extract optimizer rewrite.
+	ScalarFunction extract_2({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, RegexExtractFunction,
+	                         RegexExtractBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
+	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	ScalarFunction extract_3({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR,
+	                         RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
+	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+	ScalarFunction extract_4({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
+	                         LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                         LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                         FunctionNullHandling::SPECIAL_HANDLING);
+	for (auto *func : {&extract_2, &extract_3, &extract_4}) {
+		func->SetSerializeCallback(RegexExtractSerialize);
+		func->SetDeserializeCallback(RegexExtractDeserialize);
+	}
+	regexp_extract.AddFunction(std::move(extract_2));
+	regexp_extract.AddFunction(std::move(extract_3));
+	regexp_extract.AddFunction(std::move(extract_4));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...])
+	// Struct variants mutate the function return type at bind time (VARCHAR -> STRUCT(...)), so the
+	// bind callback must run on deserialize; these intentionally do NOT register custom callbacks.
 	regexp_extract.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
 	                   LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind, nullptr, RegexInitLocalState,

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -11,8 +11,6 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/common/serializer/deserializer.hpp"
-#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "utf8proc_wrapper.hpp"
@@ -385,38 +383,16 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 		}
 	}
 
-	// trim_dotstar_dollar is set only by the regexp_replace -> regexp_extract optimizer rewrite.
-	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,
-	                                        no_match_returns_input, false);
-}
+	// Strip a trailing `.*$`; the runtime restores end-of-text semantics via a remainder-newline
+	// check. Gated to default newline-sensitive options and group_index >= 1 (group 0 = whole match).
+	bool trim_dotstar_dollar = false;
+	if (constant_pattern && group_index >= 1 && !options.literal() && !options.dot_nl() &&
+	    constant_string.size() >= 4 && constant_string.front() == '^' &&
+	    constant_string.compare(constant_string.size() - 3, 3, ".*$") == 0) {
+		constant_string.resize(constant_string.size() - 3);
+		trim_dotstar_dollar = true;
+	}
 
-// Custom serialize/deserialize: the optimizer rewrite trims the pattern in the children and sets
-// trim_dotstar_dollar on the bind data. After the trim the bind callback can no longer detect the
-// pre-trim shape, so we round-trip the full bind data here instead of re-running the bind callback.
-static void RegexExtractSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
-                                  const ScalarFunction &) {
-	auto &info = bind_data->Cast<RegexpExtractBindData>();
-	serializer.WriteProperty(100, "case_sensitive", info.options.case_sensitive());
-	serializer.WriteProperty(101, "dot_nl", info.options.dot_nl());
-	serializer.WriteProperty(102, "literal", info.options.literal());
-	serializer.WriteProperty(103, "constant_string", info.constant_string);
-	serializer.WriteProperty(104, "constant_pattern", info.constant_pattern);
-	serializer.WriteProperty(105, "group_index", info.group_index);
-	serializer.WriteProperty(106, "no_match_returns_input", info.no_match_returns_input);
-	serializer.WriteProperty(107, "trim_dotstar_dollar", info.trim_dotstar_dollar);
-}
-
-static unique_ptr<FunctionData> RegexExtractDeserialize(Deserializer &deserializer, ScalarFunction &) {
-	duckdb_re2::RE2::Options options;
-	options.set_case_sensitive(deserializer.ReadProperty<bool>(100, "case_sensitive"));
-	options.set_dot_nl(deserializer.ReadProperty<bool>(101, "dot_nl"));
-	options.set_literal(deserializer.ReadProperty<bool>(102, "literal"));
-	options.set_log_errors(false);
-	auto constant_string = deserializer.ReadProperty<string>(103, "constant_string");
-	auto constant_pattern = deserializer.ReadProperty<bool>(104, "constant_pattern");
-	auto group_index = deserializer.ReadProperty<int8_t>(105, "group_index");
-	auto no_match_returns_input = deserializer.ReadProperty<bool>(106, "no_match_returns_input");
-	auto trim_dotstar_dollar = deserializer.ReadProperty<bool>(107, "trim_dotstar_dollar");
 	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,
 	                                        no_match_returns_input, trim_dotstar_dollar);
 }
@@ -463,29 +439,19 @@ ScalarFunctionSet RegexpReplaceFun::GetFunctions() {
 
 ScalarFunctionSet RegexpExtractFun::GetFunctions() {
 	ScalarFunctionSet regexp_extract("regexp_extract");
-	// Scalar (non-struct) variants share a fixed VARCHAR return type, so it is safe to bypass the
-	// bind callback on deserialize. The custom serialize callbacks below round-trip the
-	// trim_dotstar_dollar flag set by the regexp_replace -> regexp_extract optimizer rewrite.
-	ScalarFunction extract_2({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, RegexExtractFunction,
-	                         RegexExtractBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
-	ScalarFunction extract_3({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::VARCHAR,
-	                         RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState, LogicalType::INVALID,
-	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
-	ScalarFunction extract_4({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
-	                         LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
-	                         LogicalType::INVALID, FunctionStability::CONSISTENT,
-	                         FunctionNullHandling::SPECIAL_HANDLING);
-	for (auto *func : {&extract_2, &extract_3, &extract_4}) {
-		func->SetSerializeCallback(RegexExtractSerialize);
-		func->SetDeserializeCallback(RegexExtractDeserialize);
-	}
-	regexp_extract.AddFunction(std::move(extract_2));
-	regexp_extract.AddFunction(std::move(extract_3));
-	regexp_extract.AddFunction(std::move(extract_4));
+	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                          RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                                          LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
+	                                          LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr,
+	                                          RegexInitLocalState, LogicalType::INVALID, FunctionStability::CONSISTENT,
+	                                          FunctionNullHandling::SPECIAL_HANDLING));
+	regexp_extract.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
+	                   LogicalType::VARCHAR, RegexExtractFunction, RegexExtractBind, nullptr, RegexInitLocalState,
+	                   LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
 	// REGEXP_EXTRACT(<string>, <pattern>, [<group 1 name>[, <group n name>]...])
-	// Struct variants mutate the function return type at bind time (VARCHAR -> STRUCT(...)), so the
-	// bind callback must run on deserialize; these intentionally do NOT register custom callbacks.
 	regexp_extract.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::VARCHAR)},
 	                   LogicalType::VARCHAR, RegexExtractStructFunction, RegexExtractBind, nullptr, RegexInitLocalState,

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -15,6 +15,8 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "utf8proc_wrapper.hpp"
 
+#include <cstring>
+
 namespace duckdb {
 
 using regexp_util::CreateStringPiece;
@@ -148,12 +150,36 @@ RegexpReplaceBindData::RegexpReplaceBindData(duckdb_re2::RE2::Options options, s
 
 unique_ptr<FunctionData> RegexpReplaceBindData::Copy() const {
 	auto copy = make_uniq<RegexpReplaceBindData>(options, constant_string, constant_pattern, global_replace);
+	copy->short_extract_candidate = short_extract_candidate;
+	copy->short_pattern_string = short_pattern_string;
 	return std::move(copy);
 }
 
 bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
 	auto &other = other_p.Cast<RegexpReplaceBindData>();
-	return RegexpBaseBindData::Equals(other) && global_replace == other.global_replace;
+	return RegexpBaseBindData::Equals(other) && global_replace == other.global_replace &&
+	       short_extract_candidate == other.short_extract_candidate &&
+	       short_pattern_string == other.short_pattern_string;
+}
+
+// Bind-time gate for the short-extract fast path; capture-count is checked at local-state init.
+static bool TryDetectShortExtractShape(ClientContext &context, Expression &replace_expr, const string &pattern,
+                                       const RE2::Options &options, string &out_short_pattern) {
+	if (pattern.size() < 4 || pattern.front() != '^' || pattern.compare(pattern.size() - 3, 3, ".*$") != 0) {
+		return false;
+	}
+	if (options.dot_nl() || options.literal()) {
+		return false;
+	}
+	string constant_replace;
+	if (!TryParseConstantPattern(context, replace_expr, constant_replace)) {
+		return false;
+	}
+	if (constant_replace.size() != 2 || constant_replace[0] != '\\' || constant_replace[1] != '1') {
+		return false;
+	}
+	out_short_pattern = pattern.substr(0, pattern.size() - 3);
+	return true;
 }
 
 static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input) {
@@ -166,7 +192,24 @@ static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input)
 		ParseRegexOptions(context, *arguments[3], data->options, &data->global_replace);
 	}
 	data->options.set_log_errors(false);
+
+	if (data->constant_pattern && !data->global_replace) {
+		string short_pat;
+		if (TryDetectShortExtractShape(context, *arguments[2], data->constant_string, data->options, short_pat)) {
+			data->short_extract_candidate = true;
+			data->short_pattern_string = std::move(short_pat);
+		}
+	}
 	return std::move(data);
+}
+
+static unique_ptr<FunctionLocalState>
+RegexReplaceInitLocalState(ExpressionState &state, const BoundFunctionExpression &expr, FunctionData *bind_data) {
+	auto &info = bind_data->Cast<RegexpReplaceBindData>();
+	if (info.constant_pattern) {
+		return make_uniq<RegexReplaceLocalState>(info);
+	}
+	return nullptr;
 }
 
 static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -179,14 +222,34 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 
 	auto &heap = StringVector::GetStringHeap(result);
 	if (info.constant_pattern) {
-		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
+		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexReplaceLocalState>();
+		if (lstate.fast_path) {
+			// Slice capture group 1 directly out of the input vector via the trimmed pattern.
+			StringVector::AddHeapReference(result, strings);
+			const auto &re = *lstate.pattern;
+			UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
+				duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
+				duckdb_re2::StringPiece submatch[2];
+				bool matched = re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::ANCHOR_START, submatch, 2);
+				if (matched) {
+					const char *match_end = submatch[0].data() + submatch[0].size();
+					const char *input_end = in_piece.data() + in_piece.size();
+					auto remainder = static_cast<size_t>(input_end - match_end);
+					if (std::memchr(match_end, '\n', remainder) == nullptr) {
+						return string_t(submatch[1].data(), UnsafeNumericCast<uint32_t>(submatch[1].size()));
+					}
+				}
+				return input;
+			});
+			return;
+		}
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, replaces, result, args.size(), [&](string_t input, string_t replace) {
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
+				    RE2::GlobalReplace(&sstring, *lstate.pattern, CreateStringPiece(replace));
 			    } else {
-				    RE2::Replace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
+				    RE2::Replace(&sstring, *lstate.pattern, CreateStringPiece(replace));
 			    }
 			    return heap.AddString(sstring);
 		    });
@@ -409,10 +472,10 @@ ScalarFunctionSet RegexpReplaceFun::GetFunctions() {
 	ScalarFunctionSet regexp_replace("regexp_replace");
 	regexp_replace.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                          LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr,
-	                                          RegexInitLocalState));
-	regexp_replace.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                   LogicalType::VARCHAR, RegexReplaceFunction, RegexReplaceBind, nullptr, RegexInitLocalState));
+	                                          RegexReplaceInitLocalState));
+	regexp_replace.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	    RegexReplaceFunction, RegexReplaceBind, nullptr, RegexReplaceInitLocalState));
 	return (regexp_replace);
 }
 

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -16,8 +16,6 @@
 #include "re2/stringpiece.h"
 #include "utf8proc_wrapper.hpp"
 
-#include <cstring>
-
 namespace duckdb {
 
 using regexp_util::CreateStringPiece;
@@ -25,10 +23,9 @@ using regexp_util::ParseRegexOptions;
 using regexp_util::TryParseConstantPattern;
 
 // Zero-copy slice of capture group `group_index` from `input`'s buffer; caller must call
-// StringVector::AddHeapReference(result, source) first. check_remainder_newline=true rejects
-// matches whose remainder contains `\n` (used after RegexExtractBind has stripped a trailing `.*$`).
+// StringVector::AddHeapReference(result, source) first.
 static inline string_t ExtractCaptureGroup(const string_t &input, const RE2 &re, int8_t group_index,
-                                           bool no_match_returns_input, bool check_remainder_newline) {
+                                           bool no_match_returns_input) {
 	if (group_index < 0 || group_index > re.NumberOfCapturingGroups()) {
 		return no_match_returns_input ? input : string_t(nullptr, 0);
 	}
@@ -36,14 +33,6 @@ static inline string_t ExtractCaptureGroup(const string_t &input, const RE2 &re,
 	duckdb_re2::StringPiece submatch[10];
 	const int nsubmatch = group_index + 1;
 	if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
-		if (check_remainder_newline) {
-			const char *match_end = submatch[0].data() + submatch[0].size();
-			const char *input_end = in_piece.data() + in_piece.size();
-			const auto remainder = static_cast<size_t>(input_end - match_end);
-			if (std::memchr(match_end, '\n', remainder) != nullptr) {
-				return no_match_returns_input ? input : string_t(nullptr, 0);
-			}
-		}
 		return string_t(submatch[group_index].data(), UnsafeNumericCast<uint32_t>(submatch[group_index].size()));
 	}
 	return no_match_returns_input ? input : string_t(nullptr, 0);
@@ -242,21 +231,20 @@ RegexpExtractBindData::RegexpExtractBindData() {
 }
 
 RegexpExtractBindData::RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string_p,
-                                             bool constant_pattern, int8_t group_index, bool no_match_returns_input,
-                                             bool trim_dotstar_dollar)
+                                             bool constant_pattern, int8_t group_index, bool no_match_returns_input)
     : RegexpBaseBindData(options, std::move(constant_string_p), constant_pattern), group_index(group_index),
-      no_match_returns_input(no_match_returns_input), trim_dotstar_dollar(trim_dotstar_dollar) {
+      no_match_returns_input(no_match_returns_input) {
 }
 
 unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
 	return make_uniq<RegexpExtractBindData>(options, constant_string, constant_pattern, group_index,
-	                                        no_match_returns_input, trim_dotstar_dollar);
+	                                        no_match_returns_input);
 }
 
 bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
 	auto &other = other_p.Cast<RegexpExtractBindData>();
 	return RegexpBaseBindData::Equals(other) && group_index == other.group_index &&
-	       no_match_returns_input == other.no_match_returns_input && trim_dotstar_dollar == other.trim_dotstar_dollar;
+	       no_match_returns_input == other.no_match_returns_input;
 }
 
 static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -269,21 +257,18 @@ static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector
 	// no_match_returns_input is set), so register the heap reference once per chunk regardless of
 	// per-row outcomes.
 	StringVector::AddHeapReference(result, strings);
-	const bool check_remainder_newline = info.trim_dotstar_dollar;
 
 	if (info.constant_pattern) {
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		const auto &re = lstate.constant_pattern;
 		UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-			return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input,
-			                           check_remainder_newline);
+			return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input);
 		});
 	} else {
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, patterns, result, args.size(), [&](string_t input, string_t pattern) {
 			    RE2 re(CreateStringPiece(pattern), info.options);
-			    return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input,
-			                               check_remainder_newline);
+			    return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input);
 		    });
 	}
 }
@@ -412,23 +397,8 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 		}
 	}
 
-	// Strip a trailing `.*$`; the runtime restores end-of-text semantics via a remainder-newline
-	// check. Gated to default newline-sensitive options and group_index >= 1 (group 0 = whole match).
-	// Test-compile guards the byte-suffix check against escaped `.` (e.g. `^(a)\.*$`).
-	bool trim_dotstar_dollar = false;
-	if (constant_pattern && group_index >= 1 && !options.literal() && !options.dot_nl() &&
-	    constant_string.size() >= 4 && constant_string.front() == '^' &&
-	    constant_string.compare(constant_string.size() - 3, 3, ".*$") == 0) {
-		string trimmed = constant_string.substr(0, constant_string.size() - 3);
-		const duckdb_re2::RE2 trial(duckdb_re2::StringPiece(trimmed.c_str(), trimmed.size()), options);
-		if (trial.ok()) {
-			constant_string = std::move(trimmed);
-			trim_dotstar_dollar = true;
-		}
-	}
-
 	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,
-	                                        no_match_returns_input, trim_dotstar_dollar);
+	                                        no_match_returns_input);
 }
 
 ScalarFunctionSet RegexpFun::GetFunctions() {

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -414,12 +414,17 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 
 	// Strip a trailing `.*$`; the runtime restores end-of-text semantics via a remainder-newline
 	// check. Gated to default newline-sensitive options and group_index >= 1 (group 0 = whole match).
+	// Test-compile guards the byte-suffix check against escaped `.` (e.g. `^(a)\.*$`).
 	bool trim_dotstar_dollar = false;
 	if (constant_pattern && group_index >= 1 && !options.literal() && !options.dot_nl() &&
 	    constant_string.size() >= 4 && constant_string.front() == '^' &&
 	    constant_string.compare(constant_string.size() - 3, 3, ".*$") == 0) {
-		constant_string.resize(constant_string.size() - 3);
-		trim_dotstar_dollar = true;
+		string trimmed = constant_string.substr(0, constant_string.size() - 3);
+		const duckdb_re2::RE2 trial(duckdb_re2::StringPiece(trimmed.c_str(), trimmed.size()), options);
+		if (trial.ok()) {
+			constant_string = std::move(trimmed);
+			trim_dotstar_dollar = true;
+		}
 	}
 
 	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -17,8 +17,6 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "utf8proc_wrapper.hpp"
 
-#include <cstring>
-
 namespace duckdb {
 
 using regexp_util::CreateStringPiece;
@@ -219,31 +217,21 @@ RegexpExtractBindData::RegexpExtractBindData() {
 }
 
 RegexpExtractBindData::RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string_p,
-                                             bool constant_pattern, string group_string_p, bool no_match_returns_input,
+                                             bool constant_pattern, int8_t group_index, bool no_match_returns_input,
                                              bool trim_dotstar_dollar)
-    : RegexpBaseBindData(options, std::move(constant_string_p), constant_pattern),
-      group_string(std::move(group_string_p)), rewrite(group_string), no_match_returns_input(no_match_returns_input),
-      trim_dotstar_dollar(trim_dotstar_dollar) {
+    : RegexpBaseBindData(options, std::move(constant_string_p), constant_pattern), group_index(group_index),
+      no_match_returns_input(no_match_returns_input), trim_dotstar_dollar(trim_dotstar_dollar) {
 }
 
 unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
-	return make_uniq<RegexpExtractBindData>(options, constant_string, constant_pattern, group_string,
+	return make_uniq<RegexpExtractBindData>(options, constant_string, constant_pattern, group_index,
 	                                        no_match_returns_input, trim_dotstar_dollar);
 }
 
 bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
 	auto &other = other_p.Cast<RegexpExtractBindData>();
-	return RegexpBaseBindData::Equals(other) && group_string == other.group_string &&
+	return RegexpBaseBindData::Equals(other) && group_index == other.group_index &&
 	       no_match_returns_input == other.no_match_returns_input && trim_dotstar_dollar == other.trim_dotstar_dollar;
-}
-
-// Returns the index of the requested capture group when the rewrite is a single backreference
-// (e.g. `\1`), or -1 otherwise. Single-backref rewrites permit a zero-copy slice of the input.
-static int8_t GetSingleBackrefGroup(const string &group_string) {
-	if (group_string.size() != 2 || group_string[0] != '\\' || group_string[1] < '0' || group_string[1] > '9') {
-		return -1;
-	}
-	return static_cast<int8_t>(group_string[1] - '0');
 }
 
 static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -252,45 +240,23 @@ static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector
 
 	auto &strings = args.data[0];
 	auto &patterns = args.data[1];
-	auto &heap = StringVector::GetStringHeap(result);
-	const int8_t backref_group = GetSingleBackrefGroup(info.group_string);
-	const bool reference_input = backref_group >= 0 || info.no_match_returns_input;
-	if (reference_input) {
-		StringVector::AddHeapReference(result, strings);
-	}
+	// Result strings are zero-copy slices of the input vector (or the input itself when
+	// no_match_returns_input is set), so register the heap reference once per chunk regardless of
+	// per-row outcomes.
+	StringVector::AddHeapReference(result, strings);
+	const bool check_remainder_newline = info.trim_dotstar_dollar;
+
 	if (info.constant_pattern) {
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		const auto &re = lstate.constant_pattern;
-		if (backref_group >= 0 && backref_group <= re.NumberOfCapturingGroups()) {
-			const int nsubmatch = backref_group + 1;
-			const bool check_remainder_newline = info.trim_dotstar_dollar;
-			UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-				duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
-				duckdb_re2::StringPiece submatch[10];
-				if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
-					if (check_remainder_newline) {
-						const char *match_end = submatch[0].data() + submatch[0].size();
-						const char *input_end = in_piece.data() + in_piece.size();
-						auto remainder = static_cast<size_t>(input_end - match_end);
-						if (std::memchr(match_end, '\n', remainder) != nullptr) {
-							return info.no_match_returns_input ? input : string_t(nullptr, 0);
-						}
-					}
-					return string_t(submatch[backref_group].data(),
-					                UnsafeNumericCast<uint32_t>(submatch[backref_group].size()));
-				}
-				return info.no_match_returns_input ? input : string_t(nullptr, 0);
-			});
-			return;
-		}
 		UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-			return Extract(input, heap, re, info.rewrite, info.no_match_returns_input);
+			return Extract(input, re, info.group_index, info.no_match_returns_input, check_remainder_newline);
 		});
 	} else {
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, patterns, result, args.size(), [&](string_t input, string_t pattern) {
 			    RE2 re(CreateStringPiece(pattern), info.options);
-			    return Extract(input, heap, re, info.rewrite, info.no_match_returns_input);
+			    return Extract(input, re, info.group_index, info.no_match_returns_input, check_remainder_newline);
 		    });
 	}
 }
@@ -389,7 +355,7 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 		ParseRegexOptions(context, *arguments[3], options, nullptr, &no_match_returns_input);
 	}
 
-	string group_string = "\\0";
+	int8_t group_index = 0;
 	if (arguments.size() >= 3) {
 		if (arguments[2]->HasParameter()) {
 			throw ParameterNotResolvedException();
@@ -399,7 +365,8 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 		}
 		Value group = ExpressionExecutor::EvaluateScalar(context, *arguments[2]);
 		if (group.IsNull()) {
-			group_string = "";
+			// NULL group → never returns a capture; runtime treats out-of-range index as no match.
+			group_index = -1;
 		} else if (group.type().id() == LogicalTypeId::LIST) {
 			if (!constant_pattern) {
 				throw BinderException("%s with LIST of group names requires a constant pattern", bound_function.name);
@@ -414,13 +381,13 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 			if (group_idx < 0 || group_idx > 9) {
 				throw InvalidInputException("Group index must be between 0 and 9!");
 			}
-			group_string = "\\" + to_string(group_idx);
+			group_index = static_cast<int8_t>(group_idx);
 		}
 	}
 
 	// trim_dotstar_dollar is set only by the regexp_replace -> regexp_extract optimizer rewrite.
-	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern,
-	                                        std::move(group_string), no_match_returns_input, false);
+	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,
+	                                        no_match_returns_input, false);
 }
 
 // Custom serialize/deserialize: the optimizer rewrite trims the pattern in the children and sets
@@ -434,7 +401,7 @@ static void RegexExtractSerialize(Serializer &serializer, const optional_ptr<Fun
 	serializer.WriteProperty(102, "literal", info.options.literal());
 	serializer.WriteProperty(103, "constant_string", info.constant_string);
 	serializer.WriteProperty(104, "constant_pattern", info.constant_pattern);
-	serializer.WriteProperty(105, "group_string", info.group_string);
+	serializer.WriteProperty(105, "group_index", info.group_index);
 	serializer.WriteProperty(106, "no_match_returns_input", info.no_match_returns_input);
 	serializer.WriteProperty(107, "trim_dotstar_dollar", info.trim_dotstar_dollar);
 }
@@ -447,11 +414,11 @@ static unique_ptr<FunctionData> RegexExtractDeserialize(Deserializer &deserializ
 	options.set_log_errors(false);
 	auto constant_string = deserializer.ReadProperty<string>(103, "constant_string");
 	auto constant_pattern = deserializer.ReadProperty<bool>(104, "constant_pattern");
-	auto group_string = deserializer.ReadProperty<string>(105, "group_string");
+	auto group_index = deserializer.ReadProperty<int8_t>(105, "group_index");
 	auto no_match_returns_input = deserializer.ReadProperty<bool>(106, "no_match_returns_input");
 	auto trim_dotstar_dollar = deserializer.ReadProperty<bool>(107, "trim_dotstar_dollar");
-	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern,
-	                                        std::move(group_string), no_match_returns_input, trim_dotstar_dollar);
+	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, group_index,
+	                                        no_match_returns_input, trim_dotstar_dollar);
 }
 
 ScalarFunctionSet RegexpFun::GetFunctions() {

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -13,14 +13,41 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "re2/stringpiece.h"
 #include "utf8proc_wrapper.hpp"
+
+#include <cstring>
 
 namespace duckdb {
 
 using regexp_util::CreateStringPiece;
-using regexp_util::Extract;
 using regexp_util::ParseRegexOptions;
 using regexp_util::TryParseConstantPattern;
+
+// Zero-copy slice of capture group `group_index` from `input`'s buffer; caller must call
+// StringVector::AddHeapReference(result, source) first. check_remainder_newline=true rejects
+// matches whose remainder contains `\n` (used after RegexExtractBind has stripped a trailing `.*$`).
+static inline string_t ExtractCaptureGroup(const string_t &input, const RE2 &re, int8_t group_index,
+                                           bool no_match_returns_input, bool check_remainder_newline) {
+	if (group_index < 0 || group_index > re.NumberOfCapturingGroups()) {
+		return no_match_returns_input ? input : string_t(nullptr, 0);
+	}
+	duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
+	duckdb_re2::StringPiece submatch[10];
+	const int nsubmatch = group_index + 1;
+	if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
+		if (check_remainder_newline) {
+			const char *match_end = submatch[0].data() + submatch[0].size();
+			const char *input_end = in_piece.data() + in_piece.size();
+			const auto remainder = static_cast<size_t>(input_end - match_end);
+			if (std::memchr(match_end, '\n', remainder) != nullptr) {
+				return no_match_returns_input ? input : string_t(nullptr, 0);
+			}
+		}
+		return string_t(submatch[group_index].data(), UnsafeNumericCast<uint32_t>(submatch[group_index].size()));
+	}
+	return no_match_returns_input ? input : string_t(nullptr, 0);
+}
 
 static bool RegexOptionsEquals(const duckdb_re2::RE2::Options &opt_a, const duckdb_re2::RE2::Options &opt_b) {
 	return opt_a.case_sensitive() == opt_b.case_sensitive();
@@ -248,13 +275,15 @@ static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		const auto &re = lstate.constant_pattern;
 		UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
-			return Extract(input, re, info.group_index, info.no_match_returns_input, check_remainder_newline);
+			return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input,
+			                           check_remainder_newline);
 		});
 	} else {
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, patterns, result, args.size(), [&](string_t input, string_t pattern) {
 			    RE2 re(CreateStringPiece(pattern), info.options);
-			    return Extract(input, re, info.group_index, info.no_match_returns_input, check_remainder_newline);
+			    return ExtractCaptureGroup(input, re, info.group_index, info.no_match_returns_input,
+			                               check_remainder_newline);
 		    });
 	}
 }

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -162,26 +162,6 @@ bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
 	       short_pattern_string == other.short_pattern_string;
 }
 
-// Bind-time gate for the short-extract fast path; capture-count is checked at local-state init.
-static bool TryDetectShortExtractShape(ClientContext &context, Expression &replace_expr, const string &pattern,
-                                       const RE2::Options &options, string &out_short_pattern) {
-	if (pattern.size() < 4 || pattern.front() != '^' || pattern.compare(pattern.size() - 3, 3, ".*$") != 0) {
-		return false;
-	}
-	if (options.dot_nl() || options.literal()) {
-		return false;
-	}
-	string constant_replace;
-	if (!TryParseConstantPattern(context, replace_expr, constant_replace)) {
-		return false;
-	}
-	if (constant_replace.size() != 2 || constant_replace[0] != '\\' || constant_replace[1] != '1') {
-		return false;
-	}
-	out_short_pattern = pattern.substr(0, pattern.size() - 3);
-	return true;
-}
-
 static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &arguments = input.GetArguments();
@@ -192,14 +172,6 @@ static unique_ptr<FunctionData> RegexReplaceBind(BindScalarFunctionInput &input)
 		ParseRegexOptions(context, *arguments[3], data->options, &data->global_replace);
 	}
 	data->options.set_log_errors(false);
-
-	if (data->constant_pattern && !data->global_replace) {
-		string short_pat;
-		if (TryDetectShortExtractShape(context, *arguments[2], data->constant_string, data->options, short_pat)) {
-			data->short_extract_candidate = true;
-			data->short_pattern_string = std::move(short_pat);
-		}
-	}
 	return std::move(data);
 }
 

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -368,7 +368,8 @@ unique_ptr<FunctionData> RegexpExtractAll::Bind(BindScalarFunctionInput &input) 
 	if (arguments.size() >= 4) {
 		ParseRegexOptions(context, *arguments[3], options);
 	}
-	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern, "");
+	return make_uniq<RegexpExtractBindData>(options, std::move(constant_string), constant_pattern,
+	                                        static_cast<int8_t>(0));
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -13,7 +13,6 @@
 namespace duckdb {
 
 using regexp_util::CreateStringPiece;
-using regexp_util::Extract;
 using regexp_util::ParseRegexOptions;
 using regexp_util::TryParseConstantPattern;
 

--- a/src/function/scalar/string/regexp/regexp_util.cpp
+++ b/src/function/scalar/string/regexp/regexp_util.cpp
@@ -19,7 +19,8 @@ bool TryParseConstantPattern(ClientContext &context, Expression &expr, string &c
 	return false;
 }
 
-void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, bool *global_replace) {
+void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, bool *global_replace,
+                       bool *no_match_returns_input) {
 	for (idx_t i = 0; i < options.size(); i++) {
 		switch (options[i]) {
 		case 'c':
@@ -52,6 +53,14 @@ void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, 
 				throw InvalidInputException("Option 'g' (global replace) is only valid for regexp_replace");
 			}
 			break;
+		case 'k':
+			// keep (return) the input on no match instead of an empty string (regexp_extract only)
+			if (no_match_returns_input) {
+				*no_match_returns_input = true;
+			} else {
+				throw InvalidInputException("Option 'k' (keep input on no match) is only valid for regexp_extract");
+			}
+			break;
 		case ' ':
 		case '\t':
 		case '\n':
@@ -63,7 +72,8 @@ void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, 
 	}
 }
 
-void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &target, bool *global_replace) {
+void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &target, bool *global_replace,
+                       bool *no_match_returns_input) {
 	if (expr.HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
@@ -77,7 +87,7 @@ void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &t
 	if (options_str.type().id() != LogicalTypeId::VARCHAR) {
 		throw InvalidInputException("Regex options field must be a string");
 	}
-	ParseRegexOptions(StringValue::Get(options_str), target, global_replace);
+	ParseRegexOptions(StringValue::Get(options_str), target, global_replace, no_match_returns_input);
 }
 
 void ParseGroupNameList(ClientContext &context, const string &function_name, Expression &group_expr,

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -32,13 +32,29 @@ inline duckdb_re2::StringPiece CreateStringPiece(const string_t &input) {
 	return duckdb_re2::StringPiece(input.GetData(), input.GetSize());
 }
 
-inline string_t Extract(const string_t &input, StringHeap &heap, const RE2 &re, const duckdb_re2::StringPiece &rewrite,
-                        bool no_match_returns_input = false) {
-	string extracted;
-	if (!RE2::Extract(input.GetString(), re, rewrite, &extracted) && no_match_returns_input) {
-		return input;
+// Zero-copy slice of capture group `group_index` from `input`'s buffer; caller must call
+// StringVector::AddHeapReference(result, source) first. check_remainder_newline=true rejects
+// matches whose remainder contains `\n` (used after a trailing `.*$` has been stripped).
+inline string_t Extract(const string_t &input, const RE2 &re, int8_t group_index, bool no_match_returns_input,
+                        bool check_remainder_newline = false) {
+	if (group_index < 0 || group_index > re.NumberOfCapturingGroups()) {
+		return no_match_returns_input ? input : string_t(nullptr, 0);
 	}
-	return heap.AddString(extracted.c_str(), extracted.size());
+	duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
+	duckdb_re2::StringPiece submatch[10];
+	const int nsubmatch = group_index + 1;
+	if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
+		if (check_remainder_newline) {
+			const char *match_end = submatch[0].data() + submatch[0].size();
+			const char *input_end = in_piece.data() + in_piece.size();
+			const auto remainder = static_cast<size_t>(input_end - match_end);
+			if (std::memchr(match_end, '\n', remainder) != nullptr) {
+				return no_match_returns_input ? input : string_t(nullptr, 0);
+			}
+		}
+		return string_t(submatch[group_index].data(), UnsafeNumericCast<uint32_t>(submatch[group_index].size()));
+	}
+	return no_match_returns_input ? input : string_t(nullptr, 0);
 }
 
 } // namespace regexp_util
@@ -114,16 +130,17 @@ struct RegexpReplaceBindData : public RegexpBaseBindData {
 struct RegexpExtractBindData : public RegexpBaseBindData {
 	RegexpExtractBindData();
 	RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string, bool constant_pattern,
-	                      string group_string, bool no_match_returns_input = false, bool trim_dotstar_dollar = false);
+	                      int8_t group_index, bool no_match_returns_input = false, bool trim_dotstar_dollar = false);
 
-	string group_string;
-	duckdb_re2::StringPiece rewrite;
+	// `regexp_extract` always extracts a single capture group. -1 represents "no group requested"
+	// (e.g. NULL group argument), which the runtime treats as a no-match (returns empty/input).
+	int8_t group_index = 0;
 	// On no match, return the input instead of an empty string (set via the `k` option, also used by
 	// the regexp_replace -> regexp_extract optimizer rewrite).
 	bool no_match_returns_input = false;
 	// Set only by the regexp_replace -> regexp_extract optimizer rewrite when it strips a trailing
-	// `.*$` from the pattern. The runtime fast path then rejects matches whose remainder contains a
-	// newline to preserve the original pattern's end-of-text semantics under default options.
+	// `.*$` from the pattern. The runtime then rejects matches whose remainder contains a newline
+	// to preserve the original pattern's end-of-text semantics under default options.
 	// Round-trips via the regexp_extract custom serialize callbacks.
 	bool trim_dotstar_dollar = false;
 

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -32,31 +32,6 @@ inline duckdb_re2::StringPiece CreateStringPiece(const string_t &input) {
 	return duckdb_re2::StringPiece(input.GetData(), input.GetSize());
 }
 
-// Zero-copy slice of capture group `group_index` from `input`'s buffer; caller must call
-// StringVector::AddHeapReference(result, source) first. check_remainder_newline=true rejects
-// matches whose remainder contains `\n` (used after a trailing `.*$` has been stripped).
-inline string_t Extract(const string_t &input, const RE2 &re, int8_t group_index, bool no_match_returns_input,
-                        bool check_remainder_newline = false) {
-	if (group_index < 0 || group_index > re.NumberOfCapturingGroups()) {
-		return no_match_returns_input ? input : string_t(nullptr, 0);
-	}
-	duckdb_re2::StringPiece in_piece(input.GetData(), input.GetSize());
-	duckdb_re2::StringPiece submatch[10];
-	const int nsubmatch = group_index + 1;
-	if (re.Match(in_piece, 0, in_piece.size(), duckdb_re2::RE2::UNANCHORED, submatch, nsubmatch)) {
-		if (check_remainder_newline) {
-			const char *match_end = submatch[0].data() + submatch[0].size();
-			const char *input_end = in_piece.data() + in_piece.size();
-			const auto remainder = static_cast<size_t>(input_end - match_end);
-			if (std::memchr(match_end, '\n', remainder) != nullptr) {
-				return no_match_returns_input ? input : string_t(nullptr, 0);
-			}
-		}
-		return string_t(submatch[group_index].data(), UnsafeNumericCast<uint32_t>(submatch[group_index].size()));
-	}
-	return no_match_returns_input ? input : string_t(nullptr, 0);
-}
-
 } // namespace regexp_util
 
 struct RegexpExtractAll {

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -102,6 +102,8 @@ struct RegexpReplaceBindData : public RegexpBaseBindData {
 	                      bool global_replace);
 
 	bool global_replace;
+	bool short_extract_candidate = false;
+	string short_pattern_string;
 
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
@@ -186,6 +188,30 @@ struct RegexLocalState : public FunctionLocalState {
 	RE2 constant_pattern;
 	//! Used by regexp_extract_all to pre-allocate the args
 	RegexStringPieceArgs group_buffer;
+};
+
+// Compiles either the trimmed short-extract pattern or, on fall-through, the full pattern.
+struct RegexReplaceLocalState : public FunctionLocalState {
+	explicit RegexReplaceLocalState(RegexpReplaceBindData &info) : fast_path(false) {
+		if (info.short_extract_candidate) {
+			pattern = make_uniq<RE2>(
+			    duckdb_re2::StringPiece(info.short_pattern_string.c_str(), info.short_pattern_string.size()),
+			    info.options);
+			if (pattern->ok() && pattern->NumberOfCapturingGroups() == 1) {
+				fast_path = true;
+				return;
+			}
+			pattern.reset();
+		}
+		pattern = make_uniq<RE2>(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
+		                         info.options);
+		if (!pattern->ok()) {
+			throw InvalidInputException(pattern->error());
+		}
+	}
+
+	unique_ptr<RE2> pattern;
+	bool fast_path;
 };
 
 unique_ptr<FunctionLocalState> RegexInitLocalState(ExpressionState &state, const BoundFunctionExpression &expr,

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -18,8 +18,10 @@ namespace duckdb {
 namespace regexp_util {
 
 bool TryParseConstantPattern(ClientContext &context, Expression &expr, string &constant_string);
-void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, bool *global_replace = nullptr);
-void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &target, bool *global_replace = nullptr);
+void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, bool *global_replace = nullptr,
+                       bool *no_match_returns_input = nullptr);
+void ParseRegexOptions(ClientContext &context, Expression &expr, RE2::Options &target, bool *global_replace = nullptr,
+                       bool *no_match_returns_input = nullptr);
 void ParseGroupNameList(ClientContext &context, const string &function_name, Expression &group_expr,
                         const string &pattern_string, RE2::Options &options, bool require_constant_pattern,
                         vector<string> &out_names, child_list_t<LogicalType> &out_struct_children);
@@ -30,10 +32,12 @@ inline duckdb_re2::StringPiece CreateStringPiece(const string_t &input) {
 	return duckdb_re2::StringPiece(input.GetData(), input.GetSize());
 }
 
-inline string_t Extract(const string_t &input, StringHeap &heap, const RE2 &re,
-                        const duckdb_re2::StringPiece &rewrite) {
+inline string_t Extract(const string_t &input, StringHeap &heap, const RE2 &re, const duckdb_re2::StringPiece &rewrite,
+                        bool no_match_returns_input = false) {
 	string extracted;
-	RE2::Extract(input.GetString(), re, rewrite, &extracted);
+	if (!RE2::Extract(input.GetString(), re, rewrite, &extracted) && no_match_returns_input) {
+		return input;
+	}
 	return heap.AddString(extracted.c_str(), extracted.size());
 }
 
@@ -102,8 +106,6 @@ struct RegexpReplaceBindData : public RegexpBaseBindData {
 	                      bool global_replace);
 
 	bool global_replace;
-	bool short_extract_candidate = false;
-	string short_pattern_string;
 
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
@@ -112,10 +114,18 @@ struct RegexpReplaceBindData : public RegexpBaseBindData {
 struct RegexpExtractBindData : public RegexpBaseBindData {
 	RegexpExtractBindData();
 	RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string, bool constant_pattern,
-	                      string group_string);
+	                      string group_string, bool no_match_returns_input = false, bool trim_dotstar_dollar = false);
 
 	string group_string;
 	duckdb_re2::StringPiece rewrite;
+	// On no match, return the input instead of an empty string (set via the `k` option, also used by
+	// the regexp_replace -> regexp_extract optimizer rewrite).
+	bool no_match_returns_input = false;
+	// Set only by the regexp_replace -> regexp_extract optimizer rewrite when it strips a trailing
+	// `.*$` from the pattern. The runtime fast path then rejects matches whose remainder contains a
+	// newline to preserve the original pattern's end-of-text semantics under default options.
+	// Round-trips via the regexp_extract custom serialize callbacks.
+	bool trim_dotstar_dollar = false;
 
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
@@ -188,30 +198,6 @@ struct RegexLocalState : public FunctionLocalState {
 	RE2 constant_pattern;
 	//! Used by regexp_extract_all to pre-allocate the args
 	RegexStringPieceArgs group_buffer;
-};
-
-// Compiles either the trimmed short-extract pattern or, on fall-through, the full pattern.
-struct RegexReplaceLocalState : public FunctionLocalState {
-	explicit RegexReplaceLocalState(RegexpReplaceBindData &info) : fast_path(false) {
-		if (info.short_extract_candidate) {
-			pattern = make_uniq<RE2>(
-			    duckdb_re2::StringPiece(info.short_pattern_string.c_str(), info.short_pattern_string.size()),
-			    info.options);
-			if (pattern->ok() && pattern->NumberOfCapturingGroups() == 1) {
-				fast_path = true;
-				return;
-			}
-			pattern.reset();
-		}
-		pattern = make_uniq<RE2>(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
-		                         info.options);
-		if (!pattern->ok()) {
-			throw InvalidInputException(pattern->error());
-		}
-	}
-
-	unique_ptr<RE2> pattern;
-	bool fast_path;
 };
 
 unique_ptr<FunctionLocalState> RegexInitLocalState(ExpressionState &state, const BoundFunctionExpression &expr,

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -105,7 +105,7 @@ struct RegexpReplaceBindData : public RegexpBaseBindData {
 struct RegexpExtractBindData : public RegexpBaseBindData {
 	RegexpExtractBindData();
 	RegexpExtractBindData(duckdb_re2::RE2::Options options, string constant_string, bool constant_pattern,
-	                      int8_t group_index, bool no_match_returns_input = false, bool trim_dotstar_dollar = false);
+	                      int8_t group_index, bool no_match_returns_input = false);
 
 	// `regexp_extract` always extracts a single capture group. -1 represents "no group requested"
 	// (e.g. NULL group argument), which the runtime treats as a no-match (returns empty/input).
@@ -113,10 +113,6 @@ struct RegexpExtractBindData : public RegexpBaseBindData {
 	// On no match, return the input instead of an empty string (set via the `k` option, also used by
 	// the regexp_replace -> regexp_extract optimizer rewrite).
 	bool no_match_returns_input = false;
-	// Set when RegexExtractBind has stripped a trailing `.*$` from constant_string (see the bind
-	// for the gate). Tells the runtime to reject matches whose remainder contains `\n`, preserving
-	// the original end-of-text-without-newline semantics under default RE2 options.
-	bool trim_dotstar_dollar = false;
 
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -138,10 +138,9 @@ struct RegexpExtractBindData : public RegexpBaseBindData {
 	// On no match, return the input instead of an empty string (set via the `k` option, also used by
 	// the regexp_replace -> regexp_extract optimizer rewrite).
 	bool no_match_returns_input = false;
-	// Set only by the regexp_replace -> regexp_extract optimizer rewrite when it strips a trailing
-	// `.*$` from the pattern. The runtime then rejects matches whose remainder contains a newline
-	// to preserve the original pattern's end-of-text semantics under default options.
-	// Round-trips via the regexp_extract custom serialize callbacks.
+	// Set when RegexExtractBind has stripped a trailing `.*$` from constant_string (see the bind
+	// for the gate). Tells the runtime to reject matches whose remainder contains `\n`, preserving
+	// the original end-of-text-without-newline semantics under default RE2 options.
 	bool trim_dotstar_dollar = false;
 
 	unique_ptr<FunctionData> Copy() const override;

--- a/src/include/duckdb/optimizer/rule/regex_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/regex_optimizations.hpp
@@ -24,4 +24,12 @@ public:
 	                                 bool is_not_like);
 };
 
+class RegexpReplaceShortExtractRule : public Rule {
+public:
+	explicit RegexpReplaceShortExtractRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/rule/regex_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/regex_optimizations.hpp
@@ -24,9 +24,9 @@ public:
 	                                 bool is_not_like);
 };
 
-class RegexpReplaceShortExtractRule : public Rule {
+class RegexpReplaceExtractRule : public Rule {
 public:
-	explicit RegexpReplaceShortExtractRule(ExpressionRewriter &rewriter);
+	explicit RegexpReplaceExtractRule(ExpressionRewriter &rewriter);
 
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -67,7 +67,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<DistinctAggregateOptimizer>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistinctWindowedOptimizer>(rewriter));
 	rewriter.rules.push_back(make_uniq<RegexOptimizationRule>(rewriter));
-	rewriter.rules.push_back(make_uniq<RegexpReplaceShortExtractRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<RegexpReplaceExtractRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EmptyNeedleRemovalRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EnumComparisonRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<JoinDependentFilterRule>(rewriter));

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -67,6 +67,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<DistinctAggregateOptimizer>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistinctWindowedOptimizer>(rewriter));
 	rewriter.rules.push_back(make_uniq<RegexOptimizationRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<RegexpReplaceShortExtractRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EmptyNeedleRemovalRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EnumComparisonRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<JoinDependentFilterRule>(rewriter));

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -220,4 +220,50 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 	return std::move(like_expression);
 }
 
+RegexpReplaceShortExtractRule::RegexpReplaceShortExtractRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto func = make_uniq<FunctionExpressionMatcher>();
+	func->function = make_uniq<SpecificFunctionMatcher>("regexp_replace");
+	func->policy = SetMatcher::Policy::SOME_ORDERED;
+	func->matchers.push_back(make_uniq<ExpressionMatcher>());
+	func->matchers.push_back(make_uniq<ConstantExpressionMatcher>());
+	func->matchers.push_back(make_uniq<ConstantExpressionMatcher>());
+	root = std::move(func);
+}
+
+// Decorates the bind_info to enable a fast path inside regexp_replace; returns nullptr because the
+// expression itself is unchanged. Capture-count is checked at local-state init.
+unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
+                                                            vector<reference<Expression>> &bindings, bool &changes_made,
+                                                            bool is_root) {
+	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
+	if (!root.bind_info) {
+		return nullptr;
+	}
+	auto &bind_data = root.bind_info->Cast<RegexpReplaceBindData>();
+	if (bind_data.short_extract_candidate || !bind_data.constant_pattern || bind_data.global_replace) {
+		return nullptr;
+	}
+	if (bind_data.options.dot_nl() || bind_data.options.literal()) {
+		return nullptr;
+	}
+
+	const auto &replace_const = bindings[3].get().Cast<BoundConstantExpression>();
+	if (replace_const.value.IsNull() || replace_const.value.type().id() != LogicalTypeId::VARCHAR) {
+		return nullptr;
+	}
+	const auto &replace_str = StringValue::Get(replace_const.value);
+	if (replace_str.size() != 2 || replace_str[0] != '\\' || replace_str[1] != '1') {
+		return nullptr;
+	}
+
+	const auto &pattern = bind_data.constant_string;
+	if (pattern.size() < 4 || pattern.front() != '^' || pattern.compare(pattern.size() - 3, 3, ".*$") != 0) {
+		return nullptr;
+	}
+
+	bind_data.short_extract_candidate = true;
+	bind_data.short_pattern_string = pattern.substr(0, pattern.size() - 3);
+	return nullptr;
+}
+
 } // namespace duckdb

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -232,12 +232,9 @@ RegexpReplaceShortExtractRule::RegexpReplaceShortExtractRule(ExpressionRewriter 
 	root = std::move(func);
 }
 
-// Rewrites regexp_replace(s, '^...(group)...$', '\1') into regexp_extract(s, '^...(group)...', 1, 'k'):
-//  - `k` (keep-input-on-no-match) preserves regexp_replace's pass-through semantics.
-//  - The trailing `.*$` is stripped from the pattern so RE2 stops once `\1` is captured; the runtime
-//    fast path rejects matches whose remainder contains `\n` to preserve end-of-text semantics under
-//    default options. That bind-data flag (trim_dotstar_dollar) is set here and round-trips via the
-//    regexp_extract custom serialize callbacks.
+// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P's `^...$`
+// shape forces a whole-input match. The `.*$` trim and remainder-newline check happen in
+// regexp_extract's bind, so the bind data here stays a pure function of the children.
 unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
                                                             vector<reference<Expression>> &bindings, bool &changes_made,
                                                             bool is_root) {
@@ -249,9 +246,8 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 	if (!bind_data.constant_pattern || bind_data.global_replace) {
 		return nullptr;
 	}
-	// Trim+newline-check is only correct under default RE2 semantics: `.` excludes `\n` and `$` is
-	// end-of-text. Skip if either of those is altered.
-	if (bind_data.options.literal() || bind_data.options.dot_nl()) {
+	// Literal mode treats `^`/`$` as literal chars, so the shape check below would be meaningless.
+	if (bind_data.options.literal()) {
 		return nullptr;
 	}
 
@@ -269,13 +265,11 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 		return nullptr;
 	}
 
-	// Only rewrite when the compiled pattern has at least one capturing group for `\1`.
+	// `\1` requires at least one capture group; multi-group patterns are still valid.
 	duckdb_re2::RE2 compiled(duckdb_re2::StringPiece(pattern.c_str(), pattern.size()), bind_data.options);
 	if (!compiled.ok() || compiled.NumberOfCapturingGroups() < 1) {
 		return nullptr;
 	}
-
-	string trimmed_pattern = pattern.substr(0, pattern.size() - 3);
 
 	string options_str = "k";
 	if (root.children.size() == 4) {
@@ -288,7 +282,7 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 
 	vector<unique_ptr<Expression>> extract_children;
 	extract_children.emplace_back(std::move(root.children[0]));
-	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(std::move(trimmed_pattern))));
+	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(pattern)));
 	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
 	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(std::move(options_str))));
 
@@ -298,8 +292,6 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 	if (!extract_expr) {
 		return nullptr;
 	}
-	auto &bound_extract = extract_expr->Cast<BoundFunctionExpression>();
-	bound_extract.bind_info->Cast<RegexpExtractBindData>().trim_dotstar_dollar = true;
 	return extract_expr;
 }
 

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/optimizer/rule/regex_optimizations.hpp"
 
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
@@ -230,8 +232,12 @@ RegexpReplaceShortExtractRule::RegexpReplaceShortExtractRule(ExpressionRewriter 
 	root = std::move(func);
 }
 
-// Decorates the bind_info to enable a fast path inside regexp_replace; returns nullptr because the
-// expression itself is unchanged. Capture-count is checked at local-state init.
+// Rewrites regexp_replace(s, '^...(group)...$', '\1') into regexp_extract(s, '^...(group)...', 1, 'k'):
+//  - `k` (keep-input-on-no-match) preserves regexp_replace's pass-through semantics.
+//  - The trailing `.*$` is stripped from the pattern so RE2 stops once `\1` is captured; the runtime
+//    fast path rejects matches whose remainder contains `\n` to preserve end-of-text semantics under
+//    default options. That bind-data flag (trim_dotstar_dollar) is set here and round-trips via the
+//    regexp_extract custom serialize callbacks.
 unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
                                                             vector<reference<Expression>> &bindings, bool &changes_made,
                                                             bool is_root) {
@@ -240,10 +246,12 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 		return nullptr;
 	}
 	auto &bind_data = root.bind_info->Cast<RegexpReplaceBindData>();
-	if (bind_data.short_extract_candidate || !bind_data.constant_pattern || bind_data.global_replace) {
+	if (!bind_data.constant_pattern || bind_data.global_replace) {
 		return nullptr;
 	}
-	if (bind_data.options.dot_nl() || bind_data.options.literal()) {
+	// Trim+newline-check is only correct under default RE2 semantics: `.` excludes `\n` and `$` is
+	// end-of-text. Skip if either of those is altered.
+	if (bind_data.options.literal() || bind_data.options.dot_nl()) {
 		return nullptr;
 	}
 
@@ -261,9 +269,38 @@ unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
 		return nullptr;
 	}
 
-	bind_data.short_extract_candidate = true;
-	bind_data.short_pattern_string = pattern.substr(0, pattern.size() - 3);
-	return nullptr;
+	// Only rewrite when the compiled pattern has at least one capturing group for `\1`.
+	duckdb_re2::RE2 compiled(duckdb_re2::StringPiece(pattern.c_str(), pattern.size()), bind_data.options);
+	if (!compiled.ok() || compiled.NumberOfCapturingGroups() < 1) {
+		return nullptr;
+	}
+
+	string trimmed_pattern = pattern.substr(0, pattern.size() - 3);
+
+	string options_str = "k";
+	if (root.children.size() == 4) {
+		auto &options_const = root.children[3]->Cast<BoundConstantExpression>();
+		if (options_const.value.IsNull() || options_const.value.type().id() != LogicalTypeId::VARCHAR) {
+			return nullptr;
+		}
+		options_str = StringValue::Get(options_const.value) + options_str;
+	}
+
+	vector<unique_ptr<Expression>> extract_children;
+	extract_children.emplace_back(std::move(root.children[0]));
+	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(std::move(trimmed_pattern))));
+	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(std::move(options_str))));
+
+	FunctionBinder binder(rewriter.context);
+	ErrorData error;
+	auto extract_expr = binder.BindScalarFunction(DEFAULT_SCHEMA, "regexp_extract", std::move(extract_children), error);
+	if (!extract_expr) {
+		return nullptr;
+	}
+	auto &bound_extract = extract_expr->Cast<BoundFunctionExpression>();
+	bound_extract.bind_info->Cast<RegexpExtractBindData>().trim_dotstar_dollar = true;
+	return extract_expr;
 }
 
 } // namespace duckdb

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -241,9 +241,9 @@ static bool RegexpHasWholeTextAnchors(duckdb_re2::Regexp *regexp) {
 	       subs[regexp->nsub() - 1]->op() == duckdb_re2::kRegexpEndText;
 }
 
-// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P's byte shape and
-// parsed RE2 anchors prove that any match spans the whole input. The original pattern is preserved;
-// any regexp_extract pattern simplification belongs in a separate optimization.
+// Rewrites `regexp_replace(s, P, '\N')` into `regexp_extract(s, P, N, 'k')` when parsed RE2 anchors
+// prove that any match spans the whole input. The original pattern is preserved; any regexp_extract
+// pattern simplification belongs in a separate optimization.
 unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                        bool &changes_made, bool is_root) {
 	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
@@ -264,18 +264,17 @@ unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vect
 		return nullptr;
 	}
 	const auto &replace_str = StringValue::Get(replace_const.value);
-	if (replace_str.size() != 2 || replace_str[0] != '\\' || replace_str[1] != '1') {
+	int32_t group_index;
+	// Only a bare backreference can be represented by regexp_extract. Replacement literals or
+	// composites such as `x\1`, `\1x`, and `\1\2` must stay on regexp_replace.
+	if (replace_str.size() != 2 || replace_str[0] != '\\' || replace_str[1] < '0' || replace_str[1] > '9') {
 		return nullptr;
 	}
+	group_index = replace_str[1] - '0';
 
 	const auto &pattern = bind_data.constant_string;
-	if (pattern.size() < 4 || pattern.front() != '^' || pattern.compare(pattern.size() - 3, 3, ".*$") != 0) {
-		return nullptr;
-	}
-
-	// `\1` requires at least one capture group; multi-group patterns are still valid.
 	duckdb_re2::RE2 compiled(duckdb_re2::StringPiece(pattern.c_str(), pattern.size()), bind_data.options);
-	if (!compiled.ok() || compiled.NumberOfCapturingGroups() < 1 || !RegexpHasWholeTextAnchors(compiled.Regexp())) {
+	if (!compiled.ok() || !RegexpHasWholeTextAnchors(compiled.Regexp())) {
 		return nullptr;
 	}
 
@@ -291,7 +290,7 @@ unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vect
 	vector<unique_ptr<Expression>> extract_children;
 	extract_children.emplace_back(std::move(root.children[0]));
 	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(pattern)));
-	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value::INTEGER(group_index)));
 	extract_children.emplace_back(make_uniq<BoundConstantExpression>(Value(std::move(options_str))));
 
 	FunctionBinder binder(rewriter.context);

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -232,9 +232,18 @@ RegexpReplaceExtractRule::RegexpReplaceExtractRule(ExpressionRewriter &rewriter)
 	root = std::move(func);
 }
 
-// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P has a `^...*.$`
-// shape that forces a whole-input match. The `.*$` trim and remainder-newline check happen in
-// regexp_extract's bind, so the bind data here stays a pure function of the children.
+static bool RegexpHasWholeTextAnchors(duckdb_re2::Regexp *regexp) {
+	if (regexp->op() != duckdb_re2::kRegexpConcat || regexp->nsub() < 2) {
+		return false;
+	}
+	auto subs = regexp->sub();
+	return subs[0]->op() == duckdb_re2::kRegexpBeginText &&
+	       subs[regexp->nsub() - 1]->op() == duckdb_re2::kRegexpEndText;
+}
+
+// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P's byte shape and
+// parsed RE2 anchors prove that any match spans the whole input. The original pattern is preserved;
+// any regexp_extract pattern simplification belongs in a separate optimization.
 unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                        bool &changes_made, bool is_root) {
 	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
@@ -266,7 +275,7 @@ unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vect
 
 	// `\1` requires at least one capture group; multi-group patterns are still valid.
 	duckdb_re2::RE2 compiled(duckdb_re2::StringPiece(pattern.c_str(), pattern.size()), bind_data.options);
-	if (!compiled.ok() || compiled.NumberOfCapturingGroups() < 1) {
+	if (!compiled.ok() || compiled.NumberOfCapturingGroups() < 1 || !RegexpHasWholeTextAnchors(compiled.Regexp())) {
 		return nullptr;
 	}
 

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -222,7 +222,7 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 	return std::move(like_expression);
 }
 
-RegexpReplaceShortExtractRule::RegexpReplaceShortExtractRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+RegexpReplaceExtractRule::RegexpReplaceExtractRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
 	auto func = make_uniq<FunctionExpressionMatcher>();
 	func->function = make_uniq<SpecificFunctionMatcher>("regexp_replace");
 	func->policy = SetMatcher::Policy::SOME_ORDERED;
@@ -232,12 +232,11 @@ RegexpReplaceShortExtractRule::RegexpReplaceShortExtractRule(ExpressionRewriter 
 	root = std::move(func);
 }
 
-// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P's `^...$`
-// shape forces a whole-input match. The `.*$` trim and remainder-newline check happen in
+// Rewrites `regexp_replace(s, P, '\1')` into `regexp_extract(s, P, 1, 'k')` when P has a `^...*.$`
+// shape that forces a whole-input match. The `.*$` trim and remainder-newline check happen in
 // regexp_extract's bind, so the bind data here stays a pure function of the children.
-unique_ptr<Expression> RegexpReplaceShortExtractRule::Apply(LogicalOperator &op,
-                                                            vector<reference<Expression>> &bindings, bool &changes_made,
-                                                            bool is_root) {
+unique_ptr<Expression> RegexpReplaceExtractRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
+                                                       bool &changes_made, bool is_root) {
 	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
 	if (!root.bind_info) {
 		return nullptr;

--- a/test/sql/function/string/regex_extract.test
+++ b/test/sql/function/string/regex_extract.test
@@ -138,3 +138,24 @@ statement error
 SELECT regexp_replace('foobarbaz', 'b..', 'X', 'k')
 ----
 <REGEX>:.*Option 'k'.*
+
+# Bind-time `^...(group)Y.*$` trim is escape-aware: `^(a)\.*$` ends with "literal-dot star, EOT",
+# so chopping the last 3 bytes would leave a stray `\` that fails to compile. Non-constant input
+# bypasses constant folding.
+query T
+SELECT regexp_extract(s, '^(a)\.*$', 1) FROM (VALUES ('a.'), ('a..'), ('b')) v(s);
+----
+a
+a
+(empty)
+
+# Gates that suppress the trim — group 0 keeps the whole-match span; the `s` flag accepts newlines.
+query T
+SELECT regexp_extract('abc', '^a.*$', 0)
+----
+abc
+
+query T
+SELECT regexp_extract(E'abc\ndef', '^(a).*$', 1, 's')
+----
+a

--- a/test/sql/function/string/regex_extract.test
+++ b/test/sql/function/string/regex_extract.test
@@ -138,24 +138,3 @@ statement error
 SELECT regexp_replace('foobarbaz', 'b..', 'X', 'k')
 ----
 <REGEX>:.*Option 'k'.*
-
-# Bind-time `^...(group)Y.*$` trim is escape-aware: `^(a)\.*$` ends with "literal-dot star, EOT",
-# so chopping the last 3 bytes would leave a stray `\` that fails to compile. Non-constant input
-# bypasses constant folding.
-query T
-SELECT regexp_extract(s, '^(a)\.*$', 1) FROM (VALUES ('a.'), ('a..'), ('b')) v(s);
-----
-a
-a
-(empty)
-
-# Gates that suppress the trim — group 0 keeps the whole-match span; the `s` flag accepts newlines.
-query T
-SELECT regexp_extract('abc', '^a.*$', 0)
-----
-abc
-
-query T
-SELECT regexp_extract(E'abc\ndef', '^(a).*$', 1, 's')
-----
-a

--- a/test/sql/function/string/regex_extract.test
+++ b/test/sql/function/string/regex_extract.test
@@ -110,3 +110,31 @@ statement error
 SELECT regexp_extract('foobarbaz', 'b..', '1')
 ----
 <REGEX>:.*Binder Error.*Could not choose a best candidate.*
+
+# 'k' option: keep (return) the input on no match instead of an empty string
+query T
+SELECT regexp_extract('foobarbaz', '(zzz)', 1, 'k')
+----
+foobarbaz
+
+query T
+SELECT regexp_extract('foobarbaz', '(b..)', 1, 'k')
+----
+bar
+
+# 'k' combines with other options
+query T
+SELECT regexp_extract('FOOBARBAZ', '(zzz)', 1, 'ik')
+----
+FOOBARBAZ
+
+query T
+SELECT regexp_extract('FOOBARBAZ', '(b..)', 1, 'ik')
+----
+BAR
+
+# 'k' is rejected by regexp_replace
+statement error
+SELECT regexp_replace('foobarbaz', 'b..', 'X', 'k')
+----
+<REGEX>:.*Option 'k'.*

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -119,7 +119,7 @@ select regexp_replace(s, r, 'X') from regex;
 ----
 no argument for repetition operator: *
 
-# Anchored capture-then-truncate patterns: `^...(group).*$` with replacement `\1`.
+# Anchored whole-input patterns with a single backreference replacement.
 # The optimizer rewrites these into regexp_extract with no_match_returns_input set.
 
 # Path-segment extraction. Match and no-match rows must behave identically to the un-rewritten form.
@@ -140,6 +140,12 @@ query T
 SELECT regexp_replace('aXYbZW', '^(a)(XY)(b)(ZW).*$', '\1');
 ----
 a
+
+# Non-`\1` backreferences work, and the pattern does not need to end in `.*$`.
+query T
+SELECT regexp_replace('left-right', '^([^-]+)-([^-]+)$', '\2');
+----
+right
 
 # Embedded newline in the remainder under default options: `.*$` cannot match `\n`,
 # so the result is the input unchanged. Result contains a newline so we check by JOIN.

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -158,10 +158,13 @@ SELECT regexp_replace(E'https://www.example.com/path\nsecond-line',
 example.com
 
 # Pattern whose trailing `.*$` is preceded by an escape (`\.*$` = literal-dot star, end-of-text).
+# Non-constant input bypasses constant folding so the optimizer rewrite + bind-time trim path runs.
 query T
-SELECT regexp_replace('ab', '^a(b)\.*$', '\1');
+SELECT regexp_replace(s, '^a(b)\.*$', '\1') FROM (VALUES ('ab'), ('ab.'), ('cd')) v(s);
 ----
 b
+b
+cd
 
 # UTF-8 input: capture group must be returned on byte-aligned UTF-8 character boundaries.
 query T

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -120,10 +120,9 @@ select regexp_replace(s, r, 'X') from regex;
 no argument for repetition operator: *
 
 # Anchored capture-then-truncate patterns: `^...(group).*$` with replacement `\1`.
-# Exercised because the regexp_replace executor takes a fast path on this shape.
+# The optimizer rewrites these into regexp_extract with no_match_returns_input set.
 
-# Path-segment extraction. The shape gate fires on every input; the trailing-slash and no-match
-# rows need to behave identically to the un-optimized path.
+# Path-segment extraction. Match and no-match rows must behave identically to the un-rewritten form.
 query T
 SELECT regexp_replace(s, '^/([^/]+)/.*$', '\1') FROM (VALUES
     ('/usr/local/bin/duckdb'),
@@ -136,14 +135,13 @@ etc
 var
 relative/path/no/leading/slash
 
-# Multiple capture groups: shape gate fires but the local state must downgrade to the slow path
-# and still resolve `\1` to group 1 (not the lone group of the trimmed pattern).
+# Multiple capture groups: rewrite must still resolve `\1` to group 1.
 query T
 SELECT regexp_replace('aXYbZW', '^(a)(XY)(b)(ZW).*$', '\1');
 ----
 a
 
-# Embedded newline in the remainder under default options: original `.*$` cannot match `\n`,
+# Embedded newline in the remainder under default options: `.*$` cannot match `\n`,
 # so the result is the input unchanged. Result contains a newline so we check by JOIN.
 query T
 SELECT COUNT(*) FROM (SELECT E'https://www.example.com/path\nsecond-line') t1(a)
@@ -160,8 +158,6 @@ SELECT regexp_replace(E'https://www.example.com/path\nsecond-line',
 example.com
 
 # Pattern whose trailing `.*$` is preceded by an escape (`\.*$` = literal-dot star, end-of-text).
-# The shape gate trips on the literal three bytes `.*$`, but the trimmed pattern `^a(b)\` is invalid;
-# the local-state init must fall back to compiling the full pattern rather than throwing.
 query T
 SELECT regexp_replace('ab', '^a(b)\.*$', '\1');
 ----

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -119,3 +119,57 @@ select regexp_replace(s, r, 'X') from regex;
 ----
 no argument for repetition operator: *
 
+# Anchored capture-then-truncate patterns: `^...(group).*$` with replacement `\1`.
+# Exercised because the regexp_replace executor takes a fast path on this shape.
+
+# Path-segment extraction. The shape gate fires on every input; the trailing-slash and no-match
+# rows need to behave identically to the un-optimized path.
+query T
+SELECT regexp_replace(s, '^/([^/]+)/.*$', '\1') FROM (VALUES
+    ('/usr/local/bin/duckdb'),
+    ('/etc/hosts'),
+    ('/var/'),
+    ('relative/path/no/leading/slash')) t(s);
+----
+usr
+etc
+var
+relative/path/no/leading/slash
+
+# Multiple capture groups: shape gate fires but the local state must downgrade to the slow path
+# and still resolve `\1` to group 1 (not the lone group of the trimmed pattern).
+query T
+SELECT regexp_replace('aXYbZW', '^(a)(XY)(b)(ZW).*$', '\1');
+----
+a
+
+# Embedded newline in the remainder under default options: original `.*$` cannot match `\n`,
+# so the result is the input unchanged. Result contains a newline so we check by JOIN.
+query T
+SELECT COUNT(*) FROM (SELECT E'https://www.example.com/path\nsecond-line') t1(a)
+  JOIN (SELECT regexp_replace(E'https://www.example.com/path\nsecond-line',
+                              '^https?://(?:www\.)?([^/]+)/.*$', '\1')) t2(a) USING (a);
+----
+1
+
+# DOTALL (`s` flag) lets `.*$` cross newlines, so the same input is replaced rather than left intact.
+query T
+SELECT regexp_replace(E'https://www.example.com/path\nsecond-line',
+                      '^https?://(?:www\.)?([^/]+)/.*$', '\1', 's');
+----
+example.com
+
+# Pattern whose trailing `.*$` is preceded by an escape (`\.*$` = literal-dot star, end-of-text).
+# The shape gate trips on the literal three bytes `.*$`, but the trimmed pattern `^a(b)\` is invalid;
+# the local-state init must fall back to compiling the full pattern rather than throwing.
+query T
+SELECT regexp_replace('ab', '^a(b)\.*$', '\1');
+----
+b
+
+# UTF-8 input: capture group must be returned on byte-aligned UTF-8 character boundaries.
+query T
+SELECT regexp_replace('héllo-café/rest', '^([^/]+)/.*$', '\1');
+----
+héllo-café
+

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -157,8 +157,23 @@ SELECT regexp_replace(E'https://www.example.com/path\nsecond-line',
 ----
 example.com
 
+# Inline multiline mode makes the trailing `$` an end-of-line anchor. The match no longer spans the
+# whole input, so the optimizer must not rewrite this to regexp_extract and drop the unmatched tail.
+query T
+SELECT COUNT(*) FROM (SELECT E'a\nb') t1(a)
+  JOIN (SELECT regexp_replace(s, '^(?m)(a).*$', '\1') FROM (VALUES (E'a\nb')) v(s)) t2(a) USING (a);
+----
+1
+
+# A top-level alternation can pass a byte-level `^...*$` check without every branch being anchored.
+query T
+SELECT regexp_replace(s, '^a(.*)$|b(.*).*$', '\1') FROM (VALUES ('xxbzz'), ('azz')) v(s);
+----
+xx
+zz
+
 # Pattern whose trailing `.*$` is preceded by an escape (`\.*$` = literal-dot star, end-of-text).
-# Non-constant input bypasses constant folding so the optimizer rewrite + bind-time trim path runs.
+# Non-constant input bypasses constant folding so the optimizer rewrite path runs.
 query T
 SELECT regexp_replace(s, '^a(b)\.*$', '\1') FROM (VALUES ('ab'), ('ab.'), ('cd')) v(s);
 ----
@@ -171,4 +186,3 @@ query T
 SELECT regexp_replace('héllo-café/rest', '^([^/]+)/.*$', '\1');
 ----
 héllo-café
-


### PR DESCRIPTION

Ports the optimization from apache/datafusion#21379 to DuckDB. Per-query bind+init overhead is effectively unchanged. Existing regex test coverage continues to pass and a few targeted cases are added.

Decomposing the speedup against an intermediate variant (full regex + `RE2::Match` + zero-copy substring): trimming `.*$` accounts for ~70% of the saved time, the zero-copy substitution for `std::string` + `RE2::Replace` + heap copy accounts for ~30%.

###

### What this is for

When `regexp_replace`'s pattern is `^...(group).*$` and the replacement is `\1`, the actual work asked for is "extract capture group 1." Today's executor still pretends it's doing a generic replacement: it copies the input into a `std::string`, runs `RE2::Replace` (which has to match the trailing `.*$` and then expand the `\1` template back into the buffer), and copies the resulting string into the result vector's heap. That's two allocations and one regex-engine pass over content the caller is going to throw away.

### Why "drop the trailing `.*$`" is safe under default options

For a pattern of shape `^P(G)S.*$` with replacement `\1`, the original `RE2::Replace` either matches the whole input (because `^…$` is anchored to both ends) and emits group 1, or doesn't match and emits input unchanged. Whether it matches is determined entirely by whether `^P(G)S` can find a prefix and whether the remainder satisfies `.*$`. Under default options (`.` excludes `\n`, `$` is end-of-text), `.*$` succeeds iff the remainder contains no `\n`. So:

- trimmed matches & no `\n` after match end → original would match too, and group 1 is identical → emit group 1
- trimmed matches & `\n` after match end → original does not match → emit input
- trimmed does not match → original does not match → emit input

The check is two cheap things — a `RE2::Match` and a `memchr(b'\n', ...)` over the unmatched suffix — to avoid one `std::string` allocation, one regex pass, one `expand()`, one heap copy.

### Things explicitly not done

- Bind-time capture-group counting without compiling RE2. Could eliminate the rare "shape OK, capture count != 1" double compile (pattern like `^(a)(b).*$ → \1`), but a hand-rolled regex-syntax counter for character classes / `(?:…)` / lookarounds / `(?P<name>…)` is not worth the maintenance burden for ≈2 µs/plan in a narrow shape. A worst-case 5000-bind microbench shows +2.2 µs/query in this case vs. baseline.
- The same zero-copy slice technique applied to scalar `regexp_extract(s, pat, n)`. The shape there is even simpler — it's always "extract submatch[n]", no shape detection needed. I prototyped it and the win is small (1.04–1.22× across short / medium / whole-input captures): the existing `RE2::Extract` only allocates and copies the captured bytes, not the full input the way `RE2::Replace` does. Could be revisited if a workload with very long captures shows up.


### Benchmark

As a randomly selected query, let's run this query from ClickBench:

```sql
SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(STRLEN(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
```

Below is the performance before and after this PR:

| main |  New   |
|--------|--------|
| 2.840s  | 1.678s |

