### PR TITLE
Add support for writing list types using `FlatVector::Writer<VectorListType<...>>` and use it in the geometry methods

### DIFF
--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -1,5 +1,3 @@
-#include "duckdb/common/vector/map_vector.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
 #include "core_functions/scalar/date_functions.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/date.hpp"
@@ -54,14 +52,20 @@ void ExecuteStructMakeDate(DataChunk &input, ExpressionState &state, Vector &res
 	// this should be guaranteed by the binder
 	D_ASSERT(input.ColumnCount() == 1);
 	auto &vec = input.data[0];
+	const auto count = input.size();
 
-	auto &children = StructVector::GetEntries(vec);
-	D_ASSERT(children.size() == 3);
-	auto &yyyy = children[0];
-	auto &mm = children[1];
-	auto &dd = children[2];
-
-	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(), FromDateCast<T>);
+	auto iter = vec.Values<VectorStructType<T, T, T>>(count);
+	auto writer = FlatVector::Writer<date_t>(result, count);
+	for (const auto entry : iter) {
+		const auto y = entry.template GetChildValue<0>();
+		const auto m = entry.template GetChildValue<1>();
+		const auto d = entry.template GetChildValue<2>();
+		if (!entry.IsValid() || !y.IsValid() || !m.IsValid() || !d.IsValid()) {
+			writer.WriteNull();
+			continue;
+		}
+		writer.WriteValue(FromDateCast<T>(y.GetValueUnsafe(), m.GetValueUnsafe(), d.GetValueUnsafe()));
+	}
 }
 
 struct MakeTimeOperator {

--- a/extension/core_functions/scalar/list/range.cpp
+++ b/extension/core_functions/scalar/list/range.cpp
@@ -1,7 +1,5 @@
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/list_vector.hpp"
 #include "core_functions/scalar/list_functions.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/timestamp.hpp"
@@ -205,37 +203,25 @@ void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 			break;
 		}
 	}
