### PR TITLE
Add OPTIONS to HTTPUtil and httpfs

### DIFF
--- a/.github/patches/extensions/httpfs/0003-add-options.patch
+++ b/.github/patches/extensions/httpfs/0003-add-options.patch
@@ -1,0 +1,55 @@
+diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
+index 8a641ce..83e0d1c 100644
+--- a/src/httpfs_curl_client.cpp
++++ b/src/httpfs_curl_client.cpp
+@@ -398,6 +398,34 @@ public:
+ 		return TransformResponseCurl(res);
+ 	}
+ 
++	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) override {
++		ResetRequestInfo();
++		auto curl_headers = TransformHeadersCurl(info.headers, info.params);
++		request_info->url = info.url;
++
++		CURLcode res;
++		{
++			CURLU *url = curl_url_dup(base_url);
++
++			string normalized_path = NormalizePathToBeAdded(info.path);
++			curl_url_set(url, CURLUPART_URL, normalized_path.c_str(), 0);
++
++			curl_easy_setopt(*curl, CURLOPT_URL, nullptr);
++			curl_easy_setopt(*curl, CURLOPT_CURLU, url);
++
++			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
++
++			curl_easy_setopt(*curl, CURLOPT_HTTPHEADER, curl_headers ? curl_headers.headers : nullptr);
++
++			res = curl->Execute();
++			curl_easy_setopt(*curl, CURLOPT_CUSTOMREQUEST, nullptr);
++			curl_url_cleanup(url);
++		}
++
++		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
++		return TransformResponseCurl(res);
++	}
++
+ 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
+ 		ResetRequestInfo();
+ 		if (state) {
+diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
+index 63d7197..8027a37 100644
+--- a/src/httpfs_httplib_client.cpp
++++ b/src/httpfs_httplib_client.cpp
+@@ -87,6 +87,11 @@ public:
+ 		return TransformResult(client->Delete(info.path, headers));
+ 	}
+ 
++	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) override {
++		auto headers = TransformHeaders(info.headers, info.params);
++		return TransformResult(client->Options(info.path, headers));
++	}
++
+ 	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
+ 		if (state) {
+ 			state->post_count++;

--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -71,6 +71,7 @@ overrides = {
         "HEAD_REQUEST": "HEAD",
         "DELETE_REQUEST": "DELETE",
         "POST_REQUEST": "POST",
+        "OPTIONS_REQUEST": "OPTIONS",
     },
     "CompressionType": {
         "COMPRESSION_AUTO": "AUTO",

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4415,19 +4415,20 @@ const StringUtil::EnumStringLiteral *GetRequestTypeValues() {
 		{ static_cast<uint32_t>(RequestType::PUT_REQUEST), "PUT" },
 		{ static_cast<uint32_t>(RequestType::HEAD_REQUEST), "HEAD" },
 		{ static_cast<uint32_t>(RequestType::DELETE_REQUEST), "DELETE" },
-		{ static_cast<uint32_t>(RequestType::POST_REQUEST), "POST" }
+		{ static_cast<uint32_t>(RequestType::POST_REQUEST), "POST" },
+		{ static_cast<uint32_t>(RequestType::OPTIONS_REQUEST), "OPTIONS" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<RequestType>(RequestType value) {
-	return StringUtil::EnumToString(GetRequestTypeValues(), 5, "RequestType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetRequestTypeValues(), 6, "RequestType", static_cast<uint32_t>(value));
 }
 
 template<>
 RequestType EnumUtil::FromString<RequestType>(const char *value) {
-	return static_cast<RequestType>(StringUtil::StringToEnum(GetRequestTypeValues(), 5, "RequestType", value));
+	return static_cast<RequestType>(StringUtil::StringToEnum(GetRequestTypeValues(), 6, "RequestType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetResultModifierTypeValues() {

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -67,7 +67,14 @@ public:
 	}
 };
 
-enum class RequestType : uint8_t { GET_REQUEST, PUT_REQUEST, HEAD_REQUEST, DELETE_REQUEST, POST_REQUEST };
+enum class RequestType : uint8_t {
+	GET_REQUEST,
+	PUT_REQUEST,
+	HEAD_REQUEST,
+	DELETE_REQUEST,
+	POST_REQUEST,
+	OPTIONS_REQUEST
+};
 
 struct HTTPHeaders {
 	using header_map_t = case_insensitive_map_t<string>;
@@ -201,6 +208,12 @@ struct DeleteRequestInfo : public BaseRequest {
 	}
 };
 
+struct OptionsRequestInfo : public BaseRequest {
+	OptionsRequestInfo(const string &path, const HTTPHeaders &headers, HTTPParams &params)
+	    : BaseRequest(RequestType::OPTIONS_REQUEST, path, headers, params) {
+	}
+};
+
 struct PostRequestInfo : public BaseRequest {
 	PostRequestInfo(const string &path, const HTTPHeaders &headers, HTTPParams &params, const_data_ptr_t buffer_in,
 	                idx_t buffer_in_len)
@@ -228,6 +241,7 @@ public:
 	virtual unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) = 0;
 	virtual unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) = 0;
 	virtual unique_ptr<HTTPResponse> Post(PostRequestInfo &info) = 0;
+	virtual unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) = 0;
 	virtual void Cleanup() {};
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -196,6 +196,10 @@ public:
 		throw NotImplementedException("POST request not implemented");
 	}
 
+	unique_ptr<HTTPResponse> Options(OptionsRequestInfo &info) override {
+		throw NotImplementedException("OPTIONS request not implemented");
+	}
+
 	unique_ptr<duckdb_httplib::Client> client;
 
 private:
@@ -536,6 +540,8 @@ unique_ptr<HTTPResponse> HTTPClient::Request(BaseRequest &request) {
 		return Delete(request.Cast<DeleteRequestInfo>());
 	case RequestType::POST_REQUEST:
 		return Post(request.Cast<PostRequestInfo>());
+	case RequestType::OPTIONS_REQUEST:
+		return Options(request.Cast<OptionsRequestInfo>());
 	default:
 		throw InternalException("Unsupported request type");
 	}


### PR DESCRIPTION
I have also a CORSExplorer demo that actually stresses these codepaths by testing whether various backends require CORS or not, but that can't land as is, and was mostly handy to verify the base exposed primitives where working.

Fixes https://github.com/duckdb/duckdb/issues/21533