### PR TITLE
Tread BufferedFileHandle for single 0-12288 range request on attach

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -17,6 +17,7 @@ blacklist = [
     "ComplexJSONType",
     "UnavailableReason",
     "Slot",
+    "BufferedFileHandleState",
 ]
 
 enum_util_header_file = os.path.join("..", "src", "include", "duckdb", "common", "enum_util.hpp")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library_unity(
   bind_helpers.cpp
   box_renderer.cpp
   box_renderer_context.cpp
+  buffered_file_handle.cpp
   client_box_renderer_context.cpp
   column_data_collection_render_interface.cpp
   cgroups.cpp

--- a/src/common/buffered_file_handle.cpp
+++ b/src/common/buffered_file_handle.cpp
@@ -1,0 +1,113 @@
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/client_context.hpp"
+
+#include <cstring>
+
+namespace duckdb {
+
+BufferedFileHandle::BufferedFileHandle(unique_ptr<FileHandle> inner_p) : inner(std::move(inner_p)) {
+	D_ASSERT(inner);
+}
+
+BufferedFileHandle::~BufferedFileHandle() = default;
+
+void BufferedFileHandle::CopyBufferFrom(const BufferedFileHandle &other) {
+	if (other.state != BufferedFileHandleState::REALIZED) {
+		state = BufferedFileHandleState::EMPTY;
+		range_offset = 0;
+		range_size = 0;
+		buffer.reset();
+		return;
+	}
+	range_offset = other.range_offset;
+	range_size = other.range_size;
+	buffer = make_unsafe_uniq_array<char>(range_size);
+	std::memcpy(buffer.get(), other.buffer.get(), range_size);
+	state = BufferedFileHandleState::REALIZED;
+}
+
+void BufferedFileHandle::RegisterPrefetch(idx_t offset, idx_t size) {
+	D_ASSERT(inner);
+	// Idempotent: if we already realized this exact range, do nothing.
+	// This makes repeated CheckMagicBytes-style calls a no-op on the wire.
+	if (state == BufferedFileHandleState::REALIZED && range_offset == offset && range_size == size) {
+		return;
+	}
+	buffer.reset();
+	if (size == 0) {
+		state = BufferedFileHandleState::EMPTY;
+		range_offset = 0;
+		range_size = 0;
+		return;
+	}
+	state = BufferedFileHandleState::HINT;
+	range_offset = offset;
+	range_size = size;
+}
+
+void BufferedFileHandle::ReadIntoBuffer(QueryContext context, void *out, idx_t nr_bytes, idx_t location) {
+	D_ASSERT(inner);
+
+	if (state == BufferedFileHandleState::REALIZED) {
+		if (location >= range_offset && location + nr_bytes <= range_offset + range_size) {
+			std::memcpy(out, buffer.get() + (location - range_offset), nr_bytes);
+			return;
+		}
+		// miss → fall through to forward
+	} else if (state == BufferedFileHandleState::HINT) {
+		// Realize the hint if the request overlaps the hint range.
+		const idx_t hint_end = range_offset + range_size;
+		const bool overlaps = location < hint_end && location + nr_bytes > range_offset;
+		if (overlaps) {
+			// Clamp the prefetch to actual file size so we don't try to read past EOF.
+			const idx_t file_size = inner->GetFileSize();
+			if (range_offset >= file_size) {
+				// Hint is entirely past EOF; nothing to buffer. Forward verbatim.
+				state = BufferedFileHandleState::EMPTY;
+				range_offset = 0;
+				range_size = 0;
+			} else {
+				const idx_t available = file_size - range_offset;
+				const idx_t actual_size = MinValue<idx_t>(range_size, available);
+				buffer = make_unsafe_uniq_array<char>(actual_size);
+				inner->Read(context, buffer.get(), actual_size, range_offset);
+				range_size = actual_size;
+				state = BufferedFileHandleState::REALIZED;
+				if (location >= range_offset && location + nr_bytes <= range_offset + range_size) {
+					std::memcpy(out, buffer.get() + (location - range_offset), nr_bytes);
+					return;
+				}
+				// Caller's request straddles past the realized buffer; fall through.
+			}
+		}
+	}
+
+	// Forward verbatim to the inner handle.
+	inner->Read(context, out, nr_bytes, location);
+}
+
+void BufferedFileHandle::Read(void *out, idx_t nr_bytes, idx_t location) {
+	ReadIntoBuffer(QueryContext(), out, nr_bytes, location);
+}
+
+idx_t BufferedFileHandle::GetFileSize() {
+	D_ASSERT(inner);
+	return inner->GetFileSize();
+}
+
+string BufferedFileHandle::GetPath() const {
+	D_ASSERT(inner);
+	return inner->GetPath();
+}
+
+unique_ptr<FileHandle> BufferedFileHandle::ExtractInnerFileHandle() {
+	buffer.reset();
+	state = BufferedFileHandleState::EMPTY;
+	range_offset = 0;
+	range_size = 0;
+	return std::move(inner);
+}
+
+} // namespace duckdb

--- a/src/common/buffered_file_handle.cpp
+++ b/src/common/buffered_file_handle.cpp
@@ -47,49 +47,46 @@ void BufferedFileHandle::RegisterPrefetch(idx_t offset, idx_t size) {
 	range_size = size;
 }
 
-void BufferedFileHandle::ReadIntoBuffer(QueryContext context, void *out, idx_t nr_bytes, idx_t location) {
+idx_t BufferedFileHandle::ReadIntoBuffer(QueryContext context, void *out, idx_t nr_bytes, idx_t location) {
 	D_ASSERT(inner);
 
 	if (state == BufferedFileHandleState::REALIZED) {
 		if (location >= range_offset && location + nr_bytes <= range_offset + range_size) {
 			std::memcpy(out, buffer.get() + (location - range_offset), nr_bytes);
-			return;
+			return nr_bytes;
 		}
 		// miss → fall through to forward
 	} else if (state == BufferedFileHandleState::HINT) {
-		// Realize the hint if the request overlaps the hint range.
+		// Realize the hint if the request overlaps the hint range. The inner
+		// ReadIntoBuffer clamps to file size so we never read past EOF.
 		const idx_t hint_end = range_offset + range_size;
 		const bool overlaps = location < hint_end && location + nr_bytes > range_offset;
 		if (overlaps) {
-			// Clamp the prefetch to actual file size so we don't try to read past EOF.
-			const idx_t file_size = inner->GetFileSize();
-			if (range_offset >= file_size) {
+			auto buf = make_unsafe_uniq_array<char>(range_size);
+			const idx_t actual_size = inner->ReadIntoBuffer(context, buf.get(), range_size, range_offset);
+			if (actual_size == 0) {
 				// Hint is entirely past EOF; nothing to buffer. Forward verbatim.
 				state = BufferedFileHandleState::EMPTY;
 				range_offset = 0;
 				range_size = 0;
 			} else {
-				const idx_t available = file_size - range_offset;
-				const idx_t actual_size = MinValue<idx_t>(range_size, available);
-				buffer = make_unsafe_uniq_array<char>(actual_size);
-				inner->Read(context, buffer.get(), actual_size, range_offset);
+				buffer = std::move(buf);
 				range_size = actual_size;
 				state = BufferedFileHandleState::REALIZED;
 				if (location >= range_offset && location + nr_bytes <= range_offset + range_size) {
 					std::memcpy(out, buffer.get() + (location - range_offset), nr_bytes);
-					return;
+					return nr_bytes;
 				}
 				// Caller's request straddles past the realized buffer; fall through.
 			}
 		}
 	}
 
-	// Forward verbatim to the inner handle.
-	inner->Read(context, out, nr_bytes, location);
+	return inner->ReadIntoBuffer(context, out, nr_bytes, location);
 }
 
-void BufferedFileHandle::Read(void *out, idx_t nr_bytes, idx_t location) {
-	ReadIntoBuffer(QueryContext(), out, nr_bytes, location);
+idx_t BufferedFileHandle::Read(void *out, idx_t nr_bytes, idx_t location) {
+	return ReadIntoBuffer(QueryContext(), out, nr_bytes, location);
 }
 
 idx_t BufferedFileHandle::GetFileSize() {

--- a/src/common/buffered_file_handle.cpp
+++ b/src/common/buffered_file_handle.cpp
@@ -14,7 +14,9 @@ BufferedFileHandle::BufferedFileHandle(unique_ptr<FileHandle> inner_p) : inner(s
 BufferedFileHandle::~BufferedFileHandle() = default;
 
 void BufferedFileHandle::CopyBufferFrom(const BufferedFileHandle &other) {
-	if (other.state != BufferedFileHandleState::REALIZED) {
+	const bool has_buffer = (other.state == BufferedFileHandleState::REALIZED ||
+	                         other.state == BufferedFileHandleState::NO_HANDLE);
+	if (!has_buffer) {
 		state = BufferedFileHandleState::EMPTY;
 		range_offset = 0;
 		range_size = 0;
@@ -29,6 +31,7 @@ void BufferedFileHandle::CopyBufferFrom(const BufferedFileHandle &other) {
 }
 
 void BufferedFileHandle::RegisterPrefetch(idx_t offset, idx_t size) {
+	D_ASSERT(state != BufferedFileHandleState::NO_HANDLE);
 	D_ASSERT(inner);
 	// Idempotent: if we already realized this exact range, do nothing.
 	// This makes repeated CheckMagicBytes-style calls a no-op on the wire.
@@ -48,6 +51,7 @@ void BufferedFileHandle::RegisterPrefetch(idx_t offset, idx_t size) {
 }
 
 idx_t BufferedFileHandle::ReadIntoBuffer(QueryContext context, void *out, idx_t nr_bytes, idx_t location) {
+	D_ASSERT(state != BufferedFileHandleState::NO_HANDLE);
 	D_ASSERT(inner);
 
 	if (state == BufferedFileHandleState::REALIZED) {
@@ -90,21 +94,31 @@ idx_t BufferedFileHandle::Read(void *out, idx_t nr_bytes, idx_t location) {
 }
 
 idx_t BufferedFileHandle::GetFileSize() {
+	D_ASSERT(state != BufferedFileHandleState::NO_HANDLE);
 	D_ASSERT(inner);
 	return inner->GetFileSize();
 }
 
 string BufferedFileHandle::GetPath() const {
+	D_ASSERT(state != BufferedFileHandleState::NO_HANDLE);
 	D_ASSERT(inner);
 	return inner->GetPath();
 }
 
 unique_ptr<FileHandle> BufferedFileHandle::ExtractInnerFileHandle() {
+	D_ASSERT(state != BufferedFileHandleState::NO_HANDLE);
 	buffer.reset();
 	state = BufferedFileHandleState::EMPTY;
 	range_offset = 0;
 	range_size = 0;
 	return std::move(inner);
+}
+
+void BufferedFileHandle::CloseHandle() {
+	D_ASSERT(state == BufferedFileHandleState::REALIZED);
+	D_ASSERT(inner);
+	inner.reset();
+	state = BufferedFileHandleState::NO_HANDLE;
 }
 
 } // namespace duckdb

--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/storage/block_allocator.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/block_manager.hpp"
@@ -103,9 +104,9 @@ void FileBuffer::Resize(BlockManager &block_manager) {
 	ResizeInternal(block_manager.GetBlockSize(), block_manager.GetBlockHeaderSize());
 }
 
-void FileBuffer::Read(QueryContext context, FileHandle &handle, uint64_t location) {
+void FileBuffer::Read(QueryContext context, BaseFileHandle &handle, uint64_t location) {
 	D_ASSERT(type != FileBufferType::TINY_BUFFER);
-	handle.Read(context, internal_buffer, internal_size, location);
+	handle.ReadIntoBuffer(context, internal_buffer, internal_size, location);
 }
 
 void FileBuffer::Write(QueryContext context, FileHandle &handle, const uint64_t location) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -785,8 +785,14 @@ void FileHandle::Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t 
 	file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location);
 }
 
-void FileHandle::ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {
-	Read(context, buffer, nr_bytes, location);
+idx_t FileHandle::ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {
+	const idx_t file_size = GetFileSize();
+	if (location >= file_size) {
+		return 0;
+	}
+	const idx_t to_read = MinValue<idx_t>(nr_bytes, file_size - location);
+	Read(context, buffer, to_read, location);
+	return to_read;
 }
 
 void FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -785,6 +785,10 @@ void FileHandle::Read(QueryContext context, void *buffer, idx_t nr_bytes, idx_t 
 	file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location);
 }
 
+void FileHandle::ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {
+	Read(context, buffer, nr_bytes, location);
+}
+
 void FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) {
 	if (context.GetClientContext() != nullptr) {
 		context.GetClientContext()->client_data->profiler->AddToCounter(MetricType::TOTAL_BYTES_WRITTEN, nr_bytes);

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -13,6 +13,7 @@
 
 namespace duckdb {
 
+class BaseFileHandle;
 class BlockAllocator;
 class BlockManager;
 class QueryContext;
@@ -45,7 +46,8 @@ public:
 
 public:
 	//! Read into the FileBuffer from the location.
-	void Read(QueryContext context, FileHandle &handle, uint64_t location);
+	//! Accepts any BaseFileHandle (FileHandle, BufferedFileHandle, ...).
+	void Read(QueryContext context, BaseFileHandle &handle, uint64_t location);
 	//! Write the FileBuffer to the location.
 	void Write(QueryContext context, FileHandle &handle, const uint64_t location);
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -71,7 +71,17 @@ struct FileMetadata {
 	unordered_map<string, Value> extended_file_info;
 };
 
-struct FileHandle {
+//! Polymorphic base shared by FileHandle and BufferedFileHandle.
+class BaseFileHandle {
+public:
+	DUCKDB_API virtual ~BaseFileHandle() = default;
+
+	DUCKDB_API virtual void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) = 0;
+	DUCKDB_API virtual idx_t GetFileSize() = 0;
+	DUCKDB_API virtual string GetPath() const = 0;
+};
+
+struct FileHandle : public BaseFileHandle {
 public:
 	DUCKDB_API FileHandle(FileSystem &file_system, string path, FileOpenFlags flags);
 	FileHandle(const FileHandle &) = delete;
@@ -102,8 +112,9 @@ public:
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsPipe();
 	DUCKDB_API bool OnDiskFile();
-	DUCKDB_API idx_t GetFileSize();
+	DUCKDB_API idx_t GetFileSize() override;
 	DUCKDB_API FileType GetType();
+	DUCKDB_API void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
 	DUCKDB_API FileMetadata Stats();
 
 	DUCKDB_API void TryAddLogger(FileOpener &opener);
@@ -111,7 +122,7 @@ public:
 	//! Closes the file handle.
 	DUCKDB_API virtual void Close() = 0;
 
-	string GetPath() const {
+	string GetPath() const override {
 		return path;
 	}
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -76,7 +76,8 @@ class BaseFileHandle {
 public:
 	DUCKDB_API virtual ~BaseFileHandle() = default;
 
-	DUCKDB_API virtual void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) = 0;
+	//! Read up to nr_bytes from location. Returns bytes actually read (0 if at/past EOF). Never throws on short reads.
+	DUCKDB_API virtual idx_t ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) = 0;
 	DUCKDB_API virtual idx_t GetFileSize() = 0;
 	DUCKDB_API virtual string GetPath() const = 0;
 };
@@ -114,7 +115,7 @@ public:
 	DUCKDB_API bool OnDiskFile();
 	DUCKDB_API idx_t GetFileSize() override;
 	DUCKDB_API FileType GetType();
-	DUCKDB_API void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
+	DUCKDB_API idx_t ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
 	DUCKDB_API FileMetadata Stats();
 
 	DUCKDB_API void TryAddLogger(FileOpener &opener);

--- a/src/include/duckdb/common/file_system/buffered_file_handle.hpp
+++ b/src/include/duckdb/common/file_system/buffered_file_handle.hpp
@@ -18,7 +18,7 @@ class QueryContext;
 //! Wraps a FileHandle with an optional prefetch range. Reads fully covered by
 //! the realized buffer are served from memory; others pass through to the inner
 //! handle. Read-only — writes go via ExtractInnerFileHandle.
-//! v1: single hint slot. BufferedFileHandleState machine: EMPTY → HINT → REALIZED.
+//! v1: single hint slot. BufferedFileHandleState machine: EMPTY → HINT → REALIZED → NO_HANDLE.
 class BufferedFileHandle : public BaseFileHandle {
 public:
 	DUCKDB_API explicit BufferedFileHandle(unique_ptr<FileHandle> inner);
@@ -31,6 +31,7 @@ public:
 	DUCKDB_API void RegisterPrefetch(idx_t offset, idx_t size);
 
 	//! Copy the realized buffer from another wrapper (pending hints are not copied).
+	//! Source may be REALIZED or NO_HANDLE — both have a valid in-memory buffer.
 	DUCKDB_API void CopyBufferFrom(const BufferedFileHandle &other);
 
 	//! Positional read; serves from the buffer when fully covered, else forwards
@@ -45,8 +46,13 @@ public:
 	//! Take ownership of the inner handle; the wrapper is drained afterwards.
 	DUCKDB_API unique_ptr<FileHandle> ExtractInnerFileHandle();
 
+	//! Close the inner file handle while preserving the in-memory buffer.
+	//! Requires REALIZED state. After this, the wrapper is in NO_HANDLE state —
+	//! valid only as a CopyBufferFrom source or for destruction.
+	DUCKDB_API void CloseHandle();
+
 private:
-	enum class BufferedFileHandleState : uint8_t { EMPTY, HINT, REALIZED };
+	enum class BufferedFileHandleState : uint8_t { EMPTY, HINT, REALIZED, NO_HANDLE };
 
 	unique_ptr<FileHandle> inner;
 	BufferedFileHandleState state = BufferedFileHandleState::EMPTY;

--- a/src/include/duckdb/common/file_system/buffered_file_handle.hpp
+++ b/src/include/duckdb/common/file_system/buffered_file_handle.hpp
@@ -35,8 +35,9 @@ public:
 
 	//! Positional read; serves from the buffer when fully covered, else forwards
 	//! to the inner handle (realizing a pending hint with one inner Read).
-	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);
-	DUCKDB_API void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
+	//! Returns bytes actually read (0 at/past EOF). Never throws on short reads.
+	DUCKDB_API idx_t Read(void *buffer, idx_t nr_bytes, idx_t location);
+	DUCKDB_API idx_t ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
 
 	DUCKDB_API idx_t GetFileSize() override;
 	DUCKDB_API string GetPath() const override;

--- a/src/include/duckdb/common/file_system/buffered_file_handle.hpp
+++ b/src/include/duckdb/common/file_system/buffered_file_handle.hpp
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/file_system/buffered_file_handle.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+
+namespace duckdb {
+
+class QueryContext;
+
+//! Wraps a FileHandle with an optional prefetch range. Reads fully covered by
+//! the realized buffer are served from memory; others pass through to the inner
+//! handle. Read-only — writes go via ExtractInnerFileHandle.
+//! v1: single hint slot. BufferedFileHandleState machine: EMPTY → HINT → REALIZED.
+class BufferedFileHandle : public BaseFileHandle {
+public:
+	DUCKDB_API explicit BufferedFileHandle(unique_ptr<FileHandle> inner);
+	DUCKDB_API ~BufferedFileHandle() override;
+
+	BufferedFileHandle(const BufferedFileHandle &) = delete;
+	BufferedFileHandle &operator=(const BufferedFileHandle &) = delete;
+
+	//! Set the prefetch hint. No I/O. Replaces any prior hint or buffer.
+	DUCKDB_API void RegisterPrefetch(idx_t offset, idx_t size);
+
+	//! Copy the realized buffer from another wrapper (pending hints are not copied).
+	DUCKDB_API void CopyBufferFrom(const BufferedFileHandle &other);
+
+	//! Positional read; serves from the buffer when fully covered, else forwards
+	//! to the inner handle (realizing a pending hint with one inner Read).
+	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);
+	DUCKDB_API void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) override;
+
+	DUCKDB_API idx_t GetFileSize() override;
+	DUCKDB_API string GetPath() const override;
+
+	//! Take ownership of the inner handle; the wrapper is drained afterwards.
+	DUCKDB_API unique_ptr<FileHandle> ExtractInnerFileHandle();
+
+private:
+	enum class BufferedFileHandleState : uint8_t { EMPTY, HINT, REALIZED };
+
+	unique_ptr<FileHandle> inner;
+	BufferedFileHandleState state = BufferedFileHandleState::EMPTY;
+	idx_t range_offset = 0;
+	idx_t range_size = 0;
+	unsafe_unique_array<char> buffer;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
 
@@ -94,7 +95,8 @@ public:
 	~AttachedDatabase() override;
 
 	//! Initializes the catalog and storage of the attached database.
-	void Initialize(optional_ptr<ClientContext> context = nullptr);
+	void Initialize(optional_ptr<ClientContext> context = nullptr,
+	                unique_ptr<BufferedFileHandle> prefetched_handle = nullptr);
 	void FinalizeLoad(optional_ptr<ClientContext> context);
 	//! Close the database before shutting it down.
 	void Close(const DatabaseCloseAction action);

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/capi/extension_api.hpp"
 #include "duckdb/main/config.hpp"
@@ -81,7 +82,7 @@ public:
 private:
 	void Initialize(const char *path, DBConfig *config);
 	void LoadExtensionSettings();
-	void CreateMainDatabase();
+	void CreateMainDatabase(unique_ptr<BufferedFileHandle> prefetched_handle = nullptr);
 
 	void Configure(DBConfig &config, const char *path);
 

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
@@ -50,7 +51,8 @@ public:
 	optional_ptr<AttachedDatabase> GetDatabase(ClientContext &context, const string &name);
 	shared_ptr<AttachedDatabase> GetDatabase(const string &name);
 	//! Attach a new database
-	shared_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options);
+	shared_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options,
+	                                            unique_ptr<BufferedFileHandle> prefetched_handle = nullptr);
 
 	//! Detach an existing database
 	void DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
@@ -70,7 +72,8 @@ public:
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
 	//! to lock for this operation.
-	void GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config, AttachOptions &options);
+	void GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config, AttachOptions &options,
+	                     unique_ptr<BufferedFileHandle> *out_handle = nullptr);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<shared_ptr<AttachedDatabase>> GetDatabases(ClientContext &context,

--- a/src/include/duckdb/main/database_path_and_type.hpp
+++ b/src/include/duckdb/main/database_path_and_type.hpp
@@ -13,15 +13,21 @@
 
 namespace duckdb {
 
+class BufferedFileHandle;
 class QueryContext;
 
 struct DBPathAndType {
 	//! Parse database extension type and rest of path from combined form (type:path)
 	static void ExtractExtensionPrefix(string &path, string &db_type);
-	//! Check the magic bytes of a file and set the database type based on that
-	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type);
+	//! Check the magic bytes of a file and set the database type based on that.
+	//! If `out_handle` is non-null, returns through it an open BufferedFileHandle
+	//! with the duckdb header range prefetched (for downstream storage open).
+	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
+	                            unique_ptr<BufferedFileHandle> *out_handle = nullptr);
 
-	//! Run ExtractExtensionPrefix followed by CheckMagicBytes
-	static void ResolveDatabaseType(FileSystem &fs, string &path, string &db_type);
+	//! Run ExtractExtensionPrefix followed by CheckMagicBytes.
+	//! Same `out_handle` semantics as CheckMagicBytes.
+	static void ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
+	                                unique_ptr<BufferedFileHandle> *out_handle = nullptr);
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/magic_bytes.hpp
+++ b/src/include/duckdb/storage/magic_bytes.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 
 namespace duckdb {
+class BufferedFileHandle;
 class FileSystem;
 class QueryContext;
 
@@ -24,7 +25,12 @@ enum class DataFileType : uint8_t {
 
 class MagicBytes {
 public:
-	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path);
+	//! Check the magic bytes of the file at `path`. If `out_handle` is non-null,
+	//! returns through it an open BufferedFileHandle with the duckdb header
+	//! range (~12 KiB) prefetched, so a downstream storage open can reuse the
+	//! handle plus its buffered prefix instead of issuing a second open + reads.
+	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
+	                                    unique_ptr<BufferedFileHandle> *out_handle = nullptr);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/storage/block_manager.hpp"
 #include "duckdb/storage/block.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/common/vector.hpp"
@@ -69,8 +70,9 @@ public:
 	//! Creates a new database.
 	void CreateNewDatabase(QueryContext context);
 	//! Loads an existing database. We pass the provided block allocation size as a parameter
-	//! to detect inconsistencies with the file header.
-	void LoadExistingDatabase(QueryContext context);
+	//! to detect inconsistencies with the file header. If `prefetched_handle` is set, its
+	//! buffered prefix is reused to satisfy the header reads (avoids redundant remote I/O).
+	void LoadExistingDatabase(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle = nullptr);
 
 	//! Creates a new Block using the specified block_id and returns a pointer
 	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override;
@@ -148,8 +150,11 @@ private:
 	void CheckChecksum(FileBuffer &block, uint64_t location, uint64_t delta, bool skip_block_header = false) const;
 	void CheckChecksum(data_ptr_t start_ptr, uint64_t delta, bool skip_block_header = false) const;
 
-	void ReadAndChecksum(QueryContext context, FileBuffer &handle, uint64_t location,
-	                     bool skip_block_header = false) const;
+	//! Reads via the supplied BaseFileHandle. Pass `*handle` (the member) for
+	//! steady-state reads, or a local BufferedFileHandle during init so its
+	//! buffer hits land. Always 5-arg, no implicit-source overload.
+	void ReadAndChecksum(QueryContext context, FileBuffer &block, uint64_t location, bool skip_block_header,
+	                     BaseFileHandle &source) const;
 	void ChecksumAndWrite(QueryContext context, FileBuffer &handle, uint64_t location,
 	                      bool skip_block_header = false) const;
 

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -15,7 +15,7 @@
 
 namespace duckdb {
 
-struct FileHandle;
+class BaseFileHandle;
 class QueryContext;
 
 //! The standard row group size
@@ -116,7 +116,9 @@ public:
 	static constexpr uint64_t AES_IV_LEN = 16;
 	static constexpr uint64_t AES_TAG_LEN = 16;
 
-	static void CheckMagicBytes(QueryContext context, FileHandle &handle);
+	//! Verify the duckdb magic bytes inside an open database file.
+	//! Accepts any BaseFileHandle (FileHandle, BufferedFileHandle, ...).
+	static void CheckMagicBytes(QueryContext context, BaseFileHandle &handle);
 
 	string LibraryGitDesc() {
 		return string(char_ptr_cast(library_git_desc), MAX_VERSION_SIZE);

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/storage/table_io_manager.hpp"
 #include "duckdb/storage/write_ahead_log.hpp"
@@ -60,7 +61,7 @@ public:
 	//! Initialize a database or load an existing database from the database file path. The block_alloc_size is
 	//! either set, or invalid. If invalid, then DuckDB defaults to the default_block_alloc_size (DBConfig),
 	//! or the file's block allocation size, if it is an existing database.
-	void Initialize(QueryContext context);
+	void Initialize(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle = nullptr);
 
 	DatabaseInstance &GetDatabase();
 	AttachedDatabase &GetAttached() const {
@@ -148,7 +149,7 @@ public:
 	}
 
 protected:
-	virtual void LoadDatabase(QueryContext context) = 0;
+	virtual void LoadDatabase(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle) = 0;
 
 protected:
 	//! The attached database managed by this storage manager.
@@ -211,7 +212,7 @@ public:
 	void Destroy() override;
 
 protected:
-	void LoadDatabase(QueryContext context) override;
+	void LoadDatabase(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle) override;
 
 	unique_ptr<CheckpointWriter> CreateCheckpointWriter(QueryContext context, CheckpointOptions options);
 };

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -232,14 +232,15 @@ void AttachedDatabase::InvokeCloseIfLastReference(shared_ptr<AttachedDatabase> &
 	attached_db.reset();
 }
 
-void AttachedDatabase::Initialize(optional_ptr<ClientContext> context) {
+void AttachedDatabase::Initialize(optional_ptr<ClientContext> context,
+                                  unique_ptr<BufferedFileHandle> prefetched_handle) {
 	if (IsSystem()) {
 		catalog->Initialize(context, true);
 	} else {
 		catalog->Initialize(context, false);
 	}
 	if (storage) {
-		storage->Initialize(context);
+		storage->Initialize(context, std::move(prefetched_handle));
 	}
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/database.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/execution/index/index_type_set.hpp"
@@ -194,7 +195,7 @@ shared_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientCont
 	return attached_database;
 }
 
-void DatabaseInstance::CreateMainDatabase() {
+void DatabaseInstance::CreateMainDatabase(unique_ptr<BufferedFileHandle> prefetched_handle) {
 	AttachInfo info;
 	info.name = AttachedDatabase::ExtractDatabaseName(config.options.database_path, GetFileSystem());
 	info.path = config.options.database_path;
@@ -203,7 +204,7 @@ void DatabaseInstance::CreateMainDatabase() {
 	con.BeginTransaction();
 	AttachOptions options(config.options);
 	options.is_main_database = true;
-	db_manager->AttachDatabase(*con.context, info, options);
+	db_manager->AttachDatabase(*con.context, info, options, std::move(prefetched_handle));
 	con.Commit();
 }
 
@@ -304,7 +305,9 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	// resolve the type of the database we are opening
 	auto &fs = FileSystem::GetFileSystem(*this);
-	DBPathAndType::ResolveDatabaseType(fs, config.options.database_path, config.options.database_type);
+	unique_ptr<BufferedFileHandle> prefetched_handle;
+	DBPathAndType::ResolveDatabaseType(fs, config.options.database_path, config.options.database_type,
+	                                   &prefetched_handle);
 
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
@@ -323,7 +326,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	LoadExtensionSettings();
 
 	if (!db_manager->HasDefaultDatabase()) {
-		CreateMainDatabase();
+		CreateMainDatabase(std::move(prefetched_handle));
 	}
 
 	// only increase thread count after storage init because we get races on catalog otherwise

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -100,7 +100,8 @@ bool RequiresTrackingAttaches(const string &path, const string &db_type) {
 }
 
 shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &context, AttachInfo &info,
-                                                             AttachOptions &options) {
+                                                             AttachOptions &options,
+                                                             unique_ptr<BufferedFileHandle> prefetched_handle) {
 	string extension = "";
 	if (FileSystem::IsRemoteFile(info.path, extension)) {
 		if (options.access_mode == AccessMode::AUTOMATIC) {
@@ -171,7 +172,7 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		}
 	}
 	auto &config = DBConfig::GetConfig(context);
-	GetDatabaseType(context, info, config, options);
+	GetDatabaseType(context, info, config, options, &prefetched_handle);
 	if (!options.db_type.empty()) {
 		// we only need to prevent duplicate opening of DuckDB files
 		// if this is not a DuckDB file but e.g. a CSV or Parquet file, we don't need to do this duplicate protection
@@ -198,9 +199,9 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	//! Initialize the database.
 	if (options.is_main_database) {
 		attached_db->SetInitialDatabase();
-		attached_db->Initialize(context);
+		attached_db->Initialize(context, std::move(prefetched_handle));
 	} else {
-		attached_db->Initialize(context);
+		attached_db->Initialize(context, std::move(prefetched_handle));
 		if (!options.default_table.name.empty()) {
 			attached_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 		}
@@ -352,7 +353,7 @@ vector<string> DatabaseManager::GetAttachedDatabasePaths() {
 }
 
 void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config,
-                                      AttachOptions &options) {
+                                      AttachOptions &options, unique_ptr<BufferedFileHandle> *out_handle) {
 	// Test if the database is a DuckDB database file.
 	if (StringUtil::CIEquals(options.db_type, "duckdb")) {
 		options.db_type = "";
@@ -362,7 +363,7 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 	// Try to extract the database type from the path.
 	if (options.db_type.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type);
+		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, out_handle);
 	}
 
 	if (options.db_type.empty()) {

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/database_path_and_type.hpp"
 
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/function/replacement_scan.hpp"
@@ -16,9 +17,10 @@ void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	}
 }
 
-void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type) {
+void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
+                                    unique_ptr<BufferedFileHandle> *out_handle) {
 	// if there isn't - check the magic bytes of the file (if any)
-	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path);
+	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path, out_handle);
 	db_type = string();
 	switch (file_type) {
 	case DataFileType::SQLITE_FILE:
@@ -39,7 +41,8 @@ void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string
 	}
 }
 
-void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db_type) {
+void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
+                                        unique_ptr<BufferedFileHandle> *out_handle) {
 	if (!db_type.empty()) {
 		// database type specified explicitly - no need to check
 		return;
@@ -51,7 +54,7 @@ void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db
 		return;
 	}
 	// check database type by reading the magic bytes of a file
-	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type);
+	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type, out_handle);
 }
 
 } // namespace duckdb

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -42,6 +42,7 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 
 	handle_slot->RegisterPrefetch(0, HEADER_PREFETCH_SIZE);
 
+	// Buffer is zero-initialized so a short read at EOF yields a non-match.
 	char buffer[MAGIC_BYTES_READ_SIZE] = {};
 	handle_slot->Read(buffer, MAGIC_BYTES_READ_SIZE, 0);
 	return ClassifyMagicBytes(buffer);

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -33,8 +33,7 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 	unique_ptr<BufferedFileHandle> local_handle;
 	auto &handle_slot = out_handle ? *out_handle : local_handle;
 	if (!handle_slot) {
-		auto raw_handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS |
-		                                        FileFlags::FILE_FLAGS_DIRECT_IO);
+		auto raw_handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 		if (!raw_handle) {
 			return DataFileType::FILE_DOES_NOT_EXIST;
 		}

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -1,23 +1,16 @@
 #include "duckdb/storage/magic_bytes.hpp"
+#include "duckdb/common/file_system/buffered_file_handle.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
 
-DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path) {
-	if (path.empty() || path == IN_MEMORY_PATH) {
-		return DataFileType::DUCKDB_FILE;
-	}
-	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
-	if (!handle) {
-		return DataFileType::FILE_DOES_NOT_EXIST;
-	}
+//! Main header + 2 DB headers (3 × 4 KiB). Prefetched so a later storage open
+//! can reuse the buffered prefix instead of re-reading.
+static constexpr const idx_t HEADER_PREFETCH_SIZE = 12288;
+static constexpr const idx_t MAGIC_BYTES_READ_SIZE = 16;
 
-	constexpr const idx_t MAGIC_BYTES_READ_SIZE = 16;
-	char buffer[MAGIC_BYTES_READ_SIZE] = {};
-
-	handle->Read(context, buffer, MAGIC_BYTES_READ_SIZE);
+static DataFileType ClassifyMagicBytes(const char *buffer) {
 	if (memcmp(buffer, "SQLite format 3\0", 16) == 0) {
 		return DataFileType::SQLITE_FILE;
 	}
@@ -28,6 +21,31 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 		return DataFileType::DUCKDB_FILE;
 	}
 	return DataFileType::UNKNOWN_FILE;
+}
+
+DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
+                                         unique_ptr<BufferedFileHandle> *out_handle) {
+	if (path.empty() || path == IN_MEMORY_PATH) {
+		return DataFileType::DUCKDB_FILE;
+	}
+
+	// Reuse caller's handle if any, otherwise open into either out_handle or a local.
+	unique_ptr<BufferedFileHandle> local_handle;
+	auto &handle_slot = out_handle ? *out_handle : local_handle;
+	if (!handle_slot) {
+		auto raw_handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS |
+		                                        FileFlags::FILE_FLAGS_DIRECT_IO);
+		if (!raw_handle) {
+			return DataFileType::FILE_DOES_NOT_EXIST;
+		}
+		handle_slot = make_uniq<BufferedFileHandle>(std::move(raw_handle));
+	}
+
+	handle_slot->RegisterPrefetch(0, HEADER_PREFETCH_SIZE);
+
+	char buffer[MAGIC_BYTES_READ_SIZE] = {};
+	handle_slot->Read(buffer, MAGIC_BYTES_READ_SIZE, 0);
+	return ClassifyMagicBytes(buffer);
 }
 
 } // namespace duckdb

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -192,14 +192,14 @@ void MainHeader::Write(WriteStream &ser) {
 	SerializeTag(ser, canary_tag, encryption_enabled);
 }
 
-void MainHeader::CheckMagicBytes(QueryContext context, FileHandle &handle) {
+void MainHeader::CheckMagicBytes(QueryContext context, BaseFileHandle &handle) {
 	data_t magic_bytes[MAGIC_BYTE_SIZE];
 	if (handle.GetFileSize() < MainHeader::MAGIC_BYTE_SIZE + MainHeader::MAGIC_BYTE_OFFSET) {
-		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.GetPath());
 	}
-	handle.Read(context, magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
+	handle.ReadIntoBuffer(context, magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
 	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
-		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.GetPath());
 	}
 }
 
@@ -564,20 +564,36 @@ void SingleFileBlockManager::CreateNewDatabase(QueryContext context) {
 	max_block = 0;
 }
 
-void SingleFileBlockManager::LoadExistingDatabase(QueryContext context) {
+void SingleFileBlockManager::LoadExistingDatabase(QueryContext context,
+                                                  unique_ptr<BufferedFileHandle> prefetched_handle) {
 	auto flags = GetFileFlags(false);
 
 	// open the RDBMS handle
 	auto &fs = FileSystem::Get(db);
-	handle = fs.OpenFile(path, flags);
-	if (!handle) {
+	auto raw_handle = fs.OpenFile(path, flags);
+	if (!raw_handle) {
 		// this can only happen in read-only mode - as that is when we set FILE_FLAGS_NULL_IF_NOT_EXISTS
 		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist", path);
 	}
 
-	MainHeader::CheckMagicBytes(context, *handle);
+	// Wrap in a BufferedFileHandle for the header phase. Two paths:
+	// - prefetched_handle set (init went through MagicBytes::CheckMagicBytes):
+	//   copy the buffered bytes across; reads below hit memory.
+	// - prefetched_handle null (e.g. `duckdb:URL` prefix skipped magic-bytes
+	//   resolution): register a prefetch hint so the first header read fetches
+	//   the whole 12 KiB in one shot; the rest are buffer hits.
+	// Either way, the four header reads collapse into a single wire read.
+	static constexpr const idx_t HEADER_PREFETCH_SIZE = 12288;
+	auto buffered = make_uniq<BufferedFileHandle>(std::move(raw_handle));
+	if (prefetched_handle) {
+		buffered->CopyBufferFrom(*prefetched_handle);
+	} else {
+		buffered->RegisterPrefetch(0, HEADER_PREFETCH_SIZE);
+	}
+
+	MainHeader::CheckMagicBytes(context, *buffered);
 	// otherwise, we check the metadata of the file
-	ReadAndChecksum(context, header_buffer, 0, true);
+	ReadAndChecksum(context, header_buffer, 0, true, *buffered);
 
 	uint64_t delta = 0;
 	if (GetBlockHeaderSize() > DEFAULT_BLOCK_HEADER_STORAGE_SIZE) {
@@ -647,12 +663,17 @@ void SingleFileBlockManager::LoadExistingDatabase(QueryContext context) {
 
 	// read the database headers from disk
 	DatabaseHeader h1;
-	ReadAndChecksum(context, header_buffer, Storage::FILE_HEADER_SIZE);
+	ReadAndChecksum(context, header_buffer, Storage::FILE_HEADER_SIZE, false, *buffered);
 	h1 = DeserializeDatabaseHeader(main_header, header_buffer.buffer);
 
 	DatabaseHeader h2;
-	ReadAndChecksum(context, header_buffer, Storage::FILE_HEADER_SIZE * 2ULL);
+	ReadAndChecksum(context, header_buffer, Storage::FILE_HEADER_SIZE * 2ULL, false, *buffered);
 	h2 = DeserializeDatabaseHeader(main_header, header_buffer.buffer);
+
+	// header phase done — release the buffer wrapper, install the raw handle
+	// for the rest of the class to use.
+	handle = buffered->ExtractInnerFileHandle();
+	buffered.reset();
 
 	// check the header with the highest iteration count
 	if (h1.iteration > h2.iteration) {
@@ -714,11 +735,11 @@ void SingleFileBlockManager::CheckChecksum(FileBuffer &block, uint64_t location,
 }
 
 void SingleFileBlockManager::ReadAndChecksum(QueryContext context, FileBuffer &block, uint64_t location,
-                                             bool skip_block_header) const {
-	// read the buffer from disk
-	block.Read(context, *handle, location);
+                                             bool skip_block_header, BaseFileHandle &source) const {
+	// read the buffer via the supplied handle (BufferedFileHandle hits its
+	// in-memory buffer for prefetched ranges; FileHandle goes straight to disk)
+	block.Read(context, source, location);
 
-	//! calculate delta header bytes (if any)
 	uint64_t delta = GetBlockHeaderSize() - Storage::DEFAULT_BLOCK_HEADER_SIZE;
 
 	if (options.encryption_options.encryption_enabled && !skip_block_header) {
@@ -1121,7 +1142,7 @@ void SingleFileBlockManager::ReadBlock(Block &block, bool skip_block_header) con
 void SingleFileBlockManager::Read(QueryContext context, Block &block) {
 	D_ASSERT(block.id >= 0);
 	D_ASSERT(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
-	ReadAndChecksum(context, block, GetBlockLocation(block.id));
+	ReadAndChecksum(context, block, GetBlockLocation(block.id), false, *handle);
 }
 
 void SingleFileBlockManager::ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -568,6 +568,13 @@ void SingleFileBlockManager::LoadExistingDatabase(QueryContext context,
                                                   unique_ptr<BufferedFileHandle> prefetched_handle) {
 	auto flags = GetFileFlags(false);
 
+	// Close the read-only fd inside the prefetched wrapper (if any) BEFORE opening
+	// our own handle. Two simultaneous opens of the same file violate Windows'
+	// default share mode. The in-memory buffer is preserved for CopyBufferFrom.
+	if (prefetched_handle) {
+		prefetched_handle->CloseHandle();
+	}
+
 	// open the RDBMS handle
 	auto &fs = FileSystem::Get(db);
 	auto raw_handle = fs.OpenFile(path, flags);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -321,14 +321,14 @@ inline void ClearUserKey(shared_ptr<string> const &encryption_key) {
 	}
 }
 
-void StorageManager::Initialize(QueryContext context) {
+void StorageManager::Initialize(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle) {
 	bool in_memory = InMemory();
 	if (in_memory && read_only) {
 		throw CatalogException("Cannot launch in-memory database in read-only mode!");
 	}
 
 	// Create or load the database from disk, if not in-memory mode.
-	LoadDatabase(context);
+	LoadDatabase(context, std::move(prefetched_handle));
 
 	if (storage_options.encryption) {
 		ClearUserKey(storage_options.user_key);
@@ -363,7 +363,7 @@ SingleFileStorageManager::SingleFileStorageManager(AttachedDatabase &db, string 
     : StorageManager(db, std::move(path), options) {
 }
 
-void SingleFileStorageManager::LoadDatabase(QueryContext context) {
+void SingleFileStorageManager::LoadDatabase(QueryContext context, unique_ptr<BufferedFileHandle> prefetched_handle) {
 	if (InMemory()) {
 		block_manager = make_uniq<InMemoryBlockManager>(BufferManager::GetBufferManager(db), DEFAULT_BLOCK_ALLOC_SIZE,
 		                                                DEFAULT_BLOCK_HEADER_STORAGE_SIZE);
@@ -473,7 +473,7 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		// We'll construct the SingleFileBlockManager with the default block allocation size,
 		// and later adjust it when reading the file header.
 		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
-		sf_block_manager->LoadExistingDatabase(context);
+		sf_block_manager->LoadExistingDatabase(context, std::move(prefetched_handle));
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager, row_group_size);
 


### PR DESCRIPTION
Issue is as follow: adding logging to requests performed on the wire, and doing something like:
```sql
 ATTACH 'https://blobs.duckdb.org/data/tpch-sf1.db';
```
we (that is, duckdb `main` branch) currently performs:
```
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db       (start=0, len=1048576)
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    8	4
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    0	4096
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    4096	4096
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    8192	4096
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    259272704	262144
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    258748416	262144
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db.wal
```

After this PR, 4 range requests are removed, to:
```
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    (start=0, len= 1048576) <--this could be 12288
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    259272704	262144
GetRangeRequest 	https://blobs.duckdb.org/data/tpch-sf1.db	    258748416	262144
HeadRequest         https://blobs.duckdb.org/data/tpch-sf1.db.wal
```

There might be a path to remove also some other requests, in particular the double HEAD at 1st and 3rd, but for now, 3 HEAD + 3 GET are better than current 3+7.

----

Implementation side, there are 2 infrastructure changes to be aware: a `BaseFileHandle`, this `BaseFileHandle` has only a very limited surface:
```c++
class BaseFileHandle {
public:
       DUCKDB_API virtual ~BaseFileHandle() = default;

       DUCKDB_API virtual void ReadIntoBuffer(QueryContext context, void *buffer, idx_t nr_bytes, idx_t location) = 0;
       DUCKDB_API virtual idx_t GetFileSize() = 0;
       DUCKDB_API virtual string GetPath() const = 0;
};
```
but that's enough to handle the `CheckMagicBytes` / `ResolveDatabaseType` / `ReadAndChecksum` codepaths.

Instantiations could be either a proper `FileHandle` or a `BufferedFileHandle`, that is a  new class that packages a FileHandle plus a single optional buffer to be prefetched.

In case of attaching a database, the buffer is sized to 12288 bytes, so that a single GET (with range) covers both type discovery AND reading the MainHeader + 2 DatabaseHeaders in a go.

Once the initialisation phase has completed, `BufferedFileHandle` decays to a simple `FileHandle` (that means, also Write path becomes possible) via a call to `unique_ptr<FileHandle> BufferedFileHandle::ExtractInnerFileHandle()`.

----

Note, there are like 4 relevant path worth testing:
```
duckdb https://blobs.duckdb.org/data/tpch-sf1.db
duckdb duckdb:https://blobs.duckdb.org/data/tpch-sf1.db
duckdb -c "ATTACH 'https://blobs.duckdb.org/data/tpch-sf1.db';"
duckdb -c "ATTACH 'https://blobs.duckdb.org/data/tpch-sf1.db' (TYPE duckdb);"
```
and logging is at the moment not tracking correctly all requests in these codepaths (that's for a different PR).

As of now, there are no added tests, main thing tested by CI at the moment is whether any difference is detected.