### PR TITLE
Not using local file system directly for secret storage

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 3139e40a1b224bdb7b104f2f48d9bba8684da013
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/fix.patch
+++ b/.github/patches/extensions/httpfs/fix.patch
@@ -1,0 +1,31 @@
+diff --git a/test/sql/logging/file_system_logging.test b/test/sql/logging/file_system_logging.test
+index 6aa2ed0..5109607 100644
+--- a/test/sql/logging/file_system_logging.test
++++ b/test/sql/logging/file_system_logging.test
+@@ -45,9 +45,9 @@ FROM 'https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv'
+ 
+ # FIXME: investigate why we call READ twice?
+ query IIII
+-SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*test.csv"', '"test.csv"')
++SELECT scope, type, log_level, message
+ FROM duckdb_logs
+-WHERE type = 'FileSystem' AND message NOT LIKE '%duckdb_extension%'
++WHERE type = 'FileSystem' AND message NOT LIKE '%duckdb_extension%' AND message LIKE '%HTTPFileSystem%'
+ ORDER BY timestamp
+ ----
+ CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"OPEN"}
+diff --git a/test/sql/settings/test_disabled_file_system_httpfs.test b/test/sql/settings/test_disabled_file_system_httpfs.test
+index 9cc1ee8..f33b2b0 100644
+--- a/test/sql/settings/test_disabled_file_system_httpfs.test
++++ b/test/sql/settings/test_disabled_file_system_httpfs.test
+@@ -11,6 +11,10 @@ PRAGMA enable_verification
+ 
+ require httpfs
+ 
++# if we disable the local file system we can't have persistent secrets ^^
++statement ok
++set allow_persistent_secrets = 'false';
++
+ statement ok
+ SET disabled_filesystems='LocalFileSystem';
+ 

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -386,7 +386,7 @@ void FileLogStorage::SetPaths(const string &base_path) {
 		it.second.path.clear();
 	}
 
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(db);
 	if (normalize_contexts) {
 		tables[LoggingTargetTable::LOG_CONTEXTS].path = fs.JoinPath(base_path, "duckdb_log_contexts.csv");
 		tables[LoggingTargetTable::LOG_ENTRIES].path = fs.JoinPath(base_path, "duckdb_log_entries.csv");

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -518,7 +518,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &
 }
 
 static bool IsHTTP(const string &path) {
-	return StringUtil::StartsWith(path, "http://") || !StringUtil::StartsWith(path, "https://");
+	return StringUtil::StartsWith(path, "http://") || StringUtil::StartsWith(path, "https://");
 }
 
 static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string &local_extension_path,

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -43,7 +43,8 @@ void SecretManager::Initialize(DatabaseInstance &db) {
 	lock_guard<mutex> lck(manager_lock);
 
 	// Construct default path
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(db);
+
 	config.default_secret_path = fs.GetHomeDirectory();
 	vector<string> path_components = {".duckdb", "stored_secrets"};
 	for (auto &path_ele : path_components) {
@@ -656,7 +657,7 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(cons
 		return nullptr;
 	}
 
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(catalog.GetDatabase());
 
 	string base_secret_path = secret_manager.PersistentSecretPath();
 	string secret_path = fs.JoinPath(base_secret_path, entry_name + ".duckdb_secret");

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -1,16 +1,10 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/file_system.hpp"
-#include "duckdb/common/local_file_system.hpp"
-#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/opener_file_system.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
-#include "duckdb/common/serializer/buffered_file_reader.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "duckdb/function/function_set.hpp"
-#include "duckdb/main/extension_helper.hpp"
-#include "duckdb/main/secret/secret_storage.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
-#include "duckdb/parser/parsed_data/create_secret_info.hpp"
-#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/main/secret/secret_storage.hpp"
 
 namespace duckdb {
 
@@ -137,7 +131,8 @@ LocalFileSecretStorage::LocalFileSecretStorage(SecretManager &manager, DatabaseI
 	persistent = true;
 
 	// Check existence of persistent secret dir
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(db);
+
 	if (fs.DirectoryExists(secret_path)) {
 		fs.ListFiles(secret_path, [&](const string &fname, bool is_dir) {
 			string full_path = fs.JoinPath(secret_path, fname);
@@ -186,7 +181,7 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 }
 
 void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(db);
 
 	// We may need to create the secret dir here if the directory was not present during LocalFileSecretStorage
 	// construction
@@ -230,7 +225,8 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 }
 
 void LocalFileSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	LocalFileSystem fs;
+	auto &fs = FileSystem::GetFileSystem(db);
+
 	string file = fs.JoinPath(secret_path, secret + ".duckdb_secret");
 	persistent_secrets.erase(secret);
 	try {

--- a/test/sql/secrets/create_secret_external_access.test
+++ b/test/sql/secrets/create_secret_external_access.test
@@ -1,0 +1,14 @@
+# name: test/sql/secrets/create_secret_external_access.test
+# description: Test secrets with expressions as params
+# group: [secrets]
+
+statement ok
+set enable_external_access = false;
+
+statement error
+CREATE PERSISTENT SECRET "fuu" (
+    TYPE HTTP,
+    BEARER_TOKEN 'something'
+);
+----
+Permission Error


### PR DESCRIPTION
Secret storage directly instantiated a `LocalFileSystem` - this bypassed external access restrictions.

Thanks to @alexwaira, @kodareef5, and @shapor for flagging this independently