### PR TITLE
TPC-DS: Fix log-scaled table row counts at non-standard SF

### DIFF
--- a/extension/tpcds/dsdgen/dsdgen-c/scaling.cpp
+++ b/extension/tpcds/dsdgen/dsdgen-c/scaling.cpp
@@ -108,7 +108,7 @@ int getScaleSlot(int nTargetGB) {
  * TODO: None
  */
 static ds_key_t LogScale(int nTable, int nTargetGB) {
-	int nIndex = 1, nDelta, i;
+	int nDelta, i;
 	float fOffset;
 	ds_key_t hgRowcount = 0;
 
@@ -118,7 +118,7 @@ static ds_key_t LogScale(int nTable, int nTargetGB) {
 	fOffset = (float)(nTargetGB - arScaleVolume[i - 1]) / (float)(arScaleVolume[i] - arScaleVolume[i - 1]);
 
 	hgRowcount = (int)(fOffset * (float)nDelta);
-	hgRowcount += dist_weight(NULL, "rowcounts", nTable + 1, nIndex);
+	hgRowcount += dist_weight(NULL, "rowcounts", nTable + 1, i);
 
 	return (hgRowcount);
 }


### PR DESCRIPTION
For non-standard TPC-DS scale factors, we use `LogScale` to determine the row counts for logarithmically scaled tables like `customer` and `item`. However, the `LogScale` function incorrectly uses the row count from sf=1 as the base, causing some tables at sf=20 to have fewer rows than at sf=10.

I'm not sure if this behavior is intended for compatibility with the official TPC-DS scripts. If so, I will close this PR.

Before fix:
```
tpcds10g D call dsdgen(sf=10);
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
tpcds10g D select count(*) from customer;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│       500000 │
└──────────────┘
tpcds10g D select count(*) from item;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│       102000 │
└──────────────┘
```

```
tpcds20g D call dsdgen(sf=20);
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
tpcds20g D select count(*) from customer;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│       266000 │
└──────────────┘
tpcds20g D select count(*) from item;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│        28000 │
└──────────────┘
```

After fix: 

```
tpcds20g-2 D call dsdgen(sf=20);
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
tpcds20g-2 D select count(*) from customer;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│       666000 │
└──────────────┘
tpcds20g-2 D select count(*) from item;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│       112000 │
└──────────────┘
```