### PR TITLE
Cleanup usage of Vector APIs to improve propagation of vector sizes

### DIFF
--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -108,7 +108,7 @@ public:
 	}
 	virtual void InitializeInternal(ClientContext &context, ParquetReader &reader) {};
 	virtual idx_t TotalRowCount(ParquetReader &reader) = 0;
-	virtual void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) = 0;
+	virtual void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) = 0;
 	virtual bool ForceFlush() {
 		return false;
 	}
@@ -244,7 +244,7 @@ class ParquetRowGroupMetadataProcessor : public ParquetMetadataFileProcessor {
 public:
 	void InitializeInternal(ClientContext &context, ParquetReader &reader) override;
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 
 private:
 	vector<ParquetColumnSchema> column_schemas;
@@ -435,7 +435,7 @@ idx_t ParquetRowGroupMetadataProcessor::TotalRowCount(ParquetReader &reader) {
 	return meta_data->row_groups.size() * column_schemas.size();
 }
 
-void ParquetRowGroupMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
+void ParquetRowGroupMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx,
                                                ParquetReader &reader) {
 	auto meta_data = reader.GetFileMetadata();
 	idx_t col_idx = row_idx % column_schemas.size();
@@ -450,90 +450,81 @@ void ParquetRowGroupMetadataProcessor::ReadRow(vector<reference<Vector>> &output
 	auto &column_type = column_schema.type;
 
 	// file_name
-	output[0].get().SetValue(output_idx, reader.file.path);
+	output[0].get().Append(reader.file.path);
 	// row_group_id
-	output[1].get().SetValue(output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx)));
+	output[1].get().Append(Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx)));
 	// row_group_num_rows
-	output[2].get().SetValue(output_idx, Value::BIGINT(row_group.num_rows));
+	output[2].get().Append(Value::BIGINT(row_group.num_rows));
 	// row_group_num_columns
-	output[3].get().SetValue(output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group.columns.size())));
+	output[3].get().Append(Value::BIGINT(UnsafeNumericCast<int64_t>(row_group.columns.size())));
 	// row_group_bytes
-	output[4].get().SetValue(output_idx, Value::BIGINT(row_group.total_byte_size));
+	output[4].get().Append(Value::BIGINT(row_group.total_byte_size));
 	// column_id
-	output[5].get().SetValue(output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(col_idx)));
+	output[5].get().Append(Value::BIGINT(UnsafeNumericCast<int64_t>(col_idx)));
 	// file_offset
-	output[6].get().SetValue(output_idx, ParquetElementBigint(column.file_offset, row_group.__isset.file_offset));
+	output[6].get().Append(ParquetElementBigint(column.file_offset, row_group.__isset.file_offset));
 	// num_values
-	output[7].get().SetValue(output_idx, Value::BIGINT(col_meta.num_values));
+	output[7].get().Append(Value::BIGINT(col_meta.num_values));
 	// path_in_schema
-	output[8].get().SetValue(output_idx, StringUtil::Join(col_meta.path_in_schema, ", "));
+	output[8].get().Append(StringUtil::Join(col_meta.path_in_schema, ", "));
 	// type
-	output[9].get().SetValue(output_idx, ConvertParquetElementToString(col_meta.type));
+	output[9].get().Append(ConvertParquetElementToString(col_meta.type));
 	// stats_min
-	output[10].get().SetValue(output_idx,
-	                          ConvertParquetStats(column_type, column_schema, stats.__isset.min, stats.min));
+	output[10].get().Append(ConvertParquetStats(column_type, column_schema, stats.__isset.min, stats.min));
 	// stats_max
-	output[11].get().SetValue(output_idx,
-	                          ConvertParquetStats(column_type, column_schema, stats.__isset.max, stats.max));
+	output[11].get().Append(ConvertParquetStats(column_type, column_schema, stats.__isset.max, stats.max));
 	// stats_null_count
-	output[12].get().SetValue(output_idx, ParquetElementBigint(stats.null_count, stats.__isset.null_count));
+	output[12].get().Append(ParquetElementBigint(stats.null_count, stats.__isset.null_count));
 	// stats_distinct_count
-	output[13].get().SetValue(output_idx, ParquetElementBigint(stats.distinct_count, stats.__isset.distinct_count));
+	output[13].get().Append(ParquetElementBigint(stats.distinct_count, stats.__isset.distinct_count));
 	// stats_min_value
-	output[14].get().SetValue(
-	    output_idx, ConvertParquetStats(column_type, column_schema, stats.__isset.min_value, stats.min_value));
+	output[14].get().Append(ConvertParquetStats(column_type, column_schema, stats.__isset.min_value, stats.min_value));
 	// stats_max_value
-	output[15].get().SetValue(
-	    output_idx, ConvertParquetStats(column_type, column_schema, stats.__isset.max_value, stats.max_value));
+	output[15].get().Append(ConvertParquetStats(column_type, column_schema, stats.__isset.max_value, stats.max_value));
 	// compression
-	output[16].get().SetValue(output_idx, ConvertParquetElementToString(col_meta.codec));
+	output[16].get().Append(ConvertParquetElementToString(col_meta.codec));
 	// encodings
 	vector<string> encoding_string;
 	encoding_string.reserve(col_meta.encodings.size());
 	for (auto &encoding : col_meta.encodings) {
 		encoding_string.push_back(ConvertParquetElementToString(encoding));
 	}
-	output[17].get().SetValue(output_idx, Value(StringUtil::Join(encoding_string, ", ")));
+	output[17].get().Append(Value(StringUtil::Join(encoding_string, ", ")));
 	// index_page_offset
