### PR TITLE
[Parquet][Variant] Fix ability to disable shredding of VARIANT columns

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -307,7 +307,7 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		child_types.emplace_back("value", LogicalType::BLOB);
 		if (is_shredded) {
 			auto &typed_value_type = shredding_type->type;
-			if (typed_value_type.id() != LogicalTypeId::ANY) {
+			if (typed_value_type.id() != LogicalTypeId::SQLNULL) {
 				child_types.emplace_back("typed_value",
 				                         VariantColumnWriter::TransformTypedValueRecursive(typed_value_type));
 			}
@@ -326,6 +326,7 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		for (auto &entry : child_types) {
 			auto &child_name = entry.first;
 			auto &child_type = entry.second;
+			optional_ptr<const ShreddingType> child_shredding;
 			bool is_optional;
 			if (child_name == "metadata") {
 				is_optional = false;
@@ -338,11 +339,14 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 				}
 			} else {
 				D_ASSERT(child_name == "typed_value");
+				//! Only set shredding for the 'typed_value', just in case there's a child by the name of 'metadata' or
+				//! 'value'
+				child_shredding = shredding_type;
 				is_optional = true;
 			}
 
 			child_writers.push_back(CreateWriterRecursive(context, writer, path_in_schema, child_type, child_name,
-			                                              allow_geometry, child_field_ids, shredding_type, max_repeat,
+			                                              allow_geometry, child_field_ids, child_shredding, max_repeat,
 			                                              max_define + 1, is_optional));
 		}
 		return make_uniq<VariantColumnWriter>(writer, std::move(variant_column), path_in_schema,

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -157,7 +157,7 @@ struct ParquetWriterOptions {
 	duckdb_parquet::CompressionCodec::type codec;
 	//! The field-ids to assign to the column(s) and their fields
 	ChildFieldIDs field_ids;
-	//! The type to shred all VARIANT columns on, set explicitly by the user
+	//! The mapping of name->type to shred VARIANT on, set explicitly by the user
 	ShreddingType shredding_types;
 	//! The encryption config for the file we're writing
 	shared_ptr<ParquetEncryptionConfig> encryption_config;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -148,7 +148,6 @@ static void ParquetListCopyOptions(ClientContext &context, CopyOptionsInput &inp
 	copy_options["can_have_nan"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
 	copy_options["geoparquet_version"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::WRITE_ONLY);
 	copy_options["shredding"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
-	copy_options["disable_shredding"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::WRITE_ONLY);
 	copy_options["write_timestamp_as_int96"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::WRITE_ONLY);
 	copy_options["timestamp_is_adjusted_to_utc"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -148,6 +148,7 @@ static void ParquetListCopyOptions(ClientContext &context, CopyOptionsInput &inp
 	copy_options["can_have_nan"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
 	copy_options["geoparquet_version"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::WRITE_ONLY);
 	copy_options["shredding"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
+	copy_options["disable_shredding"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::WRITE_ONLY);
 	copy_options["write_timestamp_as_int96"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::WRITE_ONLY);
 	copy_options["timestamp_is_adjusted_to_utc"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
 

--- a/test/parquet/variant/variant_all_types_shredded.test
+++ b/test/parquet/variant/variant_all_types_shredded.test
@@ -33,8 +33,15 @@ query I nosort expected_res
 select * from data();
 ----
 
+foreach disabled true false
+
 foreach type bool tinyint smallint int bigint date time timestamp timestamp_ns timestamp_tz float double dec_9_4 dec_18_6 dec38_10 uuid varchar blob small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs
 
+onlyif disabled=true
+statement ok
+SET VARIABLE type_str = 'NULL';
+
+onlyif disabled=false
 statement ok
 SET VARIABLE type_str = (SELECT $$STRUCT("{type}" $$ || typeof("{type}") || ')' from test_all_types() limit 1);
 
@@ -50,5 +57,7 @@ COPY (
 query I nosort expected_res
 select * from '{TEST_DIR}/all_types_shredded_{type}.parquet'
 ----
+
+endloop
 
 endloop

--- a/test/parquet/variant/variant_basic_shredded_writing.test
+++ b/test/parquet/variant/variant_basic_shredded_writing.test
@@ -16,10 +16,33 @@ create macro data() AS TABLE (
 	) t(a)
 )
 
+foreach disabled true false
+
 query I nosort expected_res
 select * from data();
 ----
 
+onlyif disabled=true
+statement ok
+COPY (
+	from data() t(a)
+) TO '{TEST_DIR}/shredded_struct.parquet' (
+	shredding {
+		a: 'NULL'
+	}
+)
+
+onlyif disabled=true
+statement ok
+COPY (
+	select a from data()
+) TO '{TEST_DIR}/shredded_list.parquet' (
+	shredding {
+		a: 'NULL'
+	}
+)
+
+onlyif disabled=false
 statement ok
 COPY (
 	from data() t(a)
@@ -29,10 +52,7 @@ COPY (
 	}
 )
 
-query I nosort expected_res
-select * from '{TEST_DIR}/shredded_struct.parquet';
-----
-
+onlyif disabled=false
 statement ok
 COPY (
 	select a from data()
@@ -43,5 +63,11 @@ COPY (
 )
 
 query I nosort expected_res
+select * from '{TEST_DIR}/shredded_struct.parquet';
+----
+
+query I nosort expected_res
 select * from '{TEST_DIR}/shredded_list.parquet';
 ----
+
+endloop

--- a/test/parquet/variant/variant_multiple_files.test
+++ b/test/parquet/variant/variant_multiple_files.test
@@ -28,3 +28,36 @@ select sum(v.duck::int) = 2 * list_sum(range(2048)), sum(v.goose::int) = list_su
 from '{TEST_DIR}/variant_multiple_files/*.parquet'
 ----
 1	1
+
+# Test with a VARIANT in a nested type (STRUCT)
+
+statement error
+copy (
+    (
+        select {'a': {duck: range}::variant} v
+        from range(2048)
+    ) union all (
+        select {'a': {duck: range, goose: range + 42}::variant} v
+        from range(2048)
+    )
+) to '{TEST_DIR}/variant_in_struct_multiple_files' (format parquet, row_group_size 2048, row_groups_per_file 1)
+----
+Not implemented Error: ColumnWriter of type 'VARIANT' requires a transform, but is not a root column, this isn't supported currently
+
+# Enable these when the above statement no longer fails
+# These tests are added to help remind that the multiple-file-scanning logic likely needs adjusting when variants are allowed in non-root columns
+mode skip
+
+query I
+select count(*)
+from glob('{TEST_DIR}/variant_in_struct_multiple_files/*.parquet')
+----
+2
+
+query II
+select sum(v.a.duck::int) = 2 * list_sum(range(2048)), sum(v.a.goose::int) = list_sum(range(2048)) + 42 * 2048
+from '{TEST_DIR}/variant_in_struct_multiple_files/*.parquet'
+----
+1	1
+
+mode unskip

--- a/test/parquet/variant/variant_write_partially_shredded.test
+++ b/test/parquet/variant/variant_write_partially_shredded.test
@@ -4,6 +4,20 @@
 require parquet
 
 # Verify we can perform partial shredding
+
+foreach disabled true false
+
+onlyif disabled=true
+statement ok
+COPY (
+	SELECT {
+		'field1': CASE WHEN i%2=0 THEN CONCAT('hello', i)::VARIANT ELSE i::VARIANT END,
+		'field2': i::INT
+	}::VARIANT AS obj
+	FROM range(5) t(i)
+) TO '{TEST_DIR}/partially_shredded_struct.parquet' (SHREDDING {'obj': 'NULL'});
+
+onlyif disabled=false
 statement ok
 COPY (
 	SELECT {
@@ -26,3 +40,5 @@ query I
 SELECT COUNT(*) > 0 FROM parquet_schema('{TEST_DIR}/partially_shredded_struct.parquet') WHERE name='typed_value';
 ----
 1
+
+endloop


### PR DESCRIPTION
We previously used `ANY` to disable shredding, with the `SHREDDING` copy option.
But with the change to string->type parsing, `ANY` is no longer an accepted option, so I've switched it to `NULL`, since we can't shred on NULL anyways.

I've added tests that use this now, verifying that we can correctly read written variants that aren't shredded.