### PR TITLE
Fix duck fuzz #4430

### DIFF
--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -18,13 +18,16 @@ SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, Data
 	auto &db_manager = DatabaseManager::Get(context.client);
 
 	// Reject detach if the current transaction already has outstanding work on the database.
-	auto attached_db = db_manager.GetDatabase(info->name);
-	if (attached_db) {
-		auto &meta_transaction = MetaTransaction::Get(context.client);
-		if (meta_transaction.TryGetTransaction(*attached_db)) {
-			throw TransactionException("Cannot detach database \"%s\" because the current transaction has outstanding "
-			                           "work on it - commit or rollback first",
-			                           info->name);
+	{
+		auto attached_db = db_manager.GetDatabase(info->name);
+		if (attached_db) {
+			auto &meta_transaction = MetaTransaction::Get(context.client);
+			if (meta_transaction.TryGetTransaction(*attached_db)) {
+				throw TransactionException(
+				    "Cannot detach database \"%s\" because the current transaction has outstanding "
+				    "work on it - commit or rollback first",
+				    info->name);
+			}
 		}
 	}
 

--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -1,10 +1,12 @@
 #include "duckdb/execution/operator/schema/physical_detach.hpp"
 #include "duckdb/parser/parsed_data/detach_info.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -14,6 +16,18 @@ namespace duckdb {
 SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
 	auto &db_manager = DatabaseManager::Get(context.client);
+
+	// Reject detach if the current transaction already has outstanding work on the database.
+	auto attached_db = db_manager.GetDatabase(info->name);
+	if (attached_db) {
+		auto &meta_transaction = MetaTransaction::Get(context.client);
+		if (meta_transaction.TryGetTransaction(*attached_db)) {
+			throw TransactionException("Cannot detach database \"%s\" because the current transaction has outstanding "
+			                           "work on it - commit or rollback first",
+			                           info->name);
+		}
+	}
+
 	db_manager.DetachDatabase(context.client, info->name, info->if_not_found);
 
 	return SourceResultType::FINISHED;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_search_path.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/database.hpp"
@@ -250,7 +251,24 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		                      name);
 	}
 
-	auto attached_db = DetachInternal(name);
+	// Lookup the requested database and detech if applicable.
+	shared_ptr<AttachedDatabase> attached_db;
+	{
+		lock_guard<mutex> guard(databases_lock);
+		auto entry = databases.find(name);
+		if (entry != databases.end()) {
+			auto &meta_transaction = MetaTransaction::Get(context);
+			if (meta_transaction.TryGetTransaction(*entry->second)) {
+				throw TransactionException(
+				    "Cannot detach database \"%s\" because the current transaction has outstanding "
+				    "work on it - commit or rollback first",
+				    name);
+			}
+			attached_db = std::move(entry->second);
+			databases.erase(entry);
+		}
+	}
+
 	if (!attached_db) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 			throw BinderException("Failed to detach database with name \"%s\": database not found", name);
@@ -258,12 +276,9 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		return;
 	}
 
-	auto &meta_transaction = MetaTransaction::Get(context);
-	meta_transaction.DetachDatabase(*attached_db);
-
 	attached_db->OnDetach(context);
 
-	// DetachInternal removes the AttachedDatabase from the list of databases that can be referenced.
+	// The AttachedDatabase has been removed from the list of databases that can be referenced.
 	AttachedDatabase::InvokeCloseIfLastReference(attached_db);
 }
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_search_path.hpp"
-#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/database.hpp"
@@ -251,14 +250,7 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		                      name);
 	}
 
-	shared_ptr<AttachedDatabase> attached_db;
-	{
-		lock_guard<mutex> guard(databases_lock);
-		auto entry = databases.find(name);
-		if (entry != databases.end()) {
-			attached_db = entry->second;
-		}
-	}
+	auto attached_db = DetachInternal(name);
 	if (!attached_db) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 			throw BinderException("Failed to detach database with name \"%s\": database not found", name);
@@ -266,19 +258,6 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		return;
 	}
 
-	// Reject detach if current transaction already has outstanding work on the database.
-	if (attached_db->GetVisibility() != AttachVisibility::HIDDEN) {
-		auto &meta_transaction = MetaTransaction::Get(context);
-		if (meta_transaction.TryGetTransaction(*attached_db)) {
-			throw TransactionException("Cannot detach database \"%s\" because the current transaction has outstanding "
-			                           "work on it - commit or rollback first",
-			                           name);
-		}
-	}
-
-	// Detach the database.
-	attached_db = DetachInternal(name);
-	D_ASSERT(attached_db);
 	attached_db->OnDetach(context);
 
 	// DetachInternal removes the AttachedDatabase from the list of databases that can be referenced.

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -251,27 +251,14 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		                      name);
 	}
 
-	// Lookup the requested database and detech if applicable.
 	shared_ptr<AttachedDatabase> attached_db;
 	{
 		lock_guard<mutex> guard(databases_lock);
 		auto entry = databases.find(name);
 		if (entry != databases.end()) {
-			// Validate visible database.
-			if (entry->second->GetVisibility() != AttachVisibility::HIDDEN) {
-				auto &meta_transaction = MetaTransaction::Get(context);
-				if (meta_transaction.TryGetTransaction(*entry->second)) {
-					throw TransactionException(
-					    "Cannot detach database \"%s\" because the current transaction has outstanding "
-					    "work on it - commit or rollback first",
-					    name);
-				}
-			}
-			attached_db = std::move(entry->second);
-			databases.erase(entry);
+			attached_db = entry->second;
 		}
 	}
-
 	if (!attached_db) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 			throw BinderException("Failed to detach database with name \"%s\": database not found", name);