-	output[18].get().SetValue(output_idx,
-	                          ParquetElementBigint(col_meta.index_page_offset, col_meta.__isset.index_page_offset));
+	output[18].get().Append(ParquetElementBigint(col_meta.index_page_offset, col_meta.__isset.index_page_offset));
 	// dictionary_page_offset
-	output[19].get().SetValue(
-	    output_idx, ParquetElementBigint(col_meta.dictionary_page_offset, col_meta.__isset.dictionary_page_offset));
+	output[19].get().Append(
+	    ParquetElementBigint(col_meta.dictionary_page_offset, col_meta.__isset.dictionary_page_offset));
 	// data_page_offset
-	output[20].get().SetValue(output_idx, Value::BIGINT(col_meta.data_page_offset));
+	output[20].get().Append(Value::BIGINT(col_meta.data_page_offset));
 	// total_compressed_size
-	output[21].get().SetValue(output_idx, Value::BIGINT(col_meta.total_compressed_size));
+	output[21].get().Append(Value::BIGINT(col_meta.total_compressed_size));
 	// total_uncompressed_size
-	output[22].get().SetValue(output_idx, Value::BIGINT(col_meta.total_uncompressed_size));
+	output[22].get().Append(Value::BIGINT(col_meta.total_uncompressed_size));
 	// key_value_metadata
 	vector<Value> map_keys, map_values;
 	for (auto &entry : col_meta.key_value_metadata) {
 		map_keys.push_back(Value::BLOB_RAW(entry.key));
 		map_values.push_back(Value::BLOB_RAW(entry.value));
 	}
-	output[23].get().SetValue(
-	    output_idx, Value::MAP(LogicalType::BLOB, LogicalType::BLOB, std::move(map_keys), std::move(map_values)));
+	output[23].get().Append(
+	    Value::MAP(LogicalType::BLOB, LogicalType::BLOB, std::move(map_keys), std::move(map_values)));
 	// bloom_filter_offset
-	output[24].get().SetValue(output_idx,
-	                          ParquetElementBigint(col_meta.bloom_filter_offset, col_meta.__isset.bloom_filter_offset));
+	output[24].get().Append(ParquetElementBigint(col_meta.bloom_filter_offset, col_meta.__isset.bloom_filter_offset));
 	// bloom_filter_length
-	output[25].get().SetValue(output_idx,
-	                          ParquetElementBigint(col_meta.bloom_filter_length, col_meta.__isset.bloom_filter_length));
+	output[25].get().Append(ParquetElementBigint(col_meta.bloom_filter_length, col_meta.__isset.bloom_filter_length));
 	// min_is_exact
-	output[26].get().SetValue(output_idx,
-	                          ParquetElementBoolean(stats.is_min_value_exact, stats.__isset.is_min_value_exact));
+	output[26].get().Append(ParquetElementBoolean(stats.is_min_value_exact, stats.__isset.is_min_value_exact));
 	// max_is_exact
-	output[27].get().SetValue(output_idx,
-	                          ParquetElementBoolean(stats.is_max_value_exact, stats.__isset.is_max_value_exact));
+	output[27].get().Append(ParquetElementBoolean(stats.is_max_value_exact, stats.__isset.is_max_value_exact));
 	// row_group_compressed_bytes
-	output[28].get().SetValue(
-	    output_idx, ParquetElementBigint(row_group.total_compressed_size, row_group.__isset.total_compressed_size));
+	output[28].get().Append(
+	    ParquetElementBigint(row_group.total_compressed_size, row_group.__isset.total_compressed_size));
 	// geo_stats_bbox, LogicalType::STRUCT(...)
-	output[29].get().SetValue(output_idx, ConvertParquetGeoStatsBBOX(col_meta.geospatial_statistics));
+	output[29].get().Append(ConvertParquetGeoStatsBBOX(col_meta.geospatial_statistics));
 
 	// geo_stats_types, LogicalType::LIST(LogicalType::VARCHAR)
-	output[30].get().SetValue(output_idx, ConvertParquetGeoStatsTypes(col_meta.geospatial_statistics));
+	output[30].get().Append(ConvertParquetGeoStatsTypes(col_meta.geospatial_statistics));
 }
 
 //===--------------------------------------------------------------------===//
