### PR TITLE
Use parser cache for Appender flushes

### DIFF
--- a/benchmark/micro/append.cpp
+++ b/benchmark/micro/append.cpp
@@ -1,5 +1,7 @@
 #include "benchmark_runner.hpp"
 #include "duckdb_benchmark_macro.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/main/appender.hpp"
 
 using namespace duckdb;
@@ -219,3 +221,119 @@ string BenchmarkInfo() override {
 	return "Write 100K 4-byte integers to CSV";
 }
 FINISH_BENCHMARK(Write100KIntegers)
+
+namespace {
+
+static int32_t GenerateI32InputValue(idx_t row_idx, idx_t chunk_idx) {
+	const auto raw = static_cast<int64_t>(((row_idx + 1) * 8191 + (chunk_idx + 1) * 131) % 200000) - 100000;
+	return static_cast<int32_t>(raw);
+}
+
+template <class T>
+struct AppendDataChunkBenchmarkState : public DuckDBBenchmarkState {
+	AppendDataChunkBenchmarkState(string path) : DuckDBBenchmarkState(std::move(path)) {
+	}
+
+	vector<unique_ptr<DataChunk>> chunks;
+};
+
+template <class T>
+static void FillInputChunk(DataChunk &chunk, idx_t chunk_idx, T (*generate_value)(idx_t, idx_t), bool with_nulls,
+                           idx_t cardinality) {
+	auto &input_vector = chunk.data[0];
+	auto data = FlatVector::GetDataMutable<T>(input_vector);
+	for (idx_t row_idx = 0; row_idx < cardinality; row_idx++) {
+		data[row_idx] = generate_value(row_idx, chunk_idx);
+		if (with_nulls && ((row_idx + chunk_idx * 13) % 97) == 0) {
+			FlatVector::SetNull(input_vector, row_idx, true);
+		}
+	}
+	chunk.SetCardinality(cardinality);
+}
+
+template <class T, idx_t ROWS_PER_CHUNK>
+static void PrepareAppendDataChunkBenchmarkState(DuckDBBenchmarkState *state_p, const LogicalType &logical_type,
+                                                 const string &sql_type, T (*generate_value)(idx_t, idx_t),
+                                                 bool with_nulls) {
+	auto state = static_cast<AppendDataChunkBenchmarkState<T> *>(state_p);
+	auto result = state->conn.Query("CREATE TABLE append_data_chunk_numeric(value " + sql_type + ")");
+	if (result->HasError()) {
+		throw InternalException(result->GetError());
+	}
+
+	state->chunks.clear();
+	vector<LogicalType> types {logical_type};
+	for (idx_t row_offset = 0; row_offset < 100000; row_offset += ROWS_PER_CHUNK) {
+		const auto remaining = 100000 - row_offset;
+		const auto cardinality = remaining < ROWS_PER_CHUNK ? remaining : ROWS_PER_CHUNK;
+		const auto chunk_idx = row_offset / ROWS_PER_CHUNK;
+		auto chunk = make_uniq<DataChunk>();
+		chunk->Initialize(*state->conn.context, types);
+		FillInputChunk<T>(*chunk, chunk_idx, generate_value, with_nulls, cardinality);
+		state->chunks.push_back(std::move(chunk));
+	}
+}
+
+template <class T, bool FLUSH_PER_CHUNK>
+static void RunAppendDataChunkLoop(DuckDBBenchmarkState *state_p) {
+	auto state = static_cast<AppendDataChunkBenchmarkState<T> *>(state_p);
+	state->conn.Query("BEGIN TRANSACTION");
+	Appender appender(state->conn, "append_data_chunk_numeric");
+	for (auto &chunk : state->chunks) {
+		appender.AppendDataChunk(*chunk);
+		if (FLUSH_PER_CHUNK) {
+			appender.Flush();
+		}
+	}
+	appender.Close();
+	state->conn.Query("COMMIT");
+}
+
+template <class T, idx_t ROWS_PER_CHUNK>
+static void ResetAppendDataChunkBenchmarkState(DuckDBBenchmarkState *state_p, const LogicalType &logical_type,
+                                               const string &sql_type, T (*generate_value)(idx_t, idx_t),
+                                               bool with_nulls) {
+	auto result = state_p->conn.Query("DROP TABLE append_data_chunk_numeric");
+	if (result->HasError()) {
+		throw InternalException(result->GetError());
+	}
+	PrepareAppendDataChunkBenchmarkState<T, ROWS_PER_CHUNK>(state_p, logical_type, sql_type, generate_value,
+	                                                        with_nulls);
+}
+
+} // namespace
+
+///////////////////////////////////
+// APPEND DATA CHUNK - 1 COLUMN //
+///////////////////////////////////
+
+#define DEFINE_APPEND_DATA_CHUNK_NUMERIC_BENCHMARK(NAME, GROUP, CPP_TYPE, LOGICAL_TYPE, SQL_TYPE, GENERATE_VALUE,      \
+                                                   WITH_NULLS, ROWS_PER_CHUNK, FLUSH_PER_CHUNK, DESCRIPTION)           \
+	DUCKDB_BENCHMARK(NAME, GROUP)                                                                                      \
+	duckdb::unique_ptr<DuckDBBenchmarkState> CreateBenchmarkState() override {                                         \
+		return make_uniq<AppendDataChunkBenchmarkState<CPP_TYPE>>(GetDatabasePath());                                  \
+	}                                                                                                                  \
+	void Load(DuckDBBenchmarkState *state) override {                                                                  \
+		PrepareAppendDataChunkBenchmarkState<CPP_TYPE, ROWS_PER_CHUNK>(state, LOGICAL_TYPE, SQL_TYPE, GENERATE_VALUE,  \
+		                                                               WITH_NULLS);                                    \
+	}                                                                                                                  \
+	void RunBenchmark(DuckDBBenchmarkState *state) override {                                                          \
+		RunAppendDataChunkLoop<CPP_TYPE, FLUSH_PER_CHUNK>(state);                                                      \
+	}                                                                                                                  \
+	void Cleanup(DuckDBBenchmarkState *state) override {                                                               \
+		ResetAppendDataChunkBenchmarkState<CPP_TYPE, ROWS_PER_CHUNK>(state, LOGICAL_TYPE, SQL_TYPE, GENERATE_VALUE,    \
+		                                                             WITH_NULLS);                                      \
+	}                                                                                                                  \
+	string VerifyResult(QueryResult *result) override {                                                                \
+		return string();                                                                                               \
+	}                                                                                                                  \
+	string BenchmarkInfo() override {                                                                                  \
+		return "Append 100K values from prebuilt, 1-column DataChunks of " + string(SQL_TYPE) + " " +                  \
+		       string(DESCRIPTION);                                                                                    \
+	}                                                                                                                  \
+	FINISH_BENCHMARK(NAME)
+
+DEFINE_APPEND_DATA_CHUNK_NUMERIC_BENCHMARK(AppendDataChunkI32AllValid1ColFlushEvery128Rows,
+                                           "[append][append_data_chunk][flush]", int32_t, LogicalType::INTEGER,
+                                           "INTEGER", GenerateI32InputValue, false, 128, true,
+                                           "(all valid, 128 rows per DataChunk, flushing after every 128 rows)")

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -175,6 +175,8 @@ private:
 	//! If not empty, then this holds all logical column IDs of columns provided by the appender.
 	//! Any other columns default to NULL, or their default values.
 	vector<LogicalIndex> column_ids;