-	auto result_data = FlatVector::Writer<list_entry_t>(result, args_size);
-	uint64_t total_size = 0;
-	vector<uint64_t> list_lengths(args_size, 0);
+	auto list_writer = FlatVector::Writer<VectorListType<typename OP::TYPE>>(result, args_size);
 	for (idx_t i = 0; i < args_size; i++) {
 		if (!info.RowIsValid(i)) {
-			result_data.WriteNull(list_entry_t(total_size, 0));
-		} else {
-			const auto length = info.ListLength(i);
-			list_lengths[i] = length;
-			result_data.WriteValue(list_entry_t(total_size, length));
-			total_size += length;
+			list_writer.WriteNull();
+			continue;
 		}
-	}
-
-	// now construct the child vector of the list
-	ListVector::Reserve(result, total_size);
-	auto range_data = FlatVector::Writer<typename OP::TYPE>(ListVector::GetChildMutable(result), total_size);
-	for (idx_t i = 0; i < args_size; i++) {
 		typename OP::TYPE start_value = info.StartListValue(i);
 		typename OP::INCREMENT_TYPE increment = info.ListIncrementValue(i);
+		const auto length = info.ListLength(i);
 
 		typename OP::TYPE range_value = start_value;
-		for (idx_t range_idx = 0; range_idx < list_lengths[i]; range_idx++) {
+		for (auto &[child_writer, range_idx] : list_writer.WriteList(length)) {
 			if (range_idx > 0) {
 				OP::Increment(range_value, increment);
 			}
-			range_data.WriteValue(range_value);
+			child_writer.WriteValue(range_value);
 		}
 	}
 
-	ListVector::SetListSize(result, total_size);
 	result.SetVectorType(result_type);
 
 	result.Verify(args.size());

--- a/extension/core_functions/scalar/list/range.cpp
+++ b/extension/core_functions/scalar/list/range.cpp
@@ -214,11 +214,13 @@ void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 		const auto length = info.ListLength(i);
 
 		typename OP::TYPE range_value = start_value;
-		for (auto &[child_writer, range_idx] : list_writer.WriteList(length)) {
-			if (range_idx > 0) {
+		bool seen_value = false;
+		for (auto &child_writer : list_writer.WriteList(length)) {
+			if (seen_value) {
 				OP::Increment(range_value, increment);
 			}
 			child_writer.WriteValue(range_value);
+			seen_value = true;
 		}
 	}
 

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -1,4 +1,3 @@
-#include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
 #include "core_functions/scalar/struct_functions.hpp"
@@ -15,17 +14,11 @@ struct StructKeysBindData : public FunctionData {
 		const auto &child_types = StructType::GetChildTypes(type);
 		const auto count = child_types.size();
 
-		ListVector::Reserve(keys_vector, count);
-		auto &list_child = ListVector::GetChildMutable(keys_vector);
-		auto child_data = FlatVector::Writer<string_t>(list_child, count);
-		for (idx_t i = 0; i < count; i++) {
-			child_data.WriteValue(string_t(child_types[i].first));
+		auto list_writer = FlatVector::Writer<VectorListType<string_t>>(keys_vector, 2);
+		for (auto &[child_writer, idx] : list_writer.WriteList(count)) {
+			child_writer.WriteValue(string_t(child_types[idx].first));
 		}
-		ListVector::SetListSize(keys_vector, count);
-
-		auto list_entries = FlatVector::Writer<list_entry_t>(keys_vector, 2);
-		list_entries.WriteValue(list_entry_t(0, count));
-		list_entries.WriteNull();
+		list_writer.WriteNull();
 	}
 
 	bool Equals(const FunctionData &other) const override {

--- a/extension/core_functions/scalar/struct/struct_keys.cpp
+++ b/extension/core_functions/scalar/struct/struct_keys.cpp
@@ -15,8 +15,9 @@ struct StructKeysBindData : public FunctionData {
 		const auto count = child_types.size();
 
 		auto list_writer = FlatVector::Writer<VectorListType<string_t>>(keys_vector, 2);
-		for (auto &[child_writer, idx] : list_writer.WriteList(count)) {
-			child_writer.WriteValue(string_t(child_types[idx].first));
+		idx_t idx = 0;
+		for (auto &child_writer : list_writer.WriteList(count)) {
+			child_writer.WriteValue(string_t(child_types[idx++].first));
 		}
 		list_writer.WriteNull();
 	}

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1332,73 +1332,27 @@ static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, 
 
 template <class V = VertexXY>
 static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	// Flatten the source vector to extract all vertices
-	source_vec.Flatten(row_count);
+	auto geom_data = source_vec.Values<string_t>(row_count);
+	auto list_writer = FlatVector::Writer<VectorListType<typename V::STRUCT_TYPE>>(target_vec, row_count);
 
-	idx_t vert_total = 0;
-	idx_t vert_start = 0;
-
-	// First pass, figure out how many vertices are in this linestring
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+		auto geom_entry = geom_data[row_idx];
+		if (!geom_entry.IsValid()) {
+			list_writer.WriteNull();
 			continue;
 		}
 
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
+		const auto &blob = geom_entry.GetValue();
+		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
 		// Skip byte order and type/meta
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto vert_count = reader.Read<uint32_t>();
 
-		vert_total += vert_count;
-	}
-
-	ListVector::Reserve(target_vec, vert_total);
-	ListVector::SetListSize(target_vec, vert_total);
-
-	auto list_data = FlatVector::GetDataMutable<list_entry_t>(target_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(target_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
-
-	// Second pass, write out the linestrings
-
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			continue;
+		for (auto &[vert_writer, _] : list_writer.WriteList(vert_count)) {
+			vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 		}
-
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-		// Skip byte order and type/meta
-		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-		const auto vert_count = reader.Read<uint32_t>();
-
-		// Set list entry
-		auto &list_entry = list_data[row_idx];
-		list_entry.offset = vert_start;
-		list_entry.length = vert_count;
-
-		// Read vertices
-		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-			for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-				vert_data[dim_idx][vert_start + vert_idx] = reader.Read<double>();
-			}
-		}
-
-		vert_start += vert_count;
 	}
-
-	D_ASSERT(vert_start == vert_total);
 }
 
 template <class V = VertexXY>
@@ -1437,101 +1391,26 @@ static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 template <class V = VertexXY>
 static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	source_vec.Flatten(row_count);
-
-	idx_t vert_total = 0;
-	idx_t ring_total = 0;
-	idx_t vert_start = 0;
-	idx_t ring_start = 0;
-
-	// First pass, figure out how many vertices and rings are in this polygon
+	auto geom_data = source_vec.Values<string_t>(row_count);
+	auto poly_writer =
+	    FlatVector::Writer<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(target_vec, row_count);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+		auto geom_entry = geom_data[row_idx];
+		if (!geom_entry.IsValid()) {
+			poly_writer.WriteNull();
 			continue;
 		}
-
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
+		const auto &blob = geom_entry.GetValue();
+		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
 		const auto ring_count = reader.Read<uint32_t>();
-		for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
+		for (auto &[ring_writer, _] : poly_writer.WriteList(ring_count)) {
 			const auto vert_count = reader.Read<uint32_t>();
-
-			// Skip vertices
-			reader.Skip(sizeof(V) * vert_count);
-
-			vert_total += vert_count;
-		}
-		ring_total += ring_count;
-	}
-
-	// Reserve space in the target vector
-	ListVector::Reserve(target_vec, ring_total);
-	ListVector::SetListSize(target_vec, ring_total);
-
-	auto &ring_vec = ListVector::GetChildMutable(target_vec);
-	ListVector::Reserve(ring_vec, vert_total);
-	ListVector::SetListSize(ring_vec, vert_total);
-
-	auto poly_data = FlatVector::GetDataMutable<list_entry_t>(target_vec);
-	auto ring_data = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(ring_vec));
-	double *vert_data[V::WIDTH];
-
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
-
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			continue;
-		}
-
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
-		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-		const auto ring_count = reader.Read<uint32_t>();
-		// Set polygon entry
-		auto &poly_entry = poly_data[row_idx];
-		poly_entry.offset = ring_start;
-		poly_entry.length = ring_count;
-
-		for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-			const auto vert_count = reader.Read<uint32_t>();
-
-			// Set ring entry
-			auto &ring_entry = ring_data[ring_start + ring_idx];
-			ring_entry.offset = vert_start;
-			ring_entry.length = vert_count;
-
-			// Read vertices
-			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-					vert_data[dim_idx][vert_start + vert_idx] = reader.Read<double>();
-				}
+			for (auto &[vert_writer, _] : ring_writer.WriteList(vert_count)) {
+				vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 			}
-
-			vert_start += vert_count;
 		}