@@ -543,7 +534,7 @@ void ParquetRowGroupMetadataProcessor::ReadRow(vector<reference<Vector>> &output
 class ParquetSchemaProcessor : public ParquetMetadataFileProcessor {
 public:
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 };
 
 template <>
@@ -648,42 +639,41 @@ idx_t ParquetSchemaProcessor::TotalRowCount(ParquetReader &reader) {
 	return reader.GetFileMetadata()->schema.size();
 }
 
-void ParquetSchemaProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
-                                     ParquetReader &reader) {
+void ParquetSchemaProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) {
 	auto meta_data = reader.GetFileMetadata();
 	const auto &column = meta_data->schema[row_idx];
 
 	// file_name
-	output[0].get().SetValue(output_idx, reader.file.path);
+	output[0].get().Append(reader.file.path);
 	// name
-	output[1].get().SetValue(output_idx, column.name);
+	output[1].get().Append(column.name);
 	// type
-	output[2].get().SetValue(output_idx, ParquetElementString(column.type, column.__isset.type));
+	output[2].get().Append(ParquetElementString(column.type, column.__isset.type));
 	// type_length
-	output[3].get().SetValue(output_idx, ParquetElementInteger(column.type_length, column.__isset.type_length));
+	output[3].get().Append(ParquetElementInteger(column.type_length, column.__isset.type_length));
 	// repetition_type
-	output[4].get().SetValue(output_idx, ParquetElementString(column.repetition_type, column.__isset.repetition_type));
+	output[4].get().Append(ParquetElementString(column.repetition_type, column.__isset.repetition_type));
 	// num_children
-	output[5].get().SetValue(output_idx, ParquetElementBigint(column.num_children, column.__isset.num_children));
+	output[5].get().Append(ParquetElementBigint(column.num_children, column.__isset.num_children));
 	// converted_type
-	output[6].get().SetValue(output_idx, ParquetElementString(column.converted_type, column.__isset.converted_type));
+	output[6].get().Append(ParquetElementString(column.converted_type, column.__isset.converted_type));
 	// scale
-	output[7].get().SetValue(output_idx, ParquetElementBigint(column.scale, column.__isset.scale));
+	output[7].get().Append(ParquetElementBigint(column.scale, column.__isset.scale));
 	// precision
-	output[8].get().SetValue(output_idx, ParquetElementBigint(column.precision, column.__isset.precision));
+	output[8].get().Append(ParquetElementBigint(column.precision, column.__isset.precision));
 	// field_id
-	output[9].get().SetValue(output_idx, ParquetElementBigint(column.field_id, column.__isset.field_id));
+	output[9].get().Append(ParquetElementBigint(column.field_id, column.__isset.field_id));
 	// logical_type
-	output[10].get().SetValue(output_idx, ParquetLogicalTypeToString(column.logicalType, column.__isset.logicalType));
+	output[10].get().Append(ParquetLogicalTypeToString(column.logicalType, column.__isset.logicalType));
 	// duckdb_type
 	ParquetColumnSchema column_schema;
 	Value duckdb_type;
 	if (column.__isset.type) {
 		duckdb_type = reader.DeriveLogicalType(column, column_schema).ToString();
 	}
-	output[11].get().SetValue(output_idx, duckdb_type);
+	output[11].get().Append(duckdb_type);
 	// column_id
-	output[12].get().SetValue(output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(row_idx)));
+	output[12].get().Append(Value::BIGINT(UnsafeNumericCast<int64_t>(row_idx)));
 }
 
 //===--------------------------------------------------------------------===//
@@ -693,7 +683,7 @@ void ParquetSchemaProcessor::ReadRow(vector<reference<Vector>> &output, idx_t ou
 class ParquetKeyValueMetadataProcessor : public ParquetMetadataFileProcessor {
 public:
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 };
 
 template <>
@@ -713,14 +703,14 @@ idx_t ParquetKeyValueMetadataProcessor::TotalRowCount(ParquetReader &reader) {
 	return reader.GetFileMetadata()->key_value_metadata.size();
 }
 
-void ParquetKeyValueMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
+void ParquetKeyValueMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx,
                                                ParquetReader &reader) {
 	auto meta_data = reader.GetFileMetadata();
 	auto &entry = meta_data->key_value_metadata[row_idx];
 
-	output[0].get().SetValue(output_idx, Value(reader.file.path));
-	output[1].get().SetValue(output_idx, Value::BLOB_RAW(entry.key));
-	output[2].get().SetValue(output_idx, Value::BLOB_RAW(entry.value));
+	output[0].get().Append(Value(reader.file.path));
+	output[1].get().Append(Value::BLOB_RAW(entry.key));
+	output[2].get().Append(Value::BLOB_RAW(entry.value));
 }
 
 //===--------------------------------------------------------------------===//
@@ -730,7 +720,7 @@ void ParquetKeyValueMetadataProcessor::ReadRow(vector<reference<Vector>> &output
 class ParquetFileMetadataProcessor : public ParquetMetadataFileProcessor {
 public:
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 };
 
 template <>
@@ -771,30 +761,29 @@ idx_t ParquetFileMetadataProcessor::TotalRowCount(ParquetReader &reader) {
 	return 1;
 }
 
-void ParquetFileMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
-                                           ParquetReader &reader) {
+void ParquetFileMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) {
 	auto meta_data = reader.GetFileMetadata();
 
 	// file_name
-	output[0].get().SetValue(output_idx, Value(reader.file.path));
+	output[0].get().Append(Value(reader.file.path));
 	// created_by
-	output[1].get().SetValue(output_idx, ParquetElementStringVal(meta_data->created_by, meta_data->__isset.created_by));
+	output[1].get().Append(ParquetElementStringVal(meta_data->created_by, meta_data->__isset.created_by));
 	// num_rows
-	output[2].get().SetValue(output_idx, Value::BIGINT(meta_data->num_rows));
+	output[2].get().Append(Value::BIGINT(meta_data->num_rows));
 	// num_row_groups
-	output[3].get().SetValue(output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(meta_data->row_groups.size())));
+	output[3].get().Append(Value::BIGINT(UnsafeNumericCast<int64_t>(meta_data->row_groups.size())));
 	// format_version
-	output[4].get().SetValue(output_idx, Value::BIGINT(meta_data->version));
+	output[4].get().Append(Value::BIGINT(meta_data->version));
 	// encryption_algorithm
-	output[5].get().SetValue(
-	    output_idx, ParquetElementString(meta_data->encryption_algorithm, meta_data->__isset.encryption_algorithm));
+	output[5].get().Append(
+	    ParquetElementString(meta_data->encryption_algorithm, meta_data->__isset.encryption_algorithm));
 	// footer_signing_key_metadata
