### PR TITLE
Deprecate `KeywordHelper::Write[Optionally]Quoted` - and improve support for `SQLString` and `SQLIdentifier` instead

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -783,7 +783,7 @@ string InterpretedBenchmark::Verify(BenchmarkState *state_p) {
 		if (i > 0) {
 			create_tbl += ", ";
 		}
-		create_tbl += KeywordHelper::WriteOptionallyQuoted(names[i]);
+		create_tbl += SQLIdentifier(names[i]);
 		create_tbl += " ";
 		create_tbl += types[i].ToString();
 	}

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1023,7 +1023,7 @@ static void GetStatsUnifier(const ColumnWriter &column_writer, vector<unique_ptr
 		if (!base_name.empty()) {
 			base_name += ".";
 		}
-		base_name += KeywordHelper::WriteQuoted(schema.name, '\"');
+		base_name += SQLQuotedIdentifier(schema.name);
 	}
 
 	auto &children = column_writer.ChildWriters();

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -196,7 +196,7 @@ string TableCatalogEntry::ColumnNamesToSQL(const ColumnList &columns) {
 		if (column.Oid() > 0) {
 			ss << ", ";
 		}
-		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
+		ss << SQLIdentifier(column.Name()) << " ";
 	}
 	ss << ")";
 	return ss.str();

