### PR TITLE
Try include-what-you-use

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -436,6 +436,50 @@ jobs:
         EOF
         make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
 
+ include-what-you-use:
+    name: Include what you use
+    if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'include-what-you-use') }}
+    needs:
+      - prepare
+      - linux-release
+    runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
+    env:
+      GEN: ninja
+
+    steps:
+    - name: "Checkout"
+      uses: duckdb/duckdb-ci/.github/actions/checkout@main
+      with:
+        runner_provider: ${{ needs.prepare.outputs.runner_provider }}
+        fetch_depth: 0
+
+    - name: Install
+      run: |
+        python3 scripts/ci/retry.py -- make toolsci
+        python3 scripts/ci/retry.py -- sudo apt-get update -y -qq
+        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq clang iwyu
+
+    - uses: ./.github/actions/ccache-action
+      with:
+        save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
+
+    - name: Detect
+      run: |
+        status=0
+        make iwyu || status=$?
+        make iwyu-fix || status=$?
+        exit $status
+
+    - name: Upload artifacts
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: iwyu-artifacts
+        path: |
+          build/iwyu/iwyu.out
+          build/iwyu/iwyu.patch
+        if-no-files-found: warn
+
  extensions:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'extensions') }}
     uses: ./.github/workflows/Extensions.yml
@@ -1533,6 +1577,7 @@ jobs:
       - linux-relassert-tests
       - regression
       - tidy-check
+      - include-what-you-use
       - extensions
       - wasm-eh
       - linux-release

--- a/Makefile
+++ b/Makefile
@@ -685,6 +685,19 @@ tidy-fix:
 	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 ../.. && \
 	$(PYTHON) ../../scripts/run-clang-tidy.py -fix
 
+.PHONY: iwyu iwyu-fix
+iwyu:
+	@command -v include-what-you-use >/dev/null 2>&1 || { echo "include-what-you-use not found. Install it with: brew install include-what-you-use"; exit 1; }
+	mkdir -p ./build/iwyu && \
+	cd build/iwyu && \
+	CC="clang" CXX="clang++" cmake $(GENERATOR) $(FORCE_COLOR) -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_SHELL=0 -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use ../.. && \
+	{ cmake --build . 2>&1; echo $$? > iwyu.status; } | tee iwyu.out && \
+	test "$$(cat iwyu.status)" -eq 0 && rm -f iwyu.status && \
+	rg -v '(^|[[:space:]])third_party/' iwyu.out > iwyu.out.tmp && mv iwyu.out.tmp iwyu.out
+
+iwyu-fix:
+	bash scripts/ci/iwyu_fix.sh
+
 test_compile: # test compilation of individual cpp files
 	$(PYTHON) scripts/test_compile.py
 

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+// IWYU pragma: end_exports
 
 namespace duckdb {
 

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -81,10 +81,12 @@ if(NOT CLANG_TIDY)
 endif()
 
 build_static_extension(parquet ${PARQUET_EXTENSION_FILES})
+target_link_libraries(parquet_extension duckdb_fastpforlib)
 set(PARAMETERS "-warnings")
 
 build_loadable_extension(parquet ${PARAMETERS} ${PARQUET_EXTENSION_FILES})
-target_link_libraries(parquet_loadable_extension duckdb_mbedtls duckdb_zstd)
+target_link_libraries(parquet_loadable_extension duckdb_fastpforlib
+                      duckdb_mbedtls duckdb_zstd)
 
 install(
   TARGETS parquet_extension

--- a/scripts/ci/iwyu_fix.sh
+++ b/scripts/ci/iwyu_fix.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${1:-python3}"
+IWYU_DIR="build/iwyu"
+IWYU_OUT="${IWYU_DIR}/iwyu.out"
+IWYU_PATCH="${IWYU_DIR}/iwyu.patch"
+FIX_SCRIPT="${IWYU_DIR}/fix_includes.py"
+FIX_SCRIPT_URL="https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/9175c4eeb6084495a6945a9f33de1fc16ec0384e/fix_includes.py"
+
+if [[ ! -f "${IWYU_OUT}" ]]; then
+	echo "${IWYU_OUT} not found. Run 'make iwyu' first."
+	exit 1
+fi
+
+set -x
+
+mkdir -p "${IWYU_DIR}"
+curl --retry 5 -fsSL "${FIX_SCRIPT_URL}" -o "${FIX_SCRIPT}"
+
+"${PYTHON_BIN}" "${FIX_SCRIPT}" --nocomments < "${IWYU_OUT}"
+git diff > "${IWYU_PATCH}"
+
+if ! git diff --exit-code; then
+	cat <<'EOF'
+
+==================== IWYU FIX GUIDE ====================
+
+1) Missing include (removed but needed)
+   Add it back with:
+     #include <some/header>  // IWYU pragma: keep
+
+2) Unnecessary include (added but not needed)
+   Delete the #include
+
+3) Incorrect forward declaration
+   Fix manually (add/remove/adjust)
+
+4) Private header suggested (e.g. <bits/...>)
+   In the private header, add:
+     // IWYU pragma: private, include "public/header.h"
+
+Notes:
+- 'IWYU pragma: keep' is case-sensitive
+- Prefer public headers (e.g. <vector>) over private ones
+
+========================================================
+
+EOF
+	exit 1
+fi

