### PR TITLE
Fix double decrement of evicted_data_per_tag in .block read-back

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -563,10 +563,9 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	handle.reset();
 
 	// Delete the file and return the buffer.
+	// DeleteTemporaryFile already decrements evicted_data_per_tag for the .block path; do not
+	// decrement again here or the counter underflows on every read-back.
 	DeleteTemporaryFile(block.GetMemory());
-
-	// Decrement evicted size.
-	evicted_data_per_tag[uint8_t(tag)] -= buffer->AllocSize();
 
 	return buffer;
 }

--- a/test/sql/outofcore/block_file_double_decrement.test_slow
+++ b/test/sql/outofcore/block_file_double_decrement.test_slow
@@ -1,0 +1,85 @@
+# name: test/sql/outofcore/block_file_double_decrement.test_slow
+# description: Stricter regression test for the .block read-back double-decrement bug.
+#              Forces an explicit write→full-scan→write cycle and asserts that the
+#              OVERFLOW_STRINGS counter remains consistent with on-disk .block files
+#              after every phase.
+#
+# See block_file_evicted_bytes_accounting.test_slow for the full bug analysis. This test
+# differs by:
+#   - Establishes a baseline counter > 0 after the initial write phase.
+#   - Performs an explicit full scan that reads every .block file back through the
+#     ReadTemporaryBuffer .block path.
+#   - Performs a second write wave to force fresh evictions, and asserts the counter
+#     recovers — with the bug it stayed clamped to 0 (the wrapped uint64 stayed
+#     > INT64_MAX even after adding fresh evictions).
+#
+# Memory budget: 50 MB with a streaming-friendly setting so the read-back scan does not
+# OOM. The workload is intentionally modest (~57 MB) — it is the *number* of read-back
+# events that exercises the bug, not the absolute byte count.
+#
+# group: [outofcore]
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET temp_directory = '{TEST_DIR}/tmp_dd';
+
+statement ok
+SET memory_limit = '50MB';
+
+statement ok
+SET preserve_insertion_order = false;
+
+statement ok
+CREATE TABLE r1 (id INT, s VARCHAR);
+
+# Phase 1: write ~57 MB of incompressible OVERFLOW_STRINGS data (100 rows × ~576 KB).
+loop b 0 5
+
+statement ok
+INSERT INTO r1 SELECT range + ${b}*20, hex(repeat(md5(range::VARCHAR)::BLOB, 9000)) FROM range(20);
+
+endloop
+
+# .block files must exist after the writes.
+query I
+SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_dd/*.block');
+----
+true
+
+# Baseline: with .block files on disk, OVERFLOW_STRINGS counter must be > 0.
+# (If this fails, the bug already fired during insert-time evict/read cycles.)
+query I
+SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS';
+----
+true
+
+# Phase 2: full scan forces every .block to be read back through ReadTemporaryBuffer.
+# count(*) avoids materialising the strings themselves while still pinning each block,
+# so the read-back path runs without OOM under the tight budget.
+statement ok
+SELECT count(s) FROM r1;
+
+# Phase 3: insert another ~57 MB to force fresh OVERFLOW_STRINGS evictions.
+loop b 0 5
+
+statement ok
+INSERT INTO r1 SELECT range + 100 + ${b}*20, hex(repeat(md5(range::VARCHAR)::BLOB, 9000)) FROM range(20);
+
+endloop
+
+# .block files exist again from the new evictions.
+query I
+SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_dd/*.block');
+----
+true
+
+# Core regression assertion: after the read-back scan and a fresh wave of writes,
+# the per-tag counter must reflect the on-disk eviction state.
+# FAILS with the double-decrement bug (counter remains clamped to 0).
+# PASSES once the duplicate decrement at standard_buffer_manager.cpp:569 is removed.
+query I
+SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS';
+----
+true

--- a/test/sql/outofcore/block_file_double_decrement.test_slow
+++ b/test/sql/outofcore/block_file_double_decrement.test_slow
@@ -1,5 +1,7 @@
 # name: test/sql/outofcore/block_file_double_decrement.test_slow
 # description: Stricter regression test for the .block read-back double-decrement bug.
+# group: [outofcore]
+
 #              Forces an explicit write→full-scan→write cycle and asserts that the
 #              OVERFLOW_STRINGS counter remains consistent with on-disk .block files
 #              after every phase.
@@ -17,7 +19,6 @@
 # OOM. The workload is intentionally modest (~57 MB) — it is the *number* of read-back
 # events that exercises the bug, not the absolute byte count.
 #
-# group: [outofcore]
 
 statement ok
 SET threads = 1;

--- a/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
+++ b/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
@@ -1,0 +1,77 @@
+# name: test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
+# description: Regression test for the double-decrement bug in StandardBufferManager::ReadTemporaryBuffer
+#              for the .block (variable-sized) eviction path.
+#
+# Bug location (src/storage/standard_buffer_manager.cpp):
+#   ReadTemporaryBuffer (.block path) called DeleteTemporaryFile(), which itself does
+#   `evicted_data_per_tag[tag] -= memory.GetMemoryUsage()` (~line 602). Then ReadTemporaryBuffer
+#   immediately did a SECOND `evicted_data_per_tag[tag] -= buffer->AllocSize()`.
+#   For OVERFLOW_STRINGS those two decrements have equal magnitude, so the counter was
+#   decremented by 2× the eviction size on every .block read-back. After enough cycles the
+#   uint64 counter wrapped; ClampReportedMemory then returned 0 for the tag while .block
+#   files still existed on disk.
+#
+# Test invariant (catches the bug):
+#   When .block files exist on disk for OVERFLOW_STRINGS data, the per-tag accounting in
+#   duckdb_memory() must not be 0 — that combination is only possible if the counter
+#   underflowed and got clamped.
+#
+# Why this triggers in the harness reliably:
+#   .block path is taken when buffer.AllocSize() != GetBlockAllocSize() (default 262144).
+#   Strings wider than (BLOCK_SIZE - 4) bytes are allocated as their own OVERFLOW_STRINGS
+#   block of (string_len + 4) bytes. We use ~576 KB hex(md5) strings (incompressible) so
+#   every overflow string forces a .block file on eviction. The buffer manager continually
+#   evicts AND re-reads intermediate strings during inserts; with the bug, those intra-INSERT
+#   read-backs already wrap the counter to 0 before any explicit scan is needed.
+#
+# Notes:
+#   - duckdb_temporary_files() does NOT enumerate .block files (its ListFiles callback
+#     receives basenames but passes them to OpenFile expecting full paths), so we use
+#     glob() to verify on-disk presence.
+#
+# group: [outofcore]
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET temp_directory = '{TEST_DIR}/tmp_acct';
+
+statement ok
+SET memory_limit = '50MB';
+
+statement ok
+CREATE TABLE t (id INTEGER, val VARCHAR);
+
+# Write ~57 MB of incompressible OVERFLOW_STRINGS data in 20-row batches.
+# Each row → one OVERFLOW_STRINGS block of ~576 KB → one .block file on eviction.
+# 50 MB budget vs ~57 MB workload guarantees eviction during inserts.
+loop b 0 5
+
+statement ok
+INSERT INTO t SELECT range + ${b}*20, hex(repeat(md5(range::VARCHAR)::BLOB, 9000)) FROM range(20);
+
+endloop
+
+# Sanity: .block files exist on disk after the writes.
+query I
+SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_acct/*.block');
+----
+true
+
+# Core invariant: with .block files on disk for OVERFLOW_STRINGS data, the per-tag
+# counter must be > 0. The buffer manager performs intra-INSERT read-backs of evicted
+# overflow strings, so this single assertion is sufficient to catch the double-decrement
+# bug — it failed before the fix at standard_buffer_manager.cpp:569 was removed.
+query I
+SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS';
+----
+true
+
+# Combined sanity: both signals must agree — files on disk implies tracked bytes.
+query II
+SELECT
+    (SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_acct/*.block'))                                AS block_files_exist,
+    (SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS')      AS bytes_tracked;
+----
+true	true

--- a/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
+++ b/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
@@ -1,5 +1,7 @@
 # name: test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
 # description: Regression test for the double-decrement bug in StandardBufferManager::ReadTemporaryBuffer
+# group: [outofcore]
+
 #              for the .block (variable-sized) eviction path.
 #
 # Bug location (src/storage/standard_buffer_manager.cpp):
@@ -29,7 +31,6 @@
 #     receives basenames but passes them to OpenFile expecting full paths), so we use
 #     glob() to verify on-disk presence.
 #
-# group: [outofcore]
 
 statement ok
 SET threads = 1;


### PR DESCRIPTION
## Summary

`StandardBufferManager::ReadTemporaryBuffer` (variable-sized `.block` path) called `DeleteTemporaryFile`, which itself decrements `evicted_data_per_tag[tag]`, and then decremented the **same** counter a second time. Each `.block` read-back therefore subtracted `2 × eviction_size` from the per-tag uint64 counter, underflowing it; `ClampReportedMemory` then pinned the per-tag `temporary_storage_bytes` reported by `duckdb_memory()` to `0` even while `.block` files remained on disk.

The fix removes the duplicate decrement in `ReadTemporaryBuffer` so `DeleteTemporaryFile` (called on the line above) is the single source of truth for the per-tag bookkeeping, matching how it works for the destructor path (`~BlockMemory`).

## Why this matters

- `duckdb_memory().temporary_storage_bytes` for `OVERFLOW_STRINGS` (and any other tag whose buffers go through the `.block` path) misreports `0` once the bug fires — making the view useless for capacity tracking and potentially misleading any logic that consumes it.
- The corrupted counter does not cause data loss on its own (file deletion happens correctly via `DeleteTemporaryFile`), but it breaks any feedback loop that relies on per-tag temporary-storage accounting.

## Tests

Added two slow regression tests under `test/sql/outofcore/`:

- **`block_file_evicted_bytes_accounting.test_slow`** — minimal invariant: with a 50 MB budget and ~57 MB of incompressible OVERFLOW_STRINGS data, asserts that whenever `.block` files exist on disk, `OVERFLOW_STRINGS.temporary_storage_bytes > 0`.
- **`block_file_double_decrement.test_slow`** — explicit write → full-scan → write cycle, asserts the per-tag counter recovers after a fresh wave of evictions following a full read-back scan.

Both tests **fail before the fix** (counter clamped to 0 while files exist) and **pass after the fix** (13/13 and 20/20 assertions).

## Test plan
- [x] `build/release/test/unittest test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow` — passes
- [x] `build/release/test/unittest test/sql/outofcore/block_file_double_decrement.test_slow` — passes
- [x] `build/release/test/unittest test/sql/outofcore/evicted_memory_bytes_updates.test_slow` — passes (existing HASH_TABLE / `.tmp` path test, unaffected by the change)
- [x] Verified the new tests deterministically fail without the fix (10/11 and 11/12 assertions before the regression assertion fires)