### PR TITLE
Expose RETURNING-referenced columns to catalog extensions for write-side projection pushdown

### DIFF
--- a/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -26,6 +26,12 @@ public:
 	bool return_chunk;
 	vector<idx_t> return_columns;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
+	//! The set of target-table column indices referenced by the RETURNING list.
+	//! Populated by the binder when RETURNING is present so catalog extensions can
+	//! perform write-side projection pushdown for affected-row payloads.
+	//! An empty vector means no projection information is available; treat as a request
+	//! for all columns. Built-in DELETE ignores this field.
+	vector<column_t> returning_referenced_columns;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -67,6 +67,12 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	//! The constraints used by the table
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
+	//! The set of target-table column indices referenced by the RETURNING list.
+	//! Populated by the binder when RETURNING is present so catalog extensions can
+	//! perform write-side projection pushdown for affected-row payloads.
+	//! An empty vector means no projection information is available; treat as a request
+	//! for all columns. Built-in INSERT ignores this field.
+	vector<column_t> returning_referenced_columns;
 
 	BoundOnConflictInfo on_conflict_info;
 

--- a/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -58,6 +58,12 @@ public:
 	//! For DELETE with RETURNING: maps storage_idx -> input chunk position
 	//! Used to pass columns through instead of fetching by row ID
 	vector<idx_t> delete_return_columns;
+	//! The set of target-table column indices referenced by the RETURNING list.
+	//! Populated by the binder when RETURNING is present so catalog extensions can
+	//! perform write-side projection pushdown for affected-row payloads.
+	//! An empty vector means no projection information is available; treat as a request
+	//! for all columns. Built-in MERGE INTO ignores this field.
+	vector<column_t> returning_referenced_columns;
 
 	map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>> actions;
 

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -34,6 +34,12 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;
+	//! The set of target-table column indices referenced by the RETURNING list.
+	//! Populated by the binder when RETURNING is present so catalog extensions can
+	//! perform write-side projection pushdown for affected-row payloads.
+	//! An empty vector means no projection information is available; treat as a request
+	//! for all columns. Built-in UPDATE ignores this field.
+	vector<column_t> returning_referenced_columns;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -758,6 +758,12 @@
         "type": "bool",
         "default": "false",
         "property": "on_conflict_info.update_is_del_and_insert"
+      },
+      {
+        "id": 219,
+        "name": "returning_referenced_columns",
+        "type": "vector<column_t>",
+        "default": "vector<column_t>()"
       }
     ],
     "constructor": [
@@ -795,6 +801,12 @@
         "id": 204,
         "name": "return_columns",
         "type": "vector<idx_t>"
+      },
+      {
+        "id": 205,
+        "name": "returning_referenced_columns",
+        "type": "vector<column_t>",
+        "default": "vector<column_t>()"
       }
     ],
     "constructor": [
@@ -842,6 +854,12 @@
         "id": 206,
         "name": "update_is_del_and_insert",
         "type": "bool"
+      },
+      {
+        "id": 207,
+        "name": "returning_referenced_columns",
+        "type": "vector<column_t>",
+        "default": "vector<column_t>()"
       }
     ],
     "constructor": [
@@ -894,6 +912,12 @@
         "id": 207,
         "name": "delete_return_columns",
         "type": "vector<idx_t>"
+      },
+      {
+        "id": 208,
+        "name": "returning_referenced_columns",
+        "type": "vector<column_t>",
+        "default": "vector<column_t>()"
       }
     ],
     "constructor": ["$ClientContext", "table_info&"]

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -26,8 +26,13 @@
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_binder/returning_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/operator/logical_merge_into.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_update.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
 #include "duckdb/planner/query_node/list.hpp"
 #include "duckdb/planner/tableref/list.hpp"