-
-		ring_start += ring_count;
 	}
-
-	D_ASSERT(vert_start == vert_total);
-	D_ASSERT(ring_start == ring_total);
 }
 
 template <class V = VertexXY>
@@ -1575,76 +1454,23 @@ static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count
 
 template <class V = VertexXY>
 static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	source_vec.Flatten(row_count);
-
-	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
-
-	idx_t vert_total = 0;
-	idx_t vert_start = 0;
-
-	// First pass, figure out how many vertices are in this multipoint
+	auto geom_data = source_vec.Values<string_t>(row_count);
+	auto mult_writer = FlatVector::Writer<VectorListType<typename V::STRUCT_TYPE>>(target_vec, row_count);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+		auto geom_value = geom_data[row_idx];
+		if (!geom_value.IsValid()) {
+			mult_writer.WriteNull();
 			continue;
 		}
-		const auto &blob = geom_data[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
+		const auto &blob = geom_value.GetValue();
+		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto part_count = reader.Read<uint32_t>();
-		vert_total += part_count;
-	}
-
-	// Reserve space in the target vector
-	ListVector::Reserve(target_vec, vert_total);
-	ListVector::SetListSize(target_vec, vert_total);
-
-	auto mult_data = FlatVector::GetDataMutable<list_entry_t>(target_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(target_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
-
-	// Second pass, write out the multipoints
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			continue;
-		}
-
-		const auto &blob = geom_data[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
-		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-		const auto part_count = reader.Read<uint32_t>();
-
-		// Set multipoint entry
-		auto &mult_entry = mult_data[row_idx];
-		mult_entry.offset = vert_start;
-		mult_entry.length = part_count;
-
-		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
-			// Skip byte order and type/meta of the point
+		for (auto &[vert_writer, _] : mult_writer.WriteList(part_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-			for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-				vert_data[dim_idx][vert_start + part_idx] = reader.Read<double>();
-			}
+			vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 		}
-
-		vert_start += part_count;
 	}
-
-	D_ASSERT(vert_start == vert_total);
 }
 
 template <class V = VertexXY>
@@ -1689,109 +1515,29 @@ static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_co
 
 template <class V = VertexXY>
 static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
-
-	// This is basically the same as Polygons
-
-	idx_t vert_total = 0;
-	idx_t line_total = 0;
-	idx_t vert_start = 0;
-	idx_t line_start = 0;
-
-	// First pass, figure out how many vertices and lines are in this multilinestring
+	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
+	auto mult_writer =
+	    FlatVector::Writer<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(target_vec, row_count);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+			mult_writer.WriteNull();
 			continue;
 		}
-
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
-		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-		// Line count
-		const auto line_count = reader.Read<uint32_t>();
-		for (uint32_t line_idx = 0; line_idx < line_count; line_idx++) {
-			// Skip line metadata
-			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-			// Read vertex count
-			const auto vert_count = reader.Read<uint32_t>();
-			// Skip vertices
-			reader.Skip(sizeof(V) * vert_count);
-
-			vert_total += vert_count;
-		}
-		line_total += line_count;
-	}
-
-	// Reserve space in the target vector
-	ListVector::Reserve(target_vec, line_total);
-	ListVector::SetListSize(target_vec, line_total);
-
-	auto &line_vec = ListVector::GetChildMutable(target_vec);
-	ListVector::Reserve(line_vec, vert_total);
-	ListVector::SetListSize(line_vec, vert_total);
-
-	auto mult_data = FlatVector::GetDataMutable<list_entry_t>(target_vec);
-	auto line_data = FlatVector::GetDataMutable<list_entry_t>(line_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(line_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
-
-	// Second pass, write out the multilinestrings
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			continue;
-		}
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-		// Skip byte order and type/meta
+		const auto &blob = geom_data[row_idx];
+		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto line_count = reader.Read<uint32_t>();
-
-		// Set multilinestring entry
-		auto &mult_entry = mult_data[row_idx];
-		mult_entry.offset = line_start;
-		mult_entry.length = line_count;
-
-		for (uint32_t line_idx = 0; line_idx < line_count; line_idx++) {
-			// Skip line byte order and type/meta
+		for (auto &[line_writer, line_idx] : mult_writer.WriteList(line_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-			// Read vertex count
 			const auto vert_count = reader.Read<uint32_t>();
-
-			// Set line entry
-			auto &line_entry = line_data[line_start + line_idx];
-			line_entry.offset = vert_start;
-			line_entry.length = vert_count;
-
-			// Read vertices
-			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-				for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-					vert_data[dim_idx][vert_start + vert_idx] = reader.Read<double>();
-				}
+			for (auto &[vert_writer, vert_idx] : line_writer.WriteList(vert_count)) {
+				vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
+				(void)vert_idx;
 			}
-
-			vert_start += vert_count;
+			(void)line_idx;
 		}
-		line_start += line_count;
 	}
-
-	D_ASSERT(vert_start == vert_total);
-	D_ASSERT(line_start == line_total);
 }
 
 template <class V = VertexXY>
