### PR TITLE
Add small-build-side dictionary emission for hash joins

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"61301078-9fe6-4a8a-b8df-284501476946","pid":79057,"procStart":"Thu Apr 30 08:59:00 2026","acquiredAt":1777540222426}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"61301078-9fe6-4a8a-b8df-284501476946","pid":79057,"procStart":"Thu Apr 30 08:59:00 2026","acquiredAt":1777540222426}

--- a/benchmark/tpch/join/hash_join_dictionary_emission.benchmark
+++ b/benchmark/tpch/join/hash_join_dictionary_emission.benchmark
@@ -1,0 +1,23 @@
+# name: benchmark/tpch/join/hash_join_dictionary_emission.benchmark
+# description: small build side dictionary emission — emitted dictionaries are exploited by downstream operators
+# group: [join]
+
+name Hash Join Dictionary Emission
+group join
+subgroup tpch
+
+require tpch
+
+cache tpch_sf10.duckdb
+
+load
+CALL dbgen(sf=10);
+
+init
+SET threads=1;
+
+run
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n
+JOIN customer c ON hash(n.n_nationkey) = hash(c.c_nationkey)
+GROUP BY n.n_name;

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1072,23 +1072,31 @@ idx_t ScanStructure::ScanInnerJoin(DataChunk &keys, DataChunk &probe_data, Selec
 	}
 }
 
