### PR TITLE
Error when CMAKE_CXX_STANDARD is explicit and less than 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,16 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS AND UNIX)
   )
 endif()
 
-set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
+if(DEFINED CMAKE_CXX_STANDARD)
+  set(_duckdb_allowed_cxx_std 17 20 23 26)
+  if(NOT CMAKE_CXX_STANDARD IN_LIST _duckdb_allowed_cxx_std)
+    message(FATAL_ERROR
+      "DuckDB requires C++17 or higher; got CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}. "
+      "Pass -DCMAKE_CXX_STANDARD=17 (or higher), or unset it to use the default.")
+  endif()
+endif()
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "Default C++ standard (minimum 17)")                                                                                                             
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
It happens to me to jump (in the same duckdb folder) between `v1.5-variegata`(cxx 11) and `main`(c++ 17).

Currently, both CMake are compatible, but then it might (or not) fail at compile time due to mismatched features.
I'd say, if we require c++17, we can as well just throw (for example forcing a `make clean`) instead of silently moving forward, and erroring at a later point.

Note that bumping up, like: `CMAKE_CXX_STANDARD=20 GEN=ninja make` it's still viable.

I would assume doing that might cause some issues in some extensions (say, building from a given extension folder), but that might be good, since the extensions might need to adapt to C++17.

Note, due to 98 >= 17, let's just encode known supported versions.