### PR TITLE
Fix crash on truncated UTF-8 string statistics

### DIFF
--- a/src/optimizer/partitioned_execution.cpp
+++ b/src/optimizer/partitioned_execution.cpp
@@ -166,7 +166,14 @@ static bool PartitionedExecutionCanUseStats(const unique_ptr<BaseStatistics> &st
 		return NumericStats::HasMinMax(*stats);
 	case StatisticsType::STRING_STATS:
 		// Let's not mess with BLOB for now
-		return stats->GetType() == LogicalType::VARCHAR;
+		if (stats->GetType() != LogicalType::VARCHAR) {
+			return false;
+		}
+		if (!StringStats::HasMinMax(*stats)) {
+			return false;
+		}
+		// Truncated multibyte UTF-8 sequences produce invalid string bytes in min/max; skip those row groups
+		return Value::StringIsValid(StringStats::Min(*stats)) && Value::StringIsValid(StringStats::Max(*stats));
 	default:
 		return false; // Only numeric/string supported for now
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -532,8 +532,8 @@ FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &st
 		if (!StringStats::HasMinMax(stats)) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
-		min = Value(StringStats::Min(stats));
-		max = Value(StringStats::Max(stats));
+		min = Value::BLOB_RAW(StringStats::Min(stats));
+		max = Value::BLOB_RAW(StringStats::Max(stats));
 		break;
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/test/optimizer/partitioned_execution.test_slow
+++ b/test/optimizer/partitioned_execution.test_slow
@@ -299,3 +299,20 @@ WHERE prev_const > t_const
        prev_low_recurring > t_low_cardinality_recurring);
 ----
 0
+
+# stats with non-UTF-8 bytes (truncated multibyte sequence) must not crash PartitionedExecution
+statement ok
+CREATE TABLE test_non_utf8 AS
+SELECT CASE WHEN i < 2500000 THEN lpad(i::VARCHAR, 8, '0')
+            ELSE chr(26085) || chr(26412) || chr(35486) || lpad(i::VARCHAR, 7, '0')
+       END AS k,
+       (i % 7)::INTEGER AS g
+FROM range(5000000) t(i);
+
+query I
+WITH cte AS (
+    FROM test_non_utf8 ORDER BY k
+)
+SELECT count(*) FROM cte;
+----
+5000000

--- a/test/sql/join/inner/test_prefix_range_filter_non_utf8.test
+++ b/test/sql/join/inner/test_prefix_range_filter_non_utf8.test
@@ -1,0 +1,32 @@
+# name: test/sql/join/inner/test_prefix_range_filter_non_utf8.test
+# description: PrefixRangeFilter does not crash on parquet stats with non-UTF-8 bytes
+# group: [inner]
+
+require parquet
+
+require strinline
+
+statement ok
+SET disabled_optimizers = 'join_order,build_side_probe_side';
+
+statement ok
+COPY (
+    SELECT CASE WHEN i < 5 THEN 'ascii' || lpad(i::VARCHAR, 3, '0')
+                ELSE            chr(26085) || chr(26412) || chr(35486) || lpad(i::VARCHAR, 4, '0')
+           END AS k,
+           (i % 3)::INTEGER AS g
+    FROM range(10) t(i)
+) TO '{TEST_DIR}/prf_non_utf8_probe.parquet' (ROW_GROUP_SIZE 5);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_non_utf8 (k VARCHAR, g INTEGER, payload INTEGER);
+
+statement ok
+INSERT INTO prf_build_non_utf8 VALUES ('a', 0, 1), ('z', 0, 2), ('m', 1, 3);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/prf_non_utf8_probe.parquet') p
+JOIN prf_build_non_utf8 b ON p.k = b.k AND p.g >= b.g;
+----
+0


### PR DESCRIPTION
## Root cause

`StringStatsData` stores min/max as 8-byte arrays (`MAX_STRING_MINMAX_SIZE = 8`). Strings longer
than 8 bytes are truncated. For multibyte UTF-8 sequences whose codepoint boundary falls inside that
window, the stored bytes are not valid UTF-8.

---

## Bug 1 — `PartitionedExecutionAddStatsNodes` (`src/optimizer/partitioned_execution.cpp`, PR #22336)

```cpp
case StatisticsType::STRING_STATS:
    min = StringStats::Min(stats);   // std::string with raw truncated bytes
    max = StringStats::Max(stats);
    break;
```

Assigning a raw `std::string` to `Value` via the implicit `Value::Value(string)` constructor
validates UTF-8 and throws `"Invalid unicode (byte sequence mismatch)"` when the 8-byte window
splits a multibyte codepoint. Fires on ORDER BY / GROUP BY / WINDOW over a VARCHAR column whose
per-row-group stats contain a truncated multibyte sequence.

**Fix**: guard in `CanUseStats` before the `Value(string)` call. After confirming the stats type is
VARCHAR and `HasMinMax`, extract the raw min/max strings and return `false` if either fails
`Value::StringIsValid`. Row groups with invalid stats are dropped from the optimization — conservative
but never incorrect. `AddStatsNodes` is only reached when the stats are valid, so `Value(string)` is
safe there.

Note: `PartitionedExecutionMinMaxEqual` in the same file already uses `Value::BLOB_RAW` (as does the
PRF fix), but `AddStatsNodes` is different — its values flow eventually into `BoundColumnRefExpression` nodes typed by `range.min.type()`. Using `BLOB_RAW` there would produce BLOB-typed column references for VARCHAR columns.

---

## Bug 2 — `PrefixRangeTableFilter::CheckStatistics` (`src/planner/filter/prefix_range_filter.cpp`, PR #21279)

```cpp
min = Value(StringStats::Min(stats));
max = Value(StringStats::Max(stats));
```

Same UTF-8 validation throw. Fires during join pushdown when the probe-side table has per-row-group
stats with a truncated multibyte sequence.

**Fix**: use `Value::BLOB_RAW` instead of `Value(string)`. The values are consumed by `LookupRange`
via raw `string_t` bytes and never become typed plan expressions, so BLOB_RAW is safe here — no
UTF-8 validation needed and no type mismatch risk. A `HasMinMax` guard is also added before the
construction, consistent with the numeric branch above it.