### PR TITLE
Prefer filtered build sides for join filter pushdown

### DIFF
--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/column_binding.hpp"
@@ -59,6 +60,11 @@ struct PushdownFilterTarget {
 
 	LogicalGet &get;
 	vector<JoinFilterPushdownColumn> columns;
+};
+
+struct JoinFilterPushdownUtil {
+	static bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter);
+	static bool JoinTypeIsSupported(JoinType join_type);
 };
 
 struct JoinFilterPushdownInfo {

--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -282,7 +282,8 @@ bool BuildProbeSideOptimizer::TryFlipJoinChildren(LogicalOperator &op) const {
 }
 
 void BuildProbeSideOptimizer::VisitOperator(LogicalOperator &op) {
-	// then the currentoperator
+	VisitOperatorChildren(op);
+
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN: {
 		auto &join = op.Cast<LogicalComparisonJoin>();
@@ -336,8 +337,6 @@ void BuildProbeSideOptimizer::VisitOperator(LogicalOperator &op) {
 	default:
 		break;
 	}
-
-	VisitOperatorChildren(op);
 }
 
 } // namespace duckdb

--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -4,18 +4,25 @@
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/row/tuple_data_layout.hpp"
 #include "duckdb/execution/ht_entry.hpp"
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
+#include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/main/settings.hpp"
 
 namespace duckdb {
+
+struct JoinFilterBuildSideHeuristics {
+	static constexpr idx_t MIN_FILTER_TARGET_CARDINALITY = 1000000;
+	static constexpr idx_t MAX_BUILD_TO_TARGET_RATIO = 64;
+};
 
 static void GetRowidBindings(LogicalOperator &op, vector<ColumnBinding> &bindings) {
 	if (op.type == LogicalOperatorType::LOGICAL_GET) {
@@ -98,6 +105,51 @@ static inline idx_t ComputeOverlappingBindings(const vector<ColumnBinding> &hays
 	return result;
 }
 
+static idx_t MaxDynamicFilterTargetCardinality(LogicalOperator &op, const Expression &expr) {
+	JoinFilterPushdownColumn column;
+	if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, column)) {
+		return 0;
+	}
+
+	vector<JoinFilterPushdownColumn> columns {std::move(column)};
+	vector<PushdownFilterTarget> targets;
+	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(op, std::move(columns), targets);
+
+	// Dynamic filters are applied at the scan target found here. Estimate the work that the
+	// filter can avoid at that point, even if later filters reduce the cardinality at the join.
+	idx_t result = 0;
+	for (auto &target : targets) {
+		auto &get = target.get;
+		result = MaxValue(result, get.has_estimated_cardinality ? get.estimated_cardinality : idx_t(0));
+	}
+	return result;
+}
+
+static double DynamicFilterBuildBonus(LogicalComparisonJoin &join, const idx_t probe_idx, const idx_t build_idx,
+                                      const idx_t build_cardinality) {
+	if (!JoinFilterPushdownOptimizer::IsFiltering(join.children[build_idx])) {
+		return 1;
+	}
+
+	idx_t max_target_cardinality = 0;
+	for (auto &cond : join.conditions) {
+		if (!cond.IsComparison() || cond.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
+			continue;
+		}
+		auto &probe_expr = probe_idx == 0 ? cond.GetLHS() : cond.GetRHS();
+		max_target_cardinality =
+		    MaxValue(max_target_cardinality, MaxDynamicFilterTargetCardinality(*join.children[probe_idx], probe_expr));
+	}
+	if (max_target_cardinality < JoinFilterBuildSideHeuristics::MIN_FILTER_TARGET_CARDINALITY) {
+		return 1;
+	}
+	if (build_cardinality > 0 &&
+	    build_cardinality > max_target_cardinality / JoinFilterBuildSideHeuristics::MAX_BUILD_TO_TARGET_RATIO) {
+		return 1;
+	}
+	return static_cast<double>(max_target_cardinality) / static_cast<double>(MaxValue<idx_t>(build_cardinality, 1));
+}
+
 BuildSize BuildProbeSideOptimizer::GetBuildSizes(const LogicalOperator &op, const idx_t lhs_cardinality,
                                                  const idx_t rhs_cardinality) {
 	BuildSize ret;
@@ -176,6 +228,17 @@ bool BuildProbeSideOptimizer::TryFlipJoinChildren(LogicalOperator &op) const {
 	auto &right_side_build_cost = build_sizes.right_side;
 
 	bool swap = false;
+
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (JoinFilterPushdownUtil::JoinTypeIsSupported(join.join_type)) {
+			right_side_build_cost /= DynamicFilterBuildBonus(join, 0, 1, rhs_cardinality);
+		}
+		if (HasInverseJoinType(join.join_type) &&
+		    JoinFilterPushdownUtil::JoinTypeIsSupported(InverseJoinType(join.join_type))) {
+			left_side_build_cost /= DynamicFilterBuildBonus(join, 1, 0, lhs_cardinality);
+		}
+	}
 
 	idx_t left_child_joins = ChildHasJoins(*op.children[0]);
 	idx_t right_child_joins = ChildHasJoins(*op.children[1]);

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -20,7 +20,7 @@ namespace duckdb {
 JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
 }
 
-bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter) {
+bool JoinFilterPushdownUtil::PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter) {
 	if (expr.GetReturnType().IsNested()) {
 		// nested columns are not supported for pushdown
 		return false;
@@ -48,10 +48,28 @@ bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColu
 		    GetTypeIdSize(tgt.InternalType()) > GetTypeIdSize(PhysicalType::INT64)) {
 			return false; // Only do this for (u)bigint and smaller
 		}
-		return PushdownJoinFilterExpression(*bound_cast.child, filter);
+		return JoinFilterPushdownUtil::PushdownJoinFilterExpression(*bound_cast.child, filter);
 	}
 	default:
 		return false;
+	}
+}
+
+bool JoinFilterPushdownUtil::JoinTypeIsSupported(JoinType join_type) {
+	switch (join_type) {
+	case JoinType::MARK:
+	case JoinType::SINGLE:
+	case JoinType::LEFT:
+	case JoinType::OUTER:
+	case JoinType::ANTI:
+	case JoinType::RIGHT_ANTI:
+		// cannot generate join filters for these join types
+		// mark/single - cannot change cardinality of probe side
+		// left/outer always need to include every row from probe side
+		// FIXME: anti/right_anti - we could do this, but need to invert the join conditions
+		return false;
+	default:
+		return true;
 	}
 }
 
