### PR TITLE
Fix MERGE INTO row alias condition binding

### DIFF
--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -65,15 +65,20 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 	result->action_type = action.action_type;
 	auto expr_start_idx = expressions.size();
 	if (action.condition) {
-		WhereBinder where_binder(*this, context);
-		where_binder.target_type = LogicalType::BOOLEAN;
-
-		auto cond = where_binder.Bind(action.condition);
-		PlanSubqueries(cond, root);
-
-		auto cond_type = cond->GetReturnType();
-		auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
-		result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
+		if (action.condition->HasSubquery()) {
+			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
+			WhereBinder where_binder(*this, context);
+			auto cond = where_binder.Bind(action.condition);
+			PlanSubqueries(cond, root);
+			auto cond_type = cond->GetReturnType();
+			auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
+			result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
+		} else {
+			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
+			proj_binder.target_type = LogicalType::BOOLEAN;
+			auto cond = proj_binder.Bind(action.condition);
+			result->condition = std::move(cond);
+		}
 	}
 	switch (action.action_type) {
 	case MergeActionType::MERGE_UPDATE: {

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -76,7 +76,34 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		} else {
 			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
 			proj_binder.target_type = LogicalType::BOOLEAN;
+
+			auto condition_expr_start_idx = expressions.size();
 			auto cond = proj_binder.Bind(action.condition);
+			//
+			auto rewrite_projection_self_references = [&](unique_ptr<Expression> &expression, idx_t current_idx) {
+				ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+				    expression, [&](BoundColumnRefExpression &bound_colref, unique_ptr<Expression> &current_expr) {
+					    if (bound_colref.binding.table_index != proj_index) {
+						    return;
+					    }
+
+					    auto col_idx = bound_colref.binding.column_index.GetIndex();
+
+					    // Only rewrite references to earlier projection expressions. References
+					    // to this expression itself or later expressions would indicate a
+					    // different invalid plan shape.
+					    if (col_idx >= current_idx) {
+						    return;
+					    }
+
+					    current_expr = expressions[col_idx]->Copy();
+				    });
+			};
+
+			for (idx_t i = condition_expr_start_idx; i < expressions.size(); i++) {
+				rewrite_projection_self_references(expressions[i], i);
+			}
+
 			result->condition = std::move(cond);
 		}
 	}

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -65,20 +65,15 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 	result->action_type = action.action_type;
 	auto expr_start_idx = expressions.size();
 	if (action.condition) {
-		if (action.condition->HasSubquery()) {
-			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
-			WhereBinder where_binder(*this, context);
-			auto cond = where_binder.Bind(action.condition);
-			PlanSubqueries(cond, root);
-			auto cond_type = cond->GetReturnType();
-			auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
-			result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
-		} else {
-			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
-			proj_binder.target_type = LogicalType::BOOLEAN;
-			auto cond = proj_binder.Bind(action.condition);
-			result->condition = std::move(cond);
-		}
+		WhereBinder where_binder(*this, context);
+		where_binder.target_type = LogicalType::BOOLEAN;
+
+		auto cond = where_binder.Bind(action.condition);
+		PlanSubqueries(cond, root);
+
+		auto cond_type = cond->GetReturnType();
+		auto cond_idx = ColumnBinding::PushExpression(expressions, std::move(cond));
+		result->condition = make_uniq<BoundColumnRefExpression>(cond_type, ColumnBinding(proj_index, cond_idx));
 	}
 	switch (action.action_type) {
 	case MergeActionType::MERGE_UPDATE: {

--- a/test/sql/merge/merge_into_table_alias_distinct.test
+++ b/test/sql/merge/merge_into_table_alias_distinct.test
@@ -1,0 +1,24 @@
+# name: test/sql/merge/merge_into_table_alias_distinct.test
+# description: Test MERGE INTO with table-alias row comparison in action condition
+# group: [merge]
+
+statement ok
+CREATE TABLE tickers (
+    tableticker VARCHAR NOT NULL,
+    figi VARCHAR,
+    cik VARCHAR,
+    lastupdated DATE NOT NULL
+);
+
+statement ok
+MERGE INTO tickers AS T
+USING (
+    SELECT
+        'tablepermaticker' AS tableticker,
+        'figi' AS figi,
+        'secfilings' AS secfilings,
+        DATE '2026-05-01' AS lastupdated
+) AS Q
+ON T.tableticker = Q.tableticker
+WHEN MATCHED AND T IS DISTINCT FROM Q THEN UPDATE
+WHEN NOT MATCHED THEN INSERT;


### PR DESCRIPTION
Fixes #22427.

This PR fixes an internal binding error in `MERGE INTO` caused by projection self-references introduced while binding action conditions.

The fix rewrites these projection self-references to the underlying expressions, while preserving lazy evaluation of `MERGE INTO` action conditions.

A regression test is added for the issue.

The same branch passed CI on [my fork](https://github.com/Schwarf/duckdb/pull/2)