### PR TITLE
Add support for `Vector::Values<VectorStructType<...>>` allowing iteration over structs with a fixed (known) schema

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/vector/map_vector.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/vector/vector_iterator.hpp"
 #include "duckdb/common/types/geometry.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -1313,18 +1314,14 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
 
-	auto &vert_parts = StructVector::GetEntries(source_vec);
+	auto vert_iter = source_vec.Values<typename V::FlatStructType>(row_count);
 	auto geom_data = FlatVector::GetDataMutable<string_t>(target_vec);
-	double *vert_data[V::WIDTH];
-
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
 
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto vert_entry = vert_iter[row_idx];
+		if (!vert_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
@@ -1342,9 +1339,7 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 		writer.Write<uint32_t>(meta); // Type/meta
 
 		// Write vertex data
-		for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-			writer.Write<double>(vert_data[dim_idx][row_idx]);
-		}
+		vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 
 		blob.Finalize();
 		geom_data[out_idx] = blob;
@@ -1428,12 +1423,9 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 	source_vec.Flatten(row_count);
 
 	const auto line_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(source_vec));
-
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
+	const auto vert_total = ListVector::GetListSize(source_vec);
+	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1461,9 +1453,8 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 		// Write vertex data
 		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-			for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-				writer.Write<double>(vert_data[dim_idx][line_entry.offset + vert_idx]);
-			}
+			const auto vert_entry = vert_iter[line_entry.offset + vert_idx];
+			vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 		}
 
 		blob.Finalize();
@@ -1577,12 +1568,9 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 	const auto poly_data = FlatVector::GetData<list_entry_t>(source_vec);
 	auto &ring_vec = ListVector::GetChildMutable(source_vec);
 	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(ring_vec));
-
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
+	const auto vert_total = ListVector::GetListSize(ring_vec);
+	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1626,9 +1614,8 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 
 			// Write vertex data
 			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-					writer.Write<double>(vert_data[dim_idx][ring_entry.offset + vert_idx]);
-				}
+				const auto vert_entry = vert_iter[ring_entry.offset + vert_idx];
+				vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 			}
 		}
 
@@ -1717,12 +1704,9 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 	source_vec.Flatten(row_count);
 
 	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(source_vec));
-
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
+	const auto vert_total = ListVector::GetListSize(source_vec);
+	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1763,9 +1747,8 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 			writer.Write<uint32_t>(point_meta); // Type/meta
 
 			// Write vertex data
-			for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-				writer.Write<double>(vert_data[dim_idx][mult_entry.offset + part_idx]);
-			}
+			const auto vert_entry = vert_iter[mult_entry.offset + part_idx];
+			vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 		}
 
 		blob.Finalize();
@@ -1889,11 +1872,9 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
 	auto &line_vec = ListVector::GetChildMutable(source_vec);
 	const auto line_data = FlatVector::GetData<list_entry_t>(line_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(line_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	auto &vert_struct_vec = ListVector::GetChildMutable(line_vec);
+	const auto vert_total = ListVector::GetListSize(line_vec);
+	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1943,9 +1924,8 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 
 			// Write vertex data
 			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-					writer.Write<double>(vert_data[dim_idx][line_entry.offset + vert_idx]);
-				}
+				const auto vert_entry = vert_iter[line_entry.offset + vert_idx];
+				vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 			}
 		}
 		blob.Finalize();
@@ -2085,11 +2065,9 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 	const auto poly_data = FlatVector::GetData<list_entry_t>(poly_vec);
 	auto &ring_vec = ListVector::GetChildMutable(poly_vec);
 	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(ring_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
+	const auto vert_total = ListVector::GetListSize(ring_vec);
+	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -2151,9 +2129,8 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 
 				// Write vertex data
 				for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-					for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-						writer.Write<double>(vert_data[dim_idx][ring_entry.offset + vert_idx]);
-					}
+					const auto vert_entry = vert_iter[ring_entry.offset + vert_idx];
+					vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 				}
 			}
 		}

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1314,7 +1314,7 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
 
-	auto vert_iter = source_vec.Values<typename V::FlatStructType>(row_count);
+	auto vert_iter = source_vec.Values<typename V::STRUCT_TYPE>(row_count);
 	auto geom_data = FlatVector::GetDataMutable<string_t>(target_vec);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