@@ -547,6 +552,41 @@ BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> return
 	}
 	if (new_returning_list.empty()) {
 		throw BinderException("RETURNING list is empty!");
+	}
+	// Surface the set of target-table columns referenced by RETURNING on the write
+	// operator so catalog extensions can do projection pushdown for affected-row
+	// payloads. Filter to the target table's bindings; refs to other tables (e.g.
+	// from a correlated subquery) are not the write operator's columns.
+	{
+		unordered_set<column_t> referenced;
+		vector<column_t> referenced_ordered;
+		for (auto &expr : projection_expressions) {
+			ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+			    *expr, [&](const BoundColumnRefExpression &colref) {
+				    if (colref.binding.table_index != update_table_index) {
+					    return;
+				    }
+				    if (referenced.insert(colref.binding.column_index).second) {
+					    referenced_ordered.push_back(colref.binding.column_index);
+				    }
+			    });
+		}
+		switch (child_operator->type) {
+		case LogicalOperatorType::LOGICAL_INSERT:
+			child_operator->Cast<LogicalInsert>().returning_referenced_columns = std::move(referenced_ordered);
+			break;
+		case LogicalOperatorType::LOGICAL_UPDATE:
+			child_operator->Cast<LogicalUpdate>().returning_referenced_columns = std::move(referenced_ordered);
+			break;
+		case LogicalOperatorType::LOGICAL_DELETE:
+			child_operator->Cast<LogicalDelete>().returning_referenced_columns = std::move(referenced_ordered);
+			break;
+		case LogicalOperatorType::LOGICAL_MERGE_INTO:
+			child_operator->Cast<LogicalMergeInto>().returning_referenced_columns = std::move(referenced_ordered);
+			break;
+		default:
+			break;
+		}
 	}
 	auto projection = make_uniq<LogicalProjection>(GenerateTableIndex(), std::move(projection_expressions));
 	projection->AddChild(std::move(child_operator));

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -417,6 +417,7 @@ void LogicalDelete::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(202, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(204, "return_columns", return_columns);
+	serializer.WritePropertyWithDefault<vector<column_t>>(205, "returning_referenced_columns", returning_referenced_columns, vector<column_t>());
 }
 
 unique_ptr<LogicalOperator> LogicalDelete::Deserialize(Deserializer &deserializer) {
@@ -426,6 +427,7 @@ unique_ptr<LogicalOperator> LogicalDelete::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<bool>(202, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(204, "return_columns", result->return_columns);
+	deserializer.ReadPropertyWithExplicitDefault<vector<column_t>>(205, "returning_referenced_columns", result->returning_referenced_columns, vector<column_t>());
 	return std::move(result);
 }
 
@@ -560,6 +562,7 @@ void LogicalInsert::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<column_t>>(216, "source_columns", on_conflict_info.source_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(217, "expressions", expressions);
 	serializer.WritePropertyWithDefault<bool>(218, "update_is_del_and_insert", on_conflict_info.update_is_del_and_insert, false);
+	serializer.WritePropertyWithDefault<vector<column_t>>(219, "returning_referenced_columns", returning_referenced_columns, vector<column_t>());
 }
 
 unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserializer) {
@@ -583,6 +586,7 @@ unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<vector<column_t>>(216, "source_columns", result->on_conflict_info.source_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(217, "expressions", result->expressions);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(218, "update_is_del_and_insert", result->on_conflict_info.update_is_del_and_insert, false);
+	deserializer.ReadPropertyWithExplicitDefault<vector<column_t>>(219, "returning_referenced_columns", result->returning_referenced_columns, vector<column_t>());
 	return std::move(result);
 }
 
@@ -626,6 +630,7 @@ void LogicalMergeInto::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", actions);
 	serializer.WritePropertyWithDefault<bool>(206, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", delete_return_columns);
+	serializer.WritePropertyWithDefault<vector<column_t>>(208, "returning_referenced_columns", returning_referenced_columns, vector<column_t>());
 }
 
 unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserializer) {
@@ -638,6 +643,7 @@ unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserial
 	deserializer.ReadPropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", result->actions);
 	deserializer.ReadPropertyWithDefault<bool>(206, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", result->delete_return_columns);
+	deserializer.ReadPropertyWithExplicitDefault<vector<column_t>>(208, "returning_referenced_columns", result->returning_referenced_columns, vector<column_t>());
 	return std::move(result);
 }
 
@@ -818,6 +824,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "columns", columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", bound_defaults);
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
+	serializer.WritePropertyWithDefault<vector<column_t>>(207, "returning_referenced_columns", returning_referenced_columns, vector<column_t>());
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -829,6 +836,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
+	deserializer.ReadPropertyWithExplicitDefault<vector<column_t>>(207, "returning_referenced_columns", result->returning_referenced_columns, vector<column_t>());
 	return std::move(result);
 }
 