-	output[6].get().SetValue(output_idx, ParquetElementStringVal(meta_data->footer_signing_key_metadata,
-	                                                             meta_data->__isset.footer_signing_key_metadata));
+	output[6].get().Append(ParquetElementStringVal(meta_data->footer_signing_key_metadata,
+	                                               meta_data->__isset.footer_signing_key_metadata));
 	// file_size_bytes
-	output[7].get().SetValue(output_idx, Value::UBIGINT(reader.GetHandle().GetFileSize()));
+	output[7].get().Append(Value::UBIGINT(reader.GetHandle().GetFileSize()));
 	// footer_size
-	output[8].get().SetValue(output_idx, Value::UBIGINT(reader.metadata->footer_size));
+	output[8].get().Append(Value::UBIGINT(reader.metadata->footer_size));
 	// column_orders
 	Value column_orders_value;
 	if (meta_data->__isset.column_orders) {
@@ -805,7 +794,7 @@ void ParquetFileMetadataProcessor::ReadRow(vector<reference<Vector>> &output, id
 		}
 		column_orders_value = Value::LIST(LogicalType::VARCHAR, column_orders);
 	}
-	output[9].get().SetValue(output_idx, column_orders_value);
+	output[9].get().Append(column_orders_value);
 }
 
 //===--------------------------------------------------------------------===//
@@ -818,7 +807,7 @@ public:
 
 	void InitializeInternal(ClientContext &context, ParquetReader &reader) override;
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 
 private:
 	string probe_column_name;
@@ -875,8 +864,7 @@ idx_t ParquetBloomProbeProcessor::TotalRowCount(ParquetReader &reader) {
 	return reader.GetFileMetadata()->row_groups.size();
 }
 
-void ParquetBloomProbeProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
-                                         ParquetReader &reader) {
+void ParquetBloomProbeProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) {
 	auto meta_data = reader.GetFileMetadata();
 	auto &row_group = meta_data->row_groups[row_idx];
 	auto &column = row_group.columns[probe_column_idx.GetIndex()];
@@ -885,9 +873,9 @@ void ParquetBloomProbeProcessor::ReadRow(vector<reference<Vector>> &output, idx_
 
 	auto bloom_excludes = ParquetStatisticsUtils::BloomFilterExcludes(*filter, column.meta_data, *protocol, *allocator);
 
-	output[0].get().SetValue(output_idx, Value(reader.file.path));
-	output[1].get().SetValue(output_idx, Value::BIGINT(NumericCast<int64_t>(row_idx)));
-	output[2].get().SetValue(output_idx, Value::BOOLEAN(bloom_excludes));
+	output[0].get().Append(Value(reader.file.path));
+	output[1].get().Append(Value::BIGINT(NumericCast<int64_t>(row_idx)));
+	output[2].get().Append(Value::BOOLEAN(bloom_excludes));
 }
 
 //===--------------------------------------------------------------------===//
@@ -900,14 +888,13 @@ public:
 
 	void InitializeInternal(ClientContext &context, ParquetReader &reader) override;
 	idx_t TotalRowCount(ParquetReader &reader) override;
-	void ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx, ParquetReader &reader) override;
+	void ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) override;
 	bool ForceFlush() override {
 		return true;
 	}
 
 private:
-	void PopulateMetadata(ParquetMetadataFileProcessor &processor, Vector &output, idx_t output_idx,
-	                      ParquetReader &reader);
+	void PopulateMetadata(ParquetMetadataFileProcessor &processor, Vector &output, ParquetReader &reader);
 
 	ParquetFileMetadataProcessor file_processor;
 	ParquetRowGroupMetadataProcessor row_group_processor;
@@ -915,7 +902,7 @@ private:
 	ParquetKeyValueMetadataProcessor kv_processor;
 };
 
