### PR TITLE
Parquet: fold MIN/MAX/COUNT(*) from row-group stats for multi-file scans (cold cache)

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -195,7 +195,7 @@ struct ParquetUnionData : public BaseUnionData {
 class ParquetReader : public BaseFileReader {
 public:
 	ParquetReader(ClientContext &context, OpenFileInfo file, ParquetOptions parquet_options,
-	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);
+	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr, bool initialize_schema = true);
 	~ParquetReader() override;
 
 	mutable CachingFileSystem fs;
@@ -263,16 +263,19 @@ public:
 	void GetPartitionStats(vector<PartitionStatistics> &result);
 	static void GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result,
 	                              optional_ptr<ParquetColumnSchema> root_schema = nullptr,
-	                              optional_ptr<ParquetOptions> parquet_options = nullptr);
+	                              optional_ptr<ParquetOptions> parquet_options = nullptr,
+	                              shared_ptr<vector<idx_t>> column_remap = nullptr);
 	static bool MetadataCacheEnabled(ClientContext &context);
+	static bool PartitionStatsPrefetchDisabled(ClientContext &context);
 	static shared_ptr<ParquetFileMetadataCache> GetMetadataCacheEntry(ClientContext &context, const OpenFileInfo &file);
+
+	//! Build root_schema + columns from the metadata. Run by the ctor unless initialize_schema=false.
+	void InitializeSchema(ClientContext &context);
 
 private:
 	//! Construct a parquet reader but **do not** open a file, used in ReadStatistics only
 	ParquetReader(ClientContext &context, ParquetOptions parquet_options,
 	              shared_ptr<ParquetFileMetadataCache> metadata);
