### PR TITLE
Split `(Bound)Function` inheritance and introduce `Function(Signature/Parameter)`

### DIFF
--- a/.github/patches/extensions/avro/0003-set-child-cardinality.patch
+++ b/.github/patches/extensions/avro/0003-set-child-cardinality.patch
@@ -1,5 +1,5 @@
 diff --git a/src/avro_reader.cpp b/src/avro_reader.cpp
-index 4a21b5b..67125b5 100644
+index 191bbaf..3e11b92 100644
 --- a/src/avro_reader.cpp
 +++ b/src/avro_reader.cpp
 @@ -398,7 +398,7 @@ void AvroReader::Read(DataChunk &output) {

--- a/.github/patches/extensions/excel/0003-function-expr.patch
+++ b/.github/patches/extensions/excel/0003-function-expr.patch
@@ -1,0 +1,62 @@
+diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
+index de7bccf..b666efa 100644
+--- a/src/excel/xlsx/copy_xlsx.cpp
++++ b/src/excel/xlsx/copy_xlsx.cpp
+@@ -48,32 +48,29 @@ static void DateToExcelNumberFunction(DataChunk &args, ExpressionState &state, V
+ 	});
+ }
+ 
+-static unique_ptr<Expression> TimestampConversionExpr(unique_ptr<Expression> ref) {
++static unique_ptr<Expression> TimestampConversionExpr(ClientContext &context, unique_ptr<Expression> ref) {
+ 	vector<unique_ptr<Expression>> children;
+ 	children.push_back(std::move(ref));
+ 
+ 	ScalarFunction sfunc("timestamp_to_excel_number", {LogicalType::TIMESTAMP}, LogicalType::DOUBLE,
+ 	                     TimestampToExcelNumberFunction);
+-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+-	return std::move(func);
++	return sfunc.Bind(context, std::move(children));
+ }
+ 
+-static unique_ptr<Expression> TimeConversionExpr(unique_ptr<Expression> ref) {
++static unique_ptr<Expression> TimeConversionExpr(ClientContext &context, unique_ptr<Expression> ref) {
+ 	vector<unique_ptr<Expression>> children;
+ 	children.push_back(std::move(ref));
+ 
+ 	ScalarFunction sfunc("time_to_excel_number", {LogicalType::TIME}, LogicalType::DOUBLE, TimeToExcelNumberFunction);
+-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+-	return std::move(func);
++	return sfunc.Bind(context, std::move(children));
+ }
+ 
+-static unique_ptr<Expression> DateConversionExpr(unique_ptr<Expression> ref) {
++static unique_ptr<Expression> DateConversionExpr(ClientContext &context, unique_ptr<Expression> ref) {
+ 	vector<unique_ptr<Expression>> children;
+ 	children.push_back(std::move(ref));
+ 
+ 	ScalarFunction sfunc("date_to_excel_number", {LogicalType::DATE}, LogicalType::DOUBLE, DateToExcelNumberFunction);
+-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+-	return std::move(func);
++	return sfunc.Bind(context, std::move(children));
+ }
+ 
+ //------------------------------------------------------------------------------
+@@ -186,15 +183,15 @@ struct GlobalWriteXLSXData final : public GlobalFunctionData {
+ 			case LogicalTypeId::TIMESTAMP_NS:
+ 				expr = BoundCastExpression::AddCastToType(context, std::move(expr), LogicalType::TIMESTAMP);
+ 			case LogicalTypeId::TIMESTAMP: // Fall through
+-				expr = TimestampConversionExpr(std::move(expr));
++				expr = TimestampConversionExpr(context, std::move(expr));
+ 				break;
+ 			case LogicalTypeId::TIME_TZ:
+ 				expr = BoundCastExpression::AddCastToType(context, std::move(expr), LogicalType::TIME);
+ 			case LogicalTypeId::TIME: // Fall through
+-				expr = TimeConversionExpr(std::move(expr));
++				expr = TimeConversionExpr(context, std::move(expr));
+ 				break;
+ 			case LogicalTypeId::DATE:
+-				expr = DateConversionExpr(std::move(expr));
++				expr = DateConversionExpr(context, std::move(expr));
+ 				break;
+ 			case LogicalTypeId::BOOLEAN:
+ 				// Convert booleans to numbers first, then number to varchar

--- a/.github/patches/extensions/spatial/0010-sequential-opt-in.patch
+++ b/.github/patches/extensions/spatial/0010-sequential-opt-in.patch
@@ -11,10 +11,10 @@ index aba73b9..a1bfbe3 100644
  	return func;
  }
 diff --git a/src/spatial/modules/gdal/gdal_module.cpp b/src/spatial/modules/gdal/gdal_module.cpp
-index 996e0ff..b1030cd 100644
+index 5c44fb2..93dbe61 100644
 --- a/src/spatial/modules/gdal/gdal_module.cpp
 +++ b/src/spatial/modules/gdal/gdal_module.cpp
-@@ -1172,6 +1172,7 @@ void Register(ExtensionLoader &loader) {
+@@ -1173,6 +1173,7 @@ void Register(ExtensionLoader &loader) {
  	read_func.named_parameters["layer"] = LogicalType::VARCHAR;
  	read_func.named_parameters["max_batch_size"] = LogicalType::INTEGER;
  	read_func.named_parameters["keep_wkb"] = LogicalType::BOOLEAN;
@@ -23,10 +23,10 @@ index 996e0ff..b1030cd 100644
  	loader.RegisterFunction(read_func);
  
 diff --git a/src/spatial/modules/shapefile/shapefile_module.cpp b/src/spatial/modules/shapefile/shapefile_module.cpp
-index 57b34d0..fda8e1b 100644
+index e78d8f6..bb20369 100644
 --- a/src/spatial/modules/shapefile/shapefile_module.cpp
 +++ b/src/spatial/modules/shapefile/shapefile_module.cpp
-@@ -894,6 +894,7 @@ struct ST_ReadSHP {
+@@ -896,6 +896,7 @@ struct ST_ReadSHP {
  		read_func.table_scan_progress = GetProgress;
  		read_func.cardinality = GetCardinality;
  		read_func.projection_pushdown = true;

--- a/.github/patches/extensions/spatial/0011-function-expr.patch
+++ b/.github/patches/extensions/spatial/0011-function-expr.patch
@@ -1,0 +1,398 @@
+diff --git a/src/spatial/index/rtree/rtree_index.cpp b/src/spatial/index/rtree/rtree_index.cpp
+index 3e15656..bf3db98 100644
+--- a/src/spatial/index/rtree/rtree_index.cpp
++++ b/src/spatial/index/rtree/rtree_index.cpp
+@@ -112,13 +112,13 @@ RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_
+ 	auto &source_type = unbound_expressions[0]->GetReturnType();
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+-	auto func = entry.functions.GetFunctionByArguments(context, {source_type});
++	const auto &func = entry.functions.GetFunctionByArguments(context, {source_type});
+ 	auto child_expr = make_uniq<BoundReferenceExpression>(source_type, 0);
+ 
+ 	vector<unique_ptr<Expression>> children;
+ 	children.push_back(std::move(child_expr));
+ 
+-	key_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
++	key_expr = func.Bind(context, std::move(children));
+ 	key_executor = make_uniq<ExpressionExecutor>(context);
+ 	key_executor->AddExpression(*key_expr);
+ 	key_chunk.Initialize(context, {GeoTypes::BOX_2DF()});
+diff --git a/src/spatial/index/rtree/rtree_index_create_logical.cpp b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+index d4c8dbc..70dd812 100644
+--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
++++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
+@@ -57,8 +57,7 @@ static PhysicalOperator &CreateNullFilter(PhysicalPlanGenerator &generator, cons
+ 	auto is_empty_func = is_empty_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 	vector<unique_ptr<Expression>> is_empty_args;
+ 	is_empty_args.push_back(std::move(bound_ref));
+-	auto is_empty_expr = make_uniq_base<Expression, BoundFunctionExpression>(LogicalType::BOOLEAN, is_empty_func,
+-	                                                                         std::move(is_empty_args), nullptr);
++	auto is_empty_expr = is_empty_func.Bind(context, std::move(is_empty_args));
+ 
+ 	auto is_not_empty_expr = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
+ 	is_not_empty_expr->children.push_back(std::move(is_empty_expr));
+@@ -79,14 +78,13 @@ static PhysicalOperator &CreateBoundingBoxProjection(PhysicalPlanGenerator &plan
+ 	auto &bbox_func_entry =
+ 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "ST_Extent_Approx")
+ 	        .Cast<ScalarFunctionCatalogEntry>();
+-	auto bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
++	const auto &bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 
+ 	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::GEOMETRY(), 0);
+ 	vector<unique_ptr<Expression>> bbox_args;
+ 	bbox_args.push_back(std::move(geom_ref_expr));
+ 
+-	auto bbox_expr = make_uniq_base<Expression, BoundFunctionExpression>(GeoTypes::BOX_2DF(), bbox_func,
+-	                                                                     std::move(bbox_args), nullptr);
++	auto bbox_expr = bbox_func.Bind(context, std::move(bbox_args));
+ 
+ 	// Also project the rowid column
+ 	auto rowid_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::ROW_TYPE, 1);
+@@ -106,25 +104,24 @@ static PhysicalOperator &CreateOrderByMinX(PhysicalPlanGenerator &planner, const
+ 	auto &centroid_func_entry =
+ 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "st_centroid")
+ 	        .Cast<ScalarFunctionCatalogEntry>();
+-	auto centroid_func = centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
++	const auto &centroid_func = centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
+ 	vector<unique_ptr<Expression>> centroid_func_args;
+ 
+ 	// Reference the geometry column
+ 	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(GeoTypes::BOX_2DF(), 0);
+ 	centroid_func_args.push_back(make_uniq_base<Expression, BoundReferenceExpression>(GeoTypes::BOX_2DF(), 0));
+-	auto centroid_expr = make_uniq_base<Expression, BoundFunctionExpression>(GeoTypes::POINT_2D(), centroid_func,
+-	                                                                         std::move(centroid_func_args), nullptr);
++
++	auto centroid_expr = centroid_func.Bind(context, std::move(centroid_func_args));
+ 
+ 	// Get the xmin value function
+ 	auto &xmin_func_entry = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "st_xmin")
+ 	                            .Cast<ScalarFunctionCatalogEntry>();
+-	auto xmin_func = xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
++	const auto &xmin_func = xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
+ 	vector<unique_ptr<Expression>> xmin_func_args;
+ 
+ 	// Reference the centroid
+ 	xmin_func_args.push_back(std::move(centroid_expr));
+-	auto xmin_expr = make_uniq_base<Expression, BoundFunctionExpression>(LogicalType::DOUBLE, xmin_func,
+-	                                                                     std::move(xmin_func_args), nullptr);
++	auto xmin_expr = xmin_func.Bind(context, std::move(xmin_func_args));
+ 
+ 	vector<BoundOrderByNode> orders;
+ 	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, std::move(xmin_expr));
+diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+index 5c35637..de38847 100644
+--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
++++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+@@ -92,9 +92,9 @@ public:
+ 		});
+ 	}
+ 
+-	static bool IsSpatialPredicate(const ScalarFunction &function, const unordered_set<string> &predicates) {
++	static bool IsSpatialPredicate(const BoundScalarFunction &function, const unordered_set<string> &predicates) {
+ 
+-		if (predicates.find(function.name) == predicates.end()) {
++		if (predicates.find(function.GetName()) == predicates.end()) {
+ 			return false;
+ 		}
+ 		if (function.GetArguments().size() < 2) {
+@@ -121,13 +121,12 @@ public:
+ 		// make a new box expression
+ 		auto &catalog = Catalog::GetSystemCatalog(context);
+ 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+-		auto func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
++		const auto &func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+ 
+ 		vector<unique_ptr<Expression>> children;
+ 		children.push_back(expr.Copy());
+ 
+-		const auto bbox_expr =
+-		    make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
++		const auto bbox_expr = func.Bind(context, std::move(children));
+ 
+ 		Value result;
+ 		if (!ExpressionExecutor::TryEvaluateScalar(context, *bbox_expr, result)) {
+diff --git a/src/spatial/modules/gdal/gdal_module.cpp b/src/spatial/modules/gdal/gdal_module.cpp
+index 93dbe61..34fc469 100644
+--- a/src/spatial/modules/gdal/gdal_module.cpp
++++ b/src/spatial/modules/gdal/gdal_module.cpp
+@@ -752,7 +752,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+ 
+ 		auto found = false;
+ 		for (const auto &name : geometry_predicates) {
+-			if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
++			if (StringUtil::CIEquals(func.function.GetName().c_str(), name)) {
+ 				found = true;
+ 				break;
+ 			}
+@@ -834,7 +834,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+ 		// We can __ONLY__ do this if the filter predicate is "&&" or "st_intersects_extent"
+ 		// as other predicates may require exact geometry evaluation, the filter cannot be fully removed
+ 		for (auto &name : {"&&", "ST_Intersects_Extent"}) {
+-			if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
++			if (StringUtil::CIEquals(func.function.GetName().c_str(), name)) {
+ 				geom_filter_idx = expr_idx;
+ 				break;
+ 			}
+diff --git a/src/spatial/modules/geos/geos_module.cpp b/src/spatial/modules/geos/geos_module.cpp
+index 365aa90..53edea4 100644
+--- a/src/spatial/modules/geos/geos_module.cpp
++++ b/src/spatial/modules/geos/geos_module.cpp
+@@ -9,6 +9,7 @@
+ #include "duckdb/planner/expression/bound_constant_expression.hpp"
+ #include "duckdb/planner/expression/bound_function_expression.hpp"
+ #include "duckdb/execution/expression_executor.hpp"
++#include "duckdb/function/aggregate_function.hpp"
+ #include "spatial/geometry/geometry_serialization.hpp"
+ #include "spatial/geometry/sgl.hpp"
+ 
+@@ -2518,7 +2519,7 @@ struct ST_Union_Agg {
+ 		vector<GEOSGeometry *> geoms;
+ 	};
+ 
+-	static idx_t StateSize(const AggregateFunction &) {
++	static idx_t StateSize(const BoundAggregateFunction &) {
+ 		return sizeof(State);
+ 	}
+ 
+@@ -2543,7 +2544,7 @@ struct ST_Union_Agg {
+ 		return GeosSerde::Deserialize(context, arena, ptr, size);
+ 	}
+ 
+-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
++	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+ 		const auto state_ptr = new (state_mem) State();
+ 		auto &state = *state_ptr;
+ 		state.context = GEOS_init_r();
+@@ -2742,7 +2743,7 @@ struct GEOSCoverageAggFunction {
+ 		return GeosSerde::Deserialize(context, arena, ptr, size);
+ 	}
+ 
+-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
++	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+ 		const auto state_ptr = new (state_mem) State();
+ 		auto &state = *state_ptr;
+ 		state.context = GEOS_init_r();
+@@ -2809,7 +2810,7 @@ struct GEOSCoverageAggFunction {
+ 		}
+ 	}
+ 
+-	static idx_t StateSize(const AggregateFunction &) {
++	static idx_t StateSize(const BoundAggregateFunction &) {
+ 		return sizeof(State);
+ 	}
+ 
+@@ -2965,7 +2966,7 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
+ 			func.SetDescription("Simplifies a set of geometries while maintaining coverage");
+ 
+ 			// TODO: this is a hack
+-			agg.GetArguments().push_back(LogicalType::BOOLEAN);
++			agg.GetSignature().AddParameter(LogicalType::BOOLEAN);
+ 			func.SetFunction(agg);
+ 			func.CanThrowErrors();
+ 
+@@ -3130,7 +3131,7 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
+ 			func.CanThrowErrors();
+ 
+ 			// TODO: this is a hack
+-			agg.GetArguments().push_back(LogicalType::DOUBLE);
++			agg.GetSignature().AddParameter(LogicalType::DOUBLE);
+ 			func.SetFunction(agg);
+ 			func.CanThrowErrors();
+ 
+diff --git a/src/spatial/modules/main/spatial_functions_scalar.cpp b/src/spatial/modules/main/spatial_functions_scalar.cpp
+index 82074fa..9beacda 100644
+--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
++++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
+@@ -5814,7 +5814,7 @@ struct ST_Distance_Sphere {
+ 			    " * 'SET geometry_always_xy = false' to keep the current behavior and make this warning go away.";
+ 
+ 			auto &logger = Logger::Get(context);
+-			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.name.c_str()));
++			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.GetName().c_str()));
+ 		}
+ 
+ 		return std::move(bind_data);
+diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
+index b646469..3eb71de 100644
+--- a/src/spatial/modules/mvt/mvt_module.cpp
++++ b/src/spatial/modules/mvt/mvt_module.cpp
+@@ -5,6 +5,7 @@
+ #include "duckdb/common/types/hash.hpp"
+ #include "duckdb/common/vector_operations/generic_executor.hpp"
+ #include "duckdb/execution/expression_executor.hpp"
++#include "duckdb/function/aggregate_function.hpp"
+ #include "spatial/geometry/geometry_serialization.hpp"
+ #include "spatial/geometry/sgl.hpp"
+ #include "spatial/spatial_types.hpp"
+@@ -1009,11 +1010,11 @@ struct ST_AsMVT {
+ 		MVTLayer layer;
+ 	};
+ 
+-	static idx_t StateSize(const AggregateFunction &) {
++	static idx_t StateSize(const BoundAggregateFunction &) {
+ 		return sizeof(State);
+ 	}
+ 
+-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
++	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
+ 		new (state_mem) State();
+ 	}
+ 
+@@ -1266,7 +1267,7 @@ struct ST_AsMVT {
+ 			func.SetFunction(agg);
+ 			for (auto &arg_type : optional_args) {
+ 				// Register all the variants with optional arguments
+-				agg.GetArguments().push_back(arg_type);
++				agg.GetSignature().AddParameter(arg_type);
+ 				func.SetFunction(agg);
+ 			}
+ 
+diff --git a/src/spatial/modules/proj/proj_module.cpp b/src/spatial/modules/proj/proj_module.cpp
+index e911f0f..e5c259d 100644
+--- a/src/spatial/modules/proj/proj_module.cpp
++++ b/src/spatial/modules/proj/proj_module.cpp
+@@ -750,7 +750,7 @@ struct GeodesicBindData final : FunctionData {
+ 			    " * 'SET geometry_always_xy = false' to keep the current behavior and make this warning go away.";
+ 
+ 			auto &logger = Logger::Get(ctx);
+-			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.name.c_str()));
++			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.GetName().c_str()));
+ 		}
+ 
+ 		return std::move(result);
+diff --git a/src/spatial/operators/spatial_join_optimizer.cpp b/src/spatial/operators/spatial_join_optimizer.cpp
+index 18c5938..b3db4c1 100644
+--- a/src/spatial/operators/spatial_join_optimizer.cpp
++++ b/src/spatial/operators/spatial_join_optimizer.cpp
+@@ -56,7 +56,7 @@ static bool HasInversePredicate(const string &func_name) {
+ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique_ptr<Expression> expr) {
+ 	auto &func = expr->Cast<BoundFunctionExpression>();
+ 
+-	const auto it = spatial_predicate_inverse_map.find(func.function.name);
++	const auto it = spatial_predicate_inverse_map.find(func.function.GetName());
+ 	D_ASSERT(it != spatial_predicate_inverse_map.end());
+ 
+ 	// Swap the arguments
+@@ -70,11 +70,11 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
+ 	// Get the function from the catalog
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, it->second);
+-	auto inverse_func =
++	const auto &inverse_func =
+ 	    entry.functions.GetFunctionByArguments(context, {func.children[0]->GetReturnType(), func.children[1]->GetReturnType()});
+ 
+-	return make_uniq_base<Expression, BoundFunctionExpression>(func.GetReturnType(), inverse_func, std::move(func.children),
+-	                                                           nullptr, func.is_operator);
++	auto func_expr = inverse_func.Bind(context, std::move(func.children));
++	return std::move(func_expr);
+ }
+ 
+ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const unordered_set<TableIndex> &left_bindings,
+@@ -104,7 +104,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
+ 	}
+ 
+ 	// The function must be a recognized spatial predicate
+-	if (spatial_predicate_map.count(func.function.name) == 0) {
++	if (spatial_predicate_map.count(func.function.GetName()) == 0) {
+ 		return false;
+ 	}
+ 
+@@ -117,7 +117,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
+ 	}
+ 
+ 	if (left_side == JoinSide::RIGHT) {
+-		if (!HasInversePredicate(func.function.name)) {
++		if (!HasInversePredicate(func.function.GetName())) {
+ 			return false;
+ 		}
+ 		needs_flipping = true;
+@@ -190,7 +190,7 @@ static bool TrySwapComparisonJoin(OptimizerExtensionInput &input, unique_ptr<Log
+ 
+ 	// If this is ST_DWithin, try to extract the constant distance value
+ 	const auto &pred_func = spatial_join->spatial_predicate->Cast<BoundFunctionExpression>();
+-	if (pred_func.function.name == "ST_DWithin") {
++	if (pred_func.function.GetName() == "ST_DWithin") {
+ 		// Try to get the constant distance value from the bind data;
+ 		spatial_join->has_const_distance =
+ 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
+@@ -296,7 +296,7 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
+ 
+ 	// If this is ST_DWithin, try to extract the constant distance value
+ 	const auto &pred_func = spatial_join->spatial_predicate->Cast<BoundFunctionExpression>();
+-	if (pred_func.function.name == "ST_DWithin") {
++	if (pred_func.function.GetName() == "ST_DWithin") {
+ 		// Try to get the constant distance value from the bind data;
+ 		spatial_join->has_const_distance =
+ 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
+diff --git a/src/spatial/operators/spatial_join_physical.cpp b/src/spatial/operators/spatial_join_physical.cpp
+index 6117306..94e13c1 100644
+--- a/src/spatial/operators/spatial_join_physical.cpp
++++ b/src/spatial/operators/spatial_join_physical.cpp
+@@ -387,13 +387,13 @@ private:
+ static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const LogicalType &geom_type) {
+ 	auto &catalog = Catalog::GetSystemCatalog(context);
+ 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+-	auto func = entry.functions.GetFunctionByArguments(context, {geom_type});
++	const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
+ 
+ 	auto child_expr = make_uniq<BoundReferenceExpression>(geom_type, 0);
+ 	vector<unique_ptr<Expression>> children;
+ 	children.push_back(std::move(child_expr));
+ 
+-	auto bbox_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
++	auto bbox_expr = func.Bind(context, std::move(children));
+ 
+ 	return std::move(bbox_expr);
+ }
+@@ -547,11 +547,11 @@ public:
+ 
+ 		auto &catalog = Catalog::GetSystemCatalog(context);
+ 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_IsEmpty");
+-		auto func = entry.functions.GetFunctionByArguments(context, {geom_type});
++		const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
+ 
+-		auto is_empty_expr = make_uniq<BoundFunctionExpression>(LogicalTypeId::BOOLEAN, func,
+-		                                                        vector<unique_ptr<Expression>> {}, nullptr);
+-		is_empty_expr->children.push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
++		vector<unique_ptr<Expression>> children;
++		children.push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
++		auto is_empty_expr = func.Bind(context, std::move(children));
+ 
+ 		auto is_not_empty_expr =
+ 		    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalTypeId::BOOLEAN);
+diff --git a/src/spatial/spatial_types.cpp b/src/spatial/spatial_types.cpp
+index 2195fef..d98b266 100644
+--- a/src/spatial/spatial_types.cpp
++++ b/src/spatial/spatial_types.cpp
+@@ -85,7 +85,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
+ 	return enum_type;
+ }
+ 
+-static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, SimpleFunction &bound_function,
++static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BoundSimpleFunction &bound_function,
+                                                        vector<unique_ptr<Expression>> &arguments) {
+ 
+ 	CoordinateReferenceSystem crs;
+@@ -115,7 +115,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
+ 						    " * Use 'ST_SetCRS' to explicitly override the CRS of a geometry expression, without "
+ 						    "performing a "
+ 						    "transformation.\n",
+-						    bound_function.name, crs.GetIdentifier(), type_crs.GetIdentifier());
++						    bound_function.GetName(), crs.GetIdentifier(), type_crs.GetIdentifier());
+ 					}
+ 				}
+ 			}
+diff --git a/src/spatial/util/function_builder.hpp b/src/spatial/util/function_builder.hpp
+index e4d5165..bdebe71 100644
+--- a/src/spatial/util/function_builder.hpp
++++ b/src/spatial/util/function_builder.hpp
+@@ -68,7 +68,7 @@ private:
+ };
+ 
+ inline void ScalarFunctionVariantBuilder::AddParameter(const char *name, const LogicalType &type) {
+-	function.GetArguments().emplace_back(type);
++	function.GetSignature().AddParameter(name, type);
+ 	description.parameter_names.emplace_back(name);
+ 	description.parameter_types.emplace_back(type);
+ }

--- a/.github/patches/extensions/spatial/0012-extra-args.patch
+++ b/.github/patches/extensions/spatial/0012-extra-args.patch
@@ -1,0 +1,20 @@
+diff --git a/src/spatial/modules/main/spatial_functions_scalar.cpp b/src/spatial/modules/main/spatial_functions_scalar.cpp
+index 9beacda..2f519f7 100644
+--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
++++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
+@@ -5458,6 +5458,7 @@ struct ST_LocateAlong {
+ 		if (arguments.size() == 2) {
+ 			// Push back offset constant
+ 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
++			input.GetBoundFunction().GetArguments().push_back(LogicalType::DOUBLE);
+ 		}
+ 		return nullptr; // No additional data needed
+ 	}
+@@ -5560,6 +5561,7 @@ struct ST_LocateBetween {
+ 		if (arguments.size() == 3) {
+ 			// Push back offset constant
+ 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
++			input.GetBoundFunction().GetArguments().push_back(LogicalType::DOUBLE);
+ 		}
+ 		return nullptr; // No additional data needed
+ 	}

--- a/.github/patches/extensions/sqlsmith/0005-chunkcardinality.patch
+++ b/.github/patches/extensions/sqlsmith/0005-chunkcardinality.patch
@@ -9,5 +9,5 @@ index c5f2274..1542369 100644
 -	output.SetCardinality(count);
 +	output.SetChildCardinality(count);
  }
-
+ 
  struct FuzzyDuckFunctionData : public TableFunctionData {

--- a/.github/patches/extensions/sqlsmith/0006-function-expr.patch
+++ b/.github/patches/extensions/sqlsmith/0006-function-expr.patch
@@ -1,0 +1,94 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index 2828430..4c750ce 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -762,10 +762,12 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
+ 		auto offset = RandomValue(scalar_entry.functions.Size());
+ 		auto actual_function = scalar_entry.functions.GetFunctionByOffset(offset);
+ 		name = scalar_entry.name;
+-		arguments = actual_function.GetArguments();
+-		min_parameters = actual_function.GetArguments().size();
++		for (auto &arg : actual_function.GetSignature().GetParameters()) {
++			arguments.push_back(arg.GetType());
++		}
++		min_parameters = actual_function.GetSignature().GetParameterCount();
+ 		max_parameters = min_parameters;
+-		if (actual_function.GetVarArgs().id() != LogicalTypeId::INVALID) {
++		if (actual_function.GetSignature().GetVarArgs().id() != LogicalTypeId::INVALID) {
+ 			max_parameters += 5;
+ 		}
+ 		break;
+@@ -776,7 +778,7 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateFunction() {
+ 		    aggregate_entry.functions.GetFunctionByOffset(RandomValue(aggregate_entry.functions.Size()));
+ 
+ 		name = aggregate_entry.name;
+-		min_parameters = actual_function.GetArguments().size();
++		min_parameters = actual_function.GetSignature().GetParameterCount();
+ 		max_parameters = min_parameters;
+ 		if (actual_function.GetVarArgs().id() != LogicalTypeId::INVALID) {
+ 			max_parameters += 5;
+@@ -944,7 +946,7 @@ unique_ptr<ParsedExpression> StatementGenerator::GenerateWindowFunction(optional
+ 	if (function) {
+ 		type = ExpressionType::WINDOW_AGGREGATE;
+ 		name = function->name;
+-		min_parameters = function->GetArguments().size();
++		min_parameters = function->GetSignature().GetParameterCount();
+ 		max_parameters = min_parameters;
+ 	} else {
+ 		name = Choose<string>({"rank", "rank_dense", "percent_rank", "row_number", "first_value", "last_value",
+@@ -1281,21 +1283,21 @@ string StatementGenerator::GenerateTestAllTypes(SimpleFunction &base_function) {
+ 	auto select = make_uniq<SelectStatement>();
+ 	auto node = make_uniq<SelectNode>();
+ 
+-	bool always_null = FunctionArgumentsAlwaysNull(base_function.name);
++	bool always_null = FunctionArgumentsAlwaysNull(base_function.GetName());
+ 
+ 	vector<unique_ptr<ParsedExpression>> children;
+-	for (auto &arg : base_function.GetArguments()) {
++	for (auto &param : base_function.GetSignature().GetParameters()) {
+ 		// look up the type
+ 		unique_ptr<ParsedExpression> argument;
+ 		if (!always_null) {
+ 			for (auto &test_type : generator_context->test_types) {
+-				if (test_type.type.id() == arg.id()) {
++				if (test_type.type.id() == param.GetType().id()) {
+ 					argument = make_uniq<ColumnRefExpression>(test_type.name);
+ 				}
+ 			}
+ 		}
+ 		if (!argument) {
+-			argument = make_uniq<ConstantExpression>(Value(arg));
++			argument = make_uniq<ConstantExpression>(Value(param.GetType()));
+ 		}
+ 		children.push_back(std::move(argument));
+ 	}
+@@ -1303,7 +1305,7 @@ string StatementGenerator::GenerateTestAllTypes(SimpleFunction &base_function) {
+ 	from_clause->table_name = "all_types";
+ 	node->from_table = std::move(from_clause);
+ 
+-	auto function_expr = make_uniq<FunctionExpression>(base_function.name, std::move(children));
++	auto function_expr = make_uniq<FunctionExpression>(base_function.GetName(), std::move(children));
+ 	node->select_list.push_back(std::move(function_expr));
+ 
+ 	select->node = std::move(node);
+@@ -1319,17 +1321,17 @@ string StatementGenerator::GenerateTestVectorTypes(SimpleFunction &base_function
+ 	vector<unique_ptr<ParsedExpression>> children;
+ 	vector<unique_ptr<ParsedExpression>> test_vector_types;
+ 	vector<string> column_aliases;
+-	for (auto &arg : base_function.GetArguments()) {
++	for (auto &param : base_function.GetSignature().GetParameters()) {
+ 		unique_ptr<ParsedExpression> argument;
+ 		if (!always_null) {
+ 			string argument_name = "c" + to_string(column_aliases.size() + 1);
+ 			column_aliases.push_back(argument_name);
+ 			argument = make_uniq<ColumnRefExpression>(std::move(argument_name));
+ 			auto constant_expr = make_uniq<ConstantExpression>(Value());
+-			auto cast = make_uniq<CastExpression>(arg, std::move(constant_expr));
++			auto cast = make_uniq<CastExpression>(param.GetType(), std::move(constant_expr));
+ 			test_vector_types.push_back(std::move(cast));
+ 		} else {
+-			argument = make_uniq<ConstantExpression>(Value(arg));
++			argument = make_uniq<ConstantExpression>(Value(param.GetType()));
+ 		}
+ 		children.push_back(std::move(argument));
+ 	}

--- a/.github/patches/extensions/vss/0007-chunkcardinality.patch
+++ b/.github/patches/extensions/vss/0007-chunkcardinality.patch
@@ -3,11 +3,11 @@ index 93429a6..c3a2bc1 100644
 --- a/src/hnsw/hnsw_index_pragmas.cpp
 +++ b/src/hnsw/hnsw_index_pragmas.cpp
 @@ -168,7 +168,7 @@ static void HNSWIndexInfoExecute(ClientContext &context, TableFunctionInput &dat
-
+ 
  		row++;
  	}
 -	output.SetCardinality(row);
 +	output.SetChildCardinality(row);
  }
-
+ 
  //-------------------------------------------------------------------------

--- a/.github/patches/extensions/vss/0008-function-expr.patch
+++ b/.github/patches/extensions/vss/0008-function-expr.patch
@@ -1,0 +1,37 @@
+diff --git a/src/hnsw/hnsw_optimize_expr.cpp b/src/hnsw/hnsw_optimize_expr.cpp
+index d470fb0..6456c64 100644
+--- a/src/hnsw/hnsw_optimize_expr.cpp
++++ b/src/hnsw/hnsw_optimize_expr.cpp
+@@ -64,8 +64,8 @@ unique_ptr<Expression> CosineDistanceRule::Apply(LogicalOperator &op, vector<ref
+ 		}
+ 
+ 		changes_made = true;
+-		auto func = func_entry->functions.GetFunctionByArguments(context, arg_types);
+-		return make_uniq<BoundFunctionExpression>(similarity_expr.GetReturnType(), func, std::move(args), nullptr);
++		const auto &func = func_entry->functions.GetFunctionByArguments(context, arg_types);
++		return func.Bind(context, std::move(args));
+ 	}
+ 	return nullptr;
+ }
+diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
+index afb70c8..7108536 100644
+--- a/src/hnsw/hnsw_optimize_topk.cpp
++++ b/src/hnsw/hnsw_optimize_topk.cpp
+@@ -32,7 +32,7 @@ static unique_ptr<Expression> CreateListOrderByExpr(ClientContext &context, uniq
+ 		return nullptr;
+ 	}
+ 
+-	auto func = func_entry->functions.GetFunctionByOffset(0);
++	const auto &func = func_entry->functions.GetFunctionByOffset(0);
+ 	vector<unique_ptr<Expression>> arguments;
+ 	arguments.push_back(std::move(elem_expr));
+ 
+@@ -79,7 +79,7 @@ public:
+ 			return false;
+ 		}
+ 		auto &agg_func_expr = agg_expr->Cast<BoundAggregateExpression>();
+-		if (agg_func_expr.function.name != "min_by") {
++		if (agg_func_expr.function.GetName() != "min_by") {
+ 			return false;
+ 		}
+ 		if (agg_func_expr.children.size() != 3) {

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -290,7 +290,7 @@ unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->GetReturnType();
-	function = GetAverageAggregate(decimal_type.InternalType());
+	function.ReplaceImplementation(GetAverageAggregate(decimal_type.InternalType()));
 	function.name = "avg";
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -291,7 +291,7 @@ unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->GetReturnType();
 	function.ReplaceImplementation(GetAverageAggregate(decimal_type.InternalType()));
-	function.name = "avg";
+	function.SetName("avg");
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DOUBLE);
 	return make_uniq<AverageDecimalBindData>(

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -239,14 +239,14 @@ struct TimeTZAverageOperation : public BaseSumOperation<AverageSetOperation, Add
 	}
 };
 
-LogicalType GetAvgStateType(const AggregateFunction &function) {
+LogicalType GetAvgStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("count", LogicalType::UBIGINT);
 	children.emplace_back("value", function.GetArguments()[0]);
 	return LogicalType::STRUCT(std::move(children));
 }
 
-LogicalType GetKahanAvgStateType(const AggregateFunction &function) {
+LogicalType GetKahanAvgStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("count", LogicalType::UBIGINT);
 	children.emplace_back("value", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/algebraic/corr.cpp
+++ b/extension/core_functions/aggregate/algebraic/corr.cpp
@@ -7,14 +7,27 @@
 namespace duckdb {
 
 LogicalType GetCorrStateType() {
+	child_list_t<LogicalType> covar_children;
+	covar_children.emplace_back("count", LogicalType::UBIGINT);
+	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
+	covar_children.emplace_back("meany", LogicalType::DOUBLE);
+	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
+	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
+
+	child_list_t<LogicalType> stddev_types;
+	stddev_types.emplace_back("count", LogicalType::UBIGINT);
+	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
+	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
+	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
+
 	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
-	state_children.emplace_back("dev_pop_x", VarPopFun::GetFunction().GetStateType());
-	state_children.emplace_back("dev_pop_y", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
+	state_children.emplace_back("dev_pop_x", stddev_type);
+	state_children.emplace_back("dev_pop_y", stddev_type);
 	return LogicalType::STRUCT(std::move(state_children));
 }
 
-LogicalType GetCorrExportStateType(const AggregateFunction &) {
+LogicalType GetCorrExportStateType(const BoundAggregateFunction &) {
 	return GetCorrStateType();
 }
 

--- a/extension/core_functions/aggregate/algebraic/covar.cpp
+++ b/extension/core_functions/aggregate/algebraic/covar.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 namespace {
 
-LogicalType GetCovarStateType(const AggregateFunction &) {
+LogicalType GetCovarStateType(const BoundAggregateFunction &) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("count", LogicalType::UBIGINT);
 	child_types.emplace_back("meanx", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/algebraic/stddev.cpp
+++ b/extension/core_functions/aggregate/algebraic/stddev.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 namespace {
 
-LogicalType GetStddevStateType(const AggregateFunction &) {
+LogicalType GetStddevStateType(const BoundAggregateFunction &) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("count", LogicalType::UBIGINT);
 	child_types.emplace_back("mean", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -554,9 +554,9 @@ unique_ptr<FunctionData> BindDecimalArgMinMax(BindAggregateFunctionInput &input)
 		by_type = by_types[best_target];
 	}
 
-	auto name = std::move(function.name);
+	auto name = function.GetName();
 	function.ReplaceImplementation(GetDecimalArgMinMaxFunction<OP>(by_type, decimal_type, NULL_HANDLING));
-	function.name = std::move(name);
+	function.SetName(std::move(name));
 	function.SetReturnType(decimal_type);
 
 	auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING);

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -555,7 +555,7 @@ unique_ptr<FunctionData> BindDecimalArgMinMax(BindAggregateFunctionInput &input)
 	}
 
 	auto name = std::move(function.name);
-	function = GetDecimalArgMinMaxFunction<OP>(by_type, decimal_type, NULL_HANDLING);
+	function.ReplaceImplementation(GetDecimalArgMinMaxFunction<OP>(by_type, decimal_type, NULL_HANDLING));
 	function.name = std::move(name);
 	function.SetReturnType(decimal_type);
 

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -719,7 +719,7 @@ void ArgMinMaxNUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t inp
 // Bind
 //------------------------------------------------------------------------------
 template <class VAL_TYPE, class ARG_TYPE, class COMPARATOR>
-void SpecializeArgMinMaxNFunction(AggregateFunction &function) {
+void SpecializeArgMinMaxNFunction(BoundAggregateFunction &function) {
 	using STATE = ArgMinMaxNState<VAL_TYPE, ARG_TYPE, COMPARATOR>;
 	using OP = MinMaxNOperation;
 
@@ -733,7 +733,7 @@ void SpecializeArgMinMaxNFunction(AggregateFunction &function) {
 }
 
 template <class VAL_TYPE, class COMPARATOR>
-void SpecializeArgMinMaxNFunction(PhysicalType arg_type, AggregateFunction &function) {
+void SpecializeArgMinMaxNFunction(PhysicalType arg_type, BoundAggregateFunction &function) {
 	switch (arg_type) {
 #ifndef DUCKDB_SMALLER_BINARY
 	case PhysicalType::VARCHAR:
@@ -759,7 +759,7 @@ void SpecializeArgMinMaxNFunction(PhysicalType arg_type, AggregateFunction &func
 }
 
 template <class COMPARATOR>
-void SpecializeArgMinMaxNFunction(PhysicalType val_type, PhysicalType arg_type, AggregateFunction &function) {
+void SpecializeArgMinMaxNFunction(PhysicalType val_type, PhysicalType arg_type, BoundAggregateFunction &function) {
 	switch (val_type) {
 #ifndef DUCKDB_SMALLER_BINARY
 	case PhysicalType::VARCHAR:
@@ -785,7 +785,7 @@ void SpecializeArgMinMaxNFunction(PhysicalType val_type, PhysicalType arg_type, 
 }
 
 template <class VAL_TYPE, class ARG_TYPE, class COMPARATOR>
-void SpecializeArgMinMaxNullNFunction(AggregateFunction &function) {
+void SpecializeArgMinMaxNullNFunction(BoundAggregateFunction &function) {
 	using STATE = ArgMinMaxNState<VAL_TYPE, ARG_TYPE, COMPARATOR>;
 	using OP = MinMaxNOperation;
 
@@ -798,7 +798,7 @@ void SpecializeArgMinMaxNullNFunction(AggregateFunction &function) {
 }
 
 template <class VAL_TYPE, bool NULLS_LAST, class COMPARATOR>
-void SpecializeArgMinMaxNullNFunction(PhysicalType arg_type, AggregateFunction &function) {
+void SpecializeArgMinMaxNullNFunction(PhysicalType arg_type, BoundAggregateFunction &function) {
 	switch (arg_type) {
 #ifndef DUCKDB_SMALLER_BINARY
 	case PhysicalType::VARCHAR:
@@ -824,7 +824,7 @@ void SpecializeArgMinMaxNullNFunction(PhysicalType arg_type, AggregateFunction &
 }
 
 template <bool NULLS_LAST, class COMPARATOR>
-void SpecializeArgMinMaxNullNFunction(PhysicalType val_type, PhysicalType arg_type, AggregateFunction &function) {
+void SpecializeArgMinMaxNullNFunction(PhysicalType val_type, PhysicalType arg_type, BoundAggregateFunction &function) {
 	switch (val_type) {
 #ifndef DUCKDB_SMALLER_BINARY
 	case PhysicalType::VARCHAR:

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -18,7 +18,7 @@ struct BitState {
 };
 
 template <class T>
-LogicalType GetBitStateType(const AggregateFunction &function) {
+LogicalType GetBitStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
 
@@ -28,7 +28,7 @@ LogicalType GetBitStateType(const AggregateFunction &function) {
 	return LogicalType::STRUCT(std::move(child_types));
 }
 
-LogicalType GetBitStringStateType(const AggregateFunction &function) {
+LogicalType GetBitStringStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
 	child_types.emplace_back("value", function.GetReturnType());

--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -271,7 +271,7 @@ void BindBitString(AggregateFunctionSet &bitstring_agg, const LogicalTypeId &typ
 	function.SetStatisticsCallback(
 	    BitstringPropagateStats);        // stores min and max from column stats in BitstringAggBindData
 	bitstring_agg.AddFunction(function); // uses the BitstringAggBindData to access statistics for creating bitstring
-	function.GetArguments() = {type, type, type};
+	function.GetSignature() = FunctionSignature({type, type, type}, LogicalType::BIT);
 	function.SetStatisticsCallback(nullptr); // min and max are provided as arguments
 	bitstring_agg.AddFunction(function);
 }

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -93,7 +93,7 @@ struct BoolOrFunFunction {
 	}
 };
 
-LogicalType GetBoolAndStateType(const AggregateFunction &function) {
+LogicalType GetBoolAndStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("empty", LogicalType::BOOLEAN);
 	child_types.emplace_back("val", LogicalType::BOOLEAN);

--- a/extension/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/extension/core_functions/aggregate/distributive/kurtosis.cpp
@@ -100,7 +100,7 @@ struct KurtosisOperation {
 	}
 };
 
-LogicalType GetKurtosisStateType(const AggregateFunction &function) {
+LogicalType GetKurtosisStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("n", LogicalType::UBIGINT);
 	children.emplace_back("sum", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/distributive/product.cpp
+++ b/extension/core_functions/aggregate/distributive/product.cpp
@@ -55,7 +55,7 @@ struct ProductFunction {
 	}
 };
 
-LogicalType GetProductStateType(const AggregateFunction &function) {
+LogicalType GetProductStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("empty", LogicalType::BOOLEAN);
 	children.emplace_back("val", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/distributive/string_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/string_agg.cpp
@@ -171,7 +171,7 @@ AggregateFunctionSet StringAggFun::GetFunctions() {
 	string_agg_param.SetSerializeCallback(StringAggSerialize);
 	string_agg_param.SetDeserializeCallback(StringAggDeserialize);
 	string_agg.AddFunction(string_agg_param);
-	string_agg_param.GetArguments().emplace_back(LogicalType::VARCHAR);
+	string_agg_param.GetSignature().AddParameter(LogicalType::VARCHAR);
 	string_agg.AddFunction(string_agg_param);
 	return string_agg;
 }

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -183,7 +183,7 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 			return nullptr;
 		}
 		// total sum is guaranteed to fit in a single int64: use int64 sum instead of hugeint sum
-		expr.function = GetSumAggregateNoOverflow(internal_type);
+		expr.function.ReplaceImplementation(GetSumAggregateNoOverflow(internal_type));
 	}
 	return nullptr;
 }
@@ -235,7 +235,7 @@ unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->GetReturnType();
-	function = GetSumAggregate(decimal_type.InternalType());
+	function.ReplaceImplementation(GetSumAggregate(decimal_type.InternalType()));
 	function.name = "sum";
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type)));

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -236,7 +236,7 @@ unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	auto decimal_type = arguments[0]->GetReturnType();
 	function.ReplaceImplementation(GetSumAggregate(decimal_type.InternalType()));
-	function.name = "sum";
+	function.SetName("sum");
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type)));
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -90,7 +90,7 @@ LogicalType GetValueLogicalType<double>() {
 }
 
 template <class T>
-LogicalType GetSumStateType(const AggregateFunction &function) {
+LogicalType GetSumStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("isset", LogicalType::BOOLEAN);
 
@@ -239,7 +239,7 @@ unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
 	function.name = "sum";
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type)));
-	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	function.GetProperties().SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return nullptr;
 }
 
@@ -331,7 +331,7 @@ AggregateFunctionSet SumNoOverflowFun::GetFunctions() {
 	return sum_no_overflow;
 }
 
-LogicalType GetKahanSumStateType(const AggregateFunction &function) {
+LogicalType GetKahanSumStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("isset", LogicalType::BOOLEAN);
 	children.emplace_back("value", LogicalType::DOUBLE);

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -239,7 +239,7 @@ unique_ptr<FunctionData> BindDecimalSum(BindAggregateFunctionInput &input) {
 	function.name = "sum";
 	function.GetArguments()[0] = decimal_type;
 	function.SetReturnType(LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type)));
-	function.GetProperties().SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -283,7 +283,7 @@ unique_ptr<FunctionData> BindApproxQuantileDecimal(BindAggregateFunctionInput &i
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto bind_data = BindApproxQuantile(input);
-	function = ApproxQuantileDecimalFunction(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(ApproxQuantileDecimalFunction(arguments[0]->GetReturnType()));
 	return bind_data;
 }
 
@@ -404,7 +404,7 @@ unique_ptr<FunctionData> BindApproxQuantileDecimalList(BindAggregateFunctionInpu
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	auto bind_data = BindApproxQuantile(input);
-	function = ApproxQuantileDecimalListFunction(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(ApproxQuantileDecimalListFunction(arguments[0]->GetReturnType()));
 	return bind_data;
 }
 
@@ -424,9 +424,9 @@ unique_ptr<FunctionData> ApproxQuantileDecimalDeserialize(Deserializer &deserial
 	auto bind_data = ApproximateQuantileBindData::Deserialize(deserializer, function);
 	auto &return_type = deserializer.Get<const LogicalType &>();
 	if (return_type.id() == LogicalTypeId::LIST) {
-		function = ApproxQuantileDecimalListFunction(function.GetArguments()[0]);
+		function.ReplaceImplementation(ApproxQuantileDecimalListFunction(function.GetArguments()[0]));
 	} else {
-		function = ApproxQuantileDecimalFunction(function.GetArguments()[0]);
+		function.ReplaceImplementation(ApproxQuantileDecimalFunction(function.GetArguments()[0]));
 	}
 	return bind_data;
 }

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -293,7 +293,7 @@ AggregateFunction GetApproximateQuantileAggregate(const LogicalType &type) {
 	fun.SetSerializeCallback(ApproximateQuantileBindData::Serialize);
 	fun.SetDeserializeCallback(ApproximateQuantileBindData::Deserialize);
 	// temporarily push an argument so we can bind the actual quantile
-	fun.GetArguments().emplace_back(LogicalType::FLOAT);
+	fun.GetSignature().AddParameter(LogicalType::FLOAT);
 	return fun;
 }
 
@@ -415,7 +415,7 @@ AggregateFunction GetApproxQuantileListAggregate(const LogicalType &type) {
 	fun.SetDeserializeCallback(ApproximateQuantileBindData::Deserialize);
 	// temporarily push an argument so we can bind the actual quantile
 	auto list_of_float = LogicalType::LIST(LogicalType::FLOAT);
-	fun.GetArguments().push_back(list_of_float);
+	fun.GetSignature().AddParameter(list_of_float);
 	return fun;
 }
 

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -331,7 +331,7 @@ unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctio
 	auto impl = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
 	function.ReplaceImplementation(impl);
 	function.name = "mad";
-	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	function.GetProperties().SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return BindMAD(input);
 }
 

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -328,7 +328,8 @@ AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType 
 unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
+	auto impl = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(impl);
 	function.name = "mad";
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return BindMAD(input);

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -331,7 +331,7 @@ unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctio
 	auto impl = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
 	function.ReplaceImplementation(impl);
 	function.name = "mad";
-	function.GetProperties().SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return BindMAD(input);
 }
 

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -330,7 +330,7 @@ unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(BindAggregateFunctio
 	auto &arguments = input.GetArguments();
 	auto impl = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->GetReturnType());
 	function.ReplaceImplementation(impl);
-	function.name = "mad";
+	function.SetName("mad");
 	function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	return BindMAD(input);
 }

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -509,7 +509,7 @@ unique_ptr<FunctionData> BindModeAggregate(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	function.ReplaceImplementation(GetModeAggregate(arguments[0]->GetReturnType()));
-	function.name = "mode";
+	function.SetName("mode");
 	return nullptr;
 }
 
@@ -611,7 +611,7 @@ unique_ptr<FunctionData> BindEntropyAggregate(BindAggregateFunctionInput &input)
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
 	function.ReplaceImplementation(GetEntropyFunction(arguments[0]->GetReturnType()));
-	function.name = "entropy";
+	function.SetName("entropy");
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -508,7 +508,7 @@ AggregateFunction GetModeAggregate(const LogicalType &type) {
 unique_ptr<FunctionData> BindModeAggregate(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetModeAggregate(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(GetModeAggregate(arguments[0]->GetReturnType()));
 	function.name = "mode";
 	return nullptr;
 }
@@ -610,7 +610,7 @@ AggregateFunction GetEntropyFunction(const LogicalType &type) {
 unique_ptr<FunctionData> BindEntropyAggregate(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetEntropyFunction(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(GetEntropyFunction(arguments[0]->GetReturnType()));
 	function.name = "entropy";
 	return nullptr;
 }

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -702,7 +702,7 @@ struct DiscreteQuantileListFunction {
 		fun.SetSerializeCallback(QuantileBindData::Serialize);
 		fun.SetDeserializeCallback(Deserialize);
 		// temporarily push an argument so we can bind the actual quantile
-		fun.GetArguments().emplace_back(LogicalType::LIST(LogicalType::DOUBLE));
+		fun.GetSignature().AddParameter(LogicalType::LIST(LogicalType::DOUBLE));
 		fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return fun;
 	}
@@ -731,7 +731,7 @@ struct DiscreteQuantileFunction {
 		fun.SetSerializeCallback(QuantileBindData::Serialize);
 		fun.SetDeserializeCallback(Deserialize);
 		// temporarily push an argument so we can bind the actual quantile
-		fun.GetArguments().emplace_back(LogicalType::DOUBLE);
+		fun.GetSignature().AddParameter(LogicalType::DOUBLE);
 		fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return fun;
 	}
@@ -765,7 +765,7 @@ struct ContinuousQuantileFunction {
 		fun.SetSerializeCallback(QuantileBindData::Serialize);
 		fun.SetDeserializeCallback(Deserialize);
 		// temporarily push an argument so we can bind the actual quantile
-		fun.GetArguments().emplace_back(LogicalType::DOUBLE);
+		fun.GetSignature().AddParameter(LogicalType::DOUBLE);
 		fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return fun;
 	}
@@ -798,7 +798,7 @@ struct ContinuousQuantileListFunction {
 		fun.SetDeserializeCallback(Deserialize);
 		// temporarily push an argument so we can bind the actual quantile
 		auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
-		fun.GetArguments().push_back(list_of_double);
+		fun.GetSignature().AddParameter(list_of_double);
 		fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 		return fun;
 	}
@@ -827,7 +827,7 @@ static AggregateFunction EmptyQuantileFunction(LogicalType input, const LogicalT
                                                const LogicalType &extra_arg) {
 	AggregateFunction fun({std::move(input)}, result, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, OP::Bind);
 	if (extra_arg.id() != LogicalTypeId::INVALID) {
-		fun.GetArguments().push_back(extra_arg);
+		fun.GetSignature().AddParameter(extra_arg);
 	}
 	fun.SetSerializeCallback(QuantileBindData::Serialize);
 	fun.SetDeserializeCallback(OP::Deserialize);

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -682,14 +682,14 @@ struct MedianFunction {
 		auto bind_data = QuantileBindData::Deserialize(deserializer, function);
 
 		auto &input_type = function.GetArguments()[0];
-		function = GetAggregate(input_type);
+		function.ReplaceImplementation(GetAggregate(input_type));
 		return bind_data;
 	}
 
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->GetReturnType());
+		function.ReplaceImplementation(GetAggregate(arguments[0]->GetReturnType()));
 		return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
 	}
 };
@@ -711,14 +711,14 @@ struct DiscreteQuantileListFunction {
 		auto bind_data = QuantileBindData::Deserialize(deserializer, function);
 
 		auto &input_type = function.GetArguments()[0];
-		function = GetAggregate(input_type);
+		function.ReplaceImplementation(GetAggregate(input_type));
 		return bind_data;
 	}
 
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->GetReturnType());
+		function.ReplaceImplementation(GetAggregate(arguments[0]->GetReturnType()));
 		return BindQuantile(input);
 	}
 };
@@ -742,9 +742,9 @@ struct DiscreteQuantileFunction {
 
 		auto &input_type = function.GetArguments()[0];
 		if (quantile_data.quantiles.size() == 1) {
-			function = GetAggregate(input_type);
+			function.ReplaceImplementation(GetAggregate(input_type));
 		} else {
-			function = DiscreteQuantileListFunction::GetAggregate(input_type);
+			function.ReplaceImplementation(DiscreteQuantileListFunction::GetAggregate(input_type));
 		}
 		return bind_data;
 	}
@@ -752,7 +752,7 @@ struct DiscreteQuantileFunction {
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function = GetAggregate(arguments[0]->GetReturnType());
+		function.ReplaceImplementation(GetAggregate(arguments[0]->GetReturnType()));
 		return BindQuantile(input);
 	}
 };
@@ -774,16 +774,17 @@ struct ContinuousQuantileFunction {
 		auto bind_data = QuantileBindData::Deserialize(deserializer, function);
 
 		auto &input_type = function.GetArguments()[0];
-		function = GetAggregate(input_type);
+		function.ReplaceImplementation(GetAggregate(input_type));
 		return bind_data;
 	}
 
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function =
+		auto impl =
 		    GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->GetReturnType()
 		                                                                           : function.GetArguments()[0]);
+		function.ReplaceImplementation(impl);
 		return BindQuantile(input);
 	}
 };
@@ -806,16 +807,17 @@ struct ContinuousQuantileListFunction {
 		auto bind_data = QuantileBindData::Deserialize(deserializer, function);
 
 		auto &input_type = function.GetArguments()[0];
-		function = GetAggregate(input_type);
+		function.ReplaceImplementation(GetAggregate(input_type));
 		return bind_data;
 	}
 
 	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
 		auto &function = input.GetBoundFunction();
 		auto &arguments = input.GetArguments();
-		function =
+		auto impl =
 		    GetAggregate(function.GetArguments()[0].id() == LogicalTypeId::DECIMAL ? arguments[0]->GetReturnType()
 		                                                                           : function.GetArguments()[0]);
+		function.ReplaceImplementation(impl);
 		return BindQuantile(input);
 	}
 };

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -380,7 +380,7 @@ AggregateFunction GetReservoirQuantileAggregate(PhysicalType type) {
 	fun.SetSerializeCallback(ReservoirQuantileBindData::Serialize);
 	fun.SetDeserializeCallback(ReservoirQuantileBindData::Deserialize);
 	// temporarily push an argument so we can bind the actual quantile
-	fun.GetArguments().emplace_back(LogicalType::DOUBLE);
+	fun.GetSignature().AddParameter(LogicalType::DOUBLE);
 	return fun;
 }
 
@@ -391,7 +391,7 @@ AggregateFunction GetReservoirQuantileListAggregate(const LogicalType &type) {
 	fun.SetDeserializeCallback(ReservoirQuantileBindData::Deserialize);
 	// temporarily push an argument so we can bind the actual quantile
 	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
-	fun.GetArguments().push_back(list_of_double);
+	fun.GetSignature().AddParameter(list_of_double);
 	return fun;
 }
 
@@ -400,14 +400,14 @@ void DefineReservoirQuantile(AggregateFunctionSet &set, const LogicalType &type)
 	auto fun = GetReservoirQuantileAggregate(type.InternalType());
 	set.AddFunction(fun);
 
-	fun.GetArguments().emplace_back(LogicalType::INTEGER);
+	fun.GetSignature().AddParameter(LogicalType::INTEGER);
 	set.AddFunction(fun);
 
 	// List variants
 	fun = GetReservoirQuantileListAggregate(type);
 	set.AddFunction(fun);
 
-	fun.GetArguments().emplace_back(LogicalType::INTEGER);
+	fun.GetSignature().AddParameter(LogicalType::INTEGER);
 	set.AddFunction(fun);
 }
 
@@ -419,7 +419,7 @@ void GetReservoirQuantileDecimalFunction(AggregateFunctionSet &set, const vector
 	fun.SetDeserializeCallback(ReservoirQuantileBindData::Deserialize);
 	set.AddFunction(fun);
 
-	fun.GetArguments().emplace_back(LogicalType::INTEGER);
+	fun.GetSignature().AddParameter(LogicalType::INTEGER);
 	set.AddFunction(fun);
 }
 

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -368,7 +368,7 @@ unique_ptr<FunctionData> BindReservoirQuantileDecimal(BindAggregateFunctionInput
 	auto &arguments = input.GetArguments();
 	function.ReplaceImplementation(GetReservoirQuantileAggregateFunction(arguments[0]->GetReturnType().InternalType()));
 	auto bind_data = BindReservoirQuantile(input);
-	function.name = "reservoir_quantile";
+	function.SetName("reservoir_quantile");
 	function.SetSerializeCallback(ReservoirQuantileBindData::Serialize);
 	function.SetDeserializeCallback(ReservoirQuantileBindData::Deserialize);
 	return bind_data;

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -366,7 +366,7 @@ unique_ptr<FunctionData> BindReservoirQuantile(BindAggregateFunctionInput &input
 unique_ptr<FunctionData> BindReservoirQuantileDecimal(BindAggregateFunctionInput &input) {
 	auto &function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	function = GetReservoirQuantileAggregateFunction(arguments[0]->GetReturnType().InternalType());
+	function.ReplaceImplementation(GetReservoirQuantileAggregateFunction(arguments[0]->GetReturnType().InternalType()));
 	auto bind_data = BindReservoirQuantile(input);
 	function.name = "reservoir_quantile";
 	function.SetSerializeCallback(ReservoirQuantileBindData::Serialize);

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -400,7 +400,7 @@ unique_ptr<FunctionData> HistogramBinBindFunction(BindAggregateFunctionInput &in
 		}
 	}
 
-	function = GetHistogramBinFunction<HIST>(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(GetHistogramBinFunction<HIST>(arguments[0]->GetReturnType()));
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -213,7 +213,7 @@ unique_ptr<FunctionData> HistogramBindFunction(BindAggregateFunctionInput &input
 	if (arguments[0]->GetReturnType().id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	function = GetHistogramFunction<IS_ORDERED>(arguments[0]->GetReturnType());
+	function.ReplaceImplementation(GetHistogramFunction<IS_ORDERED>(arguments[0]->GetReturnType()));
 	return make_uniq<VariableReturnBindData>(function.GetReturnType());
 }
 

--- a/extension/core_functions/aggregate/regression/regr_avg.cpp
+++ b/extension/core_functions/aggregate/regression/regr_avg.cpp
@@ -54,7 +54,7 @@ struct RegrAvgYFunction : RegrAvgFunction {
 	}
 };
 
-LogicalType GetRegrAvgStateType(const AggregateFunction &) {
+LogicalType GetRegrAvgStateType(const BoundAggregateFunction &) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("sum", LogicalType::DOUBLE);
 	child_types.emplace_back("count", LogicalType::UBIGINT);

--- a/extension/core_functions/aggregate/regression/regr_count.cpp
+++ b/extension/core_functions/aggregate/regression/regr_count.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 namespace {
 
-LogicalType GetRegrCountStateType(const AggregateFunction &) {
+LogicalType GetRegrCountStateType(const BoundAggregateFunction &) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("count", LogicalType::UBIGINT);
 	return LogicalType::STRUCT(std::move(child_types));

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -60,14 +60,27 @@ struct RegrInterceptOperation {
 	}
 };
 
-LogicalType GetRegrInterceptStateType(const AggregateFunction &) {
+LogicalType GetRegrInterceptStateType(const BoundAggregateFunction &) {
+	child_list_t<LogicalType> covpop_children;
+	covpop_children.emplace_back("count", LogicalType::UBIGINT);
+	covpop_children.emplace_back("meanx", LogicalType::DOUBLE);
+	covpop_children.emplace_back("meany", LogicalType::DOUBLE);
+	covpop_children.emplace_back("co_moment", LogicalType::DOUBLE);
+	auto covpop_type = LogicalType::STRUCT(std::move(covpop_children));
+
+	child_list_t<LogicalType> varpop_children;
+	varpop_children.emplace_back("count", LogicalType::UBIGINT);
+	varpop_children.emplace_back("mean", LogicalType::DOUBLE);
+	varpop_children.emplace_back("dsquared", LogicalType::DOUBLE);
+	auto varpop_type = LogicalType::STRUCT(std::move(varpop_children));
+
 	child_list_t<LogicalType> state_children;
 	state_children.emplace_back("count", LogicalType::UBIGINT);
 	state_children.emplace_back("sum_x", LogicalType::DOUBLE);
 	state_children.emplace_back("sum_y", LogicalType::DOUBLE);
 	child_list_t<LogicalType> slope_children;
-	slope_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
-	slope_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
+	slope_children.emplace_back("cov_pop", std::move(covpop_type));
+	slope_children.emplace_back("var_pop", std::move(varpop_type));
 	state_children.emplace_back("slope", LogicalType::STRUCT(std::move(slope_children)));
 	return LogicalType::STRUCT(std::move(state_children));
 }

--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -61,11 +61,30 @@ struct RegrR2Operation {
 	}
 };
 
-LogicalType GetRegrR2StateType(const AggregateFunction &) {
+LogicalType GetRegrR2StateType(const BoundAggregateFunction &) {
+	child_list_t<LogicalType> covar_children;
+	covar_children.emplace_back("count", LogicalType::UBIGINT);
+	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
+	covar_children.emplace_back("meany", LogicalType::DOUBLE);
+	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
+	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
+
+	child_list_t<LogicalType> stddev_types;
+	stddev_types.emplace_back("count", LogicalType::UBIGINT);
+	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
+	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
+	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
+
+	child_list_t<LogicalType> corr_children;
+	corr_children.emplace_back("cov_pop", std::move(cov_pop_type));
+	corr_children.emplace_back("dev_pop_x", stddev_type);
+	corr_children.emplace_back("dev_pop_y", stddev_type);
+	auto corr_state = LogicalType::STRUCT(std::move(corr_children));
+
 	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("corr", CorrFun::GetFunction().GetStateType());
-	state_children.emplace_back("var_pop_x", VarPopFun::GetFunction().GetStateType());
-	state_children.emplace_back("var_pop_y", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("corr", corr_state);
+	state_children.emplace_back("var_pop_x", stddev_type);
+	state_children.emplace_back("var_pop_y", stddev_type);
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_slope.cpp
+++ b/extension/core_functions/aggregate/regression/regr_slope.cpp
@@ -14,10 +14,23 @@ namespace duckdb {
 
 namespace {
 
-LogicalType GetRegrSlopeStateType(const AggregateFunction &) {
+LogicalType GetRegrSlopeStateType(const BoundAggregateFunction &) {
+	child_list_t<LogicalType> covar_children;
+	covar_children.emplace_back("count", LogicalType::UBIGINT);
+	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
+	covar_children.emplace_back("meany", LogicalType::DOUBLE);
+	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
+	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
+
+	child_list_t<LogicalType> stddev_types;
+	stddev_types.emplace_back("count", LogicalType::UBIGINT);
+	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
+	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
+	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
+
 	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
-	state_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
+	state_children.emplace_back("var_pop", std::move(stddev_type));
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -60,10 +60,16 @@ struct RegrSYYOperation : RegrBaseOperation {
 	}
 };
 
-LogicalType GetRegrSStateType(const AggregateFunction &) {
+LogicalType GetRegrSStateType(const BoundAggregateFunction &) {
+	child_list_t<LogicalType> stddev_types;
+	stddev_types.emplace_back("count", LogicalType::UBIGINT);
+	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
+	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
+	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
+
 	child_list_t<LogicalType> state_children;
 	state_children.emplace_back("count", LogicalType::UBIGINT);
-	state_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("var_pop", stddev_type);
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -47,10 +47,18 @@ struct RegrSXYOperation {
 	}
 };
 
-LogicalType GetRegrSXYStateType(const AggregateFunction &) {
+LogicalType GetRegrSXYStateType(const BoundAggregateFunction &) {
+	child_list_t<LogicalType> covar_children;
+	covar_children.emplace_back("count", LogicalType::UBIGINT);
+	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
+	covar_children.emplace_back("meany", LogicalType::DOUBLE);
+	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
+	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
+
 	child_list_t<LogicalType> state_children;
 	state_children.emplace_back("count", LogicalType::UBIGINT);
-	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
+
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -352,7 +352,7 @@ static void ExecuteLambda(DataChunk &args, ExpressionState &state, Vector &resul
 
 unique_ptr<FunctionData> LambdaFunctions::ListLambdaPrepareBind(vector<unique_ptr<Expression>> &arguments,
                                                                 ClientContext &context,
-                                                                ScalarFunction &bound_function) {
+                                                                BoundScalarFunction &bound_function) {
 	// NULL list parameter
 	if (arguments[0]->GetReturnType().id() == LogicalTypeId::SQLNULL) {
 		bound_function.GetArguments()[0] = LogicalType::SQLNULL;
@@ -369,7 +369,7 @@ unique_ptr<FunctionData> LambdaFunctions::ListLambdaPrepareBind(vector<unique_pt
 	return nullptr;
 }
 
-unique_ptr<FunctionData> LambdaFunctions::ListLambdaBind(ClientContext &context, ScalarFunction &bound_function,
+unique_ptr<FunctionData> LambdaFunctions::ListLambdaBind(ClientContext &context, BoundScalarFunction &bound_function,
                                                          vector<unique_ptr<Expression>> &arguments,
                                                          const bool has_index) {
 	unique_ptr<FunctionData> bind_data = ListLambdaPrepareBind(arguments, context, bound_function);

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -25,14 +25,14 @@ static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &
 	if (bound_function.GetArguments()[0].id() != LogicalTypeId::ARRAY ||
 	    bound_function.GetArguments()[1].id() != LogicalTypeId::ARRAY) {
 		throw InvalidInputException(
-		    StringUtil::Format("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.name));
+		    StringUtil::Format("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.GetName()));
 	}
 
 	const auto lhs_size = ArrayType::GetSize(bound_function.GetArguments()[0]);
 	const auto rhs_size = ArrayType::GetSize(bound_function.GetArguments()[1]);
 
 	if (lhs_size != rhs_size) {
-		throw BinderException("%s: Array arguments must be of the same size", bound_function.name);
+		throw BinderException("%s: Array arguments must be of the same size", bound_function.GetName());
 	}
 
 	const auto &lhs_element_type = ArrayType::GetChildType(bound_function.GetArguments()[0]);
@@ -41,13 +41,13 @@ static unique_ptr<FunctionData> ArrayGenericBinaryBind(BindScalarFunctionInput &
 	// Resolve common type
 	LogicalType common_type;
 	if (!LogicalType::TryGetMaxLogicalType(context, lhs_element_type, rhs_element_type, common_type)) {
-		throw BinderException("%s: Cannot infer common element type (left = '%s', right = '%s')", bound_function.name,
-		                      lhs_element_type.ToString(), rhs_element_type.ToString());
+		throw BinderException("%s: Cannot infer common element type (left = '%s', right = '%s')",
+		                      bound_function.GetName(), lhs_element_type.ToString(), rhs_element_type.ToString());
 	}
 
 	// Ensure it is float or double
 	if (common_type.id() != LogicalTypeId::FLOAT && common_type.id() != LogicalTypeId::DOUBLE) {
-		throw BinderException("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.name);
+		throw BinderException("%s: Arguments must be arrays of FLOAT or DOUBLE", bound_function.GetName());
 	}
 
 	// The important part is just that we resolve the size of the input arrays
@@ -87,7 +87,7 @@ template <class TYPE, class OP, idx_t N>
 static void ArrayFixedCombine(DataChunk &args, ExpressionState &state, Vector &result) {
 	const auto &lstate = state.Cast<ExecuteFunctionState>();
 	const auto &expr = lstate.expr.Cast<BoundFunctionExpression>();
-	const auto &func_name = expr.function.name;
+	const auto &func_name = expr.function.GetName();
 
 	const auto count = args.size();
 	auto &lhs_child = ArrayVector::GetChildMutable(args.data[0]);
@@ -149,7 +149,7 @@ template <class TYPE, class OP>
 static void ArrayGenericFold(DataChunk &args, ExpressionState &state, Vector &result) {
 	const auto &lstate = state.Cast<ExecuteFunctionState>();
 	const auto &expr = lstate.expr.Cast<BoundFunctionExpression>();
-	const auto &func_name = expr.function.name;
+	const auto &func_name = expr.function.GetName();
 
 	const auto count = args.size();
 	auto &lhs_child = ArrayVector::GetChildMutable(args.data[0]);

--- a/extension/core_functions/scalar/array/array_value.cpp
+++ b/extension/core_functions/scalar/array/array_value.cpp
@@ -63,8 +63,6 @@ unique_ptr<FunctionData> ArrayValueBind(BindScalarFunctionInput &input) {
 		throw OutOfRangeException("Array size exceeds maximum allowed size");
 	}
 
-	// this is more for completeness reasons
-	bound_function.SetVarArgs(child_type);
 	bound_function.SetReturnType(LogicalType::ARRAY(child_type, arguments.size()));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -1774,7 +1774,7 @@ unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
 	case DatePartSpecifier::JULIAN_DAY:
 		arguments.erase(arguments.begin());
 		bound_function.GetArguments().erase(bound_function.GetArguments().begin());
-		bound_function.name = "julian";
+		bound_function.SetName("julian");
 		bound_function.SetReturnType(LogicalType::DOUBLE);
 		switch (arguments[0]->GetReturnType().id()) {
 		case LogicalType::TIMESTAMP:
@@ -1791,13 +1791,13 @@ unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
 			bound_function.SetStatisticsCallback(DatePart::JulianDayOperator::template PropagateStatistics<date_t>);
 			break;
 		default:
-			throw BinderException("%s can only take DATE or TIMESTAMP arguments", bound_function.name);
+			throw BinderException("%s can only take DATE or TIMESTAMP arguments", bound_function.GetName());
 		}
 		break;
 	case DatePartSpecifier::EPOCH:
 		arguments.erase(arguments.begin());
 		bound_function.GetArguments().erase(bound_function.GetArguments().begin());
-		bound_function.name = "epoch";
+		bound_function.SetName("epoch");
 		bound_function.SetReturnType(LogicalType::DOUBLE);
 		switch (arguments[0]->GetReturnType().id()) {
 		case LogicalType::TIMESTAMP:
@@ -1828,7 +1828,7 @@ unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {
 			bound_function.SetStatisticsCallback(DatePart::EpochOperator::template PropagateStatistics<dtime_tz_t>);
 			break;
 		default:
-			throw BinderException("%s can only take temporal arguments", bound_function.name);
+			throw BinderException("%s can only take temporal arguments", bound_function.GetName());
 		}
 		break;
 	default:
@@ -1949,7 +1949,7 @@ struct StructDatePart {
 			throw ParameterNotResolvedException();
 		}
 		if (!arguments[0]->IsFoldable()) {
-			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+			throw BinderException("%s can only take constant lists of part names", bound_function.GetName());
 		}
 
 		case_insensitive_set_t name_collision_set;
@@ -1960,16 +1960,17 @@ struct StructDatePart {
 		if (parts_list.type().id() == LogicalTypeId::LIST) {
 			auto &list_children = ListValue::GetChildren(parts_list);
 			if (list_children.empty()) {
-				throw BinderException("%s requires non-empty lists of part names", bound_function.name);
+				throw BinderException("%s requires non-empty lists of part names", bound_function.GetName());
 			}
 			for (const auto &part_value : list_children) {
 				if (part_value.IsNull()) {
-					throw BinderException("NULL struct entry name in %s", bound_function.name);
+					throw BinderException("NULL struct entry name in %s", bound_function.GetName());
 				}
 				const auto part_name = part_value.ToString();
 				const auto part_code = GetDateTypePartSpecifier(part_name, arguments[1]->GetReturnType());
 				if (name_collision_set.find(part_name) != name_collision_set.end()) {
-					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name, bound_function.name);
+					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name,
+					                      bound_function.GetName());
 				}
 				name_collision_set.insert(part_name);
 				part_codes.emplace_back(part_code);
@@ -1977,7 +1978,7 @@ struct StructDatePart {
 				struct_children.emplace_back(make_pair(part_name, part_type));
 			}
 		} else {
-			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+			throw BinderException("%s can only take constant lists of part names", bound_function.GetName());
 		}
 
 		Function::EraseArgument(bound_function, arguments, 0);

--- a/extension/core_functions/scalar/generic/least.cpp
+++ b/extension/core_functions/scalar/generic/least.cpp
@@ -228,8 +228,9 @@ unique_ptr<FunctionData> BindLeastGreatest(BindScalarFunctionInput &input) {
 		bound_function.SetInitStateCallback(LeastGreatestSortKeyInit<LEAST_GREATER_OP>);
 		break;
 	}
-	bound_function.GetArguments()[0] = child_type;
-	bound_function.SetVarArgs(child_type);
+	for (auto &arg : bound_function.GetArguments()) {
+		arg = child_type;
+	}
 	bound_function.SetReturnType(child_type);
 	return nullptr;
 }

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -381,7 +381,7 @@ ScalarFunctionSet ListSliceFun::GetFunctions() {
 	fun.SetFallible();
 	ScalarFunctionSet set;
 	set.AddFunction(fun);
-	fun.GetArguments().push_back(LogicalType::BIGINT);
+	fun.GetSignature().AddParameter(LogicalType::BIGINT);
 	set.AddFunction(fun);
 	return set;
 }

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -30,7 +30,7 @@ unique_ptr<FunctionLocalState> ListAggregatesInitLocalState(ExpressionState &sta
 }
 // FIXME: benchmark the use of simple_update against using update (if applicable)
 
-unique_ptr<FunctionData> ListAggregatesBindFailure(ScalarFunction &bound_function) {
+unique_ptr<FunctionData> ListAggregatesBindFailure(BoundScalarFunction &bound_function) {
 	bound_function.GetArguments()[0] = LogicalType::SQLNULL;
 	bound_function.SetReturnType(LogicalType::SQLNULL);
 	return make_uniq<VariableReturnBindData>(LogicalType::SQLNULL);
@@ -379,9 +379,10 @@ void ListUniqueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 }
 
 template <bool IS_AGGR = false>
-unique_ptr<FunctionData>
-ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_function, const LogicalType &list_child_type,
-                           AggregateFunction &aggr_function, vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, BoundScalarFunction &bound_function,
+                                                    const LogicalType &list_child_type,
+                                                    AggregateFunction &aggr_function,
+                                                    vector<unique_ptr<Expression>> &arguments) {
 	// create the child expression and its type
 	vector<unique_ptr<Expression>> children;
 	auto expr = make_uniq<BoundConstantExpression>(Value(list_child_type));

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -381,7 +381,7 @@ void ListUniqueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 template <bool IS_AGGR = false>
 unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, BoundScalarFunction &bound_function,
                                                     const LogicalType &list_child_type,
-                                                    AggregateFunction &aggr_function,
+                                                    const AggregateFunction &aggr_function,
                                                     vector<unique_ptr<Expression>> &arguments) {
 	// create the child expression and its type
 	vector<unique_ptr<Expression>> children;
@@ -472,7 +472,7 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	}
 
 	// found a matching function, bind it as an aggregate
-	auto best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
+	const auto &best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 	if (IS_AGGR) {
 		bound_function.SetErrorMode(best_function.GetErrorMode());
 		return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, child_type, best_function, arguments);

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -479,7 +479,7 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 	}
 
 	// create the unordered map histogram function
-	D_ASSERT(best_function.GetArguments().size() == 1);
+	D_ASSERT(best_function.GetSignature().GetParameterCount() == 1);
 	auto aggr_function = HistogramFun::GetHistogramUnorderedMap(child_type);
 	return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, child_type, aggr_function, arguments);
 }

--- a/extension/core_functions/scalar/list/list_distance.cpp
+++ b/extension/core_functions/scalar/list/list_distance.cpp
@@ -15,7 +15,7 @@ template <class TYPE, class OP>
 static void ListGenericFold(DataChunk &args, ExpressionState &state, Vector &result) {
 	const auto &lstate = state.Cast<ExecuteFunctionState>();
 	const auto &expr = lstate.expr.Cast<BoundFunctionExpression>();
-	const auto &func_name = expr.function.name;
+	const auto &func_name = expr.function.GetName();
 
 	auto count = args.size();
 

--- a/extension/core_functions/scalar/list/list_has_any_or_all.cpp
+++ b/extension/core_functions/scalar/list/list_has_any_or_all.cpp
@@ -95,7 +95,7 @@ static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &resul
 
 static void ListHasAllFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	const auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-	const auto swap = func_expr.function.name == "<@";
+	const auto swap = func_expr.function.GetName() == "<@";
 
 	auto &l_vec = args.data[swap ? 1 : 0];
 	auto &r_vec = args.data[swap ? 0 : 1];

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -334,7 +334,7 @@ ScalarFunctionSet ListReduceFun::GetFunctions() {
 
 	ScalarFunctionSet set;
 	set.AddFunction(fun);
-	fun.GetArguments().push_back(LogicalType::ANY);
+	fun.GetSignature().AddParameter(LogicalType::ANY);
 	set.AddFunction(fun);
 	return set;
 }

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -249,7 +249,7 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 	}
 }
 
-static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
+static unique_ptr<FunctionData> ListSortBind(ClientContext &context, BoundScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments, OrderType &order,
                                              OrderByNullType &null_order) {
 	LogicalType child_type;

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -268,8 +268,6 @@ unique_ptr<FunctionData> UnpivotBind(BindScalarFunctionInput &input) {
 	}
 	child_type = LogicalType::NormalizeType(child_type);
 
-	// this is more for completeness reasons
-	bound_function.SetVarArgs(child_type);
 	bound_function.SetReturnType(LogicalType::LIST(child_type));
 	return make_uniq<VariableReturnBindData>(bound_function.GetReturnType());
 }

--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -53,7 +53,7 @@ unique_ptr<FunctionData> SwitchBindReturnType(BindScalarFunctionInput &input) {
 		throw BinderException("SWITCH expected a constant map for the cases");
 	}
 	auto &func = cases->Cast<BoundFunctionExpression>();
-	if (func.function.name != "map") {
+	if (func.function.GetName() != "map") {
 		throw BinderException("SWITCH expected a constant map for the cases");
 	}
 	auto map_value = ExpressionExecutor::EvaluateScalar(context, *cases);
@@ -66,7 +66,7 @@ void ExtractConstantExprFromList(unique_ptr<Expression> &expr, vector<unique_ptr
 		throw BinderException("Expected a function for the cases");
 	}
 	auto &list_function = expr->Cast<BoundFunctionExpression>();
-	if (list_function.function.name != "list_value") {
+	if (list_function.function.GetName() != "list_value") {
 		throw BinderException("Expected a list function");
 	}
 	if (list_function.children.empty()) {

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -523,7 +523,7 @@ unique_ptr<FunctionData> BindDecimalRoundPrecision(BindScalarFunctionInput &inpu
 	if (arguments[1]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
-	auto fname = StringUtil::Upper(bound_function.name);
+	auto fname = StringUtil::Upper(bound_function.GetName());
 	if (!arguments[1]->IsFoldable()) {
 		throw NotImplementedException("%s(DECIMAL, INTEGER) with non-constant precision is not supported", fname);
 	}

--- a/extension/core_functions/scalar/string/parse_path.cpp
+++ b/extension/core_functions/scalar/string/parse_path.cpp
@@ -293,7 +293,7 @@ ScalarFunctionSet ParseDirnameFun::GetFunctions() {
 	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirname.AddFunction(func);
 	// separator options
-	func.GetArguments().emplace_back(LogicalType::VARCHAR);
+	func.GetSignature().AddParameter(LogicalType::VARCHAR);
 	parse_dirname.AddFunction(func);
 	return parse_dirname;
 }
@@ -304,7 +304,7 @@ ScalarFunctionSet ParseDirpathFun::GetFunctions() {
 	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_dirpath.AddFunction(func);
 	// separator options
-	func.GetArguments().emplace_back(LogicalType::VARCHAR);
+	func.GetSignature().AddParameter(LogicalType::VARCHAR);
 	parse_dirpath.AddFunction(func);
 	return parse_dirpath;
 }
@@ -334,7 +334,7 @@ ScalarFunctionSet ParsePathFun::GetFunctions() {
 	                    LogicalType::INVALID, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	parse_path.AddFunction(func);
 	// separator options
-	func.GetArguments().emplace_back(LogicalType::VARCHAR);
+	func.GetSignature().AddParameter(LogicalType::VARCHAR);
 	parse_path.AddFunction(func);
 	return parse_path;
 }

--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -28,44 +28,44 @@ static unique_ptr<FunctionData> BindPrintfFunction(BindScalarFunctionInput &inpu
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		switch (arguments[i]->GetReturnType().id()) {
 		case LogicalTypeId::BOOLEAN:
-			bound_function.GetArguments().emplace_back(LogicalType::BOOLEAN);
+			bound_function.GetArguments()[i] = LogicalType::BOOLEAN;
 			break;
 		case LogicalTypeId::TINYINT:
 		case LogicalTypeId::SMALLINT:
 		case LogicalTypeId::INTEGER:
 		case LogicalTypeId::BIGINT:
-			bound_function.GetArguments().emplace_back(LogicalType::BIGINT);
+			bound_function.GetArguments()[i] = LogicalType::BIGINT;
 			break;
 		case LogicalTypeId::UTINYINT:
 		case LogicalTypeId::USMALLINT:
 		case LogicalTypeId::UINTEGER:
 		case LogicalTypeId::UBIGINT:
-			bound_function.GetArguments().emplace_back(LogicalType::UBIGINT);
+			bound_function.GetArguments()[i] = LogicalType::UBIGINT;
 			break;
 		case LogicalTypeId::HUGEINT:
-			bound_function.GetArguments().emplace_back(LogicalType::HUGEINT);
+			bound_function.GetArguments()[i] = LogicalType::HUGEINT;
 			break;
 		case LogicalTypeId::UHUGEINT:
-			bound_function.GetArguments().emplace_back(LogicalType::UHUGEINT);
+			bound_function.GetArguments()[i] = LogicalType::UHUGEINT;
 			break;
 		case LogicalTypeId::FLOAT:
 		case LogicalTypeId::DOUBLE:
-			bound_function.GetArguments().emplace_back(LogicalType::DOUBLE);
+			bound_function.GetArguments()[i] = LogicalType::DOUBLE;
 			break;
 		case LogicalTypeId::VARCHAR:
-			bound_function.GetArguments().push_back(LogicalType::VARCHAR);
+			bound_function.GetArguments()[i] = LogicalType::VARCHAR;
 			break;
 		case LogicalTypeId::DECIMAL:
 			// decimal type: add cast to double
-			bound_function.GetArguments().emplace_back(LogicalType::DOUBLE);
+			bound_function.GetArguments()[i] = LogicalType::DOUBLE;
 			break;
 		case LogicalTypeId::UNKNOWN:
 			// parameter: accept any input and rebind later
-			bound_function.GetArguments().emplace_back(LogicalType::ANY);
+			bound_function.GetArguments()[i] = LogicalType::ANY;
 			break;
 		default:
 			// all other types: add cast to string
-			bound_function.GetArguments().emplace_back(LogicalType::VARCHAR);
+			bound_function.GetArguments()[i] = LogicalType::VARCHAR;
 			break;
 		}
 	}

--- a/extension/core_functions/scalar/string/to_base.cpp
+++ b/extension/core_functions/scalar/string/to_base.cpp
@@ -12,6 +12,7 @@ static unique_ptr<FunctionData> ToBaseBind(BindScalarFunctionInput &input) {
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	if (arguments.size() == 2) {
 		arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::INTEGER(0)));
+		input.GetBoundFunction().GetArguments().push_back(LogicalType::INTEGER);
 	}
 	return nullptr;
 }

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -424,7 +424,7 @@ struct ICUDatePart : public ICUDateFunc {
 	}
 
 	template <typename BIND_TYPE>
-	static duckdb::unique_ptr<FunctionData> BindAdapter(ClientContext &context, ScalarFunction &bound_function,
+	static duckdb::unique_ptr<FunctionData> BindAdapter(ClientContext &context, BoundScalarFunction &bound_function,
 	                                                    vector<duckdb::unique_ptr<Expression>> &arguments,
 	                                                    typename BIND_TYPE::adapter_t adapter) {
 		return make_uniq<BIND_TYPE>(context, adapter);
@@ -435,7 +435,7 @@ struct ICUDatePart : public ICUDateFunc {
 		auto &context = input.GetClientContext();
 		auto &arguments = input.GetArguments();
 
-		const auto part_code = GetDatePartSpecifier(bound_function.name);
+		const auto part_code = GetDatePartSpecifier(bound_function.GetName());
 		if (IsBigintDatepart(part_code)) {
 			using data_t = BindAdapterData<int64_t>;
 			auto adapter = PartCodeBigintFactory(part_code);
@@ -471,7 +471,7 @@ struct ICUDatePart : public ICUDateFunc {
 
 			arguments.erase(arguments.begin());
 			bound_function.GetArguments().erase(bound_function.GetArguments().begin());
-			bound_function.name = part_name;
+			bound_function.SetName(part_name);
 			bound_function.SetReturnType(LogicalType::DOUBLE);
 			bound_function.SetFunctionCallback(UnaryTimestampFunction<timestamp_t, double>);
 

--- a/extension/icu/icu-datepart.cpp
+++ b/extension/icu/icu-datepart.cpp
@@ -492,7 +492,7 @@ struct ICUDatePart : public ICUDateFunc {
 			throw ParameterNotResolvedException();
 		}
 		if (!arguments[0]->IsFoldable()) {
-			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+			throw BinderException("%s can only take constant lists of part names", bound_function.GetName());
 		}
 
 		case_insensitive_set_t name_collision_set;
@@ -503,18 +503,19 @@ struct ICUDatePart : public ICUDateFunc {
 		if (parts_list.type().id() == LogicalTypeId::LIST) {
 			auto &list_children = ListValue::GetChildren(parts_list);
 			if (list_children.empty()) {
-				throw BinderException("%s requires non-empty lists of part names", bound_function.name);
+				throw BinderException("%s requires non-empty lists of part names", bound_function.GetName());
 			}
 
 			for (size_t col = 0; col < list_children.size(); ++col) {
 				const auto &part_value = list_children[col];
 				if (part_value.IsNull()) {
-					throw BinderException("NULL struct entry name in %s", bound_function.name);
+					throw BinderException("NULL struct entry name in %s", bound_function.GetName());
 				}
 				const auto part_name = part_value.ToString();
 				const auto part_code = GetDatePartSpecifier(part_name);
 				if (name_collision_set.find(part_name) != name_collision_set.end()) {
-					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name, bound_function.name);
+					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name,
+					                      bound_function.GetName());
 				}
 				name_collision_set.insert(part_name);
 				part_codes.emplace_back(part_code);
@@ -525,7 +526,7 @@ struct ICUDatePart : public ICUDateFunc {
 				}
 			}
 		} else {
-			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+			throw BinderException("%s can only take constant lists of part names", bound_function.GetName());
 		}
 
 		Function::EraseArgument(bound_function, arguments, 0);

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -271,7 +271,7 @@ struct ICUStrptime : public ICUDateFunc {
 		if (!arguments[1]->IsFoldable()) {
 			throw InvalidInputException("strptime format must be a constant");
 		}
-		const bool is_try = (bound_function.name == "try_strptime");
+		const bool is_try = (bound_function.GetName() == "try_strptime");
 		scalar_function_t function = is_try ? TryParse<timestamp_t> : Parse<timestamp_t>;
 		Value format_value = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
 		string format_string;
@@ -341,11 +341,24 @@ struct ICUStrptime : public ICUDateFunc {
 		auto &functions = scalar_function.functions.functions;
 		optional_idx best_index;
 		for (idx_t i = 0; i < functions.size(); i++) {
-			auto &function = functions[i];
-			if (types == function.GetArguments()) {
-				best_index = i;
-				break;
+			const auto &sig = functions[i].GetSignature();
+			if (sig.GetParameterCount() != types.size()) {
+				continue;
 			}
+
+			auto match = true;
+			for (idx_t j = 0; j < sig.GetParameterCount(); j++) {
+				if (sig.GetParameter(j).GetType() != types[j]) {
+					match = false;
+					break;
+				}
+			}
+			if (!match) {
+				continue;
+			}
+
+			best_index = i;
+			break;
 		}
 		if (!best_index.IsValid()) {
 			throw InternalException("ICU - Function for TailPatch not found");

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -157,11 +157,11 @@ static duckdb::unique_ptr<FunctionData> ICUCollateBind(BindScalarFunctionInput &
 	auto &bound_function = input.GetBoundFunction();
 
 	//! Return a tagged collator
-	if (!bound_function.extra_info.empty()) {
-		return make_uniq<IcuBindData>(bound_function.extra_info);
+	if (!bound_function.GetExtraInfo().empty()) {
+		return make_uniq<IcuBindData>(bound_function.GetExtraInfo());
 	}
 
-	const auto collation = IcuBindData::DecodeFunctionName(bound_function.name);
+	const auto collation = IcuBindData::DecodeFunctionName(bound_function.GetName());
 	auto splits = StringUtil::Split(collation, "_");
 	if (splits.size() == 1) {
 		return make_uniq<IcuBindData>(splits[0], "");
@@ -185,8 +185,8 @@ static duckdb::unique_ptr<FunctionData> ICUSortKeyBind(BindScalarFunctionInput &
 		throw NotImplementedException("ICU_SORT_KEY(VARCHAR, VARCHAR) expected a non-null collation");
 	}
 	//! Verify tagged collation
-	if (!bound_function.extra_info.empty()) {
-		return make_uniq<IcuBindData>(bound_function.extra_info);
+	if (!bound_function.GetExtraInfo().empty()) {
+		return make_uniq<IcuBindData>(bound_function.GetExtraInfo());
 	}
 	auto splits = StringUtil::Split(StringValue::Get(val), "_");
 	if (splits.size() == 1) {

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -115,7 +115,7 @@ private:
 	template <class FUNCTION_INFO>
 	static void AddAliases(const vector<string> &names, FUNCTION_INFO fun, vector<FUNCTION_INFO> &functions) {
 		for (auto &name : names) {
-			fun.SetName(name);
+			fun.name = name;
 			functions.push_back(fun);
 		}
 	}

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -115,7 +115,7 @@ private:
 	template <class FUNCTION_INFO>
 	static void AddAliases(const vector<string> &names, FUNCTION_INFO fun, vector<FUNCTION_INFO> &functions) {
 		for (auto &name : names) {
-			fun.name = name;
+			fun.SetName(name);
 			functions.push_back(fun);
 		}
 	}

--- a/extension/json/json_functions/json_array_length.cpp
+++ b/extension/json/json_functions/json_array_length.cpp
@@ -33,7 +33,8 @@ ScalarFunctionSet JSONFunctions::GetArrayLengthFunction() {
 	GetArrayLengthFunctionsInternal(set, LogicalType::VARCHAR);
 	GetArrayLengthFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments().size() == 1 && func.GetArguments()[0].IsJSONType()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
 			continue;
 		}
 		func.SetFallible();

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -112,7 +112,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 	}
 }
 
-static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_function,
+static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_function,
                                                      vector<unique_ptr<Expression>> &arguments, bool object) {
 	unordered_map<string, unique_ptr<Vector>> const_struct_names;
 	for (idx_t i = 0; i < arguments.size(); i++) {

--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -50,7 +50,8 @@ ScalarFunctionSet JSONFunctions::GetExtractFunction() {
 	GetExtractFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments()[0].IsJSONType() && func.GetArguments()[1].IsNumeric()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
 			continue;
 		}
 		func.SetFallible();
@@ -74,7 +75,8 @@ ScalarFunctionSet JSONFunctions::GetExtractStringFunction() {
 	GetExtractStringFunctionsInternal(set, LogicalType::VARCHAR);
 	GetExtractStringFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments()[0].IsJSONType() && func.GetArguments()[1].IsNumeric()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
 			continue;
 		}
 		func.SetFallible();

--- a/extension/json/json_functions/json_keys.cpp
+++ b/extension/json/json_functions/json_keys.cpp
@@ -54,7 +54,8 @@ ScalarFunctionSet JSONFunctions::GetKeysFunction() {
 	GetJSONKeysFunctionsInternal(set, LogicalType::VARCHAR);
 	GetJSONKeysFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments().size() == 1 && func.GetArguments()[0].IsJSONType()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
 			continue;
 		}
 		func.SetFallible();

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -33,7 +33,8 @@ ScalarFunctionSet JSONFunctions::GetTypeFunction() {
 	GetTypeFunctionsInternal(set, LogicalType::VARCHAR);
 	GetTypeFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments().size() == 1 && func.GetArguments()[0].IsJSONType()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameterCount() == 1 && sig.GetParameter(0).GetType().IsJSONType()) {
 			continue;
 		}
 		func.SetFallible();

--- a/extension/json/json_functions/json_value.cpp
+++ b/extension/json/json_functions/json_value.cpp
@@ -26,7 +26,8 @@ ScalarFunctionSet JSONFunctions::GetValueFunction() {
 	GetValueFunctionsInternal(set, LogicalType::VARCHAR);
 	GetValueFunctionsInternal(set, LogicalType::JSON());
 	for (auto &func : set.functions) {
-		if (func.GetArguments()[0].IsJSONType() && func.GetArguments()[1].IsNumeric()) {
+		const auto &sig = func.GetSignature();
+		if (sig.GetParameter(0).GetType().IsJSONType() && sig.GetParameter(1).GetType().IsNumeric()) {
 			continue;
 		}
 		func.SetFallible();

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -11,6 +11,7 @@
 #include "struct_column_writer.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/variant.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 
 namespace duckdb {
@@ -97,7 +98,9 @@ public:
 		vector<unique_ptr<Expression>> arguments;
 		arguments.push_back(unique_ptr_cast<BoundReferenceExpression, Expression>(std::move(expr)));
 
-		return make_uniq<BoundFunctionExpression>(TransformedType(), GetTransformFunction(), std::move(arguments),
+		BoundScalarFunction bound_func(GetTransformFunction());
+
+		return make_uniq<BoundFunctionExpression>(TransformedType(), std::move(bound_func), std::move(arguments),
 		                                          nullptr, false);
 	}
 

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -99,9 +99,9 @@ public:
 		arguments.push_back(unique_ptr_cast<BoundReferenceExpression, Expression>(std::move(expr)));
 
 		BoundScalarFunction bound_func(GetTransformFunction());
+		bound_func.SetReturnType(TransformedType());
 
-		return make_uniq<BoundFunctionExpression>(TransformedType(), std::move(bound_func), std::move(arguments),
-		                                          nullptr, false);
+		return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(arguments), nullptr);
 	}
 
 public:

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -394,7 +394,7 @@ unique_ptr<ColumnReader> GeometryColumnReader::Create(const ParquetReader &reade
 	// TODO: Pass the actual target type here so we get the CRS information too
 	auto func = StGeomfromwkbFun::GetFunction();
 	func.name = "ST_GeomFromWKB";
-	auto read_expr = make_uniq_base<Expression, BoundFunctionExpression>(schema.type, func, std::move(args), nullptr);
+	auto read_expr = func.Bind(context, std::move(args));
 	auto type_expr = BoundCastExpression::AddDefaultCastToType(std::move(read_expr), schema.type);
 	return make_uniq<ExpressionColumnReader>(context, std::move(string_reader), std::move(type_expr), schema);
 }

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -874,14 +874,14 @@ static unique_ptr<Expression> CreateReferenceExpression(const LogicalType &type)
 
 static unique_ptr<Expression> CreateStructExtractExpression(unique_ptr<Expression> source_expr,
                                                             const LogicalType &source_type, idx_t child_idx) {
-	auto &child_type = StructType::GetChildType(source_type, child_idx);
 	vector<unique_ptr<Expression>> arguments;
 	arguments.push_back(std::move(source_expr));
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(static_cast<int64_t>(child_idx + 1))));
 
 	BoundScalarFunction bound_func(GetExtractAtFunction());
+	bound_func.SetReturnType(StructType::GetChildType(source_type, child_idx));
 
-	return make_uniq<BoundFunctionExpression>(child_type, std::move(bound_func), std::move(arguments),
+	return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(arguments),
 	                                          StructExtractAtFun::GetBindData(child_idx));
 }
 

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -878,7 +878,10 @@ static unique_ptr<Expression> CreateStructExtractExpression(unique_ptr<Expressio
 	vector<unique_ptr<Expression>> arguments;
 	arguments.push_back(std::move(source_expr));
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(static_cast<int64_t>(child_idx + 1))));
-	return make_uniq<BoundFunctionExpression>(child_type, GetExtractAtFunction(), std::move(arguments),
+
+	BoundScalarFunction bound_func(GetExtractAtFunction());
+
+	return make_uniq<BoundFunctionExpression>(child_type, std::move(bound_func), std::move(arguments),
 	                                          StructExtractAtFun::GetBindData(child_idx));
 }
 

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -175,13 +175,13 @@ static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &a
 static void ExecuteSelectFunction(const BoundFunctionExpression &expr, DataChunk &args, ExpressionState &state,
                                   Vector &result) {
 	if (expr.GetReturnType() != LogicalType::BOOLEAN) {
-		throw InvalidInputException("Function %s only has a select callback but returns %s", expr.function.name,
+		throw InvalidInputException("Function %s only has a select callback but returns %s", expr.function.GetName(),
 		                            expr.GetReturnType().ToString());
 	}
 	if (expr.function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
 		throw InvalidInputException("Function %s only has a select callback with SPECIAL_HANDLING but projected "
 		                            "execution requires a scalar callback to produce NULL results",
-		                            expr.function.name);
+		                            expr.function.GetName());
 	}
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
@@ -256,14 +256,14 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 		D_ASSERT(expr.function.HasFunctionCallback());
 	} else {
 		throw InternalException("Scalar function %s has neither an execution nor a select callback",
-		                        expr.function.name);
+		                        expr.function.GetName());
 	}
 	if (all_constant) {
 		if (result.GetVectorType() != VectorType::FLAT_VECTOR &&
 		    result.GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			throw InternalException(
 			    "Error while executing function %s - function must return a flat or constant vector for count = 1",
-			    expr.function.name);
+			    expr.function.GetName());
 		}
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -34,7 +34,8 @@ bool ExpressionState::HasContext() {
 
 ClientContext &ExpressionState::GetContext() {
 	if (!HasContext()) {
-		throw BinderException("Cannot use %s in this context", (expr.Cast<BoundFunctionExpression>()).function.name);
+		throw BinderException("Cannot use %s in this context",
+		                      (expr.Cast<BoundFunctionExpression>()).function.GetName());
 	}
 	return root.executor->GetContext();
 }

--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-AggregateObject::AggregateObject(AggregateFunction function, FunctionData *bind_data, idx_t child_count,
+AggregateObject::AggregateObject(BoundAggregateFunction function, FunctionData *bind_data, idx_t child_count,
                                  idx_t payload_size, AggregateType aggr_type, PhysicalType return_type,
                                  Expression *filter)
     : function(std::move(function)),

--- a/src/execution/operator/aggregate/grouped_aggregate_data.cpp
+++ b/src/execution/operator/aggregate/grouped_aggregate_data.cpp
@@ -34,7 +34,7 @@ void GroupedAggregateData::InitializeGroupby(vector<unique_ptr<Expression>> grou
 			payload_types_filters.push_back(aggr.filter->GetReturnType());
 		}
 		if (!aggr.function.HasStateCombineCallback()) {
-			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
+			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.GetName());
 		}
 		aggregates.push_back(std::move(expr));
 	}
@@ -64,7 +64,7 @@ void GroupedAggregateData::InitializeDistinct(const unique_ptr<Expression> &aggr
 		}
 	}
 	if (!aggr.function.HasStateCombineCallback()) {
-		throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
+		throw InternalException("Aggregate function %s is missing a combine method", aggr.function.GetName());
 	}
 }
 

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -129,7 +129,7 @@ public:
 			auto &fstate = states[expr_idx];
 			if (expr.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE) {
 				fstate = make_uniq<AggregateState>(client, wexpr, allocator);
-			} else if (wexpr.window && wexpr.window->GetCallbacks().HasStreamingStateCallback()) {
+			} else if (wexpr.window && wexpr.window->HasStreamingStateCallback()) {
 				fstate = wexpr.window->GetStreamingState(client, input, wexpr);
 			} else {
 				throw NotImplementedException("GetStreamingState for %s",
@@ -315,7 +315,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 		auto &fstate = *state.states[expr_idx];
 		if (expr.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE) {
 			fstate.Cast<StreamingWindowState::AggregateState>().Execute(context, output, result);
-		} else if (wexpr.window && wexpr.window->GetCallbacks().HasStreamingDataCallback()) {
+		} else if (wexpr.window && wexpr.window->HasStreamingDataCallback()) {
 			wexpr.window->GetStreamingData(context, output, delayed, state.delayed_capacity, result, fstate);
 		} else {
 			throw NotImplementedException("GetStreamingData for %s", ExpressionTypeToString(expr.GetExpressionType()));

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -40,10 +40,10 @@ public:
 			D_ASSERT(wexpr.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE);
 			auto &aggregate = *wexpr.aggregate;
 			bind_data = wexpr.bind_info.get();
-			dtor = aggregate.GetStateDestructorCallback();
-			state.resize(aggregate.GetStateSizeCallback()(aggregate));
+			dtor = aggregate.GetCallbacks().GetStateDestructorCallback();
+			state.resize(aggregate.GetCallbacks().GetStateSizeCallback()(aggregate));
 			state_ptr = state.data();
-			aggregate.GetStateInitCallback()(aggregate, state.data());
+			aggregate.GetCallbacks().GetStateInitCallback()(aggregate, state.data());
 			for (auto &child : wexpr.children) {
 				arg_types.push_back(child->GetReturnType());
 				executor.AddExpression(*child);
@@ -129,7 +129,7 @@ public:
 			auto &fstate = states[expr_idx];
 			if (expr.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE) {
 				fstate = make_uniq<AggregateState>(client, wexpr, allocator);
-			} else if (wexpr.window && wexpr.window->HasStreamingStateCallback()) {
+			} else if (wexpr.window && wexpr.window->GetCallbacks().HasStreamingStateCallback()) {
 				fstate = wexpr.window->GetStreamingState(client, input, wexpr);
 			} else {
 				throw NotImplementedException("GetStreamingState for %s",
@@ -315,7 +315,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 		auto &fstate = *state.states[expr_idx];
 		if (expr.GetExpressionType() == ExpressionType::WINDOW_AGGREGATE) {
 			fstate.Cast<StreamingWindowState::AggregateState>().Execute(context, output, result);
-		} else if (wexpr.window && wexpr.window->HasStreamingDataCallback()) {
+		} else if (wexpr.window && wexpr.window->GetCallbacks().HasStreamingDataCallback()) {
 			wexpr.window->GetStreamingData(context, output, delayed, state.delayed_capacity, result, fstate);
 		} else {
 			throw NotImplementedException("GetStreamingData for %s", ExpressionTypeToString(expr.GetExpressionType()));

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -277,7 +277,7 @@ public:
 bool PhysicalUngroupedAggregate::SinkOrderDependent() const {
 	for (auto &expr : aggregates) {
 		auto &aggr = expr->Cast<BoundAggregateExpression>();
-		if (aggr.function.GetProperties().GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT) {
+		if (aggr.function.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT) {
 			return true;
 		}
 	}

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -277,7 +277,7 @@ public:
 bool PhysicalUngroupedAggregate::SinkOrderDependent() const {
 	for (auto &expr : aggregates) {
 		auto &aggr = expr->Cast<BoundAggregateExpression>();
-		if (aggr.function.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT) {
+		if (aggr.function.GetProperties().GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT) {
 			return true;
 		}
 	}
@@ -636,7 +636,7 @@ void VerifyNullHandling(DataChunk &chunk, UngroupedAggregateState &state,
 	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
 		auto &aggr = aggregates[aggr_idx]->Cast<BoundAggregateExpression>();
 		if (state.counts[aggr_idx] == 0 &&
-		    aggr.function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING) {
+		    aggr.function.GetProperties().GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING) {
 			// Default is when 0 values go in, NULL comes out
 			UnifiedVectorFormat vdata;
 			chunk.data[aggr_idx].ToUnifiedFormat(1, vdata);

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -117,7 +117,7 @@ void GlobalUngroupedAggregateState::Combine(LocalUngroupedAggregateState &other)
 		AggregateInputData aggr_input_data(aggregate.bind_info.get(), allocator,
 		                                   AggregateCombineType::ALLOW_DESTRUCTIVE);
 		if (!aggregate.function.HasStateCombineCallback()) {
-			throw InternalException("Aggregate function " + aggregate.function.name +
+			throw InternalException("Aggregate function " + aggregate.function.GetName() +
 			                        " does not support combining of states");
 		}
 		aggregate.function.GetStateCombineCallback()(source_state, dest_state, aggr_input_data, 1);
@@ -142,7 +142,7 @@ void GlobalUngroupedAggregateState::CombineDistinct(LocalUngroupedAggregateState
 		Vector state_vec(Value::POINTER(CastPointerToValue(other.state.aggregate_data[aggr_idx].get())), count_t(1));
 		Vector combined_vec(Value::POINTER(CastPointerToValue(state.aggregate_data[aggr_idx].get())), count_t(1));
 		if (!aggregate.function.HasStateCombineCallback()) {
-			throw InternalException("Aggregate function " + aggregate.function.name +
+			throw InternalException("Aggregate function " + aggregate.function.GetName() +
 			                        " does not support combining of states");
 		}
 		aggregate.function.GetStateCombineCallback()(state_vec, combined_vec, aggr_input_data, 1);

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -228,7 +228,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 		if (!best_function.IsValid()) {
 			return nullptr;
 		}
-		auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+		const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 		auto aggr_expr = function_binder.BindAggregateFunction(bound_function, std::move(aggr_children), nullptr,
 		                                                       AggregateType::NON_DISTINCT);
 		D_ASSERT(col_type == aggr_expr->GetReturnType());

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -233,7 +233,7 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
 	if (!expr.IsDistinct() && !input.child_stats[0].CanHaveNull()) {
 		// count on a column without null values: use count star
 		expr.function.ReplaceImplementation(CountStarFun::GetFunction());
-		expr.function.name = "count_star";
+		expr.function.SetName("count_star");
 		expr.children.clear();
 	}
 	return nullptr;

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -222,7 +222,7 @@ struct CountFunction : public BaseCountFunction {
 	}
 };
 
-LogicalType GetCountStateType(const AggregateFunction &function) {
+LogicalType GetCountStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> children;
 	children.emplace_back("count", LogicalType::BIGINT);
 	return LogicalType::STRUCT(std::move(children));

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -232,7 +232,7 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
                                                AggregateStatisticsInput &input) {
 	if (!expr.IsDistinct() && !input.child_stats[0].CanHaveNull()) {
 		// count on a column without null values: use count star
-		expr.function = CountStarFun::GetFunction();
+		expr.function.ReplaceImplementation(CountStarFun::GetFunction());
 		expr.function.name = "count_star";
 		expr.children.clear();
 	}

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -292,7 +292,7 @@ AggregateFunction GetFirstFunction(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::DECIMAL) {
 		type.Verify();
 		AggregateFunction function = GetDecimalFirstFunction<LAST, SKIP_NULLS>(type);
-		function.GetArguments()[0] = type;
+		function.GetSignature().GetParameter(0).SetType(type);
 		function.SetReturnType(type);
 		return function;
 	}

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -219,7 +219,7 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	}
 };
 
-LogicalType GetFirstStateType(const AggregateFunction &function) {
+LogicalType GetFirstStateType(const BoundAggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	LogicalType value_type = function.GetArguments()[0];
 	child_types.emplace_back("value", value_type);
@@ -358,7 +358,7 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	auto name = std::move(function.name);
 	function.ReplaceImplementation(GetFirstFunction<LAST, SKIP_NULLS>(decimal_type));
 	function.name = std::move(name);
-	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	function.GetProperties().SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetReturnType(decimal_type);
 	return nullptr;
 }
@@ -380,7 +380,7 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	auto name = std::move(function.name);
 	function.ReplaceImplementation(GetFirstOperator<LAST, SKIP_NULLS>(input_type));
 	function.name = std::move(name);
-	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	function.GetProperties().SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	return nullptr;
 }
 

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -358,7 +358,7 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	auto name = std::move(function.name);
 	function.ReplaceImplementation(GetFirstFunction<LAST, SKIP_NULLS>(decimal_type));
 	function.name = std::move(name);
-	function.GetProperties().SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetReturnType(decimal_type);
 	return nullptr;
 }
@@ -380,7 +380,7 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	auto name = std::move(function.name);
 	function.ReplaceImplementation(GetFirstOperator<LAST, SKIP_NULLS>(input_type));
 	function.name = std::move(name);
-	function.GetProperties().SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
+	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	return nullptr;
 }
 

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -356,7 +356,7 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 
 	auto decimal_type = arguments[0]->GetReturnType();
 	auto name = std::move(function.name);
-	function = GetFirstFunction<LAST, SKIP_NULLS>(decimal_type);
+	function.ReplaceImplementation(GetFirstFunction<LAST, SKIP_NULLS>(decimal_type));
 	function.name = std::move(name);
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetReturnType(decimal_type);
@@ -378,7 +378,7 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 
 	auto input_type = arguments[0]->GetReturnType();
 	auto name = std::move(function.name);
-	function = GetFirstOperator<LAST, SKIP_NULLS>(input_type);
+	function.ReplaceImplementation(GetFirstOperator<LAST, SKIP_NULLS>(input_type));
 	function.name = std::move(name);
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	return nullptr;

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -355,9 +355,9 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 
 	auto decimal_type = arguments[0]->GetReturnType();
-	auto name = std::move(function.name);
+	auto name = function.GetName();
 	function.ReplaceImplementation(GetFirstFunction<LAST, SKIP_NULLS>(decimal_type));
-	function.name = std::move(name);
+	function.SetName(std::move(name));
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetReturnType(decimal_type);
 	return nullptr;
@@ -377,9 +377,9 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 
 	auto input_type = arguments[0]->GetReturnType();
-	auto name = std::move(function.name);
+	auto name = function.GetName();
 	function.ReplaceImplementation(GetFirstOperator<LAST, SKIP_NULLS>(input_type));
-	function.name = std::move(name);
+	function.SetName(std::move(name));
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	return nullptr;
 }

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -488,21 +488,22 @@ void MinMaxNUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t input_
 }
 
 template <class VAL_TYPE, class COMPARATOR>
-void SpecializeMinMaxNFunction(AggregateFunction &function) {
+void SpecializeMinMaxNFunction(BoundAggregateFunction &function) {
 	using STATE = MinMaxNState<VAL_TYPE, COMPARATOR>;
 	using OP = MinMaxNOperation;
 
-	function.SetStateSizeCallback(AggregateFunction::StateSize<STATE>);
-	function.SetStateInitCallback(AggregateFunction::StateInitialize<STATE, OP, AggregateDestructorType::LEGACY>);
-	function.SetStateCombineCallback(AggregateFunction::StateCombine<STATE, OP>);
-	function.SetStateDestructorCallback(AggregateFunction::StateDestroy<STATE, OP>);
+	function.GetCallbacks().SetStateSizeCallback(AggregateFunction::StateSize<STATE>);
+	function.GetCallbacks().SetStateInitCallback(
+	    AggregateFunction::StateInitialize<STATE, OP, AggregateDestructorType::LEGACY>);
+	function.GetCallbacks().SetStateCombineCallback(AggregateFunction::StateCombine<STATE, OP>);
+	function.GetCallbacks().SetStateDestructorCallback(AggregateFunction::StateDestroy<STATE, OP>);
 
-	function.SetStateFinalizeCallback(MinMaxNOperation::Finalize<STATE>);
-	function.SetStateUpdateCallback(MinMaxNUpdate<STATE>);
+	function.GetCallbacks().SetStateFinalizeCallback(MinMaxNOperation::Finalize<STATE>);
+	function.GetCallbacks().SetStateUpdateCallback(MinMaxNUpdate<STATE>);
 }
 
 template <class COMPARATOR>
-void SpecializeMinMaxNFunction(PhysicalType arg_type, AggregateFunction &function) {
+void SpecializeMinMaxNFunction(PhysicalType arg_type, BoundAggregateFunction &function) {
 	switch (arg_type) {
 	case PhysicalType::VARCHAR:
 		SpecializeMinMaxNFunction<MinMaxStringValue, COMPARATOR>(function);
@@ -550,7 +551,7 @@ AggregateFunction GetMinMaxNFunction() {
 	                         nullptr, nullptr, nullptr, nullptr, nullptr, MinMaxNBind<COMPARATOR>, nullptr);
 }
 
-LogicalType GetExportStateType(const AggregateFunction &function) {
+LogicalType GetExportStateType(const BoundAggregateFunction &function) {
 	auto struct_children_types = child_list_t<LogicalType> {};
 	struct_children_types.emplace_back("value", function.GetReturnType());
 	struct_children_types.emplace_back("isset", LogicalType::BOOLEAN);

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -346,7 +346,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	if (collation && ExpressionBinder::PushCollation(context, collated_arg, collated_arg->GetReturnType())) {
 		// If aggr function is min/max and uses collations, replace bound_function with arg_min/arg_max
 		// to make sure the result's correctness.
-		string function_name = function.name == "min" ? "arg_min" : "arg_max";
+		string function_name = function.GetName() == "min" ? "arg_min" : "arg_max";
 		QueryErrorContext error_context;
 		auto func = Catalog::GetEntry<AggregateFunctionCatalogEntry>(context, "", "", function_name,
 		                                                             OnEntryNotFound::RETURN_NULL, error_context);
@@ -354,7 +354,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 			throw NotImplementedException(
 			    "Failure while binding function \"%s\" using collations - arg_min/arg_max do not exist in the "
 			    "catalog - load the core_functions module to fix this issue",
-			    function.name);
+			    function.GetName());
 		}
 
 		auto &func_entry = *func;
@@ -380,13 +380,13 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	if (input_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	auto name = std::move(function.name);
+	auto name = function.GetName();
 
 	auto state_export_type = function.GetStateTypeCallback();
 	auto minmax_func = GetMinMaxOperator<OP, OP_STRING, OP_VECTOR>(input_type);
 
 	minmax_func.SetStructStateExport(state_export_type);
-	minmax_func.name = std::move(name);
+	minmax_func.SetName(std::move(name));
 	minmax_func.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	minmax_func.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -367,7 +367,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 			throw BinderException(string("Fail to find corresponding function for collation min/max: ") +
 			                      error.Message());
 		}
-		function = func_entry.functions.GetFunctionByOffset(best_function.GetIndex());
+		function.ReplaceImplementation(func_entry.functions.GetFunctionByOffset(best_function.GetIndex()));
 
 		// Bind function like arg_min/arg_max.
 		arguments.push_back(std::move(collated_arg));

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -732,7 +732,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	    SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);
 
-	expr.function = ordered_aggregate;
+	expr.function.ReplaceImplementation(ordered_aggregate);
 	expr.bind_info = std::move(sorted_bind);
 	expr.order_bys.reset();
 }
@@ -789,7 +789,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	    SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);
 
-	aggregate = ordered_aggregate;
+	aggregate.ReplaceImplementation(ordered_aggregate);
 	expr.bind_info = std::move(sorted_bind);
 	expr.arg_orders.clear();
 }

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -721,7 +721,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 
 	// Replace the aggregate with the wrapper
 	AggregateFunction ordered_aggregate(
-	    bound_function.name, arguments, bound_function.GetReturnType(),
+	    bound_function.GetName(), arguments, bound_function.GetReturnType(),
 	    AggregateFunction::StateSize<SortedAggregateState>,
 	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction,
 	                                       AggregateDestructorType::LEGACY>,
@@ -778,7 +778,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 
 	// Replace the aggregate with the wrapper
 	AggregateFunction ordered_aggregate(
-	    aggregate.name, arguments, aggregate.GetReturnType(), AggregateFunction::StateSize<SortedAggregateState>,
+	    aggregate.GetName(), arguments, aggregate.GetReturnType(), AggregateFunction::StateSize<SortedAggregateState>,
 	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction,
 	                                       AggregateDestructorType::LEGACY>,
 	    SortedAggregateFunction::ScatterUpdate,

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -739,8 +739,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr) {
 	//	Make implicit orderings explicit
 	auto &aggregate = *expr.aggregate;
-	if (aggregate.GetProperties().GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT &&
-	    expr.arg_orders.empty()) {
+	if (aggregate.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT && expr.arg_orders.empty()) {
 		for (auto &order : expr.orders) {
 			const auto type = order.type;
 			const auto null_order = order.null_order;

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -727,8 +727,9 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	                                       AggregateDestructorType::LEGACY>,
 	    SortedAggregateFunction::ScatterUpdate,
 	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
-	    SortedAggregateFunction::Finalize, bound_function.GetProperties().GetNullHandling(), SortedAggregateFunction::SimpleUpdate,
-	    nullptr, AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
+	    SortedAggregateFunction::Finalize, bound_function.GetProperties().GetNullHandling(),
+	    SortedAggregateFunction::SimpleUpdate, nullptr,
+	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
 	    SortedAggregateFunction::WindowBatch);
 
 	expr.function.ReplaceImplementation(ordered_aggregate);

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -22,7 +22,7 @@ struct SortedAggregateBindData : public FunctionData {
 	using BindInfoPtr = unique_ptr<FunctionData>;
 	using OrderBys = vector<BoundOrderByNode>;
 
-	SortedAggregateBindData(ClientContext &context, Expressions &children, AggregateFunction &aggregate,
+	SortedAggregateBindData(ClientContext &context, Expressions &children, BoundAggregateFunction &aggregate,
 	                        BindInfoPtr &bind_info, OrderBys &order_bys)
 	    : context(context), function(aggregate), bind_info(std::move(bind_info)),
 	      threshold(Settings::Get<OrderedAggregateThresholdSetting>(context)) {
@@ -129,7 +129,7 @@ struct SortedAggregateBindData : public FunctionData {
 	}
 
 	ClientContext &context;
-	AggregateFunction function;
+	BoundAggregateFunction function;
 	unique_ptr<FunctionData> bind_info;
 
 	//! The sort expressions (all references as the expressions have been computed)
@@ -542,7 +542,7 @@ struct SortedAggregateFunction {
 
 		//	 Reusable inner state
 		auto &aggr = order_bind.function;
-		vector<data_t> agg_state(aggr.GetStateSizeCallback()(aggr));
+		vector<data_t> agg_state(aggr.GetCallbacks().GetStateSizeCallback()(aggr));
 		Vector agg_state_vec(Value::POINTER(CastPointerToValue(agg_state.data())), count_t(1));
 
 		// State variables
@@ -550,11 +550,11 @@ struct SortedAggregateFunction {
 		AggregateInputData aggr_bind_info(bind_info, aggr_input_data.allocator);
 
 		// Inner aggregate APIs
-		auto initialize = aggr.GetStateInitCallback();
-		auto destructor = aggr.GetStateDestructorCallback();
-		auto simple_update = aggr.GetStateSimpleUpdateCallback();
-		auto update = aggr.GetStateUpdateCallback();
-		auto finalize = aggr.GetStateFinalizeCallback();
+		auto initialize = aggr.GetCallbacks().GetStateInitCallback();
+		auto destructor = aggr.GetCallbacks().GetStateDestructorCallback();
+		auto simple_update = aggr.GetCallbacks().GetStateSimpleUpdateCallback();
+		auto update = aggr.GetCallbacks().GetStateUpdateCallback();
+		auto finalize = aggr.GetCallbacks().GetStateFinalizeCallback();
 
 		auto sdata = states.Values<SortedAggregateState *>(count);
 
@@ -727,10 +727,9 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	                                       AggregateDestructorType::LEGACY>,
 	    SortedAggregateFunction::ScatterUpdate,
 	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
-	    SortedAggregateFunction::Finalize, bound_function.GetNullHandling(), SortedAggregateFunction::SimpleUpdate,
+	    SortedAggregateFunction::Finalize, bound_function.GetProperties().GetNullHandling(), SortedAggregateFunction::SimpleUpdate,
 	    nullptr, AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
 	    SortedAggregateFunction::WindowBatch);
-	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);
 
 	expr.function.ReplaceImplementation(ordered_aggregate);
 	expr.bind_info = std::move(sorted_bind);
@@ -740,7 +739,8 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr) {
 	//	Make implicit orderings explicit
 	auto &aggregate = *expr.aggregate;
-	if (aggregate.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT && expr.arg_orders.empty()) {
+	if (aggregate.GetProperties().GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT &&
+	    expr.arg_orders.empty()) {
 		for (auto &order : expr.orders) {
 			const auto type = order.type;
 			const auto null_order = order.null_order;
@@ -784,7 +784,8 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	                                       AggregateDestructorType::LEGACY>,
 	    SortedAggregateFunction::ScatterUpdate,
 	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
-	    SortedAggregateFunction::Finalize, aggregate.GetNullHandling(), SortedAggregateFunction::SimpleUpdate, nullptr,
+	    SortedAggregateFunction::Finalize, aggregate.GetProperties().GetNullHandling(),
+	    SortedAggregateFunction::SimpleUpdate, nullptr,
 	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
 	    SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -34,13 +34,14 @@ unique_ptr<BoundAggregateExpression> AggregateFunction::Bind(ClientContext &cont
 }
 
 BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function) {
-	this->name = function.name;
-	this->schema_name = function.schema_name;
-	this->catalog_name = function.catalog_name;
-	this->return_type = function.GetReturnType();
-	this->properties = function.GetProperties();
-	this->callbacks = function.GetCallbacks();
-	this->function_info = function.GetFunctionInfo();
+	name = function.name;
+	schema_name = function.schema_name;
+	catalog_name = function.catalog_name;
+	extra_info = function.extra_info;
+	return_type = function.GetReturnType();
+	properties = function.GetProperties();
+	callbacks = function.GetCallbacks();
+	function_info = function.GetFunctionInfo();
 
 	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
 	// "bind" callback)

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -37,11 +37,16 @@ BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function
 	this->name = function.name;
 	this->schema_name = function.schema_name;
 	this->catalog_name = function.catalog_name;
-	this->arguments = function.GetArguments();
 	this->return_type = function.GetReturnType();
 	this->properties = function.GetProperties();
 	this->callbacks = function.GetCallbacks();
 	this->function_info = function.GetFunctionInfo();
+
+	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
+	// "bind" callback)
+	for (auto &param : function.GetSignature().GetParameters()) {
+		arguments.push_back(param.GetType());
+	}
 }
 
 bool BoundAggregateFunction::operator==(const BoundAggregateFunction &rhs) const {
@@ -56,11 +61,16 @@ void BoundAggregateFunction::ReplaceImplementation(const AggregateFunction &func
 	this->name = function.name;
 	this->schema_name = function.schema_name;
 	this->catalog_name = function.catalog_name;
-	this->arguments = function.GetArguments();
 	this->return_type = function.GetReturnType();
 	this->properties = function.GetProperties();
 	this->callbacks = function.GetCallbacks();
 	this->function_info = function.GetFunctionInfo();
+
+	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
+	// "bind" callback)
+	for (auto &param : function.GetSignature().GetParameters()) {
+		arguments.push_back(param.GetType());
+	}
 }
 
 } // namespace duckdb

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -68,6 +68,7 @@ void BoundAggregateFunction::ReplaceImplementation(const AggregateFunction &func
 
 	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
 	// "bind" callback)
+	arguments.clear();
 	for (auto &param : function.GetSignature().GetParameters()) {
 		arguments.push_back(param.GetType());
 	}

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -33,4 +33,18 @@ unique_ptr<BoundAggregateExpression> AggregateFunction::Bind(ClientContext &cont
 	return func_binder.BindAggregateFunction(*this, std::move(arguments));
 }
 
+BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function) : AggregateFunction(function) {
+}
+
+void BoundAggregateFunction::ReplaceImplementation(const AggregateFunction &function) {
+	this->name = function.name;
+	this->schema_name = function.schema_name;
+	this->catalog_name = function.catalog_name;
+	this->arguments = function.GetArguments();
+	this->return_type = function.GetReturnType();
+	this->properties = function.GetProperties();
+	this->callbacks = function.GetCallbacks();
+	this->function_info = function.GetFunctionInfo();
+}
+
 } // namespace duckdb

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -33,7 +33,23 @@ unique_ptr<BoundAggregateExpression> AggregateFunction::Bind(ClientContext &cont
 	return func_binder.BindAggregateFunction(*this, std::move(arguments));
 }
 
-BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function) : AggregateFunction(function) {
+BoundAggregateFunction::BoundAggregateFunction(const AggregateFunction &function) {
+	this->name = function.name;
+	this->schema_name = function.schema_name;
+	this->catalog_name = function.catalog_name;
+	this->arguments = function.GetArguments();
+	this->return_type = function.GetReturnType();
+	this->properties = function.GetProperties();
+	this->callbacks = function.GetCallbacks();
+	this->function_info = function.GetFunctionInfo();
+}
+
+bool BoundAggregateFunction::operator==(const BoundAggregateFunction &rhs) const {
+	return callbacks == rhs.callbacks && properties == rhs.properties && arguments == rhs.arguments &&
+	       return_type == rhs.return_type;
+}
+bool BoundAggregateFunction::operator!=(const BoundAggregateFunction &rhs) const {
+	return !(*this == rhs);
 }
 
 void BoundAggregateFunction::ReplaceImplementation(const AggregateFunction &function) {

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -115,14 +115,15 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 	if (!ExtensionHelper::CanAutoloadExtension(extension_name)) {
 		throw BinderException("Trying to call function \"%s\" which is present in extension \"%s\" - but the extension "
 		                      "is not loaded and could not be auto-loaded",
-		                      bound_function.name, extension_name);
+		                      bound_function.GetName(), extension_name);
 	}
 	// auto-load the extension
 	ExtensionHelper::AutoLoadExtension(db, extension_name);
 
 	// now find the function in the catalog
 	auto &catalog = Catalog::GetSystemCatalog(db);
-	auto &function_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, bound_function.name);
+	auto &function_entry =
+	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, bound_function.GetName());
 
 	// override the function with the extension function
 	auto func = function_entry.functions.GetFunctionByArguments(context, bound_function.GetArguments());

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -126,7 +126,7 @@ static unique_ptr<Expression> BindExtensionFunction(FunctionBindExpressionInput 
 	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, bound_function.GetName());
 
 	// override the function with the extension function
-	auto func = function_entry.functions.GetFunctionByArguments(context, bound_function.GetArguments());
+	const auto &func = function_entry.functions.GetFunctionByArguments(context, bound_function.GetArguments());
 	return func.Bind(context, std::move(arguments));
 }
 

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -202,7 +202,7 @@ hash_t BoundSimpleFunction::Hash() const {
 }
 
 string BoundSimpleFunction::ToString() const {
-	return Function::CallToString(catalog_name, schema_name, name, arguments, return_type);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, LogicalTypeId::INVALID, return_type);
 }
 
 bool FunctionParameter::operator==(const FunctionParameter &other) const {

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -58,8 +58,36 @@ SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, L
 SimpleFunction::~SimpleFunction() {
 }
 
+static bool RequiresCatalogAndSchemaNamePrefix(const string &catalog_name, const string &schema_name) {
+	return !catalog_name.empty() && catalog_name != SYSTEM_CATALOG && !schema_name.empty() &&
+	       schema_name != DEFAULT_SCHEMA;
+}
+
+string FunctionParameter::ToString() const {
+	return StringUtil::Format("%s %s", name, type.ToString());
+}
+
+string FunctionSignature::ToString() const {
+	vector<string> params;
+	params.reserve(parameters.size());
+	for (auto &param : parameters) {
+		params.push_back(param.ToString());
+	}
+	if (varargs.IsValid()) {
+		params.push_back("[" + varargs.ToString() + "...]");
+	}
+	auto head = StringUtil::Format("(%s)", StringUtil::Join(params, ", "));
+	if (return_type.IsValid()) {
+		return head + " -> " + return_type.ToString();
+	}
+	return head;
+}
+
 string SimpleFunction::ToString() const {
-	throw NotImplementedException("SimpleFunction::ToString() not implemented");
+	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
+		return StringUtil::Format("%s.%s.%s%s", catalog_name, schema_name, name, signature.ToString());
+	}
+	return name + signature.ToString();
 }
 
 SimpleNamedParameterFunction::SimpleNamedParameterFunction(string name_p, vector<LogicalType> arguments_p,
@@ -108,11 +136,6 @@ hash_t FunctionSignature::Hash() const {
 
 hash_t SimpleFunction::Hash() const {
 	return signature.Hash();
-}
-
-static bool RequiresCatalogAndSchemaNamePrefix(const string &catalog_name, const string &schema_name) {
-	return !catalog_name.empty() && catalog_name != SYSTEM_CATALOG && !schema_name.empty() &&
-	       schema_name != DEFAULT_SCHEMA;
 }
 
 string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -13,6 +13,10 @@ bool FunctionProperties::operator==(const FunctionProperties &rhs) const {
 	       collation_handling == rhs.collation_handling;
 }
 
+bool FunctionProperties::operator!=(const FunctionProperties &rhs) const {
+	return !(*this == rhs);
+}
+
 FunctionData::~FunctionData() {
 }
 
@@ -156,6 +160,17 @@ string Function::CallToString(const string &catalog_name, const string &schema_n
 	return StringUtil::Format("%s%s(%s)", prefix, name, StringUtil::Join(input_arguments, ", "));
 }
 
+void Function::EraseArgument(BoundSimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
+                             idx_t argument_index) {
+	if (bound_function.GetOriginalArguments().empty()) {
+		bound_function.GetOriginalArguments() = bound_function.GetArguments();
+	}
+	D_ASSERT(arguments.size() == bound_function.GetArguments().size());
+	D_ASSERT(argument_index < arguments.size());
+	arguments.erase_at(argument_index);
+	bound_function.GetArguments().erase_at(argument_index);
+}
+
 void Function::EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
                              idx_t argument_index) {
 	if (bound_function.GetOriginalArguments().empty()) {
@@ -165,6 +180,18 @@ void Function::EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<E
 	D_ASSERT(argument_index < arguments.size());
 	arguments.erase_at(argument_index);
 	bound_function.GetArguments().erase_at(argument_index);
+}
+
+hash_t BoundSimpleFunction::Hash() const {
+	hash_t hash = return_type.Hash();
+	for (auto &arg : arguments) {
+		hash = duckdb::CombineHash(hash, arg.Hash());
+	}
+	return hash;
+}
+
+string BoundSimpleFunction::ToString() const {
+	return Function::CallToString(catalog_name, schema_name, name, arguments, return_type);
 }
 
 } // namespace duckdb

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -52,19 +52,14 @@ Function::~Function() {
 
 SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type,
                                LogicalType varargs_p)
-    : Function(std::move(name_p)), arguments(std::move(arguments_p)), varargs(std::move(varargs_p)),
-      return_type(std::move(return_type)) {
+    : Function(std::move(name_p)), signature(std::move(arguments_p), std::move(varargs_p), std::move(return_type)) {
 }
 
 SimpleFunction::~SimpleFunction() {
 }
 
 string SimpleFunction::ToString() const {
-	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs, return_type);
-}
-
-bool SimpleFunction::HasVarArgs() const {
-	return varargs.id() != LogicalTypeId::INVALID;
+	throw NotImplementedException("SimpleFunction::ToString() not implemented");
 }
 
 SimpleNamedParameterFunction::SimpleNamedParameterFunction(string name_p, vector<LogicalType> arguments_p,
@@ -103,12 +98,16 @@ void BuiltinFunctions::Initialize() {
 	RegisterExtensionOverloads();
 }
 
-hash_t SimpleFunction::Hash() const {
+hash_t FunctionSignature::Hash() const {
 	hash_t hash = return_type.Hash();
-	for (auto &arg : arguments) {
-		hash = duckdb::CombineHash(hash, arg.Hash());
+	for (auto &param : parameters) {
+		hash = duckdb::CombineHash(hash, param.GetType().Hash());
 	}
 	return hash;
+}
+
+hash_t SimpleFunction::Hash() const {
+	return signature.Hash();
 }
 
 static bool RequiresCatalogAndSchemaNamePrefix(const string &catalog_name, const string &schema_name) {
@@ -171,17 +170,6 @@ void Function::EraseArgument(BoundSimpleFunction &bound_function, vector<unique_
 	bound_function.GetArguments().erase_at(argument_index);
 }
 
-void Function::EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
-                             idx_t argument_index) {
-	if (bound_function.GetOriginalArguments().empty()) {
-		bound_function.GetOriginalArguments() = bound_function.GetArguments();
-	}
-	D_ASSERT(arguments.size() == bound_function.GetArguments().size());
-	D_ASSERT(argument_index < arguments.size());
-	arguments.erase_at(argument_index);
-	bound_function.GetArguments().erase_at(argument_index);
-}
-
 hash_t BoundSimpleFunction::Hash() const {
 	hash_t hash = return_type.Hash();
 	for (auto &arg : arguments) {
@@ -192,6 +180,40 @@ hash_t BoundSimpleFunction::Hash() const {
 
 string BoundSimpleFunction::ToString() const {
 	return Function::CallToString(catalog_name, schema_name, name, arguments, return_type);
+}
+
+bool FunctionParameter::operator==(const FunctionParameter &other) const {
+	return type == other.type && StringUtil::CIEquals(name, other.name);
+}
+
+bool FunctionParameter::operator!=(const FunctionParameter &other) const {
+	return !(*this == other);
+}
+
+bool FunctionSignature::operator==(const FunctionSignature &other) const {
+	return parameters == other.parameters && varargs == other.varargs && return_type == other.return_type;
+}
+
+bool FunctionSignature::operator!=(const FunctionSignature &other) const {
+	return !(*this == other);
+}
+
+bool FunctionSignature::Equal(const FunctionSignature &other) const {
+	if (parameters.size() != other.parameters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < parameters.size(); i++) {
+		if (parameters[i].GetType() != other.parameters[i].GetType()) {
+			return false;
+		}
+	}
+	if (varargs != other.varargs) {
+		return false;
+	}
+	if (return_type != other.return_type) {
+		return false;
+	}
+	return true;
 }
 
 } // namespace duckdb

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -352,7 +352,9 @@ void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vect
 
 	// Varargs should be expanded by this point
 	// If not, the function has somehow added more argument expressions during binding, which is not allowed.
-	D_ASSERT(children.size() == function.GetArguments().size());
+	// There is one exception, count(*) which can be invoked internally with fewer arguments than the function
+	// definition. That should be fixed separately though.
+	D_ASSERT(children.size() <= function.GetArguments().size());
 
 	for (idx_t i = 0; i < children.size(); i++) {
 		auto &target_type = function.GetArguments()[i];

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -341,15 +341,16 @@ static void PrepareTypeForCast(LogicalType &type) {
 	type = PrepareTypeForCastRecursive(type);
 }
 
-void FunctionBinder::CastToFunctionArguments(SimpleFunction &function, vector<unique_ptr<Expression>> &children) {
+void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vector<unique_ptr<Expression>> &children) {
 	for (auto &arg : function.GetArguments()) {
 		PrepareTypeForCast(arg);
 	}
 
-	PrepareTypeForCast(function.GetVarArgs());
+	// Varargs should be expanded by this point
+	D_ASSERT(children.size() == function.GetArguments().size());
 
 	for (idx_t i = 0; i < children.size(); i++) {
-		auto target_type = i < function.GetArguments().size() ? function.GetArguments()[i] : function.GetVarArgs();
+		auto &target_type = function.GetArguments()[i];
 		if (target_type.id() == LogicalTypeId::STRING_LITERAL || target_type.id() == LogicalTypeId::INTEGER_LITERAL) {
 			throw InternalException(
 			    "Function %s returned a STRING_LITERAL or INTEGER_LITERAL type - return an explicit type instead",
@@ -440,7 +441,7 @@ static string ExtractCollation(const vector<unique_ptr<Expression>> &children) {
 	return collation;
 }
 
-static void PropagateCollations(ClientContext &, ScalarFunction &bound_function,
+static void PropagateCollations(ClientContext &, BoundSimpleFunction &bound_function,
                                 vector<unique_ptr<Expression>> &children) {
 	if (!RequiresCollationPropagation(bound_function.GetReturnType())) {
 		// we only need to propagate if the function returns a varchar
@@ -456,7 +457,7 @@ static void PropagateCollations(ClientContext &, ScalarFunction &bound_function,
 	bound_function.SetReturnType(std::move(collation_type));
 }
 
-static void PushCollations(ClientContext &context, ScalarFunction &bound_function,
+static void PushCollations(ClientContext &context, BoundSimpleFunction &bound_function,
                            vector<unique_ptr<Expression>> &children, CollationType type) {
 	auto collation = ExtractCollation(children);
 	if (collation.empty()) {
@@ -479,9 +480,9 @@ static void PushCollations(ClientContext &context, ScalarFunction &bound_functio
 	}
 }
 
-static void HandleCollations(ClientContext &context, ScalarFunction &bound_function,
-                             vector<unique_ptr<Expression>> &children) {
-	switch (bound_function.GetCollationHandling()) {
+static void HandleCollations(ClientContext &context, BoundSimpleFunction &bound_function,
+                             const FunctionProperties &props, vector<unique_ptr<Expression>> &children) {
+	switch (props.GetCollationHandling()) {
 	case FunctionCollationHandling::IGNORE_COLLATIONS:
 		// explicitly ignoring collation handling
 		break;
@@ -499,7 +500,7 @@ static void HandleCollations(ClientContext &context, ScalarFunction &bound_funct
 
 static void InferTemplateType(ClientContext &context, const LogicalType &source, const LogicalType &target,
                               case_insensitive_map_t<vector<LogicalType>> &bindings, const Expression &current_expr,
-                              const SimpleFunction &function) {
+                              const BoundSimpleFunction &function) {
 	if (target.id() == LogicalTypeId::UNKNOWN || target.id() == LogicalTypeId::SQLNULL) {
 		// If the actual type is unknown, we cannot infer anything more.
 		// Therefore, we map all remaining templates in the source to UNKNOWN or SQLNULL, if not already inferred to
@@ -646,7 +647,7 @@ static void SubstituteTemplateType(LogicalType &type, case_insensitive_map_t<vec
 	});
 }
 
-void FunctionBinder::ResolveTemplateTypes(SimpleFunction &bound_function,
+void FunctionBinder::ResolveTemplateTypes(BoundSimpleFunction &bound_function,
                                           const vector<unique_ptr<Expression>> &children) {
 	case_insensitive_map_t<vector<LogicalType>> bindings;
 	vector<reference<LogicalType>> to_substitute;
@@ -662,16 +663,6 @@ void FunctionBinder::ResolveTemplateTypes(SimpleFunction &bound_function,
 
 			to_substitute.emplace_back(param);
 		}
-	}
-
-	// If the function has a templated varargs, we need to infer its type too
-	if (bound_function.GetVarArgs().IsTemplated()) {
-		// All remaining children are considered varargs.
-		for (idx_t i = bound_function.GetArguments().size(); i < children.size(); i++) {
-			auto actual = ExpressionBinder::GetExpressionReturnType(*children[i]);
-			InferTemplateType(context, bound_function.GetVarArgs(), actual, bindings, *children[i], bound_function);
-		}
-		to_substitute.emplace_back(bound_function.GetVarArgs());
 	}
 
 	// If the return type is templated, we need to substitute it as well
@@ -697,11 +688,10 @@ static void VerifyTemplateType(const LogicalType &type, const string &function_n
 }
 
 // Verify that all template types are bound to concrete types.
-void FunctionBinder::CheckTemplateTypesResolved(const SimpleFunction &bound_function) {
+void FunctionBinder::CheckTemplateTypesResolved(const BoundSimpleFunction &bound_function) {
 	for (const auto &arg : bound_function.GetArguments()) {
 		VerifyTemplateType(arg, bound_function.name);
 	}
-	VerifyTemplateType(bound_function.GetVarArgs(), bound_function.name);
 	VerifyTemplateType(bound_function.GetReturnType(), bound_function.name);
 }
 
@@ -709,6 +699,14 @@ pair<BoundScalarFunction, unique_ptr<FunctionData>>
 FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_ptr<Expression>> &children) {
 	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
 	BoundScalarFunction bound_function(function);
+
+	// Expand varargs if necessary
+	if (function.HasVarArgs()) {
+		const auto &varargs_type = function.GetVarArgs();
+		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+			bound_function.GetArguments().push_back(varargs_type);
+		}
+	}
 
 	// Attempt to resolve template types, before we call the "Bind" callback.
 	ResolveTemplateTypes(bound_function, children);
@@ -730,7 +728,8 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 		FunctionModifiedDatabasesInput input(bind_info, properties);
 		bound_function.GetModifiedDatabasesCallback()(context, input);
 	}
-	HandleCollations(context, bound_function, children);
+
+	HandleCollations(context, bound_function, bound_function.GetProperties(), children);
 
 	// check if we need to add casts to the children
 	CastToFunctionArguments(bound_function, children);
@@ -767,13 +766,21 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 	// Make a BoundFunction out of the func
 	BoundAggregateFunction bound_function(function);
 
+	// Expand varargs if necessary
+	if (function.HasVarArgs()) {
+		const auto &varargs_type = function.GetVarArgs();
+		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+			bound_function.GetArguments().push_back(varargs_type);
+		}
+	}
+
 	ResolveTemplateTypes(bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
 
-	if (bound_function.HasBindCallback()) {
+	if (bound_function.GetCallbacks().HasBindCallback()) {
 		BindAggregateFunctionInput input(context, bound_function, children);
-		bind_info = bound_function.GetBindCallback()(input);
+		bind_info = bound_function.GetCallbacks().GetBindCallback()(input);
 
 		// we may have lost some arguments in the bind
 		children.resize(MinValue(bound_function.GetArguments().size(), children.size()));
@@ -803,13 +810,21 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
                                 optional_ptr<vector<OrderByNode>> arg_orders) {
 	BoundWindowFunction bound_function(function);
 
+	// Expand varargs if necessary
+	if (function.HasVarArgs()) {
+		const auto &varargs_type = function.GetVarArgs();
+		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+			bound_function.GetArguments().push_back(varargs_type);
+		}
+	}
+
 	ResolveTemplateTypes(bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
 
-	if (bound_function.HasBindCallback()) {
+	if (bound_function.GetCallbacks().HasBindCallback()) {
 		BindWindowFunctionInput input(context, bound_function, children, orders, arg_orders);
-		bind_info = bound_function.GetBindCallback()(input);
+		bind_info = bound_function.GetCallbacks().GetBindCallback()(input);
 		// we may have lost some arguments in the bind
 		children.resize(MinValue(bound_function.GetArguments().size(), children.size()));
 	}

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -822,9 +822,9 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 
 	unique_ptr<FunctionData> bind_info;
 
-	if (bound_function.GetCallbacks().HasBindCallback()) {
+	if (bound_function.HasBindCallback()) {
 		BindWindowFunctionInput input(context, bound_function, children, orders, arg_orders);
-		bind_info = bound_function.GetCallbacks().GetBindCallback()(input);
+		bind_info = bound_function.GetBindCallback()(input);
 		// we may have lost some arguments in the bind
 		children.resize(MinValue(bound_function.GetArguments().size(), children.size()));
 	}

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -351,6 +351,7 @@ void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vect
 	}
 
 	// Varargs should be expanded by this point
+	// If not, the function has somehow added more argument expressions during binding, which is not allowed.
 	D_ASSERT(children.size() == function.GetArguments().size());
 
 	for (idx_t i = 0; i < children.size(); i++) {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -198,7 +198,7 @@ optional_idx FunctionBinder::MultipleCandidateException(const string &catalog_na
 	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments);
 	string candidate_str;
 	for (auto &conf : candidate_functions) {
-		T f = functions.GetFunctionByOffset(conf);
+		const auto &f = functions.GetFunctionByOffset(conf);
 		candidate_str += "\t" + f.ToString() + "\n";
 	}
 	error = ErrorData(
@@ -263,7 +263,7 @@ optional_idx FunctionBinder::BindFunction(const string &name, PragmaFunctionSet 
 	if (!entry.IsValid()) {
 		error.Throw();
 	}
-	auto candidate_function = functions.GetFunctionByOffset(entry.GetIndex());
+	const auto &candidate_function = functions.GetFunctionByOffset(entry.GetIndex());
 	// cast the input parameters
 	for (idx_t i = 0; i < parameters.size(); i++) {
 		auto target_type = i < candidate_function.GetArguments().size() ? candidate_function.GetArguments()[i]
@@ -359,7 +359,7 @@ void FunctionBinder::CastToFunctionArguments(BoundSimpleFunction &function, vect
 		if (target_type.id() == LogicalTypeId::STRING_LITERAL || target_type.id() == LogicalTypeId::INTEGER_LITERAL) {
 			throw InternalException(
 			    "Function %s returned a STRING_LITERAL or INTEGER_LITERAL type - return an explicit type instead",
-			    function.name);
+			    function.GetName());
 		}
 		target_type.Verify();
 		// don't cast lambda children, they get removed before execution
@@ -396,7 +396,7 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	}
 
 	// found a matching function!
-	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	// If any of the parameters are NULL, the function will just be replaced with a NULL constant.
 	// We try to give the NULL constant the correct type, but we have to do this without binding the function,
@@ -677,7 +677,7 @@ void FunctionBinder::ResolveTemplateTypes(BoundSimpleFunction &bound_function,
 
 	// Finally, substitute all template types in the bound function with their concrete types.
 	for (auto &templated_type : to_substitute) {
-		SubstituteTemplateType(templated_type, bindings, bound_function.name);
+		SubstituteTemplateType(templated_type, bindings, bound_function.GetName());
 	}
 }
 
@@ -695,9 +695,9 @@ static void VerifyTemplateType(const LogicalType &type, const string &function_n
 // Verify that all template types are bound to concrete types.
 void FunctionBinder::CheckTemplateTypesResolved(const BoundSimpleFunction &bound_function) {
 	for (const auto &arg : bound_function.GetArguments()) {
-		VerifyTemplateType(arg, bound_function.name);
+		VerifyTemplateType(arg, bound_function.GetName());
 	}
-	VerifyTemplateType(bound_function.GetReturnType(), bound_function.name);
+	VerifyTemplateType(bound_function.GetReturnType(), bound_function.GetName());
 }
 
 pair<BoundScalarFunction, unique_ptr<FunctionData>>

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -705,9 +705,11 @@ void FunctionBinder::CheckTemplateTypesResolved(const SimpleFunction &bound_func
 	VerifyTemplateType(bound_function.GetReturnType(), bound_function.name);
 }
 
-// TODO: Take a normal ScalarFunction here?
-unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundScalarFunction &bound_function,
-                                                         vector<unique_ptr<Expression>> &children) {
+pair<BoundScalarFunction, unique_ptr<FunctionData>>
+FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_ptr<Expression>> &children) {
+	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
+	BoundScalarFunction bound_function(function);
+
 	// Attempt to resolve template types, before we call the "Bind" callback.
 	ResolveTemplateTypes(bound_function, children);
 
@@ -733,16 +735,13 @@ unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundScalarFunction &bo
 	// check if we need to add casts to the children
 	CastToFunctionArguments(bound_function, children);
 
-	return bind_info;
+	return {std::move(bound_function), std::move(bind_info)};
 }
 
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &function,
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
-	// Make a BoundScalarFunction out of the ScalarFunction, so we can store bind info and other properties in it.
-	BoundScalarFunction bound_function(function);
-
-	auto bind_info = ResolveFunction(bound_function, children);
+	auto [bound_function, bind_info] = ResolveFunction(function, children);
 
 	unique_ptr<Expression> result;
 
@@ -763,8 +762,11 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &
 	return result;
 }
 
-unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundAggregateFunction &bound_function,
-                                                         vector<unique_ptr<Expression>> &children) {
+pair<BoundAggregateFunction, unique_ptr<FunctionData>>
+FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique_ptr<Expression>> &children) {
+	// Make a BoundFunction out of the func
+	BoundAggregateFunction bound_function(function);
+
 	ResolveTemplateTypes(bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
@@ -782,26 +784,25 @@ unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundAggregateFunction 
 	// check if we need to add casts to the children
 	CastToFunctionArguments(bound_function, children);
 
-	return bind_info;
+	return {std::move(bound_function), std::move(bind_info)};
 }
 
 unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(const AggregateFunction &function,
                                                                            vector<unique_ptr<Expression>> children,
                                                                            unique_ptr<Expression> filter,
                                                                            AggregateType aggr_type) {
-	// Make a BoundFunction out of the func
-	BoundAggregateFunction bound_function(function);
-
-	auto bind_info = ResolveFunction(bound_function, children);
+	auto [bound_function, bind_info] = ResolveFunction(function, children);
 
 	return make_uniq<BoundAggregateExpression>(std::move(bound_function), std::move(children), std::move(filter),
 	                                           std::move(bind_info), aggr_type);
 }
 
-unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundWindowFunction &bound_function,
-                                                         vector<unique_ptr<Expression>> &children,
-                                                         optional_ptr<vector<OrderByNode>> orders,
-                                                         optional_ptr<vector<OrderByNode>> arg_orders) {
+pair<BoundWindowFunction, unique_ptr<FunctionData>>
+FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_ptr<Expression>> &children,
+                                optional_ptr<vector<OrderByNode>> orders,
+                                optional_ptr<vector<OrderByNode>> arg_orders) {
+	BoundWindowFunction bound_function(function);
+
 	ResolveTemplateTypes(bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;
@@ -818,17 +819,14 @@ unique_ptr<FunctionData> FunctionBinder::ResolveFunction(BoundWindowFunction &bo
 	// check if we need to add casts to the children
 	CastToFunctionArguments(bound_function, children);
 
-	return bind_info;
+	return {std::move(bound_function), std::move(bind_info)};
 }
 
 unique_ptr<BoundWindowExpression> FunctionBinder::BindWindowFunction(const WindowFunction &function,
                                                                      vector<unique_ptr<Expression>> children,
                                                                      vector<OrderByNode> &orders,
-                                                                     vector<OrderByNode> &arg_orders,
-                                                                     AggregateType aggr_type) {
-	BoundWindowFunction bound_function(function);
-
-	auto bind_info = ResolveFunction(bound_function, children, orders, arg_orders);
+                                                                     vector<OrderByNode> &arg_orders) {
+	auto [bound_function, bind_info] = ResolveFunction(function, children, orders, arg_orders);
 	auto return_type = bound_function.GetReturnType();
 
 	auto window = make_uniq<BoundWindowFunction>(std::move(bound_function));

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -751,8 +751,8 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(const ScalarFunction &
 
 	unique_ptr<Expression> result;
 
-	auto result_func = make_uniq<BoundFunctionExpression>(bound_function.GetReturnType(), std::move(bound_function),
-	                                                      std::move(children), std::move(bind_info), is_operator);
+	auto result_func = make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(children),
+	                                                      std::move(bind_info), is_operator);
 
 	if (result_func->function.HasBindExpressionCallback()) {
 		// if a bind_expression callback is registered - call it and emit the resulting expression

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -23,13 +23,15 @@ FunctionBinder::FunctionBinder(Binder &binder_p) : binder(&binder_p), context(bi
 }
 
 optional_idx FunctionBinder::BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments) {
-	if (arguments.size() < func.GetArguments().size()) {
+	auto &sig = func.GetSignature();
+
+	if (arguments.size() < sig.GetParameterCount()) {
 		// not enough arguments to fulfill the non-vararg part of the function
 		return optional_idx();
 	}
 	idx_t cost = 0;
 	for (idx_t i = 0; i < arguments.size(); i++) {
-		LogicalType arg_type = i < func.GetArguments().size() ? func.GetArguments()[i] : func.GetVarArgs();
+		LogicalType arg_type = i < sig.GetParameterCount() ? sig.GetParameter(i).GetType() : sig.GetVarArgs();
 		if (arguments[i] == arg_type) {
 			// arguments match: do nothing
 			continue;
@@ -47,11 +49,13 @@ optional_idx FunctionBinder::BindVarArgsFunctionCost(const SimpleFunction &func,
 }
 
 optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments) {
-	if (func.HasVarArgs()) {
+	auto &sig = func.GetSignature();
+
+	if (sig.HasVarArgs()) {
 		// special case varargs function
 		return BindVarArgsFunctionCost(func, arguments);
 	}
-	if (func.GetArguments().size() != arguments.size()) {
+	if (sig.GetParameterCount() != arguments.size()) {
 		// invalid argument count: check the next function
 		return optional_idx();
 	}
@@ -62,7 +66,7 @@ optional_idx FunctionBinder::BindFunctionCost(const SimpleFunction &func, const 
 			has_parameter = true;
 			continue;
 		}
-		int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, arguments[i], func.GetArguments()[i]);
+		int64_t cast_cost = CastFunctionSet::ImplicitCastCost(context, arguments[i], sig.GetParameter(i).GetType());
 		if (cast_cost >= 0) {
 			// we can implicitly cast, add the cost to the total cost
 			cost += idx_t(cast_cost);
@@ -703,7 +707,7 @@ FunctionBinder::ResolveFunction(const ScalarFunction &function, vector<unique_pt
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
 		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+		for (idx_t i = function.GetSignature().GetParameterCount(); i < children.size(); i++) {
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}
@@ -769,7 +773,7 @@ FunctionBinder::ResolveFunction(const AggregateFunction &function, vector<unique
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
 		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+		for (idx_t i = function.GetSignature().GetParameterCount(); i < children.size(); i++) {
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}
@@ -813,7 +817,7 @@ FunctionBinder::ResolveFunction(const WindowFunction &function, vector<unique_pt
 	// Expand varargs if necessary
 	if (function.HasVarArgs()) {
 		const auto &varargs_type = function.GetVarArgs();
-		for (idx_t i = function.GetArguments().size(); i < children.size(); i++) {
+		for (idx_t i = function.GetSignature().GetParameterCount(); i < children.size(); i++) {
 			bound_function.GetArguments().push_back(varargs_type);
 		}
 	}

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -44,12 +44,13 @@ AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &co
 		// this is used for functions such as quantile or string_agg that delete part of their arguments during bind
 		// FIXME: we should come up with a better solution here
 		for (auto &func : functions) {
-			if (arguments.size() >= func.GetArguments().size()) {
+			auto &sig = func.GetSignature();
+			if (arguments.size() >= sig.GetParameters().size()) {
 				continue;
 			}
 			bool is_prefix = true;
 			for (idx_t k = 0; k < arguments.size(); k++) {
-				if (arguments[k].id() != func.GetArguments()[k].id()) {
+				if (arguments[k].id() != sig.GetParameter(k).GetType().id()) {
 					is_prefix = false;
 					break;
 				}

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -13,7 +13,8 @@ ScalarFunctionSet::ScalarFunctionSet(ScalarFunction fun) : FunctionSet(std::move
 	functions.push_back(std::move(fun));
 }
 
-ScalarFunction ScalarFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
+const ScalarFunction &ScalarFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -34,8 +35,8 @@ AggregateFunctionSet::AggregateFunctionSet(AggregateFunction fun) : FunctionSet(
 	functions.push_back(std::move(fun));
 }
 
-AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &context,
-                                                               const vector<LogicalType> &arguments) {
+const AggregateFunction &AggregateFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                      const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -75,7 +76,8 @@ WindowFunctionSet::WindowFunctionSet(WindowFunction fun) : FunctionSet(std::move
 	functions.push_back(std::move(fun));
 }
 
-WindowFunction WindowFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
+const WindowFunction &WindowFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                                const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);
@@ -93,7 +95,8 @@ TableFunctionSet::TableFunctionSet(TableFunction fun) : FunctionSet(std::move(fu
 	functions.push_back(std::move(fun));
 }
 
-TableFunction TableFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
+const TableFunction &TableFunctionSet::GetFunctionByArguments(ClientContext &context,
+                                                              const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
 	auto index = binder.BindFunction(name, *this, arguments, error);

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -223,7 +223,7 @@ struct StrpTimeFunction {
 				} else {
 					bound_function.SetReturnType(LogicalType::TIMESTAMP_NS);
 				}
-				if (bound_function.name == "strptime") {
+				if (bound_function.GetName() == "strptime") {
 					bound_function.SetFunctionCallback(Parse<timestamp_ns_t>);
 				} else {
 					bound_function.SetFunctionCallback(TryParse<timestamp_ns_t>);
@@ -264,7 +264,7 @@ struct StrpTimeFunction {
 				} else {
 					bound_function.SetReturnType(LogicalType::TIMESTAMP_NS);
 				}
-				if (bound_function.name == "strptime") {
+				if (bound_function.GetName() == "strptime") {
 					bound_function.SetFunctionCallback(Parse<timestamp_ns_t>);
 				} else {
 					bound_function.SetFunctionCallback(TryParse<timestamp_ns_t>);

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -94,7 +94,7 @@ unique_ptr<FunctionData> ConstantOrNull::Bind(Value value) {
 }
 
 bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value &val) {
-	if (expr.function.name != "constant_or_null") {
+	if (expr.function.GetName() != "constant_or_null") {
 		return false;
 	}
 	D_ASSERT(expr.bind_info);

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -138,11 +138,11 @@ static unique_ptr<FunctionData> ListZipBind(BindScalarFunctionInput &input) {
 	// The last argument could be a flag to be set if we want a minimal list or a maximal list
 	idx_t size = arguments.size();
 	if (size == 0) {
-		throw BinderException("Provide at least one argument to " + bound_function.name);
+		throw BinderException("Provide at least one argument to " + bound_function.GetName());
 	}
 	if (arguments[size - 1]->GetReturnType().id() == LogicalTypeId::BOOLEAN) {
 		if (--size == 0) {
-			throw BinderException("Provide at least one list argument to " + bound_function.name);
+			throw BinderException("Provide at least one list argument to " + bound_function.GetName());
 		}
 	}
 

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -203,7 +203,7 @@ void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	return StringConcatFunction(args, state, result);
 }
 
-void SetArgumentType(ScalarFunction &bound_function, const LogicalType &type, bool is_operator) {
+void SetArgumentType(BoundScalarFunction &bound_function, const LogicalType &type, bool is_operator) {
 	if (is_operator) {
 		bound_function.GetArguments()[0] = type;
 		bound_function.GetArguments()[1] = type;
@@ -214,11 +214,10 @@ void SetArgumentType(ScalarFunction &bound_function, const LogicalType &type, bo
 	for (auto &arg : bound_function.GetArguments()) {
 		arg = type;
 	}
-	bound_function.SetVarArgs(type);
 	bound_function.SetReturnType(type);
 }
 
-unique_ptr<FunctionData> BindListConcat(ClientContext &context, ScalarFunction &bound_function,
+unique_ptr<FunctionData> BindListConcat(ClientContext &context, BoundScalarFunction &bound_function,
                                         vector<unique_ptr<Expression>> &arguments, bool is_operator) {
 	LogicalType child_type = LogicalType::SQLNULL;
 	bool all_null = true;
@@ -272,7 +271,7 @@ unique_ptr<FunctionData> BindListConcat(ClientContext &context, ScalarFunction &
 	return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 }
 
-unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, ScalarFunction &bound_function,
+unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, BoundScalarFunction &bound_function,
                                                     vector<unique_ptr<Expression>> &arguments, bool is_operator) {
 	bool list_concat = false;
 	bool all_null = true;
@@ -299,14 +298,17 @@ unique_ptr<FunctionData> BindConcatFunctionInternal(ClientContext &context, Scal
 		if (is_operator) {
 			SetArgumentType(bound_function, LogicalTypeId::SQLNULL, is_operator);
 			return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
-		} else if (bound_function.GetVarArgs().id() == LogicalTypeId::LIST ||
-		           bound_function.GetVarArgs().id() == LogicalTypeId::ARRAY) {
+		}
+
+		const auto &func_args = bound_function.GetArguments();
+		if (!func_args.empty() &&
+		    (func_args[0].id() == LogicalTypeId::LIST || func_args[0].id() == LogicalTypeId::ARRAY)) {
 			SetArgumentType(bound_function, LogicalTypeId::SQLNULL, is_operator);
 			return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
-		} else {
-			SetArgumentType(bound_function, LogicalTypeId::VARCHAR, is_operator);
-			return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 		}
+
+		SetArgumentType(bound_function, LogicalTypeId::VARCHAR, is_operator);
+		return make_uniq<ConcatFunctionData>(bound_function.GetReturnType(), is_operator);
 	}
 	auto return_type = all_blob ? LogicalType::BLOB : LogicalType::VARCHAR;
 

--- a/src/function/scalar/string/concat_ws.cpp
+++ b/src/function/scalar/string/concat_ws.cpp
@@ -118,7 +118,6 @@ static unique_ptr<FunctionData> BindConcatWSFunction(BindScalarFunctionInput &in
 	for (auto &arg : bound_function.GetArguments()) {
 		arg = LogicalType::VARCHAR;
 	}
-	bound_function.SetVarArgs(LogicalType::VARCHAR);
 	return nullptr;
 }
 

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -381,11 +381,12 @@ static unique_ptr<FunctionData> RegexExtractBind(BindScalarFunctionInput &input)
 			group_index = -1;
 		} else if (group.type().id() == LogicalTypeId::LIST) {
 			if (!constant_pattern) {
-				throw BinderException("%s with LIST of group names requires a constant pattern", bound_function.name);
+				throw BinderException("%s with LIST of group names requires a constant pattern",
+				                      bound_function.GetName());
 			}
 			vector<string> dummy_names; // not reused after bind
 			child_list_t<LogicalType> struct_children;
-			regexp_util::ParseGroupNameList(context, bound_function.name, *arguments[2], constant_string, options,
+			regexp_util::ParseGroupNameList(context, bound_function.GetName(), *arguments[2], constant_string, options,
 			                                constant_pattern, dummy_names, struct_children);
 			bound_function.SetReturnType(LogicalType::STRUCT(struct_children));
 		} else {

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -338,7 +338,7 @@ unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(BindScalarFunctionInput &i
 	string constant_string;
 	bool constant_pattern = TryParseConstantPattern(context, *arguments[1], constant_string);
 	if (!constant_pattern) {
-		throw BinderException("%s with LIST requires a constant pattern", function.name);
+		throw BinderException("%s with LIST requires a constant pattern", function.GetName());
 	}
 	if (arguments.size() >= 4) {
 		ParseRegexOptions(context, *arguments[3], options);
@@ -346,8 +346,8 @@ unique_ptr<FunctionData> RegexpExtractAllStruct::Bind(BindScalarFunctionInput &i
 	options.set_log_errors(false);
 	vector<string> group_names;
 	child_list_t<LogicalType> struct_children;
-	regexp_util::ParseGroupNameList(context, function.name, *arguments[2], constant_string, options, true, group_names,
-	                                struct_children);
+	regexp_util::ParseGroupNameList(context, function.GetName(), *arguments[2], constant_string, options, true,
+	                                group_names, struct_children);
 	function.SetReturnType(LogicalType::LIST(LogicalType::STRUCT(struct_children)));
 	return make_uniq<RegexpExtractAllStructBindData>(options, std::move(constant_string), constant_pattern,
 	                                                 std::move(group_names));

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -184,7 +184,7 @@ ScalarFunctionSet StringSplitRegexFun::GetFunctions() {
 	                         FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
 	regexp_split.AddFunction(regex_fun);
 	// regexp options
-	regex_fun.GetArguments().emplace_back(LogicalType::VARCHAR);
+	regex_fun.GetSignature().AddParameter(LogicalType::VARCHAR);
 	regexp_split.AddFunction(regex_fun);
 	return regexp_split;
 }

--- a/src/function/scalar/struct/struct_contains.cpp
+++ b/src/function/scalar/struct/struct_contains.cpp
@@ -213,7 +213,7 @@ static unique_ptr<FunctionData> StructContainsBind(BindScalarFunctionInput &inpu
 		throw InternalException("Can't check for containment in an empty struct");
 	}
 	if (!StructType::IsUnnamed(child_type)) {
-		throw BinderException("%s can only be used on unnamed structs", bound_function.name);
+		throw BinderException("%s can only be used on unnamed structs", bound_function.GetName());
 	}
 	bound_function.GetArguments()[0] = child_type;
 

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -91,7 +91,7 @@ static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input
 	return StructExtractAtFun::GetBindData(key_index);
 }
 
-static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context, ScalarFunction &bound_function,
+static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context, BoundScalarFunction &bound_function,
                                                           vector<unique_ptr<Expression>> &arguments,
                                                           bool struct_extract) {
 	D_ASSERT(bound_function.GetArguments().size() == 2);

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -898,7 +898,9 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 	export_function.SetSerializeCallback(ExportStateAggregateSerialize);
 	export_function.SetDeserializeCallback(ExportStateAggregateDeserialize);
 
-	return make_uniq<BoundAggregateExpression>(export_function, std::move(child_aggregate->children),
+	BoundAggregateFunction bound_func(export_function);
+
+	return make_uniq<BoundAggregateExpression>(std::move(bound_func), std::move(child_aggregate->children),
 	                                           std::move(child_aggregate->filter), std::move(export_bind_data),
 	                                           child_aggregate->aggr_type);
 }

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -636,7 +636,7 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	if (arg_return_type.id() != LogicalTypeId::AGGREGATE_STATE &&
 	    (!allow_legacy || arg_return_type.id() != LogicalTypeId::LEGACY_AGGREGATE_STATE)) {
 		string allowed = allow_legacy ? "AGGREGATE_STATE or LEGACY_AGGREGATE_STATE" : "AGGREGATE_STATE";
-		throw BinderException("Can only %s %s, not %s", function.name, allowed, arg_return_type.ToString());
+		throw BinderException("Can only %s %s, not %s", function.GetName(), allowed, arg_return_type.ToString());
 	}
 
 	// following error states are only reachable when someone messes up creating the state_type
@@ -661,7 +661,7 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 		throw InternalException("Could not re-bind exported aggregate %s: %s", state_type.function_name,
 		                        error.Message());
 	}
-	auto aggr = aggr_entry.functions.GetFunctionByOffset(best_function.GetIndex());
+	const auto &aggr = aggr_entry.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	// FIXME: this is really hacky
 	// but the aggregate state export needs a rework around how it handles more complex aggregates anyway
@@ -699,10 +699,10 @@ unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
 		                      arguments[0]->GetReturnType().ToString(), arguments[1]->GetReturnType().ToString());
 	}
 
-	if (bound_function.name == "finalize") {
+	if (bound_function.GetName() == "finalize") {
 		bound_function.SetReturnType(bind_data->aggr.GetReturnType());
 	} else {
-		D_ASSERT(bound_function.name == "combine");
+		D_ASSERT(bound_function.GetName() == "combine");
 		bound_function.SetReturnType(arguments[0]->GetReturnType());
 		// When the second argument is a STRUCT (e.g. from a parquet round-trip), prevent casting to AGGREGATE_STATE by
 		// matching the declared parameter type to the actual argument type.
@@ -855,7 +855,7 @@ unique_ptr<BoundAggregateExpression>
 ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggregate) {
 	auto &bound_function = child_aggregate->function;
 	if (!bound_function.HasStateCombineCallback()) {
-		throw BinderException("Cannot use EXPORT_STATE for non-combinable function %s", bound_function.name);
+		throw BinderException("Cannot use EXPORT_STATE for non-combinable function %s", bound_function.GetName());
 	}
 	if (bound_function.HasBindCallback()) {
 		throw BinderException("Cannot use EXPORT_STATE on aggregate functions with custom binders");
@@ -874,7 +874,7 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 	}
 #endif
 	auto export_bind_data = make_uniq<ExportAggregateFunctionBindData>(child_aggregate->Copy());
-	aggregate_state_t state_type(child_aggregate->function.name, child_aggregate->function.GetReturnType(),
+	aggregate_state_t state_type(child_aggregate->function.GetName(), child_aggregate->function.GetReturnType(),
 	                             child_aggregate->function.GetArguments());
 
 	LogicalType return_type;
@@ -887,8 +887,8 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 	}
 
 	auto export_function =
-	    AggregateFunction("aggregate_state_export_" + bound_function.name, bound_function.GetArguments(), return_type,
-	                      bound_function.GetStateSizeCallback(), bound_function.GetStateInitCallback(),
+	    AggregateFunction("aggregate_state_export_" + bound_function.GetName(), bound_function.GetArguments(),
+	                      return_type, bound_function.GetStateSizeCallback(), bound_function.GetStateInitCallback(),
 	                      bound_function.GetStateUpdateCallback(), bound_function.GetStateCombineCallback(),
 	                      ExportAggregateFinalize, bound_function.GetStateSimpleUpdateCallback(),
 	                      /* can't bind this again */ nullptr, /* no dynamic state yet */ nullptr,

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -625,8 +625,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	}
 }
 
-// Creates the bind data by resolving the underlying aggregate function from an AGGREGATE_STATE logical type.
-unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &context, SimpleFunction &function,
+unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &context, BoundSimpleFunction &function,
                                                                vector<unique_ptr<Expression>> &arguments,
                                                                bool allow_legacy) {
 	auto &arg_return_type = arguments[0]->GetReturnType();

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -664,21 +664,18 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	}
 	auto aggr = aggr_entry.functions.GetFunctionByOffset(best_function.GetIndex());
 
-	BoundAggregateFunction bound_aggr(aggr);
+	// FIXME: this is really hacky
+	// but the aggregate state export needs a rework around how it handles more complex aggregates anyway
+	vector<unique_ptr<Expression>> args;
+	args.reserve(state_type.bound_argument_types.size());
+	for (auto &arg_type : state_type.bound_argument_types) {
+		args.push_back(make_uniq<BoundConstantExpression>(Value(arg_type)));
+	}
 
-	if (bound_aggr.GetBindCallback()) {
-		// FIXME: this is really hacky
-		// but the aggregate state export needs a rework around how it handles more complex aggregates anyway
-		vector<unique_ptr<Expression>> args;
-		args.reserve(state_type.bound_argument_types.size());
-		for (auto &arg_type : state_type.bound_argument_types) {
-			args.push_back(make_uniq<BoundConstantExpression>(Value(arg_type)));
-		}
+	auto [bound_aggr, bind_info] = function_binder.ResolveFunction(aggr, args);
 
-		auto bind_info = function_binder.ResolveFunction(bound_aggr, args);
-		if (bind_info) {
-			throw BinderException("Aggregate function with bind info not supported yet in aggregate state export");
-		}
+	if (bind_info) {
+		throw BinderException("Aggregate function with bind info not supported yet in aggregate state export");
 	}
 
 	if (bound_aggr.GetReturnType() != state_type.return_type ||

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -313,10 +313,11 @@ ScalarFunctionSet VariantExtractFun::GetFunctions() {
 	ScalarFunction variant_extract("variant_extract", {}, variant_type, VariantExtractFunction, VariantExtractBind,
 	                               VariantExtractPropagateStats);
 
-	variant_extract.GetArguments() = {variant_type, LogicalType::VARCHAR};
+	variant_extract.GetSignature().AddParameter(variant_type);
+	variant_extract.GetSignature().AddParameter(LogicalType::VARCHAR);
 	fun_set.AddFunction(variant_extract);
 
-	variant_extract.GetArguments() = {variant_type, LogicalType::UINTEGER};
+	variant_extract.GetSignature().GetParameter(1).SetType(LogicalType::UINTEGER);
 	fun_set.AddFunction(variant_extract);
 	return fun_set;
 }

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -94,4 +94,24 @@ unique_ptr<BoundFunctionExpression> ScalarFunction::Bind(ClientContext &context,
 
 	return unique_ptr_cast<Expression, BoundFunctionExpression>(std::move(expr));
 }
+
+BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function) {
+	name = function.name;
+	schema_name = function.schema_name;
+	catalog_name = function.catalog_name;
+	arguments = function.GetArguments();
+	return_type = function.GetReturnType();
+	callbacks = function.GetCallbacks();
+	properties = function.GetProperties();
+	function_info = function.GetFunctionInfo();
+}
+
+bool BoundScalarFunction::operator==(const BoundScalarFunction &rhs) const {
+	return callbacks == rhs.callbacks && properties == rhs.properties && name == rhs.name &&
+	       return_type == rhs.return_type && arguments == rhs.arguments;
+}
+bool BoundScalarFunction::operator!=(const BoundScalarFunction &rhs) const {
+	return !(*this == rhs);
+}
+
 } // namespace duckdb

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -46,8 +46,7 @@ ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return
 }
 
 bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
-	return name == rhs.name && arguments == rhs.GetArguments() && return_type == rhs.return_type &&
-	       varargs == rhs.GetVarArgs() && callbacks == rhs.callbacks && properties == rhs.properties;
+	return name == rhs.name && signature == rhs.signature && callbacks == rhs.callbacks && properties == rhs.properties;
 }
 
 bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {
@@ -55,26 +54,7 @@ bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {
 }
 
 bool ScalarFunction::Equal(const ScalarFunction &rhs) const {
-	// number of types
-	if (this->GetArguments().size() != rhs.GetArguments().size()) {
-		return false;
-	}
-	// argument types
-	for (idx_t i = 0; i < this->GetArguments().size(); ++i) {
-		if (this->GetArguments()[i] != rhs.GetArguments()[i]) {
-			return false;
-		}
-	}
-	// return type
-	if (this->return_type != rhs.return_type) {
-		return false;
-	}
-	// varargs
-	if (this->GetVarArgs() != rhs.GetVarArgs()) {
-		return false;
-	}
-
-	return true; // they are equal
+	return signature.Equal(rhs.signature);
 }
 
 void ScalarFunction::NopFunction(DataChunk &input, ExpressionState &state, Vector &result) {
@@ -99,11 +79,16 @@ BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function) {
 	name = function.name;
 	schema_name = function.schema_name;
 	catalog_name = function.catalog_name;
-	arguments = function.GetArguments();
 	return_type = function.GetReturnType();
 	callbacks = function.GetCallbacks();
 	properties = function.GetProperties();
 	function_info = function.GetFunctionInfo();
+
+	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
+	// "bind" callback)
+	for (auto &param : function.GetSignature().GetParameters()) {
+		arguments.push_back(param.GetType());
+	}
 }
 
 bool BoundScalarFunction::operator==(const BoundScalarFunction &rhs) const {

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -79,6 +79,7 @@ BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function) {
 	name = function.name;
 	schema_name = function.schema_name;
 	catalog_name = function.catalog_name;
+	extra_info = function.extra_info;
 	return_type = function.GetReturnType();
 	callbacks = function.GetCallbacks();
 	properties = function.GetProperties();

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -83,6 +83,7 @@ BoundScalarFunction::BoundScalarFunction(const ScalarFunction &function) {
 	callbacks = function.GetCallbacks();
 	properties = function.GetProperties();
 	function_info = function.GetFunctionInfo();
+	arg_props = function.GetAllArgProperties();
 
 	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
 	// "bind" callback)

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -160,7 +160,7 @@ struct ScalarFunctionExtractor {
 
 	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -168,7 +168,7 @@ struct ScalarFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -177,7 +177,7 @@ struct ScalarFunctionExtractor {
 	}
 
 	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -218,7 +218,7 @@ struct WindowFunctionExtractor {
 
 	static Value GetParameterTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -226,7 +226,7 @@ struct WindowFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -274,7 +274,7 @@ struct AggregateFunctionExtractor {
 
 	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
@@ -282,7 +282,7 @@ struct AggregateFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		vector<LogicalType> results;
 		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
 			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
@@ -291,7 +291,7 @@ struct AggregateFunctionExtractor {
 	}
 
 	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -452,7 +452,7 @@ struct TableFunctionExtractor {
 
 	static vector<Value> GetParameters(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back("col" + to_string(i));
 		}
@@ -464,7 +464,7 @@ struct TableFunctionExtractor {
 
 	static Value GetParameterTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back(fun.GetArguments()[i].ToString());
@@ -476,12 +476,12 @@ struct TableFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return fun.GetArguments();
 	}
 
 	static Value GetVarArgs(TableFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 
@@ -513,7 +513,7 @@ struct PragmaFunctionExtractor {
 
 	static vector<Value> GetParameters(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back("col" + to_string(i));
@@ -526,7 +526,7 @@ struct PragmaFunctionExtractor {
 
 	static Value GetParameterTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 
 		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
 			results.emplace_back(fun.GetArguments()[i].ToString());
@@ -538,12 +538,12 @@ struct PragmaFunctionExtractor {
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return fun.GetArguments();
 	}
 
 	static Value GetVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
-		auto fun = entry.functions.GetFunctionByOffset(offset);
+		const auto &fun = entry.functions.GetFunctionByOffset(offset);
 		return !fun.HasVarArgs() ? Value() : Value(fun.GetVarArgs().ToString());
 	}
 

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -152,7 +152,7 @@ struct ScalarFunctionExtractor {
 
 	static vector<Value> GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetArguments().size(); i++) {
+		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
 			results.emplace_back("col" + to_string(i));
 		}
 		return results;
@@ -161,15 +161,19 @@ struct ScalarFunctionExtractor {
 	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
-			results.emplace_back(fun.GetArguments()[i].ToString());
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, std::move(results));
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		return fun.GetArguments();
+		vector<LogicalType> results;
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
+		}
+		return results;
 	}
 
 	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
@@ -206,7 +210,7 @@ struct WindowFunctionExtractor {
 
 	static vector<Value> GetParameters(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetArguments().size(); i++) {
+		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
 			results.emplace_back("col" + to_string(i));
 		}
 		return results;
@@ -215,15 +219,19 @@ struct WindowFunctionExtractor {
 	static Value GetParameterTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
-			results.emplace_back(fun.GetArguments()[i].ToString());
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, std::move(results));
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		return fun.GetArguments();
+		vector<LogicalType> results;
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
+		}
+		return results;
 	}
 
 	static Value GetVarArgs(WindowFunctionCatalogEntry &entry, idx_t offset) {
@@ -258,7 +266,7 @@ struct AggregateFunctionExtractor {
 
 	static vector<Value> GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetArguments().size(); i++) {
+		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
 			results.emplace_back("col" + to_string(i));
 		}
 		return results;
@@ -267,15 +275,19 @@ struct AggregateFunctionExtractor {
 	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		for (idx_t i = 0; i < fun.GetArguments().size(); i++) {
-			results.emplace_back(fun.GetArguments()[i].ToString());
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType().ToString());
 		}
 		return Value::LIST(LogicalType::VARCHAR, std::move(results));
 	}
 
 	static vector<LogicalType> GetParameterLogicalTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		auto fun = entry.functions.GetFunctionByOffset(offset);
-		return fun.GetArguments();
+		vector<LogicalType> results;
+		for (idx_t i = 0; i < fun.GetSignature().GetParameterCount(); i++) {
+			results.emplace_back(fun.GetSignature().GetParameter(i).GetType());
+		}
+		return results;
 	}
 
 	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -152,8 +152,8 @@ struct ScalarFunctionExtractor {
 
 	static vector<Value> GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
-			results.emplace_back("col" + to_string(i));
+		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+			results.emplace_back(param.GetName());
 		}
 		return results;
 	}
@@ -210,8 +210,8 @@ struct WindowFunctionExtractor {
 
 	static vector<Value> GetParameters(WindowFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
-			results.emplace_back("col" + to_string(i));
+		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+			results.emplace_back(param.GetName());
 		}
 		return results;
 	}
@@ -266,8 +266,8 @@ struct AggregateFunctionExtractor {
 
 	static vector<Value> GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
 		vector<Value> results;
-		for (idx_t i = 0; i < entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameterCount(); i++) {
-			results.emplace_back("col" + to_string(i));
+		for (auto &param : entry.functions.GetFunctionByOffset(offset).GetSignature().GetParameters()) {
+			results.emplace_back(param.GetName());
 		}
 		return results;
 	}

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -34,10 +34,10 @@ static BoundWindowExpression &SimplifyWindowedAggregate(BoundWindowExpression &w
 	if (wexpr.aggregate && ClientConfig::GetConfig(context).enable_optimizer) {
 		const auto &aggr = wexpr.aggregate;
 		auto &arg_orders = wexpr.arg_orders;
-		if (aggr->GetDistinctDependent() != AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+		if (aggr->GetProperties().GetDistinctDependent() != AggregateDistinctDependent::DISTINCT_DEPENDENT) {
 			wexpr.distinct = false;
 		}
-		if (aggr->GetOrderDependent() != AggregateOrderDependent::ORDER_DEPENDENT) {
+		if (aggr->GetProperties().GetOrderDependent() != AggregateOrderDependent::ORDER_DEPENDENT) {
 			arg_orders.clear();
 		} else {
 			//	If the argument order is prefix of the partition ordering,

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -34,10 +34,10 @@ static BoundWindowExpression &SimplifyWindowedAggregate(BoundWindowExpression &w
 	if (wexpr.aggregate && ClientConfig::GetConfig(context).enable_optimizer) {
 		const auto &aggr = wexpr.aggregate;
 		auto &arg_orders = wexpr.arg_orders;
-		if (aggr->GetProperties().GetDistinctDependent() != AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+		if (aggr->GetDistinctDependent() != AggregateDistinctDependent::DISTINCT_DEPENDENT) {
 			wexpr.distinct = false;
 		}
-		if (aggr->GetProperties().GetOrderDependent() != AggregateOrderDependent::ORDER_DEPENDENT) {
+		if (aggr->GetOrderDependent() != AggregateOrderDependent::ORDER_DEPENDENT) {
 			arg_orders.clear();
 		} else {
 			//	If the argument order is prefix of the partition ordering,

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -154,8 +154,8 @@ void WindowSegmentTree::Finalize(ExecutionContext &context, CollectionPtr collec
 
 WindowSegmentTreePart::WindowSegmentTreePart(ArenaAllocator &allocator, const AggregateObject &aggr,
                                              unique_ptr<WindowCursor> cursor_p, const ValidityArray &filter_mask)
-    : allocator(allocator), aggr(aggr), order_insensitive(aggr.function.GetProperties().GetOrderDependent() ==
-                                                          AggregateOrderDependent::NOT_ORDER_DEPENDENT),
+    : allocator(allocator), aggr(aggr),
+      order_insensitive(aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT),
       filter_mask(filter_mask), state_size(aggr.function.GetStateSizeCallback()(aggr.function)),
       state(state_size * STANDARD_VECTOR_SIZE), cursor(std::move(cursor_p)), statep(LogicalType::POINTER),
       statel(LogicalType::POINTER), statef(LogicalType::POINTER), flush_count(0) {

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -154,8 +154,8 @@ void WindowSegmentTree::Finalize(ExecutionContext &context, CollectionPtr collec
 
 WindowSegmentTreePart::WindowSegmentTreePart(ArenaAllocator &allocator, const AggregateObject &aggr,
                                              unique_ptr<WindowCursor> cursor_p, const ValidityArray &filter_mask)
-    : allocator(allocator), aggr(aggr),
-      order_insensitive(aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT),
+    : allocator(allocator), aggr(aggr), order_insensitive(aggr.function.GetProperties().GetOrderDependent() ==
+                                                          AggregateOrderDependent::NOT_ORDER_DEPENDENT),
       filter_mask(filter_mask), state_size(aggr.function.GetStateSizeCallback()(aggr.function)),
       state(state_size * STANDARD_VECTOR_SIZE), cursor(std::move(cursor_p)), statep(LogicalType::POINTER),
       statel(LogicalType::POINTER), statef(LogicalType::POINTER), flush_count(0) {

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -588,13 +588,13 @@ WindowFunction LeadFun::GetTypedFunction(const LogicalType &type, idx_t nargs) {
 	auto funcs = GetLeadLagFunctionSet(Name, ExpressionType::WINDOW_LEAD);
 
 	for (auto &func : funcs.functions) {
-		if (func.GetArguments().size() != nargs) {
+		if (func.GetSignature().GetParameterCount() != nargs) {
 			continue;
 		}
 
-		func.GetArguments()[0] = type;
+		func.GetSignature().GetParameter(0).SetType(type);
 		if (nargs > 2) {
-			func.GetArguments()[2] = type;
+			func.GetSignature().GetParameter(2).SetType(type);
 		}
 		return func;
 	}

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -18,4 +18,7 @@ unique_ptr<BoundWindowExpression> WindowFunction::Bind(ClientContext &context,
 	return func_binder.BindWindowFunction(*this, std::move(arguments), orders, arg_orders);
 }
 
+BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : WindowFunction(base) {
+}
+
 } // namespace duckdb

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -22,6 +22,7 @@ BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : window_en
 	name = base.name;
 	schema_name = base.schema_name;
 	catalog_name = base.catalog_name;
+	extra_info = base.extra_info;
 	return_type = base.GetReturnType();
 	callbacks = base.GetCallbacks();
 	properties = base.GetProperties();

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -22,11 +22,16 @@ BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : window_en
 	name = base.name;
 	schema_name = base.schema_name;
 	catalog_name = base.catalog_name;
-	arguments = base.GetArguments();
 	return_type = base.GetReturnType();
 	callbacks = base.GetCallbacks();
 	properties = base.GetProperties();
 	function_info = base.GetFunctionInfo();
+
+	// Try to default bind the function, to fill in any missing information in the BoundScalarFunction (e.g. from the
+	// "bind" callback)
+	for (auto &param : base.GetSignature().GetParameters()) {
+		arguments.push_back(param.GetType());
+	}
 }
 
 bool BoundWindowFunction::operator==(const BoundWindowFunction &rhs) const {

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -14,9 +14,8 @@ unique_ptr<BoundWindowExpression> WindowFunction::Bind(ClientContext &context,
 	FunctionBinder func_binder(context);
 	vector<OrderByNode> orders;
 	vector<OrderByNode> arg_orders;
-	AggregateType aggr_type = AggregateType::NON_DISTINCT;
 
-	return func_binder.BindWindowFunction(*this, std::move(arguments), orders, arg_orders, aggr_type);
+	return func_binder.BindWindowFunction(*this, std::move(arguments), orders, arg_orders);
 }
 
 } // namespace duckdb

--- a/src/function/window_function.cpp
+++ b/src/function/window_function.cpp
@@ -18,7 +18,23 @@ unique_ptr<BoundWindowExpression> WindowFunction::Bind(ClientContext &context,
 	return func_binder.BindWindowFunction(*this, std::move(arguments), orders, arg_orders);
 }
 
-BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : WindowFunction(base) {
+BoundWindowFunction::BoundWindowFunction(const WindowFunction &base) : window_enum(base.window_enum) {
+	name = base.name;
+	schema_name = base.schema_name;
+	catalog_name = base.catalog_name;
+	arguments = base.GetArguments();
+	return_type = base.GetReturnType();
+	callbacks = base.GetCallbacks();
+	properties = base.GetProperties();
+	function_info = base.GetFunctionInfo();
+}
+
+bool BoundWindowFunction::operator==(const BoundWindowFunction &rhs) const {
+	return window_enum == rhs.window_enum && arguments == rhs.arguments && return_type == rhs.return_type;
+}
+
+bool BoundWindowFunction::operator!=(const BoundWindowFunction &rhs) const {
+	return !(*this == rhs);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
@@ -24,7 +24,7 @@ struct FunctionDataWrapper {
 };
 
 struct AggregateObject { // NOLINT: work-around bug in clang-tidy
-	AggregateObject(AggregateFunction function, FunctionData *bind_data, idx_t child_count, idx_t payload_size,
+	AggregateObject(BoundAggregateFunction function, FunctionData *bind_data, idx_t child_count, idx_t payload_size,
 	                AggregateType aggr_type, PhysicalType return_type, Expression *filter = nullptr);
 	explicit AggregateObject(BoundAggregateExpression *aggr);
 	explicit AggregateObject(const BoundWindowExpression &window);
@@ -33,7 +33,7 @@ struct AggregateObject { // NOLINT: work-around bug in clang-tidy
 		return bind_data_wrapper ? bind_data_wrapper->function_data.get() : nullptr;
 	}
 
-	AggregateFunction function;
+	BoundAggregateFunction function;
 	shared_ptr<FunctionDataWrapper> bind_data_wrapper;
 	idx_t child_count;
 	idx_t payload_size;

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -359,6 +359,22 @@ protected:
 	shared_ptr<AggregateFunctionInfo> function_info;
 
 public:
+	AggregateFunctionProperties &GetProperties() {
+		return properties;
+	}
+	const AggregateFunctionProperties &GetProperties() const {
+		return properties;
+	}
+	AggregateFunctionCallbacks &GetCallbacks() {
+		return callbacks;
+	}
+	const AggregateFunctionCallbacks &GetCallbacks() const {
+		return callbacks;
+	}
+	shared_ptr<AggregateFunctionInfo> GetFunctionInfo() const {
+		return function_info;
+	}
+
 	// clang-format off
 	FunctionStability GetStability() const { return properties.stability; }
 	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
@@ -569,9 +585,9 @@ public:
 
 class BoundAggregateFunction : public AggregateFunction {
 public:
-	BoundAggregateFunction(const AggregateFunction &function) // NOLINT: allow implicit conversion
-	    : AggregateFunction(function) {
-	}
+	explicit BoundAggregateFunction(const AggregateFunction &function);
+
+	void ReplaceImplementation(const AggregateFunction &function);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -77,9 +77,9 @@ private:
 };
 
 //! The type used for sizing hashed aggregate function states
-typedef idx_t (*aggregate_size_t)(const AggregateFunction &function);
+typedef idx_t (*aggregate_size_t)(const BoundAggregateFunction &function);
 //! The type used for initializing hashed aggregate function states
-typedef void (*aggregate_initialize_t)(const AggregateFunction &function, data_ptr_t state);
+typedef void (*aggregate_initialize_t)(const BoundAggregateFunction &function, data_ptr_t state);
 //! The type used for updating hashed aggregate functions
 typedef void (*aggregate_update_t)(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
                                    Vector &state, idx_t count);
@@ -125,7 +125,7 @@ typedef void (*aggregate_serialize_t)(Serializer &serializer, const optional_ptr
 typedef unique_ptr<FunctionData> (*aggregate_deserialize_t)(Deserializer &deserializer,
                                                             BoundAggregateFunction &function);
 
-typedef LogicalType (*aggregate_get_state_type_t)(const AggregateFunction &function);
+typedef LogicalType (*aggregate_get_state_type_t)(const BoundAggregateFunction &function);
 
 struct AggregateFunctionInfo {
 	DUCKDB_API virtual ~AggregateFunctionInfo();
@@ -150,6 +150,64 @@ enum class AggregateDestructorType {
 };
 
 class AggregateFunctionCallbacks {
+public:
+	// clang-format off
+	bool HasBindCallback() const { return bind != nullptr; }
+	bind_aggregate_function_t GetBindCallback() const { return bind; }
+	void SetBindCallback(bind_aggregate_function_t callback) { bind = callback; }
+
+	bool HasStateInitCallback() const { return initialize != nullptr; }
+	aggregate_initialize_t GetStateInitCallback() const { return initialize; }
+	void SetStateInitCallback(aggregate_initialize_t callback) { initialize = callback; }
+
+	bool HasStateSizeCallback() const { return state_size != nullptr; }
+	aggregate_size_t GetStateSizeCallback() const { return state_size; }
+	void SetStateSizeCallback(aggregate_size_t callback) { state_size = callback; }
+
+	bool HasStateDestructorCallback() const { return destructor != nullptr; }
+	aggregate_destructor_t GetStateDestructorCallback() const { return destructor; }
+	void SetStateDestructorCallback(aggregate_destructor_t callback) { destructor = callback; }
+
+	bool HasStateUpdateCallback() const { return update != nullptr; }
+	aggregate_update_t GetStateUpdateCallback() const { return update; }
+	void SetStateUpdateCallback(aggregate_update_t callback) { update = callback; }
+
+	bool HasStateSimpleUpdateCallback() const { return simple_update != nullptr; }
+	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return simple_update; }
+	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { simple_update = callback; }
+
+	void SetStateCombineCallback(aggregate_combine_t callback) { combine = callback; }
+	aggregate_combine_t GetStateCombineCallback() const { return combine; }
+	bool HasStateCombineCallback() const { return combine != nullptr; }
+
+	void SetStateFinalizeCallback(aggregate_finalize_t callback) { finalize = callback; }
+	aggregate_finalize_t GetStateFinalizeCallback() const { return finalize; }
+	bool HasStateFinalizeCallback() const { return finalize != nullptr; }
+
+	bool HasWindowCallback() const { return window != nullptr; }
+	aggregate_window_t GetWindowCallback() const { return window; }
+	void SetWindowCallback(aggregate_window_t callback) { window = callback; }
+
+	void SetWindowInitCallback(aggregate_wininit_t callback) { window_init = callback; }
+	aggregate_wininit_t GetWindowInitCallback() const { return window_init; }
+	bool HasWindowInitCallback() const { return window_init != nullptr; }
+
+	//! Batched window callback — takes precedence over the per-row window
+	//! callback when set. See aggregate_window_batch_t for semantics.
+	bool HasWindowBatchCallback() const { return window_batch != nullptr; }
+	aggregate_window_batch_t GetWindowBatchCallback() const { return window_batch; }
+	void SetWindowBatchCallback(aggregate_window_batch_t callback) { window_batch = callback; }
+
+	bool HasStatisticsCallback() const { return statistics != nullptr; }
+	aggregate_statistics_t GetStatisticsCallback() const { return statistics; }
+	void SetStatisticsCallback(aggregate_statistics_t callback) { statistics = callback; }
+
+	bool HasSerializationCallbacks() const { return serialize != nullptr && deserialize != nullptr; }
+	void SetSerializeCallback(aggregate_serialize_t callback) { serialize = callback; }
+	void SetDeserializeCallback(aggregate_deserialize_t callback) { deserialize = callback; }
+	aggregate_serialize_t GetSerializeCallback() const { return serialize; }
+	aggregate_deserialize_t GetDeserializeCallback() const { return deserialize; }
+
 public:
 	//! The hashed aggregate state sizing function
 	aggregate_size_t state_size = nullptr;
@@ -191,9 +249,16 @@ public:
 
 class AggregateFunctionProperties : public FunctionProperties {
 public:
-	//! Whether or not the aggregate is order dependent
+	auto GetOrderDependent() const -> AggregateOrderDependent { return order_dependent; }
+	auto SetOrderDependent(AggregateOrderDependent value) -> void { order_dependent = value; }
+
+	auto GetDistinctDependent() const -> AggregateDistinctDependent { return distinct_dependent; }
+	auto SetDistinctDependent(AggregateDistinctDependent value) -> void { distinct_dependent = value; }
+public:
+	//! Whether the aggregate is order dependent
 	AggregateOrderDependent order_dependent = AggregateOrderDependent::ORDER_DEPENDENT;
-	//! Whether or not the aggregate is affect by distinct modifiers
+
+	//! Whether the aggregate is affect by distinct modifiers
 	AggregateDistinctDependent distinct_dependent = AggregateDistinctDependent::DISTINCT_DEPENDENT;
 
 	bool operator==(const AggregateFunctionProperties &rhs) const;
@@ -435,14 +500,6 @@ public:
 		return *this;
 	}
 
-	LogicalType GetStateType() const {
-		D_ASSERT(callbacks.get_state_type);
-		const auto result = callbacks.get_state_type(*this);
-		// The underlying type of the AggregateState should be a struct
-		D_ASSERT(result.id() == LogicalTypeId::STRUCT);
-		return result;
-	}
-
 public:
 	bool operator==(const AggregateFunction &rhs) const {
 		return callbacks == rhs.callbacks;
@@ -502,12 +559,12 @@ public:
 
 public:
 	template <class STATE>
-	static idx_t StateSize(const AggregateFunction &) {
+	static idx_t StateSize(const BoundAggregateFunction &) {
 		return sizeof(STATE);
 	}
 
 	template <class STATE, class OP, AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
-	static void StateInitialize(const AggregateFunction &, data_ptr_t state) {
+	static void StateInitialize(const BoundAggregateFunction &, data_ptr_t state) {
 		// FIXME: we should remove the "destructor_type" option in the future
 #if !defined(__GNUC__) || (__GNUC__ >= 5)
 		static_assert(std::is_trivially_move_constructible<STATE>::value ||
@@ -583,11 +640,148 @@ public:
 	}
 };
 
-class BoundAggregateFunction : public AggregateFunction {
+class BoundAggregateFunction : public BoundSimpleFunction {
 public:
 	explicit BoundAggregateFunction(const AggregateFunction &function);
 
 	void ReplaceImplementation(const AggregateFunction &function);
+
+public:
+	auto GetProperties() const -> const AggregateFunctionProperties & {
+		return properties;
+	}
+	auto GetProperties() -> AggregateFunctionProperties & {
+		return properties;
+	}
+	auto GetCallbacks() const -> const AggregateFunctionCallbacks & {
+		return callbacks;
+	}
+	auto GetCallbacks() -> AggregateFunctionCallbacks & {
+		return callbacks;
+	}
+
+	DUCKDB_API bool operator==(const BoundAggregateFunction &rhs) const;
+	DUCKDB_API bool operator!=(const BoundAggregateFunction &rhs) const;
+
+	// TODO: Move to callbacks
+
+	bool HasGetStateTypeCallback() const {
+		return callbacks.get_state_type != nullptr;
+	}
+	aggregate_get_state_type_t GetStateTypeCallback() const {
+		return callbacks.get_state_type;
+	}
+	BoundAggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
+		callbacks.get_state_type = get_state_type_callback;
+		return *this;
+	}
+
+	LogicalType GetStateType() const {
+		D_ASSERT(callbacks.get_state_type);
+		const auto result = callbacks.get_state_type(*this);
+		// The underlying type of the AggregateState should be a struct
+		D_ASSERT(result.id() == LogicalTypeId::STRUCT);
+		return result;
+	}
+
+	bool HasSerializationCallbacks() const {
+		return callbacks.serialize != nullptr && callbacks.deserialize != nullptr;
+	}
+	void SetSerializeCallback(aggregate_serialize_t callback) {
+		callbacks.serialize = callback;
+	}
+	void SetDeserializeCallback(aggregate_deserialize_t callback) {
+		callbacks.deserialize = callback;
+	}
+	aggregate_serialize_t GetSerializeCallback() const {
+		return callbacks.serialize;
+	}
+	aggregate_deserialize_t GetDeserializeCallback() const {
+		return callbacks.deserialize;
+	}
+
+	// clang-format off
+	bool HasBindCallback() const { return callbacks.bind != nullptr; }
+	bind_aggregate_function_t GetBindCallback() const { return callbacks.bind; }
+	void SetBindCallback(bind_aggregate_function_t callback) { callbacks.bind = callback; }
+
+	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
+
+	bool HasStateInitCallback() const { return callbacks.initialize != nullptr; }
+	aggregate_initialize_t GetStateInitCallback() const { return callbacks.initialize; }
+	void SetStateInitCallback(aggregate_initialize_t callback) { callbacks.initialize = callback; }
+
+	bool HasStateSizeCallback() const { return callbacks.state_size != nullptr; }
+	aggregate_size_t GetStateSizeCallback() const { return callbacks.state_size; }
+	void SetStateSizeCallback(aggregate_size_t callback) { callbacks.state_size = callback; }
+
+	bool HasStateDestructorCallback() const { return callbacks.destructor != nullptr; }
+	aggregate_destructor_t GetStateDestructorCallback() const { return callbacks.destructor; }
+	void SetStateDestructorCallback(aggregate_destructor_t callback) { callbacks.destructor = callback; }
+
+	bool HasStateUpdateCallback() const { return callbacks.update != nullptr; }
+	aggregate_update_t GetStateUpdateCallback() const { return callbacks.update; }
+	void SetStateUpdateCallback(aggregate_update_t callback) { callbacks.update = callback; }
+
+	bool HasStateSimpleUpdateCallback() const { return callbacks.simple_update != nullptr; }
+	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return callbacks.simple_update; }
+	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { callbacks.simple_update = callback; }
+
+	void SetStateCombineCallback(aggregate_combine_t callback) { callbacks.combine = callback; }
+	aggregate_combine_t GetStateCombineCallback() const { return callbacks.combine; }
+	bool HasStateCombineCallback() const { return callbacks.combine != nullptr; }
+
+	void SetStateFinalizeCallback(aggregate_finalize_t callback) { callbacks.finalize = callback; }
+	aggregate_finalize_t GetStateFinalizeCallback() const { return callbacks.finalize; }
+	bool HasStateFinalizeCallback() const { return callbacks.finalize != nullptr; }
+
+	bool HasWindowCallback() const { return callbacks.window != nullptr; }
+	aggregate_window_t GetWindowCallback() const { return callbacks.window; }
+	void SetWindowCallback(aggregate_window_t callback) { callbacks.window = callback; }
+
+	void SetWindowInitCallback(aggregate_wininit_t callback) { callbacks.window_init = callback; }
+	aggregate_wininit_t GetWindowInitCallback() const { return callbacks.window_init; }
+	bool HasWindowInitCallback() const { return callbacks.window_init != nullptr; }
+
+	//! Batched window callback — takes precedence over the per-row window
+	//! callback when set. See aggregate_window_batch_t for semantics.
+	bool HasWindowBatchCallback() const { return callbacks.window_batch != nullptr; }
+	aggregate_window_batch_t GetWindowBatchCallback() const { return callbacks.window_batch; }
+	void SetWindowBatchCallback(aggregate_window_batch_t callback) { callbacks.window_batch = callback; }
+
+	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
+	aggregate_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
+	void SetStatisticsCallback(aggregate_statistics_t callback) { callbacks.statistics = callback; }
+
+
+	bool CanAggregate() const {
+		return callbacks.update || callbacks.combine || callbacks.finalize;
+	}
+	bool CanWindow() const {
+		return callbacks.window;
+	}
+
+
+	AggregateFunctionInfo &GetExtraFunctionInfo() const {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+
+	void SetExtraFunctionInfo(shared_ptr<AggregateFunctionInfo> info) {
+		function_info = std::move(info);
+	}
+
+	template <class T, class... ARGS>
+	void SetExtraFunctionInfo(ARGS &&... args) {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+	}
+
+	// clang-format on
+
+protected:
+	AggregateFunctionProperties properties;
+	AggregateFunctionCallbacks callbacks;
+	shared_ptr<AggregateFunctionInfo> function_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -249,12 +249,6 @@ public:
 
 class AggregateFunctionProperties : public FunctionProperties {
 public:
-	auto GetOrderDependent() const -> AggregateOrderDependent { return order_dependent; }
-	auto SetOrderDependent(AggregateOrderDependent value) -> void { order_dependent = value; }
-
-	auto GetDistinctDependent() const -> AggregateDistinctDependent { return distinct_dependent; }
-	auto SetDistinctDependent(AggregateDistinctDependent value) -> void { distinct_dependent = value; }
-public:
 	//! Whether the aggregate is order dependent
 	AggregateOrderDependent order_dependent = AggregateOrderDependent::ORDER_DEPENDENT;
 
@@ -265,7 +259,134 @@ public:
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
 };
 
-class AggregateFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
+class BaseAggregateFunction {
+public:
+	// clang-format off
+	auto GetProperties() const -> const AggregateFunctionProperties & { return properties; }
+	auto GetProperties() -> AggregateFunctionProperties & { return properties; }
+	auto SetProperties(const AggregateFunctionProperties &value) -> void { properties = value; }
+
+	auto GetCallbacks() const -> const AggregateFunctionCallbacks & { return callbacks; }
+	auto GetCallbacks() -> AggregateFunctionCallbacks & { return callbacks; }
+	auto SetCallbacks(const AggregateFunctionCallbacks &value) -> void { callbacks = value; }
+
+public: // Properties
+
+	auto GetStability() const -> FunctionStability { return properties.stability; }
+	auto SetStability(FunctionStability value) -> void { properties.stability = value; }
+
+	auto GetNullHandling() const -> FunctionNullHandling { return properties.null_handling; }
+	auto SetNullHandling(FunctionNullHandling value) -> void { properties.null_handling = value; }
+
+	auto GetErrorMode() const -> FunctionErrors { return properties.errors; }
+	auto SetErrorMode(FunctionErrors value) -> void { properties.errors = value; }
+
+	auto GetCollationHandling() const -> FunctionCollationHandling { return properties.collation_handling; }
+	auto SetCollationHandling(FunctionCollationHandling value) -> void { properties.collation_handling = value; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+
+	//! Whether the aggregate is order dependent
+	auto GetOrderDependent() const -> AggregateOrderDependent { return properties.order_dependent; }
+	auto SetOrderDependent(AggregateOrderDependent value) -> void { properties.order_dependent = value; }
+
+	//! Whether the aggregate is affect by distinct modifiers
+	auto GetDistinctDependent() const -> AggregateDistinctDependent { return properties.distinct_dependent; }
+	auto SetDistinctDependent(AggregateDistinctDependent value) -> void { properties.distinct_dependent = value; }
+
+	// Derived properties
+	bool CanAggregate() const { return callbacks.update || callbacks.combine || callbacks.finalize; }
+	bool CanWindow() const { return callbacks.window  || callbacks.window_batch; }
+
+public: // Callbacks
+
+	auto HasBindCallback() const -> bool { return callbacks.bind != nullptr; }
+	auto GetBindCallback() const -> bind_aggregate_function_t { return callbacks.bind; }
+	auto SetBindCallback(bind_aggregate_function_t callback) -> void { callbacks.bind = callback; }
+
+	auto HasStateInitCallback() const -> bool { return callbacks.initialize != nullptr; }
+	auto GetStateInitCallback() const -> aggregate_initialize_t { return callbacks.initialize; }
+	auto SetStateInitCallback(aggregate_initialize_t callback) -> void { callbacks.initialize = callback; }
+
+	auto HasStateSizeCallback() const -> bool { return callbacks.state_size != nullptr; }
+	auto GetStateSizeCallback() const -> aggregate_size_t { return callbacks.state_size; }
+	auto SetStateSizeCallback(aggregate_size_t callback) -> void { callbacks.state_size = callback; }
+
+	auto HasStateDestructorCallback() const -> bool { return callbacks.destructor != nullptr; }
+	auto GetStateDestructorCallback() const -> aggregate_destructor_t { return callbacks.destructor; }
+	auto SetStateDestructorCallback(aggregate_destructor_t callback) -> void { callbacks.destructor = callback; }
+
+	auto HasStateUpdateCallback() const -> bool { return callbacks.update != nullptr; }
+	auto GetStateUpdateCallback() const -> aggregate_update_t { return callbacks.update; }
+	auto SetStateUpdateCallback(aggregate_update_t callback) -> void { callbacks.update = callback; }
+
+	auto HasStateSimpleUpdateCallback() const -> bool { return callbacks.simple_update != nullptr; }
+	auto GetStateSimpleUpdateCallback() const -> aggregate_simple_update_t { return callbacks.simple_update; }
+	auto SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) -> void { callbacks.simple_update = callback; }
+
+	auto HasStateCombineCallback() const -> bool { return callbacks.combine != nullptr; }
+	auto GetStateCombineCallback() const -> aggregate_combine_t { return callbacks.combine; }
+	auto SetStateCombineCallback(aggregate_combine_t callback) -> void { callbacks.combine = callback; }
+
+	auto HasStateFinalizeCallback() const -> bool { return callbacks.finalize != nullptr; }
+	auto GetStateFinalizeCallback() const -> aggregate_finalize_t { return callbacks.finalize; }
+	auto SetStateFinalizeCallback(aggregate_finalize_t callback) -> void { callbacks.finalize = callback; }
+
+	auto HasWindowCallback() const -> bool { return callbacks.window != nullptr; }
+	auto GetWindowCallback() const -> aggregate_window_t { return callbacks.window; }
+	auto SetWindowCallback(aggregate_window_t callback) -> void { callbacks.window = callback; }
+
+	auto SetWindowInitCallback(aggregate_wininit_t callback) -> void { callbacks.window_init = callback; }
+	auto GetWindowInitCallback() const -> aggregate_wininit_t { return callbacks.window_init; }
+	auto HasWindowInitCallback() const -> bool { return callbacks.window_init != nullptr; }
+
+	auto HasWindowBatchCallback() const -> bool { return callbacks.window_batch != nullptr; }
+	auto GetWindowBatchCallback() const -> aggregate_window_batch_t { return callbacks.window_batch; }
+	auto SetWindowBatchCallback(aggregate_window_batch_t callback) -> void { callbacks.window_batch = callback; }
+
+	auto HasStatisticsCallback() const -> bool { return callbacks.statistics != nullptr; }
+	auto GetStatisticsCallback() const -> aggregate_statistics_t { return callbacks.statistics; }
+	auto SetStatisticsCallback(aggregate_statistics_t callback) -> void { callbacks.statistics = callback; }
+
+	auto HasSerializationCallbacks() const -> bool { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
+	auto SetSerializeCallback(aggregate_serialize_t callback) -> void { callbacks.serialize = callback; }
+	auto SetDeserializeCallback(aggregate_deserialize_t callback) -> void { callbacks.deserialize = callback; }
+	auto GetSerializeCallback() const -> aggregate_serialize_t { return callbacks.serialize; }
+	auto GetDeserializeCallback() const -> aggregate_deserialize_t { return callbacks.deserialize; }
+
+	bool HasGetStateTypeCallback() const { return callbacks.get_state_type != nullptr; }
+	aggregate_get_state_type_t GetStateTypeCallback() const { return callbacks.get_state_type; }
+	// clang-format on
+
+public: // Extra function info
+	auto HasExtraFunctionInfo() const -> bool {
+		return function_info != nullptr;
+	}
+	auto GetExtraFunctionInfo() const -> AggregateFunctionInfo & {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+	auto SetExtraFunctionInfo(shared_ptr<AggregateFunctionInfo> info) -> void {
+		function_info = std::move(info);
+	}
+	template <class T, class... ARGS>
+	auto SetExtraFunctionInfo(ARGS &&... args) -> void {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+	}
+	auto GetFunctionInfo() const -> shared_ptr<AggregateFunctionInfo> {
+		return function_info;
+	}
+
+protected:
+	AggregateFunctionProperties properties;
+	AggregateFunctionCallbacks callbacks;
+	shared_ptr<AggregateFunctionInfo> function_info;
+};
+
+class AggregateFunction : public BaseAggregateFunction, public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	                  aggregate_size_t state_size, aggregate_initialize_t initialize, aggregate_update_t update,
@@ -356,150 +477,6 @@ public:
 		callbacks.deserialize = deserialize;
 	}
 
-	// clang-format off
-	bool HasBindCallback() const { return callbacks.bind != nullptr; }
-	bind_aggregate_function_t GetBindCallback() const { return callbacks.bind; }
-	void SetBindCallback(bind_aggregate_function_t callback) { callbacks.bind = callback; }
-
-	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
-
-	bool HasStateInitCallback() const { return callbacks.initialize != nullptr; }
-	aggregate_initialize_t GetStateInitCallback() const { return callbacks.initialize; }
-	void SetStateInitCallback(aggregate_initialize_t callback) { callbacks.initialize = callback; }
-
-	bool HasStateSizeCallback() const { return callbacks.state_size != nullptr; }
-	aggregate_size_t GetStateSizeCallback() const { return callbacks.state_size; }
-	void SetStateSizeCallback(aggregate_size_t callback) { callbacks.state_size = callback; }
-
-	bool HasStateDestructorCallback() const { return callbacks.destructor != nullptr; }
-	aggregate_destructor_t GetStateDestructorCallback() const { return callbacks.destructor; }
-	void SetStateDestructorCallback(aggregate_destructor_t callback) { callbacks.destructor = callback; }
-
-	bool HasStateUpdateCallback() const { return callbacks.update != nullptr; }
-	aggregate_update_t GetStateUpdateCallback() const { return callbacks.update; }
-	void SetStateUpdateCallback(aggregate_update_t callback) { callbacks.update = callback; }
-
-	bool HasStateSimpleUpdateCallback() const { return callbacks.simple_update != nullptr; }
-	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return callbacks.simple_update; }
-	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { callbacks.simple_update = callback; }
-
-	void SetStateCombineCallback(aggregate_combine_t callback) { callbacks.combine = callback; }
-	aggregate_combine_t GetStateCombineCallback() const { return callbacks.combine; }
-	bool HasStateCombineCallback() const { return callbacks.combine != nullptr; }
-
-	void SetStateFinalizeCallback(aggregate_finalize_t callback) { callbacks.finalize = callback; }
-	aggregate_finalize_t GetStateFinalizeCallback() const { return callbacks.finalize; }
-	bool HasStateFinalizeCallback() const { return callbacks.finalize != nullptr; }
-
-	bool HasWindowCallback() const { return callbacks.window != nullptr; }
-	aggregate_window_t GetWindowCallback() const { return callbacks.window; }
-	void SetWindowCallback(aggregate_window_t callback) { callbacks.window = callback; }
-
-	void SetWindowInitCallback(aggregate_wininit_t callback) { callbacks.window_init = callback; }
-	aggregate_wininit_t GetWindowInitCallback() const { return callbacks.window_init; }
-	bool HasWindowInitCallback() const { return callbacks.window_init != nullptr; }
-
-	//! Batched window callback — takes precedence over the per-row window
-	//! callback when set. See aggregate_window_batch_t for semantics.
-	bool HasWindowBatchCallback() const { return callbacks.window_batch != nullptr; }
-	aggregate_window_batch_t GetWindowBatchCallback() const { return callbacks.window_batch; }
-	void SetWindowBatchCallback(aggregate_window_batch_t callback) { callbacks.window_batch = callback; }
-
-	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
-	aggregate_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
-	void SetStatisticsCallback(aggregate_statistics_t callback) { callbacks.statistics = callback; }
-
-	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
-	void SetSerializeCallback(aggregate_serialize_t callback) { callbacks.serialize = callback; }
-	void SetDeserializeCallback(aggregate_deserialize_t callback) { callbacks.deserialize = callback; }
-	aggregate_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
-	aggregate_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
-	// clang-format on
-
-protected:
-	AggregateFunctionCallbacks callbacks;
-	AggregateFunctionProperties properties;
-
-	//! Additional function info, passed to the bind
-	shared_ptr<AggregateFunctionInfo> function_info;
-
-public:
-	AggregateFunctionProperties &GetProperties() {
-		return properties;
-	}
-	const AggregateFunctionProperties &GetProperties() const {
-		return properties;
-	}
-	AggregateFunctionCallbacks &GetCallbacks() {
-		return callbacks;
-	}
-	const AggregateFunctionCallbacks &GetCallbacks() const {
-		return callbacks;
-	}
-	shared_ptr<AggregateFunctionInfo> GetFunctionInfo() const {
-		return function_info;
-	}
-
-	// clang-format off
-	FunctionStability GetStability() const { return properties.stability; }
-	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
-	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
-	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
-	FunctionErrors GetErrorMode() const { return properties.errors; }
-	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
-	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
-	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
-
-	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
-	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
-	// clang-format on
-
-public:
-	bool HasExtraFunctionInfo() const {
-		return function_info != nullptr;
-	}
-
-	AggregateFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-
-	void SetExtraFunctionInfo(shared_ptr<AggregateFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-
-	AggregateOrderDependent GetOrderDependent() const {
-		return properties.order_dependent;
-	}
-	void SetOrderDependent(AggregateOrderDependent value) {
-		properties.order_dependent = value;
-	}
-	AggregateDistinctDependent GetDistinctDependent() const {
-		return properties.distinct_dependent;
-	}
-	void SetDistinctDependent(AggregateDistinctDependent value) {
-		properties.distinct_dependent = value;
-	}
-
-	bool HasGetStateTypeCallback() const {
-		return callbacks.get_state_type != nullptr;
-	}
-	aggregate_get_state_type_t GetStateTypeCallback() const {
-		return callbacks.get_state_type;
-	}
-
-	AggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
-		callbacks.get_state_type = get_state_type_callback;
-		return *this;
-	}
-
 public:
 	bool operator==(const AggregateFunction &rhs) const {
 		return callbacks == rhs.callbacks;
@@ -508,11 +485,11 @@ public:
 		return !(*this == rhs);
 	}
 
-	bool CanAggregate() const {
-		return callbacks.update || callbacks.combine || callbacks.finalize;
-	}
-	bool CanWindow() const {
-		return callbacks.window || callbacks.window_batch;
+	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
+
+	AggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
+		callbacks.get_state_type = get_state_type_callback;
+		return *this;
 	}
 
 public:
@@ -640,41 +617,14 @@ public:
 	}
 };
 
-class BoundAggregateFunction : public BoundSimpleFunction {
+class BoundAggregateFunction : public BaseAggregateFunction, public BoundSimpleFunction {
 public:
 	explicit BoundAggregateFunction(const AggregateFunction &function);
 
 	void ReplaceImplementation(const AggregateFunction &function);
 
-public:
-	auto GetProperties() const -> const AggregateFunctionProperties & {
-		return properties;
-	}
-	auto GetProperties() -> AggregateFunctionProperties & {
-		return properties;
-	}
-	auto GetCallbacks() const -> const AggregateFunctionCallbacks & {
-		return callbacks;
-	}
-	auto GetCallbacks() -> AggregateFunctionCallbacks & {
-		return callbacks;
-	}
-
 	DUCKDB_API bool operator==(const BoundAggregateFunction &rhs) const;
 	DUCKDB_API bool operator!=(const BoundAggregateFunction &rhs) const;
-
-	// TODO: Move to callbacks
-
-	bool HasGetStateTypeCallback() const {
-		return callbacks.get_state_type != nullptr;
-	}
-	aggregate_get_state_type_t GetStateTypeCallback() const {
-		return callbacks.get_state_type;
-	}
-	BoundAggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
-		callbacks.get_state_type = get_state_type_callback;
-		return *this;
-	}
 
 	LogicalType GetStateType() const {
 		D_ASSERT(callbacks.get_state_type);
@@ -683,105 +633,6 @@ public:
 		D_ASSERT(result.id() == LogicalTypeId::STRUCT);
 		return result;
 	}
-
-	bool HasSerializationCallbacks() const {
-		return callbacks.serialize != nullptr && callbacks.deserialize != nullptr;
-	}
-	void SetSerializeCallback(aggregate_serialize_t callback) {
-		callbacks.serialize = callback;
-	}
-	void SetDeserializeCallback(aggregate_deserialize_t callback) {
-		callbacks.deserialize = callback;
-	}
-	aggregate_serialize_t GetSerializeCallback() const {
-		return callbacks.serialize;
-	}
-	aggregate_deserialize_t GetDeserializeCallback() const {
-		return callbacks.deserialize;
-	}
-
-	// clang-format off
-	bool HasBindCallback() const { return callbacks.bind != nullptr; }
-	bind_aggregate_function_t GetBindCallback() const { return callbacks.bind; }
-	void SetBindCallback(bind_aggregate_function_t callback) { callbacks.bind = callback; }
-
-	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
-
-	bool HasStateInitCallback() const { return callbacks.initialize != nullptr; }
-	aggregate_initialize_t GetStateInitCallback() const { return callbacks.initialize; }
-	void SetStateInitCallback(aggregate_initialize_t callback) { callbacks.initialize = callback; }
-
-	bool HasStateSizeCallback() const { return callbacks.state_size != nullptr; }
-	aggregate_size_t GetStateSizeCallback() const { return callbacks.state_size; }
-	void SetStateSizeCallback(aggregate_size_t callback) { callbacks.state_size = callback; }
-
-	bool HasStateDestructorCallback() const { return callbacks.destructor != nullptr; }
-	aggregate_destructor_t GetStateDestructorCallback() const { return callbacks.destructor; }
-	void SetStateDestructorCallback(aggregate_destructor_t callback) { callbacks.destructor = callback; }
-
-	bool HasStateUpdateCallback() const { return callbacks.update != nullptr; }
-	aggregate_update_t GetStateUpdateCallback() const { return callbacks.update; }
-	void SetStateUpdateCallback(aggregate_update_t callback) { callbacks.update = callback; }
-
-	bool HasStateSimpleUpdateCallback() const { return callbacks.simple_update != nullptr; }
-	aggregate_simple_update_t GetStateSimpleUpdateCallback() const { return callbacks.simple_update; }
-	void SetStateSimpleUpdateCallback(aggregate_simple_update_t callback) { callbacks.simple_update = callback; }
-
-	void SetStateCombineCallback(aggregate_combine_t callback) { callbacks.combine = callback; }
-	aggregate_combine_t GetStateCombineCallback() const { return callbacks.combine; }
-	bool HasStateCombineCallback() const { return callbacks.combine != nullptr; }
-
-	void SetStateFinalizeCallback(aggregate_finalize_t callback) { callbacks.finalize = callback; }
-	aggregate_finalize_t GetStateFinalizeCallback() const { return callbacks.finalize; }
-	bool HasStateFinalizeCallback() const { return callbacks.finalize != nullptr; }
-
-	bool HasWindowCallback() const { return callbacks.window != nullptr; }
-	aggregate_window_t GetWindowCallback() const { return callbacks.window; }
-	void SetWindowCallback(aggregate_window_t callback) { callbacks.window = callback; }
-
-	void SetWindowInitCallback(aggregate_wininit_t callback) { callbacks.window_init = callback; }
-	aggregate_wininit_t GetWindowInitCallback() const { return callbacks.window_init; }
-	bool HasWindowInitCallback() const { return callbacks.window_init != nullptr; }
-
-	//! Batched window callback — takes precedence over the per-row window
-	//! callback when set. See aggregate_window_batch_t for semantics.
-	bool HasWindowBatchCallback() const { return callbacks.window_batch != nullptr; }
-	aggregate_window_batch_t GetWindowBatchCallback() const { return callbacks.window_batch; }
-	void SetWindowBatchCallback(aggregate_window_batch_t callback) { callbacks.window_batch = callback; }
-
-	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
-	aggregate_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
-	void SetStatisticsCallback(aggregate_statistics_t callback) { callbacks.statistics = callback; }
-
-
-	bool CanAggregate() const {
-		return callbacks.update || callbacks.combine || callbacks.finalize;
-	}
-	bool CanWindow() const {
-		return callbacks.window;
-	}
-
-
-	AggregateFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-
-	void SetExtraFunctionInfo(shared_ptr<AggregateFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-
-	// clang-format on
-
-protected:
-	AggregateFunctionProperties properties;
-	AggregateFunctionCallbacks callbacks;
-	shared_ptr<AggregateFunctionInfo> function_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -99,6 +99,108 @@ struct FunctionParameters {
 	named_parameter_map_t named_parameters;
 };
 
+class FunctionParameter {
+public:
+	FunctionParameter(string name, LogicalType type) : name(std::move(name)), type(std::move(type)) {
+	}
+
+	bool operator==(const FunctionParameter &other) const;
+	bool operator!=(const FunctionParameter &other) const;
+
+	auto GetName() const -> const string & {
+		return name;
+	}
+	auto SetName(string name_p) -> void {
+		name = std::move(name_p);
+	}
+
+	auto GetType() const -> const LogicalType & {
+		return type;
+	}
+	auto SetType(LogicalType type_p) -> void {
+		type = std::move(type_p);
+	}
+
+private:
+	string name;
+	LogicalType type;
+};
+
+class FunctionSignature {
+public:
+	FunctionSignature(vector<LogicalType> arguments, LogicalType varargs, LogicalType return_type)
+	    : varargs(std::move(varargs)), return_type(std::move(return_type)) {
+		for (auto &arg : arguments) {
+			AddParameter(std::move(arg));
+		}
+	}
+	FunctionSignature(vector<LogicalType> arguments, LogicalType return_type)
+	    : FunctionSignature(std::move(arguments), LogicalType(LogicalTypeId::INVALID), std::move(return_type)) {
+	}
+
+	bool Equal(const FunctionSignature &other) const;
+	bool operator==(const FunctionSignature &other) const;
+	bool operator!=(const FunctionSignature &other) const;
+
+public:
+	auto GetParameter(idx_t index) const -> const FunctionParameter & {
+		return parameters[index];
+	}
+	auto GetParameter(idx_t index) -> FunctionParameter & {
+		return parameters[index];
+	}
+	auto GetParameters() const -> const vector<FunctionParameter> & {
+		return parameters;
+	}
+	auto GetParameterCount() const -> idx_t {
+		return parameters.size();
+	}
+
+	auto GetReturnType() const -> const LogicalType & {
+		return return_type;
+	}
+	auto SetReturnType(LogicalType return_type_p) -> void {
+		return_type = std::move(return_type_p);
+	}
+
+	auto HasVarArgs() const -> bool {
+		return varargs.id() != LogicalTypeId::INVALID;
+	}
+	auto GetVarArgs() const -> const LogicalType & {
+		return varargs;
+	}
+	auto SetVarArgs(LogicalType varargs_p) -> void {
+		varargs = std::move(varargs_p);
+	}
+
+	auto AddParameter(string name, LogicalType type) -> void {
+		parameters.emplace_back(std::move(name), std::move(type));
+	}
+
+	auto AddParameter(LogicalType type) -> void {
+		auto name = parameters.empty() ? string("col") : string("col") + to_string(parameters.size() + 1);
+
+		parameters.emplace_back(name, std::move(type));
+	}
+
+	void Verify() const {
+		case_insensitive_set_t seen_names;
+		for (const auto &param : parameters) {
+			if (seen_names.find(param.GetName()) != seen_names.end()) {
+				throw InvalidInputException("Duplicate parameter name: %s", param.GetName());
+			}
+			seen_names.insert(param.GetName());
+		}
+	}
+
+	hash_t Hash() const;
+
+private:
+	vector<FunctionParameter> parameters;
+	LogicalType varargs;
+	LogicalType return_type;
+};
+
 //! Function is the base class used for any type of function (scalar, aggregate or simple function)
 class Function {
 public:
@@ -129,10 +231,6 @@ public:
 	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
 	                                      const vector<LogicalType> &arguments,
 	                                      const named_parameter_type_map_t &named_parameters);
-
-	//! Used in the bind to erase an argument from a function
-	DUCKDB_API static void EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
-	                                     idx_t argument_index);
 	//! Used in the bind to erase an argument from a function
 	DUCKDB_API static void EraseArgument(BoundSimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
 	                                     idx_t argument_index);
@@ -145,55 +243,36 @@ public:
 	DUCKDB_API ~SimpleFunction() override;
 
 protected:
-	//! The set of arguments of the function
-	vector<LogicalType> arguments;
-	//! The set of original arguments of the function - only set if Function::EraseArgument is called
-	//! Used for (de)serialization purposes
-	vector<LogicalType> original_arguments;
-	//! The type of varargs to support, or LogicalTypeId::INVALID if the function does not accept variable length
-	//! arguments
-	LogicalType varargs;
-	//! Return type of the function
-	LogicalType return_type;
+	FunctionSignature signature;
 
 public:
 	DUCKDB_API string ToString() const;
 	DUCKDB_API hash_t Hash() const;
 
-	vector<LogicalType> &GetArguments() {
-		return arguments;
+	FunctionSignature &GetSignature() {
+		return signature;
 	}
-	const vector<LogicalType> &GetArguments() const {
-		return arguments;
-	}
-
-	vector<LogicalType> &GetOriginalArguments() {
-		return original_arguments;
-	}
-	const vector<LogicalType> &GetOriginalArguments() const {
-		return original_arguments;
+	const FunctionSignature &GetSignature() const {
+		return signature;
 	}
 
 	const LogicalType &GetVarArgs() const {
-		return varargs;
-	}
-	LogicalType &GetVarArgs() {
-		return varargs;
-	} // TODO: Dont expose mutable accessor
-	void SetVarArgs(LogicalType varargs_p) {
-		varargs = std::move(varargs_p);
+		return signature.GetVarArgs();
 	}
 
-	DUCKDB_API bool HasVarArgs() const;
+	void SetVarArgs(LogicalType varargs_p) {
+		signature.SetVarArgs(std::move(varargs_p));
+	}
+
+	DUCKDB_API bool HasVarArgs() const {
+		return signature.HasVarArgs();
+	}
 
 	void SetReturnType(LogicalType return_type_p) {
-		return_type = std::move(return_type_p);
+		signature.SetReturnType(std::move(return_type_p));
 	}
 	const LogicalType &GetReturnType() const {
-		return return_type;
-	}
-	LogicalType &GetReturnType() {
-		return return_type;
+		return signature.GetReturnType();
 	}
 };
 

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -224,6 +224,26 @@ public:
 	string schema_name;
 
 public:
+	auto SetName(string name_p) -> void {
+		name = std::move(name_p);
+	}
+	auto SetSchemaName(string schema_name_p) -> void {
+		schema_name = std::move(schema_name_p);
+	}
+	auto SetCatalogName(string catalog_name_p) -> void {
+		catalog_name = std::move(catalog_name_p);
+	}
+
+	const string &GetName() const {
+		return name;
+	}
+	const string &GetSchemaName() const {
+		return schema_name;
+	}
+	const string &GetCatalogName() const {
+		return catalog_name;
+	}
+
 	//! Returns the formatted string name(arg1, arg2, ...)
 	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
 	                                      const vector<LogicalType> &arguments,
@@ -384,12 +404,11 @@ public:
 };
 
 class BoundSimpleFunction {
-public:
+protected:
 	string name;
 	string schema_name;
 	string catalog_name;
 
-protected:
 	//! The set of arguments of the function
 	vector<LogicalType> arguments;
 	//! The set of original arguments of the function - only set if Function::EraseArgument is called
@@ -399,6 +418,20 @@ protected:
 	LogicalType return_type;
 
 public:
+	void SetName(string name_p) {
+		name = std::move(name_p);
+	}
+
+	const string &GetName() const {
+		return name;
+	}
+	const string &GetSchemaName() const {
+		return schema_name;
+	}
+	const string &GetCatalogName() const {
+		return catalog_name;
+	}
+
 	DUCKDB_API string ToString() const;
 	DUCKDB_API hash_t Hash() const;
 

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -104,6 +104,8 @@ public:
 	FunctionParameter(string name, LogicalType type) : name(std::move(name)), type(std::move(type)) {
 	}
 
+	string ToString() const;
+
 	bool operator==(const FunctionParameter &other) const;
 	bool operator!=(const FunctionParameter &other) const;
 
@@ -138,9 +140,12 @@ public:
 	    : FunctionSignature(std::move(arguments), LogicalType(LogicalTypeId::INVALID), std::move(return_type)) {
 	}
 
-	bool Equal(const FunctionSignature &other) const;
+	string ToString() const;
+
 	bool operator==(const FunctionSignature &other) const;
 	bool operator!=(const FunctionSignature &other) const;
+
+	bool Equal(const FunctionSignature &other) const;
 
 public:
 	auto GetParameter(idx_t index) const -> const FunctionParameter & {

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -36,6 +36,7 @@ class TableFunction;
 class SimpleFunction;
 class WindowFunction;
 class WindowFunctionSet;
+class BoundSimpleFunction;
 
 struct PragmaInfo;
 
@@ -131,6 +132,9 @@ public:
 
 	//! Used in the bind to erase an argument from a function
 	DUCKDB_API static void EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
+	                                     idx_t argument_index);
+	//! Used in the bind to erase an argument from a function
+	DUCKDB_API static void EraseArgument(BoundSimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,
 	                                     idx_t argument_index);
 };
 
@@ -246,6 +250,46 @@ public:
 
 class FunctionProperties {
 public:
+	auto GetStability() const -> FunctionStability {
+		return stability;
+	}
+	auto SetStability(FunctionStability value) -> void {
+		stability = value;
+	}
+
+	auto GetNullHandling() const -> FunctionNullHandling {
+		return null_handling;
+	}
+	auto SetNullHandling(FunctionNullHandling value) -> void {
+		null_handling = value;
+	}
+
+	auto GetErrorMode() const -> FunctionErrors {
+		return errors;
+	}
+	auto SetErrorMode(FunctionErrors value) -> void {
+		errors = value;
+	}
+
+	auto GetCollationHandling() const -> FunctionCollationHandling {
+		return collation_handling;
+	}
+	auto SetCollationHandling(FunctionCollationHandling value) -> void {
+		collation_handling = value;
+	}
+
+	// Helpers
+	auto SetFallible() -> void {
+		errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
+	auto SetVolatile() -> void {
+		stability = FunctionStability::VOLATILE;
+	}
+
+	bool operator==(const FunctionProperties &rhs) const;
+	bool operator!=(const FunctionProperties &rhs) const;
+
+public:
 	FunctionStability stability = FunctionStability::CONSISTENT;
 	//! How this function handles NULL values
 	FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING;
@@ -253,9 +297,50 @@ public:
 	FunctionErrors errors = FunctionErrors::CANNOT_ERROR;
 	//! Collation handling of the function
 	FunctionCollationHandling collation_handling = FunctionCollationHandling::PROPAGATE_COLLATIONS;
+};
 
-	bool operator==(const FunctionProperties &rhs) const;
-	bool operator!=(const FunctionProperties &rhs) const;
+class BoundSimpleFunction {
+public:
+	string name;
+	string schema_name;
+	string catalog_name;
+
+protected:
+	//! The set of arguments of the function
+	vector<LogicalType> arguments;
+	//! The set of original arguments of the function - only set if Function::EraseArgument is called
+	//! Used for (de)serialization purposes
+	vector<LogicalType> original_arguments;
+	//! Return type of the function
+	LogicalType return_type;
+
+public:
+	DUCKDB_API string ToString() const;
+	DUCKDB_API hash_t Hash() const;
+
+	auto GetArguments() const -> const vector<LogicalType> & {
+		return arguments;
+	}
+	auto GetArguments() -> vector<LogicalType> & {
+		return arguments;
+	}
+
+	auto GetOriginalArguments() const -> const vector<LogicalType> & {
+		return original_arguments;
+	}
+	auto GetOriginalArguments() -> vector<LogicalType> & {
+		return original_arguments;
+	}
+
+	auto GetReturnType() const -> const LogicalType & {
+		return return_type;
+	}
+	auto GetReturnType() -> LogicalType & {
+		return return_type;
+	}
+	auto SetReturnType(LogicalType return_type_p) -> void {
+		return_type = std::move(return_type_p);
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -408,6 +408,7 @@ protected:
 	string name;
 	string schema_name;
 	string catalog_name;
+	string extra_info;
 
 	//! The set of arguments of the function
 	vector<LogicalType> arguments;
@@ -430,6 +431,10 @@ public:
 	}
 	const string &GetCatalogName() const {
 		return catalog_name;
+	}
+
+	const string &GetExtraInfo() const {
+		return extra_info;
 	}
 
 	DUCKDB_API string ToString() const;

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -82,10 +82,10 @@ public:
 	                                                                vector<OrderByNode> &arg_orders);
 
 	//! Cast a set of expressions to the arguments of this function
-	void CastToFunctionArguments(SimpleFunction &function, vector<unique_ptr<Expression>> &children);
+	void CastToFunctionArguments(BoundSimpleFunction &function, vector<unique_ptr<Expression>> &children);
 
-	void ResolveTemplateTypes(SimpleFunction &bound_function, const vector<unique_ptr<Expression>> &children);
-	void CheckTemplateTypesResolved(const SimpleFunction &bound_function);
+	void ResolveTemplateTypes(BoundSimpleFunction &bound_function, const vector<unique_ptr<Expression>> &children);
+	void CheckTemplateTypesResolved(const BoundSimpleFunction &bound_function);
 
 	pair<BoundScalarFunction, unique_ptr<FunctionData>> ResolveFunction(const ScalarFunction &function,
 	                                                                    vector<unique_ptr<Expression>> &children);

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -76,10 +76,10 @@ public:
 	                                           optional_ptr<vector<GroupingSet>> grouping_sets);
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr);
 
-	DUCKDB_API unique_ptr<BoundWindowExpression>
-	BindWindowFunction(const WindowFunction &bound_function, vector<unique_ptr<Expression>> children,
-	                   vector<OrderByNode> &orders, vector<OrderByNode> &arg_orders,
-	                   AggregateType aggr_type = AggregateType::NON_DISTINCT);
+	DUCKDB_API unique_ptr<BoundWindowExpression> BindWindowFunction(const WindowFunction &function,
+	                                                                vector<unique_ptr<Expression>> children,
+	                                                                vector<OrderByNode> &orders,
+	                                                                vector<OrderByNode> &arg_orders);
 
 	//! Cast a set of expressions to the arguments of this function
 	void CastToFunctionArguments(SimpleFunction &function, vector<unique_ptr<Expression>> &children);
@@ -87,15 +87,16 @@ public:
 	void ResolveTemplateTypes(SimpleFunction &bound_function, const vector<unique_ptr<Expression>> &children);
 	void CheckTemplateTypesResolved(const SimpleFunction &bound_function);
 
-	unique_ptr<FunctionData> ResolveFunction(BoundScalarFunction &bound_function,
-	                                         vector<unique_ptr<Expression>> &children);
+	pair<BoundScalarFunction, unique_ptr<FunctionData>> ResolveFunction(const ScalarFunction &function,
+	                                                                    vector<unique_ptr<Expression>> &children);
 
-	unique_ptr<FunctionData> ResolveFunction(BoundAggregateFunction &bound_function,
-	                                         vector<unique_ptr<Expression>> &children);
-	unique_ptr<FunctionData> ResolveFunction(BoundWindowFunction &bound_function,
-	                                         vector<unique_ptr<Expression>> &children,
-	                                         optional_ptr<vector<OrderByNode>> orders = nullptr,
-	                                         optional_ptr<vector<OrderByNode>> arg_orders = nullptr);
+	pair<BoundAggregateFunction, unique_ptr<FunctionData>> ResolveFunction(const AggregateFunction &function,
+	                                                                       vector<unique_ptr<Expression>> &children);
+
+	pair<BoundWindowFunction, unique_ptr<FunctionData>>
+	ResolveFunction(const WindowFunction &function, vector<unique_ptr<Expression>> &children,
+	                optional_ptr<vector<OrderByNode>> orders = nullptr,
+	                optional_ptr<vector<OrderByNode>> arg_orders = nullptr);
 
 private:
 	optional_idx BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -180,7 +180,7 @@ public:
 			throw InternalException("DeserializeFunction - cant find catalog entry for function %s", name);
 		}
 		auto &functions = func_catalog.Cast<CATALOG_ENTRY>();
-		const auto function = functions.functions.GetFunctionByArguments(
+		const auto &function = functions.functions.GetFunctionByArguments(
 		    context, original_arguments.empty() ? arguments : original_arguments);
 
 		// Does this function support serializing its bound data?

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -20,15 +20,15 @@ class FunctionSerializer {
 public:
 	template <class FUNC>
 	static void Serialize(Serializer &serializer, const FUNC &function, optional_ptr<FunctionData> bind_info) {
-		D_ASSERT(!function.name.empty());
-		serializer.WriteProperty(500, "name", function.name);
+		D_ASSERT(!function.GetName().empty());
+		serializer.WriteProperty(500, "name", function.GetName());
 		serializer.WriteProperty(501, "arguments", function.GetArguments());
 		serializer.WriteProperty(502, "original_arguments", function.GetOriginalArguments());
 		// These are optional fields that are written out of numeric order, older
 		// databases won't contain the fields, so the defaults will be used, but if
 		// the fields are present, they will be used.
-		serializer.WritePropertyWithDefault<string>(505, "catalog_name", function.catalog_name, "");
-		serializer.WritePropertyWithDefault<string>(506, "schema_name", function.schema_name, "");
+		serializer.WritePropertyWithDefault<string>(505, "catalog_name", function.GetCatalogName(), "");
+		serializer.WritePropertyWithDefault<string>(506, "schema_name", function.GetSchemaName(), "");
 
 		bool has_serialize = function.HasSerializationCallbacks();
 		serializer.WriteProperty(503, "has_serialize", has_serialize);
@@ -97,7 +97,7 @@ public:
 	static unique_ptr<FunctionData> FunctionDeserialize(Deserializer &deserializer, FUNC &function) {
 		if (!function.HasSerializationCallbacks()) {
 			throw SerializationException("Function requires deserialization but no deserialization function for %s",
-			                             function.name);
+			                             function.GetName());
 		}
 		unique_ptr<FunctionData> result;
 		deserializer.ReadObject(504, "function_data",

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -188,9 +188,8 @@ public:
 			// No, then just rebind the function
 			try {
 				FunctionBinder binder(context);
-				FUNC bound_function(function);
 
-				auto bound_data = binder.ResolveFunction(bound_function, children);
+				auto [bound_function, bound_data] = binder.ResolveFunction(function, children);
 
 				if (TypeRequiresAssignment(bound_function.GetReturnType())) {
 					bound_function.SetReturnType(std::move(return_type));

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -72,7 +72,8 @@ public:
 	DUCKDB_API explicit ScalarFunctionSet(string name);
 	DUCKDB_API explicit ScalarFunctionSet(ScalarFunction fun);
 
-	DUCKDB_API ScalarFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
+	DUCKDB_API const ScalarFunction &GetFunctionByArguments(ClientContext &context,
+	                                                        const vector<LogicalType> &arguments);
 
 	//! Apply the same per-arg property to every overload in the set.
 	void SetArgProperties(idx_t arg_idx, ArgProperties props) {
@@ -98,7 +99,8 @@ public:
 	DUCKDB_API explicit AggregateFunctionSet(string name);
 	DUCKDB_API explicit AggregateFunctionSet(AggregateFunction fun);
 
-	DUCKDB_API AggregateFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
+	DUCKDB_API const AggregateFunction &GetFunctionByArguments(ClientContext &context,
+	                                                           const vector<LogicalType> &arguments);
 };
 
 class WindowFunctionSet : public FunctionSet<WindowFunction> {
@@ -107,7 +109,8 @@ public:
 	DUCKDB_API explicit WindowFunctionSet(string name);
 	DUCKDB_API explicit WindowFunctionSet(WindowFunction fun);
 
-	DUCKDB_API WindowFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
+	DUCKDB_API const WindowFunction &GetFunctionByArguments(ClientContext &context,
+	                                                        const vector<LogicalType> &arguments);
 };
 
 class TableFunctionSet : public FunctionSet<TableFunction> {
@@ -115,7 +118,8 @@ public:
 	DUCKDB_API explicit TableFunctionSet(string name);
 	DUCKDB_API explicit TableFunctionSet(TableFunction fun);
 
-	TableFunction GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments);
+	DUCKDB_API const TableFunction &GetFunctionByArguments(ClientContext &context,
+	                                                       const vector<LogicalType> &arguments);
 };
 
 class PragmaFunctionSet : public FunctionSet<PragmaFunction> {

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -34,14 +34,12 @@ public:
 	idx_t Size() {
 		return functions.size();
 	}
-	T GetFunctionByOffset(idx_t offset) {
+
+	const T &GetFunctionByOffset(idx_t offset) {
 		D_ASSERT(offset < functions.size());
 		return functions[offset];
 	}
-	T &GetFunctionReferenceByOffset(idx_t offset) {
-		D_ASSERT(offset < functions.size());
-		return functions[offset];
-	}
+
 	bool MergeFunctionSet(FunctionSet<T> new_functions, bool override = false) {
 		D_ASSERT(!new_functions.functions.empty());
 		for (auto &new_func : new_functions.functions) {

--- a/src/include/duckdb/function/lambda_functions.hpp
+++ b/src/include/duckdb/function/lambda_functions.hpp
@@ -62,10 +62,10 @@ public:
 
 	//! Checks for NULL list parameter and prepared statements and adds bound cast expression
 	static unique_ptr<FunctionData> ListLambdaPrepareBind(vector<unique_ptr<Expression>> &arguments,
-	                                                      ClientContext &context, ScalarFunction &bound_function);
+	                                                      ClientContext &context, BoundScalarFunction &bound_function);
 
 	//! Returns the ListLambdaBindData containing the lambda expression
-	static unique_ptr<FunctionData> ListLambdaBind(ClientContext &, ScalarFunction &bound_function,
+	static unique_ptr<FunctionData> ListLambdaBind(ClientContext &, BoundScalarFunction &bound_function,
 	                                               vector<unique_ptr<Expression>> &arguments,
 	                                               const bool has_index = false);
 

--- a/src/include/duckdb/function/scalar/struct_utils.hpp
+++ b/src/include/duckdb/function/scalar/struct_utils.hpp
@@ -33,7 +33,7 @@ public:
 };
 
 inline bool TryGetStructExtractChildIndex(const BoundFunctionExpression &func, idx_t &child_idx) {
-	if (func.function.name == "struct_extract_at") {
+	if (func.function.GetName() == "struct_extract_at") {
 		if (func.bind_info) {
 			child_idx = func.bind_info->Cast<StructExtractBindData>().index;
 			return true;
@@ -52,7 +52,7 @@ inline bool TryGetStructExtractChildIndex(const BoundFunctionExpression &func, i
 		}
 		return false;
 	}
-	if (func.function.name != "struct_extract" || func.children.size() <= 1 ||
+	if (func.function.GetName() != "struct_extract" || func.children.size() <= 1 ||
 	    func.children[1]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
 	    func.children[0]->GetReturnType().id() != LogicalTypeId::STRUCT) {
 		return false;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -309,6 +309,23 @@ public:
 	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
 	// clang-format on
 
+	auto GetProperties() const -> const FunctionProperties & {
+		return properties;
+	}
+	auto GetProperties() -> FunctionProperties & {
+		return properties;
+	}
+	auto GetCallbacks() const -> const ScalarFunctionCallbacks & {
+		return callbacks;
+	}
+	auto GetCallbacks() -> ScalarFunctionCallbacks & {
+		return callbacks;
+	}
+
+	shared_ptr<ScalarFunctionInfo> GetFunctionInfo() const {
+		return function_info;
+	}
+
 public:
 	DUCKDB_API bool operator==(const ScalarFunction &rhs) const;
 	DUCKDB_API bool operator!=(const ScalarFunction &rhs) const;
@@ -431,9 +448,108 @@ public:
 	}
 };
 
-class BoundScalarFunction : public ScalarFunction {
+class BoundScalarFunction : public BoundSimpleFunction {
 public:
-	explicit BoundScalarFunction(const ScalarFunction &function) : ScalarFunction(function) {
+	explicit BoundScalarFunction(const ScalarFunction &function);
+
+protected:
+	FunctionProperties properties;
+	ScalarFunctionCallbacks callbacks;
+	shared_ptr<ScalarFunctionInfo> function_info;
+
+public:
+	auto GetProperties() const -> const FunctionProperties & {
+		return properties;
+	}
+	auto GetProperties() -> FunctionProperties & {
+		return properties;
+	}
+	auto GetCallbacks() const -> const ScalarFunctionCallbacks & {
+		return callbacks;
+	}
+	auto GetCallbacks() -> ScalarFunctionCallbacks & {
+		return callbacks;
+	}
+
+	DUCKDB_API bool operator==(const BoundScalarFunction &rhs) const;
+	DUCKDB_API bool operator!=(const BoundScalarFunction &rhs) const;
+
+	// DUCKDB_API bool Equal(const ScalarFunction &rhs) const;
+
+public:
+	// clang-format off
+	FunctionStability GetStability() const { return properties.stability; }
+	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
+	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
+	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
+	FunctionErrors GetErrorMode() const { return properties.errors; }
+	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
+	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
+	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+
+	bool HasFunctionCallback() const { return callbacks.function != nullptr; }
+	scalar_function_t GetFunctionCallback() const { return callbacks.function; }
+	void SetFunctionCallback(scalar_function_t callback) { callbacks.function = std::move(callback); }
+
+	bool HasSelectCallback() const { return callbacks.select_function != nullptr; }
+	scalar_function_select_t GetSelectCallback() const { return callbacks.select_function; }
+	void SetSelectCallback(scalar_function_select_t callback) { callbacks.select_function = callback; }
+
+	bool HasBindCallback() const { return callbacks.bind != nullptr; };
+	bind_scalar_function_t GetBindCallback() const { return callbacks.bind; };
+	void SetBindCallback(bind_scalar_function_t callback) { callbacks.bind = callback; }
+
+	unique_ptr<BoundFunctionExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments, optional_ptr<Binder> binder = nullptr) const;
+
+	bool HasBindLambdaCallback() const { return callbacks.bind_lambda != nullptr; }
+	bind_lambda_function_t GetBindLambdaCallback() const { return callbacks.bind_lambda; }
+	void SetBindLambdaCallback(bind_lambda_function_t callback) { callbacks.bind_lambda = callback; }
+
+	bool HasBindExpressionCallback() const { return callbacks.bind_expression != nullptr; }
+	function_bind_expression_t GetBindExpressionCallback() const { return callbacks.bind_expression; }
+	void SetBindExpressionCallback(function_bind_expression_t callback) { callbacks.bind_expression = callback; }
+
+	bool HasInitStateCallback() const { return callbacks.init_local_state != nullptr; }
+	init_local_state_t GetInitStateCallback() const { return callbacks.init_local_state; }
+	void SetInitStateCallback(init_local_state_t callback) { callbacks.init_local_state = callback; }
+
+	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
+	function_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
+	void SetStatisticsCallback(function_statistics_t callback) { callbacks.statistics = callback; }
+
+	bool HasModifiedDatabasesCallback() const { return callbacks.get_modified_databases != nullptr; }
+	get_modified_databases_t GetModifiedDatabasesCallback() const { return callbacks.get_modified_databases; }
+	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { callbacks.get_modified_databases = callback; }
+
+	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
+	void SetSerializeCallback(function_serialize_t callback) { callbacks.serialize = callback; }
+	void SetDeserializeCallback(function_deserialize_t callback) { callbacks.deserialize = callback; }
+	function_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
+	function_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
+
+	bool HasFilterPruneCallback() const {return callbacks.filter_prune != nullptr; }
+	void SetFilterPruneCallback(propagate_filter_t callback) { callbacks.filter_prune = callback; }
+	propagate_filter_t GetFilterPruneCallback() const { return callbacks.filter_prune; }
+	// clang-format on
+
+	bool HasExtraFunctionInfo() const {
+		return function_info != nullptr;
+	}
+	ScalarFunctionInfo &GetExtraFunctionInfo() const {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
+		function_info = std::move(info);
+	}
+	template <class T, class... ARGS>
+	void SetExtraFunctionInfo(ARGS &&... args) {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
 	}
 };
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -484,7 +484,7 @@ public:
 	}
 	Binder &GetBinder() {
 		if (binder == nullptr) {
-			throw InternalException("Function '%s' has cannot be bound without a Binder!", bound_function.name);
+			throw InternalException("Function '%s' has cannot be bound without a Binder!", bound_function.GetName());
 		}
 		return *binder;
 	}

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -177,71 +177,109 @@ public:
 	bool operator!=(const ScalarFunctionCallbacks &rhs) const;
 };
 
-class ScalarFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
+class BaseScalarFunction {
 public:
-	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
-	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
-	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
-	                          FunctionStability stability = FunctionStability::CONSISTENT,
-	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
-	                          bind_lambda_function_t bind_lambda = nullptr);
-
-	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
-	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
-	                          init_local_state_t init_local_state = nullptr,
-	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
-	                          FunctionStability stability = FunctionStability::CONSISTENT,
-	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
-	                          bind_lambda_function_t bind_lambda = nullptr);
-
 	// clang-format off
-	// Keep these on one-line for readability
-	bool HasFunctionCallback() const { return callbacks.function != nullptr; }
-	scalar_function_t GetFunctionCallback() const { return callbacks.function; }
-	void SetFunctionCallback(scalar_function_t callback) { callbacks.function = std::move(callback); }
+	auto GetProperties() const -> const FunctionProperties & { return properties; }
+	auto GetProperties() -> FunctionProperties & { return properties; }
+	auto SetProperties(const FunctionProperties &properties_p) -> void { properties = properties_p; }
 
-	bool HasSelectCallback() const { return callbacks.select_function != nullptr; }
-	scalar_function_select_t GetSelectCallback() const { return callbacks.select_function; }
-	void SetSelectCallback(scalar_function_select_t callback) { callbacks.select_function = callback; }
+	auto GetCallbacks() const -> const ScalarFunctionCallbacks & { return callbacks; }
+	auto GetCallbacks() -> ScalarFunctionCallbacks & { return callbacks; }
+	auto SetCallbacks(const ScalarFunctionCallbacks &callbacks_p) -> void { callbacks = callbacks_p; }
 
-	bool HasBindCallback() const { return callbacks.bind != nullptr; };
-	bind_scalar_function_t GetBindCallback() const { return callbacks.bind; };
-	void SetBindCallback(bind_scalar_function_t callback) { callbacks.bind = callback; }
+public: // Properties
 
-	unique_ptr<BoundFunctionExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments, optional_ptr<Binder> binder = nullptr) const;
+	auto GetStability() const -> FunctionStability { return properties.stability; }
+	auto SetStability(FunctionStability value) -> void { properties.stability = value; }
 
-	bool HasBindLambdaCallback() const { return callbacks.bind_lambda != nullptr; }
-	bind_lambda_function_t GetBindLambdaCallback() const { return callbacks.bind_lambda; }
-	void SetBindLambdaCallback(bind_lambda_function_t callback) { callbacks.bind_lambda = callback; }
+	auto GetNullHandling() const -> FunctionNullHandling { return properties.null_handling; }
+	auto SetNullHandling(FunctionNullHandling value) -> void { properties.null_handling = value; }
 
-	bool HasBindExpressionCallback() const { return callbacks.bind_expression != nullptr; }
-	function_bind_expression_t GetBindExpressionCallback() const { return callbacks.bind_expression; }
-	void SetBindExpressionCallback(function_bind_expression_t callback) { callbacks.bind_expression = callback; }
+	auto GetErrorMode() const -> FunctionErrors { return properties.errors; }
+	auto SetErrorMode(FunctionErrors value) -> void { properties.errors = value; }
 
-	bool HasInitStateCallback() const { return callbacks.init_local_state != nullptr; }
-	init_local_state_t GetInitStateCallback() const { return callbacks.init_local_state; }
-	void SetInitStateCallback(init_local_state_t callback) { callbacks.init_local_state = callback; }
+	auto GetCollationHandling() const -> FunctionCollationHandling { return properties.collation_handling; }
+	auto SetCollationHandling(FunctionCollationHandling value) -> void { properties.collation_handling = value; }
 
-	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
-	function_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
-	void SetStatisticsCallback(function_statistics_t callback) { callbacks.statistics = callback; }
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
 
-	bool HasModifiedDatabasesCallback() const { return callbacks.get_modified_databases != nullptr; }
-	get_modified_databases_t GetModifiedDatabasesCallback() const { return callbacks.get_modified_databases; }
-	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { callbacks.get_modified_databases = callback; }
+public: // Callbacks
 
-	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
-	void SetSerializeCallback(function_serialize_t callback) { callbacks.serialize = callback; }
-	void SetDeserializeCallback(function_deserialize_t callback) { callbacks.deserialize = callback; }
-	function_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
-	function_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
+	auto HasFunctionCallback() const -> bool { return callbacks.function != nullptr; }
+	auto GetFunctionCallback() const -> scalar_function_t { return callbacks.function; }
+	auto SetFunctionCallback(scalar_function_t callback) -> void { callbacks.function = std::move(callback); }
 
-	bool HasFilterPruneCallback() const {return callbacks.filter_prune != nullptr; }
-	void SetFilterPruneCallback(propagate_filter_t callback) { callbacks.filter_prune = callback; }
-	propagate_filter_t GetFilterPruneCallback() const { return callbacks.filter_prune; }
+	auto HasSelectCallback() const -> bool { return callbacks.select_function != nullptr; }
+	auto GetSelectCallback() const -> scalar_function_select_t { return callbacks.select_function; }
+	auto SetSelectCallback(scalar_function_select_t callback) -> void { callbacks.select_function = callback; }
+
+	auto HasBindCallback() const -> bool { return callbacks.bind != nullptr; };
+	auto GetBindCallback() const -> bind_scalar_function_t { return callbacks.bind; };
+	auto SetBindCallback(bind_scalar_function_t callback) -> void { callbacks.bind = callback; }
+
+	auto HasBindLambdaCallback() const -> bool { return callbacks.bind_lambda != nullptr; }
+	auto GetBindLambdaCallback() const -> bind_lambda_function_t { return callbacks.bind_lambda; }
+	auto SetBindLambdaCallback(bind_lambda_function_t callback) -> void { callbacks.bind_lambda = callback; }
+
+	auto HasBindExpressionCallback() const -> bool { return callbacks.bind_expression != nullptr; }
+	auto GetBindExpressionCallback() const -> function_bind_expression_t { return callbacks.bind_expression; }
+	auto SetBindExpressionCallback(function_bind_expression_t callback) -> void { callbacks.bind_expression = callback; }
+
+	auto HasInitStateCallback() const -> bool { return callbacks.init_local_state != nullptr; }
+	auto GetInitStateCallback() const -> init_local_state_t { return callbacks.init_local_state; }
+	auto SetInitStateCallback(init_local_state_t callback) -> void { callbacks.init_local_state = callback; }
+
+	auto HasStatisticsCallback() const -> bool { return callbacks.statistics != nullptr; }
+	auto GetStatisticsCallback() const -> function_statistics_t { return callbacks.statistics; }
+	auto SetStatisticsCallback(function_statistics_t callback) -> void { callbacks.statistics = callback; }
+
+	auto HasModifiedDatabasesCallback() const -> bool { return callbacks.get_modified_databases != nullptr; }
+	auto GetModifiedDatabasesCallback() const -> get_modified_databases_t { return callbacks.get_modified_databases; }
+	auto SetModifiedDatabasesCallback(get_modified_databases_t callback) -> void { callbacks.get_modified_databases = callback; }
+
+	auto HasSerializationCallbacks() const -> bool { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
+	auto SetSerializeCallback(function_serialize_t callback) -> void { callbacks.serialize = callback; }
+	auto SetDeserializeCallback(function_deserialize_t callback) -> void { callbacks.deserialize = callback; }
+	auto GetSerializeCallback() const -> function_serialize_t { return callbacks.serialize; }
+	auto GetDeserializeCallback() const -> function_deserialize_t { return callbacks.deserialize; }
+
+	auto HasFilterPruneCallback() const -> bool { return callbacks.filter_prune != nullptr; }
+	auto SetFilterPruneCallback(propagate_filter_t callback) -> void { callbacks.filter_prune = callback; }
+	auto GetFilterPruneCallback() const -> propagate_filter_t { return callbacks.filter_prune; }
 	// clang-format on
 
+public:
+	bool HasExtraFunctionInfo() const {
+		return function_info != nullptr;
+	}
+	ScalarFunctionInfo &GetExtraFunctionInfo() const {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
+		function_info = std::move(info);
+	}
+	template <class T, class... ARGS>
+	void SetExtraFunctionInfo(ARGS &&... args) {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+	}
+	shared_ptr<ScalarFunctionInfo> GetFunctionInfo() const {
+		return function_info;
+	}
+
+protected:
+	FunctionProperties properties;
+	ScalarFunctionCallbacks callbacks;
+	shared_ptr<ScalarFunctionInfo> function_info;
+
+	//! Per-argument declarative properties (monotonicity). Empty = no claims made.
+	vector<ArgProperties> arg_props;
+
+public:
 	//! Per-argument declarative properties. Returns a default ArgProperties when no annotation exists.
 	const ArgProperties &GetArgProperties(idx_t arg_idx) const {
 		static const ArgProperties unknown;
@@ -267,70 +305,34 @@ public:
 	ScalarFunction &SetUnaryArgProperties(ArgProperties props) {
 		return SetArgProperties(0, props);
 	}
+};
 
-	bool HasExtraFunctionInfo() const {
-		return function_info != nullptr;
-	}
-	ScalarFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-
-protected:
-	FunctionProperties properties;
-	ScalarFunctionCallbacks callbacks;
-
-	//! Additional function info, passed to the bind
-	shared_ptr<ScalarFunctionInfo> function_info;
-	//! Per-argument declarative properties (monotonicity). Empty = no claims made.
-	vector<ArgProperties> arg_props;
-
+class ScalarFunction : public BaseScalarFunction, public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
-	// clang-format off
-	FunctionStability GetStability() const { return properties.stability; }
-	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
-	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
-	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
-	FunctionErrors GetErrorMode() const { return properties.errors; }
-	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
-	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
-	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
+	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
+	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
+	                          function_statistics_t statistics = nullptr, init_local_state_t init_local_state = nullptr,
+	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
+	                          FunctionStability stability = FunctionStability::CONSISTENT,
+	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
+	                          bind_lambda_function_t bind_lambda = nullptr);
 
-	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
-	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
-	// clang-format on
+	DUCKDB_API ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
+	                          bind_scalar_function_t bind = nullptr, function_statistics_t statistics = nullptr,
+	                          init_local_state_t init_local_state = nullptr,
+	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID),
+	                          FunctionStability stability = FunctionStability::CONSISTENT,
+	                          FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING,
+	                          bind_lambda_function_t bind_lambda = nullptr);
 
-	auto GetProperties() const -> const FunctionProperties & {
-		return properties;
-	}
-	auto GetProperties() -> FunctionProperties & {
-		return properties;
-	}
-	auto GetCallbacks() const -> const ScalarFunctionCallbacks & {
-		return callbacks;
-	}
-	auto GetCallbacks() -> ScalarFunctionCallbacks & {
-		return callbacks;
-	}
-
-	shared_ptr<ScalarFunctionInfo> GetFunctionInfo() const {
-		return function_info;
-	}
-
-public:
 	DUCKDB_API bool operator==(const ScalarFunction &rhs) const;
 	DUCKDB_API bool operator!=(const ScalarFunction &rhs) const;
 
 	DUCKDB_API bool Equal(const ScalarFunction &rhs) const;
+
+public:
+	unique_ptr<BoundFunctionExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments,
+	                                         optional_ptr<Binder> binder = nullptr) const;
 
 public:
 	DUCKDB_API static void NopFunction(DataChunk &input, ExpressionState &state, Vector &result);
@@ -448,109 +450,12 @@ public:
 	}
 };
 
-class BoundScalarFunction : public BoundSimpleFunction {
+class BoundScalarFunction : public BaseScalarFunction, public BoundSimpleFunction {
 public:
 	explicit BoundScalarFunction(const ScalarFunction &function);
 
-protected:
-	FunctionProperties properties;
-	ScalarFunctionCallbacks callbacks;
-	shared_ptr<ScalarFunctionInfo> function_info;
-
-public:
-	auto GetProperties() const -> const FunctionProperties & {
-		return properties;
-	}
-	auto GetProperties() -> FunctionProperties & {
-		return properties;
-	}
-	auto GetCallbacks() const -> const ScalarFunctionCallbacks & {
-		return callbacks;
-	}
-	auto GetCallbacks() -> ScalarFunctionCallbacks & {
-		return callbacks;
-	}
-
-	DUCKDB_API bool operator==(const BoundScalarFunction &rhs) const;
-	DUCKDB_API bool operator!=(const BoundScalarFunction &rhs) const;
-
-	// DUCKDB_API bool Equal(const ScalarFunction &rhs) const;
-
-public:
-	// clang-format off
-	FunctionStability GetStability() const { return properties.stability; }
-	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
-	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
-	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
-	FunctionErrors GetErrorMode() const { return properties.errors; }
-	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
-	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
-	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
-
-	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
-	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
-
-	bool HasFunctionCallback() const { return callbacks.function != nullptr; }
-	scalar_function_t GetFunctionCallback() const { return callbacks.function; }
-	void SetFunctionCallback(scalar_function_t callback) { callbacks.function = std::move(callback); }
-
-	bool HasSelectCallback() const { return callbacks.select_function != nullptr; }
-	scalar_function_select_t GetSelectCallback() const { return callbacks.select_function; }
-	void SetSelectCallback(scalar_function_select_t callback) { callbacks.select_function = callback; }
-
-	bool HasBindCallback() const { return callbacks.bind != nullptr; };
-	bind_scalar_function_t GetBindCallback() const { return callbacks.bind; };
-	void SetBindCallback(bind_scalar_function_t callback) { callbacks.bind = callback; }
-
-	unique_ptr<BoundFunctionExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments, optional_ptr<Binder> binder = nullptr) const;
-
-	bool HasBindLambdaCallback() const { return callbacks.bind_lambda != nullptr; }
-	bind_lambda_function_t GetBindLambdaCallback() const { return callbacks.bind_lambda; }
-	void SetBindLambdaCallback(bind_lambda_function_t callback) { callbacks.bind_lambda = callback; }
-
-	bool HasBindExpressionCallback() const { return callbacks.bind_expression != nullptr; }
-	function_bind_expression_t GetBindExpressionCallback() const { return callbacks.bind_expression; }
-	void SetBindExpressionCallback(function_bind_expression_t callback) { callbacks.bind_expression = callback; }
-
-	bool HasInitStateCallback() const { return callbacks.init_local_state != nullptr; }
-	init_local_state_t GetInitStateCallback() const { return callbacks.init_local_state; }
-	void SetInitStateCallback(init_local_state_t callback) { callbacks.init_local_state = callback; }
-
-	bool HasStatisticsCallback() const { return callbacks.statistics != nullptr; }
-	function_statistics_t GetStatisticsCallback() const { return callbacks.statistics; }
-	void SetStatisticsCallback(function_statistics_t callback) { callbacks.statistics = callback; }
-
-	bool HasModifiedDatabasesCallback() const { return callbacks.get_modified_databases != nullptr; }
-	get_modified_databases_t GetModifiedDatabasesCallback() const { return callbacks.get_modified_databases; }
-	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { callbacks.get_modified_databases = callback; }
-
-	bool HasSerializationCallbacks() const { return callbacks.serialize != nullptr && callbacks.deserialize != nullptr; }
-	void SetSerializeCallback(function_serialize_t callback) { callbacks.serialize = callback; }
-	void SetDeserializeCallback(function_deserialize_t callback) { callbacks.deserialize = callback; }
-	function_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
-	function_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
-
-	bool HasFilterPruneCallback() const {return callbacks.filter_prune != nullptr; }
-	void SetFilterPruneCallback(propagate_filter_t callback) { callbacks.filter_prune = callback; }
-	propagate_filter_t GetFilterPruneCallback() const { return callbacks.filter_prune; }
-	// clang-format on
-
-	bool HasExtraFunctionInfo() const {
-		return function_info != nullptr;
-	}
-	ScalarFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-	void SetExtraFunctionInfo(shared_ptr<ScalarFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
+	bool operator==(const BoundScalarFunction &rhs) const;
+	bool operator!=(const BoundScalarFunction &rhs) const;
 };
 
 class BindScalarFunctionInput {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -433,8 +433,7 @@ public:
 
 class BoundScalarFunction : public ScalarFunction {
 public:
-	BoundScalarFunction(const ScalarFunction &function) // NOLINT: allow implicit conversion
-	    : ScalarFunction(function) {
+	explicit BoundScalarFunction(const ScalarFunction &function) : ScalarFunction(function) {
 	}
 };
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -177,7 +177,11 @@ public:
 	bool operator!=(const ScalarFunctionCallbacks &rhs) const;
 };
 
+template <class IMPL>
 class BaseScalarFunction {
+	friend IMPL; // Only allow the derived class to access the protected members of this class.
+	BaseScalarFunction() = default;
+
 public:
 	// clang-format off
 	auto GetProperties() const -> const FunctionProperties & { return properties; }
@@ -291,23 +295,24 @@ public:
 	bool HasArgProperties() const {
 		return !arg_props.empty();
 	}
-	ScalarFunction &SetArgProperties(idx_t arg_idx, ArgProperties props) {
+	IMPL &SetArgProperties(idx_t arg_idx, ArgProperties props) {
 		if (arg_props.size() <= arg_idx) {
 			arg_props.resize(arg_idx + 1);
 		}
 		arg_props[arg_idx] = props;
-		return *this;
+		return *static_cast<IMPL *>(this);
 	}
-	ScalarFunction &SetArgProperties(vector<ArgProperties> props) {
+	IMPL &SetArgProperties(vector<ArgProperties> props) {
 		arg_props = std::move(props);
-		return *this;
+		return *static_cast<IMPL *>(this);
 	}
 	ScalarFunction &SetUnaryArgProperties(ArgProperties props) {
 		return SetArgProperties(0, props);
 	}
 };
 
-class ScalarFunction : public BaseScalarFunction, public SimpleFunction { // NOLINT: work-around bug in clang-tidy
+class ScalarFunction : public BaseScalarFunction<ScalarFunction>,
+                       public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,
@@ -450,7 +455,7 @@ public:
 	}
 };
 
-class BoundScalarFunction : public BaseScalarFunction, public BoundSimpleFunction {
+class BoundScalarFunction : public BaseScalarFunction<BoundScalarFunction>, public BoundSimpleFunction {
 public:
 	explicit BoundScalarFunction(const ScalarFunction &function);
 

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -148,6 +148,58 @@ typedef unique_ptr<FunctionData> (*window_deserialize_t)(Deserializer &deseriali
 
 class WindowFunctionCallbacks {
 public:
+	// clang-format off
+	bool HasBindCallback() const { return bind != nullptr; }
+	window_bind_function_t GetBindCallback() const { return bind; }
+	void SetBindCallback(window_bind_function_t callback) { bind = callback; }
+
+	bool HasBoundsCallback() const { return bounds != nullptr; }
+	window_bounds_function_t GetBoundsCallback() const { return bounds; }
+	void SetBoundsCallback(window_bounds_function_t callback) { bounds = callback; }
+
+	bool HasSharingCallback() const { return sharing != nullptr; }
+	window_sharing_function_t GetSharingCallback() const { return sharing; }
+	void SetSharingCallback(window_sharing_function_t callback) { sharing = callback; }
+
+	bool HasGlobalCallback() const { return global != nullptr; }
+	window_global_function_t GetGlobalCallback() const { return global; }
+	void SetGlobalCallback(window_global_function_t callback) { global = callback; }
+
+	bool HasLocalCallback() const { return local != nullptr; }
+	window_local_function_t GetLocalCallback() const { return local; }
+	void SetLocalCallback(window_local_function_t callback) { local = callback; }
+
+	bool HasSinkCallback() const { return sink != nullptr; }
+	window_sink_function_t GetSinkCallback() const { return sink; }
+	void SetSinkCallback(window_sink_function_t callback) { sink = callback; }
+
+	bool HasFinalizeCallback() const { return finalize != nullptr; }
+	window_finalize_function_t GetFinalizeCallback() const { return finalize; }
+	void SetFinalizeCallback(window_finalize_function_t callback) { finalize = callback; }
+
+	bool HasEvaluateCallback() const { return evaluate != nullptr; }
+	window_evaluate_function_t GetEvaluateCallback() const { return evaluate; }
+	void SetEvaluateCallback(window_evaluate_function_t callback) { evaluate = callback; }
+
+	bool HasCanStreamCallback() const { return can_stream != nullptr; }
+	window_canstream_function_t GetCanStreamCallback() const { return can_stream; }
+	void SetCanStreamCallback(window_canstream_function_t callback) { can_stream = callback; }
+
+	bool HasStreamingStateCallback() const { return streaming_state != nullptr; }
+	window_streaming_state_function_t GetStreamingStateCallback() const { return streaming_state; }
+	void SetStreamingStateCallback(window_streaming_state_function_t callback) { streaming_state = callback; }
+
+	bool HasStreamingDataCallback() const { return stream != nullptr; }
+	window_stream_function_t GetStreamingDataCallback() const { return stream; }
+	void SetStreamingDataCallback(window_stream_function_t callback) { stream = callback; }
+
+	bool HasSerializationCallbacks() const { return false; }
+	void SetSerializeCallback(window_serialize_t callback) { serialize = callback; }
+	void SetDeserializeCallback(window_deserialize_t callback) { deserialize = callback; }
+	window_serialize_t GetSerializeCallback() const { return serialize; }
+	window_deserialize_t GetDeserializeCallback() const { return deserialize; }
+	// clang-format on
+public:
 	//! The bind function (may be null)
 	window_bind_function_t bind = nullptr;
 
@@ -179,6 +231,42 @@ public:
 };
 
 class WindowFunctionProperties : public FunctionProperties {
+public:
+	bool CanDistinct() const {
+		return can_distinct;
+	}
+	void SetCanDistinct(bool value) {
+		can_distinct = value;
+	}
+
+	bool CanFilter() const {
+		return can_filter;
+	}
+	void SetCanFilter(bool value) {
+		can_filter = value;
+	}
+
+	bool CanOrderBy() const {
+		return can_order_by;
+	}
+	void SetCanOrderBy(bool value) {
+		can_order_by = value;
+	}
+
+	bool CanExclude() const {
+		return can_exclude;
+	}
+	void SetCanExclude(bool value) {
+		can_exclude = value;
+	}
+
+	bool CanIgnoreNulls() const {
+		return can_ignore_nulls;
+	}
+	void SetCanIgnoreNulls(bool value) {
+		can_ignore_nulls = value;
+	}
+
 public:
 	//! Does the window function support DISTINCT?
 	bool can_distinct = false;
@@ -396,6 +484,22 @@ public:
 		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
 	}
 
+	shared_ptr<WindowFunctionInfo> GetFunctionInfo() const {
+		return function_info;
+	}
+	const WindowFunctionCallbacks &GetCallbacks() const {
+		return callbacks;
+	}
+	WindowFunctionCallbacks &GetCallbacks() {
+		return callbacks;
+	}
+	WindowFunctionProperties &GetProperties() {
+		return properties;
+	}
+	const WindowFunctionProperties &GetProperties() const {
+		return properties;
+	}
+
 public:
 	bool operator==(const WindowFunction &rhs) const {
 		return name == rhs.name;
@@ -405,9 +509,195 @@ public:
 	}
 };
 
-class BoundWindowFunction : public WindowFunction {
+class BoundWindowFunction : public BoundSimpleFunction {
 public:
 	explicit BoundWindowFunction(const WindowFunction &base);
+	const ExpressionType window_enum;
+
+public:
+	auto GetProperties() const -> const WindowFunctionProperties & {
+		return properties;
+	}
+	auto GetProperties() -> WindowFunctionProperties & {
+		return properties;
+	}
+	auto GetCallbacks() const -> const WindowFunctionCallbacks & {
+		return callbacks;
+	}
+	auto GetCallbacks() -> WindowFunctionCallbacks & {
+		return callbacks;
+	}
+
+	DUCKDB_API bool operator==(const BoundWindowFunction &rhs) const;
+	DUCKDB_API bool operator!=(const BoundWindowFunction &rhs) const;
+
+	bool HasSerializationCallbacks() const {
+		return false;
+	}
+	void SetSerializeCallback(window_serialize_t callback) {
+		callbacks.serialize = callback;
+	}
+	void SetDeserializeCallback(window_deserialize_t callback) {
+		callbacks.deserialize = callback;
+	}
+	window_serialize_t GetSerializeCallback() const {
+		return callbacks.serialize;
+	}
+	window_deserialize_t GetDeserializeCallback() const {
+		return callbacks.deserialize;
+	}
+
+	bool HasBindCallback() const {
+		return callbacks.bind != nullptr;
+	}
+	window_bind_function_t GetBindCallback() const {
+		return callbacks.bind;
+	}
+	void SetBindCallback(window_bind_function_t callback) {
+		callbacks.bind = callback;
+	}
+
+	bool HasBoundsCallback() const {
+		return callbacks.bounds != nullptr;
+	}
+	window_bounds_function_t GetBoundsCallback() const {
+		return callbacks.bounds;
+	}
+	void SetBoundsCallback(window_bounds_function_t callback) {
+		callbacks.bounds = callback;
+	}
+	void GetBounds(WindowBoundsSet &bounds, const BoundWindowExpression &wexpr) const {
+		D_ASSERT(HasBoundsCallback());
+		GetBoundsCallback()(bounds, wexpr);
+	}
+
+	bool HasSharingCallback() const {
+		return callbacks.sharing != nullptr;
+	}
+	window_sharing_function_t GetSharingCallback() const {
+		return callbacks.sharing;
+	}
+	void SetSharingCallback(window_sharing_function_t callback) {
+		callbacks.sharing = callback;
+	}
+	void GetSharing(WindowExecutor &executor, WindowSharedExpressions &sharing) const {
+		D_ASSERT(HasSharingCallback());
+		GetSharingCallback()(executor, sharing);
+	}
+
+	bool HasGlobalCallback() const {
+		return callbacks.global != nullptr;
+	}
+	window_global_function_t GetGlobalCallback() const {
+		return callbacks.global;
+	}
+	void SetGlobalCallback(window_global_function_t callback) {
+		callbacks.global = callback;
+	}
+	unique_ptr<GlobalSinkState> GetGlobalState(ClientContext &client, const WindowExecutor &executor,
+	                                           const idx_t payload_count, const ValidityMask &partition_mask,
+	                                           const ValidityMask &order_mask) const {
+		D_ASSERT(HasGlobalCallback());
+		return GetGlobalCallback()(client, executor, payload_count, partition_mask, order_mask);
+	}
+
+	bool HasLocalCallback() const {
+		return callbacks.local != nullptr;
+	}
+	window_local_function_t GetLocalCallback() const {
+		return callbacks.local;
+	}
+	void SetLocalCallback(window_local_function_t callback) {
+		callbacks.local = callback;
+	}
+	unique_ptr<LocalSinkState> GetLocalState(ExecutionContext &context, const GlobalSinkState &gstate) const {
+		D_ASSERT(HasLocalCallback());
+		return GetLocalCallback()(context, gstate);
+	}
+
+	bool HasSinkCallback() const {
+		return callbacks.sink != nullptr;
+	}
+	window_sink_function_t GetSinkCallback() const {
+		return callbacks.sink;
+	}
+	void SetSinkCallback(window_sink_function_t callback) {
+		callbacks.sink = callback;
+	}
+	void Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk, idx_t input_idx,
+	          OperatorSinkInput &sink) const {
+		D_ASSERT(HasSinkCallback());
+		return GetSinkCallback()(context, sink_chunk, coll_chunk, input_idx, sink);
+	}
+
+	bool HasFinalizeCallback() const {
+		return callbacks.finalize != nullptr;
+	}
+	window_finalize_function_t GetFinalizeCallback() const {
+		return callbacks.finalize;
+	}
+	void SetFinalizeCallback(window_finalize_function_t callback) {
+		callbacks.finalize = callback;
+	}
+	void Finalize(ExecutionContext &context, optional_ptr<WindowCollection> collection, OperatorSinkInput &sink) const {
+		D_ASSERT(HasFinalizeCallback());
+		return GetFinalizeCallback()(context, collection, sink);
+	}
+
+	bool HasEvaluateCallback() const {
+		return callbacks.evaluate != nullptr;
+	}
+	window_evaluate_function_t GetEvaluateCallback() const {
+		return callbacks.evaluate;
+	}
+	void SetEvaluateCallback(window_evaluate_function_t callback) {
+		callbacks.evaluate = callback;
+	}
+	void Evaluate(ExecutionContext &context, DataChunk &eval_chunk, DataChunk &bounds, Vector &result, idx_t row_idx,
+	              OperatorSinkInput &sink) const {
+		D_ASSERT(HasEvaluateCallback());
+		return GetEvaluateCallback()(context, eval_chunk, bounds, result, row_idx, sink);
+	}
+
+	bool HasCanStreamCallback() const {
+		return callbacks.can_stream != nullptr;
+	}
+	window_canstream_function_t GetCanStreamCallback() const {
+		return callbacks.can_stream;
+	}
+	void SetCanStreamCallback(window_canstream_function_t callback) {
+		callbacks.can_stream = callback;
+	}
+	bool CanStream(ClientContext &client, const BoundWindowExpression &wexpr, idx_t max_delta) const {
+		D_ASSERT(HasCanStreamCallback());
+		return GetCanStreamCallback()(client, wexpr, max_delta);
+	}
+
+	bool HasStreamingStateCallback() const {
+		return callbacks.streaming_state != nullptr;
+	}
+	window_streaming_state_function_t GetStreamingStateCallback() const {
+		return callbacks.streaming_state;
+	}
+	void SetStreamingStateCallback(window_streaming_state_function_t callback) {
+		callbacks.streaming_state = callback;
+	}
+	unique_ptr<LocalSourceState> GetStreamingState(ClientContext &client, DataChunk &input,
+	                                               const BoundWindowExpression &wexpr) const {
+		D_ASSERT(HasStreamingStateCallback());
+		return GetStreamingStateCallback()(client, input, wexpr);
+	}
+
+	void GetStreamingData(ExecutionContext &context, DataChunk &input, DataChunk &delayed, idx_t delayed_capacity,
+	                      Vector &result, LocalSourceState &lstate) const {
+		D_ASSERT(callbacks.HasStreamingDataCallback());
+		callbacks.GetStreamingDataCallback()(context, input, delayed, delayed_capacity, result, lstate);
+	}
+
+protected:
+	WindowFunctionProperties properties;
+	WindowFunctionCallbacks callbacks;
+	shared_ptr<WindowFunctionInfo> function_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -407,8 +407,7 @@ public:
 
 class BoundWindowFunction : public WindowFunction {
 public:
-	BoundWindowFunction(const WindowFunction &base) : WindowFunction(base) { // NOLINT: allow implicit conversion
-	}
+	explicit BoundWindowFunction(const WindowFunction &base);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -148,58 +148,6 @@ typedef unique_ptr<FunctionData> (*window_deserialize_t)(Deserializer &deseriali
 
 class WindowFunctionCallbacks {
 public:
-	// clang-format off
-	bool HasBindCallback() const { return bind != nullptr; }
-	window_bind_function_t GetBindCallback() const { return bind; }
-	void SetBindCallback(window_bind_function_t callback) { bind = callback; }
-
-	bool HasBoundsCallback() const { return bounds != nullptr; }
-	window_bounds_function_t GetBoundsCallback() const { return bounds; }
-	void SetBoundsCallback(window_bounds_function_t callback) { bounds = callback; }
-
-	bool HasSharingCallback() const { return sharing != nullptr; }
-	window_sharing_function_t GetSharingCallback() const { return sharing; }
-	void SetSharingCallback(window_sharing_function_t callback) { sharing = callback; }
-
-	bool HasGlobalCallback() const { return global != nullptr; }
-	window_global_function_t GetGlobalCallback() const { return global; }
-	void SetGlobalCallback(window_global_function_t callback) { global = callback; }
-
-	bool HasLocalCallback() const { return local != nullptr; }
-	window_local_function_t GetLocalCallback() const { return local; }
-	void SetLocalCallback(window_local_function_t callback) { local = callback; }
-
-	bool HasSinkCallback() const { return sink != nullptr; }
-	window_sink_function_t GetSinkCallback() const { return sink; }
-	void SetSinkCallback(window_sink_function_t callback) { sink = callback; }
-
-	bool HasFinalizeCallback() const { return finalize != nullptr; }
-	window_finalize_function_t GetFinalizeCallback() const { return finalize; }
-	void SetFinalizeCallback(window_finalize_function_t callback) { finalize = callback; }
-
-	bool HasEvaluateCallback() const { return evaluate != nullptr; }
-	window_evaluate_function_t GetEvaluateCallback() const { return evaluate; }
-	void SetEvaluateCallback(window_evaluate_function_t callback) { evaluate = callback; }
-
-	bool HasCanStreamCallback() const { return can_stream != nullptr; }
-	window_canstream_function_t GetCanStreamCallback() const { return can_stream; }
-	void SetCanStreamCallback(window_canstream_function_t callback) { can_stream = callback; }
-
-	bool HasStreamingStateCallback() const { return streaming_state != nullptr; }
-	window_streaming_state_function_t GetStreamingStateCallback() const { return streaming_state; }
-	void SetStreamingStateCallback(window_streaming_state_function_t callback) { streaming_state = callback; }
-
-	bool HasStreamingDataCallback() const { return stream != nullptr; }
-	window_stream_function_t GetStreamingDataCallback() const { return stream; }
-	void SetStreamingDataCallback(window_stream_function_t callback) { stream = callback; }
-
-	bool HasSerializationCallbacks() const { return false; }
-	void SetSerializeCallback(window_serialize_t callback) { serialize = callback; }
-	void SetDeserializeCallback(window_deserialize_t callback) { deserialize = callback; }
-	window_serialize_t GetSerializeCallback() const { return serialize; }
-	window_deserialize_t GetDeserializeCallback() const { return deserialize; }
-	// clang-format on
-public:
 	//! The bind function (may be null)
 	window_bind_function_t bind = nullptr;
 
@@ -232,42 +180,6 @@ public:
 
 class WindowFunctionProperties : public FunctionProperties {
 public:
-	bool CanDistinct() const {
-		return can_distinct;
-	}
-	void SetCanDistinct(bool value) {
-		can_distinct = value;
-	}
-
-	bool CanFilter() const {
-		return can_filter;
-	}
-	void SetCanFilter(bool value) {
-		can_filter = value;
-	}
-
-	bool CanOrderBy() const {
-		return can_order_by;
-	}
-	void SetCanOrderBy(bool value) {
-		can_order_by = value;
-	}
-
-	bool CanExclude() const {
-		return can_exclude;
-	}
-	void SetCanExclude(bool value) {
-		can_exclude = value;
-	}
-
-	bool CanIgnoreNulls() const {
-		return can_ignore_nulls;
-	}
-	void SetCanIgnoreNulls(bool value) {
-		can_ignore_nulls = value;
-	}
-
-public:
 	//! Does the window function support DISTINCT?
 	bool can_distinct = false;
 	//! Does the window function support FILTER?
@@ -280,7 +192,127 @@ public:
 	bool can_ignore_nulls = true;
 };
 
-class WindowFunction : public SimpleFunction { // NOLINT: work-around bug in clang-tidy
+class BaseWindowFunction {
+public:
+	// clang-format off
+	auto GetProperties() const -> const WindowFunctionProperties & { return properties; }
+	auto GetProperties() -> WindowFunctionProperties & { return properties; }
+	auto SetProperties(const WindowFunctionProperties &value) -> void { properties = value; }
+
+	auto GetCallbacks() const -> const WindowFunctionCallbacks & { return callbacks; }
+	auto GetCallbacks() -> WindowFunctionCallbacks & { return callbacks; }
+	auto SetCallbacks(const WindowFunctionCallbacks &value) -> void { callbacks = value; }
+
+public: // Properties
+
+	auto GetStability() const -> FunctionStability { return properties.stability; }
+	auto SetStability(FunctionStability value) -> void { properties.stability = value; }
+
+	auto GetNullHandling() const -> FunctionNullHandling { return properties.null_handling; }
+	auto SetNullHandling(FunctionNullHandling value) -> void { properties.null_handling = value; }
+
+	auto GetErrorMode() const -> FunctionErrors { return properties.errors; }
+	auto SetErrorMode(FunctionErrors value) -> void { properties.errors = value; }
+
+	auto GetCollationHandling() const -> FunctionCollationHandling { return properties.collation_handling; }
+	auto SetCollationHandling(FunctionCollationHandling value) -> void { properties.collation_handling = value; }
+
+	//! Set this functions error-mode as fallible (can throw runtime errors)
+	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
+	//! Set this functions stability as volatile (can not be cached per row)
+	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
+
+	bool CanDistinct() const { return properties.can_distinct; }
+	bool CanFilter() const { return properties.can_filter; }
+	bool CanOrderBy() const { return properties.can_order_by; }
+	bool CanExclude() const { return properties.can_exclude; }
+	bool CanIgnoreNulls() const { return properties.can_ignore_nulls; }
+
+	void SetCanDistinct(bool value) { properties.can_distinct = value; }
+	void SetCanFilter(bool value) { properties.can_filter = value; }
+	void SetCanOrderBy(bool value) { properties.can_order_by = value; }
+	void SetCanExclude(bool value) { properties.can_exclude = value; }
+	void SetCanIgnoreNulls(bool value) { properties.can_ignore_nulls = value; }
+
+public: // Callbacks
+
+	auto HasBindCallback() const -> bool { return callbacks.bind != nullptr; }
+	auto GetBindCallback() const -> window_bind_function_t { return callbacks.bind; }
+	auto SetBindCallback(window_bind_function_t callback) -> void { callbacks.bind = callback; }
+
+	auto HasBoundsCallback() const -> bool { return callbacks.bounds != nullptr; }
+	auto GetBoundsCallback() const -> window_bounds_function_t { return callbacks.bounds; }
+	auto SetBoundsCallback(window_bounds_function_t callback) -> void { callbacks.bounds = callback; }
+
+	auto HasSharingCallback() const -> bool { return callbacks.sharing != nullptr; }
+	auto GetSharingCallback() const -> window_sharing_function_t { return callbacks.sharing; }
+	auto SetSharingCallback(window_sharing_function_t callback) -> void { callbacks.sharing = callback; }
+
+	auto HasGlobalCallback() const -> bool { return callbacks.global != nullptr; }
+	auto GetGlobalCallback() const -> window_global_function_t { return callbacks.global; }
+	auto SetGlobalCallback(window_global_function_t callback) -> void { callbacks.global = callback; }
+
+	auto HasLocalCallback() const -> bool { return callbacks.local != nullptr; }
+	auto GetLocalCallback() const -> window_local_function_t { return callbacks.local; }
+	auto SetLocalCallback(window_local_function_t callback) -> void { callbacks.local = callback; }
+
+	auto HasSinkCallback() const -> bool { return callbacks.sink != nullptr; }
+	auto GetSinkCallback() const -> window_sink_function_t { return callbacks.sink; }
+	auto SetSinkCallback(window_sink_function_t callback) -> void { callbacks.sink = callback; }
+
+	auto HasFinalizeCallback() const -> bool { return callbacks.finalize != nullptr; }
+	auto GetFinalizeCallback() const -> window_finalize_function_t { return callbacks.finalize; }
+	auto SetFinalizeCallback(window_finalize_function_t callback) -> void { callbacks.finalize = callback; }
+
+	auto HasEvaluateCallback() const -> bool { return callbacks.evaluate != nullptr; }
+	auto GetEvaluateCallback() const -> window_evaluate_function_t { return callbacks.evaluate; }
+	auto SetEvaluateCallback(window_evaluate_function_t callback) -> void { callbacks.evaluate = callback; }
+
+	auto HasCanStreamCallback() const -> bool { return callbacks.can_stream != nullptr; }
+	auto GetCanStreamCallback() const -> window_canstream_function_t { return callbacks.can_stream; }
+	auto SetCanStreamCallback(window_canstream_function_t callback) -> void { callbacks.can_stream = callback; }
+
+	auto HasStreamingStateCallback() const -> bool { return callbacks.streaming_state != nullptr; }
+	auto GetStreamingStateCallback() const -> window_streaming_state_function_t { return callbacks.streaming_state; }
+	auto SetStreamingStateCallback(window_streaming_state_function_t callback) -> void { callbacks.streaming_state = callback; }
+
+	auto HasStreamingDataCallback() const -> bool { return callbacks.stream != nullptr; }
+	auto GetStreamingDataCallback() const -> window_stream_function_t { return callbacks.stream; }
+	auto SetStreamingDataCallback(window_stream_function_t callback) -> void { callbacks.stream = callback; }
+
+	auto HasSerializationCallbacks() const -> bool { return false; } // TODO: implement this
+	auto SetSerializeCallback(window_serialize_t callback) -> void { callbacks.serialize = callback; }
+	auto SetDeserializeCallback(window_deserialize_t callback) -> void { callbacks.deserialize = callback; }
+	auto GetSerializeCallback() const -> window_serialize_t { return callbacks.serialize; }
+	auto GetDeserializeCallback() const -> window_deserialize_t { return callbacks.deserialize; }
+	// clang-format on
+
+public:
+	auto HasExtraFunctionInfo() const -> bool {
+		return function_info != nullptr;
+	}
+	auto GetExtraFunctionInfo() const -> WindowFunctionInfo & {
+		D_ASSERT(function_info.get());
+		return *function_info;
+	}
+	auto SetExtraFunctionInfo(shared_ptr<WindowFunctionInfo> info) -> void {
+		function_info = std::move(info);
+	}
+	template <class T, class... ARGS>
+	auto SetExtraFunctionInfo(ARGS &&... args) -> void {
+		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
+	}
+	auto GetFunctionInfo() const -> shared_ptr<WindowFunctionInfo> {
+		return function_info;
+	}
+
+protected:
+	WindowFunctionProperties properties;
+	WindowFunctionCallbacks callbacks;
+	shared_ptr<WindowFunctionInfo> function_info;
+};
+
+class WindowFunction : public BaseWindowFunction, public SimpleFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	WindowFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	               ExpressionType window_enum, window_bind_function_t bind = nullptr,
@@ -308,199 +340,14 @@ public:
 	                     finalize, evaluate) {
 	}
 
-	// clang-format off
-	bool HasBindCallback() const { return callbacks.bind != nullptr; }
-	window_bind_function_t GetBindCallback() const { return callbacks.bind; }
-	void SetBindCallback(window_bind_function_t callback) { callbacks.bind = callback; }
-
+public:
 	unique_ptr<BoundWindowExpression> Bind(ClientContext &context) const;
 	unique_ptr<BoundWindowExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
 
-	bool HasBoundsCallback() const { return callbacks.bounds != nullptr; }
-	window_bounds_function_t GetBoundsCallback() const { return callbacks.bounds; }
-	void SetBoundsCallback(window_bounds_function_t callback) { callbacks.bounds = callback; }
-	void GetBounds(WindowBoundsSet &bounds, const BoundWindowExpression &wexpr) const {
-		D_ASSERT(HasBoundsCallback());
-		GetBoundsCallback()(bounds, wexpr);
-	}
-
-	bool HasSharingCallback() const { return callbacks.sharing != nullptr; }
-	window_sharing_function_t GetSharingCallback() const { return callbacks.sharing; }
-	void SetSharingCallback(window_sharing_function_t callback) { callbacks.sharing = callback; }
-	void GetSharing(WindowExecutor &executor, WindowSharedExpressions &sharing) const {
-		D_ASSERT(HasSharingCallback());
-		GetSharingCallback()(executor, sharing);
-	}
-
-	bool HasGlobalCallback() const { return callbacks.global != nullptr; }
-	window_global_function_t GetGlobalCallback() const { return callbacks.global; }
-	void SetGlobalCallback(window_global_function_t callback) { callbacks.global = callback; }
-	unique_ptr<GlobalSinkState> GetGlobalState(ClientContext &client, const WindowExecutor &executor,
-								const idx_t payload_count,
-								const ValidityMask &partition_mask,
-								const ValidityMask &order_mask) const {
-		D_ASSERT(HasGlobalCallback());
-		return GetGlobalCallback()(client, executor, payload_count, partition_mask, order_mask);
-	}
-
-	bool HasLocalCallback() const { return callbacks.local != nullptr; }
-	window_local_function_t GetLocalCallback() const { return callbacks.local; }
-	void SetLocalCallback(window_local_function_t callback) { callbacks.local = callback; }
-	unique_ptr<LocalSinkState> GetLocalState(ExecutionContext &context, const GlobalSinkState &gstate) const {
-		D_ASSERT(HasLocalCallback());
-		return GetLocalCallback()(context, gstate);
-	}
-
-	bool HasSinkCallback() const { return callbacks.sink != nullptr; }
-	window_sink_function_t GetSinkCallback() const { return callbacks.sink; }
-	void SetSinkCallback(window_sink_function_t callback) { callbacks.sink = callback; }
-	void Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk,
-				    idx_t input_idx, OperatorSinkInput &sink) const {
-		D_ASSERT(HasSinkCallback());
-		return GetSinkCallback()(context, sink_chunk, coll_chunk, input_idx, sink);
-	}
-
-	bool HasFinalizeCallback() const { return callbacks.finalize != nullptr; }
-	window_finalize_function_t GetFinalizeCallback() const { return callbacks.finalize; }
-	void SetFinalizeCallback(window_finalize_function_t callback) { callbacks.finalize = callback; }
-	void Finalize(ExecutionContext &context, optional_ptr<WindowCollection> collection, OperatorSinkInput &sink) const {
-		D_ASSERT(HasFinalizeCallback());
-		return GetFinalizeCallback()(context, collection, sink);
-	}
-
-	bool HasEvaluateCallback() const { return callbacks.evaluate != nullptr; }
-	window_evaluate_function_t GetEvaluateCallback() const { return callbacks.evaluate; }
-	void SetEvaluateCallback(window_evaluate_function_t callback) { callbacks.evaluate = callback; }
-	void Evaluate(ExecutionContext &context, DataChunk &eval_chunk, DataChunk &bounds, Vector &result, idx_t row_idx,
-				  OperatorSinkInput &sink) const {
-		D_ASSERT(HasEvaluateCallback());
-		return GetEvaluateCallback()(context, eval_chunk, bounds, result, row_idx, sink);
-	}
-
-	bool HasCanStreamCallback() const { return callbacks.can_stream != nullptr; }
-	window_canstream_function_t GetCanStreamCallback() const { return callbacks.can_stream; }
-	void SetCanStreamCallback(window_canstream_function_t callback) { callbacks.can_stream = callback; }
-	bool CanStream(ClientContext &client, const BoundWindowExpression &wexpr, idx_t max_delta) const {
-		D_ASSERT(HasCanStreamCallback());
-		return GetCanStreamCallback()(client, wexpr, max_delta);
-	}
-
-	bool HasStreamingStateCallback() const { return callbacks.streaming_state != nullptr; }
-	window_streaming_state_function_t GetStreamingStateCallback() const { return callbacks.streaming_state; }
-	void SetStreamingStateCallback(window_streaming_state_function_t callback) { callbacks.streaming_state = callback; }
-	unique_ptr<LocalSourceState> GetStreamingState(ClientContext &client, DataChunk &input,
-												   const BoundWindowExpression &wexpr) const {
-		D_ASSERT(HasStreamingStateCallback());
-		return GetStreamingStateCallback()(client, input, wexpr);
-	}
-
-	bool HasStreamingDataCallback() const { return callbacks.stream != nullptr; }
-	window_stream_function_t GetStreamingDataCallback() const { return callbacks.stream; }
-	void SetStreamingDataCallback(window_stream_function_t callback) { callbacks.stream = callback; }
-	void GetStreamingData(ExecutionContext &context, DataChunk &input, DataChunk &delayed, idx_t delayed_capacity,
-						   Vector &result, LocalSourceState &lstate) const {
-		D_ASSERT(HasStreamingDataCallback());
-		GetStreamingDataCallback()(context, input, delayed, delayed_capacity, result, lstate);
-	}
-
-	bool HasSerializationCallbacks() const { return false; }
-	void SetSerializeCallback(window_serialize_t callback) { callbacks.serialize = callback; }
-	void SetDeserializeCallback(window_deserialize_t callback) { callbacks.deserialize = callback; }
-	window_serialize_t GetSerializeCallback() const { return callbacks.serialize; }
-	window_deserialize_t GetDeserializeCallback() const { return callbacks.deserialize; }
-	// clang-format on
-
+public:
 	//! The expression enum for the window function
 	const ExpressionType window_enum;
 
-public:
-	bool CanDistinct() const {
-		return properties.can_distinct;
-	}
-	bool CanFilter() const {
-		return properties.can_filter;
-	}
-	bool CanOrderBy() const {
-		return properties.can_order_by;
-	}
-	bool CanExclude() const {
-		return properties.can_exclude;
-	}
-	bool CanIgnoreNulls() const {
-		return properties.can_ignore_nulls;
-	}
-	void SetCanDistinct(bool value) {
-		properties.can_distinct = value;
-	}
-	void SetCanFilter(bool value) {
-		properties.can_filter = value;
-	}
-	void SetCanOrderBy(bool value) {
-		properties.can_order_by = value;
-	}
-	void SetCanExclude(bool value) {
-		properties.can_exclude = value;
-	}
-	void SetCanIgnoreNulls(bool value) {
-		properties.can_ignore_nulls = value;
-	}
-
-protected:
-	WindowFunctionProperties properties;
-	WindowFunctionCallbacks callbacks;
-
-	//! Additional function info, passed to the bind
-	shared_ptr<WindowFunctionInfo> function_info;
-
-public:
-	// clang-format off
-	FunctionStability GetStability() const { return properties.stability; }
-	void SetStability(FunctionStability stability_p) { properties.stability = stability_p; }
-	FunctionNullHandling GetNullHandling() const { return properties.null_handling; }
-	void SetNullHandling(FunctionNullHandling null_handling_p) { properties.null_handling = null_handling_p; }
-	FunctionErrors GetErrorMode() const { return properties.errors; }
-	void SetErrorMode(FunctionErrors errors_p) { properties.errors = errors_p; }
-	FunctionCollationHandling GetCollationHandling() const { return properties.collation_handling; }
-	void SetCollationHandling(FunctionCollationHandling collation_handling_p) { properties.collation_handling = collation_handling_p; }
-
-	//! Set this functions error-mode as fallible (can throw runtime errors)
-	void SetFallible() { properties.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR; }
-	//! Set this functions stability as volatile (can not be cached per row)
-	void SetVolatile() { properties.stability = FunctionStability::VOLATILE; }
-	// clang-format on
-public:
-	bool HasExtraFunctionInfo() const {
-		return function_info != nullptr;
-	}
-	WindowFunctionInfo &GetExtraFunctionInfo() const {
-		D_ASSERT(function_info.get());
-		return *function_info;
-	}
-	void SetExtraFunctionInfo(shared_ptr<WindowFunctionInfo> info) {
-		function_info = std::move(info);
-	}
-	template <class T, class... ARGS>
-	void SetExtraFunctionInfo(ARGS &&... args) {
-		function_info = make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-
-	shared_ptr<WindowFunctionInfo> GetFunctionInfo() const {
-		return function_info;
-	}
-	const WindowFunctionCallbacks &GetCallbacks() const {
-		return callbacks;
-	}
-	WindowFunctionCallbacks &GetCallbacks() {
-		return callbacks;
-	}
-	WindowFunctionProperties &GetProperties() {
-		return properties;
-	}
-	const WindowFunctionProperties &GetProperties() const {
-		return properties;
-	}
-
-public:
 	bool operator==(const WindowFunction &rhs) const {
 		return name == rhs.name;
 	}
@@ -509,91 +356,27 @@ public:
 	}
 };
 
-class BoundWindowFunction : public BoundSimpleFunction {
+class BoundWindowFunction : public BaseWindowFunction, public BoundSimpleFunction {
 public:
 	explicit BoundWindowFunction(const WindowFunction &base);
-	const ExpressionType window_enum;
 
 public:
-	auto GetProperties() const -> const WindowFunctionProperties & {
-		return properties;
-	}
-	auto GetProperties() -> WindowFunctionProperties & {
-		return properties;
-	}
-	auto GetCallbacks() const -> const WindowFunctionCallbacks & {
-		return callbacks;
-	}
-	auto GetCallbacks() -> WindowFunctionCallbacks & {
-		return callbacks;
-	}
+	const ExpressionType window_enum;
 
 	DUCKDB_API bool operator==(const BoundWindowFunction &rhs) const;
 	DUCKDB_API bool operator!=(const BoundWindowFunction &rhs) const;
 
-	bool HasSerializationCallbacks() const {
-		return false;
-	}
-	void SetSerializeCallback(window_serialize_t callback) {
-		callbacks.serialize = callback;
-	}
-	void SetDeserializeCallback(window_deserialize_t callback) {
-		callbacks.deserialize = callback;
-	}
-	window_serialize_t GetSerializeCallback() const {
-		return callbacks.serialize;
-	}
-	window_deserialize_t GetDeserializeCallback() const {
-		return callbacks.deserialize;
-	}
-
-	bool HasBindCallback() const {
-		return callbacks.bind != nullptr;
-	}
-	window_bind_function_t GetBindCallback() const {
-		return callbacks.bind;
-	}
-	void SetBindCallback(window_bind_function_t callback) {
-		callbacks.bind = callback;
-	}
-
-	bool HasBoundsCallback() const {
-		return callbacks.bounds != nullptr;
-	}
-	window_bounds_function_t GetBoundsCallback() const {
-		return callbacks.bounds;
-	}
-	void SetBoundsCallback(window_bounds_function_t callback) {
-		callbacks.bounds = callback;
-	}
+public:
 	void GetBounds(WindowBoundsSet &bounds, const BoundWindowExpression &wexpr) const {
 		D_ASSERT(HasBoundsCallback());
 		GetBoundsCallback()(bounds, wexpr);
 	}
 
-	bool HasSharingCallback() const {
-		return callbacks.sharing != nullptr;
-	}
-	window_sharing_function_t GetSharingCallback() const {
-		return callbacks.sharing;
-	}
-	void SetSharingCallback(window_sharing_function_t callback) {
-		callbacks.sharing = callback;
-	}
 	void GetSharing(WindowExecutor &executor, WindowSharedExpressions &sharing) const {
 		D_ASSERT(HasSharingCallback());
 		GetSharingCallback()(executor, sharing);
 	}
 
-	bool HasGlobalCallback() const {
-		return callbacks.global != nullptr;
-	}
-	window_global_function_t GetGlobalCallback() const {
-		return callbacks.global;
-	}
-	void SetGlobalCallback(window_global_function_t callback) {
-		callbacks.global = callback;
-	}
 	unique_ptr<GlobalSinkState> GetGlobalState(ClientContext &client, const WindowExecutor &executor,
 	                                           const idx_t payload_count, const ValidityMask &partition_mask,
 	                                           const ValidityMask &order_mask) const {
@@ -601,87 +384,33 @@ public:
 		return GetGlobalCallback()(client, executor, payload_count, partition_mask, order_mask);
 	}
 
-	bool HasLocalCallback() const {
-		return callbacks.local != nullptr;
-	}
-	window_local_function_t GetLocalCallback() const {
-		return callbacks.local;
-	}
-	void SetLocalCallback(window_local_function_t callback) {
-		callbacks.local = callback;
-	}
 	unique_ptr<LocalSinkState> GetLocalState(ExecutionContext &context, const GlobalSinkState &gstate) const {
 		D_ASSERT(HasLocalCallback());
 		return GetLocalCallback()(context, gstate);
 	}
 
-	bool HasSinkCallback() const {
-		return callbacks.sink != nullptr;
-	}
-	window_sink_function_t GetSinkCallback() const {
-		return callbacks.sink;
-	}
-	void SetSinkCallback(window_sink_function_t callback) {
-		callbacks.sink = callback;
-	}
 	void Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk, idx_t input_idx,
 	          OperatorSinkInput &sink) const {
 		D_ASSERT(HasSinkCallback());
 		return GetSinkCallback()(context, sink_chunk, coll_chunk, input_idx, sink);
 	}
 
-	bool HasFinalizeCallback() const {
-		return callbacks.finalize != nullptr;
-	}
-	window_finalize_function_t GetFinalizeCallback() const {
-		return callbacks.finalize;
-	}
-	void SetFinalizeCallback(window_finalize_function_t callback) {
-		callbacks.finalize = callback;
-	}
 	void Finalize(ExecutionContext &context, optional_ptr<WindowCollection> collection, OperatorSinkInput &sink) const {
 		D_ASSERT(HasFinalizeCallback());
 		return GetFinalizeCallback()(context, collection, sink);
 	}
 
-	bool HasEvaluateCallback() const {
-		return callbacks.evaluate != nullptr;
-	}
-	window_evaluate_function_t GetEvaluateCallback() const {
-		return callbacks.evaluate;
-	}
-	void SetEvaluateCallback(window_evaluate_function_t callback) {
-		callbacks.evaluate = callback;
-	}
 	void Evaluate(ExecutionContext &context, DataChunk &eval_chunk, DataChunk &bounds, Vector &result, idx_t row_idx,
 	              OperatorSinkInput &sink) const {
 		D_ASSERT(HasEvaluateCallback());
 		return GetEvaluateCallback()(context, eval_chunk, bounds, result, row_idx, sink);
 	}
 
-	bool HasCanStreamCallback() const {
-		return callbacks.can_stream != nullptr;
-	}
-	window_canstream_function_t GetCanStreamCallback() const {
-		return callbacks.can_stream;
-	}
-	void SetCanStreamCallback(window_canstream_function_t callback) {
-		callbacks.can_stream = callback;
-	}
 	bool CanStream(ClientContext &client, const BoundWindowExpression &wexpr, idx_t max_delta) const {
 		D_ASSERT(HasCanStreamCallback());
 		return GetCanStreamCallback()(client, wexpr, max_delta);
 	}
 
-	bool HasStreamingStateCallback() const {
-		return callbacks.streaming_state != nullptr;
-	}
-	window_streaming_state_function_t GetStreamingStateCallback() const {
-		return callbacks.streaming_state;
-	}
-	void SetStreamingStateCallback(window_streaming_state_function_t callback) {
-		callbacks.streaming_state = callback;
-	}
 	unique_ptr<LocalSourceState> GetStreamingState(ClientContext &client, DataChunk &input,
 	                                               const BoundWindowExpression &wexpr) const {
 		D_ASSERT(HasStreamingStateCallback());
@@ -690,14 +419,9 @@ public:
 
 	void GetStreamingData(ExecutionContext &context, DataChunk &input, DataChunk &delayed, idx_t delayed_capacity,
 	                      Vector &result, LocalSourceState &lstate) const {
-		D_ASSERT(callbacks.HasStreamingDataCallback());
-		callbacks.GetStreamingDataCallback()(context, input, delayed, delayed_capacity, result, lstate);
+		D_ASSERT(HasStreamingDataCallback());
+		GetStreamingDataCallback()(context, input, delayed, delayed_capacity, result, lstate);
 	}
-
-protected:
-	WindowFunctionProperties properties;
-	WindowFunctionCallbacks callbacks;
-	shared_ptr<WindowFunctionInfo> function_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/rule/like_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/like_optimizations.hpp
@@ -22,7 +22,7 @@ public:
 	                             bool is_root) override;
 
 	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function, string pattern,
-	                                 bool is_not_like);
+	                                 bool is_not_like) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression/bound_function_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_function_expression.hpp
@@ -20,9 +20,8 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_FUNCTION;
 
 public:
-	BoundFunctionExpression(LogicalType return_type, BoundScalarFunction bound_function,
-	                        vector<unique_ptr<Expression>> arguments, unique_ptr<FunctionData> bind_info,
-	                        bool is_operator = false);
+	BoundFunctionExpression(BoundScalarFunction bound_function, vector<unique_ptr<Expression>> arguments,
+	                        unique_ptr<FunctionData> bind_info, bool is_operator = false);
 
 	//! The bound function expression
 	BoundScalarFunction function;

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -184,7 +184,7 @@ void duckdb_aggregate_function_add_parameter(duckdb_aggregate_function function,
 	}
 	auto &aggregate_function = GetCAggregateFunction(function);
 	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
-	aggregate_function.GetArguments().push_back(*logical_type);
+	aggregate_function.GetSignature().AddParameter(*logical_type);
 }
 
 void duckdb_aggregate_function_set_return_type(duckdb_aggregate_function function, duckdb_logical_type type) {
@@ -315,8 +315,8 @@ duckdb_state duckdb_register_aggregate_function_set(duckdb_connection connection
 		    duckdb::TypeVisitor::Contains(aggregate_function.GetReturnType(), duckdb::LogicalTypeId::ANY)) {
 			return DuckDBError;
 		}
-		for (const auto &argument : aggregate_function.GetArguments()) {
-			if (duckdb::TypeVisitor::Contains(argument, duckdb::LogicalTypeId::INVALID)) {
+		for (const auto &argument : aggregate_function.GetSignature().GetParameters()) {
+			if (duckdb::TypeVisitor::Contains(argument.GetType(), duckdb::LogicalTypeId::INVALID)) {
 				return DuckDBError;
 			}
 		}

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -305,7 +305,7 @@ duckdb_state duckdb_register_aggregate_function_set(duckdb_connection connection
 	}
 	auto &set = duckdb::GetCAggregateFunctionSet(function_set);
 	for (idx_t idx = 0; idx < set.Size(); idx++) {
-		auto &aggregate_function = set.GetFunctionReferenceByOffset(idx);
+		const auto &aggregate_function = set.GetFunctionByOffset(idx);
 		auto &info = aggregate_function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 
 		if (aggregate_function.name.empty() || !info.update || !info.combine || !info.finalize) {

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -68,7 +68,7 @@ unique_ptr<FunctionData> CAPIAggregateBind(BindAggregateFunctionInput &input) {
 	return make_uniq<CAggregateFunctionBindData>(info);
 }
 
-idx_t CAPIAggregateStateSize(const AggregateFunction &function) {
+idx_t CAPIAggregateStateSize(const BoundAggregateFunction &function) {
 	auto &function_info = function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 	CAggregateExecuteInfo exec_info(function_info);
 	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);
@@ -79,7 +79,7 @@ idx_t CAPIAggregateStateSize(const AggregateFunction &function) {
 	return result;
 }
 
-void CAPIAggregateStateInit(const AggregateFunction &function, data_ptr_t state) {
+void CAPIAggregateStateInit(const BoundAggregateFunction &function, data_ptr_t state) {
 	auto &function_info = function.GetExtraFunctionInfo().Cast<duckdb::CAggregateFunctionInfo>();
 	CAggregateExecuteInfo exec_info(function_info);
 	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -276,7 +276,7 @@ void duckdb_scalar_function_add_parameter(duckdb_scalar_function function, duckd
 	}
 	auto &scalar_function = GetCScalarFunction(function);
 	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
-	scalar_function.GetArguments().push_back(*logical_type);
+	scalar_function.GetSignature().AddParameter(*logical_type);
 }
 
 void duckdb_scalar_function_set_return_type(duckdb_scalar_function function, duckdb_logical_type type) {
@@ -516,8 +516,8 @@ duckdb_state duckdb_register_scalar_function_set(duckdb_connection connection, d
 		    duckdb::TypeVisitor::Contains(scalar_function.GetReturnType(), duckdb::LogicalTypeId::ANY)) {
 			return DuckDBError;
 		}
-		for (const auto &argument : scalar_function.GetArguments()) {
-			if (duckdb::TypeVisitor::Contains(argument, duckdb::LogicalTypeId::INVALID)) {
+		for (const auto &argument : scalar_function.GetSignature().GetParameters()) {
+			if (duckdb::TypeVisitor::Contains(argument.GetType(), duckdb::LogicalTypeId::INVALID)) {
 				return DuckDBError;
 			}
 		}

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -60,13 +60,13 @@ struct CScalarFunctionBindData : public FunctionData {
 };
 
 struct CScalarFunctionInternalBindInfo {
-	CScalarFunctionInternalBindInfo(ClientContext &context, ScalarFunction &bound_function,
+	CScalarFunctionInternalBindInfo(ClientContext &context, BoundScalarFunction &bound_function,
 	                                vector<unique_ptr<Expression>> &arguments, CScalarFunctionBindData &bind_data)
 	    : context(context), bound_function(bound_function), arguments(arguments), bind_data(bind_data) {
 	}
 
 	ClientContext &context;
-	ScalarFunction &bound_function;
+	BoundScalarFunction &bound_function;
 	vector<unique_ptr<Expression>> &arguments;
 	CScalarFunctionBindData &bind_data;
 

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -506,7 +506,7 @@ duckdb_state duckdb_register_scalar_function_set(duckdb_connection connection, d
 	}
 	auto &scalar_function_set = GetCScalarFunctionSet(set);
 	for (idx_t idx = 0; idx < scalar_function_set.Size(); idx++) {
-		auto &scalar_function = scalar_function_set.GetFunctionReferenceByOffset(idx);
+		const auto &scalar_function = scalar_function_set.GetFunctionByOffset(idx);
 		auto &info = scalar_function.GetExtraFunctionInfo().Cast<duckdb::CScalarFunctionInfo>();
 
 		if (scalar_function.name.empty() || !info.function) {

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -71,7 +71,7 @@ public:
 
 		// Replace AVG(x) with SUM(x)
 		auto &sum_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(optimizer.context, DEFAULT_SCHEMA, "sum");
-		const auto sum_fun =
+		const auto &sum_fun =
 		    sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->GetReturnType()});
 		vector<unique_ptr<Expression>> args;
 		args.push_back(std::move(avg_child));

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -173,7 +173,7 @@ public:
 			return false;
 		}
 		auto &expr = expr_p.Cast<BoundAggregateExpression>();
-		if (!FunctionMatcher::Match(function, expr.function.name)) {
+		if (!FunctionMatcher::Match(function, expr.function.GetName())) {
 			return false;
 		}
 		if (!SetMatcher::Match(matchers, expr.children, bindings, policy)) {

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -398,8 +398,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetIntegralCompress(un
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
 
 	BoundScalarFunction bound_function(compress_function);
-	auto compress_expr =
-	    make_uniq<BoundFunctionExpression>(cast_type, std::move(bound_function), std::move(arguments), nullptr);
+	auto compress_expr = make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 
 	auto compress_stats = BaseStatistics::CreateEmpty(cast_type);
 	compress_stats.CopyBase(stats);
@@ -468,8 +467,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetStringCompress(uniq
 
 	BoundScalarFunction bound_function(compress_function);
 
-	auto compress_expr =
-	    make_uniq<BoundFunctionExpression>(cast_type, std::move(bound_function), std::move(arguments), nullptr);
+	auto compress_expr = make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 	return make_uniq<CompressExpression>(std::move(compress_expr), compress_stats.ToUnique());
 }
 
@@ -498,7 +496,7 @@ unique_ptr<Expression> CompressedMaterialization::GetIntegralDecompress(unique_p
 
 	BoundScalarFunction bound_function(decompress_function);
 
-	return make_uniq<BoundFunctionExpression>(result_type, std::move(bound_function), std::move(arguments), nullptr);
+	return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 }
 
 unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr<Expression> input,
@@ -511,7 +509,7 @@ unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr
 
 	BoundScalarFunction bound_function(decompress_function);
 
-	return make_uniq<BoundFunctionExpression>(result_type, std::move(bound_function), std::move(arguments), nullptr);
+	return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 }
 
 } // namespace duckdb

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/compressed_materialization_utils.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/operators.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
@@ -331,10 +332,11 @@ static Value GetIntegralRangeValue(ClientContext &context, const LogicalType &ty
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(max));
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
-	BoundFunctionExpression sub(type, SubtractFunction::GetFunction(type, type), std::move(arguments), nullptr);
+
+	auto sub = SubtractFunction::GetFunction(type, type).Bind(context, std::move(arguments));
 
 	Value result;
-	if (ExpressionExecutor::TryEvaluateScalar(context, sub, result)) {
+	if (ExpressionExecutor::TryEvaluateScalar(context, *sub, result)) {
 		return result;
 	} else {
 		// Couldn't evaluate: Return max uhugeint as range so GetIntegralCompress will return nullptr
@@ -394,8 +396,10 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetIntegralCompress(un
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
+
+	BoundScalarFunction bound_function(compress_function);
 	auto compress_expr =
-	    make_uniq<BoundFunctionExpression>(cast_type, compress_function, std::move(arguments), nullptr);
+	    make_uniq<BoundFunctionExpression>(cast_type, std::move(bound_function), std::move(arguments), nullptr);
 
 	auto compress_stats = BaseStatistics::CreateEmpty(cast_type);
 	compress_stats.CopyBase(stats);
@@ -461,8 +465,11 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetStringCompress(uniq
 	auto compress_function = CMStringCompressFun::GetFunction(cast_type);
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
+
+	BoundScalarFunction bound_function(compress_function);
+
 	auto compress_expr =
-	    make_uniq<BoundFunctionExpression>(cast_type, compress_function, std::move(arguments), nullptr);
+	    make_uniq<BoundFunctionExpression>(cast_type, std::move(bound_function), std::move(arguments), nullptr);
 	return make_uniq<CompressExpression>(std::move(compress_expr), compress_stats.ToUnique());
 }
 
@@ -485,11 +492,13 @@ unique_ptr<Expression> CompressedMaterialization::GetIntegralDecompress(unique_p
 	D_ASSERT(!stats.CanHaveNoNull() || NumericStats::HasMinMax(stats));
 	auto decompress_function = CMIntegralDecompressFun::GetFunction(input->GetReturnType(), result_type);
 	const auto min = !stats.CanHaveNoNull() ? Value(result_type) : NumericStats::Min(stats);
-
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
-	return make_uniq<BoundFunctionExpression>(result_type, decompress_function, std::move(arguments), nullptr);
+
+	BoundScalarFunction bound_function(decompress_function);
+
+	return make_uniq<BoundFunctionExpression>(result_type, std::move(bound_function), std::move(arguments), nullptr);
 }
 
 unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr<Expression> input,
@@ -499,7 +508,10 @@ unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr
 	auto decompress_function = CMStringDecompressFun::GetFunction(input->GetReturnType());
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
-	return make_uniq<BoundFunctionExpression>(result_type, decompress_function, std::move(arguments), nullptr);
+
+	BoundScalarFunction bound_function(decompress_function);
+
+	return make_uniq<BoundFunctionExpression>(result_type, std::move(bound_function), std::move(arguments), nullptr);
 }
 
 } // namespace duckdb

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -398,6 +398,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetIntegralCompress(un
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
 
 	BoundScalarFunction bound_function(compress_function);
+	bound_function.SetReturnType(cast_type);
 	auto compress_expr = make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 
 	auto compress_stats = BaseStatistics::CreateEmpty(cast_type);
@@ -466,6 +467,7 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetStringCompress(uniq
 	arguments.emplace_back(std::move(input));
 
 	BoundScalarFunction bound_function(compress_function);
+	bound_function.SetReturnType(cast_type);
 
 	auto compress_expr = make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 	return make_uniq<CompressExpression>(std::move(compress_expr), compress_stats.ToUnique());
@@ -495,6 +497,7 @@ unique_ptr<Expression> CompressedMaterialization::GetIntegralDecompress(unique_p
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(min));
 
 	BoundScalarFunction bound_function(decompress_function);
+	bound_function.SetReturnType(result_type);
 
 	return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 }
@@ -508,6 +511,7 @@ unique_ptr<Expression> CompressedMaterialization::GetStringDecompress(unique_ptr
 	arguments.emplace_back(std::move(input));
 
 	BoundScalarFunction bound_function(decompress_function);
+	bound_function.SetReturnType(result_type);
 
 	return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
 }

--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -244,7 +244,7 @@ void PreventInlining::VisitExpression(unique_ptr<Expression> *expression) {
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
 		auto &bound_function = expr->Cast<BoundFunctionExpression>();
 		// if we encounter the ErrorFun function, we still want to inline
-		if (bound_function.function == ErrorFun::GetFunction()) {
+		if (bound_function.function.name == "error") {
 			return;
 		}
 

--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -244,7 +244,7 @@ void PreventInlining::VisitExpression(unique_ptr<Expression> *expression) {
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
 		auto &bound_function = expr->Cast<BoundFunctionExpression>();
 		// if we encounter the ErrorFun function, we still want to inline
-		if (bound_function.function.name == "error") {
+		if (bound_function.function.GetName() == "error") {
 			return;
 		}
 

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -127,7 +127,7 @@ idx_t ExpressionHeuristics::ExpressionCost(BoundFunctionExpression &expr) {
 		cost_children += Cost(*child);
 	}
 
-	auto cost_function = function_costs.find(expr.function.name);
+	auto cost_function = function_costs.find(expr.function.GetName());
 	if (cost_function != function_costs.end()) {
 		return cost_children + cost_function->second;
 	} else {

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -57,7 +57,11 @@ unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expr
 	func.GetArguments()[0] = type;
 	func.SetReturnType(type);
 	children.insert(children.begin(), make_uniq<BoundConstantExpression>(value));
-	return make_uniq<BoundFunctionExpression>(type, func, std::move(children), ConstantOrNull::Bind(std::move(value)));
+
+	BoundScalarFunction bound_func(func);
+
+	return make_uniq<BoundFunctionExpression>(type, std::move(bound_func), std::move(children),
+	                                          ConstantOrNull::Bind(std::move(value)));
 }
 
 void ExpressionRewriter::VisitOperator(LogicalOperator &op) {

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -54,7 +54,7 @@ unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression>
 unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expression>> children, Value value) {
 	auto type = value.type();
 	auto func = ConstantOrNullFun::GetFunction();
-	func.GetArguments()[0] = type;
+	func.GetSignature().GetParameter(0).SetType(type);
 	func.SetReturnType(type);
 	children.insert(children.begin(), make_uniq<BoundConstantExpression>(value));
 

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -60,7 +60,7 @@ unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expr
 
 	BoundScalarFunction bound_func(func);
 
-	return make_uniq<BoundFunctionExpression>(type, std::move(bound_func), std::move(children),
+	return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(children),
 	                                          ConstantOrNull::Bind(std::move(value)));
 }
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -201,7 +201,7 @@ static bool TryGetProjectionIndex(const Expression &expr, ProjectionIndex &resul
 	}
 	case ExpressionType::BOUND_FUNCTION: {
 		auto &func = expr.Cast<BoundFunctionExpression>();
-		if (func.function.name == "struct_extract" || func.function.name == "struct_extract_at") {
+		if (func.function.GetName() == "struct_extract" || func.function.GetName() == "struct_extract_at") {
 			auto &child_expr = func.children[0];
 			return TryGetProjectionIndex(*child_expr, result);
 		}
@@ -404,7 +404,7 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &func = expr.Cast<BoundFunctionExpression>();
-	if (func.function.name != "prefix") {
+	if (func.function.GetName() != "prefix") {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	if (func.children[0]->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
@@ -440,7 +440,7 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &func = expr.Cast<BoundFunctionExpression>();
-	if (func.function.name != "~~") {
+	if (func.function.GetName() != "~~") {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	if (func.children[0]->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||

--- a/src/optimizer/matcher/expression_matcher.cpp
+++ b/src/optimizer/matcher/expression_matcher.cpp
@@ -83,7 +83,7 @@ bool FunctionExpressionMatcher::Match(Expression &expr_p, vector<reference<Expre
 		return false;
 	}
 	auto &expr = expr_p.Cast<BoundFunctionExpression>();
-	if (!FunctionMatcher::Match(function, expr.function.name)) {
+	if (!FunctionMatcher::Match(function, expr.function.GetName())) {
 		return false;
 	}
 	if (!SetMatcher::Match(matchers, expr.children, bindings, policy)) {
@@ -97,7 +97,7 @@ bool AggregateExpressionMatcher::Match(Expression &expr_p, vector<reference<Expr
 		return false;
 	}
 	auto &expr = expr_p.Cast<BoundAggregateExpression>();
-	if (!FunctionMatcher::Match(function, expr.function.name)) {
+	if (!FunctionMatcher::Match(function, expr.function.GetName())) {
 		return false;
 	}
 	// we should create matchers for these in the future

--- a/src/optimizer/regex_range_filter.cpp
+++ b/src/optimizer/regex_range_filter.cpp
@@ -29,7 +29,7 @@ unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator
 	for (auto &expr : op->expressions) {
 		if (expr->GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
 			auto &func = expr->Cast<BoundFunctionExpression>();
-			if (func.function.name != "regexp_full_match" || func.children.size() != 2) {
+			if (func.function.GetName() != "regexp_full_match" || func.children.size() != 2) {
 				continue;
 			}
 			auto &info = func.bind_info->Cast<RegexpMatchesBindData>();

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1020,8 +1020,8 @@ bool BaseColumnPruner::HandleExtractRecursive(unique_ptr<Expression> &expr_p,
 		return false;
 	}
 	auto &function = expr.Cast<BoundFunctionExpression>();
-	if (function.function.name != "struct_extract_at" && function.function.name != "struct_extract" &&
-	    function.function.name != "array_extract" && function.function.name != "variant_extract") {
+	if (function.function.GetName() != "struct_extract_at" && function.function.GetName() != "struct_extract" &&
+	    function.function.GetName() != "array_extract" && function.function.GetName() != "variant_extract") {
 		return false;
 	}
 	if (!function.bind_info) {

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -34,7 +34,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 	if (constant.value.IsNull()) {
 		return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 	}
-	auto &func_name = root.function.name;
+	auto &func_name = root.function.GetName();
 	if (func_name == "+") {
 		if (constant.value == 0) {
 			// addition with 0

--- a/src/optimizer/rule/constant_order_normalization.cpp
+++ b/src/optimizer/rule/constant_order_normalization.cpp
@@ -108,8 +108,8 @@ unique_ptr<Expression> ConstantOrderNormalizationRule::Apply(LogicalOperator &op
 	for (idx_t i = 1; i < ordered_bindings.size(); ++i) {
 		// Right child.
 		children.push_back(ordered_bindings[i].get().Copy());
-		new_root =
-		    binder.BindScalarFunction(DEFAULT_SCHEMA, root.function.name, std::move(children), error, root.is_operator);
+		new_root = binder.BindScalarFunction(DEFAULT_SCHEMA, root.function.GetName(), std::move(children), error,
+		                                     root.is_operator);
 		if (!new_root) {
 			error.Throw();
 		}

--- a/src/optimizer/rule/distinct_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/distinct_aggregate_optimizer.cpp
@@ -17,7 +17,7 @@ unique_ptr<Expression> DistinctAggregateOptimizer::Apply(ClientContext &context,
 		// no DISTINCT defined
 		return nullptr;
 	}
-	if (aggr.function.GetProperties().GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
+	if (aggr.function.GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
 		// not a distinct-sensitive aggregate but we have an DISTINCT modifier - remove it
 		aggr.aggr_type = AggregateType::NON_DISTINCT;
 		changes_made = true;
@@ -47,7 +47,7 @@ unique_ptr<Expression> DistinctWindowedOptimizer::Apply(ClientContext &context, 
 		// not an aggregate
 		return nullptr;
 	}
-	if (wexpr.aggregate->GetProperties().GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
+	if (wexpr.aggregate->GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
 		// not a distinct-sensitive aggregate but we have an DISTINCT modifier - remove it
 		wexpr.distinct = false;
 		changes_made = true;

--- a/src/optimizer/rule/distinct_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/distinct_aggregate_optimizer.cpp
@@ -17,7 +17,7 @@ unique_ptr<Expression> DistinctAggregateOptimizer::Apply(ClientContext &context,
 		// no DISTINCT defined
 		return nullptr;
 	}
-	if (aggr.function.GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
+	if (aggr.function.GetProperties().GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
 		// not a distinct-sensitive aggregate but we have an DISTINCT modifier - remove it
 		aggr.aggr_type = AggregateType::NON_DISTINCT;
 		changes_made = true;
@@ -47,7 +47,7 @@ unique_ptr<Expression> DistinctWindowedOptimizer::Apply(ClientContext &context, 
 		// not an aggregate
 		return nullptr;
 	}
-	if (wexpr.aggregate->GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
+	if (wexpr.aggregate->GetProperties().GetDistinctDependent() == AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT) {
 		// not a distinct-sensitive aggregate but we have an DISTINCT modifier - remove it
 		wexpr.distinct = false;
 		changes_made = true;

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -140,25 +140,22 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 }
 
 unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
-                                                       string pattern, bool is_not_like) {
+                                                       string pattern, bool is_not_like) const {
 	// replace LIKE by an optimized function
-	unique_ptr<Expression> result;
-	auto new_function =
-	    make_uniq<BoundFunctionExpression>(expr.GetReturnType(), function, std::move(expr.children), nullptr);
+	auto result = function.Bind(GetContext(), std::move(expr.children));
 
 	// removing "%" from the pattern
 	pattern.erase(std::remove(pattern.begin(), pattern.end(), '%'), pattern.end());
 
-	new_function->children[1] = make_uniq<BoundConstantExpression>(Value(std::move(pattern)));
+	result->children[1] = make_uniq<BoundConstantExpression>(Value(std::move(pattern)));
 
-	result = std::move(new_function);
-	if (is_not_like) {
-		auto negation = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
-		negation->children.push_back(std::move(result));
-		result = std::move(negation);
+	if (!is_not_like) {
+		return std::move(result);
 	}
 
-	return result;
+	auto negation = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
+	negation->children.push_back(std::move(result));
+	return std::move(negation);
 }
 
 } // namespace duckdb

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -120,7 +120,7 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 	D_ASSERT(constant_value.type() == constant_expr.GetReturnType());
 	auto &patt_str = StringValue::Get(constant_value);
 
-	bool is_not_like = root.function.name == "!~~";
+	bool is_not_like = root.function.GetName() == "!~~";
 	if (PatternIsConstant(patt_str)) {
 		// Pattern is constant
 		return make_uniq<BoundComparisonExpression>(is_not_like ? ExpressionType::COMPARE_NOTEQUAL

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -18,14 +18,14 @@ namespace duckdb {
 namespace {
 
 bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
-	if (expr.function.name == target_name) {
+	if (expr.function.GetName() == target_name) {
 		D_ASSERT(!expr.children.empty() && expr.children[0]->GetReturnType().id() == LogicalTypeId::LIST);
 		return true;
 	}
 
 	// Compare function name with catalog to recognize aliases
 	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, expr.function.name,
+	auto entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, expr.function.GetName(),
 	                                                          OnEntryNotFound::RETURN_NULL);
 	if (!entry) {
 		return false;
@@ -37,7 +37,7 @@ bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression 
 }
 
 bool IsStructPack(const BoundFunctionExpression &expr) {
-	return expr.function.name == "struct_pack";
+	return expr.function.GetName() == "struct_pack";
 }
 
 optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
@@ -98,7 +98,7 @@ bool MatchesStructFieldProjection(Expression &expr, const string &field_name) {
 		return false;
 	}
 	auto &extract_expr = base->Cast<BoundFunctionExpression>();
-	if (extract_expr.function.name != "struct_extract" || extract_expr.children.size() != 2) {
+	if (extract_expr.function.GetName() != "struct_extract" || extract_expr.children.size() != 2) {
 		return false;
 	}
 

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -232,9 +232,12 @@ unique_ptr<Expression> BuildListComprehensionRewrite(ListComprehensionMatch &mat
 
 	auto filter_return_type = filter_children[0]->GetReturnType();
 	auto filter_bind_info = make_uniq<ListLambdaBindData>(filter_return_type, filter_expr.Copy(), inner_bind.has_index);
-	auto new_filter =
-	    make_uniq<BoundFunctionExpression>(filter_return_type, list_filter_expr.function, std::move(filter_children),
-	                                       std::move(filter_bind_info), list_filter_expr.is_operator);
+
+	auto new_func = list_filter_expr.function;
+	new_func.SetReturnType(filter_return_type);
+
+	auto new_filter = make_uniq<BoundFunctionExpression>(std::move(new_func), std::move(filter_children),
+	                                                     std::move(filter_bind_info), list_filter_expr.is_operator);
 
 	// Build list_apply(list_filter(...), lambda result_expr)
 	vector<unique_ptr<Expression>> apply_children;
@@ -251,8 +254,8 @@ unique_ptr<Expression> BuildListComprehensionRewrite(ListComprehensionMatch &mat
 		RemoveIndexInputSlot(apply_lambda);
 	}
 	auto apply_bind_info = make_uniq<ListLambdaBindData>(apply_return_type, std::move(apply_lambda));
-	return make_uniq<BoundFunctionExpression>(apply_return_type, root.function, std::move(apply_children),
-	                                          std::move(apply_bind_info), root.is_operator);
+	return make_uniq<BoundFunctionExpression>(root.function, std::move(apply_children), std::move(apply_bind_info),
+	                                          root.is_operator);
 }
 
 } // namespace

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -52,7 +52,7 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 	hugeint_t inner_value = IntegralValue::Get(inner_constant.value);
 
 	idx_t arithmetic_child_index = arithmetic.children[0].get() == &inner_constant ? 1 : 0;
-	auto &op_type = arithmetic.function.name;
+	auto &op_type = arithmetic.function.GetName();
 	if (op_type == "+") {
 		// [x + 1 COMP 10] OR [1 + x COMP 10]
 		// order does not matter in addition:

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -24,7 +24,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 		// no ORDER BYs defined
 		return nullptr;
 	}
-	if (aggr.function.GetProperties().GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
+	if (aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
 		// not an order dependent aggregate but we have an ORDER BY clause - remove it
 		aggr.order_bys.reset();
 		changes_made = true;

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -39,7 +39,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 	}
 
 	//	Rewrite first/last/arbitrary/any_value to use arg_xxx[_null] and create_sort_key
-	const auto &aggr_name = aggr.function.name;
+	const auto &aggr_name = aggr.function.GetName();
 	string arg_xxx_name;
 	if (aggr_name == "last") {
 		arg_xxx_name = "arg_max_null";
@@ -84,7 +84,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 		error.Throw();
 	}
 	// found a matching function!
-	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 	return binder.BindAggregateFunction(bound_function, std::move(children), std::move(aggr.filter),
 	                                    aggr.IsDistinct() ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT);
 }

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -24,7 +24,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 		// no ORDER BYs defined
 		return nullptr;
 	}
-	if (aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
+	if (aggr.function.GetProperties().GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
 		// not an order dependent aggregate but we have an ORDER BY clause - remove it
 		aggr.order_bys.reset();
 		changes_made = true;

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -194,8 +194,8 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		}
 
 		auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(escaped_like_string.like_string)));
-		auto contains = make_uniq<BoundFunctionExpression>(root.GetReturnType(), GetStringContains(),
-		                                                   std::move(root.children), nullptr);
+		auto contains = GetStringContains().Bind(GetContext(), std::move(root.children));
+
 		contains->children[1] = std::move(parameter);
 
 		return std::move(contains);
@@ -215,8 +215,11 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		D_ASSERT(root.children.size() == 2);
 	}
 
-	auto like_expression = make_uniq<BoundFunctionExpression>(root.GetReturnType(), LikeFun::GetFunction(),
-	                                                          std::move(root.children), nullptr);
+	auto like_expression = LikeFun::GetFunction().Bind(GetContext(), std::move(root.children));
+
+	// Clear the bind info, as the LikeFun bind info is not valid for this new expression.
+	like_expression->bind_info.reset();
+
 	auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(like_string.like_string)));
 	like_expression->children[1] = std::move(parameter);
 	return std::move(like_expression);

--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -15,11 +15,11 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggreg
 			stats.push_back(stat->Copy());
 		}
 	}
-	if (!aggr.function.HasStatisticsCallback()) {
+	if (!aggr.function.GetCallbacks().HasStatisticsCallback()) {
 		return nullptr;
 	}
 	AggregateStatisticsInput input(aggr.bind_info.get(), stats, node_stats.get());
-	return aggr.function.GetStatisticsCallback()(context, aggr, input);
+	return aggr.function.GetCallbacks().GetStatisticsCallback()(context, aggr, input);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -16,8 +16,7 @@ static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionEx
 		children.push_back(make_uniq<BoundConstantExpression>(v));
 	}
 	auto bind_info_clone = func.bind_info ? func.bind_info->Copy() : nullptr;
-	BoundFunctionExpression clone(func.GetReturnType(), func.function, std::move(children), std::move(bind_info_clone),
-	                              func.is_operator);
+	BoundFunctionExpression clone(func.function, std::move(children), std::move(bind_info_clone), func.is_operator);
 	return ExpressionExecutor::TryEvaluateScalar(context, clone, result);
 }
 

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -111,7 +111,7 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	}
 	if (out_hi < out_lo) {
 		throw InternalException("Monotonic arg annotation violated for '%s': output min exceeds output max",
-		                        func.function.name);
+		                        func.function.GetName());
 	}
 
 	auto result = NumericStats::CreateEmpty(func.GetReturnType());

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -122,7 +122,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			// aggregate has a filter - bail
 			return;
 		}
-		const string &fun_name = aggr_expr.function.name;
+		const string &fun_name = aggr_expr.function.GetName();
 		if (fun_name == "min" || fun_name == "max") {
 			if (aggr_expr.children.size() != 1 ||
 			    aggr_expr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -292,7 +292,7 @@ TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> 
 	fun_name += params.can_be_null && (requires_arg || change_to_arg) ? "_nulls_last" : "";
 
 	auto &fun_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(context, DEFAULT_SCHEMA, fun_name);
-	const auto fun = fun_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(aggregate_params));
+	const auto &fun = fun_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(aggregate_params));
 	return function_binder.BindAggregateFunction(fun, std::move(aggregate_params));
 }
 
@@ -313,7 +313,7 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 		auto &catalog = Catalog::GetSystemCatalog(context);
 		FunctionBinder function_binder(context);
 		auto &struct_pack_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "struct_pack");
-		const auto struct_pack_fun =
+		const auto &struct_pack_fun =
 		    struct_pack_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(args));
 		auto struct_pack_expr = function_binder.BindScalarFunction(struct_pack_fun, std::move(args));
 		aggregate_params.push_back(std::move(struct_pack_expr));
@@ -365,7 +365,7 @@ TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate
 	array_length_exprs.push_back(std::move(aggregate_column_ref));
 	array_length_exprs.push_back(make_uniq<BoundConstantExpression>(1));
 
-	const auto array_length_fun = array_length_entry.functions.GetFunctionByArguments(
+	const auto &array_length_fun = array_length_entry.functions.GetFunctionByArguments(
 	    context, {array_length_exprs[0]->GetReturnType(), array_length_exprs[1]->GetReturnType()});
 	auto bound_array_length_fun = function_binder.BindScalarFunction(array_length_fun, std::move(array_length_exprs));
 
@@ -377,7 +377,7 @@ TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate
 	generate_series_exprs.push_back(make_uniq<BoundConstantExpression>(1));
 	generate_series_exprs.push_back(std::move(bound_array_length_fun));
 
-	const auto generate_series_fun = generate_series_entry.functions.GetFunctionByArguments(
+	const auto &generate_series_fun = generate_series_entry.functions.GetFunctionByArguments(
 	    context, {generate_series_exprs[0]->GetReturnType(), generate_series_exprs[1]->GetReturnType()});
 	auto bound_generate_series_fun =
 	    function_binder.BindScalarFunction(generate_series_fun, std::move(generate_series_exprs));
@@ -435,7 +435,7 @@ void TopNWindowElimination::AddStructExtractExprs(
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &struct_extract_entry =
 	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "struct_extract");
-	const auto struct_extract_fun =
+	const auto &struct_extract_fun =
 	    struct_extract_entry.functions.GetFunctionByArguments(context, {struct_type, LogicalType::VARCHAR});
 
 	const auto &child_types = StructType::GetChildTypes(struct_type);

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -262,10 +262,10 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		error.Throw();
 	}
 	// found a matching function!
-	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+	const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	if (!bound_function.CanAggregate() && bound_function.CanWindow()) {
-		auto msg = StringUtil::Format("Function '%s' can only be used as a window function", bound_function.name);
+		auto msg = StringUtil::Format("Function '%s' can only be used as a window function", bound_function.GetName());
 		error = BinderException(msg);
 		error.AddQueryLocation(aggr);
 		error.Throw();

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -60,7 +60,7 @@ static void ExtractSubqueryChildren(unique_ptr<Expression> &child, vector<unique
 		return;
 	}
 	auto &function = child->Cast<BoundFunctionExpression>();
-	if (function.function.name != "row") {
+	if (function.function.GetName() != "row") {
 		// not "ROW"
 		return;
 	}

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -220,7 +220,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		}
 
 		// found a matching function! bind it as an aggregate
-		auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+		const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 		auto window_bound_aggregate = function_binder.BindAggregateFunction(bound_function, std::move(children));
 		// create the aggregate
@@ -241,7 +241,7 @@ BindResult BaseSelectBinder::BindWindowExpression(WindowExpression &window, idx_
 		}
 
 		// found a matching function! bind it as a window
-		auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
+		const auto &bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 		if (window.distinct && !bound_function.CanDistinct()) {
 			throw BinderException(error_context, "DISTINCT is not implemented for the window function \"%s\"",

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -176,7 +176,7 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 				throw BinderException("No matching aggregate function\n%s", error.Message());
 			}
 			// Found a matching function, bind it as an aggregate
-			auto best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
+			const auto &best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 			auto aggregate = function_binder.BindAggregateFunction(best_function, std::move(bound_children), nullptr,
 			                                                       AggregateType::NON_DISTINCT);
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -43,7 +43,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 	bool has_standard_table_function = false;
 	bool has_table_parameter = false;
 	for (idx_t function_idx = 0; function_idx < table_function.functions.Size(); function_idx++) {
-		const auto &function = table_function.functions.GetFunctionReferenceByOffset(function_idx);
+		const auto &function = table_function.functions.GetFunctionByOffset(function_idx);
 		for (auto &arg : function.GetArguments()) {
 			if (arg.id() == LogicalTypeId::TABLE) {
 				has_table_parameter = true;
@@ -119,11 +119,11 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 		if (bind_type == TableFunctionBindType::TABLE_PARAMETER_FUNCTION &&
 		    child->GetExpressionType() == ExpressionType::SUBQUERY) {
 			D_ASSERT(table_function.functions.Size() == 1);
-			auto fun = table_function.functions.GetFunctionByOffset(0);
+			const auto &fun = table_function.functions.GetFunctionByOffset(0);
 			if (table_function.functions.Size() != 1 || fun.GetArguments().empty()) {
 				throw BinderException(
 				    "Only table-in-out functions can have subquery parameters - %s only accepts constant parameters",
-				    fun.name);
+				    fun.GetName());
 			}
 			if (seen_subquery) {
 				error = ErrorData("Table function can have at most one subquery parameter");

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -79,7 +79,7 @@ bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source,
 	if (function_entry.functions.Size() != 1) {
 		throw InternalException("timetz_byte_comparable should only have a single overload");
 	}
-	auto &scalar_function = function_entry.functions.GetFunctionReferenceByOffset(0);
+	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));
 
@@ -100,7 +100,7 @@ bool PushIntervalCollation(ClientContext &context, unique_ptr<Expression> &sourc
 	if (function_entry.functions.Size() != 1) {
 		throw InternalException("normalized_interval should only have a single overload");
 	}
-	auto &scalar_function = function_entry.functions.GetFunctionReferenceByOffset(0);
+	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));
 
@@ -121,7 +121,7 @@ bool PushVariantCollation(ClientContext &context, unique_ptr<Expression> &source
 		throw InternalException("variant_normalize should only have a single overload");
 	}
 	auto source_alias = source->GetAlias();
-	auto &scalar_function = function_entry.functions.GetFunctionReferenceByOffset(0);
+	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));
 

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -15,12 +15,12 @@ BoundAggregateExpression::BoundAggregateExpression(BoundAggregateFunction functi
     : Expression(ExpressionType::BOUND_AGGREGATE, ExpressionClass::BOUND_AGGREGATE, function.GetReturnType()),
       function(std::move(function)), children(std::move(children)), bind_info(std::move(bind_info)),
       aggr_type(aggr_type), filter(std::move(filter)) {
-	D_ASSERT(!this->function.name.empty());
+	D_ASSERT(!this->function.GetName().empty());
 }
 
 string BoundAggregateExpression::ToString() const {
 	return FunctionExpression::ToString<BoundAggregateExpression, Expression, BoundOrderModifier>(
-	    *this, string(), string(), function.name, false, IsDistinct(), filter.get(), order_bys.get());
+	    *this, string(), string(), function.GetName(), false, IsDistinct(), filter.get(), order_bys.get());
 }
 
 hash_t BoundAggregateExpression::Hash() const {

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -62,8 +62,9 @@ bool BoundAggregateExpression::Equals(const BaseExpression &other_p) const {
 }
 
 bool BoundAggregateExpression::PropagatesNullValues() const {
-	return function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING ? false
-	                                                                            : Expression::PropagatesNullValues();
+	return function.GetProperties().GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING
+	           ? false
+	           : Expression::PropagatesNullValues();
 }
 
 unique_ptr<Expression> BoundAggregateExpression::Copy() const {

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -15,7 +15,7 @@ BoundFunctionExpression::BoundFunctionExpression(LogicalType return_type, BoundS
     : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, std::move(return_type)),
       function(std::move(bound_function)), children(std::move(arguments)), bind_info(std::move(bind_info)),
       is_operator(is_operator) {
-	D_ASSERT(!function.name.empty());
+	D_ASSERT(!function.GetName().empty());
 }
 
 bool BoundFunctionExpression::IsVolatile() const {
@@ -50,8 +50,8 @@ bool BoundFunctionExpression::CanThrow() const {
 }
 
 string BoundFunctionExpression::ToString() const {
-	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), string(), function.name,
-	                                                                         is_operator);
+	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), string(),
+	                                                                         function.GetName(), is_operator);
 }
 bool BoundFunctionExpression::PropagatesNullValues() const {
 	return function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING ? false
@@ -95,7 +95,7 @@ unique_ptr<Expression> BoundFunctionExpression::Copy() const {
 }
 
 void BoundFunctionExpression::Verify() const {
-	D_ASSERT(!function.name.empty());
+	D_ASSERT(!function.GetName().empty());
 }
 
 void BoundFunctionExpression::Serialize(Serializer &serializer) const {

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -9,10 +9,10 @@
 
 namespace duckdb {
 
-BoundFunctionExpression::BoundFunctionExpression(LogicalType return_type, BoundScalarFunction bound_function,
+BoundFunctionExpression::BoundFunctionExpression(BoundScalarFunction bound_function,
                                                  vector<unique_ptr<Expression>> arguments,
                                                  unique_ptr<FunctionData> bind_info, bool is_operator)
-    : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, std::move(return_type)),
+    : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, bound_function.GetReturnType()),
       function(std::move(bound_function)), children(std::move(arguments)), bind_info(std::move(bind_info)),
       is_operator(is_operator) {
 	D_ASSERT(!function.GetName().empty());
@@ -88,8 +88,8 @@ unique_ptr<Expression> BoundFunctionExpression::Copy() const {
 	}
 	unique_ptr<FunctionData> new_bind_info = bind_info ? bind_info->Copy() : nullptr;
 
-	auto copy = make_uniq<BoundFunctionExpression>(return_type, function, std::move(new_children),
-	                                               std::move(new_bind_info), is_operator);
+	auto copy =
+	    make_uniq<BoundFunctionExpression>(function, std::move(new_children), std::move(new_bind_info), is_operator);
 	copy->CopyProperties(*this);
 	return std::move(copy);
 }
@@ -112,7 +112,6 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(Deserializer &deseri
 
 	auto entry = FunctionSerializer::Deserialize<BoundScalarFunction, ScalarFunctionCatalogEntry>(
 	    deserializer, CatalogType::SCALAR_FUNCTION_ENTRY, children, return_type);
-	auto function_return_type = entry.first.GetReturnType();
 
 	auto is_operator = deserializer.ReadProperty<bool>(202, "is_operator");
 
@@ -127,8 +126,8 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(Deserializer &deseri
 		}
 		// Otherwise, fall through and continue on normally
 	}
-	auto result = make_uniq<BoundFunctionExpression>(std::move(function_return_type), std::move(entry.first),
-	                                                 std::move(children), std::move(entry.second));
+	auto result =
+	    make_uniq<BoundFunctionExpression>(std::move(entry.first), std::move(children), std::move(entry.second));
 	result->is_operator = is_operator;
 	if (result->return_type != return_type) {
 		// return type mismatch - push a cast

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -18,7 +18,7 @@ BoundWindowExpression::BoundWindowExpression(LogicalType return_type, unique_ptr
 }
 
 string BoundWindowExpression::ToString() const {
-	string function_name = aggregate.get() ? aggregate->name : window->name;
+	string function_name = aggregate.get() ? aggregate->GetName() : window->GetName();
 	return WindowExpression::ToString<BoundWindowExpression, Expression, BoundOrderByNode>(*this, string(),
 	                                                                                       function_name);
 }
@@ -202,7 +202,7 @@ vector<unique_ptr<Expression>> BoundWindowExpression::SerializedChildren(Seriali
 	vector<unique_ptr<Expression>> result;
 	idx_t nargs = children.size();
 	if (!serializer.ShouldSerialize(8) && window) {
-		const auto &function_name = window->name;
+		const auto &function_name = window->GetName();
 		if (function_name == "lead" || function_name == "lag") {
 			nargs = 1;
 		}
@@ -217,7 +217,7 @@ vector<unique_ptr<Expression>> BoundWindowExpression::SerializedChildren(Seriali
 
 unique_ptr<Expression> BoundWindowExpression::SerializedOffset(Serializer &serializer) const {
 	if (!serializer.ShouldSerialize(8) && children.size() > 1 && window) {
-		const auto &function_name = window->name;
+		const auto &function_name = window->GetName();
 		if (function_name == "lead" || function_name == "lag") {
 			return children[1]->Copy();
 		}
@@ -228,7 +228,7 @@ unique_ptr<Expression> BoundWindowExpression::SerializedOffset(Serializer &seria
 
 unique_ptr<Expression> BoundWindowExpression::SerializedDefault(Serializer &serializer) const {
 	if (!serializer.ShouldSerialize(8) && children.size() > 2 && window) {
-		const auto &function_name = window->name;
+		const auto &function_name = window->GetName();
 		if (function_name == "lead" || function_name == "lag") {
 			return children[2]->Copy();
 		}
@@ -331,7 +331,7 @@ unique_ptr<Expression> BoundWindowExpression::Deserialize(Deserializer &deserial
 			error_win.Throw();
 		}
 
-		auto win_func = func.functions.GetFunctionByOffset(best.GetIndex());
+		const auto &win_func = func.functions.GetFunctionByOffset(best.GetIndex());
 
 		auto [bound_func, bind_info] = function_binder.ResolveFunction(win_func, result->children);
 

--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -333,10 +333,11 @@ unique_ptr<Expression> BoundWindowExpression::Deserialize(Deserializer &deserial
 
 		auto win_func = func.functions.GetFunctionByOffset(best.GetIndex());
 
-		BoundWindowFunction bound_win_func(win_func);
-		result->bind_info = function_binder.ResolveFunction(bound_win_func, result->children);
+		auto [bound_func, bind_info] = function_binder.ResolveFunction(win_func, result->children);
+
+		result->bind_info = std::move(bind_info);
 		result->type = expression_type;
-		result->window = make_uniq<BoundWindowFunction>(std::move(bound_win_func));
+		result->window = make_uniq<BoundWindowFunction>(std::move(bound_func));
 	}
 
 	return std::move(result);

--- a/src/planner/filter/struct_filter.cpp
+++ b/src/planner/filter/struct_filter.cpp
@@ -37,7 +37,10 @@ unique_ptr<Expression> StructFilter::ToExpression(const Expression &column) cons
 	vector<unique_ptr<Expression>> arguments;
 	arguments.push_back(column.Copy());
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(child_idx + 1))));
-	auto child = make_uniq<BoundFunctionExpression>(child_type, GetExtractAtFunction(), std::move(arguments),
+
+	BoundScalarFunction bound_func(GetExtractAtFunction());
+
+	auto child = make_uniq<BoundFunctionExpression>(child_type, std::move(bound_func), std::move(arguments),
 	                                                StructExtractAtFun::GetBindData(child_idx));
 	return child_filter->ToExpression(*child);
 }

--- a/src/planner/filter/struct_filter.cpp
+++ b/src/planner/filter/struct_filter.cpp
@@ -33,14 +33,14 @@ unique_ptr<TableFilter> StructFilter::Copy() const {
 }
 
 unique_ptr<Expression> StructFilter::ToExpression(const Expression &column) const {
-	auto &child_type = StructType::GetChildType(column.GetReturnType(), child_idx);
 	vector<unique_ptr<Expression>> arguments;
 	arguments.push_back(column.Copy());
 	arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(child_idx + 1))));
 
 	BoundScalarFunction bound_func(GetExtractAtFunction());
+	bound_func.SetReturnType(StructType::GetChildType(column.GetReturnType(), child_idx));
 
-	auto child = make_uniq<BoundFunctionExpression>(child_type, std::move(bound_func), std::move(arguments),
+	auto child = make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(arguments),
 	                                                StructExtractAtFun::GetBindData(child_idx));
 	return child_filter->ToExpression(*child);
 }

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -605,8 +605,18 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownAggregate(unique_ptr<Logica
 	}
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
 		D_ASSERT(aggr.expressions[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
-		auto &bound = aggr.expressions[i]->Cast<BoundAggregateExpression>();
-		if (bound.function == CountFunctionBase::GetFunction() || bound.function == CountStarFun::GetFunction()) {
+		auto &bound_func = aggr.expressions[i]->Cast<BoundAggregateExpression>().function;
+
+		auto count_fun = CountFunctionBase::GetFunction();
+		auto count_star_fun = CountStarFun::GetFunction();
+
+		const auto is_count_func =
+		    bound_func.name == count_fun.name && bound_func.GetCallbacks() == count_fun.GetCallbacks();
+
+		const auto is_count_star_func =
+		    bound_func.name == count_star_fun.name && bound_func.GetCallbacks() == count_star_fun.GetCallbacks();
+
+		if (is_count_func || is_count_star_func) {
 			replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(i))] = i;
 		}
 	}

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -611,10 +611,10 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownAggregate(unique_ptr<Logica
 		auto count_star_fun = CountStarFun::GetFunction();
 
 		const auto is_count_func =
-		    bound_func.name == count_fun.name && bound_func.GetCallbacks() == count_fun.GetCallbacks();
+		    bound_func.GetName() == count_fun.name && bound_func.GetCallbacks() == count_fun.GetCallbacks();
 
 		const auto is_count_star_func =
-		    bound_func.name == count_star_fun.name && bound_func.GetCallbacks() == count_star_fun.GetCallbacks();
+		    bound_func.GetName() == count_star_fun.name && bound_func.GetCallbacks() == count_star_fun.GetCallbacks();
 
 		if (is_count_func || is_count_star_func) {
 			replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(i))] = i;

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -520,8 +520,10 @@ void FlattenDependentJoins::AddCorrelatedFirstAggregates(LogicalAggregate &aggr,
 		auto colref = make_uniq<BoundColumnRefExpression>(col.name, col.type, state[i]);
 		vector<unique_ptr<Expression>> aggr_children;
 		aggr_children.push_back(std::move(colref));
-		auto first_fun = make_uniq<BoundAggregateExpression>(std::move(first_aggregate), std::move(aggr_children),
-		                                                     nullptr, nullptr, AggregateType::NON_DISTINCT);
+
+		BoundAggregateFunction bound_func(first_aggregate);
+		auto first_fun = make_uniq<BoundAggregateExpression>(std::move(bound_func), std::move(aggr_children), nullptr,
+		                                                     nullptr, AggregateType::NON_DISTINCT);
 		aggr.expressions.push_back(std::move(first_fun));
 	}
 }

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -287,7 +287,7 @@ FilterPropagateResult GeometryStats::CheckZonemap(const BaseStatistics &stats, c
 
 	auto found = false;
 	for (const auto &name : geometry_predicates) {
-		if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
+		if (StringUtil::CIEquals(func.function.GetName().c_str(), name)) {
 			found = true;
 			break;
 		}

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -454,12 +454,12 @@ struct UDFSum {
 	} sum_state_t;
 
 	template <class STATE>
-	static idx_t StateSize(const AggregateFunction &function) {
+	static idx_t StateSize(const BoundAggregateFunction &function) {
 		return sizeof(STATE);
 	}
 
 	template <class STATE>
-	static void Initialize(const AggregateFunction &function, data_ptr_t state) {
+	static void Initialize(const BoundAggregateFunction &function, data_ptr_t state) {
 		((STATE *)state)->value = 0;
 		((STATE *)state)->isset = false;
 	}

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -883,7 +883,9 @@ public:
 		// Construct the bound expression (column index 0: the filter chunk contains only the filtered column)
 		vector<unique_ptr<Expression>> children;
 		children.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0));
-		auto expr = make_uniq<BoundFunctionExpression>(LogicalType::BOOLEAN, func, std::move(children),
+
+		BoundScalarFunction bound_func(func);
+		auto expr = make_uniq<BoundFunctionExpression>(LogicalType::BOOLEAN, std::move(bound_func), std::move(children),
 		                                               make_uniq<RowIdFilterBindData>(vector<int64_t> {3, 4, 5, 7, 9}));
 
 		// Ensure ROW_ID is in the scan's column list

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -885,7 +885,7 @@ public:
 		children.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0));
 
 		BoundScalarFunction bound_func(func);
-		auto expr = make_uniq<BoundFunctionExpression>(LogicalType::BOOLEAN, std::move(bound_func), std::move(children),
+		auto expr = make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(children),
 		                                               make_uniq<RowIdFilterBindData>(vector<int64_t> {3, 4, 5, 7, 9}));
 
 		// Ensure ROW_ID is in the scan's column list


### PR DESCRIPTION
- Sever the inheritance between `*Function and `*BoundFunction` classes. You can no longer implicitly create a bound function from a non-bound function
- Move FunctionCallbacks/FunctionProperties into CRTP mixin class to reduce duplication
- Modify aggregate function callbacks to actually take `BoundAggregateFunction` in more places
- Return functions from catalog sets by const reference instead of copying
- Encapsulate additional properties (such as function name)
- Add `FunctionSignature` and `FunctionParameter` classes to the unbound functions.
- Don't pass return type in `BoundFunctionExpression` constructor, derive it from the function itself instead. 