### PR TITLE
ISSUE-22274: Fix LOGICAL_FILTER column lifetime projection mapping

### DIFF
--- a/scripts/reproduce_github_issue_22274_arrow.py
+++ b/scripts/reproduce_github_issue_22274_arrow.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Manual reproducer for https://github.com/duckdb/duckdb/issues/22274
+
+Uses pyarrow + DuckDB register() with produce_arrow_string_view and Arrow 1.5 output,
+matching the failure mode discussed on the issue and in test/arrow/arrow_filter_pushdown.cpp.
+
+Requires: pip install duckdb pyarrow
+
+Run (from repo root, with a duckdb build on PYTHONPATH or default pip duckdb):
+  python3 scripts/reproduce_github_issue_22274_arrow.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+try:
+	import duckdb
+except ImportError as e:
+	print("Install duckdb: pip install duckdb", file=sys.stderr)
+	raise SystemExit(1) from e
+
+try:
+	import pyarrow  # noqa: F401 — required for Relation.arrow() / register()
+except ImportError as e:
+	print("Install pyarrow: pip install pyarrow", file=sys.stderr)
+	raise SystemExit(1) from e
+
+
+def main() -> None:
+    con = duckdb.connect()
+    con.execute("PRAGMA threads=1")
+    con.execute("SET produce_arrow_string_view = true")
+    con.execute("SET arrow_output_version = '1.5'")
+
+    con.execute(
+        """
+		CREATE TABLE src AS SELECT
+			['TOYOTA','HONDA','FORD','CHEVROLET','BMW','MERCEDES','NISSAN','HYUNDAI','KIA','SUBARU',
+			 'MAZDA','VPG','ISUZU','SMART','LUCID','LOTUS','PLYMOUTH','DODGE_MITS','VINFAST',
+			 'POLESTAR'][((i % 20) + 1)::INTEGER] AS name,
+			CASE WHEN i % 10 != 0 THEN 0::TINYINT ELSE 1::TINYINT END AS flag
+		FROM range(50000) tbl(i)
+	"""
+    )
+
+    rel = con.sql("SELECT name, flag FROM src")
+    arrow_tbl = rel.arrow()
+    # register as in-memory Arrow table (same integration surface as many pyarrow workflows)
+    con.register("data", arrow_tbl)
+
+    sql = """
+	SELECT name, COUNT(*) AS cnt FROM data
+	WHERE flag < 1 AND name IN ('VPG','ISUZU','SMART','LUCID','LOTUS','POLESTAR')
+	GROUP BY 1 ORDER BY 1
+	"""
+    try:
+        print(con.execute(sql).fetchall())
+        print("OK: query completed without error.")
+    except duckdb.Error as e:
+        print(f"Query failed: {e}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -74,6 +74,32 @@ PhysicalHashJoin::PhysicalHashJoin(PhysicalPlan &physical_plan, LogicalOperator 
 		lhs_output_columns.col_types.push_back(lhs_input_types[lhs_col]);
 	}
 
