### PR TITLE
Disallow negate operator for unsigned input

### DIFF
--- a/src/include/duckdb/common/operator/negate.hpp
+++ b/src/include/duckdb/common/operator/negate.hpp
@@ -9,7 +9,10 @@ struct NegateOperator {
 	template <class T>
 	static bool CanNegate(T input) {
 		using Limits = NumericLimits<T>;
-		return !(Limits::IsSigned() && Limits::Minimum() == input);
+		if (!Limits::IsSigned()) {
+			return input == T(0);
+		}
+		return Limits::Minimum() != input;
 	}
 
 	template <class TA, class TR>

--- a/test/sql/types/uhugeint/test_uhugeint_arithmetic.test
+++ b/test/sql/types/uhugeint/test_uhugeint_arithmetic.test
@@ -2,13 +2,13 @@
 # description: Test arithmetic with unsigned huge integers
 # group: [uhugeint]
 
-# negation
-query II
-SELECT ~(-50::UHUGEINT), -(-(50::UHUGEINT));
+# negation: negating a non-zero unsigned value is out of range
+statement error
+SELECT -(50::UHUGEINT)
 ----
-49	50
+Out of Range Error
 
-# negate 0
+# negate 0 is well-defined
 query I
 SELECT -(0::UHUGEINT)
 ----

--- a/test/sql/types/unsigned/test_unsigned_conversion.test
+++ b/test/sql/types/unsigned/test_unsigned_conversion.test
@@ -146,25 +146,10 @@ SELECT (-42)::TINYINT::UBIGINT
 ----
 <REGEX>:Conversion Error.*INT8.*is out of range for.*UINT64.*
 
-query I
+statement error
 SELECT -42::TINYINT::UTINYINT
 ----
-214
-
-query I
-SELECT -42::TINYINT::USMALLINT
-----
-65494
-
-query I
-SELECT -42::TINYINT::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::TINYINT::UBIGINT
-----
-18446744073709551574
+Out of Range Error
 
 statement error
 SELECT (-42)::SMALLINT::UTINYINT
@@ -186,26 +171,6 @@ SELECT (-42)::SMALLINT::UBIGINT
 ----
 <REGEX>:Conversion Error.*INT16.*is out of range for.*UINT64.*
 
-query I
-SELECT -42::SMALLINT::UTINYINT
-----
-214
-
-query I
-SELECT -42::SMALLINT::USMALLINT
-----
-65494
-
-query I
-SELECT -42::SMALLINT::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::SMALLINT::UBIGINT
-----
-18446744073709551574
-
 statement error
 SELECT (-42)::INTEGER::UTINYINT
 ----
@@ -225,26 +190,6 @@ statement error
 SELECT (-42)::INTEGER::UBIGINT
 ----
 <REGEX>:Conversion Error.*INT32.*is out of range for.*UINT64.*
-
-query I
-SELECT -42::INTEGER::UTINYINT
-----
-214
-
-query I
-SELECT -42::INTEGER::USMALLINT
-----
-65494
-
-query I
-SELECT -42::INTEGER::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::INTEGER::UBIGINT
-----
-18446744073709551574
 
 statement error
 SELECT (-42)::BIGINT::UTINYINT
@@ -266,26 +211,6 @@ SELECT (-42)::BIGINT::UBIGINT
 ----
 <REGEX>:Conversion Error.*INT64.*is out of range for.*UINT64.*
 
-query I
-SELECT -42::BIGINT::UTINYINT
-----
-214
-
-query I
-SELECT -42::BIGINT::USMALLINT
-----
-65494
-
-query I
-SELECT -42::BIGINT::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::BIGINT::UBIGINT
-----
-18446744073709551574
-
 statement error
 SELECT (-42)::FLOAT::UTINYINT
 ----
@@ -306,26 +231,6 @@ SELECT (-42)::FLOAT::UBIGINT
 ----
 <REGEX>:Conversion Error.*FLOAT.*is out of range for.*UINT64.*
 
-query I
-SELECT -42::FLOAT::UTINYINT
-----
-214
-
-query I
-SELECT -42::FLOAT::USMALLINT
-----
-65494
-
-query I
-SELECT -42::FLOAT::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::FLOAT::UBIGINT
-----
-18446744073709551574
-
 statement error
 SELECT (-42)::DOUBLE::UTINYINT
 ----
@@ -345,26 +250,6 @@ statement error
 SELECT (-42)::DOUBLE::UBIGINT
 ----
 <REGEX>:Conversion Error.*DOUBLE.*is out of range for.*UINT64.*
-
-query I
-SELECT -42::DOUBLE::UTINYINT
-----
-214
-
-query I
-SELECT -42::DOUBLE::USMALLINT
-----
-65494
-
-query I
-SELECT -42::DOUBLE::UINTEGER
-----
-4294967254
-
-query I
-SELECT -42::DOUBLE::UBIGINT
-----
-18446744073709551574
 
 # Convert unsigned to signed
 statement error


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-fuzzer/issues/4489

Repro sql (copied from issue)
```sql
create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
SELECT subtract(ubigint) FROM all_types
```

Root cause:
- In [PR](https://github.com/duckdb/duckdb/pull/22384), we introduced automatic min/max population for operations
- For the buggy negate operator (which is indirectly used by subtract operator), we take UBIGINT::MAX and multiplying by -1 goes out of range, thus trigger the assertion failure

For a decreasing function
- out min = f(in max) = some positive value wrapped around
- out max = f(in min) = 0
- invariant check failure: out min > out max

Considerations I've thought about, happy to discuss
- ~~I target at v1.5 since it's fixing an existing issue.~~
  + Updated -- targets to main and behavior change should be documented
- I thought about keeping the current behavior (since I see we even have unit test to check wrap around value), then not registering arg if unsigned (diff see below), but I stick to the rejection approach since negation on negative value doesn't make too much sense to me

```diff
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -667,7 +667,9 @@ ScalarFunction SubtractFunction::GetFunction(const LogicalType &type) {
                ScalarFunction func("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type),
                                    IntegerNegateBind);
                func.SetFallible();
-               func.SetUnaryArgProperties(ArgProperties().StrictlyDecreasing());
+               if (!TypeIsUnsignedIntegral(type)) {
+                       func.SetUnaryArgProperty(ArgProperties().StrictlyDecreasing());
+               }
                return func;
        }
 }
```