### PR TITLE
String stats zone map: FILTER_ALWAYS_TRUE recovery and exact-bound logic

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1201,9 +1201,12 @@ static FilterPropagateResult CheckParquetStringFilter(BaseStatistics &stats, con
 				if (constant.value.type().id() == LogicalTypeId::VARCHAR) {
 					auto &min_value = pq_col_stats.min_value;
 					auto &max_value = pq_col_stats.max_value;
+					bool min_exact = pq_col_stats.__isset.is_min_value_exact && pq_col_stats.is_min_value_exact;
+					bool max_exact = pq_col_stats.__isset.is_max_value_exact && pq_col_stats.is_max_value_exact;
 					return StringStats::CheckZonemap(const_data_ptr_cast(min_value.c_str()), min_value.size(),
 					                                 const_data_ptr_cast(max_value.c_str()), max_value.size(),
-					                                 comp.GetExpressionType(), StringValue::Get(constant.value));
+					                                 comp.GetExpressionType(), StringValue::Get(constant.value),
+					                                 min_exact, max_exact);
 				}
 			}
 		}

--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -69,7 +69,8 @@ struct StringStats {
 	                                                     array_ptr<const Value> constants);
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const_data_ptr_t min_data, idx_t min_len,
 	                                                     const_data_ptr_t max_data, idx_t max_len,
-	                                                     ExpressionType comparison_type, const string &value);
+	                                                     ExpressionType comparison_type, const string &value,
+	                                                     bool min_is_exact = false, bool max_is_exact = false);
 
 	DUCKDB_API static void Update(BaseStatistics &stats, const string_t &value);
 	DUCKDB_API static void SetMin(BaseStatistics &stats, const string_t &value);

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -233,6 +233,7 @@ FilterPropagateResult StringStats::CheckZonemap(const BaseStatistics &stats, Exp
                                                 array_ptr<const Value> constants) {
 	auto &string_data = StringStats::GetDataUnsafe(stats);
 	D_ASSERT(stats.CanHaveNoNull());
+
 	for (auto &constant_value : constants) {
 		D_ASSERT(constant_value.type() == stats.GetType());
 		D_ASSERT(!constant_value.IsNull());
@@ -249,12 +250,25 @@ FilterPropagateResult StringStats::CheckZonemap(const BaseStatistics &stats, Exp
 }
 
 FilterPropagateResult StringStats::CheckZonemap(const_data_ptr_t min_data, idx_t min_len, const_data_ptr_t max_data,
-                                                idx_t max_len, ExpressionType comparison_type, const string &constant) {
+                                                idx_t max_len, ExpressionType comparison_type, const string &constant,
+                                                bool min_is_exact, bool max_is_exact) {
 	auto data = const_data_ptr_cast(constant.c_str());
 	idx_t size = constant.size();
 
-	int min_comp = StringValueComparison(data, MinValue(min_len, size), min_data);
-	int max_comp = StringValueComparison(data, MinValue(max_len, size), max_data);
+	// When the stored bound is exact (not truncated), use a full lexicographic comparison so that
+	// length differences resolve definitively. When not exact, compare only the shared prefix length;
+	// a tie (== 0) is ambiguous because the stored value may extend past the compared bytes.
+	auto LexCompare = [](const_data_ptr_t a, idx_t a_len, const_data_ptr_t b, idx_t b_len) -> int {
+		int c = StringValueComparison(a, MinValue(a_len, b_len), b);
+		if (c != 0) {
+			return c;
+		}
+		return (a_len < b_len) ? -1 : (a_len > b_len) ? 1 : 0;
+	};
+	int min_comp = min_is_exact ? LexCompare(data, size, min_data, min_len)
+	                            : StringValueComparison(data, MinValue(min_len, size), min_data);
+	int max_comp = max_is_exact ? LexCompare(data, size, max_data, max_len)
+	                            : StringValueComparison(data, MinValue(max_len, size), max_data);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
@@ -270,19 +284,33 @@ FilterPropagateResult StringStats::CheckZonemap(const_data_ptr_t min_data, idx_t
 		}
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		if (min_comp < 0 || (min_is_exact && min_comp == 0)) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (max_comp > 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	case ExpressionType::COMPARE_GREATERTHAN:
-		if (max_comp <= 0) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		} else {
+		if (min_comp < 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (max_comp > 0) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
-	case ExpressionType::COMPARE_LESSTHAN:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-		if (min_comp >= 0) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		} else {
+		if (max_comp > 0 || (max_is_exact && max_comp == 0)) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (min_comp < 0) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_LESSTHAN:
+		if (max_comp > 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (min_comp < 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	default:
 		throw InternalException("Expression type not implemented for string statistics zone map");
 	}

--- a/test/sql/filter/string_stats_exact.test
+++ b/test/sql/filter/string_stats_exact.test
@@ -1,0 +1,49 @@
+# name: test/sql/filter/string_stats_exact.test
+# description: Plan-level filter elimination for VARCHAR via segment zone maps
+# group: [filter]
+
+# Persist to disk so segment zone maps are evaluated on restart.
+load {TEST_DIR}/string_stats_exact.db
+
+statement ok
+CREATE TABLE t (s VARCHAR);
+
+# segment zone map: min='abc', max='xyz' (both <= 8 bytes, exact)
+statement ok
+INSERT INTO t VALUES ('abc'), ('mno'), ('xyz');
+
+restart
+
+statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY'
+
+# always-true via segment min/max: optimizer eliminates the filter from the scan
+query II
+EXPLAIN SELECT count(*) FROM t WHERE s > 'aa';
+----
+physical_plan	<!REGEX>:.*Filters:.*
+
+# always-true via exact-bound <= path (constant longer than max but shares prefix)
+query II
+EXPLAIN SELECT count(*) FROM t WHERE s <= 'xyza';
+----
+physical_plan	<!REGEX>:.*Filters:.*
+
+# always-false: optimizer collapses the entire scan to EMPTY_RESULT
+query II
+EXPLAIN SELECT count(*) FROM t WHERE s > 'zzz';
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# correctness for cases the zone map can't fully prune (constant strictly between min and max)
+query I
+SELECT count(*) FROM t WHERE s > 'mno';
+----
+1
+
+# equality with a value in [min,max] but not in the data — zone map says NO_PRUNING_POSSIBLE,
+# per-row eval correctly returns 0
+query I
+SELECT count(*) FROM t WHERE s = 'abcd';
+----
+0


### PR DESCRIPTION
Extend StringStats::CheckZonemap to recognize when a filter must be entirely satisfied by every value in the [min, max] domain, returning FILTER_ALWAYS_TRUE so callers can skip the per-row evaluation. 

Previously the directional comparisons (>, >=, <, <=) only returned NO_PRUNING_POSSIBLE or FILTER_ALWAYS_FALSE, leaving the filter in place even when zone-map analysis could prove it always true.

For >= and <=, also use a length-aware exact-bound comparison when parquet stats mark the stored bound as not truncated. This handles cases where the constant shares a prefix with the bound but exceeds it in length (e.g. 's <= xyza' against max='xyz' is always-true).

Split form #22415