### PR TITLE
Fix typo in env var for linux-relassert CI job

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -287,7 +287,7 @@ jobs:
       FORCE_ASSERT: 1
       EXPORT_DYNAMIC_SYMBOLS: 1
       REDUCE_SYMBOLS: 1
-      EXTENSIONS_STATIC_BUILD: 0
+      EXTENSION_STATIC_BUILD: 0
 
     steps:
     - name: "Checkout"


### PR DESCRIPTION
### Relassert files in artifact

```
relassert artifact includes:
  duckdb
  repository/51c97af758/linux_amd64/core_functions.duckdb_extension
  repository/51c97af758/linux_amd64/parquet.duckdb_extension
  src/libduckdb.so
  test/extension/loadable_extension_demo.duckdb_extension
  test/extension/loadable_extension_optimizer_demo.duckdb_extension
  test/unittest
```

### Before (1.1 GiB, compressed)

```
relassert artifact size:
605M	build/relassert-artifact/relassert/src
895M	build/relassert-artifact/relassert/test/extension
970M	build/relassert-artifact/relassert/test
1.1G	build/relassert-artifact/relassert/repository
1.1G	build/relassert-artifact/relassert/repository/51c97af758
1.1G	build/relassert-artifact/relassert/repository/51c97af758/linux_amd64
3.2G	build/relassert-artifact/relassert
+ tar -C build/relassert-artifact -cf - relassert | pigz -4
+ ls -lh build/relassert-artifact.tar.gz
-rw-r--r-- 1 runner runner 1.1G May  1 08:08 build/relassert-artifact.tar.gz
```

### After (471 MiB, compressed)

```
relassert artifact size:
4.1M	build/relassert-artifact/relassert/test/extension
80M	build/relassert-artifact/relassert/test
148M	build/relassert-artifact/relassert/repository
148M	build/relassert-artifact/relassert/repository/92c40caf5a
148M	build/relassert-artifact/relassert/repository/92c40caf5a/linux_amd64
605M	build/relassert-artifact/relassert/src
1.4G	build/relassert-artifact/relassert
+ tar -C build/relassert-artifact -cf - relassert | pigz -4
+ ls -lh build/relassert-artifact.tar.gz
-rw-r--r-- 1 runner runner 471M May  1 08:32 build/relassert-artifact.tar.gz
```