### PR TITLE
Preserve CREATE INDEX WITH options across checkpoint reload

### DIFF
--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -40,6 +40,7 @@ unique_ptr<CreateInfo> IndexCatalogEntry::GetInfo() const {
 
 	result->comment = comment;
 	result->tags = tags;
+	result->options = options;
 
 	return std::move(result);
 }


### PR DESCRIPTION
Close https://github.com/duckdb/duckdb/issues/22316

IndexCatalogEntry::GetInfo() rebuilds a CreateIndexInfo for catalog serialization but never copied the `options` member back, so any `WITH (...)` clause on CREATE INDEX was silently stripped on CHECKPOINT + reopen:

    CREATE INDEX idx ON t1 (x) WITH (k = 'v');
    CHECKPOINT;
    -- restart
    SELECT sql FROM duckdb_indexes() WHERE index_name = 'idx';
    -- => CREATE INDEX idx ON t1(x);

CreateIndexInfo::Serialize already persists options at field 208 and CheckpointReader::ReadIndex already reads it back, so both sides of the round-trip were ready — only GetInfo() was dropping the field. Core ART ignores options, which is why the loss was latent in core; third-party index types whose create_instance reads WITH options (quantizers, metrics, compression knobs) would see an empty map on reload and misbehave or fail to bind.

Fix: copy `options` into the rebuilt CreateIndexInfo alongside the other members.
`WITH (...)` clause on CREATE INDEX was silently stripped on CHECKPOINT + reopen:

    CREATE INDEX idx ON t1 (x) WITH (k = 'v');
    CHECKPOINT;
    -- restart
    SELECT sql FROM duckdb_indexes() WHERE index_name = 'idx';
    -- => CREATE INDEX idx ON t1(x);

CreateIndexInfo::Serialize already persists options at field 208 and CheckpointReader::ReadIndex already reads it back, so both sides of the round-trip were ready — only GetInfo() was dropping the field. Core ART ignores options, which is why the loss was latent in core; third-party index types whose create_instance reads WITH options (quantizers, metrics, compression knobs) would see an empty map on reload and misbehave or fail to bind.

Fix: copy `options` into the rebuilt CreateIndexInfo alongside the other members.