### PR TITLE
Collapse FD-derived GROUP BY groups

### DIFF
--- a/src/include/duckdb/optimizer/remove_duplicate_groups.hpp
+++ b/src/include/duckdb/optimizer/remove_duplicate_groups.hpp
@@ -8,33 +8,35 @@
 
 #pragma once
 
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
-#include "duckdb/planner/logical_operator_visitor.hpp"
 
 namespace duckdb {
 
-class BoundColumnRefExpression;
+class LogicalAggregate;
+class LogicalProjection;
+class Optimizer;
 
-//! The RemoveDuplicateGroups optimizer traverses the logical operator tree and removes any duplicate aggregate groups
-//! Duplicate groups may be introduced when joins columns are removed, e.g., by Deliminator or RemoveUnusedColumns
-class RemoveDuplicateGroups : public LogicalOperatorVisitor {
+//! Removes same-binding duplicate groups (e.g. from Deliminator / RemoveUnusedColumns) and
+//! groups that are deterministic functions of a sibling column-ref group (e.g.
+//! `GROUP BY x, x-1, cast(x AS BIGINT)`). The latter are recomputed in a projection above.
+class RemoveDuplicateGroups : public BaseColumnPruner {
 public:
-	RemoveDuplicateGroups() {
-	}
+	explicit RemoveDuplicateGroups(Optimizer &optimizer);
 
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
 	void VisitAggregate(LogicalAggregate &aggr);
 
-protected:
-	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
-
 private:
-	//! The map of column references
-	column_binding_map_t<vector<reference<BoundColumnRefExpression>>> column_references;
+	Optimizer &optimizer;
 	//! Stored expressions (kept around so we don't have dangling pointers)
 	vector<unique_ptr<Expression>> stored_expressions;
+	//! Aggregates marked for projection wrapping by VisitAggregate; consumed in VisitOperator
+	//! post-recursion (where we own the unique_ptr<LogicalOperator> child slot to swap).
+	unordered_map<LogicalAggregate *, unique_ptr<LogicalProjection>> pending_projections;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/remove_duplicate_groups.hpp
+++ b/src/include/duckdb/optimizer/remove_duplicate_groups.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/reference_map.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
 
@@ -34,9 +34,8 @@ private:
 	Optimizer &optimizer;
 	//! Stored expressions (kept around so we don't have dangling pointers)
 	vector<unique_ptr<Expression>> stored_expressions;
-	//! Aggregates marked for projection wrapping by VisitAggregate; consumed in VisitOperator
-	//! post-recursion (where we own the unique_ptr<LogicalOperator> child slot to swap).
-	unordered_map<LogicalAggregate *, unique_ptr<LogicalProjection>> pending_projections;
+	//! Filled by VisitAggregate, consumed by VisitOperator post-recursion when we own the slot.
+	reference_map_t<LogicalAggregate, unique_ptr<LogicalProjection>> pending_projections;
 };
 
 } // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -265,7 +265,7 @@ void Optimizer::RunBuiltInOptimizers() {
 
 	// Remove duplicate groups from aggregates
 	RunOptimizer(OptimizerType::DUPLICATE_GROUPS, [&]() {
-		RemoveDuplicateGroups remove;
+		RemoveDuplicateGroups remove(*this);
 		remove.VisitOperator(*plan);
 	});
 

--- a/src/optimizer/remove_duplicate_groups.cpp
+++ b/src/optimizer/remove_duplicate_groups.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/optimizer/remove_duplicate_groups.hpp"
 
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -15,8 +16,14 @@ RemoveDuplicateGroups::RemoveDuplicateGroups(Optimizer &optimizer_p) : optimizer
 
 namespace {
 
-// Collect distinct BoundColumnRef bindings into `result`. Returns false (and stops walking)
-// once a second distinct binding is seen — callers that need a singleton can bail immediately.
+// derived_expr null for same-binding duplicates, set for FD-derived
+struct GroupRemoval {
+	ProjectionIndex removed_idx;
+	ProjectionIndex target_idx;
+	unique_ptr<Expression> derived_expr;
+};
+
+// Stops once a second distinct binding is seen.
 bool CollectColumnRefBindings(const Expression &expr, column_binding_set_t &result) {
 	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 		result.insert(expr.Cast<BoundColumnRefExpression>().binding);
@@ -29,6 +36,162 @@ bool CollectColumnRefBindings(const Expression &expr, column_binding_set_t &resu
 		}
 	});
 	return ok;
+}
+
+// Bases where SQL `=` doesn't imply bit-equality are unsafe: 0e0 == -0e0 (signbit distinguishes),
+// '1 day' == '24 hour' (datepart distinguishes). INTERVAL today gets wrapped in
+// normalized_interval(...) by the binder, so it shouldn't reach here, but we exclude it
+// defensively in case that wrapping ever changes.
+bool BaseTypeAllowsCollapse(const LogicalType &type) {
+	return !TypeVisitor::Contains(type, [](const LogicalType &t) {
+		switch (t.id()) {
+		case LogicalTypeId::FLOAT:
+		case LogicalTypeId::DOUBLE:
+		case LogicalTypeId::INTERVAL:
+			return true;
+		default:
+			return false;
+		}
+	});
+}
+
+// Derived groups must reference a single bare column-ref base; non-colref bases would need a
+// per-derived injectivity proof.
+void CollectGroupRemovals(const LogicalAggregate &aggr, vector<GroupRemoval> &removals, bool &any_derived) {
+	const auto &groups = aggr.groups;
+
+	column_binding_map_t<ProjectionIndex> first_occurrence;
+	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
+		const auto &group = groups[group_idx];
+		if (group->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			continue;
+		}
+		const auto &binding = group->Cast<BoundColumnRefExpression>().binding;
+		auto it = first_occurrence.find(binding);
+		if (it == first_occurrence.end()) {
+			first_occurrence.emplace(binding, group_idx);
+		} else {
+			removals.push_back({group_idx, it->second, nullptr});
+		}
+	}
+
+	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
+		const auto &group = groups[group_idx];
+		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			continue;
+		}
+		if (group->IsFoldable() || !group->IsConsistent()) {
+			continue;
+		}
+		column_binding_set_t colrefs;
+		if (!CollectColumnRefBindings(*group, colrefs) || colrefs.size() != 1) {
+			continue;
+		}
+		auto base_it = first_occurrence.find(*colrefs.begin());
+		if (base_it == first_occurrence.end()) {
+			continue;
+		}
+		if (!BaseTypeAllowsCollapse(groups[base_it->second.GetIndex()]->return_type)) {
+			continue;
+		}
+		removals.push_back({group_idx, base_it->second, nullptr});
+		any_derived = true;
+	}
+}
+
+// Compacts survivors, fixes grouping sets, and fills group_binding_map with the pre/post-shift
+// mapping. Derived expressions move into removals[*].derived_expr (caller rebinds them above the
+// aggregate); same-binding duplicates move into stored_expressions.
+void ApplyGroupRemovals(LogicalAggregate &aggr, vector<GroupRemoval> &removals,
+                        vector<unique_ptr<Expression>> &stored_expressions,
+                        column_binding_map_t<ColumnBinding> &group_binding_map) {
+	auto &groups = aggr.groups;
+	const idx_t num_original_groups = groups.size();
+
+	vector<bool> removed_flag(num_original_groups, false);
+	for (auto &r : removals) {
+		auto &expr = groups[r.removed_idx];
+		if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			r.derived_expr = std::move(expr);
+		} else {
+			stored_expressions.emplace_back(std::move(expr));
+		}
+		removed_flag[r.removed_idx.GetIndex()] = true;
+	}
+
+	// Compact survivors and record their post-shift indices.
+	vector<idx_t> old_to_post(num_original_groups, 0);
+	idx_t write_pos = 0;
+	for (idx_t i = 0; i < num_original_groups; i++) {
+		if (!removed_flag[i]) {
+			old_to_post[i] = write_pos;
+			if (write_pos != i) {
+				groups[write_pos] = std::move(groups[i]);
+			}
+			write_pos++;
+		}
+	}
+	groups.resize(write_pos);
+	// Removed slots inherit their target's post-shift index.
+	for (auto &r : removals) {
+		old_to_post[r.removed_idx.GetIndex()] = old_to_post[r.target_idx.GetIndex()];
+	}
+
+	for (auto &grouping_set : aggr.grouping_sets) {
+		GroupingSet new_set;
+		for (auto entry : grouping_set) {
+			new_set.insert(ProjectionIndex(old_to_post[entry.GetIndex()]));
+		}
+		grouping_set = std::move(new_set);
+	}
+
+	for (idx_t i = 0; i < num_original_groups; i++) {
+		ColumnBinding old_b(aggr.group_index, ProjectionIndex(i));
+		ColumnBinding new_b(aggr.group_index, ProjectionIndex(old_to_post[i]));
+		group_binding_map.emplace(old_b, new_b);
+	}
+}
+
+// Builds a passthrough projection mirroring the pre-removal aggregate output, with derived slots
+// replaced by the rewritten derived expression. Fills derived_remap for the caller's
+// ReplaceBinding pass.
+unique_ptr<LogicalProjection>
+BuildDerivedProjection(LogicalAggregate &aggr, idx_t num_original_groups, idx_t num_aggregate_outputs,
+                       TableIndex original_group_index, TableIndex original_aggregate_index,
+                       vector<GroupRemoval> &removals, const column_binding_map_t<ColumnBinding> &group_binding_map,
+                       Optimizer &optimizer, column_binding_map_t<ColumnBinding> &derived_remap) {
+	const auto new_proj_idx = optimizer.binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> select_list;
+	select_list.reserve(num_original_groups + num_aggregate_outputs);
+
+	for (auto orig : ProjectionIndex::GetIndexes(num_original_groups)) {
+		auto post = group_binding_map.at(ColumnBinding(original_group_index, orig));
+		select_list.emplace_back(
+		    make_uniq<BoundColumnRefExpression>(aggr.groups[post.column_index]->return_type, post));
+		derived_remap.emplace(ColumnBinding(original_group_index, orig), ColumnBinding(new_proj_idx, orig));
+	}
+	for (auto k : ProjectionIndex::GetIndexes(num_aggregate_outputs)) {
+		select_list.emplace_back(make_uniq<BoundColumnRefExpression>(aggr.expressions[k.GetIndex()]->return_type,
+		                                                             ColumnBinding(original_aggregate_index, k)));
+		derived_remap.emplace(ColumnBinding(original_aggregate_index, k),
+		                      ColumnBinding(new_proj_idx, ProjectionIndex(num_original_groups + k.GetIndex())));
+	}
+
+	// Patch derived slots: replace the passthrough with the rebound derived expression.
+	ColumnBindingReplacer rebinder;
+	for (auto &r : removals) {
+		if (!r.derived_expr) {
+			continue;
+		}
+		auto base_post = group_binding_map.at(ColumnBinding(original_group_index, r.target_idx));
+		const auto &base_source = aggr.groups[base_post.column_index]->Cast<BoundColumnRefExpression>().binding;
+		rebinder.replacement_bindings.clear();
+		rebinder.replacement_bindings.emplace_back(base_source, base_post);
+		rebinder.VisitExpression(&r.derived_expr);
+		select_list[r.removed_idx.GetIndex()] = std::move(r.derived_expr);
+	}
+
+	return make_uniq<LogicalProjection>(new_proj_idx, std::move(select_list));
 }
 
 } // namespace