--- a/test/sql/returning/returning_referenced_columns.test
+++ b/test/sql/returning/returning_referenced_columns.test
@@ -1,0 +1,78 @@
+# name: test/sql/returning/returning_referenced_columns.test
+# description: Verify that returning_referenced_columns is populated on the write operator
+# group: [returning]
+
+require json
+
+statement ok
+CREATE TABLE t(a INT, b INT, c INT);
+
+# INSERT RETURNING single column -> [0]
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3) RETURNING a'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0]
+
+# INSERT RETURNING multiple columns -> [0, 2]
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3) RETURNING a, c'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0,2]
+
+# INSERT RETURNING * -> all columns
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3) RETURNING *'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0,1,2]
+
+# INSERT RETURNING expression involving multiple columns
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3) RETURNING a + b AS sum'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0,1]
+
+# INSERT RETURNING with a constant -> empty (no target columns referenced)
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3) RETURNING 42'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[]
+
+# UPDATE RETURNING single column
+query I
+SELECT json_extract(json_serialize_plan('UPDATE t SET a = 10 RETURNING b'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[1]
+
+# UPDATE RETURNING multiple columns
+query I
+SELECT json_extract(json_serialize_plan('UPDATE t SET a = 10 RETURNING a, c'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0,2]
+
+# DELETE RETURNING single column
+query I
+SELECT json_extract(json_serialize_plan('DELETE FROM t WHERE a = 1 RETURNING c'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[2]
+
+# DELETE RETURNING *
+query I
+SELECT json_extract(json_serialize_plan('DELETE FROM t RETURNING *'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0,1,2]
+
+# MERGE INTO RETURNING - target column reference only
+statement ok
+CREATE TABLE src(a INT, b INT, c INT);
+
+query I
+SELECT json_extract(json_serialize_plan('MERGE INTO t USING src ON t.a = src.a WHEN MATCHED THEN UPDATE SET b = src.b WHEN NOT MATCHED THEN INSERT VALUES (src.a, src.b, src.c) RETURNING t.a'), '$.plans[0].children[0].returning_referenced_columns');
+----
+[0]
+
+# Sanity: when there is no RETURNING clause the field is absent (or empty);
+# the plan has no projection wrapping the write op.
+query I
+SELECT json_extract(json_serialize_plan('INSERT INTO t VALUES (1, 2, 3)'), '$.plans[0].returning_referenced_columns');
+----
+[]


### PR DESCRIPTION
## Summary

Adds a `vector<column_t> returning_referenced_columns` field to `LogicalInsert`, `LogicalUpdate`, `LogicalDelete`, and `LogicalMergeInto`, populated in `Binder::BindReturning` from the bound RETURNING projection.

This lets catalog extensions (Iceberg connectors, remote table formats, etc.) implementing `Catalog::PlanInsert` / `PlanUpdate` / `PlanDelete` / `PlanMergeInto` see which target-table columns the user's RETURNING list references, so they can ship only those columns over the wire instead of the full row.

Discussion: #22406

## Implementation

- **Field**: added on the four logical write ops with a doc comment that calls out empty-vector semantics ("no projection info available; treat as a request for all columns") to avoid the foot-gun of an extension treating empty as "send nothing."
- **Binder**: `BindReturning` walks the bound `projection_expressions` for `BoundColumnRefExpression` nodes, filters to the target table's `update_table_index` (so refs from correlated subqueries don't leak in), and stores deduplicated logical column indices on the child write operator. Insertion-ordered.
- **Serialization**: new field in `logical_operator.json` with `default: vector<column_t>()` so older serialized plans deserialize cleanly. `serialize_logical_operator.cpp` regenerated via `make generate-files`.

## Backwards compatibility

The change is purely additive metadata.

- Built-in INSERT/UPDATE/DELETE/MERGE physical operators don't read the new field. Existing dataflow (write op emits full rows; the projection above computes RETURNING) is unchanged.
- Existing catalog extensions that ignore the field continue to receive full rows. They recompile cleanly.
- Extensions that opt in are responsible for coordinating with their backend.

## Test plan

- [x] New sqllogictest `test/sql/returning/returning_referenced_columns.test` (13 assertions) covering INSERT/UPDATE/DELETE/MERGE INTO with single-column, multi-column, `*`, expression, constant-only, and no-RETURNING cases — verified via `json_serialize_plan`.
- [x] Existing `[returning]` suite passes (567 assertions across 8 test cases).
- [x] `make format-fix` clean.