### PR TITLE
Prune dead filter-only columns from scans

### DIFF
--- a/benchmark/micro/parquet/dead_filter_column_prune.benchmark
+++ b/benchmark/micro/parquet/dead_filter_column_prune.benchmark
@@ -1,0 +1,30 @@
+# name: benchmark/micro/parquet/dead_filter_column_prune.benchmark
+# description: Filter is always-true via table stats; the column it referenced should not be decoded.
+# group: [parquet]
+
+name Dead Filter Column Prune
+group micro
+subgroup parquet
+
+require parquet
+
+storage persistent
+
+load
+COPY (
+  SELECT
+    (i % 20)::INTEGER AS id,
+    CASE WHEN i < 100000 AND (i % 2 = 0)
+         THEN 'a' || lpad(i::VARCHAR, 33, '0')
+         ELSE 'b' || lpad(i::VARCHAR, 33, '0')
+    END AS s
+  FROM range(100000000) t(i)
+) TO '${BENCHMARK_DIR}/dead_filter_column_prune.parquet' (
+  ROW_GROUP_SIZE 100000, COMPRESSION 'snappy', OVERWRITE_OR_IGNORE
+);
+
+run
+SELECT sum(id) FROM '${BENCHMARK_DIR}/dead_filter_column_prune.parquet' WHERE s >= '0'
+
+result I
+950000000

--- a/benchmark/micro/parquet/row_group_skip_count.benchmark
+++ b/benchmark/micro/parquet/row_group_skip_count.benchmark
@@ -1,0 +1,30 @@
+# name: benchmark/micro/parquet/row_group_skip_count.benchmark
+# description: count(*) with a filter-only column whose per-row-group stats prove the predicate always-true on most groups.
+# group: [parquet]
+
+name Row Group Skip Filter-Only Count
+group micro
+subgroup parquet
+
+require parquet
+
+storage persistent
+
+load
+COPY (
+  SELECT
+    (i % 20)::INTEGER AS id,
+    CASE WHEN i < 100000 AND (i % 2 = 0)
+         THEN 'a' || lpad(i::VARCHAR, 33, '0')
+         ELSE 'b' || lpad(i::VARCHAR, 33, '0')
+    END AS s
+  FROM range(100000000) t(i)
+) TO '${BENCHMARK_DIR}/row_group_skip_count.parquet' (
+  ROW_GROUP_SIZE 100000, COMPRESSION 'snappy', OVERWRITE_OR_IGNORE
+);
+
+run
+SELECT count(*) FROM '${BENCHMARK_DIR}/row_group_skip_count.parquet' WHERE s >= 'a800000000000000000000000000000000'
+
+result I
+99950000

