### PR TITLE
Skip late-materialization when projection columns are all already required by the scan

### DIFF
--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/optimizer/late_materialization.hpp"
 
+#include "duckdb/planner/column_binding_map.hpp"
 #include "duckdb/optimizer/late_materialization_helper.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
@@ -211,9 +212,16 @@ bool LateMaterialization::TryLateMaterialization(unique_ptr<LogicalOperator> &op
 		}
 	}
 	auto &get = child.get().Cast<LogicalGet>();
-	if (column_references.size() >= get.GetColumnIds().size()) {
+	column_binding_set_t required_columns;
+	for (auto &entry : column_references) {
+		required_columns.insert(entry.first);
+	}
+	for (auto &filter_entry : get.table_filters) {
+		required_columns.insert(ColumnBinding(get.table_index, filter_entry.GetIndex()));
+	}
+	if (required_columns.size() >= get.GetColumnIds().size()) {
 		// we do not benefit from late materialization
-		// we need all of the columns to compute the root node anyway (Top-N/Limit/etc)
+		// every column the scan reads is already required upstream (Top-N/Limit/etc) or by its pushed-down filters
 		return false;
 	}
 	if (!get.function.late_materialization) {

--- a/test/sql/copy/parquet/parquet_late_materialization.test
+++ b/test/sql/copy/parquet/parquet_late_materialization.test
@@ -46,6 +46,18 @@ explain SELECT i FROM test ORDER BY i LIMIT 2;
 ----
 logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
 
+# projection columns are all already required by the pushed-down filter
+query II
+explain SELECT j FROM test WHERE j > 3 ORDER BY i LIMIT 2;
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
+
+query I
+SELECT j FROM test WHERE j > 3 ORDER BY i LIMIT 2;
+----
+4
+5
+
 # we cannot do this with volatile expressions
 query II
 explain SELECT * FROM (SELECT i + random() AS i, j, k, l FROM test) ORDER BY i LIMIT 2;


### PR DESCRIPTION
The late-mat rewrite turns `TopN/Limit -> Scan` into `Scan -> SemiJoin(rowid) -> TopN -> Scan` so the wide payload is decoded only for surviving rows.

That only pays off when the projection has columns the right-side scan wouldn't otherwise read. Today the gate compares column-references-from-above against the get's column count, missing the fact that the get's pushed-down `table_filters` force the corresponding columns to be decoded regardless.

When projection ⊆ filter ∪ order, the right-side scan reads the same column set as a single direct scan, and late-mat just adds a SEMI join, an extra TopN, and a re-scan with no compensating I/O saving.

This PR folds `get.table_filters` into the "must read anyway" set before the `required >= scanned` check.

### Plan diffs

| Suite | Queries | Plan diffs | Late-mat fires (baseline) |
|---|---|---|---|
| TPC-H (22) | 22 | 0 | 0 |
| TPC-DS (99) | 99 | 0 | 0 |
| Imdb (113)  | 113 | 0 | 0 |
| ClickBench (43) | 43 | **1 (Q24)** | 2 |
| Misc micro/topn/limit/order/aggregate (11) | 11 | 0 | 1 |
| TPC-H topn + rowid pushdown micros (7) | 7 | 0 | 5 |
                                                                                                                                                                                                                                                                                                                                                                                         
### ClickBench Q24                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                         
```sql
SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10
```
Median wall-time over 10 runs (warmup dropped, parallel default threads.

| | wall-time | speedup |
|---|---|---|
| main | 108 ms | 1.00× |
| patched  |  80 ms | **1.35×** |