### PR TITLE
Fix MERGE condition binding for row alias comparisons

### DIFF
--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -65,20 +65,12 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 	result->action_type = action.action_type;
 	auto expr_start_idx = expressions.size();
 	if (action.condition) {
-		if (action.condition->HasSubquery()) {
-			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
-			WhereBinder where_binder(*this, context);
-			auto cond = where_binder.Bind(action.condition);
-			PlanSubqueries(cond, root);
-			auto cond_type = cond->GetReturnType();
-			auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
-			result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
-		} else {
-			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
-			proj_binder.target_type = LogicalType::BOOLEAN;
-			auto cond = proj_binder.Bind(action.condition);
-			result->condition = std::move(cond);
-		}
+		WhereBinder where_binder(*this, context);
+		auto cond = where_binder.Bind(action.condition);
+		PlanSubqueries(cond, root);
+		auto cond_type = cond->GetReturnType();
+		auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
+		result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
 	}
 	switch (action.action_type) {
 	case MergeActionType::MERGE_UPDATE: {

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -42,6 +42,30 @@ static void ValidateMergeColumns(const Expression &expr, MergeActionCondition co
 	});
 }
 
+static void InlineProjectionReferences(unique_ptr<Expression> &expr, TableIndex proj_index,
+                                       const vector<unique_ptr<Expression>> &expressions, idx_t expr_index) {
+	if (!expr) {
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+		InlineProjectionReferences(child, proj_index, expressions, expr_index);
+	});
+	if (expr->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		return;
+	}
+
+	auto &colref = expr->Cast<BoundColumnRefExpression>();
+	if (colref.binding.table_index != proj_index) {
+		return;
+	}
+	auto column_index = colref.binding.column_index.GetIndex();
+	if (column_index >= expr_index || !expressions[column_index]) {
+		throw InternalException("Projection expression cannot reference itself");
+	}
+	expr = expressions[column_index]->Copy();
+	InlineProjectionReferences(expr, proj_index, expressions, expr_index);
+}
+
 vector<unique_ptr<ParsedExpression>> GenerateColumnReferences(Binder &binder, const vector<BindingAlias> &aliases,
                                                               const vector<string> &names) {
 	vector<unique_ptr<ParsedExpression>> result;
@@ -65,12 +89,20 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 	result->action_type = action.action_type;
 	auto expr_start_idx = expressions.size();
 	if (action.condition) {
-		WhereBinder where_binder(*this, context);
-		auto cond = where_binder.Bind(action.condition);
-		PlanSubqueries(cond, root);
-		auto cond_type = cond->GetReturnType();
-		auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
-		result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
+		if (action.condition->HasSubquery()) {
+			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
+			WhereBinder where_binder(*this, context);
+			auto cond = where_binder.Bind(action.condition);
+			PlanSubqueries(cond, root);
+			auto cond_type = cond->GetReturnType();
+			auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
+			result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
+		} else {
+			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
+			proj_binder.target_type = LogicalType::BOOLEAN;
+			auto cond = proj_binder.Bind(action.condition);
+			result->condition = std::move(cond);
+		}
 	}
 	switch (action.action_type) {
 	case MergeActionType::MERGE_UPDATE: {
@@ -188,6 +220,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 
 	for (idx_t i = expr_start_idx; i < expressions.size(); i++) {
 		if (expressions[i]) {
+			InlineProjectionReferences(expressions[i], proj_index, expressions, i);
 			ValidateMergeColumns(*expressions[i], condition, get.table_index, source_table_indices);
 		}
 	}

--- a/test/sql/merge/merge_into.test
+++ b/test/sql/merge/merge_into.test
@@ -52,6 +52,30 @@ FROM Stock ORDER BY item_id
 20	1900
 30	300
 
+# relation-alias row comparison in a matched condition with a derived source
+statement ok
+CREATE TABLE merge_distinct_target(tableticker VARCHAR NOT NULL, figi VARCHAR, cik VARCHAR, lastupdated DATE NOT NULL);
+
+statement ok
+INSERT INTO merge_distinct_target VALUES ('tablepermaticker', 'old_figi', 'old_cik', DATE '2026-04-30');
+
+query I
+MERGE INTO merge_distinct_target AS t
+USING (
+	SELECT 'tablepermaticker' AS tableticker, 'new_figi' AS figi, 'new_cik' AS cik, DATE '2026-05-01' AS lastupdated
+	ORDER BY tableticker
+) AS q
+ON t.tableticker = q.tableticker
+WHEN MATCHED AND t IS DISTINCT FROM q THEN UPDATE
+WHEN NOT MATCHED THEN INSERT
+----
+1
+
+query IIII
+FROM merge_distinct_target ORDER BY tableticker
+----
+tablepermaticker	new_figi	new_cik	2026-05-01
+
 # sell - deleting all rows that are fully sold
 statement ok
 CREATE TABLE Sale(item_id int, volume int);


### PR DESCRIPTION
This fixes an internal binding error in `MERGE INTO` when a matched condition compares the target and source aliases as rows, for example:

```sql
WHEN MATCHED AND t IS DISTINCT FROM q THEN UPDATE
```

The condition now gets bound through the regular `WHERE`-style path before being projected, avoids creating stale/self-referential column bindings for expanded row alias comparisons.

Also added a regression test based on the original issue shape.

**Fixes**
#22427 

**Testing**
```bash
test/sql/merge/merge_into.test
```

Also spot-checked nearby `MERGE` condition/subquery tests.

