### PR TITLE
Ignore queue branch for push and merge tidy check jobs

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -417,20 +417,8 @@ jobs:
         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
         python3 scripts/ci/retry.py -- make install-clangd-tidy
 
-    - uses: ./.github/actions/ccache-action
-      with:
-        save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
-
-    - name: Download clang-tidy-cache
-      if: ${{ github.ref_name == 'main' || github.ref_name == 'feature' }}
-      run: |
-        set -e
-        curl -Lo /tmp/clang-tidy-cache https://github.com/ejfitzgerald/clang-tidy-cache/releases/download/v0.4.0/clang-tidy-cache-linux-amd64
-        md5sum /tmp/clang-tidy-cache | grep 880b290d7bbe7c1fb2a4f591f9a86cc1
-        chmod +x /tmp/clang-tidy-cache
-
     - name: Tidy Check Diff
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
 
     - name: Tidy Check (clangd)

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -433,10 +433,6 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
 
-    - name: Tidy Check
-      if: ${{ github.ref_name == 'main' || github.ref_name == 'feature' }}
-      run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
-
     - name: Tidy Check (clangd)
       run: |
         mkdir -p ~/.config/clangd

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -18,6 +18,7 @@ on:
       - 'main'
       - 'feature'
       - 'v*.*-*'
+      - 'gh-readonly-queue/**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -415,15 +415,19 @@ jobs:
         python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
         python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clang-tidy
         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
-        python3 scripts/ci/retry.py -- make install-clangd-tidy
 
     - name: Tidy Check Diff
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
 
+    - name: Clean
+      run: make clean
+
+    - name: Install clangd-tidy
+      run: python3 scripts/ci/retry.py -- make install-clangd-tidy
+
     - name: Tidy Check (clangd)
       run: |
-        make clean
         mkdir -p ~/.config/clangd
         cat > ~/.config/clangd/config.yaml <<'EOF'
         Diagnostics:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -435,6 +435,7 @@ jobs:
 
     - name: Tidy Check (clangd)
       run: |
+        make clean
         mkdir -p ~/.config/clangd
         cat > ~/.config/clangd/config.yaml <<'EOF'
         Diagnostics:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -395,7 +395,7 @@ jobs:
     name: Tidy Check
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'tidy-check') }}
     needs: prepare
-    runs-on: ubuntu-24.04
+    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     env:
       CC: gcc
       CXX: g++

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -400,6 +400,7 @@ jobs:
       CC: gcc
       CXX: g++
       GEN: ninja
+      CLANGD_BINARY: clangd-20
 
     steps:
     - uses: actions/checkout@v6
@@ -414,6 +415,7 @@ jobs:
         python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
         python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clang-tidy
         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
+        python3 scripts/ci/retry.py -- make install-clangd-tidy
 
     - uses: ./.github/actions/ccache-action
       with:
@@ -427,45 +429,22 @@ jobs:
         md5sum /tmp/clang-tidy-cache | grep 880b290d7bbe7c1fb2a4f591f9a86cc1
         chmod +x /tmp/clang-tidy-cache
 
+    - name: Tidy Check Diff
+      if: ${{ github.event_name == 'pull_request' }}
+      run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
+
     - name: Tidy Check
       if: ${{ github.ref_name == 'main' || github.ref_name == 'feature' }}
       run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
 
