### PR TITLE
Do not perform more operations than copying for r2 buckets

### DIFF
--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -69,13 +69,6 @@ rm $ext.append
 
 set -e
 
-# Abort if AWS key is not set
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-    echo "No AWS key found, skipping.."
-    rm "$ext.compressed"
-    exit 0
-fi
-
 if ! command -v rclone >/dev/null 2>&1; then
     case "$(uname -s)" in
       MINGW*|MSYS*|CYGWIN*)
@@ -97,6 +90,17 @@ if [ "$DUCKDB_DEPLOY_SCRIPT_MODE" == "for_real" ]; then
   DRY_RUN_PARAM=""
 fi
 
+# Abort if credentials are not set
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    echo "Missing AWS credentials: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required"
+    rm "$ext.compressed"
+    if [ "$DRY_RUN_PARAM" == "" ]; then
+      exit 1
+    else
+      exit 0
+    fi
+fi
+
 dest_extension="gz"
 extra_upload_args=()
 if [[ $4 == wasm* ]]; then
@@ -109,21 +113,26 @@ fi
 
 upload_extension() {
   local destination="$1"
+  local s3_provider="${S3_PROVIDER:-AWS}"
+  if [[ "${AWS_ENDPOINT_URL}" == *"r2.cloudflarestorage.com"* ]]; then
+    s3_provider="Cloudflare"
+  fi
   local rclone_s3_args=(
-    --s3-provider "${S3_PROVIDER:-AWS}"
+    --s3-provider "${s3_provider}"
     --s3-endpoint "${AWS_ENDPOINT_URL}"
-    --s3-access-key-id "${AWS_ACCESS_KEY_ID}"
-    --s3-secret-access-key "${AWS_SECRET_ACCESS_KEY}"
   )
 
   set -x
   rclone $DRY_RUN_PARAM copyto \
     --no-traverse \
-    --s3-acl public-read \
+    --ignore-times \
+    --ignore-checksum \
+    --s3-no-check-bucket \
+    --s3-no-head \
     "${rclone_s3_args[@]}" \
     "${extra_upload_args[@]}" \
     "$ext.compressed" \
-    ":s3:${destination}"
+    ":s3,env_auth=true:${destination}"
 }
 
 # upload versioned version

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -38,10 +38,15 @@ if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
   DRY_RUN_PARAM=""
 fi
 
-# dryrun if AWS key is not set
+# Early exit if credentials are missing
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-  echo "No access key available"
-  DRY_RUN_PARAM="--dry-run"
+  echo "No access or secret key available"
+
+  if [ "$DRY_RUN_PARAM" == "" ]; then
+    exit 1
+  else
+    exit 0
+  fi
 fi
 
 TARGET=$(git log -1 --format=%h)
@@ -77,8 +82,13 @@ cleanup() {
 trap cleanup EXIT
 printf '%s\n' "${@:2}" > "$files_from"
 
+s3_provider="${S3_PROVIDER:-AWS}"
+if [[ "${AWS_ENDPOINT_URL:-}" == *"r2.cloudflarestorage.com"* ]]; then
+  s3_provider="Cloudflare"
+fi
+
 rclone_s3_args=(
-  --s3-provider "${S3_PROVIDER:-AWS}"
+  --s3-provider "${s3_provider}"
   --s3-endpoint "${AWS_ENDPOINT_URL:-}"
   --s3-access-key-id "${AWS_ACCESS_KEY_ID:-}"
   --s3-secret-access-key "${AWS_SECRET_ACCESS_KEY:-}"
@@ -88,6 +98,10 @@ set -x
 
 rclone $DRY_RUN_PARAM copy \
   --no-traverse \
+  --ignore-times \
+  --ignore-checksum \
+  --s3-no-check-bucket \
+  --s3-no-head \
   "${rclone_s3_args[@]}" \
   --files-from "$files_from" \
   . \


### PR DESCRIPTION
### Context: extension upload failed
The CI job `Deploy extension binaries / Deploy to nightly (windows_amd64)` [failed](https://github.com/duckdb/duckdb-azure/actions/runs/25155257673/job/73743918274) to upload an extension file to an r2 bucket:
```
+ rclone copyto --no-traverse --s3-acl public-read --s3-provider AWS --s3-endpoint *** --s3-access-key-id *** --s3-secret-access-key *** /tmp/extension/azure.duckdb_extension.compressed :s3:duckdb-extensions-nightly/ca97226bd8/windows_amd64/azure.duckdb_extension.gz
2026/04/30 09:24:10 NOTICE: Config file "/home/runner/.config/rclone/rclone.conf" not found - using defaults
2026/04/30 09:24:11 ERROR : azure.duckdb_extension.compressed: Failed to copy: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:11 ERROR : Attempt 1/3 failed with 1 errors and: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:12 ERROR : azure.duckdb_extension.compressed: Failed to copy: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:12 ERROR : Attempt 2/3 failed with 1 errors and: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:12 ERROR : azure.duckdb_extension.compressed: Failed to copy: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:12 ERROR : Attempt 3/3 failed with 1 errors and: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
2026/04/30 09:24:12 NOTICE: Failed to copyto: failed to prepare upload: operation error S3: CreateBucket, https response error StatusCode: 403, RequestID: , HostID: , api error AccessDenied: Access Denied
```

CI also [failed](https://github.com/duckdb/duckdb/actions/runs/25159994061/job/73751683635#step:11:34) to deploy on duckdb's main branch.


### Changes

- Limit rclone's internal requests to only `PutObject` operations.
- Use `Cloudflare` as S3 provider, if endpoint URL matches.
- Use `env_auth=true` to read credentials from environment variables.

### Verified: download existing extension with rclone

I've downloaded an [existing](https://github.com/duckdb/duckdb-azure/actions/runs/24818784119/job/72652243201#step:5:60) extension locally using:
```
$ rclone copyto --no-traverse --ignore-times --ignore-checksum --s3-no-check-bucket \ 
--s3-no-head --s3-provider Cloudflare \
--s3-endpoint https://bf2xxxxxxx.r2.cloudflarestorage.com \
:s3,env_auth=true:duckdb-extensions-nightly/c5a6bd6a95/osx_arm64/azure.duckdb_extension.gz \
extension.compressed
$ ls -lh extension.compressed 
-rw-r--r--@ 1 sander  staff   5.1M Apr 23 09:39 extension.compressed
```
(I used R2 credentials that could read from that bucket, but I did not have credentials with write access, so testing is limited.)