### PR TITLE
Improve CLAUDE.md for parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Ensure you run formatting before committing.
 ```
 SQL String
     ↓
-[PARSER] - Uses libpg_query to parse SQL into AST
+[PARSER] - Uses a PEG parser to parse SQL into AST
     ↓
 SQLStatement tree (ParsedExpression, TableRef objects)
     ↓
@@ -105,9 +105,13 @@ Results
 
 **Parser** (`src/parser/`)
 - Converts SQL strings to Abstract Syntax Tree (AST)
-- Uses PostgreSQL's libpg_query for parsing
+- Uses a PEG-based parser
+- The grammar is located in `*.gram` files and generated using `scripts/build_peg_grammar.sh`
 - Outputs: `SQLStatement`, `ParsedExpression`, `TableRef` objects
-- Key subdirectories: `expression/`, `statement/`, `tableref/`, `transform/`
+- Key subdirectories: `expression/`, `statement/`, `tableref/`, `peg/`
+
+For more details on adding new grammar, see the README located at `src/parser/peg/README.md`. 
+Each new grammar rule must have a corresponding transformer rule, located at `peg/transformer`.
 
 **Planner** (`src/planner/`)
 - Binds symbols to catalog entries and resolves types

--- a/src/parser/peg/README.md
+++ b/src/parser/peg/README.md
@@ -146,8 +146,6 @@ After modifying `.gram` files or keyword lists, regenerate the inlined grammar f
 ./scripts/build_peg_grammar.sh
 ```
 
-**Prerequisites**: A Python virtual environment at `.venv` in the repository root.
-
 This script runs `extension/autocomplete/inline_grammar.py` twice:
 
 1. **`--grammar-file`**: Combines all `.gram` files and keyword lists into a single `inlined_grammar.gram` (useful for debugging).


### PR DESCRIPTION
Minor improvements to `CLAUDE.md` to correctly point it to the PEG-based parser and how it can generate new grammar/transformer rules. I also moved the `README.md` that was in the `autocomplete` to `src/parser/peg`.  