### PR TITLE
Fix add column if not exists for PEG parser

### DIFF
--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -32,11 +32,11 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAlterStatement(PEGTrans
 	auto null_column = column_entry.Copy();
 	null_column.SetDefaultValue(make_uniq<ConstantExpression>(ConstantExpression(Value(nullptr))));
 	auto alter_entry_data = add_column.GetAlterEntryData();
-	return unique_ptr<SQLStatement>(std::move(TransformAndMaterializeAlter(
-	    alter_entry_data,
-	    make_uniq<AddColumnInfo>(add_column.GetAlterEntryData(), std::move(null_column),
-	                             result->info->if_not_found == OnEntryNotFound::RETURN_NULL),
-	    column_entry.GetName(), column_entry.DefaultValue().Copy())));
+	return unique_ptr<SQLStatement>(std::move(
+	    TransformAndMaterializeAlter(alter_entry_data,
+	                                 make_uniq<AddColumnInfo>(add_column.GetAlterEntryData(), std::move(null_column),
+	                                                          add_column.if_column_not_exists),
+	                                 column_entry.GetName(), column_entry.DefaultValue().Copy())));
 }
 
 unique_ptr<AlterInfo> PEGTransformerFactory::TransformAlterOptions(PEGTransformer &transformer,

--- a/test/sql/alter/test_alter_if_exists.test
+++ b/test/sql/alter/test_alter_if_exists.test
@@ -91,6 +91,24 @@ ALTER TABLE IF EXISTS t1 ALTER COLUMN IF EXISTS c0 TYPE varchar;
 ----
 Parser Error: syntax error at or near "EXISTS"
 
+statement ok
+CREATE TABLE t_default (c0 INT, c1 BOOLEAN);
+
+statement ok
+ALTER TABLE t_default ADD COLUMN IF NOT EXISTS c1 BOOLEAN DEFAULT false;
+
+statement ok
+ALTER TABLE t_default ADD COLUMN IF NOT EXISTS c2 BOOLEAN DEFAULT false;
+
+statement ok
+INSERT INTO t_default VALUES (1, true, true);
+
+query III
+SELECT * FROM t_default;
+----
+1	true	true
+
+
 # 'rowid' pseudo-column
 statement ok
 CREATE TABLE unit (price INTEGER, amount_sold INTEGER);


### PR DESCRIPTION
Found this issue while fixing up DuckLake to be compatible with the `main` branch.