### PR TITLE
Use -mcpu=native on aarch64 when compiling with `NATIVE_ARCH=1`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,7 +588,11 @@ if(TREAT_WARNINGS_AS_ERRORS)
 endif()
 
 if(NATIVE_ARCH)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  endif()
 endif()
 
 if(OVERRIDE_NEW_DELETE)


### PR DESCRIPTION
On aarch64, -march=native does not fully tune for the current machine. Enabled features and applied optimizations might differ between march=native and mcpu=native.