@@ -1425,7 +1425,7 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 	const auto line_data = FlatVector::GetData<list_entry_t>(source_vec);
 	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
 	const auto vert_total = ListVector::GetListSize(source_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
+	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1570,7 +1570,7 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
 	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
 	const auto vert_total = ListVector::GetListSize(ring_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
+	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1706,7 +1706,7 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
 	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
 	const auto vert_total = ListVector::GetListSize(source_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
+	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -1874,7 +1874,7 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 	const auto line_data = FlatVector::GetData<list_entry_t>(line_vec);
 	auto &vert_struct_vec = ListVector::GetChildMutable(line_vec);
 	const auto vert_total = ListVector::GetListSize(line_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
+	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
@@ -2067,7 +2067,7 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
 	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
 	const auto vert_total = ListVector::GetListSize(ring_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::FlatStructType>(vert_total);
+	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/union_vector.hpp"
 #include "duckdb/common/vector/variant_vector.hpp"
+#include "duckdb/common/vector/vector_iterator.hpp"
 
 namespace duckdb {
 
@@ -260,6 +261,10 @@ vector<Vector> &StructVector::GetEntries(Vector &vector) {
 
 const vector<Vector> &StructVector::GetEntries(const Vector &vector) {
 	return GetEntries((Vector &)vector);
+}
+
+const vector<Vector> &VectorIteratorGetStructEntries(const Vector &vector) {
+	return StructVector::GetEntries(vector);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -29,9 +29,11 @@ struct string_t; // NOLINT: mimic std casing
 
 template <class T>
 using child_list_t = vector<std::pair<std::string, T>>;
-//! FIXME: this should be a single_thread_ptr
 template <class T>
 using buffer_ptr = shared_ptr<T>;
+
+template <class... Args>
+struct VectorStructType;
 
 template <class T, typename... ARGS>
 buffer_ptr<T> make_buffer(ARGS &&...args) { // NOLINT: mimic std casing

--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -32,15 +32,12 @@ enum class GeometryType : uint8_t {
 
 enum class VertexType : uint8_t { XY = 0, XYZ = 1, XYM = 2, XYZM = 3 };
 
-template <class... Args>
-struct FlatStruct;
-
 struct VertexXY {
 	static constexpr auto TYPE = VertexType::XY;
 	static constexpr auto HAS_Z = false;
 	static constexpr auto HAS_M = false;
 	static constexpr auto WIDTH = 2;
-	using FlatStructType = FlatStruct<double, double>;
+	using STRUCT_TYPE = VectorStructType<double, double>;
 
 	double x;
 	double y;
@@ -55,7 +52,7 @@ struct VertexXYZ {
 	static constexpr auto HAS_Z = true;
 	static constexpr auto HAS_M = false;
 	static constexpr auto WIDTH = 3;
-	using FlatStructType = FlatStruct<double, double, double>;
+	using STRUCT_TYPE = VectorStructType<double, double, double>;
 
 	double x;
 	double y;
@@ -70,7 +67,7 @@ struct VertexXYM {
 	static constexpr auto HAS_M = true;
 	static constexpr auto HAS_Z = false;
 	static constexpr auto WIDTH = 3;
-	using FlatStructType = FlatStruct<double, double, double>;
+	using STRUCT_TYPE = VectorStructType<double, double, double>;
 
 	double x;
 	double y;
@@ -86,7 +83,7 @@ struct VertexXYZM {
 	static constexpr auto HAS_Z = true;
 	static constexpr auto HAS_M = true;
 	static constexpr auto WIDTH = 4;
-	using FlatStructType = FlatStruct<double, double, double, double>;
+	using STRUCT_TYPE = VectorStructType<double, double, double, double>;
 
 	double x;
 	double y;

--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -32,11 +32,15 @@ enum class GeometryType : uint8_t {
 
 enum class VertexType : uint8_t { XY = 0, XYZ = 1, XYM = 2, XYZM = 3 };
 
+template <class... Args>
+struct FlatStruct;
+
 struct VertexXY {
 	static constexpr auto TYPE = VertexType::XY;
 	static constexpr auto HAS_Z = false;
 	static constexpr auto HAS_M = false;
 	static constexpr auto WIDTH = 2;
+	using FlatStructType = FlatStruct<double, double>;
 
 	double x;
 	double y;
@@ -51,6 +55,7 @@ struct VertexXYZ {
 	static constexpr auto HAS_Z = true;
 	static constexpr auto HAS_M = false;
 	static constexpr auto WIDTH = 3;
+	using FlatStructType = FlatStruct<double, double, double>;
 
 	double x;
 	double y;
@@ -65,6 +70,7 @@ struct VertexXYM {
 	static constexpr auto HAS_M = true;
 	static constexpr auto HAS_Z = false;
 	static constexpr auto WIDTH = 3;
+	using FlatStructType = FlatStruct<double, double, double>;
 
 	double x;
 	double y;
@@ -80,6 +86,7 @@ struct VertexXYZM {
 	static constexpr auto HAS_Z = true;
 	static constexpr auto HAS_M = true;
 	static constexpr auto WIDTH = 4;
+	using FlatStructType = FlatStruct<double, double, double, double>;
 
 	double x;
 	double y;

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -15,10 +15,6 @@
 
 namespace duckdb {
 
-//! Tag type for struct vector writers with a fixed set of child types
-template <class... Args>
-struct FlatStruct {};
-
 //! Returns StructVector::GetEntries(vector) without requiring StructVector to
 //! be complete in this header (avoids a circular include via flat_vector.hpp).
 //! Defined in struct_vector.cpp.
@@ -189,7 +185,7 @@ private:
 //! and per-child VectorIterator<T>::ValueEntry access via the compile-time
 //! GetValue<I>() accessor. Supports heterogeneous child types.
 template <class... Args>
-class VectorIterator<FlatStruct<Args...>> {
+class VectorIterator<VectorStructType<Args...>> {
 private:
 	static_assert(sizeof...(Args) > 0, "FlatStruct must have at least one child type");
 

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -12,6 +12,10 @@
 
 namespace duckdb {
 
+//! Tag type for struct vector writers with a fixed set of child types
+template <class... Args>
+struct FlatStruct {};
+
 class VectorValidityIterator {
 public:
 	VectorValidityIterator(const Vector &vector, idx_t count) : count(count) {

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -222,7 +222,7 @@ public:
 		}
 		//! Returns the ValueEntry for the I-th child at this row
 		template <idx_t I>
-		ChildEntryAt<I> GetValue() const {
+		ChildEntryAt<I> GetChildValue() const {
 			static_assert(I < sizeof...(Args), "FlatStruct child index out of range");
 			return std::get<I>(children)[index];
 		}
@@ -237,7 +237,7 @@ public:
 	private:
 		template <class FUN, std::size_t... Is>
 		void ForEachImpl(FUN &&fun, std::index_sequence<Is...>) const {
-			(fun(GetValue<Is>()), ...);
+			(fun(GetChildValue<Is>()), ...);
 		}
 
 	private:

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -10,11 +10,19 @@
 
 #include "duckdb/common/types/vector.hpp"
 
+#include <tuple>
+#include <utility>
+
 namespace duckdb {
 
 //! Tag type for struct vector writers with a fixed set of child types
 template <class... Args>
 struct FlatStruct {};
+
+//! Returns StructVector::GetEntries(vector) without requiring StructVector to
+//! be complete in this header (avoids a circular include via flat_vector.hpp).
+//! Defined in struct_vector.cpp.
+DUCKDB_API const vector<Vector> &VectorIteratorGetStructEntries(const Vector &vector);
 
 class VectorValidityIterator {
 public:
@@ -173,6 +181,139 @@ public:
 private:
 	UnifiedVectorFormat format;
 	const T *data;
+	idx_t count;
+};
+
+//! Specialization of VectorIterator for FlatStruct<Args...>.
+//! Iterates over a struct vector, exposing per-row top-level NULL information
+//! and per-child VectorIterator<T>::ValueEntry access via the compile-time
+//! GetValue<I>() accessor. Supports heterogeneous child types.
+template <class... Args>
+class VectorIterator<FlatStruct<Args...>> {
+private:
+	static_assert(sizeof...(Args) > 0, "FlatStruct must have at least one child type");
+
+	template <idx_t I>
+	using ChildTypeAt = typename std::tuple_element<I, std::tuple<Args...>>::type;
+	template <idx_t I>
+	using ChildIteratorAt = VectorIterator<ChildTypeAt<I>>;
+	template <idx_t I>
+	using ChildEntryAt = typename ChildIteratorAt<I>::ValueEntry;
+
+	using ChildIterators = std::tuple<VectorIterator<Args>...>;
+
+public:
+	static constexpr idx_t WIDTH = sizeof...(Args);
+
+	VectorIterator(const Vector &vector, idx_t count)
+	    : children(MakeChildren(vector, count, std::index_sequence_for<Args...> {})), count(count) {
+		vector.ToUnifiedFormat(count, format);
+	}
+
+public:
+	struct ValueEntry {
+		ValueEntry(const UnifiedVectorFormat &format, const ChildIterators &children, idx_t index)
+		    : format(format), children(children), index(index) {
+			sel_index = format.sel->get_index(index);
+		}
+
+		//! Returns true if the top-level struct entry is not NULL
+		bool IsValid() const {
+			return format.validity.RowIsValid(sel_index);
+		}
+		idx_t GetIndex() const {
+			return index;
+		}
+		//! Returns the ValueEntry for the I-th child at this row
+		template <idx_t I>
+		ChildEntryAt<I> GetValue() const {
+			static_assert(I < sizeof...(Args), "FlatStruct child index out of range");
+			return std::get<I>(children)[index];
+		}
+		//! Invokes fun(child_entry) for each child in declaration order.
+		//! For homogeneous structs the lambda's argument can be a concrete
+		//! VectorIterator<T>::ValueEntry; for heterogeneous structs use auto.
+		template <class FUN>
+		void ForEach(FUN &&fun) const {
+			ForEachImpl(std::forward<FUN>(fun), std::index_sequence_for<Args...> {});
+		}
+
+	private:
+		template <class FUN, std::size_t... Is>
+		void ForEachImpl(FUN &&fun, std::index_sequence<Is...>) const {
+			(fun(GetValue<Is>()), ...);
+		}
+
+	private:
+		const UnifiedVectorFormat &format;
+		const ChildIterators &children;
+		idx_t sel_index;
+		idx_t index;
+	};
+
+private:
+	template <std::size_t... Is>
+	static ChildIterators MakeChildren(const Vector &vector, idx_t count, std::index_sequence<Is...>) {
+		auto &entries = VectorIteratorGetStructEntries(vector);
+		D_ASSERT(entries.size() >= sizeof...(Is));
+		return ChildIterators(VectorIterator<Args>(entries[Is], count)...);
+	}
+
+	class Iterator {
+	public:
+		Iterator(const UnifiedVectorFormat &format, const ChildIterators &children, idx_t index)
+		    : format(format), children(children), index(index) {
+		}
+
+	public:
+		Iterator &operator++() { // NOLINT: match stl API
+			++index;
+			return *this;
+		}
+		Iterator operator++(int) { // NOLINT: match stl API
+			auto tmp = *this;
+			++index;
+			return tmp;
+		}
+		bool operator==(const Iterator &other) const {
+			return index == other.index;
+		}
+		bool operator!=(const Iterator &other) const {
+			return index != other.index;
+		}
+		ValueEntry operator*() const {
+			return ValueEntry(format, children, index);
+		}
+		ValueEntry operator[](idx_t n) const {
+			return ValueEntry(format, children, index + n);
+		}
+
+	private:
+		const UnifiedVectorFormat &format;
+		const ChildIterators &children;
+		idx_t index;
+	};
+
+public:
+	Iterator begin() { // NOLINT: match stl API
+		return Iterator(format, children, 0);
+	}
+	Iterator end() { // NOLINT: match stl API
+		return Iterator(format, children, count);
+	}
+	idx_t size() const {
+		return count;
+	}
+	ValueEntry operator[](idx_t i) const {
+		return ValueEntry(format, children, i);
+	}
+	bool CanHaveNull() const {
+		return format.validity.CanHaveNull();
+	}
+
+private:
+	UnifiedVectorFormat format;
+	ChildIterators children;
 	idx_t count;
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/21666

That PR allowed us to create iterators over primitive vectors, this PR extends this to allow iteration over structs, and uses this in the `geometry` shredding code.

Example:

```cpp
auto vert_iter = source_vec.Values<VectorStructType<double, double>>(row_count);

for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
    const auto vert_entry = vert_iter[row_idx];
	if (!vert_entry.IsValid()) {
		// entire struct is NULL
		continue;
	}
	auto x = vert_entry.GetChildValue<0>();
	auto y = vert_entry.GetChildValue<1>();
	if (!x.IsValid() || !y.IsValid()) {
		// x or y is NULL
		continue;
	}
	// get x or y value
	x.GetValue();
	y.GetValue();
}
```

This is recursive so it should in theory also allow structs within structs, but I haven't found a place in the code to test that yet.

Follow-up plan is to of course create an iterator over lists :)
