### PR TITLE
Add support for writing struct types using `FlatVector::Writer<VectorStructType<...>>` and use it in the geometry methods

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1277,24 +1277,17 @@ uint32_t Geometry::GetExtent(const string_t &wkb, GeometryExtent &extent, bool &
 
 template <class V = VertexXY>
 static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	// Flatten the source vector to extract all vertices
-	source_vec.Flatten(row_count);
-
-	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
-	auto &vert_parts = StructVector::GetEntries(target_vec);
-	double *vert_data[V::WIDTH];
-
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	const auto geom_data = source_vec.Values<string_t>(row_count);
+	auto vert_writer = FlatVector::Writer<typename V::STRUCT_TYPE>(target_vec, row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+		auto geom_entry = geom_data[row_idx];
+		if (!geom_entry.IsValid()) {
+			vert_writer.WriteNull();
 			continue;
 		}
 
-		const auto &blob = geom_data[row_idx];
+		const auto &blob = geom_entry.GetValue();
 		const auto blob_data = blob.GetData();
 		const auto blob_size = blob.GetSize();
 
@@ -1303,9 +1296,7 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 		// Skip byte order and type/meta
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 
-		for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-			vert_data[dim_idx][row_idx] = reader.Read<double>();
-		}
+		vert_writer.ForEach([&](auto &child_writer) { child_writer.WriteValue(reader.Read<double>()); });
 	}
 }
 

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1311,24 +1311,18 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 
 template <class V = VertexXY>
 static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	// Flatten the source vector to extract all vertices
-	source_vec.Flatten(row_count);
-
 	auto vert_iter = source_vec.Values<typename V::STRUCT_TYPE>(row_count);
-	auto geom_data = FlatVector::GetDataMutable<string_t>(target_vec);
-
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
-
 		const auto vert_entry = vert_iter[row_idx];
 		if (!vert_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
 		// byte order + type/meta + vertex data
 		const auto blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(V);
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		const auto blob_data = blob.GetDataWriteable();
 
 		FixedSizeBlobWriter writer(blob_data, static_cast<uint32_t>(blob_size));
@@ -1342,7 +1336,6 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 		vert_entry.ForEach([&](const auto &v) { writer.Write<double>(v.GetValueUnsafe()); });
 
 		blob.Finalize();
-		geom_data[out_idx] = blob;
 	}
 }
 
@@ -1419,14 +1412,13 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 
 template <class V = VertexXY>
 static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	source_vec.Flatten(row_count);
 	auto line_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
 		const auto line_entry = line_iter[row_idx];
 		if (!line_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
@@ -1434,7 +1426,7 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 		// byte order + type/meta + vertex count + vertex data
 		const auto blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + vert_count * sizeof(V);
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
@@ -1449,7 +1441,6 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 		}
 
 		blob.Finalize();
-		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
 }
 
@@ -1554,14 +1545,13 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 
 template <class V = VertexXY>
 static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	source_vec.Flatten(row_count);
 	auto poly_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
 		const auto poly_entry = poly_iter[row_idx];
 		if (!poly_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
@@ -1572,8 +1562,7 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 		for (const auto ring_entry : poly_entry.GetChildValues()) {
 			blob_size += sizeof(uint32_t) + ring_entry.GetListLength() * sizeof(V);
 		}
-
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta = static_cast<uint32_t>(GeometryType::POLYGON) + (V::HAS_Z ? 1000 : 0) + (V::HAS_M ? 2000 : 0);
@@ -1590,7 +1579,6 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 		}
 
 		blob.Finalize();
-		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
 }
 
@@ -1670,14 +1658,13 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 
 template <class V = VertexXY>
 static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	source_vec.Flatten(row_count);
 	auto mult_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
 		const auto mult_entry = mult_iter[row_idx];
 		if (!mult_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
@@ -1686,7 +1673,8 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 		// byte order + type/meta + part count + (point header + vertex) per part
 		const auto blob_size = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) +
 		                       part_count * (sizeof(uint8_t) + sizeof(uint32_t) + sizeof(V));
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
@@ -1705,7 +1693,6 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 		}
 
 		blob.Finalize();
