### PR TITLE
Add `ArgProperties` for stats forward-bounds

### DIFF
--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -452,6 +452,8 @@ ScalarFunctionSet DateDiffFun::GetFunctions() {
 	                                     LogicalType::BIGINT, DateDiffFunction<timestamp_t>));
 	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
 	                                     LogicalType::BIGINT, DateDiffFunction<dtime_t>));
+	date_diff.SetArgProperties(1, ArgProperties().Decreasing());
+	date_diff.SetArgProperties(2, ArgProperties().Increasing());
 	return date_diff;
 }
 

--- a/extension/core_functions/scalar/date/date_diff.cpp
+++ b/extension/core_functions/scalar/date/date_diff.cpp
@@ -452,8 +452,8 @@ ScalarFunctionSet DateDiffFun::GetFunctions() {
 	                                     LogicalType::BIGINT, DateDiffFunction<timestamp_t>));
 	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
 	                                     LogicalType::BIGINT, DateDiffFunction<dtime_t>));
-	date_diff.SetArgProperties(1, ArgProperties().Decreasing());
-	date_diff.SetArgProperties(2, ArgProperties().Increasing());
+	date_diff.SetArgProperties(1, ArgProperties().NonIncreasing());
+	date_diff.SetArgProperties(2, ArgProperties().NonDecreasing());
 	return date_diff;
 }
 

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2114,7 +2114,7 @@ ScalarFunctionSet GetCachedDatepartFunction() {
 
 ScalarFunctionSet YearFun::GetFunctions() {
 	auto set = GetCachedDatepartFunction<DatePart::YearOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
@@ -2128,19 +2128,19 @@ ScalarFunctionSet DayFun::GetFunctions() {
 
 ScalarFunctionSet DecadeFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::DecadeOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
 ScalarFunctionSet CenturyFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::CenturyOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
 ScalarFunctionSet MillenniumFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::MillenniumOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
@@ -2170,13 +2170,13 @@ ScalarFunctionSet WeekFun::GetFunctions() {
 
 ScalarFunctionSet ISOYearFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::ISOYearOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
 ScalarFunctionSet EraFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::EraOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
@@ -2206,7 +2206,7 @@ ScalarFunctionSet TimezoneMinuteFun::GetFunctions() {
 
 ScalarFunctionSet EpochFun::GetFunctions() {
 	auto set = GetTimePartFunction<DatePart::EpochOperator, double>(LogicalType::DOUBLE);
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 
@@ -2235,7 +2235,7 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
-	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }
 
@@ -2248,7 +2248,7 @@ ScalarFunctionSet EpochUsFun::GetFunctions() {
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
-	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }
 
@@ -2266,7 +2266,7 @@ ScalarFunctionSet EpochMsFun::GetFunctions() {
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
 
-	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }
 
@@ -2274,7 +2274,7 @@ ScalarFunctionSet MakeTimestampMsFun::GetFunctions() {
 	ScalarFunctionSet operator_set("make_timestamp_ms");
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
-	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
+	operator_set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return operator_set;
 }
 
@@ -2319,7 +2319,7 @@ ScalarFunctionSet HoursFun::GetFunctions() {
 
 ScalarFunctionSet YearWeekFun::GetFunctions() {
 	auto set = GetDatePartFunction<DatePart::YearWeekOperator>();
-	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	set.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return set;
 }
 

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2113,7 +2113,9 @@ ScalarFunctionSet GetCachedDatepartFunction() {
 } // namespace
 
 ScalarFunctionSet YearFun::GetFunctions() {
-	return GetCachedDatepartFunction<DatePart::YearOperator>();
+	auto set = GetCachedDatepartFunction<DatePart::YearOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet MonthFun::GetFunctions() {
@@ -2125,15 +2127,21 @@ ScalarFunctionSet DayFun::GetFunctions() {
 }
 
 ScalarFunctionSet DecadeFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::DecadeOperator>();
+	auto set = GetDatePartFunction<DatePart::DecadeOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet CenturyFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::CenturyOperator>();
+	auto set = GetDatePartFunction<DatePart::CenturyOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet MillenniumFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::MillenniumOperator>();
+	auto set = GetDatePartFunction<DatePart::MillenniumOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet QuarterFun::GetFunctions() {
@@ -2161,11 +2169,15 @@ ScalarFunctionSet WeekFun::GetFunctions() {
 }
 
 ScalarFunctionSet ISOYearFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::ISOYearOperator>();
+	auto set = GetDatePartFunction<DatePart::ISOYearOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet EraFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::EraOperator>();
+	auto set = GetDatePartFunction<DatePart::EraOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet TimezoneFun::GetFunctions() {
@@ -2193,7 +2205,9 @@ ScalarFunctionSet TimezoneMinuteFun::GetFunctions() {
 }
 
 ScalarFunctionSet EpochFun::GetFunctions() {
-	return GetTimePartFunction<DatePart::EpochOperator, double>(LogicalType::DOUBLE);
+	auto set = GetTimePartFunction<DatePart::EpochOperator, double>(LogicalType::DOUBLE);
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 struct GetEpochNanosOperator {
@@ -2221,6 +2235,7 @@ ScalarFunctionSet EpochNsFun::GetFunctions() {
 
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_NS}, LogicalType::BIGINT, ExecuteGetNanosFromTimestampNs));
+	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
 	return operator_set;
 }
 
@@ -2233,6 +2248,7 @@ ScalarFunctionSet EpochUsFun::GetFunctions() {
 	auto tstz_stats = OP::template PropagateStatistics<timestamp_t>;
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BIGINT, tstz_func, nullptr, tstz_stats));
+	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
 	return operator_set;
 }
 
@@ -2250,6 +2266,7 @@ ScalarFunctionSet EpochMsFun::GetFunctions() {
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
 
+	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
 	return operator_set;
 }
 
@@ -2257,6 +2274,7 @@ ScalarFunctionSet MakeTimestampMsFun::GetFunctions() {
 	ScalarFunctionSet operator_set("make_timestamp_ms");
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, DatePart::EpochMillisOperator::Inverse));
+	operator_set.SetUnaryArgProperties(ArgProperties().Increasing());
 	return operator_set;
 }
 
@@ -2300,7 +2318,9 @@ ScalarFunctionSet HoursFun::GetFunctions() {
 }
 
 ScalarFunctionSet YearWeekFun::GetFunctions() {
-	return GetDatePartFunction<DatePart::YearWeekOperator>();
+	auto set = GetDatePartFunction<DatePart::YearWeekOperator>();
+	set.SetUnaryArgProperties(ArgProperties().Increasing());
+	return set;
 }
 
 ScalarFunctionSet DayOfMonthFun::GetFunctions() {

--- a/extension/core_functions/scalar/date/date_sub.cpp
+++ b/extension/core_functions/scalar/date/date_sub.cpp
@@ -449,6 +449,8 @@ ScalarFunctionSet DateSubFun::GetFunctions() {
 	                                    LogicalType::BIGINT, DateSubFunction<timestamp_t>));
 	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
 	                                    LogicalType::BIGINT, DateSubFunction<dtime_t>));
+	date_sub.SetArgProperties(1, ArgProperties().Decreasing());
+	date_sub.SetArgProperties(2, ArgProperties().Increasing());
 	return date_sub;
 }
 

--- a/extension/core_functions/scalar/date/date_sub.cpp
+++ b/extension/core_functions/scalar/date/date_sub.cpp
@@ -449,8 +449,8 @@ ScalarFunctionSet DateSubFun::GetFunctions() {
 	                                    LogicalType::BIGINT, DateSubFunction<timestamp_t>));
 	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
 	                                    LogicalType::BIGINT, DateSubFunction<dtime_t>));
