### PR TITLE
`GROUPING()`/`GROUPING_ID()` with no args uses all `GROUP BY` columns by default

### DIFF
--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -766,7 +766,7 @@ const char INLINED_PEG_GRAMMAR[] = {
 	"MapExpression <- 'MAP' MapStructExpression\n"
 	"MapStructExpression <- '{' List(MapStructField)? '}'\n"
 	"MapStructField <- Expression ':' Expression\n"
-	"GroupingExpression <- GroupingOrGroupingId Parens(List(Expression))\n"
+	"GroupingExpression <- GroupingOrGroupingId Parens(List(Expression)?)\n"
 	"GroupingOrGroupingId <- 'GROUPING' / 'GROUPING_ID'\n"
 	"Parameter <- QuestionMarkNumberedParameter / AnonymousParameter / NumberedParameter / ColLabelParameter\n"
 	"QuestionMarkNumberedParameter <- '?' NumberLiteral\n"

--- a/src/parser/peg/grammar/statements/expression.gram
+++ b/src/parser/peg/grammar/statements/expression.gram
@@ -81,7 +81,7 @@ MapExpression <- 'MAP' MapStructExpression
 MapStructExpression <- '{' List(MapStructField)? '}'
 MapStructField <- Expression ':' Expression
 
-GroupingExpression <- GroupingOrGroupingId Parens(List(Expression))
+GroupingExpression <- GroupingOrGroupingId Parens(List(Expression)?)
 GroupingOrGroupingId <- 'GROUPING' / 'GROUPING_ID'
 Parameter <- QuestionMarkNumberedParameter / AnonymousParameter / NumberedParameter / ColLabelParameter
 QuestionMarkNumberedParameter <- '?' NumberLiteral

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2630,11 +2630,16 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformGroupingExpression(
                                                                                 ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto &extract_parens = ExtractResultFromParens(list_pr.Child<ListParseResult>(1));
-	auto expr_list = ExtractParseResultsFromList(extract_parens);
+	auto &expr_list_opt = extract_parens.Cast<OptionalParseResult>();
+
 	vector<unique_ptr<ParsedExpression>> grouping_expressions;
-	for (auto expr : expr_list) {
-		grouping_expressions.push_back(transformer.Transform<unique_ptr<ParsedExpression>>(expr));
+	if (expr_list_opt.HasResult()) {
+		auto expr_list = ExtractParseResultsFromList(expr_list_opt.GetResult());
+		for (auto expr : expr_list) {
+			grouping_expressions.push_back(transformer.Transform<unique_ptr<ParsedExpression>>(expr));
+		}
 	}
+
 	auto result = make_uniq<OperatorExpression>(ExpressionType::GROUPING_FUNCTION, std::move(grouping_expressions));
 	return std::move(result);
 }

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -71,24 +71,28 @@ BindResult BaseSelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_pt
 }
 
 BindResult BaseSelectBinder::BindGroupingFunction(OperatorExpression &op, idx_t depth) {
-	if (op.children.empty()) {
-		throw InternalException("GROUPING requires at least one child");
-	}
 	if (node.groups.group_expressions.empty()) {
 		return BindResult(BinderException(op, "GROUPING statement cannot be used without groups"));
 	}
-	if (op.children.size() >= 64) {
-		return BindResult(BinderException(op, "GROUPING statement cannot have more than 64 groups"));
-	}
 	vector<ProjectionIndex> group_indexes;
-	group_indexes.reserve(op.children.size());
-	for (auto &child : op.children) {
-		ExpressionBinder::QualifyColumnNames(binder, child);
-		auto idx = TryBindGroup(*child);
-		if (!idx.IsValid()) {
-			return BindResult(BinderException(op, "GROUPING child \"%s\" must be a grouping column", child->GetName()));
+	if (op.children.empty()) {
+		// No arguments provided - use all group columns
+		for (idx_t i = 0; i < node.groups.group_expressions.size(); i++) {
+			group_indexes.push_back(ProjectionIndex(i));
 		}
-		group_indexes.push_back(idx);
+	} else {
+		for (auto &child : op.children) {
+			ExpressionBinder::QualifyColumnNames(binder, child);
+			auto idx = TryBindGroup(*child);
+			if (!idx.IsValid()) {
+				return BindResult(
+				    BinderException(op, "GROUPING child \"%s\" must be a grouping column", child->GetName()));
+			}
+			group_indexes.push_back(idx);
+		}
+	}
+	if (group_indexes.size() >= 64) {
+		return BindResult(BinderException(op, "GROUPING statement cannot have more than 64 groups"));
 	}
 	ProjectionIndex col_idx(node.grouping_functions.size());
 	node.grouping_functions.push_back(std::move(group_indexes));

--- a/test/issues/monetdb/analytics11.test
+++ b/test/issues/monetdb/analytics11.test
@@ -29,12 +29,14 @@ GROUP BY ()
 ----
 1
 
-statement error
+query I
 SELECT
     GROUPING()
 FROM tbl_ProductSales
 GROUP BY Product_Category
 ----
+0
+0
 
 statement error
 SELECT

--- a/test/sql/aggregate/grouping_sets/grouping.test
+++ b/test/sql/aggregate/grouping_sets/grouping.test
@@ -73,6 +73,23 @@ SELECT GROUPING(course, type), course, type, COUNT(*) FROM students GROUP BY CUB
 2	NULL	PhD	1
 3	NULL	NULL	7
 
+# GROUPING() with no args should use all group columns (course, type)
+query IIII
+SELECT GROUPING(), course, type, COUNT(*) FROM students GROUP BY CUBE(course, type) ORDER BY 1, 2, 3, 4;
+----
+0	CS	NULL	2
+0	CS	Bachelor	2
+0	CS	PhD	1
+0	Math	NULL	1
+0	Math	Masters	1
+1	CS	NULL	5
+1	Math	NULL	2
+2	NULL	NULL	3
+2	NULL	Bachelor	2
+2	NULL	Masters	1
+2	NULL	PhD	1
+3	NULL	NULL	7
+
 query IIIIII
 SELECT GROUPING(course), GROUPING(type), GROUPING(course)+GROUPING(type), course, type, COUNT(*) FROM students GROUP BY CUBE(course, type) ORDER BY 1, 2, 3, 4, 5;
 ----
@@ -183,12 +200,12 @@ NULL	NULL	7
 statement error
 SELECT GROUPING();
 ----
-Parser Error: syntax error at or near ")"
+Binder Error: GROUPING statement cannot be used without groups
 
 statement error
 SELECT GROUPING() FROM students;
 ----
-Parser Error: syntax error at or near ")"
+Binder Error: GROUPING statement cannot be used without groups
 
 statement error
 SELECT GROUPING(NULL) FROM students;


### PR DESCRIPTION
`GROUPING()`/`GROUPING_ID()` with no args uses all `GROUP BY` columns by default.