### PR TITLE
Add support for Vector::Values<VectorListType<...>> allowing iteration over lists with a fixed (known) schema

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1419,41 +1419,32 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 
 template <class V = VertexXY>
 static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
-
-	const auto line_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
-	const auto vert_total = ListVector::GetListSize(source_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
+	auto line_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto line_entry = line_iter[row_idx];
+		if (!line_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
 
-		const auto &line_entry = line_data[row_idx];
-		const auto vert_count = line_entry.length;
+		const auto vert_count = line_entry.GetListLength();
 
-		// byte order + type/meta + vertex data
+		// byte order + type/meta + vertex count + vertex data
 		const auto blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + vert_count * sizeof(V);
 		auto blob = StringVector::EmptyString(target_vec, blob_size);
-		const auto blob_data = blob.GetDataWriteable();
-
-		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
+		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
 		    static_cast<uint32_t>(GeometryType::LINESTRING) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
 
-		writer.Write<uint8_t>(1);                                        // Little-endian
-		writer.Write<uint32_t>(meta);                                    // Type/meta
-		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(vert_count)); // Vertex count
+		writer.Write<uint8_t>(1);
+		writer.Write<uint32_t>(meta);
+		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(vert_count));
 
-		// Write vertex data
-		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-			const auto vert_entry = vert_iter[line_entry.offset + vert_idx];
+		for (const auto vert_entry : line_entry.GetChildValues()) {
 			vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 		}
 
@@ -1564,57 +1555,36 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 template <class V = VertexXY>
 static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	source_vec.Flatten(row_count);
-
-	const auto poly_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &ring_vec = ListVector::GetChildMutable(source_vec);
-	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
-	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
-	const auto vert_total = ListVector::GetListSize(ring_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
+	auto poly_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
-
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto poly_entry = poly_iter[row_idx];
+		if (!poly_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
 
-		const auto &poly_entry = poly_data[row_idx];
-		const auto ring_count = poly_entry.length;
+		const auto ring_count = poly_entry.GetListLength();
 
-		// First, compute total size
-		idx_t blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t); // byte order + type/meta + ring count
-
-		for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-			const auto &ring_entry = ring_data[poly_entry.offset + ring_idx];
-			const auto vert_count = ring_entry.length;
-			// vertex count
-			blob_size += sizeof(uint32_t);
-			// vertex data
-			blob_size += vert_count * sizeof(V);
+		// byte order + type/meta + ring count
+		idx_t blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
+		for (const auto ring_entry : poly_entry.GetChildValues()) {
+			blob_size += sizeof(uint32_t) + ring_entry.GetListLength() * sizeof(V);
 		}
 
 		auto blob = StringVector::EmptyString(target_vec, blob_size);
-		const auto blob_data = blob.GetDataWriteable();
-
-		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
+		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta = static_cast<uint32_t>(GeometryType::POLYGON) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
 
-		writer.Write<uint8_t>(1);                                        // Little-endian
-		writer.Write<uint32_t>(meta);                                    // Type/meta
-		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(ring_count)); // Ring count
+		writer.Write<uint8_t>(1);
+		writer.Write<uint32_t>(meta);
+		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(ring_count));
 
-		for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-			const auto &ring_entry = ring_data[poly_entry.offset + ring_idx];
-			const auto vert_count = ring_entry.length;
-
-			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(vert_count)); // Vertex count
-
-			// Write vertex data
-			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				const auto vert_entry = vert_iter[ring_entry.offset + vert_idx];
+		for (const auto ring_entry : poly_entry.GetChildValues()) {
+			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(ring_entry.GetListLength()));
+			for (const auto vert_entry : ring_entry.GetChildValues()) {
 				vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 			}
 		}
@@ -1700,54 +1670,37 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 
 template <class V = VertexXY>
 static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
-
-	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &vert_struct_vec = ListVector::GetChildMutable(source_vec);
-	const auto vert_total = ListVector::GetListSize(source_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
+	auto mult_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto mult_entry = mult_iter[row_idx];
+		if (!mult_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
 
-		const auto &mult_entry = mult_data[row_idx];
-		const auto part_count = mult_entry.length;
+		const auto part_count = mult_entry.GetListLength();
 
-		// First, compute total size
-		// byte order + type/meta + part count
-		idx_t blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-
-		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
-			// point byte order + type/meta + vertex data
-			blob_size += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(V);
-		}
-
+		// byte order + type/meta + part count + (point header + vertex) per part
+		const auto blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) +
+		                       part_count * (sizeof(uint8_t) + sizeof(uint32_t) + sizeof(V));
 		auto blob = StringVector::EmptyString(target_vec, blob_size);