--- a/scripts/ci/iwyu_fix.sh
+++ b/scripts/ci/iwyu_fix.sh
@@ -8,6 +8,8 @@ IWYU_OUT_FILTERED="${IWYU_DIR}/iwyu.core_functions.filtered.out"
 IWYU_PATCH="${IWYU_DIR}/iwyu.patch"
 FIX_SCRIPT="${IWYU_DIR}/fix_includes.py"
 FIX_SCRIPT_URL="https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/9175c4eeb6084495a6945a9f33de1fc16ec0384e/fix_includes.py"
+# Add more repo-relative path prefixes here to broaden IWYU fix scope.
+IWYU_PATH_FILTERS=("extension/core_functions/")
 
 if [[ ! -f "${IWYU_OUT}" ]]; then
 	echo "${IWYU_OUT} not found. Run 'make iwyu' first."
@@ -19,8 +21,32 @@ set -x
 mkdir -p "${IWYU_DIR}"
 curl --retry 5 -fsSL "${FIX_SCRIPT_URL}" -o "${FIX_SCRIPT}"
 
+AWK_FILTER_LIST=""
+for filter in "${IWYU_PATH_FILTERS[@]}"; do
+	if [[ -n "${AWK_FILTER_LIST}" ]]; then
+		AWK_FILTER_LIST+=$'\n'
+	fi
+	AWK_FILTER_LIST+="${filter}"
+done
+
 # Restrict IWYU auto-fixes to extension/core_functions and never add angle includes.