-
-	void InitializeSchema(ClientContext &context);
 	//! Parse the schema of the file
 	unique_ptr<ParquetColumnSchema> ParseSchema(ClientContext &context);
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -948,6 +948,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("parquet_metadata_cache",
 	                          "Cache Parquet metadata - useful when reading the same files multiple times",
 	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("disable_parquet_partition_stats_prefetch",
+	                          "Disable the optimizer's per-file metadata prefetch used to fold MIN/MAX/COUNT(*) "
+	                          "from row-group stats. Falls back to the regular scan path. Useful when the prefetch "
+	                          "is wasted work (e.g. MIN/MAX on string columns whose stats writers have truncated).",
+	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption(
 	    "enable_geoparquet_conversion",
 	    "Attempt to decode/encode geometry data in/as GeoParquet files if the spatial extension is present.",

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/parallel/async_result.hpp"
+#include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "parquet_column_schema.hpp"
@@ -57,6 +58,18 @@ struct ParquetReadBindData : public TableFunctionData {
 	idx_t initial_file_data_size = 0;
 	idx_t explicit_cardinality = 0; // can be set to inject exterior cardinality knowledge (e.g. from a data lake)
 	unique_ptr<ParquetFileReaderOptions> options;
+
+	// Per-file artifacts kept alive for the bind: PartitionRowGroup holds the FileMetaData and the
+	// parsed root_schema by raw pointer, so both must outlive the bind. Homogeneous files share
+	// initial_reader.root_schema and leave divergent_root_schema null. CreateReader reuses metadata
+	// to skip a footer re-read when the fold bails -- file_path lets us defend against any
+	// unexpected reorder between the optimizer pass and scan-time file_idx lookups.
+	struct PrefetchedFile {
+		string file_path;
+		shared_ptr<ParquetFileMetadataCache> metadata;
+		unique_ptr<ParquetColumnSchema> divergent_root_schema;
+	};
+	vector<PrefetchedFile> partition_stats_files;
 
 	ParquetOptions &GetParquetOptions() {
 		return options->options;
@@ -363,37 +376,228 @@ const vector<ParquetMetadataCacheEntry> &ParquetReadBindData::TryLoadCaches(cons
 	return caches;
 }
 
+// When two thrift schemas match element-wise the parsed root_schema is reusable across files.
+static bool ThriftSchemaElementsEqual(const duckdb_parquet::SchemaElement &a, const duckdb_parquet::SchemaElement &b) {
+	if (a.name != b.name) {
+		return false;
+	}
+	if (a.__isset.type != b.__isset.type || (a.__isset.type && a.type != b.type)) {
+		return false;
+	}
+	if (a.__isset.repetition_type != b.__isset.repetition_type ||
+	    (a.__isset.repetition_type && a.repetition_type != b.repetition_type)) {
+		return false;
+	}
+	if (a.__isset.num_children != b.__isset.num_children ||
+	    (a.__isset.num_children && a.num_children != b.num_children)) {
+		return false;
+	}
+	if (a.__isset.converted_type != b.__isset.converted_type ||
+	    (a.__isset.converted_type && a.converted_type != b.converted_type)) {
+		return false;
+	}
+	if (a.__isset.type_length != b.__isset.type_length || (a.__isset.type_length && a.type_length != b.type_length)) {
+		return false;
+	}
+	if (a.__isset.scale != b.__isset.scale || (a.__isset.scale && a.scale != b.scale)) {
+		return false;
+	}
+	if (a.__isset.precision != b.__isset.precision || (a.__isset.precision && a.precision != b.precision)) {
+		return false;
+	}
+	return true;
+}
+
+static bool ThriftSchemasIdentical(const vector<duckdb_parquet::SchemaElement> &a,
+                                   const vector<duckdb_parquet::SchemaElement> &b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < a.size(); i++) {
+		if (!ThriftSchemaElementsEqual(a[i], b[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// INVALID_INDEX entries mark columns missing or type-incompatible in this file.
+static shared_ptr<vector<idx_t>> BuildColumnRemap(const vector<MultiFileColumnDefinition> &initial_columns,
+                                                  const vector<MultiFileColumnDefinition> &per_file_columns) {
+	case_insensitive_map_t<idx_t> name_to_idx;
+	name_to_idx.reserve(per_file_columns.size());
+	for (idx_t j = 0; j < per_file_columns.size(); j++) {
+		name_to_idx.emplace(per_file_columns[j].name, j);
+	}
+	vector<idx_t> remap_vec(initial_columns.size(), DConstants::INVALID_INDEX);
+	for (idx_t i = 0; i < initial_columns.size(); i++) {
+		auto entry = name_to_idx.find(initial_columns[i].name);
+		if (entry != name_to_idx.end() && per_file_columns[entry->second].type == initial_columns[i].type) {
+			remap_vec[i] = entry->second;
+		}
+	}
+	return make_shared_ptr<vector<idx_t>>(std::move(remap_vec));
+}
+
+struct ParquetPerFilePartitionStats {
+	vector<PartitionStatistics> stats;
+	shared_ptr<ParquetFileMetadataCache> metadata;
+	// Owned per-file parsed schema for divergent files. ParquetPartitionRowGroup holds it by raw
+	// pointer, so we move it into bind_data alongside metadata after extraction.
+	unique_ptr<ParquetColumnSchema> divergent_root_schema;
+};
+
+// Extracts stats for one file and drops the reader; only the metadata pointer + (for divergent
+// files) the parsed root schema survive.
+static void RunPartitionStatsExtraction(ClientContext &context, const OpenFileInfo &file,
+                                        const ParquetOptions &parquet_options,
+                                        shared_ptr<ParquetFileMetadataCache> seed_metadata,
+                                        ParquetReader &initial_reader, ParquetPerFilePartitionStats &out) {
+	auto reader = make_shared_ptr<ParquetReader>(context, file, parquet_options, std::move(seed_metadata),
+	                                             /*initialize_schema=*/false);
+	const auto &per_file_thrift_schema = reader->metadata->metadata->schema;
+	const auto &initial_thrift_schema = initial_reader.metadata->metadata->schema;
+	// Use initial_reader.parquet_options (lives through the bind) rather than reader->parquet_options
+	// (dies with the reader): ParquetPartitionRowGroup holds it by raw pointer.
+	if (ThriftSchemasIdentical(initial_thrift_schema, per_file_thrift_schema)) {
+		ParquetReader::GetPartitionStats(*reader->metadata->metadata, out.stats, initial_reader.root_schema.get(),
+		                                 &initial_reader.parquet_options, /*column_remap=*/nullptr);
+	} else {
+		reader->InitializeSchema(context);
+		auto remap = BuildColumnRemap(initial_reader.GetColumns(), reader->GetColumns());
+		ParquetReader::GetPartitionStats(*reader->metadata->metadata, out.stats, reader->root_schema.get(),
+		                                 &initial_reader.parquet_options, remap);
+		out.divergent_root_schema = std::move(reader->root_schema);
+	}
+	out.metadata = std::move(reader->metadata);
+}
+
+class ParquetPartitionStatsTask : public BaseExecutorTask {
+public:
+	ParquetPartitionStatsTask(TaskExecutor &executor, ClientContext &context, OpenFileInfo file,
+	                          ParquetOptions parquet_options, ParquetReader &initial_reader,
+	                          ParquetPerFilePartitionStats &out)
+	    : BaseExecutorTask(executor), context(context), file(std::move(file)),
+	      parquet_options(std::move(parquet_options)), initial_reader(initial_reader), out(out) {
+	}
+
+	void ExecuteTask() override {
+		RunPartitionStatsExtraction(context, file, parquet_options, /*seed_metadata=*/nullptr, initial_reader, out);
+	}
+
+	string TaskType() const override {
+		return "ParquetPartitionStatsTask";
+	}
+
+private:
+	ClientContext &context;
+	OpenFileInfo file;
+	ParquetOptions parquet_options;
+	ParquetReader &initial_reader;
+	ParquetPerFilePartitionStats &out;
+};
+
+// All-or-nothing bail: returns false on the file-count cap or any has_deletes file. The fold
+// requires stats from every partition (otherwise we can't bound MIN/MAX), and DuckLake/Iceberg/
+// Delta has_deletes signals that the parquet stats describe the pre-delete view -- so even one
+// affected file makes the fold unsafe.
+static bool CollectPartitionStatsFiles(const MultiFileBindData &bind_data, vector<OpenFileInfo> &out) {
+	static constexpr idx_t MAX_PREFETCH_FILES = 10000;
+	for (auto &file : bind_data.file_list->Files()) {
+		if (out.size() >= MAX_PREFETCH_FILES) {
+			return false;
+		}
+		if (file.extended_info) {
+			auto entry = file.extended_info->options.find("has_deletes");
+			if (entry != file.extended_info->options.end() && BooleanValue::Get(entry->second)) {
+				return false;
+			}
+		}
+		out.emplace_back(file);
+	}
+	return true;
+}
+
+// Cache hits run inline (gated on parquet_metadata_cache); misses fan out to parallel workers.
+static void RunPartitionStatsPrefetch(ClientContext &context, const vector<OpenFileInfo> &files,
+                                      const ParquetOptions &parquet_options, ParquetReader &initial_reader,
+                                      vector<ParquetPerFilePartitionStats> &outputs) {
+	const bool cache_enabled = ParquetReader::MetadataCacheEnabled(context);
+	auto &task_scheduler = TaskScheduler::GetScheduler(context);
+	TaskExecutor executor(task_scheduler);
+	idx_t scheduled = 0;
+	for (idx_t i = 0; i < files.size(); i++) {
+		const auto &file = files[i];
+		shared_ptr<ParquetFileMetadataCache> cache_entry;
+		if (cache_enabled) {
+			cache_entry = ParquetReader::GetMetadataCacheEntry(context, file);
+			if (cache_entry && cache_entry->IsValid(file, context) != ParquetCacheValidity::VALID) {
+				cache_entry = nullptr;
+			}
+		}
+		if (cache_entry) {
+			RunPartitionStatsExtraction(context, file, parquet_options, std::move(cache_entry), initial_reader,
+			                            outputs[i]);
+			continue;
+		}
+		auto task =
+		    make_uniq<ParquetPartitionStatsTask>(executor, context, file, parquet_options, initial_reader, outputs[i]);
+		executor.ScheduleTask(std::move(task));
+		scheduled++;
+	}
+	if (scheduled > 0) {
+		executor.WorkOnTasks();
+	}
+}
+
 static vector<PartitionStatistics> ParquetGetPartitionStats(ClientContext &context, GetPartitionStatsInput &input) {
 	auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
 	vector<PartitionStatistics> result;
+
 	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE && bind_data.initial_reader) {
-		// we have read the metadata - get the partitions for this reader
 		auto &reader = bind_data.initial_reader->Cast<ParquetReader>();
 		reader.GetPartitionStats(result);
 		return result;
 	}
-	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
-	auto &cached_metadata = parquet_data.TryLoadCaches(bind_data, context);
-	if (cached_metadata.empty()) {
-		// no cached metadata - bail
-		return result;
+	if (!bind_data.initial_reader) {
+		return {};
 	}
-	// first check if all caches are valid and there are no deletes
-	for (auto &cache : cached_metadata) {
-		if (cache.has_deletes) {
-			// we have deletes - don't return any partition stats
-			// FIXME: we could return with count approximate
-			return result;
-		}
-		if (cache.validity != ParquetCacheValidity::VALID) {
-			// we don't know for sure if this cache entry is valid - we can't use these stats
-			return result;
-		}
+	// Field-id mapping needs per-file resolution different from the name+type remap below.
+	if (!bind_data.bind_data->Cast<ParquetReadBindData>().GetParquetOptions().schema.empty()) {
+		return {};
+	}
+	if (ParquetReader::PartitionStatsPrefetchDisabled(context)) {
+		return {};
+	}
+	auto &initial_reader = bind_data.initial_reader->Cast<ParquetReader>();
+	auto &parquet_bind_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	auto &per_file = parquet_bind_data.partition_stats_files;
+
+	vector<OpenFileInfo> files;
+	if (!CollectPartitionStatsFiles(bind_data, files)) {
+		return {};
 	}
 
-	// all caches are valid! we can return the partition stats
-	for (auto &cache : cached_metadata) {
-		ParquetReader::GetPartitionStats(*cache.metadata->metadata, result);
+	vector<ParquetPerFilePartitionStats> outputs(files.size());
+	RunPartitionStatsPrefetch(context, files, initial_reader.parquet_options, initial_reader, outputs);
+
+	per_file.clear();
+	per_file.resize(files.size());
+	idx_t total_groups = 0;
+	for (auto &out : outputs) {
+		total_groups += out.stats.size();
+	}
+	result.reserve(total_groups);
+	for (idx_t i = 0; i < outputs.size(); i++) {
+		if (!outputs[i].metadata) {
+			return {};
+		}
+		for (auto &stat : outputs[i].stats) {
+			result.push_back(std::move(stat));
+		}
+		per_file[i].file_path = files[i].path;
+		per_file[i].metadata = std::move(outputs[i].metadata);
+		per_file[i].divergent_root_schema = std::move(outputs[i].divergent_root_schema);
 	}
 	return result;
 }
@@ -669,7 +873,15 @@ shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &con
                                                               const OpenFileInfo &file, idx_t file_idx,
                                                               const MultiFileBindData &multi_bind_data) {
 	auto &bind_data = multi_bind_data.bind_data->Cast<ParquetReadBindData>();
-	return make_shared_ptr<ParquetReader>(context, file, bind_data.GetParquetOptions());
+	// Reuse metadata from the partition-stats prefetch so the scan path doesn't re-read footers
+	// when the fold bailed (e.g. MinMaxIsExact false on a truncated VARCHAR). Path equality guards
+	// against any reorder between the optimizer pass and scan-time file_idx lookups.
+	shared_ptr<ParquetFileMetadataCache> prefetched_metadata;
+	if (file_idx < bind_data.partition_stats_files.size() &&
+	    bind_data.partition_stats_files[file_idx].file_path == file.path) {
+		prefetched_metadata = bind_data.partition_stats_files[file_idx].metadata;
+	}
+	return make_shared_ptr<ParquetReader>(context, file, bind_data.GetParquetOptions(), prefetched_metadata);
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -881,7 +881,7 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 }
 
 ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, ParquetOptions parquet_options_p,
-                             shared_ptr<ParquetFileMetadataCache> metadata_p)
+                             shared_ptr<ParquetFileMetadataCache> metadata_p, bool initialize_schema)
     : BaseFileReader(std::move(file_p)), fs(CachingFileSystem::Get(context_p)),
       allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)) {
 	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
@@ -927,13 +927,21 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 			encryption_util = context_p.db->GetEncryptionUtil(true);
 		}
 	}
-	InitializeSchema(context_p);
+	if (initialize_schema) {
+		InitializeSchema(context_p);
+	}
 }
 
 bool ParquetReader::MetadataCacheEnabled(ClientContext &context) {
 	Value metadata_cache = false;
 	context.TryGetCurrentSetting("parquet_metadata_cache", metadata_cache);
 	return metadata_cache.GetValue<bool>();
+}
+
+bool ParquetReader::PartitionStatsPrefetchDisabled(ClientContext &context) {
+	Value v = false;
+	context.TryGetCurrentSetting("disable_parquet_partition_stats_prefetch", v);
+	return v.GetValue<bool>();
 }
 
 shared_ptr<ParquetFileMetadataCache> ParquetReader::GetMetadataCacheEntry(ClientContext &context,
@@ -1382,33 +1390,61 @@ void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {
 struct ParquetPartitionRowGroup : public PartitionRowGroup {
 	ParquetPartitionRowGroup(const duckdb_parquet::FileMetaData &metadata_p,
 	                         optional_ptr<ParquetColumnSchema> root_schema_p,
-	                         optional_ptr<ParquetOptions> parquet_options_p, const idx_t row_group_idx_p)
+	                         optional_ptr<ParquetOptions> parquet_options_p, const idx_t row_group_idx_p,
+	                         shared_ptr<vector<idx_t>> column_remap_p = nullptr)
 	    : metadata(metadata_p), root_schema(root_schema_p), parquet_options(parquet_options_p),
-	      row_group_idx(row_group_idx_p) {
+	      row_group_idx(row_group_idx_p), column_remap(std::move(column_remap_p)) {
 	}
 
 	const duckdb_parquet::FileMetaData &metadata;
 	const optional_ptr<ParquetColumnSchema> root_schema;
 	const optional_ptr<ParquetOptions> parquet_options;
 	const idx_t row_group_idx;
+	// Optional global -> per-file column index map. nullptr = identity. INVALID_INDEX = missing in
+	// this file (GetColumnStatistics returns null, optimizer bails for that aggregate).
+	const shared_ptr<vector<idx_t>> column_remap;
+
+	idx_t MapIndex(idx_t global_idx) const {
+		if (!column_remap) {
+			return global_idx;
+		}
+		if (global_idx >= column_remap->size()) {
+			return DConstants::INVALID_INDEX;
+		}
+		return (*column_remap)[global_idx];
+	}
 
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override {
-		const idx_t primary_index = storage_index.GetPrimaryIndex();
+		const idx_t mapped = MapIndex(storage_index.GetPrimaryIndex());
+		if (mapped == DConstants::INVALID_INDEX) {
+			// Column missing in this file (heterogeneous schema, e.g. union_by_name).
+			return nullptr;
+		}
+		// Under union_by_name the unified column index can exceed this file's native column count.
+		if (!root_schema || mapped >= root_schema->children.size()) {
+			return nullptr;
+		}
 		D_ASSERT(metadata.row_groups.size() > row_group_idx);
-		D_ASSERT(root_schema->children.size() > primary_index);
 
 		const auto &row_group = metadata.row_groups[row_group_idx];
-		const auto &column_schema = root_schema->children[primary_index];
+		const auto &column_schema = root_schema->children[mapped];
 		return column_schema.Stats(metadata, *parquet_options, row_group_idx, row_group.columns);
 	}
 
 	bool MinMaxIsExact(const BaseStatistics &, const StorageIndex &storage_index) override {
-		const idx_t primary_index = storage_index.GetPrimaryIndex();
+		const idx_t mapped = MapIndex(storage_index.GetPrimaryIndex());
+		if (mapped == DConstants::INVALID_INDEX) {
+			return false;
+		}
+		if (!root_schema || mapped >= root_schema->children.size()) {
+			return false;
+		}
 		D_ASSERT(metadata.row_groups.size() > row_group_idx);
-		D_ASSERT(root_schema->children.size() > primary_index);
 
+		const auto &column_schema = root_schema->children[mapped];
 		const auto &row_group = metadata.row_groups[row_group_idx];
-		const auto &column_chunk = row_group.columns[primary_index];
+		D_ASSERT(column_schema.column_index < row_group.columns.size());
+		const auto &column_chunk = row_group.columns[column_schema.column_index];
 
 		if (column_chunk.__isset.meta_data && column_chunk.meta_data.__isset.statistics &&
 		    column_chunk.meta_data.statistics.__isset.is_min_value_exact &&
@@ -1422,7 +1458,8 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 
 void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result,
                                       optional_ptr<ParquetColumnSchema> root_schema,
-                                      optional_ptr<ParquetOptions> parquet_options) {
+                                      optional_ptr<ParquetOptions> parquet_options,
+                                      shared_ptr<vector<idx_t>> column_remap) {
 	idx_t offset = 0;
 	for (idx_t i = 0; i < metadata.row_groups.size(); i++) {
 		auto &row_group = metadata.row_groups[i];
@@ -1432,7 +1469,7 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 		partition_stats.count_type = CountType::COUNT_EXACT;
 		if (root_schema && parquet_options) {
 			partition_stats.partition_row_group =
-			    make_shared_ptr<ParquetPartitionRowGroup>(metadata, root_schema, parquet_options, i);
+			    make_shared_ptr<ParquetPartitionRowGroup>(metadata, root_schema, parquet_options, i, column_remap);
 		}
 		offset += row_group.num_rows;
 		result.push_back(partition_stats);

--- a/test/optimizer/eager_aggregate_execution_parquet.test
+++ b/test/optimizer/eager_aggregate_execution_parquet.test
@@ -32,3 +32,247 @@ SELECT max(i), count(i), min(i) FROM '{TEST_DIR}/eager_agg.parquet'
 ----
 8191	8192	0
 
+# multi-file glob: per-file metadata is fetched in parallel during the optimizer pass
+statement ok
+COPY (FROM range (4096) t(i)) TO '{TEST_DIR}/eager_agg_a.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+statement ok
+COPY (SELECT i + 4096 AS i FROM range(4096) t(i)) TO '{TEST_DIR}/eager_agg_b.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+query II
+EXPLAIN SELECT count(*), min(i), max(i) FROM read_parquet(['{TEST_DIR}/eager_agg_a.parquet','{TEST_DIR}/eager_agg_b.parquet'])
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query III
+SELECT count(*), min(i), max(i) FROM read_parquet(['{TEST_DIR}/eager_agg_a.parquet','{TEST_DIR}/eager_agg_b.parquet'])
+----
+8192	0	8191
+
+# reordered columns: per-file column remap (by name+type) handles it; still folds
+statement ok
+COPY (SELECT 1 AS a, 'x' AS b UNION ALL SELECT 2, 'y') TO '{TEST_DIR}/reorder_a.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 'x' AS b, 1 AS a UNION ALL SELECT 'y', 2) TO '{TEST_DIR}/reorder_b.parquet' (FORMAT PARQUET)
+
+query II
+EXPLAIN SELECT min(a), max(a) FROM read_parquet(['{TEST_DIR}/reorder_a.parquet','{TEST_DIR}/reorder_b.parquet'])
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query II
+SELECT min(a), max(a) FROM read_parquet(['{TEST_DIR}/reorder_a.parquet','{TEST_DIR}/reorder_b.parquet'])
+----
+1	2
+
+# union_by_name=true with homogeneous schemas: column remap is identity, folds
+query II
+EXPLAIN SELECT min(i) FROM read_parquet(['{TEST_DIR}/eager_agg_a.parquet','{TEST_DIR}/eager_agg_b.parquet'], union_by_name=true)
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query I
+SELECT min(i) FROM read_parquet(['{TEST_DIR}/eager_agg_a.parquet','{TEST_DIR}/eager_agg_b.parquet'], union_by_name=true)
+----
+0
+
+# union_by_name=true with a column missing in one file: bail, full-scan still produces correct answer
+statement ok
+COPY (SELECT 5 AS x, 'foo' AS y) TO '{TEST_DIR}/has_x.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 'bar' AS y) TO '{TEST_DIR}/no_x.parquet' (FORMAT PARQUET)
+
+query I
+SELECT min(x) FROM read_parquet(['{TEST_DIR}/has_x.parquet','{TEST_DIR}/no_x.parquet'], union_by_name=true)
+----
+5
+
+# disable_parquet_partition_stats_prefetch setting: bails the prefetch entirely, falls back to scan
+statement ok
+COPY (FROM range(2048) t(i) SELECT i AS id) TO '{TEST_DIR}/dis_a.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 512)
+
+statement ok
+COPY (FROM range(2048, 4096) t(i) SELECT i AS id) TO '{TEST_DIR}/dis_b.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 512)
+
+# default: folds
+query II
+EXPLAIN SELECT min(id), max(id) FROM read_parquet(['{TEST_DIR}/dis_a.parquet','{TEST_DIR}/dis_b.parquet'])
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+statement ok
+SET disable_parquet_partition_stats_prefetch=true
+
+# disabled: reverts to scan
+query II
+EXPLAIN SELECT min(id), max(id) FROM read_parquet(['{TEST_DIR}/dis_a.parquet','{TEST_DIR}/dis_b.parquet'])
+----
+physical_plan	<REGEX>:.*AGGREGATE.*
+
+# correctness with the prefetch disabled
+query II
+SELECT min(id), max(id) FROM read_parquet(['{TEST_DIR}/dis_a.parquet','{TEST_DIR}/dis_b.parquet'])
+----
+0	4095
+
+statement ok
+RESET disable_parquet_partition_stats_prefetch
+
+# heterogeneous types: same column name, incompatible types -> BuildColumnRemap marks INVALID_INDEX,
+# the optimizer bails on the affected aggregate but the scan path still returns the right answer.
+statement ok
+COPY (SELECT 1 AS k) TO '{TEST_DIR}/ht_int.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 'a' AS k) TO '{TEST_DIR}/ht_str.parquet' (FORMAT PARQUET)
+
+query I
+SELECT count(*) FROM read_parquet(['{TEST_DIR}/ht_int.parquet','{TEST_DIR}/ht_str.parquet'], union_by_name=true)
+----
+2
+
+# WHERE filter prunes a whole partition: file A is 0..1023, file B is 1024..2047. WHERE i >= 1024
+# eliminates A entirely via stats; the optimizer should fold using only B's surviving partition.
+statement ok
+COPY (FROM range(1024) t(i)) TO '{TEST_DIR}/range_a.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+statement ok
+COPY (SELECT i + 1024 AS i FROM range(1024) t(i)) TO '{TEST_DIR}/range_b.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+query II
+EXPLAIN SELECT min(i), max(i), count(*) FROM read_parquet(['{TEST_DIR}/range_a.parquet','{TEST_DIR}/range_b.parquet']) WHERE i >= 1024
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query III
+SELECT min(i), max(i), count(*) FROM read_parquet(['{TEST_DIR}/range_a.parquet','{TEST_DIR}/range_b.parquet']) WHERE i >= 1024
+----
+1024	2047	1024
+
+# union_by_name + reordered columns: divergent thrift schemas trigger late-init and remap by name.
+statement ok
+COPY (SELECT 10 AS a, 'x' AS b UNION ALL SELECT 20, 'y') TO '{TEST_DIR}/ubn_ra.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 'p' AS b, 30 AS a UNION ALL SELECT 'q', 40) TO '{TEST_DIR}/ubn_rb.parquet' (FORMAT PARQUET)
+
+query II
+EXPLAIN SELECT min(a), max(a) FROM read_parquet(['{TEST_DIR}/ubn_ra.parquet','{TEST_DIR}/ubn_rb.parquet'], union_by_name=true)
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query II
+SELECT min(a), max(a) FROM read_parquet(['{TEST_DIR}/ubn_ra.parquet','{TEST_DIR}/ubn_rb.parquet'], union_by_name=true)
+----
+10	40
+
+# union_by_name + extra column in one file: MIN on the column shared by both folds; MIN on the
+# B-only column bails (missing in A) but still returns the right answer via scan.
+statement ok
+COPY (SELECT 1 AS x UNION ALL SELECT 2) TO '{TEST_DIR}/ubn_ea.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 3 AS x, 100 AS y UNION ALL SELECT 4, 200) TO '{TEST_DIR}/ubn_eb.parquet' (FORMAT PARQUET)
+
+query II
+EXPLAIN SELECT min(x), max(x) FROM read_parquet(['{TEST_DIR}/ubn_ea.parquet','{TEST_DIR}/ubn_eb.parquet'], union_by_name=true)
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query II
+SELECT min(x), max(x) FROM read_parquet(['{TEST_DIR}/ubn_ea.parquet','{TEST_DIR}/ubn_eb.parquet'], union_by_name=true)
+----
+1	4
+
+query II
+SELECT min(y), max(y) FROM read_parquet(['{TEST_DIR}/ubn_ea.parquet','{TEST_DIR}/ubn_eb.parquet'], union_by_name=true)
+----
+100	200
+
+# multi-file × multi-row-group: 2 files × 4 row groups each; the partition-stats path emits 8
+# row-group entries and the count fold sums them.
+statement ok
+COPY (FROM range(4096) t(i)) TO '{TEST_DIR}/mrg_a.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+statement ok
+COPY (SELECT i + 4096 AS i FROM range(4096) t(i)) TO '{TEST_DIR}/mrg_b.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 1024)
+
+query II
+EXPLAIN SELECT min(i), max(i), count(*) FROM read_parquet(['{TEST_DIR}/mrg_a.parquet','{TEST_DIR}/mrg_b.parquet'])
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query III
+SELECT min(i), max(i), count(*) FROM read_parquet(['{TEST_DIR}/mrg_a.parquet','{TEST_DIR}/mrg_b.parquet'])
+----
+0	8191	8192
+
+# union_by_name where file 0 has fewer columns than later files: the unified column index for
+# the extras exceeds initial_reader's native column count. count(*) folds; MIN on the extras
+# bails to scan (initial_reader's root_schema doesn't see those columns).
+statement ok
+COPY (SELECT 1 AS x) TO '{TEST_DIR}/ext_a.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 2 AS x, 10 AS y, 100 AS z) TO '{TEST_DIR}/ext_b.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 3 AS x, 20 AS y, 200 AS z) TO '{TEST_DIR}/ext_c.parquet' (FORMAT PARQUET)
+
+query I
+SELECT count(*) FROM read_parquet(['{TEST_DIR}/ext_a.parquet','{TEST_DIR}/ext_b.parquet','{TEST_DIR}/ext_c.parquet'], union_by_name=true)
+----
+3
+
+query I
+SELECT min(x) FROM read_parquet(['{TEST_DIR}/ext_a.parquet','{TEST_DIR}/ext_b.parquet','{TEST_DIR}/ext_c.parquet'], union_by_name=true)
+----
+1
+
+# MIN on a column missing from file 0: must bail to scan -- the runtime guard in
+# GetColumnStatistics/MinMaxIsExact has to keep the optimizer from reading past file 0's
+# native column count. If this assertion regresses, the fold has incorrectly succeeded.
+query II
+EXPLAIN SELECT min(y), max(z) FROM read_parquet(['{TEST_DIR}/ext_a.parquet','{TEST_DIR}/ext_b.parquet','{TEST_DIR}/ext_c.parquet'], union_by_name=true)
+----
+physical_plan	<REGEX>:.*AGGREGATE.*
+
+query II
+SELECT min(y), max(z) FROM read_parquet(['{TEST_DIR}/ext_a.parquet','{TEST_DIR}/ext_b.parquet','{TEST_DIR}/ext_c.parquet'], union_by_name=true)
+----
+10	200
+
+# Mixed homogeneous + heterogeneous in a glob: files 0/1 share a thrift schema (homogeneous fast
+# path), file 2 diverges (late-init + remap). Exercises both per-file paths in one query.
+statement ok
+COPY (SELECT 1 AS k) TO '{TEST_DIR}/mh_a.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 2 AS k) TO '{TEST_DIR}/mh_b.parquet' (FORMAT PARQUET)
+
+statement ok
+COPY (SELECT 3 AS k, 'extra' AS m) TO '{TEST_DIR}/mh_c.parquet' (FORMAT PARQUET)
+
+query II
+EXPLAIN SELECT min(k), max(k) FROM read_parquet(['{TEST_DIR}/mh_a.parquet','{TEST_DIR}/mh_b.parquet','{TEST_DIR}/mh_c.parquet'], union_by_name=true)
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query II
+SELECT min(k), max(k) FROM read_parquet(['{TEST_DIR}/mh_a.parquet','{TEST_DIR}/mh_b.parquet','{TEST_DIR}/mh_c.parquet'], union_by_name=true)
+----
+1	3
+
+# Oracle cross-check: the fold path agrees with the scan path on the union_by_name case above.
+statement ok
+SET disabled_optimizers='statistics_propagation'
+
+query II
+SELECT min(y), max(z) FROM read_parquet(['{TEST_DIR}/ext_a.parquet','{TEST_DIR}/ext_b.parquet','{TEST_DIR}/ext_c.parquet'], union_by_name=true)
+----
+10	200
+
+statement ok
+RESET disabled_optimizers

--- a/test/sql/copy/parquet/parquet_glob_cache.test
+++ b/test/sql/copy/parquet/parquet_glob_cache.test
@@ -7,18 +7,19 @@ require parquet
 statement ok
 SET parquet_metadata_cache=true;
 
-# first read reads the parquet files
+# Multi-file COUNT(*) folds via the partition-stats prefetch on the FIRST query (the optimizer
+# parallel-fetches each file's footer); both runs now skip PARQUET_SCAN.
 query II
 EXPLAIN select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*
+physical_plan	<!REGEX>:.*PARQUET_SCAN.*
 
 query I
 select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
 ----
 2
 
-# second read uses the metadata cache
+# second read also folds (now hitting the metadata cache populated above)
 query II
 EXPLAIN select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
 ----


### PR DESCRIPTION
Extends #17344 so `StatisticsPropagator::TryExecuteAggregates` folds `MIN/MAX/COUNT(*)` to constants for multi-file parquet scans on cold sessions at default settings — the prior path required `parquet_metadata_cache=true` and a prior warm-up. The optimizer prefetches each file's footer in parallel via `TaskExecutor`, hands `PartitionStatistics` back to the existing fold logic, and threads the metadata through `CreateReader` so the scan path (when the fold bails) doesn't re-read footers.

This was motivated because I tried benchmarking https://github.com/duckdb/duckdb/pull/22286 and saw it wasn't actually able to apply the optimizations in the multi file case. There is some temporary limited caching required for this to be reasonably performant. Working with union by name was rather annoying, there may be a better way for it. There is a fair bit of complexity to this one, particularly with the custom executors and handling the various bail outs / failure modes.

### Bench

Q6-shape (3 stat-foldable aggregates) on the underlying typed column — *not* the ClickBench Q6 view that wraps `EventDate` in `make_date()`, since that requires monotonic-wrapper folding tracked in a separate PR. The function-peel work composes with this one but isn't required for measuring it:

```sql
SELECT MIN(<col>), MAX(<col>), COUNT(*) FROM <files>;
```

**Datasets.** `local-100`: ClickBench `hits_partitioned/hits_{0..99}.parquet` (105 cols, ~140 MB/file, 14 GB total). Column queried is `EventDate` (INT16). `local-1000`: 1000 narrow files generated locally via pyarrow — schema `id BIGINT, val BIGINT`, 100 rows/file, `row_group_size=100`, ZSTD compression, 4 MB total. Column queried is `id`. `remote-100`: 100 explicit `https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_<n>.parquet` URLs (~50 ms RTT).

**Cold** = fresh `duckdb` process per trial, dropping of caches. **Hot** = drop dataset pages once, then run `N+2` queries within one DuckDB session via stdin with `.timer on`, discard the first two, take the median of the remaining `N`.

The optimization's effect depends heavily on cache configuration, so we report two separate scenarios.

#### Configuration A: defaults

No `SET` statements before the timed queries — `parquet_metadata_cache=false` (default), default `validate_external_file_cache`. `ObjectCache` is never populated, so the prefetch path runs on every query.

| dataset | state | baseline (main) | this PR | speedup |
|---|---|---:|---:|---:|
| `local-100` | cold (n=15) | 36 ms | 22 ms | **1.64×** |
| `local-100` | hot (n=20) | 14 ms | 7 ms | **2.00×** |
| `local-1000` | cold (n=15) | 44 ms | 21 ms | **2.10×** |
| `local-1000` | hot (n=20) | 11 ms | 7 ms | **1.57×** |
| `remote-100` | cold (n=8) | 9599 ms | 2211 ms | **4.34×** |
| `remote-100` | hot (n=12) | 1890 ms | 1538 ms | **1.23×** |

`remote-100` hot stays close to cold at defaults because `OpenFileInfo` validity returns `UNKNOWN` on explicit URL paths, so the prefetch re-fetches metadata every query.

#### Configuration B: trust the cache

`SET parquet_metadata_cache=true; SET validate_external_file_cache='NO_VALIDATION';` once at session start (cold trials still get fresh processes, so the settings only affect what populates *during* the timed query and how validation works on subsequent queries within the same session).

| dataset | state | baseline (main) | this PR | speedup |
|---|---|---:|---:|---:|
| `local-100` | cold (n=15) | 43 ms | 22 ms | **1.99×** |
| `local-100` | hot (n=20) | 11 ms | 1 ms | **11.0×** |
| `local-1000` | cold (n=15) | 47 ms | 21 ms | **2.19×** |
| `local-1000` | hot (n=20) | 8 ms | 3.5 ms | **2.29×** |
| `remote-100` | cold (n=6) | 9260 ms | 1958 ms | **4.73×** |
| `remote-100` | hot (n=10) | 11 ms | 2 ms | **5.50×** |

Trust-cache hot is the steady-state repeated-query workload: with metadata cached and validation skipped, the optimizer fold short-circuits to a constant projection in microseconds. The dramatic local-100 hot delta (14 ms → 1 ms) is what this PR's headline win looks like for that workload shape; under defaults the same query is 7 ms because the cross-query cache isn't populated.

### Notes

- **Cache validity is `OpenFileInfo`-only** (the path from #17344) — no per-file `stat()` calls, which addresses the regression #15129 disabled the prior multi-file path for. The other #15129 concern (per-call extraction cost × `num_files × num_columns`) doesn't apply: `TryGetValueFromStats` only looks up the columns the optimizer is folding, so volume is `num_files × num_aggregates`.
- **Per-file readers are dropped after extraction**; the bind retains only `shared_ptr<ParquetFileMetadataCache>`. Peak in-flight readers is bounded by thread count, not file count. Without this, retaining all readers regressed `local-1000` cold by 0.44×.
- **Lazy schema init** (`initialize_schema=false`). Workers reuse `initial_reader.root_schema` when the per-file thrift schema matches file 0's; diverging files late-init and build a name+type column remap. Handles reordered columns and `union_by_name=true` with missing columns.
- **Selective filters interaction:** when a query has a `WHERE` clause that prunes most row groups, the prefetch isn't extra work — the scan path needs the same per-row-group min/max stats to apply pushdown filtering, so the metadata read is happening either way. The optimizer's `TryExecuteAggregates` already filters partitions through table filters before folding (`FILTER_ALWAYS_FALSE` partitions are dropped). And we respect the upstream list-files filter: hive-partition pruning, glob filtering, etc. happen before `ParquetGetPartitionStats` is called, so `bind_data.file_list->Files()` only contains files the multi-file reader has already decided to scan.
- **`disable_parquet_partition_stats_prefetch`** (new, default false): toggles the entire optimizer-side prefetch off, falling back to the scan path. The most common motivation is MIN/MAX over VARCHAR/BLOB columns where writers have truncated the stats — `MinMaxIsExact` returns false at fold time and the optimizer bails after we've paid for the prefetch. Other shapes (very small files on fast local SSD, or workloads where the fold reliably fails for some other reason) can also benefit from disabling. The optimization is hard to benchmark exhaustively (results above are good but the workload space is large), so this gives operators an escape hatch without code changes.
- **Defensive cap** `MAX_PREFETCH_FILES = 10000`; glob expansions beyond bail to the scan path.

Tests in `test/optimizer/eager_aggregate_execution_parquet.test` (multi-file fold, reorder, `union_by_name`, disable-toggle); `parquet_glob_cache.test` updated since the first multi-file `count(*)` now folds.