-		const auto blob_data = blob.GetDataWriteable();
-
-		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
+		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
 		    static_cast<uint32_t>(GeometryType::MULTIPOINT) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
 
-		writer.Write<uint8_t>(1);                                        // Little-endian
-		writer.Write<uint32_t>(meta);                                    // Type/meta
-		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(part_count)); // Part count
+		writer.Write<uint8_t>(1);
+		writer.Write<uint32_t>(meta);
+		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(part_count));
 
-		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
-			// Write point byte order and type/meta
-			const auto point_meta =
-			    static_cast<uint32_t>(GeometryType::POINT) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
-			writer.Write<uint8_t>(1);           // Little-endian
-			writer.Write<uint32_t>(point_meta); // Type/meta
-
-			// Write vertex data
-			const auto vert_entry = vert_iter[mult_entry.offset + part_idx];
+		const auto point_meta =
+		    static_cast<uint32_t>(GeometryType::POINT) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
+		for (const auto vert_entry : mult_entry.GetChildValues()) {
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(point_meta);
 			vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 		}
 
@@ -1865,69 +1818,47 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 
 template <class V = VertexXY>
 static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	// Flatten the source vector to extract all vertices
-
 	source_vec.Flatten(row_count);
-
-	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &line_vec = ListVector::GetChildMutable(source_vec);
-	const auto line_data = FlatVector::GetData<list_entry_t>(line_vec);
-	auto &vert_struct_vec = ListVector::GetChildMutable(line_vec);
-	const auto vert_total = ListVector::GetListSize(line_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
+	auto mult_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto mult_entry = mult_iter[row_idx];
+		if (!mult_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
 
-		const auto &mult_entry = mult_data[row_idx];
-		const auto line_count = mult_entry.length;
+		const auto line_count = mult_entry.GetListLength();
 
-		// First, compute total size
 		// byte order + type/meta + line count
 		idx_t blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-
-		for (uint32_t line_idx = 0; line_idx < line_count; line_idx++) {
-			const auto &line_entry = line_data[mult_entry.offset + line_idx];
-			const auto vert_count = line_entry.length;
-			// line byte order + type/meta + vertex count
-			blob_size += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-			// vertex data
-			blob_size += vert_count * sizeof(V);
+		for (const auto line_entry : mult_entry.GetChildValues()) {
+			// line header (byte order + type/meta + vertex count) + vertex data
+			blob_size += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + line_entry.GetListLength() * sizeof(V);
 		}
 
 		auto blob = StringVector::EmptyString(target_vec, blob_size);
-		const auto blob_data = blob.GetDataWriteable();
-
-		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
+		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
 		    static_cast<uint32_t>(GeometryType::MULTILINESTRING) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
 
-		writer.Write<uint8_t>(1);                                        // Little-endian
-		writer.Write<uint32_t>(meta);                                    // Type/meta
-		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(line_count)); // Line count
+		writer.Write<uint8_t>(1);
+		writer.Write<uint32_t>(meta);
+		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(line_count));
 
-		for (uint32_t line_idx = 0; line_idx < line_count; line_idx++) {
-			const auto &line_entry = line_data[mult_entry.offset + line_idx];
-			const auto vert_count = line_entry.length;
-
-			// Write line byte order and type/meta
-			const auto line_meta =
-			    static_cast<uint32_t>(GeometryType::LINESTRING) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
-			writer.Write<uint8_t>(1);                                        // Little-endian
-			writer.Write<uint32_t>(line_meta);                               // Type/meta
-			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(vert_count)); // Vertex count
-
-			// Write vertex data
-			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				const auto vert_entry = vert_iter[line_entry.offset + vert_idx];
+		const auto line_meta =
+		    static_cast<uint32_t>(GeometryType::LINESTRING) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
+		for (const auto line_entry : mult_entry.GetChildValues()) {
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(line_meta);
+			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(line_entry.GetListLength()));
+			for (const auto vert_entry : line_entry.GetChildValues()) {
 				vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 			}
 		}
+
 		blob.Finalize();
 		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
