### PR TITLE
Add `debug_verify_statement` setting which splits off some verification from `PRAGMA enable_verification`

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1325,6 +1325,18 @@ jobs:
         rm -rf build/release
         tar -xzf build/release-artifact.tar.gz -C build
 
+    - name: test/configs/verify_statement_copy.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_copy.json ./build/release/test/unittest
+
+    - name: test/configs/verify_statement_to_string.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_to_string.json ./build/release/test/unittest
+
     - name: test/configs/force_storage.json
       if: success() || failure()
       shell: bash

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -194,6 +194,9 @@ string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<u
 		} else if (column.HasDefaultValue()) {
 			ss << " DEFAULT(" << column.DefaultValue().ToString() << ")";
 		}
+		if (column.CompressionType() != CompressionType::COMPRESSION_AUTO) {
+			ss << " USING COMPRESSION " << CompressionTypeToString(column.CompressionType());
+		}
 		if (not_null && !is_single_key_pk && !is_multi_key_pk) {
 			// NOT NULL but not a primary key column
 			ss << " NOT NULL";

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/common/enums/cte_materialize.hpp"
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/common/enums/debug_initialize.hpp"
+#include "duckdb/common/enums/debug_statement_verification.hpp"
 #include "duckdb/common/enums/debug_vector_verification.hpp"
 #include "duckdb/common/enums/deprecated_using_key_syntax.hpp"
 #include "duckdb/common/enums/destroy_buffer_upon.hpp"
@@ -1543,6 +1544,25 @@ const char* EnumUtil::ToChars<DebugInitialize>(DebugInitialize value) {
 template<>
 DebugInitialize EnumUtil::FromString<DebugInitialize>(const char *value) {
 	return static_cast<DebugInitialize>(StringUtil::StringToEnum(GetDebugInitializeValues(), 3, "DebugInitialize", value));
+}
+
+const StringUtil::EnumStringLiteral *GetDebugStatementVerificationValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(DebugStatementVerification::NONE), "NONE" },
+		{ static_cast<uint32_t>(DebugStatementVerification::COPY_STATEMENT), "COPY_STATEMENT" },
+		{ static_cast<uint32_t>(DebugStatementVerification::REPARSE_STATEMENT), "REPARSE_STATEMENT" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<DebugStatementVerification>(DebugStatementVerification value) {
+	return StringUtil::EnumToString(GetDebugStatementVerificationValues(), 3, "DebugStatementVerification", static_cast<uint32_t>(value));
+}
+
+template<>
+DebugStatementVerification EnumUtil::FromString<DebugStatementVerification>(const char *value) {
+	return static_cast<DebugStatementVerification>(StringUtil::StringToEnum(GetDebugStatementVerificationValues(), 3, "DebugStatementVerification", value));
 }
 
 const StringUtil::EnumStringLiteral *GetDebugVectorVerificationValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -325,6 +325,13 @@
         "default_value": "false"
     },
     {
+        "name": "debug_verify_statement",
+        "description": "DEBUG SETTING: the type of statement verification to perform",
+        "type": "ENUM<DebugStatementVerification>",
+        "default_scope": "global",
+        "default_value": "NONE"
+    },
+    {
         "name": "debug_verify_vector",
         "description": "DEBUG SETTING: enable vector verification",
         "type": "ENUM<DebugVectorVerification>",

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -162,6 +162,8 @@ enum class DatePartSpecifier : uint8_t;
 
 enum class DebugInitialize : uint8_t;
 
+enum class DebugStatementVerification : uint8_t;
+
 enum class DebugVectorVerification : uint8_t;
 
 enum class DecimalBitWidth : uint8_t;
@@ -725,6 +727,9 @@ const char* EnumUtil::ToChars<DatePartSpecifier>(DatePartSpecifier value);
 
 template<>
 const char* EnumUtil::ToChars<DebugInitialize>(DebugInitialize value);
+
+template<>
+const char* EnumUtil::ToChars<DebugStatementVerification>(DebugStatementVerification value);
 
 template<>
 const char* EnumUtil::ToChars<DebugVectorVerification>(DebugVectorVerification value);
@@ -1473,6 +1478,9 @@ DatePartSpecifier EnumUtil::FromString<DatePartSpecifier>(const char *value);
 
 template<>
 DebugInitialize EnumUtil::FromString<DebugInitialize>(const char *value);
+
+template<>
+DebugStatementVerification EnumUtil::FromString<DebugStatementVerification>(const char *value);
 
 template<>
 DebugVectorVerification EnumUtil::FromString<DebugVectorVerification>(const char *value);

--- a/src/include/duckdb/common/enums/debug_statement_verification.hpp
+++ b/src/include/duckdb/common/enums/debug_statement_verification.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/debug_statement_verification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class DebugStatementVerification : uint8_t { NONE, COPY_STATEMENT, REPARSE_STATEMENT };
+
+} // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -538,6 +538,17 @@ struct DebugVerifyBlocksSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct DebugVerifyStatementSetting {
+	using RETURN_TYPE = DebugStatementVerification;
+	static constexpr const char *Name = "debug_verify_statement";
+	static constexpr const char *Description = "DEBUG SETTING: the type of statement verification to perform";
+	static constexpr const char *InputType = "VARCHAR";
+	static constexpr const char *DefaultValue = "NONE";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct DebugVerifyVectorSetting {
 	using RETURN_TYPE = DebugVectorVerification;
 	static constexpr const char *Name = "debug_verify_vector";

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/enums/debug_statement_verification.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/progress_bar/progress_bar.hpp"
 #include "duckdb/common/serializer/buffered_file_writer.hpp"
@@ -925,43 +926,17 @@ bool ClientContext::IsActiveResult(ClientContextLock &lock, BaseQueryResult &res
 unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatementInternal(
     ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
     shared_ptr<PreparedStatementData> &prepared, const PendingQueryParameters &parameters) {
-#ifdef DUCKDB_ALTERNATIVE_VERIFY
-	if (statement && statement->type != StatementType::LOGICAL_PLAN_STATEMENT) {
-		statement = statement->Copy();
-	}
-#endif
-	if (statement && config.query_verification_enabled) {
-		// query verification is enabled
-		// create a copy of the statement, and use the copy
-		// this way we verify that the copy correctly copies all properties
-		auto copied_statement = statement->Copy();
-		switch (statement->type) {
-		case StatementType::SELECT_STATEMENT: {
-			// in case this is a select query, we verify the original statement
-			ErrorData error;
-			try {
-				error = VerifyQuery(lock, query, std::move(statement), parameters);
-			} catch (std::exception &ex) {
-				error = ErrorData(ex);
-			}
-			if (error.HasError()) {
-				// error in verifying query
-				return ErrorResult<PendingQueryResult>(std::move(error), query);
-			}
-			statement = std::move(copied_statement);
+	if (statement) {
+		switch (Settings::Get<DebugVerifyStatementSetting>(*this)) {
+		case DebugStatementVerification::NONE:
 			break;
-		}
-		default: {
-#ifndef DUCKDB_ALTERNATIVE_VERIFY
-			bool reparse_statement = true;
-#else
-			bool reparse_statement = false;
-#endif
-			statement = std::move(copied_statement);
-			if (statement->type == StatementType::RELATION_STATEMENT) {
-				reparse_statement = false;
+		case DebugStatementVerification::COPY_STATEMENT:
+			if (statement->type != StatementType::LOGICAL_PLAN_STATEMENT) {
+				statement = statement->Copy();
 			}
-			if (reparse_statement) {
+			break;
+		case DebugStatementVerification::REPARSE_STATEMENT:
+			if (statement->type != StatementType::RELATION_STATEMENT) {
 				try {
 					Parser parser(GetParserOptions());
 					ErrorData error;
@@ -987,7 +962,26 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 				}
 			}
 			break;
+		default:
+			throw InternalException("Unsupported statement verification mode");
 		}
+		if (config.query_verification_enabled && statement->type == StatementType::SELECT_STATEMENT) {
+			// query verification is enabled
+			// create a copy of the statement, and use the copy
+			// this way we verify that the copy correctly copies all properties
+			auto copied_statement = statement->Copy();
+			// in case this is a select query, we verify the original statement
+			ErrorData error;
+			try {
+				error = VerifyQuery(lock, query, std::move(statement), parameters);
+			} catch (std::exception &ex) {
+				error = ErrorData(ex);
+			}
+			if (error.HasError()) {
+				// error in verifying query
+				return ErrorResult<PendingQueryResult>(std::move(error), query);
+			}
+			statement = std::move(copied_statement);
 		}
 	}
 	return PendingStatementOrPreparedStatement(lock, query, std::move(statement), prepared, parameters);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -105,6 +105,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
     DUCKDB_SETTING(DebugVerifyBlocksSetting),
+    DUCKDB_SETTING_CALLBACK(DebugVerifyStatementSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyVectorSetting),
     DUCKDB_SETTING_CALLBACK(DebugWindowModeSetting),
     DUCKDB_SETTING_CALLBACK(DefaultBlockSizeSetting),
@@ -214,12 +215,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 102),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 44),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 122),
-                                                     DUCKDB_SETTING_ALIAS("user", 137),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 103),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 45),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 123),
+                                                     DUCKDB_SETTING_ALIAS("user", 138),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 136),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 137),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -102,6 +102,13 @@ void DebugPhysicalTableScanExecutionStrategySetting::OnSet(SettingCallbackInfo &
 }
 
 //===----------------------------------------------------------------------===//
+// Debug Verify Statement
+//===----------------------------------------------------------------------===//
+void DebugVerifyStatementSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {
+	EnumUtil::FromString<DebugStatementVerification>(StringValue::Get(parameter));
+}
+
+//===----------------------------------------------------------------------===//
 // Debug Verify Vector
 //===----------------------------------------------------------------------===//
 void DebugVerifyVectorSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {

--- a/src/parser/parsed_data/alter_database_info.cpp
+++ b/src/parser/parsed_data/alter_database_info.cpp
@@ -39,7 +39,7 @@ string RenameDatabaseInfo::ToString() const {
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		result += "IF EXISTS ";
 	}
-	result += StringUtil::Format("%s RENAME TO %s", SQLIdentifier(catalog), SQLIdentifier(new_name));
+	result += StringUtil::Format("%s SET ALIAS TO %s", SQLIdentifier(catalog), SQLIdentifier(new_name));
 	return result;
 }
 

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -36,7 +36,7 @@ string ChangeOwnershipInfo::ToString() const {
 	result += TypeToString(entry_catalog_type);
 	result += " ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += "IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " OWNED BY ";
@@ -120,7 +120,7 @@ string RenameColumnInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME COLUMN ";
@@ -153,7 +153,7 @@ string RenameFieldInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME COLUMN ";
@@ -190,7 +190,7 @@ string RenameTableInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME TO ";
@@ -220,9 +220,9 @@ unique_ptr<AlterInfo> AddColumnInfo::Copy() const {
 
 string AddColumnInfo::ToString() const {
 	string result = "";
-	result += "ALTER TABLE";
+	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += " " + QualifierToString(catalog, schema, name);
 	result += " ADD COLUMN";
@@ -264,7 +264,7 @@ string AddFieldInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ADD COLUMN";
@@ -301,7 +301,7 @@ string RemoveColumnInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " DROP COLUMN ";
@@ -337,7 +337,7 @@ string RemoveFieldInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " DROP COLUMN ";
@@ -380,7 +380,7 @@ string ChangeColumnTypeInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
@@ -426,7 +426,7 @@ string SetDefaultInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
@@ -461,7 +461,7 @@ string SetNotNullInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
@@ -491,7 +491,7 @@ string DropNotNullInfo::ToString() const {
 	string result = "";
 	result += "ALTER TABLE ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
@@ -563,7 +563,7 @@ string RenameViewInfo::ToString() const {
 	string result = "";
 	result += "ALTER VIEW ";
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-		result += " IF EXISTS";
+		result += "IF EXISTS ";
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME TO ";

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -224,7 +224,7 @@ string AddColumnInfo::ToString() const {
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		result += "IF EXISTS ";
 	}
-	result += " " + QualifierToString(catalog, schema, name);
+	result += QualifierToString(catalog, schema, name);
 	result += " ADD COLUMN";
 	if (if_column_not_exists) {
 		result += " IF NOT EXISTS";

--- a/src/parser/parsed_data/comment_on_column_info.cpp
+++ b/src/parser/parsed_data/comment_on_column_info.cpp
@@ -28,6 +28,7 @@ string SetColumnCommentInfo::ToString() const {
 	D_ASSERT(catalog_entry_type == CatalogType::INVALID);
 	result += "COMMENT ON COLUMN ";
 	result += QualifierToString(catalog, schema, name);
+	result += "." + KeywordHelper::WriteOptionallyQuoted(column_name);
 	result += " IS ";
 	result += comment_value.ToSQLString();
 	result += ";";

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -84,9 +84,13 @@ string CreateIndexInfo::ToString() const {
 		result += " WITH (";
 		idx_t i = 0;
 		for (auto &opt : options) {
-			result += StringUtil::Format("%s = %s", opt.first, opt.second.ToString());
 			if (i > 0) {
 				result += ", ";
+			}
+			if (opt.second.IsNull()) {
+				result += opt.first;
+			} else {
+				result += StringUtil::Format("%s = %s", opt.first, opt.second.ToString());
 			}
 			i++;
 		}

--- a/src/parser/query_node/insert_query_node.cpp
+++ b/src/parser/query_node/insert_query_node.cpp
@@ -45,7 +45,7 @@ string InsertQueryNode::ToString() const {
 			}
 			result += KeywordHelper::WriteOptionallyQuoted(columns[i]);
 		}
-		result += " )";
+		result += ")";
 	}
 	result += " ";
 	auto values_list = GetValuesList();

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -7,7 +7,10 @@ namespace duckdb {
 
 string JoinRef::ToString() const {
 	string result;
-	result = left->ToString() + " ";
+	if (!is_implicit) {
+		result += "(";
+	}
+	result += left->ToString() + " ";
 	switch (ref_type) {
 	case JoinRefType::REGULAR:
 		result += EnumUtil::ToString(type) + " JOIN ";
@@ -44,6 +47,9 @@ string JoinRef::ToString() const {
 			}
 			result += KeywordHelper::WriteOptionallyQuoted(using_columns[i]);
 		}
+		result += ")";
+	}
+	if (!is_implicit) {
 		result += ")";
 	}
 	return result;

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -751,7 +751,7 @@ TEST_CASE("Test SqlStatement::ToString for UPDATE, INSERT, DELETE statements wit
 
 	sql = "INSERT INTO test (id) VALUES (1) RETURNING id AS inserted";
 	auto stmts = con.ExtractStatements(sql);
-	REQUIRE(stmts[0]->ToString() == "INSERT INTO test (id ) (VALUES (1)) RETURNING id AS inserted");
+	REQUIRE(stmts[0]->ToString() == "INSERT INTO test (id) (VALUES (1)) RETURNING id AS inserted");
 
 	sql = "UPDATE test SET id = 1 RETURNING id AS updated";
 	stmts = con.ExtractStatements(sql);

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -135,6 +135,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}},
 	    {"checkpoint_on_detach", {"ENABLED"}},
 	    {"current_transaction_invalidation_policy", {"ALL_ERRORS_INVALIDATE_TRANSACTION"}},
+	    {"debug_verify_statement", {"copy_statement"}},
 	    {"enable_caching_operators", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {

--- a/test/configs/verify_statement_copy.json
+++ b/test/configs/verify_statement_copy.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with debug_verify_statement set to copy_statement - forcing all statements to be copied prior to being used",
+  "on_init": "SET debug_verify_statement='copy_statement';",
+  "skip_compiled": "true"
+}

--- a/test/configs/verify_statement_to_string.json
+++ b/test/configs/verify_statement_to_string.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with debug_verify_statement set to reparse_statement - forcing all statements to be converted to a string and reparsed using the parser prior to being used",
+  "on_init": "SET debug_verify_statement='reparse_statement';",
+  "skip_compiled": "true"
+}

--- a/test/configs/verify_statement_to_string.json
+++ b/test/configs/verify_statement_to_string.json
@@ -1,5 +1,39 @@
 {
   "description": "Run with debug_verify_statement set to reparse_statement - forcing all statements to be converted to a string and reparsed using the parser prior to being used",
   "on_init": "SET debug_verify_statement='reparse_statement';",
-  "skip_compiled": "true"
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "FIXME: failing with copy_statement verification",
+      "paths": [
+        "test/fuzzer/duckfuzz/list_try_cast.test",
+        "test/sql/types/decimal/large_decimal_constants.test",
+        "test/sql/types/uhugeint/test_uhugeint_conversion.test",
+        "test/sql/types/hugeint/test_hugeint_conversion.test",
+        "test/sql/join/natural/natural_join.test",
+        "test/sql/subquery/scalar/array_order_subquery.test",
+        "test/sql/cast/cast_error_location.test",
+        "test/sql/catalog/comment_on_dependencies.test",
+        "test/sql/catalog/comment_on_column.test",
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/comment_on_wal.test",
+        "test/sql/catalog/comment_on.test",
+        "test/sql/catalog/comment_on_extended.test",
+        "test/sql/catalog/test_set_schema.test",
+        "test/sql/catalog/comment_on_pg_description.test",
+        "test/sql/function/uuid/test_uuid.test",
+        "test/sql/alter/test_alter_database_rename.test",
+        "test/sql/alter/test_alter_if_exists.test",
+        "test/sql/window/test_ignore_nulls.test",
+        "test/sql/index/create_index_options.test",
+        "test/sql/error/lineitem_errors.test"
+      ]
+    },
+    {
+      "reason": "Expected failure",
+      "paths": [
+      "test/sql/error/lineitem_errors.test"
+      ]
+    }
+  ]
 }

--- a/test/configs/verify_statement_to_string.json
+++ b/test/configs/verify_statement_to_string.json
@@ -4,35 +4,39 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "FIXME: failing with copy_statement verification",
+      "reason": "Different error message",
       "paths": [
-        "test/fuzzer/duckfuzz/list_try_cast.test",
-        "test/sql/types/decimal/large_decimal_constants.test",
-        "test/sql/types/uhugeint/test_uhugeint_conversion.test",
-        "test/sql/types/hugeint/test_hugeint_conversion.test",
-        "test/sql/join/natural/natural_join.test",
+        "test/sql/error/lineitem_errors.test",
         "test/sql/subquery/scalar/array_order_subquery.test",
-        "test/sql/cast/cast_error_location.test",
-        "test/sql/catalog/comment_on_dependencies.test",
-        "test/sql/catalog/comment_on_column.test",
-        "test/sql/catalog/test_set_search_path.test",
-        "test/sql/catalog/comment_on_wal.test",
-        "test/sql/catalog/comment_on.test",
-        "test/sql/catalog/comment_on_extended.test",
-        "test/sql/catalog/test_set_schema.test",
-        "test/sql/catalog/comment_on_pg_description.test",
-        "test/sql/function/uuid/test_uuid.test",
-        "test/sql/alter/test_alter_database_rename.test",
-        "test/sql/alter/test_alter_if_exists.test",
-        "test/sql/window/test_ignore_nulls.test",
-        "test/sql/index/create_index_options.test",
-        "test/sql/error/lineitem_errors.test"
+        "test/fuzzer/duckfuzz/list_try_cast.test"
       ]
     },
     {
-      "reason": "Expected failure",
+      "reason": "main schema qualification is not stringified, which breaks when it's not on the search path",
       "paths": [
-      "test/sql/error/lineitem_errors.test"
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/test_set_schema.test"
+      ]
+    },
+    {
+      "reason": "Literal types not preserved in ToString",
+      "paths": [
+        "test/sql/types/hugeint/test_hugeint_conversion.test",
+        "test/sql/types/uhugeint/test_uhugeint_conversion.test",
+        "test/sql/types/decimal/large_decimal_constants.test",
+        "test/sql/cast/cast_error_location.test"
+      ]
+    },
+    {
+      "reason": "RESPECT NULLS in Window functions is not stringified as it's the default",
+      "paths": [
+        "test/sql/window/test_ignore_nulls.test"
+      ]
+    },
+    {
+      "reason": "FIXME: new parser precedence issue",
+      "paths": [
+      "test/sql/function/uuid/test_uuid.test"
       ]
     }
   ]

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -3,6 +3,9 @@
 
 require json
 
+statement ok
+SET storage_compatibility_version='v1.0.0'
+
 # Example with simple query
 statement ok
 SELECT json_serialize_sql('SELECT 1 + 2 FROM tbl1');


### PR DESCRIPTION
`PRAGMA enable_verification` is currently load bearing, it enables many different types of verifications. As a result of this, there are [many tests that are skipped for various different reasons in the config](https://github.com/duckdb/duckdb/blob/main/test/configs/enable_verification.json). It also makes it hard to understand exactly *which* part of verification is failing if you encounter a verification issue in this manner.

This PR makes an initial step towards breaking up this giant verification feature by splitting off the generic statement verification components:

```sql
-- verify SQLStatement::Copy() correctly copies the statement
SET debug_verify_statement='copy_statement';
-- verify SQLStatement::ToString() correctly round-trips
SET debug_verify_statement='reparse_statement';
```

This PR also adds two new test verification runs for these settings, with far fewer skipped tests, and fixes many of the issues encountered during the `::ToString()` verification pass which were previously part of skipped tests.