### PR TITLE
Reject running unittest without run_tests.py in CI workflows

### DIFF
--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
+          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir my_local_folder" ./build/release/test/unittest || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v7
@@ -240,7 +240,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
+          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir my_local_folder" ./build/release/test/unittest || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1249,7 +1249,7 @@ jobs:
     - name: Test
       if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
       shell: bash
-      run: valgrind ./build/relassert/test/unittest test/sql/tpch/tpch_sf001.test_slow
+      run: python3 scripts/ci/run_tests.py --workers 1 --batch-size 1 --test-command "valgrind {binary} {flags} -f {test_list}" ./build/relassert/test/unittest test/sql/tpch/tpch_sf001.test_slow
 
  threadsan:
     name: Thread Sanitizer
@@ -1419,7 +1419,7 @@ jobs:
       if: success() || failure()
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/vacuum_rebuild_indexes_force_storage.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/vacuum_rebuild_indexes_force_storage.json ./build/release/test/unittest
 
     - name: test/configs/prefetch_all_parquet_files.json
       if: success() || failure()

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -681,7 +681,7 @@ jobs:
 
      - name: Test
        shell: bash
-       run: build/relassert/test/unittest --test-config test/configs/hash_zero.json
+       run: python3 scripts/ci/run_tests.py --test-config=test/configs/hash_zero.json build/relassert/test/unittest
 
 
   bwc_build:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -318,17 +318,11 @@ jobs:
            echo "PATH=$PATH"
            where python
            python --version
-           where unittest.exe || true
-           if [ -f build/release/test/unittest.exe ]; then
-             ls -l build/release/test/unittest.exe
-           fi
            echo "Nearby DLLs and EXEs:"
            find build/release -maxdepth 3 \( -name '*.dll' -o -name '*.exe' \) | sort || true
            /c/Windows/System32/cmd.exe /c "where libstdc++-6.dll" || true
            /c/Windows/System32/cmd.exe /c "where libgcc_s_seh-1.dll" || true
            /c/Windows/System32/cmd.exe /c "where libwinpthread-1.dll" || true
-           objdump -p build/release/test/unittest.exe | sed -n '/DLL Name:/p' || true
-           ./build/release/test/unittest.exe --list-tests || true
 
        - name: Build
          run: python scripts/ci/retry.py -- make release

--- a/scripts/ci/test_job_stages.py
+++ b/scripts/ci/test_job_stages.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import shlex
 import sys
 import tempfile
 import unittest
@@ -15,6 +16,73 @@ from scripts.ci import job_stages
 
 
 class JobStagesTest(unittest.TestCase):
+    UNITTEST_TOKEN_RE = re.compile(r"(?:\./)?[\w./-]*unittest(?:\.exe)?$")
+
+    def _workflow_paths(self) -> list[Path]:
+        return sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+    def _extract_run_commands(self, workflow_text: str) -> list[tuple[int, str]]:
+        commands: list[tuple[int, str]] = []
+        lines = workflow_text.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            match = re.match(r"^(\s*)run:\s*(.*)$", line)
+            if not match:
+                i += 1
+                continue
+
+            indent = len(match.group(1))
+            value = match.group(2).strip()
+            line_no = i + 1
+
+            if value in {"|", ">"}:
+                block_lines: list[str] = []
+                i += 1
+                while i < len(lines):
+                    block_line = lines[i]
+                    if not block_line.strip():
+                        block_lines.append("")
+                        i += 1
+                        continue
+
+                    block_indent = len(block_line) - len(block_line.lstrip(" "))
+                    if block_indent <= indent:
+                        break
+                    block_lines.append(block_line[indent + 2 :] if len(block_line) > indent + 2 else "")
+                    i += 1
+
+                commands.append((line_no, "\n".join(block_lines)))
+                continue
+
+            commands.append((line_no, value))
+            i += 1
+
+        return commands
+
+    def _has_direct_unittest_invocation(self, command: str) -> bool:
+        command_parts = re.split(r"\n|&&|\|\||;", command)
+        for raw_part in command_parts:
+            part = raw_part.strip()
+            if not part:
+                continue
+            try:
+                tokens = shlex.split(part)
+            except ValueError:
+                tokens = part.split()
+            if not tokens:
+                continue
+
+            idx = 0
+            while idx < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=.*$", tokens[idx]):
+                idx += 1
+            if idx >= len(tokens):
+                continue
+
+            if self.UNITTEST_TOKEN_RE.match(tokens[idx]):
+                return True
+        return False
+
     def _compute_job_selection(
         self,
         event_name: str,
@@ -211,6 +279,25 @@ class JobStagesTest(unittest.TestCase):
             extra_in_summary,
             f"summary.needs references unknown jobs: {sorted(extra_in_summary)}",
         )
+
+    def test_workflow_unittest_commands_use_run_tests_py(self):
+        violations: list[str] = []
+
+        for workflow_path in self._workflow_paths():
+            workflow_text = workflow_path.read_text(encoding="utf-8")
+            for line_no, command in self._extract_run_commands(workflow_text):
+                if not self._has_direct_unittest_invocation(command):
+                    continue
+                if "scripts/ci/run_tests.py" in command:
+                    continue
+                snippet = " ".join(command.strip().split())
+                if len(snippet) > 180:
+                    snippet = snippet[:177] + "..."
+                violations.append(f"{workflow_path.relative_to(REPO_ROOT)}:{line_no}: {snippet}")
+
+        if violations:
+            formatted = "\n\n".join(f"- {entry}" for entry in violations)
+            self.fail("workflow `run:` commands using `unittest` must use scripts/ci/run_tests.py:\n\n" + formatted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using unittest directly in CI can cause [problems](https://github.com/duckdb/duckdb/actions/runs/25103836238/job/73560165546?pr=22224#step:23:3678):
- unittest does not retry any failed (flaky) tests.
- inefficient hardware utilization (increases CI job time by 4 min, on a 16 vCPU core machine).

This PR adds a simple check to verify that unittest uses `run_tests.py`.

Without the added invocation fixes, we would see this error in the CI job `prepare`:
```
AssertionError: workflow `run:` commands using `unittest` must use scripts/ci/run_tests.py:

- .github/workflows/CrossVersion.yml:68: ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true rm -rf my_local_folder/hive

- .github/workflows/CrossVersion.yml:242: ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true rm -rf my_local_folder/hive

- .github/workflows/Main.yml:1252: valgrind ./build/relassert/test/unittest test/sql/tpch/tpch_sf001.test_slow

- .github/workflows/Main.yml:1421: ./build/release/test/unittest --test-config test/configs/vacuum_rebuild_indexes_force_storage.json

- .github/workflows/NightlyTests.yml:684: build/relassert/test/unittest --test-config test/configs/hash_zero.json

- .github/workflows/Windows.yml:315: set -x echo "PWD=$PWD" echo "PATH=$PATH" where python python --version where unittest.exe || true if [ -f build/release/test/unittest.exe ]; then ls -l build/release/test/unitte...
```