### PR TITLE
date_trunc avoid decomposition

### DIFF
--- a/benchmark/micro/date/date_trunc.benchmark
+++ b/benchmark/micro/date/date_trunc.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/date/date_trunc.benchmark
+# description: date_trunc on a fixed-width unit
+# group: [date]
+
+name Date Trunc
+group date
+
+load
+CREATE TABLE timestamps AS
+SELECT epoch_ms(((range * 2654435761) % 315360000000 + 1000000000000)::BIGINT) AS ts
+FROM range(0, 50000000);
+
+run
+SELECT sum(epoch_ms(date_trunc('minute', ts)))::HUGEINT FROM timestamps
+
+result I
+57883998804880080000

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -96,52 +96,42 @@ struct DateTrunc {
 		}
 	};
 
+	// Truncate a UTC timestamp to the nearest fixed-width interval boundary.
+	// Applies to any unit whose length is a constant number of microseconds
+	// (second, minute, hour). Variable-length units (month, year, etc.) must
+	// use the calendar-decomposition path above.
+	static inline timestamp_t TruncFixed(timestamp_t ts, int64_t interval_us) {
+		const int64_t v = ts.value;
+		// Round towards negative infinity instead of 0
+		const int64_t q = v / interval_us - (v % interval_us != 0 && v < 0 ? 1 : 0);
+		return timestamp_t(q * interval_us);
+	}
+
 	struct HourOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			int32_t hour, min, sec, micros;
-			date_t date;
-			dtime_t time;
-			Timestamp::Convert(input, date, time);
-			Time::Convert(time, hour, min, sec, micros);
-			return Timestamp::FromDatetime(date, Time::FromTime(hour, 0, 0, 0));
+			return TruncFixed(input, Interval::MICROS_PER_HOUR);
 		}
 	};
 
 	struct MinuteOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			int32_t hour, min, sec, micros;
-			date_t date;
-			dtime_t time;
-			Timestamp::Convert(input, date, time);
-			Time::Convert(time, hour, min, sec, micros);
-			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, 0, 0));
+			return TruncFixed(input, Interval::MICROS_PER_MINUTE);
 		}
 	};
 
 	struct SecondOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			int32_t hour, min, sec, micros;
-			date_t date;
-			dtime_t time;
-			Timestamp::Convert(input, date, time);
-			Time::Convert(time, hour, min, sec, micros);
-			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, 0));
+			return TruncFixed(input, Interval::MICROS_PER_SEC);
 		}
 	};
 
 	struct MillisecondOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			int32_t hour, min, sec, micros;
-			date_t date;
-			dtime_t time;
-			Timestamp::Convert(input, date, time);
-			Time::Convert(time, hour, min, sec, micros);
-			micros -= UnsafeNumericCast<int32_t>(micros % Interval::MICROS_PER_MSEC);
-			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, micros));
+			return TruncFixed(input, Interval::MICROS_PER_MSEC);
 		}
 	};
 

--- a/extension/core_functions/scalar/date/date_trunc.cpp
+++ b/extension/core_functions/scalar/date/date_trunc.cpp
@@ -98,8 +98,8 @@ struct DateTrunc {
 
 	// Truncate a UTC timestamp to the nearest fixed-width interval boundary.
 	// Applies to any unit whose length is a constant number of microseconds
-	// (second, minute, hour). Variable-length units (month, year, etc.) must
-	// use the calendar-decomposition path above.
+	// (second, minute, hour, day). Variable-length units (month, year, etc.)
+	// must use the calendar-decomposition path above.
 	static inline timestamp_t TruncFixed(timestamp_t ts, int64_t interval_us) {
 		const int64_t v = ts.value;
 		// Round towards negative infinity instead of 0
@@ -231,7 +231,7 @@ timestamp_t DateTrunc::DayOperator::Operation(date_t input) {
 
 template <>
 timestamp_t DateTrunc::DayOperator::Operation(timestamp_t input) {
-	return DayOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+	return TruncFixed(input, Interval::MICROS_PER_DAY);
 }
 
 template <>

--- a/test/sql/function/date/test_date_trunc.test
+++ b/test/sql/function/date/test_date_trunc.test
@@ -160,6 +160,16 @@ SELECT date_trunc(s, CAST(d as DATE)) FROM timestamps;
 1992-02-02 00:00:00
 infinity
 
+# Infinity passes through every fixed-width unit unchanged
+foreach unit day hour minute second millisecond microsecond
+
+query II
+SELECT date_trunc('{unit}', '-infinity'::TIMESTAMP), date_trunc('{unit}', 'infinity'::TIMESTAMP);
+----
+-infinity	infinity
+
+endloop
+
 # Test week operator special cases
 query T
 SELECT date_trunc('week', TIMESTAMP '2020-01-01 04:03:02') FROM timestamps LIMIT 1;


### PR DESCRIPTION
For units whose length is a constant number of microseconds (`hour`, `minute`, `second`, `millisecond`), replace the calendar-decomposition path with a 2-op floor division. Variable-length units (`day`, `week`, `month`, `quarter`, `year`, `decade`, `century`, `millennium`) keep the existing path because their boundaries depend on the calendar.

Existing tests already cover negative timestamps so there were no interesting tests to add.

## Benchmark — 2.48×

```sql
CREATE TABLE t AS (
      -- Make a big table of not dictionary encoded times over a wide range relatively evenly spread out
      SELECT epoch_ms(((range * 2654435761) % 315360000000 + 1000000000000)::BIGINT) AS ts
      FROM range(50000000)
);
```
```sql
SELECT sum(extract(epoch from date_trunc('minute', ts))) FROM t;
```

50 M shuffled timestamps, single-threaded. Alternating runs to rule out branch-predictor / ordering effects.

| main | new | speedup |
|--------:|:-:|:-:|
| **531ms** | 214ms | **2.48x** |