### PR TITLE
Fix eviction size metrics report

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -283,7 +283,7 @@ public:
 	idx_t WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer);
 	bool HasTemporaryBuffer(block_id_t block_id);
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
-	                                           unique_ptr<FileBuffer> reusable_buffer);
+	                                           unique_ptr<FileBuffer> reusable_buffer, idx_t *eviction_size = nullptr);
 	idx_t DeleteTemporaryBuffer(block_id_t id);
 	bool IsEncrypted() const;
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -522,11 +522,14 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
 		// This is a block that was offloaded to a regular .tmp file, the file contains blocks of a fixed size
 
-		auto buffer =
-		    temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(context, id, std::move(reusable_buffer));
+		// Decrement by the *same* size the write side incremented (the on-disk slot size, which
+		// is the compressed size when compression applies) -- not by `buffer->AllocSize()`, which
+		// is the uncompressed size and would underflow `evicted_data_per_tag` on every read-back.
+		idx_t eviction_size = 0;
+		auto buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(
+		    context, id, std::move(reusable_buffer), &eviction_size);
 
-		// Decrement evicted size.
-		evicted_data_per_tag[uint8_t(tag)] -= buffer->AllocSize();
+		evicted_data_per_tag[uint8_t(tag)] -= eviction_size;
 
 		return buffer;
 	}

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -522,9 +522,6 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
 		// This is a block that was offloaded to a regular .tmp file, the file contains blocks of a fixed size
 
-		// Decrement by the *same* size the write side incremented (the on-disk slot size, which
-		// is the compressed size when compression applies) -- not by `buffer->AllocSize()`, which
-		// is the uncompressed size and would underflow `evicted_data_per_tag` on every read-back.
 		idx_t eviction_size = 0;
 		auto buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(
 		    context, id, std::move(reusable_buffer), &eviction_size);

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -644,13 +644,19 @@ bool TemporaryFileManager::IsEncrypted() const {
 }
 
 unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext context, block_id_t id,
-                                                                 unique_ptr<FileBuffer> reusable_buffer) {
+                                                                 unique_ptr<FileBuffer> reusable_buffer,
+                                                                 idx_t *eviction_size) {
 	TemporaryFileIndex index;
 	optional_ptr<TemporaryFileHandle> handle;
 	{
 		TemporaryFileManagerLock lock(manager_lock);
 		index = GetTempBlockIndex(lock, id);
 		handle = GetFileHandle(lock, index.identifier);
+	}
+
+	// If eviction size requested, set it to the size of the block (compressed size if applicable).
+	if (eviction_size) {
+		*eviction_size = NumericCast<idx_t>(index.identifier.size);
 	}
 
 	// before the reusable buffer is given,


### PR DESCRIPTION
The issue is:
- When we increment `evicted_data_per_tag`, we increment by compressed size, [if applicable](https://github.com/duckdb/duckdb/blob/6be1980b1e1b82f15553802bcc76aad270008ec1/src/storage/standard_buffer_manager.cpp#L491)
- When we decrement, it's reduced by decompressed size

I found this issue by [asserting](https://github.com/dentiny/duckdb/pull/95) the `evicted_data_per_tag` value cannot underflow.