### PR TITLE
Make vector / chunk verification togglable with `debug_verification_mode` setting, instead of enabling in debug mode

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1384,6 +1384,18 @@ jobs:
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/disable_optimizer.json ./build/release/test/unittest
 
+    - name: test/configs/internal_vector_serialization.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/internal_vector_serialization.json ./build/release/test/unittest
+
+    - name: test/configs/internal_vector_verification.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/internal_vector_verification.json ./build/release/test/unittest
+
     - name: test/configs/force_external.json
       if: success() || failure()
       shell: bash

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -336,7 +336,7 @@ void HistogramBinFinalizeFunction(Vector &state_vector, AggregateInputData &, Ve
 	}
 	D_ASSERT(current_offset == old_len + new_entries);
 	ListVector::SetListSize(result, current_offset);
-	result.Verify(count);
+	result.Verify();
 }
 
 template <class OP, class T, class HIST>

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -245,7 +245,7 @@ void ExecuteSlice(Vector &result, Vector &list_or_str_vector, Vector &begin_vect
 	ExecuteFlatSlice<INPUT_TYPE, INDEX_TYPE, OP>(result, list_or_str_vector, begin_vector, end_vector, step_vector,
 	                                             count, sel, sel_idx, result_child_vector, begin_is_empty,
 	                                             end_is_empty);
-	result.Verify(count);
+	result.Verify();
 }
 
 void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -173,7 +173,7 @@ struct DistinctFunctor {
 		}
 		D_ASSERT(current_offset == old_len + new_entries);
 		ListVector::SetListSize(result, current_offset);
-		result.Verify(count);
+		result.Verify();
 	}
 };
 
@@ -194,7 +194,7 @@ struct UniqueFunctor {
 			}
 			result_data.WriteValue(state->hist->size());
 		}
-		result.Verify(count);
+		result.Verify();
 	}
 };
 

--- a/extension/core_functions/scalar/list/range.cpp
+++ b/extension/core_functions/scalar/list/range.cpp
@@ -194,15 +194,7 @@ void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
 
 	RangeInfoStruct<OP, INCLUSIVE_BOUND> info(args);
-	idx_t args_size = 1;
-	auto result_type = VectorType::CONSTANT_VECTOR;
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			args_size = args.size();
-			result_type = VectorType::FLAT_VECTOR;
-			break;
-		}
-	}
+	auto args_size = args.size();
 	auto list_writer = FlatVector::Writer<VectorListType<typename OP::TYPE>>(result, args_size);
 	for (idx_t i = 0; i < args_size; i++) {
 		if (!info.RowIsValid(i)) {
@@ -223,10 +215,6 @@ void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) 
 			seen_value = true;
 		}
 	}
-
-	result.SetVectorType(result_type);
-
-	result.Verify(args.size());
 }
 
 } // namespace