+	//! Cached parsed statement template for the current insert query shape.
+	unique_ptr<SQLStatement> statement_template;
 
 protected:
 	void FlushInternal(ColumnDataCollection &collection) override;

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -18,6 +18,7 @@ class ClientContext;
 class ColumnDataCollection;
 class Connection;
 class DuckDB;
+struct ParserOptions;
 class SQLStatement;
 class TableCatalogEntry;
 
@@ -38,7 +39,7 @@ public:
 	                                                  const vector<string> &expected_names);
 	//! Parses the statement to append data.
 	static unique_ptr<SQLStatement> ParseStatement(unique_ptr<TableRef> table_ref, const string &query,
-	                                               const string &table_name);
+	                                               const string &table_name, const ParserOptions &parser_options);
 
 protected:
 	//! The allocator for the column data collection.

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -458,17 +458,8 @@ CommonTableExpressionMap &GetCTEMap(SQLStatement &statement) {
 	}
 }
 
-unique_ptr<SQLStatement> BaseAppender::ParseStatement(unique_ptr<TableRef> table_ref, const string &query,
-                                                      const string &table_name, const ParserOptions &parser_options) {
-	// Parse the query.
-	Parser parser(parser_options);
-	parser.ParseQuery(query);
-
-	// Must be a single statement.
-	if (parser.statements.size() != 1) {
-		throw InvalidInputException("Expected exactly one query for appending data.");
-	}
-
+static unique_ptr<SQLStatement> AttachAppenderCTE(unique_ptr<SQLStatement> statement, unique_ptr<TableRef> table_ref,
+                                                  const string &table_name) {
 	// Create the CTE for the appender.
 	auto cte = make_uniq<SelectNode>();
 	cte->select_list.push_back(make_uniq<StarExpression>());
@@ -485,10 +476,42 @@ unique_ptr<SQLStatement> BaseAppender::ParseStatement(unique_ptr<TableRef> table
 
 	// Add the appender data as a CTE to the CTE map of the statement.
 	string alias = table_name.empty() ? "appended_data" : table_name;
-	auto &cte_map = GetCTEMap(*parser.statements[0]);
+	auto &cte_map = GetCTEMap(*statement);
 	cte_map.map.insert(alias, std::move(cte_info));
 
+	return statement;
+}
+
+static unique_ptr<SQLStatement> ParseAppenderStatementTemplate(const string &query,
+                                                               const ParserOptions &parser_options) {
+	Parser parser(parser_options);
+	parser.ParseQuery(query);
+
+	if (parser.statements.size() != 1) {
+		throw InvalidInputException("Expected exactly one query for appending data.");
+	}
+
 	return std::move(parser.statements[0]);
+}
+
+static unique_ptr<SQLStatement> InstantiateAppenderStatement(const SQLStatement &statement_template,
+                                                             unique_ptr<TableRef> table_ref, const string &table_name) {
+	auto statement = statement_template.Copy();
+	return AttachAppenderCTE(std::move(statement), std::move(table_ref), table_name);
+}
+
+unique_ptr<SQLStatement> BaseAppender::ParseStatement(unique_ptr<TableRef> table_ref, const string &query,
+                                                      const string &table_name, const ParserOptions &parser_options) {
+	// Parse the query.
+	Parser parser(parser_options);
+	parser.ParseQuery(query);
+
+	// Must be a single statement.
+	if (parser.statements.size() != 1) {
+		throw InvalidInputException("Expected exactly one query for appending data.");
+	}
+
+	return AttachAppenderCTE(std::move(parser.statements[0]), std::move(table_ref), table_name);
 }
 
 //===--------------------------------------------------------------------===//
@@ -611,10 +634,13 @@ void Appender::FlushInternal(ColumnDataCollection &collection) {
 
 	string table_name = "__duckdb_internal_appended_data";
 	auto expected_names = GetExpectedNames();
-	auto query = ConstructQuery(*description, table_name, expected_names);
+	if (!statement_template) {
+		auto query = ConstructQuery(*description, table_name, expected_names);
+		statement_template = ParseAppenderStatementTemplate(query, context_ref->GetParserOptions());
+	}
 
 	auto table_ref = GetColumnDataTableRef(collection, table_name, expected_names);
-	auto stmt = ParseStatement(std::move(table_ref), query, table_name, context_ref->GetParserOptions());
+	auto stmt = InstantiateAppenderStatement(*statement_template, std::move(table_ref), table_name);
 	context_ref->Append(std::move(stmt));
 }
 
@@ -678,6 +704,7 @@ void Appender::AddColumn(const string &name) {
 		throw InvalidInputException("the column must exist in the table");
 	}
 
+	statement_template.reset();
 	InitializeChunk();
 	collection = make_uniq<ColumnDataCollection>(allocator, GetActiveTypes());
 }
@@ -686,6 +713,7 @@ void Appender::ClearColumns() {
 	Flush();
 	column_ids.clear();
 	active_types.clear();
+	statement_template.reset();
 
 	InitializeChunk();
 	collection = make_uniq<ColumnDataCollection>(allocator, GetActiveTypes());

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -459,9 +459,9 @@ CommonTableExpressionMap &GetCTEMap(SQLStatement &statement) {
 }
 
 unique_ptr<SQLStatement> BaseAppender::ParseStatement(unique_ptr<TableRef> table_ref, const string &query,
-                                                      const string &table_name) {
+                                                      const string &table_name, const ParserOptions &parser_options) {
 	// Parse the query.
-	Parser parser;
+	Parser parser(parser_options);
 	parser.ParseQuery(query);
 
 	// Must be a single statement.
@@ -614,7 +614,7 @@ void Appender::FlushInternal(ColumnDataCollection &collection) {
 	auto query = ConstructQuery(*description, table_name, expected_names);
 
 	auto table_ref = GetColumnDataTableRef(collection, table_name, expected_names);
-	auto stmt = ParseStatement(std::move(table_ref), query, table_name);
+	auto stmt = ParseStatement(std::move(table_ref), query, table_name, context_ref->GetParserOptions());
 	context_ref->Append(std::move(stmt));
 }
 
@@ -715,7 +715,7 @@ void QueryAppender::FlushInternal(ColumnDataCollection &collection) {
 		throw InvalidInputException("Attempting to flush query appender data on a closed connection");
 	}
 	auto table_ref = GetColumnDataTableRef(collection, table_name, names);
-	auto parsed_statement = ParseStatement(std::move(table_ref), query, table_name);
+	auto parsed_statement = ParseStatement(std::move(table_ref), query, table_name, context_ref->GetParserOptions());
 	context_ref->Append(std::move(parsed_statement));
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1311,7 +1311,7 @@ void ClientContext::Append(TableDescription &description, ColumnDataCollection &
 	vector<string> expected_names;
 	auto query = Appender::ConstructQuery(description, table_name, expected_names);
 	auto table_ref = BaseAppender::GetColumnDataTableRef(collection, table_name, expected_names);
-	auto stmt = BaseAppender::ParseStatement(std::move(table_ref), query, table_name);
+	auto stmt = BaseAppender::ParseStatement(std::move(table_ref), query, table_name, GetParserOptions());
 	Append(std::move(stmt));
 }
 

--- a/test/appender/test_appender.cpp
+++ b/test/appender/test_appender.cpp
@@ -704,6 +704,34 @@ TEST_CASE("Test changing the active column configuration", "[appender]") {
 	REQUIRE(CHECK_COLUMN(result, 2, {50, 30, 50, 50}));
 }
 
+TEST_CASE("Test repeated flushes with changing active column configuration", "[appender]") {
+	duckdb::unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE TABLE tbl (i INT DEFAULT 4, j INT, k INT DEFAULT 30)"));
+	Appender appender(con, "main", "tbl");
+
+	appender.AppendRow(1, 2, 3);
+	appender.Flush();
+
+	appender.AppendRow(4, 5, 6);
+	appender.Flush();
+
+	appender.AddColumn("j");
+	appender.AppendRow(20);
+	appender.Flush();
+
+	appender.ClearColumns();
+	appender.AppendRow(7, 8, 9);
+	appender.Close();
+
+	result = con.Query("SELECT i, j, k FROM tbl ORDER BY rowid");
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 4, 4, 7}));
+	REQUIRE(CHECK_COLUMN(result, 1, {2, 5, 20, 8}));
+	REQUIRE(CHECK_COLUMN(result, 2, {3, 6, 30, 9}));
+}
+
 TEST_CASE("Test edge cases for the active column configuration", "[appender]") {
 	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);


