### PR TITLE
Limit choco output, and show rclone command

### DIFF
--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -79,7 +79,7 @@ fi
 if ! command -v rclone >/dev/null 2>&1; then
     case "$(uname -s)" in
       MINGW*|MSYS*|CYGWIN*)
-        choco install rclone -y
+        choco install rclone -y --limit-output --no-progress
         ;;
       *)
         install_runner=(bash)
@@ -109,11 +109,21 @@ fi
 
 upload_extension() {
   local destination="$1"
+  local rclone_s3_args=(
+    --s3-provider "${S3_PROVIDER:-AWS}"
+    --s3-endpoint "${AWS_ENDPOINT_URL}"
+    --s3-access-key-id "${AWS_ACCESS_KEY_ID}"
+    --s3-secret-access-key "${AWS_SECRET_ACCESS_KEY}"
+  )
+
+  set -x
   rclone $DRY_RUN_PARAM copyto \
+    --no-traverse \
     --s3-acl public-read \
+    "${rclone_s3_args[@]}" \
     "${extra_upload_args[@]}" \
     "$ext.compressed" \
-    ":s3,provider=AWS,env_auth=true,endpoint=${AWS_ENDPOINT_URL}:${destination}"
+    ":s3:${destination}"
 }
 
 # upload versioned version

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -58,7 +58,7 @@ fi
 if ! command -v rclone >/dev/null 2>&1; then
   case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
-      python3 scripts/ci/retry.py -- choco install rclone -y
+      python3 scripts/ci/retry.py -- choco install rclone -y --limit-output --no-progress
       ;;
     *)
       install_runner=(bash)
@@ -77,13 +77,18 @@ cleanup() {
 trap cleanup EXIT
 printf '%s\n' "${@:2}" > "$files_from"
 
-rclone_remote=":s3,provider=AWS,endpoint=${AWS_ENDPOINT_URL:-},access_key_id=${AWS_ACCESS_KEY_ID:-},secret_access_key=${AWS_SECRET_ACCESS_KEY:-}"
-if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
-  rclone_remote="${rclone_remote},session_token=${AWS_SESSION_TOKEN}"
-fi
+rclone_s3_args=(
+  --s3-provider "${S3_PROVIDER:-AWS}"
+  --s3-endpoint "${AWS_ENDPOINT_URL:-}"
+  --s3-access-key-id "${AWS_ACCESS_KEY_ID:-}"
+  --s3-secret-access-key "${AWS_SECRET_ACCESS_KEY:-}"
+)
+
+set -x
 
 rclone $DRY_RUN_PARAM copy \
   --no-traverse \
+  "${rclone_s3_args[@]}" \
   --files-from "$files_from" \
   . \
-  "${rclone_remote}:duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/"
+  ":s3:duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/"


### PR DESCRIPTION
### Note: `pip install requests` error is not related

The installation error is fixed in this [PR](https://github.com/duckdb/duckdb/pull/22371).

This is the error in CI:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
[retry] attempt 3/3 failed (exit code: 1) for: pip install requests
```
