### PR TITLE
Temporary disable Windows ARM64 on CI

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -53,7 +53,7 @@ on:
         description: 'Semicolon-separated list of architectures to opt into'
         type: string
         required: false
-        default: 'windows_arm64;'
+        default: ''
       skip_tests:
         description: 'Set to true to skip all testing'
         type: boolean

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -450,7 +450,7 @@ jobs:
       extra_exclude_archs: ${{ needs.prepare.outputs.extensions_extra_exclude_archs }}
       skip_tests: ${{ fromJson(needs.prepare.outputs.skip_tests) }}
       run_all: ${{ github.event_name != 'workflow_dispatch' || inputs.run_all }}
-      opt_in_archs: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && 'windows_arm64;linux_amd64_musl;linux_arm64_musl' || '' }}
+      opt_in_archs: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && 'linux_amd64_musl;linux_arm64_musl' || '' }}
       runners: ${{ needs.prepare.outputs.runners }}
       save_cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 


### PR DESCRIPTION
There was a report (in Discord) about build failures on `windows_arm64` due to the roll out of the Visual Studio 2026 on the `windows-11-arm` image.

This PR temporary removes the `windows_arm64` from `opt_in_archs` to allow builds to pass while the problem is being investigated.