### PR TITLE
Fix validity map bisect underflow

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -422,8 +422,8 @@ static void FetchRowValidity(transaction_t start_time, transaction_t transaction
 			return;
 		}
 		idx_t left = 0;
-		idx_t right = current.N - 1;
-		while (left <= right) {
+		idx_t right = current.N;
+		while (left < right) {
 			idx_t mid = left + (right - left) / 2;
 			if (tuples[mid] == row_idx) {
 				result_mask.Set(result_idx, info_data[mid]);
@@ -431,7 +431,7 @@ static void FetchRowValidity(transaction_t start_time, transaction_t transaction
 			} else if (tuples[mid] < row_idx) {
 				left = mid + 1;
 			} else {
-				right = mid - 1;
+				right = mid;
 			}
 		}
 	});

--- a/test/sql/update/issue_22392.test
+++ b/test/sql/update/issue_22392.test
@@ -1,0 +1,28 @@
+# name: test/sql/update/issue_22392.test
+# description: Regression for issue #22392.
+# group: [update]
+
+statement ok
+SET index_scan_percentage = 1.0;
+
+statement ok
+SET index_scan_max_count = 0;
+
+statement ok
+CREATE TABLE t (k INTEGER PRIMARY KEY, v INTEGER);
+
+statement ok
+INSERT INTO t VALUES (0, 0), (1, NULL);
+
+statement ok
+UPDATE t SET v = 99 WHERE k = 1;
+
+query II
+SELECT k, v FROM t WHERE k IN (0);
+----
+0	0
+
+query II
+SELECT k, v FROM t WHERE k IN (1);
+----
+1	99


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22392

In the provided sql test, `mid` becomes 0 and `right` underflows.