-	date_sub.SetArgProperties(1, ArgProperties().Decreasing());
-	date_sub.SetArgProperties(2, ArgProperties().Increasing());
+	date_sub.SetArgProperties(1, ArgProperties().NonIncreasing());
+	date_sub.SetArgProperties(2, ArgProperties().NonDecreasing());
 	return date_sub;
 }
 

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -609,6 +609,7 @@ ScalarFunctionSet DateTruncFun::GetFunctions() {
 	                                      DateTruncFunction<interval_t, interval_t>));
 	for (auto &func : date_trunc.functions) {
 		func.SetFallible();
+		func.SetArgProperties(1, ArgProperties().Increasing());
 	}
 	return date_trunc;
 }

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -609,7 +609,7 @@ ScalarFunctionSet DateTruncFun::GetFunctions() {
 	                                      DateTruncFunction<interval_t, interval_t>));
 	for (auto &func : date_trunc.functions) {
 		func.SetFallible();
-		func.SetArgProperties(1, ArgProperties().Increasing());
+		func.SetArgProperties(1, ArgProperties().NonDecreasing());
 	}
 	return date_trunc;
 }

--- a/extension/core_functions/scalar/date/epoch.cpp
+++ b/extension/core_functions/scalar/date/epoch.cpp
@@ -55,7 +55,9 @@ void TimeTZSortKeyFunction(DataChunk &input, ExpressionState &state, Vector &res
 
 ScalarFunction ToTimestampFun::GetFunction() {
 	// to_timestamp is an alias from Postgres that converts the time in seconds to a timestamp
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::TIMESTAMP_TZ, EpochSecFunction);
+	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::TIMESTAMP_TZ, EpochSecFunction);
+	func.SetUnaryArgProperties(ArgProperties().Increasing());
+	return func;
 }
 
 ScalarFunction NormalizedIntervalFun::GetFunction() {

--- a/extension/core_functions/scalar/date/epoch.cpp
+++ b/extension/core_functions/scalar/date/epoch.cpp
@@ -56,7 +56,7 @@ void TimeTZSortKeyFunction(DataChunk &input, ExpressionState &state, Vector &res
 ScalarFunction ToTimestampFun::GetFunction() {
 	// to_timestamp is an alias from Postgres that converts the time in seconds to a timestamp
 	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::TIMESTAMP_TZ, EpochSecFunction);
-	func.SetUnaryArgProperties(ArgProperties().Increasing());
+	func.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return func;
 }
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -151,6 +151,7 @@ ScalarFunctionSet MakeDateFun::GetFunctions() {
 	    ScalarFunction({LogicalType::STRUCT(make_date_children)}, LogicalType::DATE, ExecuteStructMakeDate<int64_t>));
 	for (auto &func : make_date.functions) {
 		func.SetFallible();
+		func.SetUnaryArgProperties(ArgProperties().Increasing(true));
 	}
 	return make_date;
 }
@@ -172,6 +173,7 @@ ScalarFunctionSet MakeTimestampFun::GetFunctions() {
 
 	for (auto &func : operator_set.functions) {
 		func.SetFallible();
+		func.SetUnaryArgProperties(ArgProperties().Increasing(true));
 	}
 	return operator_set;
 }
@@ -180,6 +182,7 @@ ScalarFunctionSet MakeTimestampNsFun::GetFunctions() {
 	ScalarFunctionSet operator_set("make_timestamp_ns");
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP_NS, ExecuteMakeTimestampNs<int64_t>));
+	operator_set.SetUnaryArgProperties(ArgProperties().Increasing(true));
 	return operator_set;
 }
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -151,7 +151,7 @@ ScalarFunctionSet MakeDateFun::GetFunctions() {
 	    ScalarFunction({LogicalType::STRUCT(make_date_children)}, LogicalType::DATE, ExecuteStructMakeDate<int64_t>));
 	for (auto &func : make_date.functions) {
 		func.SetFallible();
-		func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	}
 	return make_date;
 }
@@ -173,7 +173,7 @@ ScalarFunctionSet MakeTimestampFun::GetFunctions() {
 
 	for (auto &func : operator_set.functions) {
 		func.SetFallible();
-		func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	}
 	return operator_set;
 }
@@ -182,7 +182,7 @@ ScalarFunctionSet MakeTimestampNsFun::GetFunctions() {
 	ScalarFunctionSet operator_set("make_timestamp_ns");
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP_NS, ExecuteMakeTimestampNs<int64_t>));
-	operator_set.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	operator_set.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return operator_set;
 }
 

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -364,7 +364,7 @@ ScalarFunctionSet TimeBucketFun::GetFunctions() {
 	                                       LogicalType::TIMESTAMP, TimeBucketOriginFunction<timestamp_t>));
 	for (auto &func : time_bucket.functions) {
 		func.SetFallible();
-		func.SetArgProperties(1, ArgProperties().Increasing());
+		func.SetArgProperties(1, ArgProperties().NonDecreasing());
 	}
 	return time_bucket;
 }

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -364,6 +364,7 @@ ScalarFunctionSet TimeBucketFun::GetFunctions() {
 	                                       LogicalType::TIMESTAMP, TimeBucketOriginFunction<timestamp_t>));
 	for (auto &func : time_bucket.functions) {
 		func.SetFallible();
+		func.SetArgProperties(1, ArgProperties().Increasing());
 	}
 	return time_bucket;
 }

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -428,6 +428,7 @@ ScalarFunctionSet CeilFun::GetFunctions() {
 		}
 		ceil.AddFunction(ScalarFunction({type}, type, func, bind_func));
 	}
+	ceil.SetUnaryArgProperties(ArgProperties().Increasing());
 	return ceil;
 }
 
@@ -483,6 +484,7 @@ ScalarFunctionSet FloorFun::GetFunctions() {
 		}
 		floor.AddFunction(ScalarFunction({type}, type, func, bind_func));
 	}
+	floor.SetUnaryArgProperties(ArgProperties().Increasing());
 	return floor;
 }
 
@@ -751,6 +753,7 @@ ScalarFunctionSet TruncFun::GetFunctions() {
 		trunc.AddFunction(ScalarFunction({type}, type, trunc_func, bind_func));
 		trunc.AddFunction(ScalarFunction({type, LogicalType::INTEGER}, type, trunc_prec_func, bind_prec_func));
 	}
+	trunc.SetUnaryArgProperties(ArgProperties().Increasing());
 	return trunc;
 }
 
@@ -942,6 +945,7 @@ ScalarFunctionSet RoundFun::GetFunctions() {
 		round.AddFunction(ScalarFunction({type}, type, round_func, bind_func));
 		round.AddFunction(ScalarFunction({type, LogicalType::INTEGER}, type, round_prec_func, bind_prec_func));
 	}
+	round.SetUnaryArgProperties(ArgProperties().Increasing());
 	return round;
 }
 
@@ -960,8 +964,10 @@ struct ExpOperator {
 } // namespace
 
 ScalarFunction ExpFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, ExpOperator>);
+	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                    ScalarFunction::UnaryFunction<double, double, ExpOperator>);
+	func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	return func;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1026,8 +1032,10 @@ struct CbRtOperator {
 } // namespace
 
 ScalarFunction CbrtFun::GetFunction() {
-	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                      ScalarFunction::UnaryFunction<double, double, CbRtOperator>);
+	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                    ScalarFunction::UnaryFunction<double, double, CbRtOperator>);
+	func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	return func;
 }
 
 //===--------------------------------------------------------------------===//

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -428,7 +428,7 @@ ScalarFunctionSet CeilFun::GetFunctions() {
 		}
 		ceil.AddFunction(ScalarFunction({type}, type, func, bind_func));
 	}
-	ceil.SetUnaryArgProperties(ArgProperties().Increasing());
+	ceil.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return ceil;
 }
 
@@ -484,7 +484,7 @@ ScalarFunctionSet FloorFun::GetFunctions() {
 		}
 		floor.AddFunction(ScalarFunction({type}, type, func, bind_func));
 	}
-	floor.SetUnaryArgProperties(ArgProperties().Increasing());
+	floor.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return floor;
 }
 
@@ -753,7 +753,7 @@ ScalarFunctionSet TruncFun::GetFunctions() {
 		trunc.AddFunction(ScalarFunction({type}, type, trunc_func, bind_func));
 		trunc.AddFunction(ScalarFunction({type, LogicalType::INTEGER}, type, trunc_prec_func, bind_prec_func));
 	}