--- a/src/catalog/catalog_entry/trigger_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/trigger_catalog_entry.cpp
@@ -44,7 +44,7 @@ unique_ptr<CreateInfo> TriggerCatalogEntry::GetInfo() const {
 string TriggerCatalogEntry::ToSQL() const {
 	duckdb::stringstream ss;
 	ss << "CREATE TRIGGER ";
-	ss << KeywordHelper::WriteOptionallyQuoted(name);
+	ss << SQLIdentifier(name);
 	ss << " ";
 	ss << EnumUtil::ToString(timing);
 	ss << " ";
@@ -55,7 +55,7 @@ string TriggerCatalogEntry::ToSQL() const {
 			if (i > 0) {
 				ss << ", ";
 			}
-			ss << KeywordHelper::WriteOptionallyQuoted(columns[i]);
+			ss << SQLIdentifier(columns[i]);
 		}
 	}
 	ss << " ON ";

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -46,7 +46,7 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 string TypeCatalogEntry::ToSQL() const {
 	duckdb::stringstream ss;
 	ss << "CREATE TYPE ";
-	ss << KeywordHelper::WriteOptionallyQuoted(name);
+	ss << SQLIdentifier(name);
 	ss << " AS ";
 
 	auto user_type_copy = user_type;

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -478,10 +478,10 @@ AdbcStatusCode ConnectionGetTableSchema(struct AdbcConnection *connection, const
 
 	std::string query = "SELECT * FROM ";
 	if (catalog != nullptr && strlen(catalog) > 0) {
-		query += duckdb::KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		query += duckdb::SQLIdentifier(catalog) + ".";
 	}
-	query += duckdb::KeywordHelper::WriteOptionallyQuoted(db_schema) + ".";
-	query += duckdb::KeywordHelper::WriteOptionallyQuoted(table_name) + " LIMIT 0;";
+	query += duckdb::SQLIdentifier(db_schema) + ".";
+	query += duckdb::SQLIdentifier(table_name) + " LIMIT 0;";
 
 	auto success = QueryInternal(connection, &arrow_stream, query.c_str(), error);
 	if (success != ADBC_STATUS_OK) {
@@ -550,7 +550,7 @@ static AdbcStatusCode ConnectionSetOptionCurrentValue(duckdb::DuckDBAdbcConnecti
 		return ADBC_STATUS_INVALID_STATE;
 	}
 	auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
-	std::string query = sql_prefix + duckdb::KeywordHelper::WriteOptionallyQuoted(value);
+	std::string query = sql_prefix + duckdb::SQLIdentifier(value);
 	return ExecuteQuery(conn, query.c_str(), error);
 }
 
@@ -1193,15 +1193,15 @@ static std::string BuildCreateTableSQL(const char *catalog, const char *schema, 
 	// the table is automatically placed in the temp catalog.
 	if (!temporary) {
 		if (catalog) {
-			create_table << duckdb::KeywordHelper::WriteOptionallyQuoted(catalog) << ".";
+			create_table << duckdb::SQLIdentifier(catalog) << ".";
 		}
 		if (schema) {
-			create_table << duckdb::KeywordHelper::WriteOptionallyQuoted(schema) << ".";
+			create_table << duckdb::SQLIdentifier(schema) << ".";
 		}
 	}
-	create_table << duckdb::KeywordHelper::WriteOptionallyQuoted(table_name) << " (";
+	create_table << duckdb::SQLIdentifier(table_name) << " (";
 	for (idx_t i = 0; i < types.size(); i++) {
-		create_table << duckdb::KeywordHelper::WriteOptionallyQuoted(names[i]);
+		create_table << duckdb::SQLIdentifier(names[i]);
 		create_table << " " << types[i].ToString();
 		if (i + 1 < types.size()) {
 			create_table << ", ";

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -2115,8 +2115,7 @@ AdbcStatusCode StatementSetOptionDouble(struct AdbcStatement *statement, const c
 
 std::string createFilter(const char *input) {
 	if (input) {
-		auto quoted = duckdb::KeywordHelper::WriteQuoted(input, '\'');
-		return quoted;
+		return duckdb::SQLString::ToString(input);
 	}
 	return "'%'";
 }

--- a/src/common/exception_format_value.cpp
+++ b/src/common/exception_format_value.cpp
@@ -57,12 +57,12 @@ ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const String &value
 }
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const SQLString &value) {
-	return KeywordHelper::WriteQuoted(value.raw_string, '\'');
+	return SQLString::ToString(value.raw_string);
 }
 
 template <>
 ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const SQLIdentifier &value) {
-	return KeywordHelper::WriteOptionallyQuoted(value.raw_string, '"');
+	return SQLIdentifier::ToString(value.raw_string);
 }
 
 template <>

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -489,7 +489,7 @@ string LogicalType::ToString() const {
 			if (i > 0) {
 				ret += ", ";
 			}
-			ret += KeywordHelper::WriteQuoted(EnumType::GetString(*this, i).GetString(), '\'');
+			ret += SQLString(EnumType::GetString(*this, i).GetString());
 		}
 		ret += ")";
 		return ret;
@@ -526,7 +526,7 @@ string LogicalType::ToString() const {
 			return "GEOMETRY";
 		}
 		auto &crs = GeoType::GetCRS(*this);
-		auto crs_text = KeywordHelper::WriteQuoted(crs.GetDefinition(), '\'');
+		auto crs_text = SQLString(crs.GetDefinition());
 		return StringUtil::Format("GEOMETRY(%s)", crs_text);
 	}
 	default:

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -60,7 +60,7 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 
 	//! NOTE: The catalog is explicitly not set here
 	if (exported_table.schema_name != DEFAULT_SCHEMA && !exported_table.schema_name.empty()) {
-		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
+		ss << SQLIdentifier(exported_table.schema_name) << ".";
 	}
 
 	auto file_path = StringUtil::Replace(exported_table.file_path, "\\", "/");

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -16,8 +16,7 @@
 namespace duckdb {
 
 static string PragmaTableInfo(ClientContext &context, const FunctionParameters &parameters) {
-	return StringUtil::Format("SELECT * FROM pragma_table_info(%s);",
-	                          KeywordHelper::WriteQuoted(parameters.values[0].ToString(), '\''));
+	return StringUtil::Format("SELECT * FROM pragma_table_info(%s);", SQLString(parameters.values[0].ToString()));
 }
 
 string PragmaShowTables(const string &database, const string &schema) {
@@ -129,7 +128,7 @@ static string PragmaFunctionsQuery(ClientContext &context, const FunctionParamet
 }
 
 string PragmaShow(const string &table_name) {
-	return StringUtil::Format("SELECT * FROM pragma_show(%s);", KeywordHelper::WriteQuoted(table_name, '\''));
+	return StringUtil::Format("SELECT * FROM pragma_show(%s);", SQLString(table_name));
 }
 
 static string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -184,9 +184,9 @@ static string PragmaImportDatabase(ClientContext &context, const FunctionParamet
 
 static string PragmaCopyDatabase(ClientContext &context, const FunctionParameters &parameters) {
 	string copy_stmt = "COPY FROM DATABASE ";
-	copy_stmt += KeywordHelper::WriteOptionallyQuoted(parameters.values[0].ToString());
+	copy_stmt += SQLIdentifier(parameters.values[0].ToString());
 	copy_stmt += " TO ";
-	copy_stmt += KeywordHelper::WriteOptionallyQuoted(parameters.values[1].ToString());
+	copy_stmt += SQLIdentifier(parameters.values[1].ToString());
 	string final_query;
 	final_query += copy_stmt + " (SCHEMA);\n";
 	final_query += copy_stmt + " (DATA);";

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -10,34 +10,14 @@
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/hugeint.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 
+#include <ostream>
 #include <vector>
 
 namespace duckdb {
 
 class String;
-
-// Helper class to support custom overloading
-// Escaping " and quoting the value with "
-class SQLIdentifier {
-public:
-	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
-	}
-
-public:
-	string raw_string;
-};
-
-// Helper class to support custom overloading
-// Escaping ' and quoting the value with '
-class SQLString {
-public:
-	explicit SQLString(const string &raw_string) : raw_string(raw_string) {
-	}
-
-public:
-	string raw_string;
-};
 
 enum class PhysicalType : uint8_t;
 struct LogicalType;

--- a/src/include/duckdb/common/sql_identifier.hpp
+++ b/src/include/duckdb/common/sql_identifier.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 class String;
 
 // Helper class to support custom overloading
-// Escaping " and quoting the value with "
+// Optionally escaping " and quoting the value with " if required
 class SQLIdentifier {
 public:
 	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
@@ -30,12 +30,57 @@ public:
 	string raw_string;
 };
 
-inline string operator+(const SQLIdentifier &lhs, const string &rhs) { return SQLIdentifier::ToString(lhs.raw_string) + rhs; }
-inline string operator+(const SQLIdentifier &lhs, const char *rhs) { return SQLIdentifier::ToString(lhs.raw_string) + rhs; }
-inline string operator+(const string &lhs, const SQLIdentifier &rhs) { return lhs + SQLIdentifier::ToString(rhs.raw_string); }
-inline string operator+(const char *lhs, const SQLIdentifier &rhs) { return lhs + SQLIdentifier::ToString(rhs.raw_string); }
-inline string &operator+=(string &lhs, const SQLIdentifier &rhs) { return lhs += SQLIdentifier::ToString(rhs.raw_string); }
-inline std::ostream &operator<<(std::ostream &os, const SQLIdentifier &val) { return os << SQLIdentifier::ToString(val.raw_string); }
+inline string operator+(const SQLIdentifier &lhs, const string &rhs) {
+	return SQLIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLIdentifier &lhs, const char *rhs) {
+	return SQLIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLIdentifier &rhs) {
+	return lhs + SQLIdentifier::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLIdentifier &rhs) {
+	return lhs + SQLIdentifier::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLIdentifier &rhs) {
+	return lhs += SQLIdentifier::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLIdentifier &val) {
+	return os << SQLIdentifier::ToString(val.raw_string);
+}
+
+// Helper class to support custom overloading
+// Escaping " and quoting the value with " if required
+class SQLQuotedIdentifier {
+public:
+	explicit SQLQuotedIdentifier(const string &raw_string) : raw_string(raw_string) {
+	}
+
+	//! Emits an optionally quoted identifier including required escapes (i.e. ident -> ident, table -> "table")
+	static string ToString(const string &identifier);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLQuotedIdentifier &lhs, const string &rhs) {
+	return SQLQuotedIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLQuotedIdentifier &lhs, const char *rhs) {
+	return SQLQuotedIdentifier::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs + SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs + SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLQuotedIdentifier &rhs) {
+	return lhs += SQLQuotedIdentifier::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLQuotedIdentifier &val) {
+	return os << SQLQuotedIdentifier::ToString(val.raw_string);
+}
 
 // Helper class to support custom overloading
 // Escaping ' and quoting the value with '
@@ -51,11 +96,23 @@ public:
 	string raw_string;
 };
 
-inline string operator+(const SQLString &lhs, const string &rhs) { return SQLString::ToString(lhs.raw_string) + rhs; }
-inline string operator+(const SQLString &lhs, const char *rhs) { return SQLString::ToString(lhs.raw_string) + rhs; }
-inline string operator+(const string &lhs, const SQLString &rhs) { return lhs + SQLString::ToString(rhs.raw_string); }
-inline string operator+(const char *lhs, const SQLString &rhs) { return lhs + SQLString::ToString(rhs.raw_string); }
-inline string &operator+=(string &lhs, const SQLString &rhs) { return lhs += SQLString::ToString(rhs.raw_string); }
-inline std::ostream &operator<<(std::ostream &os, const SQLString &val) { return os << SQLString::ToString(val.raw_string); }
+inline string operator+(const SQLString &lhs, const string &rhs) {
+	return SQLString::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const SQLString &lhs, const char *rhs) {
+	return SQLString::ToString(lhs.raw_string) + rhs;
+}
+inline string operator+(const string &lhs, const SQLString &rhs) {
+	return lhs + SQLString::ToString(rhs.raw_string);
+}
+inline string operator+(const char *lhs, const SQLString &rhs) {
+	return lhs + SQLString::ToString(rhs.raw_string);
+}
+inline string &operator+=(string &lhs, const SQLString &rhs) {
+	return lhs += SQLString::ToString(rhs.raw_string);
+}
+inline std::ostream &operator<<(std::ostream &os, const SQLString &val) {
+	return os << SQLString::ToString(val.raw_string);
+}
 
 } // namespace duckdb

--- a/src/include/duckdb/common/sql_identifier.hpp
+++ b/src/include/duckdb/common/sql_identifier.hpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/sql_identifier.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/sql_identifier.hpp"
+#include <ostream>
+
+namespace duckdb {
+
+class String;
+
+// Helper class to support custom overloading
+// Escaping " and quoting the value with "
+class SQLIdentifier {
+public:
+	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
+	}
+
+	//! Emits an optionally quoted identifier including required escapes (i.e. ident -> ident, table -> "table")
+	static string ToString(const string &identifier);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLIdentifier &lhs, const string &rhs) { return SQLIdentifier::ToString(lhs.raw_string) + rhs; }
+inline string operator+(const SQLIdentifier &lhs, const char *rhs) { return SQLIdentifier::ToString(lhs.raw_string) + rhs; }
+inline string operator+(const string &lhs, const SQLIdentifier &rhs) { return lhs + SQLIdentifier::ToString(rhs.raw_string); }
+inline string operator+(const char *lhs, const SQLIdentifier &rhs) { return lhs + SQLIdentifier::ToString(rhs.raw_string); }
+inline string &operator+=(string &lhs, const SQLIdentifier &rhs) { return lhs += SQLIdentifier::ToString(rhs.raw_string); }
+inline std::ostream &operator<<(std::ostream &os, const SQLIdentifier &val) { return os << SQLIdentifier::ToString(val.raw_string); }
+
+// Helper class to support custom overloading
+// Escaping ' and quoting the value with '
+class SQLString {
+public:
+	explicit SQLString(const string &raw_string) : raw_string(raw_string) {
+	}
+
+	//! Emits a quoted string literal including required escapes (i.e. ident -> 'ident')
+	static string ToString(const string &literal);
+
+public:
+	string raw_string;
+};
+
+inline string operator+(const SQLString &lhs, const string &rhs) { return SQLString::ToString(lhs.raw_string) + rhs; }
+inline string operator+(const SQLString &lhs, const char *rhs) { return SQLString::ToString(lhs.raw_string) + rhs; }
+inline string operator+(const string &lhs, const SQLString &rhs) { return lhs + SQLString::ToString(rhs.raw_string); }
+inline string operator+(const char *lhs, const SQLString &rhs) { return lhs + SQLString::ToString(rhs.raw_string); }
+inline string &operator+=(string &lhs, const SQLString &rhs) { return lhs += SQLString::ToString(rhs.raw_string); }
+inline std::ostream &operator<<(std::ostream &os, const SQLString &val) { return os << SQLString::ToString(val.raw_string); }
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -88,12 +88,12 @@ public:
 		// standard function call
 		string result;
 		if (!catalog.empty()) {
-			result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+			result += SQLIdentifier(catalog) + ".";
 		}
 		if (!schema.empty()) {
-			result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+			result += SQLIdentifier(schema) + ".";
 		}
-		result += KeywordHelper::WriteOptionallyQuoted(function_name);
+		result += SQLIdentifier(function_name);
 		result += "(";
 		if (distinct) {
 			result += "DISTINCT ";

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -20,6 +20,10 @@ public:
 
 	static KeywordCategory KeywordCategoryType(const string &text);
 
+	[[deprecated("This function has been deprecated due to it having confusing syntax, use SQLString instead for "
+	             "literals, or SQLIdentifier/SQLQuotedIdentifier for identifiers")]] static string
+	EscapeQuotes(const string &text, char quote = '"');
+
 	//! Returns true if the given string needs to be quoted when written as an identifier
 	static bool RequiresQuotes(const string &text, bool allow_caps = true);
 

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -26,10 +26,14 @@ public:
 	static bool RequiresQuotes(const string &text, bool allow_caps = true);
 
 	//! Writes a string that is quoted
-	static string WriteQuoted(const string &text, char quote = '\'');
+	[[deprecated("This function has been deprecated due to it having confusing syntax, use SQLString instead for "
+	             "literals, or SQLIdentifier/SQLQuotedIdentifier for identifiers")]] static string
+	WriteQuoted(const string &text, char quote = '\'');
 
 	//! Writes a string that is optionally quoted + escaped so it can be used as an identifier
-	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true);
+	[[deprecated("This function has been deprecated due to it having confusing syntax, use "
+	             "SQLIdentifier/SQLQuotedIdentifier instead for identifiers, or SQLString for literals")]] static string
+	WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -20,8 +20,6 @@ public:
 
 	static KeywordCategory KeywordCategoryType(const string &text);
 
-	static string EscapeQuotes(const string &text, char quote = '"');
-
 	//! Returns true if the given string needs to be quoted when written as an identifier
 	static bool RequiresQuotes(const string &text, bool allow_caps = true);
 
@@ -34,6 +32,8 @@ public:
 	[[deprecated("This function has been deprecated due to it having confusing syntax, use "
 	             "SQLIdentifier/SQLQuotedIdentifier instead for identifiers, or SQLString for literals")]] static string
 	WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true);
+
+	static string WriteQuotedAndEscaped(const string &text, char quote);
 };
 
 } // namespace duckdb

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -476,11 +476,8 @@ void FileLogStorage::UpdateConfigInternal(DatabaseInstance &db, case_insensitive
 unique_ptr<TableRef> FileLogStorage::BindReplaceInternal(ClientContext &context, TableFunctionBindInput &input,
                                                          const string &path, const string &select_clause,
                                                          const string &csv_columns) {
-	string sub_query_string;
-
-	string escaped_path = KeywordHelper::WriteOptionallyQuoted(path);
-	sub_query_string =
-	    StringUtil::Format("%s FROM read_csv_auto(%s, columns={%s})", select_clause, escaped_path, csv_columns);
+	string sub_query_string =
+	    StringUtil::Format("%s FROM read_csv_auto(%s, columns={%s})", select_clause, SQLString(path), csv_columns);
 
 	Parser parser(context.GetParserOptions());
 	parser.ParseQuery(sub_query_string);

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -128,7 +128,7 @@ bool ColumnDefinition::Generated() const {
 }
 
 string ColumnDefinition::ToSQLString() const {
-	string result = KeywordHelper::WriteOptionallyQuoted(Name()) + " ";
+	string result = SQLIdentifier(Name()) + " ";
 	auto &column_type = Type();
 	if (column_type.id() != LogicalTypeId::ANY) {
 		result += Type().ToString();

--- a/src/parser/constraints/foreign_key_constraint.cpp
+++ b/src/parser/constraints/foreign_key_constraint.cpp
@@ -21,7 +21,7 @@ string ForeignKeyConstraint::ToString() const {
 			if (i > 0) {
 				base += ", ";
 			}
-			base += KeywordHelper::WriteOptionallyQuoted(fk_columns[i]);
+			base += SQLIdentifier(fk_columns[i]);
 		}
 		base += ") REFERENCES ";
 		if (!info.schema.empty() && info.schema != DEFAULT_SCHEMA) {
@@ -36,7 +36,7 @@ string ForeignKeyConstraint::ToString() const {
 				if (i > 0) {
 					base += ", ";
 				}
-				base += KeywordHelper::WriteOptionallyQuoted(pk_columns[i]);
+				base += SQLIdentifier(pk_columns[i]);
 			}
 			base += ")";
 		}

--- a/src/parser/constraints/unique_constraint.cpp
+++ b/src/parser/constraints/unique_constraint.cpp
@@ -27,7 +27,7 @@ string UniqueConstraint::ToString() const {
 		if (i > 0) {
 			base += ", ";
 		}
-		base += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+		base += SQLIdentifier(columns[i]);
 	}
 	return base + ")";
 }

--- a/src/parser/expression/columnref_expression.cpp
+++ b/src/parser/expression/columnref_expression.cpp
@@ -73,7 +73,7 @@ string ColumnRefExpression::ToString() const {
 		if (i > 0) {
 			result += ".";
 		}
-		result += KeywordHelper::WriteOptionallyQuoted(column_names[i]);
+		result += SQLIdentifier(column_names[i]);
 	}
 	return result;
 }

--- a/src/parser/expression/star_expression.cpp
+++ b/src/parser/expression/star_expression.cpp
@@ -43,7 +43,7 @@ string StarExpression::ToString() const {
 			}
 			result += entry.second->ToString();
 			result += " AS ";
-			result += KeywordHelper::WriteOptionallyQuoted(entry.first);
+			result += SQLIdentifier(entry.first);
 			first_entry = false;
 		}
 		result += ")";
@@ -57,7 +57,7 @@ string StarExpression::ToString() const {
 			}
 			result += entry.first.ToString();
 			result += " AS ";
-			result += KeywordHelper::WriteOptionallyQuoted(entry.second);
+			result += SQLIdentifier(entry.second);
 			first_entry = false;
 		}
 		result += ")";

--- a/src/parser/expression/type_expression.cpp
+++ b/src/parser/expression/type_expression.cpp
@@ -93,7 +93,7 @@ string TypeExpression::ToString() const {
 		// Built-in type name
 		result += type_name;
 	} else {
-		result += KeywordHelper::WriteOptionallyQuoted(type_name, '"', true);
+		result += SQLIdentifier(type_name);
 	}
 
 	if (!params.empty()) {

--- a/src/parser/expression/type_expression.cpp
+++ b/src/parser/expression/type_expression.cpp
@@ -24,10 +24,10 @@ TypeExpression::TypeExpression() : ParsedExpression(ExpressionType::TYPE, Expres
 string TypeExpression::ToString() const {
 	string result;
 	if (!catalog.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		result += SQLIdentifier(catalog) + ".";
 	}
 	if (!schema.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		result += SQLIdentifier(schema) + ".";
 	}
 
 	auto &params = children;
@@ -48,7 +48,7 @@ string TypeExpression::ToString() const {
 		}
 		string struct_result = "STRUCT(";
 		for (idx_t i = 0; i < params.size(); i++) {
-			struct_result += KeywordHelper::WriteOptionallyQuoted(params[i]->GetAlias()) + " " + params[i]->ToString();
+			struct_result += SQLIdentifier(params[i]->GetAlias()) + " " + params[i]->ToString();
 			if (i < params.size() - 1) {
 				struct_result += ", ";
 			}
@@ -62,7 +62,7 @@ string TypeExpression::ToString() const {
 		}
 		string union_result = "UNION(";
 		for (idx_t i = 0; i < params.size(); i++) {
-			union_result += KeywordHelper::WriteOptionallyQuoted(params[i]->GetAlias()) + " " + params[i]->ToString();
+			union_result += SQLIdentifier(params[i]->GetAlias()) + " " + params[i]->ToString();
 			if (i < params.size() - 1) {
 				union_result += ", ";
 			}

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -50,21 +50,32 @@ bool KeywordHelper::RequiresQuotes(const string &text, bool allow_caps) {
 	return IsKeyword(text);
 }
 
-string KeywordHelper::EscapeQuotes(const string &text, char quote) {
-	return StringUtil::Replace(text, string(1, quote), string(2, quote));
+string KeywordHelper::WriteQuotedAndEscaped(const string &text, char quote) {
+	string result;
+	result.reserve(text.size() + 2);
+	result += quote;
+	for (auto c : text) {
+		if (c == quote) {
+			// character matches quote - escape by adding the quote again
+			result += quote;
+		}
+		result += c;
+	}
+	result += quote;
+	return result;
 }
 
 string KeywordHelper::WriteQuoted(const string &text, char quote) {
 	// 1. Escapes all occurrences of 'quote' by doubling them (escape in SQL)
 	// 2. Adds quotes around the string
-	return string(1, quote) + EscapeQuotes(text, quote) + string(1, quote);
+	return WriteQuotedAndEscaped(text, quote);
 }
 
 string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote, bool allow_caps) {
 	if (!RequiresQuotes(text, allow_caps)) {
 		return text;
 	}
-	return WriteQuoted(text, quote);
+	return WriteQuotedAndEscaped(text, quote);
 }
 
 string SQLIdentifier::ToString(const string &identifier) {
@@ -75,13 +86,11 @@ string SQLIdentifier::ToString(const string &identifier) {
 }
 
 string SQLQuotedIdentifier::ToString(const string &identifier) {
-	char quote = '"';
-	return string(1, quote) + KeywordHelper::EscapeQuotes(identifier, quote) + string(1, quote);
+	return KeywordHelper::WriteQuotedAndEscaped(identifier, '"');
 }
 
 string SQLString::ToString(const string &literal) {
-	char quote = '\'';
-	return string(1, quote) + KeywordHelper::EscapeQuotes(literal, quote) + string(1, quote);
+	return KeywordHelper::WriteQuotedAndEscaped(literal, '\'');
 }
 
 } // namespace duckdb

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -50,6 +50,10 @@ bool KeywordHelper::RequiresQuotes(const string &text, bool allow_caps) {
 	return IsKeyword(text);
 }
 
+string KeywordHelper::EscapeQuotes(const string &text, char quote) {
+	return StringUtil::Replace(text, string(1, quote), string(2, quote));
+}
+
 string KeywordHelper::WriteQuotedAndEscaped(const string &text, char quote) {
 	string result;
 	result.reserve(text.size() + 2);

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -67,4 +67,17 @@ string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote, bool
 	return WriteQuoted(text, quote);
 }
 
+string SQLIdentifier::ToString(const string &identifier) {
+	if (!KeywordHelper::RequiresQuotes(identifier)) {
+		return identifier;
+	}
+	char quote = '"';
+	return string(1, quote) + KeywordHelper::EscapeQuotes(identifier, quote) + string(1, quote);
+}
+
+string SQLString::ToString(const string &literal) {
+	char quote = '\'';
+	return string(1, quote) + KeywordHelper::EscapeQuotes(literal, quote) + string(1, quote);
+}
+
 } // namespace duckdb

--- a/src/parser/keyword_helper.cpp
+++ b/src/parser/keyword_helper.cpp
@@ -71,6 +71,10 @@ string SQLIdentifier::ToString(const string &identifier) {
 	if (!KeywordHelper::RequiresQuotes(identifier)) {
 		return identifier;
 	}
+	return SQLQuotedIdentifier::ToString(identifier);
+}
+
+string SQLQuotedIdentifier::ToString(const string &identifier) {
 	char quote = '"';
 	return string(1, quote) + KeywordHelper::EscapeQuotes(identifier, quote) + string(1, quote);
 }

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -706,7 +706,7 @@ string SetTableOptionsInfo::ToString() const {
 		if (i > 0) {
 			result += ", ";
 		}
-		result += KeywordHelper::WriteQuoted(entry.first, '\'') + "=" + entry.second->ToString();
+		result += SQLString(entry.first) + "=" + entry.second->ToString();
 		i++;
 	}
 	result += ")";
@@ -743,7 +743,7 @@ string ResetTableOptionsInfo::ToString() const {
 		if (i > 0) {
 			result += ", ";
 		}
-		result += KeywordHelper::WriteQuoted(entry, '\'');
+		result += SQLString(entry);
 		i++;
 	}
 	result += ")";

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -124,9 +124,9 @@ string RenameColumnInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME COLUMN ";
-	result += KeywordHelper::WriteOptionallyQuoted(old_name);
+	result += SQLIdentifier(old_name);
 	result += " TO ";
-	result += KeywordHelper::WriteOptionallyQuoted(new_name);
+	result += SQLIdentifier(new_name);
 	result += ";";
 	return result;
 }
@@ -161,10 +161,10 @@ string RenameFieldInfo::ToString() const {
 		if (i > 0) {
 			result += ".";
 		}
-		result += KeywordHelper::WriteOptionallyQuoted(column_path[i]);
+		result += SQLIdentifier(column_path[i]);
 	}
 	result += " TO ";
-	result += KeywordHelper::WriteOptionallyQuoted(new_name);
+	result += SQLIdentifier(new_name);
 	result += ";";
 	return result;
 }
@@ -194,7 +194,7 @@ string RenameTableInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME TO ";
-	result += KeywordHelper::WriteOptionallyQuoted(new_table_name);
+	result += SQLIdentifier(new_table_name);
 	result += ";";
 	return result;
 }
@@ -271,7 +271,7 @@ string AddFieldInfo::ToString() const {
 		result += "IF NOT EXISTS ";
 	}
 	for (auto &path : column_path) {
-		result += KeywordHelper::WriteOptionallyQuoted(path);
+		result += SQLIdentifier(path);
 		result += ".";
 	}
 	result += new_field.ToSQLString();
@@ -307,7 +307,7 @@ string RemoveColumnInfo::ToString() const {
 	if (if_column_exists) {
 		result += "IF EXISTS ";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(removed_column);
+	result += SQLIdentifier(removed_column);
 	if (cascade) {
 		result += " CASCADE";
 	}
@@ -347,7 +347,7 @@ string RemoveFieldInfo::ToString() const {
 		if (i > 0) {
 			result += ".";
 		}
-		result += KeywordHelper::WriteOptionallyQuoted(column_path[i]);
+		result += SQLIdentifier(column_path[i]);
 	}
 	if (cascade) {
 		result += " CASCADE";
@@ -383,7 +383,7 @@ string ChangeColumnTypeInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
-	result += KeywordHelper::WriteOptionallyQuoted(column_name);
+	result += SQLIdentifier(column_name);
 	result += " TYPE ";
 	if (target_type.IsValid()) {
 		result += target_type.ToString();
@@ -429,7 +429,7 @@ string SetDefaultInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
-	result += KeywordHelper::WriteOptionallyQuoted(column_name);
+	result += SQLIdentifier(column_name);
 	if (expression) {
 		result += " SET DEFAULT ";
 		result += expression->ToString();
@@ -464,7 +464,7 @@ string SetNotNullInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
-	result += KeywordHelper::WriteOptionallyQuoted(column_name);
+	result += SQLIdentifier(column_name);
 	result += " SET NOT NULL";
 	result += ";";
 	return result;
@@ -494,7 +494,7 @@ string DropNotNullInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " ALTER COLUMN ";
-	result += KeywordHelper::WriteOptionallyQuoted(column_name);
+	result += SQLIdentifier(column_name);
 	result += " DROP NOT NULL";
 	result += ";";
 	return result;
@@ -566,7 +566,7 @@ string RenameViewInfo::ToString() const {
 	}
 	result += QualifierToString(catalog, schema, name);
 	result += " RENAME TO ";
-	result += KeywordHelper::WriteOptionallyQuoted(new_view_name);
+	result += SQLIdentifier(new_view_name);
 	result += ";";
 	return result;
 }

--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -31,7 +31,7 @@ string AttachInfo::ToString() const {
 	if (parsed_path) {
 		result += parsed_path->ToString();
 	} else {
-		result += KeywordHelper::WriteQuoted(path, '\'');
+		result += SQLString(path);
 	}
 	if (!name.empty()) {
 		result += " AS " + SQLIdentifier(name);

--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -34,7 +34,7 @@ string AttachInfo::ToString() const {
 		result += KeywordHelper::WriteQuoted(path, '\'');
 	}
 	if (!name.empty()) {
-		result += " AS " + KeywordHelper::WriteOptionallyQuoted(name);
+		result += " AS " + SQLIdentifier(name);
 	}
 	if (!parsed_options.empty() || !options.empty()) {
 		vector<string> stringified;

--- a/src/parser/parsed_data/comment_on_column_info.cpp
+++ b/src/parser/parsed_data/comment_on_column_info.cpp
@@ -28,7 +28,7 @@ string SetColumnCommentInfo::ToString() const {
 	D_ASSERT(catalog_entry_type == CatalogType::INVALID);
 	result += "COMMENT ON COLUMN ";
 	result += QualifierToString(catalog, schema, name);
-	result += "." + KeywordHelper::WriteOptionallyQuoted(column_name);
+	result += "." + SQLIdentifier(column_name);
 	result += " IS ";
 	result += comment_value.ToSQLString();
 	result += ";";

--- a/src/parser/parsed_data/copy_info.cpp
+++ b/src/parser/parsed_data/copy_info.cpp
@@ -84,7 +84,7 @@ string CopyInfo::TablePartToString() const {
 	if (!select_list.empty()) {
 		vector<string> options;
 		for (auto &option : select_list) {
-			options.push_back(KeywordHelper::WriteOptionallyQuoted(option));
+			options.push_back(SQLIdentifier::ToString(option));
 		}
 		result += " (";
 		result += StringUtil::Join(options, ", ");

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -69,12 +69,12 @@ string CreateIndexInfo::ToString() const {
 	if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
 		result += "IF NOT EXISTS ";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(index_name);
+	result += SQLIdentifier(index_name);
 	result += " ON ";
 	result += QualifierToString(temporary ? "" : catalog, schema, table);
 	if (index_type != "ART") {
 		result += " USING ";
-		result += KeywordHelper::WriteOptionallyQuoted(index_type);
+		result += SQLIdentifier(index_type);
 		result += " ";
 	}
 	result += "(";

--- a/src/parser/parsed_data/create_secret_info.cpp
+++ b/src/parser/parsed_data/create_secret_info.cpp
@@ -45,10 +45,10 @@ string CreateSecretInfo::ToString() const {
 	}
 	result = GetCreatePrefix(create_type);
 	if (!name.empty()) {
-		result += " " + KeywordHelper::WriteOptionallyQuoted(name);
+		result += " " + SQLIdentifier(name);
 	}
 	if (!storage_type.empty()) {
-		result += " IN" + KeywordHelper::WriteOptionallyQuoted(storage_type);
+		result += " IN" + SQLIdentifier(storage_type);
 	}
 	string option_list;
 	if (provider) {

--- a/src/parser/parsed_data/create_trigger_info.cpp
+++ b/src/parser/parsed_data/create_trigger_info.cpp
@@ -33,9 +33,9 @@ string CreateTriggerInfo::ToString() const {
 		ss << "IF NOT EXISTS ";
 	}
 	if (!IsInvalidSchema(schema)) {
-		ss << KeywordHelper::WriteOptionallyQuoted(schema) << ".";
+		ss << SQLIdentifier(schema) << ".";
 	}
-	ss << KeywordHelper::WriteOptionallyQuoted(trigger_name);
+	ss << SQLIdentifier(trigger_name);
 	ss << " ";
 	ss << EnumUtil::ToString(timing);
 	ss << " ";
@@ -46,7 +46,7 @@ string CreateTriggerInfo::ToString() const {
 			if (i > 0) {
 				ss << ", ";
 			}
-			ss << KeywordHelper::WriteOptionallyQuoted(columns[i]);
+			ss << SQLIdentifier(columns[i]);
 		}
 	}
 	ss << " ON ";

--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -24,8 +24,8 @@ string CreateViewInfo::ToString() const {
 	result += QualifierToString(temporary ? "" : catalog, schema, view_name);
 	if (!aliases.empty()) {
 		result += " (";
-		result += StringUtil::Join(aliases, aliases.size(), ", ",
-		                           [](const string &name) { return SQLIdentifier(name); });
+		result +=
+		    StringUtil::Join(aliases, aliases.size(), ", ", [](const string &name) { return SQLIdentifier(name); });
 		result += ")";
 	}
 	if (binding_mode == CreateViewBindingMode::SKIP_BINDING) {

--- a/src/parser/parsed_data/create_view_info.cpp
+++ b/src/parser/parsed_data/create_view_info.cpp
@@ -25,7 +25,7 @@ string CreateViewInfo::ToString() const {
 	if (!aliases.empty()) {
 		result += " (";
 		result += StringUtil::Join(aliases, aliases.size(), ", ",
-		                           [](const string &name) { return KeywordHelper::WriteOptionallyQuoted(name); });
+		                           [](const string &name) { return SQLIdentifier(name); });
 		result += ")";
 	}
 	if (binding_mode == CreateViewBindingMode::SKIP_BINDING) {

--- a/src/parser/parsed_data/detach_info.cpp
+++ b/src/parser/parsed_data/detach_info.cpp
@@ -19,7 +19,7 @@ string DetachInfo::ToString() const {
 	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 		result += " IF EXISTS";
 	}
-	result += " " + KeywordHelper::WriteOptionallyQuoted(name);
+	result += " " + SQLIdentifier(name);
 	result += ";";
 	return result;
 }

--- a/src/parser/parsed_data/drop_info.cpp
+++ b/src/parser/parsed_data/drop_info.cpp
@@ -21,7 +21,7 @@ string DropInfo::ToString() const {
 	string result = "";
 	if (type == CatalogType::PREPARED_STATEMENT) {
 		result += "DEALLOCATE PREPARE ";
-		result += KeywordHelper::WriteOptionallyQuoted(name);
+		result += SQLIdentifier(name);
 	} else {
 		result += "DROP";
 		result += " " + ParseInfo::TypeToString(type);

--- a/src/parser/parsed_data/load_info.cpp
+++ b/src/parser/parsed_data/load_info.cpp
@@ -36,7 +36,7 @@ string LoadInfo::ToString() const {
 		if (repo_is_alias) {
 			result += " FROM " + SQLIdentifier(repository);
 		} else {
-			result += " FROM " + KeywordHelper::WriteQuoted(repository);
+			result += " FROM " + SQLString(repository);
 		}
 	}
 

--- a/src/parser/parsed_data/load_info.cpp
+++ b/src/parser/parsed_data/load_info.cpp
@@ -34,7 +34,7 @@ string LoadInfo::ToString() const {
 	result += StringUtil::Format(" '%s'", filename);
 	if (!repository.empty()) {
 		if (repo_is_alias) {
-			result += " FROM " + KeywordHelper::WriteOptionallyQuoted(repository);
+			result += " FROM " + SQLIdentifier(repository);
 		} else {
 			result += " FROM " + KeywordHelper::WriteQuoted(repository);
 		}

--- a/src/parser/parsed_data/parse_info.cpp
+++ b/src/parser/parsed_data/parse_info.cpp
@@ -38,14 +38,14 @@ string ParseInfo::TypeToString(CatalogType type) {
 string ParseInfo::QualifierToString(const string &catalog, const string &schema, const string &name) {
 	string result;
 	if (!catalog.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		result += SQLIdentifier(catalog) + ".";
 		if (!schema.empty()) {
-			result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+			result += SQLIdentifier(schema) + ".";
 		}
 	} else if (!schema.empty() && schema != DEFAULT_SCHEMA) {
-		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		result += SQLIdentifier(schema) + ".";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(name);
+	result += SQLIdentifier(name);
 	return result;
 }
 

--- a/src/parser/parsed_data/pragma_info.cpp
+++ b/src/parser/parsed_data/pragma_info.cpp
@@ -18,7 +18,7 @@ string PragmaInfo::ToString() const {
 	string result = "";
 	result += "PRAGMA";
 	// FIXME: Can pragma's live in different catalog/schemas ?
-	result += " " + KeywordHelper::WriteOptionallyQuoted(name);
+	result += " " + SQLIdentifier(name);
 	if (!parameters.empty()) {
 		vector<string> stringified;
 		for (auto &param : parameters) {

--- a/src/parser/parsed_data/vacuum_info.cpp
+++ b/src/parser/parsed_data/vacuum_info.cpp
@@ -27,7 +27,7 @@ string VacuumInfo::ToString() const {
 		if (!columns.empty()) {
 			vector<string> names;
 			for (auto &column : columns) {
-				names.push_back(KeywordHelper::WriteOptionallyQuoted(column));
+				names.push_back(SQLIdentifier::ToString(column));
 			}
 			result += "(" + StringUtil::Join(names, ", ") + ")";
 		}

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -134,7 +134,7 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 				result = StringUtil::Upper(result);
 			}
 		} else if (suggestion.candidate_type == CandidateType::IDENTIFIER) {
-			result = KeywordHelper::WriteOptionallyQuoted(result, '"');
+			result = SQLIdentifier::ToString(result);
 		}
 		if (suggestion.extra_char != '\0') {
 			result += suggestion.extra_char;

--- a/src/parser/peg/transformer/transform_use.cpp
+++ b/src/parser/peg/transformer/transform_use.cpp
@@ -13,8 +13,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransfo
 	if (IsInvalidSchema(qn.schema)) {
 		value_str = SQLIdentifier::ToString(qn.name);
 	} else {
-		value_str =
-		    SQLIdentifier(qn.schema) + "." + SQLIdentifier(qn.name);
+		value_str = SQLIdentifier(qn.schema) + "." + SQLIdentifier(qn.name);
 	}
 
 	auto value_expr = make_uniq<ConstantExpression>(Value(value_str));

--- a/src/parser/peg/transformer/transform_use.cpp
+++ b/src/parser/peg/transformer/transform_use.cpp
@@ -11,10 +11,10 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformUseStatement(PEGTransfo
 
 	string value_str;
 	if (IsInvalidSchema(qn.schema)) {
-		value_str = KeywordHelper::WriteOptionallyQuoted(qn.name);
+		value_str = SQLIdentifier::ToString(qn.name);
 	} else {
 		value_str =
-		    KeywordHelper::WriteOptionallyQuoted(qn.schema) + "." + KeywordHelper::WriteOptionallyQuoted(qn.name);
+		    SQLIdentifier(qn.schema) + "." + SQLIdentifier(qn.name);
 	}
 
 	auto value_expr = make_uniq<ConstantExpression>(Value(value_str));

--- a/src/parser/qualified_name.cpp
+++ b/src/parser/qualified_name.cpp
@@ -116,15 +116,15 @@ QualifiedColumnName QualifiedColumnName::Parse(string &input) {
 string QualifiedColumnName::ToString() const {
 	string result;
 	if (!catalog.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		result += SQLIdentifier(catalog) + ".";
 	}
 	if (!schema.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		result += SQLIdentifier(schema) + ".";
 	}
 	if (!table.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(table) + ".";
+		result += SQLIdentifier(table) + ".";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(column);
+	result += SQLIdentifier(column);
 	return result;
 }
 

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -56,14 +56,14 @@ string CommonTableExpressionMap::ToString() const {
 			result += ", ";
 		}
 		auto &cte = *kv.second;
-		result += KeywordHelper::WriteOptionallyQuoted(kv.first);
+		result += SQLIdentifier(kv.first);
 		if (!cte.aliases.empty()) {
 			result += " (";
 			for (idx_t k = 0; k < cte.aliases.size(); k++) {
 				if (k > 0) {
 					result += ", ";
 				}
-				result += KeywordHelper::WriteOptionallyQuoted(cte.aliases[k]);
+				result += SQLIdentifier(cte.aliases[k]);
 			}
 			result += ")";
 		}

--- a/src/parser/query_node/delete_query_node.cpp
+++ b/src/parser/query_node/delete_query_node.cpp
@@ -32,8 +32,7 @@ string DeleteQueryNode::ToString() const {
 			}
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
-				col +=
-				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
+				col += StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/query_node/delete_query_node.cpp
+++ b/src/parser/query_node/delete_query_node.cpp
@@ -33,7 +33,7 @@ string DeleteQueryNode::ToString() const {
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
 				col +=
-				    StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->GetAlias()));
+				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/query_node/insert_query_node.cpp
+++ b/src/parser/query_node/insert_query_node.cpp
@@ -24,15 +24,15 @@ string InsertQueryNode::ToString() const {
 	}
 	result += " INTO ";
 	if (!catalog.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		result += SQLIdentifier(catalog) + ".";
 	}
 	if (!schema.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		result += SQLIdentifier(schema) + ".";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(table);
+	result += SQLIdentifier(table);
 	// Write the (optional) alias of the insert target
 	if (table_ref && !table_ref->alias.empty()) {
-		result += StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(table_ref->alias));
+		result += StringUtil::Format(" AS %s", SQLIdentifier(table_ref->alias));
 	}
 	if (column_order == InsertColumnOrder::INSERT_BY_NAME) {
 		result += " BY NAME";
@@ -43,7 +43,7 @@ string InsertQueryNode::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+			result += SQLIdentifier(columns[i]);
 		}
 		result += ")";
 	}
@@ -112,7 +112,7 @@ string InsertQueryNode::ToString() const {
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
 				col +=
-				    StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->GetAlias()));
+				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/query_node/insert_query_node.cpp
+++ b/src/parser/query_node/insert_query_node.cpp
@@ -111,8 +111,7 @@ string InsertQueryNode::ToString() const {
 			}
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
-				col +=
-				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
+				col += StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/query_node/update_query_node.cpp
+++ b/src/parser/query_node/update_query_node.cpp
@@ -30,7 +30,7 @@ string UpdateQueryNode::ToString() const {
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
 				col +=
-				    StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->GetAlias()));
+				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/query_node/update_query_node.cpp
+++ b/src/parser/query_node/update_query_node.cpp
@@ -29,8 +29,7 @@ string UpdateQueryNode::ToString() const {
 			}
 			auto col = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
-				col +=
-				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
+				col += StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += col;
 		}

--- a/src/parser/statement/copy_database_statement.cpp
+++ b/src/parser/statement/copy_database_statement.cpp
@@ -20,9 +20,9 @@ unique_ptr<SQLStatement> CopyDatabaseStatement::Copy() const {
 string CopyDatabaseStatement::ToString() const {
 	string result;
 	result = "COPY FROM DATABASE ";
-	result += KeywordHelper::WriteOptionallyQuoted(from_database);
+	result += SQLIdentifier(from_database);
 	result += " TO ";
-	result += KeywordHelper::WriteOptionallyQuoted(to_database);
+	result += SQLIdentifier(to_database);
 	result += " (";
 	switch (copy_type) {
 	case CopyDatabaseType::COPY_DATA:

--- a/src/parser/statement/merge_into_statement.cpp
+++ b/src/parser/statement/merge_into_statement.cpp
@@ -71,8 +71,7 @@ string MergeIntoStatement::ToString() const {
 			}
 			auto column = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
-				column +=
-				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
+				column += StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += column;
 		}

--- a/src/parser/statement/merge_into_statement.cpp
+++ b/src/parser/statement/merge_into_statement.cpp
@@ -72,7 +72,7 @@ string MergeIntoStatement::ToString() const {
 			auto column = returning_list[i]->ToString();
 			if (!returning_list[i]->GetAlias().empty()) {
 				column +=
-				    StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->GetAlias()));
+				    StringUtil::Format(" AS %s", SQLIdentifier(returning_list[i]->GetAlias()));
 			}
 			result += column;
 		}
@@ -114,7 +114,7 @@ string MergeIntoAction::ToString() const {
 				if (c > 0) {
 					result += ", ";
 				}
-				result += KeywordHelper::WriteOptionallyQuoted(insert_columns[c]);
+				result += SQLIdentifier(insert_columns[c]);
 			}
 			result += ") ";
 		}

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -24,7 +24,7 @@ string UpdateSetInfo::ToString() const {
 		if (i > 0) {
 			result += ", ";
 		}
-		result += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+		result += SQLIdentifier(columns[i]);
 		result += " = ";
 		result += expressions[i]->ToString();
 	}

--- a/src/parser/tableref.cpp
+++ b/src/parser/tableref.cpp
@@ -24,7 +24,7 @@ string TableRef::AliasToString(const vector<string> &column_name_alias) const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += KeywordHelper::WriteOptionallyQuoted(column_name_alias[i]);
+			result += SQLIdentifier(column_name_alias[i]);
 		}
 		result += ")";
 	}

--- a/src/parser/tableref/basetableref.cpp
+++ b/src/parser/tableref/basetableref.cpp
@@ -8,9 +8,9 @@ namespace duckdb {
 
 string BaseTableRef::ToString() const {
 	string result;
-	result += catalog_name.empty() ? "" : (KeywordHelper::WriteOptionallyQuoted(catalog_name) + ".");
-	result += schema_name.empty() ? "" : (KeywordHelper::WriteOptionallyQuoted(schema_name) + ".");
-	result += KeywordHelper::WriteOptionallyQuoted(table_name);
+	result += catalog_name.empty() ? "" : (SQLIdentifier(catalog_name) + ".");
+	result += schema_name.empty() ? "" : (SQLIdentifier(schema_name) + ".");
+	result += SQLIdentifier(table_name);
 	result += AliasToString(column_name_alias);
 	if (at_clause) {
 		result += " " + at_clause->ToString();

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -45,7 +45,7 @@ string JoinRef::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += KeywordHelper::WriteOptionallyQuoted(using_columns[i]);
+			result += SQLIdentifier(using_columns[i]);
 		}
 		result += ")";
 	}

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -22,14 +22,14 @@ string PivotColumn::ToString() const {
 		D_ASSERT(pivot_expressions.empty());
 		// unpivot
 		if (unpivot_names.size() == 1) {
-			result += KeywordHelper::WriteOptionallyQuoted(unpivot_names[0]);
+			result += SQLIdentifier(unpivot_names[0]);
 		} else {
 			result += "(";
 			for (idx_t n = 0; n < unpivot_names.size(); n++) {
 				if (n > 0) {
 					result += ", ";
 				}
-				result += KeywordHelper::WriteOptionallyQuoted(unpivot_names[n]);
+				result += SQLIdentifier(unpivot_names[n]);
 			}
 			result += ")";
 		}
@@ -68,12 +68,12 @@ string PivotColumn::ToString() const {
 				result += ")";
 			}
 			if (!entry.alias.empty()) {
-				result += " AS " + KeywordHelper::WriteOptionallyQuoted(entry.alias);
+				result += " AS " + SQLIdentifier(entry.alias);
 			}
 		}
 		result += ")";
 	} else {
-		result += KeywordHelper::WriteOptionallyQuoted(pivot_enum);
+		result += SQLIdentifier(pivot_enum);
 	}
 	return result;
 }
@@ -337,7 +337,7 @@ string PivotRef::ToString() const {
 			}
 			result += aggregates[aggr_idx]->ToString();
 			if (!aggregates[aggr_idx]->GetAlias().empty()) {
-				result += " AS " + KeywordHelper::WriteOptionallyQuoted(aggregates[aggr_idx]->GetAlias());
+				result += " AS " + SQLIdentifier(aggregates[aggr_idx]->GetAlias());
 			}
 		}
 	} else {
@@ -348,14 +348,14 @@ string PivotRef::ToString() const {
 		}
 		result += "(";
 		if (unpivot_names.size() == 1) {
-			result += KeywordHelper::WriteOptionallyQuoted(unpivot_names[0]);
+			result += SQLIdentifier(unpivot_names[0]);
 		} else {
 			result += "(";
 			for (idx_t n = 0; n < unpivot_names.size(); n++) {
 				if (n > 0) {
 					result += ", ";
 				}
-				result += KeywordHelper::WriteOptionallyQuoted(unpivot_names[n]);
+				result += SQLIdentifier(unpivot_names[n]);
 			}
 			result += ")";
 		}
@@ -376,14 +376,14 @@ string PivotRef::ToString() const {
 	}
 	result += ")";
 	if (!alias.empty()) {
-		result += " AS " + KeywordHelper::WriteOptionallyQuoted(alias);
+		result += " AS " + SQLIdentifier(alias);
 		if (!column_name_alias.empty()) {
 			result += "(";
 			for (idx_t i = 0; i < column_name_alias.size(); i++) {
 				if (i > 0) {
 					result += ", ";
 				}
-				result += KeywordHelper::WriteOptionallyQuoted(column_name_alias[i]);
+				result += SQLIdentifier(column_name_alias[i]);
 			}
 			result += ")";
 		}

--- a/src/parser/tableref/showref.cpp
+++ b/src/parser/tableref/showref.cpp
@@ -14,12 +14,12 @@ string ShowRef::ToString() const {
 		result += "SHOW TABLES FROM ";
 		string name = "";
 		if (!catalog_name.empty()) {
-			name += KeywordHelper::WriteOptionallyQuoted(catalog_name, '"');
+			name += SQLIdentifier(catalog_name);
 			if (!schema_name.empty()) {
 				name += ".";
 			}
 		}
-		name += KeywordHelper::WriteOptionallyQuoted(schema_name, '"');
+		name += SQLIdentifier(schema_name);
 		result += name;
 	} else {
 		result += "DESCRIBE ";

--- a/src/planner/binding_alias.cpp
+++ b/src/planner/binding_alias.cpp
@@ -36,12 +36,12 @@ const string &BindingAlias::GetAlias() const {
 string BindingAlias::ToString() const {
 	string result;
 	if (!catalog.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		result += SQLIdentifier(catalog) + ".";
 	}
 	if (!schema.empty()) {
-		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		result += SQLIdentifier(schema) + ".";
 	}
-	result += KeywordHelper::WriteOptionallyQuoted(alias);
+	result += SQLIdentifier(alias);
 	return result;
 }
 

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -827,8 +827,7 @@ TEST_CASE("ADBC - Test Ingestion - Funky identifiers", "[adbc]") {
 	}
 
 	// Check we can query
-	auto schema_table =
-	    SQLIdentifier(schema_name) + "." + SQLIdentifier(table_name);
+	auto schema_table = SQLIdentifier(schema_name) + "." + SQLIdentifier(table_name);
 	auto res = db.Query("select * from " + schema_table);
 	for (size_t i = 0; i < column_names.size(); i++) {
 		REQUIRE((res->ColumnName(i) == column_names.at(i)));

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -793,7 +793,7 @@ TEST_CASE("ADBC - Test Ingestion - Funky identifiers", "[adbc]") {
 	input_data.get_next(&input_data, &prepared_array);
 
 	// Create the schema
-	db.Query("CREATE SCHEMA " + KeywordHelper::WriteOptionallyQuoted(schema_name));
+	db.Query("CREATE SCHEMA " + SQLIdentifier(schema_name));
 
 	// Create ADBC statement that will create a table called "test"
 	AdbcStatement adbc_stmt;
@@ -828,7 +828,7 @@ TEST_CASE("ADBC - Test Ingestion - Funky identifiers", "[adbc]") {
 
 	// Check we can query
 	auto schema_table =
-	    KeywordHelper::WriteOptionallyQuoted(schema_name) + "." + KeywordHelper::WriteOptionallyQuoted(table_name);
+	    SQLIdentifier(schema_name) + "." + SQLIdentifier(table_name);
 	auto res = db.Query("select * from " + schema_table);
 	for (size_t i = 0; i < column_names.size(); i++) {
 		REQUIRE((res->ColumnName(i) == column_names.at(i)));


### PR DESCRIPTION
Currently when writing identifiers or literals to SQL we have two implementations:

* `KeywordHelper::Write[Optionally]Quoted`
* `SQLString` and `SQLIdentifier`

The former is very poorly named and can be easily used incorrectly:

* `KeywordHelper::WriteOptionallyQuoted` writes a *SQL identifier*, optionally quoted with double-quotes (`"`). The quote is configurable - but optional quoting never makes sense with single quotes since a SQL string literal must always be quoted.
* `KeywordHelper::WriteQuoted` writes, by default, a *SQL string literal* quoted with single quotes (`'`). The quote is configurable - so `KeywordHelper::WriteQuoted(identifier, '"')` can be used to write an identifier that is always quoted.

These names are not very descriptive, and the flipped defaults (`WriteOptionallyQuoted` writes an identifier, `WriteQuoted` writes a literal) are a bit of a footgun.

This PR deprecates those methods, and instead improves support for the `SQLString` and `SQLIdentifier` classes - as well as adding a `SQLQuotedIdentifier` class which represents an identifier that is *always* quoted. 

These classes can now be used in string arithmetic and as part of string streams, which makes them usable as a drop-in replacement in most places for the `KeywordHelper` methods. For example, this now works:

```cpp
// push into stream
ss << SQLIdentifier(name);

// append to string
create_tbl += SQLIdentifier(names[i]);
```

This already worked:

```cpp
// use as format parameter
StringUtil::Format("FROM %s", SQLIdentifier(table_name));
```