### PR TITLE
Handle blocks with no rows correctly. Fixes #22352

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -103,7 +103,10 @@ public:
 			}
 			return false;
 		case WindowGroupStage::SINK:
-			if (sunk == count) {
+			// Gate on blocks (not rows): every SINK task must have completed before FINALIZE
+			// can run, otherwise a FINALIZE task can read a thread_states[thread_idx] entry
+			// that the matching SINK task hasn't initialised yet.
+			if (sunk == blocks) {
 				stage = WindowGroupStage::FINALIZE;
 				return true;
 			}
@@ -180,7 +183,7 @@ public:
 	atomic<idx_t> materialized;
 	//! Count of masked blocks
 	atomic<idx_t> masked;
-	//! Count of sunk rows
+	//! Count of sunk blocks (one per completed SINK task block, not per row)
 	atomic<idx_t> sunk;
 	//! Count of finalized blocks
 	atomic<idx_t> finalized;
@@ -762,9 +765,14 @@ void WindowLocalSourceState::Sink(ExecutionContext &context, InterruptState &int
 		}
 	}
 
+	//	The block range owned by this task. Counted whole so that the SINK -> FINALIZE
+	//	transition waits for every SINK task to run, even ones whose blocks contain no rows.
+	const idx_t task_blocks = task->end_idx - task->begin_idx;
+
 	//	First pass over the input without flushing
 	scanner = window_hash_group->GetScanner(task->begin_idx);
 	if (!scanner) {
+		window_hash_group->sunk += task_blocks;
 		return;
 	}
 	for (; task->begin_idx < task->end_idx; ++task->begin_idx) {
@@ -800,10 +808,9 @@ void WindowLocalSourceState::Sink(ExecutionContext &context, InterruptState &int
 			OperatorSinkInput sink {*gestates[w], *local_states[w], interrupt};
 			executors[w]->Sink(context, sink_chunk, coll_chunk, input_idx, sink);
 		}
-
-		window_hash_group->sunk += input_chunk.size();
 	}
 	scanner.reset();
+	window_hash_group->sunk += task_blocks;
 }
 
 void WindowLocalSourceState::Finalize(ExecutionContext &context, InterruptState &interrupt) {

--- a/test/sql/window/test_window_finalize_race.test
+++ b/test/sql/window/test_window_finalize_race.test
@@ -1,0 +1,64 @@
+# name: test/sql/window/test_window_finalize_race.test
+# description: Window FINALIZE must wait for all SINK tasks to complete, not just for all rows to be sunk
+# group: [window]
+
+# When the window operator's input has empty chunks (e.g. from a FILTER that produced 0 rows
+# unioned with a non-empty stream), the hash group ends up with multiple blocks but only some
+# carry rows. Each block gets its own SINK task, and each SINK task is responsible for
+# initialising the per-thread_idx local state used by the FINALIZE task with the same thread_idx.
+#
+# The SINK -> FINALIZE transition was gated only on (sunk == count), where sunk counts rows.
+# The empty-block SINK task does not contribute rows, so the transition could fire as soon as
+# the row-bearing SINK task completed, before the empty-block task had even started. The
+# corresponding FINALIZE task then read a still-empty thread_states[thread_idx] and crashed
+# with "Attempted to access index 0 within vector of size 0".
+
+statement ok
+PRAGMA threads=2
+
+# Run the racing query many times in a single session. Before the fix this is highly likely
+# to fail (and once it does, the database is invalidated and every subsequent statement fails).
+loop i 0 200
+
+query II
+WITH t AS (SELECT 0 AS x),
+u AS (
+    SELECT * FROM t WHERE x >= 5000
+    UNION ALL
+    SELECT * FROM t
+)
+SELECT x, count() OVER () FROM u ORDER BY x DESC;
+----
+0	1
+
+endloop
+
+# Also exercise the original report shape (NOT EXISTS subquery + ORDER BY DESC + LIMIT)
+loop i 0 200
+
+query II
+WITH final_cols AS (
+    SELECT i AS x
+    FROM range(1) t(i)
+),
+final_people AS (
+    SELECT *
+    FROM final_cols
+    WHERE x >= 5000
+    UNION ALL
+    SELECT *
+    FROM final_cols
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM final_cols
+        WHERE x >= 5000
+    )
+)
+SELECT x, count() OVER () AS full_count
+FROM final_people
+ORDER BY x DESC
+LIMIT 5;
+----
+0	1
+
+endloop


### PR DESCRIPTION
Proposed fix for #22352 from Claude Opus 4.7. The SINK→FINALIZE gate in TryPrepareNextStage checked sunk == count (rows). A SINK task for an empty block contributes no rows, so the gate could open as soon as the row-bearing SINK tasks finished — before the empty-block SINK task had run and initialised its thread_states slot. Counting blocks instead of rows makes the gate wait for every SINK task, matching the sibling block-based counters (materialized / masked / finalized).