### PR TITLE
Node Handle Scoping fix 

### DIFF
--- a/src/execution/index/art/base_leaf.cpp
+++ b/src/execution/index/art/base_leaf.cpp
@@ -86,13 +86,12 @@ void Node7Leaf::DeleteByte(ART &art, Node &node, Node &prefix, const uint8_t byt
 		// Get the remaining row ID.
 		remainder = UnsafeNumericCast<idx_t>(row_id.GetRowId()) & AND_LAST_BYTE;
 		remainder |= UnsafeNumericCast<idx_t>(n7.key[0]);
-
-		// Free the prefix (nodes) and inline the remainder.
-		if (prefix.GetType() == NType::PREFIX) {
-			Node::FreeTree(art, prefix);
-			Leaf::New(prefix, UnsafeNumericCast<row_t>(remainder));
-			return;
-		}
+	}
+	// Free the prefix (nodes) and inline the remainder.
+	if (prefix.GetType() == NType::PREFIX) {
+		Node::FreeTree(art, prefix);
+		Leaf::New(prefix, UnsafeNumericCast<row_t>(remainder));
+		return;
 	}
 	// Free the Node7Leaf and inline the remainder.
 	Node::FreeNode(art, node);

--- a/test/sql/index/art/insert_update_delete/test_art_update_multiple_varchar_indexes.test_slow
+++ b/test/sql/index/art/insert_update_delete/test_art_update_multiple_varchar_indexes.test_slow
@@ -1,0 +1,34 @@
+# name: test/sql/index/art/insert_update_delete/test_art_update_multiple_varchar_indexes.test_slow
+# description: Test updating multiple varchar ART indexes in one transaction
+# group: [insert_update_delete]
+
+statement ok
+CREATE TABLE q (
+    r VARCHAR PRIMARY KEY,
+    s VARCHAR,
+    t VARCHAR
+);
+
+statement ok
+CREATE INDEX i_s ON q(s);
+
+statement ok
+CREATE INDEX i_t ON q(t);
+
+statement ok
+INSERT INTO q SELECT
+    md5(i::VARCHAR),
+    'a' || (i % 1000)::VARCHAR,
+    'b' || (i % 137)::VARCHAR
+FROM range(250000) q(i);
+
+statement ok
+BEGIN;
+
+statement ok
+UPDATE q SET
+    s = s || 'c',
+    t = t || 'c';
+
+statement ok
+COMMIT;


### PR DESCRIPTION
https://github.com/duckdblabs/duckdb-internal/issues/8907 (and probably any other bugs with the same stacktrace). 

We were grabbing a node handle for the leaf node that we were deleting the rowid in. If there was only one rowid remaining, then we inline the prefix chain, replacing the parent pointer of the prefix chain with the remaining rowid. To do this, we free the tree starting from the head of the prefix chain, and overwrite the rowid into the pointer slot which was the head of the prefix chain. 

We were freeing the tree while the leaf rowid node was still scoped by the handle, hence there was a reader on the buffer and we got an error when freeing. The fix is to just end the node handle scope before the prefix inlining check. 