### PR TITLE
Fix TRY_CAST to BIGNUM for invalid strings

### DIFF
--- a/src/common/types/bignum.cpp
+++ b/src/common/types/bignum.cpp
@@ -163,6 +163,65 @@ bool Bignum::VarcharFormatting(const string_t &value, idx_t &start_pos, idx_t &e
 	return true;
 }
 
+string Bignum::EncodeBignum(const string_t &value, idx_t start_pos, idx_t end_pos, bool is_negative, bool is_zero) {
+	if (is_zero) {
+		// Return Value 0
+		return InitializeBignumZero();
+	}
+	auto int_value_char = value.GetData();
+	idx_t actual_size = end_pos - start_pos;
+
+	// we initialize result with space for our header
+	string result(BIGNUM_HEADER_SIZE, '0');
+	unsafe_vector<uint64_t> digits;
+
+	// The max number a uint64_t can represent is 18.446.744.073.709.551.615
+	// That has 20 digits
+	// In the worst case a remainder of a division will be 255, which is 3 digits
+	// Since the max value is 184, we need to take one more digit out
+	// Hence we end up with a max of 16 digits supported.
+	constexpr uint8_t max_digits = 16;
+	const idx_t number_of_digits = static_cast<idx_t>(std::ceil(static_cast<double>(actual_size) / max_digits));
+
+	// lets convert the string to a uint64_t vector
+	idx_t cur_end = end_pos;
+	for (idx_t i = 0; i < number_of_digits; i++) {
+		idx_t cur_start = static_cast<int64_t>(start_pos) > static_cast<int64_t>(cur_end - max_digits)
+		                      ? start_pos
+		                      : cur_end - max_digits;
+		std::string current_number(int_value_char + cur_start, cur_end - cur_start);
+		digits.push_back(std::stoull(current_number));
+		// move cur_end to more digits down the road
+		cur_end = cur_end - max_digits;
+	}
+
+	// Now that we have our uint64_t vector, lets start our division process to figure out the new number and remainder
+	while (!digits.empty()) {
+		idx_t digit_idx = digits.size() - 1;
+		uint8_t remainder = 0;
+		idx_t digits_size = digits.size();
+		for (idx_t i = 0; i < digits_size; i++) {
+			digits[digit_idx] += static_cast<uint64_t>(remainder * pow(10, max_digits));
+			remainder = static_cast<uint8_t>(digits[digit_idx] % 256);
+			digits[digit_idx] /= 256;
+			if (digits[digit_idx] == 0 && digit_idx == digits.size() - 1) {
+				// we can cap this
+				digits.pop_back();
+			}
+			digit_idx--;
+		}
+		if (is_negative) {
+			result.push_back(static_cast<char>(~remainder));
+		} else {
+			result.push_back(static_cast<char>(remainder));
+		}
+	}
+	std::reverse(result.begin() + BIGNUM_HEADER_SIZE, result.end());
+	// Set header after we know the size of the bignum
+	SetHeader(&result[0], result.size() - BIGNUM_HEADER_SIZE, is_negative);
+	return result;
+}
+
 void Bignum::GetByteArray(vector<uint8_t> &byte_array, bool &is_negative, const string_t &blob) {
 	if (blob.GetSize() < 4) {
 		throw InvalidInputException("Invalid blob size.");
@@ -261,62 +320,7 @@ string Bignum::VarcharToBignum(const string_t &value) {
 	if (!VarcharFormatting(value, start_pos, end_pos, is_negative, is_zero)) {
 		throw ConversionException("Could not convert string \'%s\' to Bignum", value.GetString());
 	}
-	if (is_zero) {
-		// Return Value 0
-		return InitializeBignumZero();
-	}
-	auto int_value_char = value.GetData();
-	idx_t actual_size = end_pos - start_pos;
-
-	// we initialize result with space for our header
-	string result(BIGNUM_HEADER_SIZE, '0');
-	unsafe_vector<uint64_t> digits;
-
-	// The max number a uint64_t can represent is 18.446.744.073.709.551.615
-	// That has 20 digits
-	// In the worst case a remainder of a division will be 255, which is 3 digits
-	// Since the max value is 184, we need to take one more digit out
-	// Hence we end up with a max of 16 digits supported.
-	constexpr uint8_t max_digits = 16;
-	const idx_t number_of_digits = static_cast<idx_t>(std::ceil(static_cast<double>(actual_size) / max_digits));
-
-	// lets convert the string to a uint64_t vector
-	idx_t cur_end = end_pos;
-	for (idx_t i = 0; i < number_of_digits; i++) {
-		idx_t cur_start = static_cast<int64_t>(start_pos) > static_cast<int64_t>(cur_end - max_digits)
-		                      ? start_pos
-		                      : cur_end - max_digits;
-		std::string current_number(int_value_char + cur_start, cur_end - cur_start);
-		digits.push_back(std::stoull(current_number));
-		// move cur_end to more digits down the road
-		cur_end = cur_end - max_digits;
-	}
-
-	// Now that we have our uint64_t vector, lets start our division process to figure out the new number and remainder
-	while (!digits.empty()) {
-		idx_t digit_idx = digits.size() - 1;
-		uint8_t remainder = 0;
-		idx_t digits_size = digits.size();
-		for (idx_t i = 0; i < digits_size; i++) {
-			digits[digit_idx] += static_cast<uint64_t>(remainder * pow(10, max_digits));
-			remainder = static_cast<uint8_t>(digits[digit_idx] % 256);
-			digits[digit_idx] /= 256;
-			if (digits[digit_idx] == 0 && digit_idx == digits.size() - 1) {
-				// we can cap this
-				digits.pop_back();
-			}
-			digit_idx--;
-		}
-		if (is_negative) {
-			result.push_back(static_cast<char>(~remainder));
-		} else {
-			result.push_back(static_cast<char>(remainder));
-		}
-	}
-	std::reverse(result.begin() + BIGNUM_HEADER_SIZE, result.end());
-	// Set header after we know the size of the bignum
-	SetHeader(&result[0], result.size() - BIGNUM_HEADER_SIZE, is_negative);
-	return result;
+	return EncodeBignum(value, start_pos, end_pos, is_negative, is_zero);
 }
 
 bool Bignum::BignumToDouble(const bignum_t &blob, double &result, bool &strict) {

--- a/src/function/cast/bignum_casts.cpp
+++ b/src/function/cast/bignum_casts.cpp
@@ -167,6 +167,12 @@ bignum_t HugeintCastToBignum::Operation(hugeint_t int_value, StringHeap &heap) {
 template <>
 bool TryCastToBignum::Operation(string_t input_value, bignum_t &result_value, Vector &result,
                                 CastParameters &parameters) {
+	idx_t start_pos, end_pos;
+	bool is_negative, is_zero;
+	if (!Bignum::VarcharFormatting(input_value, start_pos, end_pos, is_negative, is_zero)) {
+		return false;
+	}
+
 	auto blob_string = Bignum::VarcharToBignum(input_value);
 
 	uint32_t blob_size = static_cast<uint32_t>(blob_string.size());

--- a/src/function/cast/bignum_casts.cpp
+++ b/src/function/cast/bignum_casts.cpp
@@ -173,7 +173,7 @@ bool TryCastToBignum::Operation(string_t input_value, bignum_t &result_value, Ve
 		return false;
 	}
 
-	auto blob_string = Bignum::VarcharToBignum(input_value);
+	auto blob_string = Bignum::EncodeBignum(input_value, start_pos, end_pos, is_negative, is_zero);
 
 	uint32_t blob_size = static_cast<uint32_t>(blob_string.size());
 	result_value = bignum_t(StringVector::EmptyString(result, blob_size));

--- a/src/include/duckdb/common/types/bignum.hpp
+++ b/src/include/duckdb/common/types/bignum.hpp
@@ -56,7 +56,9 @@ public:
 	//! Returns false if this is an invalid varchar
 	DUCKDB_API static bool VarcharFormatting(const string_t &value, idx_t &start_pos, idx_t &end_pos, bool &is_negative,
 	                                         bool &is_zero);
-
+	//! Encodes a VARCHAR into a BIGNUM blob using formatting information returned by VarcharFormatting.
+	DUCKDB_API static string EncodeBignum(const string_t &value, idx_t start_pos, idx_t end_pos, bool is_negative,
+	                                      bool is_zero);
 	//! Converts a char to a Digit
 	DUCKDB_API static int CharToDigit(char c);
 	//! Converts a Digit to a char

--- a/test/sql/types/bignum/test_bignum_try_cast.test
+++ b/test/sql/types/bignum/test_bignum_try_cast.test
@@ -1,0 +1,26 @@
+# name: test/sql/types/bignum/test_bignum_try_cast.test
+# description: Test TRY_CAST to BIGNUM
+# group: [bignum]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT TRY_CAST('hello' AS BIGNUM)
+----
+NULL
+
+query I
+SELECT TRY_CAST('1e+24' AS BIGNUM)
+----
+NULL
+
+query I
+SELECT TRY_CAST('123456789012345678901234567890' AS BIGNUM)::VARCHAR
+----
+123456789012345678901234567890
+
+statement error
+SELECT CAST('hello' AS BIGNUM)
+----
+Could not convert


### PR DESCRIPTION
This PR fixes `TRY_CAST(... AS BIGNUM)` for invalid string inputs.

Previously, inputs such as `'hello'` and `'1e+24'` raised a conversion error even when using `TRY_CAST`. With this change, invalid string inputs now return `NULL`.
A regression test was added for the fixed behavior.
Fixes #22324.
## Testing
- Added `test/sql/types/bignum/test_bignum_try_cast.test`
- Verified that the same branch passed all CI checks in [my fork PR](https://github.com/Schwarf/duckdb/pull/1)