### PR TITLE
Disable tpcds temporarily to fix main CI

### DIFF
--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -8,10 +8,9 @@ import sys
 from dataclasses import dataclass
 from typing import TextIO
 
-PULL_REQUEST_JOBS = [
+COMMON_JOBS = [
     "linux-relassert",
     "linux-relassert-tests",
-    "regression",
     "tidy-check",
     "extensions",
     "wasm-eh",
@@ -28,6 +27,12 @@ PULL_REQUEST_JOBS = [
     "static-libs-linux",
 ]
 
+PULL_REQUEST_ONLY_JOBS = [
+    "regression",
+]
+
+PULL_REQUEST_JOBS = COMMON_JOBS + PULL_REQUEST_ONLY_JOBS
+
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
     "valgrind",
@@ -35,7 +40,7 @@ NIGHTLY_ONLY_JOBS = [
     "static-libs-windows-mingw",
 ]
 
-NIGHTLY_JOBS = PULL_REQUEST_JOBS + NIGHTLY_ONLY_JOBS
+NIGHTLY_JOBS = COMMON_JOBS + NIGHTLY_ONLY_JOBS
 
 MERGE_GROUP_JOBS = [
     "linux-relassert",

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/assert.hpp"
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/file_system.hpp"


### PR DESCRIPTION
### Context

Benchmark `tpcds` is [failing](https://github.com/duckdb/duckdb/actions/runs/25296251884/job/74155868365) on branch `main` with:

```
tpcds
  ====================================================
  ==============      ITERATION 0        =============
  ==============      REMAINING 99        =============
  ====================================================
  
  name	run	timing
  benchmark/tpcds/sf1/q01.benchmark	1	INCORRECT
  INCORRECT RESULT: Error in result on row 4 column 1: expected value "AAAAAAAAAAAKAAAA" but got value "AAAAAAAAAACJAAAA"
  Obtained result:
  c_customer_id	
  VARCHAR	
  [ Rows: 100]
  AAAAAAAAAAABBAAA
  AAAAAAAAAAADBAAA
  AAAAAAAAAAADBAAA

```

because tpcds output has been [changed](https://github.com/duckdb/duckdb/pull/21746) but those changes are not yet in the base branch.

This is also the reason why the benchmark [failed](https://github.com/duckdb/duckdb/actions/runs/24939176485/job/73031037385?pr=21746) in the PR's CI run (the current branch had different output than the base branch, so the reverse case).

The base ref is [selected](https://github.com/duckdb/duckdb/actions/runs/24939176485/job/73030823042?pr=21746#step:7:4) using:
```
$ bash scripts/ci/last_main_success_commit.sh
PAGER= gh run list \
  --repo duckdb/duckdb \
  --branch=main \
  --workflow=Main \
  --event=workflow_dispatch \
  --status=success \
  --json=headSha \
  --limit=1 \
  --jq '.[0].headSha'
``` 
so main CI stays stuck at that git ref until the benchmark is disabled and re-enabled after that.

### Disable benchmark CI jobs on main

Mark suggested to disable regression CI jobs on main. We want to run the benchmark between releases.

Later, we want to perhaps also run them weekly/daily to spot regressions over time.