@@ -279,9 +266,22 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		return;
 	}
 
+	// Reject detach if current transaction already has outstanding work on the database.
+	if (attached_db->GetVisibility() != AttachVisibility::HIDDEN) {
+		auto &meta_transaction = MetaTransaction::Get(context);
+		if (meta_transaction.TryGetTransaction(*attached_db)) {
+			throw TransactionException("Cannot detach database \"%s\" because the current transaction has outstanding "
+			                           "work on it - commit or rollback first",
+			                           name);
+		}
+	}
+
+	// Detach the database.
+	attached_db = DetachInternal(name);
+	D_ASSERT(attached_db);
 	attached_db->OnDetach(context);
 
-	// The AttachedDatabase has been removed from the list of databases that can be referenced.
+	// DetachInternal removes the AttachedDatabase from the list of databases that can be referenced.
 	AttachedDatabase::InvokeCloseIfLastReference(attached_db);
 }
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -258,6 +258,9 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		return;
 	}
 
+	auto &meta_transaction = MetaTransaction::Get(context);
+	meta_transaction.DetachDatabase(*attached_db);
+
 	attached_db->OnDetach(context);
 
 	// DetachInternal removes the AttachedDatabase from the list of databases that can be referenced.

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -257,12 +257,15 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 		lock_guard<mutex> guard(databases_lock);
 		auto entry = databases.find(name);
 		if (entry != databases.end()) {
-			auto &meta_transaction = MetaTransaction::Get(context);
-			if (meta_transaction.TryGetTransaction(*entry->second)) {
-				throw TransactionException(
-				    "Cannot detach database \"%s\" because the current transaction has outstanding "
-				    "work on it - commit or rollback first",
-				    name);
+			// Validate visible database.
+			if (entry->second->GetVisibility() != AttachVisibility::HIDDEN) {
+				auto &meta_transaction = MetaTransaction::Get(context);
+				if (meta_transaction.TryGetTransaction(*entry->second)) {
+					throw TransactionException(
+					    "Cannot detach database \"%s\" because the current transaction has outstanding "
+					    "work on it - commit or rollback first",
+					    name);
+				}
 			}
 			attached_db = std::move(entry->second);
 			databases.erase(entry);

--- a/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
+++ b/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
@@ -1,0 +1,21 @@
+# name: test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
+# description: Regression test for database detach
+# group: [duckfuzz]
+
+statement ok
+ATTACH '__TEST_DIR__/duckdb_fuzzer_4430_a.db' AS db1
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE db1.tbl(i INTEGER)
+
+statement ok
+DETACH db1
+
+statement ok
+ATTACH '__TEST_DIR__/duckdb_fuzzer_4430_b.db' AS db1
+
+statement ok
+COMMIT

--- a/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
+++ b/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
@@ -1,21 +1,40 @@
 # name: test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
-# description: Regression test for database detach
+# description: Regression test for DETACH while the current transaction has outstanding work on the database
 # group: [duckfuzz]
 
 statement ok
-ATTACH '__TEST_DIR__/duckdb_fuzzer_4430_a.db' AS db1
+ATTACH '__TEST_DIR__/duckdb_fuzzer_4430.db' AS db1
 
+# Write case: forbid DETACH after a write to db1 in the same transaction
 statement ok
 BEGIN
 
 statement ok
 CREATE TABLE db1.tbl(i INTEGER)
 
-statement ok
+statement error
 DETACH db1
+----
+Cannot detach database "db1"
 
 statement ok
-ATTACH '__TEST_DIR__/duckdb_fuzzer_4430_b.db' AS db1
+ROLLBACK
+
+# Read case: forbid DETACH after a read from db1 in the same transaction
+statement ok
+CREATE TABLE db1.tbl(i INTEGER)
 
 statement ok
-COMMIT
+BEGIN
+
+query I
+SELECT * FROM db1.tbl
+----
+
+statement error
+DETACH db1
+----
+Cannot detach database "db1"
+
+statement ok
+ROLLBACK

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -63,7 +63,7 @@ DETACH attach_transaction
 ----
 database not found
 
-# what if we attach, push entries, then detach, and then rollback!?
+# DETACH is forbidden while the current transaction has outstanding work on the database
 statement ok
 BEGIN TRANSACTION
 
@@ -73,33 +73,35 @@ ATTACH '__TEST_DIR__/attach_transaction.db'
 statement ok
 INSERT INTO attach_transaction.integers VALUES (84)
 
-statement ok
+statement error
 DETACH attach_transaction
+----
+Cannot detach database "attach_transaction"
 
 statement ok
 ROLLBACK
 
-# now do the same but commit
-statement ok
-BEGIN TRANSACTION
-
+# the rolled-back ATTACH+INSERT did not persist
 statement ok
 ATTACH '__TEST_DIR__/attach_transaction.db'
 
-# verify the previous data was not written
 query I
 SELECT * FROM attach_transaction.integers
 ----
 42
 
+# the supported workflow is to COMMIT first, then DETACH
+statement ok
+BEGIN TRANSACTION
+
 statement ok
 INSERT INTO attach_transaction.integers VALUES (84)
 
 statement ok
-DETACH attach_transaction
+COMMIT
 
 statement ok
-COMMIT
+DETACH attach_transaction
 
 # now if we attach we should see [42, 84]
 statement ok


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-fuzzer/issues/4430

The issue is clear from the error message "Database name db1 was already used by a different database for this meta transaction", which means [`used_databases`](https://github.com/duckdb/duckdb/blob/89f51782ee12353646ff98d525d95de8ed498a8e/src/include/duckdb/transaction/meta_transaction.hpp#L100-L101) are not cleared on database detach