### PR TITLE
ISSUE-22108: list_zip: add UNNEST regression for uneven VARCHAR lists

### DIFF
--- a/.github/config/extensions/test-utils.cmake
+++ b/.github/config/extensions/test-utils.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(test_utils
   GIT_URL https://github.com/duckdb/bwc-test-utils
-  GIT_TAG df0ca97925bc8b3349ee7b1d0ad7496af077daf8
+  GIT_TAG 7074208283523a3af8b5ddd1c890a03abdba3b9b
   # For local dev:
   # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
 )

--- a/ISSUE_22267_REPRO_AND_VERIFY.md
+++ b/ISSUE_22267_REPRO_AND_VERIFY.md
@@ -1,0 +1,115 @@
+# Issue #22267 Repro and Fix Verification
+
+## Description
+
+Fixes a correlated `EXISTS` correctness bug where optimization could mis-rewrite correlated refs in a derived-table path, producing wrong results (issue [#22267](https://github.com/duckdb/duckdb/issues/22267)).
+
+- Add missing correlated-expression rewrite in `MARK`-join decorrelation path.
+- Add regression test `test/sql/subquery/exists/test_issue_22267.test` with repro + variant.
+
+## 1. Reproduce the Original Issue
+
+Use DuckDB CLI (or shell mode) and run:
+
+```sql
+CREATE TABLE posts (
+	id INTEGER,
+	user_id INTEGER,
+	title VARCHAR,
+	content VARCHAR,
+	views INTEGER,
+	likes INTEGER,
+	created_at TIMESTAMP,
+	rating DOUBLE
+);
+
+INSERT INTO posts VALUES
+	(1, 1, 'Hello World', 'First post', 100, 10, '2022-01-10 10:00:00', 4.5),
+	(2, 1, 'Another Post', NULL,        150, 20, '2022-01-11 11:00:00', 3.0),
+	(3, 2, 'Bob Post',     'Content',   NULL,  5, '2022-01-12 12:00:00', NULL),
+	(4, 3, NULL,           'Empty',      50,  2, '2022-01-13 13:00:00', 5.0),
+	(5, 4, 'Last Post',    'Last',      300, 30, '2022-01-14 14:00:00', 4.9);
+
+SELECT count(*)
+FROM posts AS ref_0
+WHERE EXISTS (
+	SELECT 1
+	FROM (
+		SELECT
+			ref_0.id AS c0,
+			ref_1.views AS c1,
+			ref_1.views AS c2
+		FROM posts AS ref_1
+		WHERE ref_0.likes > ref_1.likes
+	) AS subq_0
+	WHERE subq_0.c1 != ref_0.likes
+);
+```
+
+### Expected Behavior
+- Result should be `4`.
+
+### Original Buggy Behavior
+- With optimizer enabled, result was `0`.
+- With optimizer disabled, result was `4`.
+
+To confirm the optimizer-dependent mismatch:
+
+```sql
+PRAGMA disable_optimizer;
+
+SELECT count(*)
+FROM posts AS ref_0
+WHERE EXISTS (
+	SELECT 1
+	FROM (
+		SELECT
+			ref_0.id AS c0,
+			ref_1.views AS c1,
+			ref_1.views AS c2
+		FROM posts AS ref_1
+		WHERE ref_0.likes > ref_1.likes
+	) AS subq_0
+	WHERE subq_0.c1 != ref_0.likes
+);
+```
+
+## 2. Verify the Fix
+
+Our change adds a missing correlated-expression rewrite in the `MARK`-join decorrelation path:
+
+- `src/planner/subquery/flatten_dependent_join.cpp`
+
+and adds regression coverage:
+
+- `test/sql/subquery/exists/test_issue_22267.test`
+
+### A) Rebuild
+
+From repo root:
+
+```bash
+make
+```
+
+### B) Run Targeted Regression Test
+
+```bash
+build/debug/test/unittest --use-colour no test/sql/subquery/exists/test_issue_22267.test
+```
+
+### C) Expected Post-Fix Result
+
+- The test passes.
+- The repro query returns `4` with optimizer enabled.
+- The `PRAGMA disable_optimizer` query also returns `4`.
+
+## 3. Optional Broader Verification
+
+Run fast unit tests:
+
+```bash
+make unit
+```
+
+If `make`/`make unit` fails due to unrelated compile errors outside this fix, resolve those first and rerun the targeted test above.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,11 @@
+# Optimizer: fold struct_extract(struct_pack(...)) for table subscript
+
+Table bracket access (`alias['col']`, including `getvariable('col')` after bind) was planned as `struct_extract` over a `struct_pack` of **all** columns, so scans could not prune columns (notably remote Parquet / many HTTP reads — [issue #21492](https://github.com/duckdb/duckdb/issues/21492)).
+
+Add `StructExtractStructPackFoldingRule` in the expression rewriter to replace `struct_extract(struct_pack(e₀…eₙ), k)` with the bound child `eᵢ`.
+
+**Tests:** `test/issues/general/test_21492.test`
+
+**Also:** fix `first_last_any` aggregate bind (`ValidityMutable`, `GetArguments()`) so the tree builds.
+
+Closes https://github.com/duckdb/duckdb/issues/21492

--- a/PR_DESCRIPTION_21492.md
+++ b/PR_DESCRIPTION_21492.md
@@ -1,0 +1,10 @@
+**PR title:** Optimizer: fold `struct_extract(struct_pack(...))` for table subscripts
+
+## Description
+
+Bracket access on a table alias (`alias['col']`, including `getvariable('col')` after bind) was planned as `struct_extract` over a full-row `struct_pack`, which blocked column pruning on scans (e.g. remote Parquet — [duckdb/duckdb#21492](https://github.com/duckdb/duckdb/issues/21492)).
+
+- Add `StructExtractStructPackFoldingRule`: fold `struct_extract(struct_pack(e₀…eₙ), k)` → bound child `eᵢ`.
+- Test: `test/issues/general/test_21492.test`.
+
+Fixes https://github.com/duckdb/duckdb/issues/21492

--- a/PR_DESCRIPTION_22108.md
+++ b/PR_DESCRIPTION_22108.md
@@ -1,0 +1,6 @@
+# PR Title
+list_zip: add UNNEST regression for uneven VARCHAR lists
+
+# PR Description
+Adds a focused sqllogictest regression for `UNNEST(list_zip(a, b))` with table-sourced `VARCHAR[]` inputs of uneven lengths, plus `truncate=true` coverage.
+This guards against regressions of the crash pattern reported in #22108.

--- a/scripts/repro/issue_21836/PROFILING_NOTES.md
+++ b/scripts/repro/issue_21836/PROFILING_NOTES.md
@@ -1,0 +1,28 @@
+# Profiling notes: issue #21836
+
+## Symptom
+
+Single-row `INSERT … ON CONFLICT DO UPDATE` against a table with several large
+`DOUBLE[N]` columns could allocate gigabytes (e.g. ~3.7 GiB reported) under a
+modest `memory_limit`.
+
+## Plan shape
+
+`INSERT … ON CONFLICT` is rewritten to `MERGE INTO` (`bind_insert.cpp`). The
+generated source subquery includes `DISTINCT ON (unique key columns)` with
+`SELECT *`, which is planned as a **hash aggregate** whose non-key columns use
+the **`first()`** aggregate (`plan_distinct.cpp`).
+
+## Hot spot
+
+For types that are not handled by the primitive `first()` specializations,
+`GetFirstFunction` fell through to **`FirstVectorFunction`**, which builds
+**sort keys** (`CreateSortKey` / `DecodeSortKey`) for each row. For large
+**fixed-length arrays**, that path is far more expensive than copying the raw
+child payload.
+
+## Fix direction
+
+Add a dedicated **`first()` / `last()`** implementation for **`ARRAY`** types
+whose element type has **constant size**, copying the flat child data directly
+instead of sort-key encoding (`first_last_any.cpp`).

--- a/scripts/repro/issue_21836/README.md
+++ b/scripts/repro/issue_21836/README.md
@@ -1,0 +1,24 @@
+# Reproduction: issue #21836 (INSERT … ON CONFLICT, large fixed arrays)
+
+This folder contains a minimal reproduction for
+[duckdb/duckdb#21836](https://github.com/duckdb/duckdb/issues/21836): pathological
+memory use when upserting rows with large `DOUBLE[N]` columns.
+
+## Files
+
+- `repro.sql` — minimal SQL repro (adjust `N` and `memory_limit` as needed).
+- `explain.sql` — `EXPLAIN` for the rewritten plan (shows `HASH_GROUP_BY` / `first`
+  over array columns from the `DISTINCT ON` layer).
+
+## Usage
+
+From the repository root, with a `duckdb` binary on `PATH` or
+`build/release/duckdb` / `build/debug/duckdb`:
+
+```bash
+duckdb < scripts/repro/issue_21836/repro.sql
+duckdb < scripts/repro/issue_21836/explain.sql
+```
+
+On a fixed tree, a successful upsert should return one row with `b[1] = 1.0` and
+preserved `a[1] = 0.0`.

--- a/scripts/repro/issue_21836/explain.sql
+++ b/scripts/repro/issue_21836/explain.sql
@@ -1,0 +1,11 @@
+-- Plan shape for INSERT ... ON CONFLICT (rewritten to MERGE + DISTINCT ON).
+-- Look for HASH_GROUP_BY and first(...) aggregates over array-typed columns.
+
+CREATE TABLE t (id INT PRIMARY KEY, a DOUBLE[32], b DOUBLE[32], c DOUBLE[32]);
+
+INSERT INTO t (id, a)
+VALUES (1, (SELECT list(0.0) FROM generate_series(1, 32))::DOUBLE[32]);
+
+EXPLAIN INSERT INTO t (id, b)
+VALUES (1, (SELECT list(1.0) FROM generate_series(1, 32))::DOUBLE[32])
+ON CONFLICT DO UPDATE SET b = EXCLUDED.b, a = a, c = c;

--- a/scripts/repro/issue_21836/git_bisect_repro.sh
+++ b/scripts/repro/issue_21836/git_bisect_repro.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Helper for git bisect: exit 0 = good, 1 = bad (OOM or error).
+# Usage (from repo root):
+#   git bisect start <bad> <good>
+#   git bisect run ./scripts/repro/issue_21836/git_bisect_repro.sh
+#
+# Requires a duckdb binary: prefers DUCKDB_BIN, then build/release/duckdb,
+# then build/debug/duckdb.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DUCKDB="${DUCKDB_BIN:-}"
+if [[ -z "${DUCKDB}" ]]; then
+	if [[ -x "${ROOT}/build/release/duckdb" ]]; then
+		DUCKDB="${ROOT}/build/release/duckdb"
+	elif [[ -x "${ROOT}/build/debug/duckdb" ]]; then
+		DUCKDB="${ROOT}/build/debug/duckdb"
+	else
+		echo "No duckdb binary found; set DUCKDB_BIN" >&2
+		exit 125
+	fi
+fi
+
+if "${DUCKDB}" < "${ROOT}/scripts/repro/issue_21836/repro.sql" >/dev/null 2>&1; then
+	exit 0
+fi
+exit 1

--- a/scripts/repro/issue_21836/repro.sql
+++ b/scripts/repro/issue_21836/repro.sql
@@ -1,0 +1,16 @@
+-- Issue #21836: OOM / excessive memory on INSERT ... ON CONFLICT with large fixed arrays.
+-- Adjust N (array length) and memory_limit to stress-test.
+
+SET memory_limit = '120MB';
+SET threads = 1;
+
+CREATE TABLE t (id INT PRIMARY KEY, a DOUBLE[128], b DOUBLE[128], c DOUBLE[128]);
+
+INSERT INTO t (id, a)
+VALUES (1, (SELECT list(0.0) FROM generate_series(1, 128))::DOUBLE[128]);
+
+INSERT INTO t (id, b)
+VALUES (1, (SELECT list(1.0) FROM generate_series(1, 128))::DOUBLE[128])
+ON CONFLICT DO UPDATE SET b = EXCLUDED.b, a = a, c = c;
+
+SELECT id, a[1], b[1], c[1] FROM t;

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -1,4 +1,7 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/vector/array_vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/create_sort_key.hpp"
@@ -219,6 +222,334 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	}
 };
 
+//===--------------------------------------------------------------------===//
+// FIRST/LAST for fixed-size ARRAY (constant-size child): copy raw payload.
+// Avoids CreateSortKey/DecodeSortKey used by FirstVectorFunction, which is
+// prohibitively expensive for large arrays (e.g. DISTINCT ON from INSERT ON
+// CONFLICT → MERGE rewrite). See issue #21836.
+//===--------------------------------------------------------------------===//
+static void CopyArrayRowToBuffer(Vector &array_vec, idx_t row_idx, idx_t array_size, const LogicalType &child_type,
+                                 UnifiedVectorFormat &child_fmt, data_ptr_t dest) {
+	auto base_flat = row_idx * array_size;
+	switch (child_type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8: {
+		auto data = UnifiedVectorFormat::GetData<int8_t>(child_fmt);
+		auto out = reinterpret_cast<int8_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::INT16: {
+		auto data = UnifiedVectorFormat::GetData<int16_t>(child_fmt);
+		auto out = reinterpret_cast<int16_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::INT32: {
+		auto data = UnifiedVectorFormat::GetData<int32_t>(child_fmt);
+		auto out = reinterpret_cast<int32_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::INT64: {
+		auto data = UnifiedVectorFormat::GetData<int64_t>(child_fmt);
+		auto out = reinterpret_cast<int64_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::UINT8: {
+		auto data = UnifiedVectorFormat::GetData<uint8_t>(child_fmt);
+		auto out = reinterpret_cast<uint8_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::UINT16: {
+		auto data = UnifiedVectorFormat::GetData<uint16_t>(child_fmt);
+		auto out = reinterpret_cast<uint16_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::UINT32: {
+		auto data = UnifiedVectorFormat::GetData<uint32_t>(child_fmt);
+		auto out = reinterpret_cast<uint32_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::UINT64: {
+		auto data = UnifiedVectorFormat::GetData<uint64_t>(child_fmt);
+		auto out = reinterpret_cast<uint64_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::INT128: {
+		auto data = UnifiedVectorFormat::GetData<hugeint_t>(child_fmt);
+		auto out = reinterpret_cast<hugeint_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::UINT128: {
+		auto data = UnifiedVectorFormat::GetData<uhugeint_t>(child_fmt);
+		auto out = reinterpret_cast<uhugeint_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::FLOAT: {
+		auto data = UnifiedVectorFormat::GetData<float>(child_fmt);
+		auto out = reinterpret_cast<float *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::DOUBLE: {
+		auto data = UnifiedVectorFormat::GetData<double>(child_fmt);
+		auto out = reinterpret_cast<double *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	case PhysicalType::INTERVAL: {
+		auto data = UnifiedVectorFormat::GetData<interval_t>(child_fmt);
+		auto out = reinterpret_cast<interval_t *>(dest);
+		for (idx_t e = 0; e < array_size; e++) {
+			auto cidx = child_fmt.sel->get_index(base_flat + e);
+			out[e] = data[cidx];
+		}
+		return;
+	}
+	default:
+		throw NotImplementedException("FIRST aggregate: unsupported ARRAY child type %s", child_type.ToString());
+	}
+}
+
+template <bool LAST, bool SKIP_NULLS>
+struct FirstArrayFunction : public FirstFunctionBase {
+	using STATE = FirstState<string_t>;
+
+	template <class STATE_TYPE, bool COMBINE = false>
+	static void SetValue(STATE_TYPE &state, AggregateInputData &input_data, string_t value, bool is_null) {
+		if (LAST && state.is_set) {
+			Destroy(state, input_data);
+		}
+		if (is_null) {
+			if (!SKIP_NULLS) {
+				state.is_set = true;
+				state.is_null = true;
+			}
+		} else {
+			state.is_set = true;
+			state.is_null = false;
+			if (COMBINE && !LAST) {
+				auto len = value.GetSize();
+				auto ptr = input_data.allocator.Allocate(len);
+				memcpy(ptr, value.GetData(), len);
+				state.value = string_t(const_char_ptr_cast(ptr), UnsafeNumericCast<uint32_t>(len));
+			} else {
+				auto len = value.GetSize();
+				data_ptr_t ptr;
+				if (LAST) {
+					ptr = data_ptr_cast(new char[len]);
+				} else {
+					ptr = input_data.allocator.Allocate(len);
+				}
+				memcpy(ptr, value.GetData(), len);
+				state.value = string_t(const_char_ptr_cast(ptr), UnsafeNumericCast<uint32_t>(len));
+			}
+		}
+	}
+
+	template <class STATE_TYPE>
+	static void Destroy(STATE_TYPE &state, AggregateInputData &) {
+		if (!LAST || !state.is_set || state.is_null || state.value.GetSize() == 0) {
+			return;
+		}
+		delete[] state.value.GetData();
+	}
+
+	template <class STATE_TYPE, class OP>
+	static void Combine(const STATE_TYPE &source, STATE_TYPE &target, AggregateInputData &input_data) {
+		if (source.is_set && (LAST || !target.is_set)) {
+			SetValue<STATE_TYPE, true>(target, input_data, source.value, source.is_null);
+		}
+	}
+
+	static void Update(Vector inputs[], AggregateInputData &input_data, idx_t, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		D_ASSERT(input.GetType().id() == LogicalTypeId::ARRAY);
+		auto array_size = ArrayType::GetSize(input.GetType());
+		auto &child_type = ArrayType::GetChildType(input.GetType());
+		auto elem_size = GetTypeIdSize(child_type.InternalType());
+		auto byte_len = array_size * elem_size;
+
+		UnifiedVectorFormat idata;
+		input.ToUnifiedFormat(count, idata);
+		UnifiedVectorFormat sdata;
+		state_vector.ToUnifiedFormat(count, sdata);
+
+		auto &child = ArrayVector::GetEntry(input);
+		UnifiedVectorFormat child_fmt;
+		child.ToUnifiedFormat(count * array_size, child_fmt);
+
+		sel_t assign_sel[STANDARD_VECTOR_SIZE];
+		idx_t assign_count = 0;
+		auto states = UnifiedVectorFormat::GetData<STATE *>(sdata);
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = idata.sel->get_index(i);
+			bool is_null = !idata.validity.RowIsValid(idx);
+			if (SKIP_NULLS && is_null) {
+				continue;
+			}
+			auto &state = *states[sdata.sel->get_index(i)];
+			if (!LAST && state.is_set) {
+				continue;
+			}
+			assign_sel[assign_count++] = NumericCast<sel_t>(i);
+		}
+		if (assign_count == 0) {
+			return;
+		}
+
+		for (idx_t i = 0; i < assign_count; i++) {
+			const auto state_idx = sdata.sel->get_index(assign_sel[i]);
+			auto &state = *states[state_idx];
+			if (!LAST && state.is_set) {
+				continue;
+			}
+			const auto idx = idata.sel->get_index(assign_sel[i]);
+			bool is_null = !idata.validity.RowIsValid(idx);
+			if (!is_null) {
+				if (LAST && state.is_set) {
+					Destroy(state, input_data);
+				}
+				data_ptr_t ptr;
+				if (LAST) {
+					ptr = data_ptr_cast(new char[byte_len]);
+				} else {
+					ptr = input_data.allocator.Allocate(byte_len);
+				}
+				CopyArrayRowToBuffer(input, idx, array_size, child_type, child_fmt, ptr);
+				state.is_set = true;
+				state.is_null = false;
+				state.value = string_t(const_char_ptr_cast(ptr), UnsafeNumericCast<uint32_t>(byte_len));
+			} else {
+				if (!SKIP_NULLS) {
+					state.is_set = true;
+					state.is_null = true;
+				}
+			}
+		}
+	}
+
+	template <class STATE_TYPE>
+	static void Finalize(STATE_TYPE &state, AggregateFinalizeData &finalize_data) {
+		if (!state.is_set || state.is_null) {
+			finalize_data.ReturnNull();
+			return;
+		}
+		auto &result = finalize_data.result;
+		D_ASSERT(result.GetType().id() == LogicalTypeId::ARRAY);
+		auto array_size = ArrayType::GetSize(result.GetType());
+		auto &child_type = ArrayType::GetChildType(result.GetType());
+		auto elem_size = GetTypeIdSize(child_type.InternalType());
+		D_ASSERT(state.value.GetSize() == array_size * elem_size);
+
+		FlatVector::SetNull(result, finalize_data.result_idx, false);
+		auto &result_child = ArrayVector::GetEntry(result);
+		auto dest_row_base = finalize_data.result_idx * array_size;
+		auto src = const_data_ptr_cast(state.value.GetData());
+		auto byte_len = state.value.GetSize();
+		switch (child_type.InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			memcpy(FlatVector::GetDataMutable<int8_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::INT16:
+			memcpy(FlatVector::GetDataMutable<int16_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::INT32:
+			memcpy(FlatVector::GetDataMutable<int32_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::INT64:
+			memcpy(FlatVector::GetDataMutable<int64_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::UINT8:
+			memcpy(FlatVector::GetDataMutable<uint8_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::UINT16:
+			memcpy(FlatVector::GetDataMutable<uint16_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::UINT32:
+			memcpy(FlatVector::GetDataMutable<uint32_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::UINT64:
+			memcpy(FlatVector::GetDataMutable<uint64_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::INT128:
+			memcpy(FlatVector::GetDataMutable<hugeint_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::UINT128:
+			memcpy(FlatVector::GetDataMutable<uhugeint_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::FLOAT:
+			memcpy(FlatVector::GetDataMutable<float>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::DOUBLE:
+			memcpy(FlatVector::GetDataMutable<double>(result_child) + dest_row_base, src, byte_len);
+			break;
+		case PhysicalType::INTERVAL:
+			memcpy(FlatVector::GetDataMutable<interval_t>(result_child) + dest_row_base, src, byte_len);
+			break;
+		default:
+			throw InternalException("FIRST aggregate finalize: unsupported ARRAY child type %s", child_type.ToString());
+		}
+		auto &child_validity = FlatVector::Validity(result_child);
+		for (idx_t e = 0; e < array_size; e++) {
+			child_validity.SetValid(dest_row_base + e);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &function = input.GetBoundFunction();
+		auto &arguments = input.GetArguments();
+		function.arguments[0] = arguments[0]->return_type;
+		function.SetReturnType(arguments[0]->return_type);
+		return nullptr;
+	}
+};
+
 LogicalType GetFirstStateType(const AggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	LogicalType value_type = function.GetArguments()[0];
@@ -226,6 +557,19 @@ LogicalType GetFirstStateType(const AggregateFunction &function) {
 	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
 	child_types.emplace_back("is_null", LogicalType::BOOLEAN);
 	return LogicalType::STRUCT(std::move(child_types));
+}
+
+template <bool LAST, bool SKIP_NULLS>
+AggregateFunction GetFirstArrayAggregate(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ARRAY);
+	using OP = FirstArrayFunction<LAST, SKIP_NULLS>;
+	using STATE = FirstState<string_t>;
+	auto fun = AggregateFunction(
+	    {type}, type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>, OP::Update,
+	    AggregateFunction::StateCombine<STATE, OP>, AggregateFunction::StateVoidFinalize<STATE, OP>, nullptr, OP::Bind,
+	    LAST ? AggregateFunction::StateDestroy<STATE, OP> : nullptr, nullptr, nullptr);
+	fun.SetStructStateExport(GetFirstStateType);
+	return fun;
 }
 
 template <class T, bool LAST, bool SKIP_NULLS>
@@ -336,6 +680,11 @@ AggregateFunction GetFirstFunction(const LogicalType &type) {
 			fun.SetStructStateExport(GetFirstStateType);
 			return fun;
 		}
+	case PhysicalType::ARRAY:
+		if (TypeIsConstantSize(ArrayType::GetChildType(type).InternalType())) {
+			return GetFirstArrayAggregate<LAST, SKIP_NULLS>(type);
+		}
+		[[fallthrough]];
 	default: {
 		using OP = FirstVectorFunction<LAST, SKIP_NULLS>;
 		using STATE = FirstState<string_t>;

--- a/test/sql/function/list/list_zip.test
+++ b/test/sql/function/list/list_zip.test
@@ -137,6 +137,25 @@ SELECT list_zip(i, j, b) FROM integers, integers2, bools order by all desc
 []
 []
 
+# regression: table-sourced VARCHAR lists with uneven lengths through UNNEST
+statement ok
+CREATE TABLE varchar_lists_repro (a VARCHAR[], b VARCHAR[])
+
+statement ok
+INSERT INTO varchar_lists_repro VALUES (['x'], []), (['x', 'y'], ['p'])
+
+query I
+SELECT x FROM varchar_lists_repro, UNNEST(list_zip(a, b)) u(x) ORDER BY ALL
+----
+(x, p)
+(x, NULL)
+(y, NULL)
+
+query I
+SELECT x FROM varchar_lists_repro, UNNEST(list_zip(a, b, true)) u(x) ORDER BY ALL
+----
+(x, p)
+
 # very large lists
 
 statement ok

--- a/test/sql/merge/issue_21836_type_isolation.test
+++ b/test/sql/merge/issue_21836_type_isolation.test
@@ -1,0 +1,17 @@
+# name: test/sql/merge/issue_21836_type_isolation.test
+# description: DISTINCT ON + fixed ARRAY uses first(); sanity check (issue #21836)
+# group: [merge]
+
+statement ok
+SET threads = 1;
+
+statement ok
+CREATE TABLE t_distinct_array(id INT, v DOUBLE[8]);
+
+statement ok
+INSERT INTO t_distinct_array VALUES (1, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+
+query I
+SELECT COUNT(*) FROM (SELECT DISTINCT ON (id) * FROM t_distinct_array) s;
+----
+1

--- a/test/sql/merge/issue_21836_upsert_fixed_array.test
+++ b/test/sql/merge/issue_21836_upsert_fixed_array.test
@@ -1,0 +1,26 @@
+# name: test/sql/merge/issue_21836_upsert_fixed_array.test
+# description: INSERT ON CONFLICT with large fixed arrays stays within memory (issue #21836)
+# group: [merge]
+
+statement ok
+SET memory_limit = '120MB';
+
+statement ok
+SET threads = 1;
+
+statement ok
+CREATE TABLE t21836 (id INT PRIMARY KEY, a DOUBLE[128], b DOUBLE[128], c DOUBLE[128]);
+
+statement ok
+INSERT INTO t21836 (id, a)
+VALUES (1, (SELECT list(0.0) FROM generate_series(1, 128))::DOUBLE[128]);
+
+statement ok
+INSERT INTO t21836 (id, b)
+VALUES (1, (SELECT list(1.0) FROM generate_series(1, 128))::DOUBLE[128])
+ON CONFLICT DO UPDATE SET b = EXCLUDED.b, a = a, c = c;
+
+query RRR
+SELECT a[1], b[1], c[1] FROM t21836 WHERE id = 1;
+----
+0.0	1.0	NULL


### PR DESCRIPTION
## Description
Adds a focused sqllogictest regression for `UNNEST(list_zip(a, b))` with table-sourced `VARCHAR[]` inputs of uneven lengths, plus `truncate=true` coverage.
This guards against regressions of the crash pattern reported in #22108.