-awk '
+awk -v filters_raw="${AWK_FILTER_LIST}" -v pwd_prefix="${PWD}/" '
+function normalize_path(path) {
+	sub(/^\/home\/runner\/work\/duckdb\/duckdb\//, "", path)
+	if (index(path, pwd_prefix) == 1) {
+		path = substr(path, length(pwd_prefix) + 1)
+	}
+	return path
+}
+function matches_filter(path,  i, norm_path) {
+	norm_path = normalize_path(path)
+	for (i = 1; i <= filter_count; i++) {
+		if (index(norm_path, filters[i]) == 1) {
+			return 1
+		}
+	}
+	return 0
+}
 function flush_add_block(  i) {
 	if (!pending_add_header) {
 		return
@@ -35,6 +61,7 @@ function flush_add_block(  i) {
 	pending_add_count = 0
 }
 BEGIN {
+	filter_count = split(filters_raw, filters, /\n/)
 	in_add_block = 0
 	pending_add_header = ""
 	pending_add_count = 0
@@ -46,19 +73,21 @@ BEGIN {
 		flush_add_block()
 		active_file = $0
 		sub(/ should add these lines:$/, "", active_file)
-		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		active_file = normalize_path(active_file)
+		keep_file = matches_filter(active_file)
 		in_add_block = 1
-		pending_add_header = keep_file ? $0 : ""
+		pending_add_header = keep_file ? active_file " should add these lines:" : ""
 		next
 	}
 	if ($0 ~ / should remove these lines:$/) {
 		flush_add_block()
 		active_file = $0
 		sub(/ should remove these lines:$/, "", active_file)
-		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		active_file = normalize_path(active_file)
+		keep_file = matches_filter(active_file)
 		in_add_block = 0
 		if (keep_file) {
-			print $0
+			print active_file " should remove these lines:"
 		}
 		next
 	}
@@ -67,10 +96,11 @@ BEGIN {
 		active_file = $0
 		sub(/^The full include-list for /, "", active_file)
 		sub(/:$/, "", active_file)
-		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		active_file = normalize_path(active_file)
+		keep_file = matches_filter(active_file)
 		in_add_block = 0
 		if (keep_file) {
-			print $0
+			print "The full include-list for " active_file ":"
 		}
 		next
 	}

--- a/scripts/ci/iwyu_fix.sh
+++ b/scripts/ci/iwyu_fix.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 PYTHON_BIN="${1:-python3}"
 IWYU_DIR="build/iwyu"
 IWYU_OUT="${IWYU_DIR}/iwyu.out"
+IWYU_OUT_FILTERED="${IWYU_DIR}/iwyu.core_functions.filtered.out"
 IWYU_PATCH="${IWYU_DIR}/iwyu.patch"
 FIX_SCRIPT="${IWYU_DIR}/fix_includes.py"
 FIX_SCRIPT_URL="https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/9175c4eeb6084495a6945a9f33de1fc16ec0384e/fix_includes.py"
@@ -18,7 +19,83 @@ set -x
 mkdir -p "${IWYU_DIR}"
 curl --retry 5 -fsSL "${FIX_SCRIPT_URL}" -o "${FIX_SCRIPT}"
 
-"${PYTHON_BIN}" "${FIX_SCRIPT}" --nocomments < "${IWYU_OUT}"
+# Restrict IWYU auto-fixes to extension/core_functions and never add angle includes.
+awk '
+function flush_add_block(  i) {
+	if (!pending_add_header) {
+		return
+	}
+	if (pending_add_count > 0) {
+		print pending_add_header
+		for (i = 1; i <= pending_add_count; i++) {
+			print pending_add_lines[i]
+		}
+	}
+	pending_add_header = ""
+	pending_add_count = 0
+}
+BEGIN {
+	in_add_block = 0
+	pending_add_header = ""
+	pending_add_count = 0
+	active_file = ""
+	keep_file = 0
+}
+{
+	if ($0 ~ / should add these lines:$/) {
+		flush_add_block()
+		active_file = $0
+		sub(/ should add these lines:$/, "", active_file)
+		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		in_add_block = 1
+		pending_add_header = keep_file ? $0 : ""
+		next
+	}
+	if ($0 ~ / should remove these lines:$/) {
+		flush_add_block()
+		active_file = $0
+		sub(/ should remove these lines:$/, "", active_file)
+		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		in_add_block = 0
+		if (keep_file) {
+			print $0
+		}
+		next
+	}
+	if ($0 ~ /^The full include-list for .*:$/) {
+		flush_add_block()
+		active_file = $0
+		sub(/^The full include-list for /, "", active_file)
+		sub(/:$/, "", active_file)
+		keep_file = (index(active_file, "extension/core_functions/") == 1)
+		in_add_block = 0
+		if (keep_file) {
+			print $0
+		}
+		next
+	}
+	if (in_add_block) {
+		if (!keep_file) {
+			next
+		}
+		# Drop all angle-bracket include additions (e.g., stdlib headers).
+		if ($0 ~ /^#include[[:space:]]+<[^>]+>/) {
+			next
+		}
+		pending_add_count++
+		pending_add_lines[pending_add_count] = $0
+		next
+	}
+	if (keep_file) {
+		print $0
+	}
+}
+END {
+	flush_add_block()
+}
+' "${IWYU_OUT}" > "${IWYU_OUT_FILTERED}"
+
+"${PYTHON_BIN}" "${FIX_SCRIPT}" --nocomments < "${IWYU_OUT_FILTERED}"
 git diff > "${IWYU_PATCH}"
 
 if ! git diff --exit-code; then

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -22,6 +22,7 @@ COMMON_JOBS = [
     "windows",
     "no-string-inline",
     "vector-sizes",
+    "include-what-you-use",
     "threadsan",
     "linux-configs",
     "static-libs-linux",

--- a/src/include/duckdb/common/common.hpp
+++ b/src/include/duckdb/common/common.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/vector.hpp"
+// IWYU pragma: end_exports

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -8,8 +8,10 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
+// IWYU pragma: end_exports
 
 #include <functional>
 

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/function/pragma_function.hpp"
 #include "duckdb/function/window_function.hpp"
+// IWYU pragma: end_exports
 
 namespace duckdb {
 


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/21962 but with more restrictions:
- Never include stdlib headers.
- Limit fixes to `extensions/core_functions` (for now).

I've added some IWYU pragma directives so leaf headers are not expanded from umbrella headers.