-	trunc.SetUnaryArgProperties(ArgProperties().Increasing());
+	trunc.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return trunc;
 }
 
@@ -945,7 +945,7 @@ ScalarFunctionSet RoundFun::GetFunctions() {
 		round.AddFunction(ScalarFunction({type}, type, round_func, bind_func));
 		round.AddFunction(ScalarFunction({type, LogicalType::INTEGER}, type, round_prec_func, bind_prec_func));
 	}
-	round.SetUnaryArgProperties(ArgProperties().Increasing());
+	round.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return round;
 }
 
@@ -966,7 +966,7 @@ struct ExpOperator {
 ScalarFunction ExpFun::GetFunction() {
 	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                    ScalarFunction::UnaryFunction<double, double, ExpOperator>);
-	func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return func;
 }
 
@@ -1034,7 +1034,7 @@ struct CbRtOperator {
 ScalarFunction CbrtFun::GetFunction() {
 	ScalarFunction func({LogicalType::DOUBLE}, LogicalType::DOUBLE,
 	                    ScalarFunction::UnaryFunction<double, double, CbRtOperator>);
-	func.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	func.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return func;
 }
 

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -661,13 +661,13 @@ void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 	// across the BC/AD flip; leave them unannotated. era/century/millennium/isoyear are signed.
 
 	//	BIGINTs
-	ICUDatePart::AddUnaryPartCodeFunctions("era", loader, LogicalType::BIGINT, ArgProperties().Increasing());
+	ICUDatePart::AddUnaryPartCodeFunctions("era", loader, LogicalType::BIGINT, ArgProperties().NonDecreasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("year", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("month", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("day", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("decade", loader);
-	ICUDatePart::AddUnaryPartCodeFunctions("century", loader, LogicalType::BIGINT, ArgProperties().Increasing());
-	ICUDatePart::AddUnaryPartCodeFunctions("millennium", loader, LogicalType::BIGINT, ArgProperties().Increasing());
+	ICUDatePart::AddUnaryPartCodeFunctions("century", loader, LogicalType::BIGINT, ArgProperties().NonDecreasing());
+	ICUDatePart::AddUnaryPartCodeFunctions("millennium", loader, LogicalType::BIGINT, ArgProperties().NonDecreasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("microsecond", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("millisecond", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("second", loader);
@@ -678,7 +678,7 @@ void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 	ICUDatePart::AddUnaryPartCodeFunctions("week", loader); //  Note that WeekOperator is ISO-8601, not US
 	ICUDatePart::AddUnaryPartCodeFunctions("dayofyear", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("quarter", loader);
-	ICUDatePart::AddUnaryPartCodeFunctions("isoyear", loader, LogicalType::BIGINT, ArgProperties().Increasing());
+	ICUDatePart::AddUnaryPartCodeFunctions("isoyear", loader, LogicalType::BIGINT, ArgProperties().NonDecreasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone_hour", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone_minute", loader);
@@ -689,7 +689,7 @@ void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 
 	//  register combinations
 	ICUDatePart::AddUnaryPartCodeFunctions("yearweek", loader, LogicalType::BIGINT,
-	                                       ArgProperties().Increasing()); //  ISO year and week
+	                                       ArgProperties().NonDecreasing()); //  ISO year and week
 
 	//  register various aliases
 	ICUDatePart::AddUnaryPartCodeFunctions("dayofmonth", loader);

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -561,9 +561,11 @@ struct ICUDatePart : public ICUDateFunc {
 
 	template <typename RESULT_TYPE = int64_t>
 	static void AddUnaryPartCodeFunctions(const string &name, ExtensionLoader &loader,
-	                                      const LogicalType &result_type = LogicalType::BIGINT) {
+	                                      const LogicalType &result_type = LogicalType::BIGINT,
+	                                      ArgProperties unary_arg0_props = {}) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetUnaryPartCodeFunction<timestamp_t, RESULT_TYPE>(LogicalType::TIMESTAMP_TZ, result_type));
+		set.SetUnaryArgProperties(unary_arg0_props);
 		loader.RegisterFunction(set);
 	}
 
@@ -655,14 +657,17 @@ struct ICUDatePart : public ICUDateFunc {
 void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 	// register the individual operators
 
+	// year/decade use UCAL_YEAR (year-of-era, positive in both BC and AD), which is non-monotonic
+	// across the BC/AD flip; leave them unannotated. era/century/millennium/isoyear are signed.
+
 	//	BIGINTs
-	ICUDatePart::AddUnaryPartCodeFunctions("era", loader);
+	ICUDatePart::AddUnaryPartCodeFunctions("era", loader, LogicalType::BIGINT, ArgProperties().Increasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("year", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("month", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("day", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("decade", loader);
-	ICUDatePart::AddUnaryPartCodeFunctions("century", loader);
-	ICUDatePart::AddUnaryPartCodeFunctions("millennium", loader);
+	ICUDatePart::AddUnaryPartCodeFunctions("century", loader, LogicalType::BIGINT, ArgProperties().Increasing());
+	ICUDatePart::AddUnaryPartCodeFunctions("millennium", loader, LogicalType::BIGINT, ArgProperties().Increasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("microsecond", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("millisecond", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("second", loader);
@@ -673,7 +678,7 @@ void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 	ICUDatePart::AddUnaryPartCodeFunctions("week", loader); //  Note that WeekOperator is ISO-8601, not US
 	ICUDatePart::AddUnaryPartCodeFunctions("dayofyear", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("quarter", loader);
-	ICUDatePart::AddUnaryPartCodeFunctions("isoyear", loader);
+	ICUDatePart::AddUnaryPartCodeFunctions("isoyear", loader, LogicalType::BIGINT, ArgProperties().Increasing());
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone_hour", loader);
 	ICUDatePart::AddUnaryPartCodeFunctions("timezone_minute", loader);
@@ -683,7 +688,8 @@ void RegisterICUDatePartFunctions(ExtensionLoader &loader) {
 	ICUDatePart::AddUnaryPartCodeFunctions<double>("julian", loader, LogicalType::DOUBLE);
 
 	//  register combinations
-	ICUDatePart::AddUnaryPartCodeFunctions("yearweek", loader); //  Note this is ISO year and week
+	ICUDatePart::AddUnaryPartCodeFunctions("yearweek", loader, LogicalType::BIGINT,
+	                                       ArgProperties().Increasing()); //  ISO year and week
 
 	//  register various aliases
 	ICUDatePart::AddUnaryPartCodeFunctions("dayofmonth", loader);

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -139,6 +139,8 @@ struct ICUCalendarSub : public ICUDateFunc {
 	static void AddFunctions(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
+		set.SetArgProperties(1, ArgProperties().Decreasing());
+		set.SetArgProperties(2, ArgProperties().Increasing());
 		loader.RegisterFunction(set);
 	}
 };
@@ -272,6 +274,8 @@ struct ICUCalendarDiff : public ICUDateFunc {
 	static void AddFunctions(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
+		set.SetArgProperties(1, ArgProperties().Decreasing());
+		set.SetArgProperties(2, ArgProperties().Increasing());
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -139,8 +139,8 @@ struct ICUCalendarSub : public ICUDateFunc {
 	static void AddFunctions(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
-		set.SetArgProperties(1, ArgProperties().Decreasing());
-		set.SetArgProperties(2, ArgProperties().Increasing());
+		set.SetArgProperties(1, ArgProperties().NonIncreasing());
+		set.SetArgProperties(2, ArgProperties().NonDecreasing());
 		loader.RegisterFunction(set);
 	}
 };
@@ -274,8 +274,8 @@ struct ICUCalendarDiff : public ICUDateFunc {
 	static void AddFunctions(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
-		set.SetArgProperties(1, ArgProperties().Decreasing());
-		set.SetArgProperties(2, ArgProperties().Increasing());
+		set.SetArgProperties(1, ArgProperties().NonIncreasing());
+		set.SetArgProperties(2, ArgProperties().NonDecreasing());
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -172,7 +172,7 @@ struct ICUDateTrunc : public ICUDateFunc {
 	static void AddBinaryTimestampFunction(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetDateTruncFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
-		set.SetArgProperties(1, ArgProperties().Increasing());
+		set.SetArgProperties(1, ArgProperties().NonDecreasing());
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -172,6 +172,7 @@ struct ICUDateTrunc : public ICUDateFunc {
 	static void AddBinaryTimestampFunction(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
 		set.AddFunction(GetDateTruncFunction<timestamp_t>(LogicalType::TIMESTAMP_TZ));
+		set.SetArgProperties(1, ArgProperties().Increasing());
 		loader.RegisterFunction(set);
 	}
 };

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -623,7 +623,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		                               LogicalType::TIMESTAMP_TZ, ICUTimeBucketTimeZoneFunction, Bind));
 		for (auto &func : set.functions) {
 			func.SetFallible();
-			func.SetArgProperties(1, ArgProperties().Increasing());
+			func.SetArgProperties(1, ArgProperties().NonDecreasing());
 		}
 		loader.RegisterFunction(set);
 	}

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -623,6 +623,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 		                               LogicalType::TIMESTAMP_TZ, ICUTimeBucketTimeZoneFunction, Bind));
 		for (auto &func : set.functions) {
 			func.SetFallible();
+			func.SetArgProperties(1, ArgProperties().Increasing());
 		}
 		loader.RegisterFunction(set);
 	}

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -121,6 +121,7 @@
 #include "duckdb/execution/physical_table_scan_enum.hpp"
 #include "duckdb/execution/reservoir_sample.hpp"
 #include "duckdb/function/aggregate_state.hpp"
+#include "duckdb/function/arg_properties.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/function/function.hpp"
@@ -3364,6 +3365,28 @@ const char* EnumUtil::ToChars<MetricType>(MetricType value) {
 template<>
 MetricType EnumUtil::FromString<MetricType>(const char *value) {
 	return static_cast<MetricType>(StringUtil::StringToEnum(GetMetricTypeValues(), 72, "MetricType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetMonotonicityValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(Monotonicity::UNKNOWN), "UNKNOWN" },
+		{ static_cast<uint32_t>(Monotonicity::CONSTANT), "CONSTANT" },
+		{ static_cast<uint32_t>(Monotonicity::NON_DECREASING), "NON_DECREASING" },
+		{ static_cast<uint32_t>(Monotonicity::STRICTLY_INCREASING), "STRICTLY_INCREASING" },
+		{ static_cast<uint32_t>(Monotonicity::NON_INCREASING), "NON_INCREASING" },
+		{ static_cast<uint32_t>(Monotonicity::STRICTLY_DECREASING), "STRICTLY_DECREASING" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<Monotonicity>(Monotonicity value) {
+	return StringUtil::EnumToString(GetMonotonicityValues(), 6, "Monotonicity", static_cast<uint32_t>(value));
+}
+
+template<>
+Monotonicity EnumUtil::FromString<Monotonicity>(const char *value) {
+	return static_cast<Monotonicity>(StringUtil::StringToEnum(GetMonotonicityValues(), 6, "Monotonicity", value));
 }
 
 const StringUtil::EnumStringLiteral *GetMultiFileColumnMappingModeValues() {

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -314,11 +314,11 @@ unique_ptr<FunctionData> NopDecimalBind(BindScalarFunctionInput &input) {
 
 ScalarFunction AddFunction::GetFunction(const LogicalType &type) {
 	D_ASSERT(type.IsNumeric());
-	if (type.id() == LogicalTypeId::DECIMAL) {
-		return ScalarFunction("+", {type}, type, ScalarFunction::NopFunction, NopDecimalBind);
-	} else {
-		return ScalarFunction("+", {type}, type, ScalarFunction::NopFunction);
-	}
+	auto fn = type.id() == LogicalTypeId::DECIMAL
+	              ? ScalarFunction("+", {type}, type, ScalarFunction::NopFunction, NopDecimalBind)
+	              : ScalarFunction("+", {type}, type, ScalarFunction::NopFunction);
+	fn.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	return fn;
 }
 
 static void BignumAdd(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -353,6 +353,8 @@ static void BignumNegate(DataChunk &args, ExpressionState &state, Vector &result
 }
 
 ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const LogicalType &right_type) {
+	const auto inc = ArgProperties().Increasing(true);
+	const auto unset = ArgProperties();
 	if (left_type.IsNumeric() && left_type.id() == right_type.id()) {
 		if (left_type.id() == LogicalTypeId::DECIMAL) {
 			auto function = ScalarFunction("+", {left_type, right_type}, left_type, nullptr,
@@ -360,6 +362,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			function.SetFallible();
 			function.SetSerializeCallback(SerializeDecimalArithmetic);
 			function.SetDeserializeCallback(DeserializeDecimalArithmetic<AddOperator, DecimalAddOverflowCheck>);
+			function.SetArgProperties({inc, inc});
 			return function;
 		} else if (left_type.IsIntegral()) {
 			ScalarFunction function("+", {left_type, right_type}, left_type,
@@ -367,11 +370,13 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			                        nullptr,
 			                        PropagateNumericStats<TryAddOperator, AddPropagateStatistics, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		} else {
 			ScalarFunction function("+", {left_type, right_type}, left_type,
 			                        GetScalarBinaryFunction<AddOperator>(left_type.InternalType()));
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		}
 	}
@@ -381,6 +386,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 		if (right_type.id() == LogicalTypeId::BIGNUM) {
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::BIGNUM, BignumAdd);
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		}
 		break;
@@ -390,11 +396,15 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::DATE,
 			                        ScalarFunction::BinaryFunction<date_t, int32_t, date_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP,
 			                        ScalarFunction::BinaryFunction<date_t, interval_t, timestamp_t, AddOperator>);
 			function.SetFallible();
+			// INTERVAL ordering uses 30-day months but DATE arithmetic uses calendar months,
+			// e.g. '2025-02-01' + INTERVAL '29 days' = '2025-03-02' > + INTERVAL '1 month' = '2025-03-01'.
+			function.SetArgProperties({inc, unset});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::TIME) {
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP,
@@ -402,6 +412,8 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			function.SetFallible();
 			return function;
 		} else if (right_type.id() == LogicalTypeId::TIME_TZ) {
+			// DATE + TIME_TZ -> TIMESTAMP_TZ orders in UTC, but TIME_TZ ordering does not agree
+			// with UTC instant ordering — corner-evaluation picks the wrong extremum.
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP_TZ,
 			                        ScalarFunction::BinaryFunction<date_t, dtime_tz_t, timestamp_t, AddOperator>);
 			function.SetFallible();
@@ -413,6 +425,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			ScalarFunction function("+", {left_type, right_type}, right_type,
 			                        ScalarFunction::BinaryFunction<int32_t, date_t, date_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		}
 		break;
@@ -421,13 +434,16 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::INTERVAL,
 			                        ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({inc, inc});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::DATE) {
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP,
 			                        ScalarFunction::BinaryFunction<interval_t, date_t, timestamp_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({unset, inc});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::TIME) {
+			// TIME +/- INTERVAL wraps modulo 24h.
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIME,
 			                        ScalarFunction::BinaryFunction<interval_t, dtime_t, dtime_t, AddTimeOperator>);
 			function.SetFallible();
@@ -442,6 +458,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP,
 			                        ScalarFunction::BinaryFunction<interval_t, timestamp_t, timestamp_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({unset, inc});
 			return function;
 		}
 		break;
@@ -477,6 +494,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const Logi
 			ScalarFunction function("+", {left_type, right_type}, LogicalType::TIMESTAMP,
 			                        ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, AddOperator>);
 			function.SetFallible();
+			function.SetArgProperties({inc, unset});
 			return function;
 		}
 		break;
@@ -630,79 +648,26 @@ static unique_ptr<FunctionData> IntegerNegateBind(BindScalarFunctionInput &input
 	return nullptr;
 }
 
-struct NegatePropagateStatistics {
-	template <class T>
-	static bool Operation(const LogicalType &type, BaseStatistics &istats, Value &new_min, Value &new_max) {
-		auto max_value = NumericStats::GetMax<T>(istats);
-		auto min_value = NumericStats::GetMin<T>(istats);
-		if (!NegateOperator::CanNegate<T>(min_value) || !NegateOperator::CanNegate<T>(max_value)) {
-			return true;
-		}
-		// new min is -max
-		new_min = Value::Numeric(type, NegateOperator::Operation<T, T>(max_value));
-		// new max is -min
-		new_max = Value::Numeric(type, NegateOperator::Operation<T, T>(min_value));
-		return false;
-	}
-};
-
-static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-	auto &child_stats = input.child_stats;
-	auto &expr = input.expr;
-	D_ASSERT(child_stats.size() == 1);
-	// can only propagate stats if the children have stats
-	auto &istats = child_stats[0];
-	Value new_min, new_max;
-	bool potential_overflow = true;
-	if (NumericStats::HasMinMax(istats)) {
-		switch (expr.GetReturnType().InternalType()) {
-		case PhysicalType::INT8:
-			potential_overflow =
-			    NegatePropagateStatistics::Operation<int8_t>(expr.GetReturnType(), istats, new_min, new_max);
-			break;
-		case PhysicalType::INT16:
-			potential_overflow =
-			    NegatePropagateStatistics::Operation<int16_t>(expr.GetReturnType(), istats, new_min, new_max);
-			break;
-		case PhysicalType::INT32:
-			potential_overflow =
-			    NegatePropagateStatistics::Operation<int32_t>(expr.GetReturnType(), istats, new_min, new_max);
-			break;
-		case PhysicalType::INT64:
-			potential_overflow =
-			    NegatePropagateStatistics::Operation<int64_t>(expr.GetReturnType(), istats, new_min, new_max);
-			break;
-		default:
-			return nullptr;
-		}
-	}
-	if (potential_overflow) {
-		new_min = Value(expr.GetReturnType());
-		new_max = Value(expr.GetReturnType());
-	}
-	auto stats = NumericStats::CreateEmpty(expr.GetReturnType());
-	NumericStats::SetMin(stats, new_min);
-	NumericStats::SetMax(stats, new_max);
-	stats.CopyValidity(istats);
-	return stats.ToUnique();
-}
-
 ScalarFunction SubtractFunction::GetFunction(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::INTERVAL) {
 		ScalarFunction func("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
 		func.SetFallible();
+		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
 		return func;
 	} else if (type.id() == LogicalTypeId::DECIMAL) {
-		ScalarFunction func("-", {type}, type, nullptr, DecimalNegateBind, NegateBindStatistics);
+		ScalarFunction func("-", {type}, type, nullptr, DecimalNegateBind);
+		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
 		return func;
 	} else if (type.id() == LogicalTypeId::BIGNUM) {
 		ScalarFunction func("+", {type}, LogicalType::BIGNUM, BignumNegate);
+		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
 		return func;
 	} else {
 		D_ASSERT(type.IsNumeric());
 		ScalarFunction func("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type),
-		                    IntegerNegateBind, NegateBindStatistics);
+		                    IntegerNegateBind);
 		func.SetFallible();
+		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
 		return func;
 	}
 }
@@ -716,6 +681,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			function.SetSerializeCallback(SerializeDecimalArithmetic);
 			function.SetDeserializeCallback(
 			    DeserializeDecimalArithmetic<SubtractOperator, DecimalSubtractOverflowCheck>);
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 		} else if (left_type.IsIntegral()) {
 			ScalarFunction function(
@@ -723,12 +689,14 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr,
 			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 
 		} else {
 			ScalarFunction function("-", {left_type, right_type}, left_type,
 			                        GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 		}
 	}
@@ -736,6 +704,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 	switch (left_type.id()) {
 	case LogicalTypeId::BIGNUM: {
 		ScalarFunction function("-", {left_type, right_type}, left_type, BignumSubtract);
+		function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 		return function;
 	}
 	case LogicalTypeId::DATE:
@@ -743,17 +712,22 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::BIGINT,
 			                        ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 
 		} else if (right_type.id() == LogicalTypeId::INTEGER) {
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::DATE,
 			                        ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::TIMESTAMP,
 			                        ScalarFunction::BinaryFunction<date_t, interval_t, timestamp_t, SubtractOperator>);
 			function.SetFallible();
+			// Monotonic in DATE only; INTERVAL ordering uses 30-day months but DATE arithmetic uses
+			// calendar months so monotonicity in the INTERVAL arg is broken (see OperatorAddFun).
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties()});
 			return function;
 		}
 		break;
@@ -763,12 +737,15 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    "-", {left_type, right_type}, LogicalType::INTERVAL,
 			    ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
 			ScalarFunction function(
 			    "-", {left_type, right_type}, LogicalType::TIMESTAMP,
 			    ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
 			function.SetFallible();
+			// Monotonic in TIMESTAMP only; see DATE - INTERVAL above.
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties()});
 			return function;
 		}
 		break;
@@ -778,6 +755,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    "-", {left_type, right_type}, LogicalType::INTERVAL,
 			    ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
 			function.SetFallible();
+			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
 			return function;
 		}
 		break;
@@ -786,6 +764,8 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::TIME,
 			                        ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>);
 			function.SetFallible();
+			// TIME - INTERVAL wraps modulo 24h (e.g. 04:00 - INTERVAL '5 hours' = 23:00), so monotonicity
+			// in either argument does not hold.
 			return function;
 		}
 		break;
@@ -795,6 +775,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    "-", {left_type, right_type}, LogicalType::TIME_TZ,
 			    ScalarFunction::BinaryFunction<dtime_tz_t, interval_t, dtime_tz_t, SubtractTimeOperator>);
 			function.SetFallible();
+			// TIME_TZ - INTERVAL wraps modulo 24h, same reasoning as TIME above.
 			return function;
 		}
 		break;

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -317,7 +317,7 @@ ScalarFunction AddFunction::GetFunction(const LogicalType &type) {
 	auto fn = type.id() == LogicalTypeId::DECIMAL
 	              ? ScalarFunction("+", {type}, type, ScalarFunction::NopFunction, NopDecimalBind)
 	              : ScalarFunction("+", {type}, type, ScalarFunction::NopFunction);
-	fn.SetUnaryArgProperties(ArgProperties().Increasing(true));
+	fn.SetUnaryArgProperties(ArgProperties().StrictlyIncreasing());
 	return fn;
 }
 
@@ -353,7 +353,7 @@ static void BignumNegate(DataChunk &args, ExpressionState &state, Vector &result
 }
 
 ScalarFunction AddFunction::GetFunction(const LogicalType &left_type, const LogicalType &right_type) {
-	const auto inc = ArgProperties().Increasing(true);
+	const auto inc = ArgProperties().StrictlyIncreasing();
 	const auto unset = ArgProperties();
 	if (left_type.IsNumeric() && left_type.id() == right_type.id()) {
 		if (left_type.id() == LogicalTypeId::DECIMAL) {
@@ -652,22 +652,22 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::INTERVAL) {
 		ScalarFunction func("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
 		func.SetFallible();
-		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyDecreasing());
 		return func;
 	} else if (type.id() == LogicalTypeId::DECIMAL) {
 		ScalarFunction func("-", {type}, type, nullptr, DecimalNegateBind);
-		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyDecreasing());
 		return func;
 	} else if (type.id() == LogicalTypeId::BIGNUM) {
 		ScalarFunction func("+", {type}, LogicalType::BIGNUM, BignumNegate);
-		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyDecreasing());
 		return func;
 	} else {
 		D_ASSERT(type.IsNumeric());
 		ScalarFunction func("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type),
 		                    IntegerNegateBind);
 		func.SetFallible();
-		func.SetUnaryArgProperties(ArgProperties().Decreasing(true));
+		func.SetUnaryArgProperties(ArgProperties().StrictlyDecreasing());
 		return func;
 	}
 }
@@ -681,7 +681,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			function.SetSerializeCallback(SerializeDecimalArithmetic);
 			function.SetDeserializeCallback(
 			    DeserializeDecimalArithmetic<SubtractOperator, DecimalSubtractOverflowCheck>);
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 		} else if (left_type.IsIntegral()) {
 			ScalarFunction function(
@@ -689,14 +689,14 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr,
 			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 
 		} else {
 			ScalarFunction function("-", {left_type, right_type}, left_type,
 			                        GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 		}
 	}
@@ -704,7 +704,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 	switch (left_type.id()) {
 	case LogicalTypeId::BIGNUM: {
 		ScalarFunction function("-", {left_type, right_type}, left_type, BignumSubtract);
-		function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+		function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 		return function;
 	}
 	case LogicalTypeId::DATE:
@@ -712,14 +712,14 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::BIGINT,
 			                        ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 
 		} else if (right_type.id() == LogicalTypeId::INTEGER) {
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::DATE,
 			                        ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
 			ScalarFunction function("-", {left_type, right_type}, LogicalType::TIMESTAMP,
@@ -727,7 +727,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			function.SetFallible();
 			// Monotonic in DATE only; INTERVAL ordering uses 30-day months but DATE arithmetic uses
 			// calendar months so monotonicity in the INTERVAL arg is broken (see OperatorAddFun).
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties()});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties()});
 			return function;
 		}
 		break;
@@ -737,7 +737,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    "-", {left_type, right_type}, LogicalType::INTERVAL,
 			    ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
 			ScalarFunction function(
@@ -745,7 +745,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
 			function.SetFallible();
 			// Monotonic in TIMESTAMP only; see DATE - INTERVAL above.
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties()});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties()});
 			return function;
 		}
 		break;
@@ -755,7 +755,7 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &left_type, const
 			    "-", {left_type, right_type}, LogicalType::INTERVAL,
 			    ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
 			function.SetFallible();
-			function.SetArgProperties({ArgProperties().Increasing(true), ArgProperties().Decreasing(true)});
+			function.SetArgProperties({ArgProperties().StrictlyIncreasing(), ArgProperties().StrictlyDecreasing()});
 			return function;
 		}
 		break;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -302,6 +302,8 @@ enum class MetricGroup : uint8_t;
 
 enum class MetricType : uint8_t;
 
