### PR TITLE
Remove unused ccache and fix julia CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -261,10 +261,6 @@ jobs:
             echo "static_libs_linux_matrix=$static_libs_linux_matrix"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: ./.github/actions/ccache-action
-        with:
-          save: ${{ fromJson(steps.config.outputs.save_cache) }}
-
       - name: Install tools
         timeout-minutes: 10
         run: python3 scripts/ci/retry.py -- make -j4 format_tools

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -122,6 +122,11 @@ jobs:
             tests_slow:
               - test/**/*.cpp
               - test/**/*.test_slow
+            capi:
+              - src/include/duckdb.h
+              - src/common/types.cpp
+              - src/include/duckdb/common/types.hpp
+              - src/function/table/system/test_all_types.cpp
             julia:
               - tools/juliapkg/**
 

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -110,7 +110,7 @@ def enabled_jobs(selection_input: JobSelectionInput) -> list[str]:
     if selection_input.skip_tests:
         selected_jobs = [job for job in selected_jobs if job not in SKIP_TESTS_JOBS]
 
-    if "julia" in selection_input.changed_keys:
+    if "julia" in selection_input.changed_keys or "capi" in selection_input.changed_keys:
         selected_jobs.append("main_julia")
 
     if selection_input.event_name in {"workflow_dispatch", "repository_dispatch"}:

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -195,6 +195,7 @@ const duckdb_cast_mode = DUCKDB_CAST_MODE_
     DUCKDB_TYPE_INTEGER_LITERAL = 38
     DUCKDB_TYPE_TIME_NS = 39
     DUCKDB_TYPE_GEOMETRY = 40
+    DUCKDB_TYPE_TIMESTAMP_TZ_NS = 42
 end
 const DUCKDB_TYPE = DUCKDB_TYPE_
 
@@ -361,6 +362,7 @@ INTERNAL_TYPE_MAP = Dict(
     DUCKDB_TYPE_TIMESTAMP_MS => duckdb_timestamp_ms,
     DUCKDB_TYPE_TIMESTAMP_NS => duckdb_timestamp_ns,
     DUCKDB_TYPE_TIMESTAMP_TZ => duckdb_timestamp,
+    DUCKDB_TYPE_TIMESTAMP_TZ_NS => duckdb_timestamp_ns,
     DUCKDB_TYPE_DATE => duckdb_date,
     DUCKDB_TYPE_TIME => duckdb_time,
     DUCKDB_TYPE_TIME_TZ => duckdb_time_tz,
@@ -400,6 +402,7 @@ JULIA_TYPE_MAP = Dict(
     DUCKDB_TYPE_TIME_TZ => Time,
     DUCKDB_TYPE_TIMESTAMP => DateTime,
     DUCKDB_TYPE_TIMESTAMP_TZ => DateTime,
+    DUCKDB_TYPE_TIMESTAMP_TZ_NS => DateTime,
     DUCKDB_TYPE_TIMESTAMP_S => DateTime,
     DUCKDB_TYPE_TIMESTAMP_MS => DateTime,
     DUCKDB_TYPE_TIMESTAMP_NS => DateTime,

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -543,6 +543,8 @@ function get_conversion_function(logical_type::LogicalType)::Function
         return convert_timestamp_ms
     elseif type == DUCKDB_TYPE_TIMESTAMP_NS
         return convert_timestamp_ns
+    elseif type == DUCKDB_TYPE_TIMESTAMP_TZ_NS
+        return convert_timestamp_ns
     elseif type == DUCKDB_TYPE_INTERVAL
         return convert_interval
     elseif type == DUCKDB_TYPE_HUGEINT


### PR DESCRIPTION
- Remove unused `ccache` action from job `prepare`.
- Add [missing](https://github.com/duckdb/duckdb/actions/runs/25352299682/job/74335946735) `DUCKDB_TYPE_TIMESTAMP_TZ_NS` to julia.
- Run julia CI jobs for PR when C types can change (to prevent future breakage).