### PR TITLE
Use Clang++ and clangd version 20 in CI

### DIFF
--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -44,10 +44,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install
-      shell: bash
-      run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq libcurl4-openssl-dev
+      run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
 
@@ -244,7 +241,6 @@ jobs:
          run: |
            python3 scripts/ci/retry.py -- make toolsci
            python3 scripts/ci/retry.py -- sudo apt-get install -y -qq llvm
-           python3 scripts/ci/retry.py -- pip install requests
 
        - uses: ./.github/actions/ccache-action
 
@@ -327,7 +323,6 @@ jobs:
          shell: bash
          run: |
            python3 scripts/ci/retry.py -- make toolsci
-           python3 scripts/ci/retry.py -- pip install requests
 
        - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -34,7 +34,6 @@ jobs:
       shell: bash
       run: |
         python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- pip install requests
 
     - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1262,7 +1262,7 @@ jobs:
       GEN: ninja
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
-      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
+      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt:external_symbolizer_path=/usr/bin/llvm-symbolizer-20
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 
     steps:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1203,8 +1203,8 @@ jobs:
       - prepare
       - linux-relassert
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-20
+      CXX: clang++-20
       DISABLE_SANITIZER: 1
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: 'icu;json;parquet;tpch'
@@ -1246,8 +1246,8 @@ jobs:
       - linux-relassert
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-20
+      CXX: clang++-20
       GEN: ninja
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -624,12 +624,12 @@ jobs:
     - name: Install tools
       run: python3 scripts/ci/retry.py -- make toolsci
 
-    - uses: ./.github/actions/cleanup_runner
-
     - name: Install pytest
       if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
       run: |
-        python3 -m pip install --break-system-packages pytest
+        python3 scripts/ci/retry.py -- pip install --break-system-packages pytest
+
+    - uses: ./.github/actions/cleanup_runner
 
     - uses: ./.github/actions/ccache-action
       with:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -423,6 +423,8 @@ jobs:
    if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'check-clangd-tidy') }}
    needs: prepare
    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
+   env:
+     CLANGD_BINARY: clangd-20
 
    steps:
      - name: "Checkout"

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -276,8 +276,8 @@ jobs:
     needs: prepare
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-20
+      CXX: clang++-20
       TREAT_WARNINGS_AS_ERRORS: 1
       GEN: ninja
       CRASH_ON_ASSERT: 1
@@ -435,8 +435,6 @@ jobs:
      - name: Install
        run: |
          python3 scripts/ci/retry.py -- make toolsci
-         python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
-         python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clangd
          python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
          python3 scripts/ci/retry.py -- make install-clangd-tidy
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -301,6 +301,17 @@ jobs:
     - name: Install tools
       run: python3 scripts/ci/retry.py -- make toolsci
 
+    - name: Fix ASan runtime
+      shell: bash
+      run: |
+        # libclang_rt.asan_static.a is missing in ubuntu 24.04.
+        asan_static_dir="/usr/lib/llvm-20/lib/clang/20/lib/x86_64-pc-linux-gnu"
+        asan_static_target="/usr/lib/llvm-20/lib/clang/20/lib/linux/libclang_rt.asan_static-x86_64.a"
+        if [[ ! -e "${asan_static_dir}/libclang_rt.asan_static.a" && -e "${asan_static_target}" ]]; then
+          sudo mkdir -p "${asan_static_dir}"
+          sudo ln -sf "${asan_static_target}" "${asan_static_dir}/libclang_rt.asan_static.a"
+        fi
+
     - uses: ./.github/actions/ccache-action
       with:
         save: ${{ fromJson(needs.prepare.outputs.save_cache) }}

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -55,7 +55,6 @@ jobs:
          python-version: '3.12'
 
      - name: Install Ninja
-       shell: bash
        run: python3 scripts/ci/retry.py -- make toolsci
 
      - uses: ./.github/actions/ccache-action
@@ -91,10 +90,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install
-      shell: bash
-      run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq libcurl4-openssl-dev
+      run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
 
@@ -175,7 +171,6 @@ jobs:
     - uses: ./.github/actions/cleanup_runner
 
     - name: Install
-      shell: bash
       run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
@@ -219,10 +214,7 @@ jobs:
     - uses: ./.github/actions/cleanup_runner
 
     - name: Install