@@ -44,12 +207,12 @@ void RemoveDuplicateGroups::VisitOperator(LogicalOperator &op) {
 	LogicalOperatorVisitor::VisitOperatorExpressions(op);
 	LogicalOperatorVisitor::VisitOperatorChildren(op);
 
-	// Inject any pending derived-collapse projections (the only place we own the unique_ptr slot).
+	// Inject pending derived-collapse projections — only here do we own the child unique_ptr slot.
 	for (auto &child_slot : op.children) {
 		if (child_slot->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
 			continue;
 		}
-		auto pp = pending_projections.find(&child_slot->Cast<LogicalAggregate>());
+		auto pp = pending_projections.find(child_slot->Cast<LogicalAggregate>());
 		if (pp == pending_projections.end()) {
 			continue;
 		}
@@ -76,158 +239,34 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 		return;
 	}
 
-	auto &groups = aggr.groups;
-
-	// `derived_expr` discriminates: null → duplicate, non-null → derived.
-	struct Removal {
-		ProjectionIndex removed_idx;
-		ProjectionIndex target_idx;
-		unique_ptr<Expression> derived_expr;
-	};
-	vector<Removal> removals;
+	vector<GroupRemoval> removals;
 	bool any_derived = false;
-
-	column_binding_map_t<ProjectionIndex> first_occurrence;
-	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
-		const auto &group = groups[group_idx];
-		if (group->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-			continue;
-		}
-		const auto &binding = group->Cast<BoundColumnRefExpression>().binding;
-		auto it = first_occurrence.find(binding);
-		if (it == first_occurrence.end()) {
-			first_occurrence.emplace(binding, group_idx);
-		} else {
-			removals.push_back({group_idx, it->second, nullptr});
-		}
-	}
-
-	// Derived: a non-column-ref group whose colref-set is a singleton matching a surviving base.
-	// Base must be a bare column-ref — non-colref bases (e.g. floor(x)) need injectivity proof
-	// on every derived to avoid splitting partitions for many-to-one inputs.
-	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
-		const auto &group = groups[group_idx];
-		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-			continue;
-		}
-		if (group->IsFoldable() || !group->IsConsistent()) {
-			continue;
-		}
-		column_binding_set_t colrefs;
-		if (!CollectColumnRefBindings(*group, colrefs) || colrefs.size() != 1) {
-			continue;
-		}
-		auto base_it = first_occurrence.find(*colrefs.begin());
-		if (base_it == first_occurrence.end()) {
-			continue;
-		}
-		removals.push_back({group_idx, base_it->second, nullptr});
-		any_derived = true;
-	}
-
+	CollectGroupRemovals(aggr, removals, any_derived);
 	if (removals.empty()) {
 		return;
-	}
-
-	const idx_t num_original_groups = groups.size();
-	const idx_t num_aggregate_outputs = aggr.expressions.size();
-	const TableIndex original_group_index = aggr.group_index;
-	const TableIndex original_aggregate_index = aggr.aggregate_index;
-
-	// Now we want to remove the duplicates, but this alters the column bindings coming out of the aggregate,
-	// so we keep track of how they shift and do another round of column binding replacements
-
-	vector<bool> removed_flag(num_original_groups, false);
-	for (auto &r : removals) {
-		// Store expression and remove it from groups
-		auto &expr = groups[r.removed_idx];
-		if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-			r.derived_expr = std::move(expr);
-		} else {
-			stored_expressions.emplace_back(std::move(expr));
-		}
-		removed_flag[r.removed_idx.GetIndex()] = true;
 	}
 
 	// This optimizer should run before statistics propagation, so this should be empty
 	// If it runs after, then group_stats should be updated too
 	D_ASSERT(aggr.group_stats.empty());
 