--- a/src/include/duckdb/optimizer/column_lifetime_analyzer.hpp
+++ b/src/include/duckdb/optimizer/column_lifetime_analyzer.hpp
@@ -16,16 +16,23 @@ namespace duckdb {
 
 class Optimizer;
 class BoundColumnRefExpression;
+class LogicalGet;
 
 //! The ColumnLifetimeAnalyzer optimizer traverses the logical operator tree and ensures that columns are removed from
 //! the plan when no longer required
 class ColumnLifetimeAnalyzer : public LogicalOperatorVisitor {
 public:
-	explicit ColumnLifetimeAnalyzer(Optimizer &optimizer_p, LogicalOperator &root_p, bool is_root = false)
-	    : optimizer(optimizer_p), root(root_p), everything_referenced(is_root) {
+	ColumnLifetimeAnalyzer(Optimizer &optimizer_p, LogicalOperator &root_p, bool is_root = false)
+	    : optimizer(optimizer_p), root(root_p), everything_referenced(is_root),
+	      owned_dead_gets(make_uniq<vector<reference<LogicalGet>>>()), dead_gets(*owned_dead_gets) {
 	}
 
 	void VisitOperator(LogicalOperator &op) override;
+
+	//! Apply the dead-column prunes recorded during the walk. Must be called by the top-level analyzer after
+	//! VisitOperator finishes; rewrites column_ids/projection_ids/table_filters and fixes upstream bindings in
+	//! a single pass.
+	void FinalizeDeadColumnPrunes();
 
 public:
 	static void ExtractColumnBindings(const Expression &expr, vector<ColumnBinding> &bindings);
@@ -35,6 +42,13 @@ protected:
 	unique_ptr<Expression> VisitReplace(BoundReferenceExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
 private:
+	//! Sub-analyzer constructor: shares the parent's dead-get queue so prunes recorded in nested traversals are
+	//! finalized together with the top-level analyzer.
+	ColumnLifetimeAnalyzer(Optimizer &optimizer_p, LogicalOperator &root_p, bool is_root,
+	                       vector<reference<LogicalGet>> &shared_dead_gets)
+	    : optimizer(optimizer_p), root(root_p), everything_referenced(is_root), dead_gets(shared_dead_gets) {
+	}
+
 	Optimizer &optimizer;
 	LogicalOperator &root;
 	//! Whether or not all the columns are referenced. This happens in the case of the root expression (because the
@@ -42,6 +56,11 @@ private:
 	bool everything_referenced;
 	//! The set of column references
 	column_binding_set_t column_references;
+	//! Owned only by the top-level analyzer; sub-analyzers reference parent's vector via dead_gets.
+	unique_ptr<vector<reference<LogicalGet>>> owned_dead_gets;
+	//! Gets queued for dead-filter-column pruning. Mutations are deferred until the walk finishes so that
+	//! projection_map generation in joins sees consistent (un-pruned) bindings throughout.
+	vector<reference<LogicalGet>> &dead_gets;
 
 private:
 	void VisitOperatorInternal(LogicalOperator &op);
@@ -49,6 +68,9 @@ private:
 	void ExtractUnusedColumnBindings(const vector<ColumnBinding> &bindings, column_binding_set_t &unused_bindings);
 	static void GenerateProjectionMap(vector<ColumnBinding> bindings, column_binding_set_t &unused_bindings,
 	                                  vector<ProjectionIndex> &map);
+	//! Record a Get for dead-column pruning if it has columns that are neither projected upstream nor referenced
+	//! by a table filter. Pruning runs after StatisticsPropagator removes always-true filters via table-level stats.
+	void RecordDeadColumnGet(LogicalGet &get);
 	void Verify(LogicalOperator &op);
 	void AddVerificationProjection(unique_ptr<LogicalOperator> &child);
 };

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/main/settings.hpp"
@@ -69,7 +70,7 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
 		// FIXME: groups that are not referenced can be removed from projection
 		// recurse into the children of the aggregate
-		ColumnLifetimeAnalyzer analyzer(optimizer, root);
+		ColumnLifetimeAnalyzer analyzer(optimizer, root, false, dead_gets);
 		analyzer.StandardVisitOperator(op);
 		return;
 	}
@@ -103,6 +104,12 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 		GenerateProjectionMap(op.children[1]->GetColumnBindings(), rhs_unused, comp_join.right_projection_map);
 		return;
 	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		RecordDeadColumnGet(op.Cast<LogicalGet>());
+		ColumnLifetimeAnalyzer analyzer(optimizer, root, true, dead_gets);
+		analyzer.StandardVisitOperator(op);
+		return;
+	}
 	case LogicalOperatorType::LOGICAL_INSERT:
 	case LogicalOperatorType::LOGICAL_UPDATE:
 	case LogicalOperatorType::LOGICAL_DELETE:
@@ -110,7 +117,6 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 		//! When RETURNING is used, a PROJECTION is the top level operator for INSERTS, UPDATES, and DELETES
 		//! We still need to project all values from these operators so the projection
 		//! on top of them can select from only the table values being inserted.
-	case LogicalOperatorType::LOGICAL_GET:
 	case LogicalOperatorType::LOGICAL_UNION:
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_INTERSECT:
@@ -119,13 +125,13 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 		// for set operations/materialized CTEs we don't remove anything, just recursively visit the children
 		// FIXME: for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
 		// encounter a UNION node that is not preceded by a DISTINCT)
-		ColumnLifetimeAnalyzer analyzer(optimizer, root, true);
+		ColumnLifetimeAnalyzer analyzer(optimizer, root, true, dead_gets);
 		analyzer.StandardVisitOperator(op);
 		return;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
 		// then recurse into the children of this projection
-		ColumnLifetimeAnalyzer analyzer(optimizer, root);
+		ColumnLifetimeAnalyzer analyzer(optimizer, root, false, dead_gets);
 		analyzer.StandardVisitOperator(op);
 		return;
 	}
@@ -193,6 +199,94 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 		break;
 	}
 	StandardVisitOperator(op);
