### PR TITLE
CLI: PostBind hook to determine if _ might be used in query, if not, reclaim memory early

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -205,6 +205,7 @@ public:
 	string initFile;
 	bool run_init = true;
 	unique_ptr<duckdb::MaterializedQueryResult> last_result;
+	bool last_result_referenced;
 	//! If the following flag is set, then command execution stops at an error
 	BailOnError bail = BailOnError::AUTOMATIC;
 	//! Table name when rendering a DESCRIBE statement

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1014,6 +1014,8 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 				cMode = RenderMode::DESCRIBE;
 			}
 
+			// Reset before bind; the `_` replacement scan sets it to true if it fires.
+			last_result_referenced = false;
 			auto rc = ExecuteStatement(std::move(statement));
 			if (rc != SuccessState::SUCCESS) {
 				return rc;

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -51,32 +51,12 @@ unique_ptr<TableRef> ShellScanLastResult(ClientContext &context, ReplacementScan
 	return make_uniq<ColumnDataRef>(state.last_result->Collection(), state.last_result->names);
 }
 
-// Conservative check: any plan node that may evaluate user-provided SQL at execution time.
-bool PlanContainsDynamicSQLFunction(LogicalOperator &op) {
-	if (op.type == LogicalOperatorType::LOGICAL_GET) {
-		auto &get = op.Cast<LogicalGet>();
-		// This likely needs to be done differently
-		if (get.function.name == "query" || get.function.name == "query_table") {
-			return true;
-		}
-	}
-	for (auto &child : op.children) {
-		if (PlanContainsDynamicSQLFunction(*child)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 // Runs after the binder has finished. Releases the previous last_result early if it's
 // safe — i.e. the new query doesn't statically reference `_` (the replacement scan
-// would have fired) and doesn't contain anything that might evaluate SQL at runtime.
+// would have fired)
 void ShellPostBind(PlannerExtensionInput &input, BoundStatement &statement) {
 	auto &state = duckdb_shell::ShellState::Get();
 	if (state.last_result_referenced) {
-		return;
-	}
-	if (statement.plan && PlanContainsDynamicSQLFunction(*statement.plan)) {
 		return;
 	}
 	state.last_result.reset();

--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -3,6 +3,9 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/planner/planner_extension.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "shell_state.hpp"
 #include "duckdb/parser/tableref/column_data_ref.hpp"
 #include "shell_renderer.hpp"
@@ -41,10 +44,42 @@ unique_ptr<TableRef> ShellScanLastResult(ClientContext &context, ReplacementScan
 		return nullptr;
 	}
 	auto &state = duckdb_shell::ShellState::Get();
+	state.last_result_referenced = true;
 	if (!state.last_result) {
 		throw BinderException("Failed to query last result \"_\": no result available");
 	}
 	return make_uniq<ColumnDataRef>(state.last_result->Collection(), state.last_result->names);
+}
+
+// Conservative check: any plan node that may evaluate user-provided SQL at execution time.
+bool PlanContainsDynamicSQLFunction(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		// This likely needs to be done differently
+		if (get.function.name == "query" || get.function.name == "query_table") {
+			return true;
+		}
+	}
+	for (auto &child : op.children) {
+		if (PlanContainsDynamicSQLFunction(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Runs after the binder has finished. Releases the previous last_result early if it's
+// safe — i.e. the new query doesn't statically reference `_` (the replacement scan
+// would have fired) and doesn't contain anything that might evaluate SQL at runtime.
+void ShellPostBind(PlannerExtensionInput &input, BoundStatement &statement) {
+	auto &state = duckdb_shell::ShellState::Get();
+	if (state.last_result_referenced) {
+		return;
+	}
+	if (statement.plan && PlanContainsDynamicSQLFunction(*statement.plan)) {
+		return;
+	}
+	state.last_result.reset();
 }
 
 void ShellExtension::Load(ExtensionLoader &loader) {
@@ -55,6 +90,10 @@ void ShellExtension::Load(ExtensionLoader &loader) {
 	auto &config = duckdb::DBConfig::GetConfig(loader.GetDatabaseInstance());
 	config.SetOptionByName("duckdb_api", DUCKDB_API_CLI);
 	config.replacement_scans.push_back(duckdb::ReplacementScan(duckdb::ShellScanLastResult));
+
+	PlannerExtension planner_ext;
+	planner_ext.post_bind_function = duckdb::ShellPostBind;
+	PlannerExtension::Register(config, planner_ext);
 }
 
 std::string ShellExtension::Name() {

--- a/tools/shell/tests/test_last_result.py
+++ b/tools/shell/tests/test_last_result.py
@@ -39,6 +39,19 @@ def test_stacking_last_result(shell):
     result = test.run()
     result.check_stdout("4200000")
 
+def test_query_last_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 a")
+        .statement('SELECT a * 10 a FROM _')
+        .statement("FROM query('SELECT a * 10 a FROM _')")
+        .statement('SELECT a * 10 a FROM _')
+        .statement("FROM query('SELECT a * 10 a FROM _')")
+        .statement('SELECT a * 10 a FROM _')
+    )
+    result = test.run()
+    result.check_stdout("4200000")
+
 # errors do not overwrite last results
 def test_last_result_error(shell):
     test = (


### PR DESCRIPTION
Saving previous result until completion can have a significant memory impact, that might translate to unpredicatable timings when memory pressure is an issues.

Weaker point of the PR: how to detect if runtime provided SQL migth be required, since that might bring back _ after bind time.

Example:
```sql
CREATE TABLE T AS FROM range(2000000000);
.timer on
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM T;
SELECT random() FROM _;
```
run like: `./build/release/duckdb -f bench.sql`
might produce, before:
```
Run Time (s): real 3.392 user 17.493033 sys 5.445696
Run Time (s): real 5.351 user 19.493194 sys 8.503265
Run Time (s): real 8.123 user 15.032880 sys 7.072808
Run Time (s): real 5.447 user 16.524685 sys 7.989273
Run Time (s): real 5.185 user 16.902774 sys 7.597875
Run Time (s): real 37.450 user 16.873521 sys 8.329162
```
and after:
```
Run Time (s): real 3.574 user 20.015416 sys 5.029162
Run Time (s): real 2.380 user 14.421186 sys 4.331557
Run Time (s): real 1.426 user 13.771404 sys 1.471389
Run Time (s): real 1.350 user 13.776350 sys 1.236231
Run Time (s): real 2.694 user 14.801196 sys 2.820113
Run Time (s): real 41.117 user 21.318719 sys 6.842708
```

That should demonstrate that _ works via opt-in in both case, but the common case (that is no reference of _) might be faster.

Alternative to https://github.com/duckdb/duckdb/pull/22282. The fact that scanning _ is significantly slower than duckdb table might also point optimizations there might be possible.