+template <bool USE_DICT_EMISSION>
+static void AdvancePointersLoop(JoinHashTable &ht, Vector &pointers, SelectionVector &out_sel,
+                                const SelectionVector &sel, const idx_t sel_count, idx_t &out_count) {
+	idx_t new_count = 0;
+	auto ptrs = FlatVector::GetDataMutable<data_ptr_t>(pointers);
+	for (idx_t i = 0; i < sel_count; i++) {
+		auto idx = sel.get_index(i);
+		ptrs[idx] = ht.GetNextPointer<USE_DICT_EMISSION>(ptrs[idx]);
+		if (ptrs[idx]) {
+			out_sel.set_index(new_count++, idx);
+		}
+	}
+	out_count = new_count;
+}
+
 void ScanStructure::AdvancePointers(const SelectionVector &sel, const idx_t sel_count) {
 	if (!ht.chains_longer_than_one) {
 		this->count = 0;
 		return;
 	}
-
-	// now for all the pointers, we move on to the next set of pointers
-	idx_t new_count = 0;
-	auto ptrs = FlatVector::GetDataMutable<data_ptr_t>(this->pointers);
-	for (idx_t i = 0; i < sel_count; i++) {
-		auto idx = sel.get_index(i);
-		ptrs[idx] = LoadPointer(ptrs[idx] + ht.pointer_offset);
-		if (ptrs[idx]) {
-			this->sel_vector.set_index(new_count++, idx);
-		}
+	if (ht.use_dict_emission) {
+		AdvancePointersLoop<true>(ht, pointers, sel_vector, sel, sel_count, count);
+	} else {
+		AdvancePointersLoop<false>(ht, pointers, sel_vector, sel, sel_count, count);
 	}
-	this->count = new_count;
 }
 
 void ScanStructure::AdvancePointers() {
@@ -1170,12 +1178,18 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 					result.SetCardinality(result_count);
 
 					// on the RHS, we need to fetch the data from the hash table
-					for (idx_t i = 0; i < ht.output_columns.size(); i++) {
-						auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
-						const auto output_col_idx = ht.output_columns[i];
-						D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
-						GatherResult(vector, chain_match_sel_vector, result_count, output_col_idx);
-						FlatVector::SetSize(vector, count_t(result_count));
+					if (ht.use_dict_emission) {
+						auto ptrs = FlatVector::GetData<data_ptr_t>(pointers);
+						ht.EmitDictVectors(ptrs, chain_match_sel_vector, result_count, result,
+						                   ht.lhs_output_in_probe.size());
+					} else {
+						for (idx_t i = 0; i < ht.output_columns.size(); i++) {
+							auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
+							const auto output_col_idx = ht.output_columns[i];
+							D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
+							GatherResult(vector, chain_match_sel_vector, result_count, output_col_idx);
+							FlatVector::SetSize(vector, count_t(result_count));
+						}
 					}
 
 					AdvancePointers();
@@ -1199,12 +1213,17 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 		result.SetCardinality(base_count);
 
 		// 2) gather RHS vectors
-		for (idx_t i = 0; i < ht.output_columns.size(); i++) {
-			auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
-			const auto output_col_idx = ht.output_columns[i];
-			D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
-			GatherResult(vector, base_count, output_col_idx);
-			FlatVector::SetSize(vector, count_t(base_count));
+		if (ht.use_dict_emission) {
+			auto rhs_ptrs = FlatVector::GetData<data_ptr_t>(rhs_pointers);
+			ht.EmitDictVectors(rhs_ptrs, base_count, result, ht.lhs_output_in_probe.size());
+		} else {
+			for (idx_t i = 0; i < ht.output_columns.size(); i++) {
+				auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
+				const auto output_col_idx = ht.output_columns[i];
+				D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
+				GatherResult(vector, base_count, output_col_idx);
+				FlatVector::SetSize(vector, count_t(base_count));
+			}
 		}
 	}
 }
@@ -1277,6 +1296,32 @@ void ScanStructure::NextAntiJoin(DataChunk &keys, DataChunk &probe_data, DataChu
 	finished = true;
 }
 
+template <bool USE_DICT_EMISSION>
+static void MarkChainsAsFoundLoop(JoinHashTable &ht, data_ptr_t ptrs[], const SelectionVector &chain_match_sel_vector,
+                                  const idx_t result_count, const data_ptr_t dead_end_ptr) {
+	for (idx_t i = 0; i < result_count; i++) {
+		const auto idx = chain_match_sel_vector.get_index(i);
+		auto &ptr = ptrs[idx];
+		if (Load<bool>(ptr + ht.tuple_size)) { // Early out: chain has been fully marked as found before
+			ptr = dead_end_ptr;
+			continue;
+		}
+
+		// Fully mark chain as found
+		while (true) {
+			// NOTE: threadsan reports this as a data race because this can be set concurrently by separate
+			// threads Technically it is, but it does not matter, since the only value that can be written is
+			// "true"
+			Store<bool>(true, ptr + ht.tuple_size);
+			auto next_ptr = ht.GetNextPointer<USE_DICT_EMISSION>(ptr);
+			if (!next_ptr) {
+				break;
+			}
+			ptr = next_ptr;
+		}
+	}
+}
+
 void ScanStructure::NextRightSemiOrAntiJoin(DataChunk &keys, DataChunk &probe_data) {
 	const auto ptrs = FlatVector::GetDataMutable<data_ptr_t>(pointers);
 	while (!PointersExhausted()) {
@@ -1285,26 +1330,11 @@ void ScanStructure::NextRightSemiOrAntiJoin(DataChunk &keys, DataChunk &probe_da
 
 		if (ht.non_equality_predicates.empty() && !ht.residual_predicate) {
 			// we only have equality predicates - the match is found for the entire chain
-			for (idx_t i = 0; i < result_count; i++) {
-				const auto idx = chain_match_sel_vector.get_index(i);
-				auto &ptr = ptrs[idx];
-				if (Load<bool>(ptr + ht.tuple_size)) { // Early out: chain has been fully marked as found before
-					ptr = ht.dead_end.get();
-					continue;
-				}
-
-				// Fully mark chain as found
-				while (true) {
-					// NOTE: threadsan reports this as a data race because this can be set concurrently by separate
-					// threads Technically it is, but it does not matter, since the only value that can be written is
-					// "true"
-					Store<bool>(true, ptr + ht.tuple_size);
-					auto next_ptr = LoadPointer(ptr + ht.pointer_offset);
-					if (!next_ptr) {
-						break;
-					}
-					ptr = next_ptr;
-				}
+			const auto dead_end_ptr = ht.dead_end.get();
+			if (ht.use_dict_emission) {
+				MarkChainsAsFoundLoop<true>(ht, ptrs, chain_match_sel_vector, result_count, dead_end_ptr);
+			} else {
+				MarkChainsAsFoundLoop<false>(ht, ptrs, chain_match_sel_vector, result_count, dead_end_ptr);
 			}
 		} else {
 			// we have non-equality predicates - we need to evaluate the join condition for every row
@@ -1656,12 +1686,17 @@ void JoinHashTable::ScanFullOuter(JoinHTScanState &state, Vector &addresses, Dat
 	}
 
 	// gather the values from the RHS
-	for (idx_t i = 0; i < output_columns.size(); i++) {
-		auto &vector = result.data[left_column_count + i];
-		const auto output_col_idx = output_columns[i];
-		D_ASSERT(vector.GetType() == layout_ptr->GetTypes()[output_col_idx]);
-		data_collection->Gather(addresses, sel_vector, found_entries, output_col_idx, vector, sel_vector, nullptr);
-		FlatVector::SetSize(vector, count_t(found_entries));
+	if (use_dict_emission && found_entries > 0) {
+		auto key_locs = FlatVector::GetData<data_ptr_t>(addresses);
+		EmitDictVectors(key_locs, found_entries, result, left_column_count);
+	} else {
+		for (idx_t i = 0; i < output_columns.size(); i++) {
+			auto &vector = result.data[left_column_count + i];
+			const auto output_col_idx = output_columns[i];
+			D_ASSERT(vector.GetType() == layout_ptr->GetTypes()[output_col_idx]);
+			data_collection->Gather(addresses, sel_vector, found_entries, output_col_idx, vector, sel_vector, nullptr);
+			FlatVector::SetSize(vector, count_t(found_entries));
+		}
 	}
 }
 
@@ -1992,6 +2027,128 @@ void ProbeSpill::PrepareNextProbe() {
 	}
 	consumer = make_uniq<ColumnDataConsumer>(*global_spill_collection, column_ids);
 	consumer->InitializeScan();
+}
+
+//===--------------------------------------------------------------------===//
+// Small Build Side Dictionary Emission
+//===--------------------------------------------------------------------===//
+idx_t JoinHashTable::ComputeBuildPayloadBytes(const vector<LogicalType> &rhs_output_types) const {
+	idx_t payload_bytes_per_row = 0;
+	for (const auto &type : rhs_output_types) {
+		payload_bytes_per_row += GetTypeIdSize(type.InternalType());
+	}
+	return Count() * payload_bytes_per_row;
+}
+
+bool JoinHashTable::CanUseDictionaryEmission(const PhysicalHashJoin &op, bool external, idx_t probe_cardinality) const {
+	// external joins rebuild partitions, invalidating row pointers
+	if (external) {
+		return false;
+	}
+	// SINGLE joins need FlatVector::SetNull for unmatched rows; dictionary vectors cannot supply it
+	if (join_type == JoinType::SINGLE) {
+		return false;
+	}
+	if (op.rhs_output_columns.col_types.empty()) {
+		return false;
+	}
+	if (Count() == 0) {
+		return false;
+	}
+	if (probe_cardinality < DictionaryEmissionActivation::MIN_PROBE_ROWS) {
+		return false;
+	}
+	if (probe_cardinality < DictionaryEmissionActivation::PROBE_BUILD_RATIO * Count()) {
+		return false;
+	}
+	// Vector::Dictionary does not support nested types
+	for (const auto &type : op.rhs_output_columns.col_types) {
+		switch (type.InternalType()) {
+		case PhysicalType::STRUCT:
+		case PhysicalType::LIST:
+		case PhysicalType::ARRAY:
+			return false;
+		default:
+			break;
+		}
+	}
+	if (ComputeBuildPayloadBytes(op.rhs_output_columns.col_types) >
+	    DictionaryEmissionActivation::MAX_BUILD_PAYLOAD_BYTES) {
+		return false;
+	}
+	// Count() fits in the uint32_t dict index stored into NEXT_PTR by BuildDictionaryArrays
+	D_ASSERT(Count() <= NumericLimits<uint32_t>::Maximum());
+	return true;
+}
+
+void JoinHashTable::EmitDictVectors(const data_ptr_t *row_ptrs, idx_t count, DataChunk &result,
+                                    idx_t rhs_col_offset) const {
+	D_ASSERT(output_columns.size() == dict_arrays.size());
+	SelectionVector build_sel_vec(count);
+	for (idx_t i = 0; i < count; i++) {
+		build_sel_vec.set_index(i, Load<uint32_t>(row_ptrs[i] + pointer_offset));
+	}
+	for (idx_t col_idx = 0; col_idx < output_columns.size(); col_idx++) {
+		auto &vector = result.data[rhs_col_offset + col_idx];
+		vector.Dictionary(dict_arrays[col_idx], build_sel_vec, count);
+	}
+}
+
+void JoinHashTable::EmitDictVectors(const data_ptr_t *row_ptrs, const SelectionVector &ptr_sel, idx_t count,
+                                    DataChunk &result, idx_t rhs_col_offset) const {
+	D_ASSERT(output_columns.size() == dict_arrays.size());
+	SelectionVector build_sel_vec(count);
+	for (idx_t i = 0; i < count; i++) {
+		const auto idx = ptr_sel.get_index(i);
+		build_sel_vec.set_index(i, Load<uint32_t>(row_ptrs[idx] + pointer_offset));
+	}
+	for (idx_t col_idx = 0; col_idx < output_columns.size(); col_idx++) {
+		auto &vector = result.data[rhs_col_offset + col_idx];
+		vector.Dictionary(dict_arrays[col_idx], build_sel_vec, count);
+	}
+}
+
+void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
+	auto &collection = *data_collection;
+	const auto build_count = collection.Count();
+	// preconditions enforced by CanUseDictionaryEmission
+	D_ASSERT(build_count > 0);
+	// dict index is a uint32_t; assert defensively if MAX_BUILD_PAYLOAD_BYTES is ever relaxed
+	D_ASSERT(build_count <= NumericLimits<uint32_t>::Maximum());
+
+	// collect a row pointer per build row; the TDC holds its own BufferHandles for its lifetime,
+	// and FinishEvent has already verified everything is pinned before calling us
+	Vector row_pointer_vector(LogicalType::POINTER, build_count);
+	JoinHTScanState scan_state(collection, 0, collection.ChunkCount(), TupleDataPinProperties::KEEP_EVERYTHING_PINNED);
+	const auto collected = FillWithHTOffsets(scan_state, row_pointer_vector);
+	D_ASSERT(collected == build_count);
+	(void)collected;
+	const auto row_ptrs = FlatVector::GetData<data_ptr_t>(row_pointer_vector);
+
+	// gather RHS output columns into columnar dictionary arrays
+	const auto &sel = *FlatVector::IncrementalSelectionVector();
+	for (idx_t col_idx = 0; col_idx < op.rhs_output_columns.col_types.size(); col_idx++) {
+		const auto &type = op.rhs_output_columns.col_types[col_idx];
+		auto dict_entry = DictionaryVector::CreateReusableDictionary(type, build_count);
+		const auto output_col_idx = output_columns[col_idx];
+		collection.Gather(row_pointer_vector, sel, build_count, output_col_idx, dict_entry->data, sel, nullptr);
+		dict_arrays.emplace_back(std::move(dict_entry));
+	}
+
+	// save chain pointers before overwriting NEXT_PTR; GetNextPointer reads them back
+	if (chains_longer_than_one) {
+		aux_next_ptrs.resize(build_count);
+		for (idx_t i = 0; i < build_count; i++) {
+			aux_next_ptrs[i] = LoadPointer(row_ptrs[i] + pointer_offset);
+		}
+	}
+
+	// embed the dict index into NEXT_PTR; GetNextPointer now resolves chains via aux_next_ptrs
+	for (idx_t i = 0; i < build_count; i++) {
+		Store<uint32_t>(static_cast<uint32_t>(i), row_ptrs[i] + pointer_offset);
+	}
+
+	use_dict_emission = true;
 }
 
 } // namespace duckdb

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -2043,6 +2043,7 @@ struct DictionaryEmissionActivation {
 };
 
 idx_t JoinHashTable::ComputeBuildPayloadBytes(const vector<LogicalType> &rhs_output_types) const {
+	// the size of variable-size strings isn't counted here because they are already stored in the TupleDataCollection
 	idx_t payload_bytes_per_row = 0;
 	for (const auto &type : rhs_output_types) {
 		payload_bytes_per_row += GetTypeIdSize(type.InternalType());

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1118,19 +1118,19 @@ void ScanStructure::GatherResult(Vector &result, const idx_t count, const idx_t 
 	                           *FlatVector::IncrementalSelectionVector(), nullptr);
 }
 
-void ScanStructure::GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result) {
-	const auto rhs_col_offset = ht.lhs_output_in_probe.size();
-	if (ht.use_dict_emission) {
+void JoinHashTable::GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result,
+                              idx_t rhs_col_offset) const {
+	if (use_dict_emission) {
 		const auto ptrs = FlatVector::GetData<data_ptr_t>(row_ptrs);
-		ht.EmitDictVectors(ptrs, ptr_sel, count, result, rhs_col_offset);
+		EmitDictVectors(ptrs, ptr_sel, count, result, rhs_col_offset);
 		return;
 	}
 	const auto &result_sel = *FlatVector::IncrementalSelectionVector();
-	for (idx_t col_idx = 0; col_idx < ht.output_columns.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < output_columns.size(); col_idx++) {
 		auto &vector = result.data[rhs_col_offset + col_idx];
-		const auto output_col_idx = ht.output_columns[col_idx];
-		D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
-		ht.data_collection->Gather(row_ptrs, ptr_sel, count, output_col_idx, vector, result_sel, nullptr);
+		const auto output_col_idx = output_columns[col_idx];
+		D_ASSERT(vector.GetType() == layout_ptr->GetTypes()[output_col_idx]);
+		data_collection->Gather(row_ptrs, ptr_sel, count, output_col_idx, vector, result_sel, nullptr);
 		FlatVector::SetSize(vector, count_t(count));
 	}
 }
@@ -1195,7 +1195,7 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 					result.SetCardinality(result_count);
 
 					// on the RHS, we need to fetch the data from the hash table
-					GatherRHS(pointers, chain_match_sel_vector, result_count, result);
+					ht.GatherRHS(pointers, chain_match_sel_vector, result_count, result, ht.lhs_output_in_probe.size());
 
 					AdvancePointers();
 					return;
@@ -1218,7 +1218,8 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 		result.SetCardinality(base_count);
 
 		// 2) gather RHS vectors
-		GatherRHS(rhs_pointers, *FlatVector::IncrementalSelectionVector(), base_count, result);
+		ht.GatherRHS(rhs_pointers, *FlatVector::IncrementalSelectionVector(), base_count, result,
+		             ht.lhs_output_in_probe.size());
 	}
 }
 
@@ -1680,18 +1681,7 @@ void JoinHashTable::ScanFullOuter(JoinHTScanState &state, Vector &addresses, Dat
 	}
 
 	// gather the values from the RHS
-	if (use_dict_emission && found_entries > 0) {
-		auto key_locs = FlatVector::GetData<data_ptr_t>(addresses);
-		EmitDictVectors(key_locs, sel_vector, found_entries, result, left_column_count);
-	} else {
-		for (idx_t i = 0; i < output_columns.size(); i++) {
-			auto &vector = result.data[left_column_count + i];
-			const auto output_col_idx = output_columns[i];
-			D_ASSERT(vector.GetType() == layout_ptr->GetTypes()[output_col_idx]);
-			data_collection->Gather(addresses, sel_vector, found_entries, output_col_idx, vector, sel_vector, nullptr);
-			FlatVector::SetSize(vector, count_t(found_entries));
-		}
-	}
+	GatherRHS(addresses, sel_vector, found_entries, result, left_column_count);
 }
 
 idx_t JoinHashTable::FillWithHTOffsets(JoinHTScanState &state, Vector &addresses) {

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -2032,6 +2032,16 @@ void ProbeSpill::PrepareNextProbe() {
 //===--------------------------------------------------------------------===//
 // Small Build Side Dictionary Emission
 //===--------------------------------------------------------------------===//
+//! Threshold constants gating small-build-side dictionary emission
+struct DictionaryEmissionActivation {
+	//! Caps the dict_arrays allocation; 8 MiB keeps them in L3 and bounds aux_next_ptrs
+	static constexpr idx_t MAX_BUILD_PAYLOAD_BYTES = 8ULL * 1024ULL * 1024ULL;
+	//! Below this, dictionary-emission setup is not amortized by probe-side savings
+	static constexpr idx_t MIN_PROBE_ROWS = 262144;
+	//! Below this ratio, per-row savings are unlikely to amortize the setup cost
+	static constexpr idx_t PROBE_BUILD_RATIO = 100;
+};
+
 idx_t JoinHashTable::ComputeBuildPayloadBytes(const vector<LogicalType> &rhs_output_types) const {
 	idx_t payload_bytes_per_row = 0;
 	for (const auto &type : rhs_output_types) {
@@ -2137,9 +2147,10 @@ void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
 
 	// save chain pointers before overwriting NEXT_PTR; GetNextPointer reads them back
 	if (chains_longer_than_one) {
-		aux_next_ptrs.resize(build_count);
+		aux_next_ptrs = buffer_manager.GetBufferAllocator().Allocate(build_count * sizeof(data_ptr_t));
+		aux_next_ptrs_data = reinterpret_cast<data_ptr_t *>(aux_next_ptrs.get());
 		for (idx_t i = 0; i < build_count; i++) {
-			aux_next_ptrs[i] = LoadPointer(row_ptrs[i] + pointer_offset);
+			aux_next_ptrs_data[i] = LoadPointer(row_ptrs[i] + pointer_offset);
 		}
 	}
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1118,6 +1118,23 @@ void ScanStructure::GatherResult(Vector &result, const idx_t count, const idx_t 
 	                           *FlatVector::IncrementalSelectionVector(), nullptr);
 }
 
+void ScanStructure::GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result) {
+	const auto rhs_col_offset = ht.lhs_output_in_probe.size();
+	if (ht.use_dict_emission) {
+		const auto ptrs = FlatVector::GetData<data_ptr_t>(row_ptrs);
+		ht.EmitDictVectors(ptrs, ptr_sel, count, result, rhs_col_offset);
+		return;
+	}
+	const auto &result_sel = *FlatVector::IncrementalSelectionVector();
+	for (idx_t col_idx = 0; col_idx < ht.output_columns.size(); col_idx++) {
+		auto &vector = result.data[rhs_col_offset + col_idx];
+		const auto output_col_idx = ht.output_columns[col_idx];
+		D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
+		ht.data_collection->Gather(row_ptrs, ptr_sel, count, output_col_idx, vector, result_sel, nullptr);
+		FlatVector::SetSize(vector, count_t(count));
+	}
+}
+
 void ScanStructure::UpdateCompactionBuffer(idx_t base_count, SelectionVector &result_vector, idx_t result_count) {
 	// matches were found
 	// record the result
@@ -1178,19 +1195,7 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 					result.SetCardinality(result_count);
 
 					// on the RHS, we need to fetch the data from the hash table
-					if (ht.use_dict_emission) {
-						auto ptrs = FlatVector::GetData<data_ptr_t>(pointers);
-						ht.EmitDictVectors(ptrs, chain_match_sel_vector, result_count, result,
-						                   ht.lhs_output_in_probe.size());
-					} else {
-						for (idx_t i = 0; i < ht.output_columns.size(); i++) {
-							auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
-							const auto output_col_idx = ht.output_columns[i];
-							D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
-							GatherResult(vector, chain_match_sel_vector, result_count, output_col_idx);
-							FlatVector::SetSize(vector, count_t(result_count));
-						}
-					}
+					GatherRHS(pointers, chain_match_sel_vector, result_count, result);
 
 					AdvancePointers();
 					return;
@@ -1213,18 +1218,7 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 		result.SetCardinality(base_count);
 
 		// 2) gather RHS vectors
-		if (ht.use_dict_emission) {
-			auto rhs_ptrs = FlatVector::GetData<data_ptr_t>(rhs_pointers);
-			ht.EmitDictVectors(rhs_ptrs, base_count, result, ht.lhs_output_in_probe.size());
-		} else {
-			for (idx_t i = 0; i < ht.output_columns.size(); i++) {
-				auto &vector = result.data[ht.lhs_output_in_probe.size() + i];
-				const auto output_col_idx = ht.output_columns[i];
-				D_ASSERT(vector.GetType() == ht.layout_ptr->GetTypes()[output_col_idx]);
-				GatherResult(vector, base_count, output_col_idx);
-				FlatVector::SetSize(vector, count_t(base_count));
-			}
-		}
+		GatherRHS(rhs_pointers, *FlatVector::IncrementalSelectionVector(), base_count, result);
 	}
 }
 
@@ -1688,7 +1682,7 @@ void JoinHashTable::ScanFullOuter(JoinHTScanState &state, Vector &addresses, Dat
 	// gather the values from the RHS
 	if (use_dict_emission && found_entries > 0) {
 		auto key_locs = FlatVector::GetData<data_ptr_t>(addresses);
-		EmitDictVectors(key_locs, found_entries, result, left_column_count);
+		EmitDictVectors(key_locs, sel_vector, found_entries, result, left_column_count);
 	} else {
 		for (idx_t i = 0; i < output_columns.size(); i++) {
 			auto &vector = result.data[left_column_count + i];
@@ -2092,19 +2086,6 @@ bool JoinHashTable::CanUseDictionaryEmission(const PhysicalHashJoin &op, bool ex
 	return true;
 }
 
-void JoinHashTable::EmitDictVectors(const data_ptr_t *row_ptrs, idx_t count, DataChunk &result,
-                                    idx_t rhs_col_offset) const {
-	D_ASSERT(output_columns.size() == dict_arrays.size());
-	SelectionVector build_sel_vec(count);
-	for (idx_t i = 0; i < count; i++) {
-		build_sel_vec.set_index(i, Load<uint32_t>(row_ptrs[i] + pointer_offset));
-	}
-	for (idx_t col_idx = 0; col_idx < output_columns.size(); col_idx++) {
-		auto &vector = result.data[rhs_col_offset + col_idx];
-		vector.Dictionary(dict_arrays[col_idx], build_sel_vec, count);
-	}
-}
-
 void JoinHashTable::EmitDictVectors(const data_ptr_t *row_ptrs, const SelectionVector &ptr_sel, idx_t count,
                                     DataChunk &result, idx_t rhs_col_offset) const {
 	D_ASSERT(output_columns.size() == dict_arrays.size());
@@ -2150,14 +2131,15 @@ void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
 	if (chains_longer_than_one) {
 		aux_next_ptrs = buffer_manager.GetBufferAllocator().Allocate(build_count * sizeof(data_ptr_t));
 		aux_next_ptrs_data = reinterpret_cast<data_ptr_t *>(aux_next_ptrs.get());
-		for (idx_t i = 0; i < build_count; i++) {
-			aux_next_ptrs_data[i] = LoadPointer(row_ptrs[i] + pointer_offset);
-		}
 	}
 
-	// embed the dict index into NEXT_PTR; GetNextPointer now resolves chains via aux_next_ptrs
+	// save the original NEXT_PTR into aux_next_ptrs (if chains exist) and embed the dict index
 	for (idx_t i = 0; i < build_count; i++) {
-		Store<uint32_t>(static_cast<uint32_t>(i), row_ptrs[i] + pointer_offset);
+		const auto next_ptr_location = row_ptrs[i] + pointer_offset;
+		if (chains_longer_than_one) {
+			aux_next_ptrs_data[i] = LoadPointer(next_ptr_location);
+		}
+		Store<uint32_t>(static_cast<uint32_t>(i), next_ptr_location);
 	}
 
 	use_dict_emission = true;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -754,6 +754,13 @@ public:
 			sink.hash_table->MergePrefixRangeBuildState(*prefix_range_state);
 		}
 		sink.hash_table->GetDataCollection().VerifyEverythingPinned();
+
+		// chains are final; materialize dict_arrays and overwrite NEXT_PTR with the dict index
+		if (sink.hash_table->CanUseDictionaryEmission(sink.op, sink.external,
+		                                              sink.op.children[0].get().estimated_cardinality)) {
+			sink.hash_table->BuildDictionaryArrays(sink.op);
+		}
+
 		sink.hash_table->finalized = true;
 	}
 

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -161,10 +161,6 @@ public:
 		                  const idx_t count, const idx_t col_idx);
 		void GatherResult(Vector &result, const SelectionVector &sel_vector, const idx_t count, const idx_t col_idx);
 		void GatherResult(Vector &result, const idx_t count, const idx_t col_idx);
-		//! Gather the RHS output columns for the matched rows in row_ptrs[ptr_sel[0..count)] into result.
-		//! When use_dict_emission is active, emits dictionary vectors via EmitDictVectors; otherwise
-		//! gathers each output column individually from the TupleDataCollection.
-		void GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result);
 		idx_t ResolvePredicates(DataChunk &keys, DataChunk &probe_data, SelectionVector &match_sel,
 		                        SelectionVector *no_match_sel);
 	};
@@ -238,6 +234,10 @@ public:
 	//! *FlatVector::IncrementalSelectionVector() when row_ptrs is already compacted
 	void EmitDictVectors(const data_ptr_t *row_ptrs, const SelectionVector &ptr_sel, idx_t count, DataChunk &result,
 	                     idx_t rhs_col_offset) const;
+	//! Emit RHS output columns for matched rows row_ptrs[ptr_sel[0..count)] into result starting at
+	//! result column rhs_col_offset; routes through EmitDictVectors when use_dict_emission is active.
+	void GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result,
+	               idx_t rhs_col_offset) const;
 	//! Follow the chain pointer; when USE_DICT_EMISSION, resolves via aux_next_ptrs
 	template <bool USE_DICT_EMISSION>
 	inline data_ptr_t GetNextPointer(data_ptr_t row_ptr) const {

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -161,6 +161,10 @@ public:
 		                  const idx_t count, const idx_t col_idx);
 		void GatherResult(Vector &result, const SelectionVector &sel_vector, const idx_t count, const idx_t col_idx);
 		void GatherResult(Vector &result, const idx_t count, const idx_t col_idx);
+		//! Gather the RHS output columns for the matched rows in row_ptrs[ptr_sel[0..count)] into result.
+		//! When use_dict_emission is active, emits dictionary vectors via EmitDictVectors; otherwise
+		//! gathers each output column individually from the TupleDataCollection.
+		void GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, const idx_t count, DataChunk &result);
 		idx_t ResolvePredicates(DataChunk &keys, DataChunk &probe_data, SelectionVector &match_sel,
 		                        SelectionVector *no_match_sel);
 	};