+}
+
+void ColumnLifetimeAnalyzer::RecordDeadColumnGet(LogicalGet &get) {
+	if (get.projection_ids.empty()) {
+		return;
+	}
+	const auto &column_ids = get.GetColumnIds();
+	idx_t kept = 0;
+	vector<bool> keep(column_ids.size(), false);
+	auto mark_kept = [&](idx_t i) {
+		if (!keep[i]) {
+			keep[i] = true;
+			kept++;
+		}
+	};
+	for (auto proj_id : get.projection_ids) {
+		mark_kept(proj_id.GetIndex());
+	}
+	for (auto &entry : get.table_filters) {
+		mark_kept(entry.GetIndex().GetIndex());
+	}
+	if (kept == column_ids.size()) {
+		return;
+	}
+	dead_gets.emplace_back(get);
+}
+
+void ColumnLifetimeAnalyzer::FinalizeDeadColumnPrunes() {
+	if (dead_gets.empty()) {
+		return;
+	}
+	ColumnBindingReplacer replacer;
+	for (auto &get_ref : dead_gets) {
+		auto &get = get_ref.get();
+		auto &column_ids = get.GetMutableColumnIds();
+		vector<bool> keep(column_ids.size(), false);
+		idx_t keep_count = 0;
+		auto mark_kept = [&](idx_t i) {
+			if (!keep[i]) {
+				keep[i] = true;
+				keep_count++;
+			}
+		};
+		for (auto proj_id : get.projection_ids) {
+			mark_kept(proj_id.GetIndex());
+		}
+		for (auto &entry : get.table_filters) {
+			mark_kept(entry.GetIndex().GetIndex());
+		}
+		if (keep_count == column_ids.size()) {
+			// Filter pushed down to this Get since RecordDeadColumnGet ran (e.g. JOIN_FILTER_PUSHDOWN);
+			// no longer dead.
+			continue;
+		}
+		vector<idx_t> old_to_new(column_ids.size(), DConstants::INVALID_INDEX);
+		vector<ColumnIndex> new_column_ids;
+		new_column_ids.reserve(keep_count);
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (keep[i]) {
+				old_to_new[i] = new_column_ids.size();
+				new_column_ids.push_back(std::move(column_ids[i]));
+			}
+		}
+		column_ids = std::move(new_column_ids);
+
+		if (get.table_filters.HasFilters()) {
+			TableFilterSet remapped_filters;
+			for (auto &entry : get.table_filters) {
+				auto new_idx = old_to_new[entry.GetIndex().GetIndex()];
+				remapped_filters.PushFilter(ProjectionIndex(new_idx), entry.TakeFilter());
+			}
+			get.table_filters = std::move(remapped_filters);
+		}
+
+		for (auto &proj_id : get.projection_ids) {
+			auto old_value = proj_id.GetIndex();
+			auto new_value = old_to_new[old_value];
+			if (new_value != old_value) {
+				replacer.replacement_bindings.emplace_back(ColumnBinding(get.table_index, ProjectionIndex(old_value)),
+				                                           ColumnBinding(get.table_index, ProjectionIndex(new_value)));
+			}
+			proj_id = ProjectionIndex(new_value);
+		}
+	}
+	if (!replacer.replacement_bindings.empty()) {
+		replacer.VisitOperator(root);
+	}
+	dead_gets.clear();
 }
 
 void ColumnLifetimeAnalyzer::Verify(LogicalOperator &op) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -281,6 +281,7 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
 		ColumnLifetimeAnalyzer column_lifetime(*this, *plan, true);
 		column_lifetime.VisitOperator(*plan);
+		column_lifetime.FinalizeDeadColumnPrunes();
 	});
 
 	// Once we know the column lifetime, we have more information regarding
@@ -359,6 +360,7 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
 		ColumnLifetimeAnalyzer column_lifetime(*this, *plan, true);
 		column_lifetime.VisitOperator(*plan);
+		column_lifetime.FinalizeDeadColumnPrunes();
 	});
 
 	// apply simple expression heuristics to get an initial reordering


### PR DESCRIPTION
When the optimizer eliminates a filter as always-true via table-level statistics, the column it referenced is left in the scan's `column_ids` and decoded at scan time for no reason. This adds a small pass at physical-plan time that drops columns from `column_ids` that are neither projected nor referenced by any remaining table filter.

Most visible when the dead column is expensive to decode — combined with #22429 skipping the string decode entirely.

There isn't a way to test for this change in behavior right now explicitly, because the EXPLAIN only shows the projected ones, not the decoded ones, benchmarks can clearly show the difference.
  
Split from #22415.

## Benchmark (Reused in other PRs)

```sql
COPY (
  SELECT
    -- 20 distinct values heavily repeated → dictionary encoding, near-zero decode cost
    (i % 20)::INTEGER AS id,
    CASE WHEN i < 100000 AND (i % 2 = 0)
         THEN 'a' || lpad(i::VARCHAR, 33, '0')
         ELSE 'b' || lpad(i::VARCHAR, 33, '0')
    END AS s
  FROM range(100000000) t(i)
) TO '/tmp/bench_pr.parquet' (
  ROW_GROUP_SIZE 100000, COMPRESSION 'snappy', OVERWRITE_OR_IGNORE
);
```


| Query | main | this branch + #22429 | speedup |
|---|---|---|---|
| `SELECT sum(k) FROM file WHERE s >= '0'` | 188 ms | 10 ms | **19×** |