### PR TITLE
Switch to using `std::optional`

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -138,7 +138,7 @@ jobs:
       uses: ./.github/actions/setup-msvc-env
     - name: Duckdb.dll export symbols with C++ on Windows
       shell: bash
-      run: cl -I src/include examples/embedded-c++-windows/cppintegration.cpp -link src/duckdb.lib
+      run: cl /std:c++17 -I src/include examples/embedded-c++-windows/cppintegration.cpp -link src/duckdb.lib
 
  win-release-32:
     name: Windows (32 Bit)

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -48,7 +48,7 @@ int64_t SequenceCatalogEntry::CurrentValue() {
 	if (!data.last_value) {
 		throw SequenceException("currval: sequence is not yet defined in this session");
 	}
-	result = data.last_value.GetValue();
+	result = data.last_value.value();
 	return result;
 }
 

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -144,9 +144,11 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 		max_value.Append(Value::BIGINT(seq_data.max_value));
 		increment_by.Append(Value::BIGINT(seq_data.increment));
 		cycle.Append(Value::BOOLEAN(seq_data.cycle));
-		last_value.Append((seq_data.usage_count == 0) || !seq_data.last_value.IsValid()
-		                      ? Value()
-		                      : Value::BIGINT(seq_data.last_value.GetValue()));
+		if (seq_data.usage_count == 0 || !seq_data.last_value) {
+			last_value.Append(Value());
+		} else {
+			last_value.Append(Value::BIGINT(seq_data.last_value.value()));
+		}
 		sql.Append(Value(seq.ToSQL()));
 
 		count++;

--- a/src/include/duckdb/common/optional.hpp
+++ b/src/include/duckdb/common/optional.hpp
@@ -8,64 +8,11 @@
 
 #pragma once
 
-#include "duckdb/common/exception.hpp"
+#include <optional>
 
 namespace duckdb {
 
-//! FIXME: Remove this in favor of std::optional once all migration to c++17  is done.
-struct nullopt_t { // NOLINT
-	constexpr explicit nullopt_t() {
-	}
-};
-
-constexpr nullopt_t nullopt {}; // NOLINT
-
-template <typename T>
-class optional {
-public:
-	optional() : has_val(false), value(T()) {
-	}
-	optional(T value) : has_val(true), value(std::move(value)) { // NOLINT: allow implicit conversion
-	}
-	optional(nullopt_t) : optional() { // NOLINT: allow implicit conversion
-	}
-
-	bool IsValid() const {
-		return has_val;
-	}
-
-	explicit operator bool() const {
-		return has_val;
-	}
-
-	const T &GetValue() const {
-		if (!has_val) {
-			throw InternalException("Attempting to get the value of an optional that is not set");
-		}
-		return value;
-	}
-
-	inline bool operator==(const optional &rhs) const {
-		if (has_val != rhs.has_val) {
-			return false;
-		}
-		if (!has_val) {
-			return true;
-		}
-		return value == rhs.value;
-	}
-
-	inline bool operator!=(const optional &rhs) const {
-		return !(*this == rhs);
-	}
-
-	const inline T &operator*() const {
-		return GetValue();
-	}
-
-private:
-	bool has_val;
-	T value;
-};
+using std::nullopt;
+using std::optional;
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -356,7 +356,7 @@ struct SerializationDefaultValue {
 
 	template <typename T = void>
 	static inline bool IsDefault(const typename std::enable_if<is_duckdb_optional<T>::value, T>::type &value) {
-		return !value.IsValid();
+		return !value;
 	}
 
 	template <typename T = void>

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -208,12 +208,12 @@ protected:
 	// DuckDB Optional
 	template <typename T>
 	void WriteValue(const optional<T> &opt) {
-		if (!opt.IsValid()) {
+		if (!opt) {
 			OnNullableBegin(false);
 			OnNullableEnd();
 		} else {
 			OnNullableBegin(true);
-			WriteValue(opt.GetValue());
+			WriteValue(opt.value());
 			OnNullableEnd();
 		}
 	}


### PR DESCRIPTION
Now that all extensions are C++17 compatible we should (hopefully) be able to use `std::optional`