-	// One pass: compact survivors in `groups` and record each survivor's post-shift index.
-	vector<idx_t> old_to_post(num_original_groups, 0);
-	idx_t write_pos = 0;
-	for (idx_t i = 0; i < num_original_groups; i++) {
-		if (!removed_flag[i]) {
-			old_to_post[i] = write_pos;
-			if (write_pos != i) {
-				groups[write_pos] = std::move(groups[i]);
-			}
-			write_pos++;
-		}
-	}
-	groups.resize(write_pos);
-	// Removed slots inherit their target's post-shift index, so old_to_post[i] now holds the
-	// final new index for every original slot — survivor or not.
-	for (auto &r : removals) {
-		old_to_post[r.removed_idx.GetIndex()] = old_to_post[r.target_idx.GetIndex()];
-	}
+	const idx_t num_original_groups = aggr.groups.size();
+	const idx_t num_aggregate_outputs = aggr.expressions.size();
+	const TableIndex original_group_index = aggr.group_index;
+	const TableIndex original_aggregate_index = aggr.aggregate_index;
 
-	// Remove from grouping sets too
-	for (auto &grouping_set : aggr.grouping_sets) {
-		GroupingSet new_set;
-		for (auto entry : grouping_set) {
-			// Replace removed group with duplicate remaining group; indices shifted
-			new_set.insert(ProjectionIndex(old_to_post[entry.GetIndex()]));
-		}
-		grouping_set = std::move(new_set);
-	}
-
-	// Update mapping
 	column_binding_map_t<ColumnBinding> group_binding_map;
-	for (idx_t i = 0; i < num_original_groups; i++) {
-		ColumnBinding old_b(original_group_index, ProjectionIndex(i));
-		ColumnBinding new_b(original_group_index, ProjectionIndex(old_to_post[i]));
-		group_binding_map.emplace(old_b, new_b);
-	}
+	ApplyGroupRemovals(aggr, removals, stored_expressions, group_binding_map);
 
 	column_binding_map_t<ColumnBinding> derived_remap;
 	if (any_derived) {
-		// Projection mirrors the aggregate's pre-removal output layout. Its child slot is filled
-		// by VisitOperator post-recursion. Init every slot as a passthrough into the post-shift
-		// aggregate bindings; in the same loop populate derived_remap.
-		const auto new_proj_idx = optimizer.binder.GenerateTableIndex();
-		vector<unique_ptr<Expression>> select_list;
-		select_list.reserve(num_original_groups + num_aggregate_outputs);
-		for (auto orig : ProjectionIndex::GetIndexes(num_original_groups)) {
-			auto post = group_binding_map.at(ColumnBinding(original_group_index, orig));
-			select_list.emplace_back(make_uniq<BoundColumnRefExpression>(groups[post.column_index]->return_type, post));
-			derived_remap.emplace(ColumnBinding(original_group_index, orig), ColumnBinding(new_proj_idx, orig));
-		}
-		for (auto k : ProjectionIndex::GetIndexes(num_aggregate_outputs)) {
-			select_list.emplace_back(make_uniq<BoundColumnRefExpression>(aggr.expressions[k.GetIndex()]->return_type,
-			                                                             ColumnBinding(original_aggregate_index, k)));
-			derived_remap.emplace(ColumnBinding(original_aggregate_index, k),
-			                      ColumnBinding(new_proj_idx, ProjectionIndex(num_original_groups + k.GetIndex())));
-		}
-
-		// Patch derived slots with the rewritten derived expression (replaces the passthrough).
-		ColumnBindingReplacer rebinder;
-		for (auto &r : removals) {
-			if (!r.derived_expr) {
-				continue;
-			}
-			auto base_post = group_binding_map.at(ColumnBinding(original_group_index, r.target_idx));
-			const auto &base_source = groups[base_post.column_index]->Cast<BoundColumnRefExpression>().binding;
-			rebinder.replacement_bindings.clear();
-			rebinder.replacement_bindings.emplace_back(base_source, base_post);
-			rebinder.VisitExpression(&r.derived_expr);
-			select_list[r.removed_idx.GetIndex()] = std::move(r.derived_expr);
-		}
-
-		pending_projections[&aggr] = make_uniq<LogicalProjection>(new_proj_idx, std::move(select_list));
+		pending_projections.emplace(aggr,
+		                            BuildDerivedProjection(aggr, num_original_groups, num_aggregate_outputs,
+		                                                   original_group_index, original_aggregate_index, removals,
+		                                                   group_binding_map, optimizer, derived_remap));
 	}
 
-	// Replace all references to the old group binding with the new group binding
+	// Replace all references to the old group binding with the new group binding.
 	for (const auto &[old_binding, new_binding] : any_derived ? derived_remap : group_binding_map) {
 		ReplaceBinding(old_binding, new_binding);
 	}

--- a/src/optimizer/remove_duplicate_groups.cpp
+++ b/src/optimizer/remove_duplicate_groups.cpp
@@ -31,44 +31,6 @@ bool CollectColumnRefBindings(const Expression &expr, column_binding_set_t &resu
 	return ok;
 }
 
