### PR TITLE
Fix jemalloc not overriding allocator by pushing extension defines earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,11 @@ endfunction()
 # this depends on disable_target_warnings so the order matters
 include(${PROJECT_SOURCE_DIR}/extension/extension_build_tools.cmake)
 
+# Must run before add_subdirectory(src) / add_subdirectory(extension) so that DUCKDB_EXTENSION_<NAME>_LINKED is defined
+# for the core files. Important for e.g. DUCKDB_EXTENSION_JEMALLOC_LINKED otherwise allocator.cpp falls back to glibc
+# malloc for all targets, including extensions.
+add_extension_definitions()
+
 if(PREBUILT_BINARY)
   message("Using pre-built static library from file ${PREBUILT_BINARY}")
   add_library(duckdb_static STATIC IMPORTED GLOBAL)

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -18,8 +18,6 @@ install(
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
-add_extension_definitions()
-
 configure_file(
   generated_extension_headers.hpp.in
   "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp.cand")


### PR DESCRIPTION
This fixes a regression introduced by [#19369](https://github.com/duckdb/duckdb/pull/19369) which changed how extensions are linked into DuckDB by making them rely on the static library build of core duckdb. The problem is that DuckDB core itself conditionally checks if `DUCKDB_EXTENSION_JEMALLOC_LINKED` is defined and if so overrides the allocator, but this no longer triggers when building core DuckDB as the define is instantiated much later in the build when extensions are built.

This PR fixes this by invoking `add_extension_definitions()` earlier in the build process.

That said, having this sort of two-way-reverse-dependency is probably not a good idea (even if jemalloc is a bit of a special extension). It kind of defeats the whole purpose of being able to build `libduckdb_static.a` separately and then link-in extensions lazily as the base archive can now change based on what extensions are added. There should be some other way for jemalloc to inject a custom allocator besides having core `#ifdef` it.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/8845