-void FullMetadataProcessor::PopulateMetadata(ParquetMetadataFileProcessor &processor, Vector &output, idx_t output_idx,
+void FullMetadataProcessor::PopulateMetadata(ParquetMetadataFileProcessor &processor, Vector &output,
                                              ParquetReader &reader) {
 	auto count = processor.TotalRowCount(reader);
 	auto *result_data = FlatVector::GetDataMutable<list_entry_t>(output);
@@ -925,10 +912,13 @@ void FullMetadataProcessor::PopulateMetadata(ParquetMetadataFileProcessor &proce
 	ListVector::SetListSize(output, count);
 	ListVector::Reserve(output, count);
 
+	auto output_idx = output.size();
+
 	result_data[output_idx].offset = 0;
 	result_data[output_idx].length = count;
 
 	FlatVector::ValidityMutable(output).SetValid(output_idx);
+	FlatVector::SetSize(output, output_idx + 1);
 
 	vector<reference<Vector>> vectors;
 	for (auto &entry : result_struct_entries) {
@@ -938,7 +928,7 @@ void FullMetadataProcessor::PopulateMetadata(ParquetMetadataFileProcessor &proce
 		validity.Initialize(count);
 	}
 	for (idx_t i = 0; i < count; i++) {
-		processor.ReadRow(vectors, i, i, reader);
+		processor.ReadRow(vectors, i, reader);
 	}
 }
 
@@ -997,12 +987,11 @@ idx_t FullMetadataProcessor::TotalRowCount(ParquetReader &reader) {
 	return 1;
 }
 
-void FullMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t output_idx, idx_t row_idx,
-                                    ParquetReader &reader) {
-	PopulateMetadata(file_processor, output[0].get(), output_idx, reader);
-	PopulateMetadata(row_group_processor, output[1].get(), output_idx, reader);
-	PopulateMetadata(schema_processor, output[2].get(), output_idx, reader);
-	PopulateMetadata(kv_processor, output[3].get(), output_idx, reader);
+void FullMetadataProcessor::ReadRow(vector<reference<Vector>> &output, idx_t row_idx, ParquetReader &reader) {
+	PopulateMetadata(file_processor, output[0].get(), reader);
+	PopulateMetadata(row_group_processor, output[1].get(), reader);
+	PopulateMetadata(schema_processor, output[2].get(), reader);
+	PopulateMetadata(kv_processor, output[3].get(), reader);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1124,8 +1113,7 @@ void ParquetMetaDataOperator::Function(ClientContext &context, TableFunctionInpu
 		output.SetCardinality(output_count + rows_to_output);
 
 		for (idx_t i = 0; i < rows_to_output; ++i) {
-			local_state.processor->ReadRow(output_vectors, output_count + i, local_state.row_idx + i,
-			                               *local_state.reader);
+			local_state.processor->ReadRow(output_vectors, local_state.row_idx + i, *local_state.reader);
 		}
 		output_count += rows_to_output;
 		local_state.row_idx += rows_to_output;

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -158,7 +158,7 @@ buffer_ptr<VectorBuffer> VectorBuffer::FlattenSliceInternal(const LogicalType &t
 buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, idx_t offset, idx_t end) {
 	if (vector_type == VectorType::CONSTANT_VECTOR) {
 		// constant vectors do not need to get sliced - but we do need to update the count
-		return ConstantSlice(type, end - offset);
+		return ConstantSlice(type, count_t(end - offset));
 	}
 	auto result = SliceInternal(type, offset, end);
 	if (result) {
@@ -172,7 +172,7 @@ buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, idx_t offs
 buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, const SelectionVector &sel, idx_t count) {
 	if (vector_type == VectorType::CONSTANT_VECTOR) {
 		// constant vectors do not need to get sliced - but we do need to update the count
-		return ConstantSlice(type, count);
+		return ConstantSlice(type, count_t(count));
 	}
 	auto result = SliceInternal(type, sel, count);
 	if (result && v_size.IsValid()) {
@@ -183,12 +183,16 @@ buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, const Sele
 	return result;
 }
 
-buffer_ptr<VectorBuffer> VectorBuffer::ConstantSlice(const LogicalType &type, idx_t count) {
+buffer_ptr<VectorBuffer> VectorBuffer::ConstantSlice(const LogicalType &type, count_t count) {
 	if (HasSize() && count == Size()) {
 		// if the size is already set correctly we don't need to do do anything
 		return nullptr;
 	}
-	return SliceInternal(type, 0, count);
+	return ConstantSliceInternal(type, count);
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	throw InternalException("Constant slice not implemented for this vector buffer");
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::SliceWithCache(SelCache &cache, const LogicalType &type,

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -157,8 +157,8 @@ buffer_ptr<VectorBuffer> VectorBuffer::FlattenSliceInternal(const LogicalType &t
 
 buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, idx_t offset, idx_t end) {
 	if (vector_type == VectorType::CONSTANT_VECTOR) {
-		// constant vectors do not need to get sliced
-		return nullptr;
+		// constant vectors do not need to get sliced - but we do need to update the count
+		return ConstantSlice(type, end - offset);
 	}
 	auto result = SliceInternal(type, offset, end);
 	if (result) {
@@ -171,8 +171,8 @@ buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, idx_t offs
 
 buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, const SelectionVector &sel, idx_t count) {
 	if (vector_type == VectorType::CONSTANT_VECTOR) {
-		// constant vectors do not need to get sliced
-		return nullptr;
+		// constant vectors do not need to get sliced - but we do need to update the count
+		return ConstantSlice(type, count);
 	}
 	auto result = SliceInternal(type, sel, count);
 	if (result && v_size.IsValid()) {
@@ -181,6 +181,14 @@ buffer_ptr<VectorBuffer> VectorBuffer::Slice(const LogicalType &type, const Sele
 		}
 	}
 	return result;
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::ConstantSlice(const LogicalType &type, idx_t count) {
+	if (HasSize() && count == Size()) {
+		// if the size is already set correctly we don't need to do do anything
+		return nullptr;
+	}
+	return SliceInternal(type, 0, count);
 }
 
 buffer_ptr<VectorBuffer> VectorBuffer::SliceWithCache(SelCache &cache, const LogicalType &type,

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -144,9 +144,9 @@ buffer_ptr<VectorBuffer> VectorArrayBuffer::SliceInternal(const LogicalType &typ
 buffer_ptr<VectorBuffer> VectorArrayBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
 	auto child_vector = make_uniq<Vector>(Vector::Ref(*child));
 	auto result = make_buffer<VectorArrayBuffer>(std::move(child_vector), array_size, capacity_t(1ULL));
-	result->SetVectorSize(count);
 	result->GetValidityMask().Set(0, validity.RowIsValid(0));
 	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	result->SetVectorSize(count);
 	return result;
 }
 

--- a/src/common/vector/array_vector.cpp
+++ b/src/common/vector/array_vector.cpp
@@ -141,6 +141,15 @@ buffer_ptr<VectorBuffer> VectorArrayBuffer::SliceInternal(const LogicalType &typ
 	return result;
 }
 
+buffer_ptr<VectorBuffer> VectorArrayBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	auto child_vector = make_uniq<Vector>(Vector::Ref(*child));
+	auto result = make_buffer<VectorArrayBuffer>(std::move(child_vector), array_size, capacity_t(1ULL));
+	result->SetVectorSize(count);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	return result;
+}
+
 void VectorArrayBuffer::Resize(idx_t current_size, idx_t new_size) {
 	// resize the validity
 	validity.Resize(new_size);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -78,6 +78,13 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &
 	return result;
 }
 
+buffer_ptr<VectorBuffer> StandardVectorBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	auto result = make_buffer<StandardVectorBuffer>(data_ptr, count, type_size);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	return result;
+}
+
 buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &type, const SelectionVector &sel,
                                                              idx_t count) {
 	Vector child_vector(type, shared_from_this());

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -74,7 +74,7 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::SliceInternal(const LogicalType &
 	auto offset_ptr = data_ptr + type_size * offset;
 	auto result = make_buffer<StandardVectorBuffer>(offset_ptr, count, type_size);
 	result->GetValidityMask().Slice(validity, offset, count);
-	result->SetVectorSize(count);
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
 	return result;
 }
 
@@ -82,6 +82,7 @@ buffer_ptr<VectorBuffer> StandardVectorBuffer::ConstantSliceInternal(const Logic
 	auto result = make_buffer<StandardVectorBuffer>(data_ptr, count, type_size);
 	result->GetValidityMask().Set(0, validity.RowIsValid(0));
 	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
 	return result;
 }
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -150,6 +150,13 @@ void VectorListBuffer::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format)
 	format.validity = validity;
 }
 
+buffer_ptr<VectorBuffer> VectorListBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	auto result = make_buffer<VectorListBuffer>(data_ptr, count, *child);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	return result;
+}
+
 buffer_ptr<VectorBuffer> VectorListBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {
 	return make_buffer<VectorListBuffer>(std::move(new_data), count, *this);
 }

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -136,7 +136,15 @@ buffer_ptr<VectorBuffer> VectorListBuffer::SliceInternal(const LogicalType &type
 	auto count = count_t(end - offset);
 	auto result = make_buffer<VectorListBuffer>(offset_ptr, count, *this);
 	result->GetValidityMask().Slice(validity, offset, count);
-	result->SetVectorSize(count);
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
+	return result;
+}
+
+buffer_ptr<VectorBuffer> VectorListBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	auto result = make_buffer<VectorListBuffer>(data_ptr, count, *child);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
 	return result;
 }
 
@@ -148,13 +156,6 @@ void VectorListBuffer::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format)
 	}
 	format.data = data_ptr;
 	format.validity = validity;
-}
-
-buffer_ptr<VectorBuffer> VectorListBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
-	auto result = make_buffer<VectorListBuffer>(data_ptr, count, *child);
-	result->GetValidityMask().Set(0, validity.RowIsValid(0));
-	result->SetVectorType(VectorType::CONSTANT_VECTOR);
-	return result;
 }
 
 buffer_ptr<VectorBuffer> VectorListBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -75,20 +75,6 @@ idx_t StringHeapHolder::GetAllocationSize() const {
 	return heap.AllocationSize();
 }
 
-buffer_ptr<VectorBuffer> VectorStringBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
-	auto type_size = GetTypeIdSize(type.InternalType());
-	auto offset_ptr = data_ptr + type_size * offset;
-	auto count = count_t(end - offset);
-	auto result = make_buffer<VectorStringBuffer>(offset_ptr, count);
-	result->GetValidityMask().Slice(validity, offset, count);
-	// keep the heap alive
-	if (auxiliary_data) {
-		result->AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(auxiliary_data));
-	}
-	result->SetVectorSize(count);
-	return result;
-}
-
 void VectorStringBuffer::CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count,
                                       idx_t source_offset, idx_t target_offset, idx_t copy_count) {
 	auto ldata = FlatVector::GetData<string_t>(source);
@@ -149,13 +135,21 @@ void VectorStringBuffer::Verify(const LogicalType &type, const SelectionVector &
 	}
 }
 
