### PR TITLE
Fold MIN/MAX through monotonic wrappers and invertible casts

### DIFF
--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -448,8 +448,8 @@ ScalarFunctionSet DateDiffFun::GetFunctions() {
 	                                     LogicalType::BIGINT, DateDiffFunction<timestamp_t>));
 	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
 	                                     LogicalType::BIGINT, DateDiffFunction<dtime_t>));
-	date_diff.SetArgProperties(1, ArgProperties().NonIncreasing());
-	date_diff.SetArgProperties(2, ArgProperties().NonDecreasing());
+	date_diff.SetArgProperties(1, ArgProperties().NonIncreasing().RequiresFinite());
+	date_diff.SetArgProperties(2, ArgProperties().NonDecreasing().RequiresFinite());
 	return date_diff;
 }
 

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2112,10 +2112,12 @@ ScalarFunctionSet GetCachedDatepartFunction() {
 
 ScalarFunctionSet YearFun::GetFunctions() {
 	auto set = GetCachedDatepartFunction<DatePart::YearOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
+// Month / Day / Quarter / Day*Of* / Week / Hours / Minutes / Seconds / sub-second extracts
+// are cyclic (wrap modulo their period) and intentionally unannotated — do not add monotonicity.
 ScalarFunctionSet MonthFun::GetFunctions() {
 	return GetCachedDatepartFunction<DatePart::MonthOperator>();
 }
@@ -2126,19 +2128,19 @@ ScalarFunctionSet DayFun::GetFunctions() {
 
 ScalarFunctionSet DecadeFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::DecadeOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
 ScalarFunctionSet CenturyFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::CenturyOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
 ScalarFunctionSet MillenniumFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::MillenniumOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
@@ -2168,13 +2170,13 @@ ScalarFunctionSet WeekFun::GetFunctions() {
 
 ScalarFunctionSet ISOYearFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::ISOYearOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
 ScalarFunctionSet EraFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::EraOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
@@ -2204,7 +2206,7 @@ ScalarFunctionSet TimezoneMinuteFun::GetFunctions() {
 
 ScalarFunctionSet EpochFun::GetFunctions() {
 	auto set = GetTimePartFunction<DatePart::EpochOperator, double>(LogicalType::DOUBLE);
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 
@@ -2233,7 +2235,7 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
-	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return operator_set;
 }
 
@@ -2246,7 +2248,7 @@ ScalarFunctionSet EpochUsFun::GetFunctions() {
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
-	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return operator_set;
 }
 
@@ -2264,7 +2266,7 @@ ScalarFunctionSet EpochMsFun::GetFunctions() {
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
 
-	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return operator_set;
 }
 
@@ -2272,6 +2274,7 @@ ScalarFunctionSet MakeTimestampMsFun::GetFunctions() {
 	ScalarFunctionSet operator_set("make_timestamp_ms");
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
+	// BIGINT input has no infinity sentinel — no need for RequiresFinite.
 	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }
@@ -2317,7 +2320,7 @@ ScalarFunctionSet HoursFun::GetFunctions() {
 
 ScalarFunctionSet YearWeekFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::YearWeekOperator>();
-	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing().RequiresFinite());
 	return set;
 }
 

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -255,63 +255,91 @@ static bool DecimalToStringCast(Vector &source, Vector &result, idx_t count, Cas
 
 BoundCastInfo DefaultCasts::DecimalCastSwitch(BindCastInput &input, const LogicalType &source,
                                               const LogicalType &target) {
-	// now switch on the result type
+	// DECIMAL -> integer: truncation toward zero, NON_DECREASING (multiple decimals can collapse
+	// to the same integer; e.g. 1.2 and 1.9 both become 1, but ordering across distinct integer
+	// targets is preserved).
+	const auto decimal_to_int = ArgProperties().NonDecreasing();
 	switch (target.id()) {
 	case LogicalTypeId::BOOLEAN:
 		return FromDecimalCast<bool>;
 	case LogicalTypeId::TINYINT:
-		return FromDecimalCast<int8_t>;
+		return BoundCastInfo(FromDecimalCast<int8_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::SMALLINT:
-		return FromDecimalCast<int16_t>;
+		return BoundCastInfo(FromDecimalCast<int16_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::INTEGER:
-		return FromDecimalCast<int32_t>;
+		return BoundCastInfo(FromDecimalCast<int32_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::BIGINT:
-		return FromDecimalCast<int64_t>;
+		return BoundCastInfo(FromDecimalCast<int64_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UTINYINT:
-		return FromDecimalCast<uint8_t>;
+		return BoundCastInfo(FromDecimalCast<uint8_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::USMALLINT:
-		return FromDecimalCast<uint16_t>;
+		return BoundCastInfo(FromDecimalCast<uint16_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UINTEGER:
-		return FromDecimalCast<uint32_t>;
+		return BoundCastInfo(FromDecimalCast<uint32_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UBIGINT:
-		return FromDecimalCast<uint64_t>;
+		return BoundCastInfo(FromDecimalCast<uint64_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::HUGEINT:
-		return FromDecimalCast<hugeint_t>;
+		return BoundCastInfo(FromDecimalCast<hugeint_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UHUGEINT:
-		return FromDecimalCast<uhugeint_t>;
+		return BoundCastInfo(FromDecimalCast<uhugeint_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::DECIMAL: {
 		// decimal to decimal cast
 		// first we need to figure out the source and target internal types
+		cast_function_t fn;
 		switch (source.InternalType()) {
 		case PhysicalType::INT16:
-			return DecimalDecimalCastSwitch<int16_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int16_t, NumericHelper>;
+			break;
 		case PhysicalType::INT32:
-			return DecimalDecimalCastSwitch<int32_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int32_t, NumericHelper>;
+			break;
 		case PhysicalType::INT64:
-			return DecimalDecimalCastSwitch<int64_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int64_t, NumericHelper>;
+			break;
 		case PhysicalType::INT128:
-			return DecimalDecimalCastSwitch<hugeint_t, Hugeint>;
+			fn = DecimalDecimalCastSwitch<hugeint_t, Hugeint>;
+			break;
 		default:
 			throw NotImplementedException("Unimplemented internal type for decimal in decimal_decimal cast");
 		}
+		// DECIMAL -> DECIMAL: multiplying / dividing by 10^Δscale is monotonic. Scale-not-decrease
+		// is strict; scale-decrease is truncation and is NON_DECREASING.
+		auto props = DecimalType::GetScale(target) >= DecimalType::GetScale(source)
+		                 ? ArgProperties().StrictlyIncreasing()
+		                 : ArgProperties().NonDecreasing();
+		return BoundCastInfo(fn).SetArgProperties(props);
 	}
 	case LogicalTypeId::FLOAT:
-		return FromDecimalCast<float>;
+		// DECIMAL -> FLOAT/DOUBLE: order is preserved but precision is lost (multiple decimals
+		// can map to the same float). NON_DECREASING.
+		return BoundCastInfo(FromDecimalCast<float>).SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::DOUBLE:
-		return FromDecimalCast<double>;
+		return BoundCastInfo(FromDecimalCast<double>).SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::VARCHAR: {
+		cast_function_t fn;
 		switch (source.InternalType()) {
 		case PhysicalType::INT16:
-			return DecimalToStringCast<int16_t>;
+			fn = DecimalToStringCast<int16_t>;
+			break;
 		case PhysicalType::INT32:
-			return DecimalToStringCast<int32_t>;
+			fn = DecimalToStringCast<int32_t>;
+			break;
 		case PhysicalType::INT64:
-			return DecimalToStringCast<int64_t>;
+			fn = DecimalToStringCast<int64_t>;
+			break;
 		case PhysicalType::INT128:
-			return DecimalToStringCast<hugeint_t>;
+			fn = DecimalToStringCast<hugeint_t>;
+			break;
 		default:
 			throw InternalException("Unimplemented internal decimal type");
 		}
+		// Decimal -> string format is sign-then-digits-with-decimal-point, fixed scale per type.
+		// Lexicographic comparison agrees with numeric comparison only for non-negative values:
+		// negative numbers' "-" prefix sorts BEFORE digits, so '-9' < '-1' lexicographically but
+		// -9 < -1 numerically. They agree by accident here. But '-9' < '0.5' lex (since '-' < '0'
+		// in ASCII) and -9 < 0.5 numerically. ✓ However width-varying integer parts break it:
+		// '10' > '9' numerically, but '10' < '9' lexicographically. So skip annotation.
+		return BoundCastInfo(fn);
 	}
 	default:
 		return DefaultCasts::TryVectorNullCast;

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -29,7 +29,9 @@ BoundCastInfo::BoundCastInfo(cast_function_t function_p, unique_ptr<BoundCastDat
 }
 
 BoundCastInfo BoundCastInfo::Copy() const {
-	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state);
+	BoundCastInfo result(function, cast_data ? cast_data->Copy() : nullptr, init_local_state);
+	result.arg_properties = arg_properties;
+	return result;
 }
 
 bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/src/function/cast/numeric_casts.cpp
+++ b/src/function/cast/numeric_casts.cpp
@@ -1,10 +1,65 @@
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/vector_cast_helpers.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/string_cast.hpp"
 #include "duckdb/common/operator/numeric_cast.hpp"
 #include "duckdb/common/types/bignum.hpp"
 
 namespace duckdb {
+
+namespace {
+//! True when SRC -> DST preserves source ordering for every successful conversion. Cross-signedness
+//! casts are excluded — they throw on out-of-range values, but the conservative thing is to
+//! refuse rather than reason about the failing-vs-non-failing rows agreeing across the rewrite.
+template <class SRC, class DST>
+constexpr bool IsOrderPreservingNumericCast() {
+	return NumericLimits<SRC>::IsSigned() == NumericLimits<DST>::IsSigned();
+}
+
+//! True when distinct source values can collapse to the same target value, making the cast
+//! non-strictly monotonic. Three causes:
+//!   - DOUBLE -> FLOAT: 53-bit mantissa narrowed to 24-bit.
+//!   - integer -> FLOAT/DOUBLE when the integer width exceeds the destination mantissa bits.
+//!   - float -> integer: truncation toward zero (1.0, 1.5, 1.999 all collapse to int 1).
+template <class SRC, class DST>
+constexpr bool HasFloatPrecisionLoss() {
+	if (std::is_same<SRC, double>::value && std::is_same<DST, float>::value) {
+		return true;
+	}
+	if (!std::is_floating_point<SRC>::value && std::is_same<DST, float>::value) {
+		return sizeof(SRC) > 2; // INT8/UINT8 (1B) and INT16/UINT16 (2B) fit in a 24-bit mantissa
+	}
+	if (!std::is_floating_point<SRC>::value && std::is_same<DST, double>::value) {
+		return sizeof(SRC) > 4; // INT8/16/32 fit in a 53-bit mantissa; INT64/HUGEINT do not
+	}
+	if (std::is_floating_point<SRC>::value && !std::is_floating_point<DST>::value) {
+		return true;
+	}
+	return false;
+}
+
+template <class SRC, class DST, class OP>
+BoundCastInfo MakeNumericToNumericCast() {
+	BoundCastInfo info(&VectorCastHelpers::TryCastLoop<SRC, DST, OP>);
+	if (IsOrderPreservingNumericCast<SRC, DST>()) {
+		auto props = HasFloatPrecisionLoss<SRC, DST>() ? ArgProperties().NonDecreasing()
+		                                               : ArgProperties().StrictlyIncreasing();
+		info.SetArgProperties(props);
+	}
+	return info;
+}
+
+template <class SRC>
+BoundCastInfo MakeNumericToDecimalCast() {
+	// Numeric -> DECIMAL: integer sources fit exactly (strict, injective). Float/double sources
+	// truncate to the target scale (non-strict).
+	BoundCastInfo info(&VectorCastHelpers::ToDecimalCast<SRC>);
+	auto props = std::is_floating_point<SRC>::value ? ArgProperties().NonDecreasing()
+	                                                : ArgProperties().StrictlyIncreasing();
+	info.SetArgProperties(props);
+	return info;
+}
+} // namespace
 
 template <class SRC>
 static BoundCastInfo InternalNumericCastSwitch(const LogicalType &source, const LogicalType &target) {
@@ -13,31 +68,31 @@ static BoundCastInfo InternalNumericCastSwitch(const LogicalType &source, const 
 	case LogicalTypeId::BOOLEAN:
 		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, bool, duckdb::NumericTryCast>);
 	case LogicalTypeId::TINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int8_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int8_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::SMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int16_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int16_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::INTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int32_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int32_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::BIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int64_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int64_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UTINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint8_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint8_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::USMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint16_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint16_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UINTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint32_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint32_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UBIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint64_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint64_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::HUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, hugeint_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, hugeint_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UHUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uhugeint_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uhugeint_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::FLOAT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, float, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, float, duckdb::NumericTryCast>();
 	case LogicalTypeId::DOUBLE:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, double, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, double, duckdb::NumericTryCast>();
 	case LogicalTypeId::DECIMAL:
-		return BoundCastInfo(&VectorCastHelpers::ToDecimalCast<SRC>);
+		return MakeNumericToDecimalCast<SRC>();
 	case LogicalTypeId::VARCHAR:
 		return BoundCastInfo(&VectorCastHelpers::StringCast<SRC, duckdb::StringCast>);
 	case LogicalTypeId::BIT:

--- a/src/function/cast/time_casts.cpp
+++ b/src/function/cast/time_casts.cpp
@@ -7,18 +7,23 @@ BoundCastInfo DefaultCasts::DateCastSwitch(BindCastInput &input, const LogicalTy
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// date to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<date_t, duckdb::StringCast>);
+		// date to varchar: ISO 8601 zero-padded; lexicographic order matches date ordering.
+		return BoundCastInfo(&VectorCastHelpers::StringCast<date_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
-		// date to timestamp
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCast>);
+		// date to timestamp: widening, distinct dates -> distinct timestamps at midnight.
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_ns_t, duckdb::TryCastToTimestampNS>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_ns_t, duckdb::TryCastToTimestampNS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -28,10 +33,11 @@ BoundCastInfo DefaultCasts::TimeCastSwitch(BindCastInput &input, const LogicalTy
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// time to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_t, duckdb::StringCast>);
+		// time to varchar: HH:MM:SS[.uuuuuu] zero-padded; lex order matches micros order.
+		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME_TZ:
-		// time to time with time zone
+		// time to time with time zone: depends on session zone semantics — leave UNKNOWN.
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_t, dtime_tz_t, duckdb::Cast>);
 	default:
 		return TryVectorNullCast;
@@ -43,10 +49,12 @@ BoundCastInfo DefaultCasts::TimeNsCastSwitch(BindCastInput &input, const Logical
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// time (ns) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_ns_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_ns_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME:
-		// time (ns) to time (µs)
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_ns_t, dtime_t, duckdb::Cast>);
+		// time (ns) to time (µs): truncation collapses 1000 ns values per us.
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_ns_t, dtime_t, duckdb::Cast>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -73,31 +81,36 @@ BoundCastInfo DefaultCasts::TimestampCastSwitch(BindCastInput &input, const Logi
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// timestamp to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
-		// timestamp to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::Cast>);
+		// timestamp to date: truncation; many timestamps in same day collapse.
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::Cast>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp to time
+		// timestamp to time: drops the date — distinct timestamps on different days share times.
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::Cast>);
 	case LogicalTypeId::TIME_TZ:
-		// timestamp to time_tz
+		// timestamp to time_tz: drops the date.
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_tz_t, duckdb::Cast>);
 	case LogicalTypeId::TIMESTAMP_TZ:
-		// timestamp (us) to timestamp with time zone
-		return ReinterpretCast;
+		// timestamp (us) to timestamp with time zone: same physical representation.
+		return BoundCastInfo(ReinterpretCast).SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
-		// timestamp (us) to timestamp (ns)
+		// timestamp (us) to timestamp (ns): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
-		// timestamp (us) to timestamp (ms)
+		// timestamp (us) to timestamp (ms): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
-		// timestamp (us) to timestamp (s)
+		// timestamp (us) to timestamp (s): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -108,26 +121,30 @@ BoundCastInfo DefaultCasts::TimestampTzCastSwitch(BindCastInput &input, const Lo
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp with time zone to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCastTZ>);
+		// timestamp with time zone to varchar: rendered in session zone, lex order matches instant.
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCastTZ>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME_TZ:
-		// timestamp with time zone to time with time zone.
+		// timestamp with time zone to time with time zone: drops the date.
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_tz_t, duckdb::Cast>);
 	case LogicalTypeId::TIMESTAMP:
-		// timestamp with time zone to timestamp (us)
-		return ReinterpretCast;
+		// timestamp with time zone to timestamp (us): identity reinterpret.
+		return BoundCastInfo(ReinterpretCast).SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
-		// timestamptz (us) to timestamp (ns)
+		// timestamptz (us) to timestamp (ns): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
-		// timestamptz (us) to timestamp (ms)
+		// timestamptz (us) to timestamp (ms): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
-		// timestamptz (us) to timestamp (s)
+		// timestamptz (us) to timestamp (s): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -138,27 +155,30 @@ BoundCastInfo DefaultCasts::TimestampNsCastSwitch(BindCastInput &input, const Lo
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (ns) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_ns_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_ns_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
-		// timestamp (ns) to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampNsToDate>);
+		// timestamp (ns) to date: truncation.
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampNsToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (ns) to time
+		// timestamp (ns) to time: drops the date.
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampNsToTime>);
 	case LogicalTypeId::TIME_NS:
-		// timestamp (ns) to time (ns)
+		// timestamp (ns) to time (ns): drops the date.
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_ns_t, dtime_ns_t, duckdb::CastTimestampNsToTimeNs>);
 	case LogicalTypeId::TIMESTAMP:
-		// timestamp (ns) to timestamp (us)
+		// timestamp (ns) to timestamp (us): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIMESTAMP_TZ:
-		// timestamp (ns) to timestamp with time zone (us)
+		// timestamp (ns) to timestamp with time zone (us): truncation.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -169,27 +189,31 @@ BoundCastInfo DefaultCasts::TimestampMsCastSwitch(BindCastInput &input, const Lo
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (ms) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampMS>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampMS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
-		// timestamp (ms) to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampMsToDate>);
+		// timestamp (ms) to date: truncation.
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampMsToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (ms) to time
+		// timestamp (ms) to time: drops the date.
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampMsToTime>);
 	case LogicalTypeId::TIMESTAMP:
-		// timestamp (ms) to timestamp (us)
+		// timestamp (ms) to timestamp (us): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
-		// timestamp (ms) to timestamp (ns)
+		// timestamp (ms) to timestamp (ns): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_TZ:
-		// timestamp (ms) to timestamp with timezone (us)
+		// timestamp (ms) to timestamp with timezone (us): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -200,32 +224,36 @@ BoundCastInfo DefaultCasts::TimestampSecCastSwitch(BindCastInput &input, const L
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (s) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampSec>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampSec>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
-		// timestamp (s) to date
-		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampSecToDate>);
+		// timestamp (s) to date: truncation.
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampSecToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (s) to time
+		// timestamp (s) to time: drops the date.
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampSecToTime>);
 	case LogicalTypeId::TIMESTAMP_MS:
-		// timestamp (s) to timestamp (ms)
+		// timestamp (s) to timestamp (ms): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToMs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP:
-		// timestamp (s) to timestamp (us)
+		// timestamp (s) to timestamp (us): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_TZ:
-		// timestamp (s) to timestamp with timezone (us)
+		// timestamp (s) to timestamp with timezone (us): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
-		// timestamp (s) to timestamp (ns)
+		// timestamp (s) to timestamp (ns): widening.
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -235,7 +263,6 @@ BoundCastInfo DefaultCasts::IntervalCastSwitch(BindCastInput &input, const Logic
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// time to varchar
 		return BoundCastInfo(&VectorCastHelpers::StringCast<interval_t, duckdb::StringCast>);
 	default:
 		return TryVectorNullCast;

--- a/src/include/duckdb/function/arg_properties.hpp
+++ b/src/include/duckdb/function/arg_properties.hpp
@@ -25,6 +25,11 @@ enum class Monotonicity : uint8_t {
 //! Per-argument metadata for a scalar function.
 struct ArgProperties {
 	Monotonicity monotonicity = Monotonicity::UNKNOWN;
+	//! True if the function may return NULL on +/-inf or NaN inputs (e.g. year(infinity) -> NULL).
+	//! The MIN/MAX peel skips wrappers with this flag unless the caller explicitly opts in via
+	//! `allow_finite_only=true` (Tier-2), since the wrapper might evaluate to NULL on a stat
+	//! boundary that isn't NULL on the underlying column.
+	bool requires_finite_input = false;
 
 	ArgProperties &StrictlyIncreasing() {
 		monotonicity = Monotonicity::STRICTLY_INCREASING;
@@ -44,6 +49,10 @@ struct ArgProperties {
 	}
 	ArgProperties &Constant() {
 		monotonicity = Monotonicity::CONSTANT;
+		return *this;
+	}
+	ArgProperties &RequiresFinite() {
+		requires_finite_input = true;
 		return *this;
 	}
 };

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/function/arg_properties.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
@@ -137,10 +138,28 @@ public:
 		function = new_function;
 	}
 
+	//! Per-arg metadata for the cast's single input. Mirrors `ScalarFunction::arg_properties[0]`,
+	//! so the MIN/MAX monotonic peel reads `cast.bound_cast.arg_properties` the same way it reads
+	//! `func.function.GetArgProperties(0)`. Defaults to UNKNOWN; opt in at the *CastSwitch
+	//! registration site for casts that preserve order. The rvalue-qualified setter lets factories
+	//! chain it onto a temporary: `return BoundCastInfo(&fn).SetArgProperties(...);`.
+	const ArgProperties &GetArgProperties() const {
+		return arg_properties;
+	}
+	BoundCastInfo &SetArgProperties(ArgProperties props) & {
+		arg_properties = props;
+		return *this;
+	}
+	BoundCastInfo SetArgProperties(ArgProperties props) && {
+		arg_properties = props;
+		return std::move(*this);
+	}
+
 private:
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;
 	unique_ptr<BoundCastData> cast_data;
+	ArgProperties arg_properties;
 };
 
 struct BindCastInput {

--- a/src/include/duckdb/optimizer/monotonic_peel.hpp
+++ b/src/include/duckdb/optimizer/monotonic_peel.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/monotonic_peel.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "duckdb/common/common.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+struct MonotonicPeelStep {
+	idx_t col_arg;
+	bool inverts;
+};
+
+//! Inspect one wrapper level of `expr`. On success, sets `step.col_arg` to the column-bearing
+//! child to walk into and `step.inverts` if this hop reverses ordering. Handles invertible
+//! casts and any function whose ArgProperties on the unique non-foldable arg declare
+//! monotonicity.
+//!
+//! `allow_finite_only`: tier-1 (false) refuses args where ArgProperties::requires_finite_input
+//! is set; tier-2 (true) accepts them, leaving null-safety to the caller.
+bool TryPeelMonotonicLevel(const Expression &expr, MonotonicPeelStep &step, bool allow_finite_only = false);
+
+//! Reference to the column-bearing child after a successful peel.
+const Expression &PeelColumnBearingChild(const Expression &expr, const MonotonicPeelStep &step);
+
+//! Move the column-bearing child out of `expr` (mutates expr).
+unique_ptr<Expression> ExtractColumnBearingChild(Expression &expr, const MonotonicPeelStep &step);
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -40,6 +40,15 @@ public:
 	static unique_ptr<BaseStatistics> TryPropagateCast(const BaseStatistics &stats, const LogicalType &source,
 	                                                   const LogicalType &target);
 
+	//! Validate corner-evaluation bounds and assemble a numeric stats result. Returns nullptr if
+	//! either bound is NaN/NULL; throws InternalException if `out_hi < out_lo` (catches an
+	//! arg_properties misannotation early). Shared by the function and cast forward-bounds paths.
+	//! `base_to_copy`, when non-null, seeds distinct-count and base validity flags before the
+	//! per-bound flags below override has_null/has_no_null.
+	static unique_ptr<BaseStatistics> BuildMonotoneBoundsStats(const LogicalType &target, Value out_lo, Value out_hi,
+	                                                           bool can_have_null, const string &error_context,
+	                                                           optional_ptr<const BaseStatistics> base_to_copy = nullptr);
+
 private:
 	//! Propagate statistics through an operator
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   duckdb_optimizer
   OBJECT
   aggregate_function_rewriter.cpp
+  monotonic_peel.cpp
   build_probe_side_optimizer.cpp
   column_binding_replacer.cpp
   column_lifetime_analyzer.cpp

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "duckdb/optimizer/monotonic_peel.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -29,6 +30,12 @@ public:
 	virtual unique_ptr<Expression>
 	CreateProjectionExpression(const LogicalType &aggr_type, unique_ptr<Expression> aggr_ref,
 	                           vector<unique_ptr<Expression>> additional_expressions) = 0;
+	//! Whether this rule needs the framework to bind a COUNT helper aggregate alongside the rewritten one.
+	//! Rules like AVG/SUM that derive a result from a count return true (default).
+	//! Rules that just lift an expression off the aggregate (LIST sort, MIN/MAX function peel) return false.
+	virtual bool NeedsHelperAggregate() const {
+		return true;
+	}
 
 public:
 	Optimizer &optimizer;
@@ -219,6 +226,10 @@ public:
 		return false;
 	}
 
+	bool NeedsHelperAggregate() const override {
+		return false;
+	}
+
 	unique_ptr<Expression> Rewrite(unique_ptr<Expression> &expr, vector<reference<Expression>> &bindings,
 	                               vector<unique_ptr<Expression>> &additional_expressions) override;
 
@@ -245,6 +256,123 @@ unique_ptr<Expression> ListRewriteRule::Rewrite(unique_ptr<Expression> &expr, ve
 
 	return nullptr;
 }
+
+//! MIN(f_mono(g(col))) -> f_mono(MIN(g(col))) — peel monotonic wrappers off the outside of MIN/MAX,
+//! lift them into a projection above the aggregate. If a wrapper is non-increasing in the column arg,
+//! swap MIN <-> MAX. Walks the chain in one go: peels every contiguous peelable level it can.
+class MonotonicPeelMatcher : public ExpressionMatcher {
+public:
+	MonotonicPeelMatcher() : ExpressionMatcher(ExpressionClass::BOUND_AGGREGATE) {
+	}
+
+	bool Match(Expression &expr_p, vector<reference<Expression>> &bindings) override {
+		if (expr_p.GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return false;
+		}
+		auto &aggr = expr_p.Cast<BoundAggregateExpression>();
+		if (aggr.function.name != "min" && aggr.function.name != "max") {
+			return false;
+		}
+		if (aggr.children.size() != 1) {
+			return false;
+		}
+		if (aggr.IsDistinct() || aggr.filter || aggr.order_bys) {
+			return false;
+		}
+		MonotonicPeelStep step;
+		if (!TryPeelMonotonicLevel(*aggr.children[0], step, /*allow_finite_only=*/false)) {
+			return false;
+		}
+		bindings.push_back(expr_p);
+		return true;
+	}
+};
+
+class MonotonicPeelRule : public AggregateRewriteRule {
+public:
+	explicit MonotonicPeelRule(Optimizer &optimizer) : AggregateRewriteRule(optimizer) {
+		matcher = make_uniq<MonotonicPeelMatcher>();
+	}
+
+	bool ShouldSkip(const LogicalAggregate &aggr) const override {
+		return !aggr.grouping_functions.empty() || aggr.grouping_sets.size() > 1;
+	}
+
+	bool NeedsHelperAggregate() const override {
+		return false;
+	}
+
+	unique_ptr<Expression> Rewrite(unique_ptr<Expression> &expr, vector<reference<Expression>> &,
+	                               vector<unique_ptr<Expression>> &additional_expressions) override {
+		auto &aggr = expr->Cast<BoundAggregateExpression>();
+		const auto original_child_type = aggr.children[0]->GetReturnType();
+		auto current = std::move(aggr.children[0]);
+		bool inverted = false;
+
+		// Stash each peeled wrapper with its column slot left empty for projection rebuild.
+		while (true) {
+			MonotonicPeelStep step;
+			if (!TryPeelMonotonicLevel(*current, step, /*allow_finite_only=*/false)) {
+				break;
+			}
+			auto inner = ExtractColumnBearingChild(*current, step);
+			if (step.inverts) {
+				inverted = !inverted;
+			}
+			additional_expressions.push_back(std::move(current));
+			current = std::move(inner);
+		}
+		D_ASSERT(!additional_expressions.empty()); // matcher confirmed at least one peelable level
+
+		// If parity is even and the peeled child's type matches the original, the existing min/max
+		// binding still applies; just swap in the new child. Otherwise rebind (child type changed,
+		// e.g. BIGINT -> TIMESTAMP, or we need to flip MIN <-> MAX).
+		if (!inverted && current->GetReturnType() == original_child_type) {
+			aggr.children[0] = std::move(current);
+			return nullptr;
+		}
+		D_ASSERT(aggr.function.name == "min" || aggr.function.name == "max");
+		const string new_name = inverted ? (aggr.function.name == "min" ? "max" : "min") : aggr.function.name;
+		auto &catalog = Catalog::GetSystemCatalog(optimizer.context);
+		auto &fn_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(optimizer.context, DEFAULT_SCHEMA, new_name);
+		const auto fn = fn_entry.functions.GetFunctionByArguments(optimizer.context, {current->GetReturnType()});
+
+		FunctionBinder function_binder(optimizer.context);
+		vector<unique_ptr<Expression>> args;
+		args.push_back(std::move(current));
+		expr = function_binder.BindAggregateFunction(fn, std::move(args));
+		return nullptr;
+	}
+
+	unique_ptr<Expression> CreateProjectionExpression(const LogicalType &, unique_ptr<Expression> aggr_ref,
+	                                                  vector<unique_ptr<Expression>> addnl) override {
+		// addnl holds wrappers in outermost-first order, each missing its column-bearing child.
+		// Rebuild inside-out, plugging the running expression into the empty slot at each level.
+		auto current = std::move(aggr_ref);
+		for (idx_t i = addnl.size(); i-- > 0;) {
+			auto wrapper = std::move(addnl[i]);
+			FillEmptySlot(*wrapper, std::move(current));
+			current = std::move(wrapper);
+		}
+		return current;
+	}
+
+private:
+	static void FillEmptySlot(Expression &wrapper, unique_ptr<Expression> filler) {
+		if (wrapper.GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+			wrapper.Cast<BoundCastExpression>().child = std::move(filler);
+			return;
+		}
+		auto &fun = wrapper.Cast<BoundFunctionExpression>();
+		for (idx_t i = 0; i < fun.children.size(); i++) {
+			if (!fun.children[i]) {
+				fun.children[i] = std::move(filler);
+				return;
+			}
+		}
+		D_ASSERT(false); // every stashed wrapper has exactly one empty slot
+	}
+};
 
 //! Internal LogicalOperatorVisitor that does the actual rewriting
 class AggregateFunctionRewriterInternal : public LogicalOperatorVisitor {
@@ -320,19 +448,22 @@ private:
 			RewriteInfo rewrite_info;
 			auto count_arg = rule.Rewrite(expr, bindings, rewrite_info.additional_expressions);
 
-			// Add COUNT([x]) to the aggregate list
-			FunctionBinder function_binder(optimizer.context);
-			const auto count_fun = CountFunctionBase::GetFunction();
-			vector<unique_ptr<Expression>> count_args;
-			if (count_arg) {
-				count_args.push_back(std::move(count_arg));
+			if (rule.NeedsHelperAggregate()) {
+				// Add COUNT([x]) to the aggregate list
+				FunctionBinder function_binder(optimizer.context);
+				const auto count_fun = CountFunctionBase::GetFunction();
+				vector<unique_ptr<Expression>> count_args;
+				if (count_arg) {
+					count_args.push_back(std::move(count_arg));
+				}
+				auto count_aggr = function_binder.BindAggregateFunction(count_fun, std::move(count_args), nullptr,
+				                                                        AggregateType::NON_DISTINCT);
+				rewrite_info.count_idx = aggr.expressions.size();
+				aggr.expressions.push_back(std::move(count_aggr));
+			} else {
+				rewrite_info.count_idx = DConstants::INVALID_INDEX;
 			}
-			auto count_aggr = function_binder.BindAggregateFunction(count_fun, std::move(count_args), nullptr,
-			                                                        AggregateType::NON_DISTINCT);
-
-			rewrite_info.count_idx = aggr.expressions.size();
 			rewrites.emplace(i, std::move(rewrite_info));
-			aggr.expressions.push_back(std::move(count_aggr));
 		}
 
 		if (rewrites.empty()) {
@@ -367,11 +498,12 @@ private:
 			}
 
 			auto &rewrite_info = rewrite_entry->second;
-			ColumnBinding count_binding(aggr.aggregate_index, ProjectionIndex(rewrite_info.count_idx));
-			auto count_ref = make_uniq<BoundColumnRefExpression>(
-			    aggr.expressions[rewrite_info.count_idx]->GetReturnType(), count_binding);
-
-			rewrite_info.additional_expressions.push_back(std::move(count_ref));
+			if (rule.NeedsHelperAggregate()) {
+				ColumnBinding count_binding(aggr.aggregate_index, ProjectionIndex(rewrite_info.count_idx));
+				auto count_ref = make_uniq<BoundColumnRefExpression>(
+				    aggr.expressions[rewrite_info.count_idx]->GetReturnType(), count_binding);
+				rewrite_info.additional_expressions.push_back(std::move(count_ref));
+			}
 			auto final_result = rule.CreateProjectionExpression(aggr_type, std::move(aggr_ref),
 			                                                    std::move(rewrite_info.additional_expressions));
 			projection_expressions.push_back(std::move(final_result));
@@ -395,6 +527,7 @@ AggregateFunctionRewriter::AggregateFunctionRewriter(Optimizer &optimizer) : opt
 	rules.push_back(make_uniq<AvgRewriteRule>(optimizer));
 	rules.push_back(make_uniq<SumRewriteRule>(optimizer));
 	rules.push_back(make_uniq<ListRewriteRule>(optimizer));
+	rules.push_back(make_uniq<MonotonicPeelRule>(optimizer));
 }
 
 AggregateFunctionRewriter::~AggregateFunctionRewriter() {

--- a/src/optimizer/monotonic_peel.cpp
+++ b/src/optimizer/monotonic_peel.cpp
@@ -1,0 +1,88 @@
+#include "duckdb/optimizer/monotonic_peel.hpp"
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/function/arg_properties.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+bool TryPeelMonotonicLevel(const Expression &expr, MonotonicPeelStep &step, bool allow_finite_only) {
+	step.inverts = false;
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+		auto &cast = expr.Cast<BoundCastExpression>();
+		// try_cast turns failures into NULLs, which changes the NULL-set across the rewrite —
+		// MIN's NULL-skipping then picks a different row in the peeled vs un-peeled query.
+		if (cast.try_cast) {
+			return false;
+		}
+		auto &props = cast.bound_cast.GetArgProperties();
+		if (props.requires_finite_input && !allow_finite_only) {
+			return false;
+		}
+		if (IsMonotonicDecreasing(props.monotonicity)) {
+			step.inverts = true;
+		} else if (!IsMonotonicIncreasing(props.monotonicity)) {
+			return false;
+		}
+		step.col_arg = 0;
+		return true;
+	}
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &fun = expr.Cast<BoundFunctionExpression>();
+	if (fun.function.GetStability() != FunctionStability::CONSISTENT) {
+		return false;
+	}
+	if (fun.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING) {
+		return false;
+	}
+	if (!fun.function.HasArgProperties()) {
+		return false;
+	}
+	// find the unique non-foldable arg
+	idx_t non_foldable = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < fun.children.size(); i++) {
+		if (fun.children[i]->IsFoldable()) {
+			continue;
+		}
+		if (non_foldable != DConstants::INVALID_INDEX) {
+			return false;
+		}
+		non_foldable = i;
+	}
+	if (non_foldable == DConstants::INVALID_INDEX) {
+		return false;
+	}
+	auto &props = fun.function.GetArgProperties(non_foldable);
+	if (props.requires_finite_input && !allow_finite_only) {
+		return false;
+	}
+	if (IsMonotonicIncreasing(props.monotonicity)) {
+		// no flip
+	} else if (IsMonotonicDecreasing(props.monotonicity)) {
+		step.inverts = true;
+	} else {
+		return false;
+	}
+	step.col_arg = non_foldable;
+	return true;
+}
+
+const Expression &PeelColumnBearingChild(const Expression &expr, const MonotonicPeelStep &step) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+		return *expr.Cast<BoundCastExpression>().child;
+	}
+	return *expr.Cast<BoundFunctionExpression>().children[step.col_arg];
+}
+
+unique_ptr<Expression> ExtractColumnBearingChild(Expression &expr, const MonotonicPeelStep &step) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+		return std::move(expr.Cast<BoundCastExpression>().child);
+	}
+	return std::move(expr.Cast<BoundFunctionExpression>().children[step.col_arg]);
+}
+
+} // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
+
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/variant_stats.hpp"
 
@@ -7,17 +10,12 @@ namespace duckdb {
 
 static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const BaseStatistics &input,
                                                                          const LogicalType &target) {
-	// Bail out if the stats are not numeric
-	if (input.GetStatsType() != StatisticsType::NUMERIC_STATS) {
-		return nullptr;
-	}
-	if (!NumericStats::HasMinMax(input)) {
+	if (input.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(input)) {
 		return nullptr;
 	}
 	Value min = NumericStats::Min(input);
 	Value max = NumericStats::Max(input);
 	if (!min.DefaultTryCastAs(target) || !max.DefaultTryCastAs(target)) {
-		// overflow in cast: bailout
 		return nullptr;
 	}
 	auto result = NumericStats::CreateEmpty(target);
@@ -205,11 +203,49 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCastEx
 	if (!child_stats) {
 		return nullptr;
 	}
-	auto result_stats = TryPropagateCast(*child_stats, cast.child->GetReturnType(), cast.GetReturnType());
-	if (cast.try_cast && result_stats) {
-		result_stats->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	auto &source = cast.child->GetReturnType();
+	auto &target = cast.GetReturnType();
+
+	if (source.id() == LogicalTypeId::VARIANT) {
+		auto result = StatisticsPropagateVariant(*child_stats, target);
+		if (cast.try_cast && result) {
+			result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		return result;
 	}
-	return result_stats;
+
+	// Identity cast: NopCast carries no arg_properties, so handle before reading metadata.
+	if (source == target) {
+		auto result = child_stats->ToUnique();
+		if (cast.try_cast && result) {
+			result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		return result;
+	}
+
+	auto &props = cast.bound_cast.GetArgProperties();
+	if (!IsKnownMonotonic(props.monotonicity)) {
+		return nullptr;
+	}
+	if (BaseStatistics::GetStatsType(target) != StatisticsType::NUMERIC_STATS) {
+		return nullptr;
+	}
+	if (child_stats->GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(*child_stats)) {
+		return nullptr;
+	}
+	// Map child min/max through the active cast registry so ICU overrides apply.
+	Value out_lo = NumericStats::Min(*child_stats);
+	Value out_hi = NumericStats::Max(*child_stats);
+	if (!out_lo.TryCastAs(context, target) || !out_hi.TryCastAs(context, target)) {
+		return nullptr;
+	}
+	if (IsMonotonicDecreasing(props.monotonicity)) {
+		std::swap(out_lo, out_hi);
+	}
+	const bool can_have_null = child_stats->CanHaveNull() || cast.try_cast;
+	return BuildMonotoneBoundsStats(target, std::move(out_lo), std::move(out_hi), can_have_null,
+	                                StringUtil::Format("cast %s -> %s", source.ToString(), target.ToString()),
+	                                child_stats.get());
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -90,6 +90,14 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	    !TryEvaluateAtConstants(context, func, hi_args, out_hi)) {
 		return nullptr;
 	}
+	return StatisticsPropagator::BuildMonotoneBoundsStats(func.GetReturnType(), std::move(out_lo), std::move(out_hi),
+	                                                     output_can_have_null, func.function.name);
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::BuildMonotoneBoundsStats(const LogicalType &target, Value out_lo,
+                                                                           Value out_hi, bool can_have_null,
+                                                                           const string &error_context,
+                                                                           optional_ptr<const BaseStatistics> base) {
 	// NaN/NULL at a corner means the input was NaN/NULL (column contains NaN, or year(±infinity)).
 	// NaN is excluded even though DuckDB orders it above all other values: negate(NaN) = NaN, which
 	// would violate NON_INCREASING if NaN were treated as a valid corner. Bail instead.
@@ -111,15 +119,20 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	}
 	if (out_hi < out_lo) {
 		throw InternalException("Monotonic arg annotation violated for '%s': output min exceeds output max",
-		                        func.function.name);
+		                        error_context);
 	}
 
-	auto result = NumericStats::CreateEmpty(func.GetReturnType());
+	auto result = NumericStats::CreateEmpty(target);
+	if (base) {
+		// Carry distinct_count and base validity flags forward; the per-bound Set calls below
+		// then re-assert the freshly-derived has_null / has_no_null on top.
+		result.CopyBase(*base);
+	}
 	NumericStats::SetMin(result, out_lo);
 	NumericStats::SetMax(result, out_hi);
 
 	result.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
-	if (output_can_have_null) {
+	if (can_have_null) {
 		result.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	}
 	return result.ToUnique();

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -3,22 +3,28 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
+#include "duckdb/optimizer/monotonic_peel.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_expression_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_index.hpp"
@@ -72,6 +78,13 @@ unique_ptr<ValueComparator> GetComparator(const string &fun_name, const LogicalT
 	return nullptr;
 }
 
+unique_ptr<ValueComparator> FlipComparator(const string &fun_name, const LogicalType &type) {
+	D_ASSERT(fun_name == "min" || fun_name == "max");
+	// "min" -> MaxValueComp, "max" -> MinValueComp
+	const string flipped = (fun_name == "min") ? "max" : "min";
+	return GetComparator(flipped, type);
+}
+
 bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &storage_index,
                           const ValueComparator &comparator, Value &result) {
 	if (!stats.partition_row_group) {
@@ -99,6 +112,36 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 	return true;
 }
 
+// Walks `expr` through invertible casts and monotonic scalar functions (Tier-2,
+// allow_finite_only=true). On success `inner_binding` holds the binding of the column ref
+// at the bottom and `inverted` is toggled for each INVERTS_INPUT_ORDER hop (accumulated XOR).
+bool TryExtractWrappedColumnRef(const Expression &expr, ColumnBinding &inner_binding, bool &inverted) {
+	reference<const Expression> e = expr;
+	while (true) {
+		if (e.get().GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			inner_binding = e.get().Cast<BoundColumnRefExpression>().binding;
+			return true;
+		}
+		MonotonicPeelStep step;
+		if (!TryPeelMonotonicLevel(e.get(), step, /*allow_finite_only=*/true)) {
+			return false;
+		}
+		if (step.inverts) {
+			inverted = !inverted;
+		}
+		e = PeelColumnBearingChild(e.get(), step);
+	}
+}
+
+void SubstituteColumnRefWithConstant(unique_ptr<Expression> &expr, const Value &value) {
+	if (expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		expr = make_uniq<BoundConstantExpression>(value);
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { SubstituteColumnRefWithConstant(child, value); });
+}
+
 } // namespace
 
 void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_ptr<LogicalOperator> &node_ptr) {
@@ -110,6 +153,11 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	vector<idx_t> count_star_idxs;
 	vector<ColumnBinding> min_max_bindings;
 	vector<unique_ptr<ValueComparator>> comparators;
+	vector<string> agg_fun_names;
+	vector<LogicalType> agg_arg_types;
+	// wrapper sitting directly inside MIN/MAX (no intervening projection); seeds the chain
+	vector<unique_ptr<Expression>> agg_arg_wrappers;
+	vector<bool> wrapper_inverted; // accumulated INVERTS parity per min/max binding
 
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
 		auto &aggr_ref = aggr.expressions[i];
@@ -124,18 +172,31 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		}
 		const string &fun_name = aggr_expr.function.name;
 		if (fun_name == "min" || fun_name == "max") {
-			if (aggr_expr.children.size() != 1 ||
-			    aggr_expr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			if (aggr_expr.children.size() != 1) {
 				return;
 			}
-			const auto &col_ref = aggr_expr.children[0]->Cast<BoundColumnRefExpression>();
-			min_max_bindings.push_back(col_ref.binding);
-			auto comparator = GetComparator(fun_name, col_ref.GetReturnType());
+			auto &agg_arg = *aggr_expr.children[0];
+			ColumnBinding inner_binding;
+			bool inverted = false;
+			if (agg_arg.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+				inner_binding = agg_arg.Cast<BoundColumnRefExpression>().binding;
+				agg_arg_wrappers.emplace_back();
+			} else {
+				if (!TryExtractWrappedColumnRef(agg_arg, inner_binding, inverted)) {
+					return;
+				}
+				agg_arg_wrappers.push_back(agg_arg.Copy());
+			}
+			wrapper_inverted.push_back(inverted);
+			min_max_bindings.push_back(inner_binding);
+			auto comparator = GetComparator(fun_name, agg_arg.GetReturnType());
 			if (!comparator) {
 				// Type has no min max statistics
 				return;
 			}
 			comparators.push_back(std::move(comparator));
+			agg_fun_names.push_back(fun_name);
+			agg_arg_types.push_back(agg_arg.GetReturnType());
 		} else if (fun_name == "count_star") {
 			count_star_idxs.push_back(i);
 		} else {
@@ -144,16 +205,31 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		}
 	}
 
-	// skip any projections
+	// walk projections, collecting the wrapper chain (outermost first) per binding
+	vector<vector<unique_ptr<Expression>>> wrapper_chains(min_max_bindings.size());
+	for (idx_t i = 0; i < min_max_bindings.size(); i++) {
+		if (agg_arg_wrappers[i]) {
+			wrapper_chains[i].push_back(std::move(agg_arg_wrappers[i]));
+		}
+	}
 	reference<LogicalOperator> child_ref = *aggr.children[0];
 	while (child_ref.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
-		for (auto &binding : min_max_bindings) {
+		for (idx_t i = 0; i < min_max_bindings.size(); i++) {
+			auto &binding = min_max_bindings[i];
 			auto &proj = child_ref.get().Cast<LogicalProjection>();
 			auto &expr = proj.GetExpression(binding);
-			if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+				binding = expr.Cast<BoundColumnRefExpression>().binding;
+				continue;
+			}
+			ColumnBinding inner_binding;
+			bool proj_inverted = false;
+			if (!TryExtractWrappedColumnRef(expr, inner_binding, proj_inverted)) {
 				return;
 			}
-			binding = expr.Cast<BoundColumnRefExpression>().binding;
+			wrapper_chains[i].push_back(expr.Copy());
+			wrapper_inverted[i] = wrapper_inverted[i] ^ proj_inverted;
+			binding = inner_binding;
 		}
 		child_ref = *child_ref.get().children[0];
 	}
@@ -252,7 +328,15 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		// Execute min/max aggregates on partition statistics
 		for (idx_t agg_idx = 0; agg_idx < min_max_storage_indexes.size(); agg_idx++) {
 			const auto &storage_index = min_max_storage_indexes[agg_idx];
-			auto &comparator = comparators[agg_idx];
+			unique_ptr<ValueComparator> flipped_holder;
+			ValueComparator *comparator = comparators[agg_idx].get();
+			if (wrapper_inverted[agg_idx]) {
+				flipped_holder = FlipComparator(agg_fun_names[agg_idx], agg_arg_types[agg_idx]);
+				if (!flipped_holder) {
+					return;
+				}
+				comparator = flipped_holder.get();
+			}
 
 			Value agg_result;
 			if (!TryGetValueFromStats(partition_stats[0], storage_index, *comparator, agg_result)) {
@@ -266,6 +350,25 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 				if (!comparator->Compare(agg_result, rhs)) {
 					agg_result = rhs;
 				}
+			}
+			// apply wrappers innermost-first to thread the column value back up.
+			// TryEvaluateScalar swallows exceptions and returns false: a wrapper that
+			// throws on the stat value would also throw on the full scan, so falling
+			// back here is correct (slow error vs fast error), not a correctness bug.
+			auto &chain = wrapper_chains[agg_idx];
+			for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+				auto wrapper = (*it)->Copy();
+				SubstituteColumnRefWithConstant(wrapper, agg_result);
+				Value evaluated;
+				if (!ExpressionExecutor::TryEvaluateScalar(context, *wrapper, evaluated)) {
+					return;
+				}
+				if (evaluated.IsNull()) {
+					// Bail if the wrapper returns NULL for this stat value (e.g. year(infinity)=NULL).
+					// The full aggregate scan will skip NULL outputs per-row and return the correct result.
+					return;
+				}
+				agg_result = std::move(evaluated);
 			}
 			types.push_back(agg_result.GetTypeMutable());
 			auto expr = make_uniq<BoundConstantExpression>(agg_result);

--- a/test/optimizer/min_max_function_peel.test
+++ b/test/optimizer/min_max_function_peel.test
@@ -1,0 +1,190 @@
+# name: test/optimizer/min_max_function_peel.test
+# description: MIN/MAX folding through monotonic wrappers and casts
+# group: [optimizer]
+
+require no_alternative_verify
+
+load {TEST_DIR}/peel.db
+
+statement ok
+CREATE TABLE t AS SELECT
+  i::INTEGER AS bi,
+  i::DOUBLE AS d,
+  DATE '2020-01-01' + INTERVAL (i) DAY AS dt,
+  TIMESTAMP '2020-01-01' + INTERVAL (i) HOUR AS ts,
+  (12 + (i % 100))::DECIMAL(5,2) AS dec
+FROM range(2048) _(i)
+
+restart
+
+# Aggregate eliminated.
+query II
+EXPLAIN SELECT MIN(year(dt)), MAX(year(dt)),
+               MIN(date_diff('day', DATE '2020-01-01', dt)),
+               MIN(date_diff('day', dt, DATE '2030-01-01')),
+               MIN(ceiling(d)),
+               MIN(bi + 5), MIN(5 + bi),
+               MIN(date_add(dt, INTERVAL '7 day')),
+               MIN(-bi), MAX(-bi),
+               MIN(5 - bi), MAX(5 - bi),
+               MIN(-(-bi)), MIN(-(bi + 5)),
+               MIN(bi::BIGINT),
+               MIN(dt::VARCHAR),
+               MIN(ts::DATE),
+               MIN(ts::TIMESTAMP_NS),
+               MIN(dec::DECIMAL(7,4)),
+               MIN(epoch_ms(ts))
+FROM t
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+# Outer Tier-1 wrapper lifts above an inner Tier-2 that stats-folds.
+query II
+EXPLAIN SELECT MIN(round(year(dt))) FROM t
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query IIIIIIIIII
+SELECT MIN(year(dt)), MAX(year(dt)),
+       MIN(date_diff('day', dt, DATE '2030-01-01')),
+       MIN(bi + 5), MIN(bi - 5),
+       MIN(-bi), MAX(-bi),
+       MIN(5 - bi), MAX(5 - bi),
+       MIN(-(bi + 5))
+FROM t
+----
+2020	2025	1606	5	-5	-2047	0	-2042	5	-2052
+
+# Aggregate must remain.
+query II
+EXPLAIN SELECT MIN(month(dt)) FROM t
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+EXPLAIN SELECT MIN(d * 2.0) FROM t
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+EXPLAIN SELECT MIN(bi - (bi + 1)) FROM t
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+# Partial peel: outer unary - lifts and flips MIN->MAX; inner month stays.
+query II
+EXPLAIN SELECT MIN(-month(dt)) FROM t
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*Aggregates: max\(#0\).*
+
+query I
+SELECT MIN(-month(dt)) FROM t
+----
+-12
+
+# Tier-2 with infinity input: year(infinity)=NULL; stats-fold must bail.
+statement ok
+CREATE TABLE t_inf AS SELECT * FROM (VALUES
+    ('2021-01-01'::DATE), ('infinity'::DATE), ('-infinity'::DATE)) v(dt)
+
+query II
+EXPLAIN SELECT MAX(year(dt)) FROM t_inf
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT MAX(year(dt)) FROM t_inf
+----
+2021
+
+# No-stats source: rewriter refuses RequiresFinite wrappers; aggregate stays.
+statement ok
+COPY (SELECT DATE '2020-01-01' + INTERVAL (i) DAY AS dt FROM range(2048) _(i))
+TO '{TEST_DIR}/peel.csv' (FORMAT CSV, HEADER 1)
+
+query II
+EXPLAIN SELECT MIN(year(dt)) FROM read_csv('{TEST_DIR}/peel.csv', auto_detect=true)
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT MIN(year(dt)) FROM read_csv('{TEST_DIR}/peel.csv', auto_detect=true)
+----
+2020
+
+# Empty / all-NULL input through wrapper.
+statement ok
+CREATE TABLE t_empty (dt DATE)
+
+query II
+SELECT MIN(year(dt)), MAX(year(dt)) FROM t_empty
+----
+NULL	NULL
+
+statement ok
+INSERT INTO t_empty VALUES (NULL), (NULL)
+
+query II
+SELECT MIN(year(dt)), MAX(year(dt)) FROM t_empty
+----
+NULL	NULL
+
+# try_cast must NOT peel — NULL-set divergence with MIN's NULL-skipping.
+statement ok
+CREATE TABLE t_trycast AS SELECT * FROM (VALUES ('!!!garbage'), ('2024-01-01'), ('2024-06-15')) v(s)
+
+query I
+SELECT MIN(TRY_CAST(s AS DATE)) FROM t_trycast
+----
+2024-01-01
+
+# INTERVAL arg of DATE/TIMESTAMP +/- INTERVAL must NOT peel — interval ordering
+# (normalize-based, 30-day months) disagrees with calendar arithmetic.
+statement ok
+CREATE TABLE t_di AS SELECT * FROM (VALUES
+    (DATE '2025-02-01', TIMESTAMP '2025-02-01 00:00', INTERVAL '1 month'),
+    (DATE '2025-02-01', TIMESTAMP '2025-02-01 00:00', INTERVAL '29 days')) v(d, ts, ival)
+
+query IIII
+SELECT MIN(d + ival), MIN(ts + ival), MIN(d - ival), MIN(ts - ival) FROM t_di
+----
+2025-03-01 00:00:00	2025-03-01 00:00:00	2025-01-01 00:00:00	2025-01-01 00:00:00
+
+query III rowsort
+SELECT d + ival, d - ival, ival FROM t_di
+----
+2025-03-01 00:00:00	2025-01-01 00:00:00	1 month
+2025-03-02 00:00:00	2025-01-03 00:00:00	29 days
+
+# Literal-interval form is monotonic in the DATE arg.
+query II
+SELECT MIN(d + INTERVAL '1 month'), MAX(d + INTERVAL '1 month') FROM t_di
+----
+2025-03-01 00:00:00	2025-03-01 00:00:00
+
+# DATE + TIMETZ result orders in UTC but TIMETZ orders raw-bits; TIME/TIMETZ +/- INTERVAL
+# wraps modulo 24h — none of these are monotonic.
+statement ok
+CREATE TABLE t_tz AS SELECT * FROM (VALUES
+    (DATE '2022-01-01', '00:01:20+00'::TIMETZ, '20:00:00'::TIME),
+    (DATE '0044-03-15 (BC)', '20:08:10.001-15:59'::TIMETZ, '01:00:00'::TIME),
+    (NULL, '20:08:10.998-07'::TIMETZ, NULL)) v(d, z, t)
+
+query I
+SELECT count(a.d + b.z) + count(a.z + b.d) + count(a.t + INTERVAL '5 hours') + count(a.t - INTERVAL '5 hours')
+     + count(a.z + INTERVAL '5 hours') + count(a.z - INTERVAL '5 hours')
+FROM t_tz a, t_tz b
+----
+42
+
+# Regression guard: MIN(time_tz) compares raw bits (time portion in high bits) and
+# epoch(time_tz) only reads the time portion, so they agree today. If MIN(time_tz) ever
+# switches to UTC-instant ordering, this starts failing and the epoch annotation must drop.
+statement ok
+CREATE TABLE t_ttz AS SELECT * FROM (VALUES
+    ('11:00:00+12'::TIMETZ), ('12:00:00-12'::TIMETZ), ('12:00:00+00'::TIMETZ)) v(z)
+
+query II
+SELECT MIN(epoch(z)), epoch(MIN(z)) FROM t_ttz
+----
+39600.0	39600.0

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -176,3 +176,54 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
 ----
 1.0	2.718281828459045
+
+# === Cast forward-bounds via BoundCastInfo::arg_properties ===
+
+statement ok
+CREATE TABLE tinies AS SELECT (i - 50)::TINYINT AS bi FROM range(100) _(i)
+
+# Strict numeric widening: min/max + distinct_count carried forward via CopyBase.
+query IIII
+SELECT s.min, s.max, s.approx_unique, s.has_null
+FROM (SELECT STATS(bi::BIGINT) s FROM tinies LIMIT 1)
+----
+-50	49	100	false
+
+# try_cast must mark has_null even when the input column has no nulls.
+query III
+SELECT s.min, s.max, s.has_null
+FROM (SELECT STATS(TRY_CAST(bi AS BIGINT)) s FROM tinies LIMIT 1)
+----
+-50	49	true
+
+# NonDecreasing cast (TIMESTAMP -> DATE truncation): bounds propagate.
+statement ok
+CREATE TABLE tstamps AS SELECT (TIMESTAMP '2024-01-01' + INTERVAL (i) HOUR) AS t FROM range(100) _(i)
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::DATE) s FROM tstamps LIMIT 1)
+----
+2024-01-01	2024-01-05
+
+# UNKNOWN-monotonicity cast (TIMESTAMP -> TIME drops the date): no bounds derived.
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIME) s FROM tstamps LIMIT 1)
+----
+NULL	NULL
+
+# Strict widening DATE -> TIMESTAMP_NS: bounds propagate.
+query II
+SELECT s.min, s.max FROM (SELECT STATS(dt::TIMESTAMP_NS) s FROM finite_dates LIMIT 1)
+----
+2020-01-01 00:00:00	2025-08-09 00:00:00
+
+# Identity cast (source == target) preserves stats including distinct_count.
+query III
+SELECT s.min, s.max, s.approx_unique
+FROM (SELECT STATS(bi::TINYINT) s FROM tinies LIMIT 1)
+----
+-50	49	100
+
+# Decreasing cast: only intentionally-decreasing annotation among casts is none; verify the
+# swap-on-decreasing branch via a synthetic UDF would require a builtin we don't have, so the
+# logic is exercised at the function level via NEGATE elsewhere in this file.


### PR DESCRIPTION

The optimization is split across two cooperating paths:

- **Structural peel** (`MonotonicPeelRule`, sibling of `AvgRewriteRule` etc.) — at plan time, lifts wrappers off `MIN(f(g(col)))` into a `LogicalProjection` above the aggregate, leaving bare `MIN(col)` for the existing stats-fold rule. Works on any source — CSV, range, in-memory CTEs — because the rewrite is structural and doesn't require row-group stats. MIN↔MAX flips on odd inversion parity (rebound through the catalog like `AvgRewriteRule`'s AVG → SUM swap).
- **Stats fold** (`StatisticsPropagator::TryExecuteAggregates`) — same shape as the existing bare-MIN/MAX fold, extended to walk through wrapper chains. Each per-row wrapper application is gated on `!IsNull()`, so a row-group bound of `±infinity` that produces NULL through `year`/`decade`/etc. silently abandons the optimization (the aggregate runs and gets the correct answer).

Both paths share `TryPeelMonotonicLevel` in `src/optimizer/monotonic_peel.cpp`. The structural path refuses to peel any wrapper whose argument is annotated `RequiresFinite()`; the stats-fold path with the IsNull guard handles those.

### Per-arg `ArgProperties` on `ScalarFunction`

Function metadata is stored per-argument on `ScalarFunction`. Each `ArgProperties` carries:

- `monotonicity` — `STRICTLY_INCREASING` / `NON_DECREASING` / `STRICTLY_DECREASING` / `NON_INCREASING` / `CONSTANT` / `UNKNOWN`. Step functions (`floor`, `round`, `year`, `date_trunc`, …) use the non-strict variants.
- `requires_finite_input` — gates the structural-peel path; functions like `year(infinity) → NULL` set this and only the stats-fold path with the IsNull guard handles them.
- `injective` — declared but currently unused; for follow-on consumers (e.g. `COUNT(DISTINCT f(col))` rewrites).
- `refine_monotonicity` callback — narrows monotonicity given the actual value range of this arg. Used for ICU `year`/`decade`/etc., which are monotonic only when the input range stays within a single era (BC vs AD).
- `preimage` callback — declared, currently unused; intended for filter pushdown through monotonic wrappers.

Plus a function-level slot:

- `codomain_bounds` — output range regardless of input (e.g. `month` is in `[1, 13)`); declared, currently unused.

Each registration site opts in through builders:

```cpp
date_diff.SetArgProperties({ArgProperties{},                                              // part literal
                            ArgProperties().Decreasing(false).RequiresFinite(),           // start
                            ArgProperties().Increasing(false).RequiresFinite()});         // end
year_set.SetUnaryArgProperties(ArgProperties().Increasing(false).RequiresFinite()
                                              .WithMonotonicityRefiner(IcuYearRefiner));
date_trunc.SetArgProperties(1, ArgProperties().Increasing(false));
unary_minus.SetUnaryArgProperties(ArgProperties().Decreasing());
```

### Output statistics derivation (falls out of the per-arg model) and was requested

`StatisticsPropagator` for `BoundFunctionExpression` now derives output min/max via corner evaluation when a function has no custom stats callback but has annotated `ArgProperties`: evaluate `f(lo_args...)` and `f(hi_args...)` with decreasing args flipped. This subsumes the hand-rolled `NegateBindStatistics` (deleted) and gives every annotated unary/binary monotonic function downstream stats for free.

### Adjacent fix in `parquet_reader.cpp::MinMaxIsExact`

Default to `true` for fixed-width physical types when the column chunk omits `is_min_value_exact` / `is_max_value_exact`. Pre-PARQUET-2352 (Oct 2023) the spec required min/max (when present) to be exact; in practice some writers truncated long binary values, which is what motivated the flag. Fixed-width physical types are not subject to that truncation, so when the flag is missing we treat them as exact. Without the fix, every parquet from a pre-PARQUET-2352 writer fails the exactness gate and the optimization can't fire. No parquet files written before Oct 2023 (including ClickHouse's clickbench parquet files) will have this field present, so on all old data this effectively eliminates this field of parquet stats related optimizations.

### Benchmarks

Each query is run in one session as 1 untimed warmup + 3 timed hot runs (page-cache resident); the table reports the median of the 3 hot runs. Default thread count (32 cores on the test machine), `PRAGMA disable_progress_bar`, `SET parquet_metadata_cache=true` (matches the canonical ClickBench `run.sh` so the thrift footer isn't reparsed per query). Comparison is against `main` (`9017a272ae`), built `release` from the same toolchain. For row E, ClickBench's `create.sql` is loaded via `-init` so it runs before `.timer on` and is excluded from per-query timing — same handling as the canonical bench's separate "Load time" measurement.

One synthetic dataset covers rows A–D — written once as parquet (256M rows for the parquet benches) and CSV (64M rows for the no-stats bench). ClickBench's `hits.parquet` covers row E.

```sql
-- Synthetic dataset. ORDER BY hash(i) defeats dictionary encoding so the
-- without-side parquet scan reflects realistic per-row decompression cost
-- instead of trivially compressed sequential data.
COPY (SELECT
        (TIMESTAMP '2000-01-01' + INTERVAL ((i % 2900000)::INTEGER) DAY) AS dt,
        i::BIGINT                                                        AS bi,
        (i + (i % 7))::BIGINT                                            AS other_col
      FROM range(256000000) _(i)
      ORDER BY hash(i))
  TO '/tmp/bench_minmax.parquet' (FORMAT PARQUET);

COPY (SELECT ... FROM range(64000000) ... ORDER BY hash(i))
  TO '/tmp/bench_minmax.csv' (FORMAT CSV, HEADER);
```

| # | Feature exercised | Query | Effective rewrite | main | this PR | Speedup |
|---|---|---|---|---|---|---|
| A | Tier-1 parquet stats fold | `MIN(date_trunc('month', dt)), MAX(date_trunc('month', dt))` from `bench_minmax.parquet` | `date_trunc('month', MIN(dt)), date_trunc('month', MAX(dt))` → both bare aggregates fold to row-group constants → projection wraps with `date_trunc` at plan time | 423 ms | **3 ms** | ~141× |
| B | Tier-2 (domain-restricted) stats fold only — structural peel refuses because `year(infinity)→NULL` | `MIN(year(dt)), MAX(year(dt))` from `bench_minmax.parquet` | `year(MIN(dt)), year(MAX(dt))` collapsed at fold time via stats-walk + IsNull guard | 204 ms | **3 ms** | ~68× |
| C | Structural peel only (CSV — no row-group stats) | `MIN(date_trunc('month', dt)), MAX(date_trunc('month', dt))` from `read_csv('bench_minmax.csv')` | aggregate becomes bare `MIN(dt), MAX(dt)`; `date_trunc` lifted into a single post-aggregate projection. The scan still runs, but per-row `date_trunc` evaluations drop to one each | 415 ms | 334 ms | 1.2× |
| D | Partial peel — chain bottoms out at non-foldable expression | `MIN(round(cbrt((bi - other_col)::DOUBLE)) - 100)` from `bench_minmax.parquet` | `round(cbrt(MIN((bi - other_col)::DOUBLE))) - 100` — `bi - other_col` has two non-foldable args and stays inside the aggregate; `round`/`cbrt`/`-100` lift above | 423 ms | 332 ms | 1.3× |
| E | Tier-1 (ClickBench Q7, `hits.parquet` ~100M rows; view applies `make_date(EventDate)`) | `SELECT MIN(EventDate), MAX(EventDate) FROM hits;` | `make_date(MIN(raw_date_int)), make_date(MAX(raw_date_int))` → constants from row-group stats | 22 ms | 10 ms | ~2.2× |

<details>
<summary>Cross-reader <strong>AI Assisted</strong> survey for absent <code>is_*_value_exact</code></summary>

Four distinct strategies across the parquet ecosystem when the flag is missing in the thrift message. Categories:

- **Strict** — only treat min/max as exact when the flag is explicitly `true`; otherwise refuse the optimization
- **Type-aware** — treat fixed-width physical types as exact when the flag is absent, variable-length as inexact (PARQUET-2352-aware)
- **Trust unconditionally** — never read the flag on the read path; treat min/max as exact regardless
- **Pass-through** — library faithfully exposes the optional; no policy decision (no query engine attached)

| Reader | Category | Fixed-width prims | BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY | Source |
|---|---|---|---|---|
| **DuckDB (pre this PR)** | Strict | requires explicit `true` | requires explicit `true` | bails unless both `__isset` and both flags `true` ([parquet_reader.cpp#L1405-L1421](https://github.com/duckdb/duckdb/blob/8b2e995727c39f314459e58930281298b6ee0484/extension/parquet/parquet_reader.cpp#L1405-L1421)) |
| **DuckDB (this PR)** | Type-aware | exact when absent | inexact when absent | `t != BYTE_ARRAY && t != FIXED_LEN_BYTE_ARRAY` |
| **arrow-rs** | Type-aware | exact when absent | inexact when absent | `ValueStatistics::new` defaults `is_*_value_exact: max.is_some()` for fixed-width arms ([statistics.rs#L530-L543](https://github.com/apache/arrow-rs/blob/4fa8d2ff5f18f2d773f9642631715509f844a062/parquet/src/file/statistics.rs#L530-L543)); BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY arms override with `unwrap_or(false)` ([L247-L269](https://github.com/apache/arrow-rs/blob/4fa8d2ff5f18f2d773f9642631715509f844a062/parquet/src/file/statistics.rs#L247-L269)) |
| **DataFusion** | Type-aware (via arrow-rs) | exact when absent | inexact when absent | `Some(true)` → `Precision::Exact`, `Some(false)`/`None` → `Precision::Inexact` ([metadata.rs#L460-L490](https://github.com/apache/datafusion/blob/65f337d6637aa069012e0e9286f859fb3a743253/datafusion/datasource-parquet/src/metadata.rs#L460-L490)) |
| **Apache Arrow C++** | Pass-through | `std::nullopt` (unknown) | `std::nullopt` (unknown) | `FromThrift` only copies the bool when `__isset`; otherwise leaves it unset for every physical type ([thrift_internal.h#L255-L275](https://github.com/apache/arrow/blob/cc15bf1e839ea31f018a82a325eca906b32c86fe/cpp/src/parquet/thrift_internal.h#L255-L275)) |
| **parquet-java** (parquet-mr) | Trust unconditionally | trusted | trusted | flags never read anywhere in the repo (0 hits at [b8f4dda](https://github.com/apache/parquet-java/tree/b8f4dda5d8492904bff33e3774a2de57f172e967)); `StatisticsFilter` and `ColumnIndexFilter` consume min/max with no exactness gate |
| **Apache Spark** | Trust unconditionally (with one prefix-aware exception) | trusted (via parquet-java) | trusted; `StringStartsWith` slices min/max to the prefix length ([ParquetFilters.scala#L818-L849](https://github.com/apache/spark/blob/9ca391927d15412fc3399117a7a1f9a74e7bdf81/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala#L818-L849)) | flags never read on read path |
| **Trino** | Trust unconditionally | trusted | trusted | `fromParquetStatistics` reads `min_value`/`max_value` and never consults the exact flags ([ParquetMetadataConverter.java#L308](https://github.com/trinodb/trino/blob/ba02373d539e809bf56aa7698af50c0d502b2124/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java#L308)); they are only set on the write path ([L296](https://github.com/trinodb/trino/blob/ba02373d539e809bf56aa7698af50c0d502b2124/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java#L296)) |
| **ClickHouse** | Trust unconditionally | trusted | trusted | only set on the write path: `Write.cpp` for fixed-width ([L75-L76](https://github.com/ClickHouse/ClickHouse/blob/7fc29dcb1a1ba3a789dfeab9255f597040c682ea/src/Processors/Formats/Impl/Parquet/Write.cpp#L75-L76)) and BYTE_ARRAY ([L220](https://github.com/ClickHouse/ClickHouse/blob/7fc29dcb1a1ba3a789dfeab9255f597040c682ea/src/Processors/Formats/Impl/Parquet/Write.cpp#L220)); read side has zero references |

</details>