@@ -2057,79 +1988,49 @@ static void ToMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 template <class V = VertexXY>
 static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
-
-	const auto mult_data = FlatVector::GetData<list_entry_t>(source_vec);
-	auto &poly_vec = ListVector::GetChildMutable(source_vec);
-	const auto poly_data = FlatVector::GetData<list_entry_t>(poly_vec);
-	auto &ring_vec = ListVector::GetChildMutable(poly_vec);
-	const auto ring_data = FlatVector::GetData<list_entry_t>(ring_vec);
-	auto &vert_struct_vec = ListVector::GetChildMutable(ring_vec);
-	const auto vert_total = ListVector::GetListSize(ring_vec);
-	auto vert_iter = vert_struct_vec.Values<typename V::STRUCT_TYPE>(vert_total);
+	auto mult_iter =
+	    source_vec.Values<VectorListType<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>>(row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto out_idx = result_offset + row_idx;
-		if (FlatVector::IsNull(source_vec, row_idx)) {
+		const auto mult_entry = mult_iter[row_idx];
+		if (!mult_entry.IsValid()) {
 			FlatVector::SetNull(target_vec, out_idx, true);
 			continue;
 		}
 
-		const auto &mult_entry = mult_data[row_idx];
-		const auto poly_count = mult_entry.length;
+		const auto poly_count = mult_entry.GetListLength();
 
-		// First, compute total size
 		// byte order + type/meta + polygon count
 		idx_t blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-
-		for (uint32_t poly_idx = 0; poly_idx < poly_count; poly_idx++) {
-			const auto &poly_entry = poly_data[mult_entry.offset + poly_idx];
-			const auto ring_count = poly_entry.length;
-			// polygon byte order + type/meta + ring count
+		for (const auto poly_entry : mult_entry.GetChildValues()) {
+			// polygon header (byte order + type/meta + ring count)
 			blob_size += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);
-
-			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-				const auto &ring_entry = ring_data[poly_entry.offset + ring_idx];
-				const auto vert_count = ring_entry.length;
-				// vertex count
-				blob_size += sizeof(uint32_t);
-				// vertex data
-				blob_size += vert_count * sizeof(V);
+			for (const auto ring_entry : poly_entry.GetChildValues()) {
+				blob_size += sizeof(uint32_t) + ring_entry.GetListLength() * sizeof(V);
 			}
 		}
 
 		auto blob = StringVector::EmptyString(target_vec, blob_size);
-		const auto blob_data = blob.GetDataWriteable();
-
-		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
+		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
 		    static_cast<uint32_t>(GeometryType::MULTIPOLYGON) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
-		writer.Write<uint8_t>(1);                                        // Little-endian
-		writer.Write<uint32_t>(meta);                                    // Type/meta
-		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(poly_count)); // Polygon count
+		writer.Write<uint8_t>(1);
+		writer.Write<uint32_t>(meta);
+		writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(poly_count));
 
-		for (uint32_t poly_idx = 0; poly_idx < poly_count; poly_idx++) {
-			const auto &poly_entry = poly_data[mult_entry.offset + poly_idx];
-			const auto ring_count = poly_entry.length;
+		const auto poly_meta =
+		    static_cast<uint32_t>(GeometryType::POLYGON) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
+		for (const auto poly_entry : mult_entry.GetChildValues()) {
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(poly_meta);
+			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(poly_entry.GetListLength()));
 
-			// Write polygon byte order and type/meta
-			const auto poly_meta =
-			    static_cast<uint32_t>(GeometryType::POLYGON) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
-			writer.Write<uint8_t>(1);                                        // Little-endian
-			writer.Write<uint32_t>(poly_meta);                               // Type/meta
-			writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(ring_count)); // Ring count
-
-			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-				const auto &ring_entry = ring_data[poly_entry.offset + ring_idx];
-				const auto vert_count = ring_entry.length;
-
-				writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(vert_count)); // Vertex count
-
-				// Write vertex data
-				for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-					const auto vert_entry = vert_iter[ring_entry.offset + vert_idx];
+			for (const auto ring_entry : poly_entry.GetChildValues()) {
+				writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(ring_entry.GetListLength()));
+				for (const auto vert_entry : ring_entry.GetChildValues()) {
 					vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 				}
 			}

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -451,4 +451,12 @@ void ListVector::GetConsecutiveChildSelVector(Vector &list, SelectionVector &sel
 	//	info.second.offset = 0;
 }
 
