### PR TITLE
Pin parquet dictionary page buffers

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -431,9 +431,13 @@ void ColumnReader::PreparePageV2(PageHeader &page_hdr) {
 void ColumnReader::AllocateBlock(idx_t size) {
 	if (!block) {
 		block = make_shared_ptr<ResizeableBuffer>(GetAllocator(), size);
-	} else {
-		block->resize(GetAllocator(), size);
+		return;
 	}
+	if (Type().InternalType() == PhysicalType::VARCHAR && block.use_count() > 1) {
+		block = make_shared_ptr<ResizeableBuffer>(GetAllocator(), size);
+		return;
+	}
+	block->resize(GetAllocator(), size);
 }
 
 void ColumnReader::PreparePage(PageHeader &page_hdr) {

--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -27,6 +27,13 @@
 
 namespace duckdb {
 
+struct DictionaryPageBufferHolder : public AuxiliaryDataHolder {
+	explicit DictionaryPageBufferHolder(shared_ptr<ResizeableBuffer> buffer_p) : buffer(std::move(buffer_p)) {
+	}
+
+	shared_ptr<ResizeableBuffer> buffer;
+};
+
 DictionaryDecoder::DictionaryDecoder(ColumnReader &reader)
     : reader(reader), offset_buffer(reader.encoding_buffers[0]), valid_sel(STANDARD_VECTOR_SIZE),
       dictionary_selection_vector(STANDARD_VECTOR_SIZE), dictionary_size(0) {
@@ -51,6 +58,9 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 
 	// now read the non-NULL values from Parquet
 	reader.Plain(reader.block, nullptr, dictionary_size, 0, dictionary_data);
+	if (dictionary_data.GetType().InternalType() == PhysicalType::VARCHAR) {
+		dictionary_data.AddAuxiliaryData(make_uniq<DictionaryPageBufferHolder>(reader.block));
+	}
 
 	// immediately filter the dictionary, if applicable
 	if (filter && CanFilter(*filter, *filter_state)) {

--- a/test/parquet/dictionary_buffer_pin.test
+++ b/test/parquet/dictionary_buffer_pin.test
@@ -1,0 +1,35 @@
+# name: test/parquet/dictionary_buffer_pin.test
+# description: Ensure dictionary-encoded string values survive page buffer reuse
+# group: [parquet]
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/extension/parquet/parquet.duckdb_extension';
+
+statement ok
+CREATE TABLE dict_buffer_ref AS
+SELECT CASE WHEN i % 2 = 0 THEN repeat('a', 512) ELSE repeat('b', 512) END AS s
+FROM range(20000) t(i);
+
+statement ok
+COPY dict_buffer_ref TO '{TEST_DIR}/dictionary_buffer_pin.parquet'
+  (FORMAT PARQUET, ROW_GROUP_SIZE 20000, PARQUET_VERSION v1);
+
+query I
+SELECT first(encodings) FROM parquet_metadata('{TEST_DIR}/dictionary_buffer_pin.parquet') GROUP BY encodings;
+----
+PLAIN_DICTIONARY
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/dictionary_buffer_pin.parquet') WHERE s = repeat('a', 512);
+----
+10000
+
+query I
+SELECT COUNT(*) FROM parquet_scan('{TEST_DIR}/dictionary_buffer_pin.parquet') WHERE s = repeat('b', 512);
+----
+10000
+
+query I
+SELECT COUNT(*) FROM (SELECT DISTINCT s FROM parquet_scan('{TEST_DIR}/dictionary_buffer_pin.parquet')) t;
+----
+2


### PR DESCRIPTION
These commits [switched dictionary decoding](https://github.com/duckdb/duckdb/commit/4a51aef5d12) to reuse the shared block buffer and [read dictionary pages](https://github.com/duckdb/duckdb/commit/3a4ee379e1d) directly into `reader.block`, shortening the lifetime of string data.

This fix pins the dictionary page buffer via auxiliary data so `string_t` values remain valid after buffer reuse, preventing the UAF crash.