--- a/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -13,7 +13,7 @@ namespace duckdb {
 
 static void StructInsertFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &starting_vec = args.data[0];
-	starting_vec.Verify(args.size());
+	starting_vec.Verify();
 
 	auto &starting_child_entries = StructVector::GetEntries(starting_vec);
 	auto &result_child_entries = StructVector::GetEntries(result);

--- a/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/extension/core_functions/scalar/struct/struct_update.cpp
@@ -13,7 +13,7 @@ namespace duckdb {
 
 static void StructUpdateFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &starting_vec = args.data[0];
-	starting_vec.Verify(args.size());
+	starting_vec.Verify();
 
 	auto &starting_child_entries = StructVector::GetEntries(starting_vec);
 	auto &result_child_entries = StructVector::GetEntries(result);

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -127,7 +127,7 @@ idx_t ListColumnReader::ReadInternal(ColumnReaderInput &input, optional_ptr<Vect
 			// no more elements available: we are done
 			break;
 		}
-		read_vector.Verify(child_actual_num_values);
+		read_vector.Verify();
 		idx_t current_chunk_offset = OP::GetOffset(result_out);
 
 		// hard-won piece of code this, modify at your own risk
@@ -175,7 +175,7 @@ idx_t ListColumnReader::ReadInternal(ColumnReaderInput &input, optional_ptr<Vect
 		if (child_idx < child_actual_num_values && result_offset == num_values) {
 			read_vector.Slice(read_vector, child_idx, child_actual_num_values);
 			overflow_child_count = child_actual_num_values - child_idx;
-			read_vector.Verify(overflow_child_count);
+			read_vector.Verify();
 
 			// move values in the child repeats and defines *backward* by child_idx
 			for (idx_t repdef_idx = 0; repdef_idx < overflow_child_count; repdef_idx++) {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -30,6 +30,7 @@
 #include "duckdb/common/enums/debug_initialize.hpp"
 #include "duckdb/common/enums/debug_statement_verification.hpp"
 #include "duckdb/common/enums/debug_vector_verification.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
 #include "duckdb/common/enums/deprecated_using_key_syntax.hpp"
 #include "duckdb/common/enums/destroy_buffer_upon.hpp"
 #include "duckdb/common/enums/explain_format.hpp"
@@ -1589,6 +1590,26 @@ const char* EnumUtil::ToChars<DebugVectorVerification>(DebugVectorVerification v
 template<>
 DebugVectorVerification EnumUtil::FromString<DebugVectorVerification>(const char *value) {
 	return static_cast<DebugVectorVerification>(StringUtil::StringToEnum(GetDebugVectorVerificationValues(), 7, "DebugVectorVerification", value));
+}
+
+const StringUtil::EnumStringLiteral *GetDebugVerificationModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(DebugVerificationMode::DEFAULT), "DEFAULT" },
+		{ static_cast<uint32_t>(DebugVerificationMode::NONE), "NONE" },
+		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_VECTORS), "VERIFY_VECTORS" },
+		{ static_cast<uint32_t>(DebugVerificationMode::VERIFY_SERIALIZATION), "VERIFY_SERIALIZATION" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<DebugVerificationMode>(DebugVerificationMode value) {
+	return StringUtil::EnumToString(GetDebugVerificationModeValues(), 4, "DebugVerificationMode", static_cast<uint32_t>(value));
+}
+
+template<>
+DebugVerificationMode EnumUtil::FromString<DebugVerificationMode>(const char *value) {
+	return static_cast<DebugVerificationMode>(StringUtil::StringToEnum(GetDebugVerificationModeValues(), 4, "DebugVerificationMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetDecimalBitWidthValues() {

--- a/src/common/row_operations/row_matcher.cpp
+++ b/src/common/row_operations/row_matcher.cpp
@@ -221,7 +221,7 @@ static idx_t GenericNestedMatch(Vector &lhs_vector, const TupleDataVectorFormat 
 	const auto gather_function = TupleDataCollection::GetGatherFunction(type);
 	gather_function.Gather(rhs_layout, rhs_row_locations, col_idx, sel, count, key,
 	                       *FlatVector::IncrementalSelectionVector(), nullptr);
-	key.Verify(count);
+	key.Verify();
 
 	// Densify the input column
 	Vector sliced(lhs_vector, sel, count);

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -332,6 +332,13 @@
         "default_value": "false"
     },
     {
+        "name": "debug_verification_mode",
+        "description": "DEBUG SETTING: toggle the verification mode.",
+        "type": "VARCHAR",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "debug_verify_blocks",
         "description": "DEBUG SETTING: verify block metadata during checkpointing",
         "type": "BOOLEAN",

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -1154,7 +1154,7 @@ void ColumnDataCollection::ScanAtIndex(ColumnDataParallelScanState &state, Colum
 	lstate.current_chunk_state.properties = state.scan_state.properties;
 	segment.ReadChunk(chunk_index, lstate.current_chunk_state, result, state.scan_state.column_ids);
 	lstate.current_row_index = row_index;
-	result.Verify();
+	result.Verify(state.scan_state.db);
 }
 
 bool ColumnDataCollection::Scan(ColumnDataScanState &state, DataChunk &result) const {
@@ -1175,7 +1175,7 @@ bool ColumnDataCollection::Scan(ColumnDataScanState &state, DataChunk &result) c
 	auto &segment = *segments[segment_index];
 	state.current_chunk_state.properties = state.properties;
 	segment.ReadChunk(chunk_index, state.current_chunk_state, result, state.column_ids);
-	result.Verify();
+	result.Verify(state.db);
 	return true;
 }
 
@@ -1207,7 +1207,7 @@ bool ColumnDataCollection::Seek(idx_t seek_idx, ColumnDataScanState &state, Data
 	auto &segment = *segments[segment_index];
 	state.current_chunk_state.properties = state.properties;
 	segment.ReadChunk(chunk_index, state.current_chunk_state, result, state.column_ids);
-	result.Verify();
+	result.Verify(state.db);
 	return true;
 }
 

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -389,7 +389,7 @@ void DataChunk::Verify(shared_ptr<DatabaseInstance> &db) {
 	if (db) {
 		Verify(*db);
 	} else {
-		Verify(DebugVerificationMode::DEFAULT);
+		Verify();
 	}
 }
 
@@ -397,7 +397,7 @@ void DataChunk::Verify(optional_ptr<ClientContext> context) {
 	if (context) {
 		Verify(*context);
 	} else {
-		Verify(DebugVerificationMode::DEFAULT);
+		Verify();
 	}
 }
 
@@ -405,8 +405,8 @@ void DataChunk::Verify(DatabaseInstance &database_instance) {
 	VerifyInternal(DebugVerificationMode::DEFAULT, database_instance);
 }
 
-void DataChunk::Verify(DebugVerificationMode mode) {
-	VerifyInternal(mode, nullptr);
+void DataChunk::Verify() {
+	VerifyInternal(DebugVerificationMode::DEFAULT, nullptr);
 }
 
 void DataChunk::VerifyInternal(DebugVerificationMode mode, optional_ptr<DatabaseInstance> db) {

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/types/sel_cache.hpp"
 #include "duckdb/common/types/vector_cache.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/execution_context.hpp"
 
@@ -17,6 +18,8 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -378,65 +381,102 @@ void DataChunk::Hash(vector<idx_t> &column_ids, Vector &result) {
 	}
 }
 
-void DataChunk::Verify(optional_ptr<DatabaseInstance> database_instance) {
-	for (idx_t i = 0; i < ColumnCount(); i++) {
-		if (data[i].size() != size()) {
-			throw InternalException(
-			    "DataChunk::Verify - size mismatch: vector %d (%s) has size %d but chunk has size %d", i,
-			    data[i].GetType().ToString(), data[i].size(), size());
-		}
-	}
-#ifdef DEBUG
-	// verify that all vectors in this chunk have the chunk selection vector
-	for (idx_t i = 0; i < ColumnCount(); i++) {
-		data[i].Verify();
-	}
+void DataChunk::Verify(ClientContext &context) {
+	Verify(DatabaseInstance::GetDatabase(context));
+}
 
-	if (!ColumnCount()) {
-		// don't try to round-trip dummy data chunks with no data
-		// e.g., these exist in queries like 'SELECT distinct(col0, col1) FROM tbl', where we have groups, but no
-		// payload so the payload will be such an empty data chunk
+void DataChunk::Verify(shared_ptr<DatabaseInstance> &db) {
+	if (db) {
+		Verify(*db);
+	} else {
+		Verify(DebugVerificationMode::DEFAULT);
+	}
+}
+
+void DataChunk::Verify(optional_ptr<ClientContext> context) {
+	if (context) {
+		Verify(*context);
+	} else {
+		Verify(DebugVerificationMode::DEFAULT);
+	}
+}
+
+void DataChunk::Verify(DatabaseInstance &database_instance) {
+	VerifyInternal(DebugVerificationMode::DEFAULT, database_instance);
+}
+
+void DataChunk::Verify(DebugVerificationMode mode) {
+	VerifyInternal(mode, nullptr);
+}
+
+void DataChunk::VerifyInternal(DebugVerificationMode mode, optional_ptr<DatabaseInstance> db) {
+	if (mode == DebugVerificationMode::DEFAULT) {
+		mode = DBConfigOptions::global_verification_mode;
+	}
+	if (mode == DebugVerificationMode::NONE) {
 		return;
 	}
-
-	// verify that we can round-trip chunk serialization
-	Allocator allocator;
-	MemoryStream mem_stream(allocator);
-
-	// this is the way we can ensure that the `Serialize` and `Deserialize` methods of a `DataChunk` are consistent with
-	// each other within the current and previous versions of the code.
-	// This is an internal round-trip sanity check performed in memory. It does not write to a
-	// persistent database file. Therefore, when a version is not indicated (latest),
-	// it should always use the full set of capabilities currently supported by the engine to ensure that all
-	// valid in-memory states can be verified.
-
-	SerializationOptions options;
-	options.serialization_compatibility = SerializationCompatibility::Latest();
-
-	if (database_instance) {
-		DBConfig &config = DBConfig::GetConfig(*database_instance);
-		if (config.options.serialization_compatibility.manually_set) {
-			options.serialization_compatibility = config.options.serialization_compatibility;
+	if (mode == DebugVerificationMode::VERIFY_VECTORS) {
+		// verify all vectors have the same size as the chunk
+		for (idx_t i = 0; i < ColumnCount(); i++) {
+			if (data[i].size() != size()) {
+				throw InternalException(
+				    "DataChunk::Verify - size mismatch: vector %d (%s) has size %d but chunk has size %d", i,
+				    data[i].GetType().ToString(), data[i].size(), size());
+			}
+		}
+		// verify internal consistency of the chunk
+		for (idx_t i = 0; i < ColumnCount(); i++) {
+			data[i].Verify();
 		}
 	}
+	if (mode == DebugVerificationMode::VERIFY_SERIALIZATION) {
+		if (!ColumnCount()) {
+			// don't try to round-trip dummy data chunks with no data
+			// e.g., these exist in queries like 'SELECT distinct(col0, col1) FROM tbl', where we have groups, but no
+			// payload so the payload will be such an empty data chunk
+			return;
+		}
 
-	BinarySerializer serializer(mem_stream, options);
+		// verify that we can round-trip chunk serialization
+		Allocator allocator;
+		MemoryStream mem_stream(allocator);
 
-	serializer.Begin();
-	Serialize(serializer);
-	serializer.End();
+		// this is the way we can ensure that the `Serialize` and `Deserialize` methods of a `DataChunk` are consistent
+		// with each other within the current and previous versions of the code. This is an internal round-trip sanity
+		// check performed in memory. It does not write to a persistent database file. Therefore, when a version is not
+		// indicated (latest), it should always use the full set of capabilities currently supported by the engine to
+		// ensure that all valid in-memory states can be verified.
 
-	mem_stream.Rewind();
+		SerializationOptions options;
+		options.serialization_compatibility = SerializationCompatibility::Latest();
 
-	BinaryDeserializer deserializer(mem_stream);
-	DataChunk new_chunk;
+		if (db) {
+			DBConfig &config = DBConfig::GetConfig(*db);
+			if (config.options.serialization_compatibility.manually_set) {
+				options.serialization_compatibility = config.options.serialization_compatibility;
+			}
+		}
 
-	deserializer.Begin();
-	new_chunk.Deserialize(deserializer);
-	deserializer.End();
+		BinarySerializer serializer(mem_stream, options);
 
-	D_ASSERT(size() == new_chunk.size());
-#endif
+		serializer.Begin();
+		Serialize(serializer);
+		serializer.End();
+
+		mem_stream.Rewind();
+
+		BinaryDeserializer deserializer(mem_stream);
+		DataChunk new_chunk;
+
+		deserializer.Begin();
+		new_chunk.Deserialize(deserializer);
+		deserializer.End();
+
+		if (size() != new_chunk.size()) {
+			throw InternalException("Data Chunk Verification: Serialization size mismatch");
+		}
+	}
 }
 
 void DataChunk::Print() const {

--- a/src/common/types/string_type.cpp
+++ b/src/common/types/string_type.cpp
@@ -11,9 +11,12 @@ constexpr idx_t string_t::INLINE_LENGTH;
 
 void string_t::Verify() const {
 #ifdef DEBUG
-	VerifyUTF8();
+	ForceVerify();
 #endif
+}
 
+void string_t::ForceVerify() const {
+	VerifyUTF8();
 	VerifyCharacters();
 }
 
@@ -23,8 +26,9 @@ void string_t::VerifyUTF8() const {
 	D_ASSERT(dataptr);
 
 	auto utf_type = Utf8Proc::Analyze(dataptr, GetSize());
-	(void)utf_type;
-	D_ASSERT(utf_type != UnicodeType::INVALID);
+	if (utf_type == UnicodeType::INVALID) {
+		throw InternalException("Invalid UTF8 found in string - %s", string(dataptr, GetSize()));
+	}
 }
 
 void string_t::VerifyCharacters() const {
@@ -34,11 +38,17 @@ void string_t::VerifyCharacters() const {
 
 	// verify that the prefix contains the first four characters of the string
 	for (idx_t i = 0; i < MinValue<idx_t>(PREFIX_LENGTH, GetSize()); i++) {
-		D_ASSERT(GetPrefix()[i] == dataptr[i]);
+		if (GetPrefix()[i] != dataptr[i]) {
+			throw InternalException("Internal string inconsistency - string_t prefix did not match actual string "
+			                        "prefix.\nThis could mean a missing string_t::Finalize() call.");
+		}
 	}
 	// verify that for strings with length <= INLINE_LENGTH, the rest of the string is zero
 	for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
-		D_ASSERT(GetData()[i] == '\0');
+		if (GetData()[i] != '\0') {
+			throw InternalException("Internal string inconsistency - string_t data did not contain padding "
+			                        "zero's\nThis could mean a missing string_t::Finalize() call.");
+		}
 	}
 }
 

--- a/src/common/types/variant/variant_value.cpp
+++ b/src/common/types/variant/variant_value.cpp
@@ -765,7 +765,7 @@ void VariantValue::ToVARIANT(vector<VariantValue> &input, Vector &result) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 	FlatVector::SetSize(result, count);
-	result.Verify(count);
+	result.Verify();
 }
 
 yyjson_mut_val *VariantValue::ToJSON(ClientContext &context, yyjson_mut_doc *doc) const {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -843,7 +843,14 @@ void Vector::SetVectorType(VectorType new_vector_type) {
 	}
 }
 
+void Vector::Verify(idx_t) const {
+	Verify();
+}
+
 void Vector::Verify() const {
+	if (DBConfigOptions::global_verification_mode != DebugVerificationMode::VERIFY_VECTORS) {
+		return;
+	}
 	if (!buffer) {
 		return;
 	}
@@ -851,14 +858,13 @@ void Vector::Verify() const {
 }
 
 void Vector::Verify(const SelectionVector &sel, idx_t count) const {
+	if (DBConfigOptions::global_verification_mode != DebugVerificationMode::VERIFY_VECTORS) {
+		return;
+	}
 	if (!buffer) {
 		return;
 	}
 	buffer->Verify(GetType(), sel, count);
-}
-
-void Vector::Verify(idx_t count) const {
-	Verify();
 }
 
 void Vector::DebugTransformToDictionary(Vector &vector, idx_t count) {
@@ -899,7 +905,7 @@ void Vector::DebugTransformToDictionary(Vector &vector, idx_t count) {
 	} else {
 		vector.Dictionary(reusable_dict, original_sel, count);
 	}
-	vector.Verify(count);
+	vector.Verify();
 }
 
 void Vector::DebugShuffleNestedVector(Vector &vector, idx_t count) {

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -101,10 +101,15 @@ void VectorBuffer::Verify(const LogicalType &type, const SelectionVector &sel, i
 void VectorBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	if (sel.IsSet()) {
 		for (idx_t i = 0; i < Size(); i++) {
-			D_ASSERT(sel.get_index(i) < Size());
+			if (sel.get_index(i) >= Size()) {
+				throw InternalException("Selection vector entry %d out of range for vector of size %d",
+				                        sel.get_index(i), Size());
+			}
 		}
 	} else {
-		D_ASSERT(count <= Size());
+		if (count > Size()) {
+			throw InternalException("Count %d out of range for vector of size %d", count, Size());
+		}
 	}
 }
 

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -42,7 +42,10 @@ idx_t DictionaryBuffer::GetAllocationSize() const {
 void DictionaryBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(vector_type == VectorType::DICTIONARY_VECTOR);
 	auto &child = GetEntry().data;
-	D_ASSERT(type == child.GetType());
+	if (type != child.GetType()) {
+		throw InternalException("Dictionary expression type mismatch - type %s does not match child type %s", type,
+		                        child.GetType());
+	}
 	if (!sel.IsSet()) {
 		// sel is not set - directly pass in the dictionary
 		child.Verify(sel_vector, count);

--- a/src/common/vector/flat_vector.cpp
+++ b/src/common/vector/flat_vector.cpp
@@ -52,17 +52,29 @@ idx_t StandardVectorBuffer::GetAllocationSize() const {
 
 void StandardVectorBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(vector_type == VectorType::FLAT_VECTOR || vector_type == VectorType::CONSTANT_VECTOR);
-	D_ASSERT(type_size == GetTypeIdSize(type.InternalType()));
+	if (type_size != GetTypeIdSize(type.InternalType())) {
+		throw InternalException("Type size mismatch in flat vector buffer");
+	}
 	// verify all entries in the sel fit within the validity
 	if (sel.IsSet()) {
 		for (idx_t i = 0; i < count; i++) {
 			auto sel_idx = sel.get_index(i);
-			D_ASSERT(sel_idx <= validity.Capacity());
-			D_ASSERT(sel_idx <= Capacity());
+			if (sel_idx > validity.Capacity()) {
+				throw InternalException("Selection vector index %d out of range for validity capacity %d", sel_idx,
+				                        validity.Capacity());
+			}
+			if (sel_idx > Capacity()) {
+				throw InternalException("Selection vector index %d out of range for vector capacity %d", sel_idx,
+				                        Capacity());
+			}
 		}
 	} else if (vector_type == VectorType::FLAT_VECTOR) {
-		D_ASSERT(count <= validity.Capacity());
-		D_ASSERT(count <= Capacity());
+		if (count > validity.Capacity()) {
+			throw InternalException("Count %d out of range for validity capacity %d", count, validity.Capacity());
+		}
+		if (count > Capacity()) {
+			throw InternalException("Count %d out of range for capacity %d", count, Capacity());
+		}
 	}
 }
 

--- a/src/common/vector/list_vector.cpp
+++ b/src/common/vector/list_vector.cpp
@@ -106,7 +106,10 @@ void VectorListBuffer::VerifyInternal(const LogicalType &type, const SelectionVe
 		idx = vector_type == VectorType::CONSTANT_VECTOR ? 0 : idx;
 		auto &le = list_data[idx];
 		if (validity.RowIsValid(idx)) {
-			D_ASSERT(le.offset + le.length <= child->size());
+			if (le.offset + le.length > child->size()) {
+				throw InternalException("List entry offset + length out of range (offset %d, size %d, child size %d)",
+				                        le.offset, le.length, child->size());
+			}
 			total_size += le.length;
 		}
 	}

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -25,8 +25,7 @@ idx_t ShreddedVectorBuffer::GetAllocationSize() const {
 void ShreddedVectorBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(type.id() == LogicalTypeId::VARIANT);
 	D_ASSERT(vector_type == VectorType::SHREDDED_VECTOR);
-	// FIXME: currently inconsistent...
-	// shredded_data->Verify(sel, count);
+	shredded_data->Verify(sel, count);
 	D_ASSERT(shredded_data->size() == Size());
 }
 

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -25,7 +25,8 @@ idx_t ShreddedVectorBuffer::GetAllocationSize() const {
 void ShreddedVectorBuffer::VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const {
 	D_ASSERT(type.id() == LogicalTypeId::VARIANT);
 	D_ASSERT(vector_type == VectorType::SHREDDED_VECTOR);
-	shredded_data->Verify(sel, count);
+	// FIXME: currently inconsistent...
+	// shredded_data->Verify(sel, count);
 	D_ASSERT(shredded_data->size() == Size());
 }
 

--- a/src/common/vector/string_vector.cpp
+++ b/src/common/vector/string_vector.cpp
@@ -116,7 +116,10 @@ void VectorStringBuffer::VerifyInternal(const LogicalType &type, const Selection
 		switch (type.id()) {
 		case LogicalTypeId::BIT: {
 			auto buf = str.GetData();
-			D_ASSERT(idx_t(*buf) < 8);
+			if (idx_t(*buf) >= 8) {
+				throw InternalException("Internal bit type inconsistency - padding bits should be < 8 but got %d",
+				                        idx_t(*buf));
+			}
 			Bit::Verify(str);
 			break;
 		}
@@ -125,7 +128,7 @@ void VectorStringBuffer::VerifyInternal(const LogicalType &type, const Selection
 			break;
 		case LogicalTypeId::VARCHAR:
 			// verify that the string is correct unicode
-			str.Verify();
+			str.ForceVerify();
 			break;
 		default:
 			break;

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -119,8 +119,10 @@ void VectorStructBuffer::VerifyInternal(const LogicalType &type, const Selection
 				for (idx_t r = 0; r < Size(); r++) {
 					if (!validity.RowIsValid(r)) {
 						if (child_validity.IsValid(r)) {
-							throw InternalException(
-							    "Struct NULL mismatch - a child of a NULL struct must always be NULL");
+							throw InternalException("Struct NULL mismatch - a child of a NULL struct must always be "
+							                        "NULL\nStruct type: %s\nChild idx: %llu, Child type: %s\nRow: %llu",
+							                        type.ToString(), (uint64_t)child_idx,
+							                        child_types[child_idx].second.ToString(), (uint64_t)r);
 						}
 					}
 				}

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -81,29 +81,51 @@ void VectorStructBuffer::VerifyInternal(const LogicalType &type, const Selection
 	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
 	D_ASSERT(vector_type == VectorType::FLAT_VECTOR || vector_type == VectorType::CONSTANT_VECTOR);
 	auto &child_types = StructType::GetChildTypes(type);
-	D_ASSERT(child_types.size() == children.size());
+	if (child_types.size() != children.size()) {
+		throw InternalException("Struct child count mismatch - expected %d children but found %d", child_types.size(),
+		                        children.size());
+	}
 	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
 		auto &child = children[child_idx];
-		D_ASSERT(child.GetType() == child_types[child_idx].second);
+		if (child.GetType() != child_types[child_idx].second) {
+			throw InternalException("Struct child type mismatch - expected child of type %s but found child of type %s",
+			                        child_types[child_idx].second, child.GetType());
+		}
 		if (!sel.IsSet() && count == Size()) {
 			child.Verify();
 		} else {
 			child.Verify(sel, count);
 		}
-		D_ASSERT(child.size() == Size());
+		if (child.size() != Size()) {
+			throw InternalException("Struct child size mismatch - parent struct had size %d but child has size %d",
+			                        Size(), child.size());
+		}
+		// for any NULL entry in the struct, the child should be NULL as well
+		// may produce structs where parent NULLs are not propagated to all children
 		if (vector_type == VectorType::CONSTANT_VECTOR) {
-			D_ASSERT(child.GetVectorType() == VectorType::CONSTANT_VECTOR);
+			if (child.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+				throw InternalException(
+				    "Struct constant mismatch - expected a child of a constant struct to also be constant");
+			}
 			if (!validity.RowIsValid(0)) {
-				D_ASSERT(ConstantVector::IsNull(child));
+				if (!ConstantVector::IsNull(child)) {
+					throw InternalException("Struct NULL mismatch - a child of a NULL struct must always be NULL");
+				}
+			}
+		} else {
+			if (child.GetVectorType() == VectorType::FLAT_VECTOR ||
+			    child.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				auto child_validity = child.Validity(child.size());
+				for (idx_t r = 0; r < Size(); r++) {
+					if (!validity.RowIsValid(r)) {
+						if (child_validity.IsValid(r)) {
+							throw InternalException(
+							    "Struct NULL mismatch - a child of a NULL struct must always be NULL");
+						}
+					}
+				}
 			}
 		}
-		if (vector_type != VectorType::FLAT_VECTOR) {
-			continue;
-		}
-		// FIXME: re-add struct NULL propagation check
-		// for any NULL entry in the struct, the child should be NULL as well
-		// this check is currently disabled because projection pushdown and other optimizations
-		// may produce structs where parent NULLs are not propagated to all children
 	}
 }
 

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -55,6 +55,10 @@ ClientContext &ExpressionExecutor::GetContext() {
 	return *context;
 }
 
+optional_ptr<ClientContext> ExpressionExecutor::GetContextPtr() {
+	return context;
+}
+
 Allocator &ExpressionExecutor::GetAllocator() {
 	return context ? Allocator::Get(*context) : Allocator::DefaultAllocator();
 }
@@ -86,7 +90,7 @@ void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
 		ExecuteExpression(i, result.data[i]);
 	}
 	result.SetCardinality(input ? input->size() : 1);
-	result.Verify(context ? context->db : nullptr);
+	result.Verify(context);
 }
 
 void ExpressionExecutor::ExecuteExpression(DataChunk &input, Vector &result) {

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -243,7 +243,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	} else {
 		arguments.SetCardinality(count);
 	}
-	arguments.Verify(context ? context->db : nullptr);
+	arguments.Verify(context);
 
 	auto &execute_function_state = state->Cast<ExecuteFunctionState>();
 	auto dictionary_executed = expr.function.HasFunctionCallback() && !all_constant &&
@@ -299,7 +299,7 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 		Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
 	}
 	arguments.SetCardinality(count);
-	arguments.Verify(context ? context->db : nullptr);
+	arguments.Verify(context);
 
 	const bool has_sel = sel && sel != FlatVector::IncrementalSelectionVector();
 	if (!has_sel) {

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -79,7 +79,7 @@ void UnnestOperatorState::PrepareInput(DataChunk &input, const vector<unique_ptr
 	executor.Execute(input, list_data);
 
 	// verify incoming lists
-	list_data.Verify(executor.HasContext() ? executor.GetContext().db : nullptr);
+	list_data.Verify(executor.GetContextPtr());
 	D_ASSERT(input.size() == list_data.size());
 	D_ASSERT(list_data.ColumnCount() == select_list.size());
 	D_ASSERT(list_vector_data.size() == list_data.ColumnCount());

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -423,7 +423,7 @@ void RadixPartitionedHashTable::PopulateGroupChunk(DataChunk &group_chunk, DataC
 	if (grouping_set.empty()) {
 		FlatVector::SetSize(group_chunk.data[0], count_t(input_chunk.size()));
 	}
-	group_chunk.Verify(DebugVerificationMode::DEFAULT);
+	group_chunk.Verify();
 }
 
 void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate) {

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/radix_partitioned_hashtable.hpp"
 
 #include "duckdb/common/radix_partitioning.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/types/row/tuple_data_collection.hpp"
@@ -422,7 +423,7 @@ void RadixPartitionedHashTable::PopulateGroupChunk(DataChunk &group_chunk, DataC
 	if (grouping_set.empty()) {
 		FlatVector::SetSize(group_chunk.data[0], count_t(input_chunk.size()));
 	}
-	group_chunk.Verify();
+	group_chunk.Verify(DebugVerificationMode::DEFAULT);
 }
 
 void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate) {

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -681,7 +681,7 @@ struct SortedAggregateFunction {
 			}
 		}
 
-		result.Verify(count);
+		result.Verify();
 	}
 };
 

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -96,7 +96,7 @@ static bool AggregateStateToStructReinterpret(Vector &source, Vector &result, id
 	source.Flatten(count);
 	FlatVector::ValidityMutable(result) = FlatVector::Validity(source);
 	FlatVector::SetSize(result, count_t(count));
-	result.Verify(count);
+	result.Verify();
 	return true;
 }
 

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -134,7 +134,7 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 
 	FlatVector::CopyValidity(result, source, count);
 	FlatVector::SetSize(result, count);
-	result.Verify(count);
+	result.Verify();
 	return all_converted;
 }
 

--- a/src/function/cast/union/from_struct.cpp
+++ b/src/function/cast/union/from_struct.cpp
@@ -105,7 +105,7 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 	}
 
 	FlatVector::SetSize(result, count_t(count));
-	result.Verify(count);
+	result.Verify();
 	return true;
 }
 

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -332,7 +332,6 @@ BoundCastInfo DefaultCasts::ImplicitToUnionCast(BindCastInput &input, const Logi
 }
 
 static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	auto constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	// first cast all union members to varchar
 	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
 	Vector varchar_union(cast_data.type, count);
@@ -362,12 +361,7 @@ static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, Cast
 			result_data.WriteValue("NULL");
 		}
 	}
-
-	if (constant) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
-
-	result.Verify(count);
+	result.Verify();
 	return true;
 }
 

--- a/src/function/cast/variant/to_variant.cpp
+++ b/src/function/cast/variant/to_variant.cpp
@@ -278,7 +278,7 @@ static bool CastToVARIANT(Vector &source, Vector &result, idx_t count, CastParam
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
-	result.Verify(count);
+	result.Verify();
 	return true;
 }
 

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -18,12 +18,12 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 	// this should be guaranteed by the binder
 	auto &vec = args.data[0];
 
-	vec.Verify(args.size());
+	vec.Verify();
 	auto &children = StructVector::GetEntries(vec);
 	D_ASSERT(info.index < children.size());
 	auto &struct_child = children[info.index];
 	result.Reference(struct_child);
-	result.Verify(args.size());
+	result.Verify();
 }
 
 static unique_ptr<FunctionData> StructExtractBind(BindScalarFunctionInput &input) {

--- a/src/function/scalar/struct/struct_pack.cpp
+++ b/src/function/scalar/struct/struct_pack.cpp
@@ -35,7 +35,7 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 	// differ when the caller is collapsing all-constant inputs to a single argument row.
 	result.BufferMutable().SetVectorTypeOnly(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
 	result.BufferMutable().SetVectorSizeOnly(children_size);
-	result.Verify(children_size);
+	result.Verify();
 }
 
 template <bool IS_STRUCT_PACK>

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -208,7 +208,7 @@ void ArrowTableFunction::ArrowScanFunction(ClientContext &context, TableFunction
 		ArrowToDuckDB(state, data.arrow_table.GetColumns(), output);
 	}
 
-	output.Verify(context.db);
+	output.Verify(context);
 	state.chunk_offset += output.size();
 }
 

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -307,12 +307,12 @@ unique_ptr<GlobalTableFunctionState> TestVectorTypesInit(ClientContext &context,
 	TestVectorDictionary::Generate(info);
 	TestVectorSequence::Generate(info);
 	for (auto &entry : result->entries) {
-		entry->Verify(context.db);
+		entry->Verify(context);
 	}
 	if (bind_data.all_flat) {
 		for (auto &entry : result->entries) {
 			entry->Flatten();
-			entry->Verify(context.db);
+			entry->Verify(context);
 		}
 	}
 	return std::move(result);

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -638,7 +638,7 @@ void WindowDistinctAggregatorLocalState::FlushStates() {
 
 	const auto &aggr = gdstate.aggr;
 	AggregateInputData aggr_input_data(aggr.GetFunctionData(), allocator);
-	statel.Verify(flush_count);
+	statel.Verify();
 	aggr.function.GetStateCombineCallback()(statel, statep, aggr_input_data, flush_count);
 
 	flush_count = 0;

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -197,7 +197,7 @@ void WindowSegmentTreePart::FlushStates(bool combining) {
 
 	AggregateInputData aggr_input_data(aggr.GetFunctionData(), allocator);
 	if (combining) {
-		statel.Verify(flush_count);
+		statel.Verify();
 		aggr.function.GetStateCombineCallback()(statel, statep, aggr_input_data, flush_count);
 	} else {
 		auto &scanned = cursor->chunk;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -166,6 +166,8 @@ enum class DebugStatementVerification : uint8_t;
 
 enum class DebugVectorVerification : uint8_t;
 
+enum class DebugVerificationMode : uint8_t;
+
 enum class DecimalBitWidth : uint8_t;
 
 enum class DefaultOrderByNullType : uint8_t;
@@ -735,6 +737,9 @@ const char* EnumUtil::ToChars<DebugStatementVerification>(DebugStatementVerifica
 
 template<>
 const char* EnumUtil::ToChars<DebugVectorVerification>(DebugVectorVerification value);
+
+template<>
+const char* EnumUtil::ToChars<DebugVerificationMode>(DebugVerificationMode value);
 
 template<>
 const char* EnumUtil::ToChars<DecimalBitWidth>(DecimalBitWidth value);
@@ -1489,6 +1494,9 @@ DebugStatementVerification EnumUtil::FromString<DebugStatementVerification>(cons
 
 template<>
 DebugVectorVerification EnumUtil::FromString<DebugVectorVerification>(const char *value);
+
+template<>
+DebugVerificationMode EnumUtil::FromString<DebugVerificationMode>(const char *value);
 
 template<>
 DecimalBitWidth EnumUtil::FromString<DecimalBitWidth>(const char *value);

--- a/src/include/duckdb/common/enums/debug_verification_mode.hpp
+++ b/src/include/duckdb/common/enums/debug_verification_mode.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/debug_verification_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class DebugVerificationMode : uint8_t { DEFAULT, NONE, VERIFY_VECTORS, VERIFY_SERIALIZATION };
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -166,7 +166,7 @@ public:
 	DUCKDB_API void Verify(shared_ptr<DatabaseInstance> &db);
 	DUCKDB_API void Verify(ClientContext &context);
 	DUCKDB_API void Verify(optional_ptr<ClientContext> context);
-	DUCKDB_API void Verify(DebugVerificationMode mode);
+	DUCKDB_API void Verify();
 
 private:
 	//! The amount of tuples stored in the data chunk

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -22,6 +22,7 @@ class ExecutionContext;
 class VectorCache;
 class Serializer;
 class Deserializer;
+enum class DebugVerificationMode : uint8_t;
 
 //!  A Data Chunk represents a set of vectors.
 /*!
@@ -161,12 +162,19 @@ public:
 
 	//! Verify that the DataChunk is in a consistent, not corrupt state. DEBUG
 	//! FUNCTION ONLY!
-	DUCKDB_API void Verify(optional_ptr<DatabaseInstance> database_instance = nullptr);
+	DUCKDB_API void Verify(DatabaseInstance &db);
+	DUCKDB_API void Verify(shared_ptr<DatabaseInstance> &db);
+	DUCKDB_API void Verify(ClientContext &context);
+	DUCKDB_API void Verify(optional_ptr<ClientContext> context);
+	DUCKDB_API void Verify(DebugVerificationMode mode);
 
 private:
 	//! The amount of tuples stored in the data chunk
 	idx_t count;
 	//! Vector caches, used to store data when ::Initialize is called
 	vector<VectorCache> vector_caches;
+
+private:
+	void VerifyInternal(DebugVerificationMode mode, optional_ptr<DatabaseInstance> db);
 };
 } // namespace duckdb

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -115,7 +115,6 @@ public:
 			memcpy(GetDataWriteable(), ptr, size);
 		}
 		Finalize();
-		VerifyCharacters();
 	}
 
 	bool Empty() const {
@@ -157,9 +156,10 @@ public:
 	}
 
 	void Verify() const;
+	//! Verify also in release mode
+	void ForceVerify() const;
 	void VerifyUTF8() const;
 	void VerifyCharacters() const;
-	void VerifyNull() const;
 
 	struct StringComparisonOperators {
 		static inline bool Equals(const string_t &a, const string_t &b) {

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -131,6 +131,7 @@ public:
 	//! Turn the vector into a shredded variant vector
 	DUCKDB_API void Shred(Vector &shredded_data, idx_t capacity);
 
+	//[[deprecated("Verify no longer requires a count - use Verify() without count instead")]]
 	DUCKDB_API void Verify(idx_t count) const;
 	//! Verify that the Vector is in a consistent, not corrupt state. DEBUG
 	//! FUNCTION ONLY!

--- a/src/include/duckdb/execution/expression_executor.hpp
+++ b/src/include/duckdb/execution/expression_executor.hpp
@@ -39,6 +39,7 @@ public:
 public:
 	bool HasContext();
 	ClientContext &GetContext();
+	optional_ptr<ClientContext> GetContextPtr();
 	Allocator &GetAllocator();
 
 	//! Add an expression to the set of to-be-executed expressions of the executor

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -503,7 +503,7 @@ struct MinMaxNOperation {
 		D_ASSERT(current_offset == old_len + new_entries);
 		ListVector::SetListSize(result, current_offset);
 		FlatVector::SetSize(result, count_t(offset + count));
-		result.Verify(count);
+		result.Verify();
 	}
 
 	template <class STATE>

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -37,6 +37,7 @@
 #include "duckdb/parser/parsed_data/create_info.hpp"
 #include "duckdb/common/types/type_manager.hpp"
 #include "duckdb/common/serialization_compatibility.hpp"
+#include "duckdb/common/enums/debug_verification_mode.hpp"
 
 namespace duckdb {
 
@@ -121,8 +122,6 @@ struct DBConfigOptions {
 	case_insensitive_map_t<Value> user_options;
 	//! The set of unrecognized (other) options
 	case_insensitive_map_t<Value> unrecognized_options;
-	//! Whether to print bindings when printing the plan (debug mode only)
-	static bool debug_print_bindings; // NOLINT: debug setting
 	//! The peak allocation threshold at which to flush the allocator after completing a task (1 << 27, ~128MB)
 	idx_t allocator_flush_threshold = 134217728ULL;
 	//! If bulk deallocation larger than this occurs, flush outstanding allocations (1 << 30, ~1GB)
@@ -145,6 +144,10 @@ struct DBConfigOptions {
 	LogConfig log_config = LogConfig();
 	//! Physical memory that the block allocator is allowed to use (this memory is never freed and cannot be reduced)
 	idx_t block_allocator_size = 0;
+	//! Whether to print bindings when printing the plan (debug mode only)
+	static bool debug_print_bindings; // NOLINT: debug setting
+	//! The global verification mode
+	static DebugVerificationMode global_verification_mode; // NOLINT: debug setting
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -548,6 +548,16 @@ struct DebugSkipCheckpointOnCommitSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct DebugVerificationModeSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "debug_verification_mode";
+	static constexpr const char *Description = "DEBUG SETTING: toggle the verification mode.";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct DebugVerifyBlocksSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_verify_blocks";

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -30,7 +30,7 @@ public:
 	//! Whether or not the table is temporary
 	bool IsTemporary() const;
 
-	AttachedDatabase &GetDB() {
+	AttachedDatabase &GetDB() const {
 		return db;
 	}
 

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -151,11 +151,15 @@ public:
 	unique_ptr<BlockingSample> GetSample();
 	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
 
-	AttachedDatabase &GetAttached();
-	BlockManager &GetBlockManager() {
+	AttachedDatabase &GetAttached() const;
+	DatabaseInstance &GetDatabase() const;
+	BlockManager &GetBlockManager() const {
 		return block_manager;
 	}
 	MetadataManager &GetMetadataManager();
+	const DataTableInfo &GetTableInfo() const {
+		return *info;
+	}
 	DataTableInfo &GetTableInfo() {
 		return *info;
 	}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -22,9 +22,8 @@
 
 namespace duckdb {
 
-#ifdef DEBUG
 bool DBConfigOptions::debug_print_bindings = false;
-#endif
+DebugVerificationMode DBConfigOptions::global_verification_mode = DebugVerificationMode::NONE;
 
 #define DUCKDB_SETTING(_PARAM)                                                                                         \
 	{                                                                                                                  \
@@ -106,6 +105,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(DebugForceNoCrossProductSetting),
     DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
+    DUCKDB_GLOBAL(DebugVerificationModeSetting),
     DUCKDB_SETTING(DebugVerifyBlocksSetting),
     DUCKDB_SETTING(DebugVerifySerializerSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyStatementSetting),
@@ -220,12 +220,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 107),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 49),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 128),
-                                                     DUCKDB_SETTING_ALIAS("user", 143),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 108),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 50),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 129),
+                                                     DUCKDB_SETTING_ALIAS("user", 144),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 142),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 143),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -549,6 +549,22 @@ void CustomUserAgentSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 }
 
 //===----------------------------------------------------------------------===//
+// Debug Verification Mode
+//===----------------------------------------------------------------------===//
+void DebugVerificationModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.global_verification_mode = EnumUtil::FromString<DebugVerificationMode>(input.ToString());
+}
+
+void DebugVerificationModeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.global_verification_mode = DebugVerificationMode::NONE;
+}
+
+Value DebugVerificationModeSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return EnumUtil::ToString(config.options.global_verification_mode);
+}
+
+//===----------------------------------------------------------------------===//
 // Default Block Size
 //===----------------------------------------------------------------------===//
 void DefaultBlockSizeSetting::OnSet(SettingCallbackInfo &, Value &input) {

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -385,7 +385,7 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 			scan_chunk.SetCardinality(to_scan);
 
 			// Verify the scan chunk
-			scan_chunk.Verify();
+			scan_chunk.Verify(GetDatabase());
 
 			append_chunk.Reset();
 			append_chunk.SetCardinality(to_scan);
@@ -480,7 +480,7 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 		scan_chunk.SetCardinality(to_scan);
 
 		// Verify the scan chunk
-		scan_chunk.Verify();
+		scan_chunk.Verify(GetDatabase());
 
 		append_chunk.Reset();
 		append_chunk.SetCardinality(to_scan);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -100,8 +100,12 @@ Allocator &RowGroupCollection::GetAllocator() const {
 	return Allocator::Get(info->GetDB());
 }
 
-AttachedDatabase &RowGroupCollection::GetAttached() {
+AttachedDatabase &RowGroupCollection::GetAttached() const {
 	return GetTableInfo().GetDB();
+}
+
+DatabaseInstance &RowGroupCollection::GetDatabase() const {
+	return GetAttached().GetDatabase();
 }
 
 MetadataManager &RowGroupCollection::GetMetadataManager() {
@@ -530,9 +534,8 @@ void RowGroupCollection::InitializeAppend(TableAppendState &state) {
 }
 
 bool RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state) {
-	const idx_t row_group_size = GetRowGroupSize();
 	D_ASSERT(chunk.ColumnCount() == types.size());
-	chunk.Verify();
+	chunk.Verify(GetDatabase());
 
 	bool new_row_group = false;
 	idx_t total_append_count = chunk.size();
@@ -585,8 +588,6 @@ bool RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state) {
 }
 
 void RowGroupCollection::FinalizeAppend(TransactionData transaction, TableAppendState &state) {
-	const idx_t row_group_size = GetRowGroupSize();
-
 	auto remaining = state.total_append_count;
 	auto row_group = state.start_row_group;
 	while (remaining > 0) {

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -251,6 +251,7 @@ public:
 	void WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, optional_ptr<const SelectionVector> sel,
 	                        optional_ptr<const SelectionVector> value_index_sel,
 	                        optional_ptr<const SelectionVector> result_sel, idx_t count) override;
+	void WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, idx_t count);
 	void AnalyzeVariantValues(UnifiedVariantVectorData &variant, optional_ptr<Vector> untyped_values,
 	                          optional_ptr<const SelectionVector> sel,
 	                          optional_ptr<const SelectionVector> value_index_sel,
@@ -680,7 +681,12 @@ void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varian
 			FlatVector::SetNull(typed_value, result_sel ? result_sel->get_index(i) : i, true);
 		}
 	}
-	//! Propagate NULL values from the input variant to the shredded child struct
+}
+
+void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, idx_t count) {
+	// write the top-level variant values
+	WriteVariantValues(variant, result, nullptr, nullptr, nullptr, count);
+	//! Propagate NULL values from the top-level input variant to the shredded child struct
 	for (idx_t row = 0; row < count; row++) {
 		if (!variant.RowIsValid(row)) {
 			FlatVector::SetNull(result, row, true);
@@ -697,7 +703,7 @@ void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t co
 
 	//! First traverse the Variant to write the shredded values and collect the 'untyped_value_index'es
 	DuckDBVariantShredding shredding(count);
-	shredding.WriteVariantValues(variant, child_vectors[1], nullptr, nullptr, nullptr, count);
+	shredding.WriteVariantValues(variant, child_vectors[1], count);
 
 	//! Now we can write the unshredded values
 	auto &unshredded = child_vectors[0];

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -680,6 +680,12 @@ void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varian
 			FlatVector::SetNull(typed_value, result_sel ? result_sel->get_index(i) : i, true);
 		}
 	}
+	//! Propagate NULL values from the input variant to the shredded child struct
+	for (idx_t row = 0; row < count; row++) {
+		if (!variant.RowIsValid(row)) {
+			FlatVector::SetNull(result, row, true);
+		}
+	}
 }
 
 void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t count) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -206,6 +206,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "progress_bar_time",
 	    "index_scan_max_count",
 	    "profiling_mode",
+	    "debug_verification_mode",
 	    "warnings_as_errors",      // requires logging to be enabled
 	    "block_allocator_memory"}; // cant reduce
 	return excluded_options.count(name) == 1;

--- a/test/configs/internal_vector_serialization.json
+++ b/test/configs/internal_vector_serialization.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with debug_verification_mode set to verify_serialization - enabling the testing of data chunk / vector serialization",
+  "on_init": "SET debug_verification_mode='verify_serialization';",
+  "skip_compiled": "true"
+}

--- a/test/configs/internal_vector_verification.json
+++ b/test/configs/internal_vector_verification.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with debug_verification_mode set to verify_vectors - enabling aggressive internal vector verification",
+  "on_init": "SET debug_verification_mode='verify_vectors';",
+  "skip_compiled": "true"
+}


### PR DESCRIPTION
We perform extensive internal verification of vectors and data chunks by default when compiling in debug mode. This is nice but has some drawbacks:

* Debug mode is always slowed down because we are always performing extra verification
* There is no way of running this in release mode aside from re-compiling
* The verification is in the form of assertions, which are not descriptive as to what the actual issue is

This PR changes this to instead be a setting:

```sql
-- perform internal vector verification
SET debug_verification_mode='verify_vectors';
-- perform vector serialization round-trip testing
SET debug_verification_mode='verify_serialization';
```

This allows these settings to instead be tested in a test config similar to other settings. The assertions are replaced with descriptive internal exceptions. 

Note that this setting is **not** per database - because these verification routines don't all have a client context / database instance available this is a static global in the `DBConfigOptions`:

```cpp
static DebugVerificationMode global_verification_mode;
```

Given that this is just a debug setting that sets an enum this is unlikely to cause any issues, but it does mean this setting behaves differently from other settings. 