### PR TITLE
Allow TypeName keywords to be used properly

### DIFF
--- a/scripts/parser/inline_grammar.py
+++ b/scripts/parser/inline_grammar.py
@@ -26,7 +26,9 @@ contents = ""
 
 IMPLICIT_RULES = {'%whitespace'}
 
-# Maps filenames to string categories
+# Maps filenames to string categories.
+# typefunc_keyword_map is the union of type name and func name keywords.
+# type_name_keyword.list also populates typename_keyword_map (TypeName-only subset).
 FILENAME_TO_CATEGORY = {
     "reserved_keyword.list": "RESERVED_KEYWORD",
     "unreserved_keyword.list": "UNRESERVED_KEYWORD",
@@ -41,6 +43,7 @@ CPP_MAP_NAMES = {
     "UNRESERVED_KEYWORD": "unreserved_keyword_map",
     "COL_NAME_KEYWORD": "colname_keyword_map",
     "TYPE_FUNC_NAME_KEYWORD": "typefunc_keyword_map",
+    "TYPE_NAME_KEYWORD": "typename_keyword_map",
 }
 
 # Use a dictionary of sets to collect keywords for each category, preventing duplicates
@@ -77,8 +80,12 @@ for filepath in keywords_dir.iterdir():
                 exit(1)
             unreserved_set.add(kw)
 
-        # Add the keyword to the appropriate set
+        # Add the keyword to the primary set
         keyword_sets[category].add(kw)
+
+        # type_name_keyword.list also populates typename_keyword_map
+        if filepath.name == "type_name_keyword.list":
+            keyword_sets["TYPE_NAME_KEYWORD"].add(kw)
 
 
 def write_keyword_map():

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3805,19 +3805,20 @@ const StringUtil::EnumStringLiteral *GetPEGKeywordCategoryValues() {
 		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_UNRESERVED), "KEYWORD_UNRESERVED" },
 		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_RESERVED), "KEYWORD_RESERVED" },
 		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_TYPE_FUNC), "KEYWORD_TYPE_FUNC" },
-		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_COL_NAME), "KEYWORD_COL_NAME" }
+		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_COL_NAME), "KEYWORD_COL_NAME" },
+		{ static_cast<uint32_t>(PEGKeywordCategory::KEYWORD_TYPE_NAME), "KEYWORD_TYPE_NAME" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<PEGKeywordCategory>(PEGKeywordCategory value) {
-	return StringUtil::EnumToString(GetPEGKeywordCategoryValues(), 5, "PEGKeywordCategory", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetPEGKeywordCategoryValues(), 6, "PEGKeywordCategory", static_cast<uint32_t>(value));
 }
 
 template<>
 PEGKeywordCategory EnumUtil::FromString<PEGKeywordCategory>(const char *value) {
-	return static_cast<PEGKeywordCategory>(StringUtil::StringToEnum(GetPEGKeywordCategoryValues(), 5, "PEGKeywordCategory", value));
+	return static_cast<PEGKeywordCategory>(StringUtil::StringToEnum(GetPEGKeywordCategoryValues(), 6, "PEGKeywordCategory", value));
 }
 
 const StringUtil::EnumStringLiteral *GetParseInfoTypeValues() {

--- a/src/include/duckdb/parser/peg/keyword_helper.hpp
+++ b/src/include/duckdb/parser/peg/keyword_helper.hpp
@@ -9,7 +9,8 @@ enum class PEGKeywordCategory : uint8_t {
 	KEYWORD_UNRESERVED,
 	KEYWORD_RESERVED,
 	KEYWORD_TYPE_FUNC,
-	KEYWORD_COL_NAME
+	KEYWORD_COL_NAME,
+	KEYWORD_TYPE_NAME
 };
 
 class PEGKeywordHelper {
@@ -33,5 +34,6 @@ private:
 	case_insensitive_set_t unreserved_keyword_map;
 	case_insensitive_set_t colname_keyword_map;
 	case_insensitive_set_t typefunc_keyword_map;
+	case_insensitive_set_t typename_keyword_map;
 };
 } // namespace duckdb

--- a/src/parser/peg/keyword_helper.cpp
+++ b/src/parser/peg/keyword_helper.cpp
@@ -29,6 +29,10 @@ bool PEGKeywordHelper::KeywordCategoryType(const std::string &text, const PEGKey
 		auto it = colname_keyword_map.find(text);
 		return it != colname_keyword_map.end();
 	}
+	case PEGKeywordCategory::KEYWORD_TYPE_NAME: {
+		auto it = typename_keyword_map.find(text);
+		return it != typename_keyword_map.end();
+	}
 	default:
 		return false;
 	}

