### PR TITLE
Fix: Move count setting in FSSTVector out of loop

### DIFF
--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -689,8 +689,8 @@ void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &sta
 			    segment, dict.end, result, baseptr,
 			    UnsafeNumericCast<int32_t>(delta_decode_buffer[i + offsets.unused_delta_decoded_values]),
 			    string_length);
-			FSSTVector::SetCount(result, scan_count);
 		}
+		FSSTVector::SetCount(result, scan_count);
 	} else {
 		// Just decompress
 		auto &str_allocator = StringVector::GetStringAllocator(result);


### PR DESCRIPTION
Hi dear DuckDB Team,

This pull request has a small fix: `FSSTVector::SetCount(result, scan_count);` statement in the `FSSTStorage::StringScanPartial` function. The call is moved outside of the loop to ensure the count is set once after processing, rather than potentially multiple times within the loop. This improves the performance of creating FSST Vectors by ~20%. 

<img width="2750" height="1012" alt="image" src="https://github.com/user-attachments/assets/5973c947-2595-4bf5-9ec8-e87660ba149d" />
