### PR TITLE
feat: aggregate functions: make segment-tree fanout configurable per-aggregate

### DIFF
--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -49,8 +49,17 @@ public:
 	//! not the lifetime of the local state that constructed part of the tree
 	vector<unique_ptr<ArenaAllocator>> tree_allocators;
 
-	// TREE_FANOUT needs to cleanly divide STANDARD_VECTOR_SIZE
-	static constexpr idx_t TREE_FANOUT = 16;
+	//! Tree fanout: number of children combined into each parent. Must
+	//! cleanly divide STANDARD_VECTOR_SIZE so combine batches stay aligned.
+	//! Initialised in the constructor from the aggregate's
+	//! ``GetWindowSegmentTreeFanout()`` (default 16). A higher value
+	//! shortens the tree (log_F(N) levels) and reduces the total combine
+	//! call count, which is profitable for aggregates whose ``combine``
+	//! has high fixed per-call overhead. The build phase prefers small
+	//! fanouts to keep intermediate state sizes bounded; the right balance
+	//! depends on the aggregate's per-pair vs. per-call cost ratio, which
+	//! is why the value is per-function rather than a single global.
+	const idx_t TREE_FANOUT;
 };
 
 class WindowSegmentTreePart {
@@ -291,8 +300,15 @@ void WindowSegmentTreePart::Finalize(Vector &result, idx_t count) {
 
 WindowSegmentTreeGlobalState::WindowSegmentTreeGlobalState(ClientContext &client, const WindowSegmentTree &aggregator,
                                                            idx_t group_count)
-    : WindowAggregatorGlobalState(client, aggregator, group_count), tree(aggregator), levels_flat_native(client, aggr) {
+    : WindowAggregatorGlobalState(client, aggregator, group_count), tree(aggregator), levels_flat_native(client, aggr),
+      TREE_FANOUT(aggr.function.GetWindowSegmentTreeFanout()) {
 	D_ASSERT(!aggregator.wexpr.children.empty());
+	// TREE_FANOUT must cleanly divide STANDARD_VECTOR_SIZE so the combine
+	// flush buffer stays aligned. SetWindowSegmentTreeFanout enforces this
+	// at registration; assert as a defence-in-depth catch for direct
+	// AggregateFunctionProperties manipulation.
+	D_ASSERT(TREE_FANOUT >= 2 && TREE_FANOUT <= STANDARD_VECTOR_SIZE);
+	D_ASSERT(STANDARD_VECTOR_SIZE % TREE_FANOUT == 0);
 
 	// compute space required to store internal nodes of segment tree
 	levels_flat_start.push_back(0);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -195,6 +195,14 @@ public:
 	AggregateOrderDependent order_dependent = AggregateOrderDependent::ORDER_DEPENDENT;
 	//! Whether or not the aggregate is affect by distinct modifiers
 	AggregateDistinctDependent distinct_dependent = AggregateDistinctDependent::DISTINCT_DEPENDENT;
+	//! Fanout used by WindowSegmentTree's per-partition tree. Each internal
+	//! node aggregates this many children. Must cleanly divide
+	//! STANDARD_VECTOR_SIZE so that combine batches stay aligned. The
+	//! default of 16 is tuned for built-in aggregates with cheap combines;
+	//! higher values reduce tree depth and the number of combine calls,
+	//! which is profitable for aggregates whose `combine` has high fixed
+	//! per-call cost (extension UDFs, FFI/RPC-mediated combines).
+	idx_t window_segment_tree_fanout = 16;
 
 	bool operator==(const AggregateFunctionProperties &rhs) const;
 	bool operator!=(const AggregateFunctionProperties &rhs) const;
@@ -405,6 +413,23 @@ public:
 	}
 	void SetDistinctDependent(AggregateDistinctDependent value) {
 		properties.distinct_dependent = value;
+	}
+	idx_t GetWindowSegmentTreeFanout() const {
+		return properties.window_segment_tree_fanout;
+	}
+	//! Set the fanout used by WindowSegmentTree for this aggregate. Must
+	//! cleanly divide STANDARD_VECTOR_SIZE; out-of-range or non-dividing
+	//! values are rejected. Default is 16.
+	void SetWindowSegmentTreeFanout(idx_t value) {
+		if (value < 2 || value > STANDARD_VECTOR_SIZE) {
+			throw InternalException("WindowSegmentTree fanout must be in [2, STANDARD_VECTOR_SIZE], got %llu",
+			                        static_cast<uint64_t>(value));
+		}
+		if (STANDARD_VECTOR_SIZE % value != 0) {
+			throw InternalException("WindowSegmentTree fanout %llu must cleanly divide STANDARD_VECTOR_SIZE %llu",
+			                        static_cast<uint64_t>(value), static_cast<uint64_t>(STANDARD_VECTOR_SIZE));
+		}
+		properties.window_segment_tree_fanout = value;
 	}
 
 	bool HasGetStateTypeCallback() const {


### PR DESCRIPTION
While working with with aggregate functions using segment trees, it became clear to me that it would be beneficial to allow the fanout number to vary from the default value of 16 when using segment trees that perform their combine() and update() function via RPCs.

The optimal fanout value for a segment tree used by an aggregate function depends on the relative cost of the aggregate's `combine()` per call versus per pair of states: a higher fanout reduces tree depth (log_F(N) levels) and the total number of `combine()` calls performed for a number of rows. This is beneficial when each call has a higher fixed overhead such as calls made via RPC. The default (16) is well suited for built-in aggregate functions whose combine method is a few machine instructions; aggregates whose combine crosses an FFI boundary or otherwise has heavy per-call cost can benefit from raising it.

This PR changes the `TREE_FANOUT` from a `static constexpr` to a const member of `WindowSegmentTreeGlobalState`, initialized in the constructor from the aggregate function's metadata via GetWindowSegmentTreeFanout(). The property lives on AggregateFunctionProperties alongside order_dependent and distinct_dependent. SetWindowSegmentTreeFanout() validates that the chosen value falls in [2, STANDARD_VECTOR_SIZE] and cleanly divides STANDARD_VECTOR_SIZE — required for combine batches to stay aligned.

Default value remains 16, so all existing aggregates' behavior is unchanged. Verified by running test/sql/window/* with the default value and again with the default temporarily set to 4 and 64; all tests passed at each value.

