### PR TITLE
Fix sporadic test failure in CI: set temp dir before setting temp dir encryption

### DIFF
--- a/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
+++ b/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
@@ -6,9 +6,6 @@
 require httpfs
 
 statement ok
-SET temp_file_encryption=true;
-
-statement ok
 PRAGMA memory_limit='400M'
 
 statement ok
@@ -16,6 +13,9 @@ PRAGMA threads=4
 
 statement ok
 SET temp_directory='{TEST_DIR}/temp.tmp'
+
+statement ok
+SET temp_file_encryption=true;
 
 # Force PhysicalAsOfJoin
 statement ok


### PR DESCRIPTION
Otherwise we can get this error if the global temp dir has been written to:

> Permission Error: Existing temporary files found: Modifying the temp_file_encryption setting while there are existing temporary files is disabled.