@@ -230,9 +234,8 @@ public:
 	//! Pre-materialize RHS output columns into dict_arrays and embed the dict index into NEXT_PTR;
 	//! called once from HashJoinFinalizeEvent::FinishEvent, after all finalize tasks have completed.
 	void BuildDictionaryArrays(const PhysicalHashJoin &op);
-	//! Emit dictionary vectors for row_ptrs[0..count)
-	void EmitDictVectors(const data_ptr_t *row_ptrs, idx_t count, DataChunk &result, idx_t rhs_col_offset) const;
-	//! Emit dictionary vectors for row_ptrs[ptr_sel[0..count)]
+	//! Emit dictionary vectors for row_ptrs[ptr_sel[0..count)]; pass
+	//! *FlatVector::IncrementalSelectionVector() when row_ptrs is already compacted
 	void EmitDictVectors(const data_ptr_t *row_ptrs, const SelectionVector &ptr_sel, idx_t count, DataChunk &result,
 	                     idx_t rhs_col_offset) const;
 	//! Follow the chain pointer; when USE_DICT_EMISSION, resolves via aux_next_ptrs

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -30,6 +30,7 @@ class ColumnDataCollection;
 struct ColumnDataAppendState;
 struct ClientConfig;
 struct ResidualPredicateInfo;