+	// MARK join output types must be lhs_payload + BOOLEAN (ConstructMarkJoinResult). Refresh only when the logical
+	// plan disagrees with the materialized LHS layout (#22274) — usually they already match after optimizer fixes.
+	if (join_type == JoinType::MARK) {
+		const idx_t n = lhs_output_columns.col_types.size();
+		const idx_t expected_cols = n + 1;
+		bool mismatch = types.size() != expected_cols;
+		if (!mismatch) {
+			for (idx_t i = 0; i < n; i++) {
+				if (types[i] != lhs_output_columns.col_types[i]) {
+					mismatch = true;
+					break;
+				}
+			}
+			if (!mismatch && types[n].id() != LogicalTypeId::BOOLEAN) {
+				mismatch = true;
+			}
+		}
+		if (mismatch) {
+			types.resize(expected_cols);
+			for (idx_t i = 0; i < n; i++) {
+				types[i] = lhs_output_columns.col_types[i];
+			}
+			types[n] = LogicalType::BOOLEAN;
+		}
+	}
+
 	// initialize residual predicate structures if present
 	if (residual_info) {
 		InitializeResidualPredicate(lhs_input_types, probe_cols);
@@ -130,20 +156,29 @@ void PhysicalHashJoin::ExtractResidualPredicateColumns(unique_ptr<Expression> &p
 void PhysicalHashJoin::InitializeResidualPredicate(const vector<LogicalType> &lhs_input_types,
                                                    const vector<idx_t> &probe_cols) {
 	D_ASSERT(residual_info);
-	// build lhs_probe_columns (output + predicate columns)
-	unordered_set<idx_t> required_probe_cols;
+	// Build lhs_probe layout with lhs OUTPUT indices first — they must remain prefix-aligned with
+	// PhysicalHashJoin::lhs_output_columns so ConstructMarkJoinResult can pair result vector types with probe vectors.
+	// Sorting merged {output ∪ predicate} indices lexicographically scrambled that order (#22274).
+	unordered_set<idx_t> seen;
+	lhs_probe_columns.col_idxs.reserve(lhs_output_columns.col_idxs.size() + probe_cols.size());
+	lhs_probe_columns.col_types.reserve(lhs_probe_columns.col_idxs.capacity());
 	for (auto col : lhs_output_columns.col_idxs) {
-		required_probe_cols.insert(col);
+		if (!seen.insert(col).second) {
+			continue;
+		}
+		lhs_probe_columns.col_idxs.push_back(col);
+		lhs_probe_columns.col_types.push_back(lhs_input_types[col]);
 	}
+	vector<idx_t> predicate_only_extra;
 	for (auto col : probe_cols) {
-		required_probe_cols.insert(col);
+		if (seen.insert(col).second) {
+			predicate_only_extra.push_back(col);
+		}
 	}
-
-	lhs_probe_columns.col_idxs.assign(required_probe_cols.begin(), required_probe_cols.end());
-	std::sort(lhs_probe_columns.col_idxs.begin(), lhs_probe_columns.col_idxs.end());
-
-	for (auto col_idx : lhs_probe_columns.col_idxs) {
-		lhs_probe_columns.col_types.push_back(lhs_input_types[col_idx]);
+	std::sort(predicate_only_extra.begin(), predicate_only_extra.end());
+	for (auto col : predicate_only_extra) {
+		lhs_probe_columns.col_idxs.push_back(col);
+		lhs_probe_columns.col_types.push_back(lhs_input_types[col]);
 	}
 
 	// build mapping for predicate probe columns
@@ -156,15 +191,11 @@ void PhysicalHashJoin::InitializeResidualPredicate(const vector<LogicalType> &lh
 		}
 	}
 
-	// build lhs_output_in_probe mapping
+	lhs_output_in_probe.clear();
 	lhs_output_in_probe.reserve(lhs_output_columns.col_idxs.size());
-	for (auto output_col_idx : lhs_output_columns.col_idxs) {
-		for (idx_t i = 0; i < lhs_probe_columns.col_idxs.size(); i++) {
-			if (lhs_probe_columns.col_idxs[i] == output_col_idx) {
-				lhs_output_in_probe.push_back(i);
-				break;
-			}
-		}
+	for (idx_t i = 0; i < lhs_output_columns.col_idxs.size(); i++) {
+		lhs_output_in_probe.push_back(i);
+		D_ASSERT(lhs_probe_columns.col_idxs[i] == lhs_output_columns.col_idxs[i]);
 	}
 }
 

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -19,7 +19,12 @@ static void RewriteJoinCondition(unique_ptr<Expression> &root_expr, idx_t offset
 }
 
 PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoin &op) {
-	// now visit the children
+	// Refresh join output types from children before planning; keeps MARK plans consistent when logical types lag
+	// behind child layouts (see ColumnBindingResolver after optimizer rewrites). Skip for delim joins: resolving
+	// before child plans are built breaks LogicalRecursiveCTE::ResolveTypes (recursive CTE key aggregation).
+	if (op.type != LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		op.ResolveOperatorTypes();
+	}
 	D_ASSERT(op.children.size() == 2);
 	idx_t lhs_cardinality = op.children[0]->EstimateCardinality(context);
 	idx_t rhs_cardinality = op.children[1]->EstimateCardinality(context);

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -1,12 +1,8 @@
 #include "duckdb/execution/operator/filter/physical_filter.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
-#include "duckdb/optimizer/matcher/expression_matcher.hpp"
-#include "duckdb/planner/expression/bound_comparison_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
-#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -17,6 +17,58 @@
 
 namespace duckdb {
 
+//! Peek through FILTER/PROJECTION/ORDER unary chains to detect the IN (...) MARK join InClauseRewriter produces.
+//! (Broad DFS is unsafe — deeper MARK joins unrelated to this FILTER must keep projection maps intact.)
+static const LogicalComparisonJoin *PeelUnaryChainToMarkJoin(const LogicalOperator *op) {
+	while (op && op->children.size() == 1) {
+		switch (op->type) {
+		case LogicalOperatorType::LOGICAL_FILTER:
+		case LogicalOperatorType::LOGICAL_PROJECTION:
+		case LogicalOperatorType::LOGICAL_ORDER_BY:
+			op = op->children[0].get();
+			continue;
+		default:
+			op = nullptr;
+			break;
+		}
+	}
+	if (!op || op->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return nullptr;
+	}
+	auto &comp_join = op->Cast<LogicalComparisonJoin>();
+	return comp_join.join_type == JoinType::MARK ? &comp_join : nullptr;
+}
+
+static void GenerateProjectionMapByBindings(const vector<ColumnBinding> &current_bindings,
+                                            const vector<ColumnBinding> &desired_output_bindings,
+                                            vector<ProjectionIndex> &projection_map) {
+	projection_map.clear();
+	if (desired_output_bindings.empty()) {
+		return;
+	}
+	projection_map.reserve(desired_output_bindings.size());
+	for (const auto &desired_binding : desired_output_bindings) {
+		bool found = false;
+		for (idx_t i = 0; i < current_bindings.size(); i++) {
+			if (current_bindings[i] != desired_binding) {
+				continue;
+			}
+			projection_map.emplace_back(i);
+			found = true;
+			break;
+		}
+		if (!found) {
+			// Child rewrites can remove or replace bindings. Fallback to identity map if we cannot express this
+			// mapping.
+			projection_map.clear();
+			return;
+		}
+	}
+	if (projection_map.size() == current_bindings.size()) {
+		projection_map.clear();
+	}
+}
+
 void ColumnLifetimeAnalyzer::ExtractUnusedColumnBindings(const vector<ColumnBinding> &bindings,
                                                          column_binding_set_t &unused_bindings) {
 	for (idx_t i = 0; i < bindings.size(); i++) {
@@ -88,19 +140,51 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 			return;
 		}
 
+		VisitOperatorExpressions(comp_join);
+
+		// Pruning LHS via Join::left_projection_map for MARK joins can desynchronize PhysicalHashJoin
+		// (lhs_output_in_probe vs probe chunk layouts) relative to LOGICAL_FILTERS/InClauseRewriter above/below —
+		// especially with arrow scans and layered predicates (#22274, PR22382). Child operators may still prune
+		// their own subgraph; MARK join forwards the full visited LHS/RHS layouts.
+		if (comp_join.join_type == JoinType::MARK) {
+			StandardVisitOperator(op);
+			comp_join.left_projection_map.clear();
+			comp_join.right_projection_map.clear();
+			return;
+		}
+
 		column_binding_set_t lhs_unused;
 		column_binding_set_t rhs_unused;
-		ExtractUnusedColumnBindings(op.children[0]->GetColumnBindings(), lhs_unused);
-		ExtractUnusedColumnBindings(op.children[1]->GetColumnBindings(), rhs_unused);
+		const auto lhs_bindings_before_visit = op.children[0]->GetColumnBindings();
+		const auto rhs_bindings_before_visit = op.children[1]->GetColumnBindings();
+		ExtractUnusedColumnBindings(lhs_bindings_before_visit, lhs_unused);
+		ExtractUnusedColumnBindings(rhs_bindings_before_visit, rhs_unused);
+
+		vector<ColumnBinding> desired_lhs_bindings;
+		desired_lhs_bindings.reserve(lhs_bindings_before_visit.size());
+		for (const auto &binding : lhs_bindings_before_visit) {
+			if (lhs_unused.find(binding) == lhs_unused.end()) {
+				desired_lhs_bindings.push_back(binding);
+			}
+		}
+		vector<ColumnBinding> desired_rhs_bindings;
+		desired_rhs_bindings.reserve(rhs_bindings_before_visit.size());
+		for (const auto &binding : rhs_bindings_before_visit) {
+			if (rhs_unused.find(binding) == rhs_unused.end()) {
+				desired_rhs_bindings.push_back(binding);
+			}
+		}
 
 		StandardVisitOperator(op);
 
-		// then generate the projection map
+		// Remap projection maps against post-visit child bindings — child visitation can rewrite bindings,
+		// so pairing pre-visit "unused" sets with post-visit column positions is insufficient (issue #22274).
 		if (op.type != LogicalOperatorType::LOGICAL_ASOF_JOIN) {
-			// FIXME: left_projection_map in ASOF join
-			GenerateProjectionMap(op.children[0]->GetColumnBindings(), lhs_unused, comp_join.left_projection_map);
+			GenerateProjectionMapByBindings(op.children[0]->GetColumnBindings(), desired_lhs_bindings,
+			                                comp_join.left_projection_map);
 		}
-		GenerateProjectionMap(op.children[1]->GetColumnBindings(), rhs_unused, comp_join.right_projection_map);
+		GenerateProjectionMapByBindings(op.children[1]->GetColumnBindings(), desired_rhs_bindings,
+		                                comp_join.right_projection_map);
 		return;
 	}
 	case LogicalOperatorType::LOGICAL_INSERT:
@@ -178,15 +262,52 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 			break;
 		}
 
-		// filter, figure out which columns are not needed after the filter
-		column_binding_set_t unused_bindings;
-		ExtractUnusedColumnBindings(op.children[0]->GetColumnBindings(), unused_bindings);
+		// FILTER has two liveness roles (#22274): (1) output columns — only bindings referenced by operators *above*
+		// this filter; (2) predicate columns — needed in the child's chunk to evaluate the filter but not necessarily
+		// emitted. Snapshot (1) before visiting predicates so predicate-only columns (e.g. flag in flag < 1) do not
+		// leak into the filter's projection_map.
+		const column_binding_set_t refs_above_filter = column_references;
 
-		StandardVisitOperator(op);
+		// InClauseRewriter (large constant IN lists) uses MARK + LOGICAL_CHUNK_GET and may layer a FILTER that must
+		// strip mark_index from propagated bindings — e.g. conjunct-splitting places ONLY "flag < 1" above an inner
+		// filter that owns IN (...). Subquery IN uses MARK with a normal RHS plan; stripping mark here breaks filters
+		// or projections that still reference the mark (predicate pushdown into CTEs — see
+		// test/optimizer/pushdown/no_mark_to_semi_if_mark_index_is_projected.test).
+		bool handled_in_clause_filter = false;
+		if (const auto *peeked_mark = PeelUnaryChainToMarkJoin(op.children[0].get());
+		    peeked_mark && peeked_mark->children.size() >= 2 &&
+		    peeked_mark->children[1]->type == LogicalOperatorType::LOGICAL_CHUNK_GET) {
+			VisitOperatorExpressions(op);
+			const auto mark_tbl = peeked_mark->mark_index;
+			VisitOperatorChildren(op);
 
-		// then generate the projection map
-		GenerateProjectionMap(op.children[0]->GetColumnBindings(), unused_bindings, filter.projection_map);
+			filter.projection_map.clear();
+			const auto child_bindings_after = op.children[0]->GetColumnBindings();
+			for (idx_t i = 0; i < child_bindings_after.size(); i++) {
+				if (child_bindings_after[i].table_index != mark_tbl) {
+					filter.projection_map.emplace_back(i);
+				}
+			}
+			if (filter.projection_map.size() == child_bindings_after.size()) {
+				filter.projection_map.clear();
+			}
+			handled_in_clause_filter = true;
+		}
+		if (!handled_in_clause_filter) {
+			const auto child_bindings_before = op.children[0]->GetColumnBindings();
+			vector<ColumnBinding> desired_output_bindings;
+			desired_output_bindings.reserve(child_bindings_before.size());
+			for (const auto &binding : child_bindings_before) {
+				if (refs_above_filter.find(binding) != refs_above_filter.end()) {
+					desired_output_bindings.push_back(binding);
+				}
+			}
 
+			VisitOperatorExpressions(op);
+			VisitOperatorChildren(op);
+			GenerateProjectionMapByBindings(op.children[0]->GetColumnBindings(), desired_output_bindings,
+			                                filter.projection_map);
+		}
 		return;
 	}
 	default:

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -450,8 +450,35 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 	default:
 		break;
 	}
-	LogicalOperatorVisitor::VisitOperatorExpressions(op);
-	LogicalOperatorVisitor::VisitOperatorChildren(op);
+
+	//! MARK comparison joins: parent filters can reference LHS payload columns only above the join. Projection
+	//! pushdown on the probe LogicalGet must not prune them, or LOGICAL and PHYSICAL LHS layouts disagree and InClause
+	//! MARK bindings bind to the wrong column (issue #22274 / PR #22382).
+	//! LOGICAL_DELIM_JOIN + MARK is excluded: correlated / delim plans rely on the standard projection-map child
+	//! visitation path; forcing LHS preserve breaks binding (see
+	//! test/optimizer/joins/delim_join_with_in_has_correct_results.test).
+	//! If either join projection map is non-empty, we must use VisitOperatorWithProjectionMapChildren so maps stay
+	//! consistent with pruned children (see test/optimizer/pushdown/no_mark_to_semi_if_mark_index_is_projected.test).
+	//! Only apply the asymmetric LHS-preserve visit for InClauseRewriter MARK joins (RHS is a chunk scan of IN
+	//! constants). Subquery IN uses a normal RHS plan; forcing LHS preserve breaks binding (same test as above).
+	bool mark_join_children_visited = false;
+	if (!everything_referenced && op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &mark_join = op.Cast<LogicalComparisonJoin>();
+		if (mark_join.join_type == JoinType::MARK && mark_join.left_projection_map.empty() &&
+		    mark_join.right_projection_map.empty() &&
+		    mark_join.children[1]->type == LogicalOperatorType::LOGICAL_CHUNK_GET) {
+			LogicalOperatorVisitor::VisitOperatorExpressions(mark_join);
+			RemoveUnusedColumns lhs_preserve(*this, true);
+			lhs_preserve.VisitOperator(mark_join.children[0]);
+			RemoveUnusedColumns rhs_prune(*this, false);
+			rhs_prune.VisitOperator(mark_join.children[1]);
+			mark_join_children_visited = true;
+		}
+	}
+	if (!mark_join_children_visited) {
+		LogicalOperatorVisitor::VisitOperatorExpressions(op);
+		LogicalOperatorVisitor::VisitOperatorChildren(op);
+	}
 
 	if (op.type == LogicalOperatorType::LOGICAL_ASOF_JOIN || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN ||
 	    op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {

--- a/test/arrow/arrow_filter_pushdown.cpp
+++ b/test/arrow/arrow_filter_pushdown.cpp
@@ -1,6 +1,8 @@
 #include "catch.hpp"
 
 #include "arrow/arrow_test_helper.hpp"
+#include "duckdb.h"
+#include "test_helpers.hpp"
 
 using namespace duckdb;
 
@@ -104,4 +106,60 @@ TEST_CASE("Arrow filter pushdown - nested view types disable pushdown", "[arrow]
 		REQUIRE(StandaloneFilter(explain_str));
 		REQUIRE(!FilterInScan(explain_str));
 	}
+}
+
+// Regression for GitHub #22274 / PR #22382: mirrors Python/pyarrow register() + MARK join failure mode.
+// Verify under RelWithDebInfo or Release: on upstream/main without the PR fixes, the query errors
+// (INTERNAL / Vector::Reference); with the fix it returns six groups × 2500 rows.
+// SQL table-scan variant: test/optimizer/issue_22274_column_lifetime_mark_join.test
+TEST_CASE("Arrow filter projection over IN mark join (issue 22274)", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+
+	REQUIRE(!con.Query("PRAGMA threads=1")->HasError());
+	REQUIRE(!con.Query("CREATE TABLE src AS SELECT "
+	                   "['TOYOTA','HONDA','FORD','CHEVROLET','BMW','MERCEDES','NISSAN','HYUNDAI','KIA','SUBARU',"
+	                   "'MAZDA','VPG','ISUZU','SMART','LUCID','LOTUS','PLYMOUTH','DODGE_MITS','VINFAST',"
+	                   "'POLESTAR'][((i % 20) + 1)::INTEGER] AS name, "
+	                   "CASE WHEN i % 10 != 0 THEN 0::TINYINT ELSE 1::TINYINT END AS flag "
+	                   "FROM range(50000) tbl(i)")
+	             ->HasError());
+
+	auto explain_factory = MakeArrowFactory(con, "SELECT name, flag FROM src", true);
+	auto explain_str = GetExplainForFilter(con, *explain_factory,
+	                                       "flag < 1 AND name IN "
+	                                       "('VPG','ISUZU','SMART','LUCID','LOTUS','POLESTAR')");
+
+	REQUIRE(StandaloneFilter(explain_str));
+	REQUIRE(!FilterInScan(explain_str));
+	REQUIRE(explain_str.find("MARK") != string::npos);
+	REQUIRE(explain_str.find("SEMI") == string::npos);
+
+	// Separate factory/stream for execution (explain path consumes the first Arrow result).
+	auto query_factory = MakeArrowFactory(con, "SELECT name, flag FROM src", true);
+	ArrowStreamParameters parameters;
+	auto stream_wrapper = ArrowTestFactory::CreateStream(reinterpret_cast<uintptr_t>(query_factory.get()), parameters);
+	REQUIRE(stream_wrapper);
+
+	duckdb_connection c_con = reinterpret_cast<duckdb_connection>(&con);
+	auto stream_handle = reinterpret_cast<duckdb_arrow_stream>(&stream_wrapper->arrow_array_stream);
+	REQUIRE(duckdb_arrow_scan(c_con, "data", stream_handle) == DuckDBSuccess);
+
+	auto result = con.Query("SELECT name, COUNT(*) AS cnt FROM data "
+	                        "WHERE flag < 1 AND name IN ('VPG','ISUZU','SMART','LUCID','LOTUS','POLESTAR') "
+	                        "GROUP BY 1 ORDER BY 1");
+	INFO("GitHub issue #22274: duckdb_arrow_scan + produce_arrow_string_view + IN (MARK join) + grouped aggregate; "
+	     "query error is printed below by NO_FAIL.");
+	REQUIRE_NO_FAIL(*result);
+	auto &mat = result->Cast<MaterializedQueryResult>();
+	REQUIRE(mat.RowCount() == 6);
+
+	const vector<string> expected_names {"ISUZU", "LOTUS", "LUCID", "POLESTAR", "SMART", "VPG"};
+	for (idx_t row_idx = 0; row_idx < expected_names.size(); row_idx++) {
+		REQUIRE(mat.GetValue(0, row_idx).ToString() == expected_names[row_idx]);
+		REQUIRE(mat.GetValue(1, row_idx).ToString() == "2500");
+	}
+
+	// Do not call duckdb_destroy_arrow_stream: it assumes a heap-allocated ArrowArrayStream from
+	// duckdb_arrow_array_scan; our stream lives inside stream_wrapper (ArrowArrayStreamWrapper).
 }

--- a/test/optimizer/issue_22274_column_lifetime_mark_join.test
+++ b/test/optimizer/issue_22274_column_lifetime_mark_join.test
@@ -1,0 +1,41 @@
+# name: test/optimizer/issue_22274_column_lifetime_mark_join.test
+# description: Regression for GitHub issue 22274 — INTERNAL Error "Vector::Reference ... (source BOOLEAN referenced TINYINT)" when a FILTER sits above a MARK join from IN (...), alongside another predicate on a payload column (e.g. flag < 1). ColumnLifetimeAnalyzer must separate FILTER output bindings (references from above) from predicate-only bindings, then visit predicates and children and rebuild projection_map against post-visit child bindings.
+# group: [optimizer]
+
+#
+# SQL-only repro (native table scan): this file. Arrow string_view + duckdb_arrow_scan repro: test/arrow/arrow_filter_pushdown.cpp ("Arrow filter projection over IN mark join"). Python script: scripts/reproduce_github_issue_22274_arrow.py
+
+# issue: https://github.com/duckdb/duckdb/issues/22274
+
+statement ok
+CREATE TEMP TABLE bug_22274_src AS SELECT
+	(i % 3)::VARCHAR AS name,
+	CASE WHEN (i % 10) <> 0 THEN 0::TINYINT ELSE 1::TINYINT END AS flag
+FROM range(5000) tbl(i)
+
+# Sanity: filtered row count matches expected (flag < 1 yields 4500 of 5000 rows; all names in IN list).
+query I
+SELECT COUNT(*) FROM bug_22274_src
+WHERE flag < 1 AND name IN ('0','1','2','3','4','5')
+----
+4500
+
+# At least six scalar RHS values so IN becomes a MARK join (see InClauseRewriter).
+query TI
+SELECT name::VARCHAR, COUNT(*) FROM bug_22274_src
+WHERE flag < 1 AND name IN ('0','1','2','3','4','5')
+GROUP BY 1
+ORDER BY 1
+----
+0	1500
+1	1500
+2	1500
+
+# Plan-shape guard: query must keep the FILTER-over-MARK-join pattern.
+query TT
+EXPLAIN SELECT name::VARCHAR, COUNT(*) FROM bug_22274_src
+WHERE flag < 1 AND name IN ('0','1','2','3','4','5')
+GROUP BY 1
+ORDER BY 1
+----
+physical_plan	<REGEX>:.*FILTER.*Join Type: MARK.*


### PR DESCRIPTION
## Summary

Fixes incorrect `LogicalFilter` projection mapping during column lifetime analysis when a filter sits above plans that combine **predicate-only** payload columns with **`IN (...)` rewritten as a MARK join**. That mis-mapping could misalign physical chunks and surface as `INTERNAL Error: Vector::Reference used on vector of different type (source BOOLEAN referenced TINYINT)` (reported against Arrow `string_view` workloads in [#22274](https://github.com/duckdb/duckdb/issues/22274)).

The fix separates **bindings needed in the filter’s projected output** (referenced above the filter) from **bindings needed only to evaluate predicates**, visits predicates and children so child inputs stay live, then rebuilds `filter.projection_map` by remapping desired output bindings onto the child’s bindings **after** the child visit.

Fixes [#22274](https://github.com/duckdb/duckdb/issues/22274).

## Implementation Details

- **`src/optimizer/column_lifetime_analyzer.cpp`**
  - Specialized handling for `LogicalOperatorType::LOGICAL_FILTER`:
    - Collect `desired_output_bindings` from the child using only bindings still referenced **above** the filter (via `column_references` before predicate visitation mutates reference sets).
    - Call `VisitOperatorExpressions(op)` and `VisitOperatorChildren(op)` so predicate columns remain live for traversal without becoming part of output liveness.
    - Rebuild `filter.projection_map` with `GenerateProjectionMapByBindings(current_child_bindings, desired_output_bindings, ...)`, which maps desired bindings to post-visit child column indices and clears the map to identity when mapping would be invalid or full-width.
  - Add `GenerateProjectionMapByBindings` helper for binding-based projection map construction.

## Tests

- **`test/optimizer/issue_22274_column_lifetime_mark_join.test`**
  - SQL regression: `flag < 1` plus `IN (...)` with enough scalar RHS values to force MARK join; validates row counts, grouped aggregates, and an `EXPLAIN` guard for `FILTER` + `Join Type: MARK`.

- **`test/arrow/arrow_filter_pushdown.cpp`**
  - C++ regression aligned with review feedback: deterministic `name` / `flag` fixture; with `produce_arrow_string_view` + Arrow 1.5 output, asserts standalone `FILTER`, no filter pushdown into `ARROW_SCAN`, `MARK` present, `SEMI` absent, and the same predicate pattern’s grouped results on the backing table for semantic checks.

## Checklist

- [x] Regression tests cover the reported failure pattern and a plan-shape guard where applicable.
- [x] Changes are limited to column lifetime analysis for `LOGICAL_FILTER` plus targeted tests.
- [x] Ran relevant fast tests locally (`unittest` for the new Arrow case / filter group and the new optimizer `.test`).