--- a/src/parser/peg/keyword_map.cpp
+++ b/src/parser/peg/keyword_map.cpp
@@ -509,5 +509,39 @@ void PEGKeywordHelper::InitializeKeywordMaps() { // Renamed for clarity
 	typefunc_keyword_map.insert("try_cast");
 	typefunc_keyword_map.insert("unpack");
 	typefunc_keyword_map.insert("verbose");
+
+	// Populating typename_keyword_map
+	typename_keyword_map.insert("anti");
+	typename_keyword_map.insert("asof");
+	typename_keyword_map.insert("at");
+	typename_keyword_map.insert("authorization");
+	typename_keyword_map.insert("binary");
+	typename_keyword_map.insert("by");
+	typename_keyword_map.insert("collation");
+	typename_keyword_map.insert("columns");
+	typename_keyword_map.insert("concurrently");
+	typename_keyword_map.insert("cross");
+	typename_keyword_map.insert("freeze");
+	typename_keyword_map.insert("full");
+	typename_keyword_map.insert("glob");
+	typename_keyword_map.insert("ilike");
+	typename_keyword_map.insert("inner");
+	typename_keyword_map.insert("is");
+	typename_keyword_map.insert("isnull");
+	typename_keyword_map.insert("join");
+	typename_keyword_map.insert("left");
+	typename_keyword_map.insert("like");
+	typename_keyword_map.insert("natural");
+	typename_keyword_map.insert("notnull");
+	typename_keyword_map.insert("outer");
+	typename_keyword_map.insert("overlaps");
+	typename_keyword_map.insert("positional");
+	typename_keyword_map.insert("right");
+	typename_keyword_map.insert("semi");
+	typename_keyword_map.insert("similar");
+	typename_keyword_map.insert("tablesample");
+	typename_keyword_map.insert("try_cast");
+	typename_keyword_map.insert("unpack");
+	typename_keyword_map.insert("verbose");
 }
 } // namespace duckdb

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -580,9 +580,13 @@ private:
 		const auto &keyword_helper = PEGKeywordHelper::Instance();
 		switch (suggestion_type) {
 		case SuggestionState::SUGGEST_TYPE_NAME:
+			if (keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_UNRESERVED) ||
+			    keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_TYPE_NAME)) {
+				break;
+			}
 			if (keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_RESERVED) ||
-			    (keyword_helper.KeywordCategoryType(token_text, GetBannedCategory()) &&
-			     !keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_TYPE_NAME))) {
+			    keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_TYPE_FUNC) ||
+			    keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_COL_NAME)) {
 				return false;
 			}
 			break;

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -581,7 +581,8 @@ private:
 		switch (suggestion_type) {
 		case SuggestionState::SUGGEST_TYPE_NAME:
 			if (keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_RESERVED) ||
-			    keyword_helper.KeywordCategoryType(token_text, GetBannedCategory())) {
+			    (keyword_helper.KeywordCategoryType(token_text, GetBannedCategory()) &&
+			     !keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_TYPE_NAME))) {
 				return false;
 			}
 			break;

--- a/test/sql/peg_parser/binary_type.test
+++ b/test/sql/peg_parser/binary_type.test
@@ -1,0 +1,14 @@
+# name: test/sql/peg_parser/binary_type.test
+# description: Test the binary data type
+# group: [peg_parser]
+
+statement ok
+CREATE TABLE t(b binary, c blob, d varbinary);
+
+statement ok
+INSERT INTO t VALUES (NULL, NULL, NULL);
+
+query III
+SELECT typeof(b), typeof(c), typeof(d) FROM t;
+----
+BLOB	BLOB	BLOB


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9095

Previously we only had the `TypeFuncKeyword` category, which combines the `TypeName` and `FuncName` keywords. However, for types, we should still allow keywords that are in the `TypeName` list. Previously, a keyword such as `BINARY` (a `TypeName` keyword) would be rejected, even though it should've been accepted. 

So, I added the separate `TypeNameKeyword` category back, such that we don't incorrectly reject those keywords. 

`Freeze` is another one of these `TypeNameKeyword`s, and this now gives the proper error again:
```sql
memory D create table foo (i freeze);
Catalog Error:
Type with name freeze does not exist!
Did you mean "real"?

LINE 1: create table foo (i freeze);
                            ^
```