-// Erase `removed_idx` from aggr (groups + grouping_sets) and shift `group_binding_map`. Caller
-// has already moved `aggr.groups[removed_idx]`'s expression out.
-void EraseGroupAndShift(LogicalAggregate &aggr, ProjectionIndex removed_idx, ProjectionIndex target_idx,
-                        column_binding_map_t<ColumnBinding> &group_binding_map) {
-	aggr.groups.erase_at(removed_idx);
-
-	// This optimizer should run before statistics propagation, so this should be empty
-	// If it runs after, then group_stats should be updated too
-	D_ASSERT(aggr.group_stats.empty());
-
-	// Remove from grouping sets too
-	for (auto &grouping_set : aggr.grouping_sets) {
-		GroupingSet new_set;
-		for (auto entry : grouping_set) {
-			// Replace removed group with duplicate remaining group
-			ProjectionIndex out = entry == removed_idx ? target_idx : entry;
-			// Indices shifted: Reinsert groups in the set with group_idx - 1
-			if (out > removed_idx) {
-				out = ProjectionIndex(out - 1);
-			}
-			new_set.insert(out);
-		}
-		grouping_set = std::move(new_set);
-	}
-
-	// Update mapping
-	auto it = group_binding_map.find(ColumnBinding(aggr.group_index, removed_idx));
-	D_ASSERT(it != group_binding_map.end());
-	it->second.column_index = target_idx;
-
-	for (auto &map_entry : group_binding_map) {
-		auto &new_binding = map_entry.second;
-		if (new_binding.column_index > removed_idx) {
-			new_binding.column_index = ProjectionIndex(new_binding.column_index - 1);
-		}
-	}
-}
-
 } // namespace
 
 void RemoveDuplicateGroups::VisitOperator(LogicalOperator &op) {
@@ -116,9 +78,7 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 
 	auto &groups = aggr.groups;
 
-	// Duplicates collapse in place; derived rewrites recompute in a projection above the aggregate.
-	// `derived_expr` discriminates: null → duplicate, non-null → derived. The base's source binding
-	// is recovered on demand from the (still-intact) base group via group_binding_map.
+	// `derived_expr` discriminates: null → duplicate, non-null → derived.
 	struct Removal {
 		ProjectionIndex removed_idx;
 		ProjectionIndex target_idx;
@@ -142,11 +102,9 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 		}
 	}
 
-	// Derived: a non-column-ref group whose entire colref-set is a single binding that matches a
-	// surviving colref base. Walk each candidate's expression tree exactly once to collect its
-	// colref-set, then a single hash lookup picks the base. The base must be a bare column-ref
-	// (trivially injective in itself) — a non-colref base like floor(x) would need an injectivity
-	// proof on every derived to avoid splitting partitions for many-to-one inputs.
+	// Derived: a non-column-ref group whose colref-set is a singleton matching a surviving base.
+	// Base must be a bare column-ref — non-colref bases (e.g. floor(x)) need injectivity proof
+	// on every derived to avoid splitting partitions for many-to-one inputs.
 	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
 		const auto &group = groups[group_idx];
 		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
@@ -178,16 +136,8 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 
 	// Now we want to remove the duplicates, but this alters the column bindings coming out of the aggregate,
 	// so we keep track of how they shift and do another round of column binding replacements
-	column_binding_map_t<ColumnBinding> group_binding_map;
-	for (auto group_idx : ProjectionIndex::GetIndexes(num_original_groups)) {
-		ColumnBinding b(original_group_index, group_idx);
-		group_binding_map.emplace(b, b);
-	}
 
-	// Sort duplicates by max duplicate group idx, because we want to remove groups from the back
-	sort(removals.begin(), removals.end(),
-	     [](const Removal &a, const Removal &b) { return a.removed_idx > b.removed_idx; });
-
+	vector<bool> removed_flag(num_original_groups, false);
 	for (auto &r : removals) {
 		// Store expression and remove it from groups
 		auto &expr = groups[r.removed_idx];
@@ -196,18 +146,56 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 		} else {
 			stored_expressions.emplace_back(std::move(expr));
 		}
-		EraseGroupAndShift(aggr, r.removed_idx, r.target_idx, group_binding_map);
+		removed_flag[r.removed_idx.GetIndex()] = true;
+	}
+
+	// This optimizer should run before statistics propagation, so this should be empty
+	// If it runs after, then group_stats should be updated too
+	D_ASSERT(aggr.group_stats.empty());
+
+	// One pass: compact survivors in `groups` and record each survivor's post-shift index.
+	vector<idx_t> old_to_post(num_original_groups, 0);
+	idx_t write_pos = 0;
+	for (idx_t i = 0; i < num_original_groups; i++) {
+		if (!removed_flag[i]) {
+			old_to_post[i] = write_pos;
+			if (write_pos != i) {
+				groups[write_pos] = std::move(groups[i]);
+			}
+			write_pos++;
+		}
+	}
+	groups.resize(write_pos);
+	// Removed slots inherit their target's post-shift index, so old_to_post[i] now holds the
+	// final new index for every original slot — survivor or not.
+	for (auto &r : removals) {
+		old_to_post[r.removed_idx.GetIndex()] = old_to_post[r.target_idx.GetIndex()];
+	}
+
+	// Remove from grouping sets too
+	for (auto &grouping_set : aggr.grouping_sets) {
+		GroupingSet new_set;
+		for (auto entry : grouping_set) {
+			// Replace removed group with duplicate remaining group; indices shifted
+			new_set.insert(ProjectionIndex(old_to_post[entry.GetIndex()]));
+		}
+		grouping_set = std::move(new_set);
+	}
+
+	// Update mapping
+	column_binding_map_t<ColumnBinding> group_binding_map;
+	for (idx_t i = 0; i < num_original_groups; i++) {
+		ColumnBinding old_b(original_group_index, ProjectionIndex(i));
+		ColumnBinding new_b(original_group_index, ProjectionIndex(old_to_post[i]));
+		group_binding_map.emplace(old_b, new_b);
 	}
 
 	column_binding_map_t<ColumnBinding> derived_remap;
 	if (any_derived) {
-		// Build a projection mirroring the aggregate's pre-removal output layout. Its child slot
-		// is filled by VisitOperator post-recursion (we don't own the unique_ptr here).
+		// Projection mirrors the aggregate's pre-removal output layout. Its child slot is filled
+		// by VisitOperator post-recursion. Init every slot as a passthrough into the post-shift
+		// aggregate bindings; in the same loop populate derived_remap.
 		const auto new_proj_idx = optimizer.binder.GenerateTableIndex();
-
-		// Initialise every projection slot as a passthrough column-ref into the aggregate's
-		// post-shift bindings; in the same loop populate derived_remap so consumers route through
-		// the projection.
 		vector<unique_ptr<Expression>> select_list;
 		select_list.reserve(num_original_groups + num_aggregate_outputs);
 		for (auto orig : ProjectionIndex::GetIndexes(num_original_groups)) {
@@ -222,9 +210,7 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 			                      ColumnBinding(new_proj_idx, ProjectionIndex(num_original_groups + k.GetIndex())));
 		}
 
