### PR TITLE
Internal #9003: TIMETZ Parsing Limit

### DIFF
--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -175,6 +175,11 @@ bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &
 		return false;
 	}
 
+	//	Interval parsing accepts larger hour counts, but we must limit ourselves to <= 24:00:00
+	if (time_part.micros > Interval::MICROS_PER_DAY) {
+		return false;
+	}
+
 	// skip optional whitespace before offset
 	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
 		pos++;

--- a/test/sql/function/timetz/test_icu_cast.test
+++ b/test/sql/function/timetz/test_icu_cast.test
@@ -19,3 +19,11 @@ query I
 SELECT '01:00:00+02'::TIMETZ AS ttz
 ----
 01:00:00+02
+
+statement ok
+create table timetzs (ttz TIMETZ);
+
+statement error
+insert into timetzs values ('2402:30:00+1200');
+----
+time field value out of range


### PR DESCRIPTION
* Reject time values > 24:00:00.