### PR TITLE
Fix enable_logging() silently resetting logging_storage

### DIFF
--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -87,6 +87,12 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 		result->config.storage = LogConfig::FILE_STORAGE_NAME;
 	}
 
+	// If the user did not specify a storage, preserve the currently configured one. Otherwise the
+	// default LogConfig would silently reset logging_storage back to 'memory'.
+	if (!storage_isset && !storage_path_isset) {
+		result->config.storage = context.db->GetLogManager().GetConfig().storage;
+	}
+
 	// Process positional params
 	if (!input.inputs.empty()) {
 		if (input.inputs[0].type() == LogicalType::VARCHAR) {

--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -53,7 +53,6 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 	auto result = make_uniq<EnableLoggingBindData>();
 
 	bool storage_isset = false;
-	bool storage_path_isset = false;
 
 	for (const auto &param : input.named_parameters) {
 		auto key = StringUtil::Lower(param.first);
@@ -71,7 +70,6 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 				result->storage_config[StructType::GetChildName(param.second.type(), i)] = children[i];
 			}
 		} else if (key == "storage_path") {
-			storage_path_isset = true;
 			result->storage_config["path"] = param.second;
 		} else if (key == "storage_normalize") {
 			result->storage_config["normalize"] = param.second;
@@ -82,15 +80,15 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 		}
 	}
 
-	// This will implicitly set the log storage if the storage_path param is set and the storage is omitted
-	if (!storage_isset && storage_path_isset) {
-		result->config.storage = LogConfig::FILE_STORAGE_NAME;
-	}
-
-	// If the user did not specify a storage, preserve the currently configured one. Otherwise the
-	// default LogConfig would silently reset logging_storage back to 'memory'.
-	if (!storage_isset && !storage_path_isset) {
-		result->config.storage = context.db->GetLogManager().GetConfig().storage;
+	// If the user didn't explicitly set storage=, infer it. A 'path' in storage_config (provided
+	// either via storage_path= or storage_config={path:...}) implies file storage. Otherwise
+	// preserve the currently configured storage so logging_storage isn't silently reset.
+	if (!storage_isset) {
+		if (result->storage_config.find("path") != result->storage_config.end()) {
+			result->config.storage = LogConfig::FILE_STORAGE_NAME;
+		} else {
+			result->config.storage = context.db->GetLogManager().GetConfig().storage;
+		}
 	}
 
 	// Process positional params

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -84,8 +84,7 @@ void LogStorage::Truncate() {
 
 void LogStorage::UpdateConfig(DatabaseInstance &db, case_insensitive_map_t<Value> &config) {
 	if (!config.empty()) {
-		throw InvalidInputException("Log storage '%s' does not support passing configuration",
-		                            GetStorageName());
+		throw InvalidInputException("Log storage '%s' does not support passing configuration", GetStorageName());
 	}
 }
 

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -83,8 +83,9 @@ void LogStorage::Truncate() {
 }
 
 void LogStorage::UpdateConfig(DatabaseInstance &db, case_insensitive_map_t<Value> &config) {
-	if (config.size() > 1) {
-		throw InvalidInputException("LogStorage does not support passing configuration");
+	if (!config.empty()) {
+		throw InvalidInputException("Log storage '%s' does not support passing configuration",
+		                            GetStorageName());
 	}
 }
 

--- a/test/sql/logging/logging_call_functions.test
+++ b/test/sql/logging/logging_call_functions.test
@@ -279,3 +279,25 @@ CALL disable_logging()
 statement ok
 RESET logging_storage
 
+# storage_config={path:...} without an explicit storage= must auto-promote to file storage
+# (mirroring the storage_path= sugar) — not silently apply a file-only config to the current storage.
+statement ok
+CALL enable_logging(storage_config:={path:'__TEST_DIR__/auto_promote.csv'})
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+file
+
+statement ok
+CALL disable_logging()
+
+statement ok
+RESET logging_storage
+
+# storage_config keys that no storage recognises must error, not silently pass.
+statement error
+CALL enable_logging(storage_config:={aaaargh:'blaargh'})
+----
+Unrecognized log storage config option
+

--- a/test/sql/logging/logging_call_functions.test
+++ b/test/sql/logging/logging_call_functions.test
@@ -154,9 +154,10 @@ logging_level	INFO
 logging_mode	LEVEL_ONLY
 logging_storage	file
 
-# Reset
+# Reset — explicitly pass storage='memory' since enable_logging() with no args now preserves
+# the previous logging_storage instead of silently resetting it.
 statement ok
-CALL enable_logging()
+CALL enable_logging(storage='memory')
 
 #### 
 # Some invalid invocations throw nice errors
@@ -220,4 +221,68 @@ enabled_log_types	(empty)
 logging_level	INFO
 logging_mode	LEVEL_ONLY
 logging_storage	memory
+
+####
+# Regression: CALL enable_logging() must not silently reset logging_storage.
+# Previously, calling enable_logging() with no storage= / storage_path= argument
+# would reset logging_storage back to 'memory' even if the user had set it
+# explicitly via SET logging_storage=... or a previous CALL enable_logging(storage=...).
+###
+
+statement ok
+CALL disable_logging()
+
+statement ok
+SET logging_storage='stdout'
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+stdout
+
+# enable_logging() with no args must preserve the user's previous storage choice
+statement ok
+CALL enable_logging()
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+stdout
+
+# Explicitly passing storage= still works and overrides the current setting
+statement ok
+CALL enable_logging(storage='memory')
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+statement ok
+RESET logging_storage
+
+# Same regression with file storage: storage configured via a prior enable_logging(storage='file', ...)
+# must survive a subsequent no-arg enable_logging() call.
+statement ok
+CALL disable_logging()
+
+statement ok
+CALL enable_logging(storage='file', storage_path='__TEST_DIR__/preserve_storage.log')
+
+statement ok
+CALL disable_logging()
+
+statement ok
+CALL enable_logging()
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+file
+
+statement ok
+CALL disable_logging()
+
+statement ok
+RESET logging_storage
 

--- a/test/sql/logging/logging_call_functions.test
+++ b/test/sql/logging/logging_call_functions.test
@@ -154,8 +154,6 @@ logging_level	INFO
 logging_mode	LEVEL_ONLY
 logging_storage	file
 
-# Reset — explicitly pass storage='memory' since enable_logging() with no args now preserves
-# the previous logging_storage instead of silently resetting it.
 statement ok
 CALL enable_logging(storage='memory')
 
@@ -222,12 +220,7 @@ logging_level	INFO
 logging_mode	LEVEL_ONLY
 logging_storage	memory
 
-####
 # Regression: CALL enable_logging() must not silently reset logging_storage.
-# Previously, calling enable_logging() with no storage= / storage_path= argument
-# would reset logging_storage back to 'memory' even if the user had set it
-# explicitly via SET logging_storage=... or a previous CALL enable_logging(storage=...).
-###
 
 statement ok
 CALL disable_logging()


### PR DESCRIPTION
When doing:

```sql
SET logging_storage = stdout;
CALL enable_logging('QueryLog');
```

The setting was silently overriden by the `enable_logging` function, even if the args for `storage_path` and/or `storage`  were not set. 