-		// Patch derived slots: replace the passthrough with the rewritten derived expression.
-		// `groups` is in post-shift state; the surviving base group at base_post.column_index is
-		// still a BoundColumnRefExpression carrying its source binding.
+		// Patch derived slots with the rewritten derived expression (replaces the passthrough).
 		ColumnBindingReplacer rebinder;
 		for (auto &r : removals) {
 			if (!r.derived_expr) {

--- a/src/optimizer/remove_duplicate_groups.cpp
+++ b/src/optimizer/remove_duplicate_groups.cpp
@@ -1,10 +1,75 @@
 #include "duckdb/optimizer/remove_duplicate_groups.hpp"
 
-#include "duckdb/common/pair.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
+
+RemoveDuplicateGroups::RemoveDuplicateGroups(Optimizer &optimizer_p) : optimizer(optimizer_p) {
+}
+
+namespace {
+
+// Collect distinct BoundColumnRef bindings into `result`. Returns false (and stops walking)
+// once a second distinct binding is seen — callers that need a singleton can bail immediately.
+bool CollectColumnRefBindings(const Expression &expr, column_binding_set_t &result) {
+	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		result.insert(expr.Cast<BoundColumnRefExpression>().binding);
+		return result.size() <= 1;
+	}
+	bool ok = true;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (ok && !CollectColumnRefBindings(child, result)) {
+			ok = false;
+		}
+	});
+	return ok;
+}
+
+// Erase `removed_idx` from aggr (groups + grouping_sets) and shift `group_binding_map`. Caller
+// has already moved `aggr.groups[removed_idx]`'s expression out.
+void EraseGroupAndShift(LogicalAggregate &aggr, ProjectionIndex removed_idx, ProjectionIndex target_idx,
+                        column_binding_map_t<ColumnBinding> &group_binding_map) {
+	aggr.groups.erase_at(removed_idx);
+
+	// This optimizer should run before statistics propagation, so this should be empty
+	// If it runs after, then group_stats should be updated too
+	D_ASSERT(aggr.group_stats.empty());
+
+	// Remove from grouping sets too
+	for (auto &grouping_set : aggr.grouping_sets) {
+		GroupingSet new_set;
+		for (auto entry : grouping_set) {
+			// Replace removed group with duplicate remaining group
+			ProjectionIndex out = entry == removed_idx ? target_idx : entry;
+			// Indices shifted: Reinsert groups in the set with group_idx - 1
+			if (out > removed_idx) {
+				out = ProjectionIndex(out - 1);
+			}
+			new_set.insert(out);
+		}
+		grouping_set = std::move(new_set);
+	}
+
+	// Update mapping
+	auto it = group_binding_map.find(ColumnBinding(aggr.group_index, removed_idx));
+	D_ASSERT(it != group_binding_map.end());
+	it->second.column_index = target_idx;
+
+	for (auto &map_entry : group_binding_map) {
+		auto &new_binding = map_entry.second;
+		if (new_binding.column_index > removed_idx) {
+			new_binding.column_index = ProjectionIndex(new_binding.column_index - 1);
+		}
+	}
+}
+
+} // namespace
 
 void RemoveDuplicateGroups::VisitOperator(LogicalOperator &op) {
 	switch (op.type) {
@@ -16,6 +81,25 @@ void RemoveDuplicateGroups::VisitOperator(LogicalOperator &op) {
 	}
 	LogicalOperatorVisitor::VisitOperatorExpressions(op);
 	LogicalOperatorVisitor::VisitOperatorChildren(op);
+
+	// Inject any pending derived-collapse projections (the only place we own the unique_ptr slot).
+	for (auto &child_slot : op.children) {
+		if (child_slot->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+			continue;
+		}
+		auto pp = pending_projections.find(&child_slot->Cast<LogicalAggregate>());
+		if (pp == pending_projections.end()) {
+			continue;
+		}
+		auto proj = std::move(pp->second);
+		pending_projections.erase(pp);
+		if (child_slot->has_estimated_cardinality) {
+			proj->SetEstimatedCardinality(child_slot->estimated_cardinality);
+		}
+		proj->children.emplace_back(std::move(child_slot));
+		proj->ResolveOperatorTypes();
+		child_slot = std::move(proj);
+	}
 }
 
 void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
@@ -32,105 +116,135 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 
 	auto &groups = aggr.groups;
 
-	column_binding_map_t<ProjectionIndex> duplicate_map;
-	vector<pair<ProjectionIndex, ProjectionIndex>> duplicates;
+	// Duplicates collapse in place; derived rewrites recompute in a projection above the aggregate.
+	// `derived_expr` discriminates: null → duplicate, non-null → derived. The base's source binding
+	// is recovered on demand from the (still-intact) base group via group_binding_map.
+	struct Removal {
+		ProjectionIndex removed_idx;
+		ProjectionIndex target_idx;
+		unique_ptr<Expression> derived_expr;
+	};
+	vector<Removal> removals;
+	bool any_derived = false;
+
+	column_binding_map_t<ProjectionIndex> first_occurrence;
 	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
 		const auto &group = groups[group_idx];
 		if (group->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 			continue;
 		}
-		const auto &colref = group->Cast<BoundColumnRefExpression>();
-		const auto &binding = colref.binding;
-		const auto it = duplicate_map.find(binding);
-		if (it == duplicate_map.end()) {
-			duplicate_map.emplace(binding, group_idx);
+		const auto &binding = group->Cast<BoundColumnRefExpression>().binding;
+		auto it = first_occurrence.find(binding);
+		if (it == first_occurrence.end()) {
+			first_occurrence.emplace(binding, group_idx);
 		} else {
-			duplicates.emplace_back(it->second, group_idx);
+			removals.push_back({group_idx, it->second, nullptr});
 		}
 	}
 
-	if (duplicates.empty()) {
+	// Derived: a non-column-ref group whose entire colref-set is a single binding that matches a
+	// surviving colref base. Walk each candidate's expression tree exactly once to collect its
+	// colref-set, then a single hash lookup picks the base. The base must be a bare column-ref
+	// (trivially injective in itself) — a non-colref base like floor(x) would need an injectivity
+	// proof on every derived to avoid splitting partitions for many-to-one inputs.
+	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
+		const auto &group = groups[group_idx];
+		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			continue;
+		}
+		if (group->IsFoldable() || !group->IsConsistent()) {
+			continue;
+		}
+		column_binding_set_t colrefs;
+		if (!CollectColumnRefBindings(*group, colrefs) || colrefs.size() != 1) {
+			continue;
+		}
+		auto base_it = first_occurrence.find(*colrefs.begin());
+		if (base_it == first_occurrence.end()) {
+			continue;
+		}
+		removals.push_back({group_idx, base_it->second, nullptr});
+		any_derived = true;
+	}
+
+	if (removals.empty()) {
 		return;
 	}
 