-		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
 }
 
@@ -1818,14 +1805,13 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 
 template <class V = VertexXY>
 static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	source_vec.Flatten(row_count);
 	auto mult_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
 		const auto mult_entry = mult_iter[row_idx];
 		if (!mult_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
@@ -1838,7 +1824,7 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 			blob_size += sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + line_entry.GetListLength() * sizeof(V);
 		}
 
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
@@ -1860,7 +1846,6 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 		}
 
 		blob.Finalize();
-		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
 }
 
@@ -1988,15 +1973,14 @@ static void ToMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 template <class V = VertexXY>
 static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
-	source_vec.Flatten(row_count);
 	auto mult_iter =
 	    source_vec.Values<VectorListType<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>>(row_count);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		const auto out_idx = result_offset + row_idx;
 		const auto mult_entry = mult_iter[row_idx];
 		if (!mult_entry.IsValid()) {
-			FlatVector::SetNull(target_vec, out_idx, true);
+			result_data.WriteNull();
 			continue;
 		}
 
@@ -2012,7 +1996,7 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 			}
 		}
 
-		auto blob = StringVector::EmptyString(target_vec, blob_size);
+		auto &blob = result_data.WriteEmptyString(blob_size);
 		FixedSizeBlobWriter writer(blob.GetDataWriteable(), static_cast<uint32_t>(blob_size));
 
 		const auto meta =
@@ -2037,7 +2021,6 @@ static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_
 		}
 
 		blob.Finalize();
-		FlatVector::GetDataMutable<string_t>(target_vec)[out_idx] = blob;
 	}
 }
 

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1312,7 +1312,7 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 template <class V = VertexXY>
 static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto vert_iter = source_vec.Values<typename V::STRUCT_TYPE>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto vert_entry = vert_iter[row_idx];
 		if (!vert_entry.IsValid()) {
@@ -1413,7 +1413,7 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 template <class V = VertexXY>
 static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto line_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto line_entry = line_iter[row_idx];
@@ -1546,7 +1546,7 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 template <class V = VertexXY>
 static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto poly_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto poly_entry = poly_iter[row_idx];
@@ -1659,7 +1659,7 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 template <class V = VertexXY>
 static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];
@@ -1806,7 +1806,7 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 template <class V = VertexXY>
 static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];
@@ -1975,7 +1975,7 @@ template <class V = VertexXY>
 static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter =
 	    source_vec.Values<VectorListType<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -274,4 +274,8 @@ const vector<Vector> &VectorIteratorGetStructEntries(const Vector &vector) {
 	return StructVector::GetEntries(vector);
 }
 
