### PR TITLE
Allow package builds to choose linked extensions

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -248,9 +248,37 @@ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list)
     sys.path = original_path
 
 
-def build_package(target_dir, extensions, linenumbers=False, unity_count=32, folder_name='duckdb', short_paths=False):
+def get_extension_linked_define(extension):
+    return f'DUCKDB_EXTENSION_{extension.upper()}_LINKED'
+
+
+def build_package(
+    target_dir,
+    extensions,
+    linenumbers=False,
+    unity_count=32,
+    folder_name='duckdb',
+    short_paths=False,
+    default_linked_extensions=None,
+):
     if not os.path.isdir(target_dir):
         os.mkdir(target_dir)
+
+    extensions = list(extensions)
+    # Keep existing package_build behavior by default: all packaged extensions are linked.
+    # Callers that package a superset can pass default_linked_extensions to emit a loader
+    # that is controlled by DUCKDB_EXTENSION_<NAME>_LINKED compile definitions instead.
+    if default_linked_extensions is None:
+        default_linked_extensions = extensions
+    default_linked_extensions = set(default_linked_extensions)
+    packaged_extensions = set(extensions)
+    unpackaged_linked_extensions = default_linked_extensions - packaged_extensions
+    if unpackaged_linked_extensions:
+        raise ValueError(
+            "default_linked_extensions must be a subset of extensions: {}".format(
+                ', '.join(sorted(unpackaged_linked_extensions))
+            )
+        )
 
     scripts_dir = os.path.dirname(os.path.abspath(__file__))
     sys.path.append(scripts_dir)
@@ -280,37 +308,52 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     include_files += [os.path.join('src', 'include', 'duckdb', 'main', 'extension_helper.hpp')]
     # include the separate extensions
     ext_loader_body = ''
+    ext_loader_defines = ''
     ext_headers = ''
+    ext_name_vector_initializer = ''
     for ext in extensions:
         ext_path = os.path.join(scripts_dir, '..', 'extension', ext)
         include_package(ext, ext_path, include_files, include_list, source_list)
 
-        ext_headers += f'#include "{ext}_extension.hpp"\n'
+        ext_linked_define = get_extension_linked_define(ext)
+        ext_linked_default = 1 if ext in default_linked_extensions else 0
+
+        ext_loader_defines += (
+            f"#ifndef {ext_linked_define}\n"
+            f"#define {ext_linked_define} {ext_linked_default}\n"
+            "#endif\n\n"
+        )
+
+        ext_headers += f'#if {ext_linked_define}\n#include "{ext}_extension.hpp"\n#endif\n'
 
         # handle generated_extension_loader
         # this - beautifully - approximates code in extension/CMakeLists.txt
         ext_name_camelcase = ext.replace('_', ' ').title().replace(' ', '')
 
