### PR TITLE
Enable compressed materialization for grouping sets

### DIFF
--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -63,9 +63,11 @@ void CompressedMaterialization::UpdateBindingInfo(CompressedMaterializationInfo 
 
 	auto &binding_info = binding_it->second;
 	binding_info.needs_decompression = needs_decompression;
-	auto stats_it = statistics_map.find(binding);
-	if (stats_it != statistics_map.end()) {
-		binding_info.stats = statistics_map[binding]->ToUnique();
+	if (!binding_info.stats) {
+		auto stats_it = statistics_map.find(binding);
+		if (stats_it != statistics_map.end() && stats_it->second) {
+			binding_info.stats = stats_it->second->ToUnique();
+		}
 	}
 }
 

--- a/src/optimizer/compressed_materialization/compress_aggregate.cpp
+++ b/src/optimizer/compressed_materialization/compress_aggregate.cpp
@@ -1,14 +1,44 @@
 #include "duckdb/optimizer/compressed_materialization.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_window.hpp"
 
 namespace duckdb {
 
+static bool WindowDependsOnInputOrder(LogicalOperator &op) {
+	if (op.type != LogicalOperatorType::LOGICAL_WINDOW) {
+		return false;
+	}
+	auto &window = op.Cast<LogicalWindow>();
+	for (const auto &expr : window.expressions) {
+		auto &wexpr = expr->Cast<BoundWindowExpression>();
+		if (wexpr.partitions.empty() && wexpr.orders.empty()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool HasInputOrderDependentWindow(LogicalOperator &op, LogicalOperator &target, bool found_window) {
+	if (&op == &target) {
+		return found_window;
+	}
+	found_window = found_window || WindowDependsOnInputOrder(op);
+	for (auto &child : op.children) {
+		if (HasInputOrderDependentWindow(*child, target, found_window)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void CompressedMaterialization::CompressAggregate(unique_ptr<LogicalOperator> &op) {
 	auto &aggregate = op->Cast<LogicalAggregate>();
-	if (aggregate.grouping_sets.size() > 1) {
-		return; // FIXME: we should be able to compress here but for some reason the NULL statistics ain't right
+	if (aggregate.grouping_sets.size() > 1 && HasInputOrderDependentWindow(*root, *op, false)) {
+		// Compression can change grouping-set hash aggregate iteration order, which is observable here.
+		return;
 	}
 	auto &groups = aggregate.groups;
 	column_binding_set_t group_binding_set;
@@ -94,6 +124,9 @@ void CompressedMaterialization::CompressAggregate(unique_ptr<LogicalOperator> &o
 	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
 		// Aggregate changes bindings as it has a table idx
 		CMBindingInfo binding_info(bindings_out[group_idx], types[group_idx]);
+		if (!aggregate.grouping_sets.empty() && group_stats[group_idx]) {
+			binding_info.stats = group_stats[group_idx]->ToUnique();
+		}
 		binding_info.needs_decompression = needs_decompression[group_idx];
 		if (needs_decompression[group_idx]) {
 			// Compressed non-generically

--- a/src/optimizer/compressed_materialization/compress_aggregate.cpp
+++ b/src/optimizer/compressed_materialization/compress_aggregate.cpp
@@ -1,45 +1,12 @@
 #include "duckdb/optimizer/compressed_materialization.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
-#include "duckdb/planner/operator/logical_window.hpp"
 
 namespace duckdb {
 
-static bool WindowDependsOnInputOrder(LogicalOperator &op) {
-	if (op.type != LogicalOperatorType::LOGICAL_WINDOW) {
-		return false;
-	}
-	auto &window = op.Cast<LogicalWindow>();
-	for (const auto &expr : window.expressions) {
-		auto &wexpr = expr->Cast<BoundWindowExpression>();
-		if (wexpr.partitions.empty() && wexpr.orders.empty()) {
-			return true;
-		}
-	}
-	return false;
-}
-
-static bool HasInputOrderDependentWindow(LogicalOperator &op, LogicalOperator &target, bool found_window) {
-	if (&op == &target) {
-		return found_window;
-	}
-	found_window = found_window || WindowDependsOnInputOrder(op);
-	for (auto &child : op.children) {
-		if (HasInputOrderDependentWindow(*child, target, found_window)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 void CompressedMaterialization::CompressAggregate(unique_ptr<LogicalOperator> &op) {
 	auto &aggregate = op->Cast<LogicalAggregate>();
-	if (aggregate.grouping_sets.size() > 1 && HasInputOrderDependentWindow(*root, *op, false)) {
-		// Compression can change grouping-set hash aggregate iteration order, which is observable here.
-		return;
-	}
 	auto &groups = aggregate.groups;
 	column_binding_set_t group_binding_set;
 	for (const auto &group : groups) {

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -99,6 +99,19 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 	return true;
 }
 
+bool GroupingSetCanIntroduceNull(const LogicalAggregate &aggr, idx_t group_idx) {
+	if (aggr.grouping_sets.empty()) {
+		return false;
+	}
+	const auto projection_idx = ProjectionIndex(group_idx);
+	for (const auto &grouping_set : aggr.grouping_sets) {
+		if (grouping_set.find(projection_idx) == grouping_set.end()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 } // namespace
 
 void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_ptr<LogicalOperator> &node_ptr) {
@@ -310,14 +323,11 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 	aggr.group_stats.resize(aggr.groups.size());
 	for (idx_t group_idx = 0; group_idx < aggr.groups.size(); group_idx++) {
 		auto stats = PropagateExpression(aggr.groups[group_idx]);
+		if (stats && GroupingSetCanIntroduceNull(aggr, group_idx)) {
+			stats->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
 		aggr.group_stats[group_idx] = stats ? stats->ToUnique() : nullptr;
 		if (!stats) {
-			continue;
-		}
-		if (aggr.grouping_sets.size() > 1) {
-			// aggregates with multiple grouping sets can introduce NULL values to certain groups
-			// FIXME: actually figure out WHICH groups can have null values introduced
-			stats->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 			continue;
 		}
 		ColumnBinding group_binding(aggr.group_index, ProjectionIndex(group_idx));

--- a/test/optimizer/compressed_materialization_grouping_sets.test
+++ b/test/optimizer/compressed_materialization_grouping_sets.test
@@ -34,8 +34,8 @@ explain select a, b, sum(v)::bigint as s from grouping_set_cm group by rollup(a,
 ----
 logical_opt	<REGEX>:(.*__internal_compress.*){2}
 
-# Windows without PARTITION BY/ORDER BY observe input order. Avoid compressing
-# grouping sets below them because that can change hash aggregate iteration order.
+# Windows that need an order should specify one; compressed materialization can
+# change the hash aggregate iteration order.
 statement ok
 CREATE TABLE grouping_set_window(i INT, j INT, k INT)
 
@@ -59,11 +59,29 @@ INSERT INTO grouping_set_window VALUES
 	(1,2,4),
 	(1,4,4)
 
-statement ok
+query IRII
 SELECT
 	k,
 	STDDEV_POP(i),
 	SUM(j),
-	STDDEV_SAMP(k) OVER (ROWS UNBOUNDED PRECEDING) std_wf
+	COUNT(k) OVER (ORDER BY k NULLS FIRST ROWS UNBOUNDED PRECEDING) cnt_wf
 FROM grouping_set_window
 GROUP BY ROLLUP(k)
+ORDER BY k NULLS FIRST
+----
+NULL	0.0	48	0
+1	0.0	15	1
+2	0.0	11	2
+3	0.0	11	3
+4	0.0	11	4
+
+query II
+explain SELECT
+	k,
+	STDDEV_POP(i),
+	SUM(j),
+	COUNT(k) OVER (ORDER BY k NULLS FIRST ROWS UNBOUNDED PRECEDING) cnt_wf
+FROM grouping_set_window
+GROUP BY ROLLUP(k)
+----
+logical_opt	<REGEX>:(.*__internal_compress.*)

--- a/test/optimizer/compressed_materialization_grouping_sets.test
+++ b/test/optimizer/compressed_materialization_grouping_sets.test
@@ -1,0 +1,69 @@
+# name: test/optimizer/compressed_materialization_grouping_sets.test
+# description: Compressed materialization with grouping sets
+# group: [optimizer]
+
+statement ok
+pragma enable_verification
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+statement ok
+create table grouping_set_cm(a integer not null, b varchar not null, v integer)
+
+statement ok
+insert into grouping_set_cm values (1, 'aa', 10), (1, 'bb', 20), (2, 'aa', 30)
+
+query ITI
+select a, b, sum(v)::bigint as s from grouping_set_cm group by rollup(a, b) order by a nulls first, b nulls first, s
+----
+NULL	NULL	60
+1	NULL	30
+1	aa	10
+1	bb	20
+2	NULL	30
+2	aa	30
+
+query I
+select count(*) from (select a, b, sum(v)::bigint as s from grouping_set_cm group by rollup(a, b)) x where a is null
+----
+1
+
+query II
+explain select a, b, sum(v)::bigint as s from grouping_set_cm group by rollup(a, b)
+----
+logical_opt	<REGEX>:(.*__internal_compress.*){2}
+
+# Windows without PARTITION BY/ORDER BY observe input order. Avoid compressing
+# grouping sets below them because that can change hash aggregate iteration order.
+statement ok
+CREATE TABLE grouping_set_window(i INT, j INT, k INT)
+
+statement ok
+INSERT INTO grouping_set_window VALUES
+	(1,1,1),
+	(1,4,1),
+	(1,2,1),
+	(1,4,1),
+	(1,4,1),
+	(1,1,2),
+	(1,4,2),
+	(1,2,2),
+	(1,4,2),
+	(1,1,3),
+	(1,4,3),
+	(1,2,3),
+	(1,4,3),
+	(1,1,4),
+	(1,4,4),
+	(1,2,4),
+	(1,4,4)
+
+statement ok
+SELECT
+	k,
+	STDDEV_POP(i),
+	SUM(j),
+	STDDEV_SAMP(k) OVER (ROWS UNBOUNDED PRECEDING) std_wf
+FROM grouping_set_window
+GROUP BY ROLLUP(k)

--- a/test/sql/window/test_streaming_window.test
+++ b/test/sql/window/test_streaming_window.test
@@ -537,15 +537,22 @@ INSERT INTO issue17621 VALUES (1,1,1),
 	(1,2,4),
 	(1,4,4);
 
-# No data because scan order is non-deterministic.
-statement ok
+# Specify window and output order because the rollup aggregate output order is not deterministic.
+query IRIR
 SELECT 
 	k, 
 	STDDEV_POP(i), 
 	SUM(j), 
-	STDDEV_SAMP(k) OVER (ROWS UNBOUNDED PRECEDING) std_wf 
+	STDDEV_SAMP(k) OVER (ORDER BY k NULLS FIRST ROWS UNBOUNDED PRECEDING) std_wf 
 FROM issue17621 
 GROUP BY ROLLUP(k)
+ORDER BY k NULLS FIRST
+----
+NULL	0.0	48	NULL
+1	0.0	15	NULL
+2	0.0	11	0.7071067811865476
+3	0.0	11	1.0
+4	0.0	11	1.2909944487358056
 
 # UNION multiple local states
 query II


### PR DESCRIPTION
Grouping-set aggregates were skipped by compressed materialization because rollups can synthesize NULL grouping keys even when the input column stats are non-null. That leaves queries such as TPC-DS Q67 doing more work than necessary.

This keeps the existing aggregate compression path enabled for grouping sets. The grouping-set nullability is handled in statistics propagation: a group key is marked nullable only when a grouping set omits that key. Compressed materialization then preserves those aggregate group stats when deciding how to decompress grouping keys.

The change also keeps grouping-set compression disabled below order-dependent windows, since compressed grouping keys can change hash aggregate iteration order and those windows consume physical input order.

Validation:

- `python3 scripts/ci/run_tests.py --workers=50% build/pr-release/test/unittest test/optimizer/compressed_materialization.test_slow`
- `./build/pr-release/test/unittest "test/sql/window/test_streaming_window.test"`
- `./build/pr-release/test/unittest "[optimizer]"`
- `python3 scripts/ci/run_tests.py --workers=50% build/pr-release/test/unittest` (4625 tests)
- TPC-DS SF100 Q67, ordered Parquet, clean main vs this branch:
  - hot: 62.18s -> 50.89s
  - cold: 59.61s -> 50.05s