-    - name: Tidy Check Diff
-      if: ${{ github.ref_name != 'main' && github.ref_name != 'feature' }}
-      run: DUCKDB_GIT_BASE_BRANCH=${{ github.base_ref }} make tidy-check-diff
-
- check-clangd-tidy:
-   name: Tidy Check (clangd)
-   if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'check-clangd-tidy') }}
-   needs: prepare
-   runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
-   env:
-     CLANGD_BINARY: clangd-20
-
-   steps:
-     - name: "Checkout"
-       uses: duckdb/duckdb-ci/.github/actions/checkout@main
-       with:
-         runner_provider: ${{ github.repository == 'duckdb/duckdb' && 'namespace' || 'github' }}
-         fetch_depth: 0
-         ref: ${{ needs.prepare.outputs.git_sha }}
-
-     - name: Install
-       timeout-minutes: 10
-       run: |
-         python3 scripts/ci/retry.py -- make toolsci
-         python3 scripts/ci/retry.py -- sudo pip3 install 'pybind11[global]' --break-system-packages
-         python3 scripts/ci/retry.py -- make install-clangd-tidy
-
-     - name: Tidy Check
-       run: |
-         mkdir -p ~/.config/clangd
-         cat > ~/.config/clangd/config.yaml <<'EOF'
-         Diagnostics:
-           UnusedIncludes: None
-         EOF
-         make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
+    - name: Tidy Check (clangd)
+      run: |
+        mkdir -p ~/.config/clangd
+        cat > ~/.config/clangd/config.yaml <<'EOF'
+        Diagnostics:
+          UnusedIncludes: None
+        EOF
+        make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
 
  extensions:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'extensions') }}
@@ -1552,7 +1531,6 @@ jobs:
       - linux-relassert-tests
       - regression
       - tidy-check
-      - check-clangd-tidy
       - extensions
       - wasm-eh
       - linux-release

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -97,12 +97,12 @@ def should_save_cache(selection_input: JobSelectionInput) -> bool:
         selection_input.repository != "duckdb/duckdb"
         or selection_input.ref_name == "main"
         or selection_input.ref_name == "v1.5-variegata"
-        or (selection_input.event_name == "push" and selection_input.ref_name.startswith("gh-readonly-queue/"))
+        or selection_input.event_name == "merge_group"
     )
 
 
 def enabled_jobs(selection_input: JobSelectionInput) -> list[str]:
-    if selection_input.event_name == "push" and selection_input.ref_name.startswith("gh-readonly-queue/"):
+    if selection_input.event_name == "merge_group":
         selected_jobs = MERGE_GROUP_JOBS.copy()
     elif selection_input.ref_name == "main":
         selected_jobs = NIGHTLY_JOBS.copy()

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -30,7 +30,6 @@ PULL_REQUEST_JOBS = [
 
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
-    "check-clangd-tidy",
     "valgrind",
     "static-libs-osx",
     "static-libs-windows-mingw",
@@ -42,7 +41,6 @@ MERGE_GROUP_JOBS = [
     "linux-relassert",
     "linux-release",
     "linux-release-tests",
-    "check-clangd-tidy",
     "tidy-check",
 ]
 

--- a/scripts/ci/test_job_stages.py
+++ b/scripts/ci/test_job_stages.py
@@ -123,8 +123,8 @@ class JobStagesTest(unittest.TestCase):
         self.assertTrue(job_ids, "failed to parse any top-level jobs from .github/workflows/Main.yml")
         return job_ids
 
-    def test_merge_queue_push_minimal_jobs(self):
-        selection = self._compute_job_selection("push", "gh-readonly-queue/main/pr-1-abc", "duckdb/duckdb")
+    def test_merge_group_minimal_jobs(self):
+        selection = self._compute_job_selection("merge_group", "gh-readonly-queue/main/pr-1-abc", "duckdb/duckdb")
         required_jobs = {"linux-relassert", "linux-release", "linux-release-tests", "tidy-check"}
         self.assertTrue(required_jobs.issubset(set(selection.enabled_jobs)))
         self.assertTrue(selection.save_cache)
@@ -193,7 +193,7 @@ class JobStagesTest(unittest.TestCase):
             sys.argv = [
                 "job_stages.py",
                 "--event",
-                "push",
+                "merge_group",
                 "--ref_name",
                 "gh-readonly-queue/main/pr-1-abc",
                 "--repository",


### PR DESCRIPTION
- Ignore queue branch for `push`; only run for `merge_group` event.
- Merge clangd tidy check job into `tidy-check`.
  - Keep the diff check to speed up CI for pull requests.