+class PhysicalHashJoin;
 
 struct JoinHTScanState {
 public:
@@ -44,6 +45,16 @@ public:
 private:
 	//! Implicit copying is not allowed
 	JoinHTScanState(const JoinHTScanState &) = delete;
+};
+
+//! Threshold constants gating small-build-side dictionary emission
+struct DictionaryEmissionActivation {
+	//! Caps the dict_arrays allocation; 8 MiB keeps them in L3 and bounds aux_next_ptrs
+	static constexpr idx_t MAX_BUILD_PAYLOAD_BYTES = 8ULL * 1024ULL * 1024ULL;
+	//! Below this, dictionary-emission setup is not amortized by probe-side savings
+	static constexpr idx_t MIN_PROBE_ROWS = 262144;
+	//! Below this ratio, per-row savings are unlikely to amortize the setup cost
+	static constexpr idx_t PROBE_BUILD_RATIO = 100;
 };
 
 //! JoinHashTable is a linear probing HT that is used for computing joins
@@ -226,6 +237,27 @@ public:
 	//! Fill the pointer with all the addresses from the hashtable for full scan
 	static idx_t FillWithHTOffsets(JoinHTScanState &state, Vector &addresses);
 
+	//! Pre-materialize RHS output columns into dict_arrays and embed the dict index into NEXT_PTR;
+	//! called once from HashJoinFinalizeEvent::FinishEvent, after all finalize tasks have completed.
+	void BuildDictionaryArrays(const PhysicalHashJoin &op);
+	//! Emit dictionary vectors for row_ptrs[0..count)
+	void EmitDictVectors(const data_ptr_t *row_ptrs, idx_t count, DataChunk &result, idx_t rhs_col_offset) const;
+	//! Emit dictionary vectors for row_ptrs[ptr_sel[0..count)]
+	void EmitDictVectors(const data_ptr_t *row_ptrs, const SelectionVector &ptr_sel, idx_t count, DataChunk &result,
+	                     idx_t rhs_col_offset) const;
+	//! Follow the chain pointer; when USE_DICT_EMISSION, resolves via aux_next_ptrs
+	template <bool USE_DICT_EMISSION>
+	inline data_ptr_t GetNextPointer(data_ptr_t row_ptr) const {
+		if (USE_DICT_EMISSION) {
+			if (!chains_longer_than_one) {
+				// aux_next_ptrs is empty in this case
+				return nullptr;
+			}
+			return aux_next_ptrs[Load<uint32_t>(row_ptr + pointer_offset)];
+		}
+		return cast_uint64_to_pointer(Load<uint64_t>(row_ptr + pointer_offset));
+	}
+
 	idx_t Count() const {
 		return data_collection->Count();
 	}
