### PR TITLE
Trust parquet stats for fixed-width missing exactness flag files

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1410,13 +1410,20 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 		const auto &row_group = metadata.row_groups[row_group_idx];
 		const auto &column_chunk = row_group.columns[primary_index];
 
-		if (column_chunk.__isset.meta_data && column_chunk.meta_data.__isset.statistics &&
-		    column_chunk.meta_data.statistics.__isset.is_min_value_exact &&
-		    column_chunk.meta_data.statistics.__isset.is_max_value_exact) {
-			const auto &stats = column_chunk.meta_data.statistics;
-			return stats.is_min_value_exact && stats.is_max_value_exact;
+		if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.statistics) {
+			return false;
 		}
-		return false;
+		const auto &col_stats = column_chunk.meta_data.statistics;
+		if (col_stats.__isset.is_min_value_exact && col_stats.__isset.is_max_value_exact) {
+			return col_stats.is_min_value_exact && col_stats.is_max_value_exact;
+		}
+		// Pre-PARQUET-2352 (Oct 2023) the spec required min/max, when present, to be the exact
+		// min/max; in practice some writers truncated long binary values, and PARQUET-2352 added
+		// is_*_value_exact so readers could detect that. Fixed-width physical types are not
+		// subject to such truncation, so when the flag is missing we mirror arrow-rs
+		// (parquet/src/file/statistics.rs ValueStatistics::new) and treat them as exact.
+		const auto t = column_chunk.meta_data.type;
+		return t != Type::BYTE_ARRAY && t != Type::FIXED_LEN_BYTE_ARRAY;
 	}
 };
 


### PR DESCRIPTION
Broken out from #22286 just to keep it slightly more focused and reviewable

Default to `true` for fixed-width physical types when the column chunk omits `is_min_value_exact` / `is_max_value_exact`. Pre-PARQUET-2352 (Oct 2023) the spec required min/max (when present) to be exact; in practice some writers truncated long binary values, which is what motivated the flag. Fixed-width physical types are not subject to that truncation, so when the flag is missing we treat them as exact. Without the fix, every parquet from a pre-PARQUET-2352 writer fails the exactness gate and the optimization can't fire. No parquet files written before Oct 2023 (including ClickHouse's clickbench parquet files) will have this field present, so on all old data this effectively eliminates this field of parquet stats related optimizations.

Pyarrow <18.0.0 also didn't write the necessary flag, so can be used to test


```bash
uv run --quiet --python 3.11 --with 'pyarrow==12.0.1' --with 'numpy<2' \
    python - <<PY
import pyarrow as pa, pyarrow.parquet as pq, random
random.seed(0)
n = 10_000
tbl = pa.table({
    'i32': pa.array([random.randint(0, 1_000_000) for _ in range(n)], type=pa.int32()),
    'i64': pa.array([random.randint(0, 1_000_000) for _ in range(n)], type=pa.int64()),
    'f64': pa.array([random.random() for _ in range(n)], type=pa.float64()),
    's':   pa.array(['apple', 'banana', 'cherry'] * (n // 3 + 1), type=pa.string())[:n],
})
pq.write_table(tbl, 'data.parquet')
PY
```
```sql
-- Verify missing exact flags
SELECT path_in_schema, type, min_is_exact, max_is_exact FROM parquet_metadata('data.parquet'); 

-- Works now
EXPLAIN ANALYZE SELECT MIN(i64), MAX(i64), MIN(f64) FROM 'data.parquet';

-- Still can't safely assume not truncated
EXPLAIN ANALYZE SELECT MIN(s), MAX(s) FROM 'data.parquet';
```
With this change PARQUET_SCAN becomes COLUMN_DATA_SCAN for fixed width types only

<details>
<summary>Cross-reader <strong>AI Assisted</strong> survey for absent <code>is_*_value_exact</code></summary>

Four distinct strategies across the parquet ecosystem when the flag is missing in the thrift message. Categories:

- **Strict** — only treat min/max as exact when the flag is explicitly `true`; otherwise refuse the optimization
- **Type-aware** — treat fixed-width physical types as exact when the flag is absent, variable-length as inexact (PARQUET-2352-aware)
- **Trust unconditionally** — never read the flag on the read path; treat min/max as exact regardless
- **Pass-through** — library faithfully exposes the optional; no policy decision (no query engine attached)

