### PR TITLE
Downcasting decimal fix incorrect out of range error

### DIFF
--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -117,7 +117,7 @@ struct DecimalScaleDownOperator {
 // This function detects if we can scale a decimal down to another.
 template <class INPUT_TYPE>
 static bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) {
-	int64_t divisor = UnsafeNumericCast<int64_t>(NumericHelper::POWERS_OF_TEN[data.source_scale]);
+	int64_t divisor = UnsafeNumericCast<int64_t>(data.factor);
 	auto value = input % divisor;
 	auto rounded_input = input;
 	if (rounded_input < 0) {
@@ -132,7 +132,7 @@ static bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> 
 
 template <>
 bool CanScaleDownDecimal<hugeint_t>(hugeint_t input, DecimalScaleInput<hugeint_t> &data) {
-	auto divisor = UnsafeNumericCast<hugeint_t>(Hugeint::POWERS_OF_TEN[data.source_scale]);
+	auto divisor = UnsafeNumericCast<hugeint_t>(data.factor);
 	hugeint_t value = input % divisor;
 	hugeint_t rounded_input = input;
 	if (rounded_input < 0) {

--- a/test/sql/cast/decimal_cast.test
+++ b/test/sql/cast/decimal_cast.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-# Valid casts that previously threw a false "out of range" error.
-
 query I
 SELECT '9.90'::DECIMAL(4,3)::DECIMAL(3,2);
 ----
@@ -31,8 +29,6 @@ query I
 SELECT '9.9000000000000000000000000000000000000'::DECIMAL(38,37)::DECIMAL(37,36);
 ----
 9.900000000000000000000000000000000000
-
-# True overflow: rounding pushes value past the limit. These should still error.
 
 statement error
 SELECT '9.995'::DECIMAL(4,3)::DECIMAL(3,2);

--- a/test/sql/cast/decimal_cast.test
+++ b/test/sql/cast/decimal_cast.test
@@ -1,0 +1,45 @@
+# name: test/sql/cast/decimal_cast.test
+# description: Test decimal-to-decimal casting with scale reduction
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+# Valid casts that previously threw a false "out of range" error.
+
+query I
+SELECT '9.90'::DECIMAL(4,3)::DECIMAL(3,2);
+----
+9.90
+
+query I
+SELECT '1.10'::DECIMAL(4,3)::DECIMAL(3,2);
+----
+1.10
+
+query I
+SELECT '9.90000000'::DECIMAL(9,8)::DECIMAL(8,7);
+----
+9.9000000
+
+query I
+SELECT '9.90000000000000000'::DECIMAL(18,17)::DECIMAL(17,16);
+----
+9.9000000000000000
+
+query I
+SELECT '9.9000000000000000000000000000000000000'::DECIMAL(38,37)::DECIMAL(37,36);
+----
+9.900000000000000000000000000000000000
+
+# True overflow: rounding pushes value past the limit. These should still error.
+
+statement error
+SELECT '9.995'::DECIMAL(4,3)::DECIMAL(3,2);
+----
+Conversion Error: Casting value "9.995" to type DECIMAL(3,2) failed: value is out of range!
+
+statement error
+SELECT '9.99999995'::DECIMAL(9,8)::DECIMAL(8,7);
+----
+Conversion Error: Casting value "9.99999995" to type DECIMAL(8,7) failed: value is out of range!


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/appian/issues/87

There was a bug in the downcasting of `DECIMAL` which caused an incorrect `out of range` error to be thrown. 
For example the following would throw an error: 
```sql
SELECT '9.90'::DECIMAL(4,3)::DECIMAL(3,2);
```
While `9.90` can be represented in a `DECIMAL(3,2)`.
The bug was caused by looking at the source's scale rather than the difference in scale, calculated here:
https://github.com/duckdb/duckdb/blob/bbe027da7d10d542e831df9ad5cb291059860ecd/src/function/cast/decimal_cast.cpp#L171

In the query above (9.90 is represented as 9900 internally), the source scale is 3 (incorrect), while the scale difference is 1
This is the logic used to check if we can round (omitting negatation for a second here): 
```cpp
auto value = input % divisor;
auto rounded_input = input;
...
if (value >= divisor / 2) {
    rounded_input += divisor;
}
return rounded_input < data.limit && rounded_input > -data.limit;
```
**Incorrect case** (source scale is 3): 
```
divisor = 10^3 = 1000
value = 9900 % 1000 = 900
value >= divisor / 2: 900 >= 500 -> True
  rounded_input += divisor = 9900 + 1000 = 10900
10900 < limit (10000) -> return False
Throws out of range exception
```
**Correct case** (scale difference / factor = 1): 
```
divisor = 10^1 = 10
value = 9900 % 10 = 0
value >= divisor / 2: 0 >= 5 -> False
9900 < limit (10000) -> return True
Passes correctly
```