### PR TITLE
Use ArgProperties for cast stats forward-bounds

### DIFF
--- a/src/execution/expression_executor/CMakeLists.txt
+++ b/src/execution/expression_executor/CMakeLists.txt
@@ -10,7 +10,8 @@ add_library_unity(
   execute_function.cpp
   execute_operator.cpp
   execute_parameter.cpp
-  execute_reference.cpp)
+  execute_reference.cpp
+  verify_arg_properties.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_expression_executor>
     PARENT_SCOPE)

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/verify_arg_properties.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 
@@ -67,6 +68,7 @@ void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionStat
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 	FlatVector::SetSize(result, count_t(count));
+	VerifyCastArgProperties(expr, child, result, count);
 }
 
 } // namespace duckdb

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -1,11 +1,9 @@
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/verify_arg_properties.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "duckdb/common/value_operations/value_operations.hpp"
-
-#include <numeric>
 
 namespace duckdb {
 
@@ -144,112 +142,6 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunct
 	return std::move(result);
 }
 
-#ifdef DEBUG
-namespace {
-
-// Build a row-index permutation sorted by (other-args, target-arg). Rows that match on every
-// non-target arg end up adjacent, sorted by the target arg within each such group.
-vector<idx_t> SortRowsByTargetArg(DataChunk &args, idx_t target_arg) {
-	vector<idx_t> perm(args.size());
-	std::iota(perm.begin(), perm.end(), idx_t(0));
-	std::sort(perm.begin(), perm.end(), [&](idx_t a, idx_t b) {
-		for (idx_t k = 0; k < args.ColumnCount(); k++) {
-			if (k == target_arg) {
-				continue;
-			}
-			const auto va = args.data[k].GetValue(a);
-			const auto vb = args.data[k].GetValue(b);
-			if (!ValueOperations::DistinctFrom(va, vb)) {
-				continue;
-			}
-			return ValueOperations::DistinctLessThan(va, vb);
-		}
-		return ValueOperations::DistinctLessThan(args.data[target_arg].GetValue(a), args.data[target_arg].GetValue(b));
-	});
-	return perm;
-}
-
-// True if every arg except target_arg has NotDistinctFrom values at rows a and b.
-bool RowsShareNonTargetArgs(DataChunk &args, idx_t target_arg, idx_t a, idx_t b) {
-	for (idx_t k = 0; k < args.ColumnCount(); k++) {
-		if (k == target_arg) {
-			continue;
-		}
-		if (ValueOperations::DistinctFrom(args.data[k].GetValue(a), args.data[k].GetValue(b))) {
-			return false;
-		}
-	}
-	return true;
-}
-
-// Asserts the monotonicity claim on a single ordered pair (in_a <= in_b by sort).
-void AssertMonotonicityPair(Monotonicity m, const Value &in_a, const Value &in_b, const Value &out_a,
-                            const Value &out_b) {
-	// CONSTANT, or equal inputs to a deterministic function: outputs must match.
-	if (m == Monotonicity::CONSTANT || !ValueOperations::DistinctFrom(in_a, in_b)) {
-		D_ASSERT(!ValueOperations::DistinctFrom(out_a, out_b));
-		return;
-	}
-	const bool strict = IsStrict(m);
-	if (IsMonotonicIncreasing(m)) {
-		D_ASSERT(strict ? ValueOperations::DistinctLessThan(out_a, out_b)
-		                : ValueOperations::DistinctLessThanEquals(out_a, out_b));
-	} else {
-		D_ASSERT(strict ? ValueOperations::DistinctGreaterThan(out_a, out_b)
-		                : ValueOperations::DistinctGreaterThanEquals(out_a, out_b));
-	}
-}
-
-void VerifyArgPropertiesForArg(DataChunk &args, idx_t target_arg, Vector &result, const ArgProperties &props,
-                               bool check_monotonicity, bool check_injectivity) {
-	const auto perm = SortRowsByTargetArg(args, target_arg);
-	auto &target_vec = args.data[target_arg];
-	for (idx_t i = 1; i < args.size(); i++) {
-		const idx_t a = perm[i - 1];
-		const idx_t b = perm[i];
-		if (!RowsShareNonTargetArgs(args, target_arg, a, b)) {
-			continue; // group boundary — claims don't apply across other-arg changes
-		}
-		const auto in_a = target_vec.GetValue(a);
-		const auto in_b = target_vec.GetValue(b);
-		const auto out_a = result.GetValue(a);
-		const auto out_b = result.GetValue(b);
-		// NULL endpoints have no monotonic relation
-		if (in_a.IsNull() || in_b.IsNull() || out_a.IsNull() || out_b.IsNull()) {
-			continue;
-		}
-		if (check_monotonicity) {
-			AssertMonotonicityPair(props.monotonicity, in_a, in_b, out_a, out_b);
-		}
-		if (check_injectivity && ValueOperations::DistinctFrom(in_a, in_b)) {
-			D_ASSERT(ValueOperations::DistinctFrom(out_a, out_b));
-		}
-	}
-}
-
-} // namespace
-#endif
-
-// Verifies declared ArgProperties hold over the chunk's actual inputs and outputs. Tolerates
-// SPECIAL_HANDLING null behavior — the pair walk skips any pair touching a NULL endpoint.
-static void VerifyArgProperties(const BoundFunctionExpression &expr, DataChunk &args, Vector &result) {
-#ifdef DEBUG
-	if (!expr.function.HasArgProperties() || args.size() < 2) {
-		return;
-	}
-	const auto &all_props = expr.function.GetAllArgProperties();
-	for (idx_t arg_idx = 0; arg_idx < all_props.size(); arg_idx++) {
-		const auto &props = all_props[arg_idx];
-		const bool check_monotonicity = IsKnownMonotonic(props.monotonicity);
-		const bool check_injectivity = props.injective;
-		if (!check_monotonicity && !check_injectivity) {
-			continue;
-		}
-		VerifyArgPropertiesForArg(args, arg_idx, result, props, check_monotonicity, check_injectivity);
-	}
-#endif
-}
-
 static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &args, Vector &result) {
 #ifdef DEBUG
 	if (args.data.empty() || expr.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING) {
@@ -383,7 +275,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	FlatVector::SetSize(result, count_t(count));
 
 	VerifyNullHandling(expr, arguments, result);
-	VerifyArgProperties(expr, arguments, result);
+	VerifyFunctionArgProperties(expr, arguments, result);
 	D_ASSERT(result.GetType() == expr.GetReturnType());
 }
 

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -3,6 +3,9 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/value_operations/value_operations.hpp"
+
+#include <numeric>
 
 namespace duckdb {
 
@@ -141,6 +144,112 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunct
 	return std::move(result);
 }
 
+#ifdef DEBUG
+namespace {
+
+// Build a row-index permutation sorted by (other-args, target-arg). Rows that match on every
+// non-target arg end up adjacent, sorted by the target arg within each such group.
+vector<idx_t> SortRowsByTargetArg(DataChunk &args, idx_t target_arg) {
+	vector<idx_t> perm(args.size());
+	std::iota(perm.begin(), perm.end(), idx_t(0));
+	std::sort(perm.begin(), perm.end(), [&](idx_t a, idx_t b) {
+		for (idx_t k = 0; k < args.ColumnCount(); k++) {
+			if (k == target_arg) {
+				continue;
+			}
+			const auto va = args.data[k].GetValue(a);
+			const auto vb = args.data[k].GetValue(b);
+			if (!ValueOperations::DistinctFrom(va, vb)) {
+				continue;
+			}
+			return ValueOperations::DistinctLessThan(va, vb);
+		}
+		return ValueOperations::DistinctLessThan(args.data[target_arg].GetValue(a), args.data[target_arg].GetValue(b));
+	});
+	return perm;
+}
+
+// True if every arg except target_arg has NotDistinctFrom values at rows a and b.
+bool RowsShareNonTargetArgs(DataChunk &args, idx_t target_arg, idx_t a, idx_t b) {
+	for (idx_t k = 0; k < args.ColumnCount(); k++) {
+		if (k == target_arg) {
+			continue;
+		}
+		if (ValueOperations::DistinctFrom(args.data[k].GetValue(a), args.data[k].GetValue(b))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Asserts the monotonicity claim on a single ordered pair (in_a <= in_b by sort).
+void AssertMonotonicityPair(Monotonicity m, const Value &in_a, const Value &in_b, const Value &out_a,
+                            const Value &out_b) {
+	// CONSTANT, or equal inputs to a deterministic function: outputs must match.
+	if (m == Monotonicity::CONSTANT || !ValueOperations::DistinctFrom(in_a, in_b)) {
+		D_ASSERT(!ValueOperations::DistinctFrom(out_a, out_b));
+		return;
+	}
+	const bool strict = IsStrict(m);
+	if (IsMonotonicIncreasing(m)) {
+		D_ASSERT(strict ? ValueOperations::DistinctLessThan(out_a, out_b)
+		                : ValueOperations::DistinctLessThanEquals(out_a, out_b));
+	} else {
+		D_ASSERT(strict ? ValueOperations::DistinctGreaterThan(out_a, out_b)
+		                : ValueOperations::DistinctGreaterThanEquals(out_a, out_b));
+	}
+}
+
+void VerifyArgPropertiesForArg(DataChunk &args, idx_t target_arg, Vector &result, const ArgProperties &props,
+                               bool check_monotonicity, bool check_injectivity) {
+	const auto perm = SortRowsByTargetArg(args, target_arg);
+	auto &target_vec = args.data[target_arg];
+	for (idx_t i = 1; i < args.size(); i++) {
+		const idx_t a = perm[i - 1];
+		const idx_t b = perm[i];
+		if (!RowsShareNonTargetArgs(args, target_arg, a, b)) {
+			continue; // group boundary — claims don't apply across other-arg changes
+		}
+		const auto in_a = target_vec.GetValue(a);
+		const auto in_b = target_vec.GetValue(b);
+		const auto out_a = result.GetValue(a);
+		const auto out_b = result.GetValue(b);
+		// NULL endpoints have no monotonic relation
+		if (in_a.IsNull() || in_b.IsNull() || out_a.IsNull() || out_b.IsNull()) {
+			continue;
+		}
+		if (check_monotonicity) {
+			AssertMonotonicityPair(props.monotonicity, in_a, in_b, out_a, out_b);
+		}
+		if (check_injectivity && ValueOperations::DistinctFrom(in_a, in_b)) {
+			D_ASSERT(ValueOperations::DistinctFrom(out_a, out_b));
+		}
+	}
+}
+
+} // namespace
+#endif
+
+// Verifies declared ArgProperties hold over the chunk's actual inputs and outputs. Tolerates
+// SPECIAL_HANDLING null behavior — the pair walk skips any pair touching a NULL endpoint.
+static void VerifyArgProperties(const BoundFunctionExpression &expr, DataChunk &args, Vector &result) {
+#ifdef DEBUG
+	if (!expr.function.HasArgProperties() || args.size() < 2) {
+		return;
+	}
+	const auto &all_props = expr.function.GetAllArgProperties();
+	for (idx_t arg_idx = 0; arg_idx < all_props.size(); arg_idx++) {
+		const auto &props = all_props[arg_idx];
+		const bool check_monotonicity = IsKnownMonotonic(props.monotonicity);
+		const bool check_injectivity = props.injective;
+		if (!check_monotonicity && !check_injectivity) {
+			continue;
+		}
+		VerifyArgPropertiesForArg(args, arg_idx, result, props, check_monotonicity, check_injectivity);
+	}
+#endif
+}
+
 static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &args, Vector &result) {
 #ifdef DEBUG
 	if (args.data.empty() || expr.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING) {
@@ -274,6 +383,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	FlatVector::SetSize(result, count_t(count));
 
 	VerifyNullHandling(expr, arguments, result);
+	VerifyArgProperties(expr, arguments, result);
 	D_ASSERT(result.GetType() == expr.GetReturnType());
 }
 

--- a/src/execution/expression_executor/verify_arg_properties.cpp
+++ b/src/execution/expression_executor/verify_arg_properties.cpp
@@ -1,0 +1,142 @@
+#include "duckdb/execution/verify_arg_properties.hpp"
+
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/value_operations/value_operations.hpp"
+#include "duckdb/function/arg_properties.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include <numeric>
+
+namespace duckdb {
+
+#ifdef DEBUG
+namespace {
+
+// Build a row-index permutation sorted by (other-args, target-arg). When `chunk` is null, only
+// the target vector contributes to the sort key. Rows that match on every non-target arg end up
+// adjacent, sorted by the target arg within each such group.
+vector<idx_t> SortRowsByTargetArg(Vector &target_vec, idx_t count, DataChunk *chunk, idx_t target_arg) {
+	vector<idx_t> perm(count);
+	std::iota(perm.begin(), perm.end(), idx_t(0));
+	std::sort(perm.begin(), perm.end(), [&](idx_t a, idx_t b) {
+		if (chunk) {
+			for (idx_t k = 0; k < chunk->ColumnCount(); k++) {
+				if (k == target_arg) {
+					continue;
+				}
+				const auto va = chunk->data[k].GetValue(a);
+				const auto vb = chunk->data[k].GetValue(b);
+				if (!ValueOperations::DistinctFrom(va, vb)) {
+					continue;
+				}
+				return ValueOperations::DistinctLessThan(va, vb);
+			}
+		}
+		return ValueOperations::DistinctLessThan(target_vec.GetValue(a), target_vec.GetValue(b));
+	});
+	return perm;
+}
+
+// True when every column of `chunk` except `target_arg` has NotDistinctFrom values at rows a, b.
+// Returns true when chunk is null (unary case has no other args to compare).
+bool RowsShareNonTargetArgs(DataChunk *chunk, idx_t target_arg, idx_t a, idx_t b) {
+	if (!chunk) {
+		return true;
+	}
+	for (idx_t k = 0; k < chunk->ColumnCount(); k++) {
+		if (k == target_arg) {
+			continue;
+		}
+		if (ValueOperations::DistinctFrom(chunk->data[k].GetValue(a), chunk->data[k].GetValue(b))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Asserts the monotonicity claim on a single ordered pair (in_a <= in_b by sort).
+void AssertMonotonicityPair(Monotonicity m, const Value &in_a, const Value &in_b, const Value &out_a,
+                            const Value &out_b) {
+	// CONSTANT, or equal inputs to a deterministic function: outputs must match.
+	if (m == Monotonicity::CONSTANT || !ValueOperations::DistinctFrom(in_a, in_b)) {
+		D_ASSERT(!ValueOperations::DistinctFrom(out_a, out_b));
+		return;
+	}
+	const bool strict = IsStrict(m);
+	if (IsMonotonicIncreasing(m)) {
+		D_ASSERT(strict ? ValueOperations::DistinctLessThan(out_a, out_b)
+		                : ValueOperations::DistinctLessThanEquals(out_a, out_b));
+	} else {
+		D_ASSERT(strict ? ValueOperations::DistinctGreaterThan(out_a, out_b)
+		                : ValueOperations::DistinctGreaterThanEquals(out_a, out_b));
+	}
+}
+
+// Shared per-arg verifier. `chunk` and `target_arg` describe the "other args" context for the
+// multi-arg scalar function case; pass nullptr for the single-arg cast case.
+void VerifyArgPropertiesForArg(Vector &target_vec, Vector &result, idx_t count, const ArgProperties &props,
+                               bool check_monotonicity, bool check_injectivity, DataChunk *chunk, idx_t target_arg) {
+	const auto perm = SortRowsByTargetArg(target_vec, count, chunk, target_arg);
+	for (idx_t i = 1; i < count; i++) {
+		const idx_t a = perm[i - 1];
+		const idx_t b = perm[i];
+		if (!RowsShareNonTargetArgs(chunk, target_arg, a, b)) {
+			continue; // group boundary — claims don't apply across other-arg changes
+		}
+		const auto in_a = target_vec.GetValue(a);
+		const auto in_b = target_vec.GetValue(b);
+		const auto out_a = result.GetValue(a);
+		const auto out_b = result.GetValue(b);
+		// NULL endpoints have no monotonic relation
+		if (in_a.IsNull() || in_b.IsNull() || out_a.IsNull() || out_b.IsNull()) {
+			continue;
+		}
+		if (check_monotonicity) {
+			AssertMonotonicityPair(props.monotonicity, in_a, in_b, out_a, out_b);
+		}
+		if (check_injectivity && ValueOperations::DistinctFrom(in_a, in_b)) {
+			D_ASSERT(ValueOperations::DistinctFrom(out_a, out_b));
+		}
+	}
+}
+
+void VerifyDeclaredProperty(Vector &target_vec, Vector &result, idx_t count, const ArgProperties &props,
+                            DataChunk *chunk, idx_t target_arg) {
+	const bool check_monotonicity = IsKnownMonotonic(props.monotonicity);
+	const bool check_injectivity = props.injective;
+	if (!check_monotonicity && !check_injectivity) {
+		return;
+	}
+	VerifyArgPropertiesForArg(target_vec, result, count, props, check_monotonicity, check_injectivity, chunk,
+	                          target_arg);
+}
+
+} // namespace
+#endif
+
+void VerifyFunctionArgProperties(const BoundFunctionExpression &expr, DataChunk &args, Vector &result) {
+#ifdef DEBUG
+	if (!expr.function.HasArgProperties() || args.size() < 2) {
+		return;
+	}
+	const auto &all_props = expr.function.GetAllArgProperties();
+	for (idx_t arg_idx = 0; arg_idx < all_props.size(); arg_idx++) {
+		VerifyDeclaredProperty(args.data[arg_idx], result, args.size(), all_props[arg_idx], &args, arg_idx);
+	}
+#endif
+}
+
+void VerifyCastArgProperties(const BoundCastExpression &expr, Vector &source, Vector &result, idx_t count) {
+#ifdef DEBUG
+	if (count < 2) {
+		return;
+	}
+	VerifyDeclaredProperty(source, result, count, expr.bound_cast.GetArgProperties(), nullptr, 0);
+#endif
+}
+
+} // namespace duckdb

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -255,63 +255,81 @@ static bool DecimalToStringCast(Vector &source, Vector &result, idx_t count, Cas
 
 BoundCastInfo DefaultCasts::DecimalCastSwitch(BindCastInput &input, const LogicalType &source,
                                               const LogicalType &target) {
-	// now switch on the result type
+	// truncation toward zero
+	const auto decimal_to_int = ArgProperties().NonDecreasing();
 	switch (target.id()) {
 	case LogicalTypeId::BOOLEAN:
 		return FromDecimalCast<bool>;
 	case LogicalTypeId::TINYINT:
-		return FromDecimalCast<int8_t>;
+		return BoundCastInfo(FromDecimalCast<int8_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::SMALLINT:
-		return FromDecimalCast<int16_t>;
+		return BoundCastInfo(FromDecimalCast<int16_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::INTEGER:
-		return FromDecimalCast<int32_t>;
+		return BoundCastInfo(FromDecimalCast<int32_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::BIGINT:
-		return FromDecimalCast<int64_t>;
+		return BoundCastInfo(FromDecimalCast<int64_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UTINYINT:
-		return FromDecimalCast<uint8_t>;
+		return BoundCastInfo(FromDecimalCast<uint8_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::USMALLINT:
-		return FromDecimalCast<uint16_t>;
+		return BoundCastInfo(FromDecimalCast<uint16_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UINTEGER:
-		return FromDecimalCast<uint32_t>;
+		return BoundCastInfo(FromDecimalCast<uint32_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UBIGINT:
-		return FromDecimalCast<uint64_t>;
+		return BoundCastInfo(FromDecimalCast<uint64_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::HUGEINT:
-		return FromDecimalCast<hugeint_t>;
+		return BoundCastInfo(FromDecimalCast<hugeint_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::UHUGEINT:
-		return FromDecimalCast<uhugeint_t>;
+		return BoundCastInfo(FromDecimalCast<uhugeint_t>).SetArgProperties(decimal_to_int);
 	case LogicalTypeId::DECIMAL: {
 		// decimal to decimal cast
 		// first we need to figure out the source and target internal types
+		cast_function_t fn;
 		switch (source.InternalType()) {
 		case PhysicalType::INT16:
-			return DecimalDecimalCastSwitch<int16_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int16_t, NumericHelper>;
+			break;
 		case PhysicalType::INT32:
-			return DecimalDecimalCastSwitch<int32_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int32_t, NumericHelper>;
+			break;
 		case PhysicalType::INT64:
-			return DecimalDecimalCastSwitch<int64_t, NumericHelper>;
+			fn = DecimalDecimalCastSwitch<int64_t, NumericHelper>;
+			break;
 		case PhysicalType::INT128:
-			return DecimalDecimalCastSwitch<hugeint_t, Hugeint>;
+			fn = DecimalDecimalCastSwitch<hugeint_t, Hugeint>;
+			break;
 		default:
 			throw NotImplementedException("Unimplemented internal type for decimal in decimal_decimal cast");
 		}
+		// strict when scale doesn't decrease; truncation otherwise
+		auto props = DecimalType::GetScale(target) >= DecimalType::GetScale(source)
+		                 ? ArgProperties().StrictlyIncreasing()
+		                 : ArgProperties().NonDecreasing();
+		return BoundCastInfo(fn).SetArgProperties(props);
 	}
 	case LogicalTypeId::FLOAT:
-		return FromDecimalCast<float>;
+		return BoundCastInfo(FromDecimalCast<float>).SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::DOUBLE:
-		return FromDecimalCast<double>;
+		return BoundCastInfo(FromDecimalCast<double>).SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::VARCHAR: {
+		cast_function_t fn;
 		switch (source.InternalType()) {
 		case PhysicalType::INT16:
-			return DecimalToStringCast<int16_t>;
+			fn = DecimalToStringCast<int16_t>;
+			break;
 		case PhysicalType::INT32:
-			return DecimalToStringCast<int32_t>;
+			fn = DecimalToStringCast<int32_t>;
+			break;
 		case PhysicalType::INT64:
-			return DecimalToStringCast<int64_t>;
+			fn = DecimalToStringCast<int64_t>;
+			break;
 		case PhysicalType::INT128:
-			return DecimalToStringCast<hugeint_t>;
+			fn = DecimalToStringCast<hugeint_t>;
+			break;
 		default:
 			throw InternalException("Unimplemented internal decimal type");
 		}
+		// width-varying integer parts break lex order ('10' < '9' lex but 10 > 9), no annotation
+		return BoundCastInfo(fn);
 	}
 	default:
 		return DefaultCasts::TryVectorNullCast;

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -29,7 +29,9 @@ BoundCastInfo::BoundCastInfo(cast_function_t function_p, unique_ptr<BoundCastDat
 }
 
 BoundCastInfo BoundCastInfo::Copy() const {
-	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state);
+	BoundCastInfo result(function, cast_data ? cast_data->Copy() : nullptr, init_local_state);
+	result.arg_properties = arg_properties;
+	return result;
 }
 
 bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/src/function/cast/numeric_casts.cpp
+++ b/src/function/cast/numeric_casts.cpp
@@ -1,10 +1,66 @@
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/vector_cast_helpers.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/string_cast.hpp"
 #include "duckdb/common/operator/numeric_cast.hpp"
 #include "duckdb/common/types/bignum.hpp"
 
 namespace duckdb {
+
+namespace {
+//! Same signedness, any int -> float, or unsigned -> strictly-wider signed.
+template <class SRC, class DST>
+constexpr bool IsOrderPreservingNumericCast() {
+	if (NumericLimits<SRC>::IsSigned() == NumericLimits<DST>::IsSigned()) {
+		return true;
+	}
+	if (std::is_floating_point<DST>::value) {
+		return true;
+	}
+	if (!NumericLimits<SRC>::IsSigned() && NumericLimits<DST>::IsSigned()) {
+		return sizeof(DST) > sizeof(SRC);
+	}
+	return false;
+}
+
+//! Distinct sources may collapse: DOUBLE->FLOAT, wide-int->float, float->int.
+template <class SRC, class DST>
+constexpr bool HasFloatPrecisionLoss() {
+	if (std::is_same<SRC, double>::value && std::is_same<DST, float>::value) {
+		return true;
+	}
+	if (!std::is_floating_point<SRC>::value && std::is_same<DST, float>::value) {
+		return sizeof(SRC) > 2;
+	}
+	if (!std::is_floating_point<SRC>::value && std::is_same<DST, double>::value) {
+		return sizeof(SRC) > 4;
+	}
+	if (std::is_floating_point<SRC>::value && !std::is_floating_point<DST>::value) {
+		return true;
+	}
+	return false;
+}
+
+template <class SRC, class DST, class OP>
+BoundCastInfo MakeNumericToNumericCast() {
+	BoundCastInfo info(&VectorCastHelpers::TryCastLoop<SRC, DST, OP>);
+	if (IsOrderPreservingNumericCast<SRC, DST>()) {
+		auto props =
+		    HasFloatPrecisionLoss<SRC, DST>() ? ArgProperties().NonDecreasing() : ArgProperties().StrictlyIncreasing();
+		info.SetArgProperties(props);
+	}
+	return info;
+}
+
+template <class SRC>
+BoundCastInfo MakeNumericToDecimalCast() {
+	BoundCastInfo info(&VectorCastHelpers::ToDecimalCast<SRC>);
+	auto props =
+	    std::is_floating_point<SRC>::value ? ArgProperties().NonDecreasing() : ArgProperties().StrictlyIncreasing();
+	info.SetArgProperties(props);
+	return info;
+}
+} // namespace
 
 template <class SRC>
 static BoundCastInfo InternalNumericCastSwitch(const LogicalType &source, const LogicalType &target) {
@@ -13,31 +69,31 @@ static BoundCastInfo InternalNumericCastSwitch(const LogicalType &source, const 
 	case LogicalTypeId::BOOLEAN:
 		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, bool, duckdb::NumericTryCast>);
 	case LogicalTypeId::TINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int8_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int8_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::SMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int16_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int16_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::INTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int32_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int32_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::BIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, int64_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, int64_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UTINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint8_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint8_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::USMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint16_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint16_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UINTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint32_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint32_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UBIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uint64_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uint64_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::HUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, hugeint_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, hugeint_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::UHUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, uhugeint_t, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, uhugeint_t, duckdb::NumericTryCast>();
 	case LogicalTypeId::FLOAT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, float, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, float, duckdb::NumericTryCast>();
 	case LogicalTypeId::DOUBLE:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<SRC, double, duckdb::NumericTryCast>);
+		return MakeNumericToNumericCast<SRC, double, duckdb::NumericTryCast>();
 	case LogicalTypeId::DECIMAL:
-		return BoundCastInfo(&VectorCastHelpers::ToDecimalCast<SRC>);
+		return MakeNumericToDecimalCast<SRC>();
 	case LogicalTypeId::VARCHAR:
 		return BoundCastInfo(&VectorCastHelpers::StringCast<SRC, duckdb::StringCast>);
 	case LogicalTypeId::BIT:

--- a/src/function/cast/time_casts.cpp
+++ b/src/function/cast/time_casts.cpp
@@ -8,18 +8,23 @@ BoundCastInfo DefaultCasts::DateCastSwitch(BindCastInput &input, const LogicalTy
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// date to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<date_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<date_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// date to timestamp
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCast>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_ns_t, duckdb::TryCastToTimestampNS>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_ns_t, duckdb::TryCastToTimestampNS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -30,10 +35,12 @@ BoundCastInfo DefaultCasts::TimeCastSwitch(BindCastInput &input, const LogicalTy
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// time to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME_TZ:
-		// time to time with time zone
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_t, dtime_tz_t, duckdb::Cast>);
+		// default packs offset 0; ICU's override is unannotated and the propagator bails (see #22259)
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_t, dtime_tz_t, duckdb::Cast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -44,10 +51,12 @@ BoundCastInfo DefaultCasts::TimeNsCastSwitch(BindCastInput &input, const Logical
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// time (ns) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_ns_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<dtime_ns_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME:
 		// time (ns) to time (µs)
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_ns_t, dtime_t, duckdb::Cast>);
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<dtime_ns_t, dtime_t, duckdb::Cast>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -74,32 +83,37 @@ BoundCastInfo DefaultCasts::TimestampCastSwitch(BindCastInput &input, const Logi
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// timestamp to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
 		// timestamp to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::Cast>);
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::Cast>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp to time
+		// timestamp to time — UNKNOWN: drops the date
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::Cast>);
 	case LogicalTypeId::TIME_TZ:
-		// timestamp to time_tz
+		// timestamp to time_tz — UNKNOWN: drops the date
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_tz_t, duckdb::Cast>);
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// timestamp (us) to timestamp with time zone
-		return ReinterpretCast;
+		return BoundCastInfo(ReinterpretCast).SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
 		// timestamp (us) to timestamp [with time zone] (ns)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
 		// timestamp (us) to timestamp (ms)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
 		// timestamp (us) to timestamp (s)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -111,25 +125,29 @@ BoundCastInfo DefaultCasts::TimestampTzCastSwitch(BindCastInput &input, const Lo
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
 		// timestamp with time zone to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCastTZ>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::StringCastTZ>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIME_TZ:
-		// timestamp with time zone to time with time zone.
+		// timestamp with time zone to time with time zone — UNKNOWN: drops the date
 		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_tz_t, duckdb::Cast>);
 	case LogicalTypeId::TIMESTAMP:
 		// timestamp with time zone to timestamp (us)
-		return ReinterpretCast;
+		return BoundCastInfo(ReinterpretCast).SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
 		// timestamptz (us) to timestamp (ns)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_MS:
 		// timestamptz (us) to timestamp (ms)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIMESTAMP_SEC:
 		// timestamptz (us) to timestamp (s)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -162,24 +180,26 @@ BoundCastInfo DefaultCasts::TimestampNsCastSwitch(BindCastInput &input, const Lo
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (ns) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_ns_t, duckdb::StringCast>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_ns_t, duckdb::StringCast>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
 		// timestamp (ns) to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampNsToDate>);
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampNsToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (ns) to time
+		// timestamp (ns) to time — UNKNOWN: drops the date
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampNsToTime>);
 	case LogicalTypeId::TIME_NS:
-		// timestamp (ns) to time (ns)
+		// timestamp (ns) to time (ns) — UNKNOWN: drops the date
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_ns_t, dtime_ns_t, duckdb::CastTimestampNsToTimeNs>);
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// timestamp (ns) to timestamp [with time zone] (us)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -190,25 +210,28 @@ BoundCastInfo DefaultCasts::TimestampMsCastSwitch(BindCastInput &input, const Lo
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (ms) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampMS>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampMS>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
 		// timestamp (ms) to date
-		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampMsToDate>);
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampMsToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (ms) to time
+		// timestamp (ms) to time — UNKNOWN: drops the date
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampMsToTime>);
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// timestamp (ms) to timestamp [with time zone] (us)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
 		// timestamp (ms) to timestamp [with time zone] (ns)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampMsToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -219,30 +242,33 @@ BoundCastInfo DefaultCasts::TimestampSecCastSwitch(BindCastInput &input, const L
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// timestamp (s) to varchar
-		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampSec>);
+		return BoundCastInfo(&VectorCastHelpers::StringCast<timestamp_t, duckdb::CastFromTimestampSec>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::DATE:
 		// timestamp (s) to date
-		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampSecToDate>);
+		return BoundCastInfo(&VectorCastHelpers::TemplatedCastLoop<timestamp_t, date_t, duckdb::CastTimestampSecToDate>)
+		    .SetArgProperties(ArgProperties().NonDecreasing());
 	case LogicalTypeId::TIME:
-		// timestamp (s) to time
+		// timestamp (s) to time — UNKNOWN: drops the date
 		return BoundCastInfo(
 		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, dtime_t, duckdb::CastTimestampSecToTime>);
 	case LogicalTypeId::TIMESTAMP_MS:
 		// timestamp (s) to timestamp (ms)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToMs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToMs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		// timestamp (s) to timestamp [with time zone] (us)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
 		// timestamp (s) to timestamp [with time zone] (ns)
 		return BoundCastInfo(
-		    &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToNs>);
+		           &VectorCastHelpers::TemplatedCastLoop<timestamp_t, timestamp_t, duckdb::CastTimestampSecToNs>)
+		    .SetArgProperties(ArgProperties().StrictlyIncreasing());
 	default:
 		return TryVectorNullCast;
 	}
@@ -252,7 +278,6 @@ BoundCastInfo DefaultCasts::IntervalCastSwitch(BindCastInput &input, const Logic
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:
-		// time to varchar
 		return BoundCastInfo(&VectorCastHelpers::StringCast<interval_t, duckdb::StringCast>);
 	default:
 		return TryVectorNullCast;

--- a/src/include/duckdb/execution/verify_arg_properties.hpp
+++ b/src/include/duckdb/execution/verify_arg_properties.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/verify_arg_properties.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+class BoundCastExpression;
+class BoundFunctionExpression;
+class DataChunk;
+class Vector;
+
+//! In DEBUG builds, verifies declared `ArgProperties` (monotonicity, injectivity) hold over a
+//! scalar function call's actual inputs and outputs. No-op in release. Tolerates SPECIAL_HANDLING
+//! null behavior — pairs touching a NULL endpoint are skipped.
+void VerifyFunctionArgProperties(const BoundFunctionExpression &expr, DataChunk &args, Vector &result);
+
+//! In DEBUG builds, verifies declared `ArgProperties` on a cast (single-arg) hold over the
+//! cast's actual source and result. No-op in release.
+void VerifyCastArgProperties(const BoundCastExpression &expr, Vector &source, Vector &result, idx_t count);
+
+} // namespace duckdb

--- a/src/include/duckdb/function/arg_properties.hpp
+++ b/src/include/duckdb/function/arg_properties.hpp
@@ -25,9 +25,14 @@ enum class Monotonicity : uint8_t {
 //! Per-argument metadata for a scalar function.
 struct ArgProperties {
 	Monotonicity monotonicity = Monotonicity::UNKNOWN;
+	//! Distinct inputs map to distinct outputs (preserves cardinality).
+	//! Strict monotonicity implies it; also true for non-monotonic mappings like reverse(s) or for
+	//! invertible casts. Non-strict monotonicity does NOT imply it (truncation collapses values).
+	bool injective = false;
 
 	ArgProperties &StrictlyIncreasing() {
 		monotonicity = Monotonicity::STRICTLY_INCREASING;
+		injective = true;
 		return *this;
 	}
 	ArgProperties &NonDecreasing() {
@@ -36,6 +41,7 @@ struct ArgProperties {
 	}
 	ArgProperties &StrictlyDecreasing() {
 		monotonicity = Monotonicity::STRICTLY_DECREASING;
+		injective = true;
 		return *this;
 	}
 	ArgProperties &NonIncreasing() {
@@ -44,6 +50,10 @@ struct ArgProperties {
 	}
 	ArgProperties &Constant() {
 		monotonicity = Monotonicity::CONSTANT;
+		return *this;
+	}
+	ArgProperties &Injective() {
+		injective = true;
 		return *this;
 	}
 };

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/function/arg_properties.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
 namespace duckdb {
@@ -137,10 +138,24 @@ public:
 		function = new_function;
 	}
 
+	//! Per-arg metadata for the cast's input; mirrors `ScalarFunction::arg_properties[0]`.
+	const ArgProperties &GetArgProperties() const {
+		return arg_properties;
+	}
+	BoundCastInfo &SetArgProperties(ArgProperties props) & {
+		arg_properties = props;
+		return *this;
+	}
+	BoundCastInfo SetArgProperties(ArgProperties props) && {
+		arg_properties = props;
+		return std::move(*this);
+	}
+
 private:
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;
 	unique_ptr<BoundCastData> cast_data;
+	ArgProperties arg_properties;
 };
 
 struct BindCastInput {

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -40,6 +40,11 @@ public:
 	static unique_ptr<BaseStatistics> TryPropagateCast(const BaseStatistics &stats, const LogicalType &source,
 	                                                   const LogicalType &target);
 
+	//! Assemble numeric stats from monotone-derived bounds; throws on `out_hi < out_lo`.
+	static unique_ptr<BaseStatistics>
+	BuildMonotoneBoundsStats(const LogicalType &target, const Value &out_lo, const Value &out_hi, bool can_have_null,
+	                         const string &error_context, optional_ptr<const BaseStatistics> base_to_copy = nullptr);
+
 private:
 	//! Propagate statistics through an operator
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -41,9 +41,12 @@ public:
 	                                                   const LogicalType &target);
 
 	//! Assemble numeric stats from monotone-derived bounds; throws on `out_hi < out_lo`.
-	static unique_ptr<BaseStatistics>
-	BuildMonotoneBoundsStats(const LogicalType &target, const Value &out_lo, const Value &out_hi, bool can_have_null,
-	                         const string &error_context, optional_ptr<const BaseStatistics> base_to_copy = nullptr);
+	//! `distinct_source`: pass the input stats only when the mapping is injective so distinct_count
+	//! is preserved; pass nullptr otherwise so distinct_count remains UNKNOWN.
+	static unique_ptr<BaseStatistics> BuildMonotoneBoundsStats(const LogicalType &target, const Value &out_lo,
+	                                                           const Value &out_hi, bool can_have_null,
+	                                                           const string &error_context,
+	                                                           optional_ptr<BaseStatistics> distinct_source = nullptr);
 
 private:
 	//! Propagate statistics through an operator

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -261,9 +261,11 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCastEx
 		std::swap(out_lo, out_hi);
 	}
 	const bool can_have_null = child_stats->CanHaveNull() || cast.try_cast;
+	// only carry distinct_count when the cast is injective; truncation / precision-loss can collapse values
+	auto distinct_source = props.injective ? child_stats.get() : nullptr;
 	return BuildMonotoneBoundsStats(target, out_lo, out_hi, can_have_null,
 	                                StringUtil::Format("cast %s -> %s", source.ToString(), target.ToString()),
-	                                child_stats.get());
+	                                distinct_source);
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
+
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/variant_stats.hpp"
 
@@ -7,17 +10,12 @@ namespace duckdb {
 
 static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const BaseStatistics &input,
                                                                          const LogicalType &target) {
-	// Bail out if the stats are not numeric
-	if (input.GetStatsType() != StatisticsType::NUMERIC_STATS) {
-		return nullptr;
-	}
-	if (!NumericStats::HasMinMax(input)) {
+	if (input.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(input)) {
 		return nullptr;
 	}
 	Value min = NumericStats::Min(input);
 	Value max = NumericStats::Max(input);
 	if (!min.DefaultTryCastAs(target) || !max.DefaultTryCastAs(target)) {
-		// overflow in cast: bailout
 		return nullptr;
 	}
 	auto result = NumericStats::CreateEmpty(target);
@@ -223,11 +221,49 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCastEx
 	if (!child_stats) {
 		return nullptr;
 	}
-	auto result_stats = TryPropagateCast(*child_stats, cast.child->GetReturnType(), cast.GetReturnType());
-	if (cast.try_cast && result_stats) {
-		result_stats->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	auto &source = cast.child->GetReturnType();
+	auto &target = cast.GetReturnType();
+
+	if (source.id() == LogicalTypeId::VARIANT) {
+		auto result = StatisticsPropagateVariant(*child_stats, target);
+		if (cast.try_cast && result) {
+			result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		return result;
 	}
-	return result_stats;
+
+	// NopCast carries no arg_properties, so handle identity before reading metadata.
+	if (source == target) {
+		auto result = child_stats->ToUnique();
+		if (cast.try_cast && result) {
+			result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		return result;
+	}
+
+	auto &props = cast.bound_cast.GetArgProperties();
+	if (!IsKnownMonotonic(props.monotonicity)) {
+		return nullptr;
+	}
+	if (BaseStatistics::GetStatsType(target) != StatisticsType::NUMERIC_STATS) {
+		return nullptr;
+	}
+	if (child_stats->GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(*child_stats)) {
+		return nullptr;
+	}
+	// active registry — extension overrides (e.g. ICU) apply
+	Value out_lo = NumericStats::Min(*child_stats);
+	Value out_hi = NumericStats::Max(*child_stats);
+	if (!out_lo.TryCastAs(context, target) || !out_hi.TryCastAs(context, target)) {
+		return nullptr;
+	}
+	if (IsMonotonicDecreasing(props.monotonicity)) {
+		std::swap(out_lo, out_hi);
+	}
+	const bool can_have_null = child_stats->CanHaveNull() || cast.try_cast;
+	return BuildMonotoneBoundsStats(target, out_lo, out_hi, can_have_null,
+	                                StringUtil::Format("cast %s -> %s", source.ToString(), target.ToString()),
+	                                child_stats.get());
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -89,9 +89,16 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	    !TryEvaluateAtConstants(context, func, hi_args, out_hi)) {
 		return nullptr;
 	}
-	// NaN/NULL at a corner means the input was NaN/NULL (column contains NaN, or year(±infinity)).
-	// NaN is excluded even though DuckDB orders it above all other values: negate(NaN) = NaN, which
-	// would violate NON_INCREASING if NaN were treated as a valid corner. Bail instead.
+	return StatisticsPropagator::BuildMonotoneBoundsStats(func.GetReturnType(), out_lo, out_hi, output_can_have_null,
+	                                                      func.function.GetName());
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::BuildMonotoneBoundsStats(const LogicalType &target,
+                                                                          const Value &out_lo, const Value &out_hi,
+                                                                          bool can_have_null,
+                                                                          const string &error_context,
+                                                                          optional_ptr<const BaseStatistics> base) {
+	// NaN-at-corner is unusable: NaN orders above all values, but negate(NaN)=NaN breaks NON_INCREASING.
 	const auto is_unusable = [](const Value &v) {
 		if (v.IsNull()) {
 			return true;
@@ -110,15 +117,19 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	}
 	if (out_hi < out_lo) {
 		throw InternalException("Monotonic arg annotation violated for '%s': output min exceeds output max",
-		                        func.function.GetName());
+		                        error_context);
 	}
 
-	auto result = NumericStats::CreateEmpty(func.GetReturnType());
+	auto result = NumericStats::CreateEmpty(target);
+	if (base) {
+		// carry distinct_count + base flags; per-bound Set below overrides has_null
+		result.CopyBase(*base);
+	}
 	NumericStats::SetMin(result, out_lo);
 	NumericStats::SetMax(result, out_hi);
 
 	result.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
-	if (output_can_have_null) {
+	if (can_have_null) {
 		result.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	}
 	return result.ToUnique();

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -23,7 +23,7 @@ static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionEx
 //! Evaluate `func` at the lo/hi corner of each child's value range to derive output min/max.
 //! Decreasing args are swapped so f(lo_args) and f(hi_args) bracket the output range.
 static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &context, BoundFunctionExpression &func,
-                                                             const vector<BaseStatistics> &child_stats) {
+                                                             vector<BaseStatistics> &child_stats) {
 	if (!func.function.HasArgProperties() || func.children.empty()) {
 		return nullptr;
 	}
@@ -39,6 +39,10 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	vector<Value> hi_args(func.children.size());
 	// SPECIAL_HANDLING means the function may produce nulls on non-null inputs (e.g. try_cast).
 	bool output_can_have_null = (func.function.GetNullHandling() != FunctionNullHandling::DEFAULT_NULL_HANDLING);
+	// per-arg injective only composes into joint injectivity when at most one arg varies; track
+	// the lone non-foldable arg so we can carry its distinct_count when it is injective
+	idx_t non_foldable_count = 0;
+	idx_t non_foldable_idx = 0;
 
 	for (idx_t i = 0; i < func.children.size(); i++) {
 		auto &child = *func.children[i];
@@ -54,6 +58,8 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 			hi_args[i] = std::move(v);
 			continue;
 		}
+		non_foldable_count++;
+		non_foldable_idx = i;
 
 		auto m = props.monotonicity;
 		if (cs.CanHaveNull()) {
@@ -89,15 +95,20 @@ static unique_ptr<BaseStatistics> TryPropagateMonotoneBounds(ClientContext &cont
 	    !TryEvaluateAtConstants(context, func, hi_args, out_hi)) {
 		return nullptr;
 	}
+	// distinct_count carries when exactly one arg varies and is injective; e.g. f(a,b)=a+b is
+	// per-arg injective but jointly collides — f(0,5)=f(5,0) — so multi-varying args must bail
+	optional_ptr<BaseStatistics> distinct_source;
+	if (non_foldable_count == 1 && func.function.GetArgProperties(non_foldable_idx).injective) {
+		distinct_source = &child_stats[non_foldable_idx];
+	}
 	return StatisticsPropagator::BuildMonotoneBoundsStats(func.GetReturnType(), out_lo, out_hi, output_can_have_null,
-	                                                      func.function.GetName());
+	                                                      func.function.GetName(), distinct_source);
 }
 
-unique_ptr<BaseStatistics> StatisticsPropagator::BuildMonotoneBoundsStats(const LogicalType &target,
-                                                                          const Value &out_lo, const Value &out_hi,
-                                                                          bool can_have_null,
-                                                                          const string &error_context,
-                                                                          optional_ptr<const BaseStatistics> base) {
+unique_ptr<BaseStatistics>
+StatisticsPropagator::BuildMonotoneBoundsStats(const LogicalType &target, const Value &out_lo, const Value &out_hi,
+                                               bool can_have_null, const string &error_context,
+                                               optional_ptr<BaseStatistics> distinct_source) {
 	// NaN-at-corner is unusable: NaN orders above all values, but negate(NaN)=NaN breaks NON_INCREASING.
 	const auto is_unusable = [](const Value &v) {
 		if (v.IsNull()) {
@@ -121,16 +132,17 @@ unique_ptr<BaseStatistics> StatisticsPropagator::BuildMonotoneBoundsStats(const 
 	}
 
 	auto result = NumericStats::CreateEmpty(target);
-	if (base) {
-		// carry distinct_count + base flags; per-bound Set below overrides has_null
-		result.CopyBase(*base);
-	}
 	NumericStats::SetMin(result, out_lo);
 	NumericStats::SetMax(result, out_hi);
 
+	// validity is recomputed from can_have_null; distinct_count only carries when the mapping is
+	// injective (caller passes distinct_source then, nullptr otherwise)
 	result.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
 	if (can_have_null) {
 		result.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+	if (distinct_source) {
+		result.SetDistinctCount(distinct_source->GetDistinctCount());
 	}
 	return result.ToUnique();
 }

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -76,6 +76,7 @@
       "reason": "Statistics are not set without optimizers.",
       "paths": [
         "test/optimizer/statistics/statistics_numeric.test",
+        "test/optimizer/statistics/statistics_distinct_count.test",
         "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
         "test/fuzzer/duckfuzz/bitstring_agg_uhugeint.test",
         "test/parquet/parquet_stats_function.test",

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -13,6 +13,7 @@
       "reason": "Stats aren't preserved for serialization",
       "paths": [
         "test/optimizer/statistics/statistics_numeric.test",
+        "test/optimizer/statistics/statistics_distinct_count.test",
         "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
         "test/parquet/parquet_stats_function.test",
         "test/parquet/variant/variant_stats_propagation.test",

--- a/test/optimizer/statistics/statistics_cast_icu.test
+++ b/test/optimizer/statistics/statistics_cast_icu.test
@@ -1,0 +1,32 @@
+# name: test/optimizer/statistics/statistics_cast_icu.test
+# description: ICU overrides correctly disable cast stats propagation (see #22235 / #22259)
+# group: [statistics]
+
+require icu
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+SET TimeZone = 'Asia/Kolkata';
+
+statement ok
+CREATE TABLE times AS SELECT (TIME '00:00:00' + INTERVAL (i) MINUTE) AS t FROM range(60) _(i)
+
+# TIME -> TIME_TZ via ICU's override picks up session zone (here +05:30). The default cast is
+# annotated StrictlyIncreasing in time_casts.cpp, but ICU's BindCastFromTime returns BoundCastInfo
+# without arg_properties — UNKNOWN. Propagation must bail; otherwise propagated bounds (computed
+# via the active registry / ICU cast) could disagree with runtime if data spans a DST change.
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIMETZ) s FROM times LIMIT 1)
+----
+NULL	NULL
+
+# TIMESTAMP_TZ -> TIME_TZ also session-zone dependent; same bail.
+statement ok
+CREATE TABLE tstz AS SELECT (TIMESTAMPTZ '2024-01-01 00:00:00+00' + INTERVAL (i) MINUTE) AS t FROM range(60) _(i)
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIMETZ) s FROM tstz LIMIT 1)
+----
+NULL	NULL

--- a/test/optimizer/statistics/statistics_distinct_count.test
+++ b/test/optimizer/statistics/statistics_distinct_count.test
@@ -1,0 +1,36 @@
+# name: test/optimizer/statistics/statistics_distinct_count.test
+# description: distinct_count propagation for injective casts/functions; gated to default vector size since HLL counts are vector-size-sensitive on small tables
+# group: [statistics]
+
+require vector_size 2048
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+# single-arg StrictlyIncreasing implies injective; distinct_count carries through exp
+statement ok
+CREATE TABLE mixed AS SELECT unnest([0.0::DOUBLE, 1.0::DOUBLE, NULL]) AS x
+
+query III
+SELECT s.min, s.max, s.approx_unique FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
+----
+1.0	2.718281828459045	2
+
+# multi-arg with foldable constants reduces to single varying arg; year is StrictlyIncreasing → injective
+statement ok
+CREATE TABLE years AS SELECT i::BIGINT AS y FROM range(2000, 2050) _(i)
+
+query III
+SELECT s.min, s.max, s.approx_unique
+FROM (SELECT STATS(make_timestamp(y, 1, 1, 0, 0, 0.0)) s FROM years LIMIT 1)
+----
+2000-01-01 00:00:00	2049-01-01 00:00:00	50
+
+# strict precision widening on cast preserves distinct_count
+statement ok
+CREATE TABLE micros AS SELECT (TIMESTAMP '2024-01-01' + INTERVAL (i) MICROSECOND) AS t FROM range(100) _(i)
+
+query III
+SELECT s.min, s.max, s.approx_unique FROM (SELECT STATS(t::TIMESTAMP_NS) s FROM micros LIMIT 1)
+----
+2024-01-01 00:00:00	2024-01-01 00:00:00.000099	100

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -177,6 +177,12 @@ SELECT s.min, s.max FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
 ----
 1.0	2.718281828459045
 
+# floor is NonDecreasing (not injective): bounds propagate but distinct_count must not
+query III
+SELECT s.min, s.max, s.approx_unique FROM (SELECT STATS(floor(x)) s FROM mixed LIMIT 1)
+----
+0.0	1.0	NULL
+
 # cast forward-bounds
 
 statement ok
@@ -210,6 +216,27 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(t::TIMESTAMP_MS) s FROM tstamps LIMIT 1)
 ----
 2024-01-01 00:00:00	2024-01-05 03:00:00
+
+# distinct_count: non-injective casts must not carry it forward — 100 distinct microseconds
+# collapse to 1 millisecond. (#22439 review; exact-value coverage in statistics_distinct_count.test)
+statement ok
+CREATE TABLE micros AS SELECT (TIMESTAMP '2024-01-01' + INTERVAL (i) MICROSECOND) AS t FROM range(100) _(i)
+
+query III
+SELECT s.min, s.max, s.approx_unique
+FROM (SELECT STATS(t::TIMESTAMP_MS) s FROM micros LIMIT 1)
+----
+2024-01-01 00:00:00	2024-01-01 00:00:00	NULL
+
+# DECIMAL -> INTEGER drops the fractional part; NonDecreasing, not injective
+statement ok
+CREATE TABLE decs AS SELECT v::DECIMAL(10, 2) AS d FROM (VALUES (1.10), (1.20), (1.50), (1.99)) _(v)
+
+query III
+SELECT s.min, s.max, s.approx_unique
+FROM (SELECT STATS(d::INTEGER) s FROM decs LIMIT 1)
+----
+1	2	NULL
 
 # TIMESTAMP -> TIME: UNKNOWN, no bounds
 query II

--- a/test/optimizer/statistics/statistics_numeric.test
+++ b/test/optimizer/statistics/statistics_numeric.test
@@ -176,3 +176,71 @@ query II
 SELECT s.min, s.max FROM (SELECT STATS(exp(x)) s FROM mixed LIMIT 1)
 ----
 1.0	2.718281828459045
+
+# cast forward-bounds
+
+statement ok
+CREATE TABLE tinies AS SELECT (i - 50)::TINYINT AS bi FROM range(100) _(i)
+
+# strict widening: min/max + distinct_count carry forward
+query IIII
+SELECT s.min, s.max, s.approx_unique, s.has_null
+FROM (SELECT STATS(bi::BIGINT) s FROM tinies LIMIT 1)
+----
+-50	49	100	false
+
+# try_cast marks has_null even on no-null input
+query III
+SELECT s.min, s.max, s.has_null
+FROM (SELECT STATS(TRY_CAST(bi AS BIGINT)) s FROM tinies LIMIT 1)
+----
+-50	49	true
+
+statement ok
+CREATE TABLE tstamps AS SELECT (TIMESTAMP '2024-01-01' + INTERVAL (i) HOUR) AS t FROM range(100) _(i)
+
+# TIMESTAMP -> TIMESTAMP_NS: strict precision widening (CanPropagateCast bailed on this)
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIMESTAMP_NS) s FROM tstamps LIMIT 1)
+----
+2024-01-01 00:00:00	2024-01-05 03:00:00
+
+# TIMESTAMP -> TIMESTAMP_MS: NonDecreasing precision truncation (CanPropagateCast bailed)
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIMESTAMP_MS) s FROM tstamps LIMIT 1)
+----
+2024-01-01 00:00:00	2024-01-05 03:00:00
+
+# TIMESTAMP -> TIME: UNKNOWN, no bounds
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIME) s FROM tstamps LIMIT 1)
+----
+NULL	NULL
+
+# identity cast preserves distinct_count
+query III
+SELECT s.min, s.max, s.approx_unique
+FROM (SELECT STATS(bi::TINYINT) s FROM tinies LIMIT 1)
+----
+-50	49	100
+
+# unsigned -> strictly-wider signed: every UTINYINT value lands in INTEGER's non-negative half,
+# so the cast is StrictlyIncreasing. Main bailed at the source physical-type filter.
+statement ok
+CREATE TABLE utinies AS SELECT (i + 1)::UTINYINT AS ub FROM range(100) _(i)
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(ub::INTEGER) s FROM utinies LIMIT 1)
+----
+1	100
+
+# TIME -> TIME_TZ default cast packs offset 0 (no ICU); strict in time portion. Under ICU,
+# the override returns BoundCastInfo without annotation and propagation bails — locked in by
+# statistics_cast_icu.test (#22235 / #22259).
+statement ok
+CREATE TABLE times AS SELECT (TIME '00:00:00' + INTERVAL (i) MINUTE) AS t FROM range(60) _(i)
+
+query II
+SELECT s.min, s.max FROM (SELECT STATS(t::TIMETZ) s FROM times LIMIT 1)
+----
+00:00:00+00	00:59:00+00


### PR DESCRIPTION
Cast-side mirror of #22384. `BoundCastInfo` gains an `arg_properties` field, the `*CastSwitch` factories opt monotonic casts in via `SetArgProperties(...)`, and `StatisticsPropagator::PropagateExpression(BoundCastExpression&)` derives output min/max by mapping the child's min/max through the bound cast.

Broken off from #22286 for review; the peel optimizer that also consumes this metadata is a separate follow-up.

## Why this PR is worth landing on its own

The set of *new* type-pair propagations visible from this PR alone is modest — the timestamp-precision FIXMEs in `CanPropagateCast` (TIMESTAMP[_TZ] → TIMESTAMP_NS/MS/S and inverses); unsigned-to-wider numeric widening (UTINYINT → USMALLINT/UINTEGER/UBIGINT/HUGEINT/FLOAT/DOUBLE and analogues — main's physical-type switch only accepted signed integer + float targets, so no unsigned source propagated through it); `TIME → TIMETZ` under the no-extension build; plus the correctness fix for ICU TIMESTAMP_TZ propagation via the active registry. The MIN/MAX peel PR is what consumes this metadata for the user-visible 25–63× speedups. Reasons to land plumbing first:

- **Extension casts can now participate in (or override) stats propagation.** The static `CanPropagateCast` allowlist in core hardcodes which type pairs propagate; extensions that register custom casts had no hook. With per-`BoundCastInfo` metadata, an extension's `BindCast` returns `BoundCastInfo(...).SetArgProperties(...)` and immediately participates — same opt-in mechanism recently introduced for extension functions.
- **Removes the allowlist from the runtime expression path.** `BoundCastExpression::PropagateExpression` no longer consults `CanPropagateCast`. The static API is retained only for storage-layer callers (struct/variant stats, multi-file column mapper) that operate on bare `LogicalType` pairs without a `BoundCastInfo` or `ClientContext`.
- **Active-registry correctness for ICU.** The previous `Value::DefaultTryCastAs` propagation constructed a fresh `CastFunctionSet` that didn't see ICU's TIMESTAMP_TZ overrides. The new path uses `Value::TryCastAs(context, ...)` so propagated bounds match runtime values when extensions are loaded.
- **Plumbing for follow-ups.** The MIN, MAX peel optimizer and more will be able to share code between functions and casts.

## What was unhandled before

`BoundCastExpression` stats went through a static type-pair allowlist (`CanPropagateCast` → `StatisticsOperationsNumericNumericCast` via `Value::DefaultTryCastAs`). That path:

- Couldn't see extension overrides — `DefaultTryCastAs` constructs a fresh `CastFunctionSet` containing only the default casts, so for ICU's `TIMESTAMP_TZ` overrides the propagated bounds didn't match runtime values.
- Bailed on the timestamp-precision conversions (`TIMESTAMP[_TZ] → TIMESTAMP_NS/MS/SEC` and the inverse) — explicitly marked `// FIXME: perform actual stats propagation for these casts`.
- Bailed on `TIME → TIMETZ` and `TIMESTAMP_TZ → TIMETZ` per #22259, because the static `DefaultTryCastAs` produces UTC-only bounds while runtime (with ICU) is session-zone-aware. The new path uses the active registry, so the bound matches runtime.
- Allowed only signed integer + float/double physical types in the source/target switch, so any cast involving an unsigned source or unsigned target bailed at the type-filter step. The new path's `IsOrderPreservingNumericCast<SRC, DST>()` annotates: same-signedness pairs; any integer→float pair (unsigned→float is just non-negative-into-mantissa); and unsigned→strictly-wider-signed (UTINYINT→SMALLINT/INTEGER/BIGINT/HUGEINT, USMALLINT→INTEGER/BIGINT/HUGEINT, etc., where every source value lands in the target's non-negative half). Same-width cross-signedness (e.g. UTINYINT→TINYINT) and signed→unsigned are deliberately left UNKNOWN — they overflow on the boundary and need range-aware refinement to be safe.

## Annotations

Numeric same-signedness widening (strict; non-decreasing for float-precision-loss cases), `INT → DECIMAL` (strict), `DECIMAL → DECIMAL` widening, `DECIMAL → FLOAT/DOUBLE` (non-decreasing), `DECIMAL → INT` truncation (non-decreasing), `DATE` → temporal widenings (strict), temporal → `VARCHAR` (strict), `TIMESTAMP_*` precision conversions (strict for widening, non-decreasing for truncation), `TIMESTAMP → DATE` (non-decreasing), and `TIME → TIMETZ` (strict; default cast packs offset 0 — ICU's session-zone override returns its own `BoundCastInfo` without `SetArgProperties` so propagation correctly bails when ICU is loaded).

### Deliberately left UNKNOWN

- **Signed→unsigned numeric casts** — not order-preserving across zero.
- **`TIMESTAMP → TIME`, `TIMESTAMP → TIMETZ`, `TIMESTAMP_TZ → TIMETZ`** — drop the date; distinct timestamps on different days collapse to the same time.
- **ICU `TIMESTAMP_TZ` casts** — DST transitions break monotonicity (the fall-back hour renders distinct UTC instants to the same naive timestamp). Since the `BoundCastInfo` defaults to `UNKNOWN` and ICU's bind path doesn't call `SetArgProperties`, no change needed in the ICU extension.

`try_cast = true` casts retain their existing `CAN_HAVE_NULL_VALUES` handling — the propagator marks the result nullable to reflect that overflow becomes NULL.