### PR TITLE
Add contiguous numeric zonemap fast paths for appends

### DIFF
--- a/benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+++ b/benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
@@ -1,0 +1,25 @@
+# name: ${FILE_PATH}
+# description: ${DESCRIPTION}
+# group: [zonemaps]
+#
+# VALUE_MODULUS is the repeat period for the row values. It needs to fit in the physical type, but doesn't need to match it.
+
+argument rows 50_000_000
+
+name Append ${TYPE_NAME} Zonemap Stats
+group zonemaps
+subgroup append_numeric_stats
+storage transient
+
+load
+SET threads=1;
+PRAGMA force_compression='uncompressed';
+CREATE TABLE source AS SELECT ((i % ${VALUE_MODULUS})::${TYPE}) AS value FROM range(${rows}) tbl(i);
+CREATE TABLE target(value ${TYPE});
+
+run
+INSERT INTO target SELECT value FROM source;
+
+cleanup
+DROP TABLE target;
+CREATE TABLE target(value ${TYPE});

--- a/benchmark/micro/zonemaps/append_numeric_stats_bigint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_bigint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_bigint.benchmark
+# description: Benchmark SQL append while computing BIGINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_bigint.benchmark
+DESCRIPTION=Benchmark SQL append while computing BIGINT zonemap statistics
+TYPE_NAME=BIGINT
+TYPE=BIGINT
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_decimal_18_6.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_decimal_18_6.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_decimal_18_6.benchmark
+# description: Benchmark SQL append while computing DECIMAL(18,6) zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_decimal_18_6.benchmark
+DESCRIPTION=Benchmark SQL append while computing DECIMAL(18,6) zonemap statistics
+TYPE_NAME=DECIMAL(18,6)
+TYPE=DECIMAL(18,6)
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_decimal_38_10.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_decimal_38_10.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_decimal_38_10.benchmark
+# description: Benchmark SQL append while computing DECIMAL(38,10) zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_decimal_38_10.benchmark
+DESCRIPTION=Benchmark SQL append while computing DECIMAL(38,10) zonemap statistics
+TYPE_NAME=DECIMAL(38,10)
+TYPE=DECIMAL(38,10)
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_decimal_4_1.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_decimal_4_1.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_decimal_4_1.benchmark
+# description: Benchmark SQL append while computing DECIMAL(4,1) zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_decimal_4_1.benchmark
+DESCRIPTION=Benchmark SQL append while computing DECIMAL(4,1) zonemap statistics
+TYPE_NAME=DECIMAL(4,1)
+TYPE=DECIMAL(4,1)
+VALUE_MODULUS=1000

--- a/benchmark/micro/zonemaps/append_numeric_stats_decimal_9_4.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_decimal_9_4.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_decimal_9_4.benchmark
+# description: Benchmark SQL append while computing DECIMAL(9,4) zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_decimal_9_4.benchmark
+DESCRIPTION=Benchmark SQL append while computing DECIMAL(9,4) zonemap statistics
+TYPE_NAME=DECIMAL(9,4)
+TYPE=DECIMAL(9,4)
+VALUE_MODULUS=100000

--- a/benchmark/micro/zonemaps/append_numeric_stats_double.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_double.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_double.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_double.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_float.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_float.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_float.benchmark
+# description: Benchmark SQL append while computing FLOAT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_float.benchmark
+DESCRIPTION=Benchmark SQL append while computing FLOAT zonemap statistics
+TYPE_NAME=FLOAT
+TYPE=FLOAT
+VALUE_MODULUS=10000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_float_special_values.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_float_special_values.benchmark
@@ -1,0 +1,33 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_float_special_values.benchmark
+# description: Benchmark FLOAT append stats with sparse special floating-point values
+# group: [zonemaps]
+
+argument rows 50_000_000
+
+name Append FLOAT Special Values Zonemap Stats
+group zonemaps
+subgroup append_numeric_stats
+storage transient
+
+load
+SET threads=1;
+PRAGMA force_compression='uncompressed';
+CREATE TABLE source AS
+	SELECT
+		CASE
+			WHEN i % 4096 = 0 THEN 'nan'::FLOAT
+			WHEN i % 4096 = 1 THEN 'inf'::FLOAT
+			WHEN i % 4096 = 2 THEN '-inf'::FLOAT
+			WHEN i % 4096 = 3 THEN '-0.0'::FLOAT
+			WHEN i % 4096 = 4 THEN '0.0'::FLOAT
+			ELSE (((i % 1000000) - 500000)::FLOAT)
+		END AS value
+	FROM range(${rows}) tbl(i);
+CREATE TABLE target(value FLOAT);
+
+run
+INSERT INTO target SELECT value FROM source;
+
+cleanup
+DROP TABLE target;
+CREATE TABLE target(value FLOAT);