### PR DESCRIPTION
I was benchmarking the write performance of the Appender API and noticed flush-heavy workloads were slow.

This PR:

1. adds an appender flush-heavy benchmark
2. uses the parser cache for appender flushes
3. caches appender statement templates across flushes

I have a [second PR that builds on this](https://github.com/duckdb/duckdb/pull/22470) that adds an autovectorisable fast path for zonemap creation when appending contiguous buffers (which is why the benchmark is so heavily templated).

`./test/appender/test_appender.cpp` has an extra test that flushes between changing column configurations.

# Benchmarks

These results are the `AppendDataChunkI32AllValid1ColFlushEvery128Rows` benchmark but with `1024*1024` rows (instead of 100k) of an i32 column which flushes every 128 rows.

- CPU: `Apple M1 Max`, 10 physical, 10 logical cores
- OS: `Darwin 24.6.0`, `arm64`
- RAM: `64.0 GiB`

| Commit | Samples |    Mean ms |              95% CI ms |    Rows/s | MB/s | Speedup vs previous |
| ------ | ------: | ---------: | ---------------------: | --------: | ---: | ------------------: |
| 1      |      15 | 13,687.567 | [13,620.014, 13,755.121] |    76,608 |  0.3 |               1.00x |
| 2      |      15 |  1,359.114 |   [1,345.502, 1,372.726] |   771,514 |  3.1 |              10.07x |
| 3      |      15 |    732.004 |     [716.819, 747.190] | 1,432,472 |  5.7 |               1.86x |

- CPU: `AMD Ryzen AI 7 PRO 350 w/ Radeon 860M`, 8 physical, 16 logical cores
- OS: `Linux 7.0.2-arch1-1`, `x86_64`
- RAM: `30.5 GiB`

| Commit | Samples |   Mean ms |            95% CI ms |    Rows/s | MB/s | Speedup vs previous |
| ------ | ------: | --------: | -------------------: | --------: | ---: | ------------------: |
| 1      |      15 | 8,024.012 | [8,001.742, 8,046.281] |   130,680 |  0.5 |               1.00x |
| 2      |      15 |   704.309 |   [700.126, 708.492] | 1,488,801 |  6.0 |              11.39x |
| 3      |      15 |   364.923 |   [361.539, 368.307] | 2,873,417 | 11.5 |               1.93x |
