### PR TITLE
Fix three performance-move-const-arg issues on main

### DIFF
--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -719,7 +719,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	    nullptr, AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
 	    SortedAggregateFunction::Window);
 
-	expr.function = std::move(ordered_aggregate);
+	expr.function = ordered_aggregate;
 	expr.bind_info = std::move(sorted_bind);
 	expr.order_bys.reset();
 }
@@ -775,7 +775,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
 	    SortedAggregateFunction::Window);
 
-	aggregate = std::move(ordered_aggregate);
+	aggregate = ordered_aggregate;
 	expr.bind_info = std::move(sorted_bind);
 	expr.arg_orders.clear();
 }

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -176,8 +176,8 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 			}
 			// Found a matching function, bind it as an aggregate
 			auto best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
-			auto aggregate = function_binder.BindAggregateFunction(std::move(best_function), std::move(bound_children),
-			                                                       nullptr, AggregateType::NON_DISTINCT);
+			auto aggregate = function_binder.BindAggregateFunction(best_function, std::move(bound_children), nullptr,
+			                                                       AggregateType::NON_DISTINCT);
 
 			if (payload_references.find(aggregate_idx) != payload_references.end()) {
 				throw BinderException(func_expr.GetQueryLocation(),


### PR DESCRIPTION
Fix 3 clang [issues](https://github.com/duckdb/duckdb/actions/runs/25085914619/job/73501383150) on main:
```

src/function/aggregate/sorted_aggregate_function.cpp:722:18: Error: Passing result of std::move() as a const reference argument; no move will actually happen [performance-move-const-arg]
  720 |  	    SortedAggregateFunction::Window);
  721 |  
  722 |  	expr.function = std::move(ordered_aggregate);
      |                   ^~~~~~~~~~
  723 |  	expr.bind_info = std::move(sorted_bind);
  724 |  	expr.order_bys.reset();

src/function/aggregate/sorted_aggregate_function.cpp:778:14: Error: Passing result of std::move() as a const reference argument; no move will actually happen [performance-move-const-arg]
  776 |  	    SortedAggregateFunction::Window);
  777 |  
  778 |  	aggregate = std::move(ordered_aggregate);
      |               ^~~~~~~~~~
  779 |  	expr.bind_info = std::move(sorted_bind);
  780 |  	expr.arg_orders.clear();

src/planner/binder/query_node/bind_recursive_cte_node.cpp:179:59: Error: Passing result of std::move() as a const reference argument; no move will actually happen [performance-move-const-arg]
  177 |  			// Found a matching function, bind it as an aggregate
  178 |  			auto best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
  179 |  			auto aggregate = function_binder.BindAggregateFunction(std::move(best_function), std::move(bound_children),
      |                                                            ^~~~~~~~~~
  180 |  			                                                       nullptr, AggregateType::NON_DISTINCT);
  181 |
make: *** [Makefile:660: tidy-check-clangd] Error 1

```