@@ -317,6 +349,18 @@ public:
 	unique_ptr<ResidualPredicateInfo> residual_info;
 	//! Mapping from lhs_output_columns positions to lhs_probe_data positions
 	vector<idx_t> lhs_output_in_probe;
+
+	//! True once BuildDictionaryArrays has embedded dictionary indices into NEXT_PTR
+	bool use_dict_emission = false;
+	//! Pre-materialized columnar data, one entry per RHS output column
+	vector<buffer_ptr<DictionaryEntry>> dict_arrays;
+	//! Saved NEXT_PTR values, indexed by dict index; only populated when chains_longer_than_one
+	vector<data_ptr_t> aux_next_ptrs;
+
+	//! Total bytes the dict_arrays allocation would cost for the given RHS output types
+	idx_t ComputeBuildPayloadBytes(const vector<LogicalType> &rhs_output_types) const;
+	//! Returns true iff small-build-side dictionary emission should activate
+	bool CanUseDictionaryEmission(const PhysicalHashJoin &op, bool external, idx_t probe_cardinality) const;
 
 	struct {
 		mutex mj_lock;

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -47,16 +47,6 @@ private:
 	JoinHTScanState(const JoinHTScanState &) = delete;
 };
 
-//! Threshold constants gating small-build-side dictionary emission
-struct DictionaryEmissionActivation {
-	//! Caps the dict_arrays allocation; 8 MiB keeps them in L3 and bounds aux_next_ptrs
-	static constexpr idx_t MAX_BUILD_PAYLOAD_BYTES = 8ULL * 1024ULL * 1024ULL;
-	//! Below this, dictionary-emission setup is not amortized by probe-side savings
-	static constexpr idx_t MIN_PROBE_ROWS = 262144;
-	//! Below this ratio, per-row savings are unlikely to amortize the setup cost
-	static constexpr idx_t PROBE_BUILD_RATIO = 100;
-};
-
 //! JoinHashTable is a linear probing HT that is used for computing joins
 /*!
    The JoinHashTable concatenates incoming chunks inside a linked list of
@@ -250,10 +240,10 @@ public:
 	inline data_ptr_t GetNextPointer(data_ptr_t row_ptr) const {
 		if (USE_DICT_EMISSION) {
 			if (!chains_longer_than_one) {
-				// aux_next_ptrs is empty in this case
+				// aux_next_ptrs is unallocated in this case
 				return nullptr;
 			}
-			return aux_next_ptrs[Load<uint32_t>(row_ptr + pointer_offset)];
+			return aux_next_ptrs_data[Load<uint32_t>(row_ptr + pointer_offset)];
 		}
 		return cast_uint64_to_pointer(Load<uint64_t>(row_ptr + pointer_offset));
 	}
@@ -354,8 +344,10 @@ public:
 	bool use_dict_emission = false;
 	//! Pre-materialized columnar data, one entry per RHS output column
 	vector<buffer_ptr<DictionaryEntry>> dict_arrays;
-	//! Saved NEXT_PTR values, indexed by dict index; only populated when chains_longer_than_one
-	vector<data_ptr_t> aux_next_ptrs;
+	//! Saved NEXT_PTR values, indexed by dict index; only allocated when chains_longer_than_one
+	AllocatedData aux_next_ptrs;
+	//! Typed pointer into aux_next_ptrs; set by BuildDictionaryArrays alongside the allocation
+	data_ptr_t *aux_next_ptrs_data = nullptr;
 
 	//! Total bytes the dict_arrays allocation would cost for the given RHS output types
 	idx_t ComputeBuildPayloadBytes(const vector<LogicalType> &rhs_output_types) const;

--- a/test/sql/join/hash_join/hash_join_dictionary_emission.test_slow
+++ b/test/sql/join/hash_join/hash_join_dictionary_emission.test_slow
@@ -1,0 +1,719 @@
+# name: test/sql/join/hash_join/hash_join_dictionary_emission.test_slow
+# description: Test hash join with dictionary emission on small build sides
+# group: [hash_join]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA verify_parallelism
+
+# shared probe table: 262200 rows, just above the min-probe-rows threshold
+statement ok
+CREATE TABLE big_probe AS
+SELECT i AS id,
+       ('K' || (((i % 10) + 1)::VARCHAR)) AS k,
+       ((i % 10) + 1) AS bucket,
+       ((i % 7))     AS extra
+FROM range(262200) t(i);
+
+query I
+SELECT COUNT(*) FROM big_probe;
+----
+262200
+
+query I
+SELECT COUNT(DISTINCT k) FROM big_probe;
+----
+10
+
+# activation path: all conditions met, dictionary emission activates
+
+# unique VARCHAR build with downstream GROUP BY
+statement ok
+CREATE TABLE small_build (k VARCHAR, name VARCHAR);
+
+statement ok
+INSERT INTO small_build VALUES
+    ('K1',  'one'),
+    ('K2',  'two'),
+    ('K3',  'three'),
+    ('K4',  'four'),
+    ('K5',  'five'),
+    ('K6',  'six'),
+    ('K7',  'seven'),
+    ('K8',  'eight'),
+    ('K9',  'nine'),
+    ('K10', 'ten');
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN small_build b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# downstream GROUP BY with MAX aggregation
+query II
+SELECT b.name, MAX(p.id) AS max_id
+FROM big_probe p JOIN small_build b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	262197
+five	262194
+four	262193
+nine	262198
+one	262190
+seven	262196
+six	262195
+ten	262199
+three	262192
+two	262191
+
+# duplicate build keys at varying chain lengths
+statement ok
+CREATE TABLE build_dup (k VARCHAR, name VARCHAR);
+
+statement ok
+INSERT INTO build_dup VALUES
+    ('K1', 'one-a'),
+    ('K1', 'one-b'),
+    ('K2', 'two'),
+    ('K3', 'three-a'),
+    ('K3', 'three-b'),
+    ('K3', 'three-c'),
+    ('K4', 'four'),
+    ('K5', 'five'),
+    ('K6', 'six'),
+    ('K7', 'seven'),
+    ('K8', 'eight'),
+    ('K9', 'nine'),
+    ('K10', 'ten');
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN build_dup b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one-a	26220
+one-b	26220
+seven	26220
+six	26220
+ten	26220
+three-a	26220
+three-b	26220
+three-c	26220
+two	26220
+
+# LEFT JOIN with unmatched probe rows
+statement ok
+CREATE TABLE big_probe_with_misses AS
+SELECT id, k FROM big_probe
+UNION ALL
+SELECT 1000000 + i, 'KX' FROM range(5) t(i);
+
+query II
+SELECT COALESCE(b.name, 'NO_MATCH') AS name, COUNT(*) AS cnt
+FROM big_probe_with_misses p LEFT JOIN small_build b ON p.k = b.k
+GROUP BY COALESCE(b.name, 'NO_MATCH')
+ORDER BY name;
+----
+NO_MATCH	5
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# RIGHT JOIN with orphan build rows
+statement ok
+CREATE TABLE build_with_orphan (k VARCHAR, name VARCHAR);
+
+statement ok
+INSERT INTO build_with_orphan VALUES
+    ('K1',  'one'),
+    ('K2',  'two'),
+    ('K3',  'three'),
+    ('K4',  'four'),
+    ('K5',  'five'),
+    ('K6',  'six'),
+    ('K7',  'seven'),
+    ('K8',  'eight'),
+    ('K9',  'nine'),
+    ('K10', 'ten'),
+    ('KZ',  'orphan');
+
+query II
+SELECT b.name, COUNT(p.id) AS cnt
+FROM big_probe p RIGHT JOIN build_with_orphan b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+orphan	0
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# FULL OUTER JOIN: unmatched rows on both sides
+query II
+SELECT COALESCE(b.name, 'NO_MATCH') AS name, COUNT(*) AS cnt
+FROM big_probe_with_misses p FULL OUTER JOIN build_with_orphan b ON p.k = b.k
+GROUP BY COALESCE(b.name, 'NO_MATCH')
+ORDER BY name;
+----
+NO_MATCH	5
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+orphan	1
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# SEMI JOIN with small build on the left (optimizer flips to RIGHT_SEMI)
+query II
+SELECT b.k, b.name
+FROM build_with_orphan b SEMI JOIN big_probe p ON b.k = p.k
+ORDER BY b.k;
+----
+K1	one
+K10	ten
+K2	two
+K3	three
+K4	four
+K5	five
+K6	six
+K7	seven
+K8	eight
+K9	nine
+
+# ANTI JOIN with small build on the left (optimizer flips to RIGHT_ANTI)
+query II
+SELECT b.k, b.name
+FROM build_with_orphan b ANTI JOIN big_probe p ON b.k = p.k
+ORDER BY b.k;
+----
+KZ	orphan
+
+# composite join key (VARCHAR + INTEGER)
+statement ok
+CREATE TABLE build_composite (k VARCHAR, b INTEGER, payload VARCHAR);
+
+statement ok
+INSERT INTO build_composite VALUES
+    ('K1',  0, 'p0'),
+    ('K2',  1, 'p1'),
+    ('K3',  2, 'p2'),
+    ('K4',  3, 'p3'),
+    ('K5',  4, 'p4'),
+    ('K6',  5, 'p5'),
+    ('K7',  6, 'p6'),
+    ('K8',  0, 'p7'),
+    ('K9',  1, 'p8'),
+    ('K10', 2, 'p9');
+
+query II
+SELECT b.payload, COUNT(*) AS cnt
+FROM big_probe p
+JOIN build_composite b ON p.k = b.k AND p.extra = b.b
+GROUP BY b.payload
+ORDER BY b.payload;
+----
+p0	3746
+p1	3746
+p2	3746
+p3	3746
+p4	3746
+p5	3746
+p6	3746
+p7	3746
+p8	3746
+p9	3746
+
+# multi-type payload (VARCHAR, INTEGER, DECIMAL, DATE)
+statement ok
+CREATE TABLE build_types (
+    k VARCHAR,
+    name VARCHAR,
+    qty INTEGER,
+    price DECIMAL(10, 2),
+    launch DATE
+);
+
+statement ok
+INSERT INTO build_types VALUES
+    ('K1',  'one',     10, 1.50,  DATE '2020-01-01'),
+    ('K2',  'two',     20, 2.50,  DATE '2020-02-02'),
+    ('K3',  'three',   30, 3.50,  DATE '2020-03-03'),
+    ('K4',  'four',    40, 4.50,  DATE '2020-04-04'),
+    ('K5',  'five',    50, 5.50,  DATE '2020-05-05'),
+    ('K6',  'six',     60, 6.50,  DATE '2020-06-06'),
+    ('K7',  'seven',   70, 7.50,  DATE '2020-07-07'),
+    ('K8',  'eight',   80, 8.50,  DATE '2020-08-08'),
+    ('K9',  'nine',    90, 9.50,  DATE '2020-09-09'),
+    ('K10', 'ten',    100, 10.50, DATE '2020-10-10');
+
+query IIIII
+SELECT b.name, b.qty, b.price, b.launch, COUNT(*) AS cnt
+FROM big_probe p JOIN build_types b ON p.k = b.k
+GROUP BY b.name, b.qty, b.price, b.launch
+ORDER BY b.name;
+----
+eight	80	8.50	2020-08-08	26220
+five	50	5.50	2020-05-05	26220
+four	40	4.50	2020-04-04	26220
+nine	90	9.50	2020-09-09	26220
+one	10	1.50	2020-01-01	26220
+seven	70	7.50	2020-07-07	26220
+six	60	6.50	2020-06-06	26220
+ten	100	10.50	2020-10-10	26220
+three	30	3.50	2020-03-03	26220
+two	20	2.50	2020-02-02	26220
+
+# integer key with duplicates (perfect hash join rejects duplicates)
+statement ok
+CREATE TABLE build_int_dup (bucket INTEGER, name VARCHAR);
+
+statement ok
+INSERT INTO build_int_dup VALUES
+    (1, 'one-a'), (1, 'one-b'),
+    (2, 'two'),   (3, 'three'), (4, 'four'),  (5, 'five'),
+    (6, 'six'),   (7, 'seven'), (8, 'eight'), (9, 'nine'), (10, 'ten');
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN build_int_dup b ON p.bucket = b.bucket
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one-a	26220
+one-b	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# NULL keys on the build side
+statement ok
+CREATE TABLE build_null_keys (k VARCHAR, name VARCHAR);
+
+statement ok
+INSERT INTO build_null_keys VALUES
+    ('K1',  'one'),
+    ('K2',  'two'),
+    ('K3',  'three'),
+    ('K4',  'four'),
+    ('K5',  'five'),
+    ('K6',  'six'),
+    ('K7',  'seven'),
+    ('K8',  'eight'),
+    ('K9',  'nine'),
+    ('K10', 'ten'),
+    (NULL,  'null-row-1'),
+    (NULL,  'null-row-2');
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN build_null_keys b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# NULL keys on the build side via IS NOT DISTINCT FROM
+# probe has no NULL keys, so build NULL rows still match nothing here
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN build_null_keys b ON p.k IS NOT DISTINCT FROM b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# NULL keys on both sides: IS NOT DISTINCT FROM treats NULL as equal to NULL
+statement ok
+CREATE TABLE big_probe_with_nulls AS
+SELECT id, k FROM big_probe
+UNION ALL
+SELECT 2000000 + i, NULL FROM range(5) t(i);
+
+# IS NOT DISTINCT FROM: 5 NULL probe rows match each of the 2 NULL build rows
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe_with_nulls p JOIN build_null_keys b ON p.k IS NOT DISTINCT FROM b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+null-row-1	5
+null-row-2	5
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# regular equality on the same data: NULL probe rows match nothing (NULL = NULL is FALSE)
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe_with_nulls p JOIN build_null_keys b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# NULL values in the build payload
+statement ok
+CREATE TABLE build_null_payload (k VARCHAR, name VARCHAR, score INTEGER);
+
+statement ok
+INSERT INTO build_null_payload VALUES
+    ('K1',  'one',   NULL),
+    ('K2',  NULL,    200),
+    ('K3',  'three', 300),
+    ('K4',  NULL,    NULL),
+    ('K5',  'five',  500),
+    ('K6',  'six',   600),
+    ('K7',  'seven', 700),
+    ('K8',  'eight', 800),
+    ('K9',  'nine',  900),
+    ('K10', 'ten',   1000);
+
+query IIII
+SELECT b.k, b.name, b.score, COUNT(*) AS cnt
+FROM big_probe p JOIN build_null_payload b ON p.k = b.k
+GROUP BY b.k, b.name, b.score
+ORDER BY b.k;
+----
+K1	one	NULL	26220
+K10	ten	1000	26220
+K2	NULL	200	26220
+K3	three	300	26220
+K4	NULL	NULL	26220
+K5	five	500	26220
+K6	six	600	26220
+K7	seven	700	26220
+K8	eight	800	26220
+K9	nine	900	26220
+
+# long duplicate-key chain: 500 build rows for K1
+statement ok
+CREATE TABLE build_chain (k VARCHAR, v INTEGER);
+
+statement ok
+INSERT INTO build_chain SELECT 'K1', i FROM range(500) t(i);
+
+statement ok
+INSERT INTO build_chain VALUES
+    ('K2', 2), ('K3', 3), ('K4', 4), ('K5', 5),
+    ('K6', 6), ('K7', 7), ('K8', 8), ('K9', 9), ('K10', 10);
+
+# K1: 26220 * 500 = 13110000; K2..K10: 9 * 26220 = 235980
+query I
+SELECT COUNT(*)
+FROM big_probe p JOIN build_chain b ON p.k = b.k;
+----
+13345980
+
+query II
+SELECT p.k, COUNT(*) AS cnt
+FROM big_probe p JOIN build_chain b ON p.k = b.k
+GROUP BY p.k
+ORDER BY p.k;
+----
+K1	13110000
+K10	26220
+K2	26220
+K3	26220
+K4	26220
+K5	26220
+K6	26220
+K7	26220
+K8	26220
+K9	26220
+
+# long chain through SEMI JOIN
+query I
+SELECT COUNT(*)
+FROM build_chain b SEMI JOIN big_probe p ON b.k = p.k;
+----
+509
+
+# long chain through ANTI JOIN: all build rows match, none survive
+query I
+SELECT COUNT(*)
+FROM build_chain b ANTI JOIN big_probe p ON b.k = p.k;
+----
+0
+
+# empty build side
+statement ok
+CREATE TABLE empty_build (k VARCHAR, v VARCHAR);
+
+query II
+SELECT b.v, COUNT(*) AS cnt
+FROM big_probe p JOIN empty_build b ON p.k = b.k
+GROUP BY b.v;
+----
+
+# single-row build side
+statement ok
+CREATE TABLE build_one (k VARCHAR, v VARCHAR);
+
+statement ok
+INSERT INTO build_one VALUES ('K5', 'only-five');
+
+query II
+SELECT b.v, COUNT(*) AS cnt
+FROM big_probe p JOIN build_one b ON p.k = b.k
+GROUP BY b.v;
+----
+only-five	26220
+
+# fallback path: exactly one activation condition violated per test
+
+# fallback: small probe side (below min-probe-rows threshold)
+statement ok
+CREATE TABLE fallback_probe AS
+SELECT i AS id, ('K' || (((i % 10) + 1)::VARCHAR)) AS k
+FROM range(100) t(i);
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM fallback_probe p JOIN small_build b ON p.k = b.k
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	10
+five	10
+four	10
+nine	10
+one	10
+seven	10
+six	10
+ten	10
+three	10
+two	10
+
+# fallback: probe-to-build ratio below threshold (262200 / 3000 = 87.4 < 100)
+statement ok
+CREATE TABLE ratio_large_build AS
+SELECT ('K' || i::VARCHAR) AS k, 'val-' || i::VARCHAR AS name
+FROM range(3000) t(i);
+
+statement ok
+CREATE TABLE ratio_matching_probe AS
+SELECT i AS id, ('K' || (i % 3000)::VARCHAR) AS k
+FROM range(262200) t(i);
+
+query I
+SELECT COUNT(*)
+FROM ratio_matching_probe p JOIN ratio_large_build b ON p.k = b.k;
+----
+262200
+
+query I
+SELECT COUNT(DISTINCT b.name)
+FROM ratio_matching_probe p JOIN ratio_large_build b ON p.k = b.k;
+----
+3000
+
+# fallback: perfect hash join wins (unique integer key, small range)
+statement ok
+CREATE TABLE build_int_unique (bucket INTEGER, name VARCHAR);
+
+statement ok
+INSERT INTO build_int_unique VALUES
+    (1, 'one'),  (2, 'two'),  (3, 'three'),  (4, 'four'),  (5, 'five'),
+    (6, 'six'),  (7, 'seven'), (8, 'eight'), (9, 'nine'), (10, 'ten');
+
+query II
+SELECT b.name, COUNT(*) AS cnt
+FROM big_probe p JOIN build_int_unique b ON p.bucket = b.bucket
+GROUP BY b.name
+ORDER BY b.name;
+----
+eight	26220
+five	26220
+four	26220
+nine	26220
+one	26220
+seven	26220
+six	26220
+ten	26220
+three	26220
+two	26220
+
+# fallback: no RHS output columns (SELECT COUNT(*))
+query I
+SELECT COUNT(*)
+FROM big_probe p JOIN small_build b ON p.k = b.k;
+----
+262200
+
+# fallback: STRUCT-typed RHS column (nested-type bailout)
+statement ok
+CREATE TABLE build_struct (k VARCHAR, payload STRUCT(x INTEGER, y VARCHAR));
+
+statement ok
+INSERT INTO build_struct VALUES
+    ('K1',  {'x':  1, 'y': 'one'}),
+    ('K2',  {'x':  2, 'y': 'two'}),
+    ('K3',  {'x':  3, 'y': 'three'}),
+    ('K4',  {'x':  4, 'y': 'four'}),
+    ('K5',  {'x':  5, 'y': 'five'}),
+    ('K6',  {'x':  6, 'y': 'six'}),
+    ('K7',  {'x':  7, 'y': 'seven'}),
+    ('K8',  {'x':  8, 'y': 'eight'}),
+    ('K9',  {'x':  9, 'y': 'nine'}),
+    ('K10', {'x': 10, 'y': 'ten'});
+
+query II
+SELECT b.payload, COUNT(*) AS cnt
+FROM big_probe p JOIN build_struct b ON p.k = b.k
+GROUP BY b.payload
+ORDER BY (b.payload).x;
+----
+{'x': 1, 'y': one}	26220
+{'x': 2, 'y': two}	26220
+{'x': 3, 'y': three}	26220
+{'x': 4, 'y': four}	26220
+{'x': 5, 'y': five}	26220
+{'x': 6, 'y': six}	26220
+{'x': 7, 'y': seven}	26220
+{'x': 8, 'y': eight}	26220
+{'x': 9, 'y': nine}	26220
+{'x': 10, 'y': ten}	26220
+
+# fallback: LIST-typed RHS column (nested-type bailout)
+statement ok
+CREATE TABLE build_list (k VARCHAR, tags INTEGER[]);
+
+statement ok
+INSERT INTO build_list VALUES
+    ('K1',  [1, 2, 3]),
+    ('K2',  [2]),
+    ('K3',  [3, 30]),
+    ('K4',  [4]),
+    ('K5',  [5, 50, 500]),
+    ('K6',  [6]),
+    ('K7',  [7]),
+    ('K8',  [8, 80]),
+    ('K9',  [9]),
+    ('K10', [10, 100, 1000]);
+
+query II
+SELECT b.tags, COUNT(*) AS cnt
+FROM big_probe p JOIN build_list b ON p.k = b.k
+GROUP BY b.tags
+ORDER BY b.tags[1];
+----
+[1, 2, 3]	26220
+[2]	26220
+[3, 30]	26220
+[4]	26220
+[5, 50, 500]	26220
+[6]	26220
+[7]	26220
+[8, 80]	26220
+[9]	26220
+[10, 100, 1000]	26220
+
+# fallback: SINGLE join via correlated scalar subquery
+query II
+SELECT b.k, b.name
+FROM small_build b
+WHERE b.k = (SELECT MAX(p.k) FROM big_probe p WHERE p.k = b.k)
+ORDER BY b.k;
+----
+K1	one
+K10	ten
+K2	two
+K3	three
+K4	four
+K5	five
+K6	six
+K7	seven
+K8	eight
+K9	nine
+
+# fallback: LEFT_SEMI / LEFT_ANTI (no RHS columns projected)
+query I
+SELECT COUNT(*)
+FROM big_probe p SEMI JOIN small_build b ON p.k = b.k;
+----
+262200
+
+query I
+SELECT COUNT(*)
+FROM big_probe_with_misses p ANTI JOIN small_build b ON p.k = b.k;
+----
+5


### PR DESCRIPTION
<h1>Add small-build-side dictionary emission for hash joins</h1>
<h2>Motivation</h2>
<p>In a regular hash join, every matched probe row copies build-side payload values out of row-format storage into the output chunk via <code>GatherResult</code>. When the build side is small but the probe side is large, the <strong>same build-side payload values get copied thousands of times.</strong></p>
<p>Perfect hash join handles a narrow case of this by emitting dictionary vectors instead of gathered values, <strong>but only for integer keys in a small dense range with no duplicates, and only for inner joins.</strong></p>
<p>This PR materializes small build sides into dictionary arrays, embeds the dictionary index into each row's <code>NEXT_PTR</code> field, and emits matched rows as dictionary vectors during probing.</p>
<h2>Approach</h2>
<p>When the build side is small and the probe side is large enough that the same build-side values would otherwise be copied many times, we apply the same dictionary-vector mechanism perfect hash join uses. After <code>Finalize()</code>, pre-materialize each RHS output column into a reusable <code>VectorChildBuffer</code> (same <code>DictionaryVector::CreateReusableDictionary</code>, same stable <code>dictionary_id</code>). Overwrite each build row's <code>NEXT_PTR</code> field with a <code>uint32_t</code> index into those arrays. At probe time, <code>EmitDictVectors</code> loads the index from each matched row and emits one <code>Vector::Dictionary(dict_arrays[col], build_sel_vec, count)</code> per build-side column — zero data copies.</p>
<p>The implementation lives in a single function — <code>BuildDictionaryArrays</code> — invoked from <code>HashJoinFinalizeEvent::FinishEvent</code>. By the time <code>FinishEvent</code> fires, all parallel finalize tasks have completed, <code>chains_longer_than_one</code> is final, every <code>NEXT_PTR</code> value is in its final state, and the <code>TupleDataCollection</code> is fully pinned — so a single pass over the rows can gather the dict arrays, snapshot chain pointers (when needed), and overwrite <code>NEXT_PTR</code>.</p>
<p>If the build side has no duplicate keys, <code>NEXT_PTR</code> is never read after finalize, so overwriting it is safe with zero auxiliary cost. If duplicate keys exist (<code>chains_longer_than_one = true</code>), <code>BuildDictionaryArrays</code> first saves the original <code>NEXT_PTR</code> values into an <code>aux_next_ptrs</code> array, and chain-walking sites read through a templated <code>GetNextPointer&lt;USE_DICT_EMISSION&gt;</code> that resolves the indirection. The runtime flag is lifted to a compile-time <code>bool</code> template parameter at the two dispatch boundaries (<code>AdvancePointers</code>, <code>NextRightSemiOrAntiJoin</code>), so the <code>use_dict_emission == false</code> specialization compiles byte-for-byte to the existing two-instruction <code>LoadPointer(ptr + pointer_offset)</code> chain-walk loop on the main branch. Non-activated joins are unaffected.</p>
<h2>Activation conditions</h2>
<p>All five must hold in <code>JoinHashTable::CanUseDictionaryEmission</code> (called from <code>HashJoinFinalizeEvent::FinishEvent</code>); any failure falls back silently to <code>GatherResult</code>.</p>


Condition | Why
-- | --
Not external | Cached row pointers don't survive partition rebuild
build_payload_bytes <= 8 MiB (MAX_BUILD_PAYLOAD_BYTES) | Caps the actual dict_arrays allocation; 8 MiB keeps the arrays in L3
probe_cardinality >= 262,144 (MIN_PROBE_ROWS) | Probe must be large enough to amortize the one-time build cost
probe / build >= 100 (PROBE_BUILD_RATIO) | Fan-out must be high enough for the per-row savings to pay off
Not SINGLE join | NextSingleJoin writes NULLs via FlatVector::SetNull, needs a flat vector



<p>Plus a nested-type bailout — STRUCT, LIST, and ARRAY are rejected because <code>Vector::Dictionary()</code> asserts non-STRUCT and <code>GetTypeIdSize</code> doesn't meaningfully measure nested-type cost. The thresholds live as <code>static constexpr</code> members of a small <code>DictionaryEmissionActivation</code> struct in <code>join_hashtable.hpp</code>. Mutual exclusion with perfect hash join is structural: <code>ScheduleFinalize</code> is only called from the <code>if (!use_perfect_hash)</code> branch, so <code>FinishEvent</code> never runs on the perfect hash join path.</p>
<p>Together these gates cover a broader set of joins than perfect hash join: any key type (not just integer), duplicate keys, and any join type that isn't SINGLE.</p>
<h2>Downstream impact</h2>
<p>The per-join savings (avoiding the per-row payload copies that <code>GatherResult</code> performs) are real but limited. The larger win is that dictionary vectors <strong>propagate</strong>, and downstream operators that recognize them can avoid re-doing work for every row that shares a dictionary entry:</p>
<ul>
<li><strong>Hash aggregate's <code>TryAddDictionaryGroups</code></strong> looks up each distinct dictionary value in the aggregate hash table once, then caches the resulting group pointer keyed by code. For every subsequent row referencing the same code, it skips the hash and key-compare — one array lookup into the cached addresses.</li>
<li>The <strong>projection operator</strong> evaluates expressions over the dictionary's <code>VectorChildBuffer</code>, computing each expression once per distinct entry rather than once per output row. Compressed Materialization, which goes through projection, benefits from this directly.</li>
</ul>
<h2>Showcase</h2>
<pre><code class="language-sql">SELECT n.n_name, COUNT(*) AS cnt
FROM nation n
JOIN customer c ON hash(n.n_nationkey) = hash(c.c_nationkey)
GROUP BY n.n_name;
</code></pre>
<p>This query is used to showcase the benefits of the optimization. The <code>hash()</code> calls on both sides bypass perfect hash join activation (in order to represent a wide key range) — purely for testing. The same end-to-end win applies whenever perfect hash join cannot be used: a string key, a LEFT JOIN, a wide range, etc.</p>
<p>With the optimization enabled, the query runs <strong>~2× faster</strong> at TPC-H SF=100 (~50% less wall time), and the speedup is consistent across scale factors 1, 10, 20, 50, and 100. The benefit comes from three places along the pipeline:</p>
<ol>
<li><strong>Hash join itself is ~1.09× faster</strong> (8.4% less time) — <code>EmitDictVectors</code> skips the per-row payload copies that <code>GatherResult</code> performs.</li>
<li><strong>Compressed Materialization is ~6.25× faster</strong> (84% less time) — its projection runs over the 25-entry dictionary instead of every matched customer row.</li>
<li><strong>The single-column hash aggregate is ~4.5× faster</strong> (78% less time) — <code>TryAddDictionaryGroups</code> looks up each of the 25 <code>n_name</code> values in the aggregate hash table once, caches the resulting group pointers, and reuses them for every subsequent row sharing the same dictionary code. The per-row hash and key-compare are skipped entirely.</li>
</ol>
<p>The flame graph below shows profiling results of the optimization compared to the main branch.</p>
<img width="3570" height="1206" alt="image" src="https://github.com/user-attachments/assets/e973a6c8-afd5-439e-a98a-ec9e10118c79" />
<h2>TPC-H Results</h2>
<p>Full suite run at SF=1, 10, 20, 50, 100, comparing this branch against <code>main</code>.</p>
<p>Hardware: Apple M4 Pro, 24 GB RAM.</p>
<p>Single-threaded setup, 10 runs per query, minimum reported.</p>
<p>The optimization activates on the following queries per scale factor:</p>
<ul>
<li><strong>SF=1</strong> → Q5, Q17, Q18, Q19, Q20</li>
<li><strong>SF=10</strong> → Q2, Q7, Q8, Q9, Q10, Q17, Q18, Q19, Q20</li>
<li><strong>SF=20</strong> → Q2, Q7, Q8, Q9, Q10, Q17, Q18, Q19, Q20</li>
<li><strong>SF=50</strong> → Q2, Q7, Q8, Q9, Q10, Q15, Q17, Q18, Q19, Q20</li>
<li><strong>SF=100</strong> → Q2, Q7, Q8, Q10, Q15, Q17, Q18, Q19, Q20</li>
</ul>
<p><strong>Zero regressions</strong> across all activated queries at any scale factor. There are no reproducible per-query wins on the activated TPC-H queries because operators that don't recognize dictionary vectors materialize them back to a flat vector before downstream dictionary-aware operators can exploit them — so the end-to-end pipeline win seen on the showcase query does not translate to TPC-H today.</p>
<p>This is itself a meaningful result: even when the emitted dictionaries are flattened almost immediately, enabling the optimization does not slow the query down. The activation gates are tight enough that the build-time cost is fully amortized, and we can ship the optimization safely.</p>
<h2>Future direction</h2>
<ul>
<li>Today only a handful of operators recognize dictionary vectors. As more dictionary-aware operators land in DuckDB over time, the value of emitting dictionary-encoded build-side columns from hash joins will compound.</li>
<li>A natural next step is to make these dictionaries pipeline-global: when a column arrives at a hash-join sink already dictionary-encoded, the build side stores only the 4-byte index in the row instead of re-flattening the value, so the encoding survives across a chain of joins. Our plan is to move directly to this idea after this PR, as the next part of my master thesis project.</li>
</ul>
<p>@lnkuiper — implementation of the project we discussed last week, ready for review.</p>
<p>Thank you for taking the time to review this! I'm looking forward to your feedback, and I'd be happy to discuss any part of the design.</p>
<!-- notionvc: c63e39df-ed20-4af9-8a24-7519fe0299a2 -->