+const Vector &VectorIteratorGetListChild(const Vector &vector) {
+	return ListVector::GetChild(vector);
+}
+
+idx_t VectorIteratorGetListSize(const Vector &vector) {
+	return ListVector::GetListSize(vector);
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -35,6 +35,9 @@ using buffer_ptr = shared_ptr<T>;
 template <class... Args>
 struct VectorStructType;
 
+template <class T>
+struct VectorListType;
+
 template <class T, typename... ARGS>
 buffer_ptr<T> make_buffer(ARGS &&...args) { // NOLINT: mimic std casing
 	return make_shared_ptr<T>(std::forward<ARGS>(args)...);

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -20,6 +20,12 @@ namespace duckdb {
 //! Defined in struct_vector.cpp.
 DUCKDB_API const vector<Vector> &VectorIteratorGetStructEntries(const Vector &vector);
 
+//! Returns ListVector::GetChild(vector) / ListVector::GetListSize(vector) without
+//! requiring list_vector.hpp to be complete in this header.
+//! Defined in list_vector.cpp.
+DUCKDB_API const Vector &VectorIteratorGetListChild(const Vector &vector);
+DUCKDB_API idx_t VectorIteratorGetListSize(const Vector &vector);
+
 class VectorValidityIterator {
 public:
 	VectorValidityIterator(const Vector &vector, idx_t count) : count(count) {
@@ -310,6 +316,179 @@ public:
 private:
 	UnifiedVectorFormat format;
 	ChildIterators children;
+	idx_t count;
+};
+
+//! Specialization of VectorIterator for VectorListType<T>.
+//! Iterates over a list vector, exposing per-row NULL information and access to
+//! the child entries via GetChildValue(idx) / GetChildValues().  Supports
+//! recursive nesting: VectorListType<VectorListType<T>>, etc.
+//!
+//! The source vector must not be a DICTIONARY_VECTOR; call Flatten() first if needed.
+template <class T>
+class VectorIterator<VectorListType<T>> {
+private:
+	using ChildIteratorType = VectorIterator<T>;
+	using ChildEntryType = typename ChildIteratorType::ValueEntry;
+
+public:
+	VectorIterator(const Vector &vector, idx_t count)
+	    : count(count), child_iter(VectorIteratorGetListChild(vector), VectorIteratorGetListSize(vector)) {
+		vector.ToUnifiedFormat(count, format);
+		list_data = UnifiedVectorFormat::GetData<list_entry_t>(format);
+	}
+
+public:
+	//! Range object returned by ValueEntry::GetChildValues() for range-based for loops.
+	struct ChildRange {
+	private:
+		struct RangeIterator {
+		public:
+			RangeIterator(const ChildIteratorType &child_iter, idx_t pos) : child_iter(child_iter), pos(pos) {
+			}
+			RangeIterator &operator++() { // NOLINT: match stl API
+				++pos;
+				return *this;
+			}
+			RangeIterator operator++(int) { // NOLINT: match stl API
+				auto tmp = *this;
+				++pos;
+				return tmp;
+			}
+			bool operator==(const RangeIterator &other) const {
+				return pos == other.pos;
+			}
+			bool operator!=(const RangeIterator &other) const {
+				return pos != other.pos;
+			}
+			ChildEntryType operator*() const {
+				return child_iter[pos];
+			}
+
+		private:
+			const ChildIteratorType &child_iter;
+			idx_t pos;
+		};
+
+	public:
+		ChildRange(const ChildIteratorType &child_iter, idx_t offset, idx_t length)
+		    : child_iter(child_iter), offset(offset), length(length) {
+		}
+		RangeIterator begin() const { // NOLINT: match stl API
+			return RangeIterator(child_iter, offset);
+		}
+		RangeIterator end() const { // NOLINT: match stl API
+			return RangeIterator(child_iter, offset + length);
+		}
+		idx_t size() const {
+			return length;
+		}
+
+	private:
+		const ChildIteratorType &child_iter;
+		idx_t offset;
+		idx_t length;
+	};
+
+	struct ValueEntry {
+		ValueEntry(const UnifiedVectorFormat &format, const list_entry_t *list_data,
+		           const ChildIteratorType &child_iter, idx_t index)
+		    : format(format), list_data(list_data), child_iter(child_iter), index(index) {
+			sel_index = format.sel->get_index(index);
+		}
+
+		bool IsValid() const {
+			return format.validity.RowIsValid(sel_index);
+		}
+		idx_t GetIndex() const {
+			return index;
+		}
+		//! Returns the list_entry_t (offset + length). The entry must be valid.
+		const list_entry_t &GetValue() const {
+			D_ASSERT(IsValid());
+			return list_data[sel_index];
+		}
+		//! Returns the number of child elements in this list entry.
+		idx_t GetListLength() const {
+			return GetValue().length;
+		}
+		//! Returns the child entry at position idx within this list.
+		ChildEntryType GetChildValue(idx_t idx) const {
+			return child_iter[GetValue().offset + idx];
+		}
+		//! Returns an iterable range over all child entries in this list.
+		ChildRange GetChildValues() const {
+			const auto &entry = GetValue();
+			return ChildRange(child_iter, entry.offset, entry.length);
+		}
+
+	private:
+		const UnifiedVectorFormat &format;
+		const list_entry_t *list_data;
+		const ChildIteratorType &child_iter;
+		idx_t sel_index;
+		idx_t index;
+	};
+
+private:
+	class Iterator {
+	public:
+		Iterator(const UnifiedVectorFormat &format, const list_entry_t *list_data, const ChildIteratorType &child_iter,
+		         idx_t index)
+		    : format(format), list_data(list_data), child_iter(child_iter), index(index) {
+		}
+
+	public:
+		Iterator &operator++() { // NOLINT: match stl API
+			++index;
+			return *this;
+		}
+		Iterator operator++(int) { // NOLINT: match stl API
+			auto tmp = *this;
+			++index;
+			return tmp;
+		}
+		bool operator==(const Iterator &other) const {
+			return index == other.index;
+		}
+		bool operator!=(const Iterator &other) const {
+			return index != other.index;
+		}
+		ValueEntry operator*() const {
+			return ValueEntry(format, list_data, child_iter, index);
+		}
+		ValueEntry operator[](idx_t n) const {
+			return ValueEntry(format, list_data, child_iter, index + n);
+		}
+
+	private:
+		const UnifiedVectorFormat &format;
+		const list_entry_t *list_data;
+		const ChildIteratorType &child_iter;
+		idx_t index;
+	};
+
+public:
+	Iterator begin() { // NOLINT: match stl API
+		return Iterator(format, list_data, child_iter, 0);
+	}
+	Iterator end() { // NOLINT: match stl API
+		return Iterator(format, list_data, child_iter, count);
+	}
+	idx_t size() const {
+		return count;
+	}
+	ValueEntry operator[](idx_t i) const {
+		return ValueEntry(format, list_data, child_iter, i);
+	}
+	bool CanHaveNull() const {
+		return format.validity.CanHaveNull();
+	}
+
+private:
+	UnifiedVectorFormat format;
+	const list_entry_t *list_data;
+	ChildIteratorType child_iter;
 	idx_t count;
 };
 

--- a/src/include/duckdb/common/vector/vector_iterator.hpp
+++ b/src/include/duckdb/common/vector/vector_iterator.hpp
@@ -333,7 +333,7 @@ private:
 
 public:
 	VectorIterator(const Vector &vector, idx_t count)
-	    : count(count), child_iter(VectorIteratorGetListChild(vector), VectorIteratorGetListSize(vector)) {
+	    : child_iter(VectorIteratorGetListChild(vector), VectorIteratorGetListSize(vector)), count(count) {
 		vector.ToUnifiedFormat(count, format);
 		list_data = UnifiedVectorFormat::GetData<list_entry_t>(format);
 	}


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/22417

This PR also adds support for iteration over lists.

```cpp
auto list_iter = source_vec.Values<VectorListType<double>>(row_count);

for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
    const auto list_entry = list_iter[row_idx];
	if (!list_entry.IsValid()) {
		// entire list is NULL
		continue;
	}
	for (auto list_child : list_entry.GetChildValues()) {
		if (!list_child.IsValid()) {
			// list child element is null
			continue;
		}
		// get child value (double)
		list_child.GetValue();
	}
}
```

This is recursive, and the child types can be anything, including other lists or structs. This PR also rewrites the geometry code to use these iterators. This shows how this can work also with lists of lists of structs or other complex nested types.