### PR TITLE
Use batch limit for table scans with filters

### DIFF
--- a/src/execution/physical_plan/plan_limit.cpp
+++ b/src/execution/physical_plan/plan_limit.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/helper/physical_limit.hpp"
 #include "duckdb/execution/operator/helper/physical_streaming_limit.hpp"
 #include "duckdb/execution/operator/helper/physical_limit_percent.hpp"
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
@@ -18,8 +19,15 @@ bool UseBatchLimit(PhysicalOperator &child_node, BoundLimitNode &limit_val, Boun
 	while (!finished) {
 		auto &current_op = current_ref.get();
 		switch (current_op.type) {
-		case PhysicalOperatorType::TABLE_SCAN:
+		case PhysicalOperatorType::TABLE_SCAN: {
+			auto &table_scan = current_op.Cast<PhysicalTableScan>();
+			if (table_scan.table_filters && !table_scan.table_filters->filters.empty()) {
+				finished = true;
+				break;
+			}
+			// limit on a table scan without filters - never use batch limit
 			return false;
+		}
 		case PhysicalOperatorType::PROJECTION:
 			current_ref = current_op.children[0];
 			break;

--- a/test/sql/limit/test_batch_limit_filters.test
+++ b/test/sql/limit/test_batch_limit_filters.test
@@ -1,0 +1,17 @@
+# name: test/sql/limit/test_batch_limit_filters.test
+# description: Verify batch limit is used with filters
+# group: [limit]
+
+statement ok
+CREATE TABLE tbl AS SELECT concat('thisisastring', i) s FROM range(1_000_000) t(i)
+
+query I
+FROM tbl WHERE s LIKE '%string999999%' LIMIT 5
+----
+thisisastring999999
+
+# this should use the batch limit
+query II
+EXPLAIN FROM tbl WHERE s LIKE '%string999999%' LIMIT 5
+----
+physical_plan	<!REGEX>:.*STREAMING_LIMIT.*


### PR DESCRIPTION
We avoid using the batch limit for limit on top of a table scan to avoid unnecessarily launching threads to do pointless work. However, this doesn't apply to table scans that have filters, as we can still benefit from parallelism depending on the selectivity of the filter. 


```sql
from lineitem where l_comment like '%doggedly pending pi%' limit 2148;
```

| Version | Time (s) |
|---------|----------|
| v1.5.2  | 21s      |
| New     | 1.5s     |