+buffer_ptr<VectorBuffer> VectorStringBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
+	auto type_size = GetTypeIdSize(type.InternalType());
+	auto offset_ptr = data_ptr + type_size * offset;
+	auto count = count_t(end - offset);
+	auto result = make_buffer<VectorStringBuffer>(offset_ptr, count);
+	result->GetValidityMask().Slice(validity, offset, count);
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
+	return result;
+}
+
 buffer_ptr<VectorBuffer> VectorStringBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
 	auto result = make_buffer<VectorStringBuffer>(data_ptr, count);
 	result->GetValidityMask().Set(0, validity.RowIsValid(0));
 	result->SetVectorType(VectorType::CONSTANT_VECTOR);
-	if (auxiliary_data) {
-		result->AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(auxiliary_data));
-	}
+	result->AddAuxiliaryData(make_uniq<VectorBufferHolder>(shared_from_this()));
 	return result;
 }
 

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -149,6 +149,16 @@ void VectorStringBuffer::Verify(const LogicalType &type, const SelectionVector &
 	}
 }
 
+buffer_ptr<VectorBuffer> VectorStringBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	auto result = make_buffer<VectorStringBuffer>(data_ptr, count);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	if (auxiliary_data) {
+		result->AddAuxiliaryData(make_uniq<AuxiliaryDataSetHolder>(auxiliary_data));
+	}
+	return result;
+}
+
 buffer_ptr<VectorBuffer> VectorStringBuffer::CreateBuffer(AllocatedData &&new_data, count_t count) const {
 	return make_buffer<VectorStringBuffer>(std::move(new_data), count, *this);
 }

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -115,6 +115,18 @@ buffer_ptr<VectorBuffer> VectorStructBuffer::SliceInternal(const LogicalType &ty
 	return make_buffer<VectorStructBuffer>(*this, sel, count);
 }
 
