### PR TITLE
Protect `(Base)Expression` members

### DIFF
--- a/.github/config/extensions/unity_catalog.cmake
+++ b/.github/config/extensions/unity_catalog.cmake
@@ -3,5 +3,6 @@ if(NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             GIT_URL https://github.com/duckdb/unity_catalog
             GIT_TAG 02024095fe6eeed6f53e78dce43e83c7424abec2
             LOAD_TESTS
+            APPLY_PATCHES
   )
 endif()

--- a/.github/patches/extensions/avro/0002-invalid-option-lowercase.patch
+++ b/.github/patches/extensions/avro/0002-invalid-option-lowercase.patch
@@ -1,5 +1,5 @@
 diff --git a/test/sql/copy/invalid_option.test b/test/sql/copy/invalid_option.test
-index 2d1da31..3fe4eb2 100644
+index 14daccb..0d3e1e6 100644
 --- a/test/sql/copy/invalid_option.test
 +++ b/test/sql/copy/invalid_option.test
 @@ -8,7 +8,7 @@ COPY (

--- a/.github/patches/extensions/delta/0002-expr.patch
+++ b/.github/patches/extensions/delta/0002-expr.patch
@@ -1,0 +1,37 @@
+diff --git a/src/delta_utils.cpp b/src/delta_utils.cpp
+index 708dd0a..c2f58b9 100644
+--- a/src/delta_utils.cpp
++++ b/src/delta_utils.cpp
+@@ -277,7 +277,7 @@ void ExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_i
+ 	}
+ 
+ 	for (idx_t i = 0; i < children_keys->size(); i++) {
+-		(*children_values)[i]->alias = (*children_keys)[i]->ToString();
++		(*children_values)[i]->SetAlias((*children_keys)[i]->ToString());
+ 	}
+ 
+ 	unique_ptr<ParsedExpression> expression = make_uniq<FunctionExpression>("struct_pack", std::move(*children_values));
+@@ -839,8 +839,8 @@ KernelUtils::UnpackTransformExpression(const vector<unique_ptr<ParsedExpression>
+ 	}
+ 
+ 	const auto &root_expression = parsed_expression.get(0);
+-	if (root_expression->type != ExpressionType::FUNCTION) {
+-		throw IOException("Unexpected type of root expression returned by delta kernel: %d", root_expression->type);
++	if (root_expression->GetExpressionType() != ExpressionType::FUNCTION) {
++		throw IOException("Unexpected type of root expression returned by delta kernel: %d", root_expression->GetExpressionType());
+ 	}
+ 
+ 	if (root_expression->Cast<FunctionExpression>().function_name != "delta_kernel_transform_expression") {
+diff --git a/src/storage/delta_schema_entry.cpp b/src/storage/delta_schema_entry.cpp
+index 30cc040..f08f1d0 100644
+--- a/src/storage/delta_schema_entry.cpp
++++ b/src/storage/delta_schema_entry.cpp
+@@ -41,7 +41,7 @@ optional_ptr<CatalogEntry> DeltaSchemaEntry::CreateFunction(CatalogTransaction t
+ }
+ 
+ void DeltaUnqualifyColumnRef(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};

--- a/.github/patches/extensions/ducklake/0003-expr.patch
+++ b/.github/patches/extensions/ducklake/0003-expr.patch
@@ -1,0 +1,182 @@
+diff --git a/src/functions/ducklake_flush_inlined_data.cpp b/src/functions/ducklake_flush_inlined_data.cpp
+index 290183e2..0eeb8d52 100644
+--- a/src/functions/ducklake_flush_inlined_data.cpp
++++ b/src/functions/ducklake_flush_inlined_data.cpp
+@@ -698,7 +698,7 @@ static unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context,
+ 	sum_args.push_back(make_uniq<BoundColumnRefExpression>(child->types[2], child_bindings[2]));
+ 
+ 	// Pick the right sum overload
+-	auto sum_func = sum_entry.functions.GetFunctionByArguments(context, {sum_args[0]->return_type});
++	auto sum_func = sum_entry.functions.GetFunctionByArguments(context, {sum_args[0]->GetReturnType()});
+ 	FunctionBinder function_binder(context);
+ 	auto sum_aggregate =
+ 	    function_binder.BindAggregateFunction(sum_func,            // The SUM(BIGINT) -> HUGEINT function
+diff --git a/src/storage/ducklake_field_data.cpp b/src/storage/ducklake_field_data.cpp
+index 66737af6..81b7c5ae 100644
+--- a/src/storage/ducklake_field_data.cpp
++++ b/src/storage/ducklake_field_data.cpp
+@@ -59,7 +59,7 @@ static Value ExtractInitialValue(optional_ptr<const ParsedExpression> initial_ex
+ 	if (!initial_expr) {
+ 		return Value(type);
+ 	}
+-	if (initial_expr->type != ExpressionType::VALUE_CONSTANT) {
++	if (initial_expr->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+ 		if (!add_column) {
+ 			return Value(type);
+ 		}
+@@ -330,7 +330,7 @@ shared_ptr<DuckLakeFieldData> DuckLakeFieldData::SetDefault(const DuckLakeFieldD
+ 	auto result = make_shared_ptr<DuckLakeFieldData>();
+ 	auto new_default =
+ 	    new_col.HasDefaultValue() ? optional_ptr<const ParsedExpression>(new_col.DefaultValue()) : nullptr;
+-	if (new_default && new_default->type != ExpressionType::VALUE_CONSTANT && add_column) {
++	if (new_default && new_default->GetExpressionType() != ExpressionType::VALUE_CONSTANT && add_column) {
+ 		throw NotImplementedException("We cannot add a column with a non-literal default value. Add the column and "
+ 		                              "then explicitly set the default for new values using \"ALTER ... SET DEFAULT\"");
+ 	}
+diff --git a/src/storage/ducklake_insert.cpp b/src/storage/ducklake_insert.cpp
+index ed0a6ffd..eaa5537d 100644
+--- a/src/storage/ducklake_insert.cpp
++++ b/src/storage/ducklake_insert.cpp
+@@ -475,7 +475,7 @@ static void GeneratePartitionExpressions(ClientContext &context, DuckLakeCopyInp
+ 		auto expr = GetPartitionExpression(context, copy_input, field);
+ 		copy_options.names.push_back(GetPartitionExpressionName(copy_input, field, names));
+ 		names.insert(copy_options.names.back());
+-		copy_options.expected_types.push_back(expr->return_type);
++		copy_options.expected_types.push_back(expr->GetReturnType());
+ 		copy_options.projection_list.push_back(std::move(expr));
+ 	}
+ }
+@@ -613,7 +613,7 @@ static void GenerateProjection(ClientContext &context, PhysicalPlanGenerator &pl
+ 	// push the projection
+ 	vector<LogicalType> types;
+ 	for (auto &expr : expressions) {
+-		types.push_back(expr->return_type);
++		types.push_back(expr->GetReturnType());
+ 	}
+ 	auto &proj =
+ 	    planner.Make<PhysicalProjection>(std::move(types), std::move(expressions), plan->estimated_cardinality);
+diff --git a/src/storage/ducklake_merge_into.cpp b/src/storage/ducklake_merge_into.cpp
+index e7dfc462..1099072f 100644
+--- a/src/storage/ducklake_merge_into.cpp
++++ b/src/storage/ducklake_merge_into.cpp
+@@ -175,7 +175,7 @@ unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionConte
+ 		result->expression_executor = make_uniq<ExpressionExecutor>(context.client, extra_projections);
+ 		vector<LogicalType> insert_types;
+ 		for (auto &expr : result->expression_executor->expressions) {
+-			insert_types.push_back(expr->return_type);
++			insert_types.push_back(expr->GetReturnType());
+ 		}
+ 		result->chunk.Initialize(context.client, insert_types);
+ 	}
+diff --git a/src/storage/ducklake_metadata_manager.cpp b/src/storage/ducklake_metadata_manager.cpp
+index cb38892c..583b97af 100644
+--- a/src/storage/ducklake_metadata_manager.cpp
++++ b/src/storage/ducklake_metadata_manager.cpp
+@@ -1955,10 +1955,10 @@ string DuckLakeMetadataManager::WriteNewSchemas(const vector<DuckLakeSchemaInfo>
+ }
+ 
+ string GetExpressionType(ParsedExpression &expression) {
+-	switch (expression.type) {
++	switch (expression.GetExpressionType()) {
+ 	case ExpressionType::OPERATOR_CAST: {
+ 		auto &cast_expression = expression.Cast<CastExpression>();
+-		if (cast_expression.child->type == ExpressionType::VALUE_CONSTANT) {
++		if (cast_expression.child->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+ 			return "literal";
+ 		}
+ 		return "expression";
+diff --git a/src/storage/ducklake_table_entry.cpp b/src/storage/ducklake_table_entry.cpp
+index 7d6f67c8..811fd68b 100644
+--- a/src/storage/ducklake_table_entry.cpp
++++ b/src/storage/ducklake_table_entry.cpp
+@@ -419,7 +419,7 @@ void DuckLakeTableEntry::ValidateSortExpressionColumns(DuckLakeTableEntry &table
+ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpression &expr) {
+ 	string column_name;
+ 	DuckLakeTransformType transform_type;
+-	switch (expr.type) {
++	switch (expr.GetExpressionType()) {
+ 	case ExpressionType::COLUMN_REF: {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		column_name = GetPartitionColumnName(colref);
+@@ -441,7 +441,7 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
+ 			throw NotImplementedException(
+ 			    "Unsupported partition function %s - only year, month, day, hour are supported", name);
+ 		}
+-		if (function.children.size() != 1 || function.children[0]->type != ExpressionType::COLUMN_REF) {
++		if (function.children.size() != 1 || function.children[0]->GetExpressionType() != ExpressionType::COLUMN_REF) {
+ 			throw NotImplementedException("Expected %s(column), but got %s", name, expr.ToString());
+ 		}
+ 		auto &colref = function.children[0]->Cast<ColumnRefExpression>();
+@@ -611,7 +611,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
+ 		Value default_value;
+ 		if (info.new_column.HasDefaultValue()) {
+ 			auto &default_expr = info.new_column.DefaultValue();
+-			if (default_expr.type == ExpressionType::VALUE_CONSTANT) {
++			if (default_expr.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+ 				auto &constant_expr = default_expr.Cast<ConstantExpression>();
+ 				default_value = constant_expr.value.DefaultCastAs(new_col.Type());
+ 			}
+@@ -770,11 +770,11 @@ bool TypePromotionIsAllowed(const LogicalType &source, const LogicalType &target
+ }
+ 
+ bool IsSimpleCast(const ParsedExpression &expr) {
+-	if (expr.type != ExpressionType::OPERATOR_CAST) {
++	if (expr.GetExpressionType() != ExpressionType::OPERATOR_CAST) {
+ 		return false;
+ 	}
+ 	auto &cast = expr.Cast<CastExpression>();
+-	if (cast.child->type != ExpressionType::COLUMN_REF) {
++	if (cast.child->GetExpressionType() != ExpressionType::COLUMN_REF) {
+ 		return false;
+ 	}
+ 	return true;
+@@ -963,7 +963,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
+ static void ExtractDefaultValue(const DuckLakeColumnData &col_data, DuckLakeColumnInfo &info) {
+ 	info.initial_default = col_data.initial_default;
+ 	if (col_data.default_value) {
+-		if (col_data.default_value->type == ExpressionType::VALUE_CONSTANT) {
++		if (col_data.default_value->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+ 			auto &constant_value = col_data.default_value->Cast<ConstantExpression>();
+ 			info.default_value = constant_value.value;
+ 			info.default_value_type = "literal";
+diff --git a/src/storage/ducklake_update.cpp b/src/storage/ducklake_update.cpp
+index 13c10de5..7e6d1451 100644
+--- a/src/storage/ducklake_update.cpp
++++ b/src/storage/ducklake_update.cpp
+@@ -93,7 +93,7 @@ unique_ptr<LocalSinkState> DuckLakeUpdate::GetLocalSinkState(ExecutionContext &c
+ 	vector<LogicalType> expression_types;
+ 	result->expression_executor = make_uniq<ExpressionExecutor>(context.client, expressions);
+ 	for (auto &expr : result->expression_executor->expressions) {
+-		expression_types.push_back(expr->return_type);
++		expression_types.push_back(expr->GetReturnType());
+ 	}
+ 
+ 	for (auto &type : expression_types) {
+@@ -343,7 +343,7 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
+ 		throw BinderException("RETURNING clause not yet supported for updates of a DuckLake table");
+ 	}
+ 	for (auto &expr : op.expressions) {
+-		if (expr->type == ExpressionType::VALUE_DEFAULT) {
++		if (expr->GetExpressionType() == ExpressionType::VALUE_DEFAULT) {
+ 			throw BinderException("SET DEFAULT is not yet supported for updates of a DuckLake table");
+ 		}
+ 	}
+@@ -388,15 +388,15 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
+ 				D_ASSERT(col_idx.IsValid());
+ 				auto &child_expression = expressions[col_idx.GetIndex()]->Cast<BoundReferenceExpression>();
+ 				auto column_reference =
+-				    make_uniq<BoundReferenceExpression>(child_expression.return_type, child_expression.index);
++				    make_uniq<BoundReferenceExpression>(child_expression.GetReturnType(), child_expression.index);
+ 				expressions.push_back(GetPartitionExpressionForUpdate(context, std::move(column_reference), field));
+ 			}
+ 		}
+ 	}
+ 
+ 	for (auto &expr : expressions) {
+-		if (DuckLakeTypes::RequiresCast(expr->return_type)) {
+-			auto target_type = DuckLakeTypes::GetCastedType(expr->return_type);
++		if (DuckLakeTypes::RequiresCast(expr->GetReturnType())) {
++			auto target_type = DuckLakeTypes::GetCastedType(expr->GetReturnType());
+ 			expr = BoundCastExpression::AddCastToType(context, std::move(expr), std::move(target_type));
+ 		}
+ 	}

--- a/.github/patches/extensions/iceberg/0003-expr.patch
+++ b/.github/patches/extensions/iceberg/0003-expr.patch
@@ -1,0 +1,151 @@
+diff --git a/src/iceberg_functions/iceberg_multi_file_reader.cpp b/src/iceberg_functions/iceberg_multi_file_reader.cpp
+index 6693bcab..7d0598a8 100644
+--- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
++++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
+@@ -391,7 +391,7 @@ void IcebergMultiFileReader::ApplyEqualityDeletes(ClientContext &context, DataCh
+ 
+ 				//! This means that if the expression is 'IS_NOT_NULL', the result is False for this column, otherwise
+ 				//! it's True (because nothing compares equal to NULL)
+-				if (expression->type == ExpressionType::OPERATOR_IS_NOT_NULL) {
++				if (expression->GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+ 					equalities.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(false)));
+ 				} else {
+ 					equalities.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+diff --git a/src/iceberg_predicate.cpp b/src/iceberg_predicate.cpp
+index d986603b..c6fa6b3c 100644
+--- a/src/iceberg_predicate.cpp
++++ b/src/iceberg_predicate.cpp
+@@ -27,7 +27,7 @@ public:
+ 		if (expr.index != 0) {
+ 			return nullptr;
+ 		}
+-		auto &return_type = expr.return_type;
++		auto &return_type = expr.GetReturnType();
+ 		return make_uniq<BoundConstantExpression>(val.DefaultCastAs(return_type, true));
+ 	}
+ 
+@@ -185,7 +185,7 @@ bool MatchBoundsTemplated(ClientContext &context, const TableFilter &filter, con
+ 		auto &expression_filter = filter.Cast<ExpressionFilter>();
+ 		auto &expr = *expression_filter.expr;
+ 
+-		switch (expr.type) {
++		switch (expr.GetExpressionType()) {
+ 		case ExpressionType::OPERATOR_IS_NULL:
+ 		case ExpressionType::OPERATOR_IS_NOT_NULL: {
+ 			D_ASSERT(expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR);
+@@ -193,15 +193,15 @@ bool MatchBoundsTemplated(ClientContext &context, const TableFilter &filter, con
+ 
+ 			D_ASSERT(bound_operator_expr.children.size() == 1);
+ 			auto &child_expr = bound_operator_expr.children[0];
+-			if (child_expr->type != ExpressionType::BOUND_REF) {
++			if (child_expr->GetExpressionType() != ExpressionType::BOUND_REF) {
+ 				//! We can't evaluate expressions that aren't direct column references
+ 				return true;
+ 			}
+ 
+-			if (expr.type == ExpressionType::OPERATOR_IS_NULL) {
++			if (expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NULL) {
+ 				return MatchBoundsIsNullFilter<TRANSFORM>(stats, transform);
+ 			}
+-			D_ASSERT(expr.type == ExpressionType::OPERATOR_IS_NOT_NULL);
++			D_ASSERT(expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL);
+ 			return MatchBoundsIsNotNullFilter<TRANSFORM>(stats, transform);
+ 		}
+ 		case ExpressionType::COMPARE_GREATERTHAN:
+@@ -224,9 +224,9 @@ bool MatchBoundsTemplated(ClientContext &context, const TableFilter &filter, con
+ 				}
+ 
+ 				if (left_foldable) {
+-					return MatchTransformedBounds<TRANSFORM>(context, expr.type, right, left, stats, transform);
++					return MatchTransformedBounds<TRANSFORM>(context, expr.GetExpressionType(), right, left, stats, transform);
+ 				} else {
+-					return MatchTransformedBounds<TRANSFORM>(context, expr.type, left, right, stats, transform);
++					return MatchTransformedBounds<TRANSFORM>(context, expr.GetExpressionType(), left, right, stats, transform);
+ 				}
+ 				return true;
+ 			}
+diff --git a/src/storage/catalog/iceberg_schema_entry.cpp b/src/storage/catalog/iceberg_schema_entry.cpp
+index 32fc8d55..19cf9597 100644
+--- a/src/storage/catalog/iceberg_schema_entry.cpp
++++ b/src/storage/catalog/iceberg_schema_entry.cpp
+@@ -128,7 +128,7 @@ optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateFunction(CatalogTransaction
+ }
+ 
+ void ICUnqualifyColumnRef(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};
+diff --git a/src/storage/iceberg_insert.cpp b/src/storage/iceberg_insert.cpp
+index 469de632..9290d91b 100644
+--- a/src/storage/iceberg_insert.cpp
++++ b/src/storage/iceberg_insert.cpp
+@@ -606,7 +606,7 @@ static void GeneratePartitionExpressions(ClientContext &context, IcebergCopyInpu
+ 
+ 		auto expr = GetPartitionExpression(context, copy_input, field);
+ 		projection_names.push_back(field.name);
+-		projection_types.push_back(expr->return_type);
++		projection_types.push_back(expr->GetReturnType());
+ 		projection_expressions.push_back(std::move(expr));
+ 	}
+ 
+@@ -677,7 +677,7 @@ PhysicalOperator &IcebergInsert::PlanCopyForInsert(ClientContext &context, Physi
+ 			// Build the projection types from the expressions
+ 			vector<LogicalType> proj_types;
+ 			for (auto &expr : projection_expressions) {
+-				proj_types.push_back(expr->return_type);
++				proj_types.push_back(expr->GetReturnType());
+ 			}
+ 			auto &proj = planner.Make<PhysicalProjection>(std::move(proj_types), std::move(projection_expressions),
+ 			                                              plan->estimated_cardinality);
+diff --git a/src/storage/iceberg_table_information.cpp b/src/storage/iceberg_table_information.cpp
+index acc5d517..1b5682eb 100644
+--- a/src/storage/iceberg_table_information.cpp
++++ b/src/storage/iceberg_table_information.cpp
+@@ -336,19 +336,19 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
+ 		string transform_name = "identity";
+ 		idx_t bucket_modulo_val;
+ 
+-		if (key->type == ExpressionType::COLUMN_REF) {
++		if (key->GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 			auto &colref = key->Cast<ColumnRefExpression>();
+ 			column_name = colref.column_names.back();
+-		} else if (key->type == ExpressionType::FUNCTION) {
++		} else if (key->GetExpressionType() == ExpressionType::FUNCTION) {
+ 			auto &funcexpr = key->Cast<FunctionExpression>();
+ 			transform_name = funcexpr.function_name;
+ 			if (funcexpr.children.empty()) {
+ 				throw NotImplementedException("Unrecognized transform ('%s')", transform_name);
+ 			} else if (!IcebergTransform::TransformFunctionSupported(transform_name)) {
+ 				throw NotImplementedException("Unrecognized transform ('%s')", transform_name);
+-			} else if (funcexpr.children[0]->type != ExpressionType::COLUMN_REF) {
++			} else if (funcexpr.children[0]->GetExpressionType() != ExpressionType::COLUMN_REF) {
+ 				throw NotImplementedException("Transforms are only supported on column references, not %s",
+-				                              EnumUtil::ToChars(funcexpr.children[0]->type));
++				                              EnumUtil::ToChars(funcexpr.children[0]->GetExpressionType()));
+ 			}
+ 			auto &colref = funcexpr.children[0]->Cast<ColumnRefExpression>();
+ 			column_name = colref.column_names.back();
+@@ -358,7 +358,7 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
+ 					                            transform_name);
+ 				}
+ 				auto &param_expr = *funcexpr.children[1];
+-				if (param_expr.type != ExpressionType::VALUE_CONSTANT) {
++				if (param_expr.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+ 					throw InvalidInputException("%s second argument must be a constant integer", transform_name);
+ 				}
+ 				auto &const_expr = param_expr.Cast<ConstantExpression>();
+diff --git a/src/storage/iceberg_update.cpp b/src/storage/iceberg_update.cpp
+index 7964c7c7..363816d0 100644
+--- a/src/storage/iceberg_update.cpp
++++ b/src/storage/iceberg_update.cpp
+@@ -49,7 +49,7 @@ public:
+ 		vector<LogicalType> update_types;
+ 		update_types.reserve(expressions.size());
+ 		for (auto &expr : expressions) {
+-			update_types.push_back(expr->return_type);
++			update_types.push_back(expr->GetReturnType());
+ 		}
+ 		update_chunk.Initialize(allocator, update_types);
+ 	}

--- a/.github/patches/extensions/mysql_scanner/0002-expr.patch
+++ b/.github/patches/extensions/mysql_scanner/0002-expr.patch
@@ -1,0 +1,49 @@
+diff --git a/src/storage/mysql_execute_query.cpp b/src/storage/mysql_execute_query.cpp
+index 73699f6..4508f70 100644
+--- a/src/storage/mysql_execute_query.cpp
++++ b/src/storage/mysql_execute_query.cpp
+@@ -97,7 +97,7 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
+ 	} else if (child.type == PhysicalOperatorType::PROJECTION) {
+ 		auto &proj = child.Cast<PhysicalProjection>();
+ 		for (auto &expr : proj.select_list) {
+-			switch (expr->type) {
++			switch (expr->GetExpressionType()) {
+ 			case ExpressionType::BOUND_REF:
+ 			case ExpressionType::BOUND_COLUMN_REF:
+ 			case ExpressionType::VALUE_CONSTANT:
+@@ -189,11 +189,11 @@ string ConstructUpdateStatement(LogicalUpdate &op, PhysicalOperator &child) {
+ 		auto &col = op.table.GetColumn(op.table.GetColumns().PhysicalToLogical(op.columns[c]));
+ 		result += MySQLUtils::WriteIdentifier(col.GetName());
+ 		result += " = ";
+-		if (op.expressions[c]->type == ExpressionType::VALUE_DEFAULT) {
++		if (op.expressions[c]->GetExpressionType() == ExpressionType::VALUE_DEFAULT) {
+ 			result += "DEFAULT";
+ 			continue;
+ 		}
+-		if (op.expressions[c]->type != ExpressionType::BOUND_REF) {
++		if (op.expressions[c]->GetExpressionType() != ExpressionType::BOUND_REF) {
+ 			throw NotImplementedException("MySQL Update not supported - Expected a bound reference expression");
+ 		}
+ 		auto &ref = op.expressions[c]->Cast<BoundReferenceExpression>();
+diff --git a/src/storage/mysql_schema_entry.cpp b/src/storage/mysql_schema_entry.cpp
+index d82c444..db5d0ce 100644
+--- a/src/storage/mysql_schema_entry.cpp
++++ b/src/storage/mysql_schema_entry.cpp
+@@ -49,7 +49,7 @@ optional_ptr<CatalogEntry> MySQLSchemaEntry::CreateFunction(CatalogTransaction t
+ }
+ 
+ void MySQLUnqualifyColumnRef(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};
+@@ -74,7 +74,7 @@ string GetMySQLCreateIndex(CreateIndexInfo &info, TableCatalogEntry &tbl) {
+ 			sql += ", ";
+ 		}
+ 		MySQLUnqualifyColumnRef(*info.parsed_expressions[i]);
+-		if (info.parsed_expressions[i]->type == ExpressionType::COLUMN_REF) {
++		if (info.parsed_expressions[i]->GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 			// index on column
+ 			sql += info.parsed_expressions[i]->ToString();
+ 		} else {

--- a/.github/patches/extensions/postgres_scanner/0002-expr.patch
+++ b/.github/patches/extensions/postgres_scanner/0002-expr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/postgres_index_set.cpp b/src/storage/postgres_index_set.cpp
+index 2ccd309..178699d 100644
+--- a/src/storage/postgres_index_set.cpp
++++ b/src/storage/postgres_index_set.cpp
+@@ -46,7 +46,7 @@ void PostgresIndexSet::LoadEntries(ClientContext &context, PostgresTransaction &
+ }
+ 
+ void PGUnqualifyColumnReferences(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};

--- a/.github/patches/extensions/spatial/0004-protect-function-callbacks.patch
+++ b/.github/patches/extensions/spatial/0004-protect-function-callbacks.patch
@@ -47,7 +47,7 @@ index 5456a8b..de3d79d 100644
  	FunctionBuilder::RegisterAggregate(loader, "ST_Extent_Agg", [&](AggregateFunctionBuilder &func) {
  		func.SetFunction(agg);
 diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
-index ec69387..1a3a2ae 100644
+index 8f7ed76..e3bc335 100644
 --- a/src/spatial/modules/proj/proj_module.cpp
 +++ b/src/spatial/modules/proj/proj_module.cpp
 @@ -302,7 +302,7 @@ struct ST_Transform {

--- a/.github/patches/extensions/spatial/0005-protect-function-args.patch
+++ b/.github/patches/extensions/spatial/0005-protect-function-args.patch
@@ -88,7 +88,7 @@ index 34b85e1..4127b90 100644
  			}
  
 diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
-index 1a3a2ae..61429a7 100644
+index e3bc335..d5276e5 100644
 --- a/src/spatial/modules/proj/proj_module.cpp
 +++ b/src/spatial/modules/proj/proj_module.cpp
 @@ -301,7 +301,7 @@ struct ST_Transform {

--- a/.github/patches/extensions/spatial/0008-expr.patch
+++ b/.github/patches/extensions/spatial/0008-expr.patch
@@ -1,0 +1,347 @@
+diff --git a/src/spatial/index/rtree/rtree_index.cpp b/src/spatial/index/rtree/rtree_index.cpp
+index f073188..3e15656 100644
+--- a/src/spatial/index/rtree/rtree_index.cpp
++++ b/src/spatial/index/rtree/rtree_index.cpp
+@@ -109,7 +109,7 @@ RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_
+ 	}
+ 
+ 	// Construct the key expression executor
+-	auto &source_type = unbound_expressions[0]->return_type;
++	auto &source_type = unbound_expressions[0]->GetReturnType();
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+ 	auto func = entry.functions.GetFunctionByArguments(context, {source_type});
+diff --git a/src/spatial/index/rtree/rtree_index_create_logical.cpp b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+index 63d35f1..d4c8dbc 100644
+--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
++++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+@@ -151,7 +151,7 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
+ 	auto &expr = op.unbound_expressions[0];
+ 
+ 	// Validate that we have the right type of expression (float array)
+-	if (expr->return_type != LogicalType::GEOMETRY()) {
++	if (expr->GetReturnType() != LogicalType::GEOMETRY()) {
+ 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
+ 	}
+ 
+@@ -167,7 +167,7 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
+ 
+ 	// Add the geometry expression to the select list
+ 	auto geom_expr = op.expressions[0]->Copy();
+-	new_column_types.push_back(geom_expr->return_type);
++	new_column_types.push_back(geom_expr->GetReturnType());
+ 	select_list.push_back(std::move(geom_expr));
+ 
+ 	// Add the row ID to the select list
+@@ -218,7 +218,7 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
+ 	auto &expr = op.unbound_expressions[0];
+ 
+ 	// Validate that we have the right type of expression (float array)
+-	if (expr->return_type != LogicalType::GEOMETRY()) {
++	if (expr->GetReturnType() != LogicalType::GEOMETRY()) {
+ 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
+ 	}
+ 
+@@ -244,7 +244,7 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
+ 
+ 	// Add the geometry expression to the select list
+ 	auto geom_expr = op.expressions[0]->Copy();
+-	new_column_types.push_back(geom_expr->return_type);
++	new_column_types.push_back(geom_expr->GetReturnType());
+ 	select_list.push_back(std::move(geom_expr));
+ 
+ 	// Add the row ID to the select list
+diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+index b313294..5c35637 100644
+--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
++++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+@@ -40,7 +40,7 @@ public:
+ 	}
+ 
+ 	static void RewriteIndexExpression(Index &index, LogicalGet &get, Expression &expr, bool &rewrite_possible) {
+-		if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
++		if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+ 			auto &bound_colref = expr.Cast<BoundColumnRefExpression>();
+ 			// bound column ref: rewrite to fit in the current set of bound column ids
+ 			bound_colref.binding.table_index = get.table_index;
+@@ -63,7 +63,7 @@ public:
+ 
+ 	static void RewriteIndexExpressionForFilter(Index &index, LogicalGet &get, unique_ptr<Expression> &expr,
+ 	                                            const ColumnIndex &filter_idx, bool &rewrite_possible) {
+-		if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
++		if (expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+ 			auto &bound_colref = expr->Cast<BoundColumnRefExpression>();
+ 
+ 			auto &indexed_columns = index.GetColumnIds();
+@@ -84,7 +84,7 @@ public:
+ 			}
+ 
+ 			// this column matches the index column - turn it into a BoundReference
+-			expr = make_uniq<BoundReferenceExpression>(bound_colref.return_type, 0ULL);
++			expr = make_uniq<BoundReferenceExpression>(bound_colref.GetReturnType(), 0ULL);
+ 			return;
+ 		}
+ 		ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+diff --git a/src/spatial/modules/gdal/gdal_module.cpp b/src/spatial/modules/gdal/gdal_module.cpp
+index 996e0ff..df5cdd6 100644
+--- a/src/spatial/modules/gdal/gdal_module.cpp
++++ b/src/spatial/modules/gdal/gdal_module.cpp
+@@ -732,7 +732,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+ 		if (expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+ 			continue;
+ 		}
+-		if (expr->return_type != LogicalType::BOOLEAN) {
++		if (expr->GetReturnType() != LogicalType::BOOLEAN) {
+ 			continue;
+ 		}
+ 		const auto &func = expr->Cast<BoundFunctionExpression>();
+@@ -740,8 +740,8 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+ 			continue;
+ 		}
+ 
+-		if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
+-		    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
++		if (func.children[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY ||
++		    func.children[1]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
+ 			continue;
+ 		}
+ 
+@@ -814,7 +814,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+ 			// Constant is NULL
+ 			continue;
+ 		}
+-		if (geometry_expr->return_type.id() != LogicalTypeId::GEOMETRY) {
++		if (geometry_expr->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
+ 			// Not the geometry column
+ 			continue;
+ 		}
+diff --git a/src/spatial/modules/main/spatial_functions_scalar.cpp b/src/spatial/modules/main/spatial_functions_scalar.cpp
+index b9c0aee..4a9e3f6 100644
+--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
++++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
+@@ -4600,7 +4600,7 @@ struct ST_GeomFromText {
+ 		if (arguments.empty()) {
+ 			throw InvalidInputException("ST_GeomFromText requires at least one argument");
+ 		}
+-		const auto &input_type = arguments[0]->return_type;
++		const auto &input_type = arguments[0]->GetReturnType();
+ 		if (input_type.id() != LogicalTypeId::VARCHAR) {
+ 			throw InvalidInputException("ST_GeomFromText requires a string argument");
+ 		}
+@@ -4615,8 +4615,8 @@ struct ST_GeomFromText {
+ 				throw InvalidInputException(
+ 				    "Non-constant arguments are not supported in ST_GeomFromText optional arguments");
+ 			}
+-			if (arg->alias == "ignore_invalid") {
+-				if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
++			if (arg->GetAlias() == "ignore_invalid") {
++				if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
+ 					throw InvalidInputException("ST_GeomFromText optional argument 'ignore_invalid' must be a boolean");
+ 				}
+ 				ignore_invalid = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
+diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
+index 4127b90..b646469 100644
+--- a/src/spatial/modules/mvt/mvt_module.cpp
++++ b/src/spatial/modules/mvt/mvt_module.cpp
+@@ -833,7 +833,7 @@ struct ST_AsMVT {
+ 		auto result = make_uniq<BindData>();
+ 
+ 		// Figure part of the row is the geometry column
+-		const auto &row_type = arguments[0]->return_type;
++		const auto &row_type = arguments[0]->GetReturnType();
+ 		if (row_type.id() != LogicalTypeId::STRUCT) {
+ 			throw InvalidInputException("ST_AsMVT: first argument must be a STRUCT (i.e. a row type)");
+ 		}
+diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
+index a2481ab..e911f0f 100644
+--- a/src/spatial/modules/proj/proj_module.cpp
++++ b/src/spatial/modules/proj/proj_module.cpp
+@@ -251,32 +251,32 @@ struct ST_Transform {
+ 
+ 		// Get CRS from source geometry
+ 		const auto &geo_arg = args[0];
+-		if (!GeoType::HasCRS(geo_arg->return_type)) {
+-			throw BinderException(geo_arg->query_location, "Source geometry must have a coordinate reference system");
++		if (!GeoType::HasCRS(geo_arg->GetReturnType())) {
++			throw BinderException(geo_arg->GetQueryLocation(), "Source geometry must have a coordinate reference system");
+ 		}
+-		result->source_crs = GeoType::GetCRS(geo_arg->return_type).GetDefinition();
++		result->source_crs = GeoType::GetCRS(geo_arg->GetReturnType()).GetDefinition();
+ 		if (result->source_crs.empty()) {
+-			throw BinderException(geo_arg->query_location, "Source geometry must have a coordinate reference system");
++			throw BinderException(geo_arg->GetQueryLocation(), "Source geometry must have a coordinate reference system");
+ 		}
+ 
+ 		// Constant-fold target_crs
+ 		const auto &crs_arg = args[1];
+ 		if (crs_arg->HasParameter()) {
+-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a constant");
++			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a constant");
+ 		}
+ 		if (!crs_arg->IsFoldable()) {
+-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a constant");
++			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a constant");
+ 		}
+-		if (crs_arg->return_type.id() != LogicalTypeId::VARCHAR) {
+-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a string");
++		if (crs_arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
++			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a string");
+ 		}
+ 		result->target_crs = StringValue::Get(ExpressionExecutor::EvaluateScalar(ctx, *crs_arg));
+ 		if (result->target_crs.empty()) {
+-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter cannot be empty");
++			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter cannot be empty");
+ 		}
+ 		const auto result_crs = CoordinateReferenceSystem::TryIdentify(ctx, result->target_crs);
+ 		if (!result_crs) {
+-			throw BinderException(crs_arg->query_location,
++			throw BinderException(crs_arg->GetQueryLocation(),
+ 			                      "The 'target_crs' parameter '%s' is not a recognized coordinate reference system",
+ 			                      result->target_crs);
+ 		}
+@@ -286,13 +286,13 @@ struct ST_Transform {
+ 		if (args.size() == 3) {
+ 			const auto &xy_arg = args[2];
+ 			if (xy_arg->HasParameter()) {
+-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a constant");
++				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a constant");
+ 			}
+ 			if (!xy_arg->IsFoldable()) {
+-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a constant");
++				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a constant");
+ 			}
+-			if (xy_arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a boolean");
++			if (xy_arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
++				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a boolean");
+ 			}
+ 			result->normalize = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(ctx, *xy_arg));
+ 			explicit_normalize = true;
+@@ -301,7 +301,7 @@ struct ST_Transform {
+ 		}
+ 
+ 		// Set return types
+-		func.GetArguments()[0] = geo_arg->return_type;
++		func.GetArguments()[0] = geo_arg->GetReturnType();
+ 		func.SetReturnType(LogicalType::GEOMETRY(*result_crs));
+ 
+ 		// Check if we need to warn for this
+diff --git a/src/spatial/operators/spatial_join_optimizer.cpp b/src/spatial/operators/spatial_join_optimizer.cpp
+index b0b219c..18c5938 100644
+--- a/src/spatial/operators/spatial_join_optimizer.cpp
++++ b/src/spatial/operators/spatial_join_optimizer.cpp
+@@ -71,9 +71,9 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, it->second);
+ 	auto inverse_func =
+-	    entry.functions.GetFunctionByArguments(context, {func.children[0]->return_type, func.children[1]->return_type});
++	    entry.functions.GetFunctionByArguments(context, {func.children[0]->GetReturnType(), func.children[1]->GetReturnType()});
+ 
+-	return make_uniq_base<Expression, BoundFunctionExpression>(func.return_type, inverse_func, std::move(func.children),
++	return make_uniq_base<Expression, BoundFunctionExpression>(func.GetReturnType(), inverse_func, std::move(func.children),
+ 	                                                           nullptr, func.is_operator);
+ }
+ 
+@@ -87,7 +87,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
+ 	}
+ 
+ 	// Check if the expression is a spatial predicate
+-	if (expr->type != ExpressionType::BOUND_FUNCTION) {
++	if (expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+ 		return false;
+ 	}
+ 
+@@ -99,7 +99,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
+ 	}
+ 
+ 	// The function must return a boolean
+-	if (func.return_type != LogicalType::BOOLEAN) {
++	if (func.GetReturnType() != LogicalType::BOOLEAN) {
+ 		return false;
+ 	}
+ 
+diff --git a/src/spatial/operators/spatial_join_physical.cpp b/src/spatial/operators/spatial_join_physical.cpp
+index c9f55a4..b9f75c0 100644
+--- a/src/spatial/operators/spatial_join_physical.cpp
++++ b/src/spatial/operators/spatial_join_physical.cpp
+@@ -444,7 +444,7 @@ PhysicalSpatialJoin::PhysicalSpatialJoin(PhysicalPlan &physical_plan, LogicalOpe
+ 		conditions_in_layout.emplace(build_side_key->Cast<BoundReferenceExpression>().index, 0); // TODO: i, not 0
+ 	}
+ 	// TODO Add rest too
+-	build_side_key_types.push_back(build_side_key->return_type);
++	build_side_key_types.push_back(build_side_key->GetReturnType());
+ 
+ 	const auto &build_side_input_types = children[1].get().types;
+ 	auto right_projection_map_copy = FillProjectionMap(children[1].get(), lop.right_projection_map);
+@@ -543,7 +543,7 @@ public:
+ 
+ 		build_side_payload_chunk.InitializeEmpty(op.build_side_payload_types);
+ 
+-		auto &geom_type = op.build_side_key->return_type;
++		auto &geom_type = op.build_side_key->GetReturnType();
+ 
+ 		auto &catalog = Catalog::GetSystemCatalog(context);
+ 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_IsEmpty");
+@@ -838,8 +838,8 @@ unique_ptr<OperatorState> PhysicalSpatialJoin::GetOperatorState(ExecutionContext
+ 	// Create a match expression using the condition, that will be used to filter the results
+ 	lstate->match_expr = condition->Copy();
+ 	auto &func_expr = lstate->match_expr->Cast<BoundFunctionExpression>();
+-	func_expr.children[0] = make_uniq<BoundReferenceExpression>(probe_side_key->return_type, 0);
+-	func_expr.children[1] = make_uniq<BoundReferenceExpression>(build_side_key->return_type, 1);
++	func_expr.children[0] = make_uniq<BoundReferenceExpression>(probe_side_key->GetReturnType(), 0);
++	func_expr.children[1] = make_uniq<BoundReferenceExpression>(build_side_key->GetReturnType(), 1);
+ 
+ 	lstate->join_match_executor.AddExpression(*lstate->match_expr);
+ 
+@@ -847,15 +847,15 @@ unique_ptr<OperatorState> PhysicalSpatialJoin::GetOperatorState(ExecutionContext
+ 	lstate->join_probe_executor.AddExpression(*probe_side_key);
+ 
+ 	// Make bbox expression for probe side
+-	lstate->bound_expr = GetBBOXExpression(context.client, probe_side_key->return_type);
++	lstate->bound_expr = GetBBOXExpression(context.client, probe_side_key->GetReturnType());
+ 	lstate->bbox_probe_executor.AddExpression(*lstate->bound_expr);
+ 
+ 	// The chunks we need for the join
+ 	lstate->probe_side_row_chunk.Initialize(context.client, probe_side_output_types);
+-	lstate->probe_side_key_chunk.Initialize(context.client, {probe_side_key->return_type});
+-	lstate->probe_side_box_chunk.Initialize(context.client, {lstate->bound_expr->return_type});
+-	lstate->build_side_key_chunk.Initialize(context.client, {build_side_key->return_type});
+-	lstate->match_pred_arg_chunk.Initialize(context.client, {probe_side_key->return_type, build_side_key->return_type});
++	lstate->probe_side_key_chunk.Initialize(context.client, {probe_side_key->GetReturnType()});
++	lstate->probe_side_box_chunk.Initialize(context.client, {lstate->bound_expr->GetReturnType()});
++	lstate->build_side_key_chunk.Initialize(context.client, {build_side_key->GetReturnType()});
++	lstate->match_pred_arg_chunk.Initialize(context.client, {probe_side_key->GetReturnType(), build_side_key->GetReturnType()});
+ 
+ 	return std::move(lstate);
+ }
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index e731bf3..2195fef 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -96,7 +96,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
+ 
+ 		auto has_crs = false;
+ 
+-		TypeVisitor::Contains(arg->return_type, [&](const LogicalType &type) {
++		TypeVisitor::Contains(arg->GetReturnType(), [&](const LogicalType &type) {
+ 			if (type.id() == LogicalTypeId::GEOMETRY && GeoType::HasCRS(type)) {
+ 				has_crs = true;
+ 				if (!found_crs) {
+@@ -106,7 +106,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
+ 					auto &type_crs = GeoType::GetCRS(type);
+ 					if (!crs.Equals(type_crs)) {
+ 						throw BinderException(
+-						    arg->query_location,
++						    arg->GetQueryLocation(),
+ 						    "Cannot call function '%s' with geometries of different coordinate reference systems "
+ 						    "(CRS).\n"
+ 						    "First geometry type is in '%s' which is not compatible with '%s'.\n"
+@@ -124,7 +124,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
+ 
+ 		if (has_crs) {
+ 			// Override the type so that we set the CRS
+-			bound_function.GetArguments()[arg_idx] = arg->return_type;
++			bound_function.GetArguments()[arg_idx] = arg->GetReturnType();
+ 		}
+ 	}
+ 

--- a/.github/patches/extensions/sqlite_scanner/0002-expr.patch
+++ b/.github/patches/extensions/sqlite_scanner/0002-expr.patch
@@ -1,0 +1,26 @@
+diff --git a/src/storage/sqlite_schema_entry.cpp b/src/storage/sqlite_schema_entry.cpp
+index d0b7fa3..593f388 100644
+--- a/src/storage/sqlite_schema_entry.cpp
++++ b/src/storage/sqlite_schema_entry.cpp
+@@ -70,7 +70,7 @@ optional_ptr<CatalogEntry> SQLiteSchemaEntry::CreateFunction(CatalogTransaction
+ }
+ 
+ void UnqualifyColumnReferences(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};
+diff --git a/src/storage/sqlite_update.cpp b/src/storage/sqlite_update.cpp
+index f49b4ea..565c185 100644
+--- a/src/storage/sqlite_update.cpp
++++ b/src/storage/sqlite_update.cpp
+@@ -111,7 +111,7 @@ PhysicalOperator &SQLiteCatalog::PlanUpdate(ClientContext &context, PhysicalPlan
+ 		throw BinderException("RETURNING clause not yet supported for updates of a SQLite table");
+ 	}
+ 	for (auto &expr : op.expressions) {
+-		if (expr->type == ExpressionType::VALUE_DEFAULT) {
++		if (expr->GetExpressionType() == ExpressionType::VALUE_DEFAULT) {
+ 			throw BinderException("SET DEFAULT is not yet supported for updates of a SQLite table");
+ 		}
+ 	}

--- a/.github/patches/extensions/sqlsmith/0004-expr.patch
+++ b/.github/patches/extensions/sqlsmith/0004-expr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index a6361c0..2828430 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -576,7 +576,7 @@ unique_ptr<TableRef> StatementGenerator::GenerateTableFunctionRef() {
+ 		auto name = Choose(names);
+ 		names.erase(std::find(names.begin(), names.end(), name));
+ 		auto expr = GenerateConstant();
+-		expr->alias = name;
++		expr->SetAlias(name);
+ 		children.push_back(std::move(expr));
+ 	}
+ 	result->function = make_uniq<FunctionExpression>(entry.name, std::move(children));

--- a/.github/patches/extensions/unity_catalog/0001-expr.patch
+++ b/.github/patches/extensions/unity_catalog/0001-expr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/uc_schema_entry.cpp b/src/storage/uc_schema_entry.cpp
+index d958ba3..53493d2 100644
+--- a/src/storage/uc_schema_entry.cpp
++++ b/src/storage/uc_schema_entry.cpp
+@@ -53,7 +53,7 @@ optional_ptr<CatalogEntry> UCSchemaEntry::CreateFunction(CatalogTransaction tran
+ }
+ 
+ void UCUnqualifyColumnRef(ParsedExpression &expr) {
+-	if (expr.type == ExpressionType::COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
+ 		auto &colref = expr.Cast<ColumnRefExpression>();
+ 		auto name = std::move(colref.column_names.back());
+ 		colref.column_names = {std::move(name)};

--- a/.github/patches/extensions/vss/0004-reset-storage.patch
+++ b/.github/patches/extensions/vss/0004-reset-storage.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
-index b85f470..edb4d5a 100644
+index 4d16e3d..1eb697a 100644
 --- a/src/hnsw/hnsw_index.cpp
 +++ b/src/hnsw/hnsw_index.cpp
 @@ -408,7 +408,7 @@ void HNSWIndex::ResetMultiScan(IndexScanState &state) {

--- a/.github/patches/extensions/vss/0006-expr.patch
+++ b/.github/patches/extensions/vss/0006-expr.patch
@@ -1,0 +1,223 @@
+diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
+index 1eb697a..c22ac10 100644
+--- a/src/hnsw/hnsw_index.cpp
++++ b/src/hnsw/hnsw_index.cpp
+@@ -617,7 +617,7 @@ void HNSWIndex::VerifyAllocations(IndexLock &state) {
+ static void TryBindIndexExpressionInternal(Expression &expr, TableIndex table_idx, const vector<column_t> &index_columns,
+                                            const vector<ColumnIndex> &table_columns, bool &success, bool &found) {
+ 
+-	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
++	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+ 		found = true;
+ 		auto &ref = expr.Cast<BoundColumnRefExpression>();
+ 
+diff --git a/src/hnsw/hnsw_index_physical_create.cpp b/src/hnsw/hnsw_index_physical_create.cpp
+index ef33ebe..dd3692a 100644
+--- a/src/hnsw/hnsw_index_physical_create.cpp
++++ b/src/hnsw/hnsw_index_physical_create.cpp
+@@ -62,7 +62,7 @@ public:
+ unique_ptr<GlobalSinkState> PhysicalCreateHNSWIndex::GetGlobalSinkState(ClientContext &context) const {
+ 	auto gstate = make_uniq<CreateHNSWIndexGlobalState>(*this);
+ 
+-	vector<LogicalType> data_types = {unbound_expressions[0]->return_type, LogicalType::ROW_TYPE};
++	vector<LogicalType> data_types = {unbound_expressions[0]->GetReturnType(), LogicalType::ROW_TYPE};
+ 	gstate->collection = make_uniq<ColumnDataCollection>(BufferManager::GetBufferManager(context), data_types);
+ 	gstate->context = context.shared_from_this();
+ 
+@@ -90,7 +90,7 @@ public:
+ unique_ptr<LocalSinkState> PhysicalCreateHNSWIndex::GetLocalSinkState(ExecutionContext &context) const {
+ 	auto state = make_uniq<CreateHNSWIndexLocalState>();
+ 
+-	vector<LogicalType> data_types = {unbound_expressions[0]->return_type, LogicalType::ROW_TYPE};
++	vector<LogicalType> data_types = {unbound_expressions[0]->GetReturnType(), LogicalType::ROW_TYPE};
+ 	state->collection = make_uniq<ColumnDataCollection>(BufferManager::GetBufferManager(context.client), data_types);
+ 	state->collection->InitializeAppend(state->append_state);
+ 	return std::move(state);
+diff --git a/src/hnsw/hnsw_index_plan.cpp b/src/hnsw/hnsw_index_plan.cpp
+index 1ca593a..d96e1cf 100644
+--- a/src/hnsw/hnsw_index_plan.cpp
++++ b/src/hnsw/hnsw_index_plan.cpp
+@@ -83,7 +83,7 @@ PhysicalOperator &HNSWIndex::CreatePlan(PlanIndexInput &input) {
+ 	if (create_index.expressions.size() != 1) {
+ 		throw BinderException("HNSW indexes can only be created over a single column of keys.");
+ 	}
+-	auto &arr_type = create_index.expressions[0]->return_type;
++	auto &arr_type = create_index.expressions[0]->GetReturnType();
+ 	if (arr_type.id() != LogicalTypeId::ARRAY) {
+ 		throw BinderException("HNSW index keys must be of type FLOAT[N]");
+ 	}
+@@ -103,7 +103,7 @@ PhysicalOperator &HNSWIndex::CreatePlan(PlanIndexInput &input) {
+ 	vector<LogicalType> new_column_types;
+ 	vector<unique_ptr<Expression>> select_list;
+ 	for (auto &expression : create_index.expressions) {
+-		new_column_types.push_back(expression->return_type);
++		new_column_types.push_back(expression->GetReturnType());
+ 		select_list.push_back(std::move(expression));
+ 	}
+ 	new_column_types.emplace_back(LogicalType::ROW_TYPE);
+diff --git a/src/hnsw/hnsw_optimize_expr.cpp b/src/hnsw/hnsw_optimize_expr.cpp
+index 7a88816..d470fb0 100644
+--- a/src/hnsw/hnsw_optimize_expr.cpp
++++ b/src/hnsw/hnsw_optimize_expr.cpp
+@@ -50,8 +50,8 @@ unique_ptr<Expression> CosineDistanceRule::Apply(LogicalOperator &op, vector<ref
+ 		// Create the new array_cosine_distance function
+ 		vector<unique_ptr<Expression>> args;
+ 		vector<LogicalType> arg_types;
+-		arg_types.push_back(similarity_expr.children[0]->return_type);
+-		arg_types.push_back(similarity_expr.children[1]->return_type);
++		arg_types.push_back(similarity_expr.children[0]->GetReturnType());
++		arg_types.push_back(similarity_expr.children[1]->GetReturnType());
+ 		args.push_back(std::move(similarity_expr.children[0]));
+ 		args.push_back(std::move(similarity_expr.children[1]));
+ 
+@@ -65,7 +65,7 @@ unique_ptr<Expression> CosineDistanceRule::Apply(LogicalOperator &op, vector<ref
+ 
+ 		changes_made = true;
+ 		auto func = func_entry->functions.GetFunctionByArguments(context, arg_types);
+-		return make_uniq<BoundFunctionExpression>(similarity_expr.return_type, func, std::move(args), nullptr);
++		return make_uniq<BoundFunctionExpression>(similarity_expr.GetReturnType(), func, std::move(args), nullptr);
+ 	}
+ 	return nullptr;
+ }
+diff --git a/src/hnsw/hnsw_optimize_join.cpp b/src/hnsw/hnsw_optimize_join.cpp
+index 9fabcae..36c220f 100644
+--- a/src/hnsw/hnsw_optimize_join.cpp
++++ b/src/hnsw/hnsw_optimize_join.cpp
+@@ -445,15 +445,15 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 	if (filter.expressions.size() != 1) {
+ 		return false;
+ 	}
+-	if (filter.expressions.back()->type != ExpressionType::COMPARE_LESSTHANOREQUALTO) {
++	if (filter.expressions.back()->GetExpressionType() != ExpressionType::COMPARE_LESSTHANOREQUALTO) {
+ 		return false;
+ 	}
+ 	const auto &compare_expr = filter.expressions.back()->Cast<BoundComparisonExpression>();
+-	if (compare_expr.right->type != ExpressionType::VALUE_CONSTANT) {
++	if (compare_expr.right->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+ 		return false;
+ 	}
+ 	const auto &constant_expr = compare_expr.right->Cast<BoundConstantExpression>();
+-	if (constant_expr.return_type != LogicalType::BIGINT) {
++	if (constant_expr.GetReturnType() != LogicalType::BIGINT) {
+ 		return false;
+ 	}
+ 	auto k_value = constant_expr.value.GetValue<int64_t>();
+@@ -461,7 +461,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 		// Can only optimize up to SVS
+ 		return false;
+ 	}
+-	if (compare_expr.left->type != ExpressionType::BOUND_COLUMN_REF) {
++	if (compare_expr.left->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+ 		return false;
+ 	}
+ 	auto &filter_ref_expr = compare_expr.left->Cast<BoundColumnRefExpression>();
+@@ -476,7 +476,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 	if (window.expressions.size() != 1) {
+ 		return false;
+ 	}
+-	if (window.expressions.back()->type != ExpressionType::WINDOW_ROW_NUMBER) {
++	if (window.expressions.back()->GetExpressionType() != ExpressionType::WINDOW_ROW_NUMBER) {
+ 		return false;
+ 	}
+ 	auto &window_expr = window.expressions.back()->Cast<BoundWindowExpression>();
+@@ -486,7 +486,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 	if (window_expr.orders.back().type != OrderType::ASCENDING) {
+ 		return false;
+ 	}
+-	if (window_expr.orders.back().expression->type != ExpressionType::BOUND_COLUMN_REF) {
++	if (window_expr.orders.back().expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+ 		return false;
+ 	}
+ 	const auto &distance_ref_expr = window_expr.orders.back().expression->Cast<BoundColumnRefExpression>();
+@@ -532,7 +532,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 
+ 		// We also have to replace the outer table index here with the delim_get table index
+ 		ExpressionIterator::EnumerateExpression(bound_index_expr, [&](Expression &child) {
+-			if (child.type == ExpressionType::BOUND_COLUMN_REF) {
++			if (child.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+ 				auto &bound_colref_expr = child.Cast<BoundColumnRefExpression>();
+ 				if (bound_colref_expr.binding.table_index == outer_get.table_index) {
+ 					bound_colref_expr.binding.table_index = delim_get.table_index;
+@@ -562,10 +562,10 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 	}
+ 
+ 	// Fuck it, for now dont allow expressions on the index
+-	if (bindings[1].get().type != ExpressionType::BOUND_COLUMN_REF) {
++	if (bindings[1].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+ 		return false;
+ 	}
+-	if (bindings[2].get().type != ExpressionType::BOUND_COLUMN_REF) {
++	if (bindings[2].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+ 		return false;
+ 	}
+ 	const auto &outer_ref_expr = bindings[1].get().Cast<BoundColumnRefExpression>();
+diff --git a/src/hnsw/hnsw_optimize_scan.cpp b/src/hnsw/hnsw_optimize_scan.cpp
+index 5d47cb0..075328e 100644
+--- a/src/hnsw/hnsw_optimize_scan.cpp
++++ b/src/hnsw/hnsw_optimize_scan.cpp
+@@ -49,7 +49,7 @@ public:
+ 			return false;
+ 		}
+ 
+-		if (order.expression->type != ExpressionType::BOUND_COLUMN_REF) {
++		if (order.expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+ 			// The expression has to reference the child operator (a projection with the distance function)
+ 			return false;
+ 		}
+@@ -124,10 +124,10 @@ public:
+ 			auto &const_expr_ref = bindings[1];
+ 			auto &index_expr_ref = bindings[2];
+ 
+-			if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
++			if (const_expr_ref.get().GetExpressionType() != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+ 				// Swap the bindings and try again
+ 				std::swap(const_expr_ref, index_expr_ref);
+-				if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT ||
++				if (const_expr_ref.get().GetExpressionType() != ExpressionType::VALUE_CONSTANT ||
+ 				    !index_expr->Equals(index_expr_ref)) {
+ 					// Nope, not a match, we can't optimize.
+ 					continue;
+@@ -211,7 +211,7 @@ public:
+ 					column_binding_set_t referenced_bindings;
+ 					for (auto &expr : parent_projection.expressions) {
+ 						ExpressionIterator::EnumerateExpression(expr, [&](Expression &expr_ref) {
+-							if (expr_ref.type == ExpressionType::BOUND_COLUMN_REF) {
++							if (expr_ref.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+ 								auto &bound_column_ref = expr_ref.Cast<BoundColumnRefExpression>();
+ 								referenced_bindings.insert(bound_column_ref.binding);
+ 							}
+diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
+index c48a9f9..afb70c8 100644
+--- a/src/hnsw/hnsw_optimize_topk.cpp
++++ b/src/hnsw/hnsw_optimize_topk.cpp
+@@ -75,7 +75,7 @@ public:
+ 		}
+ 
+ 		auto &agg_expr = agg.expressions[0];
+-		if (agg_expr->type != ExpressionType::BOUND_AGGREGATE) {
++		if (agg_expr->GetExpressionType() != ExpressionType::BOUND_AGGREGATE) {
+ 			return false;
+ 		}
+ 		auto &agg_func_expr = agg_expr->Cast<BoundAggregateExpression>();
+@@ -85,7 +85,7 @@ public:
+ 		if (agg_func_expr.children.size() != 3) {
+ 			return false;
+ 		}
+-		if (agg_func_expr.children[2]->type != ExpressionType::VALUE_CONSTANT) {
++		if (agg_func_expr.children[2]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+ 			return false;
+ 		}
+ 		const auto &col_expr = agg_func_expr.children[0];
+@@ -149,10 +149,10 @@ public:
+ 			auto &const_expr_ref = bindings[1];
+ 			auto &index_expr_ref = bindings[2];
+ 
+-			if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
++			if (const_expr_ref.get().GetExpressionType() != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+ 				// Swap the bindings and try again
+ 				std::swap(const_expr_ref, index_expr_ref);
+-				if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT ||
++				if (const_expr_ref.get().GetExpressionType() != ExpressionType::VALUE_CONSTANT ||
+ 				    !index_expr->Equals(index_expr_ref)) {
+ 					// Nope, not a match, we can't optimize.
+ 					continue;

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -289,7 +289,7 @@ AggregateFunction GetAverageAggregate(PhysicalType type) {
 unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	auto decimal_type = arguments[0]->return_type;
+	auto decimal_type = arguments[0]->GetReturnType();
 	function = GetAverageAggregate(decimal_type.InternalType());
 	function.name = "avg";
 	function.GetArguments()[0] = decimal_type;

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -189,11 +189,11 @@ struct ArgMinMaxBase {
 		auto &context = input.GetClientContext();
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
-			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
+		if (arguments[1]->GetReturnType().InternalType() == PhysicalType::VARCHAR) {
+			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->GetReturnType());
 		}
-		function.GetArguments()[0] = arguments[0]->return_type;
-		function.SetReturnType(arguments[0]->return_type);
+		function.GetArguments()[0] = arguments[0]->GetReturnType();
+		function.SetReturnType(arguments[0]->GetReturnType());
 
 		auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING);
 		return unique_ptr<FunctionData>(std::move(function_data));
@@ -354,11 +354,11 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 		auto &context = input.GetClientContext();
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
-			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
+		if (arguments[1]->GetReturnType().InternalType() == PhysicalType::VARCHAR) {
+			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->GetReturnType());
 		}
-		function.GetArguments()[0] = arguments[0]->return_type;
-		function.SetReturnType(arguments[0]->return_type);
+		function.GetArguments()[0] = arguments[0]->GetReturnType();
+		function.SetReturnType(arguments[0]->GetReturnType());
 
 		auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING);
 		return unique_ptr<FunctionData>(std::move(function_data));
@@ -526,8 +526,8 @@ unique_ptr<FunctionData> BindDecimalArgMinMax(BindAggregateFunctionInput &input)
 	auto &context = input.GetClientContext();
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	auto decimal_type = arguments[0]->return_type;
-	auto by_type = arguments[1]->return_type;
+	auto decimal_type = arguments[0]->GetReturnType();
+	auto by_type = arguments[1]->GetReturnType();
 
 	// To avoid a combinatorial explosion, cast the ordering argument to one from the list
 	auto by_types = ArgMaxByTypes();
@@ -858,14 +858,14 @@ unique_ptr<FunctionData> ArgMinMaxNBind(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}
 
-	const auto val_type = arguments[0]->return_type.InternalType();
-	const auto arg_type = arguments[1]->return_type.InternalType();
-	function.SetReturnType(LogicalType::LIST(arguments[0]->return_type));
+	const auto val_type = arguments[0]->GetReturnType().InternalType();
+	const auto arg_type = arguments[1]->GetReturnType().InternalType();
+	function.SetReturnType(LogicalType::LIST(arguments[0]->GetReturnType()));
 
 	// Specialize the function based on the input types
 	auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING, NULLS_LAST);

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -402,7 +402,7 @@ AggregateFunction GetVectorArgMinMaxFunctionInternal(const LogicalType &by_type,
 #else
 	auto function = GetGenericArgMinMaxFunction<OP>(null_handling);
 	function.GetArguments() = {type, by_type};
-	function.return_type = type;
+	function.SetReturnType(type);
 	return function;
 #endif
 }
@@ -463,7 +463,7 @@ AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &by_type, const
 #else
 	auto function = GetGenericArgMinMaxFunction<OP>(null_handling);
 	function.GetArguments() = {type, by_type};
-	function.return_type = type;
+	function.SetReturnType(type);
 #endif
 	return function;
 }

--- a/extension/core_functions/aggregate/distributive/string_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/string_agg.cpp
@@ -124,7 +124,7 @@ unique_ptr<FunctionData> StringAggBind(BindAggregateFunctionInput &input) {
 	D_ASSERT(arguments.size() == 2);
 	// Check if any argument is of UNKNOWN type (parameter not yet bound)
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -234,7 +234,7 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	auto decimal_type = arguments[0]->return_type;
+	auto decimal_type = arguments[0]->GetReturnType();
 	function = GetSumAggregate(decimal_type.InternalType());
 	function.name = "sum";
 	function.GetArguments()[0] = decimal_type;

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -388,15 +388,15 @@ unique_ptr<FunctionData> ApproxTopKBind(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}
-	if (arguments[0]->return_type.id() == LogicalTypeId::VARCHAR) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::VARCHAR) {
 		function.SetStateUpdateCallback(ApproxTopKUpdate<string_t, HistogramStringFunctor>);
 		function.SetStateFinalizeCallback(ApproxTopKFinalize<HistogramStringFunctor>);
 	}
-	function.SetReturnType(LogicalType::LIST(arguments[0]->return_type));
+	function.SetReturnType(LogicalType::LIST(arguments[0]->GetReturnType()));
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -283,7 +283,7 @@ unique_ptr<FunctionData> BindApproxQuantileDecimal(BindAggregateFunctionInput &i
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto bind_data = BindApproxQuantile(input);
-	function = ApproxQuantileDecimalFunction(arguments[0]->return_type);
+	function = ApproxQuantileDecimalFunction(arguments[0]->GetReturnType());
 	return bind_data;
 }
 
@@ -404,7 +404,7 @@ unique_ptr<FunctionData> BindApproxQuantileDecimalList(BindAggregateFunctionInpu
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto bind_data = BindApproxQuantile(input);
-	function = ApproxQuantileDecimalListFunction(arguments[0]->return_type);
+	function = ApproxQuantileDecimalListFunction(arguments[0]->GetReturnType());
 	return bind_data;
 }
 

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -322,7 +322,7 @@ AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType 
 unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->return_type);
+	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
 	function.name = "mad";
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return BindMAD(input);

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -503,7 +503,7 @@ AggregateFunction GetModeAggregate(const LogicalType &type) {
 unique_ptr<FunctionData> BindModeAggregate(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetModeAggregate(arguments[0]->return_type);
+	function = GetModeAggregate(arguments[0]->GetReturnType());
 	function.name = "mode";
 	return nullptr;
 }
@@ -605,7 +605,7 @@ AggregateFunction GetEntropyFunction(const LogicalType &type) {
 unique_ptr<FunctionData> BindEntropyAggregate(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetEntropyFunction(arguments[0]->return_type);
+	function = GetEntropyFunction(arguments[0]->GetReturnType());
 	function.name = "entropy";
 	return nullptr;
 }

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -660,7 +660,7 @@ struct MedianFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->return_type);
+		function = GetAggregate(arguments[0]->GetReturnType());
 		return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
 	}
 };
@@ -689,7 +689,7 @@ struct DiscreteQuantileListFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->return_type);
+		function = GetAggregate(arguments[0]->GetReturnType());
 		return BindQuantile(input);
 	}
 };
@@ -723,7 +723,7 @@ struct DiscreteQuantileFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->return_type);
+		function = GetAggregate(arguments[0]->GetReturnType());
 		return BindQuantile(input);
 	}
 };
@@ -752,8 +752,9 @@ struct ContinuousQuantileFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->return_type
-		                                                                                  : function.GetArguments()[0]);
+		function =
+		    GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->GetReturnType()
+		                                                                           : function.GetArguments()[0]);
 		return BindQuantile(input);
 	}
 };
@@ -783,8 +784,9 @@ struct ContinuousQuantileListFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->return_type
-		                                                                                  : function.GetArguments()[0]);
+		function =
+		    GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->GetReturnType()
+		                                                                           : function.GetArguments()[0]);
 		return BindQuantile(input);
 	}
 };

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -366,7 +366,7 @@ unique_ptr<FunctionData> BindReservoirQuantile(BindAggregateFunctionInput &input
 unique_ptr<FunctionData> BindReservoirQuantileDecimal(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetReservoirQuantileAggregateFunction(arguments[0]->return_type.InternalType());
+	function = GetReservoirQuantileAggregateFunction(arguments[0]->GetReturnType().InternalType());
 	auto bind_data = BindReservoirQuantile(input);
 	function.name = "reservoir_quantile";
 	function.SetSerializeCallback(ReservoirQuantileBindData::Serialize);

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -393,12 +393,12 @@ unique_ptr<FunctionData> HistogramBinBindFunction(BindAggregateFunctionInput &in
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}
 
-	function = GetHistogramBinFunction<HIST>(arguments[0]->return_type);
+	function = GetHistogramBinFunction<HIST>(arguments[0]->GetReturnType());
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -210,10 +210,10 @@ unique_ptr<FunctionData> HistogramBindFunction(BindAggregateFunctionInput &input
 	auto &arguments = input.GetArguments();
 	D_ASSERT(arguments.size() == 1);
 
-	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	function = GetHistogramFunction<IS_ORDERED>(arguments[0]->return_type);
+	function = GetHistogramFunction<IS_ORDERED>(arguments[0]->GetReturnType());
 	return make_uniq<VariableReturnBindData>(function.GetReturnType());
 }
 

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -170,7 +170,7 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 unique_ptr<FunctionData> ListBindFunction(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function.SetReturnType(LogicalType::LIST(arguments[0]->return_type));
+	function.SetReturnType(LogicalType::LIST(arguments[0]->GetReturnType()));
 	return make_uniq<ListBindData>(function.GetReturnType());
 }
 

--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -32,7 +32,7 @@ struct LambdaExecuteInfo {
 		}
 
 		// get the result types
-		vector<LogicalType> result_types {lambda_expr.return_type};
+		vector<LogicalType> result_types {lambda_expr.GetReturnType()};
 
 		// initialize the data chunks
 		input_chunk.InitializeEmpty(input_types);
@@ -352,18 +352,18 @@ unique_ptr<FunctionData> LambdaFunctions::ListLambdaPrepareBind(vector<unique_pt
                                                                 ClientContext &context,
                                                                 ScalarFunction &bound_function) {
 	// NULL list parameter
-	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
 		bound_function.GetArguments()[0] = LogicalType::SQLNULL;
 		bound_function.SetReturnType(LogicalType::SQLNULL);
 		return make_uniq<ListLambdaBindData>(bound_function.GetReturnType(), nullptr);
 	}
 	// prepared statements
-	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
-	D_ASSERT(arguments[0]->return_type.id() == LogicalTypeId::LIST);
+	D_ASSERT(arguments[0]->GetReturnType().id() == LogicalTypeId::LIST);
 	return nullptr;
 }
 

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -9,8 +9,8 @@ static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	const auto &lhs_type = arguments[0]->return_type;
-	const auto &rhs_type = arguments[1]->return_type;
+	const auto &lhs_type = arguments[0]->GetReturnType();
+	const auto &rhs_type = arguments[1]->GetReturnType();
 
 	if (lhs_type.IsUnknown() && rhs_type.IsUnknown()) {
 		bound_function.GetArguments()[0] = rhs_type;

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -54,9 +54,9 @@ unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 	}
 
 	// construct return type
-	LogicalType child_type = arguments[0]->return_type;
+	LogicalType child_type = arguments[0]->GetReturnType();
 	for (idx_t i = 1; i < arguments.size(); i++) {
-		child_type = LogicalType::MaxLogicalType(context, child_type, arguments[i]->return_type);
+		child_type = LogicalType::MaxLogicalType(context, child_type, arguments[i]->GetReturnType());
 	}
 
 	if (arguments.size() > ArrayType::MAX_ARRAY_SIZE) {
@@ -72,7 +72,7 @@ unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 unique_ptr<BaseStatistics> ArrayValueStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
-	auto list_stats = ArrayStats::CreateEmpty(expr.return_type);
+	auto list_stats = ArrayStats::CreateEmpty(expr.GetReturnType());
 	auto &list_child_stats = ArrayStats::GetChildStats(list_stats);
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		list_child_stats.Merge(child_stats[i]);

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 namespace {
-DatePartSpecifier GetDateTypePartSpecifier(const string &specifier, LogicalType &type) {
+DatePartSpecifier GetDateTypePartSpecifier(const string &specifier, const LogicalType &type) {
 	const auto part = GetDatePartSpecifier(specifier);
 	switch (type.id()) {
 	case LogicalType::TIMESTAMP:
@@ -1779,7 +1779,7 @@ unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
 		bound_function.GetArguments().erase(bound_function.GetArguments().begin());
 		bound_function.name = "julian";
 		bound_function.SetReturnType(LogicalType::DOUBLE);
-		switch (arguments[0]->return_type.id()) {
+		switch (arguments[0]->GetReturnType().id()) {
 		case LogicalType::TIMESTAMP:
 		case LogicalType::TIMESTAMP_S:
 		case LogicalType::TIMESTAMP_MS:
@@ -1802,7 +1802,7 @@ unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
 		bound_function.GetArguments().erase(bound_function.GetArguments().begin());
 		bound_function.name = "epoch";
 		bound_function.SetReturnType(LogicalType::DOUBLE);
-		switch (arguments[0]->return_type.id()) {
+		switch (arguments[0]->GetReturnType().id()) {
 		case LogicalType::TIMESTAMP:
 		case LogicalType::TIMESTAMP_S:
 		case LogicalType::TIMESTAMP_MS:
@@ -1970,7 +1970,7 @@ struct StructDatePart {
 					throw BinderException("NULL struct entry name in %s", bound_function.name);
 				}
 				const auto part_name = part_value.ToString();
-				const auto part_code = GetDateTypePartSpecifier(part_name, arguments[1]->return_type);
+				const auto part_code = GetDateTypePartSpecifier(part_name, arguments[1]->GetReturnType());
 				if (name_collision_set.find(part_name) != name_collision_set.end()) {
 					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name, bound_function.name);
 				}

--- a/extension/core_functions/scalar/debug/index_key.cpp
+++ b/extension/core_functions/scalar/debug/index_key.cpp
@@ -74,7 +74,8 @@ static TableDescription EvaluateTableDescription(ClientContext &context, const E
 		throw BinderException("index_key: path parameter must evaluate to a STRUCT");
 	}
 
-	return ExtractTableDescription(StructType::GetChildTypes(expr.return_type), StructValue::GetChildren(input_struct));
+	return ExtractTableDescription(StructType::GetChildTypes(expr.GetReturnType()),
+	                               StructValue::GetChildren(input_struct));
 }
 
 static string GetStringArgument(ClientContext &context, const Expression &expr, const string &param_name) {
@@ -178,8 +179,8 @@ static unique_ptr<FunctionData> IndexKeyBind(BindScalarFunctionInput &input) {
 	// that only references the key columns during execution. We could erase the first two arguments here, but
 	// that also requires some (de)serialization boilerplate, so for now we don't do it.
 	bound_function.GetArguments().clear();
-	bound_function.GetArguments().push_back(arguments[0]->return_type);
-	bound_function.GetArguments().push_back(arguments[1]->return_type);
+	bound_function.GetArguments().push_back(arguments[0]->GetReturnType());
+	bound_function.GetArguments().push_back(arguments[1]->GetReturnType());
 	for (auto &key_type : key_types) {
 		bound_function.GetArguments().push_back(key_type);
 	}

--- a/extension/core_functions/scalar/enum/enum_functions.cpp
+++ b/extension/core_functions/scalar/enum/enum_functions.cpp
@@ -74,7 +74,7 @@ static void CheckEnumParameter(const Expression &expr) {
 static unique_ptr<FunctionData> BindEnumFunction(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
-	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::ENUM) {
 		throw BinderException("This function needs an ENUM as an argument");
 	}
 	return nullptr;
@@ -84,11 +84,11 @@ static unique_ptr<FunctionData> BindEnumCodeFunction(BindScalarFunctionInput &in
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
-	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::ENUM) {
 		throw BinderException("This function needs an ENUM as an argument");
 	}
 
-	auto phy_type = EnumType::GetPhysicalType(arguments[0]->return_type);
+	auto phy_type = EnumType::GetPhysicalType(arguments[0]->GetReturnType());
 	switch (phy_type) {
 	case PhysicalType::UINT8:
 		bound_function.SetReturnType(LogicalType(LogicalTypeId::UTINYINT));
@@ -113,18 +113,21 @@ static unique_ptr<FunctionData> BindEnumRangeBoundaryFunction(BindScalarFunction
 	auto &arguments = input.GetArguments();
 	CheckEnumParameter(*arguments[0]);
 	CheckEnumParameter(*arguments[1]);
-	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM && arguments[0]->return_type != LogicalType::SQLNULL) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::ENUM &&
+	    arguments[0]->GetReturnType() != LogicalType::SQLNULL) {
 		throw BinderException("This function needs an ENUM as an argument");
 	}
-	if (arguments[1]->return_type.id() != LogicalTypeId::ENUM && arguments[1]->return_type != LogicalType::SQLNULL) {
+	if (arguments[1]->GetReturnType().id() != LogicalTypeId::ENUM &&
+	    arguments[1]->GetReturnType() != LogicalType::SQLNULL) {
 		throw BinderException("This function needs an ENUM as an argument");
 	}
-	if (arguments[0]->return_type == LogicalType::SQLNULL && arguments[1]->return_type == LogicalType::SQLNULL) {
+	if (arguments[0]->GetReturnType() == LogicalType::SQLNULL &&
+	    arguments[1]->GetReturnType() == LogicalType::SQLNULL) {
 		throw BinderException("This function needs an ENUM as an argument");
 	}
-	if (arguments[0]->return_type.id() == LogicalTypeId::ENUM &&
-	    arguments[1]->return_type.id() == LogicalTypeId::ENUM &&
-	    arguments[0]->return_type != arguments[1]->return_type) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::ENUM &&
+	    arguments[1]->GetReturnType().id() == LogicalTypeId::ENUM &&
+	    arguments[0]->GetReturnType() != arguments[1]->GetReturnType()) {
 		throw BinderException("The parameters need to link to ONLY one enum OR be NULL ");
 	}
 	return nullptr;

--- a/extension/core_functions/scalar/generic/binning.cpp
+++ b/extension/core_functions/scalar/generic/binning.cpp
@@ -411,7 +411,7 @@ unique_ptr<FunctionData> BindEquiWidthFunction(BindScalarFunctionInput &input) {
 	// while internally the bins are computed over a unified type
 	// the equi_width_bins function returns the same type as the input MAX
 	LogicalType child_type;
-	switch (arguments[1]->return_type.id()) {
+	switch (arguments[1]->GetReturnType().id()) {
 	case LogicalTypeId::UNKNOWN:
 	case LogicalTypeId::SQLNULL:
 		return nullptr;
@@ -420,7 +420,7 @@ unique_ptr<FunctionData> BindEquiWidthFunction(BindScalarFunctionInput &input) {
 		child_type = LogicalType::DOUBLE;
 		break;
 	default:
-		child_type = arguments[1]->return_type;
+		child_type = arguments[1]->GetReturnType();
 		break;
 	}
 	bound_function.SetReturnType(LogicalType::LIST(child_type));

--- a/extension/core_functions/scalar/generic/can_implicitly_cast.cpp
+++ b/extension/core_functions/scalar/generic/can_implicitly_cast.cpp
@@ -20,8 +20,8 @@ void CanCastImplicitlyFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 unique_ptr<Expression> BindCanCastImplicitlyExpression(FunctionBindExpressionInput &input) {
-	auto &source_type = input.children[0]->return_type;
-	auto &target_type = input.children[1]->return_type;
+	auto &source_type = input.children[0]->GetReturnType();
+	auto &target_type = input.children[1]->GetReturnType();
 	if (source_type.id() == LogicalTypeId::UNKNOWN || source_type.id() == LogicalTypeId::SQLNULL ||
 	    target_type.id() == LogicalTypeId::UNKNOWN || target_type.id() == LogicalTypeId::SQLNULL) {
 		// parameter - unknown return type

--- a/extension/core_functions/scalar/generic/cast_to_type.cpp
+++ b/extension/core_functions/scalar/generic/cast_to_type.cpp
@@ -10,7 +10,7 @@ void CastToTypeFunction(DataChunk &args, ExpressionState &state, Vector &result)
 }
 
 unique_ptr<Expression> BindCastToTypeFunction(FunctionBindExpressionInput &input) {
-	auto &return_type = input.children[1]->return_type;
+	auto &return_type = input.children[1]->GetReturnType();
 	if (return_type.id() == LogicalTypeId::UNKNOWN) {
 		// parameter - unknown return type
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/extension/core_functions/scalar/generic/current_setting.cpp
@@ -38,11 +38,11 @@ unique_ptr<FunctionData> CurrentSettingBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto &key_child = arguments[0];
-	if (key_child->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (key_child->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	if (key_child->return_type.id() != LogicalTypeId::VARCHAR ||
-	    key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+	if (key_child->GetReturnType().id() != LogicalTypeId::VARCHAR ||
+	    key_child->GetReturnType().id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
 		throw ParserException("Key name for current_setting needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(context, *key_child);

--- a/extension/core_functions/scalar/generic/replace_type.cpp
+++ b/extension/core_functions/scalar/generic/replace_type.cpp
@@ -9,8 +9,8 @@ static void ReplaceTypeFunction(DataChunk &, ExpressionState &, Vector &) {
 }
 
 static unique_ptr<Expression> BindReplaceTypeFunction(FunctionBindExpressionInput &input) {
-	const auto &from = input.children[1]->return_type;
-	const auto &to = input.children[2]->return_type;
+	const auto &from = input.children[1]->GetReturnType();
+	const auto &to = input.children[2]->GetReturnType();
 	if (from.id() == LogicalTypeId::UNKNOWN || to.id() == LogicalTypeId::UNKNOWN) {
 		// parameters - unknown return type
 		throw ParameterNotResolvedException();
@@ -19,7 +19,7 @@ static unique_ptr<Expression> BindReplaceTypeFunction(FunctionBindExpressionInpu
 		throw InvalidInputException("replace_type cannot be used to replace type with NULL");
 	}
 	const auto return_type = TypeVisitor::VisitReplace(
-	    input.children[0]->return_type, [&from, &to](const LogicalType &type) { return type == from ? to : type; });
+	    input.children[0]->GetReturnType(), [&from, &to](const LogicalType &type) { return type == from ? to : type; });
 	return BoundCastExpression::AddCastToType(input.context, std::move(input.children[0]), return_type);
 }
 

--- a/extension/core_functions/scalar/generic/system_functions.cpp
+++ b/extension/core_functions/scalar/generic/system_functions.cpp
@@ -50,7 +50,7 @@ public:
 unique_ptr<FunctionData> CurrentSchemasBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &arguments = input.GetArguments();
-	if (arguments[0]->return_type.id() != LogicalTypeId::BOOLEAN) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 		throw BinderException("current_schemas requires a boolean input");
 	}
 	if (!arguments[0]->IsFoldable()) {

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -18,7 +18,7 @@ static void TypeOfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 static unique_ptr<Expression> BindTypeOfFunctionExpression(FunctionBindExpressionInput &input) {
-	auto &return_type = input.children[0]->return_type;
+	auto &return_type = input.children[0]->GetReturnType();
 	if (return_type.id() == LogicalTypeId::UNKNOWN || return_type.id() == LogicalTypeId::SQLNULL) {
 		// parameter - unknown return type
 		return nullptr;
@@ -50,12 +50,12 @@ static unique_ptr<FunctionData> BindGetTypeFunction(BindScalarFunctionInput &inp
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	return nullptr;
 }
 
 static unique_ptr<Expression> BindGetTypeFunctionExpression(FunctionBindExpressionInput &input) {
-	auto &return_type = input.children[0]->return_type;
+	auto &return_type = input.children[0]->GetReturnType();
 	if (return_type.id() == LogicalTypeId::UNKNOWN || return_type.id() == LogicalTypeId::SQLNULL) {
 		// parameter - unknown return type
 		return nullptr;

--- a/extension/core_functions/scalar/generic/type_functions.cpp
+++ b/extension/core_functions/scalar/generic/type_functions.cpp
@@ -83,7 +83,7 @@ static unique_ptr<Expression> BindMakeTypeFunctionExpression(FunctionBindExpress
 
 	// Evaluate all arguments to constant values
 	for (auto &child : input.children) {
-		string name = child->alias;
+		string name = child->GetAlias();
 		if (!child->IsFoldable()) {
 			throw BinderException("make_type function arguments must be constant expressions");
 		}

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -300,7 +300,7 @@ void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 bool CheckIfParamIsEmpty(duckdb::unique_ptr<duckdb::Expression> &param) {
 	bool is_empty = false;
-	if (param->return_type.id() == LogicalTypeId::LIST) {
+	if (param->GetReturnType().id() == LogicalTypeId::LIST) {
 		auto empty_list = make_uniq<BoundConstantExpression>(Value::LIST(LogicalType::INTEGER, vector<Value>()));
 		is_empty = param->Equals(*empty_list);
 		if (!is_empty) {
@@ -318,17 +318,17 @@ unique_ptr<FunctionData> ArraySliceBind(BindScalarFunctionInput &input) {
 	D_ASSERT(arguments.size() == 3 || arguments.size() == 4);
 	D_ASSERT(bound_function.GetArguments().size() == 3 || bound_function.GetArguments().size() == 4);
 
-	switch (arguments[0]->return_type.id()) {
+	switch (arguments[0]->GetReturnType().id()) {
 	case LogicalTypeId::ARRAY: {
 		// Cast to list
-		auto child_type = ArrayType::GetChildType(arguments[0]->return_type);
+		auto child_type = ArrayType::GetChildType(arguments[0]->GetReturnType());
 		auto target_type = LogicalType::LIST(child_type);
 		arguments[0] = BoundCastExpression::AddCastToType(context, std::move(arguments[0]), target_type);
-		bound_function.SetReturnType(arguments[0]->return_type);
+		bound_function.SetReturnType(arguments[0]->GetReturnType());
 	} break;
 	case LogicalTypeId::LIST:
 		// The result is the same type
-		bound_function.SetReturnType(arguments[0]->return_type);
+		bound_function.SetReturnType(arguments[0]->GetReturnType());
 		break;
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::VARCHAR:
@@ -338,15 +338,15 @@ unique_ptr<FunctionData> ArraySliceBind(BindScalarFunctionInput &input) {
 			    "Slice with steps has not been implemented for string types, you can consider rewriting your query as "
 			    "follows:\n SELECT array_to_string((str_split(string, '')[begin:end:step], '');");
 		}
-		if (arguments[0]->return_type.IsJSONType()) {
+		if (arguments[0]->GetReturnType().IsJSONType()) {
 			// This is needed to avoid producing invalid JSON
 			bound_function.GetArguments()[0] = LogicalType::VARCHAR;
 			bound_function.SetReturnType(LogicalType::VARCHAR);
 		} else {
-			bound_function.SetReturnType(arguments[0]->return_type);
+			bound_function.SetReturnType(arguments[0]->GetReturnType());
 		}
 		for (idx_t i = 1; i < 3; i++) {
-			if (arguments[i]->return_type.id() != LogicalTypeId::LIST) {
+			if (arguments[i]->GetReturnType().id() != LogicalTypeId::LIST) {
 				bound_function.GetArguments()[i] = LogicalType::BIGINT;
 			}
 		}

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -418,17 +418,17 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
-	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
 		return ListAggregatesBindFailure(bound_function);
 	}
 
-	bool is_parameter = arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN;
+	bool is_parameter = arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN;
 	LogicalType child_type;
 	if (is_parameter) {
 		child_type = LogicalType::ANY;
-	} else if (arguments[0]->return_type.id() == LogicalTypeId::LIST ||
-	           arguments[0]->return_type.id() == LogicalTypeId::MAP) {
-		child_type = ListType::GetChildType(arguments[0]->return_type);
+	} else if (arguments[0]->GetReturnType().id() == LogicalTypeId::LIST ||
+	           arguments[0]->GetReturnType().id() == LogicalTypeId::MAP) {
+		child_type = ListType::GetChildType(arguments[0]->GetReturnType());
 	} else {
 		// Unreachable
 		throw InvalidInputException("First argument of list aggregate must be a list, map or array");
@@ -461,7 +461,7 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	types.push_back(child_type);
 	// push any extra arguments into the type list
 	for (idx_t i = 2; i < arguments.size(); i++) {
-		types.push_back(arguments[i]->return_type);
+		types.push_back(arguments[i]->GetReturnType());
 	}
 
 	FunctionBinder function_binder(context);

--- a/extension/core_functions/scalar/list/list_filter.cpp
+++ b/extension/core_functions/scalar/list/list_filter.cpp
@@ -19,7 +19,7 @@ static unique_ptr<FunctionData> ListFilterBind(BindScalarFunctionInput &input) {
 	auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
 
 	// try to cast to boolean, if the return type of the lambda filter expression is not already boolean
-	if (bound_lambda_expr.lambda_expr->return_type != LogicalType::BOOLEAN) {
+	if (bound_lambda_expr.lambda_expr->GetReturnType() != LogicalType::BOOLEAN) {
 		auto cast_lambda_expr =
 		    BoundCastExpression::AddCastToType(context, std::move(bound_lambda_expr.lambda_expr), LogicalType::BOOLEAN);
 		bound_lambda_expr.lambda_expr = std::move(cast_lambda_expr);
@@ -27,7 +27,7 @@ static unique_ptr<FunctionData> ListFilterBind(BindScalarFunctionInput &input) {
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
-	bound_function.SetReturnType(arguments[0]->return_type);
+	bound_function.SetReturnType(arguments[0]->GetReturnType());
 	auto has_index = bound_lambda_expr.parameter_count == 2;
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -48,7 +48,7 @@ struct ReduceExecuteInfo {
 			input_types.push_back(LogicalType::BIGINT);
 		}
 		input_types.push_back(info.child_vector->GetType());
-		input_types.push_back(info.lambda_expr->return_type);
+		input_types.push_back(info.lambda_expr->GetReturnType());
 
 		// info.column_infos includes the list column plus captured args (and the initial value if present).
 		// skip the first entry if there is an initial value
@@ -56,7 +56,7 @@ struct ReduceExecuteInfo {
 			input_types.push_back(info.column_infos[i].vector.get().GetType());
 		}
 
-		accumulator_cast = make_uniq<Vector>(info.lambda_expr->return_type, info.row_count);
+		accumulator_cast = make_uniq<Vector>(info.lambda_expr->GetReturnType(), info.row_count);
 		expr_executor = make_uniq<ExpressionExecutor>(context, *info.lambda_expr);
 	};
 
@@ -230,15 +230,15 @@ unique_ptr<FunctionData> ListReduceBind(BindScalarFunctionInput &input) {
 	bool has_initial = arguments.size() == 3;
 	LogicalType accumulator_type;
 	if (has_initial) {
-		const auto &initial_value_type = arguments[2]->return_type;
+		const auto &initial_value_type = arguments[2]->GetReturnType();
 		auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
-		auto &lambda_return_type = bound_lambda_expr.lambda_expr->return_type;
+		auto &lambda_return_type = bound_lambda_expr.lambda_expr->GetReturnType();
 		accumulator_type = ResolveReduceAccumulatorType(context, initial_value_type, lambda_return_type);
 		arguments[2] = BoundCastExpression::AddCastToType(context, std::move(arguments[2]), accumulator_type);
 	} else {
 		auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
-		auto list_child_type = LambdaFunctions::DetermineListChildType(arguments[0]->return_type);
-		auto &lambda_return_type = bound_lambda_expr.lambda_expr->return_type;
+		auto list_child_type = LambdaFunctions::DetermineListChildType(arguments[0]->GetReturnType());
+		auto &lambda_return_type = bound_lambda_expr.lambda_expr->GetReturnType();
 		if (!LogicalType::TryGetMaxLogicalType(context, list_child_type, lambda_return_type, accumulator_type)) {
 			throw BinderException("No common super type between list element type %s and lambda return type %s",
 			                      list_child_type.ToString(), lambda_return_type.ToString());
@@ -251,14 +251,14 @@ unique_ptr<FunctionData> ListReduceBind(BindScalarFunctionInput &input) {
 	}
 	auto has_index = bound_lambda_expr.parameter_count == 3;
 
-	const auto lambda_return_type = bound_lambda_expr.lambda_expr->return_type;
+	const auto lambda_return_type = bound_lambda_expr.lambda_expr->GetReturnType();
 	auto cast_lambda_expr =
 	    BoundCastExpression::AddCastToType(context, std::move(bound_lambda_expr.lambda_expr), accumulator_type);
 	if (!cast_lambda_expr) {
 		throw BinderException("Could not cast lambda return type %s to accumulator type %s",
 		                      lambda_return_type.ToString(), accumulator_type.ToString());
 	}
-	bound_function.SetReturnType(cast_lambda_expr->return_type);
+	bound_function.SetReturnType(cast_lambda_expr->GetReturnType());
 	return make_uniq<ListLambdaBindData>(bound_function.GetReturnType(), std::move(cast_lambda_expr), has_index,
 	                                     has_initial);
 }
@@ -301,10 +301,10 @@ void LambdaFunctions::ListReduceFunction(DataChunk &args, ExpressionState &state
 	// This means there is always an empty result chunk for the next iteration,
 	// without the referenced chunk having to be reset until the current iteration is complete.
 	DataChunk odd_result_chunk;
-	odd_result_chunk.Initialize(Allocator::DefaultAllocator(), {info.lambda_expr->return_type});
+	odd_result_chunk.Initialize(Allocator::DefaultAllocator(), {info.lambda_expr->GetReturnType()});
 
 	DataChunk even_result_chunk;
-	even_result_chunk.Initialize(Allocator::DefaultAllocator(), {info.lambda_expr->return_type});
+	even_result_chunk.Initialize(Allocator::DefaultAllocator(), {info.lambda_expr->GetReturnType()});
 
 	// Execute reduce until all rows are finished.
 	idx_t loops = 0;

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -253,7 +253,7 @@ static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunct
                                              vector<unique_ptr<Expression>> &arguments, OrderType &order,
                                              OrderByNullType &null_order) {
 	LogicalType child_type;
-	if (arguments[0]->return_type == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->GetReturnType() == LogicalTypeId::UNKNOWN) {
 		bound_function.GetArguments()[0] = LogicalTypeId::UNKNOWN;
 		bound_function.SetReturnType(LogicalType::SQLNULL);
 		child_type = bound_function.GetReturnType();
@@ -262,10 +262,10 @@ static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunct
 	}
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
-	child_type = ListType::GetChildType(arguments[0]->return_type);
+	child_type = ListType::GetChildType(arguments[0]->GetReturnType());
 
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
-	bound_function.SetReturnType(arguments[0]->return_type);
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
+	bound_function.SetReturnType(arguments[0]->GetReturnType());
 
 	return make_uniq<ListSortBindData>(order, null_order, false, bound_function.GetReturnType(), child_type, context);
 }
@@ -302,9 +302,9 @@ static unique_ptr<FunctionData> ListGradeUpBind(BindScalarFunctionInput &input) 
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	bound_function.SetReturnType(LogicalType::LIST(LogicalTypeId::BIGINT));
-	auto child_type = ListType::GetChildType(arguments[0]->return_type);
+	auto child_type = ListType::GetChildType(arguments[0]->GetReturnType());
 	return make_uniq<ListSortBindData>(order, null_order, true, bound_function.GetReturnType(), child_type, context);
 }
 

--- a/extension/core_functions/scalar/list/list_transform.cpp
+++ b/extension/core_functions/scalar/list/list_transform.cpp
@@ -19,7 +19,7 @@ static unique_ptr<FunctionData> ListTransformBind(BindScalarFunctionInput &input
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
 	auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
-	bound_function.SetReturnType(LogicalType::LIST(bound_lambda_expr.lambda_expr->return_type));
+	bound_function.SetReturnType(LogicalType::LIST(bound_lambda_expr.lambda_expr->GetReturnType()));
 	auto has_index = bound_lambda_expr.parameter_count == 2;
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -258,7 +258,7 @@ unique_ptr<FunctionData> UnpivotBind(BindScalarFunctionInput &input) {
 				if (k == i) {
 					error_index = list_arguments.size();
 				}
-				list_arguments += arguments[k]->ToString() + " " + arguments[k]->return_type.ToString();
+				list_arguments += arguments[k]->ToString() + " " + arguments[k]->GetReturnType().ToString();
 			}
 			auto error = StringUtil::Format("Cannot unpivot columns of types %s and %s - an explicit cast is required",
 			                                child_type.ToString(), arg_type.ToString());
@@ -277,7 +277,7 @@ unique_ptr<FunctionData> UnpivotBind(BindScalarFunctionInput &input) {
 unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
-	auto list_stats = ListStats::CreateEmpty(expr.return_type);
+	auto list_stats = ListStats::CreateEmpty(expr.GetReturnType());
 	auto &list_child_stats = ListStats::GetChildStats(list_stats);
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		list_child_stats.Merge(child_stats[i]);

--- a/extension/core_functions/scalar/map/cardinality.cpp
+++ b/extension/core_functions/scalar/map/cardinality.cpp
@@ -29,7 +29,7 @@ static unique_ptr<FunctionData> CardinalityBind(BindScalarFunctionInput &input) 
 		throw BinderException("Cardinality must have exactly one arguments");
 	}
 
-	if (arguments[0]->return_type.id() != LogicalTypeId::MAP) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::MAP) {
 		throw BinderException("Cardinality can only operate on MAPs");
 	}
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -131,7 +131,7 @@ unique_ptr<FunctionData> MapConcatBind(BindScalarFunctionInput &input) {
 		throw InvalidInputException("The provided amount of arguments is incorrect, please provide 2 or more maps");
 	}
 
-	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		// Prepared statement
 		bound_function.GetArguments().emplace_back(LogicalTypeId::UNKNOWN);
 		bound_function.SetReturnType(LogicalTypeId::SQLNULL);
@@ -144,7 +144,7 @@ unique_ptr<FunctionData> MapConcatBind(BindScalarFunctionInput &input) {
 	// Check and verify that all the maps are of the same type
 	for (idx_t i = 0; i < arg_count; i++) {
 		auto &arg = arguments[i];
-		auto &map = arg->return_type;
+		auto &map = arg->GetReturnType();
 		if (map.id() == LogicalTypeId::UNKNOWN) {
 			// Prepared statement
 			bound_function.GetArguments().emplace_back(LogicalTypeId::UNKNOWN);

--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -34,7 +34,7 @@ struct SwitchFunctionBindData : FunctionData {
 
 idx_t FindMapArgumentIndex(const vector<unique_ptr<Expression>> &arguments) {
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		if (arguments[i]->return_type.id() == LogicalTypeId::MAP) {
+		if (arguments[i]->GetReturnType().id() == LogicalTypeId::MAP) {
 			return i;
 		}
 	}
@@ -119,8 +119,8 @@ unique_ptr<Expression> SwitchBindExpression(FunctionBindExpressionInput &input) 
 	for (idx_t i = 0; i < keys_unpacked.size(); i++) {
 		BoundCaseCheck case_check;
 		if (base_expr) {
-			auto max_type =
-			    LogicalType::MaxLogicalType(input.context, base_expr->return_type, keys_unpacked[i]->return_type);
+			auto max_type = LogicalType::MaxLogicalType(input.context, base_expr->GetReturnType(),
+			                                            keys_unpacked[i]->GetReturnType());
 			case_check.when_expr = make_uniq<BoundComparisonExpression>(
 			    ExpressionType::COMPARE_EQUAL, base_expr->Copy(),
 			    BoundCastExpression::AddCastToType(input.context, std::move(keys_unpacked[i]), max_type));
@@ -128,7 +128,7 @@ unique_ptr<Expression> SwitchBindExpression(FunctionBindExpressionInput &input) 
 			case_check.when_expr =
 			    BoundCastExpression::AddCastToType(input.context, std::move(keys_unpacked[i]), LogicalType::BOOLEAN);
 		}
-		auto then_type = values_unpacked[i]->return_type;
+		auto then_type = values_unpacked[i]->GetReturnType();
 		if (!LogicalType::TryGetMaxLogicalType(input.context, function_data.return_type, then_type,
 		                                       function_data.return_type)) {
 			throw BinderException(

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -109,7 +109,7 @@ static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, Func
 	Value new_min, new_max;
 	bool potential_overflow = true;
 	if (NumericStats::HasMinMax(lstats)) {
-		switch (expr.return_type.InternalType()) {
+		switch (expr.GetReturnType().InternalType()) {
 		case PhysicalType::INT8:
 			potential_overflow = NumericStats::Min(lstats).GetValue<int8_t>() == NumericLimits<int8_t>::Minimum();
 			break;
@@ -127,8 +127,8 @@ static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, Func
 		}
 	}
 	if (potential_overflow) {
-		new_min = Value(expr.return_type);
-		new_max = Value(expr.return_type);
+		new_min = Value(expr.GetReturnType());
+		new_max = Value(expr.GetReturnType());
 	} else {
 		// no potential overflow
 
@@ -152,11 +152,11 @@ static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, Func
 			*input.expr_ptr = std::move(input.expr.children[0]);
 			return child_stats[0].ToUnique();
 		}
-		new_min = Value::Numeric(expr.return_type, min_val);
-		new_max = Value::Numeric(expr.return_type, max_val);
-		expr.function.SetFunctionCallback(ScalarFunction::GetScalarUnaryFunction<AbsOperator>(expr.return_type));
+		new_min = Value::Numeric(expr.GetReturnType(), min_val);
+		new_max = Value::Numeric(expr.GetReturnType(), max_val);
+		expr.function.SetFunctionCallback(ScalarFunction::GetScalarUnaryFunction<AbsOperator>(expr.GetReturnType()));
 	}
-	auto stats = NumericStats::CreateEmpty(expr.return_type);
+	auto stats = NumericStats::CreateEmpty(expr.GetReturnType());
 	NumericStats::SetMin(stats, new_min);
 	NumericStats::SetMax(stats, new_max);
 	stats.CopyValidity(lstats);
@@ -167,7 +167,7 @@ template <class OP>
 static unique_ptr<FunctionData> DecimalUnaryOpBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	auto decimal_type = arguments[0]->return_type;
+	auto decimal_type = arguments[0]->GetReturnType();
 	switch (decimal_type.InternalType()) {
 	case PhysicalType::INT16:
 		bound_function.SetFunctionCallback(ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::SMALLINT));
@@ -351,7 +351,8 @@ struct CeilOperator {
 template <class T, class POWERS_OF_TEN, class OP>
 static void GenericRoundFunctionDecimal(DataChunk &input, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-	OP::template Operation<T, POWERS_OF_TEN>(input, DecimalType::GetScale(func_expr.children[0]->return_type), result);
+	OP::template Operation<T, POWERS_OF_TEN>(input, DecimalType::GetScale(func_expr.children[0]->GetReturnType()),
+	                                         result);
 }
 
 template <class OP>
@@ -359,7 +360,7 @@ static unique_ptr<FunctionData> BindGenericRoundFunctionDecimal(BindScalarFuncti
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	// ceil essentially removes the scale
-	auto &decimal_type = arguments[0]->return_type;
+	auto &decimal_type = arguments[0]->GetReturnType();
 	auto scale = DecimalType::GetScale(decimal_type);
 	auto width = DecimalType::GetWidth(decimal_type);
 	if (scale == 0) {
@@ -516,7 +517,7 @@ unique_ptr<FunctionData> BindDecimalRoundPrecision(BindScalarFunctionInput &inpu
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	auto &decimal_type = arguments[0]->return_type;
+	auto &decimal_type = arguments[0]->GetReturnType();
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
@@ -626,8 +627,8 @@ struct TruncDecimalNegativePrecisionOperator {
 	static void Operation(DataChunk &input, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<RoundPrecisionFunctionData>();
-		auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
-		auto width = DecimalType::GetWidth(func_expr.children[0]->return_type);
+		auto source_scale = DecimalType::GetScale(func_expr.children[0]->GetReturnType());
+		auto width = DecimalType::GetWidth(func_expr.children[0]->GetReturnType());
 		if (info.target_scale <= -int32_t(width - source_scale)) {
 			// scale too big for width
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -649,7 +650,7 @@ struct TruncDecimalPositivePrecisionOperator {
 	static void Operation(DataChunk &input, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<RoundPrecisionFunctionData>();
-		auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+		auto source_scale = DecimalType::GetScale(func_expr.children[0]->GetReturnType());
 		T power_of_ten = UnsafeNumericCast<T>(POWERS_OF_TEN_CLASS::POWERS_OF_TEN[source_scale - info.target_scale]);
 		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(),
 		                             [&](T input) { return UnsafeNumericCast<T>(input / power_of_ten); });
@@ -847,8 +848,8 @@ struct DecimalRoundNegativePrecisionOperator {
 	static void Operation(DataChunk &input, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<RoundPrecisionFunctionData>();
-		auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
-		auto width = DecimalType::GetWidth(func_expr.children[0]->return_type);
+		auto source_scale = DecimalType::GetScale(func_expr.children[0]->GetReturnType());
+		auto width = DecimalType::GetWidth(func_expr.children[0]->GetReturnType());
 		if (info.target_scale <= -int32_t(width - source_scale)) {
 			// scale too big for width
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -876,7 +877,7 @@ struct DecimalRoundPositivePrecisionOperator {
 	static void Operation(DataChunk &input, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<RoundPrecisionFunctionData>();
-		auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+		auto source_scale = DecimalType::GetScale(func_expr.children[0]->GetReturnType());
 		T power_of_ten = UnsafeNumericCast<T>(POWERS_OF_TEN_CLASS::POWERS_OF_TEN[source_scale - info.target_scale]);
 		T addition = power_of_ten / 2;
 		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -22,11 +22,11 @@ struct FMTFormat {
 	}
 };
 
-unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &input) {
+static unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	for (idx_t i = 1; i < arguments.size(); i++) {
-		switch (arguments[i]->return_type.id()) {
+		switch (arguments[i]->GetReturnType().id()) {
 		case LogicalTypeId::BOOLEAN:
 			bound_function.GetArguments().emplace_back(LogicalType::BOOLEAN);
 			break;
@@ -88,8 +88,8 @@ struct StringConstructArgument {
 };
 
 template <class T, class OP = StandardConstructArgument, class CTX>
-void ConvertArguments(const Vector &input, idx_t count, idx_t arg_idx,
-                      vector<vector<duckdb_fmt::basic_format_arg<CTX>>> &result_args) {
+static void ConvertArguments(const Vector &input, idx_t count, idx_t arg_idx,
+                             vector<vector<duckdb_fmt::basic_format_arg<CTX>>> &result_args) {
 	auto result = input.Values<T>(count);
 	for (idx_t i = 0; i < count; i++) {
 		auto &args = result_args[i];

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -36,7 +36,7 @@ static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input)
 	if (arguments.empty()) {
 		throw InvalidInputException("Missing required arguments for struct_insert function.");
 	}
-	if (LogicalTypeId::STRUCT != arguments[0]->return_type.id()) {
+	if (LogicalTypeId::STRUCT != arguments[0]->GetReturnType().id()) {
 		throw InvalidInputException("The first argument to struct_insert must be a STRUCT");
 	}
 	if (arguments.size() < 2) {
@@ -45,7 +45,7 @@ static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input)
 
 	case_insensitive_set_t name_collision_set;
 	child_list_t<LogicalType> new_children;
-	auto &existing_children = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &existing_children = StructType::GetChildTypes(arguments[0]->GetReturnType());
 
 	for (idx_t i = 0; i < existing_children.size(); i++) {
 		auto &child = existing_children[i];
@@ -63,7 +63,7 @@ static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input)
 			throw BinderException("Duplicate struct entry name \"%s\"", child->GetAlias());
 		}
 		name_collision_set.insert(child->GetAlias());
-		new_children.push_back(make_pair(child->GetAlias(), arguments[i]->return_type));
+		new_children.push_back(make_pair(child->GetAlias(), arguments[i]->GetReturnType()));
 	}
 
 	bound_function.SetReturnType(LogicalType::STRUCT(new_children));
@@ -73,7 +73,7 @@ static unique_ptr<FunctionData> StructInsertBind(BindScalarFunctionInput &input)
 static unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
-	auto new_stats = StructStats::CreateUnknown(expr.return_type);
+	auto new_stats = StructStats::CreateUnknown(expr.GetReturnType());
 
 	auto existing_count = StructType::GetChildCount(child_stats[0].GetType());
 	auto existing_stats = StructStats::GetChildStats(child_stats[0]);
@@ -81,7 +81,7 @@ static unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, Func
 		StructStats::SetChildStats(new_stats, i, existing_stats[i]);
 	}
 
-	auto new_count = StructType::GetChildCount(expr.return_type);
+	auto new_count = StructType::GetChildCount(expr.GetReturnType());
 	auto offset = new_count - child_stats.size();
 	for (idx_t i = 1; i < child_stats.size(); i++) {
 		StructStats::SetChildStats(new_stats, offset + i, child_stats[i]);

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -65,16 +65,16 @@ static void StructKeysFunction(DataChunk &args, ExpressionState &state, Vector &
 
 static unique_ptr<FunctionData> StructKeysBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
-	auto return_type = arguments[0]->return_type;
+	auto return_type = arguments[0]->GetReturnType();
 	if (return_type.id() != LogicalTypeId::STRUCT && !return_type.IsAggregateStateStructType()) {
 		throw InvalidInputException("struct_keys() expects a STRUCT argument");
 	}
 
-	const bool is_unnamed = StructType::IsUnnamed(arguments[0]->return_type);
+	const bool is_unnamed = StructType::IsUnnamed(arguments[0]->GetReturnType());
 	if (is_unnamed) {
 		throw InvalidInputException("struct_keys() cannot be applied to an unnamed STRUCT");
 	}
-	return make_uniq<StructKeysBindData>(arguments[0]->return_type);
+	return make_uniq<StructKeysBindData>(arguments[0]->GetReturnType());
 }
 
 ScalarFunction StructKeysFun::GetFunction() {

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -59,7 +59,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	if (arguments.empty()) {
 		throw InvalidInputException("Missing required arguments for struct_update function.");
 	}
-	if (LogicalTypeId::STRUCT != arguments[0]->return_type.id()) {
+	if (LogicalTypeId::STRUCT != arguments[0]->GetReturnType().id()) {
 		throw InvalidInputException("The first argument to struct_update must be a STRUCT");
 	}
 	if (arguments.size() < 2) {
@@ -67,7 +67,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	}
 
 	child_list_t<LogicalType> new_children;
-	auto &existing_children = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &existing_children = StructType::GetChildTypes(arguments[0]->GetReturnType());
 
 	auto incoming_children = case_insensitive_tree_t<idx_t>();
 	auto is_new_field = vector<bool>(arguments.size(), true);
@@ -93,7 +93,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 			// Update the struct with the new data of the same name
 			auto arg_idx = update->second;
 			auto &new_child = arguments[arg_idx];
-			new_children.push_back(make_pair(new_child->GetAlias(), new_child->return_type));
+			new_children.push_back(make_pair(new_child->GetAlias(), new_child->GetReturnType()));
 			is_new_field[arg_idx] = false;
 		}
 	}
@@ -102,7 +102,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
 		if (is_new_field[arg_idx]) {
 			auto &child = arguments[arg_idx];
-			new_children.push_back(make_pair(child->GetAlias(), child->return_type));
+			new_children.push_back(make_pair(child->GetAlias(), child->GetReturnType()));
 		}
 	}
 
@@ -110,13 +110,13 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
 
-unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionStatisticsInput &input) {
+static unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
 
 	auto incoming_children = case_insensitive_tree_t<idx_t>();
 	auto is_new_field = vector<bool>(expr.children.size(), true);
-	auto new_stats = StructStats::CreateUnknown(expr.return_type);
+	auto new_stats = StructStats::CreateUnknown(expr.GetReturnType());
 
 	for (idx_t arg_idx = 1; arg_idx < expr.children.size(); arg_idx++) {
 		auto &new_child = expr.children[arg_idx];

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -26,7 +26,7 @@ static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector
 
 	for (idx_t arg_idx = 1; arg_idx < func_args.size(); arg_idx++) {
 		auto &new_child = func_args[arg_idx];
-		new_entries.emplace(new_child->alias, arg_idx);
+		new_entries.emplace(new_child->GetAlias(), arg_idx);
 	}
 
 	// Assign the original child entries to the STRUCT.
@@ -75,12 +75,12 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	// Validate incoming arguments and record names
 	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
 		auto &child = arguments[arg_idx];
-		if (child->alias.empty()) {
+		if (child->GetAlias().empty()) {
 			throw BinderException("Need named argument for struct update, e.g., a := b");
-		} else if (incoming_children.find(child->alias) != incoming_children.end()) {
-			throw InvalidInputException("Duplicate named argument provided for %s", child->alias.c_str());
+		} else if (incoming_children.find(child->GetAlias()) != incoming_children.end()) {
+			throw InvalidInputException("Duplicate named argument provided for %s", child->GetAlias().c_str());
 		}
-		incoming_children.emplace(child->alias, arg_idx);
+		incoming_children.emplace(child->GetAlias(), arg_idx);
 	}
 
 	for (idx_t field_idx = 0; field_idx < existing_children.size(); field_idx++) {
@@ -93,7 +93,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 			// Update the struct with the new data of the same name
 			auto arg_idx = update->second;
 			auto &new_child = arguments[arg_idx];
-			new_children.push_back(make_pair(new_child->alias, new_child->return_type));
+			new_children.push_back(make_pair(new_child->GetAlias(), new_child->return_type));
 			is_new_field[arg_idx] = false;
 		}
 	}
@@ -102,7 +102,7 @@ static unique_ptr<FunctionData> StructUpdateBind(BindScalarFunctionInput &input)
 	for (idx_t arg_idx = 1; arg_idx < arguments.size(); arg_idx++) {
 		if (is_new_field[arg_idx]) {
 			auto &child = arguments[arg_idx];
-			new_children.push_back(make_pair(child->alias, child->return_type));
+			new_children.push_back(make_pair(child->GetAlias(), child->return_type));
 		}
 	}
 
@@ -120,7 +120,7 @@ unique_ptr<BaseStatistics> StructUpdateStats(ClientContext &context, FunctionSta
 
 	for (idx_t arg_idx = 1; arg_idx < expr.children.size(); arg_idx++) {
 		auto &new_child = expr.children[arg_idx];
-		incoming_children.emplace(new_child->alias, arg_idx);
+		incoming_children.emplace(new_child->GetAlias(), arg_idx);
 	}
 
 	auto existing_type = child_stats[0].GetType();

--- a/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/extension/core_functions/scalar/struct/struct_values.cpp
@@ -56,7 +56,7 @@ static void StructValuesFunction(DataChunk &args, ExpressionState &state, Vector
 static unique_ptr<FunctionData> StructValuesBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	const auto arg_type = arguments[0]->return_type;
+	const auto arg_type = arguments[0]->GetReturnType();
 	if (arg_type == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -67,7 +67,7 @@ static unique_ptr<FunctionData> StructValuesBind(BindScalarFunctionInput &input)
 
 	// Build unnamed children list using only types, with empty names
 	child_list_t<LogicalType> unnamed_children;
-	auto &children = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &children = StructType::GetChildTypes(arguments[0]->GetReturnType());
 	unnamed_children.reserve(children.size());
 	for (auto &child : children) {
 		unnamed_children.emplace_back("", child.second);

--- a/extension/core_functions/scalar/union/union_extract.cpp
+++ b/extension/core_functions/scalar/union/union_extract.cpp
@@ -47,24 +47,24 @@ unique_ptr<FunctionData> UnionExtractBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.GetArguments().size() == 2);
-	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	if (arguments[0]->return_type.id() != LogicalTypeId::UNION) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::UNION) {
 		throw BinderException("union_extract can only take a union parameter");
 	}
-	idx_t union_member_count = UnionType::GetMemberCount(arguments[0]->return_type);
+	idx_t union_member_count = UnionType::GetMemberCount(arguments[0]->GetReturnType());
 	if (union_member_count == 0) {
 		throw InternalException("Can't extract something from an empty union");
 	}
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 
 	auto &key_child = arguments[1];
 	if (key_child->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
 
-	if (key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+	if (key_child->GetReturnType().id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
 		throw BinderException("Key name for union_extract needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(context, *key_child);
@@ -80,11 +80,11 @@ unique_ptr<FunctionData> UnionExtractBind(BindScalarFunctionInput &input) {
 	bool found_key = false;
 
 	for (size_t i = 0; i < union_member_count; i++) {
-		auto &member_name = UnionType::GetMemberName(arguments[0]->return_type, i);
+		auto &member_name = UnionType::GetMemberName(arguments[0]->GetReturnType(), i);
 		if (StringUtil::Lower(member_name) == key) {
 			found_key = true;
 			key_index = i;
-			return_type = UnionType::GetMemberType(arguments[0]->return_type, i);
+			return_type = UnionType::GetMemberType(arguments[0]->GetReturnType(), i);
 			break;
 		}
 	}
@@ -93,7 +93,7 @@ unique_ptr<FunctionData> UnionExtractBind(BindScalarFunctionInput &input) {
 		vector<string> candidates;
 		candidates.reserve(union_member_count);
 		for (idx_t i = 0; i < union_member_count; i++) {
-			candidates.push_back(UnionType::GetMemberName(arguments[0]->return_type, i));
+			candidates.push_back(UnionType::GetMemberName(arguments[0]->GetReturnType(), i));
 		}
 		auto closest_settings = StringUtil::TopNJaroWinkler(candidates, key);
 		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");

--- a/extension/core_functions/scalar/union/union_tag.cpp
+++ b/extension/core_functions/scalar/union/union_tag.cpp
@@ -16,11 +16,11 @@ unique_ptr<FunctionData> UnionTagBind(BindScalarFunctionInput &input) {
 		throw BinderException("Missing required arguments for union_tag function.");
 	}
 
-	if (LogicalTypeId::UNKNOWN == arguments[0]->return_type.id()) {
+	if (LogicalTypeId::UNKNOWN == arguments[0]->GetReturnType().id()) {
 		throw ParameterNotResolvedException();
 	}
 
-	if (LogicalTypeId::UNION != arguments[0]->return_type.id()) {
+	if (LogicalTypeId::UNION != arguments[0]->GetReturnType().id()) {
 		throw BinderException("First argument to union_tag function must be a union type.");
 	}
 
@@ -28,18 +28,18 @@ unique_ptr<FunctionData> UnionTagBind(BindScalarFunctionInput &input) {
 		throw BinderException("Too many arguments, union_tag takes at most one argument.");
 	}
 
-	auto member_count = UnionType::GetMemberCount(arguments[0]->return_type);
+	auto member_count = UnionType::GetMemberCount(arguments[0]->GetReturnType());
 	if (member_count == 0) {
 		// this should never happen, empty unions are not allowed
 		throw InternalException("Can't get tags from an empty union");
 	}
 
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 
 	auto varchar_vector = Vector(LogicalType::VARCHAR, member_count);
 	auto result_data = FlatVector::Writer<string_t>(varchar_vector, member_count);
 	for (idx_t i = 0; i < member_count; i++) {
-		result_data.WriteValue(string_t(UnionType::GetMemberName(arguments[0]->return_type, i)));
+		result_data.WriteValue(string_t(UnionType::GetMemberName(arguments[0]->GetReturnType(), i)));
 	}
 	auto enum_type = LogicalType::ENUM(varchar_vector, member_count);
 	bound_function.SetReturnType(enum_type);

--- a/extension/core_functions/scalar/union/union_value.cpp
+++ b/extension/core_functions/scalar/union/union_value.cpp
@@ -47,7 +47,7 @@ unique_ptr<FunctionData> UnionValueBind(BindScalarFunctionInput &input) {
 
 	child_list_t<LogicalType> union_members;
 
-	union_members.push_back(make_pair(child->GetAlias(), child->return_type));
+	union_members.push_back(make_pair(child->GetAlias(), child->GetReturnType()));
 
 	bound_function.SetReturnType(LogicalType::UNION(std::move(union_members)));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -74,7 +74,7 @@ unique_ptr<FunctionData> JSONReadFunctionData::Bind(BindScalarFunctionInput &inp
 			path_type = CheckPath(path_val, path, len);
 		}
 	}
-	if (arguments[1]->return_type.IsIntegral()) {
+	if (arguments[1]->GetReturnType().IsIntegral()) {
 		bound_function.GetArguments()[1] = LogicalType::BIGINT;
 	} else {
 		bound_function.GetArguments()[1] = LogicalType::VARCHAR;

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -115,7 +115,7 @@ static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_funct
                                                      vector<unique_ptr<Expression>> &arguments, bool object) {
 	unordered_map<string, unique_ptr<Vector>> const_struct_names;
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		auto &type = arguments[i]->return_type;
+		auto &type = arguments[i]->GetReturnType();
 		if (arguments[i]->HasParameter()) {
 			throw ParameterNotResolvedException();
 		} else if (object && i % 2 == 0) {
@@ -162,7 +162,7 @@ static unique_ptr<FunctionData> ArrayToJSONBind(BindScalarFunctionInput &input) 
 	if (arguments.size() != 1) {
 		throw BinderException("array_to_json() takes exactly one argument");
 	}
-	auto arg_id = arguments[0]->return_type.id();
+	auto arg_id = arguments[0]->GetReturnType().id();
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
@@ -178,11 +178,11 @@ static unique_ptr<FunctionData> RowToJSONBind(BindScalarFunctionInput &input) {
 	if (arguments.size() != 1) {
 		throw BinderException("row_to_json() takes exactly one argument");
 	}
-	auto arg_id = arguments[0]->return_type.id();
+	auto arg_id = arguments[0]->GetReturnType().id();
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
-	if (arguments[0]->return_type.id() != LogicalTypeId::STRUCT && arg_id != LogicalTypeId::SQLNULL) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::STRUCT && arg_id != LogicalTypeId::SQLNULL) {
 		throw BinderException("row_to_json() argument type must be STRUCT");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);

--- a/extension/json/json_functions/json_serialize_plan.cpp
+++ b/extension/json/json_functions/json_serialize_plan.cpp
@@ -45,7 +45,7 @@ static unique_ptr<FunctionData> JsonSerializePlanBind(BindScalarFunctionInput &i
 		throw BinderException("json_serialize_plan takes at least one argument");
 	}
 
-	if (arguments[0]->return_type != LogicalType::VARCHAR) {
+	if (arguments[0]->GetReturnType() != LogicalType::VARCHAR) {
 		throw InvalidTypeException("json_serialize_plan first argument must be a VARCHAR");
 	}
 
@@ -66,27 +66,27 @@ static unique_ptr<FunctionData> JsonSerializePlanBind(BindScalarFunctionInput &i
 		}
 		auto &alias = arg->GetAlias();
 		if (alias == "skip_null") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_plan: 'skip_null' argument must be a boolean");
 			}
 			skip_if_null = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "skip_empty") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_plan: 'skip_empty' argument must be a boolean");
 			}
 			skip_if_empty = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "skip_default") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_plan: 'skip_default' argument must be a boolean");
 			}
 			skip_if_default = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "format") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_plan: 'format' argument must be a boolean");
 			}
 			format = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "optimize") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_plan: 'optimize' argument must be a boolean");
 			}
 			optimize = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -36,7 +36,7 @@ static unique_ptr<FunctionData> JsonSerializeBind(BindScalarFunctionInput &input
 		throw BinderException("json_serialize_sql takes at least one argument");
 	}
 
-	if (arguments[0]->return_type != LogicalType::VARCHAR) {
+	if (arguments[0]->GetReturnType() != LogicalType::VARCHAR) {
 		throw InvalidTypeException("json_serialize_sql first argument must be a VARCHAR");
 	}
 
@@ -57,22 +57,22 @@ static unique_ptr<FunctionData> JsonSerializeBind(BindScalarFunctionInput &input
 		}
 		auto &alias = arg->GetAlias();
 		if (alias == "skip_null") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_sql: 'skip_null' argument must be a boolean");
 			}
 			skip_if_null = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "skip_empty") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_sql: 'skip_empty' argument must be a boolean");
 			}
 			skip_if_empty = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "format") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_sql: 'format' argument must be a boolean");
 			}
 			format = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (alias == "skip_default") {
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("json_serialize_sql: 'skip_default' argument must be a boolean");
 			}
 			skip_if_default = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -86,7 +86,7 @@ static unique_ptr<FunctionData> JSONTransformBind(BindScalarFunctionInput &input
 		throw BinderException("JSON structure must be a constant!");
 	}
 	auto structure_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
-	if (structure_val.IsNull() || arguments[1]->return_type == LogicalTypeId::SQLNULL) {
+	if (structure_val.IsNull() || arguments[1]->GetReturnType() == LogicalTypeId::SQLNULL) {
 		bound_function.SetReturnType(LogicalTypeId::SQLNULL);
 	} else {
 		if (!structure_val.DefaultTryCastAs(LogicalType::JSON())) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -834,7 +834,7 @@ static vector<unique_ptr<Expression>> ParquetWriteSelect(CopyToSelectInput &inpu
 	bool any_change = false;
 
 	for (auto &expr : input.select_list) {
-		const auto &type = expr->return_type;
+		const auto &type = expr->GetReturnType();
 		const auto &name = expr->GetAlias();
 
 		// Spatial types need to be encoded into WKB when writing GeoParquet.

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1172,14 +1172,14 @@ static FilterPropagateResult CheckParquetStringFilter(BaseStatistics &stats, con
 		// Handle comparison expressions (from ConstantFilter conversion)
 		if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
 			auto &comp = expr.Cast<BoundComparisonExpression>();
-			if (comp.right->type == ExpressionType::VALUE_CONSTANT) {
+			if (comp.right->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 				auto &constant = comp.right->Cast<BoundConstantExpression>();
 				if (constant.value.type().id() == LogicalTypeId::VARCHAR) {
 					auto &min_value = pq_col_stats.min_value;
 					auto &max_value = pq_col_stats.max_value;
 					return StringStats::CheckZonemap(const_data_ptr_cast(min_value.c_str()), min_value.size(),
 					                                 const_data_ptr_cast(max_value.c_str()), max_value.size(),
-					                                 comp.type, StringValue::Get(constant.value));
+					                                 comp.GetExpressionType(), StringValue::Get(constant.value));
 				}
 			}
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1362,7 +1362,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		if (it != expression_map.end()) {
 			auto &expression = it->second;
 			auto expr_schema = make_uniq<ParquetColumnSchema>(ParquetColumnSchema::FromParentSchema(
-			    column_reader->Schema(), expression->return_type, ParquetColumnSchemaType::EXPRESSION));
+			    column_reader->Schema(), expression->GetReturnType(), ParquetColumnSchemaType::EXPRESSION));
 			auto expr_reader = make_uniq<ExpressionColumnReader>(context, std::move(column_reader), expression->Copy(),
 			                                                     std::move(expr_schema));
 			state.column_readers[i] = std::move(expr_reader);

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -641,7 +641,8 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 static bool HasFilterConstants(const Expression &expr) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
 		auto &comp = expr.Cast<BoundComparisonExpression>();
-		if (comp.type == ExpressionType::COMPARE_EQUAL && comp.right->type == ExpressionType::VALUE_CONSTANT) {
+		if (comp.GetExpressionType() == ExpressionType::COMPARE_EQUAL &&
+		    comp.right->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 			auto &constant = comp.right->Cast<BoundConstantExpression>();
 			return !constant.value.IsNull();
 		}
@@ -730,7 +731,8 @@ static uint64_t ValueXXH64(const Value &constant) {
 static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_filter) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
 		auto &comp = expr.Cast<BoundComparisonExpression>();
-		if (comp.type != ExpressionType::COMPARE_EQUAL || comp.right->type != ExpressionType::VALUE_CONSTANT) {
+		if (comp.GetExpressionType() != ExpressionType::COMPARE_EQUAL ||
+		    comp.right->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			return false;
 		}
 		auto &constant = comp.right->Cast<BoundConstantExpression>();
@@ -741,7 +743,7 @@ static bool ApplyBloomFilter(const Expression &expr, ParquetBloomFilter &bloom_f
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
 		return false;
 	}
-	switch (expr.type) {
+	switch (expr.GetExpressionType()) {
 	case ExpressionType::CONJUNCTION_AND: {
 		bool any_children_true = false;
 		ExpressionIterator::EnumerateChildren(

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1078,7 +1078,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 
 	// Infer the target_type from the USING expression, if not set explicitly.
 	if (info.target_type == LogicalType::UNKNOWN) {
-		info.target_type = bound_expression->return_type;
+		info.target_type = bound_expression->GetReturnType();
 	}
 
 	// Check if type is supported in this database version

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -328,7 +328,7 @@ void UnboundTypeInfo::Serialize(Serializer &serializer) const {
 	}
 
 	// Try to write this as an old "USER" type, if possible
-	if (expr->type != ExpressionType::TYPE) {
+	if (expr->GetExpressionType() != ExpressionType::TYPE) {
 		throw SerializationException(
 		    "Cannot serialize non-type type expression when targeting database storage version '%s'",
 		    serializer.GetOptions().serialization_compatibility.duckdb_version);
@@ -342,7 +342,7 @@ void UnboundTypeInfo::Serialize(Serializer &serializer) const {
 	// Try to write the user type mods too
 	vector<Value> user_type_mods;
 	for (auto &param : type_expr.GetChildren()) {
-		if (param->type != ExpressionType::VALUE_CONSTANT) {
+		if (param->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			throw SerializationException(
 			    "Cannot serialize non-constant type parameter when targeting serialization version %s",
 			    serializer.GetOptions().serialization_compatibility.duckdb_version);

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -70,7 +70,7 @@ ConvertKnownColRefToConstants(ClientContext &context, unique_ptr<Expression> &ex
 			} else {
 				// hive partitioning column - cast the value to the target type
 				result_val = HivePartitioning::GetValue(context, partition_val.key, partition_val.value,
-				                                        bound_colref.return_type);
+				                                        bound_colref.GetReturnType());
 			}
 			expr = make_uniq<BoundConstantExpression>(std::move(result_val));
 		}

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -119,7 +119,7 @@ struct FieldIdMapper : public ColumnMapper {
 		if (!default_val) {
 			throw InternalException("No default expression in FieldId Map");
 		}
-		if (default_val->type != ExpressionType::VALUE_CONSTANT) {
+		if (default_val->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			throw NotImplementedException("Default expression that isn't constant is not supported yet");
 		}
 		auto &constant_expr = default_val->Cast<ConstantExpression>();
@@ -306,7 +306,7 @@ ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefin
 	if (is_selected && child_map.default_value) {
 		// we have default values at a previous level wrap it in a "list"
 		vector<unique_ptr<Expression>> default_expressions;
-		child_map.default_value->alias = "list";
+		child_map.default_value->SetAlias("list");
 		default_expressions.push_back(std::move(child_map.default_value));
 
 		// auto default_type = LogicalType::STRUCT(std::move(default_type_list));
@@ -394,7 +394,7 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 			column_mapping.emplace_back(name, std::move(map_result.column_map));
 		}
 		if (map_result.default_value) {
-			map_result.default_value->alias = name;
+			map_result.default_value->SetAlias(name);
 			default_expressions.push_back(std::move(map_result.default_value));
 		}
 	}
@@ -479,7 +479,7 @@ ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDef
 		//! FIXME: the 'default_value' should only be used if the STRUCT's default value is not NULL
 		if (child_map.default_value) {
 			// found a default value for this child - emplace it
-			child_map.default_value->alias = global_child.name;
+			child_map.default_value->SetAlias(global_child.name);
 			default_expressions.push_back(std::move(child_map.default_value));
 		}
 	}
@@ -644,13 +644,13 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 					Doing neither or both is not a valid option.
 				)");
 			}
-			if (expr && expr->type == ExpressionType::VALUE_CONSTANT) {
+			if (expr && expr->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 				// the column is constant after all - handle it
 				expressions.push_back(std::move(expr));
 				continue;
 			}
 			if (!global_column_reference) {
-				auto is_reference = expr->type == ExpressionType::BOUND_REF;
+				auto is_reference = expr->GetExpressionType() == ExpressionType::BOUND_REF;
 				expressions.push_back(std::move(expr));
 
 				MultiFileLocalColumnId local_id(reader.columns.size());
@@ -826,7 +826,7 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(const TableFilter &fil
 Value MultiFileColumnMapper::GetConstantValue(MultiFileGlobalIndex global_index) {
 	auto global_column_id = global_column_ids[global_index].GetPrimaryIndex();
 	auto &expr = reader_data.expressions[global_index];
-	if (expr->type == ExpressionType::VALUE_CONSTANT) {
+	if (expr->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 		return expr->Cast<BoundConstantExpression>().value;
 	}
 	for (idx_t i = 0; i < reader_data.constant_map.size(); i++) {
@@ -936,7 +936,7 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_COMPARISON: {
 		auto &comparison = expr.Cast<BoundComparisonExpression>();
-		if (comparison.right->type != ExpressionType::VALUE_CONSTANT) {
+		if (comparison.right->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			return nullptr;
 		}
 		auto lhs = RewriteMappedValueExpression(*comparison.left, mapping, target_type);
@@ -947,12 +947,12 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 		if (!TryCastConstant(constant, *lhs.type)) {
 			return nullptr;
 		}
-		return make_uniq<BoundComparisonExpression>(comparison.type, std::move(lhs.expr),
+		return make_uniq<BoundComparisonExpression>(comparison.GetExpressionType(), std::move(lhs.expr),
 		                                            make_uniq<BoundConstantExpression>(std::move(constant)));
 	}
 	case ExpressionClass::BOUND_CONJUNCTION: {
 		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
-		auto result = make_uniq<BoundConjunctionExpression>(conjunction.type);
+		auto result = make_uniq<BoundConjunctionExpression>(conjunction.GetExpressionType());
 		for (auto &child : conjunction.children) {
 			auto rewritten_child = TryCastFilterExpression(*child, mapping, target_type);
 			if (!rewritten_child) {
@@ -964,7 +964,7 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 	}
 	case ExpressionClass::BOUND_OPERATOR: {
 		auto &op = expr.Cast<BoundOperatorExpression>();
-		switch (op.type) {
+		switch (op.GetExpressionType()) {
 		case ExpressionType::OPERATOR_IS_NULL:
 		case ExpressionType::OPERATOR_IS_NOT_NULL: {
 			if (op.children.size() != 1) {
@@ -974,7 +974,7 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 			if (!child.expr) {
 				return nullptr;
 			}
-			auto result = make_uniq<BoundOperatorExpression>(op.type, op.return_type);
+			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.return_type);
 			result->children.push_back(std::move(child.expr));
 			return std::move(result);
 		}
@@ -986,10 +986,10 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 			if (!lhs.expr || !lhs.type) {
 				return nullptr;
 			}
-			auto result = make_uniq<BoundOperatorExpression>(op.type, op.return_type);
+			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.return_type);
 			result->children.push_back(std::move(lhs.expr));
 			for (idx_t i = 1; i < op.children.size(); i++) {
-				if (op.children[i]->type != ExpressionType::VALUE_CONSTANT) {
+				if (op.children[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 					return nullptr;
 				}
 				auto constant = op.children[i]->Cast<BoundConstantExpression>().value;

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -200,9 +200,9 @@ void MultiFileColumnMapper::ThrowColumnNotFoundError(const string &global_column
 }
 
 //! Check if a column is trivially mappable (i.e. the column is effectively identical to the global column)
-bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
-                         const vector<MultiFileColumnDefinition> &local_columns, const ColumnMapper &mapper,
-                         optional_idx expected_idx = optional_idx()) {
+static bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
+                                const vector<MultiFileColumnDefinition> &local_columns, const ColumnMapper &mapper,
+                                optional_idx expected_idx = optional_idx()) {
 	auto entry = mapper.Find(global_column);
 	if (!entry.IsValid()) {
 		return false;
@@ -235,10 +235,10 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
                                  const vector<MultiFileColumnDefinition> &local_columns, const ColumnMapper &mapper,
                                  MultiFileLocalIndex top_level_index = MultiFileLocalIndex());
 
-ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefinition &global_column,
-                              const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                              const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
-                              unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
+static ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefinition &global_column,
+                                     const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
+                                     const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
+                                     unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	const idx_t expected_list_children = 1;
 	if (global_column.children.size() != expected_list_children) {
 		throw InvalidInputException(
@@ -345,10 +345,10 @@ MapColumnMapComponent(ClientContext &context,
 	return child_map;
 }
 
-ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefinition &global_column,
-                             const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                             const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
-                             unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
+static ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefinition &global_column,
+                                    const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
+                                    const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
+                                    unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	const idx_t expected_map_children = 2;
 	if (global_column.children.size() != expected_map_children) {
 		throw InvalidInputException(
@@ -424,10 +424,10 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 	return result;
 }
 
-ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDefinition &global_column,
-                                const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                                const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
-                                unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
+static ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDefinition &global_column,
+                                       const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
+                                       const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
+                                       unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	auto &struct_children = StructType::GetChildTypes(global_column.type);
 	if (struct_children.size() != global_column.children.size()) {
 		throw InvalidInputException(
@@ -552,9 +552,10 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 	}
 }
 
-unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileLocalIndex local_idx,
-                                              ColumnMapResult &mapping, const MultiFileColumnDefinition &global_column,
-                                              bool is_trivially_mappable) {
+static unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileLocalIndex local_idx,
+                                                     ColumnMapResult &mapping,
+                                                     const MultiFileColumnDefinition &global_column,
+                                                     bool is_trivially_mappable) {
 	auto &local_column = *mapping.local_column;
 	unique_ptr<Expression> expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx.GetIndex());
 	bool can_use_remap_struct =
@@ -974,7 +975,7 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 			if (!child.expr) {
 				return nullptr;
 			}
-			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.return_type);
+			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.GetReturnType());
 			result->children.push_back(std::move(child.expr));
 			return std::move(result);
 		}
@@ -986,7 +987,7 @@ static unique_ptr<Expression> TryCastFilterExpression(const Expression &expr, co
 			if (!lhs.expr || !lhs.type) {
 				return nullptr;
 			}
-			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.return_type);
+			auto result = make_uniq<BoundOperatorExpression>(op.GetExpressionType(), op.GetReturnType());
 			result->children.push_back(std::move(lhs.expr));
 			for (idx_t i = 1; i < op.children.size(); i++) {
 				if (op.children[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
@@ -1087,7 +1088,7 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 	}
 }
 
-void SetIndexToZero(unique_ptr<Expression> &root_expr) {
+static void SetIndexToZero(unique_ptr<Expression> &root_expr) {
 #ifdef DEBUG
 	optional_idx index;
 	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(root_expr, [&](BoundReferenceExpression &ref,
@@ -1104,8 +1105,8 @@ void SetIndexToZero(unique_ptr<Expression> &root_expr) {
 #endif
 }
 
-bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &local_type,
-                      const LogicalType &global_type) {
+static bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &local_type,
+                             const LogicalType &global_type) {
 	if (local_type.id() == LogicalTypeId::STRUCT && global_type.id() == LogicalTypeId::STRUCT) {
 		// struct fields - check along the mapping
 		// mapping is global to local

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -1105,16 +1105,6 @@ static void SetIndexToZero(unique_ptr<Expression> &root_expr) {
 #endif
 }
 
-static bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &local_type,
-                             const LogicalType &global_type) {
-	if (local_type.id() == LogicalTypeId::STRUCT && global_type.id() == LogicalTypeId::STRUCT) {
-		// struct fields - check along the mapping
-		// mapping is global to local
-		throw InternalException("Propagate cast - check mapping");
-	}
-	return StatisticsPropagator::CanPropagateCast(local_type, global_type);
-}
-
 unique_ptr<TableFilterSet>
 MultiFileColumnMapper::CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters,
                                      ResultColumnMapping &mapping) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -388,12 +388,12 @@ ReaderInitializeType MultiFileReader::CreateMapping(
 
 string GetExtendedMultiFileError(const MultiFileBindData &bind_data, const Expression &expr, BaseFileReader &reader,
                                  idx_t expr_idx, string &first_message) {
-	if (expr.type != ExpressionType::OPERATOR_CAST) {
+	if (expr.GetExpressionType() != ExpressionType::OPERATOR_CAST) {
 		// not a cast
 		return string();
 	}
 	auto &cast_expr = expr.Cast<BoundCastExpression>();
-	if (cast_expr.child->type != ExpressionType::BOUND_REF) {
+	if (cast_expr.child->GetExpressionType() != ExpressionType::BOUND_REF) {
 		return string();
 	}
 	auto &ref = cast_expr.child->Cast<BoundReferenceExpression>();

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -386,8 +386,8 @@ ReaderInitializeType MultiFileReader::CreateMapping(
 	                     virtual_columns, bind_data.mapping);
 }
 
-string GetExtendedMultiFileError(const MultiFileBindData &bind_data, const Expression &expr, BaseFileReader &reader,
-                                 idx_t expr_idx, string &first_message) {
+static string GetExtendedMultiFileError(const MultiFileBindData &bind_data, const Expression &expr,
+                                        BaseFileReader &reader, idx_t expr_idx, string &first_message) {
 	if (expr.GetExpressionType() != ExpressionType::OPERATOR_CAST) {
 		// not a cast
 		return string();
@@ -397,8 +397,8 @@ string GetExtendedMultiFileError(const MultiFileBindData &bind_data, const Expre
 		return string();
 	}
 	auto &ref = cast_expr.child->Cast<BoundReferenceExpression>();
-	auto &source_type = ref.return_type;
-	auto &target_type = cast_expr.return_type;
+	auto &source_type = ref.GetReturnType();
+	auto &target_type = cast_expr.GetReturnType();
 	auto &columns = reader.GetColumns();
 	auto local_col_id = reader.column_indexes[ref.index].GetPrimaryIndex();
 	auto &local_col = columns[local_col_id];

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -43,8 +43,8 @@ ConversionException TryCast::UnimplementedErrorMessage(PhysicalType source, Phys
 		if (parameters->cast_source && parameters->cast_target) {
 			auto &source_expr = *parameters->cast_source;
 			auto &target_expr = *parameters->cast_target;
-			return ConversionException(query_location,
-			                           UnimplementedCastMessage(source_expr.return_type, target_expr.return_type));
+			return ConversionException(
+			    query_location, UnimplementedCastMessage(source_expr.GetReturnType(), target_expr.GetReturnType()));
 		}
 	}
 	return ConversionException(query_location, "Unimplemented type for cast (%s -> %s)", source, target);

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1605,7 +1605,7 @@ template <>
 bool TryCastToGeometry::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	// Pass the query location of the cast source if available.
 	return Geometry::FromString(input, result, StringVector::GetStringHeap(result_vector), parameters.strict,
-	                            parameters.cast_source ? parameters.cast_source->query_location : optional_idx());
+	                            parameters.cast_source ? parameters.cast_source->GetQueryLocation() : optional_idx());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/sort/full_sort.cpp
+++ b/src/common/sort/full_sort.cpp
@@ -133,7 +133,7 @@ FullSortLocalSinkState::FullSortLocalSinkState(ExecutionContext &context, const 
     : full_sort(full_sort), sort_exec(context.client) {
 	vector<LogicalType> sort_types;
 	for (const auto &expr : full_sort.sort_exprs) {
-		sort_types.emplace_back(expr->return_type);
+		sort_types.emplace_back(expr->GetReturnType());
 		sort_exec.AddExpression(*expr);
 	}
 	sort_chunk.Initialize(context.client, sort_types);
@@ -256,7 +256,7 @@ FullSort::FullSort(ClientContext &client, const vector<BoundOrderByNode> &order_
 
 		//	Real expression - replace with a ref and save the expression
 		auto saved = std::move(order.expression);
-		const auto type = saved->return_type;
+		const auto type = saved->GetReturnType();
 		const auto idx = payload_types.size();
 		order.expression = make_uniq<BoundReferenceExpression>(type, idx);
 		sort_ids.emplace_back(idx);

--- a/src/common/sort/hashed_sort.cpp
+++ b/src/common/sort/hashed_sort.cpp
@@ -318,13 +318,13 @@ HashedSortLocalSinkState::HashedSortLocalSinkState(ExecutionContext &context, co
 	vector<LogicalType> group_types;
 	for (idx_t prt_idx = 0; prt_idx < hashed_sort.partitions.size(); prt_idx++) {
 		auto &pexpr = *hashed_sort.partitions[prt_idx].expression.get();
-		group_types.push_back(pexpr.return_type);
+		group_types.push_back(pexpr.GetReturnType());
 		hash_exec.AddExpression(pexpr);
 	}
 
 	vector<LogicalType> sort_types;
 	for (const auto &expr : hashed_sort.sort_exprs) {
-		sort_types.emplace_back(expr->return_type);
+		sort_types.emplace_back(expr->GetReturnType());
 		sort_exec.AddExpression(*expr);
 	}
 	sort_chunk.Initialize(context.client, sort_types);
@@ -539,7 +539,7 @@ HashedSort::HashedSort(ClientContext &client, const vector<unique_ptr<Expression
 
 		//	Real expression - replace with a ref and save the expression
 		auto saved = std::move(order.expression);
-		const auto type = saved->return_type;
+		const auto type = saved->GetReturnType();
 		const auto idx = payload_types.size();
 		order.expression = make_uniq<BoundReferenceExpression>(type, idx);
 		sort_ids.emplace_back(idx);

--- a/src/common/sort/sort.cpp
+++ b/src/common/sort/sort.cpp
@@ -33,7 +33,7 @@ Sort::Sort(ClientContext &context_p, const vector<BoundOrderByNode> &orders, con
 
 		// Avoid having unnamed structs fields (otherwise we get a parser exception while binding)
 		const auto col_name = StringUtil::Format("c%llu", col_idx);
-		auto col_type = order.expression->return_type;
+		auto col_type = order.expression->GetReturnType();
 		decode_child_list.emplace_back(col_name, col_type);
 		col_type = TypeVisitor::VisitReplace(col_type, [](const LogicalType &type) {
 			if (type.id() != LogicalTypeId::STRUCT) {
@@ -57,13 +57,13 @@ Sort::Sort(ClientContext &context_p, const vector<BoundOrderByNode> &orders, con
 		throw InternalException("Unable to bind create_sort_key in Sort::Sort");
 	}
 
-	switch (create_sort_key->return_type.id()) {
+	switch (create_sort_key->GetReturnType().id()) {
 	case LogicalTypeId::BIGINT:
 		decode_children.insert(decode_children.begin(),
 		                       make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, static_cast<storage_t>(0)));
 		break;
 	default:
-		D_ASSERT(create_sort_key->return_type.id() == LogicalTypeId::BLOB);
+		D_ASSERT(create_sort_key->GetReturnType().id() == LogicalTypeId::BLOB);
 		decode_children.insert(decode_children.begin(),
 		                       make_uniq<BoundReferenceExpression>(LogicalType::BLOB, static_cast<storage_t>(0)));
 	}
@@ -74,7 +74,7 @@ Sort::Sort(ClientContext &context_p, const vector<BoundOrderByNode> &orders, con
 	}
 
 	// A bit hacky, but this way we make sure that the output does contain the unnamed structs again
-	decode_sort_key->return_type = LogicalType::STRUCT(std::move(decode_child_list));
+	decode_sort_key->SetReturnType(LogicalType::STRUCT(std::move(decode_child_list)));
 
 	// For convenience, we fill the projection map if it is empty
 	if (projection_map.empty()) {
@@ -123,7 +123,7 @@ Sort::Sort(ClientContext &context_p, const vector<BoundOrderByNode> &orders, con
 	          });
 
 	// Finally, initialize the key layout (now that we know whether we have a payload)
-	key_layout->Initialize(orders, create_sort_key->return_type, !payload_types.empty());
+	key_layout->Initialize(orders, create_sort_key->GetReturnType(), !payload_types.empty());
 }
 
 //===--------------------------------------------------------------------===//
@@ -133,7 +133,7 @@ class SortLocalSinkState : public LocalSinkState {
 public:
 	SortLocalSinkState(const Sort &sort, ClientContext &context)
 	    : maximum_run_size(0), external(false), key_executor(context, *sort.create_sort_key) {
-		key.Initialize(context, {sort.create_sort_key->return_type});
+		key.Initialize(context, {sort.create_sort_key->GetReturnType()});
 		payload.Initialize(context, sort.payload_layout->GetTypes());
 	}
 
@@ -452,8 +452,9 @@ SourceResultType Sort::MaterializeColumnData(ExecutionContext &context, Operator
 	vector<LogicalType> types;
 	types.resize(output_projection_columns.size());
 	for (auto &opc : output_projection_columns) {
-		const auto &type = opc.is_payload ? payload_layout->GetTypes()[opc.layout_col_idx]
-		                                  : StructType::GetChildType(decode_sort_key->return_type, opc.layout_col_idx);
+		const auto &type = opc.is_payload
+		                       ? payload_layout->GetTypes()[opc.layout_col_idx]
+		                       : StructType::GetChildType(decode_sort_key->GetReturnType(), opc.layout_col_idx);
 		types[opc.output_col_idx] = type;
 	}
 

--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -19,7 +19,7 @@ namespace duckdb {
 SortedRunScanState::SortedRunScanState(ClientContext &context, const Sort &sort_p)
     : sort(sort_p), key_executor(context, *sort.decode_sort_key) {
 	key.Initialize(context, {sort.key_layout->GetTypes()[0]});
-	decoded_key.Initialize(context, {sort.decode_sort_key->return_type});
+	decoded_key.Initialize(context, {sort.decode_sort_key->GetReturnType()});
 }
 
 void SortedRunScanState::Scan(const SortedRun &sorted_run, const Vector &sort_key_pointers, const idx_t &count,
@@ -56,8 +56,8 @@ void SortedRunScanState::Clear() {
 }
 
 template <class SORT_KEY, class PHYSICAL_TYPE>
-void TemplatedGetKeyAndPayload(SORT_KEY *const *const sort_keys, SORT_KEY *temp_keys, const idx_t &count,
-                               DataChunk &key, data_ptr_t *const payload_ptrs) {
+static void TemplatedGetKeyAndPayload(SORT_KEY *const *const sort_keys, SORT_KEY *temp_keys, const idx_t &count,
+                                      DataChunk &key, data_ptr_t *const payload_ptrs) {
 	const auto key_data = FlatVector::GetDataMutable<PHYSICAL_TYPE>(key.data[0]);
 	for (idx_t i = 0; i < count; i++) {
 		auto &sort_key = temp_keys[i];
@@ -71,8 +71,8 @@ void TemplatedGetKeyAndPayload(SORT_KEY *const *const sort_keys, SORT_KEY *temp_
 }
 
 template <class SORT_KEY>
-void GetKeyAndPayload(SORT_KEY *const *const sort_keys, SORT_KEY *temp_keys, const idx_t &count, DataChunk &key,
-                      data_ptr_t *const payload_ptrs) {
+static void GetKeyAndPayload(SORT_KEY *const *const sort_keys, SORT_KEY *temp_keys, const idx_t &count, DataChunk &key,
+                             data_ptr_t *const payload_ptrs) {
 	const auto type_id = key.data[0].GetType().id();
 	switch (type_id) {
 	case LogicalTypeId::BLOB:

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -500,7 +500,7 @@ string LogicalType::ToString() const {
 		}
 
 		auto &expr = UnboundType::GetTypeExpression(*this);
-		if (expr->type != ExpressionType::TYPE) {
+		if (expr->GetExpressionType() != ExpressionType::TYPE) {
 			return "(" + expr->ToString() + ")";
 		} else {
 			return expr->ToString();
@@ -2048,7 +2048,7 @@ LogicalType UnboundType::TryParseAndDefaultBind(const string &type_str) {
 }
 
 static LogicalType TryDefaultBindTypeExpression(const ParsedExpression &expr) {
-	if (expr.type != ExpressionType::TYPE) {
+	if (expr.GetExpressionType() != ExpressionType::TYPE) {
 		throw InvalidInputException("Cannot default bind unbound type with non-type expression");
 	}
 	const auto &type_expr = expr.Cast<TypeExpression>();

--- a/src/common/types/row/tuple_data_layout.cpp
+++ b/src/common/types/row/tuple_data_layout.cpp
@@ -170,7 +170,7 @@ void TupleDataLayout::Initialize(const vector<BoundOrderByNode> &orders, const L
 	bool all_valid_and_truly_constant = true;
 	for (idx_t order_idx = 0; order_idx < orders.size(); order_idx++) {
 		const auto &order = orders[order_idx];
-		const auto &logical_type = order.expression->return_type;
+		const auto &logical_type = order.expression->GetReturnType();
 		const auto physical_type = logical_type.InternalType();
 
 		if (all_valid_and_truly_constant && order.stats && !order.stats->CanHaveNull() &&

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -199,17 +199,17 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 					    expr.GetAlias(), expr.binding.table_index.index, expr.binding.column_index, bindings.size(),
 					    types.size());
 				}
-				if (expr.return_type != types[i]) {
+				if (expr.GetReturnType() != types[i]) {
 					throw InternalException("Failed to bind column reference \"%s\" [%d.%d]: inequal types (%s != %s)",
 					                        expr.GetAlias(), expr.binding.table_index.index, expr.binding.column_index,
-					                        expr.return_type.ToString(), types[i].ToString());
+					                        expr.GetReturnType().ToString(), types[i].ToString());
 				}
 			}
 			if (verify_only) {
 				// in verification mode
 				return nullptr;
 			}
-			return make_uniq<BoundReferenceExpression>(expr.GetAlias(), expr.return_type, i);
+			return make_uniq<BoundReferenceExpression>(expr.GetAlias(), expr.GetReturnType(), i);
 		}
 	}
 	// LCOV_EXCL_START

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -120,7 +120,7 @@ void ExpressionExecutor::ExecuteExpression(Vector &result) {
 
 void ExpressionExecutor::ExecuteExpression(idx_t expr_idx, Vector &result) {
 	D_ASSERT(expr_idx < expressions.size());
-	D_ASSERT(result.GetType().id() == expressions[expr_idx]->return_type.id());
+	D_ASSERT(result.GetType().id() == expressions[expr_idx]->GetReturnType().id());
 	Execute(*expressions[expr_idx], states[expr_idx]->root_state.get(), nullptr, chunk ? chunk->size() : 1, result);
 }
 
@@ -130,12 +130,12 @@ Value ExpressionExecutor::EvaluateScalar(ClientContext &context, const Expressio
 	// use an ExpressionExecutor to execute the expression
 	ExpressionExecutor executor(context, expr);
 
-	Vector result(expr.return_type);
+	Vector result(expr.GetReturnType());
 	executor.ExecuteExpression(result);
 
 	D_ASSERT(allow_unfoldable || result.GetVectorType() == VectorType::CONSTANT_VECTOR);
 	auto result_value = result.GetValue(0);
-	D_ASSERT(result_value.type().InternalType() == expr.return_type.InternalType());
+	D_ASSERT(result_value.type().InternalType() == expr.GetReturnType().InternalType());
 	return result_value;
 }
 
@@ -151,10 +151,10 @@ bool ExpressionExecutor::TryEvaluateScalar(ClientContext &context, const Express
 }
 
 void ExpressionExecutor::Verify(const Expression &expr, Vector &vector, idx_t count) {
-	D_ASSERT(expr.return_type.id() == vector.GetType().id());
+	D_ASSERT(expr.GetReturnType().id() == vector.GetType().id());
 	vector.Verify(count);
-	if (expr.verification_stats) {
-		expr.verification_stats->Verify(vector, count);
+	if (expr.GetVerificationStats()) {
+		expr.GetVerificationStats()->Verify(vector, count);
 	}
 	if (debug_vector_verification == DebugVectorVerification::DICTIONARY_EXPRESSION) {
 		Vector::DebugTransformToDictionary(vector, count);
@@ -243,10 +243,10 @@ void ExpressionExecutor::Execute(const Expression &expr, ExpressionState *state,
 	if (count == 0) {
 		return;
 	}
-	if (result.GetType().id() != expr.return_type.id()) {
+	if (result.GetType().id() != expr.GetReturnType().id()) {
 		throw InternalException(
 		    "ExpressionExecutor::Execute called with a result vector of type %s that does not match expression type %s",
-		    result.GetType(), expr.return_type);
+		    result.GetType(), expr.GetReturnType());
 	}
 	switch (expr.GetExpressionClass()) {
 	case ExpressionClass::BOUND_BETWEEN:
@@ -291,7 +291,7 @@ idx_t ExpressionExecutor::Select(const Expression &expr, ExpressionState *state,
 		return 0;
 	}
 	D_ASSERT(true_sel || false_sel);
-	D_ASSERT(expr.return_type.id() == LogicalTypeId::BOOLEAN);
+	D_ASSERT(expr.GetReturnType().id() == LogicalTypeId::BOOLEAN);
 	switch (expr.GetExpressionClass()) {
 #ifndef DUCKDB_SMALLER_BINARY
 	case ExpressionClass::BOUND_BETWEEN:

--- a/src/execution/expression_executor/execute_constant.cpp
+++ b/src/execution/expression_executor/execute_constant.cpp
@@ -13,7 +13,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConst
 
 void ExpressionExecutor::Execute(const BoundConstantExpression &expr, ExpressionState *state,
                                  const SelectionVector *sel, idx_t count, Vector &result) {
-	D_ASSERT(expr.value.type() == expr.return_type);
+	D_ASSERT(expr.value.type() == expr.GetReturnType());
 	result.Reference(expr.value, count_t(count));
 }
 

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -12,7 +12,7 @@ ExecuteFunctionState::ExecuteFunctionState(const Expression &expr, ExpressionExe
 		return; // Needs to be consistent, non-volatile, and non-throwing
 	}
 
-	if (expr.return_type.InternalType() == PhysicalType::STRUCT) {
+	if (expr.GetReturnType().InternalType() == PhysicalType::STRUCT) {
 		return; // FIXME: get this working for STRUCT
 	}
 
@@ -30,7 +30,7 @@ ExecuteFunctionState::ExecuteFunctionState(const Expression &expr, ExpressionExe
 				input_col_idx.SetInvalid(); // Found more than 1 non-constant
 				break;
 			}
-			if (child.return_type.InternalType() == PhysicalType::STRUCT) {
+			if (child.GetReturnType().InternalType() == PhysicalType::STRUCT) {
 				break; // FIXME
 			}
 			input_col_idx = child_idx;
@@ -173,9 +173,9 @@ static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &a
 
 static void ExecuteSelectFunction(const BoundFunctionExpression &expr, DataChunk &args, ExpressionState &state,
                                   Vector &result) {
-	if (expr.return_type != LogicalType::BOOLEAN) {
+	if (expr.GetReturnType() != LogicalType::BOOLEAN) {
 		throw InvalidInputException("Function %s only has a select callback but returns %s", expr.function.name,
-		                            expr.return_type.ToString());
+		                            expr.GetReturnType().ToString());
 	}
 	if (expr.function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
 		throw InvalidInputException("Function %s only has a select callback with SPECIAL_HANDLING but projected "
@@ -225,7 +225,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	auto default_null_handling = expr.function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING;
 	if (!state->types.empty()) {
 		for (idx_t i = 0; i < expr.children.size(); i++) {
-			D_ASSERT(state->types[i] == expr.children[i]->return_type);
+			D_ASSERT(state->types[i] == expr.children[i]->GetReturnType());
 			Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
 			if (arguments.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 				all_constant = false;
@@ -263,7 +263,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	}
 
 	VerifyNullHandling(expr, arguments, result);
-	D_ASSERT(result.GetType() == expr.return_type);
+	D_ASSERT(result.GetType() == expr.GetReturnType());
 }
 
 static void ScatterSelectionResult(const SelectionVector &source, idx_t source_count, const SelectionVector *sel,
@@ -287,7 +287,7 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 	state->intermediate_chunk.Reset();
 	auto &arguments = state->intermediate_chunk;
 	for (idx_t i = 0; i < expr.children.size(); i++) {
-		D_ASSERT(state->types[i] == expr.children[i]->return_type);
+		D_ASSERT(state->types[i] == expr.children[i]->GetReturnType());
 		Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
 	}
 	arguments.SetCardinality(count);

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -25,7 +25,7 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 			throw InvalidInputException("IN needs at least two children");
 		}
 
-		Vector left(expr.children[0]->return_type);
+		Vector left(expr.children[0]->GetReturnType());
 		// eval left side
 		Execute(*expr.children[0], state->child_states[0].get(), sel, count, left);
 
@@ -37,7 +37,7 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 		// for every child, OR the result of the comparison with the left
 		// to get the overall result.
 		for (idx_t child = 1; child < expr.children.size(); child++) {
-			Vector vector_to_check(expr.children[child]->return_type);
+			Vector vector_to_check(expr.children[child]->GetReturnType());
 			Vector comp_res(LogicalType::BOOLEAN);
 
 			Execute(*expr.children[child], state->child_states[child].get(), sel, count, vector_to_check);
@@ -70,7 +70,7 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 		idx_t remaining_count = count;
 		idx_t next_count;
 		for (idx_t child = 0; child < expr.children.size(); child++) {
-			Vector vector_to_check(expr.children[child]->return_type);
+			Vector vector_to_check(expr.children[child]->GetReturnType());
 			Execute(*expr.children[child], state->child_states[child].get(), current_sel, remaining_count,
 			        vector_to_check);
 

--- a/src/execution/expression_executor/execute_parameter.cpp
+++ b/src/execution/expression_executor/execute_parameter.cpp
@@ -14,8 +14,8 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundParam
 void ExpressionExecutor::Execute(const BoundParameterExpression &expr, ExpressionState *state,
                                  const SelectionVector *sel, idx_t count, Vector &result) {
 	D_ASSERT(expr.parameter_data);
-	D_ASSERT(expr.parameter_data->return_type == expr.return_type);
-	D_ASSERT(expr.parameter_data->GetValue().type() == expr.return_type);
+	D_ASSERT(expr.parameter_data->return_type == expr.GetReturnType());
+	D_ASSERT(expr.parameter_data->GetValue().type() == expr.GetReturnType());
 	result.Reference(expr.parameter_data->GetValue(), count_t(count));
 }
 

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 void ExpressionState::AddChild(Expression &child_expr) {
-	types.push_back(child_expr.return_type);
+	types.push_back(child_expr.GetReturnType());
 	auto child_state = ExpressionExecutor::InitializeState(child_expr, root);
 	child_states.push_back(std::move(child_state));
 

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -21,8 +21,8 @@ BoundIndex::BoundIndex(const string &name, const string &index_type, IndexConstr
     : Index(column_ids, table_io_manager, db), name(name), index_type(index_type),
       index_constraint_type(index_constraint_type) {
 	for (auto &expr : unbound_expressions_p) {
-		types.push_back(expr->return_type.InternalType());
-		logical_types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType().InternalType());
+		logical_types.push_back(expr->GetReturnType());
 		unbound_expressions.emplace_back(expr->Copy());
 		bound_expressions.push_back(BindExpression(expr->Copy()));
 		executor.AddExpression(*bound_expressions.back());
@@ -147,8 +147,8 @@ void BoundIndex::ExecuteExpressions(DataChunk &input, DataChunk &result) {
 unique_ptr<Expression> BoundIndex::BindExpression(unique_ptr<Expression> root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &bound_colref, unique_ptr<Expression> &expr) {
-		    expr =
-		        make_uniq<BoundReferenceExpression>(expr->return_type, column_ids[bound_colref.binding.column_index]);
+		    expr = make_uniq<BoundReferenceExpression>(expr->GetReturnType(),
+		                                               column_ids[bound_colref.binding.column_index]);
 	    });
 	return root_expr;
 }

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -51,8 +51,8 @@ JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &o
 	for (idx_t i = 0; i < conditions.size(); ++i) {
 		auto &condition = conditions[i];
 		D_ASSERT(condition.IsComparison());
-		D_ASSERT(condition.GetLHS().return_type == condition.GetRHS().return_type);
-		auto type = condition.GetLHS().return_type;
+		D_ASSERT(condition.GetLHS().GetReturnType() == condition.GetRHS().GetReturnType());
+		auto type = condition.GetLHS().GetReturnType();
 		if (condition.GetComparisonType() == ExpressionType::COMPARE_EQUAL ||
 		    condition.GetComparisonType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 			// ensure that all equality conditions are at the front,

--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -17,14 +17,14 @@ AggregateObject::AggregateObject(AggregateFunction function, FunctionData *bind_
 AggregateObject::AggregateObject(BoundAggregateExpression *aggr)
     : AggregateObject(aggr->function, aggr->bind_info.get(), aggr->children.size(),
                       AlignValue(aggr->function.GetStateSizeCallback()(aggr->function)), aggr->aggr_type,
-                      aggr->return_type.InternalType(), aggr->filter.get()) {
+                      aggr->GetReturnType().InternalType(), aggr->filter.get()) {
 }
 
 AggregateObject::AggregateObject(const BoundWindowExpression &window)
     : AggregateObject(*window.aggregate, window.bind_info.get(), window.children.size(),
                       AlignValue(window.aggregate->GetStateSizeCallback()(*window.aggregate)),
                       window.distinct ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT,
-                      window.return_type.InternalType(), window.filter_expr.get()) {
+                      window.GetReturnType().InternalType(), window.filter_expr.get()) {
 }
 
 vector<AggregateObject> AggregateObject::CreateAggregateObjects(const vector<BoundAggregateExpression *> &bindings) {

--- a/src/execution/operator/aggregate/distinct_aggregate_data.cpp
+++ b/src/execution/operator/aggregate/distinct_aggregate_data.cpp
@@ -109,7 +109,7 @@ DistinctAggregateData::DistinctAggregateData(const DistinctAggregateCollectionIn
 		// Fill the chunk_types (only contains the payload of the distinct aggregates)
 		vector<LogicalType> chunk_types;
 		for (auto &child_p : aggregate.children) {
-			chunk_types.push_back(child_p->return_type);
+			chunk_types.push_back(child_p->GetReturnType());
 		}
 	}
 }

--- a/src/execution/operator/aggregate/grouped_aggregate_data.cpp
+++ b/src/execution/operator/aggregate/grouped_aggregate_data.cpp
@@ -25,13 +25,13 @@ void GroupedAggregateData::InitializeGroupby(vector<unique_ptr<Expression>> grou
 		auto &aggr = expr->Cast<BoundAggregateExpression>();
 		bindings.push_back(&aggr);
 
-		aggregate_return_types.push_back(aggr.return_type);
+		aggregate_return_types.push_back(aggr.GetReturnType());
 		for (auto &child : aggr.children) {
-			payload_types.push_back(child->return_type);
+			payload_types.push_back(child->GetReturnType());
 		}
 		if (aggr.filter) {
 			filter_count++;
-			payload_types_filters.push_back(aggr.filter->return_type);
+			payload_types_filters.push_back(aggr.filter->GetReturnType());
 		}
 		if (!aggr.function.HasStateCombineCallback()) {
 			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
@@ -53,12 +53,12 @@ void GroupedAggregateData::InitializeDistinct(const unique_ptr<Expression> &aggr
 
 	// bindings.push_back(&aggr);
 	filter_count = 0;
-	aggregate_return_types.push_back(aggr.return_type);
+	aggregate_return_types.push_back(aggr.GetReturnType());
 	for (idx_t i = 0; i < aggr.children.size(); i++) {
 		auto &child = aggr.children[i];
-		group_types.push_back(child->return_type);
+		group_types.push_back(child->GetReturnType());
 		groups.push_back(child->Copy());
-		payload_types.push_back(child->return_type);
+		payload_types.push_back(child->GetReturnType());
 		if (aggr.filter) {
 			filter_count++;
 		}
@@ -73,7 +73,7 @@ void GroupedAggregateData::InitializeDistinctGroups(const vector<unique_ptr<Expr
 		return;
 	}
 	for (auto &expr : *groups_p) {
-		group_types.push_back(expr->return_type);
+		group_types.push_back(expr->GetReturnType());
 		groups.push_back(expr->Copy());
 	}
 }
@@ -81,7 +81,7 @@ void GroupedAggregateData::InitializeDistinctGroups(const vector<unique_ptr<Expr
 void GroupedAggregateData::InitializeGroupbyGroups(vector<unique_ptr<Expression>> groups) {
 	// Add all the expressions of the group by clause
 	for (auto &expr : groups) {
-		group_types.push_back(expr->return_type);
+		group_types.push_back(expr->GetReturnType());
 	}
 	this->groups = std::move(groups);
 }

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -90,7 +90,7 @@ static vector<LogicalType> CreateGroupChunkTypes(vector<unique_ptr<Expression>> 
 	vector<LogicalType> types(highest_index + 1, LogicalType::SQLNULL);
 	for (auto &group : groups) {
 		auto &bound_ref = group->Cast<BoundReferenceExpression>();
-		types[bound_ref.index] = bound_ref.return_type;
+		types[bound_ref.index] = bound_ref.GetReturnType();
 	}
 	return types;
 }
@@ -202,10 +202,10 @@ public:
 		for (auto &aggr : op.grouped_aggregate_data.aggregates) {
 			auto &aggregate = aggr->Cast<BoundAggregateExpression>();
 			for (auto &child : aggregate.children) {
-				payload_types.push_back(child->return_type);
+				payload_types.push_back(child->GetReturnType());
 			}
 			if (aggregate.filter) {
-				filter_types.push_back(aggregate.filter->return_type);
+				filter_types.push_back(aggregate.filter->GetReturnType());
 			}
 		}
 		payload_types.reserve(payload_types.size() + filter_types.size());

--- a/src/execution/operator/aggregate/physical_limited_distinct.cpp
+++ b/src/execution/operator/aggregate/physical_limited_distinct.cpp
@@ -12,7 +12,7 @@ static vector<LogicalType> GetPayloadTypes(const vector<unique_ptr<Expression>> 
 	for (auto &aggr_expr : aggregates) {
 		auto &aggr = aggr_expr->Cast<BoundAggregateExpression>();
 		for (auto &child : aggr.children) {
-			payload_types.push_back(child->return_type);
+			payload_types.push_back(child->GetReturnType());
 		}
 	}
 	return payload_types;
@@ -33,7 +33,7 @@ PhysicalLimitedDistinct::PhysicalLimitedDistinct(PhysicalPlan &physical_plan, ve
     : PhysicalOperator(physical_plan, PhysicalOperatorType::LIMITED_DISTINCT, std::move(types), estimated_cardinality),
       groups(std::move(groups_p)), aggregates(std::move(aggregates_p)), limit(limit_p) {
 	for (auto &group : groups) {
-		group_types.push_back(group->return_type);
+		group_types.push_back(group->GetReturnType());
 	}
 }
 
@@ -160,7 +160,7 @@ struct LimitedDistinctGlobalSourceState : public GlobalSourceState {
 		vector<LogicalType> payload_types;
 		for (auto &aggr_expr : op.aggregates) {
 			auto &aggr = aggr_expr->Cast<BoundAggregateExpression>();
-			payload_types.push_back(aggr.return_type);
+			payload_types.push_back(aggr.GetReturnType());
 		}
 		if (!payload_types.empty()) {
 			payload_chunk.Initialize(Allocator::Get(context), payload_types);

--- a/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
@@ -25,7 +25,7 @@ PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(PhysicalPlan &physica
 		group_minima.push_back(NumericStats::Min(nstats));
 	}
 	for (auto &expr : groups) {
-		group_types.push_back(expr->return_type);
+		group_types.push_back(expr->GetReturnType());
 	}
 
 	vector<BoundAggregateExpression *> bindings;
@@ -39,10 +39,10 @@ PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(PhysicalPlan &physica
 		D_ASSERT(!aggr.IsDistinct());
 		D_ASSERT(aggr.function.HasStateCombineCallback());
 		for (auto &child : aggr.children) {
-			payload_types.push_back(child->return_type);
+			payload_types.push_back(child->GetReturnType());
 		}
 		if (aggr.filter) {
-			payload_types_filters.push_back(aggr.filter->return_type);
+			payload_types_filters.push_back(aggr.filter->GetReturnType());
 		}
 	}
 	for (const auto &pay_filters : payload_types_filters) {

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -44,7 +44,7 @@ public:
 			state_ptr = state.data();
 			aggregate.GetStateInitCallback()(aggregate, state.data());
 			for (auto &child : wexpr.children) {
-				arg_types.push_back(child->return_type);
+				arg_types.push_back(child->GetReturnType());
 				executor.AddExpression(*child);
 			}
 			if (!arg_types.empty()) {

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -166,7 +166,7 @@ UngroupedAggregateExecuteState::UngroupedAggregateExecuteState(ClientContext &co
 		auto &aggr = aggregate->Cast<BoundAggregateExpression>();
 		// initialize the payload chunk
 		for (auto &child : aggr.children) {
-			payload_types.push_back(child->return_type);
+			payload_types.push_back(child->GetReturnType());
 			child_executor.AddExpression(*child);
 		}
 		aggregate_objects.emplace_back(&aggr);

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -463,7 +463,7 @@ WindowHashGroup::WindowHashGroup(WindowGlobalSinkState &gsink, const ChunkRow &c
 	const auto &shared = WindowSharedExpressions::GetSortedExpressions(gsink.shared.coll_shared);
 	vector<LogicalType> types;
 	for (auto &expr : shared) {
-		types.emplace_back(expr->return_type);
+		types.emplace_back(expr->GetReturnType());
 	}
 	auto &buffer_manager = BufferManager::GetBufferManager(gsink.client);
 	collection = make_uniq<WindowCollection>(buffer_manager, count, types);
@@ -840,7 +840,7 @@ WindowLocalSourceState::WindowLocalSourceState(WindowGlobalSourceState &gsource)
 	vector<LogicalType> output_types;
 	for (auto &wexec : gsink.executors) {
 		auto &wexpr = wexec->wexpr;
-		output_types.emplace_back(wexpr.return_type);
+		output_types.emplace_back(wexpr.GetReturnType());
 	}
 	output_chunk.Initialize(gsource.client, output_types);
 

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -225,7 +225,7 @@ bool PhysicalLimit::HandleOffset(DataChunk &input, idx_t &current_offset, idx_t 
 
 Value PhysicalLimit::GetDelimiter(ExecutionContext &context, DataChunk &input, const Expression &expr) {
 	DataChunk limit_chunk;
-	vector<LogicalType> types {expr.return_type};
+	vector<LogicalType> types {expr.GetReturnType()};
 	auto &allocator = Allocator::Get(context.client);
 	limit_chunk.Initialize(allocator, types);
 	ExpressionExecutor limit_executor(context.client, &expr);

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -78,7 +78,7 @@ bool PerfectHashJoinExecutor::CanDoPerfectHashJoin(const PhysicalHashJoin &op, c
 	}
 
 	// We only do this optimization for inner joins with one integer equality condition
-	const auto key_type = op.conditions[0].GetLHS().return_type;
+	const auto key_type = op.conditions[0].GetLHS().GetReturnType();
 	if (op.join_type != JoinType::INNER || op.conditions.size() != 1 ||
 	    op.conditions[0].GetComparisonType() != ExpressionType::COMPARE_EQUAL ||
 	    !TypeIsInteger(key_type.InternalType())) {

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -22,8 +22,8 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalCompariso
 	// Convert the conditions partitions and sorts
 	for (auto &cond : conditions) {
 		D_ASSERT(cond.IsComparison());
-		D_ASSERT(cond.GetLHS().return_type == cond.GetRHS().return_type);
-		join_key_types.push_back(cond.GetLHS().return_type);
+		D_ASSERT(cond.GetLHS().GetReturnType() == cond.GetRHS().GetReturnType());
+		join_key_types.push_back(cond.GetLHS().GetReturnType());
 
 		auto left_cond = cond.LeftReference()->Copy();
 		auto right_cond = cond.RightReference()->Copy();
@@ -912,7 +912,7 @@ AsOfProbeBuffer::AsOfProbeBuffer(ClientContext &client, const PhysicalAsOfJoin &
 	vector<LogicalType> prefix_types;
 	for (idx_t i = 0; i < op.conditions.size() - 1; ++i) {
 		const auto &cond = op.conditions[i];
-		const auto &type = cond.GetLHS().return_type;
+		const auto &type = cond.GetLHS().GetReturnType();
 		prefix_types.emplace_back(type);
 		SortKeyPrefixComparisonColumn col;
 		col.size = DConstants::INVALID_INDEX;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -57,7 +57,7 @@ PhysicalHashJoin::PhysicalHashJoin(PhysicalPlan &physical_plan, LogicalOperator 
 
 	for (auto &condition : conditions) {
 		D_ASSERT(condition.IsComparison());
-		condition_types.push_back(condition.GetLHS().return_type);
+		condition_types.push_back(condition.GetLHS().GetReturnType());
 	}
 
 	vector<idx_t> probe_cols;
@@ -440,7 +440,7 @@ unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &c
 			aggr = function_binder.BindAggregateFunction(CountStarFun::GetFunction(), {}, nullptr,
 			                                             AggregateType::NON_DISTINCT);
 			correlated_aggregates.push_back(&*aggr);
-			delim_payload_types.push_back(aggr->return_type);
+			delim_payload_types.push_back(aggr->GetReturnType());
 			info.correlated_aggregates.push_back(std::move(aggr));
 
 			auto count_fun = CountFunctionBase::GetFunction();
@@ -450,7 +450,7 @@ unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &c
 			aggr = function_binder.BindAggregateFunction(count_fun, std::move(children), nullptr,
 			                                             AggregateType::NON_DISTINCT);
 			correlated_aggregates.push_back(&*aggr);
-			delim_payload_types.push_back(aggr->return_type);
+			delim_payload_types.push_back(aggr->GetReturnType());
 			info.correlated_aggregates.push_back(std::move(aggr));
 
 			auto &allocator = BufferAllocator::Get(context);
@@ -1010,7 +1010,7 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 		return false;
 	}
 
-	const auto &key_type = ht->conditions[0].GetLHS().return_type;
+	const auto &key_type = ht->conditions[0].GetLHS().GetReturnType();
 	return PrefixRangeTableFilter::SupportedType(key_type);
 }
 
@@ -1020,7 +1020,7 @@ void JoinFilterPushdownInfo::PushBloomFilter(const PhysicalOperator &op, JoinHas
 	// If the nulls are equal, we let nulls pass. If not, we filter them
 	auto filters_null_values = !ht.NullValuesAreEqual(0);
 	const auto key_name = ht.conditions[0].GetRHS().ToString();
-	const auto key_type = ht.conditions[0].GetLHS().return_type;
+	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
 	ht.SetBuildBloomFilter(true);
 	auto filter =
 	    make_uniq_base<TableFilter, BFTableFilter>(ht.GetBloomFilter(), filters_null_values, key_name, key_type);
@@ -1043,7 +1043,7 @@ void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownF
                                                        JoinHashTable &ht, const PhysicalOperator &op,
                                                        ProjectionIndex filter_col_idx, const Value &min_val,
                                                        const Value &max_val) const {
-	const auto key_type = ht.conditions[0].GetLHS().return_type;
+	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
 	if (!ht.GetPrefixRangeFilter()) {
 		auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
 		prefix_filter->Initialize(context, ht.Count(), min_val, max_val);
@@ -1062,7 +1062,7 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeMinMax(JoinFilterGlobalSta
 	// finalize the min/max aggregates
 	vector<LogicalType> min_max_types;
 	for (auto &aggr_expr : min_max_aggregates) {
-		min_max_types.push_back(aggr_expr->return_type);
+		min_max_types.push_back(aggr_expr->GetReturnType());
 	}
 	auto final_min_max = make_uniq<DataChunk>();
 	final_min_max->Initialize(Allocator::DefaultAllocator(), min_max_types);
@@ -1274,9 +1274,9 @@ SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 		filter_min_max = filter_pushdown->FinalizeMinMax(*sink.global_filter_state);
 		min = filter_min_max->data[0].GetValue(0);
 		max = filter_min_max->data[1].GetValue(0);
-	} else if (TypeIsIntegral(conditions[0].GetRHS().return_type.InternalType())) {
-		min = Value::MinimumValue(conditions[0].GetRHS().return_type);
-		max = Value::MaximumValue(conditions[0].GetRHS().return_type);
+	} else if (TypeIsIntegral(conditions[0].GetRHS().GetReturnType().InternalType())) {
+		min = Value::MinimumValue(conditions[0].GetRHS().GetReturnType());
+		max = Value::MaximumValue(conditions[0].GetRHS().GetReturnType());
 	}
 
 	// check for possible perfect hash table

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -25,8 +25,8 @@ PhysicalIEJoin::PhysicalIEJoin(PhysicalPlan &physical_plan, LogicalComparisonJoi
 	D_ASSERT(conditions.size() >= 2);
 	for (idx_t i = 0; i < 2; ++i) {
 		auto &cond = conditions[i];
-		D_ASSERT(cond.GetLHS().return_type == cond.GetRHS().return_type);
-		join_key_types.push_back(cond.GetLHS().return_type);
+		D_ASSERT(cond.GetLHS().GetReturnType() == cond.GetRHS().GetReturnType());
+		join_key_types.push_back(cond.GetLHS().GetReturnType());
 
 		// Convert the conditions to sort orders
 		auto left = cond.GetLHS().Copy();
@@ -55,8 +55,8 @@ PhysicalIEJoin::PhysicalIEJoin(PhysicalPlan &physical_plan, LogicalComparisonJoi
 
 	for (idx_t i = 2; i < conditions.size(); ++i) {
 		auto &cond = conditions[i];
-		D_ASSERT(cond.GetLHS().return_type == cond.GetRHS().return_type);
-		join_key_types.push_back(cond.GetLHS().return_type);
+		D_ASSERT(cond.GetLHS().GetReturnType() == cond.GetRHS().GetReturnType());
+		join_key_types.push_back(cond.GetLHS().GetReturnType());
 	}
 }
 
@@ -576,7 +576,7 @@ idx_t IEJoinUnion::AppendKey(ExecutionContext &context, InterruptState &interrup
 	auto local_sort_state = sort.GetLocalSinkState(context);
 	vector<LogicalType> types;
 	for (const auto &expr : executor.expressions) {
-		types.emplace_back(expr->return_type);
+		types.emplace_back(expr->GetReturnType());
 	}
 	const idx_t rid_idx = types.size();
 	types.emplace_back(LogicalType::BIGINT);
@@ -884,11 +884,11 @@ IEJoinGlobalSourceState::IEJoinGlobalSourceState(const PhysicalIEJoin &op, Clien
 	//		X/X', Y/Y', R/R'/Li
 	// The first position is the sort key.
 	vector<LogicalType> types;
-	types.emplace_back(order2.expression->return_type);
+	types.emplace_back(order2.expression->GetReturnType());
 	types.emplace_back(LogicalType::BIGINT);
 
 	// Sort on the first expression
-	auto ref = make_uniq<BoundReferenceExpression>(order1.expression->return_type, 0U);
+	auto ref = make_uniq<BoundReferenceExpression>(order1.expression->GetReturnType(), 0U);
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(order1.type, order1.null_order, std::move(ref));
 	// The goal is to make i (from the left table) < j (from the right table),
@@ -923,7 +923,7 @@ IEJoinGlobalSourceState::IEJoinGlobalSourceState(const PhysicalIEJoin &op, Clien
 
 	// Sort on the first expression
 	orders.clear();
-	ref = make_uniq<BoundReferenceExpression>(order2.expression->return_type, 0U);
+	ref = make_uniq<BoundReferenceExpression>(order2.expression->GetReturnType(), 0U);
 	orders.emplace_back(order2.type, order2.null_order, std::move(ref));
 
 	l2 = make_uniq<SortedTable>(client, orders, types, op);
@@ -998,10 +998,10 @@ public:
 		for (idx_t i = 2; i < op.conditions.size(); ++i) {
 			const auto &cond = op.conditions[i];
 
-			left_types.push_back(cond.GetLHS().return_type);
+			left_types.push_back(cond.GetLHS().GetReturnType());
 			left_executor.AddExpression(cond.GetLHS());
 
-			right_types.push_back(cond.GetLHS().return_type);
+			right_types.push_back(cond.GetLHS().GetReturnType());
 			right_executor.AddExpression(cond.GetRHS());
 		}
 
@@ -1256,7 +1256,7 @@ void IEJoinLocalSourceState::ExecuteSinkL2Task(ExecutionContext &context, Interr
 
 	auto &op = gsource.op;
 	const auto &order2 = op.lhs_orders[1];
-	auto ref = make_uniq<BoundReferenceExpression>(order2.expression->return_type, 0U);
+	auto ref = make_uniq<BoundReferenceExpression>(order2.expression->GetReturnType(), 0U);
 
 	ExpressionExecutor executor(context.client);
 	executor.AddExpression(*ref);

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -121,9 +121,9 @@ bool PhysicalNestedLoopJoin::IsSupported(const vector<JoinCondition> &conditions
 		if (!cond.IsComparison()) {
 			continue;
 		}
-		if (cond.GetLHS().return_type.InternalType() == PhysicalType::STRUCT ||
-		    cond.GetLHS().return_type.InternalType() == PhysicalType::LIST ||
-		    cond.GetLHS().return_type.InternalType() == PhysicalType::ARRAY) {
+		if (cond.GetLHS().GetReturnType().InternalType() == PhysicalType::STRUCT ||
+		    cond.GetLHS().GetReturnType().InternalType() == PhysicalType::LIST ||
+		    cond.GetLHS().GetReturnType().InternalType() == PhysicalType::ARRAY) {
 			return false;
 		}
 	}
@@ -181,7 +181,7 @@ public:
 		vector<LogicalType> condition_types;
 		for (auto &cond : op.conditions) {
 			rhs_executor.AddExpression(cond.GetRHS());
-			condition_types.push_back(cond.GetRHS().return_type);
+			condition_types.push_back(cond.GetRHS().GetReturnType());
 		}
 		right_condition.Initialize(Allocator::Get(context), condition_types);
 
@@ -201,7 +201,7 @@ public:
 vector<LogicalType> PhysicalNestedLoopJoin::GetJoinTypes() const {
 	vector<LogicalType> result;
 	for (auto &cond : conditions) {
-		result.push_back(cond.GetRHS().return_type);
+		result.push_back(cond.GetRHS().GetReturnType());
 	}
 	return result;
 }
@@ -283,7 +283,7 @@ public:
 		vector<LogicalType> condition_types;
 		for (auto &cond : conditions) {
 			lhs_executor.AddExpression(cond.GetLHS());
-			condition_types.push_back(cond.GetLHS().return_type);
+			condition_types.push_back(cond.GetLHS().GetReturnType());
 		}
 		auto &allocator = Allocator::Get(context);
 		left_condition.Initialize(allocator, condition_types);

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -21,8 +21,8 @@ PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(PhysicalPlan &physical_pl
     : PhysicalRangeJoin(physical_plan, op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, left, right, std::move(cond),
                         join_type, estimated_cardinality, std::move(pushdown_info_p)) {
 	for (auto &join_cond : conditions) {
-		D_ASSERT(join_cond.GetLHS().return_type == join_cond.GetRHS().return_type);
-		join_key_types.push_back(join_cond.GetLHS().return_type);
+		D_ASSERT(join_cond.GetLHS().GetReturnType() == join_cond.GetRHS().GetReturnType());
+		join_key_types.push_back(join_cond.GetLHS().GetReturnType());
 
 		// Convert the conditions to sort orders
 		auto left_expr = join_cond.GetLHS().Copy();
@@ -204,7 +204,7 @@ public:
 		vector<LogicalType> condition_types;
 		for (auto &order : op.rhs_orders) {
 			rhs_executor.AddExpression(*order.expression);
-			condition_types.push_back(order.expression->return_type);
+			condition_types.push_back(order.expression->GetReturnType());
 		}
 		rhs_keys.Initialize(client, condition_types);
 		rhs_input.Initialize(client, op.children[1].get().GetTypes());
@@ -316,7 +316,7 @@ static bool MergeJoinStrictComparison(ExpressionType comparison) {
 
 //	Compare using </<=
 template <typename T>
-bool MergeJoinBefore(const T &lhs, const T &rhs, const bool strict) {
+static bool MergeJoinBefore(const T &lhs, const T &rhs, const bool strict) {
 	const bool less_than = lhs < rhs;
 	if (!less_than && !strict) {
 		return !(rhs < lhs);

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -24,7 +24,7 @@ PhysicalRangeJoin::LocalSortedTable::LocalSortedTable(ExecutionContext &context,
 		const auto &expr = child ? cond.GetRHS() : cond.GetLHS();
 		executor.AddExpression(expr);
 
-		types.push_back(expr.return_type);
+		types.push_back(expr.GetReturnType());
 	}
 	auto &allocator = Allocator::Get(context.client);
 	keys.Initialize(allocator, types);
@@ -78,7 +78,7 @@ PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &client,
 	vector<LogicalType> input_types;
 	for (const auto &order_by : order_bys) {
 		auto order = order_by.Copy();
-		const auto type = order.expression->return_type;
+		const auto type = order.expression->GetReturnType();
 		input_types.emplace_back(type);
 		order.expression = make_uniq<BoundReferenceExpression>(type, orders.size());
 		orders.emplace_back(std::move(order));
@@ -248,12 +248,12 @@ bool PhysicalRangeJoin::LessThan(const JoinCondition &a, const JoinCondition &b)
 	const auto a_left = a.GetLeftStats() ? a.GetLeftStats()->GetDistinctCount() : 0;
 	const auto a_right = a.GetRightStats() ? a.GetRightStats()->GetDistinctCount() : 0;
 	const auto a_min = MinValue(a_left, a_right);
-	const auto a_type = a.GetRHS().return_type.InternalType();
+	const auto a_type = a.GetRHS().GetReturnType().InternalType();
 
 	const auto b_left = b.GetLeftStats() ? b.GetLeftStats()->GetDistinctCount() : 0;
 	const auto b_right = b.GetRightStats() ? b.GetRightStats()->GetDistinctCount() : 0;
 	const auto b_min = MinValue(b_left, b_right);
-	const auto b_type = b.GetRHS().return_type.InternalType();
+	const auto b_type = b.GetRHS().GetReturnType().InternalType();
 
 	switch (a.GetComparisonType()) {
 	case ExpressionType::COMPARE_LESSTHAN:

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -45,7 +45,7 @@ struct TopNScanState {
 
 struct TopNBoundaryValue {
 	explicit TopNBoundaryValue(const PhysicalTopN &op)
-	    : op(op), boundary_vector(op.orders[0].expression->return_type),
+	    : op(op), boundary_vector(op.orders[0].expression->GetReturnType()),
 	      boundary_modifiers(op.orders[0].type, op.orders[0].null_order) {
 	}
 
@@ -174,7 +174,7 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
 	vector<LogicalType> sort_types;
 	for (auto &order : orders) {
 		auto &expr = order.expression;
-		sort_types.push_back(expr->return_type);
+		sort_types.push_back(expr->GetReturnType());
 		executor.AddExpression(*expr);
 		modifiers.emplace_back(order.type, order.null_order);
 	}

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -86,7 +86,7 @@ public:
 				state.insert_executor = make_uniq<ExpressionExecutor>(context.client, action->expressions);
 				vector<LogicalType> insert_types;
 				for (auto &expr : action->expressions) {
-					insert_types.push_back(expr->return_type);
+					insert_types.push_back(expr->GetReturnType());
 				}
 				state.insert_chunk = make_uniq<DataChunk>();
 				state.insert_chunk->Initialize(context.client, insert_types);

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -73,7 +73,7 @@ public:
 		vector<LogicalType> update_types;
 		update_types.reserve(expressions.size());
 		for (auto &expr : expressions) {
-			update_types.push_back(expr->return_type);
+			update_types.push_back(expr->GetReturnType());
 		}
 		update_chunk.Initialize(allocator, update_types);
 

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -26,7 +26,7 @@ PhysicalPivot::PhysicalPivot(PhysicalPlan &physical_plan, vector<LogicalType> ty
 		auto state = make_unsafe_uniq_array<data_t>(aggr.function.GetStateSizeCallback()(aggr.function));
 		aggr.function.GetStateInitCallback()(aggr.function, state.get());
 		Vector state_vector(Value::POINTER(CastPointerToValue(state.get())), count_t(1));
-		Vector result_vector(aggr_expr->return_type);
+		Vector result_vector(aggr_expr->GetReturnType());
 		AggregateInputData aggr_input_data(aggr.bind_info.get(), physical_plan.ArenaRef());
 		aggr.function.GetStateFinalizeCallback()(state_vector, aggr_input_data, result_vector, 1, 0);
 		empty_aggregates.push_back(result_vector.GetValue(0));

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -22,7 +22,7 @@ public:
 		for (auto &exp : select_list) {
 			D_ASSERT(exp->GetExpressionType() == ExpressionType::BOUND_UNNEST);
 			auto &bue = exp->Cast<BoundUnnestExpression>();
-			list_data_types.push_back(bue.child->return_type);
+			list_data_types.push_back(bue.child->GetReturnType());
 			executor.AddExpression(*bue.child.get());
 
 			unnest_sels.emplace_back(STANDARD_VECTOR_SIZE);

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -31,7 +31,7 @@ PhysicalCreateIndex::PhysicalCreateIndex(PhysicalPlan &physical_plan, LogicalOpe
 
 	for (idx_t i = 0; i < unbound_expressions.size(); ++i) {
 		auto &expr = unbound_expressions[i];
-		indexed_column_types.push_back(expr->return_type);
+		indexed_column_types.push_back(expr->GetReturnType());
 		indexed_columns.push_back(i);
 	}
 

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -42,7 +42,7 @@ public:
 			auto &bound_aggr_expr = op.payload_aggregates[i]->Cast<BoundAggregateExpression>();
 			for (auto &child_expr : bound_aggr_expr.children) {
 				executor.AddExpression(*child_expr);
-				aggr_input_types.push_back(child_expr->return_type);
+				aggr_input_types.push_back(child_expr->GetReturnType());
 			}
 			payload_aggregates_ptr.push_back(&bound_aggr_expr);
 		}
@@ -82,7 +82,8 @@ idx_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, RecursiveCTEState &state) 
 	return new_group_count;
 }
 
-void PopulateChunk(DataChunk &group_chunk, DataChunk &input_chunk, const vector<idx_t> &idx_set, bool reference) {
+static void PopulateChunk(DataChunk &group_chunk, DataChunk &input_chunk, const vector<idx_t> &idx_set,
+                          bool reference) {
 	idx_t chunk_index = 0;
 	// Populate the group_chunk
 	for (auto &group_idx : idx_set) {

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -123,7 +123,7 @@ static bool CanUsePerfectHashAggregate(ClientContext &context, LogicalAggregate 
 		auto &group = op.groups[group_idx];
 		auto &stats = op.group_stats[group_idx];
 
-		switch (group->return_type.InternalType()) {
+		switch (group->GetReturnType().InternalType()) {
 		case PhysicalType::INT8:
 		case PhysicalType::INT16:
 		case PhysicalType::INT32:
@@ -138,7 +138,7 @@ static bool CanUsePerfectHashAggregate(ClientContext &context, LogicalAggregate 
 			return false;
 		}
 		// check if the group has stats available
-		auto &group_type = group->return_type;
+		auto &group_type = group->GetReturnType();
 		if (!stats) {
 			// no stats, but we might still be able to use perfect hashing if the type is small enough
 			// for small types we can just set the stats to [type_min, type_max]
@@ -319,23 +319,23 @@ PhysicalOperator &PhysicalPlanGenerator::ExtractAggregateExpressions(PhysicalOpe
 		}
 	}
 	for (auto &group : groups) {
-		auto ref = make_uniq<BoundReferenceExpression>(group->return_type, expressions.size());
-		types.push_back(group->return_type);
+		auto ref = make_uniq<BoundReferenceExpression>(group->GetReturnType(), expressions.size());
+		types.push_back(group->GetReturnType());
 		expressions.push_back(std::move(group));
 		group = std::move(ref);
 	}
 	for (auto &aggr : aggregates) {
 		auto &bound_aggr = aggr->Cast<BoundAggregateExpression>();
 		for (auto &child_expr : bound_aggr.children) {
-			auto ref = make_uniq<BoundReferenceExpression>(child_expr->return_type, expressions.size());
-			types.push_back(child_expr->return_type);
+			auto ref = make_uniq<BoundReferenceExpression>(child_expr->GetReturnType(), expressions.size());
+			types.push_back(child_expr->GetReturnType());
 			expressions.push_back(std::move(child_expr));
 			child_expr = std::move(ref);
 		}
 		if (bound_aggr.filter) {
 			auto &filter = bound_aggr.filter;
-			auto ref = make_uniq<BoundReferenceExpression>(filter->return_type, expressions.size());
-			types.push_back(filter->return_type);
+			auto ref = make_uniq<BoundReferenceExpression>(filter->GetReturnType(), expressions.size());
+			types.push_back(filter->GetReturnType());
 			expressions.push_back(std::move(filter));
 			bound_aggr.filter = std::move(ref);
 		}

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -182,7 +182,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	}
 	vector<LogicalType> comp_types = join_op.types;
 	auto comp_expr = op.conditions[asof_idx].GetRHS().Copy();
-	comp_types.emplace_back(comp_expr->return_type);
+	comp_types.emplace_back(comp_expr->GetReturnType());
 	comp_list.emplace_back(std::move(comp_expr));
 
 	//	Bind the aggregates first so we can abort safely if we can't find one.
@@ -201,7 +201,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 
 		auto aggr_expr = FirstFunctionGetter::GetFunction(col_type).Bind(context, std::move(aggr_children));
 
-		D_ASSERT(col_type == aggr_expr->return_type);
+		D_ASSERT(col_type == aggr_expr->GetReturnType());
 		aggregates.emplace_back(std::move(aggr_expr));
 	}
 
@@ -219,7 +219,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 		aggr_children.push_back(std::move(comp_expr));
 		vector<LogicalType> child_types;
 		for (const auto &child : aggr_children) {
-			child_types.emplace_back(child->return_type);
+			child_types.emplace_back(child->GetReturnType());
 		}
 
 		auto &func = arg_min_max_entry;
@@ -231,7 +231,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 		auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 		auto aggr_expr = function_binder.BindAggregateFunction(bound_function, std::move(aggr_children), nullptr,
 		                                                       AggregateType::NON_DISTINCT);
-		D_ASSERT(col_type == aggr_expr->return_type);
+		D_ASSERT(col_type == aggr_expr->GetReturnType());
 		aggregates.emplace_back(std::move(aggr_expr));
 	}
 
@@ -240,7 +240,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	vector<unique_ptr<Expression>> window_select;
 
 	auto pk = RowNumberFun::GetFunction().Bind(context);
-	D_ASSERT(pk->return_type == pk_type);
+	D_ASSERT(pk->GetReturnType() == pk_type);
 
 	pk->start = WindowBoundary::UNBOUNDED_PRECEDING;
 	pk->end = WindowBoundary::CURRENT_ROW_ROWS;
@@ -363,7 +363,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 	//	LEAD(asof_column, 1, infinity) OVER (PARTITION BY equi_column... ORDER BY asof_column) AS asof_end
 	auto &asof_comp = op.conditions[asof_idx];
 	auto &asof_column = asof_comp.RightReference();
-	auto asof_type = asof_column->return_type;
+	auto asof_type = asof_column->GetReturnType();
 
 	vector<unique_ptr<Expression>> children;
 	vector<unique_ptr<Expression>> partitions;

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -244,7 +244,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 
 	pk->start = WindowBoundary::UNBOUNDED_PRECEDING;
 	pk->end = WindowBoundary::CURRENT_ROW_ROWS;
-	pk->alias = "row_number";
+	pk->SetAlias("row_number");
 	window_select.emplace_back(std::move(pk));
 
 	auto window_types = probe.GetTypes();

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -393,7 +393,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 
 	auto asof_end = LeadFun::GetTypedFunction(asof_type, 3).Bind(context, std::move(children));
 
-	D_ASSERT(asof_end->return_type == asof_type);
+	D_ASSERT(asof_end->GetReturnType() == asof_type);
 
 	asof_end->partitions = std::move(partitions);
 	asof_end->orders = std::move(orders);

--- a/src/execution/physical_plan/plan_create_index.cpp
+++ b/src/execution/physical_plan/plan_create_index.cpp
@@ -58,7 +58,7 @@ static PhysicalOperator &AddProjection(PhysicalPlanGenerator &plan, LogicalCreat
 	auto select_exprs = vector<unique_ptr<Expression>>();
 
 	for (auto &expression : op.expressions) {
-		select_types.push_back(expression->return_type);
+		select_types.push_back(expression->GetReturnType());
 		select_exprs.push_back(std::move(expression));
 	}
 

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -44,8 +44,8 @@ PhysicalOperator &PhysicalPlanGenerator::PlanDelimJoin(LogicalComparisonJoin &op
 	for (auto &delim_expr : op.duplicate_eliminated_columns) {
 		D_ASSERT(delim_expr->GetExpressionType() == ExpressionType::BOUND_REF);
 		auto &bound_ref = delim_expr->Cast<BoundReferenceExpression>();
-		delim_types.push_back(bound_ref.return_type);
-		distinct_groups.push_back(make_uniq<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
+		delim_types.push_back(bound_ref.GetReturnType());
+		distinct_groups.push_back(make_uniq<BoundReferenceExpression>(bound_ref.GetReturnType(), bound_ref.index));
 	}
 
 	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -28,7 +28,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
 			auto &bound_ref = target->Cast<BoundReferenceExpression>();
 			group_by_references[bound_ref.index] = i;
 		}
-		aggregate_types.push_back(target->return_type);
+		aggregate_types.push_back(target->GetReturnType());
 		groups.push_back(std::move(target));
 	}
 	bool requires_projection = false;
@@ -68,7 +68,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
 				auto new_expr =
 				    OrderedAggregateOptimizer::Apply(context, *first_aggregate, groups, nullptr, changes_made);
 				if (new_expr) {
-					D_ASSERT(new_expr->return_type == first_aggregate->return_type);
+					D_ASSERT(new_expr->GetReturnType() == first_aggregate->GetReturnType());
 					D_ASSERT(new_expr->GetExpressionType() == ExpressionType::BOUND_AGGREGATE);
 					first_aggregate = unique_ptr_cast<Expression, BoundAggregateExpression>(std::move(new_expr));
 				}

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -48,7 +48,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 	unordered_map<idx_t, idx_t> group_by_references;
 	for (idx_t i = 0; i < op.key_targets.size(); i++) {
 		auto &target = op.key_targets[i];
-		D_ASSERT(target->type == ExpressionType::BOUND_REF);
+		D_ASSERT(target->GetExpressionType() == ExpressionType::BOUND_REF);
 		auto &bound_ref = target->Cast<BoundReferenceExpression>();
 		distinct_idx.emplace_back(bound_ref.index);
 		distinct_types.push_back(bound_ref.return_type);
@@ -64,7 +64,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 		// Check if we can directly refer to a group, or if we need to push an aggregate
 		auto entry = group_by_references.find(i);
 		if (entry == group_by_references.end()) {
-			D_ASSERT(op.payload_aggregates[pay_idx]->type == ExpressionType::BOUND_AGGREGATE);
+			D_ASSERT(op.payload_aggregates[pay_idx]->GetExpressionType() == ExpressionType::BOUND_AGGREGATE);
 			auto &bound_aggr = op.payload_aggregates[pay_idx]->Cast<BoundAggregateExpression>();
 
 			// add the logical type of the aggregate to the payload types

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -51,7 +51,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 		D_ASSERT(target->GetExpressionType() == ExpressionType::BOUND_REF);
 		auto &bound_ref = target->Cast<BoundReferenceExpression>();
 		distinct_idx.emplace_back(bound_ref.index);
-		distinct_types.push_back(bound_ref.return_type);
+		distinct_types.push_back(bound_ref.GetReturnType());
 		group_by_references[bound_ref.index] = i;
 	}
 
@@ -68,7 +68,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 			auto &bound_aggr = op.payload_aggregates[pay_idx]->Cast<BoundAggregateExpression>();
 
 			// add the logical type of the aggregate to the payload types
-			payload_types.push_back(bound_aggr.return_type);
+			payload_types.push_back(bound_aggr.GetReturnType());
 			payload_aggregates.push_back(std::move(op.payload_aggregates[pay_idx++]));
 			payload_idx.emplace_back(i);
 		}

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -213,8 +213,8 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
 
-		function.GetArguments()[0] = arguments[0]->return_type;
-		function.SetReturnType(arguments[0]->return_type);
+		function.GetArguments()[0] = arguments[0]->GetReturnType();
+		function.SetReturnType(arguments[0]->GetReturnType());
 		return nullptr;
 	}
 };
@@ -354,7 +354,7 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 
-	auto decimal_type = arguments[0]->return_type;
+	auto decimal_type = arguments[0]->GetReturnType();
 	auto name = std::move(function.name);
 	function = GetFirstFunction<LAST, SKIP_NULLS>(decimal_type);
 	function.name = std::move(name);
@@ -376,7 +376,7 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 
-	auto input_type = arguments[0]->return_type;
+	auto input_type = arguments[0]->GetReturnType();
 	auto name = std::move(function.name);
 	function = GetFirstOperator<LAST, SKIP_NULLS>(input_type);
 	function.name = std::move(name);

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -297,8 +297,8 @@ struct VectorMinMaxBase {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function.GetArguments()[0] = arguments[0]->return_type;
-		function.SetReturnType(arguments[0]->return_type);
+		function.GetArguments()[0] = arguments[0]->GetReturnType();
+		function.SetReturnType(arguments[0]->GetReturnType());
 		return nullptr;
 	}
 };
@@ -339,11 +339,11 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 
 	// We should also push collations for non-VARCHAR here, but we aren't ready for it yet (see internal #8704)
-	const auto collation = arguments[0]->return_type.id() == LogicalTypeId::VARCHAR &&
-	                       (!StringType::GetCollation(arguments[0]->return_type).empty() ||
+	const auto collation = arguments[0]->GetReturnType().id() == LogicalTypeId::VARCHAR &&
+	                       (!StringType::GetCollation(arguments[0]->GetReturnType()).empty() ||
 	                        !Settings::Get<DefaultCollationSetting>(context).empty());
 	auto collated_arg = collation ? arguments[0]->Copy() : nullptr;
-	if (collation && ExpressionBinder::PushCollation(context, collated_arg, collated_arg->return_type)) {
+	if (collation && ExpressionBinder::PushCollation(context, collated_arg, collated_arg->GetReturnType())) {
 		// If aggr function is min/max and uses collations, replace bound_function with arg_min/arg_max
 		// to make sure the result's correctness.
 		string function_name = function.name == "min" ? "arg_min" : "arg_max";
@@ -360,7 +360,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 		auto &func_entry = *func;
 
 		FunctionBinder function_binder(context);
-		vector<LogicalType> types {arguments[0]->return_type, collated_arg->return_type};
+		vector<LogicalType> types {arguments[0]->GetReturnType(), collated_arg->GetReturnType()};
 		ErrorData error;
 		auto best_function = function_binder.BindFunction(func_entry.name, func_entry.functions, types, error);
 		if (!best_function.IsValid()) {
@@ -371,12 +371,12 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 
 		// Bind function like arg_min/arg_max.
 		arguments.push_back(std::move(collated_arg));
-		function.GetArguments()[0] = arguments[0]->return_type;
-		function.SetReturnType(arguments[0]->return_type);
+		function.GetArguments()[0] = arguments[0]->GetReturnType();
+		function.SetReturnType(arguments[0]->GetReturnType());
 		return make_uniq<ArgMinMaxFunctionData>();
 	}
 
-	auto input_type = arguments[0]->return_type;
+	auto input_type = arguments[0]->GetReturnType();
 	if (input_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -530,17 +530,17 @@ unique_ptr<FunctionData> MinMaxNBind(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}
 
-	const auto val_type = arguments[0]->return_type.InternalType();
+	const auto val_type = arguments[0]->GetReturnType().InternalType();
 
 	// Specialize the function based on the input types
 	SpecializeMinMaxNFunction<COMPARATOR>(val_type, function);
 
-	function.SetReturnType(LogicalType::LIST(arguments[0]->return_type));
+	function.SetReturnType(LogicalType::LIST(arguments[0]->GetReturnType()));
 	return nullptr;
 }
 

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -28,7 +28,7 @@ struct SortedAggregateBindData : public FunctionData {
 		//	Describe the arguments.
 		for (const auto &child : children) {
 			buffered_cols.emplace_back(buffered_cols.size());
-			buffered_types.emplace_back(child->return_type);
+			buffered_types.emplace_back(child->GetReturnType());
 
 			//	Column 0 in the sort data is the group number
 			scan_cols.emplace_back(buffered_cols.size());
@@ -45,7 +45,7 @@ struct SortedAggregateBindData : public FunctionData {
 		for (idx_t ord_idx = 0; ord_idx < order_bys.size(); ++ord_idx) {
 			auto order = order_bys[ord_idx].Copy();
 			bool matched = false;
-			const auto &type = order.expression->return_type;
+			const auto &type = order.expression->GetReturnType();
 
 			for (idx_t arg_idx = 0; arg_idx < children.size(); ++arg_idx) {
 				auto &child = children[arg_idx];
@@ -704,7 +704,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	vector<LogicalType> arguments;
 	arguments.reserve(children.size());
 	for (const auto &child : children) {
-		arguments.emplace_back(child->return_type);
+		arguments.emplace_back(child->GetReturnType());
 	}
 
 	// Replace the aggregate with the wrapper
@@ -761,7 +761,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	vector<LogicalType> arguments;
 	arguments.reserve(children.size());
 	for (const auto &child : children) {
-		arguments.emplace_back(child->return_type);
+		arguments.emplace_back(child->GetReturnType());
 	}
 
 	// Replace the aggregate with the wrapper

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -45,7 +45,7 @@ void HandleCastError::AssignError(const string &error_message, string *error_mes
                                   optional_ptr<const Expression> cast_source, optional_idx error_location) {
 	string column;
 	if (cast_source && cast_source->HasAlias()) {
-		column = " when casting from source column " + cast_source->alias;
+		column = " when casting from source column " + cast_source->GetAlias();
 	}
 	if (!error_message_ptr) {
 		throw ConversionException(error_location, error_message + column);

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -357,12 +357,12 @@ void FunctionBinder::CastToFunctionArguments(SimpleFunction &function, vector<un
 		}
 		target_type.Verify();
 		// don't cast lambda children, they get removed before execution
-		if (children[i]->return_type.id() == LogicalTypeId::LAMBDA) {
+		if (children[i]->GetReturnType().id() == LogicalTypeId::LAMBDA) {
 			continue;
 		}
 		// check if the type of child matches the type of function argument
 		// if not we need to add a cast
-		auto cast_result = RequiresCast(children[i]->return_type, target_type);
+		auto cast_result = RequiresCast(children[i]->GetReturnType(), target_type);
 		// except for one special case: if the function accepts ANY argument
 		// in that case we don't add a cast
 		if (cast_result == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
@@ -401,7 +401,7 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	    bound_function.GetReturnType().IsComplete() ? bound_function.GetReturnType() : LogicalType::SQLNULL;
 	if (bound_function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING) {
 		for (auto &child : children) {
-			if (child->return_type == LogicalTypeId::SQLNULL) {
+			if (child->GetReturnType() == LogicalTypeId::SQLNULL) {
 				return make_uniq<BoundConstantExpression>(Value(return_type_if_null));
 			}
 			if (!child->IsFoldable()) {
@@ -426,11 +426,11 @@ static bool RequiresCollationPropagation(const LogicalType &type) {
 static string ExtractCollation(const vector<unique_ptr<Expression>> &children) {
 	string collation;
 	for (auto &arg : children) {
-		if (!RequiresCollationPropagation(arg->return_type)) {
+		if (!RequiresCollationPropagation(arg->GetReturnType())) {
 			// not a varchar column
 			continue;
 		}
-		auto child_collation = StringType::GetCollation(arg->return_type);
+		auto child_collation = StringType::GetCollation(arg->GetReturnType());
 		if (collation.empty()) {
 			collation = child_collation;
 		} else if (!child_collation.empty() && collation != child_collation) {
@@ -470,12 +470,12 @@ static void PushCollations(ClientContext &context, ScalarFunction &bound_functio
 	}
 	// push collations to the children
 	for (auto &arg : children) {
-		if (RequiresCollationPropagation(arg->return_type)) {
+		if (RequiresCollationPropagation(arg->GetReturnType())) {
 			// if this is a varchar type - propagate the collation
-			arg->return_type = collation_type;
+			arg->SetReturnType(collation_type);
 		}
 		// now push the actual collation handling
-		ExpressionBinder::PushCollation(context, arg, arg->return_type, type);
+		ExpressionBinder::PushCollation(context, arg, arg->GetReturnType(), type);
 	}
 }
 

--- a/src/function/macro_function.cpp
+++ b/src/function/macro_function.cpp
@@ -70,7 +70,7 @@ MacroBindResult MacroFunction::BindMacroFunction(
 		LogicalType arg_type = LogicalType::UNKNOWN;
 		if (requires_bind) {
 			const auto arg_bind_result = expr_binder.BindExpression(arg_copy, depth + 1);
-			arg_type = arg_bind_result.HasError() ? LogicalType::UNKNOWN : arg_bind_result.expression->return_type;
+			arg_type = arg_bind_result.HasError() ? LogicalType::UNKNOWN : arg_bind_result.expression->GetReturnType();
 		}
 		if (!arg->GetAlias().empty()) {
 			// Default argument

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -58,7 +58,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
 	bool all_constant = true;
 	idx_t constant_size = 0;
 	for (idx_t i = 0; i < arguments.size(); i += 2) {
-		auto physical_type = arguments[i]->return_type.InternalType();
+		auto physical_type = arguments[i]->GetReturnType().InternalType();
 		if (!TypeIsConstantSize(physical_type)) {
 			all_constant = false;
 		} else {
@@ -855,17 +855,17 @@ unique_ptr<FunctionData> DecodeSortKeyBind(BindScalarFunctionInput &input) {
 	}
 
 	const auto &sort_key_arg = *arguments[0];
-	if (sort_key_arg.return_type == LogicalType::BIGINT) {
+	if (sort_key_arg.GetReturnType() == LogicalType::BIGINT) {
 		if (!all_constant || constant_size > sizeof(int64_t)) {
 			throw BinderException("sort_key has type BIGINT but arguments require BLOB");
 		}
-	} else if (sort_key_arg.return_type == LogicalType::BLOB) {
+	} else if (sort_key_arg.GetReturnType() == LogicalType::BLOB) {
 		if (all_constant && constant_size <= sizeof(int64_t)) {
 			throw BinderException("sort_key has type BLOB but arguments require BIGINT");
 		}
 	} else {
 		throw BinderException("sort_key must be either BIGINT or BLOB, got %s instead",
-		                      sort_key_arg.return_type.ToString());
+		                      sort_key_arg.GetReturnType().ToString());
 	}
 	function.SetReturnType(LogicalType::STRUCT(std::move(children)));
 

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -83,7 +83,7 @@ unique_ptr<FunctionData> ConstantOrNullBind(BindScalarFunctionInput &input) {
 	}
 	D_ASSERT(arguments.size() >= 2);
 	auto value = ExpressionExecutor::EvaluateScalar(context, *arguments[0]);
-	function.SetReturnType(arguments[0]->return_type);
+	function.SetReturnType(arguments[0]->GetReturnType());
 	return make_uniq<ConstantOrNullBindData>(std::move(value));
 }
 

--- a/src/function/scalar/generic/getvariable.cpp
+++ b/src/function/scalar/generic/getvariable.cpp
@@ -28,7 +28,7 @@ unique_ptr<FunctionData> GetVariableBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	auto &function = input.GetBoundFunction();
 
-	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->HasParameter() || arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
 	if (!arguments[0]->IsFoldable()) {

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -81,7 +81,7 @@ static void CRSFunction(DataChunk &args, ExpressionState &state, Vector &result)
 }
 
 static unique_ptr<Expression> BindCRSFunctionExpression(FunctionBindExpressionInput &input) {
-	const auto &return_type = input.children[0]->return_type;
+	const auto &return_type = input.children[0]->GetReturnType();
 	if (return_type.id() != LogicalTypeId::GEOMETRY) {
 		// parameter - unknown return type
 		return nullptr;
@@ -94,12 +94,12 @@ static unique_ptr<FunctionData> BindCRSFunction(BindScalarFunctionInput &input) 
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 
-	if (arguments[0]->return_type.id() != LogicalTypeId::GEOMETRY) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
 		return nullptr;
 	}
 
 	// Propagate the CRS from the input argument to the parameter type
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	return nullptr;
 }
 

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -128,26 +128,26 @@ static unique_ptr<FunctionData> ListResizeBind(BindScalarFunctionInput &input) {
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
 	// Early-out, if the first argument is a constant NULL.
-	if (arguments[0]->return_type == LogicalType::SQLNULL) {
+	if (arguments[0]->GetReturnType() == LogicalType::SQLNULL) {
 		bound_function.GetArguments()[0] = LogicalType::SQLNULL;
 		bound_function.SetReturnType(LogicalType::SQLNULL);
 		return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 	}
 
 	// Early-out, if the first argument is a prepared statement.
-	if (arguments[0]->return_type == LogicalType::UNKNOWN) {
-		bound_function.SetReturnType(arguments[0]->return_type);
+	if (arguments[0]->GetReturnType() == LogicalType::UNKNOWN) {
+		bound_function.SetReturnType(arguments[0]->GetReturnType());
 		return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 	}
 
 	// Attempt implicit casting, if the default type does not match list the list child type.
 	if (bound_function.GetArguments().size() == 3 &&
-	    ListType::GetChildType(arguments[0]->return_type) != arguments[2]->return_type &&
-	    arguments[2]->return_type != LogicalTypeId::SQLNULL) {
-		bound_function.GetArguments()[2] = ListType::GetChildType(arguments[0]->return_type);
+	    ListType::GetChildType(arguments[0]->GetReturnType()) != arguments[2]->GetReturnType() &&
+	    arguments[2]->GetReturnType() != LogicalTypeId::SQLNULL) {
+		bound_function.GetArguments()[2] = ListType::GetChildType(arguments[0]->GetReturnType());
 	}
 
-	bound_function.SetReturnType(arguments[0]->return_type);
+	bound_function.SetReturnType(arguments[0]->GetReturnType());
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }
 

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -140,7 +140,7 @@ static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
 	if (size == 0) {
 		throw BinderException("Provide at least one argument to " + bound_function.name);
 	}
-	if (arguments[size - 1]->return_type.id() == LogicalTypeId::BOOLEAN) {
+	if (arguments[size - 1]->GetReturnType().id() == LogicalTypeId::BOOLEAN) {
 		if (--size == 0) {
 			throw BinderException("Provide at least one list argument to " + bound_function.name);
 		}
@@ -149,11 +149,11 @@ static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
 	case_insensitive_set_t struct_names;
 	for (idx_t i = 0; i < size; i++) {
 		auto &child = arguments[i];
-		switch (child->return_type.id()) {
+		switch (child->GetReturnType().id()) {
 		case LogicalTypeId::LIST:
 		case LogicalTypeId::ARRAY:
 			child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
-			struct_children.push_back(make_pair(string(), ListType::GetChildType(child->return_type)));
+			struct_children.push_back(make_pair(string(), ListType::GetChildType(child->GetReturnType())));
 			break;
 		case LogicalTypeId::SQLNULL:
 			struct_children.push_back(make_pair(string(), LogicalTypeId::SQLNULL));

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -151,39 +151,39 @@ unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, Functio
 	Value new_min, new_max;
 	bool potential_overflow = true;
 	if (NumericStats::HasMinMax(lstats) && NumericStats::HasMinMax(rstats)) {
-		switch (expr.return_type.InternalType()) {
+		switch (expr.GetReturnType().InternalType()) {
 		case PhysicalType::INT8:
 			potential_overflow =
-			    PROPAGATE::template Operation<int8_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			    PROPAGATE::template Operation<int8_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
 			break;
 		case PhysicalType::INT16:
 			potential_overflow =
-			    PROPAGATE::template Operation<int16_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			    PROPAGATE::template Operation<int16_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
 			break;
 		case PhysicalType::INT32:
 			potential_overflow =
-			    PROPAGATE::template Operation<int32_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			    PROPAGATE::template Operation<int32_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
 			break;
 		case PhysicalType::INT64:
 			potential_overflow =
-			    PROPAGATE::template Operation<int64_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			    PROPAGATE::template Operation<int64_t, OP>(expr.GetReturnType(), lstats, rstats, new_min, new_max);
 			break;
 		default:
 			return nullptr;
 		}
 	}
 	if (potential_overflow) {
-		new_min = Value(expr.return_type);
-		new_max = Value(expr.return_type);
+		new_min = Value(expr.GetReturnType());
+		new_max = Value(expr.GetReturnType());
 	} else {
 		// no potential overflow: replace with non-overflowing operator
 		if (input.bind_data) {
 			auto &bind_data = input.bind_data->Cast<DecimalArithmeticBindData>();
 			bind_data.check_overflow = false;
 		}
-		expr.function.SetFunctionCallback(GetScalarIntegerFunction<BASEOP>(expr.return_type.InternalType()));
+		expr.function.SetFunctionCallback(GetScalarIntegerFunction<BASEOP>(expr.GetReturnType().InternalType()));
 	}
-	auto result = NumericStats::CreateEmpty(expr.return_type);
+	auto result = NumericStats::CreateEmpty(expr.GetReturnType());
 	NumericStats::SetMin(result, new_min);
 	NumericStats::SetMax(result, new_max);
 	result.CombineValidity(lstats, rstats);
@@ -199,13 +199,14 @@ unique_ptr<DecimalArithmeticBindData> BindDecimalArithmetic(BindScalarFunctionIn
 	// get the max width and scale of the input arguments
 	uint8_t max_width = 0, max_scale = 0, max_width_over_scale = 0;
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		if (arguments[i]->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arguments[i]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			continue;
 		}
 		uint8_t width, scale;
-		auto can_convert = arguments[i]->return_type.GetDecimalProperties(width, scale);
+		auto can_convert = arguments[i]->GetReturnType().GetDecimalProperties(width, scale);
 		if (!can_convert) {
-			throw InternalException("Could not convert type %s to a decimal.", arguments[i]->return_type.ToString());
+			throw InternalException("Could not convert type %s to a decimal.",
+			                        arguments[i]->GetReturnType().ToString());
 		}
 		max_width = MaxValue<uint8_t>(width, max_width);
 		max_scale = MaxValue<uint8_t>(scale, max_scale);
@@ -233,7 +234,7 @@ unique_ptr<DecimalArithmeticBindData> BindDecimalArithmetic(BindScalarFunctionIn
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		// first check if the cast is necessary
 		// if the argument has a matching scale and internal type as the output type, no casting is necessary
-		auto &argument_type = arguments[i]->return_type;
+		auto &argument_type = arguments[i]->GetReturnType();
 		uint8_t width, scale;
 		argument_type.GetDecimalProperties(width, scale);
 		if (scale == DecimalType::GetScale(result_type) && argument_type.InternalType() == result_type.InternalType()) {
@@ -304,8 +305,8 @@ unique_ptr<FunctionData> NopDecimalBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 
-	bound_function.SetReturnType(arguments[0]->return_type);
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.SetReturnType(arguments[0]->GetReturnType());
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	return nullptr;
 }
 
@@ -567,7 +568,7 @@ static unique_ptr<FunctionData> DecimalNegateBind(BindScalarFunctionInput &input
 
 	auto bind_data = make_uniq<DecimalNegateBindData>();
 
-	auto &decimal_type = arguments[0]->return_type;
+	auto &decimal_type = arguments[0]->GetReturnType();
 	auto width = DecimalType::GetWidth(decimal_type);
 	if (width <= Decimal::MAX_WIDTH_INT16) {
 		bound_function.SetFunctionCallback(
@@ -654,32 +655,32 @@ static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, F
 	Value new_min, new_max;
 	bool potential_overflow = true;
 	if (NumericStats::HasMinMax(istats)) {
-		switch (expr.return_type.InternalType()) {
+		switch (expr.GetReturnType().InternalType()) {
 		case PhysicalType::INT8:
 			potential_overflow =
-			    NegatePropagateStatistics::Operation<int8_t>(expr.return_type, istats, new_min, new_max);
+			    NegatePropagateStatistics::Operation<int8_t>(expr.GetReturnType(), istats, new_min, new_max);
 			break;
 		case PhysicalType::INT16:
 			potential_overflow =
-			    NegatePropagateStatistics::Operation<int16_t>(expr.return_type, istats, new_min, new_max);
+			    NegatePropagateStatistics::Operation<int16_t>(expr.GetReturnType(), istats, new_min, new_max);
 			break;
 		case PhysicalType::INT32:
 			potential_overflow =
-			    NegatePropagateStatistics::Operation<int32_t>(expr.return_type, istats, new_min, new_max);
+			    NegatePropagateStatistics::Operation<int32_t>(expr.GetReturnType(), istats, new_min, new_max);
 			break;
 		case PhysicalType::INT64:
 			potential_overflow =
-			    NegatePropagateStatistics::Operation<int64_t>(expr.return_type, istats, new_min, new_max);
+			    NegatePropagateStatistics::Operation<int64_t>(expr.GetReturnType(), istats, new_min, new_max);
 			break;
 		default:
 			return nullptr;
 		}
 	}
 	if (potential_overflow) {
-		new_min = Value(expr.return_type);
-		new_max = Value(expr.return_type);
+		new_min = Value(expr.GetReturnType());
+		new_max = Value(expr.GetReturnType());
 	}
-	auto stats = NumericStats::CreateEmpty(expr.return_type);
+	auto stats = NumericStats::CreateEmpty(expr.GetReturnType());
 	NumericStats::SetMin(stats, new_min);
 	NumericStats::SetMax(stats, new_max);
 	stats.CopyValidity(istats);
@@ -886,13 +887,14 @@ unique_ptr<FunctionData> BindDecimalMultiply(BindScalarFunctionInput &input) {
 	uint8_t result_width = 0, result_scale = 0;
 	uint8_t max_width = 0;
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		if (arguments[i]->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arguments[i]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			continue;
 		}
 		uint8_t width, scale;
-		auto can_convert = arguments[i]->return_type.GetDecimalProperties(width, scale);
+		auto can_convert = arguments[i]->GetReturnType().GetDecimalProperties(width, scale);
 		if (!can_convert) {
-			throw InternalException("Could not convert type %s to a decimal?", arguments[i]->return_type.ToString());
+			throw InternalException("Could not convert type %s to a decimal?",
+			                        arguments[i]->GetReturnType().ToString());
 		}
 		if (width > max_width) {
 			max_width = width;
@@ -921,7 +923,7 @@ unique_ptr<FunctionData> BindDecimalMultiply(BindScalarFunctionInput &input) {
 	// since our scale is the summation of our input scales, we do not need to cast to the result scale
 	// however, we might need to cast to the correct internal type
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		auto &argument_type = arguments[i]->return_type;
+		auto &argument_type = arguments[i]->GetReturnType();
 		if (argument_type.InternalType() == result_type.InternalType()) {
 			bound_function.GetArguments()[i] = argument_type;
 		} else {

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -93,7 +93,7 @@ void NextValFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 unique_ptr<FunctionData> NextValBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 
-	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->HasParameter() || arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
 	if (!arguments[0]->IsFoldable()) {

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -223,7 +223,7 @@ unique_ptr<FunctionData> BindListConcat(ClientContext &context, ScalarFunction &
 	LogicalType child_type = LogicalType::SQLNULL;
 	bool all_null = true;
 	for (auto &arg : arguments) {
-		auto &return_type = arg->return_type;
+		auto &return_type = arg->GetReturnType();
 		if (return_type == LogicalTypeId::SQLNULL) {
 			// we mimic postgres behaviour: list_concat(NULL, my_list) = my_list
 			continue;
@@ -250,7 +250,7 @@ unique_ptr<FunctionData> BindListConcat(ClientContext &context, ScalarFunction &
 						type_list += ", ";
 					}
 				}
-				type_list += arguments[arg_idx]->return_type.ToString();
+				type_list += arguments[arg_idx]->GetReturnType().ToString();
 			}
 			throw BinderException(*arg, "Cannot concatenate types %s - an explicit cast is required", type_list);
 		}
@@ -279,16 +279,16 @@ unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, Scal
 	// blob concat is only supported for the concat operator - regular concat converts to varchar
 	bool all_blob = is_operator ? true : false;
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
-		if (arg->return_type.id() == LogicalTypeId::LIST || arg->return_type.id() == LogicalTypeId::ARRAY) {
+		if (arg->GetReturnType().id() == LogicalTypeId::LIST || arg->GetReturnType().id() == LogicalTypeId::ARRAY) {
 			list_concat = true;
 		}
-		if (arg->return_type.id() != LogicalTypeId::BLOB) {
+		if (arg->GetReturnType().id() != LogicalTypeId::BLOB) {
 			all_blob = false;
 		}
-		if (arg->return_type.id() != LogicalTypeId::SQLNULL) {
+		if (arg->GetReturnType().id() != LogicalTypeId::SQLNULL) {
 			all_null = false;
 		}
 	}

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -105,11 +105,11 @@ void ArrayLengthFunction(DataChunk &args, ExpressionState &state, Vector &result
 unique_ptr<FunctionData> ArrayOrListLengthBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->HasParameter() || arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
 
-	const auto &arg_type = arguments[0]->return_type.id();
+	const auto &arg_type = arguments[0]->GetReturnType().id();
 	if (arg_type == LogicalTypeId::ARRAY) {
 		bound_function.SetFunctionCallback(ArrayLengthFunction);
 	} else if (arg_type == LogicalTypeId::LIST) {
@@ -118,7 +118,7 @@ unique_ptr<FunctionData> ArrayOrListLengthBind(BindScalarFunctionInput &input) {
 		// Unreachable
 		throw BinderException("length can only be used on arrays or lists");
 	}
-	bound_function.GetArguments()[0] = arguments[0]->return_type;
+	bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	return nullptr;
 }
 
@@ -174,10 +174,10 @@ void ArrayLengthBinaryFunction(DataChunk &args, ExpressionState &state, Vector &
 unique_ptr<FunctionData> ArrayOrListLengthBinaryBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments[0]->HasParameter() || arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	if (arguments[0]->HasParameter() || arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	auto type = arguments[0]->return_type;
+	auto type = arguments[0]->GetReturnType();
 	if (type.id() == LogicalTypeId::ARRAY) {
 		bound_function.GetArguments()[0] = type;
 		bound_function.SetFunctionCallback(ArrayLengthBinaryFunction);

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -358,7 +358,8 @@ unique_ptr<FunctionData> LikeBindFunction(BindScalarFunctionInput &input) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	for (auto &arg : arguments) {
-		if (arg->GetReturnType().id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(arg->GetReturnType()).empty()) {
+		if (arg->GetReturnType().id() == LogicalTypeId::VARCHAR &&
+		    !StringType::GetCollation(arg->GetReturnType()).empty()) {
 			return nullptr;
 		}
 	}

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -358,7 +358,7 @@ unique_ptr<FunctionData> LikeBindFunction(BindScalarFunctionInput &input) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	for (auto &arg : arguments) {
-		if (arg->return_type.id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(arg->return_type).empty()) {
+		if (arg->GetReturnType().id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(arg->GetReturnType()).empty()) {
 			return nullptr;
 		}
 	}

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -541,27 +541,27 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 	D_ASSERT(arguments.size() == 4);
 	for (idx_t arg_idx = 0; arg_idx < 3; arg_idx++) {
 		auto &arg = arguments[arg_idx];
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
-		if (arg->return_type.id() == LogicalTypeId::SQLNULL && arg_idx == 2) {
+		if (arg->GetReturnType().id() == LogicalTypeId::SQLNULL && arg_idx == 2) {
 			// remap target can be NULL
 			continue;
 		}
-		if (!IsRemappable(arg->return_type)) {
-			throw BinderException("Struct remap can only remap nested types, not '%s'", arg->return_type.ToString());
-		} else if (arg->return_type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(arg->return_type)) {
+		if (!IsRemappable(arg->GetReturnType())) {
+			throw BinderException("Struct remap can only remap nested types, not '%s'", arg->GetReturnType().ToString());
+		} else if (arg->GetReturnType().id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(arg->GetReturnType())) {
 			throw BinderException("Struct remap can only remap named structs");
 		}
 	}
-	auto &from_type = arguments[0]->return_type;
-	auto &to_type = arguments[1]->return_type;
+	auto &from_type = arguments[0]->GetReturnType();
+	auto &to_type = arguments[1]->GetReturnType();
 
 	auto &defaults = arguments[3];
-	if (defaults->return_type.id() != LogicalTypeId::SQLNULL && defaults->return_type.id() != LogicalTypeId::STRUCT) {
+	if (defaults->GetReturnType().id() != LogicalTypeId::SQLNULL && defaults->GetReturnType().id() != LogicalTypeId::STRUCT) {
 		throw BinderException("The defaults provided to 'remap_struct' should be of type STRUCT if they're not NULL");
 	}
-	if (defaults->return_type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(defaults->return_type)) {
+	if (defaults->GetReturnType().id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(defaults->GetReturnType())) {
 		throw BinderException("The defaults have to be either NULL or a named STRUCT, not an unnamed struct");
 	}
 
@@ -581,7 +581,7 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 	// (recursively) generate the remap entries
 	case_insensitive_map_t<RemapEntry> remap_map;
 	if (!remap_val.IsNull()) {
-		auto &remap_types = StructType::GetChildTypes(arguments[2]->return_type);
+		auto &remap_types = StructType::GetChildTypes(arguments[2]->GetReturnType());
 		auto &remap_values = StructValue::GetChildren(remap_val);
 		for (idx_t remap_idx = 0; remap_idx < remap_values.size(); remap_idx++) {
 			auto &remap_val = remap_values[remap_idx];
@@ -593,9 +593,9 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 		throw BinderException("Default values must be constants");
 	}
 
-	if (arguments[3]->return_type.id() != LogicalTypeId::SQLNULL) {
+	if (arguments[3]->GetReturnType().id() != LogicalTypeId::SQLNULL) {
 		// (recursively) handle the defaults (if there are any)
-		auto &default_types = StructType::GetChildTypes(arguments[3]->return_type);
+		auto &default_types = StructType::GetChildTypes(arguments[3]->GetReturnType());
 		for (idx_t default_idx = 0; default_idx < default_types.size(); default_idx++) {
 			auto &default_target = default_types[default_idx].first;
 			auto &default_type = default_types[default_idx].second;
@@ -610,10 +610,10 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 	auto new_type = RemapEntry::RemapCast(from_type, remap_map);
 
 	bound_function.GetArguments()[0] = std::move(new_type);
-	bound_function.GetArguments()[1] = arguments[1]->return_type;
-	bound_function.GetArguments()[2] = arguments[2]->return_type;
-	bound_function.GetArguments()[3] = arguments[3]->return_type;
-	bound_function.SetReturnType(arguments[1]->return_type);
+	bound_function.GetArguments()[1] = arguments[1]->GetReturnType();
+	bound_function.GetArguments()[2] = arguments[2]->GetReturnType();
+	bound_function.GetArguments()[3] = arguments[3]->GetReturnType();
+	bound_function.SetReturnType(arguments[1]->GetReturnType());
 
 	return make_uniq<RemapStructBindData>(std::move(remap));
 }

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -549,7 +549,8 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 			continue;
 		}
 		if (!IsRemappable(arg->GetReturnType())) {
-			throw BinderException("Struct remap can only remap nested types, not '%s'", arg->GetReturnType().ToString());
+			throw BinderException("Struct remap can only remap nested types, not '%s'",
+			                      arg->GetReturnType().ToString());
 		} else if (arg->GetReturnType().id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(arg->GetReturnType())) {
 			throw BinderException("Struct remap can only remap named structs");
 		}
@@ -558,7 +559,8 @@ unique_ptr<FunctionData> RemapStructBind(BindScalarFunctionInput &input) {
 	auto &to_type = arguments[1]->GetReturnType();
 
 	auto &defaults = arguments[3];
-	if (defaults->GetReturnType().id() != LogicalTypeId::SQLNULL && defaults->GetReturnType().id() != LogicalTypeId::STRUCT) {
+	if (defaults->GetReturnType().id() != LogicalTypeId::SQLNULL &&
+	    defaults->GetReturnType().id() != LogicalTypeId::STRUCT) {
 		throw BinderException("The defaults provided to 'remap_struct' should be of type STRUCT if they're not NULL");
 	}
 	if (defaults->GetReturnType().id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(defaults->GetReturnType())) {

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -43,15 +43,15 @@ static unique_ptr<FunctionData> StructConcatBind(BindScalarFunctionInput &input)
 	for (idx_t arg_idx = 0; arg_idx < arguments.size(); arg_idx++) {
 		const auto &arg = arguments[arg_idx];
 
-		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (arg->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 
-		if (arg->return_type.id() != LogicalTypeId::STRUCT) {
+		if (arg->GetReturnType().id() != LogicalTypeId::STRUCT) {
 			throw InvalidInputException("struct_concat: Argument at position \"%d\" is not a STRUCT", arg_idx + 1);
 		}
 
-		const auto &child_types = StructType::GetChildTypes(arg->return_type);
+		const auto &child_types = StructType::GetChildTypes(arg->GetReturnType());
 		for (const auto &child : child_types) {
 			if (!child.first.empty()) {
 				auto it = name_set.find(child.first);
@@ -86,12 +86,12 @@ static unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, Func
 	auto &arg_stats = input.child_stats;
 	auto &arg_exprs = input.expr.children;
 
-	auto struct_stats = StructStats::CreateUnknown(expr.return_type);
+	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
 	idx_t struct_index = 0;
 
 	for (idx_t arg_idx = 0; arg_idx < arg_exprs.size(); arg_idx++) {
 		auto &arg_stat = arg_stats[arg_idx];
-		auto &arg_type = arg_exprs[arg_idx]->return_type;
+		auto &arg_type = arg_exprs[arg_idx]->GetReturnType();
 		for (idx_t child_idx = 0; child_idx < StructType::GetChildCount(arg_type); child_idx++) {
 			auto &child_stat = StructStats::GetChildStats(arg_stat, child_idx);
 			StructStats::SetChildStats(struct_stats, struct_index++, child_stat);

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -196,7 +196,7 @@ static unique_ptr<FunctionData> StructContainsBind(BindScalarFunctionInput &inpu
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.GetArguments().size() == 2);
-	auto &child_type = arguments[0]->return_type;
+	auto &child_type = arguments[0]->GetReturnType();
 	if (child_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -208,7 +208,7 @@ static unique_ptr<FunctionData> StructContainsBind(BindScalarFunctionInput &inpu
 		return nullptr;
 	}
 
-	auto &struct_children = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &struct_children = StructType::GetChildTypes(arguments[0]->GetReturnType());
 	if (struct_children.empty()) {
 		throw InternalException("Can't check for containment in an empty struct");
 	}
@@ -218,7 +218,7 @@ static unique_ptr<FunctionData> StructContainsBind(BindScalarFunctionInput &inpu
 	bound_function.GetArguments()[0] = child_type;
 
 	// the value type must match one of the struct's children
-	LogicalType max_child_type = arguments[1]->return_type;
+	LogicalType max_child_type = arguments[1]->GetReturnType();
 	vector<LogicalType> new_child_types;
 	for (auto &child : struct_children) {
 		if (!LogicalType::TryGetMaxLogicalType(context, child.second, max_child_type, max_child_type)) {

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -31,7 +31,7 @@ static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	D_ASSERT(bound_function.GetArguments().size() == 2);
-	auto &child_type = arguments[0]->return_type;
+	auto &child_type = arguments[0]->GetReturnType();
 	if (child_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
@@ -51,7 +51,7 @@ static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input
 		throw ParameterNotResolvedException();
 	}
 
-	if (key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+	if (key_child->GetReturnType().id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
 		throw BinderException("Key name for struct_extract needs to be a constant string");
 	}
 	Value key_val = ExpressionExecutor::EvaluateScalar(context, *key_child);
@@ -95,7 +95,7 @@ static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context
                                                           vector<unique_ptr<Expression>> &arguments,
                                                           bool struct_extract) {
 	D_ASSERT(bound_function.GetArguments().size() == 2);
-	auto &child_type = arguments[0]->return_type;
+	auto &child_type = arguments[0]->GetReturnType();
 	if (child_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -57,7 +57,7 @@ static unique_ptr<FunctionData> StructPackBind(BindScalarFunctionInput &input) {
 			}
 			name_collision_set.insert(alias);
 		}
-		struct_children.push_back(make_pair(alias, arguments[i]->return_type));
+		struct_children.push_back(make_pair(alias, arguments[i]->GetReturnType()));
 	}
 
 	// this is more for completeness reasons
@@ -68,7 +68,7 @@ static unique_ptr<FunctionData> StructPackBind(BindScalarFunctionInput &input) {
 static unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &expr = input.expr;
-	auto struct_stats = StructStats::CreateUnknown(expr.return_type);
+	auto struct_stats = StructStats::CreateUnknown(expr.GetReturnType());
 	for (idx_t i = 0; i < child_stats.size(); i++) {
 		StructStats::SetChildStats(struct_stats, i, child_stats[i]);
 	}

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -629,7 +629,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &context, SimpleFunction &function,
                                                                vector<unique_ptr<Expression>> &arguments,
                                                                bool allow_legacy) {
-	auto &arg_return_type = arguments[0]->return_type;
+	auto &arg_return_type = arguments[0]->GetReturnType();
 	for (auto &arg_type : function.GetArguments()) {
 		arg_type = arg_return_type;
 	}
@@ -696,22 +696,22 @@ unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
 	    BindAggregateStateInternal(input.GetClientContext(), input.GetBoundFunction(), input.GetArguments(), true);
 
 	// combine
-	if (arguments.size() == 2 && arguments[0]->return_type != arguments[1]->return_type &&
-	    arguments[1]->return_type.id() != LogicalTypeId::BLOB &&
-	    arguments[1]->return_type.id() != LogicalTypeId::STRUCT) {
+	if (arguments.size() == 2 && arguments[0]->GetReturnType() != arguments[1]->GetReturnType() &&
+	    arguments[1]->GetReturnType().id() != LogicalTypeId::BLOB &&
+	    arguments[1]->GetReturnType().id() != LogicalTypeId::STRUCT) {
 		throw BinderException("Cannot COMBINE aggregate states from different functions, %s <> %s",
-		                      arguments[0]->return_type.ToString(), arguments[1]->return_type.ToString());
+		                      arguments[0]->GetReturnType().ToString(), arguments[1]->GetReturnType().ToString());
 	}
 
 	if (bound_function.name == "finalize") {
 		bound_function.SetReturnType(bind_data->aggr.GetReturnType());
 	} else {
 		D_ASSERT(bound_function.name == "combine");
-		bound_function.SetReturnType(arguments[0]->return_type);
+		bound_function.SetReturnType(arguments[0]->GetReturnType());
 		// When the second argument is a STRUCT (e.g. from a parquet round-trip), prevent casting to AGGREGATE_STATE by
 		// matching the declared parameter type to the actual argument type.
-		if (arguments.size() == 2 && arguments[1]->return_type.id() == LogicalTypeId::STRUCT) {
-			bound_function.GetArguments()[1] = arguments[1]->return_type;
+		if (arguments.size() == 2 && arguments[1]->GetReturnType().id() == LogicalTypeId::STRUCT) {
+			bound_function.GetArguments()[1] = arguments[1]->GetReturnType();
 		}
 	}
 
@@ -781,7 +781,7 @@ unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
 	function.SetStateInitCallback(bind_data->aggr.GetStateInitCallback());
 	function.SetStateCombineCallback(bind_data->aggr.GetStateCombineCallback());
 
-	function.SetReturnType(arguments[0]->return_type);
+	function.SetReturnType(arguments[0]->GetReturnType());
 
 	return std::move(bind_data);
 }

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -35,11 +35,11 @@ unique_ptr<FunctionData> ParseLogMessageBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 
 	if (arguments.size() != 2) {
-		throw BinderException("structured_log_schema: expects 1 argument", arguments[0]->alias);
+		throw BinderException("structured_log_schema: expects 1 argument", arguments[0]->GetAlias());
 	}
 
 	if (!arguments[0]->IsFoldable()) {
-		throw BinderException("structured_log_schema: argument '%s' must be constant", arguments[0]->alias);
+		throw BinderException("structured_log_schema: argument '%s' must be constant", arguments[0]->GetAlias());
 	}
 
 	if (arguments[0]->return_type.id() != LogicalTypeId::VARCHAR) {

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -42,7 +42,7 @@ unique_ptr<FunctionData> ParseLogMessageBind(BindScalarFunctionInput &input) {
 		throw BinderException("structured_log_schema: argument '%s' must be constant", arguments[0]->GetAlias());
 	}
 
-	if (arguments[0]->return_type.id() != LogicalTypeId::VARCHAR) {
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::VARCHAR) {
 		throw BinderException("structured_log_schema: 'log_type' argument must be a string");
 	}
 

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -60,7 +60,7 @@ unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
 		throw BinderException("write_log takes at least one argument");
 	}
 
-	if (arguments[0]->return_type != LogicalType::VARCHAR) {
+	if (arguments[0]->GetReturnType() != LogicalType::VARCHAR) {
 		throw InvalidTypeException("write_log first argument must be a VARCHAR");
 	}
 
@@ -77,31 +77,31 @@ unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
 		}
 		if (arg->GetAlias() == "disable_logging") {
 			ThrowIfNotConstant(*arg);
-			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("write_log: 'disable_logging' argument must be a boolean");
 			}
 			result->disable_logging = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (arg->GetAlias() == "scope") {
 			ThrowIfNotConstant(*arg);
-			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
+			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'scope' argument must be a string");
 			}
 			result->scope = StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (arg->GetAlias() == "level") {
 			ThrowIfNotConstant(*arg);
-			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
+			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'level' argument must be a string");
 			}
 			result->level =
 			    EnumUtil::FromString<LogLevel>(StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg)));
 		} else if (arg->GetAlias() == "log_type") {
 			ThrowIfNotConstant(*arg);
-			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
+			if (arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'log_type' argument must be a string");
 			}
 			result->type = StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (arg->GetAlias() == "return_value") {
-			result->return_type = arg->return_type;
+			result->return_type = arg->GetReturnType();
 			result->output_col = i;
 			bound_function.SetReturnType(result->return_type);
 		} else {

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -47,7 +47,7 @@ public:
 
 void ThrowIfNotConstant(const Expression &arg) {
 	if (!arg.IsFoldable()) {
-		throw BinderException("write_log: argument '%s' must be constant", arg.alias);
+		throw BinderException("write_log: argument '%s' must be constant", arg.GetAlias());
 	}
 }
 
@@ -75,37 +75,37 @@ unique_ptr<FunctionData> WriteLogBind(BindScalarFunctionInput &input) {
 		if (arg->HasParameter()) {
 			throw ParameterNotResolvedException();
 		}
-		if (arg->alias == "disable_logging") {
+		if (arg->GetAlias() == "disable_logging") {
 			ThrowIfNotConstant(*arg);
 			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
 				throw BinderException("write_log: 'disable_logging' argument must be a boolean");
 			}
 			result->disable_logging = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
-		} else if (arg->alias == "scope") {
+		} else if (arg->GetAlias() == "scope") {
 			ThrowIfNotConstant(*arg);
 			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'scope' argument must be a string");
 			}
 			result->scope = StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
-		} else if (arg->alias == "level") {
+		} else if (arg->GetAlias() == "level") {
 			ThrowIfNotConstant(*arg);
 			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'level' argument must be a string");
 			}
 			result->level =
 			    EnumUtil::FromString<LogLevel>(StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg)));
-		} else if (arg->alias == "log_type") {
+		} else if (arg->GetAlias() == "log_type") {
 			ThrowIfNotConstant(*arg);
 			if (arg->return_type.id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("write_log: 'log_type' argument must be a string");
 			}
 			result->type = StringValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
-		} else if (arg->alias == "return_value") {
+		} else if (arg->GetAlias() == "return_value") {
 			result->return_type = arg->return_type;
 			result->output_col = i;
 			bound_function.SetReturnType(result->return_type);
 		} else {
-			throw BinderException(StringUtil::Format("write_log: Unknown argument '%s'", arg->alias));
+			throw BinderException(StringUtil::Format("write_log: Unknown argument '%s'", arg->GetAlias()));
 		}
 	}
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -84,9 +84,9 @@ static unique_ptr<FunctionData> VariantExtractBind(BindScalarFunctionInput &inpu
 		throw BinderException("'variant_extract' expects two arguments, VARIANT column and VARCHAR path");
 	}
 	auto &path = *arguments[1];
-	if (path.return_type.id() != LogicalTypeId::VARCHAR && path.return_type.id() != LogicalTypeId::UINTEGER) {
+	if (path.GetReturnType().id() != LogicalTypeId::VARCHAR && path.GetReturnType().id() != LogicalTypeId::UINTEGER) {
 		throw BinderException("'variant_extract' expects the second argument to be of type VARCHAR or UINTEGER, not %s",
-		                      path.return_type.ToString());
+		                      path.GetReturnType().ToString());
 	}
 
 	Value constant_arg;

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -472,13 +472,14 @@ struct ComparisonCondition {
 
 static bool CollectValuesAndComparisonsFromExpression(const Expression &expr, value_set_t &in_values,
                                                       vector<ComparisonCondition> &comparisons) {
-	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR && expr.type == ExpressionType::COMPARE_IN) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    expr.GetExpressionType() == ExpressionType::COMPARE_IN) {
 		auto &op = expr.Cast<BoundOperatorExpression>();
 		if (op.children.empty() || op.children[0]->GetExpressionClass() != ExpressionClass::BOUND_REF) {
 			return false;
 		}
 		for (idx_t i = 1; i < op.children.size(); i++) {
-			if (op.children[i]->type != ExpressionType::VALUE_CONSTANT) {
+			if (op.children[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 				return false;
 			}
 			auto &value = op.children[i]->Cast<BoundConstantExpression>().value;
@@ -493,9 +494,9 @@ static bool CollectValuesAndComparisonsFromExpression(const Expression &expr, va
 		Value val;
 		bool left_is_ref = comp.left->GetExpressionClass() == ExpressionClass::BOUND_REF;
 		bool right_is_ref = comp.right->GetExpressionClass() == ExpressionClass::BOUND_REF;
-		if (comp.right->type == ExpressionType::VALUE_CONSTANT && left_is_ref) {
+		if (comp.right->GetExpressionType() == ExpressionType::VALUE_CONSTANT && left_is_ref) {
 			val = comp.right->Cast<BoundConstantExpression>().value;
-		} else if (comp.left->type == ExpressionType::VALUE_CONSTANT && right_is_ref) {
+		} else if (comp.left->GetExpressionType() == ExpressionType::VALUE_CONSTANT && right_is_ref) {
 			val = comp.left->Cast<BoundConstantExpression>().value;
 		} else {
 			return false;
@@ -503,14 +504,14 @@ static bool CollectValuesAndComparisonsFromExpression(const Expression &expr, va
 		if (val.IsNull()) {
 			return false;
 		}
-		if (comp.type == ExpressionType::COMPARE_EQUAL) {
+		if (comp.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
 			in_values.insert(val);
 		}
-		comparisons.push_back({comp.type, std::move(val)});
+		comparisons.push_back({comp.GetExpressionType(), std::move(val)});
 		return true;
 	}
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
-	    expr.type == ExpressionType::CONJUNCTION_AND) {
+	    expr.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
 		auto &conj = expr.Cast<BoundConjunctionExpression>();
 		for (auto &child : conj.children) {
 			if (!CollectValuesAndComparisonsFromExpression(*child, in_values, comparisons)) {

--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -72,11 +72,11 @@ static unique_ptr<GlobalTableFunctionState> UnnestInit(ClientContext &context, T
 	auto result = make_uniq<UnnestGlobalState>();
 
 	unique_ptr<Expression> child = make_uniq<BoundReferenceExpression>(bind_data.input_type, 0U);
-	if (child->return_type.id() == LogicalTypeId::ARRAY) {
+	if (child->GetReturnType().id() == LogicalTypeId::ARRAY) {
 		child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
 	}
 
-	auto bound_unnest = make_uniq<BoundUnnestExpression>(ListType::GetChildType(child->return_type));
+	auto bound_unnest = make_uniq<BoundUnnestExpression>(ListType::GetChildType(child->GetReturnType()));
 	bound_unnest->child = std::move(child);
 	result->select_list.push_back(std::move(bound_unnest));
 	return std::move(result);

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -87,7 +87,7 @@ WindowAggregateExecutor::WindowAggregateExecutor(BoundWindowExpression &wexpr, C
 	// Anyone who needs it can then convert it to the form they need.
 	if (wexpr.filter_expr) {
 		const auto filter_idx = shared.RegisterSink(wexpr.filter_expr);
-		filter_ref = make_uniq<BoundReferenceExpression>(wexpr.filter_expr->return_type, filter_idx);
+		filter_ref = make_uniq<BoundReferenceExpression>(wexpr.filter_expr->GetReturnType(), filter_idx);
 	}
 }
 

--- a/src/function/window/window_aggregator.cpp
+++ b/src/function/window/window_aggregator.cpp
@@ -10,10 +10,10 @@ namespace duckdb {
 // WindowAggregator
 //===--------------------------------------------------------------------===//
 WindowAggregator::WindowAggregator(const BoundWindowExpression &wexpr)
-    : wexpr(wexpr), aggr(wexpr), result_type(wexpr.return_type),
+    : wexpr(wexpr), aggr(wexpr), result_type(wexpr.GetReturnType()),
       state_size(aggr.function.GetStateSizeCallback()(aggr.function)), exclude_mode(wexpr.exclude_clause) {
 	for (auto &child : wexpr.children) {
-		arg_types.emplace_back(child->return_type);
+		arg_types.emplace_back(child->GetReturnType());
 	}
 }
 

--- a/src/function/window/window_executor.cpp
+++ b/src/function/window/window_executor.cpp
@@ -47,7 +47,7 @@ WindowExecutorGlobalState::WindowExecutorGlobalState(ClientContext &client, cons
     : client(client), executor(executor), payload_count(payload_count), partition_mask(partition_mask),
       order_mask(order_mask) {
 	for (const auto &child : executor.wexpr.children) {
-		arg_types.emplace_back(child->return_type);
+		arg_types.emplace_back(child->GetReturnType());
 	}
 }
 

--- a/src/function/window/window_merge_sort_tree.cpp
+++ b/src/function/window/window_merge_sort_tree.cpp
@@ -25,7 +25,7 @@ WindowMergeSortTree::WindowMergeSortTree(ClientContext &client, const vector<Bou
 	vector<BoundOrderByNode> orders;
 	for (const auto &order_p : orders_p) {
 		auto order = order_p.Copy();
-		const auto &type = order.expression->return_type;
+		const auto &type = order.expression->GetReturnType();
 		scan_types.emplace_back(type);
 		order.expression = make_uniq<BoundReferenceExpression>(type, orders.size());
 		orders.emplace_back(std::move(order));

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -135,7 +135,7 @@ void WindowNaiveLocalState::Finalize(ExecutionContext &context, WindowAggregator
 		vector<BoundOrderByNode> orders;
 		for (const auto &order_by : aggregator.wexpr.arg_orders) {
 			auto order = order_by.Copy();
-			const auto &type = order.expression->return_type;
+			const auto &type = order.expression->GetReturnType();
 			order.expression = make_uniq<BoundReferenceExpression>(type, orders.size());
 			orders.emplace_back(std::move(order));
 		}

--- a/src/function/window/window_shared_expressions.cpp
+++ b/src/function/window/window_shared_expressions.cpp
@@ -39,7 +39,7 @@ void WindowSharedExpressions::PrepareExecutors(Shared &shared, ExpressionExecuto
 	vector<LogicalType> types;
 	for (auto expr : sorted) {
 		exec.AddExpression(*expr);
-		types.emplace_back(expr->return_type);
+		types.emplace_back(expr->GetReturnType());
 	}
 
 	if (!types.empty()) {

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -142,7 +142,7 @@ public:
 		ExpressionExecutor executor(client);
 		executor.AddExpression(*wexpr.children[0]);
 		DataChunk result;
-		result.Initialize(client, {wexpr.children[0]->return_type});
+		result.Initialize(client, {wexpr.children[0]->GetReturnType()});
 		executor.Execute(input, result);
 
 		return result.GetValue(0, 0);
@@ -150,7 +150,7 @@ public:
 
 	WindowValueStreamingState(ClientContext &client, DataChunk &input, const BoundWindowExpression &wexpr)
 	    : wexpr(wexpr), vec(GetFirstValue(client, input, wexpr), count_t(STANDARD_VECTOR_SIZE)),
-	      sel(STANDARD_VECTOR_SIZE), eval(client), arg(wexpr.children[0]->return_type) {
+	      sel(STANDARD_VECTOR_SIZE), eval(client), arg(wexpr.children[0]->GetReturnType()) {
 		eval.AddExpression(*wexpr.children[0]);
 	}
 
@@ -190,7 +190,7 @@ unique_ptr<FunctionData> WindowValueExecutor::Bind(BindWindowFunctionInput &inpu
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 
-	function.SetReturnType(arguments[0]->return_type);
+	function.SetReturnType(arguments[0]->GetReturnType());
 
 	return nullptr;
 }
@@ -373,7 +373,7 @@ public:
 
 	static bool ComputeDefault(ClientContext &client, const BoundWindowExpression &wexpr, Value &result) {
 		if (wexpr.children.size() < 3) {
-			result = Value(wexpr.return_type);
+			result = Value(wexpr.GetReturnType());
 			return true;
 		}
 
@@ -382,11 +382,11 @@ public:
 			return false;
 		}
 		auto dflt_value = ExpressionExecutor::EvaluateScalar(client, *default_expr);
-		return dflt_value.DefaultTryCastAs(wexpr.return_type, result, nullptr, false);
+		return dflt_value.DefaultTryCastAs(wexpr.GetReturnType(), result, nullptr, false);
 	}
 
 	WindowLeadLagStreamingState(ClientContext &context, const BoundWindowExpression &wexpr)
-	    : wexpr(wexpr), executor(context, *wexpr.children[0]), prev(wexpr.return_type), temp(wexpr.return_type),
+	    : wexpr(wexpr), executor(context, *wexpr.children[0]), prev(wexpr.GetReturnType()), temp(wexpr.GetReturnType()),
 	      sel(STANDARD_VECTOR_SIZE) {
 		ComputeOffset(context, wexpr, offset);
 		ComputeDefault(context, wexpr, dflt);
@@ -821,7 +821,7 @@ void WindowFirstValueExecutor::StreamData(ExecutionContext &context, DataChunk &
 			result.Reference(prev);
 		} else {
 			auto &sel = sstate.sel;
-			Vector split(wexpr.children[0]->return_type);
+			Vector split(wexpr.children[0]->GetReturnType());
 			split.SetValue(0, prev.GetValue(0));
 			sel_t s = 0;
 			for (sel_t i = 0; i < count; ++i) {
@@ -937,7 +937,7 @@ void WindowLastValueExecutor::StreamData(ExecutionContext &context, DataChunk &i
 			VectorOperations::Copy(arg, result, count, 0, 0);
 		} else {
 			//	Copy the data as it may be a reference to the argument
-			Vector copy(wexpr.children[0]->return_type);
+			Vector copy(wexpr.children[0]->GetReturnType());
 			VectorOperations::Copy(arg, copy, count, 0, 0);
 			//	Overwrite the previous non-NULL value if the first one is NULL
 			if (!validity.RowIsValidUnsafe(0)) {
@@ -1054,7 +1054,7 @@ public:
 	}
 	WindowNthValueStreamingState(ClientContext &client, DataChunk &input, const BoundWindowExpression &wexpr)
 	    : WindowValueStreamingState(client, input, wexpr) {
-		vec.SetValue(0, Value(wexpr.return_type));
+		vec.SetValue(0, Value(wexpr.GetReturnType()));
 		ComputeNthIndex(client, wexpr, nth_index);
 	}
 
@@ -1113,7 +1113,7 @@ void WindowNthValueStreamingState::StreamData(ExecutionContext &context, DataChu
 	const auto &validity = unified.validity;
 
 	//	Split the result between NULLs and the Nth Value
-	Vector split(wexpr.children[0]->return_type, 2);
+	Vector split(wexpr.children[0]->GetReturnType(), 2);
 	sel_t s = 0;
 	split.SetValue(s, vec.GetValue(0));
 
@@ -1228,7 +1228,7 @@ struct WindowFillExecutor : public WindowValueExecutor {
 };
 
 template <class TO, class FROM>
-TO LossyFillCast(FROM val) {
+static TO LossyFillCast(FROM val) {
 	return LossyNumericCast<TO, FROM>(val);
 }
 
@@ -1396,7 +1396,7 @@ static fill_interpolate_t GetFillInterpolateFunction(const LogicalType &type) {
 typedef bool (*fill_value_t)(idx_t i, WindowCursor &cursor);
 
 template <typename T>
-bool FillValueFunction(idx_t row_idx, WindowCursor &cursor) {
+static bool FillValueFunction(idx_t row_idx, WindowCursor &cursor) {
 	return !cursor.CellIsNull(0, row_idx) && Value::IsFinite(cursor.GetCell<T>(0, row_idx));
 }
 
@@ -1455,7 +1455,7 @@ unique_ptr<FunctionData> WindowFillExecutor::Bind(BindWindowFunctionInput &input
 	const auto &arguments = input.GetArguments();
 
 	//	Check FILL arguments support subtraction
-	if (!IsFillType(arguments[0]->return_type)) {
+	if (!IsFillType(arguments[0]->GetReturnType())) {
 		throw BinderException("FILL argument must support subtraction");
 	}
 
@@ -1476,11 +1476,11 @@ unique_ptr<FunctionData> WindowFillExecutor::Bind(BindWindowFunctionInput &input
 		D_ASSERT(!orders.empty());
 		auto &order_expr = orders[0].expression;
 		auto &bound = BoundExpression::GetExpression(*order_expr);
-		order_type = bound->return_type;
+		order_type = bound->GetReturnType();
 	} else {
 		auto &order_expr = arg_orders[0].expression;
 		auto &bound = BoundExpression::GetExpression(*order_expr);
-		order_type = bound->return_type;
+		order_type = bound->GetReturnType();
 	}
 	if (!IsFillType(order_type)) {
 		throw BinderException("FILL ordering must support subtraction");
@@ -1632,15 +1632,15 @@ void WindowFillExecutor::GetData(ExecutionContext &context, DataChunk &eval_chun
 	idx_t next_valid = DConstants::INVALID_INDEX;
 
 	const auto &wexpr = gfstate.executor.wexpr;
-	auto interpolate_func = GetFillInterpolateFunction(wexpr.children[0]->return_type);
-	auto value_func = GetFillValueFunction(wexpr.children[0]->return_type);
+	auto interpolate_func = GetFillInterpolateFunction(wexpr.children[0]->GetReturnType());
+	auto value_func = GetFillValueFunction(wexpr.children[0]->GetReturnType());
 
 	//	Secondary sort - use the MSTs
 	if (gfstate.value_tree) {
 		//	Roughly what we need to do is find the previous and next non-null values
 		//	with non-null ordering values. This is essentially LEAD/LAG(IGNORE NULLS)
-		auto slope_func = GetFillSlopeFunction(wexpr.arg_orders[0].expression->return_type);
-		auto order_value_func = GetFillValueFunction(wexpr.arg_orders[0].expression->return_type);
+		auto slope_func = GetFillSlopeFunction(wexpr.arg_orders[0].expression->GetReturnType());
+		auto order_value_func = GetFillValueFunction(wexpr.arg_orders[0].expression->GetReturnType());
 		auto &frames = lfstate.frames;
 		frames.resize(1);
 		auto &frame = frames[0];
@@ -1751,8 +1751,8 @@ void WindowFillExecutor::GetData(ExecutionContext &context, DataChunk &eval_chun
 	auto valid_begin = FlatVector::GetData<const idx_t>(bounds.data[VALID_BEGIN]);
 	auto valid_end = FlatVector::GetData<const idx_t>(bounds.data[VALID_END]);
 	idx_t prev_partition = DConstants::INVALID_INDEX;
-	auto slope_func = GetFillSlopeFunction(wexpr.orders[0].expression->return_type);
-	auto order_value_func = GetFillValueFunction(wexpr.orders[0].expression->return_type);
+	auto slope_func = GetFillSlopeFunction(wexpr.orders[0].expression->GetReturnType());
+	auto order_value_func = GetFillValueFunction(wexpr.orders[0].expression->GetReturnType());
 
 	for (idx_t i = 0; i < count; ++i, ++row_idx) {
 		//	Did we change partitions?

--- a/src/include/duckdb/common/multi_file/multi_file_data.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_data.hpp
@@ -110,7 +110,7 @@ public:
 
 	Value GetDefaultValue() const {
 		D_ASSERT(default_expression);
-		if (default_expression->type != ExpressionType::VALUE_CONSTANT) {
+		if (default_expression->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			throw NotImplementedException("Default expression that isn't constant is not supported yet");
 		}
 		auto &constant_expr = default_expression->Cast<ConstantExpression>();

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -378,7 +378,7 @@ public:
 			if (cast_entry != reader.cast_map.end()) {
 				intermediate_chunk_types.push_back(cast_entry->second);
 			} else if (expr_entry != reader.expression_map.end()) {
-				intermediate_chunk_types.push_back(expr_entry->second->return_type);
+				intermediate_chunk_types.push_back(expr_entry->second->GetReturnType());
 			} else {
 				auto &col = local_columns[local_id];
 				intermediate_chunk_types.push_back(col.type);

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -79,7 +79,7 @@ public:
 			// This can happen when we change a function that used to take varargs, to no longer do so.
 			arguments.reserve(children->size());
 			for (auto &child : *children) {
-				arguments.push_back(child->return_type);
+				arguments.push_back(child->GetReturnType());
 			}
 		}
 

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -168,7 +168,7 @@ public:
 			// This can happen when we change a function that used to take varargs, to no longer do so.
 			arguments.reserve(children.size());
 			for (auto &child : children) {
-				arguments.push_back(child->return_type);
+				arguments.push_back(child->GetReturnType());
 			}
 		}
 

--- a/src/include/duckdb/function/scalar/struct_utils.hpp
+++ b/src/include/duckdb/function/scalar/struct_utils.hpp
@@ -54,14 +54,14 @@ inline bool TryGetStructExtractChildIndex(const BoundFunctionExpression &func, i
 	}
 	if (func.function.name != "struct_extract" || func.children.size() <= 1 ||
 	    func.children[1]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
-	    func.children[0]->return_type.id() != LogicalTypeId::STRUCT) {
+	    func.children[0]->GetReturnType().id() != LogicalTypeId::STRUCT) {
 		return false;
 	}
 	auto &field_value = func.children[1]->Cast<BoundConstantExpression>().value;
 	if (field_value.IsNull() || field_value.type().id() != LogicalTypeId::VARCHAR) {
 		return false;
 	}
-	child_idx = StructType::GetChildIndexUnsafe(func.children[0]->return_type, field_value.GetValue<string>());
+	child_idx = StructType::GetChildIndexUnsafe(func.children[0]->GetReturnType(), field_value.GetValue<string>());
 	return true;
 }
 

--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -28,7 +28,7 @@ public:
 		if (!FoundExpression()) {
 			return false;
 		}
-		return expression->type == ExpressionType::BOUND_COLUMN_REF;
+		return expression->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF;
 	}
 
 public:

--- a/src/include/duckdb/parser/base_expression.hpp
+++ b/src/include/duckdb/parser/base_expression.hpp
@@ -51,6 +51,11 @@ public:
 		query_location = location;
 	}
 
+	//! Returns true if the expression has a valid query location
+	bool HasQueryLocation() const {
+		return query_location.IsValid();
+	}
+
 	//! Returns true if the expression has a non-empty alias
 	bool HasAlias() const {
 		return !alias.empty();
@@ -76,9 +81,7 @@ public:
 		alias.clear();
 	}
 
-	// TODO: Make the following protected
-	// protected:
-
+protected:
 	//! Type of the expression
 	ExpressionType type;
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -98,7 +98,7 @@ struct CorrelatedColumnInfo {
 	    : binding(binding), type(std::move(type_p)), name(std::move(name_p)), depth(depth) {
 	}
 	explicit CorrelatedColumnInfo(BoundColumnRefExpression &expr)
-	    : CorrelatedColumnInfo(expr.binding, expr.return_type, expr.GetName(), expr.depth) {
+	    : CorrelatedColumnInfo(expr.binding, expr.GetReturnType(), expr.GetName(), expr.depth) {
 	}
 
 	bool operator==(const CorrelatedColumnInfo &rhs) const {

--- a/src/include/duckdb/planner/expression.hpp
+++ b/src/include/duckdb/planner/expression.hpp
@@ -20,25 +20,27 @@ class Expression : public BaseExpression {
 public:
 	Expression(ExpressionType type, ExpressionClass expression_class, LogicalType return_type);
 	~Expression() override;
+
 protected:
 	//! The return type of the expression
 	LogicalType return_type;
 
+protected:
 	//! Expression statistics (if any) - ONLY USED FOR VERIFICATION
 	unique_ptr<BaseStatistics> verification_stats;
+
 public:
 	const LogicalType &GetReturnType() const {
-		return return_type;
-	}
-	LogicalType &GetReturnType() {
 		return return_type;
 	}
 	void SetReturnType(LogicalType type) {
 		return_type = std::move(type);
 	}
 
-	const unique_ptr<BaseStatistics> &GetVerificationStats() const { return verification_stats; }
-	void SetVerificationStats(unique_ptr<BaseStatistics> stats) { verification_stats = std::move(stats); }
+	const unique_ptr<BaseStatistics> &GetVerificationStats() const {
+		return verification_stats;
+	}
+	void SetVerificationStats(unique_ptr<BaseStatistics> stats);
 
 	bool IsAggregate() const override;
 	bool IsWindow() const override;

--- a/src/include/duckdb/planner/expression.hpp
+++ b/src/include/duckdb/planner/expression.hpp
@@ -20,13 +20,26 @@ class Expression : public BaseExpression {
 public:
 	Expression(ExpressionType type, ExpressionClass expression_class, LogicalType return_type);
 	~Expression() override;
-
+protected:
 	//! The return type of the expression
 	LogicalType return_type;
+
 	//! Expression statistics (if any) - ONLY USED FOR VERIFICATION
 	unique_ptr<BaseStatistics> verification_stats;
-
 public:
+	const LogicalType &GetReturnType() const {
+		return return_type;
+	}
+	LogicalType &GetReturnType() {
+		return return_type;
+	}
+	void SetReturnType(LogicalType type) {
+		return_type = std::move(type);
+	}
+
+	const unique_ptr<BaseStatistics> &GetVerificationStats() const { return verification_stats; }
+	void SetVerificationStats(unique_ptr<BaseStatistics> stats) { verification_stats = std::move(stats); }
+
 	bool IsAggregate() const override;
 	bool IsWindow() const override;
 	bool HasSubquery() const override;

--- a/src/include/duckdb/planner/expression/bound_cast_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_cast_expression.hpp
@@ -30,8 +30,8 @@ public:
 
 public:
 	LogicalType source_type() { // NOLINT: allow casing for legacy reasons
-		D_ASSERT(child->return_type.IsValid());
-		return child->return_type;
+		D_ASSERT(child->GetReturnType().IsValid());
+		return child->GetReturnType();
 	}
 
 	//! Cast an expression to the specified SQL type, using only the built-in SQL casts

--- a/src/main/capi/expression-c.cpp
+++ b/src/main/capi/expression-c.cpp
@@ -19,7 +19,7 @@ duckdb_logical_type duckdb_expression_return_type(duckdb_expression expr) {
 		return nullptr;
 	}
 	auto wrapper = reinterpret_cast<ExpressionWrapper *>(expr);
-	auto logical_type = new duckdb::LogicalType(wrapper->expr->return_type);
+	auto logical_type = new duckdb::LogicalType(wrapper->expr->GetReturnType());
 	return reinterpret_cast<duckdb_logical_type>(logical_type);
 }
 

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -71,7 +71,7 @@ public:
 
 		// Replace AVG(x) with SUM(x)
 		auto &sum_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(optimizer.context, DEFAULT_SCHEMA, "sum");
-		const auto sum_fun = sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->return_type});
+		const auto sum_fun = sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->GetReturnType()});
 		vector<unique_ptr<Expression>> args;
 		args.push_back(std::move(avg_child));
 		auto count_arg = args.back()->Copy();
@@ -348,14 +348,14 @@ private:
 			ColumnBinding aggregate_binding(aggr.group_index, ProjectionIndex(group_idx));
 			aggregate_map[aggregate_binding] = ColumnBinding(proj_index, ProjectionIndex(group_idx));
 			auto group_ref =
-			    make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->return_type, aggregate_binding);
+			    make_uniq<BoundColumnRefExpression>(aggr.groups[group_idx]->GetReturnType(), aggregate_binding);
 			projection_expressions.push_back(std::move(group_ref));
 		}
 
 		for (idx_t i = 0; i < aggr_count; i++) {
 			ColumnBinding aggregate_binding(aggr.aggregate_index, ProjectionIndex(i));
 			aggregate_map[aggregate_binding] = ColumnBinding(proj_index, ProjectionIndex(group_count + i));
-			auto &aggr_type = aggr.expressions[i]->return_type;
+			auto &aggr_type = aggr.expressions[i]->GetReturnType();
 			auto aggr_ref = make_uniq<BoundColumnRefExpression>(aggr_type, aggregate_binding);
 
 			const auto rewrite_entry = rewrites.find(i);
@@ -367,7 +367,7 @@ private:
 
 			auto &rewrite_info = rewrite_entry->second;
 			ColumnBinding count_binding(aggr.aggregate_index, ProjectionIndex(rewrite_info.count_idx));
-			auto count_ref = make_uniq<BoundColumnRefExpression>(aggr.expressions[rewrite_info.count_idx]->return_type,
+			auto count_ref = make_uniq<BoundColumnRefExpression>(aggr.expressions[rewrite_info.count_idx]->GetReturnType(),
 			                                                     count_binding);
 
 			rewrite_info.additional_expressions.push_back(std::move(count_ref));

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -71,7 +71,8 @@ public:
 
 		// Replace AVG(x) with SUM(x)
 		auto &sum_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(optimizer.context, DEFAULT_SCHEMA, "sum");
-		const auto sum_fun = sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->GetReturnType()});
+		const auto sum_fun =
+		    sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->GetReturnType()});
 		vector<unique_ptr<Expression>> args;
 		args.push_back(std::move(avg_child));
 		auto count_arg = args.back()->Copy();
@@ -367,8 +368,8 @@ private:
 
 			auto &rewrite_info = rewrite_entry->second;
 			ColumnBinding count_binding(aggr.aggregate_index, ProjectionIndex(rewrite_info.count_idx));
-			auto count_ref = make_uniq<BoundColumnRefExpression>(aggr.expressions[rewrite_info.count_idx]->GetReturnType(),
-			                                                     count_binding);
+			auto count_ref = make_uniq<BoundColumnRefExpression>(
+			    aggr.expressions[rewrite_info.count_idx]->GetReturnType(), count_binding);
 
 			rewrite_info.additional_expressions.push_back(std::move(count_ref));
 			auto final_result = rule.CreateProjectionExpression(aggr_type, std::move(aggr_ref),

--- a/src/optimizer/column_binding_replacer.cpp
+++ b/src/optimizer/column_binding_replacer.cpp
@@ -31,7 +31,7 @@ void ColumnBindingReplacer::VisitExpression(unique_ptr<Expression> *expression) 
 			if (bound_column_ref.binding == replace_binding.old_binding) {
 				bound_column_ref.binding = replace_binding.new_binding;
 				if (replace_binding.replace_type) {
-					bound_column_ref.return_type = replace_binding.new_type;
+					bound_column_ref.SetReturnType(replace_binding.new_type);
 				}
 			}
 		}

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -350,14 +350,14 @@ private:
 		// Replace default fields
 		switch (TYPE) {
 		case ConversionType::TO_CANONICAL:
-			expression_info.emplace_back(std::move(expr.alias), expr.query_location);
-			expr.alias.clear();
-			expr.query_location.SetInvalid();
+			expression_info.emplace_back(expr.GetAlias(), expr.GetQueryLocation());
+			expr.ClearAlias();
+			expr.SetQueryLocation(optional_idx());
 			break;
 		case ConversionType::RESTORE_ORIGINAL:
 			auto &info = expression_info[info_idx++];
-			expr.alias = std::move(info.first);
-			expr.query_location = info.second;
+			expr.SetAlias(std::move(info.first));
+			expr.SetQueryLocation(info.second);
 			break;
 		}
 		if (expr.IsVolatile()) {

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -309,7 +309,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetCompressExpression(
 
 unique_ptr<CompressExpression> CompressedMaterialization::GetCompressExpression(unique_ptr<Expression> input,
                                                                                 const BaseStatistics &stats) {
-	const auto &type = input->return_type;
+	const auto &type = input->GetReturnType();
 	if (type != stats.GetType()) { // LCOV_EXCL_START
 		return nullptr;
 	} // LCOV_EXCL_STOP
@@ -344,7 +344,7 @@ static Value GetIntegralRangeValue(ClientContext &context, const LogicalType &ty
 
 unique_ptr<CompressExpression> CompressedMaterialization::GetIntegralCompress(unique_ptr<Expression> input,
                                                                               const BaseStatistics &stats) {
-	const auto &type = input->return_type;
+	const auto &type = input->GetReturnType();
 	if (GetTypeIdSize(type.InternalType()) == 1) {
 		return nullptr;
 	}
@@ -356,7 +356,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetIntegralCompress(un
 		// All NULL
 		cast_type = LogicalType::UTINYINT;
 		range_value = Value::UTINYINT(0);
-		min = Value(input->return_type);
+		min = Value(input->GetReturnType());
 	} else if (NumericStats::HasMinMax(stats)) {
 		// Get range and cast to UBIGINT (might fail for HUGEINT, in which case we just return)
 		range_value = GetIntegralRangeValue(context, type, stats);
@@ -483,7 +483,7 @@ unique_ptr<Expression> CompressedMaterialization::GetIntegralDecompress(unique_p
                                                                         const LogicalType &result_type,
                                                                         const BaseStatistics &stats) {
 	D_ASSERT(!stats.CanHaveNoNull() || NumericStats::HasMinMax(stats));
-	auto decompress_function = CMIntegralDecompressFun::GetFunction(input->return_type, result_type);
+	auto decompress_function = CMIntegralDecompressFun::GetFunction(input->GetReturnType(), result_type);
 	const auto min = !stats.CanHaveNoNull() ? Value(result_type) : NumericStats::Min(stats);
 
 	vector<unique_ptr<Expression>> arguments;
@@ -496,7 +496,7 @@ unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr
                                                                       const LogicalType &result_type,
                                                                       const BaseStatistics &stats) {
 	D_ASSERT(!stats.CanHaveNoNull() || StringStats::HasMaxStringLength(stats));
-	auto decompress_function = CMStringDecompressFun::GetFunction(input->return_type);
+	auto decompress_function = CMStringDecompressFun::GetFunction(input->GetReturnType());
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
 	return make_uniq<BoundFunctionExpression>(result_type, decompress_function, std::move(arguments), nullptr);

--- a/src/optimizer/compressed_materialization/compress_aggregate.cpp
+++ b/src/optimizer/compressed_materialization/compress_aggregate.cpp
@@ -130,7 +130,7 @@ void CompressedMaterialization::UpdateAggregateStats(unique_ptr<LogicalOperator>
 		if (!group_stats[group_idx]) {
 			continue;
 		}
-		if (colref.return_type == group_stats[group_idx]->GetType()) {
+		if (colref.GetReturnType() == group_stats[group_idx]->GetType()) {
 			continue;
 		}
 		auto it = statistics_map.find(colref.binding);

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -101,7 +101,7 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 		if (column_entry == state.column_map.end()) {
 			// not there yet: push the expression
 			auto new_col_ref = make_uniq<BoundColumnRefExpression>(
-			    bound_column_ref.GetAlias(), bound_column_ref.return_type, bound_column_ref.binding);
+			    bound_column_ref.GetAlias(), bound_column_ref.GetReturnType(), bound_column_ref.binding);
 			auto new_column_index = ColumnBinding::PushExpression(state.expressions, std::move(new_col_ref));
 			state.column_map[bound_column_ref.binding] = new_column_index;
 			bound_column_ref.binding = ColumnBinding(state.projection_index, new_column_index);
@@ -118,7 +118,7 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 			// this expression occurs more than once! push it into the projection
 			// check if it has already been pushed into the projection
 			auto alias = expr.GetAlias();
-			auto type = expr.return_type;
+			auto type = expr.GetReturnType();
 			if (!node.column_index.IsValid()) {
 				// has not been pushed yet: push it
 				node.column_index = ColumnBinding::PushExpression(state.expressions, std::move(expr_ptr));

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -126,7 +126,7 @@ bool Deliminator::HasSelection(const LogicalOperator &op) {
 			auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "Deliminator::HasSelection");
 			auto &expr = *expr_filter.expr;
 			if (expr.GetExpressionClass() != ExpressionClass::BOUND_OPERATOR ||
-			    expr.type != ExpressionType::OPERATOR_IS_NOT_NULL) {
+			    expr.GetExpressionType() != ExpressionType::OPERATOR_IS_NOT_NULL) {
 				return true;
 			}
 		}

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -86,11 +86,11 @@ idx_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
 	// OPERATOR_CAST
 	// determine cast cost by comparing cast_expr.source_type and cast_expr_target_type
 	idx_t cast_cost = 0;
-	if (expr.return_type != expr.source_type()) {
+	if (expr.GetReturnType() != expr.source_type()) {
 		// if cast from or to varchar
 		// TODO: we might want to add more cases
-		if (expr.return_type.id() == LogicalTypeId::VARCHAR || expr.source_type().id() == LogicalTypeId::VARCHAR ||
-		    expr.return_type.id() == LogicalTypeId::BLOB || expr.source_type().id() == LogicalTypeId::BLOB) {
+		if (expr.GetReturnType().id() == LogicalTypeId::VARCHAR || expr.source_type().id() == LogicalTypeId::VARCHAR ||
+		    expr.GetReturnType().id() == LogicalTypeId::BLOB || expr.source_type().id() == LogicalTypeId::BLOB) {
 			cast_cost = 200;
 		} else {
 			cast_cost = 5;
@@ -200,19 +200,19 @@ idx_t ExpressionHeuristics::Cost(Expression &expr) {
 	}
 	case ExpressionClass::BOUND_COLUMN_REF: {
 		auto &col_expr = expr.Cast<BoundColumnRefExpression>();
-		return ExpressionCost(col_expr.return_type.InternalType(), 8);
+		return ExpressionCost(col_expr.GetReturnType().InternalType(), 8);
 	}
 	case ExpressionClass::BOUND_CONSTANT: {
 		auto &const_expr = expr.Cast<BoundConstantExpression>();
-		return ExpressionCost(const_expr.return_type.InternalType(), 1);
+		return ExpressionCost(const_expr.GetReturnType().InternalType(), 1);
 	}
 	case ExpressionClass::BOUND_PARAMETER: {
 		auto &const_expr = expr.Cast<BoundParameterExpression>();
-		return ExpressionCost(const_expr.return_type.InternalType(), 1);
+		return ExpressionCost(const_expr.GetReturnType().InternalType(), 1);
 	}
 	case ExpressionClass::BOUND_REF: {
 		auto &col_expr = expr.Cast<BoundReferenceExpression>();
-		return ExpressionCost(col_expr.return_type.InternalType(), 8);
+		return ExpressionCost(col_expr.GetReturnType().InternalType(), 8);
 	}
 	default: {
 		break;

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -17,14 +17,14 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 		if (rule.get().root->Match(*expr, bindings)) {
 			// the rule matches! try to apply it
 			bool rule_made_change = false;
-			auto alias = expr->alias;
+			auto alias = expr->GetAlias();
 			auto result = rule.get().Apply(op, bindings, rule_made_change, is_root);
 			if (result) {
 				changes_made = true;
 				// the base node changed: the rule applied changes
 				// rerun on the new node
 				if (!alias.empty()) {
-					result->alias = std::move(alias);
+					result->SetAlias(std::move(alias));
 				}
 				return ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
 			} else if (rule_made_change) {

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -362,7 +362,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &expr) {
-		    expr = make_uniq<BoundReferenceExpression>(col_ref.alias, col_ref.return_type, 0ULL);
+		    expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.return_type, 0ULL);
 	    });
 }
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -30,7 +30,7 @@ namespace duckdb {
 
 using ExpressionValueInformation = FilterCombiner::ExpressionValueInformation;
 
-ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, ExpressionValueInformation &right);
+static ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, ExpressionValueInformation &right);
 
 FilterCombiner::FilterCombiner(ClientContext &context) : context(context) {
 }
@@ -307,7 +307,7 @@ bool FilterCombiner::FindNextLegalUTF8(string &prefix_string) {
 	return true;
 }
 
-bool TypeSupportsConstantFilter(const LogicalType &type) {
+static bool TypeSupportsConstantFilter(const LogicalType &type) {
 	if (TypeIsNumeric(type.InternalType())) {
 		return true;
 	}
@@ -362,7 +362,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &expr) {
-		    expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.return_type, 0ULL);
+		    expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.GetReturnType(), 0ULL);
 	    });
 }
 
@@ -801,7 +801,7 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	auto &const_side = invert ? *comp.left : *comp.right;
 	auto &cast_expr = cast_side.Cast<BoundCastExpression>();
 	auto source_type = cast_expr.source_type();
-	auto &target_type = cast_expr.return_type;
+	auto &target_type = cast_expr.GetReturnType();
 	int64_t margin = GetTemporalCastMargin(source_type.id(), target_type.id());
 	if (margin < 0) {
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -951,7 +951,7 @@ FilterResult FilterCombiner::AddBoundComparisonFilter(Expression &expr) {
 		// get the current bucket of constant values
 		D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 		auto &info_list = constant_values.find(equivalence_set)->second;
-		if (node.return_type != info.constant.type()) {
+		if (node.GetReturnType() != info.constant.type()) {
 			return FilterResult::UNSUPPORTED;
 		}
 		// check the existing constant comparisons to see if we can do any pruning
@@ -1157,7 +1157,7 @@ FilterResult FilterCombiner::AddTransitiveFilters(BoundComparisonExpression &com
 			if (st_col_ref.binding != col_ref.binding) {
 				continue;
 			}
-			if (bound_cast_expr.return_type != stored_exp.second->return_type) {
+			if (bound_cast_expr.GetReturnType() != stored_exp.second->GetReturnType()) {
 				continue;
 			}
 			bound_cast_expr.child = stored_exp.second->Copy();
@@ -1287,7 +1287,7 @@ unique_ptr<Expression> FilterCombiner::FindTransitiveFilter(Expression &expr) {
 	return nullptr;
 }
 
-ValueComparisonResult InvertValueComparisonResult(ValueComparisonResult result) {
+static ValueComparisonResult InvertValueComparisonResult(ValueComparisonResult result) {
 	if (result == ValueComparisonResult::PRUNE_RIGHT) {
 		return ValueComparisonResult::PRUNE_LEFT;
 	}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -30,7 +30,8 @@ namespace duckdb {
 
 using ExpressionValueInformation = FilterCombiner::ExpressionValueInformation;
 
-static ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, ExpressionValueInformation &right);
+static ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left,
+                                                     ExpressionValueInformation &right);
 
 FilterCombiner::FilterCombiner(ClientContext &context) : context(context) {
 }

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -38,7 +38,7 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 		return nullptr;
 	}
 	D_ASSERT(root);
-	auto in_type = expr.children[0]->return_type;
+	auto in_type = expr.children[0]->GetReturnType();
 	bool is_regular_in = expr.GetExpressionType() == ExpressionType::COMPARE_IN;
 	bool all_scalar = true;
 	// IN clause with many children: try to generate a mark join that replaces this IN expression

--- a/src/optimizer/join_elimination.cpp
+++ b/src/optimizer/join_elimination.cpp
@@ -43,13 +43,13 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 			break;
 		}
 		column_binding_set_t distinct_group;
-		if (distinct.distinct_targets[0]->type != ExpressionType::BOUND_COLUMN_REF) {
+		if (distinct.distinct_targets[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 			break;
 		}
 		auto table_idx = distinct.distinct_targets[0]->Cast<BoundColumnRefExpression>().binding.table_index;
 		bool can_add = true;
 		for (auto &target : distinct.distinct_targets) {
-			if (target->type != ExpressionType::BOUND_COLUMN_REF) {
+			if (target->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 				can_add = false;
 				break;
 			}

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -21,11 +21,11 @@ JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) :
 }
 
 bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter) {
-	if (expr.return_type.IsNested()) {
+	if (expr.GetReturnType().IsNested()) {
 		// nested columns are not supported for pushdown
 		return false;
 	}
-	if (expr.return_type.id() == LogicalTypeId::INTERVAL) {
+	if (expr.GetReturnType().id() == LogicalTypeId::INTERVAL) {
 		// interval is not supported for pushdown
 		return false;
 	}
@@ -39,8 +39,8 @@ bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColu
 	case ExpressionClass::BOUND_CAST: {
 		// We allow pushing through integral down/upcasts, as long as source/target are (u)bigint or smaller
 		const auto &bound_cast = expr.Cast<BoundCastExpression>();
-		const auto &src = bound_cast.child->return_type;
-		const auto &tgt = bound_cast.return_type;
+		const auto &src = bound_cast.child->GetReturnType();
+		const auto &tgt = bound_cast.GetReturnType();
 		if (!src.IsIntegral() || !tgt.IsIntegral()) {
 			return false;
 		}
@@ -277,7 +277,7 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 	const auto compute_aggregates_anyway =
 	    join.join_type == JoinType::INNER && join.conditions.size() == 1 && pushdown_info->join_condition.size() == 1 &&
 	    join.conditions[0].IsComparison() && join.conditions[0].GetComparisonType() == ExpressionType::COMPARE_EQUAL &&
-	    TypeIsIntegral(join.conditions[0].GetRHS().return_type.InternalType());
+	    TypeIsIntegral(join.conditions[0].GetRHS().GetReturnType().InternalType());
 	if (pushdown_info->probe_info.empty() && !compute_aggregates_anyway) {
 		// no table sources found in which we can push down filters
 		return;

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -451,7 +451,7 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, const Tabl
 	auto cardinality_after_filters = cardinality;
 	auto expr_filter = ExpressionFilter::FromTableFilter(filter, base_stats.GetType());
 	auto &expr = *expr_filter->expr;
-	if (expr.type == ExpressionType::CONJUNCTION_AND) {
+	if (expr.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
 		auto &conj = expr.Cast<BoundConjunctionExpression>();
 		for (auto &child : conj.children) {
 			ExpressionFilter child_filter(child->Copy());
@@ -464,7 +464,7 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, const Tabl
 		return cardinality_after_filters;
 	}
 	auto &comparison = expr.Cast<BoundComparisonExpression>();
-	if (comparison.type != ExpressionType::COMPARE_EQUAL) {
+	if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
 		return cardinality_after_filters;
 	}
 	auto column_count = base_stats.GetDistinctCount();

--- a/src/optimizer/matcher/expression_matcher.cpp
+++ b/src/optimizer/matcher/expression_matcher.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 bool ExpressionMatcher::Match(Expression &expr, vector<reference<Expression>> &bindings) {
-	if (type && !type->Match(expr.return_type)) {
+	if (type && !type->Match(expr.GetReturnType())) {
 		return false;
 	}
 	if (expr_type && !expr_type->Match(expr.GetExpressionType())) {

--- a/src/optimizer/projection_pullup.cpp
+++ b/src/optimizer/projection_pullup.cpp
@@ -129,7 +129,7 @@ void ProjectionPullup::PullUpNonColrefProjection(unique_ptr<LogicalOperator> &op
 	// Prepare the column binding replacer once
 	ColumnBindingReplacer replacer;
 	for (idx_t i = 0; i < proj.expressions.size(); i++) {
-		if (proj.expressions[i]->type == ExpressionType::BOUND_COLUMN_REF) {
+		if (proj.expressions[i]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 			auto &colref = proj.expressions[i]->Cast<BoundColumnRefExpression>();
 			replacer.replacement_bindings.emplace_back(proj_bindings[i], colref.binding);
 		}
@@ -280,7 +280,7 @@ void ProjectionPullup::Optimize(unique_ptr<LogicalOperator> &op) {
 		column_binding_map_t<unique_ptr<Expression>> projection_map;
 		for (idx_t i = 0; i < proj.expressions.size(); i++) {
 			projection_map[proj_bindings[i]] = proj.expressions[i]->Copy();
-			if (proj.expressions[i]->type != ExpressionType::BOUND_COLUMN_REF) {
+			if (proj.expressions[i]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 				all_column_refs = false;
 			}
 			if (proj.expressions[i]->IsVolatile()) {

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -80,7 +80,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		// Allow pushing down filters that can throw only if there is a single expression
 		// For now, do not push down single expressions with IN either. Later we can change InClauseRewriter to handle
 		// this case
-		if (expr.CanThrow() && (expr.type == ExpressionType::COMPARE_IN || filters.size() > 1)) {
+		if (expr.CanThrow() && (expr.GetExpressionType() == ExpressionType::COMPARE_IN || filters.size() > 1)) {
 			continue;
 		}
 		pushdown_result = combiner.TryPushdownGenericExpression(get, expr);

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -37,7 +37,7 @@ static unique_ptr<Expression> ReplaceColRefWithNull(unique_ptr<Expression> root_
 		    if (right_bindings.find(bound_colref.binding.table_index) != right_bindings.end()) {
 			    // bound colref belongs to RHS
 			    // replace it with a constant NULL
-			    expr = make_uniq<BoundConstantExpression>(Value(expr->return_type));
+			    expr = make_uniq<BoundConstantExpression>(Value(expr->GetReturnType()));
 		    }
 	    });
 	return root_expr;

--- a/src/optimizer/pushdown/pushdown_outer_join.cpp
+++ b/src/optimizer/pushdown/pushdown_outer_join.cpp
@@ -80,7 +80,7 @@ static bool ExprIsFunctionOnlyOf(const Expression &expr, const expression_set_t 
 
 	ExpressionIterator::EnumerateExpression(expr_to_check, [&](unique_ptr<Expression> &sub_expr) {
 		if (args.find(*sub_expr) != args.end()) {
-			auto null_value = make_uniq<BoundConstantExpression>(Value(sub_expr->return_type));
+			auto null_value = make_uniq<BoundConstantExpression>(Value(sub_expr->GetReturnType()));
 			sub_expr = std::move(null_value);
 		}
 	});

--- a/src/optimizer/pushdown/pushdown_projection.cpp
+++ b/src/optimizer/pushdown/pushdown_projection.cpp
@@ -27,8 +27,8 @@ static unique_ptr<Expression> ReplaceProjectionBindings(LogicalProjection &proj,
 		    // replace the binding with a copy to the expression at the referenced index
 		    auto &proj_expr = proj.GetExpression(colref.binding);
 		    auto copy = proj_expr.Copy();
-		    if (!colref.alias.empty()) {
-			    copy->alias = colref.alias;
+		    if (!colref.GetAlias().empty()) {
+			    copy->SetAlias(colref.GetAlias());
 		    }
 		    expr = std::move(copy);
 	    });

--- a/src/optimizer/remove_duplicate_groups.cpp
+++ b/src/optimizer/remove_duplicate_groups.cpp
@@ -91,7 +91,7 @@ void CollectGroupRemovals(const LogicalAggregate &aggr, vector<GroupRemoval> &re
 		if (base_it == first_occurrence.end()) {
 			continue;
 		}
-		if (!BaseTypeAllowsCollapse(groups[base_it->second.GetIndex()]->return_type)) {
+		if (!BaseTypeAllowsCollapse(groups[base_it->second.GetIndex()]->GetReturnType())) {
 			continue;
 		}
 		removals.push_back({group_idx, base_it->second, nullptr});
@@ -167,11 +167,11 @@ BuildDerivedProjection(LogicalAggregate &aggr, idx_t num_original_groups, idx_t 
 	for (auto orig : ProjectionIndex::GetIndexes(num_original_groups)) {
 		auto post = group_binding_map.at(ColumnBinding(original_group_index, orig));
 		select_list.emplace_back(
-		    make_uniq<BoundColumnRefExpression>(aggr.groups[post.column_index]->return_type, post));
+		    make_uniq<BoundColumnRefExpression>(aggr.groups[post.column_index]->GetReturnType(), post));
 		derived_remap.emplace(ColumnBinding(original_group_index, orig), ColumnBinding(new_proj_idx, orig));
 	}
 	for (auto k : ProjectionIndex::GetIndexes(num_aggregate_outputs)) {
-		select_list.emplace_back(make_uniq<BoundColumnRefExpression>(aggr.expressions[k.GetIndex()]->return_type,
+		select_list.emplace_back(make_uniq<BoundColumnRefExpression>(aggr.expressions[k.GetIndex()]->GetReturnType(),
 		                                                             ColumnBinding(original_aggregate_index, k)));
 		derived_remap.emplace(ColumnBinding(original_aggregate_index, k),
 		                      ColumnBinding(new_proj_idx, ProjectionIndex(num_original_groups + k.GetIndex())));

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -692,7 +692,7 @@ void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {
 				//! No children of this column are referenced, skip
 				continue;
 			}
-			if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
+			if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 				//! Not a column reference, can't pull up the extract
 				continue;
 			}
@@ -1182,7 +1182,7 @@ void BaseColumnPruner::AddBinding(BoundColumnRefExpression &col) {
 }
 
 static bool TryGetCastChild(unique_ptr<Expression> &expr, optional_ptr<unique_ptr<Expression>> &child) {
-	if (expr->type != ExpressionType::OPERATOR_CAST) {
+	if (expr->GetExpressionType() != ExpressionType::OPERATOR_CAST) {
 		return false;
 	}
 	D_ASSERT(expr->GetExpressionClass() == ExpressionClass::BOUND_CAST);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -182,10 +182,10 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			if (cond.GetRHS().GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
 				continue;
 			}
-			if (cond.GetLHS().Cast<BoundColumnRefExpression>().return_type.IsFloating()) {
+			if (cond.GetLHS().Cast<BoundColumnRefExpression>().GetReturnType().IsFloating()) {
 				continue;
 			}
-			if (cond.GetRHS().Cast<BoundColumnRefExpression>().return_type.IsFloating()) {
+			if (cond.GetRHS().Cast<BoundColumnRefExpression>().GetReturnType().IsFloating()) {
 				continue;
 			}
 			// comparison join between two bound column refs
@@ -545,15 +545,15 @@ void RemoveUnusedColumns::WritePushdownExtractColumns(
 		auto &component = struct_extract.components[depth];
 		auto &expr = component.cast ? *component.cast : component.extract;
 
-		auto return_type = expr->return_type;
+		auto return_type = expr->GetReturnType();
 
 		auto &colref = col.bindings[struct_extract.bindings_idx];
 		auto colref_copy = colref.get().Copy();
 		expr = std::move(colref_copy);
 		auto &new_expr = expr->Cast<BoundColumnRefExpression>();
-		new_expr.return_type = return_type;
+		new_expr.SetReturnType(return_type);
 
-		auto column_index = callback(*entry, component.cast ? &(*component.cast)->return_type : nullptr);
+		auto column_index = callback(*entry, component.cast ? &(*component.cast)->GetReturnType() : nullptr);
 		new_expr.binding.column_index = column_index;
 	}
 }
@@ -562,7 +562,7 @@ static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &cont
                                                              const ColumnIndex &path) {
 	auto extract_function = GetKeyExtractFunction();
 
-	auto &struct_type = target->return_type;
+	auto &struct_type = target->GetReturnType();
 	D_ASSERT(struct_type.id() == LogicalTypeId::STRUCT);
 	reference<const LogicalType> type_iter(struct_type);
 	reference<const ColumnIndex> path_iter(path);
@@ -606,7 +606,7 @@ void RemoveUnusedColumns::RewriteExpressions(LogicalProjection &proj, idx_t expr
 		auto &expr = *proj.expressions[expression_idx++];
 		auto &colref = expr.Cast<BoundColumnRefExpression>();
 		auto original_binding = colref.binding;
-		auto &column_type = expr.return_type;
+		auto &column_type = expr.GetReturnType();
 		idx_t start = expressions.size();
 		//! Pushdown Extract is supported, emit a column for every field
 		WritePushdownExtractColumns(
@@ -696,7 +696,7 @@ void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {
 				//! Not a column reference, can't pull up the extract
 				continue;
 			}
-			if (expr.return_type.id() != LogicalTypeId::STRUCT) {
+			if (expr.GetReturnType().id() != LogicalTypeId::STRUCT) {
 				//! Extract pull up only supported for STRUCT currently
 				continue;
 			}
@@ -942,13 +942,13 @@ bool BaseColumnPruner::HandleStructExtract(unique_ptr<Expression> &expr_p,
                                            vector<ReferencedExtractComponent> &expressions) {
 	auto &function = expr_p->Cast<BoundFunctionExpression>();
 	auto &child = function.children[0];
-	D_ASSERT(child->return_type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(child->GetReturnType().id() == LogicalTypeId::STRUCT);
 	auto &bind_data = function.bind_info->Cast<StructExtractBindData>();
 	// struct extract, check if left child is a bound column ref
 	if (child->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 		// column reference - check if it is a struct
 		auto &ref = child->Cast<BoundColumnRefExpression>();
-		if (ref.return_type.id() != LogicalTypeId::STRUCT) {
+		if (ref.GetReturnType().id() != LogicalTypeId::STRUCT) {
 			return false;
 		}
 		colref = &ref;
@@ -976,7 +976,7 @@ bool BaseColumnPruner::HandleVariantExtract(unique_ptr<Expression> &expr_p,
                                             vector<ReferencedExtractComponent> &expressions) {
 	auto &function = expr_p->Cast<BoundFunctionExpression>();
 	auto &child = function.children[0];
-	D_ASSERT(child->return_type.id() == LogicalTypeId::VARIANT);
+	D_ASSERT(child->GetReturnType().id() == LogicalTypeId::VARIANT);
 	auto &bind_data = function.bind_info->Cast<VariantExtractBindData>();
 	if (bind_data.component.lookup_mode != VariantChildLookupMode::BY_KEY) {
 		//! We don't push down variant extract on ARRAY values
@@ -986,7 +986,7 @@ bool BaseColumnPruner::HandleVariantExtract(unique_ptr<Expression> &expr_p,
 	if (child->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 		// column reference - check if it is a variant
 		auto &ref = child->Cast<BoundColumnRefExpression>();
-		if (ref.return_type.id() != LogicalTypeId::VARIANT) {
+		if (ref.GetReturnType().id() != LogicalTypeId::VARIANT) {
 			return false;
 		}
 		colref = &ref;
@@ -1028,7 +1028,7 @@ bool BaseColumnPruner::HandleExtractRecursive(unique_ptr<Expression> &expr_p,
 		return false;
 	}
 	auto &child = function.children[0];
-	auto child_type = child->return_type.id();
+	auto child_type = child->GetReturnType().id();
 	switch (child_type) {
 	case LogicalTypeId::STRUCT:
 		return HandleStructExtract(expr_p, colref, path_ref, expressions);
@@ -1052,7 +1052,7 @@ bool BaseColumnPruner::HandleExtractExpression(unique_ptr<Expression> *expressio
 	if (cast_expression) {
 		auto &top_level = expressions.back();
 		top_level.cast = cast_expression;
-		path_ref.get().SetType((*cast_expression)->return_type);
+		path_ref.get().SetType((*cast_expression)->GetReturnType());
 	}
 
 	AddBinding(*colref, path.GetChildIndex(0), expressions);

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -114,7 +114,7 @@ optional_ptr<LogicalOrder> RowGroupPruner::FindLogicalOrder(const LogicalLimit &
 	}
 
 	auto &logical_order = current_op.get().Cast<LogicalOrder>();
-	auto order_column_type = logical_order.orders[0].expression->return_type;
+	auto order_column_type = logical_order.orders[0].expression->GetReturnType();
 	if (!order_column_type.IsNumeric() && !order_column_type.IsTemporal() &&
 	    order_column_type != LogicalType::VARCHAR) {
 		return nullptr;
@@ -162,7 +162,7 @@ RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, con
                                                const StorageIndex &storage_index, LogicalLimit &logical_limit) const {
 	const auto &colref = primary_order.expression->Cast<BoundColumnRefExpression>();
 	const auto column_type =
-	    colref.return_type == LogicalType::VARCHAR ? OrderByColumnType::STRING : OrderByColumnType::NUMERIC;
+	    colref.GetReturnType() == LogicalType::VARCHAR ? OrderByColumnType::STRING : OrderByColumnType::NUMERIC;
 	const auto order_type = primary_order.type;
 	const auto null_order = primary_order.null_order;
 	const auto order_by = order_type == OrderType::ASCENDING ? OrderByStatistics::MIN : OrderByStatistics::MAX;

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -120,7 +120,7 @@ optional_ptr<LogicalOrder> RowGroupPruner::FindLogicalOrder(const LogicalLimit &
 		return nullptr;
 	}
 
-	if (logical_order.orders[0].expression->type != ExpressionType::BOUND_COLUMN_REF) {
+	if (logical_order.orders[0].expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 		return nullptr;
 	}
 

--- a/src/optimizer/row_number_rewriter.cpp
+++ b/src/optimizer/row_number_rewriter.cpp
@@ -16,7 +16,7 @@ bool RowNumberRewriter::CanOptimize(LogicalOperator &op) {
 	}
 
 	auto &expression = op.expressions[0];
-	if (expression->type != ExpressionType::WINDOW_ROW_NUMBER) {
+	if (expression->GetExpressionType() != ExpressionType::WINDOW_ROW_NUMBER) {
 		return false;
 	}
 	auto &window_expr = expression->Cast<BoundWindowExpression>();

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -32,7 +32,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 	(void)root;
 	// any arithmetic operator involving NULL is always NULL
 	if (constant.value.IsNull()) {
-		return make_uniq<BoundConstantExpression>(Value(root.return_type));
+		return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 	}
 	auto &func_name = root.function.name;
 	if (func_name == "+") {
@@ -54,7 +54,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 		} else if (constant.value == 0) {
 			// multiply by zero: replace with constant or null
 			return ExpressionRewriter::ConstantOrNull(std::move(root.children[1 - constant_child]),
-			                                          Value::Numeric(root.return_type, 0));
+			                                          Value::Numeric(root.GetReturnType(), 0));
 		}
 	} else if (func_name == "//") {
 		if (constant_child == 1) {
@@ -63,7 +63,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 				return std::move(root.children[1 - constant_child]);
 			} else if (constant.value == 0) {
 				// divide by 0, replace with NULL
-				return make_uniq<BoundConstantExpression>(Value(root.return_type));
+				return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 			}
 		}
 	} else {

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -39,7 +39,7 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		//! invertible in practice.
 		auto &cast_expression = column_ref_expr->Cast<BoundCastExpression>();
 		auto target_type = cast_expression.source_type();
-		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.return_type)) {
+		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
 			return nullptr;
 		}
 
@@ -54,7 +54,7 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 
 		// Is the constant cast invertible?
 		if (!cast_constant.IsNull() &&
-		    !BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type)) {
+		    !BoundCastExpression::CastIsInvertible(cast_expression.GetReturnType(), target_type)) {
 			// Cast is not invertible, so we do not rewrite this expression to ensure that the cast is executed
 			return nullptr;
 		}

--- a/src/optimizer/rule/constant_folding.cpp
+++ b/src/optimizer/rule/constant_folding.cpp
@@ -36,7 +36,7 @@ unique_ptr<Expression> ConstantFoldingRule::Apply(LogicalOperator &op, vector<re
 	if (!ExpressionExecutor::TryEvaluateScalar(GetContext(), root, result_value)) {
 		return nullptr;
 	}
-	D_ASSERT(result_value.type().InternalType() == root.return_type.InternalType());
+	D_ASSERT(result_value.type().InternalType() == root.GetReturnType().InternalType());
 	// now get the value from the result vector and insert it back into the plan as a constant expression
 	return make_uniq<BoundConstantExpression>(result_value);
 }

--- a/src/optimizer/rule/constant_order_normalization.cpp
+++ b/src/optimizer/rule/constant_order_normalization.cpp
@@ -119,7 +119,7 @@ unique_ptr<Expression> ConstantOrderNormalizationRule::Apply(LogicalOperator &op
 	}
 
 	D_ASSERT(children.size() == 1);
-	D_ASSERT(children[0]->return_type == root.return_type);
+	D_ASSERT(children[0]->GetReturnType() == root.GetReturnType());
 
 	return std::move(children[0]);
 }

--- a/src/optimizer/rule/date_part_simplification.cpp
+++ b/src/optimizer/rule/date_part_simplification.cpp
@@ -28,7 +28,7 @@ unique_ptr<Expression> DatePartSimplificationRule::Apply(LogicalOperator &op, ve
 
 	if (constant.IsNull()) {
 		// NULL specifier: return constant NULL
-		return make_uniq<BoundConstantExpression>(Value(date_part.return_type));
+		return make_uniq<BoundConstantExpression>(Value(date_part.GetReturnType()));
 	}
 	// otherwise check the specifier
 	auto specifier = GetDatePartSpecifier(StringValue::Get(constant));

--- a/src/optimizer/rule/date_trunc_simplification.cpp
+++ b/src/optimizer/rule/date_trunc_simplification.cpp
@@ -97,12 +97,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 					return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
 				}
 
-				auto trunc = CreateTrunc(date_part, rhs, column_part.return_type);
+				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());
 				if (!trunc) {
 					return nullptr;
 				}
 
-				auto trunc_add = CreateTruncAdd(date_part, rhs, column_part.return_type);
+				auto trunc_add = CreateTruncAdd(date_part, rhs, column_part.GetReturnType());
 				if (!trunc_add) {
 					return nullptr;
 				}
@@ -165,12 +165,12 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 					return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
 				}
 
-				auto trunc = CreateTrunc(date_part, rhs, column_part.return_type);
+				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());
 				if (!trunc) {
 					return nullptr;
 				}
 
-				auto trunc_add = CreateTruncAdd(date_part, rhs, column_part.return_type);
+				auto trunc_add = CreateTruncAdd(date_part, rhs, column_part.GetReturnType());
 				if (!trunc_add) {
 					return nullptr;
 				}
@@ -210,7 +210,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 			// use the rhs as-is, instead of using trunc(rhs + 1 date_part).
 			if (!is_truncated) {
 				// Create date_trunc(part, date_add(rhs, INTERVAL 1 part)) and fold the constant.
-				auto trunc = CreateTruncAdd(date_part, rhs, column_part.return_type);
+				auto trunc = CreateTruncAdd(date_part, rhs, column_part.GetReturnType());
 				if (!trunc) {
 					return nullptr; // Something went wrong---don't do the optimization.
 				}
@@ -228,14 +228,14 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 				if (col_is_lhs) {
 					expr.left = column_part.Copy();
 					// Determine whether the RHS needs to be casted.
-					if (rhs.return_type.id() != expr.left->return_type.id()) {
-						expr.right = CastAndEvaluate(std::move(expr.right), expr.left->return_type);
+					if (rhs.GetReturnType().id() != expr.left->GetReturnType().id()) {
+						expr.right = CastAndEvaluate(std::move(expr.right), expr.left->GetReturnType());
 					}
 				} else {
 					expr.right = column_part.Copy();
 					// Determine whether the RHS needs to be casted.
-					if (rhs.return_type.id() != expr.right->return_type.id()) {
-						expr.left = CastAndEvaluate(std::move(expr.left), expr.right->return_type);
+					if (rhs.GetReturnType().id() != expr.right->GetReturnType().id()) {
+						expr.left = CastAndEvaluate(std::move(expr.left), expr.right->GetReturnType());
 					}
 				}
 			}
@@ -252,7 +252,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 		//                                                                                    INTERVAL 1 part))
 		{
 			// Create date_trunc(part, date_add(rhs, INTERVAL 1 part)) and fold the constant.
-			auto trunc = CreateTruncAdd(date_part, rhs, column_part.return_type);
+			auto trunc = CreateTruncAdd(date_part, rhs, column_part.GetReturnType());
 			if (!trunc) {
 				return nullptr; // Something went wrong---don't do the optimization.
 			}
@@ -347,7 +347,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::CreateTrunc(const BoundConst
 	auto trunc = binder.BindScalarFunction(DEFAULT_SCHEMA, "date_trunc", std::move(args), error);
 
 	// Ensure that the RHS type matches the column type.
-	if (trunc->return_type.id() != return_type.id()) {
+	if (trunc->GetReturnType().id() != return_type.id()) {
 		trunc = BoundCastExpression::AddDefaultCastToType(std::move(trunc), return_type, true);
 	}
 
@@ -397,7 +397,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::CreateTruncAdd(const BoundCo
 	auto trunc = binder.BindScalarFunction(DEFAULT_SCHEMA, "date_trunc", std::move(args3), error);
 
 	// Ensure that the RHS type matches the column type.
-	if (trunc->return_type.id() != return_type.id()) {
+	if (trunc->GetReturnType().id() != return_type.id()) {
 		trunc = BoundCastExpression::AddDefaultCastToType(std::move(trunc), return_type, true);
 	}
 
@@ -421,7 +421,7 @@ bool DateTruncSimplificationRule::DateIsTruncated(const BoundConstantExpression 
 	}
 
 	// Create the node date_trunc(date_part, rhs).
-	auto trunc = CreateTrunc(date_part, rhs, rhs.return_type);
+	auto trunc = CreateTrunc(date_part, rhs, rhs.GetReturnType());
 
 	Value trunc_result, result;
 	if (!ExpressionExecutor::TryEvaluateScalar(rewriter.context, *trunc, trunc_result)) {

--- a/src/optimizer/rule/empty_needle_removal.cpp
+++ b/src/optimizer/rule/empty_needle_removal.cpp
@@ -32,7 +32,7 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 	if (!prefix_expr.IsFoldable()) {
 		return nullptr;
 	}
-	D_ASSERT(root.return_type.id() == LogicalTypeId::BOOLEAN);
+	D_ASSERT(root.GetReturnType().id() == LogicalTypeId::BOOLEAN);
 
 	auto prefix_value = ExpressionExecutor::EvaluateScalar(GetContext(), prefix_expr);
 
@@ -40,7 +40,7 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
 	}
 
-	D_ASSERT(prefix_value.type() == prefix_expr.return_type);
+	D_ASSERT(prefix_value.type() == prefix_expr.GetReturnType());
 	if (prefix_value.type().InternalType() != PhysicalType::VARCHAR) {
 		return nullptr;
 	}

--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -25,8 +25,8 @@ EnumComparisonRule::EnumComparisonRule(ExpressionRewriter &rewriter) : Rule(rewr
 	root = std::move(op);
 }
 
-bool AreMatchesPossible(LogicalType &left, LogicalType &right) {
-	LogicalType *small_enum, *big_enum;
+static bool AreMatchesPossible(const LogicalType &left, const LogicalType &right) {
+	const LogicalType *small_enum, *big_enum;
 	if (EnumType::GetSize(left) < EnumType::GetSize(right)) {
 		small_enum = &left;
 		big_enum = &right;
@@ -51,7 +51,7 @@ unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<ref
 	auto &left_child = bindings[1].get().Cast<BoundCastExpression>();
 	auto &right_child = bindings[3].get().Cast<BoundCastExpression>();
 
-	if (!AreMatchesPossible(left_child.child->return_type, right_child.child->return_type)) {
+	if (!AreMatchesPossible(left_child.child->GetReturnType(), right_child.child->GetReturnType())) {
 		vector<unique_ptr<Expression>> children;
 		children.push_back(std::move(root.left));
 		children.push_back(std::move(root.right));
@@ -62,8 +62,8 @@ unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<ref
 		return nullptr;
 	}
 
-	auto cast_left_to_right =
-	    BoundCastExpression::AddDefaultCastToType(std::move(left_child.child), right_child.child->return_type, true);
+	auto cast_left_to_right = BoundCastExpression::AddDefaultCastToType(std::move(left_child.child),
+	                                                                    right_child.child->GetReturnType(), true);
 	return make_uniq<BoundComparisonExpression>(root.GetExpressionType(), std::move(cast_left_to_right),
 	                                            std::move(right_child.child));
 }

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -28,7 +28,7 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 	//! if the semantics do not change, which only happens when BOTH casts
 	//! are invertible.
 	auto target_type = cast_expression.source_type();
-	if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.return_type)) {
+	if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression.GetReturnType())) {
 		return nullptr;
 	}
 	vector<unique_ptr<BoundConstantExpression>> cast_list;

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -108,7 +108,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	D_ASSERT(root.children.size() == 2);
 
 	if (constant_expr.value.IsNull()) {
-		return make_uniq<BoundConstantExpression>(Value(root.return_type));
+		return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 	}
 
 	// the constant_expr is a scalar expression that we have to fold
@@ -117,7 +117,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	}
 
 	auto constant_value = ExpressionExecutor::EvaluateScalar(GetContext(), constant_expr);
-	D_ASSERT(constant_value.type() == constant_expr.return_type);
+	D_ASSERT(constant_value.type() == constant_expr.GetReturnType());
 	auto &patt_str = StringValue::Get(constant_value);
 
 	bool is_not_like = root.function.name == "!~~";
@@ -144,7 +144,7 @@ unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &
 	// replace LIKE by an optimized function
 	unique_ptr<Expression> result;
 	auto new_function =
-	    make_uniq<BoundFunctionExpression>(expr.return_type, std::move(function), std::move(expr.children), nullptr);
+	    make_uniq<BoundFunctionExpression>(expr.GetReturnType(), std::move(function), std::move(expr.children), nullptr);
 
 	// removing "%" from the pattern
 	pattern.erase(std::remove(pattern.begin(), pattern.end(), '%'), pattern.end());

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -143,8 +143,8 @@ unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &
                                                        string pattern, bool is_not_like) {
 	// replace LIKE by an optimized function
 	unique_ptr<Expression> result;
-	auto new_function =
-	    make_uniq<BoundFunctionExpression>(expr.GetReturnType(), std::move(function), std::move(expr.children), nullptr);
+	auto new_function = make_uniq<BoundFunctionExpression>(expr.GetReturnType(), std::move(function),
+	                                                       std::move(expr.children), nullptr);
 
 	// removing "%" from the pattern
 	pattern.erase(std::remove(pattern.begin(), pattern.end(), '%'), pattern.end());

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -19,7 +19,7 @@ namespace {
 
 bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
 	if (expr.function.name == target_name) {
-		D_ASSERT(!expr.children.empty() && expr.children[0]->return_type.id() == LogicalTypeId::LIST);
+		D_ASSERT(!expr.children.empty() && expr.children[0]->GetReturnType().id() == LogicalTypeId::LIST);
 		return true;
 	}
 
@@ -49,7 +49,7 @@ optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
 }
 
 optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &struct_pack, const string &name) {
-	D_ASSERT(struct_pack.return_type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(struct_pack.GetReturnType().id() == LogicalTypeId::STRUCT);
 	for (auto &child : struct_pack.children) {
 		if (child->GetAlias() == name) {
 			return child.get();
@@ -230,7 +230,7 @@ unique_ptr<Expression> BuildListComprehensionRewrite(ListComprehensionMatch &mat
 		filter_children.push_back(std::move(inner_apply.children[i]));
 	}
 
-	auto filter_return_type = filter_children[0]->return_type;
+	auto filter_return_type = filter_children[0]->GetReturnType();
 	auto filter_bind_info = make_uniq<ListLambdaBindData>(filter_return_type, filter_expr.Copy(), inner_bind.has_index);
 	auto new_filter =
 	    make_uniq<BoundFunctionExpression>(filter_return_type, list_filter_expr.function, std::move(filter_children),
@@ -244,7 +244,7 @@ unique_ptr<Expression> BuildListComprehensionRewrite(ListComprehensionMatch &mat
 		apply_children.push_back(std::move(captured_child));
 	}
 
-	auto apply_return_type = LogicalType::LIST(result_expr.return_type);
+	auto apply_return_type = LogicalType::LIST(result_expr.GetReturnType());
 	auto apply_lambda = result_expr.Copy();
 	if (inner_bind.has_index) {
 		// The apply function included an index but it was not used. Adapt references to exclude index

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -38,16 +38,16 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 	auto &outer_constant = bindings[1].get().Cast<BoundConstantExpression>();
 	auto &arithmetic = bindings[2].get().Cast<BoundFunctionExpression>();
 	auto &inner_constant = bindings[3].get().Cast<BoundConstantExpression>();
-	D_ASSERT(arithmetic.return_type.IsIntegral());
-	D_ASSERT(arithmetic.children[0]->return_type.IsIntegral());
+	D_ASSERT(arithmetic.GetReturnType().IsIntegral());
+	D_ASSERT(arithmetic.children[0]->GetReturnType().IsIntegral());
 	if (inner_constant.value.IsNull() || outer_constant.value.IsNull()) {
 		if (comparison.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
 		    comparison.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 			return nullptr;
 		}
-		return make_uniq<BoundConstantExpression>(Value(comparison.return_type));
+		return make_uniq<BoundConstantExpression>(Value(comparison.GetReturnType()));
 	}
-	auto &constant_type = outer_constant.return_type;
+	auto &constant_type = outer_constant.GetReturnType();
 	hugeint_t outer_value = IntegralValue::Get(outer_constant.value);
 	hugeint_t inner_value = IntegralValue::Get(inner_constant.value);
 

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -77,7 +77,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 	// bind the aggregate
 	vector<LogicalType> types;
 	for (const auto &child : children) {
-		types.emplace_back(child->return_type);
+		types.emplace_back(child->GetReturnType());
 	}
 	auto best_function = binder.BindFunction(func.name, func.functions, types, error);
 	if (!best_function.IsValid()) {

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -213,8 +213,8 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		D_ASSERT(root.children.size() == 2);
 	}
 
-	auto like_expression =
-	    make_uniq<BoundFunctionExpression>(root.GetReturnType(), LikeFun::GetFunction(), std::move(root.children), nullptr);
+	auto like_expression = make_uniq<BoundFunctionExpression>(root.GetReturnType(), LikeFun::GetFunction(),
+	                                                          std::move(root.children), nullptr);
 	auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(like_string.like_string)));
 	like_expression->children[1] = std::move(parameter);
 	return std::move(like_expression);

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -155,12 +155,12 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 	auto regexp_bind_data = root.bind_info.get()->Cast<RegexpMatchesBindData>();
 
 	auto constant_value = ExpressionExecutor::EvaluateScalar(GetContext(), constant_expr);
-	D_ASSERT(constant_value.type() == constant_expr.return_type);
+	D_ASSERT(constant_value.type() == constant_expr.GetReturnType());
 
 	duckdb_re2::RE2::Options parsed_options = regexp_bind_data.options;
 
 	if (constant_expr.value.IsNull()) {
-		return make_uniq<BoundConstantExpression>(Value(root.return_type));
+		return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 	}
 	auto patt_str = StringValue::Get(constant_value);
 
@@ -192,7 +192,7 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		}
 
 		auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(escaped_like_string.like_string)));
-		auto contains = make_uniq<BoundFunctionExpression>(root.return_type, GetStringContains(),
+		auto contains = make_uniq<BoundFunctionExpression>(root.GetReturnType(), GetStringContains(),
 		                                                   std::move(root.children), nullptr);
 		contains->children[1] = std::move(parameter);
 
@@ -214,7 +214,7 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 	}
 
 	auto like_expression =
-	    make_uniq<BoundFunctionExpression>(root.return_type, LikeFun::GetFunction(), std::move(root.children), nullptr);
+	    make_uniq<BoundFunctionExpression>(root.GetReturnType(), LikeFun::GetFunction(), std::move(root.children), nullptr);
 	auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(like_string.like_string)));
 	like_expression->children[1] = std::move(parameter);
 	return std::move(like_expression);

--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -10,7 +10,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggreg
 	for (auto &child : aggr.children) {
 		auto stat = PropagateExpression(child);
 		if (!stat) {
-			stats.push_back(BaseStatistics::CreateUnknown(child->return_type));
+			stats.push_back(BaseStatistics::CreateUnknown(child->GetReturnType()));
 		} else {
 			stats.push_back(stat->Copy());
 		}

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -205,7 +205,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCastEx
 	if (!child_stats) {
 		return nullptr;
 	}
-	auto result_stats = TryPropagateCast(*child_stats, cast.child->return_type, cast.return_type);
+	auto result_stats = TryPropagateCast(*child_stats, cast.child->GetReturnType(), cast.GetReturnType());
 	if (cast.try_cast && result_stats) {
 		result_stats->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	}

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -10,7 +10,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 	for (idx_t i = 0; i < func.children.size(); i++) {
 		auto stat = PropagateExpression(func.children[i]);
 		if (!stat) {
-			stats.push_back(BaseStatistics::CreateUnknown(func.children[i]->return_type));
+			stats.push_back(BaseStatistics::CreateUnknown(func.children[i]->GetReturnType()));
 		} else {
 			stats.push_back(stat->Copy());
 		}

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -124,7 +124,8 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		}
 		const string &fun_name = aggr_expr.function.name;
 		if (fun_name == "min" || fun_name == "max") {
-			if (aggr_expr.children.size() != 1 || aggr_expr.children[0]->type != ExpressionType::BOUND_COLUMN_REF) {
+			if (aggr_expr.children.size() != 1 ||
+			    aggr_expr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 				return;
 			}
 			const auto &col_ref = aggr_expr.children[0]->Cast<BoundColumnRefExpression>();
@@ -149,7 +150,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		for (auto &binding : min_max_bindings) {
 			auto &proj = child_ref.get().Cast<LogicalProjection>();
 			auto &expr = proj.GetExpression(binding);
-			if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
+			if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 				return;
 			}
 			binding = expr.Cast<BoundColumnRefExpression>().binding;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -130,7 +130,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			}
 			const auto &col_ref = aggr_expr.children[0]->Cast<BoundColumnRefExpression>();
 			min_max_bindings.push_back(col_ref.binding);
-			auto comparator = GetComparator(fun_name, col_ref.return_type);
+			auto comparator = GetComparator(fun_name, col_ref.GetReturnType());
 			if (!comparator) {
 				// Type has no min max statistics
 				return;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -16,14 +16,15 @@
 namespace duckdb {
 
 static bool IsDirectFilterColumnRef(const Expression &expr) {
-	return expr.type == ExpressionType::BOUND_REF || expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
+	return expr.GetExpressionType() == ExpressionType::BOUND_REF ||
+	       expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
 }
 
 static void GetColumnIndex(const unique_ptr<Expression> &expr, idx_t &index, string &alias) {
-	if (expr->type == ExpressionType::BOUND_REF) {
+	if (expr->GetExpressionType() == ExpressionType::BOUND_REF) {
 		auto &bound_ref = expr->Cast<BoundReferenceExpression>();
 		index = bound_ref.index;
-		alias = bound_ref.alias;
+		alias = bound_ref.GetAlias();
 		return;
 	}
 	ExpressionIterator::EnumerateChildren(*expr,
@@ -92,14 +93,15 @@ void StatisticsPropagator::UpdateExpressionFilterStatistics(BaseStatistics &inpu
 		auto &comp = expr.Cast<BoundComparisonExpression>();
 		auto is_compare_distinct = comp.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
 		                           comp.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM;
-		if (IsDirectFilterColumnRef(*comp.left) && comp.right->type == ExpressionType::VALUE_CONSTANT) {
+		if (IsDirectFilterColumnRef(*comp.left) && comp.right->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 			auto &constant = comp.right->Cast<BoundConstantExpression>();
 			if (constant.value.type().InternalType() == input.GetType().InternalType()) {
 				UpdateFilterStatistics(input, comp.GetExpressionType(), constant.value);
 			} else if (!is_compare_distinct) {
 				input.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 			}
-		} else if (comp.left->type == ExpressionType::VALUE_CONSTANT && IsDirectFilterColumnRef(*comp.right)) {
+		} else if (comp.left->GetExpressionType() == ExpressionType::VALUE_CONSTANT &&
+		           IsDirectFilterColumnRef(*comp.right)) {
 			auto &constant = comp.left->Cast<BoundConstantExpression>();
 			if (constant.value.type().InternalType() == input.GetType().InternalType()) {
 				UpdateFilterStatistics(input, FlipComparisonExpression(comp.GetExpressionType()), constant.value);
@@ -120,7 +122,7 @@ void StatisticsPropagator::UpdateExpressionFilterStatistics(BaseStatistics &inpu
 	}
 	case ExpressionClass::BOUND_OPERATOR: {
 		auto &op = expr.Cast<BoundOperatorExpression>();
-		if (expr.type == ExpressionType::OPERATOR_IS_NOT_NULL && !op.children.empty() &&
+		if (expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL && !op.children.empty() &&
 		    IsDirectFilterColumnRef(*op.children[0])) {
 			input.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 		}
@@ -136,7 +138,7 @@ static bool IsConstantOrNullFilter(const TableFilter &table_filter) {
 		return false;
 	}
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(table_filter, "IsConstantOrNullFilter");
-	if (expr_filter.expr->type != ExpressionType::BOUND_FUNCTION) {
+	if (expr_filter.expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
 		return false;
 	}
 	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
@@ -152,7 +154,7 @@ static bool CanReplaceConstantOrNull(const TableFilter &table_filter) {
 	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
 	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
 		for (auto child = ++func.children.begin(); child != func.children.end(); child++) {
-			switch (child->get()->type) {
+			switch (child->get()->GetExpressionType()) {
 			case ExpressionType::BOUND_REF:
 			case ExpressionType::VALUE_CONSTANT:
 				continue;

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -327,7 +327,7 @@ void StatisticsPropagator::CreateFilterFromJoinStats(unique_ptr<LogicalOperator>
                                                      const BaseStatistics &stats_before,
                                                      const BaseStatistics &stats_after) {
 	// Only do this for integral colref's that have stats
-	if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF || !expr->return_type.IsIntegral() ||
+	if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF || !expr->GetReturnType().IsIntegral() ||
 	    !NumericStats::HasMinMax(stats_before) || !NumericStats::HasMinMax(stats_after)) {
 		return;
 	}

--- a/src/optimizer/statistics_propagator.cpp
+++ b/src/optimizer/statistics_propagator.cpp
@@ -151,7 +151,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(Expression 
 unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(unique_ptr<Expression> &expr) {
 	auto stats = PropagateExpression(*expr, expr);
 	if (Settings::Get<DebugVerifyStatsSetting>(context) && stats) {
-		expr->verification_stats = stats->ToUnique();
+		expr->SetVerificationStats(stats->ToUnique());
 	}
 	return stats;
 }

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -67,7 +67,7 @@ bool TopN::CanOptimize(LogicalOperator &op, optional_ptr<ClientContext> context)
 void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	// pushdown dynamic filters through the Top-N operator
 	bool nulls_first = op.orders[0].null_order == OrderByNullType::NULLS_FIRST;
-	auto &type = op.orders[0].expression->return_type;
+	auto &type = op.orders[0].expression->GetReturnType();
 	if (!TypeIsNumeric(type.InternalType()) && type.id() != LogicalTypeId::VARCHAR) {
 		// only supported for numeric and varchar types
 		return;

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -74,7 +74,7 @@ vector<LogicalType> ExtractReturnTypes(const vector<unique_ptr<Expression>> &exp
 	vector<LogicalType> types;
 	types.reserve(exprs.size());
 	for (const auto &expr : exprs) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 	return types;
 }
@@ -366,7 +366,7 @@ TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate
 	array_length_exprs.push_back(make_uniq<BoundConstantExpression>(1));
 
 	const auto array_length_fun = array_length_entry.functions.GetFunctionByArguments(
-	    context, {array_length_exprs[0]->return_type, array_length_exprs[1]->return_type});
+	    context, {array_length_exprs[0]->GetReturnType(), array_length_exprs[1]->GetReturnType()});
 	auto bound_array_length_fun = function_binder.BindScalarFunction(array_length_fun, std::move(array_length_exprs));
 
 	// generate_series
@@ -378,7 +378,7 @@ TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate
 	generate_series_exprs.push_back(std::move(bound_array_length_fun));
 
 	const auto generate_series_fun = generate_series_entry.functions.GetFunctionByArguments(
-	    context, {generate_series_exprs[0]->return_type, generate_series_exprs[1]->return_type});
+	    context, {generate_series_exprs[0]->GetReturnType(), generate_series_exprs[1]->GetReturnType()});
 	auto bound_generate_series_fun =
 	    function_binder.BindScalarFunction(generate_series_fun, std::move(generate_series_exprs));
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -157,7 +157,7 @@ string GetLHSRowIdColumnName(const unique_ptr<LogicalOperator> &op, idx_t column
 	if (op.get()->type != LogicalOperatorType::LOGICAL_GET) {
 		D_ASSERT(op.get()->type == LogicalOperatorType::LOGICAL_PROJECTION);
 		D_ASSERT(op.get()->expressions.size() > column_id &&
-		         op.get()->expressions[column_id]->type == ExpressionType::BOUND_COLUMN_REF);
+		         op.get()->expressions[column_id]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF);
 		const auto &colref = op.get()->expressions[column_id]->Cast<BoundColumnRefExpression>();
 		column_id = colref.binding.column_index;
 		current_op = *op.get()->children[0];
@@ -340,7 +340,7 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 	aggregate->group_stats.resize(aggregate->groups.size());
 	for (idx_t i = 0; i < aggregate->groups.size(); i++) {
 		auto &group = aggregate->groups[i];
-		if (group->type == ExpressionType::BOUND_COLUMN_REF) {
+		if (group->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 			auto &column_ref = group->Cast<BoundColumnRefExpression>();
 			auto group_stats = stats->find(column_ref.binding);
 			if (group_stats == stats->end()) {
@@ -384,7 +384,7 @@ TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate
 
 	// unnest
 	auto unnest_row_number_expr = make_uniq<BoundUnnestExpression>(LogicalType::BIGINT);
-	unnest_row_number_expr->alias = "row_number";
+	unnest_row_number_expr->SetAlias("row_number");
 	unnest_row_number_expr->child = std::move(bound_generate_series_fun);
 
 	return unique_ptr<Expression>(std::move(unnest_row_number_expr));
@@ -447,7 +447,7 @@ void TopNWindowElimination::AddStructExtractExprs(
 		fun_args[1] = make_uniq<BoundConstantExpression>(alias);
 
 		auto bound_function = function_binder.BindScalarFunction(struct_extract_fun, std::move(fun_args));
-		bound_function->alias = alias;
+		bound_function->SetAlias(alias);
 		exprs.push_back(std::move(bound_function));
 	}
 }
@@ -512,7 +512,7 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 		return false;
 	}
 
-	const auto comparison = filter.expressions[0]->type;
+	const auto comparison = filter.expressions[0]->GetExpressionType();
 	switch (comparison) {
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 	case ExpressionType::COMPARE_LESSTHAN:
@@ -523,7 +523,7 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 	}
 
 	auto &filter_comparison = filter.expressions[0]->Cast<BoundComparisonExpression>();
-	if (filter_comparison.right->type != ExpressionType::VALUE_CONSTANT) {
+	if (filter_comparison.right->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 		return false;
 	}
 	auto &filter_value = filter_comparison.right->Cast<BoundConstantExpression>();
@@ -556,7 +556,7 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 		return false;
 	}
 
-	if (filter_comparison.left->type != ExpressionType::BOUND_COLUMN_REF) {
+	if (filter_comparison.left->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 		return false;
 	}
 	VisitExpression(&filter_comparison.left);
@@ -604,7 +604,7 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 			}
 		}
 	}
-	if (window.expressions[0]->type != ExpressionType::WINDOW_ROW_NUMBER) {
+	if (window.expressions[0]->GetExpressionType() != ExpressionType::WINDOW_ROW_NUMBER) {
 		return false;
 	}
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
@@ -679,7 +679,7 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 		const auto aggregate_value_binding = column_references.begin()->first;
 		column_references.clear();
 
-		if (window_expr.orders[0].expression->type == ExpressionType::BOUND_COLUMN_REF &&
+		if (window_expr.orders[0].expression->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF &&
 		    aggregate_args[0]->Cast<BoundColumnRefExpression>().binding == aggregate_value_binding) {
 			return {};
 		}
@@ -868,7 +868,7 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 
 bool TopNWindowElimination::ExtractSingleBinding(unique_ptr<Expression> *expr, ColumnBinding &binding,
                                                  const bool require_direct_column_ref) {
-	if (require_direct_column_ref && expr->get()->type != ExpressionType::BOUND_COLUMN_REF) {
+	if (require_direct_column_ref && expr->get()->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 		return false;
 	}
 	VisitExpression(expr);

--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -166,7 +166,7 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &root, unique_pt
 				bind_col.binding = ColumnBinding(unnest_get_index, bind_col.binding.column_index);
 				auto unnest_proj_idx = ColumnBinding::PushExpression(unnest->expressions, std::move(unnest_expr));
 				ColumnBinding new_column_ref(bind_col.binding.table_index, unnest_proj_idx);
-				auto unnest_ref = make_uniq<BoundColumnRefExpression>(bind_col.alias, unnest_get->types[i],
+				auto unnest_ref = make_uniq<BoundColumnRefExpression>(bind_col.GetAlias(), unnest_get->types[i],
 				                                                      new_column_ref, bind_col.depth);
 				proj.expressions[col_bind.column_index] = std::move(unnest_ref);
 				proj.types[col_bind.column_index] = unnest_get->types[i];

--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -272,7 +272,7 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		auto join = make_uniq<LogicalComparisonJoin>(JoinType::INNER);
 		for (size_t i = 0; i < partitions.size(); ++i) {
 			auto left_expr = partitions[i]->Copy();
-			auto right_expr = make_uniq<BoundColumnRefExpression>(partitions[i]->return_type,
+			auto right_expr = make_uniq<BoundColumnRefExpression>(partitions[i]->GetReturnType(),
 			                                                      ColumnBinding(group_index, ProjectionIndex(i)));
 			join->conditions.push_back(
 			    JoinCondition(std::move(left_expr), std::move(right_expr), ExpressionType::COMPARE_NOT_DISTINCT_FROM));

--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -159,7 +159,7 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::Optimize(unique_ptr<Logical
 
 bool WindowSelfJoinOptimizer::CanOptimize(const BoundWindowExpression &w_expr,
                                           const BoundWindowExpression &w_expr0) const {
-	if (w_expr.type != ExpressionType::WINDOW_AGGREGATE) {
+	if (w_expr.GetExpressionType() != ExpressionType::WINDOW_AGGREGATE) {
 		return false;
 	}
 	//	We can only accept ORDER BY clauses if the frame is the entire partition

--- a/src/parser/peg/transformer/transform_common.cpp
+++ b/src/parser/peg/transformer/transform_common.cpp
@@ -310,7 +310,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformRowType(PEGTransfor
 	for (auto &child : colid_list) {
 		auto &type_expr = UnboundType::GetTypeExpression(child.second);
 		auto new_type_expr = type_expr->Copy();
-		new_type_expr->alias = child.first;
+		new_type_expr->SetAlias(child.first);
 		struct_children.push_back(std::move(new_type_expr));
 	}
 	return make_uniq<TypeExpression>("STRUCT", std::move(struct_children));
@@ -348,7 +348,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformUnionType(PEGTransf
 		union_names.insert(colid.first);
 		auto &type_expr = UnboundType::GetTypeExpression(colid.second);
 		auto new_type_expr = type_expr->Copy();
-		new_type_expr->alias = colid.first;
+		new_type_expr->SetAlias(colid.first);
 		union_children.push_back(std::move(new_type_expr));
 	}
 	return make_uniq<TypeExpression>("UNION", std::move(union_children));

--- a/src/parser/peg/transformer/transform_create_secret.cpp
+++ b/src/parser/peg/transformer/transform_create_secret.cpp
@@ -4,10 +4,10 @@
 namespace duckdb {
 
 Value PEGTransformerFactory::GetConstantExpressionValue(unique_ptr<ParsedExpression> &expr) {
-	if (expr->type == ExpressionType::VALUE_CONSTANT) {
+	if (expr->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 		return expr->Cast<ConstantExpression>().value;
 	}
-	if (expr->type == ExpressionType::COLUMN_REF) {
+	if (expr->GetExpressionType() == ExpressionType::COLUMN_REF) {
 		return expr->Cast<ColumnRefExpression>().GetName();
 	}
 	return Value();

--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -540,7 +540,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformColumnCollation(PEG
 	auto dotted_identifier = transformer.Transform<vector<string>>(list_pr.Child<ListParseResult>(1));
 	string collation = StringUtil::Join(dotted_identifier, ".");
 	auto expr = make_uniq<ConstantExpression>(Value(collation));
-	expr->alias = "collation";
+	expr->SetAlias("collation");
 	return std::move(expr);
 }
 

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -496,7 +496,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformArrayParensSelect(P
 			} else if (sub_select) {
 				// if we have a SELECT we can push the ORDER BY clause into the SELECT list and reference it
 				auto alias = "__array_internal_idx_" + to_string(++array_idx);
-				order.expression->alias = alias;
+				order.expression->SetAlias(alias);
 				sub_select->select_list.push_back(std::move(order.expression));
 				order.expression = make_uniq<ColumnRefExpression>(alias);
 			} else {
@@ -1337,7 +1337,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformPrefixExpression(PE
 	for (auto it = prefixes.rbegin(); it != prefixes.rend(); ++it) {
 		const string &prefix = *it;
 
-		if (prefix == "-" && expr->type == ExpressionType::VALUE_CONSTANT) {
+		if (prefix == "-" && expr->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 			auto &const_expr = expr->Cast<ConstantExpression>();
 			if (TryNegateValue(const_expr.value)) {
 				continue;
@@ -2509,8 +2509,8 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformListComprehensionEx
 	auto filter_expr = transformer.Transform<unique_ptr<ParsedExpression>>(list_comprehension_filter.GetResult());
 
 	// STAGE 1: list_apply(in_expr, x -> struct_pack(filter := ..., result := ...))
-	filter_expr->alias = "filter";
-	result_expr->alias = "result";
+	filter_expr->SetAlias("filter");
+	result_expr->SetAlias("result");
 
 	vector<unique_ptr<ParsedExpression>> struct_children;
 	struct_children.push_back(std::move(filter_expr));

--- a/src/parser/peg/transformer/transform_select.cpp
+++ b/src/parser/peg/transformer/transform_select.cpp
@@ -199,9 +199,9 @@ unique_ptr<SelectStatement> PEGTransformerFactory::TransformSimpleSelect(PEGTran
 		auto window_functions =
 		    transformer.Transform<vector<unique_ptr<ParsedExpression>>>(opt_window_clause.GetResult());
 		for (auto &window_func : window_functions) {
-			D_ASSERT(!window_func->alias.empty());
-			string window_name(window_func->alias);
-			window_func->alias = "";
+			D_ASSERT(!window_func->GetAlias().empty());
+			string window_name(window_func->GetAlias());
+			window_func->ClearAlias();
 			auto it = transformer.window_clauses.find(window_name);
 			if (it != transformer.window_clauses.end()) {
 				throw ParserException("window \"%s\" is already defined", window_name);
@@ -348,7 +348,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionArgument(PE
 	auto &choice_pr = list_pr.Child<ChoiceParseResult>(0).GetResult();
 	if (choice_pr.name == "NamedParameter") {
 		auto parameter = transformer.Transform<MacroParameter>(choice_pr);
-		parameter.expression->alias = parameter.name;
+		parameter.expression->SetAlias(parameter.name);
 		return std::move(parameter.expression);
 	}
 	return transformer.Transform<unique_ptr<ParsedExpression>>(choice_pr);
@@ -507,7 +507,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformExpressionAsCollabe
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto expr = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.Child<ListParseResult>(0));
 	auto &collabel_or_string = list_pr.Child<ListParseResult>(2);
-	expr->alias = transformer.Transform<string>(collabel_or_string);
+	expr->SetAlias(transformer.Transform<string>(collabel_or_string));
 	return expr;
 }
 
@@ -516,7 +516,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformColIdExpression(PEG
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto &colid = list_pr.Child<ListParseResult>(0);
 	auto expr = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.Child<ListParseResult>(2));
-	expr->alias = transformer.Transform<string>(colid);
+	expr->SetAlias(transformer.Transform<string>(colid));
 	return expr;
 }
 
@@ -526,7 +526,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformExpressionOptIdenti
 	auto expr = transformer.Transform<unique_ptr<ParsedExpression>>(list_pr.Child<ListParseResult>(0));
 	auto &opt_identifier = list_pr.Child<OptionalParseResult>(1);
 	if (opt_identifier.HasResult()) {
-		expr->alias = opt_identifier.GetResult().Cast<IdentifierParseResult>().identifier;
+		expr->SetAlias(opt_identifier.GetResult().Cast<IdentifierParseResult>().identifier);
 	}
 	return expr;
 }
@@ -738,7 +738,7 @@ vector<PivotColumnEntry> PEGTransformerFactory::TransformUnpivotTargetList(PEGTr
 	vector<PivotColumnEntry> result;
 	for (auto &target : target_list) {
 		PivotColumnEntry pivot_entry;
-		pivot_entry.alias = target->alias;
+		pivot_entry.alias = target->GetAlias();
 		pivot_entry.expr = std::move(target);
 		result.push_back(std::move(pivot_entry));
 	}
@@ -828,7 +828,7 @@ vector<PivotColumnEntry> PEGTransformerFactory::TransformPivotTargetList(PEGTran
 	auto target_list = transformer.Transform<vector<unique_ptr<ParsedExpression>>>(extract_target_list);
 	for (auto &target : target_list) {
 		PivotColumnEntry pivot_entry;
-		pivot_entry.alias = target->alias;
+		pivot_entry.alias = target->GetAlias();
 		bool transformed = TransformPivotInList(target, pivot_entry);
 		if (!transformed) {
 			// For pivot we throw an exception
@@ -1704,7 +1704,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformWindowDefinition(PE
 	transformer.in_window_definition = true;
 	auto window_function = transformer.Transform<unique_ptr<WindowExpression>>(list_pr.Child<ListParseResult>(2));
 	transformer.in_window_definition = false;
-	window_function->alias = list_pr.Child<IdentifierParseResult>(0).identifier;
+	window_function->SetAlias(list_pr.Child<IdentifierParseResult>(0).identifier);
 	return std::move(window_function);
 }
 

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -6,7 +6,7 @@
 
 namespace duckdb {
 
-QueryErrorContext::QueryErrorContext(const ParsedExpression &expr) : query_location(expr.query_location) {
+QueryErrorContext::QueryErrorContext(const ParsedExpression &expr) : query_location(expr.GetQueryLocation()) {
 }
 
 string QueryErrorContext::Format(const string &query, const string &error_message, optional_idx error_loc,

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -233,8 +233,8 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		if (aggr.children.size() < ordered_set_agg) {
 			for (auto &order : aggr.order_bys->orders) {
 				auto &child = BoundExpression::GetExpression(*order.expression);
-				types.push_back(child->return_type);
-				arguments.push_back(child->return_type);
+				types.push_back(child->GetReturnType());
+				arguments.push_back(child->GetReturnType());
 				if (order_sensitive) {
 					children.push_back(child->Copy());
 				} else {
@@ -249,8 +249,8 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 
 	for (idx_t i = 0; i < aggr.children.size(); i++) {
 		auto &child = BoundExpression::GetExpression(*aggr.children[i]);
-		types.push_back(child->return_type);
-		arguments.push_back(child->return_type);
+		types.push_back(child->GetReturnType());
+		arguments.push_back(child->GetReturnType());
 		children.push_back(std::move(child));
 	}
 
@@ -278,7 +278,7 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		auto &config = DBConfig::GetConfig(context);
 		for (auto &order : aggr.order_bys->orders) {
 			auto &order_expr = BoundExpression::GetExpression(*order.expression);
-			PushCollation(context, order_expr, order_expr->return_type);
+			PushCollation(context, order_expr, order_expr->GetReturnType());
 			const auto sense = config.ResolveOrder(context, order.type);
 			const auto null_order = config.ResolveNullOrder(context, sense, order.null_order);
 			order_bys->orders.emplace_back(sense, null_order, std::move(order_expr));
@@ -321,7 +321,7 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 
 	// now create a column reference referring to the aggregate
 	auto colref = make_uniq<BoundColumnRefExpression>(aggr.GetAlias().empty() ? bound_aggr.ToString() : aggr.GetAlias(),
-	                                                  bound_aggr.return_type,
+	                                                  bound_aggr.GetReturnType(),
 	                                                  ColumnBinding(node.aggregate_index, aggr_index), depth);
 	// move the aggregate expression into the set of bound aggregates
 	return BindResult(std::move(colref));

--- a/src/planner/binder/expression/bind_collate_expression.cpp
+++ b/src/planner/binder/expression/bind_collate_expression.cpp
@@ -15,14 +15,14 @@ BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth
 	if (child->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
-	if (child->return_type.id() != LogicalTypeId::VARCHAR) {
+	if (child->GetReturnType().id() != LogicalTypeId::VARCHAR) {
 		throw BinderException(child->GetQueryLocation(), "collations are only supported for type varchar");
 	}
 	// Validate the collation, but don't use it
-	auto collation_test = make_uniq_base<Expression, BoundConstantExpression>(Value(child->return_type));
+	auto collation_test = make_uniq_base<Expression, BoundConstantExpression>(Value(child->GetReturnType()));
 	auto collation_type = LogicalType::VARCHAR_COLLATION(expr.collation);
 	PushCollation(context, collation_test, collation_type);
-	child->return_type = collation_type;
+	child->SetReturnType(collation_type);
 	return BindResult(std::move(child));
 }
 

--- a/src/planner/binder/expression/bind_collate_expression.cpp
+++ b/src/planner/binder/expression/bind_collate_expression.cpp
@@ -16,7 +16,7 @@ BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth
 		throw ParameterNotResolvedException();
 	}
 	if (child->return_type.id() != LogicalTypeId::VARCHAR) {
-		throw BinderException(child->query_location, "collations are only supported for type varchar");
+		throw BinderException(child->GetQueryLocation(), "collations are only supported for type varchar");
 	}
 	// Validate the collation, but don't use it
 	auto collation_test = make_uniq_base<Expression, BoundConstantExpression>(Value(child->return_type));

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -141,17 +141,17 @@ LogicalType BoundComparisonExpression::BindComparison(ClientContext &context, co
 
 LogicalType ExpressionBinder::GetExpressionReturnType(const Expression &expr) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-		if (expr.return_type == LogicalTypeId::VARCHAR && StringType::GetCollation(expr.return_type).empty()) {
+		if (expr.GetReturnType() == LogicalTypeId::VARCHAR && StringType::GetCollation(expr.GetReturnType()).empty()) {
 			return LogicalTypeId::STRING_LITERAL;
 		}
-		if (expr.return_type.IsIntegral()) {
+		if (expr.GetReturnType().IsIntegral()) {
 			auto &constant = expr.Cast<BoundConstantExpression>();
 			if (!constant.value.IsNull()) {
 				return LogicalType::INTEGER_LITERAL(constant.value);
 			}
 		}
 	}
-	return expr.return_type;
+	return expr.GetReturnType();
 }
 
 BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t depth) {

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -439,7 +439,8 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 
 	// get the logical type of the children of the list
 	auto &list_child = BoundExpression::GetExpression(*function.children[list_idx]);
-	if (list_child->GetReturnType().id() != LogicalTypeId::LIST && list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
+	if (list_child->GetReturnType().id() != LogicalTypeId::LIST &&
+	    list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
 	    list_child->GetReturnType().id() != LogicalTypeId::SQLNULL &&
 	    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN) {
 		return BindResult("Invalid LIST argument during lambda function binding!");

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -115,7 +115,7 @@ ListReduceRebindResult MaybeRebindListReduceLambda(ClientContext &context, idx_t
 
 	const bool has_initial = function_child_types.size() == 3;
 	auto &bound_lambda_expr = bind_lambda_result.expression->Cast<BoundLambdaExpression>();
-	const auto &lambda_return_type = bound_lambda_expr.lambda_expr->return_type;
+	const auto &lambda_return_type = bound_lambda_expr.lambda_expr->GetReturnType();
 
 	auto list_child_type = function_child_types[0];
 	if (list_child_type.id() != LogicalTypeId::SQLNULL && list_child_type.id() != LogicalTypeId::UNKNOWN) {
@@ -159,9 +159,9 @@ ListReduceRebindResult MaybeRebindListReduceLambda(ClientContext &context, idx_t
 		// Avoid repeated rebinds for DECIMAL type widening by forcing the lambda return type to the chosen
 		// accumulator type when decimals are involved.
 		if (TypeContainsDecimal(accumulator_type) ||
-		    TypeContainsDecimal(rebound_lambda_expr.lambda_expr->return_type)) {
-			if (rebound_lambda_expr.lambda_expr->return_type != accumulator_type) {
-				const auto old_return_type = rebound_lambda_expr.lambda_expr->return_type;
+		    TypeContainsDecimal(rebound_lambda_expr.lambda_expr->GetReturnType())) {
+			if (rebound_lambda_expr.lambda_expr->GetReturnType() != accumulator_type) {
+				const auto old_return_type = rebound_lambda_expr.lambda_expr->GetReturnType();
 				auto cast_expr = BoundCastExpression::AddCastToType(context, std::move(rebound_lambda_expr.lambda_expr),
 				                                                    accumulator_type);
 				if (!cast_expr) {
@@ -434,14 +434,14 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 		}
 
 		const auto &child = BoundExpression::GetExpression(*function.children[i]);
-		function_child_types.push_back(child->return_type);
+		function_child_types.push_back(child->GetReturnType());
 	}
 
 	// get the logical type of the children of the list
 	auto &list_child = BoundExpression::GetExpression(*function.children[list_idx]);
-	if (list_child->return_type.id() != LogicalTypeId::LIST && list_child->return_type.id() != LogicalTypeId::ARRAY &&
-	    list_child->return_type.id() != LogicalTypeId::SQLNULL &&
-	    list_child->return_type.id() != LogicalTypeId::UNKNOWN) {
+	if (list_child->GetReturnType().id() != LogicalTypeId::LIST && list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
+	    list_child->GetReturnType().id() != LogicalTypeId::SQLNULL &&
+	    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN) {
 		return BindResult("Invalid LIST argument during lambda function binding!");
 	}
 

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -207,7 +207,7 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 	offset += bound_lambda_expr.parameter_count;
 	offset += bound_lambda_expr.captures.size();
 
-	replacement = make_uniq<BoundReferenceExpression>(original->GetAlias(), original->return_type, offset);
+	replacement = make_uniq<BoundReferenceExpression>(original->GetAlias(), original->GetReturnType(), offset);
 	bound_lambda_expr.captures.push_back(std::move(original));
 }
 

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -66,7 +66,7 @@ LogicalType ExpressionBinder::ResolveOperatorType(OperatorExpression &op, vector
 	case ExpressionType::OPERATOR_IS_NULL:
 	case ExpressionType::OPERATOR_IS_NOT_NULL:
 		// IS (NOT) NULL always returns a boolean, and does not cast its children
-		if (!children[0]->return_type.IsValid()) {
+		if (!children[0]->GetReturnType().IsValid()) {
 			throw ParameterNotResolvedException();
 		}
 		return LogicalType::BOOLEAN;
@@ -79,7 +79,7 @@ LogicalType ExpressionBinder::ResolveOperatorType(OperatorExpression &op, vector
 		return ResolveCoalesceType(op, children);
 	}
 	case ExpressionType::OPERATOR_TRY: {
-		return children[0]->return_type;
+		return children[0]->GetReturnType();
 	}
 	case ExpressionType::OPERATOR_NOT:
 		return ResolveNotType(op, children);
@@ -129,7 +129,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	case ExpressionType::ARRAY_EXTRACT: {
 		D_ASSERT(op.children[0]->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 		auto &b_exp = BoundExpression::GetExpression(*op.children[0]);
-		const auto &b_exp_type = b_exp->return_type;
+		const auto &b_exp_type = b_exp->GetReturnType();
 		if (b_exp_type.id() == LogicalTypeId::MAP) {
 			function_name = "map_extract_value";
 		} else if (b_exp_type.IsJSONType() && op.children.size() == 2) {
@@ -143,11 +143,11 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 					// Array extraction: if the cast fails it's definitely out-of-bounds for a JSON array
 					auto index = UIntegerValue::Get(const_exp.value);
 					const_exp.value = StringUtil::Format("$[%lld]", index);
-					const_exp.return_type = LogicalType::VARCHAR;
-				} else if (const_exp.return_type.id() == LogicalType::VARCHAR) {
+					const_exp.SetReturnType(LogicalType::VARCHAR);
+				} else if (const_exp.GetReturnType().id() == LogicalType::VARCHAR) {
 					// Field extraction
 					const_exp.value = StringUtil::Format("$.\"%s\"", const_exp.value.ToString());
-					const_exp.return_type = LogicalType::VARCHAR;
+					const_exp.SetReturnType(LogicalType::VARCHAR);
 				}
 			}
 		} else if (b_exp_type.id() == LogicalTypeId::VARIANT && op.children.size() == 2) {
@@ -155,9 +155,9 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 			auto &i_exp = BoundExpression::GetExpression(*op.children[1]);
 			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 				auto &const_exp = i_exp->Cast<BoundConstantExpression>();
-				if (!const_exp.value.IsNull() && const_exp.return_type.IsNumeric()) {
+				if (!const_exp.value.IsNull() && const_exp.GetReturnType().IsNumeric()) {
 					const_exp.value = const_exp.value.DefaultCastAs(LogicalType::UINTEGER, true);
-					const_exp.return_type = LogicalType::UINTEGER;
+					const_exp.SetReturnType(LogicalType::UINTEGER);
 				}
 			}
 		} else {
@@ -173,11 +173,11 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		D_ASSERT(op.children[0]->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 		D_ASSERT(op.children[1]->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 		auto &extract_exp = BoundExpression::GetExpression(*op.children[0]);
-		if (extract_exp->HasParameter() || extract_exp->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (extract_exp->HasParameter() || extract_exp->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 		auto &name_exp = BoundExpression::GetExpression(*op.children[1]);
-		const auto &extract_expr_type = extract_exp->return_type;
+		const auto &extract_expr_type = extract_exp->GetReturnType();
 		if (extract_expr_type.id() != LogicalTypeId::STRUCT && extract_expr_type.id() != LogicalTypeId::UNION &&
 		    extract_expr_type.id() != LogicalTypeId::MAP && extract_expr_type.id() != LogicalTypeId::SQLNULL &&
 		    !extract_expr_type.IsJSONType() && extract_expr_type.id() != LogicalTypeId::VARIANT &&
@@ -197,7 +197,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 				auto &const_exp = i_exp->Cast<BoundConstantExpression>();
 				if (!const_exp.value.IsNull()) {
 					const_exp.value = StringUtil::Format("%s", const_exp.value.ToString());
-					const_exp.return_type = LogicalType::VARCHAR;
+					const_exp.SetReturnType(LogicalType::VARCHAR);
 				}
 			}
 		} else if (extract_expr_type.IsJSONType()) {
@@ -207,7 +207,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 				auto &const_exp = name_exp->Cast<BoundConstantExpression>();
 				if (!const_exp.value.IsNull()) {
 					const_exp.value = StringUtil::Format("$.\"%s\"", const_exp.value.ToString());
-					const_exp.return_type = LogicalType::VARCHAR;
+					const_exp.SetReturnType(LogicalType::VARCHAR);
 				}
 			}
 		} else {

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -43,7 +43,7 @@ static bool TypeIsUnnamedStruct(const LogicalType &type) {
 }
 
 static void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique_ptr<Expression>> &result,
-                             const vector<LogicalType> &types, ExpressionType comparison_type) {
+                                    const vector<LogicalType> &types, ExpressionType comparison_type) {
 	// two scenarios
 	// Single Expression (standard):
 	// x IN (...)

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -35,14 +35,14 @@ public:
 	}
 };
 
-bool TypeIsUnnamedStruct(const LogicalType &type) {
+static bool TypeIsUnnamedStruct(const LogicalType &type) {
 	if (type.id() != LogicalTypeId::STRUCT) {
 		return false;
 	}
 	return StructType::IsUnnamed(type);
 }
 
-void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique_ptr<Expression>> &result,
+static void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique_ptr<Expression>> &result,
                              const vector<LogicalType> &types, ExpressionType comparison_type) {
 	// two scenarios
 	// Single Expression (standard):
@@ -50,7 +50,7 @@ void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique_ptr<Ex
 	// Multi-Expression/Struct:
 	// (a, b) IN (SELECT ...)
 	// the latter has an unnamed struct on the LHS that is created by a "ROW" expression
-	auto &return_type = child->return_type;
+	auto &return_type = child->GetReturnType();
 	if (!TypeIsUnnamedStruct(return_type)) {
 		// child is not an unnamed struct
 		return;
@@ -125,7 +125,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		if (expr.child) {
 			auto &child = BoundExpression::GetExpression(*expr.child);
 			// Check if child is an unexpanded struct before extraction
-			has_unexpanded_struct = TypeIsUnnamedStruct(child->return_type);
+			has_unexpanded_struct = TypeIsUnnamedStruct(child->GetReturnType());
 			ExtractSubqueryChildren(child, child_expressions, bound_subquery.bound_node.types, expr.comparison_type);
 			if (child_expressions.empty()) {
 				child_expressions.push_back(std::move(child));
@@ -135,7 +135,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		// If we have an unexpanded struct (kept intact for ordered comparison),
 		// the subquery might return multiple columns that need to be combined into a struct
 		if (has_unexpanded_struct && expected_columns == 1 && bound_subquery.bound_node.types.size() > 1 &&
-		    TypeIsUnnamedStruct(child_expressions[0]->return_type)) {
+		    TypeIsUnnamedStruct(child_expressions[0]->GetReturnType())) {
 			// The child is a struct with N elements, and the subquery returns N columns
 			// This is allowed - the subquery columns will be matched against the struct during execution
 			expected_columns = bound_subquery.bound_node.types.size();
@@ -162,7 +162,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		// Special case: if we have a single struct child and multiple subquery types,
 		// this means we kept the struct intact for ordered comparison (e.g., (a,b) < ANY(...))
 		if (child_expressions.size() == 1 && bound_node.types.size() > 1 &&
-		    TypeIsUnnamedStruct(child_expressions[0]->return_type)) {
+		    TypeIsUnnamedStruct(child_expressions[0]->GetReturnType())) {
 			// Keep the struct as-is for proper lexicographic row comparison
 			result->children.push_back(std::move(child_expressions[0]));
 			// Store all the subquery types - they will be used to construct the RHS struct during planning

--- a/src/planner/binder/expression/bind_type_expression.cpp
+++ b/src/planner/binder/expression/bind_type_expression.cpp
@@ -71,7 +71,7 @@ BindResult ExpressionBinder::BindExpression(TypeExpression &type_expr, idx_t dep
 
 		// Otherwise, return the user type directly!
 		auto result_expr = make_uniq<BoundConstantExpression>(Value::TYPE(type_entry.user_type));
-		result_expr->query_location = type_expr.GetQueryLocation();
+		result_expr->SetQueryLocation(type_expr.GetQueryLocation());
 		return BindResult(std::move(result_expr));
 	}
 
@@ -107,7 +107,7 @@ BindResult ExpressionBinder::BindExpression(TypeExpression &type_expr, idx_t dep
 
 	// Return the resulting type!
 	auto result_expr = make_uniq<BoundConstantExpression>(Value::TYPE(result_type));
-	result_expr->query_location = type_expr.GetQueryLocation();
+	result_expr->SetQueryLocation(type_expr.GetQueryLocation());
 	return BindResult(std::move(result_expr));
 }
 

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -138,7 +138,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	}
 	auto &child = BoundExpression::GetExpression(*function.children[0]);
 	child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
-	auto &child_type = child->return_type;
+	auto &child_type = child->GetReturnType();
 	unnest_level--;
 
 	if (unnest_level > 0) {
@@ -199,7 +199,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 			return_type = ArrayType::GetChildType(return_type);
 		}
 
-		if (unnest_expr->return_type.id() == LogicalTypeId::ARRAY) {
+		if (unnest_expr->GetReturnType().id() == LogicalTypeId::ARRAY) {
 			unnest_expr = BoundCastExpression::AddArrayCastToList(context, std::move(unnest_expr));
 		}
 
@@ -234,10 +234,10 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 			// check if there are any structs left
 			bool has_structs = false;
 			for (auto &expr : struct_expressions) {
-				if (expr->return_type.id() == LogicalTypeId::STRUCT) {
+				if (expr->GetReturnType().id() == LogicalTypeId::STRUCT) {
 					// struct! push a struct_extract
-					auto &child_types = StructType::GetChildTypes(expr->return_type);
-					if (StructType::IsUnnamed(expr->return_type)) {
+					auto &child_types = StructType::GetChildTypes(expr->GetReturnType());
+					if (StructType::IsUnnamed(expr->GetReturnType())) {
 						for (idx_t child_index = 0; child_index < child_types.size(); child_index++) {
 							new_expressions.push_back(
 							    CreateBoundStructExtractIndex(context, expr->Copy(), child_index + 1));

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -246,8 +246,8 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 						for (auto &entry : child_types) {
 							vector<string> current_key_path;
 							// During recursive expansion, not all expressions are BoundFunctionExpression
-							if (keep_parent_names && expr->type == ExpressionType::BOUND_FUNCTION) {
-								current_key_path.push_back(expr->alias);
+							if (keep_parent_names && expr->GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+								current_key_path.push_back(expr->GetAlias());
 							}
 							current_key_path.push_back(entry.first);
 							new_expressions.push_back(

--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -16,7 +16,7 @@ static void AddChild(unique_ptr<ParsedExpression> &child, expression_list_t &new
 		return;
 	}
 	auto &unpack = child->Cast<OperatorExpression>();
-	D_ASSERT(unpack.type == ExpressionType::OPERATOR_UNPACK);
+	D_ASSERT(unpack.GetExpressionType() == ExpressionType::OPERATOR_UNPACK);
 	D_ASSERT(unpack.children.size() == 1);
 	auto &unpack_child = unpack.children[0];
 
@@ -79,13 +79,13 @@ static void ReplaceInOperator(unique_ptr<ParsedExpression> &expr, expression_lis
 	bool allowed = false;
 	for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
 		auto &type = allowed_types[i];
-		if (operator_expr.type == type) {
+		if (operator_expr.GetExpressionType() == type) {
 			allowed = true;
 		}
 	}
 	if (!allowed) {
 		throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
-		                      EnumUtil::ToString(operator_expr.type));
+		                      EnumUtil::ToString(operator_expr.GetExpressionType()));
 	}
 
 	// Replace children

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -73,7 +73,7 @@ static LogicalType BindRangeExpression(ClientContext &context, const string &nam
 	D_ASSERT(expr->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 	auto &bound = BoundExpression::GetExpression(*expr);
 	QueryErrorContext error_context(bound->GetQueryLocation());
-	if (bound->return_type == LogicalType::SQLNULL) {
+	if (bound->GetReturnType() == LogicalType::SQLNULL) {
 		throw BinderException(error_context, "Window RANGE expressions cannot be NULL");
 	}
 	children.emplace_back(std::move(bound));
@@ -86,11 +86,11 @@ static LogicalType BindRangeExpression(ClientContext &context, const string &nam
 	}
 	// +/- can be applied to non-scalar types,
 	// so we can't rely on function binding to catch all problems.
-	if (!IsRangeType(function->return_type)) {
+	if (!IsRangeType(function->GetReturnType())) {
 		throw BinderException(error_context, "Invalid type for Window RANGE expression");
 	}
 	bound = std::move(function);
-	return bound->return_type;
+	return bound->GetReturnType();
 }
 
 BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_t depth) {
@@ -151,7 +151,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		}
 		auto &order_expr = order.expression;
 		auto &bound_order = BoundExpression::GetExpression(*order_expr);
-		const auto type_id = bound_order->return_type.id();
+		const auto type_id = bound_order->GetReturnType().id();
 		if (type_id == LogicalTypeId::TIME || type_id == LogicalTypeId::TIME_TZ) {
 			//	Convert to time + epoch and rebind
 			unique_ptr<ParsedExpression> epoch = make_uniq<ConstantExpression>(Value::DATE(date_t::epoch()));
@@ -177,16 +177,16 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 	for (auto &order : window.arg_orders) {
 		auto &order_expr = order.expression;
 		auto &bound_order = BoundExpression::GetExpression(*order_expr);
-		ExpressionBinder::PushCollation(context, bound_order, bound_order->return_type);
+		ExpressionBinder::PushCollation(context, bound_order, bound_order->GetReturnType());
 	}
 	for (auto &part_expr : window.partitions) {
 		auto &bound_partition = BoundExpression::GetExpression(*part_expr);
-		ExpressionBinder::PushCollation(context, bound_partition, bound_partition->return_type);
+		ExpressionBinder::PushCollation(context, bound_partition, bound_partition->GetReturnType());
 	}
 	for (auto &order : window.orders) {
 		auto &order_expr = order.expression;
 		auto &bound_order = BoundExpression::GetExpression(*order_expr);
-		ExpressionBinder::PushCollation(context, bound_order, bound_order->return_type);
+		ExpressionBinder::PushCollation(context, bound_order, bound_order->GetReturnType());
 	}
 	// successfully bound all children: create bound window function
 	vector<LogicalType> types;
@@ -195,7 +195,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		D_ASSERT(child.get());
 		D_ASSERT(child->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 		auto &bound = BoundExpression::GetExpression(*child);
-		types.push_back(bound->return_type);
+		types.push_back(bound->GetReturnType());
 		children.push_back(std::move(bound));
 	}
 	//  Determine the function type.
@@ -227,7 +227,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		aggregate = make_uniq<BoundAggregateFunction>(window_bound_aggregate->function);
 		bind_info = std::move(window_bound_aggregate->bind_info);
 		children = std::move(window_bound_aggregate->children);
-		sql_type = window_bound_aggregate->return_type;
+		sql_type = window_bound_aggregate->GetReturnType();
 	} else {
 		auto &func = entry->Cast<WindowFunctionCatalogEntry>();
 
@@ -278,7 +278,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		window_func = std::move(window_bound_function->window);
 		bind_info = std::move(window_bound_function->bind_info);
 		children = std::move(window_bound_function->children);
-		sql_type = window_bound_function->return_type;
+		sql_type = window_bound_function->GetReturnType();
 	}
 	auto result =
 	    make_uniq<BoundWindowExpression>(sql_type, std::move(aggregate), std::move(window_func), std::move(bind_info));
@@ -331,7 +331,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		D_ASSERT(order_expr.get());
 		D_ASSERT(order_expr->GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION);
 		auto &bound_order = BoundExpression::GetExpression(*order_expr);
-		auto order_type = bound_order->return_type;
+		auto order_type = bound_order->GetReturnType();
 		if (window.start_expr) {
 			order_type = LogicalType::MaxLogicalType(context, order_type, start_type);
 		}
@@ -367,7 +367,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 	result->exclude_clause = window.exclude_clause;
 
 	// move the WINDOW expression into the set of bound windows
-	auto &window_type = result->return_type;
+	auto &window_type = result->GetReturnType();
 	auto window_idx = ColumnBinding::PushExpression(node.windows, std::move(result));
 	auto colref = make_uniq<BoundColumnRefExpression>(std::move(name), window_type,
 	                                                  ColumnBinding(node.window_index, window_idx), depth);

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -107,7 +107,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		return BindMacro(*macro, entry->Cast<ScalarMacroCatalogEntry>(), depth, macro_expr);
 	}
 
-	auto name = window.alias;
+	auto name = window.GetAlias();
 
 	if (inside_window) {
 		throw BinderException(error_context, "window function calls cannot be nested");

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -88,7 +88,7 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 	for (idx_t expr_idx = 0; expr_idx < statement.key_targets.size(); expr_idx++) {
 		auto &expr = statement.key_targets[expr_idx];
 
-		if (expr->type == ExpressionType::COLUMN_REF) {
+		if (expr->GetExpressionType() == ExpressionType::COLUMN_REF) {
 			if (expr->HasAlias()) {
 				throw BinderException(expr->GetQueryLocation(),
 				                      "In USING KEY, only direct calls to an aggregate function can have an alias.");
@@ -104,7 +104,7 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 
 			key_references.insert(column_index);
 			key_targets.push_back(std::move(bound_expr));
-		} else if (expr->type == ExpressionType::FUNCTION) {
+		} else if (expr->GetExpressionType() == ExpressionType::FUNCTION) {
 			auto &func_expr = expr->Cast<FunctionExpression>();
 
 			if (func_expr.filter) {
@@ -159,7 +159,8 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 				}
 				aggregate_idx = ProjectionIndex(NumericCast<idx_t>(std::distance(result.names.begin(), names_iter)));
 			} else {
-				if (bound_children.empty() || bound_children[0]->type != ExpressionType::BOUND_COLUMN_REF) {
+				if (bound_children.empty() ||
+				    bound_children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 					// No alias and no way to infer target column through first argument
 					throw BinderException(
 					    expr->GetQueryLocation(),

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -143,7 +143,7 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 			// Bind the children of the aggregate function
 			for (auto &child : func_expr.children) {
 				auto bound_child = expression_binder.Bind(child);
-				aggregation_input_types.push_back(bound_child->return_type);
+				aggregation_input_types.push_back(bound_child->GetReturnType());
 				bound_children.push_back(std::move(bound_child));
 			}
 
@@ -194,7 +194,7 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 				                      result.names[aggregate_idx]);
 			}
 
-			return_types[aggregate_idx] = aggregate->return_type;
+			return_types[aggregate_idx] = aggregate->GetReturnType();
 			payload_references[aggregate_idx] = std::move(aggregate);
 		} else {
 			throw BinderException(

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -252,9 +252,9 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 	}
 }
 
-unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const vector<string> &names,
-                                             const vector<LogicalType> &sql_types, TableIndex table_index,
-                                             ProjectionIndex index) {
+static unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const vector<string> &names,
+                                                    const vector<LogicalType> &sql_types, TableIndex table_index,
+                                                    ProjectionIndex index) {
 	if (index >= sql_types.size()) {
 		throw BinderException(*expr, "ORDER term out of range - should be between 1 and %lld", sql_types.size());
 	}
@@ -266,9 +266,10 @@ unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const 
 	return std::move(result);
 }
 
-unique_ptr<Expression> FinalizeBindOrderExpression(unique_ptr<Expression> expr, TableIndex table_index,
-                                                   const vector<string> &names, const vector<LogicalType> &sql_types,
-                                                   const SelectBindState &bind_state) {
+static unique_ptr<Expression> FinalizeBindOrderExpression(unique_ptr<Expression> expr, TableIndex table_index,
+                                                          const vector<string> &names,
+                                                          const vector<LogicalType> &sql_types,
+                                                          const SelectBindState &bind_state) {
 	auto &constant = expr->Cast<BoundConstantExpression>();
 	switch (constant.value.type().id()) {
 	case LogicalTypeId::UBIGINT: {
@@ -296,7 +297,7 @@ unique_ptr<Expression> FinalizeBindOrderExpression(unique_ptr<Expression> expr, 
 			if (sql_types[index].id() != LogicalTypeId::VARCHAR) {
 				throw BinderException(*result, "COLLATE can only be applied to varchar columns");
 			}
-			result->return_type = LogicalType::VARCHAR_COLLATION(std::move(collation));
+			result->SetReturnType(LogicalType::VARCHAR_COLLATION(std::move(collation)));
 		}
 		return result;
 	}
@@ -317,7 +318,7 @@ static void AssignReturnType(unique_ptr<Expression> &expr, TableIndex table_inde
 		return;
 	}
 	auto &bound_colref = expr->Cast<BoundColumnRefExpression>();
-	bound_colref.return_type = sql_types[bound_colref.binding.column_index];
+	bound_colref.SetReturnType(sql_types[bound_colref.binding.column_index]);
 }
 
 void Binder::BindModifiers(BoundQueryNode &result, TableIndex table_index, const vector<string> &names,
@@ -334,7 +335,7 @@ void Binder::BindModifiers(BoundQueryNode &result, TableIndex table_index, const
 				}
 			}
 			for (auto &expr : distinct.target_distincts) {
-				ExpressionBinder::PushCollation(context, expr, expr->return_type);
+				ExpressionBinder::PushCollation(context, expr, expr->GetReturnType());
 			}
 			break;
 		}
@@ -370,7 +371,7 @@ void Binder::BindModifiers(BoundQueryNode &result, TableIndex table_index, const
 			}
 			for (auto &order_node : order.orders) {
 				auto &expr = order_node.expression;
-				ExpressionBinder::PushCollation(context, order_node.expression, expr->return_type);
+				ExpressionBinder::PushCollation(context, order_node.expression, expr->GetReturnType());
 			}
 			break;
 		}
@@ -498,7 +499,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			// bind the groups
 			LogicalType group_type;
 			auto bound_expr = group_binder.Bind(group_expressions[i], &group_type);
-			D_ASSERT(bound_expr->return_type.id() != LogicalTypeId::INVALID);
+			D_ASSERT(bound_expr->GetReturnType().id() != LogicalTypeId::INVALID);
 
 			// find out whether the expression contains a subquery, it can't be copied if so
 			auto &bound_expr_ref = *bound_expr;
@@ -510,7 +511,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 				// if there is a collation on a group x, we should group by the collated expr,
 				// but also push a first(x) aggregate in case x is selected (uncollated)
 
-				auto first_fun = FirstFunctionGetter::GetFunction(bound_expr_ref.return_type);
+				auto first_fun = FirstFunctionGetter::GetFunction(bound_expr_ref.GetReturnType());
 				vector<unique_ptr<Expression>> first_children;
 				// FIXME: would be better to just refer to this expression, but for now we copy
 				first_children.push_back(bound_expr_ref.Copy());
@@ -593,8 +594,8 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 			for (auto &struct_expr : struct_expressions) {
 				new_names.push_back(struct_expr->GetName());
-				result.types.push_back(struct_expr->return_type);
-				internal_sql_types.push_back(struct_expr->return_type);
+				result.types.push_back(struct_expr->GetReturnType());
+				internal_sql_types.push_back(struct_expr->GetReturnType());
 				result.select_list.push_back(std::move(struct_expr));
 			}
 			bind_state.AddExpandedColumn(struct_expressions.size());
@@ -639,7 +640,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	// push the GROUP BY ALL expressions into the group set
 	for (auto &group_by_all_index : group_by_all_indexes) {
 		auto &expr = result.select_list[group_by_all_index];
-		auto &return_type = expr->return_type;
+		auto &return_type = expr->GetReturnType();
 		auto group_proj_idx = ColumnBinding::PushExpression(result.groups.group_expressions, std::move(expr));
 		auto group_ref =
 		    make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(result.group_index, group_proj_idx));

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -215,7 +215,7 @@ void Binder::BuildUnionByNameInfo(BoundSetOperationNode &result) {
 		// if we have re-order expressions push a projection
 		vector<LogicalType> child_types;
 		for (auto &expr : child_reorder_expressions) {
-			child_types.push_back(expr->return_type);
+			child_types.push_back(expr->GetReturnType());
 		}
 		auto child_projection =
 		    make_uniq<LogicalProjection>(GenerateTableIndex(), std::move(child_reorder_expressions));

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -119,8 +119,9 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		D_ASSERT(root);
 		vector<unique_ptr<Expression>> prune_expressions;
 		for (idx_t i = 0; i < statement.column_count; i++) {
-			prune_expressions.push_back(make_uniq<BoundColumnRefExpression>(
-			    projection.expressions[i]->GetReturnType(), ColumnBinding(statement.projection_index, ProjectionIndex(i))));
+			prune_expressions.push_back(
+			    make_uniq<BoundColumnRefExpression>(projection.expressions[i]->GetReturnType(),
+			                                        ColumnBinding(statement.projection_index, ProjectionIndex(i))));
 		}
 		auto prune = make_uniq<LogicalProjection>(statement.prune_index, std::move(prune_expressions));
 		prune->AddChild(std::move(root));

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -120,7 +120,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		vector<unique_ptr<Expression>> prune_expressions;
 		for (idx_t i = 0; i < statement.column_count; i++) {
 			prune_expressions.push_back(make_uniq<BoundColumnRefExpression>(
-			    projection.expressions[i]->return_type, ColumnBinding(statement.projection_index, ProjectionIndex(i))));
+			    projection.expressions[i]->GetReturnType(), ColumnBinding(statement.projection_index, ProjectionIndex(i))));
 		}
 		auto prune = make_uniq<LogicalProjection>(statement.prune_index, std::move(prune_expressions));
 		prune->AddChild(std::move(root));

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -42,7 +42,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		FunctionBinder function_binder(binder);
 		auto count_star =
 		    function_binder.BindAggregateFunction(count_star_fun, {}, nullptr, AggregateType::NON_DISTINCT);
-		auto idx_type = count_star->return_type;
+		auto idx_type = count_star->GetReturnType();
 		vector<unique_ptr<Expression>> aggregate_list;
 		aggregate_list.push_back(std::move(count_star));
 		auto aggregate_index = binder.GenerateTableIndex();
@@ -86,13 +86,13 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		// we push an aggregate that returns the FIRST element
 		vector<unique_ptr<Expression>> expressions;
 		auto bound =
-		    make_uniq<BoundColumnRefExpression>(expr.return_type, ColumnBinding(table_idx, ProjectionIndex(0)));
+		    make_uniq<BoundColumnRefExpression>(expr.GetReturnType(), ColumnBinding(table_idx, ProjectionIndex(0)));
 		vector<unique_ptr<Expression>> first_children;
 		first_children.push_back(std::move(bound));
 
 		FunctionBinder function_binder(binder);
 		auto first_agg =
-		    function_binder.BindAggregateFunction(FirstFunctionGetter::GetFunction(expr.return_type),
+		    function_binder.BindAggregateFunction(FirstFunctionGetter::GetFunction(expr.GetReturnType()),
 		                                          std::move(first_children), nullptr, AggregateType::NON_DISTINCT);
 
 		expressions.push_back(std::move(first_agg));
@@ -112,9 +112,9 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			// CASE WHEN count > 1 THEN error('Scalar subquery can only return a single row') ELSE first_agg END
 			auto proj_index = binder.GenerateTableIndex();
 
-			auto first_ref = make_uniq<BoundColumnRefExpression>(plan->expressions[0]->return_type,
+			auto first_ref = make_uniq<BoundColumnRefExpression>(plan->expressions[0]->GetReturnType(),
 			                                                     ColumnBinding(aggr_index, ProjectionIndex(0)));
-			auto count_ref = make_uniq<BoundColumnRefExpression>(plan->expressions[1]->return_type,
+			auto count_ref = make_uniq<BoundColumnRefExpression>(plan->expressions[1]->GetReturnType(),
 			                                                     ColumnBinding(aggr_index, ProjectionIndex(1)));
 
 			auto constant_one = make_uniq<BoundConstantExpression>(Value::BIGINT(1));
@@ -127,7 +127,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			          "return a single row.\n\nUse \"SET scalar_subquery_error_on_multiple_rows=false\" to revert to "
 			          "previous behavior of returning a random row.")));
 			auto error_expr = function_binder.BindScalarFunction(ErrorFun::GetFunction(), std::move(error_children));
-			error_expr->return_type = first_ref->return_type;
+			error_expr->SetReturnType(first_ref->GetReturnType());
 			auto case_expr =
 			    make_uniq<BoundCaseExpression>(std::move(count_check), std::move(error_expr), std::move(first_ref));
 
@@ -149,7 +149,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 
 		// we replace the original subquery with a BoundColumnRefExpression referring to the first result of the
 		// aggregation
-		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.return_type,
+		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(),
 		                                           ColumnBinding(aggr_index, ProjectionIndex(0)));
 	}
 	default: {
@@ -190,8 +190,8 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			JoinCondition cond(std::move(expr.children[0]), std::move(struct_expr), expr.comparison_type);
 
 			// push collations
-			ExpressionBinder::PushCollation(binder.context, cond.LeftReference(), cond.GetLHS().return_type);
-			ExpressionBinder::PushCollation(binder.context, cond.RightReference(), cond.GetRHS().return_type);
+			ExpressionBinder::PushCollation(binder.context, cond.LeftReference(), cond.GetLHS().GetReturnType());
+			ExpressionBinder::PushCollation(binder.context, cond.RightReference(), cond.GetRHS().GetReturnType());
 
 			join->conditions.push_back(std::move(cond));
 		} else {
@@ -213,7 +213,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		root = std::move(join);
 
 		// we replace the original subquery with a BoundColumnRefExpression referring to the mark column
-		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.return_type,
+		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(),
 		                                           ColumnBinding(mark_index, ProjectionIndex(0)));
 	}
 	}
@@ -311,7 +311,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		delim_join->AddChild(std::move(plan));
 		root = std::move(delim_join);
 		// finally push the BoundColumnRefExpression referring to the data element returned by the join
-		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.return_type, plan_column);
+		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(), plan_column);
 	}
 	case SubqueryType::EXISTS: {
 		// correlated EXISTS query
@@ -326,7 +326,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		delim_join->AddChild(std::move(plan));
 		root = std::move(delim_join);
 		// finally push the BoundColumnRefExpression referring to the marker
-		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.return_type,
+		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(),
 		                                           ColumnBinding(mark_index, ProjectionIndex(0)));
 	}
 	default: {
@@ -364,7 +364,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 		delim_join->AddChild(std::move(dependent_join));
 		root = std::move(delim_join);
 		// finally push the BoundColumnRefExpression referring to the marker
-		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.return_type,
+		return make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(),
 		                                           ColumnBinding(mark_index, ProjectionIndex(0)));
 	}
 	}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -295,7 +295,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 			select_node.types.clear();
 			for (auto &expr : projection->expressions) {
 				select_node.names.push_back(expr->GetName());
-				select_node.types.push_back(expr->return_type);
+				select_node.types.push_back(expr->GetReturnType());
 			}
 			select_node.plan = std::move(projection);
 		}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -454,7 +454,7 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 	if (!expr) {
 		return result;
 	}
-	if (expr->type == ExpressionType::STAR) {
+	if (expr->GetExpressionType() == ExpressionType::STAR) {
 		auto &star = expr->Cast<StarExpression>();
 		// for compatibility with previous copy implementation - turn a raw * into a * string literal
 		if (star.relation_name.empty() && star.exclude_list.empty() && star.replace_list.empty() &&

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -294,7 +294,7 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 			auto &param_name = it.first;
 			auto &param_expr = it.second;
 
-			if (param_expr->type == ExpressionType::VALUE_CONSTANT) {
+			if (param_expr->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 				continue;
 			}
 
@@ -311,7 +311,7 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 
 			// Save this back as a constant expression
 			auto const_expr = make_uniq<ConstantExpression>(default_val);
-			const_expr->alias = param_name;
+			const_expr->SetAlias(param_name);
 			it.second = std::move(const_expr);
 		}
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -424,9 +424,9 @@ LogicalType Binder::BindLogicalTypeInternal(const unique_ptr<ParsedExpression> &
 		throw BinderException(*type_expr, "Type expression is not constant");
 	}
 
-	if (expr->return_type != LogicalTypeId::TYPE) {
+	if (expr->GetReturnType() != LogicalTypeId::TYPE) {
 		throw BinderException(*type_expr, "Expected a type returning expression, but got expression of type '%s'",
-		                      expr->return_type.ToString());
+		                      expr->GetReturnType().ToString());
 	}
 
 	// Shortcut for constant expressions

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -296,8 +296,8 @@ void Binder::BindGeneratedColumns(BoundCreateTableInfo &info) {
 		}
 		if (col.Type().id() == LogicalTypeId::ANY) {
 			// Do this before changing the type, so we know it's the first time the type is set
-			col.ChangeGeneratedExpressionType(bound_expression->return_type);
-			col.SetType(bound_expression->return_type);
+			col.ChangeGeneratedExpressionType(bound_expression->GetReturnType());
+			col.SetType(bound_expression->GetReturnType());
 
 			// Update the type in the binding, for future expansions
 			table_binding->SetColumnType(i.index, col.Type());

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -43,10 +43,10 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		if (is_literal) {
 			auto &constant = bound_expr->Cast<BoundConstantExpression>();
 			LogicalType return_type;
-			if (constant.return_type == LogicalTypeId::VARCHAR &&
-			    StringType::GetCollation(constant.return_type).empty()) {
+			if (constant.GetReturnType() == LogicalTypeId::VARCHAR &&
+			    StringType::GetCollation(constant.GetReturnType()).empty()) {
 				return_type = LogicalTypeId::STRING_LITERAL;
-			} else if (constant.return_type.IsIntegral()) {
+			} else if (constant.GetReturnType().IsIntegral()) {
 				return_type = LogicalType::INTEGER_LITERAL(constant.value);
 			} else {
 				return_type = constant.value.type();

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -33,11 +33,11 @@ static void ValidateMergeColumns(const Expression &expr, MergeActionCondition co
 
 		if (condition == MergeActionCondition::WHEN_NOT_MATCHED_BY_TARGET && is_target_column) {
 			throw BinderException("Target column '%s' cannot be referenced in a WHEN NOT MATCHED BY TARGET clause",
-			                      colref.alias.empty() ? colref.ToString() : colref.alias);
+			                      colref.GetAlias().empty() ? colref.ToString() : colref.GetAlias());
 		}
 		if (condition == MergeActionCondition::WHEN_NOT_MATCHED_BY_SOURCE && is_source_column) {
 			throw BinderException("Source column '%s' cannot be referenced in a WHEN NOT MATCHED BY SOURCE clause",
-			                      colref.alias.empty() ? colref.ToString() : colref.alias);
+			                      colref.GetAlias().empty() ? colref.ToString() : colref.GetAlias());
 		}
 	});
 }
@@ -383,7 +383,7 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 
 		// insert the source marker
 		auto marker = make_uniq<BoundConstantExpression>(Value::INTEGER(42));
-		marker->alias = "source_marker";
+		marker->SetAlias("source_marker");
 		ColumnBinding source_marker;
 		auto source_marker_idx = ColumnBinding::PushExpression(select_list, std::move(marker));
 		source_marker = ColumnBinding(new_proj_index, source_marker_idx);
@@ -404,7 +404,7 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 		// push a reference
 		merge_into->source_marker = projection_expressions.size();
 		auto marker_ref = make_uniq<BoundColumnRefExpression>(LogicalType::INTEGER, source_marker);
-		marker_ref->alias = "source_marker";
+		marker_ref->SetAlias("source_marker");
 		projection_expressions.push_back(std::move(marker_ref));
 	}
 

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -70,7 +70,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 			WhereBinder where_binder(*this, context);
 			auto cond = where_binder.Bind(action.condition);
 			PlanSubqueries(cond, root);
-			auto cond_type = cond->return_type;
+			auto cond_type = cond->GetReturnType();
 			auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
 			result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
 		} else {
@@ -169,7 +169,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		}
 
 		for (auto &insert_expr : insert_expressions) {
-			auto insert_type = insert_expr->return_type;
+			auto insert_type = insert_expr->GetReturnType();
 			auto expr_index = ColumnBinding::PushExpression(expressions, std::move(insert_expr));
 			result->expressions.push_back(
 			    make_uniq<BoundColumnRefExpression>(insert_type, ColumnBinding(proj_index, expr_index)));

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -109,7 +109,7 @@ void Binder::BindRowIdColumns(TableCatalogEntry &table, LogicalGet &get, vector<
 		}
 		auto row_id_expr = make_uniq<BoundColumnRefExpression>(
 		    row_id_entry->second.type, ColumnBinding(get.table_index, ProjectionIndex(column_idx)));
-		row_id_expr->alias = row_id_entry->second.name;
+		row_id_expr->SetAlias(row_id_entry->second.name);
 		expressions.push_back(std::move(row_id_expr));
 		if (column_idx == column_ids.size()) {
 			get.AddColumnId(row_id_column);

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -61,7 +61,7 @@ void Binder::BindUpdateSet(TableIndex proj_index, unique_ptr<LogicalOperator> &r
 			auto bound_expr = binder.Bind(expr);
 			PlanSubqueries(bound_expr, root);
 
-			auto bound_type = bound_expr->return_type;
+			auto bound_type = bound_expr->GetReturnType();
 			auto expr_index = ColumnBinding::PushExpression(projection_expressions, std::move(bound_expr));
 
 			update_expressions.push_back(

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -494,7 +494,7 @@ BoundStatement Binder::BindBoundPivot(PivotRef &ref) {
 			}
 			result.bound_pivot.pivot_values.push_back(std::move(pivot_str));
 			names.push_back(std::move(name));
-			types.push_back(aggr->return_type);
+			types.push_back(aggr->GetReturnType());
 		}
 	}
 	result.bound_pivot.group_count = ref.bound_group_names.size();

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -89,7 +89,7 @@ struct ReplacePivotAggregateOperator {
 
 	static void HandleAggregate(unique_ptr<ParsedExpression> &expr, FunctionExpression &aggr_function,
 	                            TYPE &replacement_expr) {
-		if (replacement_expr->type != ExpressionType::COLUMN_REF) {
+		if (replacement_expr->GetExpressionType() != ExpressionType::COLUMN_REF) {
 			throw BinderException(*expr, "Pivot expression can only have one aggregate");
 		}
 		auto aggr = std::move(expr);
@@ -375,7 +375,7 @@ static unique_ptr<SelectNode> PivotFinalOperator(PivotBindState &bind_state, Piv
 			auto &pivot_aggr_name = aggregate_names[aggr_name_idx++];
 			// replace column ref with name
 			ReplacePivotColumnRef(*aggr, pivot_aggr_name);
-			aggr->alias = pivot_aggr_name;
+			aggr->SetAlias(pivot_aggr_name);
 
 			final_pivot_operator->select_list.push_back(std::move(aggr));
 		}
@@ -876,7 +876,7 @@ unique_ptr<SelectNode> Binder::BindUnpivot(Binder &child_binder, PivotRef &ref,
 	// construct the UNNEST expression for the set of names (constant)
 	auto unpivot_list = Value::LIST(LogicalType::VARCHAR, std::move(unpivot_names));
 	auto unpivot_name_expr = make_uniq<ConstantExpression>(std::move(unpivot_list));
-	unpivot_name_expr->alias = select_names[column_count];
+	unpivot_name_expr->SetAlias(select_names[column_count]);
 	select_node->select_list.push_back(std::move(unpivot_name_expr));
 
 	// construct the unpivot lists for the set of unpivoted columns
@@ -886,7 +886,7 @@ unique_ptr<SelectNode> Binder::BindUnpivot(Binder &child_binder, PivotRef &ref,
 	}
 	for (idx_t i = 0; i < unpivot_expressions.size(); i++) {
 		auto list_expr = make_uniq<FunctionExpression>("unpivot_list", std::move(unpivot_expressions[i]));
-		list_expr->alias = select_names[column_count + 1 + i];
+		list_expr->SetAlias(select_names[column_count + 1 + i]);
 		select_node->select_list.push_back(std::move(list_expr));
 	}
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -310,10 +310,10 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 		row_number->end = WindowBoundary::CURRENT_ROW_ROWS;
 		string ordinality_alias = ordinality_column_name;
 		if (return_names.size() < column_name_alias.size()) {
-			row_number->alias = column_name_alias[return_names.size()];
+			row_number->SetAlias(column_name_alias[return_names.size()]);
 			ordinality_alias = column_name_alias[return_names.size()];
 		} else {
-			row_number->alias = ordinality_column_name;
+			row_number->SetAlias(ordinality_column_name);
 		}
 		return_names.push_back(ordinality_alias);
 		return_types.push_back(LogicalType::BIGINT);

--- a/src/planner/bound_parameter_map.cpp
+++ b/src/planner/bound_parameter_map.cpp
@@ -65,7 +65,7 @@ unique_ptr<BoundParameterExpression> BoundParameterMap::BindParameterExpression(
 		rebind = true;
 	}
 
-	bound_expr->return_type = identifier_type;
+	bound_expr->SetReturnType(identifier_type);
 	return bound_expr;
 }
 

--- a/src/planner/expression.cpp
+++ b/src/planner/expression.cpp
@@ -125,4 +125,8 @@ bool Expression::ListEquals(const vector<unique_ptr<Expression>> &left, const ve
 	return ExpressionUtil::ListEquals(left, right);
 }
 
+void Expression::SetVerificationStats(unique_ptr<BaseStatistics> stats) {
+	verification_stats = std::move(stats);
+}
+
 } // namespace duckdb

--- a/src/planner/expression/bound_case_expression.cpp
+++ b/src/planner/expression/bound_case_expression.cpp
@@ -9,7 +9,7 @@ BoundCaseExpression::BoundCaseExpression(LogicalType type)
 
 BoundCaseExpression::BoundCaseExpression(unique_ptr<Expression> when_expr, unique_ptr<Expression> then_expr,
                                          unique_ptr<Expression> else_expr_p)
-    : Expression(ExpressionType::CASE_EXPR, ExpressionClass::BOUND_CASE, then_expr->return_type),
+    : Expression(ExpressionType::CASE_EXPR, ExpressionClass::BOUND_CASE, then_expr->GetReturnType()),
       else_expr(std::move(else_expr_p)) {
 	BoundCaseCheck check;
 	check.when_expr = std::move(when_expr);

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -26,7 +26,7 @@ BoundCastExpression::BoundCastExpression(ClientContext &context, unique_ptr<Expr
                                          LogicalType target_type_p)
     : Expression(ExpressionType::OPERATOR_CAST, ExpressionClass::BOUND_CAST, std::move(target_type_p)),
       child(std::move(child_p)), try_cast(false),
-      bound_cast(BindCastFunction(context, child->return_type, return_type)) {
+      bound_cast(BindCastFunction(context, child->GetReturnType(), return_type)) {
 }
 
 static unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> expr, const LogicalType &target_type,
@@ -34,7 +34,7 @@ static unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> e
 	if (ExpressionBinder::GetExpressionReturnType(*expr) == target_type) {
 		return expr;
 	}
-	auto &expr_type = expr->return_type;
+	auto &expr_type = expr->GetReturnType();
 	if (target_type.id() == LogicalTypeId::LIST && expr_type.id() == LogicalTypeId::LIST) {
 		auto &target_list = ListType::GetChildType(target_type);
 		auto &expr_list = ListType::GetChildType(expr_type);
@@ -56,40 +56,40 @@ static unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr,
 		if (!target_type.IsValid()) {
 			// invalidate the parameter
 			parameter.parameter_data->return_type = LogicalType::INVALID;
-			parameter.return_type = target_type;
+			parameter.SetReturnType(target_type);
 			return expr;
 		}
 		if (parameter.parameter_data->return_type.id() == LogicalTypeId::INVALID) {
 			// we don't know the type of this parameter
-			parameter.return_type = target_type;
+			parameter.SetReturnType(target_type);
 			return expr;
 		}
 		if (parameter.parameter_data->return_type.id() == LogicalTypeId::UNKNOWN) {
 			// prepared statement parameter cast - but there is no type, convert the type
 			parameter.parameter_data->return_type = target_type;
-			parameter.return_type = target_type;
+			parameter.SetReturnType(target_type);
 			return expr;
 		}
 		// prepared statement parameter already has a type
 		if (parameter.parameter_data->return_type == target_type) {
 			// this type! we are done
-			parameter.return_type = parameter.parameter_data->return_type;
+			parameter.SetReturnType(parameter.parameter_data->return_type);
 			return expr;
 		}
 		// invalidate the type
 		parameter.parameter_data->return_type = LogicalType::INVALID;
-		parameter.return_type = target_type;
+		parameter.SetReturnType(target_type);
 		return expr;
 	} else if (expr->GetExpressionClass() == ExpressionClass::BOUND_DEFAULT) {
 		D_ASSERT(target_type.IsValid());
 		auto &def = expr->Cast<BoundDefaultExpression>();
-		def.return_type = target_type;
+		def.SetReturnType(target_type);
 	}
 	if (!target_type.IsValid()) {
 		return expr;
 	}
 
-	auto cast_function = cast_functions.GetCastFunction(expr->return_type, target_type, get_input);
+	auto cast_function = cast_functions.GetCastFunction(expr->GetReturnType(), target_type, get_input);
 	return AddCastExpressionInternal(std::move(expr), target_type, std::move(cast_function), try_cast);
 }
 
@@ -110,10 +110,10 @@ unique_ptr<Expression> BoundCastExpression::AddCastToType(ClientContext &context
 }
 
 unique_ptr<Expression> BoundCastExpression::AddArrayCastToList(ClientContext &context, unique_ptr<Expression> expr) {
-	if (expr->return_type.id() != LogicalTypeId::ARRAY) {
+	if (expr->GetReturnType().id() != LogicalTypeId::ARRAY) {
 		return expr;
 	}
-	auto &child_type = ArrayType::GetChildType(expr->return_type);
+	auto &child_type = ArrayType::GetChildType(expr->GetReturnType());
 	return BoundCastExpression::AddCastToType(context, std::move(expr), LogicalType::LIST(child_type));
 }
 
@@ -227,7 +227,7 @@ unique_ptr<Expression> BoundCastExpression::Copy() const {
 }
 
 bool BoundCastExpression::CanThrow() const {
-	const auto child_type = child->return_type;
+	const auto child_type = child->GetReturnType();
 	if (return_type.id() != child_type.id() &&
 	    LogicalType::ForceMaxLogicalType(return_type, child_type) == child_type.id()) {
 		return true;

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -315,7 +315,7 @@ unique_ptr<Expression> BoundWindowExpression::Deserialize(Deserializer &deserial
 		vector<LogicalType> arguments;
 		arguments.reserve(result->children.size());
 		for (auto &child : result->children) {
-			arguments.push_back(child->return_type);
+			arguments.push_back(child->GetReturnType());
 		}
 
 		auto &context = deserializer.Get<ClientContext &>();

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -344,17 +344,17 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 		if (!binder.can_contain_nulls) {
 			// SQL NULL type is only used internally in the binder
 			// cast to INTEGER if we encounter it outside of the binder
-			if (ContainsNullType(result->return_type)) {
-				auto exchanged_type = ExchangeNullType(result->return_type);
+			if (ContainsNullType(result->GetReturnType())) {
+				auto exchanged_type = ExchangeNullType(result->GetReturnType());
 				result = BoundCastExpression::AddCastToType(context, std::move(result), exchanged_type);
 			}
 		}
-		if (result->return_type.id() == LogicalTypeId::UNKNOWN) {
+		if (result->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
 	}
 	if (result_type) {
-		*result_type = result->return_type;
+		*result_type = result->GetReturnType();
 	}
 	return result;
 }

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -101,7 +101,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 	if (it != info.collated_groups.end()) {
 		// This is an implicitly collated group, so we need to refer to the first() aggregate
 		const auto &aggr_index = it->second;
-		const auto return_type = node.aggregates[aggr_index]->return_type;
+		const auto return_type = node.aggregates[aggr_index]->GetReturnType();
 		auto uncollated_first_expression = make_uniq<BoundColumnRefExpression>(
 		    expr.GetName(), return_type, ColumnBinding(node.aggregate_index, aggr_index), depth);
 
@@ -115,7 +115,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 		// otherwise you can return the "first" of the uncollated expression.
 		auto &group = node.groups.group_expressions[group_index];
 		auto collated_group_expression = make_uniq<BoundColumnRefExpression>(
-		    expr.GetName(), group->return_type, ColumnBinding(node.group_index, group_index), depth);
+		    expr.GetName(), group->GetReturnType(), ColumnBinding(node.group_index, group_index), depth);
 
 		auto sql_null = make_uniq<BoundConstantExpression>(Value(return_type));
 		auto when_expr = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
@@ -127,7 +127,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 		return BindResult(std::move(case_expr));
 	} else {
 		auto &group = node.groups.group_expressions[group_index];
-		return BindResult(make_uniq<BoundColumnRefExpression>(expr.GetName(), group->return_type,
+		return BindResult(make_uniq<BoundColumnRefExpression>(expr.GetName(), group->GetReturnType(),
 		                                                      ColumnBinding(node.group_index, group_index), depth));
 	}
 }

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -85,7 +85,7 @@ BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, i
 	}
 
 	// Return a GROUP BY column reference expression.
-	auto return_type = expr.expression->return_type;
+	auto return_type = expr.expression->GetReturnType();
 	auto group_idx = ColumnBinding::PushExpression(node.groups.group_expressions, std::move(expr.expression));
 	auto column_binding = ColumnBinding(node.group_index, group_idx);
 	auto group_ref = make_uniq<BoundColumnRefExpression>(return_type, column_binding);

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -90,7 +90,7 @@ optional_idx OrderBinder::TryGetProjectionReference(ParsedExpression &expr) cons
 		// check the expression list
 		vector<idx_t> matching_columns;
 		for (idx_t i = 0; i < bind_state.original_expressions.size(); i++) {
-			if (bind_state.original_expressions[i]->type != ExpressionType::COLUMN_REF) {
+			if (bind_state.original_expressions[i]->GetExpressionType() != ExpressionType::COLUMN_REF) {
 				continue;
 			}
 			auto &colref = bind_state.original_expressions[i]->Cast<ColumnRefExpression>();

--- a/src/planner/expression_binder/projection_binder.cpp
+++ b/src/planner/expression_binder/projection_binder.cpp
@@ -22,7 +22,7 @@ BindResult ProjectionBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_pt
 	auto alias = result.expression->GetName();
 	auto proj_col_idx = ColumnBinding::PushExpression(proj_expressions, std::move(result.expression));
 	auto proj_ref = make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(proj_index, proj_col_idx));
-	proj_ref->alias = std::move(alias);
+	proj_ref->SetAlias(std::move(alias));
 	return BindResult(std::move(proj_ref));
 }
 

--- a/src/planner/expression_binder/projection_binder.cpp
+++ b/src/planner/expression_binder/projection_binder.cpp
@@ -18,7 +18,7 @@ BindResult ProjectionBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_pt
 		return result;
 	}
 	// we have successfully bound a column - push it into the projection and emit a reference
-	auto return_type = result.expression->return_type;
+	auto return_type = result.expression->GetReturnType();
 	auto alias = result.expression->GetName();
 	auto proj_col_idx = ColumnBinding::PushExpression(proj_expressions, std::move(result.expression));
 	auto proj_ref = make_uniq<BoundColumnRefExpression>(return_type, ColumnBinding(proj_index, proj_col_idx));

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -140,11 +140,11 @@ static FilterPropagateResult CheckComparisonStatistics(const BoundComparisonExpr
 	vector<unique_ptr<BaseStatistics>> owned_stats;
 	optional_ptr<const BaseStatistics> filter_stats;
 	optional_ptr<const BoundConstantExpression> constant_expr;
-	auto comparison_type = comp_expr.type;
-	if (comp_expr.right->type == ExpressionType::VALUE_CONSTANT) {
+	auto comparison_type = comp_expr.GetExpressionType();
+	if (comp_expr.right->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 		filter_stats = TryGetFilterStats(*comp_expr.left, stats, owned_stats);
 		constant_expr = &comp_expr.right->Cast<BoundConstantExpression>();
-	} else if (comp_expr.left->type == ExpressionType::VALUE_CONSTANT) {
+	} else if (comp_expr.left->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 		filter_stats = TryGetFilterStats(*comp_expr.right, stats, owned_stats);
 		constant_expr = &comp_expr.left->Cast<BoundConstantExpression>();
 		comparison_type = FlipComparisonExpression(comparison_type);
@@ -208,7 +208,7 @@ static FilterPropagateResult CheckInOperatorStatistics(const BoundOperatorExpres
 	vector<Value> values;
 	values.reserve(op_expr.children.size() - 1);
 	for (idx_t i = 1; i < op_expr.children.size(); i++) {
-		if (op_expr.children[i]->type != ExpressionType::VALUE_CONSTANT) {
+		if (op_expr.children[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 		auto &value = op_expr.children[i]->Cast<BoundConstantExpression>().value;
@@ -231,10 +231,10 @@ static FilterPropagateResult CheckInOperatorStatistics(const BoundOperatorExpres
 }
 
 static FilterPropagateResult CheckOperatorStatistics(const BoundOperatorExpression &op_expr, BaseStatistics &stats) {
-	switch (op_expr.type) {
+	switch (op_expr.GetExpressionType()) {
 	case ExpressionType::OPERATOR_IS_NULL:
 	case ExpressionType::OPERATOR_IS_NOT_NULL:
-		return CheckNullOperatorStatistics(op_expr, stats, op_expr.type);
+		return CheckNullOperatorStatistics(op_expr, stats, op_expr.GetExpressionType());
 	case ExpressionType::COMPARE_IN:
 		return CheckInOperatorStatistics(op_expr, stats);
 	default:
@@ -243,7 +243,7 @@ static FilterPropagateResult CheckOperatorStatistics(const BoundOperatorExpressi
 }
 
 static FilterPropagateResult CheckConjunctionStatistics(const BoundConjunctionExpression &conj, BaseStatistics &stats) {
-	switch (conj.type) {
+	switch (conj.GetExpressionType()) {
 	case ExpressionType::CONJUNCTION_AND: {
 		auto result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
 		for (auto &child : conj.children) {
@@ -317,7 +317,7 @@ string ExpressionFilter::ToString(const string &column_name) const {
 
 void ExpressionFilter::ReplaceExpressionRecursive(unique_ptr<Expression> &expr, const Expression &column,
                                                   ExpressionType replace_type) {
-	if (expr->type == replace_type) {
+	if (expr->GetExpressionType() == replace_type) {
 		expr = column.Copy();
 		return;
 	}

--- a/src/planner/filter/struct_filter.cpp
+++ b/src/planner/filter/struct_filter.cpp
@@ -33,7 +33,7 @@ unique_ptr<TableFilter> StructFilter::Copy() const {
 }
 
 unique_ptr<Expression> StructFilter::ToExpression(const Expression &column) const {
-	auto &child_type = StructType::GetChildType(column.return_type, child_idx);
+	auto &child_type = StructType::GetChildType(column.GetReturnType(), child_idx);
 	vector<unique_ptr<Expression>> arguments;
 	arguments.push_back(column.Copy());
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(child_idx + 1))));

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -32,11 +32,11 @@ const Expression &LogicalAggregate::GetGroupExpression(ProjectionIndex group_col
 void LogicalAggregate::ResolveTypes() {
 	D_ASSERT(groupings_index.IsValid() || grouping_functions.empty());
 	for (auto &expr : groups) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 	// get the chunk types from the projection list
 	for (auto &expr : expressions) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 	for (idx_t i = 0; i < grouping_functions.size(); i++) {
 		types.emplace_back(LogicalType::BIGINT);

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -14,7 +14,7 @@ vector<ColumnBinding> LogicalProjection::GetColumnBindings() {
 
 void LogicalProjection::ResolveTypes() {
 	for (auto &expr : expressions) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 }
 

--- a/src/planner/operator/logical_recursive_cte.cpp
+++ b/src/planner/operator/logical_recursive_cte.cpp
@@ -55,7 +55,7 @@ void LogicalRecursiveCTE::ResolveTypes() {
 		if (key_idx.find(ProjectionIndex(i)) != key_idx.end()) {
 			continue;
 		}
-		types[i] = payload_aggregates[pay_idx++]->return_type;
+		types[i] = payload_aggregates[pay_idx++]->GetReturnType();
 	}
 }
 

--- a/src/planner/operator/logical_recursive_cte.cpp
+++ b/src/planner/operator/logical_recursive_cte.cpp
@@ -45,7 +45,7 @@ void LogicalRecursiveCTE::ResolveTypes() {
 
 	unordered_set<ProjectionIndex> key_idx;
 	for (auto &key_target : key_targets) {
-		D_ASSERT(key_target->type == ExpressionType::BOUND_COLUMN_REF);
+		D_ASSERT(key_target->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF);
 		auto &bound_ref = key_target->Cast<BoundColumnRefExpression>();
 		key_idx.insert(bound_ref.binding.column_index);
 	}

--- a/src/planner/operator/logical_unnest.cpp
+++ b/src/planner/operator/logical_unnest.cpp
@@ -15,7 +15,7 @@ vector<ColumnBinding> LogicalUnnest::GetColumnBindings() {
 void LogicalUnnest::ResolveTypes() {
 	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
 	for (auto &expr : expressions) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 }
 

--- a/src/planner/operator/logical_window.cpp
+++ b/src/planner/operator/logical_window.cpp
@@ -15,7 +15,7 @@ vector<ColumnBinding> LogicalWindow::GetColumnBindings() {
 void LogicalWindow::ResolveTypes() {
 	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
 	for (auto &expr : expressions) {
-		types.push_back(expr->return_type);
+		types.push_back(expr->GetReturnType());
 	}
 }
 

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -87,7 +87,7 @@ unique_ptr<Expression> RewriteCountAggregates::VisitReplace(BoundColumnRefExpres
 		auto is_null = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
 		is_null->children.push_back(expr.Copy());
 		auto check = std::move(is_null);
-		auto result_if_true = make_uniq<BoundConstantExpression>(Value::Numeric(expr.return_type, 0));
+		auto result_if_true = make_uniq<BoundConstantExpression>(Value::Numeric(expr.GetReturnType(), 0));
 		auto result_if_false = std::move(*expr_ptr);
 		return make_uniq<BoundCaseExpression>(std::move(check), std::move(result_if_true), std::move(result_if_false));
 	}

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -108,7 +108,7 @@ static unique_ptr<TableFilter> WrapStructFilterPath(unique_ptr<TableFilter> filt
 static void NormalizeLegacyExpression(unique_ptr<Expression> &expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    expr, [](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &owned_expr) {
-		    owned_expr = make_uniq<BoundReferenceExpression>(col_ref.alias, col_ref.return_type, 0ULL);
+		    owned_expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.return_type, 0ULL);
 	    });
 	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(
 	    expr, [](BoundReferenceExpression &ref, unique_ptr<Expression> &owned_expr) { ref.index = 0; });
@@ -117,7 +117,7 @@ static void NormalizeLegacyExpression(unique_ptr<Expression> &expr) {
 static unique_ptr<TableFilter> TrySerializeComparisonToLegacyFilter(const BoundComparisonExpression &comparison) {
 	const Expression *subject = nullptr;
 	const Value *constant = nullptr;
-	auto comparison_type = comparison.type;
+	auto comparison_type = comparison.GetExpressionType();
 	if (comparison.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 		subject = comparison.left.get();
 		constant = &comparison.right->Cast<BoundConstantExpression>().value;
@@ -150,7 +150,7 @@ static unique_ptr<TableFilter> TrySerializeComparisonToLegacyFilter(const BoundC
 }
 
 static unique_ptr<TableFilter> TrySerializeOperatorToLegacyFilter(const BoundOperatorExpression &op) {
-	switch (op.type) {
+	switch (op.GetExpressionType()) {
 	case ExpressionType::OPERATOR_IS_NULL:
 	case ExpressionType::OPERATOR_IS_NOT_NULL: {
 		if (op.children.size() != 1) {
@@ -160,7 +160,7 @@ static unique_ptr<TableFilter> TrySerializeOperatorToLegacyFilter(const BoundOpe
 		if (!TryExtractLegacySubject(*op.children[0], struct_path)) {
 			return nullptr;
 		}
-		if (op.type == ExpressionType::OPERATOR_IS_NULL) {
+		if (op.GetExpressionType() == ExpressionType::OPERATOR_IS_NULL) {
 			return WrapStructFilterPath(make_uniq<IsNullFilter>(), struct_path);
 		}
 		return WrapStructFilterPath(make_uniq<IsNotNullFilter>(), struct_path);
@@ -197,13 +197,13 @@ static unique_ptr<TableFilter> TrySerializeOperatorToLegacyFilter(const BoundOpe
 
 static unique_ptr<TableFilter> SerializeConjunctionToLegacyFilter(const BoundConjunctionExpression &conjunction) {
 	unique_ptr<ConjunctionFilter> result;
-	if (conjunction.type == ExpressionType::CONJUNCTION_AND) {
+	if (conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
 		result = make_uniq<ConjunctionAndFilter>();
-	} else if (conjunction.type == ExpressionType::CONJUNCTION_OR) {
+	} else if (conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
 		result = make_uniq<ConjunctionOrFilter>();
 	} else {
 		throw SerializationException("Unsupported conjunction type %s during table-filter serialization",
-		                             EnumUtil::ToString(conjunction.type));
+		                             EnumUtil::ToString(conjunction.GetExpressionType()));
 	}
 	for (auto &child : conjunction.children) {
 		auto child_filter = SerializeExpressionToLegacyFilter(*child);

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -85,9 +85,9 @@ static bool TryExtractLegacySubject(const Expression &expr, vector<LegacyStructP
 			return false;
 		}
 		string child_name;
-		if (func.children[0]->return_type.id() == LogicalTypeId::STRUCT &&
-		    !StructType::IsUnnamed(func.children[0]->return_type)) {
-			child_name = StructType::GetChildName(func.children[0]->return_type, child_idx);
+		if (func.children[0]->GetReturnType().id() == LogicalTypeId::STRUCT &&
+		    !StructType::IsUnnamed(func.children[0]->GetReturnType())) {
+			child_name = StructType::GetChildName(func.children[0]->GetReturnType(), child_idx);
 		}
 		struct_path.push_back({child_idx, std::move(child_name)});
 		return true;
@@ -108,7 +108,7 @@ static unique_ptr<TableFilter> WrapStructFilterPath(unique_ptr<TableFilter> filt
 static void NormalizeLegacyExpression(unique_ptr<Expression> &expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    expr, [](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &owned_expr) {
-		    owned_expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.return_type, 0ULL);
+		    owned_expr = make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.GetReturnType(), 0ULL);
 	    });
 	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(
 	    expr, [](BoundReferenceExpression &ref, unique_ptr<Expression> &owned_expr) { ref.index = 0; });

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -269,7 +269,7 @@ FilterPropagateResult GeometryStats::CheckZonemap(const BaseStatistics &stats, c
 	if (expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	if (expr->return_type != LogicalType::BOOLEAN) {
+	if (expr->GetReturnType() != LogicalType::BOOLEAN) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	const auto &func = expr->Cast<BoundFunctionExpression>();
@@ -277,8 +277,8 @@ FilterPropagateResult GeometryStats::CheckZonemap(const BaseStatistics &stats, c
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 
-	if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
-	    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
+	if (func.children[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY ||
+	    func.children[1]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -33,7 +33,8 @@ static bool IsDirectNullCheckFilter(const TableFilter &filter) {
 			return false;
 		}
 		auto &op = expr->Cast<BoundOperatorExpression>();
-		if ((op.type != ExpressionType::OPERATOR_IS_NULL && op.type != ExpressionType::OPERATOR_IS_NOT_NULL) ||
+		if ((op.GetExpressionType() != ExpressionType::OPERATOR_IS_NULL &&
+		     op.GetExpressionType() != ExpressionType::OPERATOR_IS_NOT_NULL) ||
 		    op.children.size() != 1) {
 			return false;
 		}

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -231,7 +231,7 @@ public:
 	static unique_ptr<FunctionData> Bind(BindWindowFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function.SetReturnType(arguments[0]->return_type);
+		function.SetReturnType(arguments[0]->GetReturnType());
 		return nullptr;
 	}
 
@@ -292,8 +292,8 @@ public:
 	class StreamingState : public WindowExecutorStreamingState {
 	public:
 		StreamingState(ClientContext &client, DataChunk &input, const BoundWindowExpression &wexpr)
-		    : wexpr(wexpr), filler(Value(wexpr.children[0]->return_type), count_t(STANDARD_VECTOR_SIZE)),
-		      executor(client), arg(wexpr.children[0]->return_type) {
+		    : wexpr(wexpr), filler(Value(wexpr.children[0]->GetReturnType()), count_t(STANDARD_VECTOR_SIZE)),
+		      executor(client), arg(wexpr.children[0]->GetReturnType()) {
 			executor.AddExpression(*wexpr.children[0]);
 		}
 		//! The window expression
@@ -561,8 +561,8 @@ static void BoundedMaxFunc(DataChunk &args, ExpressionState &state, Vector &resu
 static unique_ptr<FunctionData> BoundedMaxBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments[0]->return_type == BoundedType::GetDefault()) {
-		bound_function.GetArguments()[0] = arguments[0]->return_type;
+	if (arguments[0]->GetReturnType() == BoundedType::GetDefault()) {
+		bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
 	} else {
 		throw BinderException("bounded_max expects a BOUNDED type");
 	}
@@ -580,14 +580,14 @@ static void BoundedAddFunc(DataChunk &args, ExpressionState &state, Vector &resu
 static unique_ptr<FunctionData> BoundedAddBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (BoundedType::GetDefault() == arguments[0]->return_type &&
-	    BoundedType::GetDefault() == arguments[1]->return_type) {
-		auto left_max_val = BoundedType::GetMaxValue(arguments[0]->return_type);
-		auto right_max_val = BoundedType::GetMaxValue(arguments[1]->return_type);
+	if (BoundedType::GetDefault() == arguments[0]->GetReturnType() &&
+	    BoundedType::GetDefault() == arguments[1]->GetReturnType()) {
+		auto left_max_val = BoundedType::GetMaxValue(arguments[0]->GetReturnType());
+		auto right_max_val = BoundedType::GetMaxValue(arguments[1]->GetReturnType());
 
 		auto new_max_val = left_max_val + right_max_val;
-		bound_function.GetArguments()[0] = arguments[0]->return_type;
-		bound_function.GetArguments()[1] = arguments[1]->return_type;
+		bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
+		bound_function.GetArguments()[1] = arguments[1]->GetReturnType();
 		bound_function.SetReturnType(BoundedType::Get(new_max_val));
 	} else {
 		throw BinderException("bounded_add expects two BOUNDED types");
@@ -613,9 +613,9 @@ struct BoundedFunctionData : public FunctionData {
 static unique_ptr<FunctionData> BoundedInvertBind(BindScalarFunctionInput &input) {
 	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	if (arguments[0]->return_type == BoundedType::GetDefault()) {
-		bound_function.GetArguments()[0] = arguments[0]->return_type;
-		bound_function.SetReturnType(arguments[0]->return_type);
+	if (arguments[0]->GetReturnType() == BoundedType::GetDefault()) {
+		bound_function.GetArguments()[0] = arguments[0]->GetReturnType();
+		bound_function.SetReturnType(arguments[0]->GetReturnType());
 	} else {
 		throw BinderException("bounded_invert expects a BOUNDED type");
 	}

--- a/tools/shell/shell_render_table_metadata.cpp
+++ b/tools/shell/shell_render_table_metadata.cpp
@@ -20,7 +20,8 @@ bool ShellState::UseDescribeRenderMode(const duckdb::SQLStatement &statement, st
 		return false;
 	}
 	auto &select_node = select.node->Cast<duckdb::SelectNode>();
-	if (select_node.select_list.size() != 1 || select_node.select_list[0]->type != duckdb::ExpressionType::STAR) {
+	if (select_node.select_list.size() != 1 ||
+	    select_node.select_list[0]->GetExpressionType() != duckdb::ExpressionType::STAR) {
 		return false;
 	}
 	if (select_node.from_table->type != duckdb::TableReferenceType::SHOW_REF) {


### PR DESCRIPTION
This PR looks large, but really only does two things:
- Moves the members of `BaseExpression` to be `protected`
- Moves the members of `Expression` to be `protected`.

Also const-ify and static-ify some functions I came across while mechanically doing the replacements.
