### PR TITLE
First initialize system, then load extensions (to peek at file to be opened)

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -302,12 +302,12 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	// initialize the secret manager
 	config.secret_manager->Initialize(*this);
 
+	// initialize the system catalog
+	db_manager->InitializeSystemCatalog();
+
 	// resolve the type of the database we are opening
 	auto &fs = FileSystem::GetFileSystem(*this);
 	DBPathAndType::ResolveDatabaseType(fs, config.options.database_path, config.options.database_type);
-
-	// initialize the system catalog
-	db_manager->InitializeSystemCatalog();
 
 	if (!config.options.database_type.empty() && !StringUtil::CIEquals(config.options.database_type, "duckdb")) {
 		// if we are opening an extension database - load the extension


### PR DESCRIPTION
Fixes an internally reporte issues where:
```
duckdb https://blobs.duckdb.org/data/tpch-sf1.db
```
would file like:
```
Extension Autoloading Error:
An error occurred while trying to automatically install the required extension 'httpfs':
Initialization function "httpfs_duckdb_cpp_init" from file "/Users/gabor/.duckdb/extensions/v1.5.2/osx_arm64/httpfs.duckdb_extension" threw an exception: "Schema with name main does not exist!"
```
This was covered httpfs side, but fix there can be reverted (after this is merged).

Issue was weird, since required a few things to materialize:
* registration of table function in httpfs extension (this was there only for a few weeks, unfortunately around 1.5.2)
* duckdb https://some.org/file.db, that autoload httpfs (so not built in)