+buffer_ptr<VectorBuffer> VectorStructBuffer::ConstantSliceInternal(const LogicalType &type, count_t count) {
+	vector<Vector> result_children;
+	for (idx_t i = 0; i < children.size(); i++) {
+		result_children.emplace_back(Vector::Ref(children[i]));
+	}
+	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), capacity_t(1ULL));
+	result->SetVectorSize(count);
+	result->GetValidityMask().Set(0, validity.RowIsValid(0));
+	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	return result;
+}
+
 void VectorStructBuffer::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format) const {
 	if (vector_type == VectorType::CONSTANT_VECTOR) {
 		format.sel = ConstantVector::ZeroSelectionVector(count, format.owned_sel);

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -121,9 +121,9 @@ buffer_ptr<VectorBuffer> VectorStructBuffer::ConstantSliceInternal(const Logical
 		result_children.emplace_back(Vector::Ref(children[i]));
 	}
 	auto result = make_buffer<VectorStructBuffer>(std::move(result_children), capacity_t(1ULL));
-	result->SetVectorSize(count);
 	result->GetValidityMask().Set(0, validity.RowIsValid(0));
 	result->SetVectorType(VectorType::CONSTANT_VECTOR);
+	result->SetVectorSize(count);
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -213,17 +213,10 @@ bool PhysicalLimit::HandleOffset(DataChunk &input, idx_t &current_offset, idx_t 
 		}
 	} else {
 		// have to copy either the entire chunk or part of it
-		idx_t chunk_count;
 		if (current_offset + input.size() >= max_element) {
 			// have to limit the count of the chunk
-			chunk_count = max_element - current_offset;
-		} else {
-			// we copy the entire chunk
-			chunk_count = input.size();
+			input.Slice(0, max_element - current_offset);
 		}
-		// instead of copying we just change the pointer in the current chunk
-		input.Reference(input);
-		input.SetCardinality(chunk_count);
 	}
 
 	current_offset += input_size;

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -122,24 +122,25 @@ void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool h
 	} else if (join_type == JoinType::MARK) {
 		// MARK join with empty hash table
 		D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
-		auto &result_vector = result.data.back();
-		D_ASSERT(result_vector.GetType() == LogicalType::BOOLEAN);
 		// for every data vector, we just reference the child chunk
 		result.SetCardinality(input);
 		for (idx_t i = 0; i < input.ColumnCount(); i++) {
 			result.data[i].Reference(input.data[i]);
 		}
+		auto &mark_vector = result.data.back();
+		D_ASSERT(mark_vector.GetType() == LogicalType::BOOLEAN);
 		// for the MARK vector:
 		// if the HT has no NULL values (i.e. empty result set), return a vector that has false for every input
 		// entry if the HT has NULL values (i.e. result set had values, but all were NULL), return a vector that
 		// has NULL for every input entry
 		if (!has_null) {
-			auto bool_result = FlatVector::GetDataMutable<bool>(result_vector);
+			auto mark_data = FlatVector::Writer<bool>(mark_vector, result.size());
 			for (idx_t i = 0; i < result.size(); i++) {
-				bool_result[i] = false;
+				mark_data.WriteValue(false);
 			}
 		} else {
-			FlatVector::ValidityMutable(result_vector).SetAllInvalid(result.size());
+			FlatVector::ValidityMutable(mark_vector).SetAllInvalid(result.size());
+			FlatVector::SetSize(mark_vector, result.size());
 		}
 	} else if (join_type == JoinType::LEFT || join_type == JoinType::OUTER || join_type == JoinType::SINGLE) {
 		// LEFT/FULL OUTER/SINGLE join and build side is empty

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -110,6 +110,7 @@ void PhysicalJoin::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &left
 			}
 		}
 	}
