### PR TITLE
Fix QUALIFY alias priority when name collides with a column

### DIFF
--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -21,6 +21,8 @@ public:
 
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
+	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &colref, ErrorData &error) override;
+
 protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -551,7 +551,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			throw BinderException("Combining QUALIFY with GROUP BY ALL is not supported yet");
 		}
 		QualifyBinder qualify_binder(*this, context, result, info);
-		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
+		ExpressionBinder::QualifyColumnNames(qualify_binder, statement.qualify);
 		result.qualify = qualify_binder.Bind(statement.qualify);
 		if (qualify_binder.HasBoundColumns()) {
 			if (qualify_binder.BoundAggregates()) {

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -18,6 +18,11 @@ bool QualifyBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
 	return column_alias_binder.DoesColumnAliasExist(colref);
 }
 
+static bool IsExplicitAliasPrefix(const ColumnRefExpression &colref) {
+	return colref.IsQualified() && colref.column_names.size() == 2 &&
+	       StringUtil::CIEquals(colref.GetTableName(), "alias");
+}
+
 unique_ptr<ParsedExpression> QualifyBinder::QualifyColumnName(ColumnRefExpression &colref, ErrorData &error) {
 	auto qualified_colref = ExpressionBinder::QualifyColumnName(colref, error);
 	if (!qualified_colref) {
@@ -28,18 +33,27 @@ unique_ptr<ParsedExpression> QualifyBinder::QualifyColumnName(ColumnRefExpressio
 	if (group_index.IsValid()) {
 		return qualified_colref;
 	}
-	if (column_alias_binder.DoesColumnAliasExist(colref)) {
+	// Inside a window's children a bare reference must bind to the FROM column: alias bodies
+	// for window aliases cannot legally be expanded into another OVER clause. The explicit
+	// `alias.X` form is exempt — the user has named the alias scope intentionally.
+	bool allow_alias = !inside_window || IsExplicitAliasPrefix(colref);
+	if (allow_alias && column_alias_binder.DoesColumnAliasExist(colref)) {
 		return nullptr;
 	}
 	return qualified_colref;
 }
 
 BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-	// First try alias resolution if the colref is a potential alias and the alias exists.
-	// The alias binder's visited-set guards against self-referential expansion (e.g. `lead(n) OVER() AS n`),
-	// in which case the inner `n` falls through to a regular column lookup.
+	// At top-level QUALIFY scope, aliases take priority over base columns when the names
+	// collide. The alias binder's visited-set guards against self-referential expansion
+	// (e.g. `lead(n) OVER() AS n`), so the inner `n` falls through to a column lookup.
+	// Inside a window's children we keep the original "column first, alias fallback" order
+	// to avoid expanding an alias whose body is itself a window into another OVER clause.
+	// The explicit `alias.X` form is exempt — the user has named the alias scope.
 	auto &colref = expr_ptr->Cast<ColumnRefExpression>();
-	if (column_alias_binder.DoesColumnAliasExist(colref)) {
+	bool prefer_alias_first = !inside_window || IsExplicitAliasPrefix(colref);
+
+	if (prefer_alias_first && column_alias_binder.DoesColumnAliasExist(colref)) {
 		BindResult alias_result;
 		auto found_alias = column_alias_binder.BindAlias(*this, expr_ptr, depth, root_expression, alias_result);
 		if (found_alias) {
@@ -50,6 +64,14 @@ BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, 
 	auto result = duckdb::BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
 	if (!result.HasError()) {
 		return result;
+	}
+
+	if (!prefer_alias_first && column_alias_binder.DoesColumnAliasExist(colref)) {
+		BindResult alias_result;
+		auto found_alias = column_alias_binder.BindAlias(*this, expr_ptr, depth, root_expression, alias_result);
+		if (found_alias) {
+			return alias_result;
+		}
 	}
 
 	auto expr_string = expr_ptr->Cast<ColumnRefExpression>().ToString();

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -18,22 +18,41 @@ bool QualifyBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
 	return column_alias_binder.DoesColumnAliasExist(colref);
 }
 
+unique_ptr<ParsedExpression> QualifyBinder::QualifyColumnName(ColumnRefExpression &colref, ErrorData &error) {
+	auto qualified_colref = ExpressionBinder::QualifyColumnName(colref, error);
+	if (!qualified_colref) {
+		return nullptr;
+	}
+
+	auto group_index = TryBindGroup(*qualified_colref);
+	if (group_index.IsValid()) {
+		return qualified_colref;
+	}
+	if (column_alias_binder.DoesColumnAliasExist(colref)) {
+		return nullptr;
+	}
+	return qualified_colref;
+}
+
 BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
+	// First try alias resolution if the colref is a potential alias and the alias exists.
+	// The alias binder's visited-set guards against self-referential expansion (e.g. `lead(n) OVER() AS n`),
+	// in which case the inner `n` falls through to a regular column lookup.
+	auto &colref = expr_ptr->Cast<ColumnRefExpression>();
+	if (column_alias_binder.DoesColumnAliasExist(colref)) {
+		BindResult alias_result;
+		auto found_alias = column_alias_binder.BindAlias(*this, expr_ptr, depth, root_expression, alias_result);
+		if (found_alias) {
+			return alias_result;
+		}
+	}
+
 	auto result = duckdb::BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
 	if (!result.HasError()) {
 		return result;
 	}
 
-	// Keep the original column reference's string to return a meaningful error message.
 	auto expr_string = expr_ptr->Cast<ColumnRefExpression>().ToString();
-
-	// Try to bind as an alias.
-	BindResult alias_result;
-	auto found_alias = column_alias_binder.BindAlias(*this, expr_ptr, depth, root_expression, alias_result);
-	if (found_alias) {
-		return alias_result;
-	}
-
 	return BindResult(BinderException(
 	    *expr_ptr, "Referenced column %s not found in FROM clause and can't find in alias map.", expr_string));
 }

--- a/test/sql/binder/alias_qualification_qualify.test
+++ b/test/sql/binder/alias_qualification_qualify.test
@@ -59,3 +59,46 @@ SELECT list(c2) over(partition BY c1) AS "c3"
 QUALIFY "c3".len() = 1;
 ----
 [Masters]
+
+# Issue #20305: alias should take priority over column when names match in QUALIFY.
+# lead(n)=[2, NULL]; alias `n` should resolve to lead, so QUALIFY n IS NOT NULL keeps only the first row.
+query I
+FROM VALUES (1), (2) AS t(n)
+SELECT lead(n) OVER() AS n
+QUALIFY n IS NOT NULL;
+----
+2
+
+# Same as above with the prefix-alias syntax.
+query I
+FROM VALUES (1), (2) AS t(n)
+SELECT n: lead(n) OVER()
+QUALIFY n IS NOT NULL;
+----
+2
+
+# Explicit table prefix bypasses alias and references the FROM column.
+query I
+FROM VALUES (1), (2) AS t(n)
+SELECT lead(n) OVER() AS n
+QUALIFY t.n IS NOT NULL
+ORDER BY t.n;
+----
+2
+NULL
+
+# Explicit alias prefix continues to resolve to the SELECT alias.
+query I
+FROM VALUES (1), (2) AS t(n)
+SELECT lead(n) OVER() AS n
+QUALIFY alias.n IS NOT NULL;
+----
+2
+
+# Comparison: when alias name does not collide, behavior is unchanged.
+query I
+FROM VALUES (1), (2) AS t(n)
+SELECT lead(n) OVER() AS m
+QUALIFY m IS NOT NULL;
+----
+2


### PR DESCRIPTION
## Summary

Fixes #20305. When a SELECT alias collides with a FROM column,
QUALIFY currently resolves the bare reference to the column instead
of the alias.

```sql
FROM VALUES (1), (2) AS t(n)
SELECT lead(n) OVER() AS n
QUALIFY n IS NOT NULL;
```

Before: returns `2, NULL` — filters on the FROM column `n`, so both
rows pass and the projection emits the lead values.
After: returns `2` — the alias points at the lead result, and the
NULL row is filtered out.

This matches ORDER BY's behavior in the same shape of query, and the
existing `QUALIFY alias.n IS NOT NULL` form was already aligned with
this expectation.

## Approach

Mirror the pattern HavingBinder uses:

- `QualifyBinder::QualifyColumnName` (new override) returns `nullptr`
  when the qualified column is not in GROUP BY but an alias of the
  same name exists, leaving the parsed expression unqualified through
  the pre-bind pass.
- `bind_select_node.cpp` now calls `QualifyColumnNames(qualify_binder, ...)`
  so the override participates in pre-binding (HAVING already does this).
- `QualifyBinder::BindColumnRef` attempts alias resolution before the
  column path. The alias binder's visited-set guards self-referential
  expansion: when the alias body is `lead(n) OVER()`, the inner `n`
  falls back to the FROM column.

Explicit \`t.column\` (table-qualified) and \`alias.column\` (explicit
alias prefix) keep their existing semantics.

## Test plan

- [ ] \`build/reldebug/test/unittest "test/sql/binder/alias_qualification_qualify.test"\` (5 new cases covering the bug and edge cases)
- [ ] Existing QUALIFY suites: \`test_qualify\`, \`test_qualify_view\`,
  \`test_qualify_macro\`, \`test_qualify_view_no_view_dependencies\`,
  \`unnest_having_qualify\`, \`lateral_qualify\`
- [ ] HAVING / alias / window / optimizer suites: \`alias_qualification_*\`,
  \`test_alias\`, \`test/sql/window/*\`, \`test_window_self_join\`,
  \`topn_window_set_elimination\`