+vector<Vector> &VectorWriterGetStructEntries(Vector &vector) {
+	return StructVector::GetEntries(vector);
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -11,13 +11,24 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/types/string_heap.hpp"
 
+#include <tuple>
+#include <utility>
+
 namespace duckdb {
+
+//! Returns StructVector::GetEntries(vector) (mutable) without requiring struct_vector.hpp
+//! to be complete in this header. Defined in struct_vector.cpp.
+DUCKDB_API vector<Vector> &VectorWriterGetStructEntries(Vector &vector);
 
 template <class T>
 struct VectorWriter {
 	VectorWriter(Vector &vector, idx_t count, idx_t offset)
 	    : data(FlatVector::GetDataMutable<T>(vector)), validity(FlatVector::ValidityMutable(vector)),
 	      count(offset + count), current_idx(offset) {
+	}
+	VectorWriter(VectorWriter &&other) noexcept
+	    : data(other.data), validity(other.validity), count(other.count), current_idx(other.current_idx) {
+		other.count = other.current_idx;
 	}
 	~VectorWriter() {
 		// ensure that all values we said we were going to write have been written
@@ -53,6 +64,11 @@ private:
 template <>
 struct VectorWriter<string_t> {
 	VectorWriter(Vector &vector, idx_t count, idx_t offset);
+	VectorWriter(VectorWriter &&other) noexcept
+	    : vector(other.vector), data(other.data), validity(other.validity), heap(other.heap), count(other.count),
+	      current_idx(other.current_idx) {
+		other.count = other.current_idx;
+	}
 	~VectorWriter() {
 		D_ASSERT(Exception::UncaughtException() || current_idx == count);
 	}
@@ -113,6 +129,79 @@ private:
 	optional_ptr<StringHeap> heap;
 	idx_t count;
 	idx_t current_idx;
+};
+
+//! Specialization of VectorWriter for VectorStructType<Args...>.
+//! Writes rows to a struct vector with NULL propagation to all children.
+//! Supports recursive nesting: a child writer may itself be a struct writer.
+template <class... Args>
+struct VectorWriter<VectorStructType<Args...>> {
+private:
+	static_assert(sizeof...(Args) > 0, "VectorStructType must have at least one child type");
+
+	using ChildWriters = std::tuple<VectorWriter<Args>...>;
+
+public:
+	VectorWriter(Vector &vector, idx_t count, idx_t offset)
+	    : validity(FlatVector::ValidityMutable(vector)), count(offset + count), current_idx(offset),
+	      children(MakeChildren(vector, count, offset, std::index_sequence_for<Args...> {})) {
+	}
+	~VectorWriter() {
+		D_ASSERT(Exception::UncaughtException() || current_idx == count);
+	}
+
+	//! Write a NULL for this struct row. Also writes NULL to every child so all
+	//! per-child row counters stay in sync with the top-level counter.
+	void WriteNull() {
+		D_ASSERT(current_idx < count);
+		validity.SetInvalid(current_idx);
+		WriteNullToChildren(std::index_sequence_for<Args...> {});
+		current_idx++;
+	}
+
+	//! Write a non-NULL row by calling fun(child0, child1, ...) with each child
+	//! writer as a separate argument. fun is responsible for writing one value to
+	//! each child. Advances the top-level row counter automatically.
+	template <class FUN>
+	void WriteValue(FUN &&fun) {
+		D_ASSERT(current_idx < count);
+		std::apply(std::forward<FUN>(fun), children);
+		current_idx++;
+	}
+
+	//! Call fun(child_writer) for each child in declaration order, then advance
+	//! the top-level row counter. Useful when all children share the same type
+	//! and the same operation is applied to each.
+	template <class FUN>
+	void ForEach(FUN &&fun) {
+		D_ASSERT(current_idx < count);
+		ForEachImpl(std::forward<FUN>(fun), std::index_sequence_for<Args...> {});
+		current_idx++;
+	}
+
+private:
+	template <std::size_t... Is>
+	void WriteNullToChildren(std::index_sequence<Is...>) {
+		(std::get<Is>(children).WriteNull(), ...);
+	}
+
+	template <class FUN, std::size_t... Is>
+	void ForEachImpl(FUN &&fun, std::index_sequence<Is...>) {
+		(fun(std::get<Is>(children)), ...);
+	}
+
+	template <std::size_t... Is>
+	static ChildWriters MakeChildren(Vector &vector, idx_t count, idx_t offset, std::index_sequence<Is...>) {
+		auto &entries = VectorWriterGetStructEntries(vector);
+		D_ASSERT(entries.size() >= sizeof...(Is));
+		return ChildWriters(VectorWriter<Args>(entries[Is], count, offset)...);
+	}
+
+private:
+	ValidityMask &validity;
+	idx_t count;
+	idx_t current_idx;
+	ChildWriters children;
 };
 
 template <class T>


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/22417 but for writing

API looks like this:

```cpp
auto vert_writer = FlatVector::Writer<VectorStructType<double, double>>(target_vec, row_count);
for(idx_t i = 0; i < row_count; i++) {
	if (!geom_entry.IsValid()) {
		// top-level struct is NULL
		vert_writer.WriteNull();
		continue;
	}
	// write into each struct child
	vert_writer.WriteValue([&](auto &x_writer, auto &y_writer) {
		x_writer.WriteValue(x);
		y_writer.WriteValue(y);
	});
	// write into each struct child, if they all have the same type (used for geom as the vert count is templated)
	vert_writer.ForEach([&](auto &child_writer) { child_writer.WriteValue(reader.Read<double>()); });
}
```