+	FlatVector::SetSize(mark_vector, result.size());
 }
 
 bool PhysicalNestedLoopJoin::IsSupported(const vector<JoinCondition> &conditions, JoinType join_type) {

--- a/src/execution/perfect_aggregate_hashtable.cpp
+++ b/src/execution/perfect_aggregate_hashtable.cpp
@@ -201,19 +201,18 @@ void PerfectAggregateHashTable::Combine(PerfectAggregateHashTable &other) {
 template <class T>
 static void ReconstructGroupVectorTemplated(uint32_t group_values[], Value &min, idx_t mask, idx_t shift,
                                             idx_t entry_count, Vector &result) {
-	auto data = FlatVector::GetDataMutable<T>(result);
-	auto &validity_mask = FlatVector::ValidityMutable(result);
+	auto data = FlatVector::Writer<T>(result, entry_count);
 	auto min_data = min.GetValueUnsafe<T>();
 	for (idx_t i = 0; i < entry_count; i++) {
 		// extract the value of this group from the total group index
 		auto group_index = UnsafeNumericCast<int32_t>((group_values[i] >> shift) & mask);
 		if (group_index == 0) {
 			// if it is 0, the value is NULL
-			validity_mask.SetInvalid(i);
+			data.WriteNull();
 		} else {
 			// otherwise we add the value (minus 1) to the min value
-			data[i] = UnsafeNumericCast<T>(UnsafeNumericCast<int64_t>(min_data) +
-			                               UnsafeNumericCast<int64_t>(group_index) - 1);
+			data.WriteValue(UnsafeNumericCast<T>(UnsafeNumericCast<int64_t>(min_data) +
+			                                     UnsafeNumericCast<int64_t>(group_index) - 1));
 		}
 	}
 }

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -130,7 +130,7 @@ struct TestVectorFlat {
 			auto cardinality = MinValue<idx_t>(STANDARD_VECTOR_SIZE, result_values.Rows() - cur_row);
 			for (idx_t c = 0; c < info.types.size(); c++) {
 				for (idx_t i = 0; i < cardinality; i++) {
-					result->data[c].SetValue(i, result_values.GetValue(cur_row + i, c));
+					result->data[c].Append(result_values.GetValue(cur_row + i, c));
 				}
 			}
 			result->SetCardinality(cardinality);
@@ -147,8 +147,7 @@ struct TestVectorConstant {
 			result->Initialize(Allocator::DefaultAllocator(), info.types);
 			auto cardinality = MinValue<idx_t>(STANDARD_VECTOR_SIZE, TestVectorFlat::TEST_VECTOR_CARDINALITY - cur_row);
 			for (idx_t c = 0; c < info.types.size(); c++) {
-				result->data[c].SetValue(0, values.GetValue(0, c));
-				result->data[c].SetVectorType(VectorType::CONSTANT_VECTOR);
+				result->data[c].Reference(values.GetValue(0, c), count_t(cardinality));
 			}
 			result->SetCardinality(cardinality);
 
@@ -201,9 +200,9 @@ struct TestVectorSequence {
 			if (entry == info.test_type_map.end()) {
 				throw NotImplementedException("Unimplemented type for test_vector_types %s", type.ToString());
 			}
-			result.SetValue(0, entry->second.min_value);
-			result.SetValue(1, entry->second.max_value);
-			result.SetValue(2, Value(type));
+			result.Append(entry->second.min_value);
+			result.Append(entry->second.max_value);
+			result.Append(Value(type));
 			break;
 		}
 		}

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -71,6 +71,15 @@ private:
 	buffer_ptr<AuxiliaryDataSet> auxiliary_data;
 };
 
+class VectorBufferHolder : public AuxiliaryDataHolder {
+public:
+	explicit VectorBufferHolder(buffer_ptr<VectorBuffer> buffer_p) : buffer(std::move(buffer_p)) {
+	}
+
+private:
+	buffer_ptr<VectorBuffer> buffer;
+};
+
 //! The VectorBuffer is a class used by the vector to hold its data
 class VectorBuffer : public enable_shared_from_this<VectorBuffer> {
 public:

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -187,6 +187,8 @@ protected:
 	virtual buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count);
 	//! Slice the buffer with an offset range, returning a new buffer
 	virtual buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end);
+	//! Slice a constant vector with a specific count
+	buffer_ptr<VectorBuffer> ConstantSlice(const LogicalType &type, idx_t count);
 	//! Copy data from another vector into this vectors' buffer
 	virtual void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count,
 	                          idx_t source_offset, idx_t target_offset, idx_t copy_count);

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -183,12 +183,14 @@ public:
 	virtual void Resize(idx_t current_size, idx_t new_size);
 
 protected:
+	//! Slice a constant vector with a specific count
+	buffer_ptr<VectorBuffer> ConstantSlice(const LogicalType &type, count_t count);
+	//! Slice a constant vector with a specific count
+	virtual buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count);
 	//! Slice the buffer with a selection vector, returning a new buffer
 	virtual buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count);
 	//! Slice the buffer with an offset range, returning a new buffer
 	virtual buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end);
-	//! Slice a constant vector with a specific count
-	buffer_ptr<VectorBuffer> ConstantSlice(const LogicalType &type, idx_t count);
 	//! Copy data from another vector into this vectors' buffer
 	virtual void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count,
 	                          idx_t source_offset, idx_t target_offset, idx_t copy_count);

--- a/src/include/duckdb/common/vector/array_vector.hpp
+++ b/src/include/duckdb/common/vector/array_vector.hpp
@@ -46,6 +46,7 @@ public:
 
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
+	buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count) override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,

--- a/src/include/duckdb/common/vector/flat_vector.hpp
+++ b/src/include/duckdb/common/vector/flat_vector.hpp
@@ -52,6 +52,7 @@ public:
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) override;
+	buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count) override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,

--- a/src/include/duckdb/common/vector/list_vector.hpp
+++ b/src/include/duckdb/common/vector/list_vector.hpp
@@ -62,6 +62,7 @@ public:
 
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
+	buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count) override;
 	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, count_t count) const override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;

--- a/src/include/duckdb/common/vector/string_vector.hpp
+++ b/src/include/duckdb/common/vector/string_vector.hpp
@@ -61,6 +61,7 @@ public:
 
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
+	buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count) override;
 	buffer_ptr<VectorBuffer> CreateBuffer(AllocatedData &&new_data, count_t count) const override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;

--- a/src/include/duckdb/common/vector/struct_vector.hpp
+++ b/src/include/duckdb/common/vector/struct_vector.hpp
@@ -55,6 +55,7 @@ public:
 protected:
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
 	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) override;
+	buffer_ptr<VectorBuffer> ConstantSliceInternal(const LogicalType &type, count_t count) override;
 	void CopyInternal(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
 	                  idx_t target_offset, idx_t copy_count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,


### PR DESCRIPTION
* Rework Parquet metadata functions and `test_vector_types` functions to use `Append` API
* Use `FlatVector::Writer` in perfect aggregate HT
* Set vector sizes explicitly in joins
* In PhysicalLimit, instead of using `DataChunk::SetCardinality` as a pseudo-slice for the last chunk, actually slice the input chunk
* When slicing constant vectors, now actually perform a slice in order to create a new buffer with the correct count