@@ -1842,123 +1588,32 @@ static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t r
 
 template <class V = VertexXY>
 static void ToMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	// Flatten the source vector to extract all vertices
 	source_vec.Flatten(row_count);
-
-	idx_t vert_total = 0;
-	idx_t ring_total = 0;
-	idx_t poly_total = 0;
-	idx_t vert_start = 0;
-	idx_t ring_start = 0;
-	idx_t poly_start = 0;
-
-	// First pass, figure out how many vertices, rings and polygons are in this multipolygon
+	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
+	auto mult_writer = FlatVector::Writer<VectorListType<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>>(
+	    target_vec, row_count);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+			mult_writer.WriteNull();
 			continue;
 		}
-
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
-		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-		const auto poly_count = reader.Read<uint32_t>();
-		for (uint32_t poly_idx = 0; poly_idx < poly_count; poly_idx++) {
-			// Skip polygon byte order and metadata
-			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-			// Read ring count
-			const auto ring_count = reader.Read<uint32_t>();
-			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-				// Read vertex count
-				const auto vert_count = reader.Read<uint32_t>();
-				// Skip vertices
-				reader.Skip(sizeof(V) * vert_count);
-
-				vert_total += vert_count;
-			}
-			ring_total += ring_count;
-		}
-		poly_total += poly_count;
-	}
-
-	// Reserve space in the target vector
-	ListVector::Reserve(target_vec, poly_total);
-	ListVector::SetListSize(target_vec, poly_total);
-	auto &poly_vec = ListVector::GetChildMutable(target_vec);
-	ListVector::Reserve(poly_vec, ring_total);
-	ListVector::SetListSize(poly_vec, ring_total);
-	auto &ring_vec = ListVector::GetChildMutable(poly_vec);
-	ListVector::Reserve(ring_vec, vert_total);
-	ListVector::SetListSize(ring_vec, vert_total);
-
-	auto mult_data = FlatVector::GetDataMutable<list_entry_t>(target_vec);
-	auto poly_data = FlatVector::GetDataMutable<list_entry_t>(poly_vec);
-	auto ring_data = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
-	auto &vert_parts = StructVector::GetEntries(ListVector::GetChildMutable(ring_vec));
-	double *vert_data[V::WIDTH];
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
-
-	// Second pass, write out the multipolygons
-	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			continue;
-		}
-		const auto &blob = FlatVector::GetData<string_t>(source_vec)[row_idx];
-		const auto blob_data = blob.GetData();
-		const auto blob_size = blob.GetSize();
-
-		BlobReader reader(blob_data, static_cast<uint32_t>(blob_size));
-
-		// Skip byte order and type/meta
+		const auto &blob = geom_data[row_idx];
+		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto poly_count = reader.Read<uint32_t>();
-
-		// Set multipolygon entry
-		auto &mult_entry = mult_data[row_idx];
-		mult_entry.offset = poly_start;
-		mult_entry.length = poly_count;
-
-		// Read polygons
-		for (uint32_t poly_idx = 0; poly_idx < poly_count; poly_idx++) {
-			// Skip polygon byte order and type/meta
+		for (auto &[poly_writer, poly_idx] : mult_writer.WriteList(poly_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
-
-			// Read ring count
 			const auto ring_count = reader.Read<uint32_t>();
-
-			// Set polygon entry
-			auto &poly_entry = poly_data[poly_start + poly_idx];
-			poly_entry.offset = ring_start;
-			poly_entry.length = ring_count;
-
-			// Read rings
-			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
-				// Read vertex count
+			for (auto &[ring_writer, ring_idx] : poly_writer.WriteList(ring_count)) {
 				const auto vert_count = reader.Read<uint32_t>();
-				// Set ring entry
-				auto &ring_entry = ring_data[ring_start + ring_idx];
-				ring_entry.offset = vert_start;
-				ring_entry.length = vert_count;
-
-				// Read vertices
-				for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
-					for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-						vert_data[dim_idx][vert_start + vert_idx] = reader.Read<double>();
-					}
+				for (auto &[vert_writer, vert_idx] : ring_writer.WriteList(vert_count)) {
+					vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
+					(void)vert_idx;
 				}
-				vert_start += vert_count;
+				(void)ring_idx;
 			}
-			ring_start += ring_count;
+			(void)poly_idx;
 		}
-		poly_start += poly_count;
 	}
 }
 

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1349,7 +1349,7 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto vert_count = reader.Read<uint32_t>();
 
-		for (auto &[vert_writer, _] : list_writer.WriteList(vert_count)) {
+		for (auto &vert_writer : list_writer.WriteList(vert_count)) {
 			vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 		}
 	}