--- a/benchmark/micro/zonemaps/append_numeric_stats_hugeint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_hugeint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_hugeint.benchmark
+# description: Benchmark SQL append while computing HUGEINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_hugeint.benchmark
+DESCRIPTION=Benchmark SQL append while computing HUGEINT zonemap statistics
+TYPE_NAME=HUGEINT
+TYPE=HUGEINT
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_integer.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_integer.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_integer.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_integer.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
@@ -1,0 +1,27 @@
+# name: ${FILE_PATH}
+# description: ${DESCRIPTION}
+# group: [zonemaps]
+#
+# NULL_EXPR is evaluated over the generated row id i. Rows where it is true are NULL.
+
+argument rows 50_000_000
+
+name Append ${TYPE_NAME} Nullable ${SHAPE_NAME} Zonemap Stats
+group zonemaps
+subgroup append_numeric_stats_nullable
+storage transient
+
+load
+SET threads=1;
+PRAGMA force_compression='uncompressed';
+CREATE TABLE source AS
+	SELECT CASE WHEN ${NULL_EXPR} THEN NULL ELSE ((i % ${VALUE_MODULUS})::${TYPE}) END AS value
+	FROM range(${rows}) tbl(i);
+CREATE TABLE target(value ${TYPE});
+
+run
+INSERT INTO target SELECT value FROM source;
+
+cleanup
+DROP TABLE target;
+CREATE TABLE target(value ${TYPE});

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_all_null.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_all_null.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_all_null.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with all NULL values
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_all_null.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with all NULL values
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=all null
+NULL_EXPR=true

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_1_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_1_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_1_per_64.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with one NULL per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_1_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with one NULL per validity word
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 null per 64
+NULL_EXPR=(i % 64) IN (0)

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_32_clustered_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_32_clustered_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_32_clustered_per_64.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with half clustered NULLs per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_32_clustered_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with half clustered NULLs per validity word
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=32 clustered nulls per 64
+NULL_EXPR=(i % 64) > 31

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_4_clustered_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_4_clustered_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_4_clustered_per_64.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with four clustered NULLs per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_4_clustered_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with four clustered NULLs per validity word
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=4 clustered nulls per 64
+NULL_EXPR=(i % 64) < 4

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_alternating_50.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_alternating_50.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_alternating_50.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with alternating NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_alternating_50.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with alternating NULLs
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=alternating 50 percent nulls
+NULL_EXPR=(i % 2) < 1

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_10.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_10.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_10.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 10 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_10.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 10 percent NULLs
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 10 percent nulls
+NULL_EXPR=(hash(i) % 100) < 10

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_50.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_50.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_50.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 50 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_50.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 50 percent NULLs
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 50 percent nulls
+NULL_EXPR=(hash(i) % 100) < 50

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_90.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_90.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_90.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 90 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_nulls_random_90.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with pseudorandom 90 percent NULLs
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 90 percent nulls
+NULL_EXPR=(hash(i) % 100) < 90

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_1024.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_1024.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_1024.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with one valid value per 1024 rows
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_1024.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with one valid value per 1024 rows
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 valid per 1024
+NULL_EXPR=(i % 1024) > 0

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_64.benchmark
+# description: Benchmark SQL append while computing DOUBLE zonemap statistics with one valid value per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_double_valids_1_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing DOUBLE zonemap statistics with one valid value per validity word
+TYPE_NAME=DOUBLE
+TYPE=DOUBLE
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 valid per 64
+NULL_EXPR=(i % 64) > 0

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_all_null.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_all_null.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_all_null.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with all NULL values
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_all_null.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with all NULL values
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=all null
+NULL_EXPR=true

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_long_runs.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_long_runs.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_long_runs.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with long alternating valid and NULL runs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_long_runs.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with long alternating valid and NULL runs
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=long valid and null runs
+NULL_EXPR=((i // 4096) % 2) > 0

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_1_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_1_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_1_per_64.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with one NULL per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_1_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with one NULL per validity word
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 null per 64
+NULL_EXPR=(i % 64) IN (0)

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_32_clustered_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_32_clustered_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_32_clustered_per_64.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with half clustered NULLs per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_32_clustered_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with half clustered NULLs per validity word
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=32 clustered nulls per 64
+NULL_EXPR=(i % 64) > 31

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_4_clustered_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_4_clustered_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_4_clustered_per_64.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with four clustered NULLs per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_4_clustered_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with four clustered NULLs per validity word
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=4 clustered nulls per 64
+NULL_EXPR=(i % 64) < 4

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_alternating_50.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_alternating_50.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_alternating_50.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with alternating NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_alternating_50.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with alternating NULLs
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=alternating 50 percent nulls
+NULL_EXPR=(i % 2) < 1

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_10.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_10.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_10.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 10 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_10.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 10 percent NULLs
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 10 percent nulls
+NULL_EXPR=(hash(i) % 100) < 10

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_50.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_50.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_50.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 50 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_50.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 50 percent NULLs
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 50 percent nulls
+NULL_EXPR=(hash(i) % 100) < 50

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_90.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_90.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_90.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 90 percent NULLs
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_nulls_random_90.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with pseudorandom 90 percent NULLs
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=random 90 percent nulls
+NULL_EXPR=(hash(i) % 100) < 90

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_1024.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_1024.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_1024.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with one valid value per 1024 rows
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_1024.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with one valid value per 1024 rows
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 valid per 1024
+NULL_EXPR=(i % 1024) > 0

--- a/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_64.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_64.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_64.benchmark
+# description: Benchmark SQL append while computing INTEGER zonemap statistics with one valid value per validity word
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats_nullable.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_nullable_integer_valids_1_per_64.benchmark
+DESCRIPTION=Benchmark SQL append while computing INTEGER zonemap statistics with one valid value per validity word
+TYPE_NAME=INTEGER
+TYPE=INTEGER
+VALUE_MODULUS=1000000000
+SHAPE_NAME=1 valid per 64
+NULL_EXPR=(i % 64) > 0

--- a/benchmark/micro/zonemaps/append_numeric_stats_smallint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_smallint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_smallint.benchmark
+# description: Benchmark SQL append while computing SMALLINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_smallint.benchmark
+DESCRIPTION=Benchmark SQL append while computing SMALLINT zonemap statistics
+TYPE_NAME=SMALLINT
+TYPE=SMALLINT
+VALUE_MODULUS=10000

--- a/benchmark/micro/zonemaps/append_numeric_stats_tinyint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_tinyint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_tinyint.benchmark
+# description: Benchmark SQL append while computing TINYINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_tinyint.benchmark
+DESCRIPTION=Benchmark SQL append while computing TINYINT zonemap statistics
+TYPE_NAME=TINYINT
+TYPE=TINYINT
+VALUE_MODULUS=100

--- a/benchmark/micro/zonemaps/append_numeric_stats_ubigint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_ubigint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_ubigint.benchmark
+# description: Benchmark SQL append while computing UBIGINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_ubigint.benchmark
+DESCRIPTION=Benchmark SQL append while computing UBIGINT zonemap statistics
+TYPE_NAME=UBIGINT
+TYPE=UBIGINT
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_uhugeint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_uhugeint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_uhugeint.benchmark
+# description: Benchmark SQL append while computing UHUGEINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_uhugeint.benchmark
+DESCRIPTION=Benchmark SQL append while computing UHUGEINT zonemap statistics
+TYPE_NAME=UHUGEINT
+TYPE=UHUGEINT
+VALUE_MODULUS=10000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_uinteger.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_uinteger.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_uinteger.benchmark
+# description: Benchmark SQL append while computing UINTEGER zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_uinteger.benchmark
+DESCRIPTION=Benchmark SQL append while computing UINTEGER zonemap statistics
+TYPE_NAME=UINTEGER
+TYPE=UINTEGER
+VALUE_MODULUS=1000000000

--- a/benchmark/micro/zonemaps/append_numeric_stats_usmallint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_usmallint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_usmallint.benchmark
+# description: Benchmark SQL append while computing USMALLINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_usmallint.benchmark
+DESCRIPTION=Benchmark SQL append while computing USMALLINT zonemap statistics
+TYPE_NAME=USMALLINT
+TYPE=USMALLINT
+VALUE_MODULUS=10000

--- a/benchmark/micro/zonemaps/append_numeric_stats_utinyint.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_utinyint.benchmark
@@ -1,0 +1,10 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_utinyint.benchmark
+# description: Benchmark SQL append while computing UTINYINT zonemap statistics
+# group: [zonemaps]
+
+template benchmark/micro/zonemaps/append_numeric_stats.benchmark.in
+FILE_PATH=benchmark/micro/zonemaps/append_numeric_stats_utinyint.benchmark
+DESCRIPTION=Benchmark SQL append while computing UTINYINT zonemap statistics
+TYPE_NAME=UTINYINT
+TYPE=UTINYINT
+VALUE_MODULUS=100

--- a/benchmark/micro/zonemaps/append_numeric_stats_wide_numeric_8cols.benchmark
+++ b/benchmark/micro/zonemaps/append_numeric_stats_wide_numeric_8cols.benchmark
@@ -1,0 +1,51 @@
+# name: benchmark/micro/zonemaps/append_numeric_stats_wide_numeric_8cols.benchmark
+# description: Benchmark wide numeric append while computing zonemap statistics
+# group: [zonemaps]
+
+argument rows 50_000_000
+
+name Append Wide Numeric 8 Column Zonemap Stats
+group zonemaps
+subgroup append_numeric_stats
+storage transient
+
+load
+SET threads=1;
+PRAGMA force_compression='uncompressed';
+CREATE TABLE source AS
+	SELECT
+		((i % 1000000000) - 500000000)::INTEGER AS i0,
+		((i % 1000000000) - 250000000)::INTEGER AS i1,
+		((i % 1000000000))::INTEGER AS i2,
+		((i % 1000000000) // 2)::INTEGER AS i3,
+		(((i % 1000000) - 500000)::FLOAT) AS f0,
+		(((i % 1000000) - 250000)::FLOAT) AS f1,
+		((i % 1000000)::FLOAT) AS f2,
+		(((i % 1000000)::FLOAT) / 2.0) AS f3
+	FROM range(${rows}) tbl(i);
+CREATE TABLE target(
+	i0 INTEGER,
+	i1 INTEGER,
+	i2 INTEGER,
+	i3 INTEGER,
+	f0 FLOAT,
+	f1 FLOAT,
+	f2 FLOAT,
+	f3 FLOAT
+);
+
+run
+INSERT INTO target SELECT * FROM source;
+
+cleanup
+DROP TABLE target;
+CREATE TABLE target(
+	i0 INTEGER,
+	i1 INTEGER,
+	i2 INTEGER,
+	i3 INTEGER,
+	f0 FLOAT,
+	f1 FLOAT,
+	f2 FLOAT,
+	f3 FLOAT
+);

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -12,17 +12,117 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/string_type.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/limits.hpp"
 
-#include <cfloat>
 #include <cstring> // strlen() on Solaris
-#include <limits.h>
+#include <limits>
 
 namespace duckdb {
 
 struct Radix {
+private:
+	template <class WORD_TYPE, idx_t exponent_bits, idx_t fraction_bits>
+	struct RadixKeyConstants {
+	public:
+		using WORD = WORD_TYPE;
+		static constexpr idx_t WORD_BITS = sizeof(WORD) * 8;
+		static constexpr idx_t EXPONENT_BITS = exponent_bits;
+		static constexpr idx_t FRACTION_BITS = fraction_bits;
+
+		static_assert(WORD_BITS == EXPONENT_BITS + FRACTION_BITS + 1,
+		              "Key constants must describe an IEEE 754 binary format");
+		static constexpr WORD SIGN_BIT = WORD(1) << (WORD_BITS - 1);
+		static constexpr WORD ABS_MASK = SIGN_BIT - 1;
+		static constexpr WORD EXPONENT_MASK = ((WORD(1) << EXPONENT_BITS) - 1) << FRACTION_BITS;
+
+		static constexpr WORD POSITIVE_ZERO_BITS = WORD(0);
+		static constexpr WORD NEGATIVE_ZERO_BITS = SIGN_BIT;
+
+	public:
+		// Map raw floating-point bits into the unsigned comparison order.
+		static constexpr WORD EncodeSignAwareKeyBits(WORD bits) {
+			const auto sign_mask = WORD(0) - (bits >> (WORD_BITS - 1));
+			// Positive numbers just have the sign bit flipped, moving them into the upper
+			// part of unsigned integer space.
+			// Negative numbers have every bit inverted, moving them into the lower part
+			// of unsigned integer space with reversed order, so higher magnitude negative
+			// values sort before lower magnitude negative values.
+			return bits ^ (SIGN_BIT | sign_mask);
+		}
+
+		static constexpr WORD ART_ORDERED_NAN_RADIX_KEY = ~WORD(0);
+		static constexpr WORD ART_ORDERED_NEGATIVE_INFINITY_RADIX_KEY = WORD(0);
+		static constexpr WORD ART_ORDERED_POSITIVE_ZERO_RADIX_KEY = EncodeSignAwareKeyBits(POSITIVE_ZERO_BITS);
+		static constexpr WORD ART_ORDERED_POSITIVE_INFINITY_RADIX_KEY = ART_ORDERED_NAN_RADIX_KEY - 1;
+
+		static constexpr WORD MINMAX_NEGATIVE_ZERO_RADIX_KEY = EncodeSignAwareKeyBits(NEGATIVE_ZERO_BITS);
+	};
+
+	using FloatKeyConstants = RadixKeyConstants<uint32_t, 8, 23>;
+	using DoubleKeyConstants = RadixKeyConstants<uint64_t, 11, 52>;
+
+	template <class WORD>
+	static inline WORD BooleanMask(bool value) {
+		return WORD(0) - static_cast<WORD>(value);
+	}
+
+	template <class WORD>
+	static inline WORD SelectByMask(WORD true_value, WORD false_value, WORD mask) {
+		return (true_value & mask) | (false_value & ~mask);
+	}
+
+	template <class CONSTANTS>
+	static inline typename CONSTANTS::WORD EncodeKeyBits(typename CONSTANTS::WORD bits) {
+		using WORD = typename CONSTANTS::WORD;
+		auto key = CONSTANTS::EncodeSignAwareKeyBits(bits);
+
+		// Clear the sign bit, leaving the exponent and fractional parts
+		const auto abs_bits = bits & CONSTANTS::ABS_MASK;
+
+		// NaNs sort above everything and have their payload destroyed:
+		// float:  NaN 0xFFFFFFFF
+		// double: NaN 0xFFFFFFFFFFFFFFFF
+		key |= BooleanMask<WORD>(abs_bits > CONSTANTS::EXPONENT_MASK);
+		return key;
+	}
+
+	template <class CONSTANTS>
+	static inline typename CONSTANTS::WORD EncodeARTOrderedKeyBits(typename CONSTANTS::WORD bits) {
+		using WORD = typename CONSTANTS::WORD;
+		auto key = EncodeKeyBits<CONSTANTS>(bits);
+
+		const auto abs_bits = bits & CONSTANTS::ABS_MASK;
+		const auto sign_mask = WORD(0) - (bits >> (CONSTANTS::WORD_BITS - 1));
+		const auto is_infinity_mask = BooleanMask<WORD>(abs_bits == CONSTANTS::EXPONENT_MASK);
+		const auto is_zero_mask = BooleanMask<WORD>(abs_bits == WORD(0));
+
+		// Set the ART-ordered infinity radix keys:
+		// float:  -inf 0x00000000,         +inf 0xFFFFFFFE
+		// double: -inf 0x0000000000000000, +inf 0xFFFFFFFFFFFFFFFE
+		const auto infinity_key = CONSTANTS::ART_ORDERED_POSITIVE_INFINITY_RADIX_KEY & ~sign_mask;
+		key = SelectByMask<WORD>(infinity_key, key, is_infinity_mask);
+
+		// Canonicalise -0.0 to the +0.0 ART-ordered radix key:
+		// float:  -0.0 0x80000000,         +0.0 0x80000000
+		// double: -0.0 0x8000000000000000, +0.0 0x8000000000000000
+		key = SelectByMask<WORD>(CONSTANTS::ART_ORDERED_POSITIVE_ZERO_RADIX_KEY, key, is_zero_mask);
+
+		return key;
+	}
+
+	template <class CONSTANTS>
+	static inline typename CONSTANTS::WORD NormalizeMinMaxKeyForDecode(typename CONSTANTS::WORD key) {
+		using WORD = typename CONSTANTS::WORD;
+		// Sortable min/max keys keep -0.0 and +0.0 separate while reducing.
+		// Canonicalise the min/max -0.0 key to the +0.0 ART-ordered radix key before decode:
+		// float:  0x7FFFFFFF -> 0x80000000
+		// double: 0x7FFFFFFFFFFFFFFF -> 0x8000000000000000
+		return SelectByMask<WORD>(CONSTANTS::ART_ORDERED_POSITIVE_ZERO_RADIX_KEY, key,
+		                          BooleanMask<WORD>(key == CONSTANTS::MINMAX_NEGATIVE_ZERO_RADIX_KEY));
+	}
+
 public:
 	template <class T>
 	static inline void EncodeData(data_ptr_t dataptr, T value) {
@@ -46,52 +146,26 @@ public:
 		return key_byte ^ 128;
 	}
 
+	//! Encode a float value into an ART-ordered radix key.
 	static inline uint32_t EncodeFloat(float x) {
-		uint32_t buff;
-		//! zero
-		if (x == 0) {
-			buff = 0;
-			buff |= (1u << 31);
-			return buff;
-		}
-
-		// nan
-		if (Value::IsNan(x)) {
-			return UINT_MAX;
-		}
-		//! infinity
-		if (x > FLT_MAX) {
-			return UINT_MAX - 1;
-		}
-		//! -infinity
-		if (x < -FLT_MAX) {
-			return 0;
-		}
-		buff = Load<uint32_t>(const_data_ptr_cast(&x));
-		if ((buff & (1U << 31)) == 0) { //! +0 and positive numbers
-			buff |= (1U << 31);
-		} else {          //! negative numbers
-			buff = ~buff; //! complement 1
-		}
-
-		return buff;
+		return EncodeARTOrderedKeyBits<FloatKeyConstants>(Load<uint32_t>(const_data_ptr_cast(&x)));
 	}
 
+	//! Decode a float ART-ordered radix key.
 	static inline float DecodeFloat(uint32_t input) {
-		// nan
-		if (input == UINT_MAX) {
+		if (input == FloatKeyConstants::ART_ORDERED_NAN_RADIX_KEY) {
 			return std::numeric_limits<float>::quiet_NaN();
 		}
-		if (input == UINT_MAX - 1) {
+		if (input == FloatKeyConstants::ART_ORDERED_POSITIVE_INFINITY_RADIX_KEY) {
 			return std::numeric_limits<float>::infinity();
 		}
-		if (input == 0) {
+		if (input == FloatKeyConstants::ART_ORDERED_NEGATIVE_INFINITY_RADIX_KEY) {
 			return -std::numeric_limits<float>::infinity();
 		}
 		float result;
-		if (input & (1U << 31)) {
+		if (input & FloatKeyConstants::SIGN_BIT) {
 			// positive numbers - flip sign bit
-			input = input ^ (1U << 31);
+			input = input ^ FloatKeyConstants::SIGN_BIT;
 		} else {
 			// negative numbers - invert
 			input = ~input;
@@ -100,55 +174,58 @@ public:
 		return result;
 	}
 
-	static inline uint64_t EncodeDouble(double x) {
-		uint64_t buff;
-		//! zero
-		if (x == 0) {
-			buff = 0;
-			buff += (1ULL << 63);
-			return buff;
-		}
-		// nan
-		if (Value::IsNan(x)) {
-			return ULLONG_MAX;
-		}
-		//! infinity
-		if (x > DBL_MAX) {
-			return ULLONG_MAX - 1;
-		}
-		//! -infinity
-		if (x < -DBL_MAX) {
-			return 0;
-		}
-		buff = Load<uint64_t>(const_data_ptr_cast(&x));
-		if (buff < (1ULL << 63)) { //! +0 and positive numbers
-			buff += (1ULL << 63);
-		} else {          //! negative numbers
-			buff = ~buff; //! complement 1
-		}
-		return buff;
+	//! Encode raw float bits as a sortable min/max key.
+	static inline uint32_t EncodeFloatMinMaxKeyBits(uint32_t bits) {
+		// The min/max keys don't use the ART-ordered radix keys for -inf and +inf, and
+		// keep -0.0 and +0.0 distinct while reducing, canonicalising zeros
+		// on decode.
+		return EncodeKeyBits<FloatKeyConstants>(bits);
 	}
+
+	//! Decode a float min/max key.
+	static inline float DecodeFloatMinMaxKey(uint32_t key) {
+		return DecodeFloat(NormalizeMinMaxKeyForDecode<FloatKeyConstants>(key));
+	}
+
+	//! Encode a double value into an ART-ordered radix key.
+	static inline uint64_t EncodeDouble(double x) {
+		return EncodeARTOrderedKeyBits<DoubleKeyConstants>(Load<uint64_t>(const_data_ptr_cast(&x)));
+	}
+
+	//! Decode a double ART-ordered radix key.
 	static inline double DecodeDouble(uint64_t input) {
-		// nan
-		if (input == ULLONG_MAX) {
+		if (input == DoubleKeyConstants::ART_ORDERED_NAN_RADIX_KEY) {
 			return std::numeric_limits<double>::quiet_NaN();
 		}
-		if (input == ULLONG_MAX - 1) {
+		if (input == DoubleKeyConstants::ART_ORDERED_POSITIVE_INFINITY_RADIX_KEY) {
 			return std::numeric_limits<double>::infinity();
 		}
-		if (input == 0) {
+		if (input == DoubleKeyConstants::ART_ORDERED_NEGATIVE_INFINITY_RADIX_KEY) {
 			return -std::numeric_limits<double>::infinity();
 		}
 		double result;
-		if (input & (1ULL << 63)) {
+		if (input & DoubleKeyConstants::SIGN_BIT) {
 			// positive numbers - flip sign bit
-			input = input ^ (1ULL << 63);
+			input = input ^ DoubleKeyConstants::SIGN_BIT;
 		} else {
 			// negative numbers - invert
 			input = ~input;
 		}
 		Store<uint64_t>(input, data_ptr_cast(&result));
 		return result;
+	}
+
+	//! Encode raw double bits as a sortable min/max key.
+	static inline uint64_t EncodeDoubleMinMaxKeyBits(uint64_t bits) {
+		// The min/max keys don't use the ART-ordered radix keys for -inf and +inf, and
+		// keep -0.0 and +0.0 distinct while reducing, canonicalising zeros
+		// on decode.
+		return EncodeKeyBits<DoubleKeyConstants>(bits);
+	}
+
+	//! Decode a double min/max key.
+	static inline double DecodeDoubleMinMaxKey(uint64_t key) {
+		return DecodeDouble(NormalizeMinMaxKeyForDecode<DoubleKeyConstants>(key));
 	}
 
 private:

--- a/src/include/duckdb/common/vector_operations/validity_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/validity_executor.hpp
@@ -1,0 +1,521 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/vector_operations/validity_executor.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/bit_utils.hpp"
+#include "duckdb/common/types/validity_mask.hpp"
+
+namespace duckdb {
+
+// These helpers sit in the inner validity-dispatch loop. Forcing inlining significantly
+// improves overall performance.
+#if defined(__GNUC__) || defined(__clang__)
+#define DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE __forceinline
+#else
+#define DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE inline
+#endif
+
+//! A normalized slice of one ValidityMask word.
+struct ValidityWordSlice {
+public:
+	explicit ValidityWordSlice(validity_t bits_p, idx_t count_p)
+	    : bits(NormalizeBits(bits_p, count_p)), count(count_p) {
+	}
+
+	inline validity_t Bits() const {
+		return bits;
+	}
+
+	inline idx_t Count() const {
+		return count;
+	}
+
+	inline bool RowIsValid(idx_t offset) const {
+		D_ASSERT(offset < count);
+		return ValidityMask::RowIsValid(bits, offset);
+	}
+
+	inline bool AllValid() const {
+		D_ASSERT(count > 0);
+		return bits == ValidityMask::EntryWithValidBits(count);
+	}
+
+	inline bool HasValid() const {
+		D_ASSERT(count > 0);
+		return bits != 0;
+	}
+
+	inline bool NoneValid() const {
+		D_ASSERT(count > 0);
+		return bits == 0;
+	}
+
+	inline bool HasInvalid() const {
+		D_ASSERT(count > 0);
+		return bits != ValidityMask::EntryWithValidBits(count);
+	}
+
+	//! Counts consecutive runs starting at `offset` and stopping at this slice's count.
+	inline idx_t RunLength(idx_t offset) const {
+		D_ASSERT(count > 0);
+		D_ASSERT(offset < count);
+
+		const auto is_valid = RowIsValid(offset);
+		const auto run_bits = is_valid ? bits : ~bits;
+		return GetRunLength(run_bits, offset);
+	}
+
+	inline ValidityWordSlice Slice(idx_t offset, idx_t slice_count) const {
+		D_ASSERT(slice_count > 0);
+		D_ASSERT(offset + slice_count <= count);
+		return ValidityWordSlice(bits >> offset, slice_count);
+	}
+
+private:
+	static inline validity_t NormalizeBits(validity_t bits, idx_t count) {
+		D_ASSERT(count <= ValidityMask::BITS_PER_VALUE);
+		return bits & ValidityMask::EntryWithValidBits(count);
+	}
+
+	//! Counts consecutive set bits in the `run_bits` ValidityMast, starting at `offset` and stopping at this slice's
+	//! count.
+	inline idx_t GetRunLength(validity_t run_bits, idx_t offset) const {
+		D_ASSERT(offset < count);
+
+		const auto bits_left = count - offset;
+		const auto active_mask = ValidityMask::EntryWithValidBits(bits_left);
+		// Move offset to bit 0, then keep only the rows that remain in the slice.
+		const auto shifted_bits = (run_bits >> offset) & active_mask;
+		const auto stop_bits = (~shifted_bits) & active_mask;
+		if (!stop_bits) {
+			return bits_left;
+		}
+		return CountZeros<validity_t>::Trailing(stop_bits);
+	}
+
+private:
+	const validity_t bits;
+	const idx_t count;
+};
+
+struct ValidityExecutor {
+private:
+	template <idx_t RUN_LENGTH>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t SetBitRunStartMask(validity_t bits) {
+		// Returns a mask of possible run starts. Bit i is set in the result only when the RUN_LENGTH input bits
+		// starting at i are all set. For example, a 5-row run with RUN_LENGTH = 3 produces three start candidates:
+		//
+		// bit position:  4 3 2 1 0
+		// bits:          1 1 1 1 1
+		// candidate 1:       - - ^
+		// candidate 2:     - - ^
+		// candidate 3:   - - ^
+		//
+		// As a worked example, SetBitRunStartMask<3>(bits) is called with:
+		//
+		// bit position:             9 8 7 6 5 4 3 2 1 0
+		// bits:                     1 1 0 1 1 1 0 1 1 1
+		//
+		// Please read the odd branch, then follow the recursive call stack.
+		//
+		// returns:                  0 0 0 0 0 1 0 0 0 1
+		//                                 - - ^   - - ^
+		//                                     |       +-- since original bits 0, 1, 2 are set
+		//                                     +---------- since original bits 4, 5, 6 are set
+		//
+		static_assert(RUN_LENGTH > 0, "RUN_LENGTH must be positive");
+
+		if constexpr (RUN_LENGTH > ValidityMask::BITS_PER_VALUE) {
+			return 0;
+		} else if constexpr (RUN_LENGTH == 1) {
+			// Handles one bit runs, which is just an identity function.
+			// Eg for SetBitRunStartMask<1>(bits)
+			//
+			// bits:                     1 1 0 1 1 1 0 1 1 1
+			//
+			// return bits
+
+			return bits;
+		} else if constexpr ((RUN_LENGTH & (RUN_LENGTH - 1)) == 0) {
+			// Handles even numbered bit runs.
+			// Eg for SetBitRunStartMask<2>(bits)
+			//
+			// half_runs = b:            0 1 1 0 1 1 1 0 1 1
+			// c = half_runs >> 1:       0 0 1 1 0 1 1 1 0 1
+			// d = half_runs & c:        0 0 1 0 0 1 1 0 0 1
+			//
+			// return d
+
+			const auto half_runs = SetBitRunStartMask<RUN_LENGTH / 2>(bits);
+			return half_runs & (half_runs >> (RUN_LENGTH / 2));
+		} else {
+			// Handles odd numbered bit runs.
+			// Eg for SetBitRunStartMask<3>(bits)
+			//
+			// LEFT_RUN_LENGTH  = 3 / 2: 1
+			// RIGHT_RUN_LENGTH = 3 - 1: 2
+			//
+			// a = bits:                1 1 0 1 1 1 0 1 1 1
+			// b = bits >> 1:           0 1 1 0 1 1 1 0 1 1
+			//
+			// left: SetBitRunStartMask<1>(a)
+			// right: SetBitRunStartMask<2>(b)
+			//
+			// left:                    1 1 0 1 1 1 0 1 1 1
+			// right:                   0 0 1 0 0 1 1 0 0 1
+			//
+			// return left & right:     0 0 0 0 0 1 0 0 0 1
+
+			constexpr idx_t LEFT_RUN_LENGTH = RUN_LENGTH / 2;
+			constexpr idx_t RIGHT_RUN_LENGTH = RUN_LENGTH - LEFT_RUN_LENGTH;
+			return SetBitRunStartMask<LEFT_RUN_LENGTH>(bits) &
+			       SetBitRunStartMask<RIGHT_RUN_LENGTH>(bits >> LEFT_RUN_LENGTH);
+		}
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t SetBitRunFirstBitMask(validity_t bits) {
+		// SetBitRunFirstBitMask(bits) returns a mask with the first 1 bit of each consecutive 1 run.
+		// Eg:
+		// bit position:      9 8 7 6 5 4 3 2 1 0
+		// bits:              0 1 1 1 0 0 1 1 0 1
+		// a =   bits << 1:   1 1 1 0 0 1 1 0 1 0
+		// b = ~(bits << 1):  0 0 0 1 1 0 0 1 0 1
+		// return a & b:      0 0 0 1 0 0 0 1 0 1
+
+		return bits & ~(bits << 1);
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t SetBitRunLastBitMask(validity_t bits) {
+		// SetBitRunLastBitMask(bits) returns a mask with the last 1 bit of each consecutive 1 run.
+		// Eg:
+		// bit position:      9 8 7 6 5 4 3 2 1 0
+		// bits:              0 1 1 1 0 0 1 1 0 1
+		//       bits >> 1:   0 0 1 1 1 0 0 1 1 0
+		// b = ~(bits >> 1):  1 1 0 0 0 1 1 0 0 1
+		// return bits & b:   0 1 0 0 0 0 1 0 0 1
+
+		return bits & ~(bits >> 1);
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t InvertedBitMask(validity_t bits, validity_t active_mask) {
+		// InvertedBitMask(bits, active_mask) returns the inverse of bits within active_mask.
+		// Eg:
+		// bit position:     9 8 7 6 5 4 3 2 1 0
+		// bits:             1 0 1 1 0 0 1 0 1 1
+		// a = ~bits:        0 1 0 0 1 1 0 1 0 0
+		// active_mask:      0 0 0 0 1 1 1 1 1 1
+		// return a & mask:  0 0 0 0 1 1 0 1 0 0
+
+		return (~bits) & active_mask;
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t SingleBitMask(idx_t offset) {
+		// SingleBitMask(offset) returns a mask with bit offset set.
+		// Eg, offset = 4:
+		// bit position:        9 8 7 6 5 4 3 2 1 0
+		// validity_t(1):       0 0 0 0 0 0 0 0 0 1
+		// return 1 << offset:  0 0 0 0 0 1 0 0 0 0
+
+		D_ASSERT(offset < ValidityMask::BITS_PER_VALUE);
+		return validity_t(1) << offset;
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE bool MaskContainsBit(validity_t bits, idx_t offset) {
+		// MaskContainsBit(bits, offset) returns true when bit offset is set in bits.
+		// Eg, offset = 4:
+		// bit position:           9 8 7 6 5 4 3 2 1 0
+		// bits:                   1 0 1 1 0 1 0 0 1 0
+		// SingleBitMask(offset):  0 0 0 0 0 1 0 0 0 0
+		// bits & mask:            0 0 0 0 0 1 0 0 0 0
+		// return:                 true
+
+		// Eg, offset = 5:
+		// bit position:           9 8 7 6 5 4 3 2 1 0
+		// bits:                   1 0 1 1 0 1 0 0 1 0
+		// SingleBitMask(offset):  0 0 0 0 1 0 0 0 0 0
+		// bits & mask:            0 0 0 0 0 0 0 0 0 0
+		// return:                 false
+
+		return (bits & SingleBitMask(offset)) != 0;
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t BitsAtOrAfter(idx_t offset) {
+		// BitsAtOrAfter(offset) returns a mask with bit offset and every higher bit set.
+		// Eg, offset = 4:
+		// bit position:    9 8 7 6 5 4 3 2 1 0
+		// ~validity_t(0):  1 1 1 1 1 1 1 1 1 1
+		// return:          1 1 1 1 1 1 0 0 0 0
+
+		D_ASSERT(offset < ValidityMask::BITS_PER_VALUE);
+		return ~validity_t(0) << offset;
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE idx_t FirstSetBit(validity_t bits) {
+		// FirstSetBit(bits) returns the lowest set bit position.
+		// Eg:
+		// bit position:         9 8 7 6 5 4 3 2 1 0
+		// bits:                 0 1 1 0 1 0 0 0 0 0
+		// trailing zero count:            4 3 2 1 0
+		// return:                         4
+
+		D_ASSERT(bits);
+		return CountZeros<validity_t>::Trailing(bits);
+	}
+
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE validity_t ClearFirstSetBit(validity_t bits) {
+		// ClearFirstSetBit(bits) returns bits with the lowest set bit cleared.
+		// Eg:
+		// bit position:     9 8 7 6 5 4 3 2 1 0
+		// bits:             0 1 1 0 1 0 0 0 0 0
+		// a = bits - 1:     0 1 1 0 0 1 1 1 1 1
+		// return a & bits:  0 1 1 0 0 0 0 0 0 0
+
+		D_ASSERT(bits);
+		return bits & (bits - 1);
+	}
+
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void ProcessAllValidNoMask(idx_t count, VALID_FUNC &valid_func,
+	                                                                         VALIDITY_SLICE_FUNC &validity_slice_func) {
+		if (count >= MIN_EXTRACT_RUN_LENGTH) {
+			valid_func(0, count);
+			return;
+		}
+
+		idx_t local_offset = 0;
+		const auto full_word_count = count / ValidityMask::BITS_PER_VALUE;
+		for (idx_t word_idx = 0; word_idx < full_word_count; word_idx++) {
+			validity_slice_func(local_offset,
+			                    ValidityWordSlice(ValidityMask::EntryWithValidBits(ValidityMask::BITS_PER_VALUE),
+			                                      ValidityMask::BITS_PER_VALUE));
+			local_offset += ValidityMask::BITS_PER_VALUE;
+		}
+
+		if (local_offset < count) {
+			const auto slice_count = count - local_offset;
+			validity_slice_func(local_offset,
+			                    ValidityWordSlice(ValidityMask::EntryWithValidBits(slice_count), slice_count));
+		}
+	}
+
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class INVALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void
+	ProcessFullValidityWordSlice(idx_t local_offset, validity_t entry, VALID_FUNC &valid_func,
+	                             INVALID_FUNC &invalid_func, VALIDITY_SLICE_FUNC &validity_slice_func) {
+		if (ValidityMask::AllValid(entry)) {
+			if constexpr (ValidityMask::BITS_PER_VALUE >= MIN_EXTRACT_RUN_LENGTH) {
+				valid_func(local_offset, ValidityMask::BITS_PER_VALUE);
+			} else {
+				validity_slice_func(local_offset, ValidityWordSlice(entry, ValidityMask::BITS_PER_VALUE));
+			}
+			return;
+		}
+
+		if (ValidityMask::NoneValid(entry)) {
+			if constexpr (ValidityMask::BITS_PER_VALUE >= MIN_EXTRACT_RUN_LENGTH) {
+				invalid_func(local_offset, ValidityMask::BITS_PER_VALUE);
+			} else {
+				validity_slice_func(local_offset, ValidityWordSlice(entry, ValidityMask::BITS_PER_VALUE));
+			}
+			return;
+		}
+
+		ProcessMixedValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset,
+		                                                      ValidityWordSlice(entry, ValidityMask::BITS_PER_VALUE),
+		                                                      valid_func, invalid_func, validity_slice_func);
+	}
+
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class INVALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void
+	ProcessPartialValidityWordSlice(idx_t local_offset, validity_t entry, idx_t idx_in_entry, idx_t slice_count,
+	                                VALID_FUNC &valid_func, INVALID_FUNC &invalid_func,
+	                                VALIDITY_SLICE_FUNC &validity_slice_func) {
+		D_ASSERT(idx_in_entry < ValidityMask::BITS_PER_VALUE);
+		D_ASSERT(slice_count > 0);
+		D_ASSERT(slice_count <= ValidityMask::BITS_PER_VALUE - idx_in_entry);
+
+		// The raw word still uses the ValidityMask's word-local bit positions. The requested slice starts at
+		// idx_in_entry, so shift that down to local row 0, then keep only slice_count rows.
+		// Eg,
+		//
+		// idx_in_entry = 3 and slice_count = 4 maps ValidityMask word bits 3..6 to local bits 0..3.
+		//
+		// bit position:                    9 8 7 6 5 4 3 2 1 0
+		// entry:                           1 0 1 1 0 1 1 0 0 1
+		// a = shifted_entry = entry >> 3:  0 0 0 1 0 1 1 0 1 1
+		// b = active_mask:                 0 0 0 0 0 0 1 1 1 1
+		// valid_bits = a & b =             0 0 0 0 0 0 1 0 1 1
+		const auto shifted_entry = entry >> idx_in_entry;
+		const auto active_mask = ValidityMask::EntryWithValidBits(slice_count);
+		const auto valid_bits = shifted_entry & active_mask;
+		ProcessValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset, ValidityWordSlice(valid_bits, slice_count),
+		                                                 valid_func, invalid_func, validity_slice_func);
+	}
+
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class INVALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void
+	ProcessValidityWordSlice(idx_t local_offset, const ValidityWordSlice &word, VALID_FUNC &valid_func,
+	                         INVALID_FUNC &invalid_func, VALIDITY_SLICE_FUNC &validity_slice_func) {
+		D_ASSERT(word.Count() > 0);
+		if (word.AllValid()) {
+			if (word.Count() >= MIN_EXTRACT_RUN_LENGTH) {
+				valid_func(local_offset, word.Count());
+			} else {
+				validity_slice_func(local_offset, word);
+			}
+			return;
+		}
+
+		if (word.NoneValid()) {
+			if (word.Count() >= MIN_EXTRACT_RUN_LENGTH) {
+				invalid_func(local_offset, word.Count());
+			} else {
+				validity_slice_func(local_offset, word);
+			}
+			return;
+		}
+
+		ProcessMixedValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset, word, valid_func, invalid_func,
+		                                                      validity_slice_func);
+	}
+
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class INVALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void
+	ProcessMixedValidityWordSlice(idx_t local_offset, const ValidityWordSlice &word, VALID_FUNC &valid_func,
+	                              INVALID_FUNC &invalid_func, VALIDITY_SLICE_FUNC &validity_slice_func) {
+		D_ASSERT(word.Count() > 0);
+		D_ASSERT(!word.AllValid());
+		D_ASSERT(!word.NoneValid());
+		// Every mask below uses slice-local row offsets: bit i describes row i in this slice.
+
+		if constexpr (MIN_EXTRACT_RUN_LENGTH >= ValidityMask::BITS_PER_VALUE) {
+			// If the min extract length is longer than the word size, this whole function should boil off,
+			// calling validity_slice_func instead.
+			validity_slice_func(local_offset, word);
+			return;
+		} else {
+			if (word.Count() < MIN_EXTRACT_RUN_LENGTH) {
+				// Fewer bits set than the minimum run length guarantees a lack of runs
+				validity_slice_func(local_offset, word);
+				return;
+			}
+
+			const auto active_mask = ValidityMask::EntryWithValidBits(word.Count());
+			const auto valid_bits = word.Bits();
+			const auto invalid_bits = InvertedBitMask(valid_bits, active_mask);
+
+			const auto valid_run_candidates = SetBitRunStartMask<MIN_EXTRACT_RUN_LENGTH>(valid_bits);
+			const auto invalid_run_candidates = SetBitRunStartMask<MIN_EXTRACT_RUN_LENGTH>(invalid_bits);
+			const auto run_candidates = valid_run_candidates | invalid_run_candidates;
+			if (!run_candidates) {
+				// No runs, send to the mixed callback.
+				validity_slice_func(local_offset, word);
+				return;
+			}
+
+			const auto valid_run_starts = valid_run_candidates & SetBitRunFirstBitMask(valid_bits);
+			const auto invalid_run_starts = invalid_run_candidates & SetBitRunFirstBitMask(invalid_bits);
+			auto run_starts = valid_run_starts | invalid_run_starts;
+			// Candidate masks mark every position where MIN_EXTRACT_RUN_LENGTH rows fit, including positions inside a
+			// longer run. Intersecting with the first-bit masks leaves exactly one start for each extractable run.
+			const auto valid_run_ends = SetBitRunLastBitMask(valid_bits);
+			const auto invalid_run_ends = SetBitRunLastBitMask(invalid_bits);
+
+			idx_t slice_start = 0;
+			while (run_starts) {
+				const auto run_offset = FirstSetBit(run_starts);
+				D_ASSERT(run_offset >= slice_start);
+
+				const auto is_valid = MaskContainsBit(valid_run_starts, run_offset);
+				const auto run_end_mask = is_valid ? valid_run_ends : invalid_run_ends;
+				// Once a run is worth extracting, emit the entire run.
+				// Ends before run_offset belong to earlier runs of the same state, so ignore them.
+				const auto run_end_candidates = run_end_mask & BitsAtOrAfter(run_offset);
+				D_ASSERT(run_end_candidates);
+				const auto run_end = FirstSetBit(run_end_candidates);
+				const auto run_count = run_end - run_offset + 1;
+				D_ASSERT(run_count >= MIN_EXTRACT_RUN_LENGTH);
+
+				if (slice_start < run_offset) {
+					validity_slice_func(local_offset + slice_start, word.Slice(slice_start, run_offset - slice_start));
+				}
+				if (is_valid) {
+					valid_func(local_offset + run_offset, run_count);
+				} else {
+					invalid_func(local_offset + run_offset, run_count);
+				}
+
+				slice_start = run_offset + run_count;
+				run_starts = ClearFirstSetBit(run_starts);
+			}
+
+			if (slice_start < word.Count()) {
+				validity_slice_func(local_offset + slice_start, word.Slice(slice_start, word.Count() - slice_start));
+			}
+		}
+	}
+
+public:
+	//! Walk a slice of a ValidityMask and dispatch local validity work.
+	//! Callback offsets are local to [source_offset, source_offset + count): callback offset 0 is source_offset in the
+	//! input mask. valid_func and invalid_func receive uniform runs of at least MIN_EXTRACT_RUN_LENGTH rows.
+	//! validity_slice_func receives the remaining pieces that still need bitwise validity checks.
+	template <idx_t MIN_EXTRACT_RUN_LENGTH, class VALID_FUNC, class INVALID_FUNC, class VALIDITY_SLICE_FUNC>
+	static DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE void
+	Execute(const ValidityMask &validity, idx_t source_offset, idx_t count, VALID_FUNC &&valid_func,
+	        INVALID_FUNC &&invalid_func, VALIDITY_SLICE_FUNC &&validity_slice_func) {
+		static_assert(MIN_EXTRACT_RUN_LENGTH > 0, "MIN_EXTRACT_RUN_LENGTH must be positive");
+
+		if (count == 0) {
+			return;
+		}
+
+		if (validity.CannotHaveNull()) {
+			ProcessAllValidNoMask<MIN_EXTRACT_RUN_LENGTH>(count, valid_func, validity_slice_func);
+			return;
+		}
+
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityMask::GetEntryIndex(source_offset, entry_idx, idx_in_entry);
+
+		idx_t local_offset = 0;
+		// If source_offset starts in the middle of a ValidityMask word, normalize that prefix before processing whole
+		// words.
+		if (DUCKDB_UNLIKELY(idx_in_entry != 0)) {
+			const auto slice_count = MinValue<idx_t>(ValidityMask::BITS_PER_VALUE - idx_in_entry, count);
+			const auto entry = validity.GetValidityEntryUnsafe(entry_idx++);
+			ProcessPartialValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset, entry, idx_in_entry, slice_count,
+			                                                        valid_func, invalid_func, validity_slice_func);
+			local_offset += slice_count;
+		}
+
+		// Process ValidityMask::BITS_PER_VALUE sized chunks
+		const auto full_word_count = (count - local_offset) / ValidityMask::BITS_PER_VALUE;
+		for (idx_t word_idx = 0; word_idx < full_word_count; word_idx++) {
+			const auto entry = validity.GetValidityEntryUnsafe(entry_idx++);
+			ProcessFullValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset, entry, valid_func, invalid_func,
+			                                                     validity_slice_func);
+			local_offset += ValidityMask::BITS_PER_VALUE;
+		}
+
+		// Process the tail.
+		if (local_offset < count) {
+			const auto entry = validity.GetValidityEntryUnsafe(entry_idx);
+			ProcessPartialValidityWordSlice<MIN_EXTRACT_RUN_LENGTH>(local_offset, entry, 0, count - local_offset,
+			                                                        valid_func, invalid_func, validity_slice_func);
+		}
+	}
+};
+
+#undef DUCKDB_VALIDITY_EXECUTOR_ALWAYS_INLINE
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/statistics/numeric_stats_traits.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats_traits.hpp
@@ -1,0 +1,225 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/statistics/numeric_stats_traits.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/radix.hpp"
+#include "duckdb/common/types/null_value.hpp"
+
+#include <limits>
+
+namespace duckdb {
+
+struct FloatMinMaxKey {
+public:
+	using WORD = uint32_t;
+
+	static inline FloatMinMaxKey FromBits(uint32_t bits) {
+		return FloatMinMaxKey(Radix::EncodeFloatMinMaxKeyBits(bits));
+	}
+
+	static inline FloatMinMaxKey MinInitialValue() {
+		return FloatMinMaxKey(std::numeric_limits<WORD>::max());
+	}
+
+	static inline FloatMinMaxKey MaxInitialValue() {
+		return FloatMinMaxKey(std::numeric_limits<WORD>::min());
+	}
+
+	inline float Decode() const {
+		return Radix::DecodeFloatMinMaxKey(key);
+	}
+
+	inline bool LessThan(const FloatMinMaxKey &other) const {
+		return key < other.key;
+	}
+
+	inline bool GreaterThan(const FloatMinMaxKey &other) const {
+		return key > other.key;
+	}
+
+private:
+	explicit FloatMinMaxKey(WORD key_p) : key(key_p) {
+	}
+
+private:
+	WORD key;
+};
+
+struct DoubleMinMaxKey {
+public:
+	using WORD = uint64_t;
+
+	static inline DoubleMinMaxKey FromBits(uint64_t bits) {
+		return DoubleMinMaxKey(Radix::EncodeDoubleMinMaxKeyBits(bits));
+	}
+
+	static inline DoubleMinMaxKey MinInitialValue() {
+		return DoubleMinMaxKey(std::numeric_limits<WORD>::max());
+	}
+
+	static inline DoubleMinMaxKey MaxInitialValue() {
+		return DoubleMinMaxKey(std::numeric_limits<WORD>::min());
+	}
+
+	inline double Decode() const {
+		return Radix::DecodeDoubleMinMaxKey(key);
+	}
+
+	inline bool LessThan(const DoubleMinMaxKey &other) const {
+		return key < other.key;
+	}
+
+	inline bool GreaterThan(const DoubleMinMaxKey &other) const {
+		return key > other.key;
+	}
+
+private:
+	explicit DoubleMinMaxKey(WORD key_p) : key(key_p) {
+	}
+
+private:
+	WORD key;
+};
+
+//! Float/double load/store integer words so appends copy values without floating-point operations.
+//! Stats reduction treats those words as raw floating-point bits and maps them to sortable min/max keys.
+//! The min/max keys keep -0.0 and +0.0 distinct while reducing, canonicalise zeros on decode, and canonicalise NaNs.
+//! This allows the zonemap stats loops to autovectorise well.
+template <class T>
+struct NumericStatsTraits {
+	using INPUT = T;
+	using KEY = T;
+
+	static inline INPUT LoadInput(const T *source) {
+		return *source;
+	}
+
+	static inline void StoreInput(T *target, INPUT input) {
+		*target = input;
+	}
+
+	static inline INPUT NullInput() {
+		return NullValue<T>();
+	}
+
+	static inline KEY EncodeInput(INPUT input) {
+		return input;
+	}
+
+	static inline T Decode(KEY key) {
+		return key;
+	}
+
+	static inline KEY MinInitialValue() {
+		return NumericLimits<T>::Maximum();
+	}
+
+	static inline KEY MaxInitialValue() {
+		return NumericLimits<T>::Minimum();
+	}
+
+	static inline bool LessThan(KEY left, KEY right) {
+		return duckdb::LessThan::Operation(left, right);
+	}
+
+	static inline bool GreaterThan(KEY left, KEY right) {
+		return duckdb::GreaterThan::Operation(left, right);
+	}
+};
+
+template <>
+struct NumericStatsTraits<float> {
+	using INPUT = uint32_t;
+	using KEY = FloatMinMaxKey;
+
+	static inline INPUT LoadInput(const float *source) {
+		return Load<INPUT>(const_data_ptr_cast(source));
+	}
+
+	static inline void StoreInput(float *target, INPUT input) {
+		Store<INPUT>(input, data_ptr_cast(target));
+	}
+
+	static inline INPUT NullInput() {
+		float null_value = NullValue<float>();
+		return LoadInput(&null_value);
+	}
+
+	static inline KEY EncodeInput(INPUT input) {
+		return KEY::FromBits(input);
+	}
+
+	static inline float Decode(KEY key) {
+		return key.Decode();
+	}
+
+	static inline KEY MinInitialValue() {
+		return KEY::MinInitialValue();
+	}
+
+	static inline KEY MaxInitialValue() {
+		return KEY::MaxInitialValue();
+	}
+
+	static inline bool LessThan(const KEY &left, const KEY &right) {
+		return left.LessThan(right);
+	}
+
+	static inline bool GreaterThan(const KEY &left, const KEY &right) {
+		return left.GreaterThan(right);
+	}
+};
+
+template <>
+struct NumericStatsTraits<double> {
+	using INPUT = uint64_t;
+	using KEY = DoubleMinMaxKey;
+
+	static inline INPUT LoadInput(const double *source) {
+		return Load<INPUT>(const_data_ptr_cast(source));
+	}
+
+	static inline void StoreInput(double *target, INPUT input) {
+		Store<INPUT>(input, data_ptr_cast(target));
+	}
+
+	static inline INPUT NullInput() {
+		double null_value = NullValue<double>();
+		return LoadInput(&null_value);
+	}
+
+	static inline KEY EncodeInput(INPUT input) {
+		return KEY::FromBits(input);
+	}
+
+	static inline double Decode(KEY key) {
+		return key.Decode();
+	}
+
+	static inline KEY MinInitialValue() {
+		return KEY::MinInitialValue();
+	}
+
+	static inline KEY MaxInitialValue() {
+		return KEY::MaxInitialValue();
+	}
+
+	static inline bool LessThan(const KEY &left, const KEY &right) {
+		return left.LessThan(right);
+	}
+
+	static inline bool GreaterThan(const KEY &left, const KEY &right) {
+		return left.GreaterThan(right);
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/statistics/stats_writer.hpp
+++ b/src/include/duckdb/storage/statistics/stats_writer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/numeric_stats_traits.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -48,6 +49,16 @@ struct BaseStatsWriter {
 		}
 	}
 
+	//! Merge validity state into another writer without touching BaseStatistics.
+	void MergeBase(BaseStatsWriter &other) const {
+		if (has_null) {
+			other.SetHasNull();
+		}
+		if (has_valid) {
+			other.SetHasValid();
+		}
+	}
+
 private:
 	bool has_null = false;
 	bool has_valid = false;
@@ -55,14 +66,18 @@ private:
 
 template <class T>
 struct StatsWriter : public BaseStatsWriter {
+	using OPERATIONS = NumericStatsTraits<T>;
+	using INPUT = typename OPERATIONS::INPUT;
+	using KEY = typename OPERATIONS::KEY;
+
 	explicit StatsWriter() {
 		Clear();
 	}
 
 	inline void Clear() {
 		ClearBase();
-		min = NumericLimits<T>::Maximum();
-		max = NumericLimits<T>::Minimum();
+		min = OPERATIONS::MinInitialValue();
+		max = OPERATIONS::MaxInitialValue();
 	}
 
 	void Update(T new_value) {
@@ -71,21 +86,68 @@ struct StatsWriter : public BaseStatsWriter {
 	}
 
 	void UpdateMinMax(T new_value) {
-		min = LessThan::Operation(new_value, min) ? new_value : min;
-		max = GreaterThan::Operation(new_value, max) ? new_value : max;
+		UpdateMinMaxFromInput(OPERATIONS::LoadInput(&new_value));
+	}
+
+	//! Updates only min/max from an already-loaded NumericStatsTraits<T>::INPUT value.
+	//! Callers must mark validity separately with SetHasValid() when at least one input is valid.
+	void UpdateMinMaxFromInput(INPUT input) {
+		UpdateKey(OPERATIONS::EncodeInput(input));
 	}
 
 	void Merge(BaseStatistics &target) const {
+		const auto target_had_valid = target.CanHaveNoNull();
 		MergeBase(target);
 		if (AnyValid()) {
-			target.UpdateNumericStats<T>(min);
-			target.UpdateNumericStats<T>(max);
+			if (!target_had_valid) {
+				NumericStats::SetMin<T>(target, OPERATIONS::Decode(min));
+				NumericStats::SetMax<T>(target, OPERATIONS::Decode(max));
+				return;
+			}
+
+			// StatsWriter merges into initialized segment stats.
+			// Existing valid values mean there are existing numeric bounds.
+			D_ASSERT(NumericStats::HasMin(target));
+			D_ASSERT(NumericStats::HasMax(target));
+
+			auto merged_min = min;
+			auto merged_max = max;
+			const auto target_min = EncodeValue(NumericStats::GetMin<T>(target));
+			const auto target_max = EncodeValue(NumericStats::GetMax<T>(target));
+			merged_min = OPERATIONS::LessThan(target_min, merged_min) ? target_min : merged_min;
+			merged_max = OPERATIONS::GreaterThan(target_max, merged_max) ? target_max : merged_max;
+			NumericStats::SetMin<T>(target, OPERATIONS::Decode(merged_min));
+			NumericStats::SetMax<T>(target, OPERATIONS::Decode(merged_max));
+		}
+	}
+
+	//! Merge numeric min/max state into another writer without decoding the stored keys.
+	void Merge(StatsWriter<T> &target) const {
+		const auto target_had_valid = target.AnyValid();
+		MergeBase(target);
+		if (AnyValid()) {
+			if (!target_had_valid) {
+				target.min = min;
+				target.max = max;
+				return;
+			}
+			target.min = OPERATIONS::LessThan(min, target.min) ? min : target.min;
+			target.max = OPERATIONS::GreaterThan(max, target.max) ? max : target.max;
 		}
 	}
 
 private:
-	T min;
-	T max;
+	static inline KEY EncodeValue(T value) {
+		return OPERATIONS::EncodeInput(OPERATIONS::LoadInput(&value));
+	}
+
+	inline void UpdateKey(KEY key) {
+		min = OPERATIONS::LessThan(key, min) ? key : min;
+		max = OPERATIONS::GreaterThan(key, max) ? key : max;
+	}
+
+	KEY min = OPERATIONS::MinInitialValue();
+	KEY max = OPERATIONS::MaxInitialValue();
 };
 
 template <>

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -1,13 +1,21 @@
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/validity_executor.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/checkpoint/write_overflow_strings_to_disk.hpp"
 #include "duckdb/storage/segment/uncompressed.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/numeric_stats_traits.hpp"
+#include "duckdb/storage/statistics/stats_writer.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/column_data_checkpointer.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
+
+#include <type_traits>
 
 namespace duckdb {
 
@@ -203,36 +211,240 @@ static unique_ptr<CompressionAppendState> FixedSizeInitAppend(ColumnSegment &seg
 	return make_uniq<CompressionAppendState>(std::move(handle));
 }
 
+template <class T>
+struct FixedSizeStatsWriterTraits {
+	using TYPE = typename std::remove_cv<T>::type;
+	static constexpr bool SUPPORTS_NUMERIC_STATS_WRITER =
+	    std::is_integral<TYPE>::value || std::is_floating_point<TYPE>::value || std::is_same<TYPE, hugeint_t>::value ||
+	    std::is_same<TYPE, uhugeint_t>::value;
+};
+
+template <class T>
+using FixedSizeStatsWriter = typename std::conditional<FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER,
+                                                       StatsWriter<T>, StatsWriter<void>>::type;
+
+static constexpr idx_t FIXED_SIZE_UNCOMPRESSED_VALIDITY_EXTRACT_RUN_LENGTH = 16;
+
+template <class T>
+static inline void AppendContiguousValidFixedSizeValues(BaseStatistics &stats, FixedSizeStatsWriter<T> &writer,
+                                                        T *__restrict target, const T *__restrict source, idx_t count) {
+	D_ASSERT(count > 0);
+	if constexpr (FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER) {
+		using OPERATIONS = NumericStatsTraits<T>;
+		FixedSizeStatsWriter<T> local_writer;
+		local_writer.SetHasValid();
+		for (idx_t i = 0; i < count; i++) {
+			const auto input = OPERATIONS::LoadInput(source + i);
+			OPERATIONS::StoreInput(target + i, input);
+			local_writer.UpdateMinMaxFromInput(input);
+		}
+		local_writer.Merge(writer);
+	} else {
+		writer.SetHasValid();
+		for (idx_t i = 0; i < count; i++) {
+			const auto value = source[i];
+			target[i] = value;
+			stats.UpdateNumericStats<T>(value);
+		}
+	}
+}
+
+template <class T>
+static inline void AppendContiguousFixedSizeValues(BaseStatistics &stats, T *__restrict target,
+                                                   const T *__restrict source, idx_t count) {
+	FixedSizeStatsWriter<T> writer;
+	AppendContiguousValidFixedSizeValues<T>(stats, writer, target, source, count);
+	writer.Merge(stats);
+}
+
+template <class T>
+static inline void AppendContiguousInvalidFixedSizeValues(FixedSizeStatsWriter<T> &writer, T *__restrict target,
+                                                          idx_t count) {
+	D_ASSERT(count > 0);
+	writer.SetHasNull();
+	if constexpr (FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER) {
+		using OPERATIONS = NumericStatsTraits<T>;
+		const auto null_input = OPERATIONS::NullInput();
+		for (idx_t i = 0; i < count; i++) {
+			OPERATIONS::StoreInput(target + i, null_input);
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			target[i] = NullValue<T>();
+		}
+	}
+}
+
+// Validity slices are word-local fragments from ValidityExecutor. Numeric fixed-size types use NumericStatsTraits
+// for local min/max reduction; other fixed-size types update validity through StatsWriter<void>.
+template <class T>
+static inline void AppendContiguousValiditySlice(BaseStatistics &stats, FixedSizeStatsWriter<T> &writer,
+                                                 T *__restrict target, const T *__restrict source,
+                                                 const ValidityWordSlice &word) {
+	const auto slice_count = word.Count();
+	const auto has_valid = word.HasValid();
+	const auto has_invalid = word.HasInvalid();
+	if constexpr (FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER) {
+		using OPERATIONS = NumericStatsTraits<T>;
+		FixedSizeStatsWriter<T> local_writer;
+		if (has_valid) {
+			local_writer.SetHasValid();
+		}
+		if (has_invalid) {
+			local_writer.SetHasNull();
+		}
+		for (idx_t i = 0; i < slice_count; i++) {
+			if (word.RowIsValid(i)) {
+				const auto input = OPERATIONS::LoadInput(source + i);
+				OPERATIONS::StoreInput(target + i, input);
+				local_writer.UpdateMinMaxFromInput(input);
+			} else {
+				OPERATIONS::StoreInput(target + i, OPERATIONS::NullInput());
+			}
+		}
+		local_writer.Merge(writer);
+	} else {
+		if (has_valid) {
+			writer.SetHasValid();
+		}
+		if (has_invalid) {
+			writer.SetHasNull();
+		}
+		for (idx_t i = 0; i < slice_count; i++) {
+			if (word.RowIsValid(i)) {
+				const auto value = source[i];
+				target[i] = value;
+				stats.UpdateNumericStats<T>(value);
+			} else {
+				target[i] = NullValue<T>();
+			}
+		}
+	}
+}
+
+template <class T>
+static inline void AppendContiguousNullableFixedSizeValues(BaseStatistics &stats, T *__restrict target,
+                                                           const T *__restrict source, const ValidityMask &validity,
+                                                           idx_t source_offset, idx_t count) {
+	FixedSizeStatsWriter<T> writer;
+	auto valid_func = [&](idx_t local_offset, idx_t append_count) {
+		AppendContiguousValidFixedSizeValues<T>(stats, writer, target + local_offset, source + local_offset,
+		                                        append_count);
+	};
+	auto invalid_func = [&](idx_t local_offset, idx_t append_count) {
+		AppendContiguousInvalidFixedSizeValues<T>(writer, target + local_offset, append_count);
+	};
+	auto validity_slice_func = [&](idx_t local_offset, ValidityWordSlice word) {
+		AppendContiguousValiditySlice<T>(stats, writer, target + local_offset, source + local_offset, word);
+	};
+
+	ValidityExecutor::Execute<FIXED_SIZE_UNCOMPRESSED_VALIDITY_EXTRACT_RUN_LENGTH>(
+	    validity, source_offset, count, valid_func, invalid_func, validity_slice_func);
+	writer.Merge(stats);
+}
+
+template <class T>
+static inline void AppendSelectedValidFixedSizeValues(BaseStatistics &stats, T *__restrict target,
+                                                      const T *__restrict source, const SelectionVector &sel,
+                                                      idx_t source_offset, idx_t count) {
+	D_ASSERT(count > 0);
+	if constexpr (FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER) {
+		using OPERATIONS = NumericStatsTraits<T>;
+		StatsWriter<T> writer;
+		writer.SetHasValid();
+		for (idx_t i = 0; i < count; i++) {
+			const auto source_idx = sel.get_index(source_offset + i);
+			const auto input = OPERATIONS::LoadInput(source + source_idx);
+			OPERATIONS::StoreInput(target + i, input);
+			writer.UpdateMinMaxFromInput(input);
+		}
+		writer.Merge(stats);
+	} else {
+		stats.SetHasNoNullFast();
+		for (idx_t i = 0; i < count; i++) {
+			const auto source_idx = sel.get_index(source_offset + i);
+			const auto value = source[source_idx];
+			target[i] = value;
+			stats.UpdateNumericStats<T>(value);
+		}
+	}
+}
+
+template <class T>
+static inline void AppendSelectedNullableFixedSizeValues(BaseStatistics &stats, T *__restrict target,
+                                                         const T *__restrict source, const SelectionVector &sel,
+                                                         const ValidityMask &validity, idx_t source_offset,
+                                                         idx_t count) {
+	D_ASSERT(count > 0);
+	if constexpr (FixedSizeStatsWriterTraits<T>::SUPPORTS_NUMERIC_STATS_WRITER) {
+		using OPERATIONS = NumericStatsTraits<T>;
+		StatsWriter<T> writer;
+		bool has_valid = false;
+		bool has_null = false;
+		for (idx_t i = 0; i < count; i++) {
+			const auto source_idx = sel.get_index(source_offset + i);
+			if (validity.RowIsValid(source_idx)) {
+				has_valid = true;
+				const auto input = OPERATIONS::LoadInput(source + source_idx);
+				OPERATIONS::StoreInput(target + i, input);
+				writer.UpdateMinMaxFromInput(input);
+			} else {
+				has_null = true;
+				OPERATIONS::StoreInput(target + i, OPERATIONS::NullInput());
+			}
+		}
+		if (has_valid) {
+			writer.SetHasValid();
+		}
+		if (has_null) {
+			writer.SetHasNull();
+		}
+		writer.Merge(stats);
+	} else {
+		bool has_valid = false;
+		bool has_null = false;
+		for (idx_t i = 0; i < count; i++) {
+			const auto source_idx = sel.get_index(source_offset + i);
+			if (validity.RowIsValid(source_idx)) {
+				has_valid = true;
+				const auto value = source[source_idx];
+				target[i] = value;
+				stats.UpdateNumericStats<T>(value);
+			} else {
+				has_null = true;
+				target[i] = NullValue<T>();
+			}
+		}
+		if (has_valid) {
+			stats.SetHasNoNullFast();
+		}
+		if (has_null) {
+			stats.SetHasNullFast();
+		}
+	}
+}
+
 struct StandardFixedSizeAppend {
 	template <class T>
 	static void Append(BaseStatistics &stats, data_ptr_t target, idx_t target_offset, UnifiedVectorFormat &adata,
 	                   idx_t offset, idx_t count) {
 		auto sdata = UnifiedVectorFormat::GetData<T>(adata);
 		auto tdata = reinterpret_cast<T *>(target);
-		if (adata.validity.CanHaveNull()) {
-			for (idx_t i = 0; i < count; i++) {
-				auto source_idx = adata.sel->get_index(offset + i);
-				auto target_idx = target_offset + i;
-				bool is_null = !adata.validity.RowIsValid(source_idx);
-				if (!is_null) {
-					stats.SetHasNoNullFast();
-					stats.UpdateNumericStats<T>(sdata[source_idx]);
-					tdata[target_idx] = sdata[source_idx];
-				} else {
-					stats.SetHasNullFast();
-					// we insert a NullValue<T> in the null gap for debuggability
-					// this value should never be used or read anywhere
-					tdata[target_idx] = NullValue<T>();
-				}
+		if (!adata.sel->IsSet()) {
+			// Contiguous buffer fast path
+			auto source = sdata + offset;
+			auto target_data = tdata + target_offset;
+			if (adata.validity.CannotHaveNull()) {
+				AppendContiguousFixedSizeValues<T>(stats, target_data, source, count);
+			} else {
+				AppendContiguousNullableFixedSizeValues<T>(stats, target_data, source, adata.validity, offset, count);
 			}
+			return;
+		} else if (adata.validity.CanHaveNull()) {
+			AppendSelectedNullableFixedSizeValues<T>(stats, tdata + target_offset, sdata, *adata.sel, adata.validity,
+			                                         offset, count);
 		} else {
-			stats.SetHasNoNullFast();
-			for (idx_t i = 0; i < count; i++) {
-				auto source_idx = adata.sel->get_index(offset + i);
-				auto target_idx = target_offset + i;
-				stats.UpdateNumericStats<T>(sdata[source_idx]);
-				tdata[target_idx] = sdata[source_idx];
-			}
+			AppendSelectedValidFixedSizeValues<T>(stats, tdata + target_offset, sdata, *adata.sel, offset, count);
 		}
 	}
 };
@@ -259,6 +471,13 @@ idx_t FixedSizeAppend(CompressionAppendState &append_state, ColumnSegment &segme
 	auto target_ptr = append_state.handle.GetDataMutable();
 	idx_t max_tuple_count = segment.SegmentSize() / sizeof(T);
 	idx_t copy_count = MinValue<idx_t>(count, max_tuple_count - segment.count);
+
+	// Compress() flushes when Append() returns _fewer_ rows than requested. If the previous call filled this segment
+	// exactly, this call starts with no remaining capacity, so copy_count is zero.
+	// StandardFixedSizeAppend assumes at least one row, so if copy_count is zero, exit early here.
+	if (copy_count == 0) {
+		return 0;
+	}
 
 	OP::template Append<T>(stats, target_ptr, segment.count, data, offset, copy_count);
 	segment.count += copy_count;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library_unity(
   test_buffer_pool_reservation.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
+  test_stats_writer.cpp
+  test_validity_executor.cpp
   test_string_util.cpp)
 
 set(UNITTEST_OBJECT_FILES

--- a/test/common/test_stats_writer.cpp
+++ b/test/common/test_stats_writer.cpp
@@ -1,0 +1,120 @@
+#include "catch.hpp"
+#include "duckdb/storage/statistics/stats_writer.hpp"
+
+#include <cmath>
+#include <limits>
+
+using namespace duckdb;
+
+template <class T>
+static void UpdateRawInputMinMax(StatsWriter<T> &writer, const T &value) {
+	writer.UpdateMinMaxFromInput(NumericStatsTraits<T>::LoadInput(&value));
+}
+
+TEST_CASE("StatsWriter canonicalizes float signed zero stats", "[stats_writer]") {
+	StatsWriter<float> writer;
+	writer.Update(-0.0f);
+	writer.Update(0.0f);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::FLOAT);
+	writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<float>(stats);
+	auto max = NumericStats::GetMax<float>(stats);
+	REQUIRE(min == 0.0f);
+	REQUIRE(max == 0.0f);
+	REQUIRE_FALSE(std::signbit(min));
+	REQUIRE_FALSE(std::signbit(max));
+}
+
+TEST_CASE("StatsWriter canonicalizes double signed zero stats", "[stats_writer]") {
+	StatsWriter<double> writer;
+	writer.Update(-0.0);
+	writer.Update(0.0);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::DOUBLE);
+	writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<double>(stats);
+	auto max = NumericStats::GetMax<double>(stats);
+	REQUIRE(min == 0.0);
+	REQUIRE(max == 0.0);
+	REQUIRE_FALSE(std::signbit(min));
+	REQUIRE_FALSE(std::signbit(max));
+}
+
+TEST_CASE("StatsWriter merges float NaN into valid target as max", "[stats_writer]") {
+	StatsWriter<float> finite_writer;
+	finite_writer.Update(1.0f);
+	finite_writer.Update(10.0f);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::FLOAT);
+	finite_writer.Merge(stats);
+
+	StatsWriter<float> nan_writer;
+	nan_writer.Update(std::numeric_limits<float>::quiet_NaN());
+	nan_writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<float>(stats);
+	auto max = NumericStats::GetMax<float>(stats);
+	REQUIRE(min == 1.0f);
+	REQUIRE(std::isnan(max));
+}
+
+TEST_CASE("StatsWriter merges double NaN into valid target as max", "[stats_writer]") {
+	StatsWriter<double> finite_writer;
+	finite_writer.Update(1.0);
+	finite_writer.Update(10.0);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::DOUBLE);
+	finite_writer.Merge(stats);
+
+	StatsWriter<double> nan_writer;
+	nan_writer.Update(std::numeric_limits<double>::quiet_NaN());
+	nan_writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<double>(stats);
+	auto max = NumericStats::GetMax<double>(stats);
+	REQUIRE(min == 1.0);
+	REQUIRE(std::isnan(max));
+}
+
+TEST_CASE("StatsWriter folds float raw input min max values", "[stats_writer]") {
+	float one = 1.0f;
+	float ten = 10.0f;
+	float nan = std::numeric_limits<float>::quiet_NaN();
+
+	StatsWriter<float> writer;
+	writer.SetHasValid();
+	UpdateRawInputMinMax(writer, one);
+	UpdateRawInputMinMax(writer, ten);
+	UpdateRawInputMinMax(writer, nan);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::FLOAT);
+	writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<float>(stats);
+	auto max = NumericStats::GetMax<float>(stats);
+	REQUIRE(min == 1.0f);
+	REQUIRE(std::isnan(max));
+}
+
+TEST_CASE("StatsWriter folds double raw input min max values", "[stats_writer]") {
+	double one = 1.0;
+	double ten = 10.0;
+	double nan = std::numeric_limits<double>::quiet_NaN();
+
+	StatsWriter<double> writer;
+	writer.SetHasValid();
+	UpdateRawInputMinMax(writer, one);
+	UpdateRawInputMinMax(writer, ten);
+	UpdateRawInputMinMax(writer, nan);
+
+	auto stats = BaseStatistics::CreateEmpty(LogicalType::DOUBLE);
+	writer.Merge(stats);
+
+	auto min = NumericStats::GetMin<double>(stats);
+	auto max = NumericStats::GetMax<double>(stats);
+	REQUIRE(min == 1.0);
+	REQUIRE(std::isnan(max));
+}

--- a/test/common/test_validity_executor.cpp
+++ b/test/common/test_validity_executor.cpp
@@ -1,0 +1,601 @@
+#include "catch.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/validity_executor.hpp"
+
+#include <array>
+
+using namespace duckdb;
+
+namespace {
+
+static constexpr std::array<idx_t, 15> MIN_RUN_LENGTHS = {{idx_t(1), idx_t(2), idx_t(3), idx_t(4), idx_t(7), idx_t(8),
+                                                           idx_t(15), idx_t(16), idx_t(17), idx_t(31), idx_t(32),
+                                                           idx_t(63), idx_t(64), idx_t(65), idx_t(128)}};
+static constexpr idx_t TEST_VALIDITY_ENTRY_COUNT = 8;
+
+enum class EventKind : uint8_t { VALID_RANGE, INVALID_RANGE, VALIDITY_SLICE };
+
+struct Event {
+	EventKind kind;
+	idx_t offset;
+	idx_t count;
+	validity_t bits;
+};
+
+struct TestContext {
+	const char *name;
+	idx_t min_run_length;
+	idx_t source_offset;
+	idx_t count;
+	bool no_mask;
+};
+
+static void Fail(const TestContext &context, const string &message);
+
+struct EventList {
+	static constexpr idx_t MAX_EVENTS = ValidityMask::BITS_PER_VALUE * 8;
+
+	std::array<Event, MAX_EVENTS> events;
+	idx_t count = 0;
+
+	void Add(const TestContext &context, EventKind kind, idx_t offset, idx_t row_count, validity_t bits = 0) {
+		if (count >= events.size()) {
+			Fail(context, "too many callback events");
+		}
+		events[count++] = Event {kind, offset, row_count, bits};
+	}
+
+	const Event &operator[](idx_t index) const {
+		return events[index];
+	}
+};
+
+static string ContextMessage(const TestContext &context, const string &message) {
+	return StringUtil::Format("%s: %s (MIN=%llu, source_offset=%llu, count=%llu, no_mask=%s)", context.name,
+	                          message.c_str(), context.min_run_length, context.source_offset, context.count,
+	                          context.no_mask ? "true" : "false");
+}
+
+static void Fail(const TestContext &context, const string &message) {
+	FAIL(ContextMessage(context, message));
+}
+
+static void Check(const TestContext &context, bool condition, const string &message) {
+	if (!condition) {
+		Fail(context, message);
+	}
+}
+
+static validity_t ActiveMask(idx_t count) {
+	D_ASSERT(count <= ValidityMask::BITS_PER_VALUE);
+	if (count == ValidityMask::BITS_PER_VALUE) {
+		return ~validity_t(0);
+	}
+	return (validity_t(1) << count) - 1;
+}
+
+static validity_t SingleBit(idx_t offset) {
+	D_ASSERT(offset < ValidityMask::BITS_PER_VALUE);
+	return validity_t(1) << offset;
+}
+
+static validity_t RunMask(idx_t offset, idx_t count) {
+	D_ASSERT(offset + count <= ValidityMask::BITS_PER_VALUE);
+	if (count == 0) {
+		return 0;
+	}
+	return ActiveMask(count) << offset;
+}
+
+static bool RowIsValid(validity_t bits, idx_t offset) {
+	return (bits & SingleBit(offset)) != 0;
+}
+
+static void SetRow(std::array<validity_t, TEST_VALIDITY_ENTRY_COUNT> &entries, idx_t row_idx, bool valid) {
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityMask::GetEntryIndex(row_idx, entry_idx, idx_in_entry);
+	if (valid) {
+		entries[entry_idx] |= SingleBit(idx_in_entry);
+	} else {
+		entries[entry_idx] &= ~SingleBit(idx_in_entry);
+	}
+}
+
+struct RawValidityMask {
+	template <class ROW_VALIDITY_FUNC>
+	explicit RawValidityMask(idx_t capacity, idx_t source_offset, idx_t count, ROW_VALIDITY_FUNC row_is_valid)
+	    : entries(), validity(entries.data(), MaxValue<idx_t>(capacity, 1)) {
+		D_ASSERT(ValidityMask::EntryCount(MaxValue<idx_t>(capacity, 1)) <= entries.size());
+		entries.fill(~validity_t(0));
+		for (idx_t i = 0; i < count; i++) {
+			SetRow(entries, source_offset + i, row_is_valid(i));
+		}
+	}
+
+	std::array<validity_t, TEST_VALIDITY_ENTRY_COUNT> entries;
+	ValidityMask validity;
+};
+
+static validity_t ReadLocalBits(const ValidityMask &validity, idx_t source_offset, idx_t local_offset, idx_t count) {
+	validity_t result = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (validity.RowIsValid(source_offset + local_offset + i)) {
+			result |= SingleBit(i);
+		}
+	}
+	return result;
+}
+
+static idx_t MaxUniformRunLength(validity_t bits, idx_t count) {
+	idx_t max_run = 0;
+	idx_t offset = 0;
+	while (offset < count) {
+		const auto valid = RowIsValid(bits, offset);
+		idx_t run_count = 1;
+		while (offset + run_count < count && RowIsValid(bits, offset + run_count) == valid) {
+			run_count++;
+		}
+		max_run = MaxValue(max_run, run_count);
+		offset += run_count;
+	}
+	return max_run;
+}
+
+static idx_t UniformRunLength(validity_t bits, idx_t count, idx_t offset) {
+	D_ASSERT(offset < count);
+	const auto valid = RowIsValid(bits, offset);
+	idx_t run_count = 1;
+	while (offset + run_count < count && RowIsValid(bits, offset + run_count) == valid) {
+		run_count++;
+	}
+	return run_count;
+}
+
+static void CheckValidityWordSlice(const TestContext &context, const ValidityWordSlice &word) {
+	const auto count = word.Count();
+	const auto bits = word.Bits();
+	Check(context, count > 0, "validity slice has zero rows");
+	Check(context, count <= ValidityMask::BITS_PER_VALUE, "validity slice is wider than one word");
+
+	const auto active_mask = ActiveMask(count);
+	const auto all_valid = bits == active_mask;
+	const auto none_valid = bits == 0;
+
+	Check(context, (bits & ~active_mask) == 0, "validity slice has inactive high bits set");
+	Check(context, word.AllValid() == all_valid, "validity slice AllValid result is incorrect");
+	Check(context, word.NoneValid() == none_valid, "validity slice NoneValid result is incorrect");
+	Check(context, word.HasValid() == !none_valid, "validity slice HasValid result is incorrect");
+	Check(context, word.HasInvalid() == !all_valid, "validity slice HasInvalid result is incorrect");
+
+	for (idx_t i = 0; i < count; i++) {
+		Check(context, word.RowIsValid(i) == RowIsValid(bits, i), "validity slice row validity is incorrect");
+		Check(context, word.RunLength(i) == UniformRunLength(bits, count, i), "validity slice run length is incorrect");
+	}
+}
+
+static const char *KindName(EventKind kind) {
+	switch (kind) {
+	case EventKind::VALID_RANGE:
+		return "valid range";
+	case EventKind::INVALID_RANGE:
+		return "invalid range";
+	case EventKind::VALIDITY_SLICE:
+		return "validity slice";
+	default:
+		return "unknown";
+	}
+}
+
+static bool HasRangeEvent(const EventList &events, EventKind kind, idx_t offset, idx_t count) {
+	for (idx_t i = 0; i < events.count; i++) {
+		const auto &event = events[i];
+		if (event.kind == kind && event.offset == offset && event.count == count) {
+			return true;
+		}
+	}
+	return false;
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static idx_t CheckExpectedRangesInSegment(const TestContext &context, const EventList &events,
+                                          const ValidityMask &validity, idx_t source_offset, idx_t segment_offset,
+                                          idx_t segment_count) {
+	idx_t expected_ranges = 0;
+	idx_t offset = 0;
+	while (offset < segment_count) {
+		const auto valid = validity.RowIsValid(source_offset + segment_offset + offset);
+		idx_t run_count = 1;
+		while (offset + run_count < segment_count &&
+		       validity.RowIsValid(source_offset + segment_offset + offset + run_count) == valid) {
+			run_count++;
+		}
+		if (run_count >= MIN_RUN_LENGTH) {
+			const auto kind = valid ? EventKind::VALID_RANGE : EventKind::INVALID_RANGE;
+			const auto range_offset = segment_offset + offset;
+			Check(context, HasRangeEvent(events, kind, range_offset, run_count),
+			      StringUtil::Format("missing %s at offset %llu with count %llu", KindName(kind), range_offset,
+			                         run_count));
+			expected_ranges++;
+		}
+		offset += run_count;
+	}
+	return expected_ranges;
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static idx_t CheckExpectedRanges(const TestContext &context, const EventList &events, const ValidityMask &validity,
+                                 idx_t source_offset, idx_t count) {
+	if (count == 0) {
+		return 0;
+	}
+	if (validity.CannotHaveNull()) {
+		return CheckExpectedRangesInSegment<MIN_RUN_LENGTH>(context, events, validity, source_offset, 0, count);
+	}
+
+	idx_t expected_ranges = 0;
+	idx_t local_offset = 0;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityMask::GetEntryIndex(source_offset, entry_idx, idx_in_entry);
+
+	if (idx_in_entry != 0) {
+		const auto segment_count = MinValue<idx_t>(ValidityMask::BITS_PER_VALUE - idx_in_entry, count);
+		expected_ranges += CheckExpectedRangesInSegment<MIN_RUN_LENGTH>(context, events, validity, source_offset,
+		                                                                local_offset, segment_count);
+		local_offset += segment_count;
+	}
+
+	while (count - local_offset >= ValidityMask::BITS_PER_VALUE) {
+		expected_ranges += CheckExpectedRangesInSegment<MIN_RUN_LENGTH>(context, events, validity, source_offset,
+		                                                                local_offset, ValidityMask::BITS_PER_VALUE);
+		local_offset += ValidityMask::BITS_PER_VALUE;
+	}
+
+	if (local_offset < count) {
+		expected_ranges += CheckExpectedRangesInSegment<MIN_RUN_LENGTH>(context, events, validity, source_offset,
+		                                                                local_offset, count - local_offset);
+	}
+	return expected_ranges;
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static void CheckEvents(const TestContext &context, const EventList &events, const ValidityMask &validity,
+                        idx_t source_offset, idx_t count) {
+	idx_t cursor = 0;
+	idx_t range_count = 0;
+	for (idx_t event_idx = 0; event_idx < events.count; event_idx++) {
+		const auto &event = events[event_idx];
+		Check(context, event.count > 0, "callback event has zero rows");
+		Check(context, event.offset == cursor,
+		      StringUtil::Format("callback event starts at %llu, expected %llu", event.offset, cursor));
+		Check(context, event.offset + event.count <= count, "callback event extends past requested count");
+
+		if (event.kind == EventKind::VALID_RANGE || event.kind == EventKind::INVALID_RANGE) {
+			const auto expected_valid = event.kind == EventKind::VALID_RANGE;
+			Check(context, event.count >= MIN_RUN_LENGTH, "range callback is shorter than MIN_RUN_LENGTH");
+			for (idx_t i = 0; i < event.count; i++) {
+				Check(context, validity.RowIsValid(source_offset + event.offset + i) == expected_valid,
+				      "range callback covers rows with the wrong validity");
+			}
+			range_count++;
+		} else {
+			Check(context, event.count <= ValidityMask::BITS_PER_VALUE, "validity slice is wider than one word");
+			Check(context, event.bits == ReadLocalBits(validity, source_offset, event.offset, event.count),
+			      "validity slice bits do not match source validity");
+			Check(context, (event.bits & ~ActiveMask(event.count)) == 0, "validity slice has inactive high bits set");
+			Check(context, MaxUniformRunLength(event.bits, event.count) < MIN_RUN_LENGTH,
+			      "validity slice contains an extractable run");
+			if (!validity.CannotHaveNull()) {
+				const auto source_begin = source_offset + event.offset;
+				const auto source_end = source_begin + event.count - 1;
+				Check(context, source_begin / ValidityMask::BITS_PER_VALUE == source_end / ValidityMask::BITS_PER_VALUE,
+				      "validity slice crosses a source validity word boundary");
+			}
+		}
+
+		cursor += event.count;
+	}
+
+	Check(context, cursor == count, "callback events do not cover the requested count");
+	const auto expected_ranges = CheckExpectedRanges<MIN_RUN_LENGTH>(context, events, validity, source_offset, count);
+	Check(context, range_count == expected_ranges,
+	      StringUtil::Format("got %llu range callbacks, expected %llu", range_count, expected_ranges));
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static void CheckValidityExecutorCase(const TestContext &context, const ValidityMask &validity) {
+	EventList events;
+	auto valid_func = [&](idx_t offset, idx_t count) {
+		events.Add(context, EventKind::VALID_RANGE, offset, count);
+	};
+	auto invalid_func = [&](idx_t offset, idx_t count) {
+		events.Add(context, EventKind::INVALID_RANGE, offset, count);
+	};
+	auto validity_slice_func = [&](idx_t offset, ValidityWordSlice word) {
+		CheckValidityWordSlice(context, word);
+		events.Add(context, EventKind::VALIDITY_SLICE, offset, word.Count(), word.Bits());
+	};
+
+	ValidityExecutor::Execute<MIN_RUN_LENGTH>(validity, context.source_offset, context.count, valid_func, invalid_func,
+	                                          validity_slice_func);
+	CheckEvents<MIN_RUN_LENGTH>(context, events, validity, context.source_offset, context.count);
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static void CheckAllocatedMaskCase(const char *name, idx_t source_offset, idx_t count, validity_t bits) {
+	D_ASSERT(count <= ValidityMask::BITS_PER_VALUE);
+	TestContext context {name, MIN_RUN_LENGTH, source_offset, count, false};
+	RawValidityMask raw_mask(source_offset + count, source_offset, count,
+	                         [bits](idx_t i) { return RowIsValid(bits, i); });
+	CheckValidityExecutorCase<MIN_RUN_LENGTH>(context, raw_mask.validity);
+}
+
+template <idx_t MIN_RUN_LENGTH, class ROW_VALIDITY_FUNC>
+static void CheckAllocatedMaskCase(const char *name, idx_t source_offset, idx_t count, ROW_VALIDITY_FUNC row_is_valid) {
+	TestContext context {name, MIN_RUN_LENGTH, source_offset, count, false};
+	RawValidityMask raw_mask(source_offset + count, source_offset, count, row_is_valid);
+	CheckValidityExecutorCase<MIN_RUN_LENGTH>(context, raw_mask.validity);
+}
+
+template <idx_t MIN_RUN_LENGTH>
+static void CheckNoMaskCase(const char *name, idx_t source_offset, idx_t count) {
+	TestContext context {name, MIN_RUN_LENGTH, source_offset, count, true};
+	ValidityMask validity(MaxValue<idx_t>(source_offset + count, 1));
+	CheckValidityExecutorCase<MIN_RUN_LENGTH>(context, validity);
+}
+
+template <class ROW_VALIDITY_FUNC>
+static void CheckAllocatedMaskCase(idx_t min_run_length, const char *name, idx_t source_offset, idx_t count,
+                                   ROW_VALIDITY_FUNC row_is_valid) {
+	switch (min_run_length) {
+	case 1:
+		CheckAllocatedMaskCase<1>(name, source_offset, count, row_is_valid);
+		break;
+	case 2:
+		CheckAllocatedMaskCase<2>(name, source_offset, count, row_is_valid);
+		break;
+	case 3:
+		CheckAllocatedMaskCase<3>(name, source_offset, count, row_is_valid);
+		break;
+	case 4:
+		CheckAllocatedMaskCase<4>(name, source_offset, count, row_is_valid);
+		break;
+	case 7:
+		CheckAllocatedMaskCase<7>(name, source_offset, count, row_is_valid);
+		break;
+	case 8:
+		CheckAllocatedMaskCase<8>(name, source_offset, count, row_is_valid);
+		break;
+	case 15:
+		CheckAllocatedMaskCase<15>(name, source_offset, count, row_is_valid);
+		break;
+	case 16:
+		CheckAllocatedMaskCase<16>(name, source_offset, count, row_is_valid);
+		break;
+	case 17:
+		CheckAllocatedMaskCase<17>(name, source_offset, count, row_is_valid);
+		break;
+	case 31:
+		CheckAllocatedMaskCase<31>(name, source_offset, count, row_is_valid);
+		break;
+	case 32:
+		CheckAllocatedMaskCase<32>(name, source_offset, count, row_is_valid);
+		break;
+	case 63:
+		CheckAllocatedMaskCase<63>(name, source_offset, count, row_is_valid);
+		break;
+	case 64:
+		CheckAllocatedMaskCase<64>(name, source_offset, count, row_is_valid);
+		break;
+	case 65:
+		CheckAllocatedMaskCase<65>(name, source_offset, count, row_is_valid);
+		break;
+	case 128:
+		CheckAllocatedMaskCase<128>(name, source_offset, count, row_is_valid);
+		break;
+	default:
+		FAIL(StringUtil::Format("unhandled MIN_RUN_LENGTH %llu", min_run_length));
+	}
+}
+
+static void CheckAllocatedMaskCase(idx_t min_run_length, const char *name, idx_t source_offset, idx_t count,
+                                   validity_t bits) {
+	CheckAllocatedMaskCase(min_run_length, name, source_offset, count, [bits](idx_t i) { return RowIsValid(bits, i); });
+}
+
+static void CheckNoMaskCase(idx_t min_run_length, const char *name, idx_t source_offset, idx_t count) {
+	switch (min_run_length) {
+	case 1:
+		CheckNoMaskCase<1>(name, source_offset, count);
+		break;
+	case 2:
+		CheckNoMaskCase<2>(name, source_offset, count);
+		break;
+	case 3:
+		CheckNoMaskCase<3>(name, source_offset, count);
+		break;
+	case 4:
+		CheckNoMaskCase<4>(name, source_offset, count);
+		break;
+	case 7:
+		CheckNoMaskCase<7>(name, source_offset, count);
+		break;
+	case 8:
+		CheckNoMaskCase<8>(name, source_offset, count);
+		break;
+	case 15:
+		CheckNoMaskCase<15>(name, source_offset, count);
+		break;
+	case 16:
+		CheckNoMaskCase<16>(name, source_offset, count);
+		break;
+	case 17:
+		CheckNoMaskCase<17>(name, source_offset, count);
+		break;
+	case 31:
+		CheckNoMaskCase<31>(name, source_offset, count);
+		break;
+	case 32:
+		CheckNoMaskCase<32>(name, source_offset, count);
+		break;
+	case 63:
+		CheckNoMaskCase<63>(name, source_offset, count);
+		break;
+	case 64:
+		CheckNoMaskCase<64>(name, source_offset, count);
+		break;
+	case 65:
+		CheckNoMaskCase<65>(name, source_offset, count);
+		break;
+	case 128:
+		CheckNoMaskCase<128>(name, source_offset, count);
+		break;
+	default:
+		FAIL(StringUtil::Format("unhandled MIN_RUN_LENGTH %llu", min_run_length));
+	}
+}
+
+static idx_t CheckAllMinValuesAllocated(const char *name, idx_t source_offset, idx_t count, validity_t bits) {
+	for (const auto min_run_length : MIN_RUN_LENGTHS) {
+		CheckAllocatedMaskCase(min_run_length, name, source_offset, count, bits);
+	}
+	return MIN_RUN_LENGTHS.size();
+}
+
+template <class ROW_VALIDITY_FUNC>
+static idx_t CheckAllMinValuesAllocatedRows(const char *name, idx_t source_offset, idx_t count,
+                                            ROW_VALIDITY_FUNC row_is_valid) {
+	for (const auto min_run_length : MIN_RUN_LENGTHS) {
+		CheckAllocatedMaskCase(min_run_length, name, source_offset, count, row_is_valid);
+	}
+	return MIN_RUN_LENGTHS.size();
+}
+
+static idx_t CheckAllMinValuesNoMask(const char *name, idx_t source_offset, idx_t count) {
+	for (const auto min_run_length : MIN_RUN_LENGTHS) {
+		CheckNoMaskCase(min_run_length, name, source_offset, count);
+	}
+	return MIN_RUN_LENGTHS.size();
+}
+
+} // namespace
+
+TEST_CASE("ValidityExecutor exhaustive small masks", "[validity_executor]") {
+	idx_t checked_cases = 0;
+	for (const auto source_offset : {idx_t(0), idx_t(63)}) {
+		for (idx_t count = 0; count <= 16; count++) {
+			const auto pattern_count = validity_t(1) << count;
+			for (validity_t bits = 0; bits < pattern_count; bits++) {
+				checked_cases +=
+				    CheckAllMinValuesAllocated("exhaustive small allocated mask", source_offset, count, bits);
+			}
+			checked_cases += CheckAllMinValuesNoMask("exhaustive small no-mask all-valid", source_offset, count);
+		}
+	}
+	REQUIRE(checked_cases > 0);
+}
+
+TEST_CASE("ValidityExecutor 64-bit masks", "[validity_executor]") {
+	const auto all_valid = ActiveMask(ValidityMask::BITS_PER_VALUE);
+	const auto alternating = validity_t(0xAAAAAAAAAAAAAAAA);
+	const auto inverse_alternating = ~alternating;
+
+	idx_t checked_cases = 0;
+	for (const auto source_offset : {idx_t(0), idx_t(1), idx_t(63), idx_t(64), idx_t(65)}) {
+		checked_cases += CheckAllMinValuesAllocated("64-bit all valid allocated", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, all_valid);
+		checked_cases +=
+		    CheckAllMinValuesNoMask("64-bit all valid no-mask", source_offset, ValidityMask::BITS_PER_VALUE);
+		checked_cases +=
+		    CheckAllMinValuesAllocated("64-bit all invalid", source_offset, ValidityMask::BITS_PER_VALUE, 0);
+		checked_cases +=
+		    CheckAllMinValuesAllocated("64-bit alternating", source_offset, ValidityMask::BITS_PER_VALUE, alternating);
+		checked_cases += CheckAllMinValuesAllocated("64-bit inverse alternating", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, inverse_alternating);
+		checked_cases += CheckAllMinValuesAllocated("64-bit single invalid first", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, all_valid & ~SingleBit(0));
+		checked_cases += CheckAllMinValuesAllocated("64-bit single invalid last", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, all_valid & ~SingleBit(63));
+		checked_cases += CheckAllMinValuesAllocated("64-bit single valid first", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, SingleBit(0));
+		checked_cases += CheckAllMinValuesAllocated("64-bit single valid last", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, SingleBit(63));
+		checked_cases += CheckAllMinValuesAllocated("64-bit valid run starts first", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, RunMask(0, 8));
+		checked_cases += CheckAllMinValuesAllocated("64-bit valid run ends last", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, RunMask(56, 8));
+		checked_cases += CheckAllMinValuesAllocated("64-bit invalid run starts first", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, all_valid & ~RunMask(0, 8));
+		checked_cases += CheckAllMinValuesAllocated("64-bit invalid run ends last", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, all_valid & ~RunMask(56, 8));
+		checked_cases += CheckAllMinValuesAllocated("64-bit two valid runs", source_offset,
+		                                            ValidityMask::BITS_PER_VALUE, RunMask(4, 8) | RunMask(24, 9));
+		checked_cases +=
+		    CheckAllMinValuesAllocated("64-bit two invalid runs", source_offset, ValidityMask::BITS_PER_VALUE,
+		                               all_valid & ~(RunMask(4, 8) | RunMask(24, 9)));
+	}
+	REQUIRE(checked_cases > 0);
+}
+
+TEST_CASE("ValidityExecutor multi-entry masks", "[validity_executor]") {
+	idx_t checked_cases = 0;
+
+	for (const auto source_offset : {idx_t(0), idx_t(1), idx_t(63)}) {
+		checked_cases += CheckAllMinValuesAllocatedRows("multi-entry all valid allocated", source_offset, 130,
+		                                                [](idx_t) { return true; });
+		checked_cases += CheckAllMinValuesAllocatedRows("multi-entry all invalid allocated", source_offset, 130,
+		                                                [](idx_t) { return false; });
+		checked_cases += CheckAllMinValuesAllocatedRows("multi-entry alternating allocated", source_offset, 130,
+		                                                [](idx_t i) { return (i & 1) != 0; });
+	}
+
+	for (const auto count : {idx_t(128), idx_t(192)}) {
+		checked_cases += CheckAllMinValuesAllocatedRows("multi-entry aligned all valid allocated", 0, count,
+		                                                [](idx_t) { return true; });
+		checked_cases += CheckAllMinValuesAllocatedRows("multi-entry aligned all invalid allocated", 0, count,
+		                                                [](idx_t) { return false; });
+	}
+
+	checked_cases += CheckAllMinValuesAllocatedRows("multi-entry clustered runs allocated", 1, 130, [](idx_t i) {
+		return (i < 17) || (i >= 40 && i < 104) || (i >= 121);
+	});
+	CheckNoMaskCase<128>("multi-entry no-mask all-valid short of MIN", 0, 96);
+	checked_cases++;
+
+	REQUIRE(checked_cases > 0);
+}
+
+TEST_CASE("ValidityExecutor minimum run lengths", "[validity_executor]") {
+	idx_t checked_cases = 0;
+	for (const auto min_run_length : MIN_RUN_LENGTHS) {
+		for (const auto source_offset : {idx_t(0), idx_t(1), idx_t(63), idx_t(64), idx_t(65)}) {
+			if (min_run_length > 1) {
+				const auto short_count = MinValue<idx_t>(min_run_length - 1, ValidityMask::BITS_PER_VALUE);
+				CheckAllocatedMaskCase(min_run_length, "64-bit valid run shorter than MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, RunMask(0, short_count));
+				CheckAllocatedMaskCase(min_run_length, "64-bit invalid run shorter than MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, ActiveMask(64) & ~RunMask(0, short_count));
+				checked_cases += 2;
+			}
+
+			if (min_run_length <= ValidityMask::BITS_PER_VALUE) {
+				CheckAllocatedMaskCase(min_run_length, "64-bit valid run exactly MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, RunMask(0, min_run_length));
+				CheckAllocatedMaskCase(min_run_length, "64-bit invalid run exactly MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, ActiveMask(64) & ~RunMask(0, min_run_length));
+				checked_cases += 2;
+			}
+
+			if (min_run_length < ValidityMask::BITS_PER_VALUE) {
+				const auto long_count = min_run_length + 1;
+				CheckAllocatedMaskCase(min_run_length, "64-bit valid run longer than MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, RunMask(0, long_count));
+				CheckAllocatedMaskCase(min_run_length, "64-bit invalid run longer than MIN", source_offset,
+				                       ValidityMask::BITS_PER_VALUE, ActiveMask(64) & ~RunMask(0, long_count));
+				checked_cases += 2;
+			}
+		}
+	}
+	REQUIRE(checked_cases > 0);
+}

--- a/test/sql/index/art/types/test_art_double.test
+++ b/test/sql/index/art/types/test_art_double.test
@@ -12,6 +12,9 @@ statement ok
 INSERT INTO numbers VALUES (CAST(-0 AS DOUBLE))
 
 statement ok
+INSERT INTO numbers VALUES ('-inf'::DOUBLE), (-2.5::DOUBLE), (1.5::DOUBLE), ('inf'::DOUBLE), ('nan'::DOUBLE)
+
+statement ok
 CREATE INDEX i_index ON numbers(i)
 
 query I
@@ -24,3 +27,32 @@ SELECT COUNT(i) FROM numbers WHERE i = CAST(-0 AS DOUBLE)
 ----
 2
 
+query I
+SELECT COUNT(i) FROM numbers WHERE i = '-inf'::DOUBLE
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i = 'inf'::DOUBLE
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i = 'nan'::DOUBLE
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i < '-inf'::DOUBLE
+----
+0
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i > 'inf'::DOUBLE
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i >= -2.5::DOUBLE AND i <= 1.5::DOUBLE
+----
+4

--- a/test/sql/index/art/types/test_art_real.test
+++ b/test/sql/index/art/types/test_art_real.test
@@ -14,6 +14,9 @@ statement ok
 INSERT INTO numbers VALUES (CAST(-0 AS REAL))
 
 statement ok
+INSERT INTO numbers VALUES ('-inf'::REAL), (-2.5::REAL), (1.5::REAL), ('inf'::REAL), ('nan'::REAL)
+
+statement ok
 CREATE INDEX i_index ON numbers(i)
 
 # +0
@@ -28,3 +31,32 @@ SELECT COUNT(i) FROM numbers WHERE i = CAST(-0 AS REAL)
 ----
 2
 
+query I
+SELECT COUNT(i) FROM numbers WHERE i = '-inf'::REAL
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i = 'inf'::REAL
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i = 'nan'::REAL
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i < '-inf'::REAL
+----
+0
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i > 'inf'::REAL
+----
+1
+
+query I
+SELECT COUNT(i) FROM numbers WHERE i >= -2.5::REAL AND i <= 1.5::REAL
+----
+4

--- a/test/sql/index/test_art_keys.cpp
+++ b/test/sql/index/test_art_keys.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <limits>
 
 using namespace duckdb;
 
@@ -265,5 +266,61 @@ TEST_CASE("Test correct functioning of art EncodeFloat/EncodeDouble", "[art-enc]
 			REQUIRE(next_encoded > current_encoded);
 			current_encoded = next_encoded;
 		}
+	}
+}
+
+template <class T, class WORD>
+static T FloatingValueFromBits(WORD bits) {
+	T result;
+	memcpy(&result, &bits, sizeof(T));
+	return result;
+}
+
+TEST_CASE("Radix floating point special value encodings", "[art-enc]") {
+	{
+		REQUIRE(Radix::EncodeFloat(0.0f) == 0x80000000);
+		REQUIRE(Radix::EncodeFloat(-0.0f) == 0x80000000);
+
+		REQUIRE(Radix::EncodeFloat(-std::numeric_limits<float>::infinity()) == 0x00000000);
+		REQUIRE(Radix::EncodeFloat(std::numeric_limits<float>::infinity()) == 0xfffffffe);
+		REQUIRE(Radix::EncodeFloat(std::numeric_limits<float>::quiet_NaN()) == 0xffffffff);
+		REQUIRE(Radix::EncodeFloat(FloatingValueFromBits<float>(uint32_t(0xffc00000))) == 0xffffffff);
+
+		// Finite positive values set the sign bit:
+		//  1.5f word    0x3FC00000
+		//  sign bit   | 0x80000000
+		//               ----------
+		//  radix key    0xBFC00000
+		REQUIRE(Radix::EncodeFloat(1.5f) == 0xbfc00000);
+
+		// Finite negative values invert all bits:
+		//  -2.5f word   0xC0200000
+		//  radix key   ~0xC0200000
+		//               ----------
+		//               0x3FDFFFFF
+		REQUIRE(Radix::EncodeFloat(-2.5f) == 0x3fdfffff);
+	}
+	{
+		REQUIRE(Radix::EncodeDouble(0.0) == 0x8000000000000000);
+		REQUIRE(Radix::EncodeDouble(-0.0) == 0x8000000000000000);
+
+		REQUIRE(Radix::EncodeDouble(-std::numeric_limits<double>::infinity()) == 0x0000000000000000);
+		REQUIRE(Radix::EncodeDouble(std::numeric_limits<double>::infinity()) == 0xfffffffffffffffe);
+		REQUIRE(Radix::EncodeDouble(std::numeric_limits<double>::quiet_NaN()) == 0xffffffffffffffff);
+		REQUIRE(Radix::EncodeDouble(FloatingValueFromBits<double>(uint64_t(0xfff8000000000000))) == 0xffffffffffffffff);
+
+		// Finite positive values set the sign bit:
+		//  1.5 word     0x3FF8000000000000
+		//  sign bit   | 0x8000000000000000
+		//               ------------------
+		//  radix key    0xBFF8000000000000
+		REQUIRE(Radix::EncodeDouble(1.5) == 0xbff8000000000000);
+
+		// Finite negative values invert all bits:
+		//  -2.5 word   0xC004000000000000
+		//  radix key  ~0xC004000000000000
+		//              ------------------
+		//              0x3FFBFFFFFFFFFFFF
+		REQUIRE(Radix::EncodeDouble(-2.5) == 0x3ffbffffffffffff);
 	}
 }

--- a/test/sql/storage/append_contiguous_numeric_stats.test
+++ b/test/sql/storage/append_contiguous_numeric_stats.test
@@ -1,0 +1,347 @@
+# name: test/sql/storage/append_contiguous_numeric_stats.test
+# description: Verify contiguous fixed-size appends preserve numeric statistics
+# group: [storage]
+
+# load the DB from disk
+load {TEST_DIR}/append_contiguous_numeric_stats.db
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+statement ok
+CREATE TABLE append_contiguous_primitive_integers(
+	i8 TINYINT,
+	i16 SMALLINT,
+	i32 INTEGER,
+	i64 BIGINT,
+	u8 UTINYINT,
+	u16 USMALLINT,
+	u32 UINTEGER,
+	u64 UBIGINT
+)
+
+statement ok
+INSERT INTO append_contiguous_primitive_integers
+SELECT
+	CAST((i % 256) - 128 AS TINYINT),
+	CAST((i % 65536) - 32768 AS SMALLINT),
+	CAST(i - 150000 AS INTEGER),
+	CAST(i - 150000 AS BIGINT),
+	CAST(i % 256 AS UTINYINT),
+	CAST(i % 65536 AS USMALLINT),
+	CAST(i AS UINTEGER),
+	CAST(i AS UBIGINT)
+FROM range(300000) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_floats(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_floats VALUES ('nan'::FLOAT), ('inf'::FLOAT), ('-inf'::FLOAT), (-0.0::FLOAT), (0.0::FLOAT), (1.5::FLOAT), (-2.5::FLOAT)
+
+statement ok
+CREATE TABLE append_contiguous_doubles(d DOUBLE)
+
+statement ok
+INSERT INTO append_contiguous_doubles VALUES ('nan'::DOUBLE), ('inf'::DOUBLE), ('-inf'::DOUBLE), (-0.0::DOUBLE), (0.0::DOUBLE), (1.5::DOUBLE), (-2.5::DOUBLE)
+
+statement ok
+CREATE TABLE append_contiguous_all_nan_float(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_all_nan_float SELECT 'nan'::FLOAT FROM range(4096)
+
+statement ok
+CREATE TABLE append_contiguous_all_nan_double(d DOUBLE)
+
+statement ok
+INSERT INTO append_contiguous_all_nan_double SELECT 'nan'::DOUBLE FROM range(4096)
+
+statement ok
+CREATE TABLE append_contiguous_nullable_integers(i INTEGER, u UINTEGER)
+
+statement ok
+INSERT INTO append_contiguous_nullable_integers
+SELECT
+	CASE WHEN i % 97 = 0 THEN NULL ELSE CAST(i - 2048 AS INTEGER) END,
+	CASE WHEN i % 97 = 0 THEN NULL ELSE CAST(i AS UINTEGER) END
+FROM range(4096) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_128bit_numeric(
+	h HUGEINT,
+	u UHUGEINT,
+	d DECIMAL(38,10)
+)
+
+statement ok
+INSERT INTO append_contiguous_128bit_numeric
+SELECT
+	CAST(CAST(i AS HUGEINT) - 2048 AS HUGEINT),
+	CAST(i AS UHUGEINT),
+	CAST(CAST(i AS BIGINT) - 2048 AS DECIMAL(38,10))
+FROM range(4096) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_nullable_128bit_numeric(
+	h HUGEINT,
+	u UHUGEINT,
+	d DECIMAL(38,10)
+)
+
+statement ok
+INSERT INTO append_contiguous_nullable_128bit_numeric
+SELECT
+	CASE WHEN i % 97 = 0 THEN NULL ELSE CAST(CAST(i AS HUGEINT) - 2048 AS HUGEINT) END,
+	CASE WHEN i % 97 = 0 THEN NULL ELSE CAST(i AS UHUGEINT) END,
+	CASE WHEN i % 97 = 0 THEN NULL ELSE CAST(CAST(i AS BIGINT) - 2048 AS DECIMAL(38,10)) END
+FROM range(4096) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_nullable_float_special(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_nullable_float_special
+SELECT
+	CASE
+		WHEN i % 97 = 0 THEN NULL
+		WHEN i % 11 = 0 THEN 'nan'::FLOAT
+		WHEN i % 13 = 0 THEN 'inf'::FLOAT
+		WHEN i % 17 = 0 THEN '-inf'::FLOAT
+		WHEN i % 2 = 0 THEN -0.0::FLOAT
+		ELSE CAST(i AS FLOAT)
+	END
+FROM range(4096) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_nullable_double_special(d DOUBLE)
+
+statement ok
+INSERT INTO append_contiguous_nullable_double_special
+SELECT
+	CASE
+		WHEN i % 97 = 0 THEN NULL
+		WHEN i % 11 = 0 THEN 'nan'::DOUBLE
+		WHEN i % 13 = 0 THEN 'inf'::DOUBLE
+		WHEN i % 17 = 0 THEN '-inf'::DOUBLE
+		WHEN i % 2 = 0 THEN -0.0::DOUBLE
+		ELSE CAST(i AS DOUBLE)
+	END
+FROM range(4096) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_all_null_integer(i INTEGER)
+
+statement ok
+INSERT INTO append_contiguous_all_null_integer SELECT NULL::INTEGER FROM range(4096)
+
+statement ok
+CREATE TABLE append_contiguous_all_null_float(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_all_null_float SELECT NULL::FLOAT FROM range(4096)
+
+statement ok
+CHECKPOINT
+
+restart
+
+query III
+SELECT count(*), min(i8), max(i8) FROM append_contiguous_primitive_integers
+----
+300000	-128	127
+
+query III
+SELECT count(*), min(i16), max(i16) FROM append_contiguous_primitive_integers
+----
+300000	-32768	32767
+
+query III
+SELECT count(*), min(i32), max(i32) FROM append_contiguous_primitive_integers
+----
+300000	-150000	149999
+
+query III
+SELECT count(*), min(i64), max(i64) FROM append_contiguous_primitive_integers
+----
+300000	-150000	149999
+
+query III
+SELECT count(*), min(u8), max(u8) FROM append_contiguous_primitive_integers
+----
+300000	0	255
+
+query III
+SELECT count(*), min(u16), max(u16) FROM append_contiguous_primitive_integers
+----
+300000	0	65535
+
+query III
+SELECT count(*), min(u32), max(u32) FROM append_contiguous_primitive_integers
+----
+300000	0	299999
+
+query III
+SELECT count(*), min(u64), max(u64) FROM append_contiguous_primitive_integers
+----
+300000	0	299999
+
+query I
+SELECT count(*) FROM append_contiguous_floats WHERE f='nan'::FLOAT
+----
+1
+
+query I
+SELECT count(*) FROM append_contiguous_floats WHERE f>'inf'::FLOAT
+----
+1
+
+query I
+SELECT count(*) FROM append_contiguous_floats WHERE f<'-inf'::FLOAT
+----
+0
+
+query I
+SELECT count(*) FROM append_contiguous_floats WHERE f=0.0::FLOAT
+----
+2
+
+query I
+SELECT count(*) FROM append_contiguous_doubles WHERE d='nan'::DOUBLE
+----
+1
+
+query I
+SELECT count(*) FROM append_contiguous_doubles WHERE d>'inf'::DOUBLE
+----
+1
+
+query I
+SELECT count(*) FROM append_contiguous_doubles WHERE d<'-inf'::DOUBLE
+----
+0
+
+query I
+SELECT count(*) FROM append_contiguous_doubles WHERE d=0.0::DOUBLE
+----
+2
+
+query I
+SELECT count(*) FROM append_contiguous_all_nan_float WHERE f='nan'::FLOAT
+----
+4096
+
+query I
+SELECT count(*) FROM append_contiguous_all_nan_double WHERE d='nan'::DOUBLE
+----
+4096
+
+query IIIIIIII
+SELECT count(*), count(i), count(*) FILTER (WHERE i IS NULL), min(i), max(i), count(u), min(u), max(u)
+FROM append_contiguous_nullable_integers
+----
+4096	4053	43	-2047	2047	4053	1	4095
+
+query III
+SELECT count(*), count(h), count(u) FROM append_contiguous_128bit_numeric
+----
+4096	4096	4096
+
+query TTTTTT
+SELECT
+	s_h.min::VARCHAR,
+	s_h.max::VARCHAR,
+	s_u.min::VARCHAR,
+	s_u.max::VARCHAR,
+	s_d.min::VARCHAR,
+	s_d.max::VARCHAR
+FROM (SELECT stats(h) s_h, stats(u) s_u, stats(d) s_d FROM append_contiguous_128bit_numeric LIMIT 1)
+----
+-2048	2047	0	4095	-2048.0000000000	2047.0000000000
+
+query IIII
+SELECT count(*), count(h), count(u), count(d) FROM append_contiguous_nullable_128bit_numeric
+----
+4096	4053	4053	4053
+
+query TTTTTT
+SELECT
+	s_h.min::VARCHAR,
+	s_h.max::VARCHAR,
+	s_u.min::VARCHAR,
+	s_u.max::VARCHAR,
+	s_d.min::VARCHAR,
+	s_d.max::VARCHAR
+FROM (SELECT stats(h) s_h, stats(u) s_u, stats(d) s_d FROM append_contiguous_nullable_128bit_numeric LIMIT 1)
+----
+-2047	2047	1	4095	-2047.0000000000	2047.0000000000
+
+query III
+SELECT count(*), count(f), count(*) FILTER (WHERE f IS NULL) FROM append_contiguous_nullable_float_special
+----
+4096	4053	43
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_float_special WHERE f='nan'::FLOAT
+----
+369
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_float_special WHERE f>'inf'::FLOAT
+----
+369
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_float_special WHERE f<'-inf'::FLOAT
+----
+0
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_float_special WHERE f=1.0::FLOAT
+----
+1
+
+query III
+SELECT count(*), count(d), count(*) FILTER (WHERE d IS NULL) FROM append_contiguous_nullable_double_special
+----
+4096	4053	43
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_double_special WHERE d='nan'::DOUBLE
+----
+369
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_double_special WHERE d>'inf'::DOUBLE
+----
+369
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_double_special WHERE d<'-inf'::DOUBLE
+----
+0
+
+query I
+SELECT count(*) FROM append_contiguous_nullable_double_special WHERE d=1.0::DOUBLE
+----
+1
+
+query III
+SELECT count(*), count(i), count(*) FILTER (WHERE i IS NULL) FROM append_contiguous_all_null_integer
+----
+4096	0	4096
+
+query I
+SELECT count(*) FROM (SELECT min(i) AS m FROM append_contiguous_all_null_integer) tbl WHERE m IS NULL
+----
+1
+
+query III
+SELECT count(*), count(f), count(*) FILTER (WHERE f IS NULL) FROM append_contiguous_all_null_float
+----
+4096	0	4096
+
+query I
+SELECT count(*) FROM (SELECT min(f) AS m FROM append_contiguous_all_null_float) tbl WHERE m IS NULL
+----
+1

--- a/test/sql/storage/append_floating_signed_zero_stats.test
+++ b/test/sql/storage/append_floating_signed_zero_stats.test
@@ -1,0 +1,68 @@
+# name: test/sql/storage/append_floating_signed_zero_stats.test
+# description: Signed-zero canonicalization for floating-point append stats
+# group: [storage]
+
+load {TEST_DIR}/append_floating_signed_zero_stats.db
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+# Floating-point append stats canonicalize -0.0 and +0.0 to +0.0. The
+# CHECKPOINT/restart plus stats() query makes the test observe persisted segment
+# statistics rather than the physical row values.
+statement ok
+CREATE TABLE append_contiguous_negative_zero_float(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_negative_zero_float SELECT '-0.0'::FLOAT FROM range(2)
+
+statement ok
+CREATE TABLE append_contiguous_mixed_zero_float(f FLOAT)
+
+statement ok
+INSERT INTO append_contiguous_mixed_zero_float
+SELECT CASE WHEN i = 0 THEN '-0.0'::FLOAT ELSE '0.0'::FLOAT END
+FROM range(2) tbl(i)
+
+statement ok
+CREATE TABLE append_contiguous_negative_zero_double(d DOUBLE)
+
+statement ok
+INSERT INTO append_contiguous_negative_zero_double SELECT '-0.0'::DOUBLE FROM range(2)
+
+statement ok
+CREATE TABLE append_contiguous_mixed_zero_double(d DOUBLE)
+
+statement ok
+INSERT INTO append_contiguous_mixed_zero_double
+SELECT CASE WHEN i = 0 THEN '-0.0'::DOUBLE ELSE '0.0'::DOUBLE END
+FROM range(2) tbl(i)
+
+statement ok
+CHECKPOINT
+
+restart
+
+query TTTT
+SELECT s.min, s.max, signbit(s.min), signbit(s.max)
+FROM (SELECT stats(f) s FROM append_contiguous_negative_zero_float LIMIT 1)
+----
+0.0	0.0	false	false
+
+query TTTT
+SELECT s.min, s.max, signbit(s.min), signbit(s.max)
+FROM (SELECT stats(f) s FROM append_contiguous_mixed_zero_float LIMIT 1)
+----
+0.0	0.0	false	false
+
+query TTTT
+SELECT s.min, s.max, signbit(s.min), signbit(s.max)
+FROM (SELECT stats(d) s FROM append_contiguous_negative_zero_double LIMIT 1)
+----
+0.0	0.0	false	false
+
+query TTTT
+SELECT s.min, s.max, signbit(s.min), signbit(s.max)
+FROM (SELECT stats(d) s FROM append_contiguous_mixed_zero_double LIMIT 1)
+----
+0.0	0.0	false	false


### PR DESCRIPTION
~This builds on https://github.com/duckdb/duckdb/pull/22469~ This no longer builds on that PR.

I was benchmarking the write performance of the Appender API and noticed `appender.AppendDataChunk` wasn't as fast as I would have expected.

For my contiguous append f32 buffer use case, 30%+ of the time was spent in `duckdb::GreaterThan::Operation<float>(float const&, float const&)`. Despite the buffers being contiguous, the zonemap stats creation was not being autovectorised, and the comparison function was not being inlined.

I happened to read https://blobs.duckdb.org/slides/DiDi-04.pdf recently and figured the key normalisation could be applied to the floating point zonemap creation.

This PR adds contiguous buffer fast paths that are autovectorised.

- ~I've extended the benchmarks to cover i32 and f32 with and without nulls (I can add all the primitive types easily if you like?)~ I've added SQL benchmarks for all numeric types.
- The primitive integer fast path is a simple for loop that now triggers the autovectoriser.
- The floating point fast path is inspired by `./src/include/duckdb/common/radix.hpp` and is bit-manipulation heavy. It is ~30% faster than Radix::EncodeFloat in a microbenchmark (both end up being branchless when compiled).
- Nulls are handled via batching within valid runs.
- `./test/sql/storage/append_contiguous_numeric_stats.test` contains SQL tests (it wasn't obvious to me that this exercised the right path - I can write appender based tests if that's more clear?)

The floats are encoded into an order-preserving word, the stats are calculated in the loop, then the min and max are decoded back into floats. I've discarded the +0.0 and -0.0 distinction, as well as the exact bit payload of NaNs since I believe they're essentially unobservable and the NaN-payload-to-NaN-payload sort semantics were undefined.

Enabling LTO did inline the `GreaterThan` calls but didn't replicate these performance gains. Enabling LTO _and_ this PR increases the performance gains.

# Benchmarks

I tested on an M1 Macbook and a Ryzen system, the timings show the baseline per benchmark then with the changes. The benchmarks create `1024*1024` rows of a numeric column but do not flush within the loop.

The benchmarking environment wasn't _pristine_, so the few regressions are hopefully noise.

I've added just the 100k row versions of i32 and f32, all valid and with nulls to the benchmark file. These results are expanded:

<summary>

### M1

<details>


- OS: `Darwin 24.6.0`, `arm64`
- CPU: `Apple M1 Max`, 10 physical, 10 logical cores
- RAM: `64.0 GiB`

## Timings

| Commit   |  Type | Validity   | Samples | Mean ms |        95% CI ms |      Rows/s |    MB/s | Speedup vs previous |
| -------- |  ---- | ---------- | ------: | ------: | ---------------: | ----------: | ------: | ------------------: |
| baseline |  u32  | all valid  |      15 |   4.363 |   [4.215, 4.511] | 240,319,027 |   961.3 |               1.00x |
| baseline |  u32  | with nulls |      15 |   6.820 |   [6.609, 7.031] | 153,748,644 |   615.0 |               1.00x |
| baseline |  u16  | all valid  |      15 |   6.140 |   [6.048, 6.232] | 170,787,122 |   341.6 |               1.00x |
| baseline |  u16  | with nulls |      15 |   7.813 |   [7.581, 8.045] | 134,209,139 |   268.4 |               1.00x |
| baseline |  u8   | all valid  |      15 |   6.387 |   [6.280, 6.493] | 164,178,618 |   164.2 |               1.00x |
| baseline |  u8   | with nulls |      15 |   8.010 |   [7.740, 8.279] | 130,915,992 |   130.9 |               1.00x |
| baseline |  i32  | all valid  |      15 |   4.311 |   [4.170, 4.452] | 243,232,661 |   972.9 |               1.00x |
| baseline |  i32  | with nulls |      15 |   6.394 |   [6.260, 6.528] | 163,995,454 |   656.0 |               1.00x |
| baseline |  i16  | all valid  |      15 |   6.233 |   [6.131, 6.334] | 168,240,542 |   336.5 |               1.00x |
| baseline |  i16  | with nulls |      15 |   7.810 |   [7.694, 7.926] | 134,262,984 |   268.5 |               1.00x |
| baseline |  i8   | all valid  |      15 |   6.479 |   [6.357, 6.601] | 161,840,594 |   161.8 |               1.00x |
| baseline |  i8   | with nulls |      15 |   7.839 |   [7.594, 8.084] | 133,767,413 |   133.8 |               1.00x |
| baseline |  f32  | all valid  |      15 |  17.457 | [15.325, 19.590] |  60,065,761 |   240.3 |               1.00x |
| baseline |  f32  | with nulls |      15 |  18.343 | [17.938, 18.748] |  57,164,082 |   228.7 |               1.00x |
| baseline |  f64  | all valid  |      15 |  18.131 | [17.119, 19.144] |  57,832,474 |   462.7 |               1.00x |
| baseline |  f64  | with nulls |      15 |  18.825 | [18.489, 19.162] |  55,700,065 |   445.6 |               1.00x |
| changes  |  u32  | all valid  |      15 |   3.757 |   [3.629, 3.886] | 279,069,569 | 1,116.3 |               1.16x |
| changes  |  u32  | with nulls |      15 |   5.768 |   [5.649, 5.888] | 181,777,249 |   727.1 |               1.18x |
| changes  |  u16  | all valid  |      15 |   3.773 |   [3.687, 3.860] | 277,886,256 |   555.8 |               1.63x |
| changes  |  u16  | with nulls |      15 |   5.846 |   [5.735, 5.956] | 179,380,724 |   358.8 |               1.34x |
| changes  |  u8   | all valid  |      15 |   3.936 |   [3.897, 3.975] | 266,424,555 |   266.4 |               1.62x |
| changes  |  u8   | with nulls |      15 |   5.430 |   [5.355, 5.505] | 193,105,548 |   193.1 |               1.48x |
| changes  |  i32  | all valid  |      15 |   3.774 |   [3.639, 3.909] | 277,851,894 | 1,111.4 |               1.14x |
| changes  |  i32  | with nulls |      15 |   5.912 |   [5.754, 6.069] | 177,378,007 |   709.5 |               1.08x |
| changes  |  i16  | all valid  |      15 |   5.274 |   [3.694, 6.854] | 198,829,924 |   397.7 |               1.18x |
| changes  |  i16  | with nulls |      15 |   5.839 |   [5.710, 5.967] | 179,593,738 |   359.2 |               1.34x |
| changes  |  i8   | all valid  |      15 |   3.949 |   [3.862, 4.036] | 265,547,433 |   265.5 |               1.64x |
| changes  |  i8   | with nulls |      15 |   5.640 |   [5.484, 5.796] | 185,915,533 |   185.9 |               1.39x |
| changes  |  f32  | all valid  |      15 |   4.041 |   [3.866, 4.216] | 259,467,164 | 1,037.9 |               4.32x |
| changes  |  f32  | with nulls |      15 |   6.671 |   [5.520, 7.822] | 157,184,230 |   628.7 |               2.75x |
| changes  |  f64  | all valid  |      15 |   4.413 |   [4.255, 4.570] | 237,635,825 | 1,901.1 |               4.11x |
| changes  |  f64  | with nulls |      15 |   6.346 |   [6.142, 6.550] | 165,228,956 | 1,321.8 |               2.97x |

`Speedup vs previous` is computed per benchmark. The first commit for each benchmark is `1.00x`.

## Comparisons

| Type | Validity   | Old MB/s | New MB/s | Improvement |
| ---- | ---------- | -------: | -------: | ----------: |
| u32  | all valid  |    961.3 |  1,116.3 |       1.16x |
| u32  | with nulls |    615.0 |    727.1 |       1.18x |
| u16  | all valid  |    341.6 |    555.8 |       1.63x |
| u16  | with nulls |    268.4 |    358.8 |       1.34x |
| u8   | all valid  |    164.2 |    266.4 |       1.62x |
| u8   | with nulls |    130.9 |    193.1 |       1.48x |
| i32  | all valid  |    972.9 |  1,111.4 |       1.14x |
| i32  | with nulls |    656.0 |    709.5 |       1.08x |
| i16  | all valid  |    336.5 |    397.7 |       1.18x |
| i16  | with nulls |    268.5 |    359.2 |       1.34x |
| i8   | all valid  |    161.8 |    265.5 |       1.64x |
| i8   | with nulls |    133.8 |    185.9 |       1.39x |
| f32  | all valid  |    240.3 |  1,037.9 |       4.32x |
| f32  | with nulls |    228.7 |    628.7 |       2.75x |
| f64  | all valid  |    462.7 |  1,901.1 |       4.11x |
| f64  | with nulls |    445.6 |  1,321.8 |       2.97x |

</details>
</summary>

<summary>

### Ryzen

<details>


- OS: `Linux 7.0.2-arch1-1`, `x86_64`
- CPU: `AMD Ryzen AI 7 PRO 350 w/ Radeon 860M`, 8 physical, 16 logical cores
- RAM: `30.5 GiB`

## Timings

| Commit   | Type | Validity   | Samples | Mean ms |        95% CI ms |      Rows/s |    MB/s | Speedup vs previous |
| -------- | ---- | ---------- | ------: | ------: | ---------------: | ----------: | ------: | ------------------: |
| baseline | u32  | all valid  |      15 |   3.630 |   [3.505, 3.756] | 288,858,607 | 1,155.4 |               1.00x |
| baseline | u32  | with nulls |      15 |   4.801 |   [4.742, 4.861] | 218,392,669 |   873.6 |               1.00x |
| baseline | u16  | all valid  |      15 |   5.531 |   [5.145, 5.917] | 189,588,486 |   379.2 |               1.00x |
| baseline | u16  | with nulls |      15 |   6.154 |   [6.078, 6.231] | 170,376,420 |   340.8 |               1.00x |
| baseline | u8   | all valid  |      15 |   5.813 |   [5.434, 6.193] | 180,378,449 |   180.4 |               1.00x |
| baseline | u8   | with nulls |      15 |   6.791 |   [6.511, 7.072] | 154,403,683 |   154.4 |               1.00x |
| baseline | i32  | all valid  |      15 |   3.753 |   [3.502, 4.004] | 279,411,639 | 1,117.6 |               1.00x |
| baseline | i32  | with nulls |      15 |   5.478 |   [5.129, 5.826] | 191,427,493 |   765.7 |               1.00x |
| baseline | i16  | all valid  |      15 |   5.074 |   [4.975, 5.173] | 206,643,106 |   413.3 |               1.00x |
| baseline | i16  | with nulls |      15 |   6.544 |   [6.261, 6.827] | 160,236,351 |   320.5 |               1.00x |
| baseline | i8   | all valid  |      15 |   5.297 |   [5.241, 5.353] | 197,944,123 |   197.9 |               1.00x |
| baseline | i8   | with nulls |      15 |   6.393 |   [6.049, 6.738] | 164,014,265 |   164.0 |               1.00x |
| baseline | f32  | all valid  |      15 |  10.204 |  [9.368, 11.040] | 102,761,270 |   411.0 |               1.00x |
| baseline | f32  | with nulls |      15 |  11.013 | [10.839, 11.188] |  95,209,685 |   380.8 |               1.00x |
| baseline | f64  | all valid  |      15 |   9.850 |  [9.628, 10.072] | 106,453,696 |   851.6 |               1.00x |
| baseline | f64  | with nulls |      15 |  12.216 | [11.682, 12.750] |  85,835,812 |   686.7 |               1.00x |
| changes  | u32  | all valid  |      15 |   3.805 |   [3.556, 4.053] | 275,602,593 | 1,102.4 |               0.95x |
| changes  | u32  | with nulls |      15 |   5.426 |   [5.104, 5.747] | 193,264,524 |   773.1 |               0.88x |
| changes  | u16  | all valid  |      15 |   3.500 |   [3.324, 3.675] | 299,598,850 |   599.2 |               1.58x |
| changes  | u16  | with nulls |      15 |   4.814 |   [4.590, 5.038] | 217,827,080 |   435.7 |               1.28x |
| changes  | u8   | all valid  |      15 |   3.690 |   [3.273, 4.107] | 284,187,475 |   284.2 |               1.58x |
| changes  | u8   | with nulls |      15 |   4.464 |   [4.318, 4.611] | 234,878,519 |   234.9 |               1.52x |
| changes  | i32  | all valid  |      15 |   3.971 |   [3.691, 4.252] | 264,031,828 | 1,056.1 |               0.94x |
| changes  | i32  | with nulls |      15 |   4.802 |   [4.746, 4.858] | 218,353,255 |   873.4 |               1.14x |
| changes  | i16  | all valid  |      15 |   3.328 |   [3.275, 3.381] | 315,114,797 |   630.2 |               1.52x |
| changes  | i16  | with nulls |      15 |   5.273 |   [4.763, 5.784] | 198,839,979 |   397.7 |               1.24x |
| changes  | i8   | all valid  |      15 |   3.557 |   [3.454, 3.660] | 294,803,291 |   294.8 |               1.49x |
| changes  | i8   | with nulls |      15 |   4.835 |   [4.423, 5.247] | 216,874,966 |   216.9 |               1.32x |
| changes  | f32  | all valid  |      15 |   2.859 |   [2.764, 2.954] | 366,771,756 | 1,467.1 |               3.57x |
| changes  | f32  | with nulls |      15 |   4.371 |   [4.334, 4.408] | 239,901,164 |   959.6 |               2.52x |
| changes  | f64  | all valid  |      15 |   3.785 |   [3.714, 3.857] | 277,000,458 | 2,216.0 |               2.60x |
| changes  | f64  | with nulls |      15 |   5.838 |   [5.645, 6.030] | 179,624,503 | 1,437.0 |               2.09x |

`Speedup vs previous` is computed per benchmark. The first commit for each benchmark is `1.00x`.

## Comparisons

 | Type | Validity   | Old MB/s | New MB/s | Improvement |
 | ---- | ---------- | -------: | -------: | ----------: |
 | u32  | all valid  |  1,155.4 |  1,102.4 |       0.95x |
 | u32  | with nulls |    873.6 |    773.1 |       0.88x |
 | u16  | all valid  |    379.2 |    599.2 |       1.58x |
 | u16  | with nulls |    340.8 |    435.7 |       1.28x |
 | u8   | all valid  |    180.4 |    284.2 |       1.58x |
 | u8   | with nulls |    154.4 |    234.9 |       1.52x |
 | i32  | all valid  |  1,117.6 |  1,056.1 |       0.94x |
 | i32  | with nulls |    765.7 |    873.4 |       1.14x |
 | i16  | all valid  |    413.3 |    630.2 |       1.52x |
 | i16  | with nulls |    320.5 |    397.7 |       1.24x |
 | i8   | all valid  |    197.9 |    294.8 |       1.49x |
 | i8   | with nulls |    164.0 |    216.9 |       1.32x |
 | f32  | all valid  |    411.0 |  1,467.1 |       3.57x |
 | f32  | with nulls |    380.8 |    959.6 |       2.52x |
 | f64  | all valid  |    851.6 |  2,216.0 |       2.60x |
 | f64  | with nulls |    686.7 |  1,437.0 |       2.09x |

</details>
</summary>

My application-end benchmark (using [@duckdb/node-neo](https://github.com/duckdb/duckdb-node-neo), baseline v1.5.2-r.1) improved end-to-end with these two PRs (tested on the M1 Macbook):

| type |    size | baseline (MiB/s) | candidate (MiB/s) | candidate vs baseline improvement | candidate outcome |
| ---: | ------: | ---------------: | -------------------: | ---------------------------: | :------------------- |
|  f32 | 1048576 |           230.62 |              801.234 |                      3.47x | improved             |
|  i32 | 1048576 |          382.572 |              716.391 |                      1.87x | improved             |
|  u16 | 1048576 |          310.239 |              658.197 |                      2.12x | improved             |
|   u8 | 1048576 |           304.93 |              627.586 |                      2.05x | improved             |

