### PR TITLE
Fix vsize = 2 issue in JSON create

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -12,21 +12,38 @@
 
 namespace duckdb {
 
-using StructNames = unordered_map<string, unique_ptr<Vector>>;
+struct StructNames {
+	void Insert(const string &name) {
+		values[name] = make_uniq<Vector>(Value(name), count_t(0ULL));
+	}
+
+	Vector &Get(const string &name, idx_t count) const {
+		auto &result = *values.at(name);
+		FlatVector::SetSize(result, count);
+		return result;
+	}
+
+	StructNames Copy() const {
+		StructNames result;
+		// Have to do this because we can't implicitly copy Vector
+		for (const auto &kv : values) {
+			// The vectors are const vectors of the key value
+			result.values[kv.first] = make_uniq<Vector>(Value(kv.first), count_t(0ULL));
+		}
+		return result;
+	}
+
+private:
+	unordered_map<string, unique_ptr<Vector>> values;
+};
 
 struct JSONCreateFunctionData : public FunctionData {
 public:
-	explicit JSONCreateFunctionData(unordered_map<string, unique_ptr<Vector>> const_struct_names)
-	    : const_struct_names(std::move(const_struct_names)) {
+	explicit JSONCreateFunctionData(StructNames const_struct_names_p)
+	    : const_struct_names(std::move(const_struct_names_p)) {
 	}
 	unique_ptr<FunctionData> Copy() const override {
-		// Have to do this because we can't implicitly copy Vector
-		unordered_map<string, unique_ptr<Vector>> map_copy;
-		for (const auto &kv : const_struct_names) {
-			// The vectors are const vectors of the key value
-			map_copy[kv.first] = make_uniq<Vector>(Value(kv.first), count_t(STANDARD_VECTOR_SIZE));
-		}
-		return make_uniq<JSONCreateFunctionData>(std::move(map_copy));
+		return make_uniq<JSONCreateFunctionData>(const_struct_names.Copy());
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		return true;
@@ -86,8 +103,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 	case LogicalTypeId::STRUCT: {
 		child_list_t<LogicalType> child_types;
 		for (const auto &child_type : StructType::GetChildTypes(type)) {
-			const_struct_names[child_type.first] =
-			    make_uniq<Vector>(Value(child_type.first), count_t(STANDARD_VECTOR_SIZE));
+			const_struct_names.Insert(child_type.first);
 			child_types.emplace_back(child_type.first, GetJSONType(const_struct_names, child_type.second));
 		}
 		return LogicalType::STRUCT(child_types);
@@ -100,8 +116,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 		for (idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(type); member_idx++) {
 			auto &member_name = UnionType::GetMemberName(type, member_idx);
 			auto &member_type = UnionType::GetMemberType(type, member_idx);
-
-			const_struct_names[member_name] = make_uniq<Vector>(Value(member_name), count_t(STANDARD_VECTOR_SIZE));
+			const_struct_names.Insert(member_name);
 			member_types.emplace_back(member_name, GetJSONType(const_struct_names, member_type));
 		}
 		return LogicalType::UNION(member_types);
@@ -114,7 +129,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 
 static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_function,
                                                      vector<unique_ptr<Expression>> &arguments, bool object) {
-	unordered_map<string, unique_ptr<Vector>> const_struct_names;
+	StructNames const_struct_names;
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		auto &type = arguments[i]->GetReturnType();
 		if (arguments[i]->HasParameter()) {
@@ -265,16 +280,13 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 
 static void AddKeyValuePairs(yyjson_mut_doc *doc, yyjson_mut_val *objs[], Vector &key_v, yyjson_mut_val *vals[],
                              idx_t count) {
-	UnifiedVectorFormat key_data;
-	key_v.ToUnifiedFormat(count, key_data);
-	auto keys = UnifiedVectorFormat::GetData<string_t>(key_data);
-
+	auto keys = key_v.Values<string_t>(count);
 	for (idx_t i = 0; i < count; i++) {
-		auto key_idx = key_data.sel->get_index(i);
-		if (!key_data.validity.RowIsValid(key_idx)) {
+		auto key_entry = keys[i];
+		if (!key_entry.IsValid()) {
 			continue;
 		}
-		auto key = CreateJSONValue<string_t, string_t>::Operation(doc, keys[key_idx]);
+		auto key = CreateJSONValue<string_t, string_t>::Operation(doc, key_entry.GetValue());
 		yyjson_mut_obj_add(objs[i], key, vals[i]);
 	}
 }
@@ -339,7 +351,7 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 	// Add the key/value pairs to the values
 	auto &entries = StructVector::GetEntries(value_v);
 	for (idx_t entry_i = 0; entry_i < entries.size(); entry_i++) {
-		auto &struct_key_v = *names.at(StructType::GetChildName(value_v.GetType(), entry_i));
+		auto &struct_key_v = names.Get(StructType::GetChildName(value_v.GetType(), entry_i), count);
 		auto &struct_val_v = entries[entry_i];
 		CreateKeyValuePairs(names, doc, vals, nested_vals, struct_key_v, struct_val_v, count);
 	}
@@ -421,7 +433,7 @@ static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyj
 	// Add the key/value pairs to the values
 	for (idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(value_v.GetType()); member_idx++) {
 		auto &member_val_v = UnionVector::GetMember(value_v, member_idx);
-		auto &member_key_v = *names.at(UnionType::GetMemberName(value_v.GetType(), member_idx));
+		auto &member_key_v = names.Get(UnionType::GetMemberName(value_v.GetType(), member_idx), count);
 
 		// This implementation is not optimal since we convert the entire member vector,
 		// and then skip the rows not matching the tag afterwards.
@@ -776,10 +788,7 @@ public:
 
 	unique_ptr<BoundCastData> Copy() const override {
 		auto result = make_uniq<NestedToJSONCastData>();
-		for (auto &csn : const_struct_names) {
-			result->const_struct_names.emplace(
-			    csn.first, make_uniq<Vector>(csn.second->GetValue(0), count_t(STANDARD_VECTOR_SIZE)));
-		}
+		result->const_struct_names = const_struct_names.Copy();
 		return std::move(result);
 	}
 


### PR DESCRIPTION
We were creating vectors with size `STANDARD_VECTOR_SIZE` and then using them with a larger size - this is incorrect. This PR fixes that. 