@@ -1404,9 +1404,9 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto ring_count = reader.Read<uint32_t>();
-		for (auto &[ring_writer, _] : poly_writer.WriteList(ring_count)) {
+		for (auto &ring_writer : poly_writer.WriteList(ring_count)) {
 			const auto vert_count = reader.Read<uint32_t>();
-			for (auto &[vert_writer, _] : ring_writer.WriteList(vert_count)) {
+			for (auto &vert_writer : ring_writer.WriteList(vert_count)) {
 				vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 			}
 		}
@@ -1466,7 +1466,7 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto part_count = reader.Read<uint32_t>();
-		for (auto &[vert_writer, _] : mult_writer.WriteList(part_count)) {
+		for (auto &vert_writer : mult_writer.WriteList(part_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 			vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
 		}
@@ -1528,14 +1528,12 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto line_count = reader.Read<uint32_t>();
-		for (auto &[line_writer, line_idx] : mult_writer.WriteList(line_count)) {
+		for (auto &line_writer : mult_writer.WriteList(line_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 			const auto vert_count = reader.Read<uint32_t>();
-			for (auto &[vert_writer, vert_idx] : line_writer.WriteList(vert_count)) {
+			for (auto &vert_writer : line_writer.WriteList(vert_count)) {
 				vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
-				(void)vert_idx;
 			}
-			(void)line_idx;
 		}
 	}
 }
@@ -1601,18 +1599,15 @@ static void ToMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_co
 		BlobReader reader(blob.GetData(), static_cast<uint32_t>(blob.GetSize()));
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 		const auto poly_count = reader.Read<uint32_t>();
-		for (auto &[poly_writer, poly_idx] : mult_writer.WriteList(poly_count)) {
+		for (auto &poly_writer : mult_writer.WriteList(poly_count)) {
 			reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 			const auto ring_count = reader.Read<uint32_t>();
-			for (auto &[ring_writer, ring_idx] : poly_writer.WriteList(ring_count)) {
+			for (auto &ring_writer : poly_writer.WriteList(ring_count)) {
 				const auto vert_count = reader.Read<uint32_t>();
-				for (auto &[vert_writer, vert_idx] : ring_writer.WriteList(vert_count)) {
+				for (auto &vert_writer : ring_writer.WriteList(vert_count)) {
 					vert_writer.ForEach([&](auto &dim_writer) { dim_writer.WriteValue(reader.Read<double>()); });
-					(void)vert_idx;
 				}
-				(void)ring_idx;
 			}
-			(void)poly_idx;
 		}
 	}
 }

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1277,24 +1277,17 @@ uint32_t Geometry::GetExtent(const string_t &wkb, GeometryExtent &extent, bool &
 
 template <class V = VertexXY>
 static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
-	// Flatten the source vector to extract all vertices
-	source_vec.Flatten(row_count);
-
-	const auto geom_data = FlatVector::GetData<string_t>(source_vec);
-	auto &vert_parts = StructVector::GetEntries(target_vec);
-	double *vert_data[V::WIDTH];
-
-	for (idx_t i = 0; i < V::WIDTH; i++) {
-		vert_data[i] = FlatVector::GetDataMutable<double>(vert_parts[i]);
-	}
+	const auto geom_data = source_vec.Values<string_t>(row_count);
+	auto vert_writer = FlatVector::Writer<typename V::STRUCT_TYPE>(target_vec, row_count);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		if (FlatVector::IsNull(source_vec, row_idx)) {
-			FlatVector::SetNull(target_vec, row_idx, true);
+		auto geom_entry = geom_data[row_idx];
+		if (!geom_entry.IsValid()) {
+			vert_writer.WriteNull();
 			continue;
 		}
 
-		const auto &blob = geom_data[row_idx];
+		const auto &blob = geom_entry.GetValue();
 		const auto blob_data = blob.GetData();
 		const auto blob_size = blob.GetSize();
 
@@ -1303,9 +1296,7 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 		// Skip byte order and type/meta
 		reader.Skip(sizeof(uint8_t) + sizeof(uint32_t));
 
-		for (uint32_t dim_idx = 0; dim_idx < V::WIDTH; dim_idx++) {
-			vert_data[dim_idx][row_idx] = reader.Read<double>();
-		}
+		vert_writer.ForEach([&](auto &child_writer) { child_writer.WriteValue(reader.Read<double>()); });
 	}
 }
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -459,4 +459,20 @@ idx_t VectorIteratorGetListSize(const Vector &vector) {
 	return ListVector::GetListSize(vector);
 }
 
+Vector &VectorWriterGetListChild(Vector &vector) {
+	return ListVector::GetChildMutable(vector);
+}
+
+idx_t VectorWriterGetListSize(const Vector &vector) {
+	return ListVector::GetListSize(vector);
+}
+
+void VectorWriterReserveList(Vector &vector, idx_t required_capacity) {
+	ListVector::Reserve(vector, required_capacity);
+}
+
+void VectorWriterSetListSize(Vector &vector, idx_t size) {
+	ListVector::SetListSize(vector, size);
+}
+
 } // namespace duckdb

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -274,4 +274,8 @@ const vector<Vector> &VectorIteratorGetStructEntries(const Vector &vector) {
 	return StructVector::GetEntries(vector);
 }
 
+vector<Vector> &VectorWriterGetStructEntries(Vector &vector) {
+	return StructVector::GetEntries(vector);
+}
+
 } // namespace duckdb

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -98,7 +98,7 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 	ListVector::Reserve(result, list_size);
 	ListVector::SetListSize(result, list_size);
 
-	// copy over the NULL values from the input vector
+	// copy over the list_entry_t values from the input vector, preserving top-level validity
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(input)) {
 			ConstantVector::SetNull(result, count_t(result_size));
@@ -108,18 +108,13 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
 		memcpy(result_list_data, list_data, sizeof(list_entry_t));
 	} else {
-		auto entries = input.Values<list_entry_t>(result_size);
-		if (entries.CanHaveNull()) {
-			auto &result_validity = FlatVector::ValidityMutable(result);
-			for (idx_t i = 0; i < result_size; i++) {
-				if (!entries[i].IsValid()) {
-					result_validity.SetInvalid(i);
-				}
+		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
+		for (const auto entry : input.Values<list_entry_t>(result_size)) {
+			if (entry.IsValid()) {
+				writer.WriteValue(entry.GetValueUnsafe());
+			} else {
+				writer.WriteNull();
 			}
-		}
-		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		for (idx_t i = 0; i < result_size; i++) {
-			result_list_data[i] = entries.GetValueUnsafe(i);
 		}
 	}
 	// set up the correct vector references
@@ -145,7 +140,7 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 	ListVector::Reserve(result, list_size);
 	ListVector::SetListSize(result, list_size);
 
-	// copy over the NULL values from the input vector
+	// copy over the list_entry_t values from the input vector, preserving top-level validity
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (ConstantVector::IsNull(input)) {
 			ConstantVector::SetNull(result, count_t(result_size));
@@ -155,18 +150,13 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
 		memcpy(result_list_data, list_data, sizeof(list_entry_t));
 	} else {
-		auto entries = input.Values<list_entry_t>(result_size);
-		if (entries.CanHaveNull()) {
-			auto &result_validity = FlatVector::ValidityMutable(result);
-			for (idx_t i = 0; i < result_size; i++) {
-				if (!entries[i].IsValid()) {
-					result_validity.SetInvalid(i);
-				}
+		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
+		for (const auto entry : input.Values<list_entry_t>(result_size)) {
+			if (entry.IsValid()) {
+				writer.WriteValue(entry.GetValueUnsafe());
+			} else {
+				writer.WriteNull();
 			}
-		}
-		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		for (idx_t i = 0; i < result_size; i++) {
-			result_list_data[i] = entries.GetValueUnsafe(i);
 		}
 	}
 

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -11,13 +11,24 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/types/string_heap.hpp"
 
+#include <tuple>
+#include <utility>
+
 namespace duckdb {
+
+//! Returns StructVector::GetEntries(vector) (mutable) without requiring struct_vector.hpp
+//! to be complete in this header. Defined in struct_vector.cpp.
+DUCKDB_API vector<Vector> &VectorWriterGetStructEntries(Vector &vector);
 
 template <class T>
 struct VectorWriter {
 	VectorWriter(Vector &vector, idx_t count, idx_t offset)
 	    : data(FlatVector::GetDataMutable<T>(vector)), validity(FlatVector::ValidityMutable(vector)),
 	      count(offset + count), current_idx(offset) {
+	}
+	VectorWriter(VectorWriter &&other) noexcept
+	    : data(other.data), validity(other.validity), count(other.count), current_idx(other.current_idx) {
+		other.count = other.current_idx;
 	}
 	~VectorWriter() {
 		// ensure that all values we said we were going to write have been written
@@ -53,6 +64,11 @@ private:
 template <>
 struct VectorWriter<string_t> {
 	VectorWriter(Vector &vector, idx_t count, idx_t offset);
+	VectorWriter(VectorWriter &&other) noexcept
+	    : vector(other.vector), data(other.data), validity(other.validity), heap(other.heap), count(other.count),
+	      current_idx(other.current_idx) {
+		other.count = other.current_idx;
+	}
 	~VectorWriter() {
 		D_ASSERT(Exception::UncaughtException() || current_idx == count);
 	}
@@ -113,6 +129,79 @@ private:
 	optional_ptr<StringHeap> heap;
 	idx_t count;
 	idx_t current_idx;
+};
+
+//! Specialization of VectorWriter for VectorStructType<Args...>.
+//! Writes rows to a struct vector with NULL propagation to all children.
+//! Supports recursive nesting: a child writer may itself be a struct writer.
+template <class... Args>
+struct VectorWriter<VectorStructType<Args...>> {
+private:
+	static_assert(sizeof...(Args) > 0, "VectorStructType must have at least one child type");
+
+	using ChildWriters = std::tuple<VectorWriter<Args>...>;
+
+public:
+	VectorWriter(Vector &vector, idx_t count, idx_t offset)
+	    : validity(FlatVector::ValidityMutable(vector)), count(offset + count), current_idx(offset),
+	      children(MakeChildren(vector, count, offset, std::index_sequence_for<Args...> {})) {
+	}
+	~VectorWriter() {
+		D_ASSERT(Exception::UncaughtException() || current_idx == count);
+	}
+
+	//! Write a NULL for this struct row. Also writes NULL to every child so all
+	//! per-child row counters stay in sync with the top-level counter.
+	void WriteNull() {
+		D_ASSERT(current_idx < count);
+		validity.SetInvalid(current_idx);
+		WriteNullToChildren(std::index_sequence_for<Args...> {});
+		current_idx++;
+	}
+
+	//! Write a non-NULL row by calling fun(child0, child1, ...) with each child
+	//! writer as a separate argument. fun is responsible for writing one value to
+	//! each child. Advances the top-level row counter automatically.
+	template <class FUN>
+	void WriteValue(FUN &&fun) {
+		D_ASSERT(current_idx < count);
+		std::apply(std::forward<FUN>(fun), children);
+		current_idx++;
+	}
+
+	//! Call fun(child_writer) for each child in declaration order, then advance
+	//! the top-level row counter. Useful when all children share the same type
+	//! and the same operation is applied to each.
+	template <class FUN>
+	void ForEach(FUN &&fun) {
+		D_ASSERT(current_idx < count);
+		ForEachImpl(std::forward<FUN>(fun), std::index_sequence_for<Args...> {});
+		current_idx++;
+	}
+
+private:
+	template <std::size_t... Is>
+	void WriteNullToChildren(std::index_sequence<Is...>) {
+		(std::get<Is>(children).WriteNull(), ...);
+	}
+
+	template <class FUN, std::size_t... Is>
+	void ForEachImpl(FUN &&fun, std::index_sequence<Is...>) {
+		(fun(std::get<Is>(children)), ...);
+	}
+
+	template <std::size_t... Is>
+	static ChildWriters MakeChildren(Vector &vector, idx_t count, idx_t offset, std::index_sequence<Is...>) {
+		auto &entries = VectorWriterGetStructEntries(vector);
+		D_ASSERT(entries.size() >= sizeof...(Is));
+		return ChildWriters(VectorWriter<Args>(entries[Is], count, offset)...);
+	}
+
+private:
+	ValidityMask &validity;
+	idx_t count;
+	idx_t current_idx;
+	ChildWriters children;
 };
 
 template <class T>

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -221,21 +221,14 @@ struct VectorWriter<VectorListType<T>> {
 public:
 	//! Range returned by WriteList(n). Holds a VectorWriter<T> scoped to the
 	//! n reserved child slots. Destroying the range asserts all n were written.
-	//! The Entry reference member makes WriteRange non-movable; C++17 guaranteed
-	//! copy elision ensures it is always constructed in place.
+	//! C++17 guaranteed copy elision ensures it is always constructed in place.
 	struct WriteRange {
-		struct Entry {
-			VectorWriter<T> &writer;
-			idx_t idx;
-		};
-
 		class RangeIterator {
 		public:
-			RangeIterator(Entry &entry, idx_t pos) : entry(entry), pos(pos) {
+			RangeIterator(VectorWriter<T> &writer, idx_t pos) : writer(writer), pos(pos) {
 			}
-			Entry &operator*() {
-				entry.idx = pos;
-				return entry;
+			VectorWriter<T> &operator*() {
+				return writer;
 			}
 			RangeIterator &operator++() { // NOLINT: match stl API
 				++pos;
@@ -246,24 +239,22 @@ public:
 			}
 
 		private:
-			Entry &entry;
+			VectorWriter<T> &writer;
 			idx_t pos;
 		};
 
-		WriteRange(Vector &child_vec, idx_t n, idx_t offset)
-		    : child_writer(child_vec, n, offset), length(n), current_entry {child_writer, 0} {
+		WriteRange(Vector &child_vec, idx_t n, idx_t offset) : child_writer(child_vec, n, offset), length(n) {
 		}
 
 		RangeIterator begin() { // NOLINT: match stl API
-			return RangeIterator(current_entry, 0);
+			return RangeIterator(child_writer, 0);
 		}
 		RangeIterator end() { // NOLINT: match stl API
-			return RangeIterator(current_entry, length);
+			return RangeIterator(child_writer, length);
 		}
 
 		VectorWriter<T> child_writer;
 		idx_t length;
-		Entry current_entry; // must be declared after child_writer (references it)
 	};
 
 public:
@@ -288,7 +279,7 @@ public:
 	}
 
 	//! Reserve n child slots, record the list entry for this row, and return a
-	//! WriteRange whose iterator yields {child_writer, in-list-index} pairs.
+	//! WriteRange whose iterator yields child writers for each slot.
 	//! Destroying the range asserts that all n child slots were written.
 	WriteRange WriteList(idx_t n) {
 		D_ASSERT(current_idx < count);

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -20,6 +20,13 @@ namespace duckdb {
 //! to be complete in this header. Defined in struct_vector.cpp.
 DUCKDB_API vector<Vector> &VectorWriterGetStructEntries(Vector &vector);
 
+//! List-vector helpers that avoid a circular include with list_vector.hpp.
+//! Defined in list_vector.cpp.
+DUCKDB_API Vector &VectorWriterGetListChild(Vector &vector);
+DUCKDB_API idx_t VectorWriterGetListSize(const Vector &vector);
+DUCKDB_API void VectorWriterReserveList(Vector &vector, idx_t required_capacity);
+DUCKDB_API void VectorWriterSetListSize(Vector &vector, idx_t size);
+
 template <class T>
 struct VectorWriter {
 	VectorWriter(Vector &vector, idx_t count, idx_t offset)
@@ -202,6 +209,106 @@ private:
 	idx_t count;
 	idx_t current_idx;
 	ChildWriters children;
+};
+
+//! Specialization of VectorWriter for VectorListType<T>.
+//! Writes rows to a list vector. Non-null rows are opened with WriteList(n),
+//! which returns a range that iterates over n child writers with their in-list
+//! index. Null rows are written with WriteNull(). Supports recursive nesting:
+//! the child writer T may itself be a list or struct writer.
+template <class T>
+struct VectorWriter<VectorListType<T>> {
+public:
+	//! Range returned by WriteList(n). Holds a VectorWriter<T> scoped to the
+	//! n reserved child slots. Destroying the range asserts all n were written.
+	//! The Entry reference member makes WriteRange non-movable; C++17 guaranteed
+	//! copy elision ensures it is always constructed in place.
+	struct WriteRange {
+		struct Entry {
+			VectorWriter<T> &writer;
+			idx_t idx;
+		};
+
+		class RangeIterator {
+		public:
+			RangeIterator(Entry &entry, idx_t pos) : entry(entry), pos(pos) {
+			}
+			Entry &operator*() {
+				entry.idx = pos;
+				return entry;
+			}
+			RangeIterator &operator++() { // NOLINT: match stl API
+				++pos;
+				return *this;
+			}
+			bool operator!=(const RangeIterator &other) const {
+				return pos != other.pos;
+			}
+
+		private:
+			Entry &entry;
+			idx_t pos;
+		};
+
+		WriteRange(Vector &child_vec, idx_t n, idx_t offset)
+		    : child_writer(child_vec, n, offset), length(n), current_entry {child_writer, 0} {
+		}
+
+		RangeIterator begin() { // NOLINT: match stl API
+			return RangeIterator(current_entry, 0);
+		}
+		RangeIterator end() { // NOLINT: match stl API
+			return RangeIterator(current_entry, length);
+		}
+
+		VectorWriter<T> child_writer;
+		idx_t length;
+		Entry current_entry; // must be declared after child_writer (references it)
+	};
+
+public:
+	VectorWriter(Vector &vector, idx_t count, idx_t offset)
+	    : list_data(FlatVector::GetDataMutable<list_entry_t>(vector)), validity(FlatVector::ValidityMutable(vector)),
+	      list_vec(vector), child_vec(VectorWriterGetListChild(vector)), count(offset + count), current_idx(offset),
+	      child_offset(VectorWriterGetListSize(vector)) {
+	}
+	VectorWriter(VectorWriter &&other) noexcept
+	    : list_data(other.list_data), validity(other.validity), list_vec(other.list_vec), child_vec(other.child_vec),
+	      count(other.count), current_idx(other.current_idx), child_offset(other.child_offset) {
+		other.count = other.current_idx;
+	}
+	~VectorWriter() {
+		D_ASSERT(Exception::UncaughtException() || current_idx == count);
+	}
+
+	void WriteNull() {
+		D_ASSERT(current_idx < count);
+		validity.SetInvalid(current_idx);
+		current_idx++;
+	}
+
+	//! Reserve n child slots, record the list entry for this row, and return a
+	//! WriteRange whose iterator yields {child_writer, in-list-index} pairs.
+	//! Destroying the range asserts that all n child slots were written.
+	WriteRange WriteList(idx_t n) {
+		D_ASSERT(current_idx < count);
+		VectorWriterReserveList(list_vec, child_offset + n);
+		VectorWriterSetListSize(list_vec, child_offset + n);
+		list_data[current_idx] = {child_offset, n};
+		current_idx++;
+		const auto old_offset = child_offset;
+		child_offset += n;
+		return WriteRange(child_vec, n, old_offset);
+	}
+
+private:
+	list_entry_t *list_data;
+	ValidityMask &validity;
+	Vector &list_vec;
+	Vector &child_vec;
+	idx_t count;
+	idx_t current_idx;
+	idx_t child_offset;
 };
 
 template <class T>


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/22443

This can be used recursively (i.e. we can do list-of-list, list-of-struct, struct-of-list, etc).

API looks like this:

```cpp
auto list_writer = FlatVector::Writer<VectorListType<double>>(target_vec, row_count);
for(idx_t i = 0; i < row_count; i++) {
	if (!geom_entry.IsValid()) {
		// top-level list is NULL
		list_writer.WriteNull();
		continue;
	}
	// write a list of size "list_size" to the row at this position
	idx_t idx_in_list = 0;
	for (auto &child_writer : list_writer.WriteList(list_size)) {
		// this loop is invoked once per entry in the list
		// we should call child_writer.WriteValue once per loop iteration
		child_writer.WriteValue(idx_in_list++);
	}
}
```