-	// Sort duplicates by max duplicate group idx, because we want to remove groups from the back
-	sort(duplicates.begin(), duplicates.end(),
-	     [](const pair<ProjectionIndex, ProjectionIndex> &lhs, const pair<ProjectionIndex, ProjectionIndex> &rhs) {
-		     return lhs.second > rhs.second;
-	     });
+	const idx_t num_original_groups = groups.size();
+	const idx_t num_aggregate_outputs = aggr.expressions.size();
+	const TableIndex original_group_index = aggr.group_index;
+	const TableIndex original_aggregate_index = aggr.aggregate_index;
 
 	// Now we want to remove the duplicates, but this alters the column bindings coming out of the aggregate,
 	// so we keep track of how they shift and do another round of column binding replacements
 	column_binding_map_t<ColumnBinding> group_binding_map;
-	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
-		ColumnBinding group_binding(aggr.group_index, group_idx);
-		group_binding_map.emplace(group_binding, group_binding);
+	for (auto group_idx : ProjectionIndex::GetIndexes(num_original_groups)) {
+		ColumnBinding b(original_group_index, group_idx);
+		group_binding_map.emplace(b, b);
 	}
 
-	for (idx_t duplicate_idx = 0; duplicate_idx < duplicates.size(); duplicate_idx++) {
-		const auto &duplicate = duplicates[duplicate_idx];
-		const auto &remaining_idx = duplicate.first;
-		const auto &removed_idx = duplicate.second;
+	// Sort duplicates by max duplicate group idx, because we want to remove groups from the back
+	sort(removals.begin(), removals.end(),
+	     [](const Removal &a, const Removal &b) { return a.removed_idx > b.removed_idx; });
 
+	for (auto &r : removals) {
 		// Store expression and remove it from groups
-		stored_expressions.emplace_back(std::move(groups[removed_idx]));
-		groups.erase_at(removed_idx);
+		auto &expr = groups[r.removed_idx];
+		if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			r.derived_expr = std::move(expr);
+		} else {
+			stored_expressions.emplace_back(std::move(expr));
+		}
+		EraseGroupAndShift(aggr, r.removed_idx, r.target_idx, group_binding_map);
+	}
 
