### PR TITLE
Remove `BaseScalarFunction`

### DIFF
--- a/.github/patches/extensions/spatial/0006-remove-base-scalar-func.patch
+++ b/.github/patches/extensions/spatial/0006-remove-base-scalar-func.patch
@@ -1,0 +1,13 @@
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index e075ca5..e731bf3 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -85,7 +85,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
+ 	return enum_type;
+ }
+ 
+-static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BaseScalarFunction &bound_function,
++static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, SimpleFunction &bound_function,
+                                                        vector<unique_ptr<Expression>> &arguments) {
+ 
+ 	CoordinateReferenceSystem crs;

--- a/.github/patches/extensions/sqlsmith/0003-remove-base-scalar-func.patch
+++ b/.github/patches/extensions/sqlsmith/0003-remove-base-scalar-func.patch
@@ -1,0 +1,22 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index ae18964..a6361c0 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -1277,7 +1277,7 @@ bool StatementGenerator::FunctionArgumentsAlwaysNull(const string &name) {
+ 
+ 	return always_null_functions.find(name) != always_null_functions.end();
+ }
+-string StatementGenerator::GenerateTestAllTypes(BaseScalarFunction &base_function) {
++string StatementGenerator::GenerateTestAllTypes(SimpleFunction &base_function) {
+ 	auto select = make_uniq<SelectStatement>();
+ 	auto node = make_uniq<SelectNode>();
+ 
+@@ -1310,7 +1310,7 @@ string StatementGenerator::GenerateTestAllTypes(BaseScalarFunction &base_functio
+ 	return select->ToString();
+ }
+ 
+-string StatementGenerator::GenerateTestVectorTypes(BaseScalarFunction &base_function) {
++string StatementGenerator::GenerateTestVectorTypes(SimpleFunction &base_function) {
+ 	auto select = make_uniq<SelectStatement>();
+ 	auto node = make_uniq<SelectNode>();
+ 

--- a/.github/patches/extensions/sqlsmith/0003-remove-base-scalar-function.patch
+++ b/.github/patches/extensions/sqlsmith/0003-remove-base-scalar-function.patch
@@ -1,3 +1,18 @@
+diff --git a/src/include/statement_generator.hpp b/src/include/statement_generator.hpp
+index 2b60c00..639860e 100644
+--- a/src/include/statement_generator.hpp
++++ b/src/include/statement_generator.hpp
+@@ -96,8 +96,8 @@ private:
+ 
+ 	void GenerateAllScalar(ScalarFunctionCatalogEntry &scalar_function, vector<string> &result);
+ 	void GenerateAllAggregate(AggregateFunctionCatalogEntry &aggregate_function, vector<string> &result);
+-	string GenerateTestAllTypes(BaseScalarFunction &base_function);
+-	string GenerateTestVectorTypes(BaseScalarFunction &base_function);
++	string GenerateTestAllTypes(SimpleFunction &base_function);
++	string GenerateTestVectorTypes(SimpleFunction &base_function);
+ 	string GenerateCast(const LogicalType &target, const string &source_name, bool add_varchar);
+ 	bool FunctionArgumentsAlwaysNull(const string &name);
+ 
 diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
 index ae18964..a6361c0 100644
 --- a/src/statement_generator.cpp

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -46,15 +46,17 @@ Function::Function(string name_p) : name(std::move(name_p)) {
 Function::~Function() {
 }
 
-SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType varargs_p)
-    : Function(std::move(name_p)), arguments(std::move(arguments_p)), varargs(std::move(varargs_p)) {
+SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type,
+                               LogicalType varargs_p)
+    : Function(std::move(name_p)), arguments(std::move(arguments_p)), varargs(std::move(varargs_p)),
+      return_type(std::move(return_type)) {
 }
 
 SimpleFunction::~SimpleFunction() {
 }
 
 string SimpleFunction::ToString() const {
-	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs, return_type);
 }
 
 bool SimpleFunction::HasVarArgs() const {
@@ -63,7 +65,7 @@ bool SimpleFunction::HasVarArgs() const {
 
 SimpleNamedParameterFunction::SimpleNamedParameterFunction(string name_p, vector<LogicalType> arguments_p,
                                                            LogicalType varargs_p)
-    : SimpleFunction(std::move(name_p), std::move(arguments_p), std::move(varargs_p)) {
+    : Function(std::move(name_p)), arguments(std::move(arguments_p)), varargs(std::move(varargs_p)) {
 }
 
 SimpleNamedParameterFunction::~SimpleNamedParameterFunction() {
@@ -75,19 +77,6 @@ string SimpleNamedParameterFunction::ToString() const {
 
 bool SimpleNamedParameterFunction::HasNamedParameters() const {
 	return !named_parameters.empty();
-}
-
-BaseScalarFunction::BaseScalarFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type_p,
-                                       LogicalType varargs_p)
-    : SimpleFunction(std::move(name_p), std::move(arguments_p), std::move(varargs_p)),
-      return_type(std::move(return_type_p)) {
-}
-
-BaseScalarFunction::~BaseScalarFunction() {
-}
-
-string BaseScalarFunction::ToString() const {
-	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs, return_type);
 }
 
 // add your initializer for new functions here
@@ -110,7 +99,7 @@ void BuiltinFunctions::Initialize() {
 	RegisterExtensionOverloads();
 }
 
-hash_t BaseScalarFunction::Hash() const {
+hash_t SimpleFunction::Hash() const {
 	hash_t hash = return_type.Hash();
 	for (auto &arg : arguments) {
 		hash = duckdb::CombineHash(hash, arg.Hash());

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -78,6 +78,64 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 	return cost;
 }
 
+optional_idx FunctionBinder::BindVarArgsFunctionCost(const SimpleNamedParameterFunction &func,
+                                                     const vector<LogicalType> &arguments) {
+	if (arguments.size() < func.GetArguments().size()) {
+		// not enough arguments to fulfill the non-vararg part of the function
+		return optional_idx();
+	}
+	idx_t cost = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		LogicalType arg_type = i < func.GetArguments().size() ? func.GetArguments()[i] : func.GetVarArgs();
+		if (arguments[i] == arg_type) {
+			// arguments match: do nothing
+			continue;
+		}
+		int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, arguments[i], arg_type);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += idx_t(cast_cost);
+		} else {
+			// we can't implicitly cast: throw an error
+			return optional_idx();
+		}
+	}
+	return cost;
+}
+
+optional_idx FunctionBinder::BindFunctionCost(const SimpleNamedParameterFunction &func,
+                                              const vector<LogicalType> &arguments) {
+	if (func.HasVarArgs()) {
+		// special case varargs function
+		return BindVarArgsFunctionCost(func, arguments);
+	}
+	if (func.GetArguments().size() != arguments.size()) {
+		// invalid argument count: check the next function
+		return optional_idx();
+	}
+	idx_t cost = 0;
+	bool has_parameter = false;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id() == LogicalTypeId::UNKNOWN) {
+			has_parameter = true;
+			continue;
+		}
+		int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, arguments[i], func.GetArguments()[i]);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += idx_t(cast_cost);
+		} else {
+			// we can't implicitly cast: throw an error
+			return optional_idx();
+		}
+	}
+	if (has_parameter) {
+		// all arguments are implicitly castable and there is a parameter - return 0 as cost
+		return 0;
+	}
+	return cost;
+}
+
 template <class T>
 vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const string &name, FunctionSet<T> &functions,
                                                          const vector<LogicalType> &arguments, ErrorData &error) {
@@ -441,7 +499,7 @@ static void HandleCollations(ClientContext &context, ScalarFunction &bound_funct
 
 static void InferTemplateType(ClientContext &context, const LogicalType &source, const LogicalType &target,
                               case_insensitive_map_t<vector<LogicalType>> &bindings, const Expression &current_expr,
-                              const BaseScalarFunction &function) {
+                              const SimpleFunction &function) {
 	if (target.id() == LogicalTypeId::UNKNOWN || target.id() == LogicalTypeId::SQLNULL) {
 		// If the actual type is unknown, we cannot infer anything more.
 		// Therefore, we map all remaining templates in the source to UNKNOWN or SQLNULL, if not already inferred to
@@ -588,7 +646,7 @@ static void SubstituteTemplateType(LogicalType &type, case_insensitive_map_t<vec
 	});
 }
 
-void FunctionBinder::ResolveTemplateTypes(BaseScalarFunction &bound_function,
+void FunctionBinder::ResolveTemplateTypes(SimpleFunction &bound_function,
                                           const vector<unique_ptr<Expression>> &children) {
 	case_insensitive_map_t<vector<LogicalType>> bindings;
 	vector<reference<LogicalType>> to_substitute;
@@ -639,7 +697,7 @@ static void VerifyTemplateType(const LogicalType &type, const string &function_n
 }
 
 // Verify that all template types are bound to concrete types.
-void FunctionBinder::CheckTemplateTypesResolved(const BaseScalarFunction &bound_function) {
+void FunctionBinder::CheckTemplateTypesResolved(const SimpleFunction &bound_function) {
 	for (const auto &arg : bound_function.GetArguments()) {
 		VerifyTemplateType(arg, bound_function.name);
 	}

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -24,7 +24,7 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
                                function_statistics_t statistics, init_local_state_t init_local_state,
                                LogicalType varargs, FunctionStability side_effects, FunctionNullHandling null_handling,
                                bind_lambda_function_t bind_lambda)
-    : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), std::move(varargs)) {
+    : SimpleFunction(std::move(name), std::move(arguments), std::move(return_type), std::move(varargs)) {
 	properties.stability = side_effects;
 	properties.null_handling = null_handling;
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -198,7 +198,7 @@ public:
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
 };
 
-class AggregateFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
+class AggregateFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	                  aggregate_size_t state_size, aggregate_initialize_t initialize, aggregate_update_t update,
@@ -208,7 +208,7 @@ public:
 	                  aggregate_destructor_t destructor = nullptr, aggregate_statistics_t statistics = nullptr,
 	                  aggregate_window_t window = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type) {
+	    : SimpleFunction(name, arguments, return_type) {
 		properties.null_handling = null_handling;
 
 		callbacks.state_size = state_size;
@@ -232,7 +232,7 @@ public:
 	                  aggregate_destructor_t destructor = nullptr, aggregate_statistics_t statistics = nullptr,
 	                  aggregate_window_t window = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type) {
+	    : SimpleFunction(name, arguments, return_type) {
 		callbacks.state_size = state_size;
 		callbacks.initialize = initialize;
 		callbacks.update = update;
@@ -277,7 +277,7 @@ public:
 	                  bind_aggregate_function_t bind = nullptr, aggregate_destructor_t destructor = nullptr,
 	                  aggregate_statistics_t statistics = nullptr, aggregate_serialize_t serialize = nullptr,
 	                  aggregate_deserialize_t deserialize = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type) {
+	    : SimpleFunction(name, arguments, return_type) {
 		callbacks.state_size = state_size;
 		callbacks.initialize = initialize;
 		callbacks.window = window;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -135,7 +135,7 @@ public:
 
 class SimpleFunction : public Function {
 public:
-	DUCKDB_API SimpleFunction(string name, vector<LogicalType> arguments,
+	DUCKDB_API SimpleFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
 	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
 	DUCKDB_API ~SimpleFunction() override;
 
@@ -148,8 +148,13 @@ protected:
 	//! The type of varargs to support, or LogicalTypeId::INVALID if the function does not accept variable length
 	//! arguments
 	LogicalType varargs;
+	//! Return type of the function
+	LogicalType return_type;
 
 public:
+	DUCKDB_API string ToString() const;
+	DUCKDB_API hash_t Hash() const;
+
 	vector<LogicalType> &GetArguments() {
 		return arguments;
 	}
@@ -174,23 +179,68 @@ public:
 		varargs = std::move(varargs_p);
 	}
 
-	DUCKDB_API virtual string ToString() const;
-
 	DUCKDB_API bool HasVarArgs() const;
+
+	void SetReturnType(LogicalType return_type_p) {
+		return_type = std::move(return_type_p);
+	}
+	const LogicalType &GetReturnType() const {
+		return return_type;
+	}
+	LogicalType &GetReturnType() {
+		return return_type;
+	}
 };
 
-class SimpleNamedParameterFunction : public SimpleFunction {
+class SimpleNamedParameterFunction : public Function {
 public:
 	DUCKDB_API SimpleNamedParameterFunction(string name, vector<LogicalType> arguments,
 	                                        LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
 	DUCKDB_API ~SimpleNamedParameterFunction() override;
 
+	//! The set of arguments of the function
+	vector<LogicalType> arguments;
+	//! The set of original arguments of the function - only set if Function::EraseArgument is called
+	//! Used for (de)serialization purposes
+	vector<LogicalType> original_arguments;
+	//! The type of varargs to support, or LogicalTypeId::INVALID if the function does not accept variable length
+	//! arguments
+	LogicalType varargs;
+
 	//! The named parameters of the function
 	named_parameter_type_map_t named_parameters;
 
 public:
-	DUCKDB_API string ToString() const override;
+	DUCKDB_API virtual string ToString() const;
 	DUCKDB_API bool HasNamedParameters() const;
+
+	vector<LogicalType> &GetArguments() {
+		return arguments;
+	}
+	const vector<LogicalType> &GetArguments() const {
+		return arguments;
+	}
+
+	vector<LogicalType> &GetOriginalArguments() {
+		return original_arguments;
+	}
+	const vector<LogicalType> &GetOriginalArguments() const {
+		return original_arguments;
+	}
+
+	const LogicalType &GetVarArgs() const {
+		return varargs;
+	}
+	LogicalType &GetVarArgs() {
+		return varargs;
+	}
+	// TODO: Dont expose mutable accessor
+	void SetVarArgs(LogicalType varargs_p) {
+		varargs = std::move(varargs_p);
+	}
+	bool HasVarArgs() const {
+		return varargs.id() != LogicalTypeId::INVALID;
+	}
 };
 
 class FunctionProperties {
@@ -205,33 +255,6 @@ public:
 
 	bool operator==(const FunctionProperties &rhs) const;
 	bool operator!=(const FunctionProperties &rhs) const;
-};
-
-class BaseScalarFunction : public SimpleFunction {
-public:
-	DUCKDB_API BaseScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
-	                              LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
-	DUCKDB_API ~BaseScalarFunction() override;
-
-public:
-	void SetReturnType(LogicalType return_type_p) {
-		return_type = std::move(return_type_p);
-	}
-	const LogicalType &GetReturnType() const {
-		return return_type;
-	}
-	LogicalType &GetReturnType() {
-		return return_type;
-	}
-
-protected:
-	//! Return type of the function
-	LogicalType return_type;
-
-public:
-	DUCKDB_API hash_t Hash() const;
-
-	DUCKDB_API string ToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -84,12 +84,16 @@ public:
 	//! Cast a set of expressions to the arguments of this function
 	void CastToFunctionArguments(SimpleFunction &function, vector<unique_ptr<Expression>> &children);
 
-	void ResolveTemplateTypes(BaseScalarFunction &bound_function, const vector<unique_ptr<Expression>> &children);
-	void CheckTemplateTypesResolved(const BaseScalarFunction &bound_function);
+	void ResolveTemplateTypes(SimpleFunction &bound_function, const vector<unique_ptr<Expression>> &children);
+	void CheckTemplateTypesResolved(const SimpleFunction &bound_function);
 
 private:
 	optional_idx BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
 	optional_idx BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
+
+	optional_idx BindVarArgsFunctionCost(const SimpleNamedParameterFunction &func,
+	                                     const vector<LogicalType> &arguments);
+	optional_idx BindFunctionCost(const SimpleNamedParameterFunction &func, const vector<LogicalType> &arguments);
 
 	template <class T>
 	vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<T> &functions,

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -174,7 +174,7 @@ public:
 	bool operator!=(const ScalarFunctionCallbacks &rhs) const;
 };
 
-class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
+class ScalarFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -192,7 +192,7 @@ public:
 	bool can_ignore_nulls = true;
 };
 
-class WindowFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
+class WindowFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	WindowFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	               ExpressionType window_enum, window_bind_function_t bind = nullptr,
@@ -200,7 +200,7 @@ public:
 	               window_global_function_t global = nullptr, window_local_function_t local = nullptr,
 	               window_sink_function_t sink = nullptr, window_finalize_function_t finalize = nullptr,
 	               window_evaluate_function_t evaluate = nullptr)
-	    : BaseScalarFunction(name, arguments, return_type), window_enum(window_enum) {
+	    : SimpleFunction(name, arguments, return_type), window_enum(window_enum) {
 		callbacks.bind = bind;
 		callbacks.bounds = bounds;
 		callbacks.sharing = sharing;


### PR DESCRIPTION
This PR removes the `BaseScalarFunction` class to untangle and streamline the inheritance hierarchy for function objects. There are now only two "branches", `SimpleFunction` (Scalar/Aggregate/Window) and `SimpleNamedParameterFunction` (Pragma/Table).

This also duplicates the argument binding logic for each of these branches in the `FunctionBinder` - but this is temporary as the binding logic corresponding to each function family will necessarily diverge further (before hopefully being unified again) in the subsequent PRs in this series.