| Reader | Category | Fixed-width prims | BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY | Source |
|---|---|---|---|---|
| **DuckDB (pre this PR)** | Strict | requires explicit `true` | requires explicit `true` | bails unless both `__isset` and both flags `true` ([parquet_reader.cpp#L1405-L1421](https://github.com/duckdb/duckdb/blob/8b2e995727c39f314459e58930281298b6ee0484/extension/parquet/parquet_reader.cpp#L1405-L1421)) |
| **DuckDB (this PR)** | Type-aware | exact when absent | inexact when absent | `t != BYTE_ARRAY && t != FIXED_LEN_BYTE_ARRAY` |
| **arrow-rs** | Type-aware | exact when absent | inexact when absent | `ValueStatistics::new` defaults `is_*_value_exact: max.is_some()` for fixed-width arms ([statistics.rs#L530-L543](https://github.com/apache/arrow-rs/blob/4fa8d2ff5f18f2d773f9642631715509f844a062/parquet/src/file/statistics.rs#L530-L543)); BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY arms override with `unwrap_or(false)` ([L247-L269](https://github.com/apache/arrow-rs/blob/4fa8d2ff5f18f2d773f9642631715509f844a062/parquet/src/file/statistics.rs#L247-L269)) |
| **DataFusion** | Type-aware (via arrow-rs) | exact when absent | inexact when absent | `Some(true)` → `Precision::Exact`, `Some(false)`/`None` → `Precision::Inexact` ([metadata.rs#L460-L490](https://github.com/apache/datafusion/blob/65f337d6637aa069012e0e9286f859fb3a743253/datafusion/datasource-parquet/src/metadata.rs#L460-L490)) |
| **Apache Arrow C++** | Pass-through | `std::nullopt` (unknown) | `std::nullopt` (unknown) | `FromThrift` only copies the bool when `__isset`; otherwise leaves it unset for every physical type ([thrift_internal.h#L255-L275](https://github.com/apache/arrow/blob/cc15bf1e839ea31f018a82a325eca906b32c86fe/cpp/src/parquet/thrift_internal.h#L255-L275)) |
| **parquet-java** (parquet-mr) | Trust unconditionally | trusted | trusted | flags never read anywhere in the repo (0 hits at [b8f4dda](https://github.com/apache/parquet-java/tree/b8f4dda5d8492904bff33e3774a2de57f172e967)); `StatisticsFilter` and `ColumnIndexFilter` consume min/max with no exactness gate |
| **Apache Spark** | Trust unconditionally (with one prefix-aware exception) | trusted (via parquet-java) | trusted; `StringStartsWith` slices min/max to the prefix length ([ParquetFilters.scala#L818-L849](https://github.com/apache/spark/blob/9ca391927d15412fc3399117a7a1f9a74e7bdf81/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala#L818-L849)) | flags never read on read path |
| **Trino** | Trust unconditionally | trusted | trusted | `fromParquetStatistics` reads `min_value`/`max_value` and never consults the exact flags ([ParquetMetadataConverter.java#L308](https://github.com/trinodb/trino/blob/ba02373d539e809bf56aa7698af50c0d502b2124/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java#L308)); they are only set on the write path ([L296](https://github.com/trinodb/trino/blob/ba02373d539e809bf56aa7698af50c0d502b2124/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java#L296)) |
| **ClickHouse** | Trust unconditionally | trusted | trusted | only set on the write path: `Write.cpp` for fixed-width ([L75-L76](https://github.com/ClickHouse/ClickHouse/blob/7fc29dcb1a1ba3a789dfeab9255f597040c682ea/src/Processors/Formats/Impl/Parquet/Write.cpp#L75-L76)) and BYTE_ARRAY ([L220](https://github.com/ClickHouse/ClickHouse/blob/7fc29dcb1a1ba3a789dfeab9255f597040c682ea/src/Processors/Formats/Impl/Parquet/Write.cpp#L220)); read side has zero references |

</details>