### PR TITLE
Fix BlockAllocator invalid memory access

### DIFF
--- a/src/include/duckdb/storage/block_allocator.hpp
+++ b/src/include/duckdb/storage/block_allocator.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
 
@@ -86,6 +87,9 @@ private:
 	unsafe_unique_ptr<BlockQueue> untouched;
 	//! Touched by block IDs
 	unsafe_unique_ptr<BlockQueue> touched;
+
+	//! Token used to indicate whether current BlockAllocator is alive.
+	shared_ptr<atomic<bool>> alive_token;
 };
 
 } // namespace duckdb

--- a/src/storage/block_allocator.cpp
+++ b/src/storage/block_allocator.cpp
@@ -136,21 +136,24 @@ public:
 	}
 
 	void Clear() {
-		// Return all local blocks back to global
-		if (!touched.empty()) {
-			block_allocator->touched->q.enqueue_bulk(touched.begin(), touched.size());
-			touched.clear();
+		if (alive_token && alive_token->load()) {
+			// Allocator is still alive — return local blocks to global queues
+			if (!touched.empty()) {
+				block_allocator->touched->q.enqueue_bulk(touched.begin(), touched.size());
+			}
+			if (!untouched.empty()) {
+				block_allocator->untouched->q.enqueue_bulk(untouched.begin(), untouched.size());
+			}
 		}
-		if (!untouched.empty()) {
-			block_allocator->untouched->q.enqueue_bulk(untouched.begin(), untouched.size());
-			untouched.clear();
-		}
+		touched.clear();
+		untouched.clear();
 	}
 
 private:
 	void Initialize(const BlockAllocator &block_allocator_p) {
 		cached_uuid = block_allocator_p.uuid;
 		block_allocator = block_allocator_p;
+		alive_token = block_allocator_p.alive_token;
 		untouched.clear();
 		touched.clear();
 		untouched.reserve(BATCH_SIZE);
@@ -184,6 +187,8 @@ private:
 private:
 	hugeint_t cached_uuid;
 	optional_ptr<const BlockAllocator> block_allocator;
+	// Whether the BlockAllocator is still alive.
+	shared_ptr<atomic<bool>> alive_token;
 
 	static constexpr idx_t BATCH_SIZE = 128;
 	static constexpr idx_t FREE_THRESHOLD = BATCH_SIZE * 2;
@@ -214,12 +219,14 @@ BlockAllocator::BlockAllocator(Allocator &allocator_p, const idx_t block_size_p,
     : uuid(UUID::GenerateRandomUUID()), allocator(allocator_p), block_size(block_size_p),
       block_size_div_shift(CountZeros<idx_t>::Trailing(block_size)),
       virtual_memory_size(AlignValue(virtual_memory_size_p, block_size)), virtual_memory_space(nullptr),
-      physical_memory_size(0), untouched(make_unsafe_uniq<BlockQueue>()), touched(make_unsafe_uniq<BlockQueue>()) {
+      physical_memory_size(0), untouched(make_unsafe_uniq<BlockQueue>()), touched(make_unsafe_uniq<BlockQueue>()),
+      alive_token(make_shared_ptr<atomic<bool>>(true)) {
 	D_ASSERT(IsPowerOfTwo(block_size));
 	Resize(physical_memory_size_p);
 }
 
 BlockAllocator::~BlockAllocator() {
+	alive_token->store(false);
 	GetBlockAllocatorThreadLocalState(*this).Clear();
 	if (IsActive()) {
 		try {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -38,7 +38,8 @@ set(TEST_API_OBJECTS
     test_windows_unicode_path.cpp
     test_object_cache.cpp
     test_partial_executor.cpp
-    test_buffer_pool_eviction.cpp)
+    test_buffer_pool_eviction.cpp
+    test_block_allocator_tls.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_block_allocator_tls.cpp
+++ b/test/api/test_block_allocator_tls.cpp
@@ -1,0 +1,67 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/storage/block_allocator.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/mutex.hpp"
+
+#include <condition_variable>
+#include <thread>
+
+using namespace duckdb;
+
+TEST_CASE("BlockAllocator usage and de-allocation on different threads", "[api][block_allocator]") {
+	constexpr idx_t BLOCK_SIZE = 4096;
+	constexpr idx_t VIRTUAL_MEM_SIZE = 256 * 1024 * 1024;
+	constexpr idx_t PHYSICAL_MEM_SIZE = 256 * 1024 * 1024;
+
+	std::thread worker;
+	mutex mtx;
+	std::condition_variable cv;
+	bool alloc_done = false;
+	bool allocator_destroyed = false;
+
+	// Thread-A, where we construct BlockAllocator.
+	{
+		Allocator alloc;
+		BlockAllocator ba(alloc, BLOCK_SIZE, VIRTUAL_MEM_SIZE, PHYSICAL_MEM_SIZE);
+
+		// Thread-B, where we allocate blocks and creates thread-local state.
+		worker = std::thread([&]() {
+			constexpr int NUM_BLOCKS = 16;
+			data_ptr_t blocks[NUM_BLOCKS];
+			for (int i = 0; i < NUM_BLOCKS; i++) {
+				blocks[i] = ba.AllocateData(BLOCK_SIZE);
+				REQUIRE(blocks[i] != nullptr);
+			}
+			for (int i = 0; i < NUM_BLOCKS; i++) {
+				ba.FreeData(blocks[i], BLOCK_SIZE);
+			}
+
+			{
+				lock_guard<mutex> lk(mtx);
+				alloc_done = true;
+			}
+			cv.notify_one();
+
+			{
+				unique_lock<mutex> lk(mtx);
+				cv.wait(lk, [&] { return allocator_destroyed; });
+			}
+		});
+
+		{
+			unique_lock<mutex> lk(mtx);
+			cv.wait(lk, [&] { return alloc_done; });
+		}
+	}
+	// BlockAllocator destructs here, which clears thread-local allocation state in thread-B, instead of the one in
+	// thread-A, which records free blocks.
+
+	// Destroy thread-B and thread-local state, where allocation happens.
+	{
+		lock_guard<mutex> lk(mtx);
+		allocator_destroyed = true;
+		cv.notify_one();
+	}
+	worker.join();
+}


### PR DESCRIPTION
In the current implementation, we suffer invalid memory access with the unit test.
ASAN reports see below
```sh
hjiang@hjiangs-MacBook-Pro$ ./build/debug/test/unittest "[block_allocator]"
Filters: [block_allocator]
[0/1] (0%): BlockAllocator usage and de-allocation on different threads                                                              =================================================================
==23765==ERROR: AddressSanitizer: stack-use-after-scope on address 0x00016f4ff6f8 at pc 0x00010d437368 bp 0x00016f58abf0 sp 0x00016f58abe8
READ of size 8 at 0x00016f4ff6f8 thread T1
    #0 0x00010d437364 in std::__1::unique_ptr<duckdb::BlockQueue, std::__1::default_delete<duckdb::BlockQueue>>::get[abi:ne200100]() const unique_ptr.h:281
    #1 0x00010d2cddd4 in duckdb::unique_ptr<duckdb::BlockQueue, std::__1::default_delete<duckdb::BlockQueue>, false>::operator->() const unique_ptr.hpp:41
    #2 0x00010d2cd000 in duckdb::BlockAllocatorThreadLocalState::Clear() block_allocator.cpp:141
    #3 0x00010d434348 in duckdb::BlockAllocatorThreadLocalState::~BlockAllocatorThreadLocalState() block_allocator.cpp:97
    #4 0x00010d2cb87c in duckdb::BlockAllocatorThreadLocalState::~BlockAllocatorThreadLocalState() block_allocator.cpp:96
    #5 0x00019527fdc8 in invocation function for block in dyld::ThreadLocalVariables::finalizeList(void*)+0x34 (libdyld.dylib:arm64e+0x3dc8)
```

The root cause is (which is the plain english explanation for the unit test)
- Assume we have two threads: A and B
- BlockAllocator is created in thread-A, and allocates memory in thread-B, which means there's one [thread-local state](https://github.com/duckdb/duckdb/blob/67a0a733f12119424dddee68aed6ad271792ec42/src/storage/block_allocator.cpp#L204) created in thread-B and records free blocks
- When BlockAllocator is destructed in thread-A, a new thread-local state will be created and cleared => thread-A's thread-local state is unchanged
- Now when thread-A destructs, it [attempts to access BlockAllocator](https://github.com/duckdb/duckdb/blob/67a0a733f12119424dddee68aed6ad271792ec42/src/storage/block_allocator.cpp#L139-L149), which leads to invalid memory access

In one word, there's no guarantee on lifecycle for BlockAllocator and threa-local state, this PR simply adds a guard to block possible invalid access.

BlockAllocator is a [per-db instance](https://github.com/duckdb/duckdb/blob/67a0a733f12119424dddee68aed6ad271792ec42/src/include/duckdb/main/config.hpp#L175-L176), so the issue could happen in cases where user creates a DB in one worker thread and performs query.