### PR TITLE
Adapt Hive-partitioned write flushing to number of partitions

### DIFF
--- a/src/common/sort/hashed_sort.cpp
+++ b/src/common/sort/hashed_sort.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/sorting/hashed_sort.hpp"
 #include "duckdb/common/sorting/sorted_run.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
+#include "duckdb/common/types/hyperloglog.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
@@ -307,9 +308,12 @@ public:
 	//! Merge the state into the global state.
 	void Combine(ExecutionContext &context);
 
-	// OVER(PARTITION BY...) (hash grouping)
+	//! OVER(PARTITION BY...) (hash grouping)
 	GroupingPartition local_grouping;
 	GroupingAppend grouping_append;
+
+	//! (optional) HyperLogLog state
+	optional_ptr<ParallelHyperLogLogLocalState> hll;
 };
 
 HashedSortLocalSinkState::HashedSortLocalSinkState(ExecutionContext &context, const HashedSort &hashed_sort)
@@ -391,6 +395,11 @@ SinkResultType HashedSort::Sink(ExecutionContext &context, DataChunk &input_chun
 	lstate.Hash(input_chunk, hash_vector);
 	for (idx_t col_idx = 0; col_idx < input_chunk.ColumnCount(); ++col_idx) {
 		payload_chunk.data[col_idx].Reference(input_chunk.data[col_idx]);
+	}
+
+	// Update HLL state with hashes if necessary
+	if (lstate.hll) {
+		lstate.hll->Update(hash_vector);
 	}
 
 	auto &local_grouping = lstate.local_grouping;
@@ -572,6 +581,11 @@ unique_ptr<GlobalSinkState> HashedSort::GetGlobalSinkState(ClientContext &client
 
 unique_ptr<LocalSinkState> HashedSort::GetLocalSinkState(ExecutionContext &context) const {
 	return make_uniq<HashedSortLocalSinkState>(context, *this);
+}
+
+void HashedSort::RegisterHyperLogLog(LocalSinkState &local_state, ParallelHyperLogLogLocalState &hll_state) const {
+	auto &lstate = local_state.Cast<HashedSortLocalSinkState>();
+	lstate.hll = hll_state;
 }
 
 unique_ptr<GlobalSourceState> HashedSort::GetGlobalSourceState(ClientContext &client, GlobalSinkState &sink) const {

--- a/src/common/sort/sort_strategy.cpp
+++ b/src/common/sort/sort_strategy.cpp
@@ -44,4 +44,8 @@ unique_ptr<SortStrategy> SortStrategy::Factory(ClientContext &client,
 	}
 }
 
+void SortStrategy::RegisterHyperLogLog(LocalSinkState &, ParallelHyperLogLogLocalState &) const {
+	// NOP for all but HashedSort
+}
+
 } // namespace duckdb

--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -76,8 +76,8 @@ void PartitionedTupleData::AppendUnified(PartitionedTupleDataAppendState &state,
 			TupleDataCollection::ComputeHeapSizes(state.chunk_state, input, state.partition_sel, actual_append_count);
 		}
 
-		BuildBufferSpace(state);
 		// Build the buffer space
+		BuildBufferSpace(state);
 
 		// Now scatter everything in one go
 		partitions[0]->Scatter(state.chunk_state, input, state.partition_sel, actual_append_count);

--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -76,8 +76,8 @@ void PartitionedTupleData::AppendUnified(PartitionedTupleDataAppendState &state,
 			TupleDataCollection::ComputeHeapSizes(state.chunk_state, input, state.partition_sel, actual_append_count);
 		}
 
-		// Build the buffer space
 		BuildBufferSpace(state);
+		// Build the buffer space
 
 		// Now scatter everything in one go
 		partitions[0]->Scatter(state.chunk_state, input, state.partition_sel, actual_append_count);
@@ -89,6 +89,9 @@ void PartitionedTupleData::AppendUnified(PartitionedTupleDataAppendState &state,
 
 void PartitionedTupleData::Append(PartitionedTupleDataAppendState &state, TupleDataChunkState &input,
                                   const idx_t append_count) {
+	const auto max_partition_idx = MaxPartitionIndex();
+	const auto use_fixed_size_map = max_partition_idx < PartitionedTupleDataAppendState::MAP_THRESHOLD;
+
 	// Compute partition indices and store them in state.partition_indices
 	ComputePartitionIndices(input.row_locations, append_count, state.partition_indices, state.utility_vector);
 
@@ -96,7 +99,7 @@ void PartitionedTupleData::Append(PartitionedTupleDataAppendState &state, TupleD
 	BuildPartitionSel(state, *FlatVector::IncrementalSelectionVector(), append_count);
 
 	// Early out: check if everything belongs to a single partition
-	auto partition_index = state.GetPartitionIndexIfSinglePartition(UseFixedSizeMap());
+	auto partition_index = state.GetPartitionIndexIfSinglePartition(use_fixed_size_map);
 	if (partition_index.IsValid()) {
 		auto &partition = *partitions[partition_index.GetIndex()];
 		auto &partition_pin_state = state.partition_pin_states[partition_index.GetIndex()];
@@ -131,19 +134,40 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 	}
 }
 
+template <bool FIXED>
+static void AddPartitionEntry(PartitionedTupleDataAppendState &state, const idx_t partition_index) {
+	using GETTER = TemplatedMapGetter<list_entry_t, FIXED>;
+	auto &partition_entries = state.GetMap<FIXED>();
+	auto partition_entry = partition_entries.emplace(partition_index, list_entry_t(0, 1));
+	if (!partition_entry.second) {
+		GETTER::GetValue(partition_entry.first).length++;
+	}
+}
+
+template <>
+void AddPartitionEntry<true>(PartitionedTupleDataAppendState &state, const idx_t partition_index) {
+	bool inserted;
+	auto &partition_entry = state.fixed_partition_entries.GetOrInsert(partition_index, inserted);
+	if (inserted) {
+		partition_entry = list_entry_t(0, 1);
+	} else {
+		partition_entry.length++;
+	}
+}
+
 template <bool FIXED, bool HAS_SEL, bool COMPUTE_REVERSE_PARTITION_SEL>
 static void TemplatedBuildPartitionSel(PartitionedTupleDataAppendState &state, const SelectionVector &append_sel,
                                        const idx_t append_count) {
-	auto &partition_entries = state.GetMap<FIXED>();
 	D_ASSERT(state.partition_indices.GetVectorType() == VectorType::FLAT_VECTOR);
 	const auto partition_indices = FlatVector::GetData<idx_t>(state.partition_indices);
 	auto &partition_sel = state.partition_sel;
 	auto &reverse_partition_sel = state.reverse_partition_sel;
+	auto &partition_offsets = state.partition_offsets;
 
 	for (idx_t i = 0; i < append_count; i++) {
 		const auto index = HAS_SEL ? append_sel[i] : i;
 		const auto &partition_index = partition_indices[i];
-		auto &partition_offset = partition_entries[partition_index].offset;
+		auto &partition_offset = partition_offsets[partition_index];
 		if (COMPUTE_REVERSE_PARTITION_SEL) {
 			reverse_partition_sel.set_index(index, partition_offset);
 		}
@@ -170,13 +194,7 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 		D_ASSERT(state.partition_indices.GetVectorType() == VectorType::FLAT_VECTOR);
 		const auto partition_indices = FlatVector::GetData<idx_t>(state.partition_indices);
 		for (idx_t i = 0; i < append_count; i++) {
-			const auto &partition_index = partition_indices[i];
-			auto partition_entry = partition_entries.find(partition_index);
-			if (partition_entry == partition_entries.end()) {
-				partition_entries[partition_index] = list_entry_t(0, 1);
-			} else {
-				GETTER::GetValue(partition_entry).length++;
-			}
+			AddPartitionEntry<FIXED>(state, partition_indices[i]);
 		}
 	}
 
@@ -197,10 +215,15 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 	}
 
 	// Compute offsets from the counts
+	if (state.partition_offsets.size() <= max_partition_idx) {
+		state.partition_offsets.resize(max_partition_idx + 1);
+	}
 	idx_t offset = 0;
 	for (auto it = partition_entries.begin(); it != partition_entries.end(); ++it) {
+		const auto &partition_index = GETTER::GetKey(it);
 		auto &partition_entry = GETTER::GetValue(it);
 		partition_entry.offset = offset;
+		state.partition_offsets[partition_index] = offset;
 		offset += partition_entry.length;
 	}
 
@@ -242,7 +265,7 @@ void PartitionedTupleData::BuildBufferSpace(PartitionedTupleDataAppendState &sta
 		// Length and offset for this partition
 		const auto &partition_entry = GETTER::GetValue(it);
 		const auto &partition_length = partition_entry.length;
-		const auto partition_offset = partition_entry.offset - partition_length;
+		const auto partition_offset = partition_entry.offset;
 
 		// Build out the buffer space for this partition
 		const auto size_before = partition.data_size;

--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -200,6 +200,9 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 
 	// Early out: check if everything belongs to a single partition
 	if (partition_entries.size() == 1) {
+		if (!state.compute_reverse_partition_sel) {
+			return;
+		}
 		// This needs to be initialized, even if we go the short path here
 		if (append_sel.IsSet()) {
 			for (sel_t i = 0; i < append_count; i++) {
@@ -251,10 +254,10 @@ void PartitionedTupleData::BuildBufferSpace(PartitionedTupleDataAppendState &sta
 	}
 }
 
-template <bool fixed>
+template <bool FIXED>
 void PartitionedTupleData::BuildBufferSpace(PartitionedTupleDataAppendState &state) {
-	using GETTER = TemplatedMapGetter<list_entry_t, fixed>;
-	const auto &partition_entries = state.GetMap<fixed>();
+	using GETTER = TemplatedMapGetter<list_entry_t, FIXED>;
+	const auto &partition_entries = state.GetMap<FIXED>();
 	for (auto it = partition_entries.begin(); it != partition_entries.end(); ++it) {
 		const auto &partition_index = GETTER::GetKey(it);
 

--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -131,6 +131,26 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 	}
 }
 
+template <bool FIXED, bool HAS_SEL, bool COMPUTE_REVERSE_PARTITION_SEL>
+static void TemplatedBuildPartitionSel(PartitionedTupleDataAppendState &state, const SelectionVector &append_sel,
+                                       const idx_t append_count) {
+	auto &partition_entries = state.GetMap<FIXED>();
+	D_ASSERT(state.partition_indices.GetVectorType() == VectorType::FLAT_VECTOR);
+	const auto partition_indices = FlatVector::GetData<idx_t>(state.partition_indices);
+	auto &partition_sel = state.partition_sel;
+	auto &reverse_partition_sel = state.reverse_partition_sel;
+
+	for (idx_t i = 0; i < append_count; i++) {
+		const auto index = HAS_SEL ? append_sel[i] : i;
+		const auto &partition_index = partition_indices[i];
+		auto &partition_offset = partition_entries[partition_index].offset;
+		if (COMPUTE_REVERSE_PARTITION_SEL) {
+			reverse_partition_sel.set_index(index, partition_offset);
+		}
+		partition_sel[partition_offset++] = UnsafeNumericCast<sel_t>(index);
+	}
+}
+
 template <bool FIXED>
 void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &state, const SelectionVector &append_sel,
                                              const idx_t append_count, const idx_t max_partition_idx) {
@@ -185,24 +205,17 @@ void PartitionedTupleData::BuildPartitionSel(PartitionedTupleDataAppendState &st
 	}
 
 	// Now initialize a single selection vector that acts as a selection vector for every partition
-	D_ASSERT(state.partition_indices.GetVectorType() == VectorType::FLAT_VECTOR);
-	const auto partition_indices = FlatVector::GetData<idx_t>(state.partition_indices);
-	auto &partition_sel = state.partition_sel;
-	auto &reverse_partition_sel = state.reverse_partition_sel;
 	if (append_sel.IsSet()) {
-		for (idx_t i = 0; i < append_count; i++) {
-			const auto index = append_sel[i];
-			const auto &partition_index = partition_indices[i];
-			auto &partition_offset = partition_entries[partition_index].offset;
-			reverse_partition_sel.set_index(index, partition_offset);
-			partition_sel[partition_offset++] = index;
+		if (state.compute_reverse_partition_sel) {
+			TemplatedBuildPartitionSel<FIXED, true, true>(state, append_sel, append_count);
+		} else {
+			TemplatedBuildPartitionSel<FIXED, true, false>(state, append_sel, append_count);
 		}
 	} else {
-		for (idx_t i = 0; i < append_count; i++) {
-			const auto &partition_index = partition_indices[i];
-			auto &partition_offset = partition_entries[partition_index].offset;
-			reverse_partition_sel.set_index(i, partition_offset);
-			partition_sel.set_index(partition_offset++, i);
+		if (state.compute_reverse_partition_sel) {
+			TemplatedBuildPartitionSel<FIXED, false, true>(state, append_sel, append_count);
+		} else {
+			TemplatedBuildPartitionSel<FIXED, false, false>(state, append_sel, append_count);
 		}
 	}
 }

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -685,7 +685,7 @@ idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, V
 	TupleDataCollection::ToUnifiedFormat(state.partitioned_append_state.chunk_state, state.group_chunk);
 
 	if (enable_hll) {
-		hll.Update(group_hashes_v, group_hashes_v, groups.size());
+		hll.Update(group_hashes_v);
 	}
 
 	const auto hashes = group_hashes_v.Values<hash_t>(chunk_size);

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -69,6 +69,9 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
 	    layout_ptr->CannotHaveNull() ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOT_DISTINCT_FROM;
 	predicates.resize(layout_ptr->ColumnCount() - 1, expr_type);
 	row_matcher.Initialize(true, *layout_ptr, predicates);
+
+	state.partitioned_append_state.compute_reverse_partition_sel = true;
+	state.unpartitioned_append_state.compute_reverse_partition_sel = true;
 }
 
 void GroupedAggregateHashTable::InitializePartitionedData() {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/sorting/hashed_sort.hpp"
+#include "duckdb/common/sorting/sort_strategy.hpp"
 #include "duckdb/common/types/column/column_data_collection_segment.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/function/window/window_collection.hpp"
@@ -371,8 +371,8 @@ public:
 	//! Lock for managing this state
 	mutable annotated_mutex lock;
 
-	//! To estimate how many partitions
-	ParallelHyperLogLogGlobalState hll_state;
+	//! To estimate number of partitions
+	ParallelHyperLogLogGlobalState hll;
 	//! Sink management
 	unique_ptr<GlobalSinkState> global_sink_state;
 	//! Sort management
@@ -421,7 +421,7 @@ public:
 	string GetOrCreateDirectory(string path, const vector<Value> &values) DUCKDB_REQUIRES(copy_gstate.lock);
 
 private:
-	unique_ptr<const HashedSort> ConstructHashedSort() const;
+	unique_ptr<const SortStrategy> ConstructSortStrategy() const;
 	void CreateNextState();
 	bool ShouldStopFlushing() const;
 
@@ -434,8 +434,8 @@ public:
 	vector<column_t> write_columns;
 	vector<LogicalType> write_types;
 
-	//! Hashed sort with PhysicalOperator-like interface
-	const unique_ptr<const HashedSort> hashed_sort;
+	//! Partition/sort strategy with PhysicalOperator-like interface
+	const unique_ptr<const SortStrategy> sort_strategy;
 
 	//! Lock for managing states (sinking_state, flushing_state, flushing flag)
 	mutable annotated_mutex lock;
@@ -648,7 +648,7 @@ void PartitionedCopyHashGroup::Sort(ExecutionContext &execution_context, GlobalS
                                     InterruptState &interrupt, const PartitionedCopyTask &task) {
 	D_ASSERT(task.stage == PartitionedCopyStage::SORT);
 	OperatorSinkFinalizeInput finalize_input {sink, interrupt};
-	partitioned_copy.hashed_sort->SortColumnData(execution_context, group_idx, finalize_input);
+	partitioned_copy.sort_strategy->SortColumnData(execution_context, group_idx, finalize_input);
 	sorted += (task.end_idx - task.begin_idx);
 }
 
@@ -657,13 +657,13 @@ void PartitionedCopyHashGroup::Materialize(ExecutionContext &execution_context, 
 	D_ASSERT(task.stage == PartitionedCopyStage::MATERIALIZE);
 	auto unused = make_uniq<LocalSourceState>();
 	OperatorSourceInput source_input {source, *unused, interrupt};
-	partitioned_copy.hashed_sort->MaterializeColumnData(execution_context, group_idx, source_input);
+	partitioned_copy.sort_strategy->MaterializeColumnData(execution_context, group_idx, source_input);
 	materialized += (task.end_idx - task.begin_idx);
 
 	if (materialized >= blocks) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (!collection) {
-			collection = partitioned_copy.hashed_sort->GetColumnData(group_idx, source_input);
+			collection = partitioned_copy.sort_strategy->GetColumnData(group_idx, source_input);
 			collection->InitializeScan(batch_scan_state);
 
 			idx_t chunk_index;
@@ -695,7 +695,7 @@ void PartitionedCopyHashGroup::Mask(const PartitionedCopyTask &task) {
 
 	// Only compare partition columns (not order columns)
 	const auto key_count = partitioned_copy.op.partition_columns.size();
-	auto &scan_cols = partitioned_copy.hashed_sort->sort_ids;
+	auto &scan_cols = partitioned_copy.sort_strategy->sort_ids;
 
 	WindowDeltaScanner(*collection, task.begin_idx, task.end_idx, scan_cols, key_count,
 	                   [&](const idx_t row_idx, DataChunk &, DataChunk &, const idx_t ndistinct,
@@ -806,8 +806,8 @@ PartitionedCopyState::PartitionedCopyState(PartitionedCopy &partitioned_copy_p,
 
 void PartitionedCopyState::CreateTaskList() {
 	global_source_state =
-	    partitioned_copy.hashed_sort->GetGlobalSourceState(partitioned_copy.context, *global_sink_state);
-	const auto &chunk_rows = partitioned_copy.hashed_sort->GetHashGroups(*global_source_state);
+	    partitioned_copy.sort_strategy->GetGlobalSourceState(partitioned_copy.context, *global_sink_state);
+	const auto &chunk_rows = partitioned_copy.sort_strategy->GetHashGroups(*global_source_state);
 	hash_groups.resize(chunk_rows.size());
 
 	for (idx_t group_idx = 0; group_idx < hash_groups.size(); ++group_idx) {
@@ -935,13 +935,13 @@ void PartitionedCopyState::FinishTask(const PartitionedCopyTask &task) {
 class PartitionedCopyLocalState : public LocalSinkState {
 public:
 	shared_ptr<PartitionedCopyState> current_state;
-	unique_ptr<LocalSinkState> hashed_sort_local_state;
+	unique_ptr<LocalSinkState> sort_strategy_local_state;
 	idx_t append_count = 0;
 };
 
 PartitionedCopy::PartitionedCopy(const PhysicalCopyToFile &op_p, ClientContext &context_p,
                                  CopyToFileGlobalState &copy_gstate_p)
-    : op(op_p), context(context_p), copy_gstate(copy_gstate_p), hashed_sort(ConstructHashedSort()), flushing(false),
+    : op(op_p), context(context_p), copy_gstate(copy_gstate_p), sort_strategy(ConstructSortStrategy()), flushing(false),
       locals(0), combined(0), finalized(false) {
 	unordered_set<idx_t> part_col_set(op.partition_columns.begin(), op.partition_columns.end());
 	for (idx_t col_idx = 0; col_idx < op.expected_types.size(); col_idx++) {
@@ -952,7 +952,7 @@ PartitionedCopy::PartitionedCopy(const PhysicalCopyToFile &op_p, ClientContext &
 	}
 }
 
-unique_ptr<const HashedSort> PartitionedCopy::ConstructHashedSort() const {
+unique_ptr<const SortStrategy> PartitionedCopy::ConstructSortStrategy() const {
 	vector<unique_ptr<Expression>> partition_bys;
 	for (auto &col : op.partition_columns) {
 		partition_bys.push_back(make_uniq<BoundReferenceExpression>(op.expected_types[col], col));
@@ -960,12 +960,12 @@ unique_ptr<const HashedSort> PartitionedCopy::ConstructHashedSort() const {
 	vector<BoundOrderByNode> order_bys;
 	vector<unique_ptr<BaseStatistics>> partition_stats;
 
-	return make_uniq<HashedSort>(context, partition_bys, order_bys, op.children[0].get().GetTypes(), partition_stats,
+	return SortStrategy::Factory(context, partition_bys, order_bys, op.children[0].get().GetTypes(), partition_stats,
 	                             op.children[0].get().estimated_cardinality);
 }
 
 void PartitionedCopy::CreateNextState() {
-	auto global_sink_state = hashed_sort->GetGlobalSinkState(context);
+	auto global_sink_state = sort_strategy->GetGlobalSinkState(context);
 	annotated_lock_guard<annotated_mutex> guard(lock);
 	D_ASSERT(!sinking_state);
 	sinking_state = make_shared_ptr<PartitionedCopyState>(*this, std::move(global_sink_state));
@@ -992,8 +992,8 @@ void PartitionedCopy::InitializeFlush() {
 
 void PartitionedCopy::FinalizeState(PartitionedCopyState &state, InterruptState &interrupt_state) {
 	D_ASSERT(state.combined == state.locals);
-	OperatorSinkFinalizeInput hashed_sort_finalize_input {*state.global_sink_state, interrupt_state};
-	hashed_sort->Finalize(context, hashed_sort_finalize_input);
+	OperatorSinkFinalizeInput sort_strategy_finalize_input {*state.global_sink_state, interrupt_state};
+	sort_strategy->Finalize(context, sort_strategy_finalize_input);
 	state.CreateTaskList();
 }
 
@@ -1004,7 +1004,7 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 		{
 			annotated_lock_guard<annotated_mutex> global_guard(lock);
 			if (!sinking_state) {
-				auto global_sink_state = hashed_sort->GetGlobalSinkState(context);
+				auto global_sink_state = sort_strategy->GetGlobalSinkState(context);
 				sinking_state = make_shared_ptr<PartitionedCopyState>(*this, std::move(global_sink_state));
 			}
 			lstate.current_state = sinking_state;
@@ -1015,16 +1015,16 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 			lstate.current_state->locals++;
 		}
 
-		lstate.hashed_sort_local_state = hashed_sort->GetLocalSinkState(execution_context);
-		hashed_sort->RegisterHyperLogLog(*lstate.hashed_sort_local_state,
-		                                 lstate.current_state->hll_state.GetLocalState());
+		lstate.sort_strategy_local_state = sort_strategy->GetLocalSinkState(execution_context);
+		sort_strategy->RegisterHyperLogLog(*lstate.sort_strategy_local_state,
+		                                   lstate.current_state->hll.GetLocalState());
 		lstate.append_count = 0;
 	}
 
-	// Sink into hashed sort
-	OperatorSinkInput hashed_sort_sink_input {*lstate.current_state->global_sink_state, *lstate.hashed_sort_local_state,
-	                                          interrupt_state};
-	hashed_sort->Sink(execution_context, chunk, hashed_sort_sink_input);
+	// Sink into sort strategy
+	OperatorSinkInput sort_strategy_sink_input {*lstate.current_state->global_sink_state,
+	                                            *lstate.sort_strategy_local_state, interrupt_state};
+	sort_strategy->Sink(execution_context, chunk, sort_strategy_sink_input);
 	lstate.append_count += chunk.size();
 
 	if (lstate.append_count >= Settings::Get<PartitionedWriteFlushThresholdSetting>(context) &&
@@ -1048,9 +1048,9 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 	}
 
 	if (combine_type == PartitionedCopyCombineType::DURING_PIPELINE_COMBINE) {
-		OperatorSinkCombineInput hashed_sort_combine_input {*lstate.current_state->global_sink_state,
-		                                                    *lstate.hashed_sort_local_state, interrupt_state};
-		hashed_sort->Combine(execution_context, hashed_sort_combine_input);
+		OperatorSinkCombineInput sort_strategy_combine_input {*lstate.current_state->global_sink_state,
+		                                                      *lstate.sort_strategy_local_state, interrupt_state};
+		sort_strategy->Combine(execution_context, sort_strategy_combine_input);
 
 		annotated_lock_guard<annotated_mutex> guard(lstate.current_state->lock);
 		++lstate.current_state->combined;
@@ -1066,9 +1066,9 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 		}
 	}
 
-	OperatorSinkCombineInput hashed_sort_combine_input {*lstate.current_state->global_sink_state,
-	                                                    *lstate.hashed_sort_local_state, interrupt_state};
-	hashed_sort->Combine(execution_context, hashed_sort_combine_input);
+	OperatorSinkCombineInput sort_strategy_combine_input {*lstate.current_state->global_sink_state,
+	                                                      *lstate.sort_strategy_local_state, interrupt_state};
+	sort_strategy->Combine(execution_context, sort_strategy_combine_input);
 
 	{
 		// Finalize if this is the last combine
@@ -1079,7 +1079,7 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 	}
 
 	// Reset local state
-	lstate.hashed_sort_local_state.reset();
+	lstate.sort_strategy_local_state.reset();
 	lstate.current_state.reset();
 }
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -358,6 +358,7 @@ public:
 	PartitionedCopyState(PartitionedCopy &partitioned_copy, unique_ptr<GlobalSinkState> global_sink_state);
 
 public:
+	bool ShouldInitiateFlush(const idx_t &local_append_count);
 	void CreateTaskList() DUCKDB_REQUIRES(lock);
 	bool HasCompleted() const;
 	optional<PartitionedCopyTask> TryAssignTask();
@@ -373,6 +374,9 @@ public:
 
 	//! To estimate number of partitions
 	ParallelHyperLogLogGlobalState hll;
+	//! Check if we should flush once a thread's append count exceeds this value
+	atomic<idx_t> next_flush_check;
+
 	//! Sink management
 	unique_ptr<GlobalSinkState> global_sink_state;
 	//! Sort management
@@ -800,8 +804,32 @@ void PartitionedCopyHashGroup::Flush(const PartitionedCopyTask &task) {
 
 PartitionedCopyState::PartitionedCopyState(PartitionedCopy &partitioned_copy_p,
                                            unique_ptr<GlobalSinkState> global_sink_state_p)
-    : partitioned_copy(partitioned_copy_p), global_sink_state(std::move(global_sink_state_p)), total_blocks(0),
-      next_group(0), locals(0), combined(0) {
+    : partitioned_copy(partitioned_copy_p),
+      next_flush_check(Settings::Get<PartitionedWriteFlushThresholdSetting>(partitioned_copy.context)),
+      global_sink_state(std::move(global_sink_state_p)), total_blocks(0), next_group(0), locals(0), combined(0) {
+}
+
+bool PartitionedCopyState::ShouldInitiateFlush(const idx_t &local_append_count) {
+	auto expected = next_flush_check.load(std::memory_order_relaxed);
+	if (local_append_count < expected) {
+		return false; // Not enough rows accumulated yet
+	}
+
+	// CAS so only one thread increments "next_flush_check"
+	const auto desired = expected + Settings::Get<PartitionedWriteFlushThresholdSetting>(partitioned_copy.context);
+	const auto exchanged = next_flush_check.compare_exchange_strong(expected, desired, std::memory_order_relaxed,
+	                                                                std::memory_order_relaxed);
+	if (!exchanged) {
+		return false; // Another thread beat us to it
+	}
+
+	// Get counts from the HLL states
+	const auto merged_state = hll.GetMergedState();
+	auto [unique_count, total_count] = merged_state->GetCounts();
+	unique_count = MaxValue<idx_t>(unique_count, 1);
+
+	// If we have enough rows per partition on average, we can start flushing
+	return total_count / unique_count >= Settings::Get<PartitionedWriteFlushThresholdSetting>(partitioned_copy.context);
 }
 
 void PartitionedCopyState::CreateTaskList() {
@@ -1027,8 +1055,7 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 	sort_strategy->Sink(execution_context, chunk, sort_strategy_sink_input);
 	lstate.append_count += chunk.size();
 
-	if (lstate.append_count >= Settings::Get<PartitionedWriteFlushThresholdSetting>(context) &&
-	    !flushing.load(std::memory_order_relaxed)) {
+	if (!flushing.load(std::memory_order_relaxed) && lstate.current_state->ShouldInitiateFlush(lstate.append_count)) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		InitializeFlush();
 	}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/sorting/sort_strategy.hpp"
+#include "duckdb/common/sorting/hashed_sort.hpp"
 #include "duckdb/common/types/column/column_data_collection_segment.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/function/window/window_collection.hpp"
@@ -419,7 +419,7 @@ public:
 	string GetOrCreateDirectory(string path, const vector<Value> &values) DUCKDB_REQUIRES(copy_gstate.lock);
 
 private:
-	unique_ptr<const SortStrategy> ConstructSortStrategy() const;
+	unique_ptr<const HashedSort> ConstructHashedSort() const;
 	void CreateNextState();
 	bool ShouldStopFlushing() const;
 
@@ -432,8 +432,8 @@ public:
 	vector<column_t> write_columns;
 	vector<LogicalType> write_types;
 
-	//! Partition/sort strategy with PhysicalOperator-like interface
-	const unique_ptr<const SortStrategy> sort_strategy;
+	//! Hashed sort with PhysicalOperator-like interface
+	const unique_ptr<const HashedSort> hashed_sort;
 
 	//! Lock for managing states (sinking_state, flushing_state, flushing flag)
 	mutable annotated_mutex lock;
@@ -646,7 +646,7 @@ void PartitionedCopyHashGroup::Sort(ExecutionContext &execution_context, GlobalS
                                     InterruptState &interrupt, const PartitionedCopyTask &task) {
 	D_ASSERT(task.stage == PartitionedCopyStage::SORT);
 	OperatorSinkFinalizeInput finalize_input {sink, interrupt};
-	partitioned_copy.sort_strategy->SortColumnData(execution_context, group_idx, finalize_input);
+	partitioned_copy.hashed_sort->SortColumnData(execution_context, group_idx, finalize_input);
 	sorted += (task.end_idx - task.begin_idx);
 }
 
@@ -655,13 +655,13 @@ void PartitionedCopyHashGroup::Materialize(ExecutionContext &execution_context, 
 	D_ASSERT(task.stage == PartitionedCopyStage::MATERIALIZE);
 	auto unused = make_uniq<LocalSourceState>();
 	OperatorSourceInput source_input {source, *unused, interrupt};
-	partitioned_copy.sort_strategy->MaterializeColumnData(execution_context, group_idx, source_input);
+	partitioned_copy.hashed_sort->MaterializeColumnData(execution_context, group_idx, source_input);
 	materialized += (task.end_idx - task.begin_idx);
 
 	if (materialized >= blocks) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (!collection) {
-			collection = partitioned_copy.sort_strategy->GetColumnData(group_idx, source_input);
+			collection = partitioned_copy.hashed_sort->GetColumnData(group_idx, source_input);
 			collection->InitializeScan(batch_scan_state);
 
 			idx_t chunk_index;
@@ -693,7 +693,7 @@ void PartitionedCopyHashGroup::Mask(const PartitionedCopyTask &task) {
 
 	// Only compare partition columns (not order columns)
 	const auto key_count = partitioned_copy.op.partition_columns.size();
-	auto &scan_cols = partitioned_copy.sort_strategy->sort_ids;
+	auto &scan_cols = partitioned_copy.hashed_sort->sort_ids;
 
 	WindowDeltaScanner(*collection, task.begin_idx, task.end_idx, scan_cols, key_count,
 	                   [&](const idx_t row_idx, DataChunk &, DataChunk &, const idx_t ndistinct,
@@ -804,8 +804,8 @@ PartitionedCopyState::PartitionedCopyState(PartitionedCopy &partitioned_copy_p,
 
 void PartitionedCopyState::CreateTaskList() {
 	global_source_state =
-	    partitioned_copy.sort_strategy->GetGlobalSourceState(partitioned_copy.context, *global_sink_state);
-	const auto &chunk_rows = partitioned_copy.sort_strategy->GetHashGroups(*global_source_state);
+	    partitioned_copy.hashed_sort->GetGlobalSourceState(partitioned_copy.context, *global_sink_state);
+	const auto &chunk_rows = partitioned_copy.hashed_sort->GetHashGroups(*global_source_state);
 	hash_groups.resize(chunk_rows.size());
 
 	for (idx_t group_idx = 0; group_idx < hash_groups.size(); ++group_idx) {
@@ -933,13 +933,13 @@ void PartitionedCopyState::FinishTask(const PartitionedCopyTask &task) {
 class PartitionedCopyLocalState : public LocalSinkState {
 public:
 	shared_ptr<PartitionedCopyState> current_state;
-	unique_ptr<LocalSinkState> sort_strategy_local_state;
+	unique_ptr<LocalSinkState> hashed_sort_local_state;
 	idx_t append_count = 0;
 };
 
 PartitionedCopy::PartitionedCopy(const PhysicalCopyToFile &op_p, ClientContext &context_p,
                                  CopyToFileGlobalState &copy_gstate_p)
-    : op(op_p), context(context_p), copy_gstate(copy_gstate_p), sort_strategy(ConstructSortStrategy()), flushing(false),
+    : op(op_p), context(context_p), copy_gstate(copy_gstate_p), hashed_sort(ConstructHashedSort()), flushing(false),
       locals(0), combined(0), finalized(false) {
 	unordered_set<idx_t> part_col_set(op.partition_columns.begin(), op.partition_columns.end());
 	for (idx_t col_idx = 0; col_idx < op.expected_types.size(); col_idx++) {
@@ -950,7 +950,7 @@ PartitionedCopy::PartitionedCopy(const PhysicalCopyToFile &op_p, ClientContext &
 	}
 }
 
-unique_ptr<const SortStrategy> PartitionedCopy::ConstructSortStrategy() const {
+unique_ptr<const HashedSort> PartitionedCopy::ConstructHashedSort() const {
 	vector<unique_ptr<Expression>> partition_bys;
 	for (auto &col : op.partition_columns) {
 		partition_bys.push_back(make_uniq<BoundReferenceExpression>(op.expected_types[col], col));
@@ -958,12 +958,12 @@ unique_ptr<const SortStrategy> PartitionedCopy::ConstructSortStrategy() const {
 	vector<BoundOrderByNode> order_bys;
 	vector<unique_ptr<BaseStatistics>> partition_stats;
 
-	return SortStrategy::Factory(context, partition_bys, order_bys, op.children[0].get().GetTypes(), partition_stats,
+	return make_uniq<HashedSort>(context, partition_bys, order_bys, op.children[0].get().GetTypes(), partition_stats,
 	                             op.children[0].get().estimated_cardinality);
 }
 
 void PartitionedCopy::CreateNextState() {
-	auto global_sink_state = sort_strategy->GetGlobalSinkState(context);
+	auto global_sink_state = hashed_sort->GetGlobalSinkState(context);
 	annotated_lock_guard<annotated_mutex> guard(lock);
 	D_ASSERT(!sinking_state);
 	sinking_state = make_shared_ptr<PartitionedCopyState>(*this, std::move(global_sink_state));
@@ -990,8 +990,8 @@ void PartitionedCopy::InitializeFlush() {
 
 void PartitionedCopy::FinalizeState(PartitionedCopyState &state, InterruptState &interrupt_state) {
 	D_ASSERT(state.combined == state.locals);
-	OperatorSinkFinalizeInput sort_strategy_finalize_input {*state.global_sink_state, interrupt_state};
-	sort_strategy->Finalize(context, sort_strategy_finalize_input);
+	OperatorSinkFinalizeInput hashed_sort_finalize_input {*state.global_sink_state, interrupt_state};
+	hashed_sort->Finalize(context, hashed_sort_finalize_input);
 	state.CreateTaskList();
 }
 
@@ -1002,7 +1002,7 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 		{
 			annotated_lock_guard<annotated_mutex> global_guard(lock);
 			if (!sinking_state) {
-				auto global_sink_state = sort_strategy->GetGlobalSinkState(context);
+				auto global_sink_state = hashed_sort->GetGlobalSinkState(context);
 				sinking_state = make_shared_ptr<PartitionedCopyState>(*this, std::move(global_sink_state));
 			}
 			lstate.current_state = sinking_state;
@@ -1013,14 +1013,14 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 			lstate.current_state->locals++;
 		}
 
-		lstate.sort_strategy_local_state = sort_strategy->GetLocalSinkState(execution_context);
+		lstate.hashed_sort_local_state = hashed_sort->GetLocalSinkState(execution_context);
 		lstate.append_count = 0;
 	}
 
-	// Sink into sort strategy
-	OperatorSinkInput sort_strategy_sink_input {*lstate.current_state->global_sink_state,
-	                                            *lstate.sort_strategy_local_state, interrupt_state};
-	sort_strategy->Sink(execution_context, chunk, sort_strategy_sink_input);
+	// Sink into hashed sort
+	OperatorSinkInput hashed_sort_sink_input {*lstate.current_state->global_sink_state, *lstate.hashed_sort_local_state,
+	                                          interrupt_state};
+	hashed_sort->Sink(execution_context, chunk, hashed_sort_sink_input);
 	lstate.append_count += chunk.size();
 
 	if (lstate.append_count >= Settings::Get<PartitionedWriteFlushThresholdSetting>(context) &&
@@ -1044,9 +1044,9 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 	}
 
 	if (combine_type == PartitionedCopyCombineType::DURING_PIPELINE_COMBINE) {
-		OperatorSinkCombineInput sort_strategy_combine_input {*lstate.current_state->global_sink_state,
-		                                                      *lstate.sort_strategy_local_state, interrupt_state};
-		sort_strategy->Combine(execution_context, sort_strategy_combine_input);
+		OperatorSinkCombineInput hashed_sort_combine_input {*lstate.current_state->global_sink_state,
+		                                                    *lstate.hashed_sort_local_state, interrupt_state};
+		hashed_sort->Combine(execution_context, hashed_sort_combine_input);
 
 		annotated_lock_guard<annotated_mutex> guard(lstate.current_state->lock);
 		++lstate.current_state->combined;
@@ -1062,9 +1062,9 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 		}
 	}
 
-	OperatorSinkCombineInput sort_strategy_combine_input {*lstate.current_state->global_sink_state,
-	                                                      *lstate.sort_strategy_local_state, interrupt_state};
-	sort_strategy->Combine(execution_context, sort_strategy_combine_input);
+	OperatorSinkCombineInput hashed_sort_combine_input {*lstate.current_state->global_sink_state,
+	                                                    *lstate.hashed_sort_local_state, interrupt_state};
+	hashed_sort->Combine(execution_context, hashed_sort_combine_input);
 
 	{
 		// Finalize if this is the last combine
@@ -1075,7 +1075,7 @@ void PartitionedCopy::Combine(ExecutionContext &execution_context, PartitionedCo
 	}
 
 	// Reset local state
-	lstate.sort_strategy_local_state.reset();
+	lstate.hashed_sort_local_state.reset();
 	lstate.current_state.reset();
 }
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -371,6 +371,8 @@ public:
 	//! Lock for managing this state
 	mutable annotated_mutex lock;
 
+	//! To estimate how many partitions
+	ParallelHyperLogLogGlobalState hll_state;
 	//! Sink management
 	unique_ptr<GlobalSinkState> global_sink_state;
 	//! Sort management
@@ -1014,6 +1016,8 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 		}
 
 		lstate.hashed_sort_local_state = hashed_sort->GetLocalSinkState(execution_context);
+		hashed_sort->RegisterHyperLogLog(*lstate.hashed_sort_local_state,
+		                                 lstate.current_state->hll_state.GetLocalState());
 		lstate.append_count = 0;
 	}
 

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -186,6 +186,21 @@ struct SortKeyConstantOperator {
 		}
 		return sizeof(T);
 	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value) {
+		if (FLIP_BYTES) {
+			// descending order - so flip bytes
+			data_t flipped_bytes[sizeof(T)];
+			for (idx_t b = 0; b < sizeof(T); b++) {
+				flipped_bytes[b] = static_cast<data_t>(~input[b]);
+			}
+			result_value = Radix::DecodeData<T>(flipped_bytes);
+		} else {
+			result_value = Radix::DecodeData<T>(input);
+		}
+		return sizeof(T);
+	}
 };
 
 struct SortKeyVarcharOperator {
@@ -233,6 +248,31 @@ struct SortKeyVarcharOperator {
 		auto str_data = data_ptr_cast(result_value.GetDataWriteable());
 		for (pos = 0; pos < str_len; pos++) {
 			if (flip_bytes) {
+				str_data[pos] = static_cast<data_t>((~input[pos]) - 1);
+			} else {
+				str_data[pos] = static_cast<data_t>(input[pos] - 1);
+			}
+		}
+		result_value.Finalize();
+		return pos + 1;
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value) {
+		// iterate until we encounter the string delimiter to figure out the string length
+		data_t string_delimiter = SortKeyVectorData::STRING_DELIMITER;
+		if (FLIP_BYTES) {
+			string_delimiter = static_cast<data_t>(~string_delimiter);
+		}
+		idx_t pos;
+		for (pos = 0; input[pos] != string_delimiter; pos++) {
+		}
+		idx_t str_len = pos;
+		// now allocate the string data and fill it with the decoded data
+		result_value = StringVector::EmptyString(result, str_len);
+		auto str_data = data_ptr_cast(result_value.GetDataWriteable());
+		for (pos = 0; pos < str_len; pos++) {
+			if (FLIP_BYTES) {
 				str_data[pos] = static_cast<data_t>((~input[pos]) - 1);
 			} else {
 				str_data[pos] = static_cast<data_t>(input[pos] - 1);
@@ -319,6 +359,42 @@ struct SortKeyBlobOperator {
 				input_pos++;
 			}
 			if (flip_bytes) {
+				str_data[result_pos++] = static_cast<data_t>(~input[input_pos]);
+			} else {
+				str_data[result_pos++] = input[input_pos];
+			}
+		}
+		result_value.Finalize();
+		return pos + 1;
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value) {
+		// scan until we find the delimiter, keeping in mind escapes
+		data_t string_delimiter = SortKeyVectorData::STRING_DELIMITER;
+		data_t escape_character = SortKeyVectorData::BLOB_ESCAPE_CHARACTER;
+		if (FLIP_BYTES) {
+			string_delimiter = static_cast<data_t>(~string_delimiter);
+			escape_character = static_cast<data_t>(~escape_character);
+		}
+		idx_t blob_len = 0;
+		idx_t pos;
+		for (pos = 0; input[pos] != string_delimiter; pos++) {
+			blob_len++;
+			if (input[pos] == escape_character) {
+				// escape character - skip the next byte
+				pos++;
+			}
+		}
+		// now allocate the blob data and fill it with the decoded data
+		result_value = StringVector::EmptyString(result, blob_len);
+		auto str_data = data_ptr_cast(result_value.GetDataWriteable());
+		for (idx_t input_pos = 0, result_pos = 0; input_pos < pos; input_pos++) {
+			if (input[input_pos] == escape_character) {
+				// if we encounter an escape character - copy the NEXT byte
+				input_pos++;
+			}
+			if (FLIP_BYTES) {
 				str_data[result_pos++] = static_cast<data_t>(~input[input_pos]);
 			} else {
 				str_data[result_pos++] = input[input_pos];
@@ -993,26 +1069,37 @@ struct DecodeSortKeyData {
 void DecodeSortKeyRecursive(DecodeSortKeyData decode_data[], DecodeSortKeyVectorData &vector_data, Vector &result,
                             idx_t result_offset, idx_t count);
 
-template <class OP>
-void TemplatedDecodeSortKey(DecodeSortKeyData decode_data_arr[], DecodeSortKeyVectorData &vector_data, Vector &result,
-                            const idx_t result_offset, const idx_t count) {
+template <class OP, bool FLIP_BYTES>
+void TemplatedDecodeSortKeyInternal(DecodeSortKeyData decode_data_arr[], DecodeSortKeyVectorData &vector_data,
+                                    Vector &result, const idx_t result_offset, const idx_t count) {
 	const auto is_const = result.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	auto &result_validity = is_const ? ConstantVector::Validity(result) : FlatVector::ValidityMutable(result);
 	const auto result_data = is_const ? ConstantVector::GetData<typename OP::TYPE>(result)
 	                                  : FlatVector::GetDataMutable<typename OP::TYPE>(result);
+	const auto null_byte = vector_data.null_byte;
 	for (idx_t i = 0; i < count; i++) {
 		const auto result_idx = result_offset + i;
 		auto &decode_data = decode_data_arr[i];
 		auto validity_byte = decode_data.data[decode_data.position];
 		decode_data.position++;
-		if (validity_byte == vector_data.null_byte) {
+		if (validity_byte == null_byte) {
 			// NULL value
 			result_validity.SetInvalid(result_idx);
 			continue;
 		}
-		idx_t increment = OP::Decode(decode_data.data + decode_data.position, result, result_data[result_idx],
-		                             vector_data.flip_bytes);
+		idx_t increment =
+		    OP::template Decode<FLIP_BYTES>(decode_data.data + decode_data.position, result, result_data[result_idx]);
 		decode_data.position += increment;
+	}
+}
+
+template <class OP>
+void TemplatedDecodeSortKey(DecodeSortKeyData decode_data_arr[], DecodeSortKeyVectorData &vector_data, Vector &result,
+                            const idx_t result_offset, const idx_t count) {
+	if (vector_data.flip_bytes) {
+		TemplatedDecodeSortKeyInternal<OP, true>(decode_data_arr, vector_data, result, result_offset, count);
+	} else {
+		TemplatedDecodeSortKeyInternal<OP, false>(decode_data_arr, vector_data, result, result_offset, count);
 	}
 }
 

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -24,11 +24,12 @@ struct SortKeyBindData : public FunctionData {
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<SortKeyBindData>();
-		return modifiers == other.modifiers;
+		return modifiers == other.modifiers && all_constant == other.all_constant;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<SortKeyBindData>();
 		result->modifiers = modifiers;
+		result->all_constant = all_constant;
 		return std::move(result);
 	}
 };

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -20,6 +20,7 @@ namespace duckdb {
 namespace {
 struct SortKeyBindData : public FunctionData {
 	vector<OrderModifiers> modifiers;
+	bool all_constant = false;
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<SortKeyBindData>();
@@ -71,6 +72,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(BindScalarFunctionInput &input) {
 			function.SetReturnType(LogicalType::BIGINT);
 		}
 	}
+	result->all_constant = all_constant;
 	return std::move(result);
 }
 
@@ -674,17 +676,30 @@ void ConstructSortKey(SortKeyVectorData &vector_data, SortKeyConstructInfo &info
 	ConstructSortKeyRecursive(vector_data, SortKeyChunk(0, vector_data.size), info);
 }
 
-void PrepareSortData(Vector &result, idx_t size, SortKeyLengthInfo &key_lengths, data_ptr_t *data_pointers) {
+void PrepareSortData(Vector &result, idx_t size, SortKeyLengthInfo &key_lengths, data_ptr_t *data_pointers,
+                     const bool &all_constant) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::BLOB: {
 		auto result_data = FlatVector::Writer<string_t>(result, size);
-		for (idx_t r = 0; r < size; r++) {
-			auto blob_size = key_lengths.variable_lengths[r] + key_lengths.constant_length;
-			auto &empty_string = result_data.WriteEmptyString(blob_size);
-			data_pointers[r] = data_ptr_cast(empty_string.GetDataWriteable());
+		if (all_constant && key_lengths.constant_length <= string_t::INLINE_LENGTH) {
+			// Fast path
+			const auto length = key_lengths.constant_length;
+			for (idx_t r = 0; r < size; r++) {
+				auto &empty_string = result_data.WriteEmptyString(length);
+				data_pointers[r] = data_ptr_cast(empty_string.GetPrefixWriteable());
 #ifdef DEBUG
-			memset(data_pointers[r], 0xFF, blob_size);
+				memset(data_pointers[r], 0xFF, length);
 #endif
+			}
+		} else {
+			for (idx_t r = 0; r < size; r++) {
+				auto blob_size = key_lengths.variable_lengths[r] + key_lengths.constant_length;
+				auto &empty_string = result_data.WriteEmptyString(blob_size);
+				data_pointers[r] = data_ptr_cast(empty_string.GetDataWriteable());
+#ifdef DEBUG
+				memset(data_pointers[r], 0xFF, blob_size);
+#endif
+			}
 		}
 		break;
 	}
@@ -708,7 +723,7 @@ void FinalizeSortData(Vector &result, idx_t size, const SortKeyLengthInfo &key_l
 		auto result_data = FlatVector::GetDataMutable<string_t>(result);
 		// call Finalize on the result
 		for (idx_t r = 0; r < size; r++) {
-			result_data[r].SetSizeAndFinalize(NumericCast<uint32_t>(offsets[r]),
+			result_data[r].SetSizeAndFinalize(UnsafeNumericCast<uint32_t>(offsets[r]),
 			                                  key_lengths.variable_lengths[r] + key_lengths.constant_length);
 		}
 		break;
@@ -726,7 +741,8 @@ void FinalizeSortData(Vector &result, idx_t size, const SortKeyLengthInfo &key_l
 }
 
 void CreateSortKeyInternal(vector<unique_ptr<SortKeyVectorData>> &sort_key_data,
-                           const vector<OrderModifiers> &modifiers, Vector &result, idx_t row_count) {
+                           const vector<OrderModifiers> &modifiers, const bool &all_constant, Vector &result,
+                           idx_t row_count) {
 	// two phases
 	// a) get the length of the final sorted key
 	// b) allocate the sorted key and construct
@@ -737,7 +753,7 @@ void CreateSortKeyInternal(vector<unique_ptr<SortKeyVectorData>> &sort_key_data,
 	}
 	// allocate the empty sort keys
 	auto data_pointers = unique_ptr<data_ptr_t[]>(new data_ptr_t[row_count]);
-	PrepareSortData(result, row_count, key_lengths, data_pointers.get());
+	PrepareSortData(result, row_count, key_lengths, data_pointers.get(), all_constant);
 
 	unsafe_vector<idx_t> offsets;
 	offsets.resize(row_count, 0);
@@ -758,7 +774,7 @@ void CreateSortKeyHelpers::CreateSortKey(Vector &input, idx_t input_count, Order
 	vector<unique_ptr<SortKeyVectorData>> sort_key_data;
 	sort_key_data.push_back(make_uniq<SortKeyVectorData>(input, input_count, order_modifier));
 
-	CreateSortKeyInternal(sort_key_data, modifiers, result, input_count);
+	CreateSortKeyInternal(sort_key_data, modifiers, false, result, input_count);
 }
 
 void CreateSortKeyHelpers::CreateSortKey(DataChunk &input, const vector<OrderModifiers> &modifiers, Vector &result) {
@@ -767,7 +783,7 @@ void CreateSortKeyHelpers::CreateSortKey(DataChunk &input, const vector<OrderMod
 	for (idx_t r = 0; r < modifiers.size(); r++) {
 		sort_key_data.push_back(make_uniq<SortKeyVectorData>(input.data[r], input.size(), modifiers[r]));
 	}
-	CreateSortKeyInternal(sort_key_data, modifiers, result, input.size());
+	CreateSortKeyInternal(sort_key_data, modifiers, false, result, input.size());
 }
 
 void CreateSortKeyHelpers::CreateSortKeyWithValidity(Vector &input, Vector &result, const OrderModifiers &modifiers,
@@ -793,7 +809,7 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 	for (idx_t c = 0; c < args.ColumnCount(); c += 2) {
 		sort_key_data.push_back(make_uniq<SortKeyVectorData>(args.data[c], args.size(), bind_data.modifiers[c / 2]));
 	}
-	CreateSortKeyInternal(sort_key_data, bind_data.modifiers, result, args.size());
+	CreateSortKeyInternal(sort_key_data, bind_data.modifiers, bind_data.all_constant, result, args.size());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -162,6 +162,17 @@ struct SortKeyConstantOperator {
 		return sizeof(T);
 	}
 
+	template <bool FLIP_BYTES>
+	static idx_t Encode(data_ptr_t result, TYPE input) {
+		Radix::EncodeData<T>(result, input);
+		if (FLIP_BYTES) {
+			for (idx_t b = 0; b < sizeof(T); b++) {
+				result[b] = static_cast<data_t>(~result[b]);
+			}
+		}
+		return sizeof(T);
+	}
+
 	static idx_t Decode(const_data_ptr_t input, Vector &result, TYPE &result_value, bool flip_bytes) {
 		if (flip_bytes) {
 			// descending order - so flip bytes
@@ -191,6 +202,19 @@ struct SortKeyVarcharOperator {
 			result[r] = input_data[r] + 1;
 		}
 		result[input_size] = SortKeyVectorData::STRING_DELIMITER; // null-byte delimiter
+		return input_size + 1;
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Encode(data_ptr_t result, TYPE input) {
+		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
+		auto input_size = input.GetSize();
+		for (idx_t r = 0; r < input_size; r++) {
+			auto encoded_byte = static_cast<data_t>(input_data[r] + 1);
+			result[r] = FLIP_BYTES ? static_cast<data_t>(~encoded_byte) : encoded_byte;
+		}
+		auto delimiter = SortKeyVectorData::STRING_DELIMITER;
+		result[input_size] = FLIP_BYTES ? static_cast<data_t>(~delimiter) : delimiter;
 		return input_size + 1;
 	}
 
@@ -249,6 +273,23 @@ struct SortKeyBlobOperator {
 			}
 		}
 		result[result_offset++] = SortKeyVectorData::STRING_DELIMITER; // null-byte delimiter
+		return result_offset;
+	}
+
+	template <bool FLIP_BYTES>
+	static idx_t Encode(data_ptr_t result, TYPE input) {
+		auto input_data = data_ptr_t(input.GetDataUnsafe());
+		auto input_size = input.GetSize();
+		idx_t result_offset = 0;
+		for (idx_t r = 0; r < input_size; r++) {
+			if (input_data[r] <= 1) {
+				auto escape = SortKeyVectorData::BLOB_ESCAPE_CHARACTER;
+				result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~escape) : escape;
+			}
+			result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~input_data[r]) : input_data[r];
+		}
+		auto delimiter = SortKeyVectorData::STRING_DELIMITER;
+		result[result_offset++] = FLIP_BYTES ? static_cast<data_t>(~delimiter) : delimiter;
 		return result_offset;
 	}
 
@@ -493,31 +534,27 @@ struct SortKeyConstructInfo {
 
 static void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, SortKeyChunk chunk, SortKeyConstructInfo &info);
 
-template <class OP, bool ALL_VALID, bool HAS_RESULT_INDEX_OR_SEL>
+template <class OP, bool ALL_VALID_NO_SELS, bool FLIP_BYTES>
 void TemplatedConstructSortKeyInternal(const SortKeyVectorData &vector_data, const SortKeyChunk chunk,
                                        const SortKeyConstructInfo &info) {
 	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
 	auto &offsets = info.offsets;
 	for (idx_t r = chunk.start; r < chunk.end; r++) {
-		const auto result_index = HAS_RESULT_INDEX_OR_SEL ? chunk.GetResultIndex(r) : r;
-		const auto idx = HAS_RESULT_INDEX_OR_SEL ? vector_data.format.sel->get_index(r) : r;
-		auto &offset = offsets[result_index];
+		const auto result_index = ALL_VALID_NO_SELS ? r : chunk.GetResultIndex(r);
+		const auto idx = ALL_VALID_NO_SELS ? r : vector_data.format.sel->get_index(r);
+		auto offset = offsets[result_index];
 		auto result_ptr = info.result_data[result_index];
-		if (!ALL_VALID && !vector_data.format.validity.RowIsValid(idx)) {
+		if (!ALL_VALID_NO_SELS && !vector_data.format.validity.RowIsValidUnsafe(idx)) {
 			// NULL value - write the null byte and skip
 			result_ptr[offset++] = vector_data.null_byte;
+			offsets[result_index] = offset;
 			continue;
 		}
 		// valid value - write the validity byte
 		result_ptr[offset++] = vector_data.valid_byte;
-		idx_t encode_len = OP::Encode(result_ptr + offset, data[idx]);
-		if (info.flip_bytes) {
-			// descending order - so flip bytes
-			for (idx_t b = offset; b < offset + encode_len; b++) {
-				result_ptr[b] = static_cast<data_t>(~result_ptr[b]);
-			}
-		}
+		idx_t encode_len = OP::template Encode<FLIP_BYTES>(result_ptr + offset, data[idx]);
 		offset += encode_len;
+		offsets[result_index] = offset;
 	}
 }
 
@@ -526,18 +563,17 @@ void TemplatedConstructSortKey(SortKeyVectorData &vector_data, SortKeyChunk chun
 	if (chunk.start == chunk.end) {
 		return;
 	}
-	if (vector_data.format.validity.CannotHaveNull()) {
-		if (!chunk.has_result_index && !vector_data.format.sel->IsSet()) {
-			TemplatedConstructSortKeyInternal<OP, true, false>(vector_data, chunk, info);
-		} else {
-			TemplatedConstructSortKeyInternal<OP, true, true>(vector_data, chunk, info);
-		}
+	const auto all_valid = vector_data.format.validity.CannotHaveNull();
+	const auto has_sel = vector_data.format.sel->IsSet();
+	const auto all_valid_no_sels = all_valid && !chunk.has_result_index && !has_sel;
+	if (all_valid_no_sels && !info.flip_bytes) {
+		TemplatedConstructSortKeyInternal<OP, true, false>(vector_data, chunk, info);
+	} else if (all_valid_no_sels) {
+		TemplatedConstructSortKeyInternal<OP, true, true>(vector_data, chunk, info);
+	} else if (!info.flip_bytes) {
+		TemplatedConstructSortKeyInternal<OP, false, false>(vector_data, chunk, info);
 	} else {
-		if (!chunk.has_result_index && !vector_data.format.sel->IsSet()) {
-			TemplatedConstructSortKeyInternal<OP, false, false>(vector_data, chunk, info);
-		} else {
-			TemplatedConstructSortKeyInternal<OP, false, true>(vector_data, chunk, info);
-		}
+		TemplatedConstructSortKeyInternal<OP, false, true>(vector_data, chunk, info);
 	}
 }
 

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -610,17 +610,17 @@ struct SortKeyConstructInfo {
 
 static void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, SortKeyChunk chunk, SortKeyConstructInfo &info);
 
-template <class OP, bool ALL_VALID_NO_SELS, bool FLIP_BYTES>
+template <class OP, bool ALL_VALID, bool NO_SELS, bool FLIP_BYTES>
 void TemplatedConstructSortKeyInternal(const SortKeyVectorData &vector_data, const SortKeyChunk chunk,
                                        const SortKeyConstructInfo &info) {
 	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
 	auto &offsets = info.offsets;
 	for (idx_t r = chunk.start; r < chunk.end; r++) {
-		const auto result_index = ALL_VALID_NO_SELS ? r : chunk.GetResultIndex(r);
-		const auto idx = ALL_VALID_NO_SELS ? r : vector_data.format.sel->get_index(r);
+		const auto result_index = NO_SELS ? r : chunk.GetResultIndex(r);
+		const auto idx = NO_SELS ? r : vector_data.format.sel->get_index(r);
 		auto offset = offsets[result_index];
 		auto result_ptr = info.result_data[result_index];
-		if (!ALL_VALID_NO_SELS && !vector_data.format.validity.RowIsValidUnsafe(idx)) {
+		if (!ALL_VALID && !vector_data.format.validity.RowIsValidUnsafe(idx)) {
 			// NULL value - write the null byte and skip
 			result_ptr[offset++] = vector_data.null_byte;
 			offsets[result_index] = offset;
@@ -634,22 +634,31 @@ void TemplatedConstructSortKeyInternal(const SortKeyVectorData &vector_data, con
 	}
 }
 
+template <class OP, bool ALL_VALID, bool NO_SELS>
+void TemplatedConstructSortKeyDispatchFlip(SortKeyVectorData &vector_data, SortKeyChunk chunk,
+                                           SortKeyConstructInfo &info) {
+	if (info.flip_bytes) {
+		TemplatedConstructSortKeyInternal<OP, ALL_VALID, NO_SELS, true>(vector_data, chunk, info);
+	} else {
+		TemplatedConstructSortKeyInternal<OP, ALL_VALID, NO_SELS, false>(vector_data, chunk, info);
+	}
+}
+
 template <class OP>
 void TemplatedConstructSortKey(SortKeyVectorData &vector_data, SortKeyChunk chunk, SortKeyConstructInfo &info) {
 	if (chunk.start == chunk.end) {
 		return;
 	}
 	const auto all_valid = vector_data.format.validity.CannotHaveNull();
-	const auto has_sel = vector_data.format.sel->IsSet();
-	const auto all_valid_no_sels = all_valid && !chunk.has_result_index && !has_sel;
-	if (all_valid_no_sels && !info.flip_bytes) {
-		TemplatedConstructSortKeyInternal<OP, true, false>(vector_data, chunk, info);
-	} else if (all_valid_no_sels) {
-		TemplatedConstructSortKeyInternal<OP, true, true>(vector_data, chunk, info);
-	} else if (!info.flip_bytes) {
-		TemplatedConstructSortKeyInternal<OP, false, false>(vector_data, chunk, info);
+	const auto no_sels = !chunk.has_result_index && !vector_data.format.sel->IsSet();
+	if (all_valid && no_sels) {
+		TemplatedConstructSortKeyDispatchFlip<OP, true, true>(vector_data, chunk, info);
+	} else if (all_valid) {
+		TemplatedConstructSortKeyDispatchFlip<OP, true, false>(vector_data, chunk, info);
+	} else if (no_sels) {
+		TemplatedConstructSortKeyDispatchFlip<OP, false, true>(vector_data, chunk, info);
 	} else {
-		TemplatedConstructSortKeyInternal<OP, false, true>(vector_data, chunk, info);
+		TemplatedConstructSortKeyDispatchFlip<OP, false, false>(vector_data, chunk, info);
 	}
 }
 

--- a/src/include/duckdb/common/fixed_size_map.hpp
+++ b/src/include/duckdb/common/fixed_size_map.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/perfect_map_set.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 
@@ -131,33 +132,7 @@ public:
 		if (++idx_in_entry == occupied_mask::BITS_PER_VALUE) {
 			NextEntry();
 		}
-		// Loop until we find an occupied index, or until the end
-		auto end = map.end();
-		while (*this < end) {
-			const auto &entry = map.occupied.GetValidityEntryUnsafe(entry_idx);
-			if (entry == static_cast<uint8_t>(~occupied_mask::ValidityBuffer::MAX_ENTRY)) {
-				// Entire entry is unoccupied, skip
-				if (entry_idx == end.entry_idx) {
-					// This is the last entry
-					idx_in_entry = end.idx_in_entry;
-					break;
-				}
-				NextEntry();
-			} else {
-				// One or more occupied in entry, loop over it
-				const auto idx_to = entry_idx == end.entry_idx ? end.idx_in_entry : occupied_mask::BITS_PER_VALUE;
-				for (; idx_in_entry < idx_to; idx_in_entry++) {
-					if (map.occupied.RowIsValid(entry, idx_in_entry)) {
-						// We found an occupied index
-						return *this;
-					}
-				}
-				// We did not find an occupied index
-				if (*this != end) {
-					NextEntry();
-				}
-			}
-		}
+		MoveToNextOccupied();
 		return *this;
 	}
 
@@ -201,6 +176,27 @@ private:
 	void NextEntry() {
 		entry_idx++;
 		idx_in_entry = 0;
+	}
+
+	void MoveToNextOccupied() {
+		idx_t end_entry_idx;
+		idx_t end_idx_in_entry;
+		occupied_mask::GetEntryIndex(map.capacity, end_entry_idx, end_idx_in_entry);
+		while (entry_idx < end_entry_idx || (entry_idx == end_entry_idx && idx_in_entry < end_idx_in_entry)) {
+			const auto entry_end =
+			    entry_idx == end_entry_idx ? end_idx_in_entry : occupied_mask::BITS_PER_VALUE;
+			const auto entry = map.occupied.GetValidityEntryUnsafe(entry_idx);
+			const auto valid_until_end = static_cast<uint8_t>(entry & occupied_mask::EntryWithValidBits(entry_end));
+			const auto remaining =
+			    static_cast<uint8_t>(valid_until_end & ~occupied_mask::EntryWithValidBits(idx_in_entry));
+			if (remaining) {
+				idx_in_entry = CountZeros<uint64_t>::Trailing(remaining);
+				return;
+			}
+			NextEntry();
+		}
+		entry_idx = end_entry_idx;
+		idx_in_entry = end_idx_in_entry;
 	}
 
 private:

--- a/src/include/duckdb/common/fixed_size_map.hpp
+++ b/src/include/duckdb/common/fixed_size_map.hpp
@@ -48,13 +48,19 @@ public:
 
 	void clear() { // NOLINT: match stl case
 		count = 0;
+		min_occupied_key = capacity;
+		max_occupied_key = 0;
 		occupied.SetAllInvalid(capacity);
 	}
 
 	mapped_type &operator[](const key_type &key) {
 		D_ASSERT(key < capacity);
-		count += 1 - occupied.RowIsValidUnsafe(key);
-		occupied.SetValidUnsafe(key);
+		if (!occupied.RowIsValidUnsafe(key)) {
+			count++;
+			min_occupied_key = MinValue(min_occupied_key, key);
+			max_occupied_key = MaxValue(max_occupied_key, key);
+			occupied.SetValidUnsafe(key);
+		}
 		return values[key];
 	}
 
@@ -63,6 +69,8 @@ public:
 		inserted = !occupied.RowIsValidUnsafe(key);
 		if (inserted) {
 			count++;
+			min_occupied_key = MinValue(min_occupied_key, key);
+			max_occupied_key = MaxValue(max_occupied_key, key);
 			occupied.SetValidUnsafe(key);
 		}
 		return values[key];
@@ -74,19 +82,17 @@ public:
 	}
 
 	iterator begin() { // NOLINT: match stl case
-		iterator result(*this, 0);
-		if (!occupied_mask::RowIsValid(occupied.GetValidityEntryUnsafe(0), 0)) {
-			++result;
+		if (count == 0) {
+			return end();
 		}
-		return result;
+		return iterator(*this, min_occupied_key);
 	}
 
 	const_iterator begin() const { // NOLINT: match stl case
-		const_iterator result(*this, 0);
-		if (!occupied_mask::RowIsValid(occupied.GetValidityEntryUnsafe(0), 0)) {
-			++result;
+		if (count == 0) {
+			return end();
 		}
-		return result;
+		return const_iterator(*this, min_occupied_key);
 	}
 
 	iterator end() { // NOLINT: match stl case
@@ -108,6 +114,8 @@ public:
 private:
 	idx_t capacity;
 	idx_t count;
+	idx_t min_occupied_key;
+	idx_t max_occupied_key;
 
 	occupied_mask occupied;
 	unsafe_unique_array<mapped_type> values;
@@ -179,12 +187,13 @@ private:
 	}
 
 	void MoveToNextOccupied() {
+		const auto iterator_end = map.capacity;
+		const auto scan_end = map.count == 0 ? iterator_end : map.max_occupied_key + 1;
 		idx_t end_entry_idx;
 		idx_t end_idx_in_entry;
-		occupied_mask::GetEntryIndex(map.capacity, end_entry_idx, end_idx_in_entry);
+		occupied_mask::GetEntryIndex(scan_end, end_entry_idx, end_idx_in_entry);
 		while (entry_idx < end_entry_idx || (entry_idx == end_entry_idx && idx_in_entry < end_idx_in_entry)) {
-			const auto entry_end =
-			    entry_idx == end_entry_idx ? end_idx_in_entry : occupied_mask::BITS_PER_VALUE;
+			const auto entry_end = entry_idx == end_entry_idx ? end_idx_in_entry : occupied_mask::BITS_PER_VALUE;
 			const auto entry = map.occupied.GetValidityEntryUnsafe(entry_idx);
 			const auto valid_until_end = static_cast<uint8_t>(entry & occupied_mask::EntryWithValidBits(entry_end));
 			const auto remaining =
@@ -195,8 +204,7 @@ private:
 			}
 			NextEntry();
 		}
-		entry_idx = end_entry_idx;
-		idx_in_entry = end_idx_in_entry;
+		occupied_mask::GetEntryIndex(iterator_end, entry_idx, idx_in_entry);
 	}
 
 private:

--- a/src/include/duckdb/common/fixed_size_map.hpp
+++ b/src/include/duckdb/common/fixed_size_map.hpp
@@ -57,6 +57,16 @@ public:
 		return values[key];
 	}
 
+	mapped_type &GetOrInsert(const key_type &key, bool &inserted) {
+		D_ASSERT(key < capacity);
+		inserted = !occupied.RowIsValidUnsafe(key);
+		if (inserted) {
+			count++;
+			occupied.SetValidUnsafe(key);
+		}
+		return values[key];
+	}
+
 	const mapped_type &operator[](const key_type &key) const {
 		D_ASSERT(key < capacity);
 		return values[key];

--- a/src/include/duckdb/common/sorting/hashed_sort.hpp
+++ b/src/include/duckdb/common/sorting/hashed_sort.hpp
@@ -12,6 +12,8 @@
 
 namespace duckdb {
 
+class ParallelHyperLogLogLocalState;
+
 class HashedSort : public SortStrategy {
 public:
 	using Orders = vector<BoundOrderByNode>;
@@ -62,6 +64,8 @@ public:
 	SortedRunPtr GetSortedRun(ClientContext &client, idx_t hash_bin, OperatorSourceInput &source) const override;
 
 	const ChunkRows &GetHashGroups(GlobalSourceState &global_state) const override;
+
+	void RegisterHyperLogLog(LocalSinkState &local_state, ParallelHyperLogLogLocalState &hll_state) const;
 
 public:
 	//! The host's estimated row count

--- a/src/include/duckdb/common/sorting/hashed_sort.hpp
+++ b/src/include/duckdb/common/sorting/hashed_sort.hpp
@@ -12,8 +12,6 @@
 
 namespace duckdb {
 
-class ParallelHyperLogLogLocalState;
-
 class HashedSort : public SortStrategy {
 public:
 	using Orders = vector<BoundOrderByNode>;
@@ -65,7 +63,7 @@ public:
 
 	const ChunkRows &GetHashGroups(GlobalSourceState &global_state) const override;
 
-	void RegisterHyperLogLog(LocalSinkState &local_state, ParallelHyperLogLogLocalState &hll_state) const;
+	void RegisterHyperLogLog(LocalSinkState &local_state, ParallelHyperLogLogLocalState &hll_state) const override;
 
 public:
 	//! The host's estimated row count

--- a/src/include/duckdb/common/sorting/sort_strategy.hpp
+++ b/src/include/duckdb/common/sorting/sort_strategy.hpp
@@ -12,6 +12,8 @@
 
 namespace duckdb {
 
+class ParallelHyperLogLogLocalState;
+
 class SortStrategy {
 public:
 	using Types = vector<LogicalType>;
@@ -68,6 +70,8 @@ public:
 	};
 	using ChunkRows = vector<ChunkRow>;
 	virtual const ChunkRows &GetHashGroups(GlobalSourceState &global_state) const = 0;
+
+	virtual void RegisterHyperLogLog(LocalSinkState &local_state, ParallelHyperLogLogLocalState &hll_state) const;
 
 public:
 	//! The inserted data schema

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -141,23 +141,32 @@ public:
 //! Utility for computing HLL in parallel
 class ParallelHyperLogLogLocalState {
 public:
-	ParallelHyperLogLogLocalState() {
+	ParallelHyperLogLogLocalState() : count(0) {
 	}
 
 public:
 	void Update(Vector &hashes) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		hll.Update(hashes, hashes, hashes.size());
+		count += hashes.size();
 	}
 
-	void Merge(HyperLogLog &other) const {
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		other.Merge(hll);
+	void Merge(ParallelHyperLogLogLocalState &other) const DUCKDB_REQUIRES(lock) DUCKDB_REQUIRES(other.lock) {
+		other.hll.Merge(hll);
+		other.count += count;
 	}
+
+	pair<idx_t, idx_t> GetCounts() const {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return {hll.Count(), count};
+	}
+
+public:
+	mutable annotated_mutex lock;
 
 private:
-	mutable annotated_mutex lock;
 	HyperLogLog hll DUCKDB_GUARDED_BY(lock);
+	idx_t count DUCKDB_GUARDED_BY(lock);
 };
 
 class ParallelHyperLogLogGlobalState {
@@ -174,13 +183,16 @@ public:
 		return result;
 	}
 
-	idx_t GetCount() const {
-		HyperLogLog hll;
-		annotated_lock_guard<annotated_mutex> guard(lock);
+	unique_ptr<ParallelHyperLogLogLocalState> GetMergedState() const {
+		auto merged_state = make_uniq<ParallelHyperLogLogLocalState>();
+		annotated_lock_guard<annotated_mutex> merged_guard(merged_state->lock);
+
+		annotated_lock_guard<annotated_mutex> global_guard(lock);
 		for (const auto &state : states) {
-			state->Merge(hll);
+			annotated_lock_guard<annotated_mutex> state_guard(state->lock);
+			merged_state->Merge(*state);
 		}
-		return hll.Count();
+		return merged_state;
 	}
 
 private:

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -138,4 +138,54 @@ public:
 	static unique_ptr<HyperLogLog> Deserialize(Deserializer &deserializer);
 };
 
+//! Utility for computing HLL in parallel
+class ParallelHyperLogLogLocalState {
+public:
+	ParallelHyperLogLogLocalState() {
+	}
+
+public:
+	void Update(Vector &hashes) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		hll.Update(hashes, hashes, hashes.size());
+	}
+
+	void Merge(HyperLogLog &other) const {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		other.Merge(hll);
+	}
+
+private:
+	mutable annotated_mutex lock;
+	HyperLogLog hll DUCKDB_GUARDED_BY(lock);
+};
+
+class ParallelHyperLogLogGlobalState {
+public:
+	ParallelHyperLogLogGlobalState() {
+	}
+
+public:
+	ParallelHyperLogLogLocalState &GetLocalState() {
+		auto state = make_uniq<ParallelHyperLogLogLocalState>();
+		auto &result = *state;
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		states.emplace_back(std::move(state));
+		return result;
+	}
+
+	idx_t GetCount() const {
+		HyperLogLog hll;
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		for (const auto &state : states) {
+			state->Merge(hll);
+		}
+		return hll.Count();
+	}
+
+private:
+	mutable annotated_mutex lock;
+	vector<unique_ptr<ParallelHyperLogLogLocalState>> states DUCKDB_GUARDED_BY(lock);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -111,7 +111,8 @@ public:
 			InsertElement(hashes[0]);
 		} else {
 			D_ASSERT(hash_vec.GetVectorType() == VectorType::FLAT_VECTOR);
-			for (idx_t i = 0; i < hash_vec.size(); ++i) {
+			const auto count = hash_vec.size();
+			for (idx_t i = 0; i < count; ++i) {
 				InsertElement(hashes[i]);
 			}
 		}

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -164,9 +164,9 @@ public:
 		count += hashes.size();
 	}
 
-	void Merge(ParallelHyperLogLogLocalState &other) const DUCKDB_REQUIRES(lock) DUCKDB_REQUIRES(other.lock) {
-		other.hll.Merge(hll);
-		other.count += count;
+	void Merge(const ParallelHyperLogLogLocalState &other) DUCKDB_REQUIRES(lock) DUCKDB_REQUIRES(other.lock) {
+		hll.Merge(other.hll);
+		count += other.count;
 	}
 
 	pair<idx_t, idx_t> GetCounts() const {

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 
 namespace duckdb {
 
@@ -102,7 +103,19 @@ public:
 				}
 			}
 		}
-	};
+	}
+
+	void Update(const Vector &hash_vec) {
+		const auto hashes = FlatVector::GetData<const hash_t>(hash_vec);
+		if (hash_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			InsertElement(hashes[0]);
+		} else {
+			D_ASSERT(hash_vec.GetVectorType() == VectorType::FLAT_VECTOR);
+			for (idx_t i = 0; i < hash_vec.size(); ++i) {
+				InsertElement(hashes[i]);
+			}
+		}
+	}
 
 	//! Algorithm 4
 	void ExtractCounts(uint32_t *c) const {
@@ -145,9 +158,9 @@ public:
 	}
 
 public:
-	void Update(Vector &hashes) {
+	void Update(const Vector &hashes) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		hll.Update(hashes, hashes, hashes.size());
+		hll.Update(hashes);
 		count += hashes.size();
 	}
 

--- a/src/include/duckdb/common/types/row/partitioned_tuple_data.hpp
+++ b/src/include/duckdb/common/types/row/partitioned_tuple_data.hpp
@@ -23,6 +23,8 @@ public:
 	}
 
 public:
+	bool compute_reverse_partition_sel = false;
+
 	Vector partition_indices;
 	SelectionVector partition_sel;
 	SelectionVector reverse_partition_sel;

--- a/src/include/duckdb/common/types/row/partitioned_tuple_data.hpp
+++ b/src/include/duckdb/common/types/row/partitioned_tuple_data.hpp
@@ -32,6 +32,7 @@ public:
 	static constexpr idx_t MAP_THRESHOLD = 256;
 	perfect_map_t<list_entry_t> partition_entries;
 	fixed_size_map_t<list_entry_t> fixed_partition_entries;
+	unsafe_vector<idx_t> partition_offsets;
 
 	unsafe_vector<TupleDataPinState> partition_pin_states;
 	TupleDataChunkState chunk_state;
@@ -172,12 +173,12 @@ protected:
 	//! - returns true if everything belongs to the same partition - stores partition index in single_partition_idx
 	void BuildPartitionSel(PartitionedTupleDataAppendState &state, const SelectionVector &append_sel,
 	                       const idx_t append_count) const;
-	template <bool fixed>
+	template <bool FIXED>
 	static void BuildPartitionSel(PartitionedTupleDataAppendState &state, const SelectionVector &append_sel,
 	                              const idx_t append_count, const idx_t max_partition_idx);
 	//! Builds out the buffer space in the partitions
 	void BuildBufferSpace(PartitionedTupleDataAppendState &state);
-	template <bool fixed>
+	template <bool FIXED>
 	void BuildBufferSpace(PartitionedTupleDataAppendState &state);
 	//! Create a collection for a specific a partition
 	unique_ptr<TupleDataCollection> CreatePartitionCollection() {

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -43,7 +43,7 @@ void DistinctStatistics::UpdateInternal(Vector &new_data, idx_t count, Vector &h
 	sample_count += count;
 	VectorOperations::Hash(new_data, hashes, count);
 
-	log->Update(hashes);
+	log->Update(new_data, hashes, count);
 }
 
 string DistinctStatistics::ToString() const {

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -43,7 +43,7 @@ void DistinctStatistics::UpdateInternal(Vector &new_data, idx_t count, Vector &h
 	sample_count += count;
 	VectorOperations::Hash(new_data, hashes, count);
 
-	log->Update(new_data, hashes, count);
+	log->Update(hashes);
 }
 
 string DistinctStatistics::ToString() const {


### PR DESCRIPTION
Addresses the issue raised in https://github.com/duckdb/duckdb/pull/22225#issuecomment-4299804259.

This is the simplest fix for the issue that I could think of, which should cover most use cases, but if needed, the approach could be improved in a future PR.

## HyperLogLog!

I've added a `HyperLogLog` to the `Sink` phase of `PartitionedCopyState`.

The resulting estimated unique count is used to estimate the number of rows per partition. Only if the number of rows per partition exceeds the `partitioned_write_flush_threshold` setting, we initiate a flush. If there are very few partitions, the behaviour is very similar to before: we flush after at least one thread accumulates `partitioned_write_flush_threshold` rows. If there are many partitions, the flush is delayed according to the rule above. The performance impact of computing `HyperLogLog` is negligible.

This is somewhat coarse-grained and not skew-resistant, but despite being such a simple approach it is already a significantly improvement over the current behaviour.

For the large partition count query in https://github.com/duckdb/duckdb/pull/22225#issuecomment-4299804259 (partitioning `lineitem` by `l_shipdate`) the number of files/row groups is minimized: there are 2526 files, each with one row group.

For the small partition count query (partitioning `lineitem` by `l_returnflag, l_linestatus`), the number of files/row groups is unchanged.