### PR TITLE
Use 2m timeout and make apt more verbose in CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Install tools
         timeout-minutes: 10
-        run: python3 scripts/ci/retry.py -- make -j4 format_tools
+        run: python3 scripts/ci/retry.py --timeout 2m -- make -j4 format_tools
 
       - name: Check format
         run: |
@@ -311,7 +311,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - name: Fix ASan runtime
       shell: bash
@@ -360,7 +360,7 @@ jobs:
         ref: ${{ needs.prepare.outputs.git_sha }}
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - name: Download relassert build artifact
       uses: actions/download-artifact@v8
@@ -482,7 +482,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - uses: ./.github/actions/ccache-action
       with:
@@ -509,7 +509,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - uses: ./.github/actions/ccache-action
       with:
@@ -574,7 +574,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - name: Download linux release artifact
       uses: actions/download-artifact@v8
@@ -609,7 +609,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - name: Install pytest
       timeout-minutes: 10
@@ -711,7 +711,7 @@ jobs:
 
     - name: Install tools
       timeout-minutes: 10
-      run: python3 scripts/ci/retry.py -- make toolsci
+      run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
     - uses: ./.github/actions/cleanup_runner
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -259,7 +259,7 @@ jobs:
 
      - name: Install tools
        shell: bash
-       run: python3 scripts/ci/retry.py -- make toolsci
+       run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
      # Build is implied by 'make sqlite' that will invoke implicitly 'make release' (we make it explicit)
      - name: Build

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -74,7 +74,7 @@ jobs:
           ref: ${{ env.GIT_REF }}
 
       - name: Install tools
-        run: python3 scripts/ci/retry.py -- make toolsci
+        run: python3 scripts/ci/retry.py --timeout 2m -- make toolsci
 
       - uses: ./.github/actions/ccache-action
 

--- a/Makefile
+++ b/Makefile
@@ -575,8 +575,8 @@ define ensure_apt_commands
 		command -v $$cmd >/dev/null 2>&1 || missing=1; \
 	done; \
 	if [ $$missing -eq 1 ]; then \
-		sudo apt-get update -y -qq; \
-		sudo apt-get install -y -qq $(2); \
+		sudo apt-get update -y -q; \
+		sudo apt-get install -y -q $(2); \
 	fi
 endef
 
@@ -586,8 +586,8 @@ define ensure_apt_packages
 		dpkg-query -W -f='$${Status}' $$pkg 2>/dev/null | grep -q "install ok installed" || missing=1; \
 	done; \
 	if [ $$missing -eq 1 ]; then \
-		sudo apt-get update -y -qq; \
-		sudo apt-get install -y -qq $(1); \
+		sudo apt-get update -y -q; \
+		sudo apt-get install -y -q $(1); \
 	fi
 endef
 

--- a/scripts/ci/retry.py
+++ b/scripts/ci/retry.py
@@ -1,10 +1,26 @@
 import argparse
+import re
 import os
 import subprocess
 import sys
 import time
 
 RETRY_DELAY_SECONDS = 15.0
+
+
+def parse_timeout(timeout: str) -> float:
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)?)([smhSMH]?)\s*", timeout)
+    if not match:
+        raise ValueError("invalid timeout format")
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+    if unit == "m":
+        value *= 60.0
+    elif unit == "h":
+        value *= 3600.0
+    if value <= 0:
+        raise ValueError("timeout must be > 0")
+    return value
 
 
 def parse_args() -> argparse.Namespace:
@@ -17,9 +33,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--timeout",
-        type=float,
+        type=str,
         default=None,
-        help="Optional per-attempt timeout in seconds.",
+        help="Optional per-attempt timeout (e.g. '30', '45s', '2m', '1.5h').",
     )
     parser.add_argument(
         "command",
@@ -29,8 +45,13 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     if args.retries < 0:
         parser.error("--retries must be >= 0")
-    if args.timeout is not None and args.timeout <= 0:
-        parser.error("--timeout must be > 0")
+    if args.timeout is not None:
+        try:
+            args.timeout_seconds = parse_timeout(args.timeout)
+        except ValueError:
+            parser.error("--timeout must be a positive duration (e.g. '30', '45s', '2m', '1.5h')")
+    else:
+        args.timeout_seconds = None
     if not args.command:
         parser.error("missing command")
     if args.command[0] == "--":
@@ -57,12 +78,12 @@ def main() -> int:
 
     for attempt in range(1, attempts + 1):
         try:
-            completed = run_command(args.command, command_text, args.timeout)
+            completed = run_command(args.command, command_text, args.timeout_seconds)
             exit_code = completed.returncode
         except subprocess.TimeoutExpired:
             exit_code = 124
             print(
-                f"[retry] attempt {attempt}/{attempts} timed out after {args.timeout} sec",
+                f"[retry] attempt {attempt}/{attempts} timed out after {args.timeout}",
                 flush=True,
             )
         except OSError as exc:


### PR DESCRIPTION
Some CI jobs [hang](https://github.com/Mytherin/duckdb/actions/runs/25483897784/job/74774750551) in the `Install tools` step for duckdb forks:
```shell
Thu, 07 May 2026 08:09:50 GMT ##[debug]Evaluating condition for step: 'Install tools'
Thu, 07 May 2026 08:09:50 GMT ##[debug]Evaluating: success()
Thu, 07 May 2026 08:09:50 GMT ##[debug]Evaluating success:
Thu, 07 May 2026 08:09:50 GMT ##[debug]=> true
Thu, 07 May 2026 08:09:50 GMT ##[debug]Result: true
Thu, 07 May 2026 08:09:50 GMT ##[debug]Starting: Install tools
Thu, 07 May 2026 08:09:50 GMT ##[debug]Loading inputs
Thu, 07 May 2026 08:09:50 GMT ##[debug]Loading env
Thu, 07 May 2026 08:09:50 GMT
Run python3 scripts/ci/retry.py -- make toolsci
Thu, 07 May 2026 08:09:50 GMT ##[debug]/usr/bin/bash -e /home/runner/work/_temp/71f5086f-e13f-4ec9-ad34-7bccb959c83d.sh
Thu, 07 May 2026 08:09:50 GMT missing=0; for cmd in ninja mold ccache pkg-config pigz clang++-20 clangd-20; do command -v $cmd >/dev/null 2>&1 || missing=1; done; if [ $missing -eq 1 ]; then sudo apt-get update -y -qq; sudo apt-get install -y -qq ninja-build mold ccache pkg-config pigz clang++-20 clangd-20; fi
Thu, 07 May 2026 08:20:03 GMT Error: The action 'Install tools' has timed out after 10 minutes.
Thu, 07 May 2026 08:20:03 GMT ##[debug]Finishing: Install tools
```

Use a short timeout of 2 min to retry installation a few times.

To make troubleshooting easier in the future, also let `apt` print more diagnostics.

### Nighty Tests failures

These failures are unrelated to this PR. I'll address them in another PR so that workflow becomes useful again.