### PR TITLE
Exception format: accept string literals

### DIFF
--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -135,7 +135,7 @@ public:
 	template <class T, typename... ARGS>
 	static string ConstructMessageRecursive(const string &msg, std::vector<ExceptionFormatValue> &values,
 	                                        const T &param, ARGS &&...params) {
-		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
+		values.push_back(ExceptionFormatValue::CreateFormatValue(param));
 		return ConstructMessageRecursive(msg, values, params...);
 	}
 

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -68,6 +68,11 @@ public:
 	static ExceptionFormatValue CreateFormatValue(const T &value) {
 		return int64_t(value);
 	}
+	template <size_t N>
+	static ExceptionFormatValue CreateFormatValue(const char (&value)[N]) {
+		const char *ptr = value;
+		return CreateFormatValue<const char *>(ptr);
+	}
 	static string Format(const string &msg, std::vector<ExceptionFormatValue> &values);
 };
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -37,7 +37,7 @@ void IsFormatExtensionKnown(const string &format) {
 			// It's a match, we must throw
 			throw CatalogException(
 			    "Copy Function with name \"%s\" is not in the catalog, but it exists in the %s extension.", format,
-			    std::string(file_postfixes.extension));
+			    file_postfixes.extension);
 		}
 	}
 }
@@ -565,8 +565,8 @@ BoundStatement Binder::Bind(CopyStatement &stmt, CopyToType copy_to_type) {
 			// check if this matches the mode
 			if (copy_option.mode != CopyOptionMode::READ_WRITE && copy_option.mode != copy_mode) {
 				throw InvalidInputException("Option \"%s\" is not supported for %s - only for %s", provided_option,
-				                            std::string(stmt.info->is_from ? "reading" : "writing"),
-				                            std::string(stmt.info->is_from ? "writing" : "reading"));
+				                            stmt.info->is_from ? "reading" : "writing",
+				                            stmt.info->is_from ? "writing" : "reading");
 			}
 			if (copy_option.type.id() != LogicalTypeId::ANY) {
 				if (provided_entry.second.empty()) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -127,11 +127,11 @@ void Binder::SearchSchema(CreateInfo &info) {
 	if (!info.temporary) {
 		// non-temporary create: not read only
 		if (info.catalog == TEMP_CATALOG) {
-			throw ParserException("Only TEMPORARY table names can use the \"%s\" catalog", std::string(TEMP_CATALOG));
+			throw ParserException("Only TEMPORARY table names can use the \"%s\" catalog", TEMP_CATALOG);
 		}
 	} else {
 		if (info.catalog != TEMP_CATALOG) {
-			throw ParserException("TEMPORARY table names can *only* use the \"%s\" catalog", std::string(TEMP_CATALOG));
+			throw ParserException("TEMPORARY table names can *only* use the \"%s\" catalog", TEMP_CATALOG);
 		}
 	}
 }


### PR DESCRIPTION
Connected to https://github.com/duckdb/duckdb-httpfs/pull/319, where a string literal bubbling up in an error case will throw a SecondaryException, due to type mismatch. httpfs will be fixed (so that it works also in 1.5.2), but I think we could as well to just fix this quirkness.

Changed also a few callsites where wrapping in `string` was done explicitly to avoid the pitfall now fixed.