### PR TITLE
Add duckdb_bind_has_named_parameter to the C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -4356,6 +4356,17 @@ The result must be destroyed with `duckdb_destroy_value`.
 DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
 
 /*!
+Returns whether a named parameter with the given name was provided to the function.
+
+This can be used to differentiate between an omitted named parameter and one that was set to `NULL`.
+
+* @param info The info object
+* @param name The name of the parameter
+* @return True if the named parameter was provided, false otherwise.
+*/
+DUCKDB_C_API bool duckdb_bind_has_named_parameter(duckdb_bind_info info, const char *name);
+
+/*!
 Sets the user-provided bind data in the bind object of the table function.
 This object can be retrieved again during execution.
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -656,6 +656,7 @@ typedef struct {
 	// New functions around table function binding
 
 	void (*duckdb_table_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
+	bool (*duckdb_bind_has_named_parameter)(duckdb_bind_info info, const char *name);
 	// New value functions that are added
 
 	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value *keys, duckdb_value *values,
@@ -1216,6 +1217,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_table_description_get_column_count = duckdb_table_description_get_column_count;
 	result.duckdb_table_description_get_column_type = duckdb_table_description_get_column_type;
 	result.duckdb_table_function_get_client_context = duckdb_table_function_get_client_context;
+	result.duckdb_bind_has_named_parameter = duckdb_bind_has_named_parameter;
 	result.duckdb_create_map_value = duckdb_create_map_value;
 	result.duckdb_create_union_value = duckdb_create_union_value;
 	result.duckdb_create_time_ns = duckdb_create_time_ns;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_table_function_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_table_function_functions.json
@@ -2,6 +2,7 @@
   "version": "unstable_new_table_function_functions",
   "description": "New functions around table function binding",
   "entries": [
-    "duckdb_table_function_get_client_context"
+    "duckdb_table_function_get_client_context",
+    "duckdb_bind_has_named_parameter"
   ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
@@ -129,6 +129,28 @@
             }
         },
         {
+            "name": "duckdb_bind_has_named_parameter",
+            "return_type": "bool",
+            "params": [
+                {
+                    "type": "duckdb_bind_info",
+                    "name": "info"
+                },
+                {
+                    "type": "const char *",
+                    "name": "name"
+                }
+            ],
+            "comment": {
+                "description": "Returns whether a named parameter with the given name was provided to the function.\n\nThis can be used to differentiate between an omitted named parameter and one that was set to `NULL`.\n\n",
+                "param_comments": {
+                    "info": "The info object",
+                    "name": "The name of the parameter"
+                },
+                "return_value": "True if the named parameter was provided, false otherwise."
+            }
+        },
+        {
             "name": "duckdb_bind_set_bind_data",
             "return_type": "void",
             "params": [

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -759,6 +759,7 @@ typedef struct {
 // New functions around table function binding
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	void (*duckdb_table_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
+	bool (*duckdb_bind_has_named_parameter)(duckdb_bind_info info, const char *name);
 #endif
 
 // New value functions that are added
@@ -1370,6 +1371,7 @@ typedef struct {
 
 // Version unstable_new_table_function_functions
 #define duckdb_table_function_get_client_context duckdb_ext_api.duckdb_table_function_get_client_context
+#define duckdb_bind_has_named_parameter          duckdb_ext_api.duckdb_bind_has_named_parameter
 
 // Version unstable_new_value_functions
 #define duckdb_create_time_ns     duckdb_ext_api.duckdb_create_time_ns

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -374,6 +374,14 @@ duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *
 	}
 }
 
+bool duckdb_bind_has_named_parameter(duckdb_bind_info info, const char *name) {
+	if (!info || !name) {
+		return false;
+	}
+	auto &bind_info = GetCTableFunctionBindInfo(info);
+	return bind_info.named_parameters.find(name) != bind_info.named_parameters.end();
+}
+
 void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy) {
 	if (!info) {
 		return;

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -184,11 +184,17 @@ void my_named_bind(duckdb_bind_info info) {
 
 	auto nparam = duckdb_bind_get_named_parameter(info, "my_parameter");
 	if (nparam) {
+		REQUIRE(duckdb_bind_has_named_parameter(info, "my_parameter"));
 		my_bind_data->multiplier = duckdb_get_int64(nparam);
 	} else {
+		REQUIRE(!duckdb_bind_has_named_parameter(info, "my_parameter"));
 		my_bind_data->multiplier = 1;
 	}
 	duckdb_destroy_value(&nparam);
+
+	REQUIRE(!duckdb_bind_has_named_parameter(info, "unknown_parameter"));
+	REQUIRE(!duckdb_bind_has_named_parameter(info, nullptr));
+	REQUIRE(!duckdb_bind_has_named_parameter(nullptr, "my_parameter"));
 
 	duckdb_bind_set_bind_data(info, my_bind_data, free);
 }


### PR DESCRIPTION
## Summary

Adds a new C API function `duckdb_bind_has_named_parameter(info, name)` returning whether a named parameter was provided to a table function call.

`duckdb_bind_get_named_parameter` already exists, but it returns a null `duckdb_value` both when a parameter is omitted and when callers might otherwise want to distinguish "omitted" from a parameter explicitly set to `NULL`. This new function provides that disambiguation.

## Why

Language bindings (e.g. [duckdb-go #130](https://github.com/duckdb/duckdb-go/pull/130)) surface named parameters as a map and want to let users detect omission to apply defaults — which currently has no clean path through the C API. The maintainers requested this addition; see [this comment](https://github.com/duckdb/duckdb-go/pull/130#discussion_r3161489689).

## Changes

- New entry in `src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json`
- Registered in the unstable extension API (`apis/v1/unstable/new_table_function_functions.json`)
- Implementation in `src/main/capi/table_function-c.cpp`
- Generated headers refreshed via `scripts/generate_c_api.py`
- Test coverage in `test/api/capi/capi_table_functions.cpp` covering: parameter present, parameter omitted, unknown name, null `info`, null `name`

## Test plan

- [x] `make debug` succeeds
- [x] `build/debug/test/unittest "[capi]"` — all 137 cases / 1.36M assertions pass
- [x] `build/debug/test/unittest "Test Table Function named parameters in C API"` passes with new assertions