+enum class Monotonicity : uint8_t;
+
 enum class MultiFileColumnMappingMode : uint8_t;
 
 enum class MultiFileFileState : uint8_t;
@@ -935,6 +937,9 @@ const char* EnumUtil::ToChars<MetricGroup>(MetricGroup value);
 
 template<>
 const char* EnumUtil::ToChars<MetricType>(MetricType value);
+
+template<>
+const char* EnumUtil::ToChars<Monotonicity>(Monotonicity value);
 
 template<>
 const char* EnumUtil::ToChars<MultiFileColumnMappingMode>(MultiFileColumnMappingMode value);
@@ -1683,6 +1688,9 @@ MetricGroup EnumUtil::FromString<MetricGroup>(const char *value);
 
 template<>
 MetricType EnumUtil::FromString<MetricType>(const char *value);
+
+template<>
+Monotonicity EnumUtil::FromString<Monotonicity>(const char *value);
 
 template<>
 MultiFileColumnMappingMode EnumUtil::FromString<MultiFileColumnMappingMode>(const char *value);

--- a/src/include/duckdb/function/arg_properties.hpp
+++ b/src/include/duckdb/function/arg_properties.hpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/arg_properties.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+//! Monotonicity of a function in one argument (other args held constant).
+enum class Monotonicity : uint8_t {
+	UNKNOWN = 0,
+	CONSTANT,
+	NON_DECREASING,
+	STRICTLY_INCREASING,
+	NON_INCREASING,
+	STRICTLY_DECREASING,
+};
+
+//! Per-argument metadata for a scalar function.
+struct ArgProperties {
+	Monotonicity monotonicity = Monotonicity::UNKNOWN;
+
+	//! Default is non-strict (NON_DECREASING / NON_INCREASING) — the conservative claim.
+	//! Pass `true` only when distinct inputs are guaranteed to map to distinct outputs.
+	ArgProperties &Increasing(bool strict = false) {
+		monotonicity = strict ? Monotonicity::STRICTLY_INCREASING : Monotonicity::NON_DECREASING;
+		return *this;
+	}
+	ArgProperties &Decreasing(bool strict = false) {
+		monotonicity = strict ? Monotonicity::STRICTLY_DECREASING : Monotonicity::NON_INCREASING;
+		return *this;
+	}
+	ArgProperties &Constant() {
+		monotonicity = Monotonicity::CONSTANT;
+		return *this;
+	}
+};
+
+constexpr bool IsMonotonicIncreasing(Monotonicity m) {
+	return m == Monotonicity::NON_DECREASING || m == Monotonicity::STRICTLY_INCREASING;
+}
+constexpr bool IsMonotonicDecreasing(Monotonicity m) {
+	return m == Monotonicity::NON_INCREASING || m == Monotonicity::STRICTLY_DECREASING;
+}
+constexpr bool IsKnownMonotonic(Monotonicity m) {
+	return m != Monotonicity::UNKNOWN;
+}
+constexpr bool IsStrict(Monotonicity m) {
+	return m == Monotonicity::STRICTLY_INCREASING || m == Monotonicity::STRICTLY_DECREASING;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/arg_properties.hpp
+++ b/src/include/duckdb/function/arg_properties.hpp
@@ -26,14 +26,20 @@ enum class Monotonicity : uint8_t {
 struct ArgProperties {
 	Monotonicity monotonicity = Monotonicity::UNKNOWN;
 
-	//! Default is non-strict (NON_DECREASING / NON_INCREASING) — the conservative claim.
-	//! Pass `true` only when distinct inputs are guaranteed to map to distinct outputs.
-	ArgProperties &Increasing(bool strict = false) {
-		monotonicity = strict ? Monotonicity::STRICTLY_INCREASING : Monotonicity::NON_DECREASING;
+	ArgProperties &StrictlyIncreasing() {
+		monotonicity = Monotonicity::STRICTLY_INCREASING;
 		return *this;
 	}
-	ArgProperties &Decreasing(bool strict = false) {
-		monotonicity = strict ? Monotonicity::STRICTLY_DECREASING : Monotonicity::NON_INCREASING;
+	ArgProperties &NonDecreasing() {
+		monotonicity = Monotonicity::NON_DECREASING;
+		return *this;
+	}
+	ArgProperties &StrictlyDecreasing() {
+		monotonicity = Monotonicity::STRICTLY_DECREASING;
+		return *this;
+	}
+	ArgProperties &NonIncreasing() {
+		monotonicity = Monotonicity::NON_INCREASING;
 		return *this;
 	}
 	ArgProperties &Constant() {

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/enums/function_errors.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 class CatalogEntry;

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -75,6 +75,23 @@ public:
 	DUCKDB_API explicit ScalarFunctionSet(ScalarFunction fun);
 
 	DUCKDB_API ScalarFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
+
+	//! Apply the same per-arg property to every overload in the set.
+	void SetArgProperties(idx_t arg_idx, ArgProperties props) {
+		for (auto &fun : functions) {
+			fun.SetArgProperties(arg_idx, props);
+		}
+	}
+	void SetArgProperties(const vector<ArgProperties> &props) {
+		for (auto &fun : functions) {
+			fun.SetArgProperties(props);
+		}
+	}
+	void SetUnaryArgProperties(ArgProperties props) {
+		for (auto &fun : functions) {
+			fun.SetUnaryArgProperties(props);
+		}
+	}
 };
 
 class AggregateFunctionSet : public FunctionSet<AggregateFunction> {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
+#include "duckdb/function/arg_properties.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/common/optional_ptr.hpp"
@@ -241,6 +242,32 @@ public:
 	propagate_filter_t GetFilterPruneCallback() const { return callbacks.filter_prune; }
 	// clang-format on
 
+	//! Per-argument declarative properties. Returns a default ArgProperties when no annotation exists.
+	const ArgProperties &GetArgProperties(idx_t arg_idx) const {
+		static const ArgProperties unknown;
+		return arg_idx < arg_props.size() ? arg_props[arg_idx] : unknown;
+	}
+	const vector<ArgProperties> &GetAllArgProperties() const {
+		return arg_props;
+	}
+	bool HasArgProperties() const {
+		return !arg_props.empty();
+	}
+	ScalarFunction &SetArgProperties(idx_t arg_idx, ArgProperties props) {
+		if (arg_props.size() <= arg_idx) {
+			arg_props.resize(arg_idx + 1);
+		}
+		arg_props[arg_idx] = props;
+		return *this;
+	}
+	ScalarFunction &SetArgProperties(vector<ArgProperties> props) {
+		arg_props = std::move(props);
+		return *this;
+	}
+	ScalarFunction &SetUnaryArgProperties(ArgProperties props) {
+		return SetArgProperties(0, props);
+	}
+
 	bool HasExtraFunctionInfo() const {
 		return function_info != nullptr;
 	}
@@ -262,6 +289,8 @@ protected:
 
 	//! Additional function info, passed to the bind
 	shared_ptr<ScalarFunctionInfo> function_info;
+	//! Per-argument declarative properties (monotonicity). Empty = no claims made.
+	vector<ArgProperties> arg_props;
 
 public:
 	// clang-format off

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -1,7 +1,133 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
+
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/arg_properties.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 
 namespace duckdb {
+
+static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionExpression &func,
+                                   const vector<Value> &arg_values, Value &result) {
+	vector<unique_ptr<Expression>> children;
+	children.reserve(arg_values.size());
+	for (auto &v : arg_values) {
+		children.push_back(make_uniq<BoundConstantExpression>(v));
+	}
+	auto bind_info_clone = func.bind_info ? func.bind_info->Copy() : nullptr;
+	BoundFunctionExpression clone(func.GetReturnType(), func.function, std::move(children), std::move(bind_info_clone),
+	                              func.is_operator);
+	return ExpressionExecutor::TryEvaluateScalar(context, clone, result);
+}
+
+//! Evaluate `func` at the lo/hi corner of each child's value range to derive output min/max.
+//! Decreasing args are swapped so f(lo_args) and f(hi_args) bracket the output range.
+static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &context, BoundFunctionExpression &func,
+                                                             const vector<BaseStatistics> &child_stats) {
+	if (!func.function.HasArgProperties() || func.children.empty()) {
+		return nullptr;
+	}
+	if (func.function.GetStability() != FunctionStability::CONSISTENT) {
+		return nullptr;
+	}
+	if (func.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING) {
+		return nullptr;
+	}
+	if (BaseStatistics::GetStatsType(func.GetReturnType()) != StatisticsType::NUMERIC_STATS ||
+	    func.GetReturnType().InternalType() == PhysicalType::BOOL) {
+		return nullptr;
+	}
+
+	vector<Value> lo_args(func.children.size());
+	vector<Value> hi_args(func.children.size());
+	bool any_input_can_have_null = false;
+
+	for (idx_t i = 0; i < func.children.size(); i++) {
+		auto &child = *func.children[i];
+		auto &cs = child_stats[i];
+		auto &props = func.function.GetArgProperties(i);
+
+		if (child.IsFoldable()) {
+			Value v;
+			if (!ExpressionExecutor::TryEvaluateScalar(context, child, v) || v.IsNull()) {
+				return nullptr;
+			}
+			lo_args[i] = v;
+			hi_args[i] = std::move(v);
+			continue;
+		}
+
+		auto m = props.monotonicity;
+		if (cs.CanHaveNull()) {
+			any_input_can_have_null = true;
+		}
+		if (cs.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(cs)) {
+			return nullptr;
+		}
+		Value lo = NumericStats::Min(cs);
+		Value hi = NumericStats::Max(cs);
+
+		if (!IsKnownMonotonic(m)) {
+			return nullptr;
+		}
+
+		if (m == Monotonicity::CONSTANT) {
+			lo_args[i] = lo;
+			hi_args[i] = std::move(lo);
+			continue;
+		}
+		if (IsMonotonicIncreasing(m)) {
+			lo_args[i] = std::move(lo);
+			hi_args[i] = std::move(hi);
+		} else {
+			D_ASSERT(IsMonotonicDecreasing(m));
+			lo_args[i] = std::move(hi);
+			hi_args[i] = std::move(lo);
+		}
+	}
+
+	Value out_lo, out_hi;
+	if (!TryEvaluateAtConstants(context, func, lo_args, out_lo) ||
+	    !TryEvaluateAtConstants(context, func, hi_args, out_hi)) {
+		return nullptr;
+	}
+	// NaN/NULL at a corner means the input was NaN/NULL (column contains NaN, or year(±infinity));
+	// the function may still be monotonic on its finite domain, but no bounds derivable here.
+	const auto is_unusable = [](const Value &v) {
+		if (v.IsNull()) {
+			return true;
+		}
+		switch (v.type().id()) {
+		case LogicalTypeId::DOUBLE:
+			return Value::IsNan(v.GetValue<double>());
+		case LogicalTypeId::FLOAT:
+			return Value::IsNan(v.GetValue<float>());
+		default:
+			return false;
+		}
+	};
+	if (is_unusable(out_lo) || is_unusable(out_hi)) {
+		return nullptr;
+	}
+	// Ordering violation indicates the annotation is wrong (function isn't actually monotonic in
+	// the direction claimed). Assert in debug builds so this surfaces during testing; bail in
+	// release builds so a misannotation can't propagate unsound stats.
+	D_ASSERT(!(out_hi < out_lo));
+	if (out_hi < out_lo) {
+		return nullptr;
+	}
+
+	auto result = NumericStats::CreateEmpty(func.GetReturnType());
+	NumericStats::SetMin(result, out_lo);
+	NumericStats::SetMax(result, out_hi);
+
+	result.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
+	if (any_input_can_have_null) {
+		result.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+	return result.ToUnique();
+}
 
 unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFunctionExpression &func,
                                                                      unique_ptr<Expression> &expr_ptr) {
@@ -15,11 +141,11 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 			stats.push_back(stat->Copy());
 		}
 	}
-	if (!func.function.HasStatisticsCallback()) {
-		return nullptr;
+	if (func.function.HasStatisticsCallback()) {
+		FunctionStatisticsInput input(func, func.bind_info.get(), stats, &expr_ptr);
+		return func.function.GetStatisticsCallback()(context, input);
 	}
-	FunctionStatisticsInput input(func, func.bind_info.get(), stats, &expr_ptr);
-	return func.function.GetStatisticsCallback()(context, input);
+	return TryPropagateMonotoneBounds(context, func, stats);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -31,9 +31,6 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	if (func.function.GetStability() != FunctionStability::CONSISTENT) {
 		return nullptr;
 	}
-	if (func.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING) {
-		return nullptr;
-	}
 	if (BaseStatistics::GetStatsType(func.GetReturnType()) != StatisticsType::NUMERIC_STATS ||
 	    func.GetReturnType().InternalType() == PhysicalType::BOOL) {
 		return nullptr;
@@ -41,7 +38,8 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 
 	vector<Value> lo_args(func.children.size());
 	vector<Value> hi_args(func.children.size());
-	bool any_input_can_have_null = false;
+	// SPECIAL_HANDLING means the function may produce nulls on non-null inputs (e.g. try_cast).
+	bool output_can_have_null = (func.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING);
 
 	for (idx_t i = 0; i < func.children.size(); i++) {
 		auto &child = *func.children[i];
@@ -60,7 +58,7 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 
 		auto m = props.monotonicity;
 		if (cs.CanHaveNull()) {
-			any_input_can_have_null = true;
+			output_can_have_null = true;
 		}
 		if (cs.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(cs)) {
 			return nullptr;
@@ -92,8 +90,9 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	    !TryEvaluateAtConstants(context, func, hi_args, out_hi)) {
 		return nullptr;
 	}
-	// NaN/NULL at a corner means the input was NaN/NULL (column contains NaN, or year(±infinity));
-	// the function may still be monotonic on its finite domain, but no bounds derivable here.
+	// NaN/NULL at a corner means the input was NaN/NULL (column contains NaN, or year(±infinity)).
+	// NaN is excluded even though DuckDB orders it above all other values: negate(NaN) = NaN, which
+	// would violate NON_INCREASING if NaN were treated as a valid corner. Bail instead.
 	const auto is_unusable = [](const Value &v) {
 		if (v.IsNull()) {
 			return true;
@@ -110,12 +109,9 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	if (is_unusable(out_lo) || is_unusable(out_hi)) {
 		return nullptr;
 	}
-	// Ordering violation indicates the annotation is wrong (function isn't actually monotonic in
-	// the direction claimed). Assert in debug builds so this surfaces during testing; bail in
-	// release builds so a misannotation can't propagate unsound stats.
-	D_ASSERT(!(out_hi < out_lo));
 	if (out_hi < out_lo) {
-		return nullptr;
+		throw InternalException("Monotonic arg annotation violated for '%s': output min exceeds output max",
+		                        func.function.name);
 	}
 
 	auto result = NumericStats::CreateEmpty(func.GetReturnType());
@@ -123,7 +119,7 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	NumericStats::SetMax(result, out_hi);
 
 	result.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
-	if (any_input_can_have_null) {
+	if (output_can_have_null) {
 		result.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	}
 	return result.ToUnique();

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -100,3 +100,48 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(ABS(i)) s FROM integers LIMIT 1)
 ----
 1	10
+
+# negate: i in [-10, -1] -> -i in [1, 10]
+query II
+SELECT s.min, s.max FROM (SELECT STATS(-i) s FROM integers LIMIT 1)
+----
+1	10
+
+# impossible filter folds away
+query II
+EXPLAIN SELECT count(*) FROM integers WHERE -i < 0;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# floor: non-decreasing, x in [1.5, 9.7] -> floor(x) in [1.0, 9.0]
+statement ok
+CREATE TABLE doubles(x DOUBLE);
+
+statement ok
+INSERT INTO doubles VALUES (1.5), (9.7);
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(floor(x)) s FROM doubles LIMIT 1)
+----
+1.0	9.0
+
+# year(date) is non-decreasing: corner eval succeeds when min/max are finite dates
+statement ok
+CREATE TABLE finite_dates AS SELECT (DATE '2020-01-01' + INTERVAL (range) DAY)::DATE AS dt FROM range(2048);
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(year(dt)) s FROM finite_dates LIMIT 1)
+----
+2020	2025
+
+# year(infinity) is NULL: corner eval returns NULL, propagator bails (no derived stats)
+statement ok
+CREATE TABLE inf_dates(dt DATE);
+
+statement ok
+INSERT INTO inf_dates VALUES (DATE '2021-01-01'), ('infinity'::DATE);
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(year(dt)) s FROM inf_dates LIMIT 1)
+----
+NULL	NULL

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -145,3 +145,34 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(year(dt)) s FROM inf_dates LIMIT 1)
 ----
 NULL	NULL
+
+# i: [-10, -1] with a NULL; x: [0.0, 1.0] finite; x_nan: NaN present (stats max = NaN)
+statement ok
+CREATE TABLE mixed(i INTEGER, x DOUBLE, x_nan DOUBLE);
+
+statement ok
+INSERT INTO mixed VALUES (-10, 0.0, 0.0), (-1, 1.0, 'nan'::DOUBLE), (NULL, NULL, NULL);
+
+# nullable input: null flag propagates but bounds are still derived
+query II
+SELECT s.min, s.max FROM (SELECT STATS(-i) s FROM mixed LIMIT 1)
+----
+1	10
+
+# impossible filter still folds even though input column has nulls
+query II
+EXPLAIN SELECT count(*) FROM mixed WHERE -i < 0;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# NaN in column: corner eval returns NaN, is_unusable fires, no bounds derived
+query II
+SELECT s.min, s.max FROM (SELECT STATS(exp(x_nan)) s FROM mixed LIMIT 1)
+----
+NULL	NULL
+
+# finite column: exp bounds propagate correctly
+query II
+SELECT s.min, s.max FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
+----
+1.0	2.718281828459045


### PR DESCRIPTION
Adds per-argument `ArgProperties` metadata on `ScalarFunction` and uses it in `StatisticsPropagator::PropagateExpression(BoundFunctionExpression&)` to derive output min/max via corner evaluation — `f(lo_args)` and `f(hi_args)` with decreasing args swapped — for any annotated function that lacks a custom statistics callback. Drops `NegateBindStatistics` since the generic path subsumes it.

Going forward more properties can be built on and added to `ArgProperties`, broken off from #22286 for easier reviewability

## What was unhandled before

Most scalar functions outside a hand-written allowlist had no statistics callback, so `STATS(f(col))` returned `NULL,NULL` and downstream optimizations (impossible-filter elimination, NULL-set inference, range pushdown) saw the function as a black box.

```sql
CREATE TABLE m(x DOUBLE);
INSERT INTO m VALUES (1.5), (9.7);

-- baseline:
SELECT s.min, s.max FROM (SELECT STATS(floor(x)) s FROM m LIMIT 1);
-- Binder Error:
-- Cannot extract field 'min' from expression "s" because it is not a struct, union, map, or json


-- with this PR:
-- min=1.0, max=9.0
```

Stats implications:

```sql
EXPLAIN SELECT count(*) FROM m WHERE floor(x) > 100;
-- baseline: SEQ_SCAN -> UNGROUPED_AGGREGATE
-- this PR : EMPTY_RESULT -> UNGROUPED_AGGREGATE
```

Same change unlocks `negate`, `ceil`, `round`, `trunc`, `abs`, `epoch_*`, `date_trunc`, `time_bucket`, `make_date`, plus arithmetic `+`/`-`/unary-`-` against bounded inputs.

## Design


```cpp
struct ArgProperties {
	Monotonicity monotonicity = Monotonicity::UNKNOWN;

	ArgProperties &StrictlyIncreasing();
	ArgProperties &NonDecreasing();
	ArgProperties &StrictlyDecreasing();
	ArgProperties &NonIncreasing();
	ArgProperties &Constant();
};

// Annotation site:
ScalarFunctionSet set("floor");
set.AddFunction(...);
set.SetUnaryArgProperties(ArgProperties().NonDecreasing());  // floor is non-strict — many-to-one
```

## Custom stats callbacks take precedence

A function with a registered statistics callback keeps it; the generic forward-bounds path only fires as a fallback. This matters for integer `+`/`-` and decimal arithmetic, which use `PropagateNumericStats` to do something the generic path **cannot**: when the input ranges prove no overflow is possible in the output type, the callback **rewrites the bound function** at plan time to the non-overflow-checking variant (`AddOperator` instead of `AddOperatorOverflowCheck`), removing per-row overflow detection from the hot loop. The forward-bounds path computes output stats only — it has no analogous bind-time rewrite — so we keep both paths and let the existing callback win.

## What remains unannotated

`*`, `/`, `%`, `pow`, etc. are deliberately not annotated:

Annotating these incorrectly would propagate wrong bounds to downstream optimizations. Leaving them unannotated keeps today's behavior exactly. A future PR can add richer per-arg metadata (e.g. preimage callbacks for non-monotonic-but-piecewise-monotonic functions) when there's a use case worth the complexity.

```sql
SELECT era('infinity'::TIMESTAMPTZ);  -- NULL
-- propagator sees out_hi=NULL and returns nullptr
```

- `TIME +/- INTERVAL` and `TIMETZ +/- INTERVAL` are unannotated (24h wrap breaks monotonicity).
- `DATE +/- INTERVAL`, `TIMESTAMP +/- INTERVAL` annotate the date/timestamp arg only — the INTERVAL arg is unannotated because `INTERVAL '29 days' < INTERVAL '1 month'` (interval-normalize) does not match calendar arithmetic (`DATE '2025-02-01' + 29d = 2025-03-02` but `+ 1mo = 2025-03-01`).

## Out of scope

- Per-arg `ArgProperties` on `BoundCastInfo` (cast-side analogue) — separate PR, mechanical mirror of this work.
- The peel optimizer that consumes `injective` and `requires_finite_input` — separate PR.
- ICU year-of-era refiner — lands with the peel PR where it has a consumer.