@@ -150,7 +168,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 			auto &expr = proj.GetExpression(filter.probe_column_index);
-			if (!PushdownJoinFilterExpression(expr, filter)) {
+			if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, filter)) {
 				// cannot push through this expression - bail-out
 				return;
 			}
@@ -167,7 +185,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 			auto &expr = aggr.GetExpression(filter.probe_column_index);
-			if (!PushdownJoinFilterExpression(expr, filter)) {
+			if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, filter)) {
 				// cannot push through this expression - bail-out
 				return;
 			}
@@ -204,20 +222,8 @@ bool JoinFilterPushdownOptimizer::IsFiltering(const unique_ptr<LogicalOperator> 
 }
 
 void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &join) {
-	switch (join.join_type) {
-	case JoinType::MARK:
-	case JoinType::SINGLE:
-	case JoinType::LEFT:
-	case JoinType::OUTER:
-	case JoinType::ANTI:
-	case JoinType::RIGHT_ANTI:
-		// cannot generate join filters for these join types
-		// mark/single - cannot change cardinality of probe side
-		// left/outer always need to include every row from probe side
-		// FIXME: anti/right_anti - we could do this, but need to invert the join conditions
+	if (!JoinFilterPushdownUtil::JoinTypeIsSupported(join.join_type)) {
 		return;
-	default:
-		break;
 	}
 	// re-order conditions here - otherwise this will happen later on and invalidate the indexes we generate
 	PhysicalComparisonJoin::ReorderConditions(join.conditions);
@@ -244,7 +250,7 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		}
 
 		JoinFilterPushdownColumn pushdown_col;
-		if (!PushdownJoinFilterExpression(cond.GetLHS(), pushdown_col)) {
+		if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(cond.GetLHS(), pushdown_col)) {
 			continue;
 		}
 

--- a/test/optimizer/joins/join_filter_build_side.test
+++ b/test/optimizer/joins/join_filter_build_side.test
@@ -1,0 +1,42 @@
+# name: test/optimizer/joins/join_filter_build_side.test
+# description: Prefer filtered build sides when they can drive join filter pushdown
+# group: [joins]
+
+statement ok
+CREATE TABLE jf_probe AS SELECT range::INTEGER AS id FROM range(1000000);
+
+statement ok
+CREATE TABLE jf_build AS SELECT
+	range::INTEGER AS id,
+	range < 10 AS keep,
+	(range::VARCHAR || '1111') a,
+	(range::VARCHAR || '2222') b,
+	(range::VARCHAR || '3333') c,
+	(range::VARCHAR || '4444') d,
+	(range::VARCHAR || '5555') e,
+	(range::VARCHAR || '6666') f,
+	(range::VARCHAR || '7777') g,
+	(range::VARCHAR || '8888') h,
+	(range::VARCHAR || '9999') i,
+	(range::VARCHAR || '0000') j
+FROM range(100000);
+
+statement ok
+ANALYZE jf_probe;
+
+statement ok
+ANALYZE jf_build;
+
+statement ok
+PRAGMA explain_output='physical_only';
+
+# jf_build is wide enough that the normal build-side cost prefers jf_probe.
+# The filter on jf_build can generate a dynamic filter for the large jf_probe scan,
+# so jf_build should remain on the build side.
+query II
+EXPLAIN SELECT *
+FROM jf_probe p
+JOIN jf_build b ON p.id = b.id
+WHERE b.keep;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*jf_probe.*jf_build.*


### PR DESCRIPTION
This keeps a selective join input on the build side when that input can drive join filter pushdown into a much larger scan.

The build/probe side optimizer normally picks the cheapest hash-table build. For queries such as TPC-DS Q13 and Q85, that can move a filtered `date_dim` side to the probe side, so the later join filter can no longer be pushed into the large sales scan.

The change is narrow:

- reuse the join-filter pushdown expression and join-type support checks
- only consider equality conditions with an existing pushdown target
- require a filtered candidate build side and a large target scan relative to that build side
- apply the dynamic-filter benefit as a multiplier on the existing build-size cost, not as a separate override

TPC-DS SF100, sorted Parquet, 4 threads, 12GB memory, cold cache spot-check after cleanup:

| Query | main | this PR | Speedup |
|---|---:|---:|---:|
| Q13 | 57.239s | 11.618s | 4.93x |
| Q85 | 13.276s | 4.504s | 2.95x |
| Q23 | 58.881s | 53.664s | 1.10x |
| Q67 | 57.799s | 57.787s | 1.00x |

All result hashes matched main.

Validation:

- `python3 scripts/ci/run_tests.py --workers=50% build/release/test/unittest`
- `./build/release/test/unittest '[joins]'`
- `./build/release/test/unittest '[pushdown]'`
- `./build/release/test/unittest test/optimizer/joins/join_filter_build_side.test`