-		// This optimizer should run before statistics propagation, so this should be empty
-		// If it runs after, then group_stats should be updated too
-		D_ASSERT(aggr.group_stats.empty());
+	column_binding_map_t<ColumnBinding> derived_remap;
+	if (any_derived) {
+		// Build a projection mirroring the aggregate's pre-removal output layout. Its child slot
+		// is filled by VisitOperator post-recursion (we don't own the unique_ptr here).
+		const auto new_proj_idx = optimizer.binder.GenerateTableIndex();
 
-		// Remove from grouping sets too
-		for (auto &grouping_set : aggr.grouping_sets) {
-			// Replace removed group with duplicate remaining group
-			if (grouping_set.erase(removed_idx) != 0) {
-				grouping_set.insert(remaining_idx);
-			}
-
-			// Indices shifted: Reinsert groups in the set with group_idx - 1
-			vector<ProjectionIndex> group_indices_to_reinsert;
-			for (auto &entry : grouping_set) {
-				if (entry > removed_idx) {
-					group_indices_to_reinsert.emplace_back(entry);
-				}
-			}
-			for (const auto group_idx : group_indices_to_reinsert) {
-				grouping_set.erase(group_idx);
-			}
-			for (const auto group_idx : group_indices_to_reinsert) {
-				grouping_set.insert(ProjectionIndex(group_idx - 1));
-			}
+		// Initialise every projection slot as a passthrough column-ref into the aggregate's
+		// post-shift bindings; in the same loop populate derived_remap so consumers route through
+		// the projection.
+		vector<unique_ptr<Expression>> select_list;
+		select_list.reserve(num_original_groups + num_aggregate_outputs);
+		for (auto orig : ProjectionIndex::GetIndexes(num_original_groups)) {
+			auto post = group_binding_map.at(ColumnBinding(original_group_index, orig));
+			select_list.emplace_back(make_uniq<BoundColumnRefExpression>(groups[post.column_index]->return_type, post));
+			derived_remap.emplace(ColumnBinding(original_group_index, orig), ColumnBinding(new_proj_idx, orig));
+		}
+		for (auto k : ProjectionIndex::GetIndexes(num_aggregate_outputs)) {
+			select_list.emplace_back(make_uniq<BoundColumnRefExpression>(aggr.expressions[k.GetIndex()]->return_type,
+			                                                             ColumnBinding(original_aggregate_index, k)));
+			derived_remap.emplace(ColumnBinding(original_aggregate_index, k),
+			                      ColumnBinding(new_proj_idx, ProjectionIndex(num_original_groups + k.GetIndex())));
 		}
 
-		// Update mapping
-		auto it = group_binding_map.find(ColumnBinding(aggr.group_index, removed_idx));
-		D_ASSERT(it != group_binding_map.end());
-		it->second.column_index = remaining_idx;
-
-		for (auto &map_entry : group_binding_map) {
-			auto &new_binding = map_entry.second;
-			if (new_binding.column_index > removed_idx) {
-				new_binding.column_index = ProjectionIndex(new_binding.column_index - 1);
+		// Patch derived slots: replace the passthrough with the rewritten derived expression.
+		// `groups` is in post-shift state; the surviving base group at base_post.column_index is
+		// still a BoundColumnRefExpression carrying its source binding.
+		ColumnBindingReplacer rebinder;
+		for (auto &r : removals) {
+			if (!r.derived_expr) {
+				continue;
 			}
+			auto base_post = group_binding_map.at(ColumnBinding(original_group_index, r.target_idx));
+			const auto &base_source = groups[base_post.column_index]->Cast<BoundColumnRefExpression>().binding;
+			rebinder.replacement_bindings.clear();
+			rebinder.replacement_bindings.emplace_back(base_source, base_post);
+			rebinder.VisitExpression(&r.derived_expr);
+			select_list[r.removed_idx.GetIndex()] = std::move(r.derived_expr);
 		}
+
+		pending_projections[&aggr] = make_uniq<LogicalProjection>(new_proj_idx, std::move(select_list));
 	}
 
 	// Replace all references to the old group binding with the new group binding
-	for (const auto &map_entry : group_binding_map) {
-		auto it = column_references.find(map_entry.first);
-		if (it != column_references.end()) {
-			for (auto expr : it->second) {
-				expr.get().binding = map_entry.second;
-			}
-		}
+	for (const auto &[old_binding, new_binding] : any_derived ? derived_remap : group_binding_map) {
+		ReplaceBinding(old_binding, new_binding);
 	}
-}
-
-unique_ptr<Expression> RemoveDuplicateGroups::VisitReplace(BoundColumnRefExpression &expr,
-                                                           unique_ptr<Expression> *expr_ptr) {
-	// add a column reference
-	column_references[expr.binding].push_back(expr);
-	return nullptr;
 }
 
 } // namespace duckdb

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -1,0 +1,101 @@
+# name: test/sql/optimizer/test_fd_derived_groups.test
+# description: GROUP BY collapses derived FD groups into a post-aggregate projection
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(x INTEGER);
+
+statement ok
+INSERT INTO t SELECT range FROM range(0, 100);
+
+statement ok
+CREATE TABLE f(x DOUBLE);
+
+statement ok
+INSERT INTO f VALUES (1.5), (1.7), (2.3);
+
+# Result queries: enable_verification re-runs each query unoptimized and checks the result
+# matches, replacing manual `disabled_optimizers='duplicate_groups'` toggling.
+statement ok
+PRAGMA enable_verification;
+
+query III
+SELECT x, (x-1)*2, count(*) FROM t WHERE x < 4 GROUP BY x, (x-1)*2 ORDER BY x;
+----
+0	-2	1
+1	0	1
+2	2	1
+3	4	1
+
+# x=1.5, 1.7 both have floor=1 → one group with count=2. Verification confirms the un-collapsed
+# plan produces the same answer.
+query III
+SELECT floor(x), floor(x)+1, count(*) FROM f GROUP BY floor(x), floor(x)+1 ORDER BY floor(x);
+----
+1.0	2.0	2
+2.0	3.0	1
+
+# Plan-shape assertions: EXPLAIN output differs between optimized and unoptimized, so verification
+# must be off here.
+statement ok
+PRAGMA disable_verification;
+
+statement ok
+PRAGMA explain_output='optimized_only';
+
+# ----- Collapses (the AGGREGATE must end up with the single base group `x`) ----
+
+query II
+EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY x, x-1;
+----
+logical_opt	<REGEX>:.*"Groups":\s*"x".*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT x, x-1, x+2, x*3, count(*) FROM t GROUP BY x, x-1, x+2, x*3;
+----
+logical_opt	<REGEX>:.*"Groups":\s*"x".*
+
+# Nested expressions over a single base (cast over function, multi-ref).
+query II
+EXPLAIN (FORMAT JSON) SELECT x, (x-1)*2, CAST((x+5)*7 AS BIGINT), count(*)
+                       FROM t GROUP BY x, (x-1)*2, CAST((x+5)*7 AS BIGINT);
+----
+logical_opt	<REGEX>:.*"Groups":\s*"x".*
+
+# ----- Negatives (Groups array must keep two entries) ---------------------
+
+statement ok
+CREATE TABLE u(a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO u VALUES (1, 10), (2, 20), (3, 30);
+
+# Multi-input expression (a+b uses two columns).
+query II
+EXPLAIN (FORMAT JSON) SELECT a, a+b, count(*) FROM u GROUP BY a, a+b;
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
+
+# Volatile (random() at any depth must reject via IsConsistent).
+query II
+EXPLAIN (FORMAT JSON) SELECT x, (x - random()) * 2, count(*) FROM t GROUP BY x, (x - random()) * 2;
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
+
+# ROLLUP: positional groups must not collapse.
+query II
+EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY ROLLUP(x, x-1);
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
+
+# No raw-column base: synthesising one would need an injectivity proof per derived.
+query II
+EXPLAIN (FORMAT JSON) SELECT x+1, x+2, count(*) FROM t GROUP BY x+1, x+2;
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
+
+# Many-to-one base (floor): collapsing to GROUP BY x would split partitions.
+query II
+EXPLAIN (FORMAT JSON) SELECT floor(x), floor(x)+1, count(*) FROM f GROUP BY floor(x), floor(x)+1;
+----
+logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -14,25 +14,6 @@ CREATE TABLE f(x DOUBLE);
 statement ok
 INSERT INTO f VALUES (1.5), (1.7), (2.3);
 
-# Insert -0e0 before enable_verification: it gets folded to 0e0 on insert under verification.
-statement ok
-CREATE TABLE z(x DOUBLE);
-
-statement ok
-INSERT INTO z VALUES (0e0), (-0e0);
-
-statement ok
-CREATE TABLE zf(x FLOAT);
-
-statement ok
-INSERT INTO zf VALUES (0e0::FLOAT), (-0e0::FLOAT);
-
-statement ok
-CREATE TABLE zs(s STRUCT(a INTEGER, b DOUBLE));
-
-statement ok
-INSERT INTO zs VALUES ({'a': 1, 'b': 0e0}), ({'a': 1, 'b': -0e0});
-
 # Result queries: enable_verification re-runs each query unoptimized and checks the result
 # matches, replacing manual `disabled_optimizers='duplicate_groups'` toggling.
 statement ok
@@ -55,21 +36,22 @@ SELECT floor(x), floor(x)+1, count(*) FROM f GROUP BY floor(x), floor(x)+1 ORDER
 2.0	3.0	1
 
 # Float base: 0e0 == -0e0 but signbit distinguishes them — must not collapse.
+# Inline VALUES so -0e0's sign bit survives storage/verification round-trips.
 query III
-SELECT x, signbit(x), count(*) FROM z GROUP BY x, signbit(x) ORDER BY signbit(x);
+SELECT x, signbit(x), count(*) FROM (VALUES (0e0::DOUBLE), (-0e0::DOUBLE)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
 ----
 0.0	false	1
 -0.0	true	1
 
 query III
-SELECT x, signbit(x), count(*) FROM zf GROUP BY x, signbit(x) ORDER BY signbit(x);
+SELECT x, signbit(x), count(*) FROM (VALUES (0e0::FLOAT), (-0e0::FLOAT)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
 ----
 0.0	false	1
 -0.0	true	1
 
 # Nested float (STRUCT containing DOUBLE) is also unsafe.
 query III
-SELECT s, signbit(s.b), count(*) FROM zs GROUP BY s, signbit(s.b) ORDER BY signbit(s.b);
+SELECT s, signbit(s.b), count(*) FROM (VALUES ({'a': 1::INTEGER, 'b': 0e0::DOUBLE}), ({'a': 1::INTEGER, 'b': -0e0::DOUBLE})) t(s) GROUP BY s, signbit(s.b) ORDER BY signbit(s.b);
 ----
 {'a': 1, 'b': 0.0}	false	1
 {'a': 1, 'b': -0.0}	true	1

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -36,25 +36,25 @@ SELECT floor(x), floor(x)+1, count(*) FROM f GROUP BY floor(x), floor(x)+1 ORDER
 2.0	3.0	1
 
 # Float base: 0e0 == -0e0 but signbit distinguishes them — must not collapse.
-# Inline VALUES so -0e0's sign bit survives storage/verification round-trips.
-query III
-SELECT x, signbit(x), count(*) FROM (VALUES (0e0::DOUBLE), (-0e0::DOUBLE)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
+# Project signbit only; -0.0 renders as 0.0 under --verify-vector sequence_operator.
+query II
+SELECT signbit(x), count(*) FROM (VALUES (0e0::DOUBLE), (-0e0::DOUBLE)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
 ----
-0.0	false	1
--0.0	true	1
+0	1
+1	1
 
-query III
-SELECT x, signbit(x), count(*) FROM (VALUES (0e0::FLOAT), (-0e0::FLOAT)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
+query II
+SELECT signbit(x), count(*) FROM (VALUES (0e0::FLOAT), (-0e0::FLOAT)) t(x) GROUP BY x, signbit(x) ORDER BY signbit(x);
 ----
-0.0	false	1
--0.0	true	1
+0	1
+1	1
 
 # Nested float (STRUCT containing DOUBLE) is also unsafe.
-query III
-SELECT s, signbit(s.b), count(*) FROM (VALUES ({'a': 1::INTEGER, 'b': 0e0::DOUBLE}), ({'a': 1::INTEGER, 'b': -0e0::DOUBLE})) t(s) GROUP BY s, signbit(s.b) ORDER BY signbit(s.b);
+query II
+SELECT signbit(s.b), count(*) FROM (VALUES ({'a': 1::INTEGER, 'b': 0e0::DOUBLE}), ({'a': 1::INTEGER, 'b': -0e0::DOUBLE})) t(s) GROUP BY s, signbit(s.b) ORDER BY signbit(s.b);
 ----
-{'a': 1, 'b': 0.0}	false	1
-{'a': 1, 'b': -0.0}	true	1
+0	1
+1	1
 
 # INTERVAL: '1 day' == '24 hour' but datepart('day', ...) distinguishes them. The binder
 # currently wraps INTERVAL groups in normalized_interval(...) so a bare colref shouldn't

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -14,6 +14,25 @@ CREATE TABLE f(x DOUBLE);
 statement ok
 INSERT INTO f VALUES (1.5), (1.7), (2.3);
 
+# Insert -0e0 before enable_verification: it gets folded to 0e0 on insert under verification.
+statement ok
+CREATE TABLE z(x DOUBLE);
+
+statement ok
+INSERT INTO z VALUES (0e0), (-0e0);
+
+statement ok
+CREATE TABLE zf(x FLOAT);
+
+statement ok
+INSERT INTO zf VALUES (0e0::FLOAT), (-0e0::FLOAT);
+
+statement ok
+CREATE TABLE zs(s STRUCT(a INTEGER, b DOUBLE));
+
+statement ok
+INSERT INTO zs VALUES ({'a': 1, 'b': 0e0}), ({'a': 1, 'b': -0e0});
+
 # Result queries: enable_verification re-runs each query unoptimized and checks the result
 # matches, replacing manual `disabled_optimizers='duplicate_groups'` toggling.
 statement ok
@@ -34,6 +53,41 @@ SELECT floor(x), floor(x)+1, count(*) FROM f GROUP BY floor(x), floor(x)+1 ORDER
 ----
 1.0	2.0	2
 2.0	3.0	1
+
+# Float base: 0e0 == -0e0 but signbit distinguishes them — must not collapse.
+query III
+SELECT x, signbit(x), count(*) FROM z GROUP BY x, signbit(x) ORDER BY signbit(x);
+----
+0.0	false	1
+-0.0	true	1
+
+query III
+SELECT x, signbit(x), count(*) FROM zf GROUP BY x, signbit(x) ORDER BY signbit(x);
+----
+0.0	false	1
+-0.0	true	1
+
+# Nested float (STRUCT containing DOUBLE) is also unsafe.
+query III
+SELECT s, signbit(s.b), count(*) FROM zs GROUP BY s, signbit(s.b) ORDER BY signbit(s.b);
+----
+{'a': 1, 'b': 0.0}	false	1
+{'a': 1, 'b': -0.0}	true	1
+
+# INTERVAL: '1 day' == '24 hour' but datepart('day', ...) distinguishes them. The binder
+# currently wraps INTERVAL groups in normalized_interval(...) so a bare colref shouldn't
+# reach the optimizer, but BaseTypeAllowsCollapse rejects INTERVAL defensively.
+statement ok
+CREATE TABLE iv(i INTERVAL);
+
+statement ok
+INSERT INTO iv VALUES (INTERVAL '1' DAY), (INTERVAL '24' HOUR);
+
+query III
+SELECT i, datepart('day', i), count(*) FROM iv GROUP BY i, datepart('day', i) ORDER BY datepart('day', i);
+----
+24:00:00	0	1
+1 day	1	1
 
 # Plan-shape assertions: EXPLAIN output differs between optimized and unoptimized, so verification
 # must be off here.


### PR DESCRIPTION
`RemoveDuplicateGroups` already collapses same-binding duplicates. This PR extends it to also collapse groups that are deterministic functions of a sibling column-ref group: `GROUP BY x, x-1, cast(x AS BIGINT), (x+5)*7` becomes `GROUP BY x` with a projection above the aggregate that recomputes the derived columns.

### Detection

A group expression is "derived from base column-ref `x`" when:

- it is not itself a bare colref (the same-binding path handles that),
- it is not wholly foldable (constant — different optimization),
- `IsConsistent()` returns true (rejects volatile / non-deterministic), and
- every column-ref leaf in its tree references `x`.

The recursion handles arbitrary nesting: `(x-1)*2`, `cast(x-1 AS BIGINT)`, `(x+2)*(x-3)`, `extract(year FROM x)*100 + extract(month FROM x)` are all detected. The base must be a bare column-ref — column-refs are trivially injective in themselves, which keeps the partition equivalence sound. A non-colref base (e.g. `floor(x)`) would need an injectivity proof on every derived expression to avoid silently splitting partitions for many-to-one inputs; that's a separate (and probably excessive) piece of work.

### Plan rewrite

If at least one derived rewrite is found, we synthesise a `LogicalProjection` above the aggregate with one slot per original aggregate output (groups + aggregate fns). Derived slots evaluate the original expression rebound onto the surviving base's post-shift aggregate output; every other slot — true survivors, duplicate-removed slots that mirror their dup-target, and aggregate function outputs — is a passthrough column-ref. Consumer references then route through the projection's table index via `BaseColumnPruner::ReplaceBinding` (the same mechanism `RemoveUnusedColumns` uses). The pure same-binding duplicate path skips the projection entirely and rewrites consumer refs to the aggregate's surviving slot in place, preserving its pre-PR plan shape.

### Complexity

Detection: walk each non-colref group's expression tree, short-circuiting on the second distinct column-ref binding; one hash lookup picks the base — `O(N · D)` worst case (D = expression size). Removal: apply the old→new index map in a single pass over `aggr.groups`, each `grouping_set`, and `group_binding_map` — `O(N + K)`. The unified removal also speeds up the pre-existing same-binding duplicate path in cases of large number being removed, otherwise it is ever so slightly slower, but generally negligible.

### Bench (ClickBench Q35 on hits.parquet, n=3, median)

| threads | optimizer ON | OFF | speedup |
|--------:|:-:|:-:|:-:|
| 1 | **1.81 s** | 2.36 s | **1.3x** |
| default (32) | **0.24 s** | 0.30 s | **1.25x** |

```sql
  SELECT ClientIP, ClientIP-1, ClientIP-2, ClientIP-3, COUNT(*) AS c
  FROM 'hits.parquet'
  GROUP BY ClientIP, ClientIP-1, ClientIP-2, ClientIP-3
  ORDER BY c DESC LIMIT 10;
```
