### PR TITLE
Add support for writing dynamic lists using both `FlatVector::Writer<VectorListType<...>>` and `FlatVector::Writer<list_entry_t>`

### DIFF
--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -68,41 +68,31 @@ static void MapExtractListFunc(DataChunk &args, ExpressionState &state, Vector &
 	Vector pos_vec(LogicalType::INTEGER, count);
 	ListSearchOp<int32_t>(map_vec, key_vec, arg_vec, pos_vec, args.size());
 
-	UnifiedVectorFormat pos_format;
-	UnifiedVectorFormat lst_format;
-
-	pos_vec.ToUnifiedFormat(count, pos_format);
-	map_vec.ToUnifiedFormat(count, lst_format);
-
-	const auto pos_data = UnifiedVectorFormat::GetData<int32_t>(pos_format);
-	const auto inc_list_data = UnifiedVectorFormat::GetData<list_entry_t>(lst_format);
+	auto pos_entries = pos_vec.Values<int32_t>(count);
+	auto map_entries = map_vec.Values<list_entry_t>(count);
+	const auto val_size = ListVector::GetListSize(map_vec);
 	auto out_list_data = FlatVector::Writer<list_entry_t>(result, count);
 
-	idx_t offset = 0;
-	vector<sel_t> val_idx_data;
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
-		const auto lst_idx = lst_format.sel->get_index(row_idx);
-		if (!lst_format.validity.RowIsValid(lst_idx)) {
+		auto map_entry = map_entries[row_idx];
+		if (!map_entry.IsValid()) {
 			out_list_data.WriteNull();
 			continue;
 		}
 
-		const auto pos_idx = pos_format.sel->get_index(row_idx);
-		if (!pos_format.validity.RowIsValid(pos_idx)) {
-			// We didnt find the key in the map, so return empty list
-			out_list_data.WriteValue(list_entry_t(offset, 0));
+		auto list = out_list_data.WriteDynamicList();
+		auto pos_entry = pos_entries[row_idx];
+		if (!pos_entry.IsValid()) {
+			// key not found: return empty list
 			continue;
 		}
 
-		auto &inc_list = inc_list_data[lst_idx];
-		// Compute the actual position of the value in the map value vector
-		const auto pos = inc_list.offset + UnsafeNumericCast<idx_t>(pos_data[pos_idx] - 1);
-		out_list_data.WriteValue(list_entry_t(offset, 1));
-		val_idx_data.emplace_back(pos);
-		offset++;
+		const auto &inc_list = map_entry.GetValue();
+		const auto pos = inc_list.offset + UnsafeNumericCast<idx_t>(pos_entry.GetValue() - 1);
+		SelectionVector sel(1);
+		sel.set_index(0, pos);
+		list.Append(val_vec, sel, val_size, 0, 1);
 	}
-	SelectionVector val_sel(val_idx_data.data(), val_idx_data.size());
-	ListVector::Append(result, val_vec, val_sel, val_idx_data.size());
 }
 
 ScalarFunction MapExtractValueFun::GetFunction() {

--- a/extension/core_functions/scalar/string/parse_path.cpp
+++ b/extension/core_functions/scalar/string/parse_path.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/list_vector.hpp"
 #include "core_functions/scalar/string_functions.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/common/local_file_system.hpp"
@@ -26,26 +25,6 @@ static string GetSeparator(const string_t &input) {
 	}
 	return separator;
 }
-
-struct SplitInput {
-	SplitInput(Vector &result_list, Vector &result_child, idx_t offset)
-	    : result_list(result_list), result_child(result_child), offset(offset) {
-	}
-
-	Vector &result_list;
-	Vector &result_child;
-	idx_t offset;
-
-	void AddSplit(const char *split_data, idx_t split_size, idx_t list_idx) {
-		auto list_entry = offset + list_idx;
-		if (list_entry >= ListVector::GetListCapacity(result_list)) {
-			ListVector::SetListSize(result_list, offset + list_idx);
-			ListVector::Reserve(result_list, ListVector::GetListCapacity(result_list) * 2);
-		}
-		FlatVector::GetDataMutable<string_t>(result_child)[list_entry] =
-		    StringVector::AddString(result_child, split_data, split_size);
-	}
-};
 
 static bool IsIdxValid(const idx_t &i, const idx_t &sentence_size) {
 	if (i > sentence_size || i == DConstants::INVALID_INDEX) {
@@ -88,7 +67,8 @@ static idx_t FindLast(const char *data_ptr, idx_t input_size, const string &sep_
 	return start - 1;
 }
 
-static idx_t SplitPath(string_t input, const string &sep, SplitInput &state) {
+template <class CB>
+static idx_t SplitPath(string_t input, const string &sep, CB &&emit) {
 	auto input_data = input.GetData();
 	auto input_size = input.GetSize();
 	if (!input_size) {
@@ -104,21 +84,21 @@ static idx_t SplitPath(string_t input, const string &sep, SplitInput &state) {
 		D_ASSERT(input_size >= pos);
 		if (pos == 0) {
 			if (list_idx == 0) { // first character in path is separator
-				state.AddSplit(input_data, 1, list_idx);
+				emit(input_data, 1);
 				list_idx++;
 				if (input_size == 1) { // special case: the only character in path is a separator
 					return list_idx;
 				}
 			} // else: separator is in the path
 		} else {
-			state.AddSplit(input_data, pos, list_idx);
+			emit(input_data, pos);
 			list_idx++;
 		}
 		input_data += (pos + 1);
 		input_size -= (pos + 1);
 	}
 	if (input_size > 0) {
-		state.AddSplit(input_data, input_size, list_idx);
+		emit(input_data, input_size);
 		list_idx++;
 	}
 	return list_idx;
@@ -266,25 +246,19 @@ static void ParsePathFunction(DataChunk &args, ExpressionState &state, Vector &r
 
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	ListVector::SetListSize(result, 0);
 
-	// set up the list entries
-	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
-	auto &child_entry = ListVector::GetChildMutable(result);
-	idx_t total_splits = 0;
+	auto list_writer = FlatVector::Writer<VectorListType<string_t>>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		auto input_idx = input_data.sel->get_index(i);
 		if (!input_data.validity.RowIsValid(input_idx)) {
-			result_data.WriteNull();
+			list_writer.WriteNull();
 			continue;
 		}
-		SplitInput split_input(result, child_entry, total_splits);
-		auto list_length = SplitPath(inputs[input_idx], sep, split_input);
-		result_data.WriteValue(list_entry_t(total_splits, list_length));
-		total_splits += list_length;
+		auto list = list_writer.WriteDynamicList();
+		SplitPath(inputs[input_idx], sep, [&](const char *split_data, idx_t split_size) {
+			list.WriteElement().WriteValue(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
+		});
 	}
-	ListVector::SetListSize(result, total_splits);
-	D_ASSERT(ListVector::GetListSize(result) == total_splits);
 }
 
 ScalarFunctionSet ParseDirnameFun::GetFunctions() {

--- a/extension/core_functions/scalar/string/repeat.cpp
+++ b/extension/core_functions/scalar/string/repeat.cpp
@@ -36,37 +36,38 @@ static void RepeatFunction(DataChunk &args, ExpressionState &, Vector &result) {
 static void RepeatListFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	auto &list_vector = args.data[0];
 	auto &cnt_vector = args.data[1];
-
 	auto &source_child = ListVector::GetChildMutable(list_vector);
+	auto count = args.size();
 
-	idx_t current_size = ListVector::GetListSize(result);
-	BinaryExecutor::Execute<list_entry_t, int64_t, list_entry_t>(
-	    list_vector, cnt_vector, result, args.size(), [&](list_entry_t list_input, int64_t cnt) {
-		    idx_t copy_count = cnt <= 0 || list_input.length == 0 ? 0 : UnsafeNumericCast<idx_t>(cnt);
-		    idx_t result_length;
-		    if (!TryMultiplyOperator::Operation(list_input.length, copy_count, result_length)) {
-			    throw OutOfRangeException("Cannot create a list of size: '%d' * '%d', the result is too large",
-			                              list_input.length, copy_count);
-		    }
-		    idx_t new_size;
-		    if (!TryAddOperator::Operation(current_size, result_length, new_size)) {
-			    throw OutOfRangeException("Cannot create a list of size: '%d' + '%d', the result is too large",
-			                              current_size, result_length);
-		    }
-		    ListVector::Reserve(result, new_size);
-		    auto &result_child = ListVector::GetChildMutable(result);
-		    list_entry_t result_list;
-		    result_list.offset = current_size;
-		    result_list.length = result_length;
-		    for (idx_t i = 0; i < copy_count; i++) {
-			    // repeat the list contents "cnt" times
-			    VectorOperations::Copy(source_child, result_child, list_input.offset + list_input.length,
-			                           list_input.offset, current_size);
-			    current_size += list_input.length;
-		    }
-		    return result_list;
-	    });
-	ListVector::SetListSize(result, current_size);
+	auto list_entries = list_vector.Values<list_entry_t>(count);
+	auto cnt_entries = cnt_vector.Values<int64_t>(count);
+
+	auto result_writer = FlatVector::Writer<list_entry_t>(result, count);
+	for (idx_t i = 0; i < count; i++) {
+		auto list_entry = list_entries[i];
+		auto cnt_entry = cnt_entries[i];
+		if (!list_entry.IsValid() || !cnt_entry.IsValid()) {
+			result_writer.WriteNull();
+			continue;
+		}
+		const auto &list_input = list_entry.GetValue();
+		const auto cnt = cnt_entry.GetValue();
+		const idx_t copy_count = cnt <= 0 || list_input.length == 0 ? 0 : UnsafeNumericCast<idx_t>(cnt);
+		idx_t result_length;
+		if (!TryMultiplyOperator::Operation(list_input.length, copy_count, result_length)) {
+			throw OutOfRangeException("Cannot create a list of size: '%d' * '%d', the result is too large",
+			                          list_input.length, copy_count);
+		}
+		// reserve the worst-case child capacity up front so an absurd target
+		// size fails before we enter a 10^N-iteration Append loop
+		ListVector::Reserve(result, ListVector::GetListSize(result) + result_length);
+		auto list = result_writer.WriteDynamicList();
+		for (idx_t j = 0; j < copy_count; j++) {
+			list.Append(source_child, *FlatVector::IncrementalSelectionVector(), list_input.offset + list_input.length,
+			            list_input.offset, list_input.length);
+		}
+	}
+	result.Verify(count);
 }
 
 ScalarFunctionSet RepeatFun::GetFunctions() {

--- a/extension/icu/icu-list-range.cpp
+++ b/extension/icu/icu-list-range.cpp
@@ -144,37 +144,24 @@ struct ICUListRange : public ICUDateFunc {
 				break;
 			}
 		}
-		auto result_data = FlatVector::Writer<list_entry_t>(result, args_size);
-		int64_t total_size = 0;
-		vector<int64_t> list_lengths(args_size, 0);
+		auto list_writer = FlatVector::Writer<VectorListType<timestamp_t>>(result, args_size);
 		for (idx_t i = 0; i < args_size; i++) {
 			if (!info.RowIsValid(i)) {
-				result_data.WriteNull(list_entry_t(NumericCast<uint64_t>(total_size), 0));
-			} else {
-				const auto length = info.ListLength(i, calendar);
-				list_lengths[i] = length;
-				result_data.WriteValue(list_entry_t(NumericCast<uint64_t>(total_size), NumericCast<uint64_t>(length)));
-				total_size += length;
+				list_writer.WriteNull();
+				continue;
 			}
-		}
+			const auto length = info.ListLength(i, calendar);
+			auto list = list_writer.WriteDynamicList();
 
-		// now construct the child vector of the list
-		ListVector::Reserve(result, total_size);
-		auto range_data = FlatVector::Writer<timestamp_t>(ListVector::GetChildMutable(result), total_size);
-		for (idx_t i = 0; i < args_size; i++) {
-			timestamp_t start_value = info.StartListValue(i);
+			timestamp_t range_value = info.StartListValue(i);
 			interval_t increment = info.ListIncrementValue(i);
-
-			timestamp_t range_value = start_value;
-			for (idx_t range_idx = 0; range_idx < NumericCast<idx_t>(list_lengths[i]); range_idx++) {
+			for (idx_t range_idx = 0; range_idx < NumericCast<idx_t>(length); range_idx++) {
 				if (range_idx > 0) {
 					info.Increment(range_value, increment, calendar);
 				}
-				range_data.WriteValue(range_value);
+				list.WriteElement().WriteValue(range_value);
 			}
 		}
-
-		ListVector::SetListSize(result, total_size);
 		result.SetVectorType(result_type);
 
 		result.Verify(args.size());

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1303,7 +1303,7 @@ static void ToPoints(Vector &source_vec, Vector &target_vec, idx_t row_count) {
 template <class V = VertexXY>
 static void FromPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto vert_iter = source_vec.Values<typename V::STRUCT_TYPE>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto vert_entry = vert_iter[row_idx];
 		if (!vert_entry.IsValid()) {
@@ -1358,7 +1358,7 @@ static void ToLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_coun
 template <class V = VertexXY>
 static void FromLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto line_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto line_entry = line_iter[row_idx];
@@ -1416,7 +1416,7 @@ static void ToPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count) 
 template <class V = VertexXY>
 static void FromPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto poly_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto poly_entry = poly_iter[row_idx];
@@ -1476,7 +1476,7 @@ static void ToMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_coun
 template <class V = VertexXY>
 static void FromMultiPoints(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter = source_vec.Values<VectorListType<typename V::STRUCT_TYPE>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];
@@ -1543,7 +1543,7 @@ static void ToMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row
 template <class V = VertexXY>
 static void FromMultiLineStrings(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter = source_vec.Values<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];
@@ -1621,7 +1621,7 @@ template <class V = VertexXY>
 static void FromMultiPolygons(Vector &source_vec, Vector &target_vec, idx_t row_count, idx_t result_offset) {
 	auto mult_iter =
 	    source_vec.Values<VectorListType<VectorListType<VectorListType<typename V::STRUCT_TYPE>>>>(row_count);
-	auto result_data = FlatVector::Writer<string_t>(target_vec, result_offset + row_count, result_offset);
+	auto result_data = FlatVector::Writer<string_t>(target_vec, row_count, result_offset);
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		const auto mult_entry = mult_iter[row_idx];

--- a/src/function/scalar/list/list_intersect.cpp
+++ b/src/function/scalar/list/list_intersect.cpp
@@ -8,23 +8,6 @@
 
 namespace duckdb {
 
-static idx_t CalculateMaxResultLength(idx_t row_count, const UnifiedVectorFormat &l_format,
-                                      const UnifiedVectorFormat &r_format, const list_entry_t *l_entries,
-                                      const list_entry_t *r_entries) {
-	idx_t max_result_length = 0;
-	for (idx_t i = 0; i < row_count; i++) {
-		const auto l_idx = l_format.sel->get_index(i);
-		const auto r_idx = r_format.sel->get_index(i);
-
-		if (l_format.validity.RowIsValid(l_idx) && r_format.validity.RowIsValid(r_idx)) {
-			const auto &l_list = l_entries[l_idx];
-			const auto &r_list = r_entries[r_idx];
-			max_result_length += MinValue(l_list.length, r_list.length);
-		}
-	}
-	return max_result_length;
-}
-
 static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto row_count = args.size();
 
@@ -43,20 +26,13 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 	auto &l_child = ListVector::GetChildMutable(l_vec);
 	auto &r_child = ListVector::GetChildMutable(r_vec);
 
-	const auto current_left_child_type = l_child.GetType();
+	auto l_entries = l_vec.Values<list_entry_t>(row_count);
+	auto r_entries = r_vec.Values<list_entry_t>(row_count);
 
-	UnifiedVectorFormat l_format;
-	UnifiedVectorFormat r_format;
-
-	l_vec.ToUnifiedFormat(row_count, l_format);
-	r_vec.ToUnifiedFormat(row_count, r_format);
-
-	const auto l_entries = UnifiedVectorFormat::GetData<list_entry_t>(l_format);
-	const auto r_entries = UnifiedVectorFormat::GetData<list_entry_t>(r_format);
-
+	// child element type is generic T, so we cannot use Values<>; UnifiedVectorFormat
+	// gives us per-row validity + selection regardless of the child vector kind.
 	UnifiedVectorFormat l_child_format;
 	UnifiedVectorFormat r_child_format;
-
 	l_child.ToUnifiedFormat(l_size, l_child_format);
 	r_child.ToUnifiedFormat(r_size, r_child_format);
 
@@ -71,48 +47,29 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 	const auto l_sortkey_ptr = FlatVector::GetData<string_t>(l_sortkey_vec);
 	const auto r_sortkey_ptr = FlatVector::GetData<string_t>(r_sortkey_vec);
 
-	auto &result_entry = ListVector::GetChildMutable(result);
-
 	string_set_t set;
 	string_set_t result_set;
 	string_map_t<idx_t> key_to_index_map;
 
-	const idx_t max_result_length = CalculateMaxResultLength(row_count, l_format, r_format, l_entries, r_entries);
-
-	ListVector::Reserve(result, max_result_length);
-	ListVector::SetListSize(result, max_result_length);
-
-	SelectionVector result_sel(max_result_length);
-	ValidityMask result_entry_validity_mask(max_result_length);
-	idx_t offset = 0;
-
 	auto result_data = FlatVector::Writer<list_entry_t>(result, row_count);
 	for (idx_t i = 0; i < row_count; i++) {
-		const auto l_idx = l_format.sel->get_index(i);
-		const auto r_idx = r_format.sel->get_index(i);
+		auto l_entry = l_entries[i];
+		auto r_entry = r_entries[i];
 
-		const bool l_valid = l_format.validity.RowIsValid(l_idx);
-		const bool r_valid = r_format.validity.RowIsValid(r_idx);
-
-		list_entry_t entry;
-		entry.offset = offset;
-
-		if (!l_valid) {
+		if (!l_entry.IsValid()) {
 			result_data.WriteNull();
 			continue;
 		}
-		if (!r_valid) {
-			entry.length = 0;
-			result_data.WriteValue(entry);
+
+		auto list = result_data.WriteDynamicList();
+		if (!r_entry.IsValid()) {
 			continue;
 		}
 
-		const auto &l_list = l_entries[l_idx];
-		const auto &r_list = r_entries[r_idx];
+		const auto &l_list = l_entry.GetValue();
+		const auto &r_list = r_entry.GetValue();
 
 		if (l_list.length == 0 || r_list.length == 0) {
-			entry.length = 0;
-			result_data.WriteValue(entry);
 			continue;
 		}
 
@@ -143,6 +100,8 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 		}
 
 		// Iterate the chosen side, but ALWAYS emit a LEFT index
+		const idx_t row_max_length = MinValue(l_list.length, r_list.length);
+		SelectionVector row_sel(row_max_length);
 		idx_t row_result_length = 0;
 		for (idx_t j = 0; j < iter_list.length; j++) {
 			const idx_t it_idx = iter_list.offset + j;
@@ -159,20 +118,12 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 
 			const idx_t emit_left_idx = use_l_for_hash ? key_to_index_map[key] : it_idx;
 
-			result_sel.set_index(offset + row_result_length, emit_left_idx);
+			row_sel.set_index(row_result_length, emit_left_idx);
 			row_result_length++;
 		}
 
-		entry.length = row_result_length;
-		offset += row_result_length;
-		result_data.WriteValue(entry);
+		list.Append(l_child, row_sel, l_size, 0, row_result_length);
 	}
-
-	ListVector::SetListSize(result, offset);
-
-	result_entry.Slice(l_child, result_sel, offset);
-	result_entry.Flatten(offset);
-	FlatVector::SetValidity(result_entry, result_entry_validity_mask);
 }
 static unique_ptr<FunctionData> ListIntersectBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -18,40 +18,29 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 	auto &lists = args.data[0];
 	auto &new_sizes = args.data[1];
 	auto row_count = args.size();
-
-	UnifiedVectorFormat lists_data;
-	lists.ToUnifiedFormat(row_count, lists_data);
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(lists_data);
-
-	auto &child_vector = ListVector::GetChild(lists);
-	UnifiedVectorFormat child_data;
-	child_vector.ToUnifiedFormat(row_count, child_data);
-
-	UnifiedVectorFormat new_sizes_data;
-	new_sizes.ToUnifiedFormat(row_count, new_sizes_data);
 	D_ASSERT(new_sizes.GetType().id() == LogicalTypeId::UBIGINT);
-	auto new_size_entries = UnifiedVectorFormat::GetData<ubigint_t>(new_sizes_data);
 
-	// Get the new size of the result child vector.
-	// We skip rows with NULL values in the input lists.
-	ubigint_t child_vector_size(0);
+	auto list_entries = lists.Values<list_entry_t>(row_count);
+	auto new_size_entries = new_sizes.Values<ubigint_t>(row_count);
+	auto &child_vector = ListVector::GetChild(lists);
+
+	// Sum up the total child capacity using checked arithmetic so we trip an
+	// Overflow exception up-front for absurd target sizes (e.g. UINT64_MAX).
+	ubigint_t total_child_size(0);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		auto list_idx = lists_data.sel->get_index(row_idx);
-		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
-
-		if (lists_data.validity.RowIsValid(list_idx) && new_sizes_data.validity.RowIsValid(new_size_idx)) {
-			child_vector_size += new_size_entries[new_size_idx];
+		auto list_entry = list_entries[row_idx];
+		auto new_size_entry = new_size_entries[row_idx];
+		if (list_entry.IsValid() && new_size_entry.IsValid()) {
+			total_child_size += new_size_entry.GetValue();
 		}
 	}
-	ListVector::Reserve(result, child_vector_size.value);
-	ListVector::SetListSize(result, child_vector_size.value);
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_entries = FlatVector::Writer<list_entry_t>(result, row_count);
-	auto &result_child_vector = ListVector::GetChildMutable(result);
 
-	// Get the default values, if provided.
+	// the default vector's element type is dynamic so we can't use Values<T>
+	// here -- ToUnifiedFormat lets us check validity for any payload type.
 	UnifiedVectorFormat default_data;
 	optional_ptr<Vector> default_vector;
 	if (args.ColumnCount() == 3) {
@@ -59,61 +48,47 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 		default_vector->ToUnifiedFormat(row_count, default_data);
 	}
 
-	ubigint_t offset(0);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-		auto list_idx = lists_data.sel->get_index(row_idx);
-		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
-
+		auto list_entry = list_entries[row_idx];
 		// Set to NULL, if the list is NULL.
-		if (!lists_data.validity.RowIsValid(list_idx)) {
+		if (!list_entry.IsValid()) {
 			result_entries.WriteNull();
 			continue;
 		}
 
-		ubigint_t new_size(0);
-		if (new_sizes_data.validity.RowIsValid(new_size_idx)) {
-			new_size = new_size_entries[new_size_idx];
-		}
+		auto new_size_entry = new_size_entries[row_idx];
+		ubigint_t new_size = new_size_entry.IsValid() ? new_size_entry.GetValue() : ubigint_t(0);
 
 		// If new_size >= length, then we copy [0, length) values.
 		// If new_size < length, then we copy [0, new_size) values.
-		auto copy_count = MinValue<ubigint_t>(list_entries[list_idx].length, new_size);
+		const auto &source_list = list_entry.GetValue();
+		auto copy_count = MinValue<ubigint_t>(source_list.length, new_size);
 
-		// Set the result entry.
-		result_entries.WriteValue(list_entry_t(offset.value, new_size.value));
-
-		// Copy the child vector's values.
-		// The number of elements to copy is later determined like so: source_count - source_offset.
-		ubigint_t source_offset = list_entries[list_idx].offset;
+		auto list = result_entries.WriteDynamicList();
+		ubigint_t source_offset = source_list.offset;
 		ubigint_t source_count = source_offset + copy_count;
-		VectorOperations::Copy(child_vector, result_child_vector, source_count.value, source_offset.value,
-		                       offset.value);
-		offset += copy_count;
+		list.Append(child_vector, *FlatVector::IncrementalSelectionVector(), source_count.value, source_offset.value,
+		            copy_count.value);
 
-		// Fill the remaining space with the default values.
-		if (copy_count < new_size) {
-			ubigint_t remaining_count = new_size - copy_count;
+		if (copy_count >= new_size) {
+			continue;
+		}
+		ubigint_t remaining_count = new_size - copy_count;
 
-			if (default_vector) {
-				auto default_idx = default_data.sel->get_index(row_idx);
-				if (default_data.validity.RowIsValid(default_idx)) {
-					SelectionVector sel(remaining_count.value);
-					for (idx_t j = 0; j < remaining_count.value; j++) {
-						sel.set_index(j, row_idx);
-					}
-					VectorOperations::Copy(*default_vector, result_child_vector, sel, remaining_count.value, 0,
-					                       offset.value);
-					offset += remaining_count;
-					continue;
+		if (default_vector) {
+			auto default_idx = default_data.sel->get_index(row_idx);
+			if (default_data.validity.RowIsValid(default_idx)) {
+				SelectionVector sel(remaining_count.value);
+				for (idx_t j = 0; j < remaining_count.value; j++) {
+					sel.set_index(j, row_idx);
 				}
-			}
-
-			// Fill the remaining space with NULL.
-			for (idx_t j = copy_count.value; j < new_size.value; j++) {
-				FlatVector::SetNull(result_child_vector, offset.value, true);
-				offset += 1;
+				list.Append(*default_vector, sel, remaining_count.value, 0, remaining_count.value);
+				continue;
 			}
 		}
+
+		// Fill the remaining space with NULL.
+		list.AppendNulls(remaining_count.value);
 	}
 }
 

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -150,53 +150,36 @@ void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result,
 		}
 		input_data.emplace_back(input, count);
 	}
-	// First pass: compute per-row lengths/validity and total child size
-	vector<idx_t> row_lengths(count, 0);
+
+	// the || operator yields NULL whenever any input is NULL, while list_concat skips NULLs
 	vector<bool> row_invalid(count, false);
-	idx_t total_size = 0;
-	for (auto &input : input_data) {
-		auto &list_data = input.list_data;
-		for (idx_t r = 0; r < count; r++) {
-			auto list_entry = list_data[r];
-			if (!list_entry.IsValid()) {
-				if (is_operator) {
-					// LIST_CONCAT ignores NULL values, but || does not
+	if (is_operator) {
+		for (auto &input : input_data) {
+			for (idx_t r = 0; r < count; r++) {
+				if (!input.list_data[r].IsValid()) {
 					row_invalid[r] = true;
 				}
-				continue;
 			}
-			auto list_length = list_entry.GetValue().length;
-			row_lengths[r] += list_length;
-			total_size += list_length;
 		}
 	}
 
-	// Pre-reserve total child capacity in one shot
-	ListVector::Reserve(result, total_size);
-	auto &result_child = ListVector::GetChildMutable(result);
-
-	// Second pass: write list entries and copy children
 	auto result_writer = FlatVector::Writer<list_entry_t>(result, count);
-	idx_t offset = 0;
 	for (idx_t r = 0; r < count; r++) {
 		if (row_invalid[r]) {
 			result_writer.WriteNull();
 			continue;
 		}
-		list_entry_t row_entry {offset, row_lengths[r]};
+		auto list = result_writer.WriteDynamicList();
 		for (auto &input : input_data) {
 			auto list_val = input.list_data[r];
 			if (!list_val.IsValid()) {
 				continue;
 			}
 			const auto &list_entry = list_val.GetValue();
-			result_child.Copy(input.child_vec, *FlatVector::IncrementalSelectionVector(),
-			                  list_entry.offset + list_entry.length, list_entry.offset, offset, list_entry.length);
-			offset += list_entry.length;
+			list.Append(input.child_vec, *FlatVector::IncrementalSelectionVector(),
+			            list_entry.offset + list_entry.length, list_entry.offset, list_entry.length);
 		}
-		result_writer.WriteValue(row_entry);
 	}
-	ListVector::SetListSize(result, offset);
 }
 
 void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -156,33 +157,55 @@ void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result,
 		input_data.push_back(std::move(data));
 	}
 
-	vector<sel_t> child_idx_data;
-	idx_t offset = 0;
-	auto result_data = FlatVector::ScatterWriter<list_entry_t>(result);
+	// First pass: compute per-row lengths/validity and total child size
+	vector<idx_t> row_lengths(count, 0);
+	vector<bool> row_invalid(count, false);
+	idx_t total_size = 0;
 	for (idx_t i = 0; i < count; i++) {
-		result_data[i].offset = offset;
-		result_data[i].length = 0;
+		idx_t row_length = 0;
+		bool is_invalid = false;
 		for (auto &data : input_data) {
 			auto list_index = data.vdata.sel->get_index(i);
 			if (!data.vdata.validity.RowIsValid(list_index)) {
 				// LIST_CONCAT ignores NULL values, but || does not
 				if (is_operator) {
-					result_data.SetInvalid(i);
+					is_invalid = true;
 				}
 				continue;
 			}
-			const auto &list_entry = data.input_entries[list_index];
-			result_data[i].length += list_entry.length;
-			if (child_idx_data.size() < list_entry.length) {
-				child_idx_data.resize(NextPowerOfTwo(list_entry.length));
-			}
-			for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
-				child_idx_data[child_idx] = NumericCast<sel_t>(list_entry.offset + child_idx);
-			}
-			SelectionVector child_sel(child_idx_data.data(), list_entry.length);
-			ListVector::Append(result, data.child_vec, child_sel, list_entry.length);
+			row_length += data.input_entries[list_index].length;
 		}
-		offset += result_data[i].length;
+		row_invalid[i] = is_invalid;
+		if (!is_invalid) {
+			row_lengths[i] = row_length;
+			total_size += row_length;
+		}
+	}
+
+	// Pre-reserve total child capacity in one shot
+	ListVector::Reserve(result, total_size);
+	auto &result_child = ListVector::GetChildMutable(result);
+
+	// Second pass: write list entries and copy children
+	auto result_writer = FlatVector::Writer<list_entry_t>(result, count);
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (row_invalid[i]) {
+			result_writer.WriteNull();
+			continue;
+		}
+		list_entry_t row_entry {offset, row_lengths[i]};
+		for (auto &data : input_data) {
+			auto list_index = data.vdata.sel->get_index(i);
+			if (!data.vdata.validity.RowIsValid(list_index)) {
+				continue;
+			}
+			const auto &list_entry = data.input_entries[list_index];
+			VectorOperations::Copy(data.child_vec, result_child, list_entry.offset + list_entry.length,
+			                       list_entry.offset, offset);
+			offset += list_entry.length;
+		}
+		result_writer.WriteValue(row_entry);
 	}
 	ListVector::SetListSize(result, offset);
 }

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -130,13 +130,13 @@ void ConcatOperator(DataChunk &args, ExpressionState &state, Vector &result) {
 }
 
 struct ListConcatInputData {
-	ListConcatInputData(Vector &input, Vector &child_vec) : input(input), child_vec(child_vec) {
+	ListConcatInputData(Vector &input, idx_t size)
+	    : input(input), child_vec(ListVector::GetChild(input)), list_data(input.Values<list_entry_t>(size)) {
 	}
 
-	UnifiedVectorFormat vdata;
-	Vector &input;
-	Vector &child_vec;
-	const list_entry_t *input_entries = nullptr;
+	const Vector &input;
+	const Vector &child_vec;
+	VectorIterator<list_entry_t> list_data;
 };
 
 void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result, bool is_operator) {
@@ -148,37 +148,26 @@ void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result,
 			// LIST_CONCAT ignores NULL values
 			continue;
 		}
-
-		auto &child_vec = ListVector::GetChildMutable(input);
-		ListConcatInputData data(input, child_vec);
-		input.ToUnifiedFormat(count, data.vdata);
-
-		data.input_entries = UnifiedVectorFormat::GetData<list_entry_t>(data.vdata);
-		input_data.push_back(std::move(data));
+		input_data.emplace_back(input, count);
 	}
-
 	// First pass: compute per-row lengths/validity and total child size
 	vector<idx_t> row_lengths(count, 0);
 	vector<bool> row_invalid(count, false);
 	idx_t total_size = 0;
-	for (idx_t i = 0; i < count; i++) {
-		idx_t row_length = 0;
-		bool is_invalid = false;
-		for (auto &data : input_data) {
-			auto list_index = data.vdata.sel->get_index(i);
-			if (!data.vdata.validity.RowIsValid(list_index)) {
-				// LIST_CONCAT ignores NULL values, but || does not
+	for (auto &input : input_data) {
+		auto &list_data = input.list_data;
+		for (idx_t r = 0; r < count; r++) {
+			auto list_entry = list_data[r];
+			if (!list_entry.IsValid()) {
 				if (is_operator) {
-					is_invalid = true;
+					// LIST_CONCAT ignores NULL values, but || does not
+					row_invalid[r] = true;
 				}
 				continue;
 			}
-			row_length += data.input_entries[list_index].length;
-		}
-		row_invalid[i] = is_invalid;
-		if (!is_invalid) {
-			row_lengths[i] = row_length;
-			total_size += row_length;
+			auto list_length = list_entry.GetValue().length;
+			row_lengths[r] += list_length;
+			total_size += list_length;
 		}
 	}
 
@@ -189,20 +178,20 @@ void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result,
 	// Second pass: write list entries and copy children
 	auto result_writer = FlatVector::Writer<list_entry_t>(result, count);
 	idx_t offset = 0;
-	for (idx_t i = 0; i < count; i++) {
-		if (row_invalid[i]) {
+	for (idx_t r = 0; r < count; r++) {
+		if (row_invalid[r]) {
 			result_writer.WriteNull();
 			continue;
 		}
-		list_entry_t row_entry {offset, row_lengths[i]};
-		for (auto &data : input_data) {
-			auto list_index = data.vdata.sel->get_index(i);
-			if (!data.vdata.validity.RowIsValid(list_index)) {
+		list_entry_t row_entry {offset, row_lengths[r]};
+		for (auto &input : input_data) {
+			auto list_val = input.list_data[r];
+			if (!list_val.IsValid()) {
 				continue;
 			}
-			const auto &list_entry = data.input_entries[list_index];
-			VectorOperations::Copy(data.child_vec, result_child, list_entry.offset + list_entry.length,
-			                       list_entry.offset, offset);
+			const auto &list_entry = list_val.GetValue();
+			result_child.Copy(input.child_vec, *FlatVector::IncrementalSelectionVector(),
+			                  list_entry.offset + list_entry.length, list_entry.offset, offset, list_entry.length);
 			offset += list_entry.length;
 		}
 		result_writer.WriteValue(row_entry);

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -54,69 +54,32 @@ bool ExtractAll(duckdb_re2::StringPiece &input, duckdb_re2::RE2 &pattern, idx_t 
 	return true;
 }
 
-void ExtractSingleTuple(const string_t &string, duckdb_re2::RE2 &pattern, int32_t group, RegexStringPieceArgs &args,
-                        Vector &result, idx_t row) {
-	auto input = CreateStringPiece(string);
-
-	auto &child_vector = ListVector::GetChildMutable(result);
-
-	auto current_list_size = ListVector::GetListSize(result);
-	auto current_list_capacity = ListVector::GetListCapacity(result);
-
-	auto result_data = FlatVector::GetDataMutable<list_entry_t>(result);
-	auto &list_entry = result_data[row];
-	list_entry.offset = current_list_size;
-
+template <class CB>
+idx_t ExtractAllMatches(const string_t &string, duckdb_re2::RE2 &pattern, int32_t group, RegexStringPieceArgs &args,
+                        CB &&emit) {
 	if (group < 0) {
-		list_entry.length = 0;
-		return;
+		return 0;
 	}
+	auto input = CreateStringPiece(string);
 	// If the requested group index is out of bounds
 	// we want to throw only if there is a match
 	bool throw_on_group_found = (idx_t)group > args.size;
 
 	idx_t startpos = 0;
+	idx_t count = 0;
 	for (idx_t iteration = 0;
 	     ExtractAll(input, pattern, &startpos, args.group_buffer, UnsafeNumericCast<int>(args.size)); iteration++) {
 		if (!iteration && throw_on_group_found) {
 			throw InvalidInputException("Pattern has %d groups. Cannot access group %d", args.size, group);
 		}
-
-		// Make sure we have enough room for the new entries
-		if (current_list_size + 1 >= current_list_capacity) {
-			ListVector::Reserve(result, current_list_capacity * 2);
-			current_list_capacity = ListVector::GetListCapacity(result);
-		}
-		auto list_content = FlatVector::GetDataMutable<string_t>(child_vector);
-		auto &child_validity = FlatVector::ValidityMutable(child_vector);
-
-		// Write the captured groups into the list-child vector
-		auto &match_group = args.group_buffer[group];
-
-		idx_t child_idx = current_list_size;
-		if (match_group.empty()) {
-			// This group was not matched
-			list_content[child_idx] = string_t(string.GetData(), 0);
-			if (match_group.begin() == nullptr) {
-				// This group is optional
-				child_validity.SetInvalid(child_idx);
-			}
-		} else {
-			// Every group is a substring of the original, we can find out the offset using the pointer
-			// the 'match_group' address is guaranteed to be bigger than that of the source
-			D_ASSERT(const_char_ptr_cast(match_group.begin()) >= string.GetData());
-			auto offset = UnsafeNumericCast<idx_t>(match_group.begin() - string.GetData());
-			list_content[child_idx] =
-			    string_t(string.GetData() + offset, UnsafeNumericCast<uint32_t>(match_group.size()));
-		}
-		current_list_size++;
+		emit(args.group_buffer[group]);
+		count++;
 		if (startpos > input.size()) {
 			// Empty match found at the end of the string
 			break;
 		}
 	}
-	list_entry.length = current_list_size - list_entry.offset;
-	ListVector::SetListSize(result, current_list_size);
+	return count;
 }
 
 int32_t GetGroupIndex(DataChunk &args, idx_t row, int32_t &result) {
@@ -143,16 +106,6 @@ duckdb_re2::RE2 &GetPattern(const RegexpBaseBindData &info, ExpressionState &sta
 	return *pattern_p;
 }
 
-RegexStringPieceArgs &GetGroupsBuffer(const RegexpBaseBindData &info, ExpressionState &state,
-                                      unique_ptr<RegexStringPieceArgs> &groups_p) {
-	if (info.constant_pattern) {
-		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
-		return lstate.group_buffer;
-	}
-	D_ASSERT(groups_p);
-	return *groups_p;
-}
-
 void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	const auto &info = func_expr.bind_info->Cast<RegexpBaseBindData>();
@@ -160,15 +113,13 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 	auto &strings = args.data[0];
 	auto &patterns = args.data[1];
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-	auto &output_child = ListVector::GetChildMutable(result);
 
 	auto strings_entries = strings.Values<string_t>(args.size());
 	auto pattern_entries = patterns.Values<string_t>(args.size());
 
-	ListVector::Reserve(result, STANDARD_VECTOR_SIZE);
 	// Reference the 'strings' StringBuffer, because we won't need to allocate new data
 	// for the result, all returned strings are substrings of the originals
-	StringVector::AddHeapReference(output_child, strings);
+	StringVector::AddHeapReference(ListVector::GetChildMutable(result), strings);
 
 	unique_ptr<RegexStringPieceArgs> non_const_args;
 	unique_ptr<duckdb_re2::RE2> stored_re;
@@ -183,20 +134,16 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 		}
 	}
 
+	auto list_writer = FlatVector::Writer<VectorListType<string_t>>(result, args.size());
 	for (idx_t row = 0; row < args.size(); row++) {
 		bool pattern_valid = true;
 		if (!info.constant_pattern) {
-			// Check if the pattern is NULL or not,
-			// and compile the pattern if it's not constant
 			auto pattern_entry = pattern_entries[row];
 			if (!pattern_entry.IsValid()) {
 				pattern_valid = false;
 			} else {
-				auto &pattern_p = pattern_entry.GetValue();
-				auto pattern_strpiece = CreateStringPiece(pattern_p);
+				auto pattern_strpiece = CreateStringPiece(pattern_entry.GetValue());
 				stored_re = make_uniq<duckdb_re2::RE2>(pattern_strpiece, info.options);
-
-				// Increase the size of the args buffer if needed
 				auto group_count_p = stored_re->NumberOfCapturingGroups();
 				if (group_count_p == -1) {
 					throw InvalidInputException("Pattern failed to parse, error: '%s'", stored_re->error());
@@ -204,24 +151,35 @@ void RegexpExtractAll::Execute(DataChunk &args, ExpressionState &state, Vector &
 				non_const_args->SetSize(UnsafeNumericCast<idx_t>(group_count_p));
 			}
 		}
-
 		auto string_entry = strings_entries[row];
 		int32_t group_index;
 		if (!pattern_valid || !string_entry.IsValid() || !GetGroupIndex(args, row, group_index)) {
-			// If something is NULL, the result is NULL
-			// FIXME: do we even need 'SPECIAL_HANDLING'?
-			auto result_data = FlatVector::GetDataMutable<list_entry_t>(result);
-			auto &result_validity = FlatVector::ValidityMutable(result);
-			result_data[row].length = 0;
-			result_data[row].offset = ListVector::GetListSize(result);
-			result_validity.SetInvalid(row);
+			list_writer.WriteNull();
 			continue;
 		}
-
 		auto &re = GetPattern(info, state, stored_re);
-		auto &groups = GetGroupsBuffer(info, state, non_const_args);
-		auto &string = string_entry.GetValue();
-		ExtractSingleTuple(string, re, group_index, groups, result, row);
+		auto &groups = info.constant_pattern
+		                   ? ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>().group_buffer
+		                   : *non_const_args;
+		auto &string_val = string_entry.GetValue();
+		auto list = list_writer.WriteDynamicList();
+		ExtractAllMatches(string_val, re, group_index, groups, [&](const duckdb_re2::StringPiece &match_group) {
+			auto &child_writer = list.WriteElement();
+			if (match_group.empty()) {
+				if (match_group.begin() == nullptr) {
+					// Unmatched optional group → NULL
+					child_writer.WriteNull();
+				} else {
+					child_writer.WriteStringRef(string_t(string_val.GetData(), 0));
+				}
+			} else {
+				// Every group is a substring of the original, we can find the offset via pointer
+				D_ASSERT(const_char_ptr_cast(match_group.begin()) >= string_val.GetData());
+				auto offset = UnsafeNumericCast<idx_t>(match_group.begin() - string_val.GetData());
+				child_writer.WriteStringRef(
+				    string_t(string_val.GetData() + offset, UnsafeNumericCast<uint32_t>(match_group.size())));
+			}
+		});
 	}
 }
 

--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -6,33 +6,12 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
-#include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
 namespace {
-
-struct StringSplitInput {
-	StringSplitInput(Vector &result_list, Vector &result_child, idx_t offset)
-	    : result_list(result_list), result_child(result_child), offset(offset) {
-	}
-
-	Vector &result_list;
-	Vector &result_child;
-	idx_t offset;
-
-	void AddSplit(const char *split_data, idx_t split_size, idx_t list_idx) {
-		auto list_entry = offset + list_idx;
-		if (list_entry >= ListVector::GetListCapacity(result_list)) {
-			ListVector::SetListSize(result_list, offset + list_idx);
-			ListVector::Reserve(result_list, ListVector::GetListCapacity(result_list) * 2);
-		}
-		FlatVector::GetDataMutable<string_t>(result_child)[list_entry] =
-		    string_t(split_data, UnsafeNumericCast<uint32_t>(split_size));
-	}
-};
 
 struct RegularStringSplit {
 	static idx_t Find(const char *input_data, idx_t input_size, const char *delim_data, idx_t delim_size,
@@ -71,8 +50,8 @@ struct RegexpStringSplit {
 };
 
 struct StringSplitter {
-	template <class OP>
-	static idx_t Split(string_t input, string_t delim, StringSplitInput &state, void *data) {
+	template <class OP, class CB>
+	static idx_t Split(string_t input, string_t delim, void *data, CB &&emit) {
 		auto input_data = input.GetData();
 		auto input_size = input.GetSize();
 		auto delim_data = delim.GetData();
@@ -97,13 +76,12 @@ struct StringSplitter {
 				}
 			}
 			D_ASSERT(input_size >= pos + match_size);
-			state.AddSplit(input_data, pos, list_idx);
-
+			emit(input_data, pos);
 			list_idx++;
 			input_data += (pos + match_size);
 			input_size -= (pos + match_size);
 		}
-		state.AddSplit(input_data, input_size, list_idx);
+		emit(input_data, input_size);
 		list_idx++;
 		return list_idx;
 	}
@@ -115,38 +93,29 @@ void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result
 	auto delim_entries = args.data[1].Values<string_t>(args.size());
 
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-
 	result.SetVectorType(VectorType::FLAT_VECTOR);
-	ListVector::SetListSize(result, 0);
 
-	auto result_data = FlatVector::Writer<list_entry_t>(result, args.size());
-
-	// count all the splits and set up the list entries
-	auto &child_entry = ListVector::GetChildMutable(result);
-	idx_t total_splits = 0;
+	auto list_writer = FlatVector::Writer<VectorListType<string_t>>(result, args.size());
 	for (idx_t i = 0; i < args.size(); i++) {
 		auto input_entry = input_entries[i];
-		auto delim_entry = delim_entries[i];
 		if (!input_entry.IsValid()) {
-			result_data.WriteNull();
+			list_writer.WriteNull();
 			continue;
 		}
-		StringSplitInput split_input(result, child_entry, total_splits);
+		auto delim_entry = delim_entries[i];
+		auto list = list_writer.WriteDynamicList();
 		if (!delim_entry.IsValid()) {
 			// delim is NULL: copy the complete entry
-			split_input.AddSplit(input_entry.GetValue().GetData(), input_entry.GetValue().GetSize(), 0);
-			result_data.WriteValue(list_entry_t(total_splits, 1));
-			total_splits++;
+			list.WriteElement().WriteStringRef(input_entry.GetValue());
 			continue;
 		}
-		auto list_length = StringSplitter::Split<OP>(input_entry.GetValue(), delim_entry.GetValue(), split_input, data);
-		result_data.WriteValue(list_entry_t(total_splits, list_length));
-		total_splits += list_length;
+		StringSplitter::Split<OP>(
+		    input_entry.GetValue(), delim_entry.GetValue(), data, [&](const char *split_data, idx_t split_size) {
+			    list.WriteElement().WriteStringRef(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
+		    });
 	}
-	ListVector::SetListSize(result, total_splits);
-	D_ASSERT(ListVector::GetListSize(result) == total_splits);
 
-	StringVector::AddHeapReference(child_entry, args.data[0]);
+	StringVector::AddHeapReference(ListVector::GetChildMutable(result), args.data[0]);
 }
 
 void StringSplitFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -237,6 +237,9 @@ private:
 template <class T>
 class DynamicListWriter;
 
+//! Forward declaration for the type-erased dynamic list appender (defined below).
+class DynamicListAppender;
+
 //! Specialization of VectorWriter for VectorListType<T>.
 //! Writes rows to a list vector. Non-null rows are opened with WriteList(n),
 //! which returns a range that iterates over n child writers with their in-list
@@ -426,6 +429,131 @@ inline DynamicListWriter<T> VectorWriter<VectorListType<T>>::WriteDynamicList() 
 	const auto row_idx = current_idx;
 	current_idx++;
 	return DynamicListWriter<T>(*this, row_idx, old_offset);
+}
+
+//! Specialization of VectorWriter for list_entry_t. Writes per-row list entries
+//! to a list vector without a templated child type. Supports the primitive-style
+//! WriteValue(list_entry_t) / WriteNull() API for callers that compute list
+//! entries themselves, plus WriteDynamicList() which returns a DynamicListAppender
+//! that grows the child vector via Vector::Copy from another vector.
+template <>
+struct VectorWriter<list_entry_t> {
+	VectorWriter(Vector &vector, idx_t count, idx_t offset)
+	    : list_data(FlatVector::GetDataMutable<list_entry_t>(vector)), validity(FlatVector::ValidityMutable(vector)),
+	      list_vec(vector), count(offset + count), current_idx(offset), child_offset(VectorWriterGetListSize(vector)) {
+	}
+	VectorWriter(VectorWriter &&other) noexcept
+	    : list_data(other.list_data), validity(other.validity), list_vec(other.list_vec), count(other.count),
+	      current_idx(other.current_idx), child_offset(other.child_offset) {
+		other.count = other.current_idx;
+	}
+	~VectorWriter() {
+		D_ASSERT(Exception::UncaughtException() || current_idx == count);
+	}
+
+	void WriteValue(const list_entry_t &value) {
+		D_ASSERT(current_idx < count);
+		list_data[current_idx] = value;
+		current_idx++;
+	}
+
+	void WriteNull() {
+		D_ASSERT(current_idx < count);
+		validity.SetInvalid(current_idx);
+		current_idx++;
+	}
+
+	void WriteNull(const list_entry_t &value) {
+		D_ASSERT(current_idx < count);
+		list_data[current_idx] = value;
+		validity.SetInvalid(current_idx);
+		current_idx++;
+	}
+
+	void Truncate() noexcept {
+		count = current_idx;
+	}
+
+	//! Open a list whose final length is unknown. Returns a DynamicListAppender
+	//! that copies entries from other vectors into the child via Vector::Copy.
+	//! The list_entry for this row is finalized when the appender goes out of scope.
+	DynamicListAppender WriteDynamicList();
+
+private:
+	friend class DynamicListAppender;
+
+	list_entry_t *list_data;
+	ValidityMask &validity;
+	Vector &list_vec;
+	idx_t count;
+	idx_t current_idx;
+	idx_t child_offset;
+};
+
+//! Type-erased counterpart to DynamicListWriter<T> for callers that don't know
+//! the child element type at compile time (e.g., list_concat). Instead of
+//! offering a per-element writer, it appends ranges from another vector via
+//! Vector::Copy. The list_entry length is recorded when the appender goes out
+//! of scope.
+//!
+//! Typical usage:
+//!     auto list = list_writer.WriteDynamicList();
+//!     for (auto &input : inputs) {
+//!         list.Append(input.child_vec, *FlatVector::IncrementalSelectionVector(),
+//!                     entry.offset + entry.length, entry.offset, entry.length);
+//!     }
+class DynamicListAppender {
+public:
+	DynamicListAppender(VectorWriter<list_entry_t> &parent, idx_t row_idx, idx_t base_offset)
+	    : parent(parent), row_idx(row_idx), base_offset(base_offset), current_length(0) {
+	}
+	DynamicListAppender(const DynamicListAppender &) = delete;
+	DynamicListAppender(DynamicListAppender &&) = delete;
+	~DynamicListAppender() {
+		parent.list_data[row_idx] = {base_offset, current_length};
+		parent.child_offset = base_offset + current_length;
+		VectorWriterSetListSize(parent.list_vec, base_offset + current_length);
+	}
+
+	//! Copy `copy_count` rows out of `source` (selected via source_sel/source_offset/source_count)
+	//! into the list under construction. Grows the parent's child vector as needed.
+	void Append(const Vector &source, const SelectionVector &source_sel, idx_t source_count, idx_t source_offset,
+	            idx_t copy_count) {
+		const idx_t target_offset = base_offset + current_length;
+		VectorWriterReserveList(parent.list_vec, target_offset + copy_count);
+		VectorWriterSetListSize(parent.list_vec, target_offset + copy_count);
+		Vector &child_vec = VectorWriterGetListChild(parent.list_vec);
+		child_vec.Copy(source, source_sel, source_count, source_offset, target_offset, copy_count);
+		current_length += copy_count;
+	}
+
+	//! Append `count` NULL elements to the list under construction. Used to pad a
+	//! list to a target length when no source value is available. Goes through
+	//! FlatVector::SetNull so NULL propagates correctly to struct/array children.
+	void AppendNulls(idx_t count) {
+		const idx_t target_offset = base_offset + current_length;
+		VectorWriterReserveList(parent.list_vec, target_offset + count);
+		VectorWriterSetListSize(parent.list_vec, target_offset + count);
+		Vector &child_vec = VectorWriterGetListChild(parent.list_vec);
+		for (idx_t i = 0; i < count; i++) {
+			FlatVector::SetNull(child_vec, target_offset + i, true);
+		}
+		current_length += count;
+	}
+
+private:
+	VectorWriter<list_entry_t> &parent;
+	idx_t row_idx;
+	idx_t base_offset;
+	idx_t current_length;
+};
+
+inline DynamicListAppender VectorWriter<list_entry_t>::WriteDynamicList() {
+	D_ASSERT(current_idx < count);
+	const auto old_offset = child_offset;
+	const auto row_idx = current_idx;
+	current_idx++;
+	return DynamicListAppender(*this, row_idx, old_offset);
 }
 
 template <class T>

--- a/src/include/duckdb/common/vector/vector_writer.hpp
+++ b/src/include/duckdb/common/vector/vector_writer.hpp
@@ -61,6 +61,14 @@ struct VectorWriter {
 		current_idx++;
 	}
 
+	//! Cap the writer's count to the values written so far. Use this when
+	//! releasing a writer that hasn't been fully written (e.g., when a
+	//! dynamic-length list is closed early); subsequent destruction passes
+	//! the count==current_idx assertion.
+	void Truncate() noexcept {
+		count = current_idx;
+	}
+
 private:
 	T *data;
 	ValidityMask &validity;
@@ -108,6 +116,10 @@ struct VectorWriter<string_t> {
 		auto &res = data[current_idx];
 		current_idx++;
 		return res;
+	}
+
+	void Truncate() noexcept {
+		count = current_idx;
 	}
 
 	inline StringHeap &GetHeap() {
@@ -186,7 +198,17 @@ public:
 		current_idx++;
 	}
 
+	void Truncate() noexcept {
+		count = current_idx;
+		TruncateChildren(std::index_sequence_for<Args...> {});
+	}
+
 private:
+	template <std::size_t... Is>
+	void TruncateChildren(std::index_sequence<Is...>) {
+		(std::get<Is>(children).Truncate(), ...);
+	}
+
 	template <std::size_t... Is>
 	void WriteNullToChildren(std::index_sequence<Is...>) {
 		(std::get<Is>(children).WriteNull(), ...);
@@ -210,6 +232,10 @@ private:
 	idx_t current_idx;
 	ChildWriters children;
 };
+
+//! Forward declaration for the dynamic list-of-T writer (defined below).
+template <class T>
+class DynamicListWriter;
 
 //! Specialization of VectorWriter for VectorListType<T>.
 //! Writes rows to a list vector. Non-null rows are opened with WriteList(n),
@@ -287,6 +313,10 @@ public:
 		current_idx++;
 	}
 
+	void Truncate() noexcept {
+		count = current_idx;
+	}
+
 	//! Reserve n child slots, record the list entry for this row, and return a
 	//! WriteRange whose iterator yields {child_writer, in-list-index} pairs.
 	//! Destroying the range asserts that all n child slots were written.
@@ -301,7 +331,15 @@ public:
 		return WriteRange(child_vec, n, old_offset);
 	}
 
+	//! Open a list whose final length is unknown. Returns a DynamicListWriter<T>
+	//! that pre-reserves a small capacity in the child vector and grows on demand.
+	//! Each call to WriteElement() returns a writer for the next slot; the list
+	//! length is recorded when the returned writer goes out of scope.
+	DynamicListWriter<T> WriteDynamicList();
+
 private:
+	friend class DynamicListWriter<T>;
+
 	list_entry_t *list_data;
 	ValidityMask &validity;
 	Vector &list_vec;
@@ -310,6 +348,85 @@ private:
 	idx_t current_idx;
 	idx_t child_offset;
 };
+
+//! Writer for a single list whose final length is unknown. Holds a single
+//! VectorWriter<T> that is reused across all elements. When the underlying
+//! child vector needs to grow (because the user wrote past the reserved
+//! capacity), the stored writer is destroyed and reconstructed in place with
+//! a refreshed data pointer. Each WriteElement() call returns a reference to
+//! that writer, advanced to the next slot. The actual list_entry length is
+//! recorded when the DynamicListWriter goes out of scope.
+//!
+//! Typical usage:
+//!     auto list = list_writer.WriteDynamicList();
+//!     while (...) {
+//!         auto &child_writer = list.WriteElement();
+//!         child_writer.WriteValue(value);
+//!     }
+template <class T>
+class DynamicListWriter {
+public:
+	DynamicListWriter(VectorWriter<VectorListType<T>> &parent, idx_t row_idx, idx_t base_offset)
+	    : parent(parent), row_idx(row_idx), base_offset(base_offset), capacity(INITIAL_CAPACITY), current_idx(0) {
+		VectorWriterReserveList(parent.list_vec, base_offset + capacity);
+		VectorWriterSetListSize(parent.list_vec, base_offset + capacity);
+		new (&child_writer) VectorWriter<T>(parent.child_vec, capacity, base_offset);
+	}
+	DynamicListWriter(const DynamicListWriter &) = delete;
+	DynamicListWriter(DynamicListWriter &&) = delete;
+	~DynamicListWriter() {
+		parent.list_data[row_idx] = {base_offset, current_idx};
+		parent.child_offset = base_offset + current_idx;
+		VectorWriterSetListSize(parent.list_vec, base_offset + current_idx);
+		// suppress the writer's count-mismatch assertion (the reserved capacity
+		// is typically larger than what was actually written) and destroy it.
+		child_writer.Truncate();
+		child_writer.~VectorWriter<T>();
+	}
+
+	//! Returns a reference to the stored child writer, advanced to the next
+	//! slot. The caller must write exactly one value via the returned writer
+	//! before calling WriteElement() again.
+	VectorWriter<T> &WriteElement() {
+		if (current_idx == capacity) {
+			Grow();
+		}
+		current_idx++;
+		return child_writer;
+	}
+
+private:
+	void Grow() {
+		// the stored writer was filled to capacity, so its assertion passes
+		child_writer.~VectorWriter<T>();
+		capacity = capacity * 2;
+		VectorWriterReserveList(parent.list_vec, base_offset + capacity);
+		VectorWriterSetListSize(parent.list_vec, base_offset + capacity);
+		new (&child_writer) VectorWriter<T>(parent.child_vec, capacity - current_idx, base_offset + current_idx);
+	}
+
+	static constexpr idx_t INITIAL_CAPACITY = 8;
+
+	VectorWriter<VectorListType<T>> &parent;
+	idx_t row_idx;
+	idx_t base_offset;
+	idx_t capacity;
+	idx_t current_idx;
+	// stored via union so the writer's lifetime is managed manually -- it must
+	// be destroyed and reconstructed when the underlying buffer is reallocated.
+	union {
+		VectorWriter<T> child_writer;
+	};
+};
+
+template <class T>
+inline DynamicListWriter<T> VectorWriter<VectorListType<T>>::WriteDynamicList() {
+	D_ASSERT(current_idx < count);
+	const auto old_offset = child_offset;
+	const auto row_idx = current_idx;
+	current_idx++;
+	return DynamicListWriter<T>(*this, row_idx, old_offset);
+}
 
 template <class T>
 struct VectorScatterWriter {


### PR DESCRIPTION

Follow-up to https://github.com/duckdb/duckdb/pull/22446

This PR extends the situations in which the `FlatVector::Writer` can be used by allowing the writing of dynamic lists, instead of only static lists. Example API:

```cpp
auto list_writer = FlatVector::Writer<VectorListType<string_t>>(result, args.size());
for (idx_t i = 0; i < args.size(); i++) {
	auto input_idx = input_data.sel->get_index(i);
	if (!input_data.validity.RowIsValid(input_idx)) {
		list_writer.WriteNull();
		continue;
	}
	auto list = list_writer.WriteDynamicList();
	SplitPath(inputs[input_idx], sep, [&](const char *split_data, idx_t split_size) {
		list.WriteElement().WriteValue(string_t(split_data, UnsafeNumericCast<uint32_t>(split_size)));
	});
}
```

Essentially instead of calling `list_writer.WriteList(n)` with a fixed list size we call `list_writer.WriteDynamicList()`. This returns a new writer that can be used to write rows to the list. Calling `list.WriteElement()` adds an entry to the list, and returns a `VectorWriter` that should be used to write this entry. 

For lists with types we don't know up-front, we can use `FlatVector::Writer<list_entry_t>`. We can then use `WriteDynamicList` followed by appending from a vector to fill the list with values:

```cpp
auto out_list_data = FlatVector::Writer<list_entry_t>(result, count);

for (idx_t i = 0; i < args.size(); i++) {
	auto input_idx = input_data.sel->get_index(i);
	if (!input_data.validity.RowIsValid(input_idx)) {
		out_list_data.WriteNull();
		continue;
	}
	auto list = list_writer.WriteDynamicList();
	list.Append(source_vec, sel, size, 0, 1);
}
```