-        ext_loader_body += """
-    if (extension=="${EXT_NAME}") {
-        db.LoadStaticExtension<${EXT_NAME_CAMELCASE}Extension>();
-        return ExtensionLoadResult::LOADED_EXTENSION;
-    }
-        """.replace(
-            '${EXT_NAME}', ext
-        ).replace(
-            '${EXT_NAME_CAMELCASE}', ext_name_camelcase
+        ext_loader_body += (
+            f"#if {ext_linked_define}\n"
+            f"    if (extension==\"{ext}\") {{\n"
+            f"        db.LoadStaticExtension<{ext_name_camelcase}Extension>();\n"
+            "        return ExtensionLoadResult::LOADED_EXTENSION;\n"
+            "    }\n"
+            "#endif\n"
+        )
+
+        ext_name_vector_initializer += (
+            f"\n#if {ext_linked_define}\n"
+            f"        \"{ext}\",\n"
+            "#endif"
         )
 
     loader_code = open(os.path.join('extension', 'generated_extension_loader.cpp.in'), 'rb').read().decode('utf8')
     loader_code = (
         loader_code.replace('${EXT_LOADER_BODY}', ext_loader_body)
-        .replace('${EXT_NAME_VECTOR_INITIALIZER}', ', '.join([f'"{x}"' for x in extensions]))
+        .replace('${EXT_NAME_VECTOR_INITIALIZER}', ext_name_vector_initializer)
         .replace('${EXT_TEST_PATH_INITIALIZER}', '')
         .replace('CMake', 'package_build.py')
     )
 
-    loader_code = ext_headers + loader_code
+    loader_code = ext_loader_defines + ext_headers + loader_code
 
     loader_name = 'generated_extension_loader_package_build.cpp'
     f = open(loader_name, 'wb')

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -319,9 +319,7 @@ def build_package(
         ext_linked_default = 1 if ext in default_linked_extensions else 0
 
         ext_loader_defines += (
-            f"#ifndef {ext_linked_define}\n"
-            f"#define {ext_linked_define} {ext_linked_default}\n"
-            "#endif\n\n"
+            f"#ifndef {ext_linked_define}\n" f"#define {ext_linked_define} {ext_linked_default}\n" "#endif\n\n"
         )
 
         ext_headers += f'#if {ext_linked_define}\n#include "{ext}_extension.hpp"\n#endif\n'
@@ -339,11 +337,7 @@ def build_package(
             "#endif\n"
         )
 
-        ext_name_vector_initializer += (
-            f"\n#if {ext_linked_define}\n"
-            f"        \"{ext}\",\n"
-            "#endif"
-        )
+        ext_name_vector_initializer += f"\n#if {ext_linked_define}\n" f"        \"{ext}\",\n" "#endif"
 
     loader_code = open(os.path.join('extension', 'generated_extension_loader.cpp.in'), 'rb').read().decode('utf8')
     loader_code = (


### PR DESCRIPTION
Downstream clients such as duckdb-rs can vendor a source package that contains a superset of extension sources while compiling only the subset selected by their own build configuration. duckdb-rs does this for Cargo features: the packaged archive includes core_functions, parquet, and json sources, but a plain bundled build only compiles core_functions.

The loader generated by `package_build.py` previously treated every packaged extension as linked. That made core-only downstream builds still include and load parquet/json extension code, which fails when those extension sources are deliberately not compiled.

Add `default_linked_extensions` so package builders can preserve the existing default behavior while optionally generating loader defaults independently from the packaged source list. The generated loader now gates extension headers, load branches, and `LinkedExtensions` entries behind `DUCKDB_EXTENSION_<NAME>_LINKED`.

This gets rid of an ugly hack in duckdb-rs where we currently [patch the generated loader]( https://github.com/duckdb/duckdb-rs/blob/4c25ac7efc096c899d137ea8519725b572aec2ce/crates/libduckdb-sys/build_bundled_cc.rs#L37).

## Test

```bash
git switch v1.5-variegata

before="$(mktemp -d)"
python3 - "$before" <<'PY'
import sys
sys.path.append("scripts")
import package_build

package_build.build_package(sys.argv[1], ["core_functions", "parquet", "json"])
PY

git switch package-build-default-linked-extensions

after="$(mktemp -d)"
python3 - "$after" <<'PY'
import sys
sys.path.append("scripts")
import package_build

package_build.build_package(
    sys.argv[1],
    ["core_functions", "parquet", "json"],
    default_linked_extensions=[],
)
PY

diff -u \
  "$before/generated_extension_loader_package_build.cpp" \
  "$after/generated_extension_loader_package_build.cpp"
```

produces:

```diff
--- /var/folders/_h/ryx0_g112sbfj9pqwcq5047w0000gn/T/tmp.U4TI6m1gQS/generated_extension_loader_package_build.cpp        2026-04-27 17:22:45
+++ /var/folders/_h/ryx0_g112sbfj9pqwcq5047w0000gn/T/tmp.IKZR43httv/generated_extension_loader_package_build.cpp        2026-04-27 17:22:46
@@ -1,6 +1,24 @@
+#ifndef DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED
+#define DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED 0
+#endif
+
+#ifndef DUCKDB_EXTENSION_PARQUET_LINKED
+#define DUCKDB_EXTENSION_PARQUET_LINKED 0
+#endif
+
+#ifndef DUCKDB_EXTENSION_JSON_LINKED
+#define DUCKDB_EXTENSION_JSON_LINKED 0
+#endif
+
+#if DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED
 #include "core_functions_extension.hpp"
+#endif
+#if DUCKDB_EXTENSION_PARQUET_LINKED
 #include "parquet_extension.hpp"
+#endif
+#if DUCKDB_EXTENSION_JSON_LINKED
 #include "json_extension.hpp"
+#endif
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/main/extension_helper.hpp"

@@ -8,27 +26,39 @@

 //! Looks through the package_build.py-generated list of extensions that are linked into DuckDB currently to try load <extension>
 ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string &extension) {
-
+#if DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED
     if (extension=="core_functions") {
         db.LoadStaticExtension<CoreFunctionsExtension>();
         return ExtensionLoadResult::LOADED_EXTENSION;
     }
-
+#endif
+#if DUCKDB_EXTENSION_PARQUET_LINKED
     if (extension=="parquet") {
         db.LoadStaticExtension<ParquetExtension>();
         return ExtensionLoadResult::LOADED_EXTENSION;
     }
-
+#endif
+#if DUCKDB_EXTENSION_JSON_LINKED
     if (extension=="json") {
         db.LoadStaticExtension<JsonExtension>();
         return ExtensionLoadResult::LOADED_EXTENSION;
     }
-
+#endif
+
     return ExtensionLoadResult::NOT_LOADED;
 }

 vector<string> LinkedExtensions(){
-    vector<string> VEC = {"core_functions", "parquet", "json"
+    vector<string> VEC = {
+#if DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED
+        "core_functions",
+#endif
+#if DUCKDB_EXTENSION_PARQUET_LINKED
+        "parquet",
+#endif
+#if DUCKDB_EXTENSION_JSON_LINKED
+        "json",
+#endif
     };
     return VEC;
 }
```