-      shell: bash
-      run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq llvm libcurl4-openssl-dev
+      run: python3 scripts/ci/retry.py -- make toolsci
 
     - uses: ./.github/actions/ccache-action
 
@@ -334,7 +326,6 @@ jobs:
           path: duckdb-httpfs
 
       - name: Install
-        shell: bash
         run: python3 scripts/ci/retry.py -- make toolsci
 
       - uses: actions/setup-python@v6
@@ -402,11 +393,7 @@ jobs:
          python-version: '3.12'
 
      - name: Install
-       shell: bash
-       run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq libcurl4-openssl-dev
-        python3 scripts/ci/retry.py -- pip install requests
+       run: python3 scripts/ci/retry.py -- make toolsci
 
      - uses: ./.github/actions/ccache-action
 
@@ -470,7 +457,6 @@ jobs:
           fetch-depth: 0
 
       - name: Install
-        shell: bash
         run: python3 scripts/ci/retry.py -- make toolsci
 
       - uses: ./.github/actions/ccache-action
@@ -512,7 +498,6 @@ jobs:
           fetch-depth: 0
 
       - name: Install
-        shell: bash
         run: python3 scripts/ci/retry.py -- make toolsci
 
       - uses: ./.github/actions/ccache-action
@@ -629,7 +614,6 @@ jobs:
          fetch-depth: 0
 
      - name: Install
-       shell: bash
        run: python3 scripts/ci/retry.py -- make toolsci
 
      - uses: ./.github/actions/ccache-action
@@ -655,8 +639,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build libcurl4-openssl-dev
+      - name: Install
+        run: python3 scripts/ci/retry.py -- make toolsci
 
       - name: Setup ccache
         uses: ./.github/actions/ccache-action

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -167,7 +167,6 @@ jobs:
       - name: Install
         run: |
           python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install --break-system-packages requests
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -236,7 +235,6 @@ jobs:
       - name: Install
         run: |
           python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install requests
 
       - name: Checkout Private Regression
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
@@ -287,7 +285,6 @@ jobs:
       - name: Install
         run: |
           python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install requests
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8
@@ -364,7 +361,6 @@ jobs:
       - name: Install
         run: |
           python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install requests
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install
         run: |
           python3 scripts/ci/retry.py -- make toolsci
-          python3 scripts/ci/retry.py -- pip install requests
+          python3 scripts/ci/retry.py -- pip install --break-system-packages requests
 
       - name: Download current release artifact
         uses: actions/download-artifact@v8

--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,7 @@ endef
 .PHONY: toolsci
 
 toolsci:
-	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz,ninja-build mold ccache pkg-config pigz)
+	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz clang++-20 clangd-20,ninja-build mold ccache pkg-config pigz clang++-20 clangd-20)
 	pkg-config --exists libcurl || { \
 		sudo apt-get update -y -qq; \
 		sudo apt-get install -y -qq libcurl4-openssl-dev; \

--- a/Makefile
+++ b/Makefile
@@ -573,17 +573,26 @@ define ensure_apt_commands
 	fi
 endef
 
+define ensure_apt_packages
+	missing=0; \
+	for pkg in $(1); do \
+		dpkg-query -W -f='$${Status}' $$pkg 2>/dev/null | grep -q "install ok installed" || missing=1; \
+	done; \
+	if [ $$missing -eq 1 ]; then \
+		sudo apt-get update -y -qq; \
+		sudo apt-get install -y -qq $(1); \
+	fi
+endef
+
 .PHONY: toolsci
 
 toolsci:
 	$(call ensure_apt_commands,ninja mold ccache pkg-config pigz clang++-20 clangd-20,ninja-build mold ccache pkg-config pigz clang++-20 clangd-20)
-	pkg-config --exists libcurl || { \
-		sudo apt-get update -y -qq; \
-		sudo apt-get install -y -qq libcurl4-openssl-dev; \
-	}
-	ls -lh /usr/bin/gcc* /usr/bin/g++*
+	$(call ensure_apt_packages,python3-requests libcurl4-openssl-dev llvm-20-dev libclang-rt-20-dev)
+	ls -lh /usr/bin/gcc* /usr/bin/g++* /usr/bin/clang++*
 	gcc --version
 	g++ --version
+	clang++ --version
 
 test_ci:
 	python3 -m unittest discover --buffer --start-directory scripts/ci $(T)

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -13,7 +13,6 @@ PULL_REQUEST_JOBS = [
     "linux-relassert-tests",
     "regression",
     "tidy-check",
-    "check-clangd-tidy",
     "extensions",
     "wasm-eh",
     "linux-release",
@@ -31,7 +30,7 @@ PULL_REQUEST_JOBS = [
 
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
-    # "check-clangd-tidy",
+    "check-clangd-tidy",
     "valgrind",
     "static-libs-osx",
     "static-libs-windows-mingw",

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -13,6 +13,7 @@ PULL_REQUEST_JOBS = [
     "linux-relassert-tests",
     "regression",
     "tidy-check",
+    "check-clangd-tidy",
     "extensions",
     "wasm-eh",
     "linux-release",
@@ -30,7 +31,7 @@ PULL_REQUEST_JOBS = [
 
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
-    "check-clangd-tidy",
+    # "check-clangd-tidy",
     "valgrind",
     "static-libs-osx",
     "static-libs-windows-mingw",

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -704,7 +704,7 @@ void ReservoirSample::UpdateSampleAppend(DataChunk &this_, DataChunk &other, Sel
 	auto types = reservoir_chunk->chunk.GetTypes();
 
 	for (idx_t i = 0; i < reservoir_chunk->chunk.ColumnCount(); i++) {
-		auto col_type = types[i];
+		const auto &col_type = types[i];
 		if (ValidSampleType(col_type) || !stats_sample) {
 			D_ASSERT(this_.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
 			VectorOperations::Copy(other.data[i], this_.data[i], other_sel, append_count, 0, this_.size());

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -26,7 +26,7 @@ struct MinMaxState {
 };
 
 template <class OP>
-static AggregateFunction GetUnaryAggregate(LogicalType type) {
+static AggregateFunction GetUnaryAggregate(const LogicalType &type) {
 	switch (type.InternalType()) {
 	case PhysicalType::BOOL:
 		return AggregateFunction::UnaryAggregate<MinMaxState<int8_t>, int8_t, int8_t, OP>(type, type);
@@ -398,9 +398,9 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 }
 
 template <class OP, class OP_STRING, class OP_VECTOR>
-AggregateFunction GetMinMaxOperator(string name) {
-	return AggregateFunction(std::move(name), {LogicalType::ANY}, LogicalType::ANY, nullptr, nullptr, nullptr, nullptr,
-	                         nullptr, nullptr, BindMinMax<OP, OP_STRING, OP_VECTOR>);
+AggregateFunction GetMinMaxOperator(const string &name) {
+	return AggregateFunction(name, {LogicalType::ANY}, LogicalType::ANY, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                         nullptr, BindMinMax<OP, OP_STRING, OP_VECTOR>);
 }
 
 } // namespace
@@ -432,7 +432,7 @@ public:
 		is_initialized = true;
 	}
 
-	static const T &GetValue(const T &val) {
+	static T GetValue(T val) {
 		return val;
 	}
 };

--- a/src/include/duckdb/optimizer/rule/like_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/like_optimizations.hpp
@@ -21,7 +21,7 @@ public:
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;
 
-	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, ScalarFunction function, string pattern,
+	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function, string pattern,
 	                                 bool is_not_like);
 };
 

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -139,7 +139,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	return nullptr;
 }
 
-unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, ScalarFunction function,
+unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
                                                        string pattern, bool is_not_like) {
 	// replace LIKE by an optimized function
 	unique_ptr<Expression> result;

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -42,7 +42,7 @@ idx_t GetQualifyingTupleCount(RowGroup &row_group, BaseStatistics &stats, const 
 }
 
 template <typename It, typename End>
-void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It it, End end,
+void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It it, const End &end,
                   vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups, const idx_t row_limit,
                   const OrderByColumnType column_type, const OrderByStatistics stat_type) {
 	const auto opposite_stat_type =
@@ -93,7 +93,7 @@ void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It i
 }
 
 template <typename It, typename End>
-It SkipOffsetPrunedRowGroups(It it, End end, idx_t row_group_offset) {
+It SkipOffsetPrunedRowGroups(It it, const End &end, idx_t row_group_offset) {
 	while (row_group_offset > 0 && it != end) {
 		++it;
 		row_group_offset--;
@@ -102,7 +102,7 @@ It SkipOffsetPrunedRowGroups(It it, End end, idx_t row_group_offset) {
 }
 
 template <typename It, typename End>
-void InsertAllRowGroups(It it, End end, vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups) {
+void InsertAllRowGroups(It it, const End &end, vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups) {
 	for (; it != end; ++it) {
 		ordered_row_groups.push_back(it->second.row_group);
 	}
@@ -145,7 +145,7 @@ void AppendRowGroups(const vector<reference<SegmentNode<RowGroup>>> &source, idx
 }
 
 template <typename It, typename End>
-OffsetPruningResult FindOffsetPrunableChunks(It it, End end, const OrderByStatistics order_by,
+OffsetPruningResult FindOffsetPrunableChunks(It it, const End &end, const OrderByStatistics order_by,
                                              const OrderByColumnType column_type, const idx_t row_offset) {
 	if (it == end) {
 		return {row_offset, 0, 0};


### PR DESCRIPTION
### Upgrade clang to v20

Detect more warnings, errors and use improved thread/address/ub sanitizers.

**We don't change compiler for most jobs.**
The compiler is only changed for the CI jobs `linux-relassert`, `threadsan` and `check-clangd-tidy`.

### Detected more tidy errors
```
src/execution/sample/reservoir_sample.cpp:707:8: Error: The variable 'col_type' is copy-constructed from a const reference but is only used as const reference; consider making it a const reference [performance-unnecessary-copy-initialization]
  705 |  
  706 |  	for (idx_t i = 0; i < reservoir_chunk->chunk.ColumnCount(); i++) {
  707 |  		auto col_type = types[i];
      |         ^~~~~~~~
  708 |  		if (ValidSampleType(col_type) || !stats_sample) {
  709 |  			D_ASSERT(this_.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
src/function/aggregate/distributive/minmax.cpp:29:56: Error: The parameter 'type' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
   27 |  
   28 |  template <class OP>
   29 |  static AggregateFunction GetUnaryAggregate(LogicalType type) {
      |                                                         ^~~~
   30 |  	switch (type.InternalType()) {
   31 |  	case PhysicalType::BOOL:
src/function/aggregate/distributive/minmax.cpp:401:44: Error: The parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
  399 |  
  400 |  template <class OP, class OP_STRING, class OP_VECTOR>
  401 |  AggregateFunction GetMinMaxOperator(string name) {
      |                                             ^~~~
  402 |  	return AggregateFunction(std::move(name), {LogicalType::ANY}, LogicalType::ANY, nullptr, nullptr, nullptr, nullptr,
  403 |  	                         nullptr, nullptr, BindMinMax<OP, OP_STRING, OP_VECTOR>);
src/function/aggregate/distributive/minmax.cpp:436:10: Error: Returning a constant reference parameter may cause use-after-free when the parameter is constructed from a temporary [bugprone-return-const-ref-from-parameter]
  434 |  
  435 |  	static const T &GetValue(const T &val) {
  436 |  		return val;
      |           ^~~
  437 |  	}
  438 |  };
src/storage/table/row_group_reorderer.cpp:45:88: Error: The parameter 'end' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
   43 |  
   44 |  template <typename It, typename End>
   45 |  void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It it, End end,
      |                                                                                         ^~~
   46 |                    vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups, const idx_t row_limit,
   47 |                    const OrderByColumnType column_type, const OrderByStatistics stat_type) {
src/storage/table/row_group_reorderer.cpp:96:41: Error: The parameter 'end' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
   94 |  
   95 |  template <typename It, typename End>
   96 |  It SkipOffsetPrunedRowGroups(It it, End end, idx_t row_group_offset) {
      |                                          ^~~
   97 |  	while (row_group_offset > 0 && it != end) {
   98 |  		++it;
src/storage/table/row_group_reorderer.cpp:105:36: Error: The parameter 'end' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
  103 |  
  104 |  template <typename It, typename End>
  105 |  void InsertAllRowGroups(It it, End end, vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups) {
      |                                     ^~~
  106 |  	for (; it != end; ++it) {
  107 |  		ordered_row_groups.push_back(it->second.row_group);
src/storage/table/row_group_reorderer.cpp:148:57: Error: The parameter 'end' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
  146 |  
  147 |  template <typename It, typename End>
  148 |  OffsetPruningResult FindOffsetPrunableChunks(It it, End end, const OrderByStatistics order_by,
      |                                                          ^~~
  149 |                                               const OrderByColumnType column_type, const idx_t row_offset) {
  150 |  	if (it == end) {
make: *** [Makefile:660: tidy-check-clangd] Error 1

```