### PR TITLE
Add shared pointer to client context to QueryResult

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/arrow/appender/append_data.hpp"
 #include "duckdb/common/arrow/appender/list.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
@@ -15,9 +16,11 @@ namespace duckdb {
 // ArrowAppender
 //===--------------------------------------------------------------------===//
 
-ArrowAppender::ArrowAppender(vector<LogicalType> types_p, const idx_t initial_capacity, ClientProperties options,
+ArrowAppender::ArrowAppender(vector<LogicalType> types_p, const idx_t initial_capacity,
+                             const shared_ptr<ClientContext> &client_context,
                              unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast)
-    : types(std::move(types_p)), options(options) {
+    : types(std::move(types_p)), client_context(client_context) {
+	auto options = client_context->GetClientProperties();
 	for (idx_t i = 0; i < types.size(); i++) {
 		unique_ptr<ArrowAppendData> entry;
 		bool bitshift_boolean = types[i].id() == LogicalTypeId::BOOLEAN && !options.arrow_lossless_conversion;
@@ -40,8 +43,7 @@ void ArrowAppender::Append(DataChunk &input, const idx_t from, const idx_t to, c
 	for (idx_t i = 0; i < input.ColumnCount(); i++) {
 		if (root_data[i]->extension_data && root_data[i]->extension_data->duckdb_to_arrow) {
 			Vector input_data(root_data[i]->extension_data->GetInternalType());
-			root_data[i]->extension_data->duckdb_to_arrow(*options.client_context, input.data[i], input_data,
-			                                              input_size);
+			root_data[i]->extension_data->duckdb_to_arrow(*client_context, input.data[i], input_data, input_size);
 			root_data[i]->append_vector(*root_data[i], input_data, from, to, input_size);
 		} else {
 			root_data[i]->append_vector(*root_data[i], input.data[i], from, to, input_size);
@@ -104,6 +106,7 @@ ArrowArray *ArrowAppender::FinalizeChild(const LogicalType &type, unique_ptr<Arr
 //! Returns the underlying arrow array
 ArrowArray ArrowAppender::Finalize() {
 	D_ASSERT(root_data.size() == types.size());
+	auto options = client_context->GetClientProperties();
 	auto root_holder = make_uniq<ArrowAppendData>(options);
 
 	ArrowArray result;

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -4,10 +4,6 @@
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/types/interval.hpp"
-#include "duckdb/common/types/sel_cache.hpp"
-#include "duckdb/common/types/vector_cache.hpp"
-#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/config.hpp"
 
@@ -17,9 +13,9 @@
 namespace duckdb {
 
 void ArrowConverter::ToArrowArray(
-    DataChunk &input, ArrowArray *out_array, ClientProperties options,
+    DataChunk &input, ArrowArray *out_array, ClientContext &client_context,
     const unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> &extension_type_cast) {
-	ArrowAppender appender(input.GetTypes(), input.size(), std::move(options), extension_type_cast);
+	ArrowAppender appender(input.GetTypes(), input.size(), client_context.shared_from_this(), extension_type_cast);
 	appender.Append(input, 0, input.size(), input.size());
 	*out_array = appender.Finalize();
 }
@@ -61,10 +57,10 @@ void InitializeChild(ArrowSchema &child, DuckDBArrowSchemaHolder &root_holder, c
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    ClientProperties &options, ClientContext &context);
+                    ClientContext &client_context);
 
 void SetArrowStructFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                          ClientProperties &options, ClientContext &context, bool map_is_parent = false) {
+                          ClientContext &client_context, bool map_is_parent = false) {
 	child.format = "+s";
 	auto &child_types = StructType::GetChildTypes(type);
 	child.n_children = NumericCast<int64_t>(child_types.size());
@@ -80,7 +76,7 @@ void SetArrowStructFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &chi
 		InitializeChild(*child.children[type_idx], root_holder);
 		root_holder.owned_type_names.push_back(AddName(child_types[type_idx].first));
 		child.children[type_idx]->name = root_holder.owned_type_names.back().get();
-		SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, options, context);
+		SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, client_context);
 	}
 	if (map_is_parent) {
 		child.children[0]->flags = 0; // Set the 'keys' field to non-nullable
@@ -88,7 +84,7 @@ void SetArrowStructFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &chi
 }
 
 void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       ClientProperties &options, ClientContext &context) {
+                       ClientContext &client_context) {
 	child.format = "+m";
 	//! Map has one child which is a struct
 	child.n_children = 1;
@@ -100,27 +96,28 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 	child.children = &root_holder.nested_children_ptr.back()[0];
 	child.children[0]->name = "entries";
 	child.children[0]->flags = 0; // Set the 'entries' field to non-nullable
-	SetArrowStructFormat(root_holder, **child.children, ListType::GetChildType(type), options, context, true);
+	SetArrowStructFormat(root_holder, **child.children, ListType::GetChildType(type), client_context, true);
 }
 
 bool SetArrowExtension(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       ClientContext &context) {
-	auto &config = DBConfig::GetConfig(context);
+                       ClientContext &client_context) {
+	auto &config = DBConfig::GetConfig(client_context);
 	if (config.HasArrowExtension(type)) {
 		auto arrow_extension = config.GetArrowExtension(type);
-		arrow_extension.PopulateArrowSchema(root_holder, child, type, context, arrow_extension);
+		arrow_extension.PopulateArrowSchema(root_holder, child, type, client_context, arrow_extension);
 		return true;
 	}
 	return false;
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    ClientProperties &options, ClientContext &context) {
+                    ClientContext &client_context) {
+	auto options = client_context.GetClientProperties();
 	if (type.HasAlias()) {
 		// If it is a json type, we only export it as json if arrow_lossless_conversion = True
 		if (!(type.IsJSONType() && !options.arrow_lossless_conversion)) {
 			// If the type has an alias, we check if it is an Arrow-Type extension
-			if (SetArrowExtension(root_holder, child, type, context)) {
+			if (SetArrowExtension(root_holder, child, type, client_context)) {
 				return;
 			}
 		}
@@ -128,7 +125,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
 		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
+			SetArrowExtension(root_holder, child, type, client_context);
 		} else {
 			child.format = "b";
 		}
@@ -163,7 +160,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::UHUGEINT:
 	case LogicalTypeId::HUGEINT: {
 		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
+			SetArrowExtension(root_holder, child, type, client_context);
 		} else {
 			child.format = "d:38,0";
 		}
@@ -174,7 +171,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::UUID: {
 		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
+			SetArrowExtension(root_holder, child, type, client_context);
 		} else {
 			if (options.produce_arrow_string_view && options.arrow_output_version >= ArrowFormatVersion::V1_4) {
 				// List views are only introduced in arrow format v1.4
@@ -206,7 +203,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::TIME_TZ: {
 		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
+			SetArrowExtension(root_holder, child, type, client_context);
 		} else {
 			child.format = "ttu";
 		}
@@ -283,7 +280,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::BIT: {
 		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
+			SetArrowExtension(root_holder, child, type, client_context);
 		} else {
 			if (options.arrow_output_version >= ArrowFormatVersion::V1_4) {
 				// Views are only introduced in arrow format v1.4
@@ -320,11 +317,11 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		InitializeChild(root_holder.nested_children.back()[0], root_holder);
 		child.children = &root_holder.nested_children_ptr.back()[0];
 		child.children[0]->name = "l";
-		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), options, context);
+		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), client_context);
 		break;
 	}
 	case LogicalTypeId::STRUCT: {
-		SetArrowStructFormat(root_holder, child, type, options, context);
+		SetArrowStructFormat(root_holder, child, type, client_context);
 		break;
 	}
 	case LogicalTypeId::ARRAY: {
@@ -341,11 +338,11 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
 		InitializeChild(root_holder.nested_children.back()[0], root_holder);
 		child.children = &root_holder.nested_children_ptr.back()[0];
-		SetArrowFormat(root_holder, **child.children, child_type, options, context);
+		SetArrowFormat(root_holder, **child.children, child_type, client_context);
 		break;
 	}
 	case LogicalTypeId::MAP: {
-		SetArrowMapFormat(root_holder, child, type, options, context);
+		SetArrowMapFormat(root_holder, child, type, client_context);
 		break;
 	}
 	case LogicalTypeId::UNION: {
@@ -367,7 +364,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 			root_holder.owned_type_names.push_back(AddName(child_types[type_idx].first));
 
 			child.children[type_idx]->name = root_holder.owned_type_names.back().get();
-			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, options, context);
+			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, client_context);
 
 			format += to_string(type_idx) + ",";
 		}
@@ -405,7 +402,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	}
 	default: {
 		// It is possible we can export this type as a registered extension
-		auto success = SetArrowExtension(root_holder, child, type, context);
+		auto success = SetArrowExtension(root_holder, child, type, client_context);
 		if (!success) {
 			throw NotImplementedException("Unsupported Arrow type %s", type.ToString());
 		}
@@ -414,7 +411,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 }
 
 void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
-                                   const vector<string> &names, ClientProperties &options) {
+                                   const vector<string> &names, ClientContext &client_context) {
 	D_ASSERT(out_schema);
 	D_ASSERT(types.size() == names.size());
 	const idx_t column_count = types.size();
@@ -442,7 +439,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 		root_holder->owned_column_names.push_back(AddName(names[col_idx]));
 		auto &child = root_holder->children[col_idx];
 		InitializeChild(child, *root_holder, names[col_idx]);
-		SetArrowFormat(*root_holder, child, types[col_idx], options, *options.client_context);
+		SetArrowFormat(*root_holder, child, types[col_idx], client_context);
 	}
 
 	// Release ownership to caller

--- a/src/common/arrow/arrow_merge_event.cpp
+++ b/src/common/arrow/arrow_merge_event.cpp
@@ -17,12 +17,11 @@ ArrowBatchTask::ArrowBatchTask(ArrowQueryResult &result, vector<idx_t> record_ba
 
 void ArrowBatchTask::ProduceRecordBatches() {
 	auto &arrays = result.Arrays();
-	auto arrow_options = executor.context.GetClientProperties();
 	for (auto &index : record_batch_indices) {
 		auto &array = arrays[index];
 		D_ASSERT(array);
 		const idx_t count = ArrowUtil::FetchChunk(
-		    scan_state, arrow_options, batch_size, &array->arrow_array,
+		    scan_state, executor.context, batch_size, &array->arrow_array,
 		    ArrowTypeExtensionData::GetExtensionTypes(event->GetClientContext(), scan_state.Types()));
 		(void)count;
 		D_ASSERT(count != 0);

--- a/src/common/arrow/arrow_query_result.cpp
+++ b/src/common/arrow/arrow_query_result.cpp
@@ -7,9 +7,10 @@
 namespace duckdb {
 
 ArrowQueryResult::ArrowQueryResult(StatementType statement_type, StatementProperties properties, vector<string> names_p,
-                                   vector<LogicalType> types_p, ClientProperties client_properties, idx_t batch_size)
+                                   vector<LogicalType> types_p, const shared_ptr<ClientContext> &client_context,
+                                   idx_t batch_size)
     : QueryResult(QueryResultType::ARROW_RESULT, statement_type, std::move(properties), std::move(types_p),
-                  std::move(names_p), std::move(client_properties)),
+                  std::move(names_p), client_context),
       batch_size(batch_size) {
 }
 

--- a/src/common/arrow/arrow_util.cpp
+++ b/src/common/arrow/arrow_util.cpp
@@ -4,13 +4,15 @@
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+
 namespace duckdb {
 
-bool ArrowUtil::TryFetchChunk(ChunkScanState &scan_state, ClientProperties options, idx_t batch_size, ArrowArray *out,
-                              idx_t &count, ErrorData &error,
+bool ArrowUtil::TryFetchChunk(ChunkScanState &scan_state, ClientContext &client_context, idx_t batch_size,
+                              ArrowArray *out, idx_t &count, ErrorData &error,
                               unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast) {
 	count = 0;
-	ArrowAppender appender(scan_state.Types(), batch_size, std::move(options), std::move(extension_type_cast));
+	ArrowAppender appender(scan_state.Types(), batch_size, client_context.shared_from_this(),
+	                       std::move(extension_type_cast));
 	const auto remaining_tuples_in_chunk = scan_state.RemainingInChunk();
 	if (remaining_tuples_in_chunk) {
 		// We start by scanning the non-finished current chunk
@@ -51,11 +53,12 @@ bool ArrowUtil::TryFetchChunk(ChunkScanState &scan_state, ClientProperties optio
 	return true;
 }
 
-idx_t ArrowUtil::FetchChunk(ChunkScanState &scan_state, ClientProperties options, idx_t chunk_size, ArrowArray *out,
+idx_t ArrowUtil::FetchChunk(ChunkScanState &scan_state, ClientContext &client_context, idx_t chunk_size,
+                            ArrowArray *out,
                             const unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> &extension_type_cast) {
 	ErrorData error;
 	idx_t result_count;
-	if (!TryFetchChunk(scan_state, std::move(options), chunk_size, out, result_count, error, extension_type_cast)) {
+	if (!TryFetchChunk(scan_state, client_context, chunk_size, out, result_count, error, extension_type_cast)) {
 		error.Throw();
 	}
 	return result_count;

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/main/stream_query_result.hpp"
 
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
-#include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/chunk_scan_state/query_result.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
@@ -73,7 +72,7 @@ int ResultArrowArrayStreamWrapper::MyStreamGetSchema(struct ArrowArrayStream *st
 	if (!my_stream->column_types.empty()) {
 		try {
 			ArrowConverter::ToArrowSchema(out, my_stream->column_types, my_stream->column_names,
-			                              my_stream->result->client_properties);
+			                              *my_stream->result->client_context);
 		} catch (std::runtime_error &e) {
 			my_stream->last_error = ErrorData(e);
 			return -1;
@@ -99,7 +98,7 @@ int ResultArrowArrayStreamWrapper::MyStreamGetSchema(struct ArrowArrayStream *st
 	}
 	try {
 		ArrowConverter::ToArrowSchema(out, my_stream->column_types, my_stream->column_names,
-		                              my_stream->result->client_properties);
+		                              *my_stream->result->client_context);
 	} catch (std::runtime_error &e) {
 		my_stream->last_error = ErrorData(e);
 		return -1;
@@ -134,7 +133,7 @@ int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stre
 	try {
 		idx_t result_count;
 		ErrorData error;
-		if (!ArrowUtil::TryFetchChunk(scan_state, result.client_properties, my_stream->batch_size, out, result_count,
+		if (!ArrowUtil::TryFetchChunk(scan_state, *result.client_context, my_stream->batch_size, out, result_count,
 		                              error, my_stream->extension_types)) {
 			D_ASSERT(error.HasError());
 			my_stream->last_error = error;
@@ -184,8 +183,7 @@ ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryRes
 	stream.release = ResultArrowArrayStreamWrapper::MyStreamRelease;
 	stream.get_last_error = ResultArrowArrayStreamWrapper::MyStreamGetLastError;
 
-	extension_types =
-	    ArrowTypeExtensionData::GetExtensionTypes(*result->client_properties.client_context, result->types);
+	extension_types = ArrowTypeExtensionData::GetExtensionTypes(*result->client_context, result->types);
 }
 
 } // namespace duckdb

--- a/src/common/arrow/physical_arrow_batch_collector.cpp
+++ b/src/common/arrow/physical_arrow_batch_collector.cpp
@@ -19,12 +19,12 @@ SinkFinalizeType PhysicalArrowBatchCollector::Finalize(Pipeline &pipeline, Event
 	if (total_tuple_count == 0) {
 		// Create the result containing a single empty result conversion
 		gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types,
-		                                            context.GetClientProperties(), record_batch_size);
+		                                            context.shared_from_this(), record_batch_size);
 		return SinkFinalizeType::READY;
 	}
 
 	// Already create the final query result
-	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
+	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.shared_from_this(),
 	                                            record_batch_size);
 	// Spawn an event that will populate the conversion result
 	auto &arrow_result = gstate.result->Cast<ArrowQueryResult>();

--- a/src/common/arrow/physical_arrow_collector.cpp
+++ b/src/common/arrow/physical_arrow_collector.cpp
@@ -40,10 +40,9 @@ SinkResultType PhysicalArrowCollector::Sink(ExecutionContext &context, DataChunk
 	do {
 		if (!appender) {
 			// Create the appender if we haven't started this chunk yet
-			auto properties = context.client.GetClientProperties();
 			D_ASSERT(processed < count);
 			auto initial_capacity = MinValue(record_batch_size, count - processed);
-			appender = make_uniq<ArrowAppender>(types, initial_capacity, properties,
+			appender = make_uniq<ArrowAppender>(types, initial_capacity, context.client.shared_from_this(),
 			                                    ArrowTypeExtensionData::GetExtensionTypes(context.client, types));
 		}
 
@@ -112,11 +111,11 @@ SinkFinalizeType PhysicalArrowCollector::Finalize(Pipeline &pipeline, Event &eve
 			    gstate.tuple_count);
 		}
 		gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types,
-		                                            context.GetClientProperties(), record_batch_size);
+		                                            context.shared_from_this(), record_batch_size);
 		return SinkFinalizeType::READY;
 	}
 
-	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
+	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.shared_from_this(),
 	                                            record_batch_size);
 	auto &arrow_result = gstate.result->Cast<ArrowQueryResult>();
 	arrow_result.SetArrowData(std::move(gstate.chunks));

--- a/src/execution/operator/helper/physical_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_batch_collector.cpp
@@ -34,7 +34,7 @@ SinkFinalizeType PhysicalBatchCollector::Finalize(Pipeline &pipeline, Event &eve
 	auto collection = gstate.data.FetchCollection();
 	D_ASSERT(collection);
 	auto result = make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(collection),
-	                                                 context.GetClientProperties());
+	                                                 context.shared_from_this());
 	gstate.result = std::move(result);
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/helper/physical_buffered_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_batch_collector.cpp
@@ -100,8 +100,7 @@ unique_ptr<GlobalSinkState> PhysicalBufferedBatchCollector::GetGlobalSinkState(C
 unique_ptr<QueryResult> PhysicalBufferedBatchCollector::GetResult(GlobalSinkState &state) const {
 	auto &gstate = state.Cast<BufferedBatchCollectorGlobalState>();
 	auto cc = gstate.context.lock();
-	auto result = make_uniq<StreamQueryResult>(statement_type, properties, types, names, cc->GetClientProperties(),
-	                                           gstate.buffered_data);
+	auto result = make_uniq<StreamQueryResult>(statement_type, properties, types, names, gstate.buffered_data);
 	return std::move(result);
 }
 

--- a/src/execution/operator/helper/physical_buffered_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_collector.cpp
@@ -62,8 +62,7 @@ unique_ptr<QueryResult> PhysicalBufferedCollector::GetResult(GlobalSinkState &st
 	lock_guard<mutex> l(gstate.glock);
 	// FIXME: maybe we want to check if the execution was successful before creating the StreamQueryResult ?
 	auto cc = gstate.context.lock();
-	auto result = make_uniq<StreamQueryResult>(statement_type, properties, types, names, cc->GetClientProperties(),
-	                                           gstate.buffered_data);
+	auto result = make_uniq<StreamQueryResult>(statement_type, properties, types, names, gstate.buffered_data);
 	return std::move(result);
 }
 

--- a/src/execution/operator/helper/physical_materialized_collector.cpp
+++ b/src/execution/operator/helper/physical_materialized_collector.cpp
@@ -68,7 +68,7 @@ unique_ptr<QueryResult> PhysicalMaterializedCollector::GetResult(GlobalSinkState
 		gstate.collection = CreateCollection(*gstate.context);
 	}
 	auto result = make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(gstate.collection),
-	                                                 gstate.context->GetClientProperties());
+	                                                 gstate.context);
 	return std::move(result);
 }
 

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -428,9 +428,9 @@ LogicalType ArrowTypeExtensionData::GetInternalType() const {
 }
 
 unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>>
-ArrowTypeExtensionData::GetExtensionTypes(ClientContext &context, const vector<LogicalType> &duckdb_types) {
+ArrowTypeExtensionData::GetExtensionTypes(ClientContext &client_context, const vector<LogicalType> &duckdb_types) {
 	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
-	const auto &db_config = DBConfig::GetConfig(context);
+	const auto &db_config = DBConfig::GetConfig(client_context);
 	for (idx_t i = 0; i < duckdb_types.size(); i++) {
 		if (db_config.HasArrowExtension(duckdb_types[i])) {
 			extension_types.insert({i, db_config.GetArrowExtension(duckdb_types[i]).GetTypeExtension()});

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -20,7 +20,8 @@ class ArrowTypeExtensionData;
 //! The ArrowAppender class can be used to incrementally construct an arrow array by appending data chunks into it
 class ArrowAppender {
 public:
-	DUCKDB_API ArrowAppender(vector<LogicalType> types_p, const idx_t initial_capacity, ClientProperties options,
+	DUCKDB_API ArrowAppender(vector<LogicalType> types_p, const idx_t initial_capacity,
+	                         const shared_ptr<ClientContext> &client_context,
 	                         unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast);
 	DUCKDB_API ~ArrowAppender();
 
@@ -45,7 +46,7 @@ private:
 	//! The total row count that has been appended
 	idx_t row_count = 0;
 
-	ClientProperties options;
+	shared_ptr<ClientContext> client_context;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/arrow_converter.hpp
+++ b/src/include/duckdb/common/arrow/arrow_converter.hpp
@@ -18,9 +18,9 @@ class ArrowTypeExtensionData;
 struct DBConfig;
 struct ArrowConverter {
 	DUCKDB_API static void ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
-	                                     const vector<string> &names, ClientProperties &options);
+	                                     const vector<string> &names, ClientContext &client_context);
 	DUCKDB_API static void
-	ToArrowArray(DataChunk &input, ArrowArray *out_array, ClientProperties options,
+	ToArrowArray(DataChunk &input, ArrowArray *out_array, ClientContext &client_context,
 	             const unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> &extension_type_cast);
 };
 

--- a/src/include/duckdb/common/arrow/arrow_query_result.hpp
+++ b/src/include/duckdb/common/arrow/arrow_query_result.hpp
@@ -26,7 +26,8 @@ public:
 	friend class ClientContext;
 	//! Creates a successful query result with the specified names and types
 	DUCKDB_API ArrowQueryResult(StatementType statement_type, StatementProperties properties, vector<string> names_p,
-	                            vector<LogicalType> types_p, ClientProperties client_properties, idx_t batch_size);
+	                            vector<LogicalType> types_p, const shared_ptr<ClientContext> &client_context,
+	                            idx_t batch_size);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API explicit ArrowQueryResult(ErrorData error);
 

--- a/src/include/duckdb/common/arrow/arrow_util.hpp
+++ b/src/include/duckdb/common/arrow/arrow_util.hpp
@@ -9,7 +9,7 @@
 #pragma once
 #include "duckdb/common/arrow/arrow.hpp"
 #include "duckdb/main/chunk_scan_state.hpp"
-#include "duckdb/main/client_properties.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/error_data.hpp"
 
@@ -21,10 +21,11 @@ class ArrowTypeExtensionData;
 
 class ArrowUtil {
 public:
-	static bool TryFetchChunk(ChunkScanState &scan_state, ClientProperties options, idx_t chunk_size, ArrowArray *out,
-	                          idx_t &result_count, ErrorData &error,
+	static bool TryFetchChunk(ChunkScanState &scan_state, ClientContext &client_context, idx_t chunk_size,
+	                          ArrowArray *out, idx_t &result_count, ErrorData &error,
 	                          unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast);
-	static idx_t FetchChunk(ChunkScanState &scan_state, ClientProperties options, idx_t chunk_size, ArrowArray *out,
+	static idx_t FetchChunk(ChunkScanState &scan_state, ClientContext &client_context, idx_t chunk_size,
+	                        ArrowArray *out,
 	                        const unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> &extension_type_cast);
 
 private:

--- a/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
@@ -47,7 +47,7 @@ public:
 
 	//! This function returns possible extension types to given DuckDB types
 	static unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>>
-	GetExtensionTypes(ClientContext &context, const vector<LogicalType> &duckdb_types);
+	GetExtensionTypes(ClientContext &client_context, const vector<LogicalType> &duckdb_types);
 	LogicalType GetDuckDBType() const;
 
 private:

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -18,9 +18,6 @@
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
 
-#include <cstring>
-#include <cassert>
-
 #ifdef _WIN32
 #ifndef strdup
 #define strdup _strdup
@@ -43,8 +40,9 @@ struct CClientContextWrapper {
 };
 
 struct CClientArrowOptionsWrapper {
-	explicit CClientArrowOptionsWrapper(ClientProperties &properties) : properties(properties) {};
-	ClientProperties properties;
+	explicit CClientArrowOptionsWrapper(const shared_ptr<ClientContext> &client_context)
+	    : client_context(client_context) {};
+	const shared_ptr<ClientContext> client_context;
 };
 
 struct PreparedStatementWrapper {

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -18,11 +18,10 @@ namespace duckdb {
 struct ClientProperties {
 	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
 	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
-	                 const ArrowFormatVersion arrow_output_version, const optional_ptr<ClientContext> client_context)
+	                 const ArrowFormatVersion arrow_output_version)
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
-	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
-	      client_context(client_context) {
+	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version) {
 	}
 	ClientProperties() {};
 
@@ -32,6 +31,5 @@ struct ClientProperties {
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
 	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_0;
-	optional_ptr<ClientContext> client_context;
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -14,8 +14,6 @@
 
 namespace duckdb {
 
-class ClientContext;
-
 class MaterializedQueryResult : public QueryResult {
 public:
 	static constexpr const QueryResultType TYPE = QueryResultType::MATERIALIZED_RESULT;
@@ -25,7 +23,7 @@ public:
 	//! Creates a successful query result with the specified names and types
 	DUCKDB_API MaterializedQueryResult(StatementType statement_type, StatementProperties properties,
 	                                   vector<string> names, unique_ptr<ColumnDataCollection> collection,
-	                                   ClientProperties client_properties);
+	                                   const shared_ptr<ClientContext> &client_context);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API explicit MaterializedQueryResult(ErrorData error);
 

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -62,13 +62,14 @@ class QueryResult : public BaseQueryResult {
 public:
 	//! Creates a successful query result with the specified names and types
 	DUCKDB_API QueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
-	                       vector<LogicalType> types, vector<string> names, ClientProperties client_properties);
+	                       vector<LogicalType> types, vector<string> names,
+	                       const shared_ptr<ClientContext> &client_context);
 	//! Creates an unsuccessful query result with error condition
-	DUCKDB_API QueryResult(QueryResultType type, ErrorData error);
+	DUCKDB_API QueryResult(QueryResultType type, ErrorData error) : BaseQueryResult(type, std::move(error)) {};
 	DUCKDB_API ~QueryResult() override;
 
-	//! Properties from the client context
-	ClientProperties client_properties;
+	//! The client context
+	const shared_ptr<ClientContext> client_context;
 	//! The next result (if any)
 	unique_ptr<QueryResult> next;
 

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -33,7 +33,7 @@ public:
 	//! Create a successful StreamQueryResult. StreamQueryResults should always be successful initially (it makes no
 	//! sense to stream an error).
 	DUCKDB_API StreamQueryResult(StatementType statement_type, StatementProperties properties,
-	                             vector<LogicalType> types, vector<string> names, ClientProperties client_properties,
+	                             vector<LogicalType> types, vector<string> names,
 	                             shared_ptr<BufferedData> buffered_data);
 	DUCKDB_API explicit StreamQueryResult(ErrorData error);
 	DUCKDB_API ~StreamQueryResult() override;
@@ -53,9 +53,6 @@ public:
 
 	//! Closes the StreamQueryResult
 	DUCKDB_API void Close();
-
-	//! The client context this StreamQueryResult belongs to
-	shared_ptr<ClientContext> context;
 
 protected:
 	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override;

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -34,7 +34,7 @@ duckdb_error_data duckdb_to_arrow_schema(duckdb_arrow_options arrow_options, duc
 	}
 	const auto arrow_options_wrapper = reinterpret_cast<CClientArrowOptionsWrapper *>(arrow_options);
 	try {
-		ArrowConverter::ToArrowSchema(out_schema, schema_types, schema_names, arrow_options_wrapper->properties);
+		ArrowConverter::ToArrowSchema(out_schema, schema_types, schema_names, *arrow_options_wrapper->client_context);
 	} catch (const duckdb::Exception &ex) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, ex.what());
 	} catch (const std::exception &ex) {
@@ -53,11 +53,12 @@ duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options arrow_options,
 	}
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto arrow_options_wrapper = reinterpret_cast<CClientArrowOptionsWrapper *>(arrow_options);
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *arrow_options_wrapper->properties.client_context, dchunk->GetTypes());
+	auto extension_type_cast =
+	    duckdb::ArrowTypeExtensionData::GetExtensionTypes(*arrow_options_wrapper->client_context, dchunk->GetTypes());
 
 	try {
-		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, arrow_options_wrapper->properties, extension_type_cast);
+		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, *arrow_options_wrapper->client_context,
+		                             extension_type_cast);
 	} catch (const duckdb::Exception &ex) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, ex.what());
 	} catch (const std::exception &ex) {
@@ -179,7 +180,7 @@ duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema 
 	auto wrapper = reinterpret_cast<ArrowResultWrapper *>(result);
 	try {
 		ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
-		                              wrapper->result->client_properties);
+		                              *wrapper->result->client_context);
 	} catch (...) {
 		return DuckDBError;
 	}
@@ -194,7 +195,6 @@ duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared, du
 	if (!wrapper || !wrapper->statement || !wrapper->statement->data) {
 		return DuckDBError;
 	}
-	auto properties = wrapper->statement->context->GetClientProperties();
 	duckdb::vector<duckdb::LogicalType> prepared_types;
 	duckdb::vector<duckdb::string> prepared_names;
 
@@ -221,7 +221,7 @@ duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared, du
 		D_ASSERT(!result_schema->release);
 	}
 
-	ArrowConverter::ToArrowSchema(result_schema, prepared_types, prepared_names, properties);
+	ArrowConverter::ToArrowSchema(result_schema, prepared_types, prepared_names, *wrapper->statement->context);
 	return DuckDBSuccess;
 }
 
@@ -237,10 +237,10 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	if (!wrapper->current_chunk || wrapper->current_chunk->size() == 0) {
 		return DuckDBSuccess;
 	}
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *wrapper->result->client_properties.client_context, wrapper->result->types);
+	auto extension_type_cast =
+	    duckdb::ArrowTypeExtensionData::GetExtensionTypes(*wrapper->result->client_context, wrapper->result->types);
 	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
-	                             wrapper->result->client_properties, extension_type_cast);
+	                             *wrapper->result->client_context, extension_type_cast);
 	return DuckDBSuccess;
 }
 
@@ -250,11 +250,11 @@ void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, du
 	}
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
-	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
-	    *result_data.result->client_properties.client_context, result_data.result->types);
+	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(*result_data.result->client_context,
+	                                                                             result_data.result->types);
 
 	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
-	                             result_data.result->client_properties, extension_type_cast);
+	                             *result_data.result->client_context, extension_type_cast);
 }
 
 idx_t duckdb_arrow_row_count(duckdb_arrow result) {

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -162,8 +162,7 @@ void duckdb_connection_get_arrow_options(duckdb_connection connection, duckdb_ar
 	}
 	Connection *conn = reinterpret_cast<Connection *>(connection);
 	try {
-		auto client_properties = conn->context->GetClientProperties();
-		auto wrapper = new CClientArrowOptionsWrapper(client_properties);
+		const auto wrapper = new CClientArrowOptionsWrapper(conn->context);
 		*out_arrow_options = reinterpret_cast<duckdb_arrow_options>(wrapper);
 	} catch (...) {
 		*out_arrow_options = nullptr;

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/allocator.hpp"
+#include <cassert>
 
 namespace duckdb {
 
@@ -454,7 +455,7 @@ duckdb_arrow_options duckdb_result_get_arrow_options(duckdb_result *result) {
 	if (!result_data.result) {
 		return nullptr;
 	}
-	auto arrow_options_wrapper = new duckdb::CClientArrowOptionsWrapper(result_data.result->client_properties);
+	auto arrow_options_wrapper = new duckdb::CClientArrowOptionsWrapper(result_data.result->client_context);
 	return reinterpret_cast<duckdb_arrow_options>(arrow_options_wrapper);
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1053,7 +1053,7 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 		vector<string> names;
 		auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
 		return make_uniq<MaterializedQueryResult>(StatementType::INVALID_STATEMENT, properties, std::move(names),
-		                                          std::move(collection), GetClientProperties());
+		                                          std::move(collection), shared_from_this());
 	}
 
 	unique_ptr<QueryResult> result;
@@ -1491,8 +1491,7 @@ ClientProperties ClientContext::GetClientProperties() {
 	        arrow_use_list_view,
 	        arrow_use_string_view,
 	        arrow_lossless_conversion,
-	        arrow_format_version,
-	        this};
+	        arrow_format_version};
 }
 
 bool ClientContext::ExecutionIsFinished() {

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -7,9 +7,9 @@ namespace duckdb {
 
 MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type, StatementProperties properties,
                                                  vector<string> names_p, unique_ptr<ColumnDataCollection> collection_p,
-                                                 ClientProperties client_properties)
+                                                 const shared_ptr<ClientContext> &client_context)
     : QueryResult(QueryResultType::MATERIALIZED_RESULT, statement_type, std::move(properties), collection_p->Types(),
-                  std::move(names_p), std::move(client_properties)),
+                  std::move(names_p), client_context),
       collection(std::move(collection_p)), scan_initialized(false) {
 }
 

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/main/query_result.hpp"
 
-#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -55,14 +54,10 @@ idx_t BaseQueryResult::ColumnCount() {
 }
 
 QueryResult::QueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
-                         vector<LogicalType> types_p, vector<string> names_p, ClientProperties client_properties_p)
+                         vector<LogicalType> types_p, vector<string> names_p,
+                         const shared_ptr<ClientContext> &client_context)
     : BaseQueryResult(type, statement_type, std::move(properties), std::move(types_p), std::move(names_p)),
-      client_properties(std::move(client_properties_p)) {
-}
-
-QueryResult::QueryResult(QueryResultType type, ErrorData error)
-    : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, ArrowFormatVersion::V1_0, nullptr) {
+      client_context(client_context) {
 }
 
 QueryResult::~QueryResult() {

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -2,18 +2,15 @@
 
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
-#include "duckdb/common/box_renderer.hpp"
 #include "duckdb/main/database.hpp"
 
 namespace duckdb {
 
 StreamQueryResult::StreamQueryResult(StatementType statement_type, StatementProperties properties,
-                                     vector<LogicalType> types, vector<string> names,
-                                     ClientProperties client_properties, shared_ptr<BufferedData> data)
+                                     vector<LogicalType> types, vector<string> names, shared_ptr<BufferedData> data)
     : QueryResult(QueryResultType::STREAM_RESULT, statement_type, std::move(properties), std::move(types),
-                  std::move(names), std::move(client_properties)),
+                  std::move(names), data->GetContext()),
       buffered_data(std::move(data)) {
-	context = buffered_data->GetContext();
 }
 
 StreamQueryResult::StreamQueryResult(ErrorData error) : QueryResult(QueryResultType::STREAM_RESULT, std::move(error)) {
@@ -34,14 +31,14 @@ string StreamQueryResult::ToString() {
 }
 
 unique_ptr<ClientContextLock> StreamQueryResult::LockContext() {
-	if (!context) {
+	if (!client_context) {
 		string error_str = "Attempting to execute an unsuccessful or closed pending query result";
 		if (HasError()) {
 			error_str += StringUtil::Format("\nError: %s", GetError());
 		}
 		throw InvalidInputException(error_str);
 	}
-	return context->LockContext();
+	return client_context->LockContext();
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
@@ -56,7 +53,7 @@ StreamExecutionResult StreamQueryResult::ExecuteTask() {
 void StreamQueryResult::WaitForTask() {
 	auto lock = LockContext();
 	buffered_data->UnblockSinks();
-	context->WaitForTask(*lock, *this);
+	client_context->WaitForTask(*lock, *this);
 }
 
 static bool ExecutionErrorOccurred(StreamExecutionResult result) {
@@ -80,7 +77,7 @@ unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lo
 		}
 		chunk = buffered_data->Scan();
 		if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
-			context->CleanupInternal(lock, this);
+			client_context->CleanupInternal(lock, this);
 			chunk = nullptr;
 		}
 		return chunk;
@@ -91,18 +88,18 @@ unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lo
 			invalidate_query = false;
 		} else if (Exception::InvalidatesDatabase(error.Type())) {
 			// fatal exceptions invalidate the entire database
-			auto &config = context->config;
+			auto &config = client_context->config;
 			if (!config.query_verification_enabled) {
-				auto &db_instance = DatabaseInstance::GetDatabase(*context);
+				auto &db_instance = DatabaseInstance::GetDatabase(*client_context);
 				ValidChecker::Invalidate(db_instance, error.RawMessage());
 			}
 		}
-		context->ProcessError(error, context->GetCurrentQuery());
+		client_context->ProcessError(error, client_context->GetCurrentQuery());
 		SetError(std::move(error));
 	} catch (...) { // LCOV_EXCL_START
 		SetError(ErrorData("Unhandled exception in FetchInternal"));
 	} // LCOV_EXCL_STOP
-	context->CleanupInternal(lock, this, invalidate_query);
+	client_context->CleanupInternal(lock, this, invalidate_query);
 	return nullptr;
 }
 
@@ -142,7 +139,7 @@ static unique_ptr<DataChunk> AlternativeFetch(StreamQueryResult &stream_result) 
 #endif
 
 unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
-	if (HasError() || !context) {
+	if (HasError() || !client_context) {
 		return make_uniq<MaterializedQueryResult>(GetErrorObject());
 	}
 	auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), types);
@@ -161,7 +158,7 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 		collection->Append(append_state, *chunk);
 	}
 	auto result =
-	    make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(collection), client_properties);
+	    make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(collection), client_context);
 	if (HasError()) {
 		return make_uniq<MaterializedQueryResult>(GetErrorObject());
 	}
@@ -169,9 +166,9 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 }
 
 bool StreamQueryResult::IsOpenInternal(ClientContextLock &lock) {
-	bool invalidated = !success || !context;
+	bool invalidated = !success || !client_context;
 	if (!invalidated) {
-		invalidated = !context->IsActiveResult(lock, *this);
+		invalidated = !client_context->IsActiveResult(lock, *this);
 	}
 	return !invalidated;
 }
@@ -187,7 +184,7 @@ void StreamQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
 }
 
 bool StreamQueryResult::IsOpen() {
-	if (!success || !context) {
+	if (!success || !client_context) {
 		return false;
 	}
 	auto lock = LockContext();
@@ -196,7 +193,6 @@ bool StreamQueryResult::IsOpen() {
 
 void StreamQueryResult::Close() {
 	buffered_data->Close();
-	context.reset();
 }
 
 bool StreamQueryResult::IsChunkReady(StreamExecutionResult result) {

--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -162,8 +162,8 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 		arrow_schema.Init();
 		auto arrow_schema_ptr = &arrow_schema;
 
-		ClientProperties options = (reinterpret_cast<Connection *>(tester.connection)->context->GetClientProperties());
-		duckdb::ArrowConverter::ToArrowSchema(arrow_schema_ptr, logical_types, column_names, options);
+		auto client_context = (reinterpret_cast<Connection *>(tester.connection)->context);
+		duckdb::ArrowConverter::ToArrowSchema(arrow_schema_ptr, logical_types, column_names, *client_context);
 
 		ArrowArray arrow_array;
 		arrow_array.Init();
@@ -207,7 +207,7 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 			// Create a view with a `value` column containing 4096 values.
 			int num_buffers = 2, size = STANDARD_VECTOR_SIZE * num_buffers;
 			unordered_map<idx_t, const duckdb::shared_ptr<ArrowTypeExtensionData>> extension_type_cast;
-			ArrowAppender appender(logical_types, size, options, extension_type_cast);
+			ArrowAppender appender(logical_types, size, client_context, extension_type_cast);
 			Allocator allocator;
 
 			auto data_chunks = std::vector<DataChunk>(num_buffers);

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -793,6 +793,7 @@ TEST_CASE("Test buffer managed query result", "[api]") {
 	REQUIRE_NOTHROW(result->ToString());
 
 	// Reset connection AND db
+	result.reset();
 	con.reset();
 	db.reset();
 
@@ -809,6 +810,7 @@ TEST_CASE("Test buffer managed query result", "[api]") {
 	REQUIRE_NOTHROW(result->ToString());
 
 	// Reset connection AND db
+	result.reset();
 	con.reset();
 	db.reset();
 

--- a/test/api/test_appender_api.cpp
+++ b/test/api/test_appender_api.cpp
@@ -71,6 +71,7 @@ TEST_CASE("Test using appender after connection is gone", "[api]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 
 	// removing the connection invalidates the appender
+	result.reset();
 	conn.reset();
 	appender->BeginRow();
 	appender->Append<int32_t>(2);

--- a/test/arrow/arrow_filter_pushdown.cpp
+++ b/test/arrow/arrow_filter_pushdown.cpp
@@ -20,8 +20,7 @@ static unique_ptr<ArrowTestFactory> MakeArrowFactory(Connection &con, const stri
 	REQUIRE(!result->HasError());
 	auto types = result->types;
 	auto names = result->names;
-	return make_uniq<ArrowTestFactory>(std::move(types), std::move(names), std::move(result), false, client_properties,
-	                                   *con.context);
+	return make_uniq<ArrowTestFactory>(std::move(types), std::move(names), std::move(result), false, *con.context);
 }
 
 // Helper: get the EXPLAIN output for an arrow_scan with a filter

--- a/test/arrow/arrow_move_children.cpp
+++ b/test/arrow/arrow_move_children.cpp
@@ -87,7 +87,6 @@ TEST_CASE("Test move children", "[arrow]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 	auto initial_result = conn.Query(query);
-	auto client_properties = conn.context->GetClientProperties();
 	auto types = initial_result->types;
 	auto names = initial_result->names;
 
@@ -103,11 +102,10 @@ TEST_CASE("Test move children", "[arrow]") {
 	}
 	auto res_names = initial_result->names;
 	auto res_types = initial_result->types;
-	auto res_properties = initial_result->client_properties;
 
 	// Create a test factory and produce a stream from it
-	auto factory = ArrowTestFactory(std::move(types), std::move(names), std::move(initial_result), false,
-	                                client_properties, *conn.context);
+	auto factory =
+	    ArrowTestFactory(std::move(types), std::move(names), std::move(initial_result), false, *conn.context);
 	auto stream = ArrowTestFactory::CreateStream((uintptr_t)&factory, parameters);
 
 	// For every array, extract the children and scan them
@@ -122,7 +120,7 @@ TEST_CASE("Test move children", "[arrow]") {
 			ArrowSchema schema;
 			vector<LogicalType> single_type {res_types[i]};
 			vector<string> single_name {res_names[i]};
-			ArrowConverter::ToArrowSchema(&schema, single_type, single_name, res_properties);
+			ArrowConverter::ToArrowSchema(&schema, single_type, single_name, *conn.context);
 
 			if (i == 0) {
 				AssertExpectedResult<string>(&schema, children[i], "a");

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -222,12 +222,11 @@ TEST_CASE("Test Arrow Extension Types", "[arrow][.]") {
 	{
 		DuckDB db;
 		Connection con(db);
-		auto client_properties = con.context->GetClientProperties();
 		ArrowSchema schema;
 		schema.Init();
 		vector<LogicalType> types = {LogicalType::UHUGEINT};
 		vector<string> names = {"col"};
-		ArrowConverter::ToArrowSchema(&schema, types, names, client_properties);
+		ArrowConverter::ToArrowSchema(&schema, types, names, *con.context);
 		REQUIRE(schema.n_children == 1);
 		REQUIRE(string(schema.children[0]->format) == "d:38,0");
 		schema.release(&schema);

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -30,13 +30,12 @@ int ArrowTestFactory::ArrowArrayStreamGetSchema(struct ArrowArrayStream *stream,
 	return 0;
 }
 
-static int NextFromMaterialized(MaterializedQueryResult &res, bool big, ClientProperties properties,
-                                struct ArrowArray *out) {
+static int NextFromMaterialized(MaterializedQueryResult &res, bool big, struct ArrowArray *out) {
 	auto &types = res.types;
 	unordered_map<idx_t, const duckdb::shared_ptr<ArrowTypeExtensionData>> extension_type_cast;
 	if (big) {
 		// Combine all chunks into a single ArrowArray
-		ArrowAppender appender(types, STANDARD_VECTOR_SIZE, properties, extension_type_cast);
+		ArrowAppender appender(types, STANDARD_VECTOR_SIZE, res.client_context, extension_type_cast);
 		idx_t count = 0;
 		while (true) {
 			auto chunk = res.Fetch();
@@ -54,7 +53,7 @@ static int NextFromMaterialized(MaterializedQueryResult &res, bool big, ClientPr
 		if (!chunk || chunk->size() == 0) {
 			return 0;
 		}
-		ArrowConverter::ToArrowArray(*chunk, out, properties, extension_type_cast);
+		ArrowConverter::ToArrowArray(*chunk, out, *res.client_context, extension_type_cast);
 	}
 	return 0;
 }
@@ -83,7 +82,7 @@ int ArrowTestFactory::ArrowArrayStreamGetNext(struct ArrowArrayStream *stream, s
 	auto &data = *((ArrowArrayStreamData *)stream->private_data);
 	if (data.factory.result->type == QueryResultType::MATERIALIZED_RESULT) {
 		auto &materialized_result = data.factory.result->Cast<MaterializedQueryResult>();
-		return NextFromMaterialized(materialized_result, data.factory.big_result, data.options, out);
+		return NextFromMaterialized(materialized_result, data.factory.big_result, out);
 	} else {
 		D_ASSERT(data.factory.result->type == QueryResultType::ARROW_RESULT);
 		return NextFromArrow(data.factory, out);
@@ -114,7 +113,7 @@ duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> ArrowTestFactory::CreateStre
 
 	auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
 	stream_wrapper->number_of_rows = -1;
-	auto private_data = make_uniq<ArrowArrayStreamData>(factory, factory.options);
+	auto private_data = make_uniq<ArrowArrayStreamData>(factory);
 	stream_wrapper->arrow_array_stream.get_schema = ArrowArrayStreamGetSchema;
 	stream_wrapper->arrow_array_stream.get_next = ArrowArrayStreamGetNext;
 	stream_wrapper->arrow_array_stream.get_last_error = ArrowArrayStreamGetLastError;
@@ -130,8 +129,8 @@ void ArrowTestFactory::GetSchema(ArrowArrayStream *factory_ptr, ArrowSchema &sch
 	factory.ToArrowSchema(&schema);
 }
 
-void ArrowTestFactory::ToArrowSchema(struct ArrowSchema *out) {
-	ArrowConverter::ToArrowSchema(out, types, names, options);
+void ArrowTestFactory::ToArrowSchema(struct ArrowSchema *out) const {
+	ArrowConverter::ToArrowSchema(out, types, names, context);
 }
 
 unique_ptr<QueryResult> ArrowTestHelper::ScanArrowObject(Connection &con, vector<Value> &params) {
@@ -259,8 +258,7 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 	auto types = initial_result->types;
 	auto names = initial_result->names;
 	// We create an "arrow object" that consists of the arrays from our ArrowQueryResult
-	ArrowTestFactory factory(std::move(types), std::move(names), std::move(initial_result), big_result,
-	                         client_properties, *con.context);
+	ArrowTestFactory factory(std::move(types), std::move(names), std::move(initial_result), big_result, *con.context);
 	// And construct a `arrow_scan` to read the created "arrow object"
 	auto params = ConstructArrowScan(factory);
 
@@ -286,7 +284,7 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, A
 		vector<string> names;
 		auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
 		arrow_result = make_uniq<MaterializedQueryResult>(StatementType::INVALID_STATEMENT, properties,
-		                                                  std::move(names), std::move(collection), ClientProperties());
+		                                                  std::move(names), std::move(collection), con.context);
 	} else {
 		// construct the arrow scan
 		auto params = ConstructArrowScan(arrow_stream);

--- a/test/include/arrow/arrow_test_helper.hpp
+++ b/test/include/arrow/arrow_test_helper.hpp
@@ -16,7 +16,6 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/connection.hpp"
-#include "duckdb/main/client_config.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/common/arrow/arrow_appender.hpp"
@@ -37,9 +36,9 @@ namespace duckdb {
 class ArrowTestFactory {
 public:
 	ArrowTestFactory(vector<LogicalType> types_p, vector<string> names_p, duckdb::unique_ptr<QueryResult> result_p,
-	                 bool big_result, ClientProperties options, ClientContext &context)
+	                 bool big_result, ClientContext &context)
 	    : types(std::move(types_p)), names(std::move(names_p)), result(std::move(result_p)), big_result(big_result),
-	      options(std::move(options)), context(context) {
+	      context(context) {
 		if (result->type == QueryResultType::ARROW_RESULT) {
 			auto &arrow_result = result->Cast<ArrowQueryResult>();
 			prefetched_chunks = arrow_result.ConsumeArrays();
@@ -53,16 +52,13 @@ public:
 	vector<unique_ptr<ArrowArrayWrapper>> prefetched_chunks;
 	vector<unique_ptr<ArrowArrayWrapper>>::iterator chunk_iterator;
 	bool big_result;
-	ClientProperties options;
 	ClientContext &context;
 
 	struct ArrowArrayStreamData {
-		explicit ArrowArrayStreamData(ArrowTestFactory &factory, ClientProperties options)
-		    : factory(factory), options(options) {
+		explicit ArrowArrayStreamData(ArrowTestFactory &factory) : factory(factory) {
 		}
 
 		ArrowTestFactory &factory;
-		ClientProperties options;
 	};
 
 	static int ArrowArrayStreamGetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out);
@@ -78,7 +74,7 @@ public:
 
 	static void GetSchema(ArrowArrayStream *, ArrowSchema &schema);
 
-	void ToArrowSchema(struct ArrowSchema *out);
+	void ToArrowSchema(struct ArrowSchema *out) const;
 };
 
 class ArrowTestHelper {

--- a/test/sql/storage/catalog/test_storage_sequences.cpp
+++ b/test/sql/storage/catalog/test_storage_sequences.cpp
@@ -6,7 +6,6 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Use sequences over different runs without checkpointing", "[storage]") {
-	duckdb::unique_ptr<QueryResult> result;
 	auto storage_database = TestCreatePath("storage_test");
 
 	// make sure the database does not exist
@@ -15,6 +14,7 @@ TEST_CASE("Use sequences over different runs without checkpointing", "[storage]"
 		// create a database and insert values
 		DuckDB db(storage_database);
 		Connection con(db);
+		duckdb::unique_ptr<QueryResult> result;
 		REQUIRE_NO_FAIL(con.Query("CREATE SEQUENCE seq;"));
 		REQUIRE_NO_FAIL(con.Query("CREATE SEQUENCE seq_cycle INCREMENT 1 MAXVALUE 3 START 2 CYCLE;"));
 		result = con.Query("SELECT nextval('seq')");
@@ -34,6 +34,7 @@ TEST_CASE("Use sequences over different runs without checkpointing", "[storage]"
 	{
 		DuckDB db(storage_database);
 		Connection con(db);
+		duckdb::unique_ptr<QueryResult> result;
 		result = con.Query("SELECT nextval('seq')");
 		REQUIRE(CHECK_COLUMN(result, 0, {2}));
 		result = con.Query("SELECT currval('seq')");
@@ -47,6 +48,7 @@ TEST_CASE("Use sequences over different runs without checkpointing", "[storage]"
 	{
 		DuckDB db(storage_database);
 		Connection con(db);
+		duckdb::unique_ptr<QueryResult> result;
 		result = con.Query("SELECT nextval('seq'), nextval('seq');");
 		REQUIRE(CHECK_COLUMN(result, 0, {3}));
 		REQUIRE(CHECK_COLUMN(result, 1, {4}));


### PR DESCRIPTION
This PR replaces the `optional_ptr<ClientContext>` in `ClientProperties` with a proper `shared_ptr<ClientContext>` on `QueryResult`. The real change here is that the lifetime of a client context object is now tied to that of result objects. I.e. a connection stays open as long a a result object exists. This was already the case for `StreamQueryResult`, which held a shared pointer to the client context.

This is triggered by #21927 / #22007, which started with duckdb/duckdb-spatial#788. In short: the GeoArrow extension's `PopulateSchema` callback needs `ClientContext::ParseLogicalType` to bind the CRS type, which requires a valid client context. When Arrow results are consumed lazily, e.g. via the Arrow C Stream API, ADBC, the Python client, or any callback-driven consumer, then the original context may have been closed, and `PopulateSchema` fails with: 

> INTERNAL Error: TransactionContext::ActiveTransaction called without active transaction

~The underlying issue is that Arrow extensions are registered in the catalog, and the catalog is queried whenever an Arrow schema is created or record batches are created.~

Edit: The underlying issue is that Arrow type extensions (which may be implemented by duckdb extension authors) implement callbacks that in their signature promise to provide a valid client context.

As a first fix I've patched duckdb-python in duckdb/duckdb-python#423 by caching the Arrow schema eagerly so it doesn't need to be regenerated after the connection has closed. But that's a workaround that only works in Python and for the specific arrow C stream issue (i.e. the `get_schema` callback through Python).

### Summary of changes
- `ClientProperties::client_context` is removed.
- The property `shared_ptr<ClientContext> client_context` is added to `QueryResult` and initialized in the constructors.
- The `MaterializedQueryResult`, `StreamQueryResult`, and `ArrowQueryResult` constructors are updated.
- The private `shared_ptr<ClientContext> context` member of `StreamQueryResult` is dropped in favor of the inherited context.
- `ArrowConverter::ToArrowSchema/ToArrowArray`, `ArrowUtil::TryFetchChunk/FetchChunk` take `ClientContext &`, and `ArrowAppender` takes a `shared_ptr<ClientContext>`.
- All collectors (`PhysicalMaterializedCollector`, `PhysicalBatchCollector`, `PhysicalBufferedCollector`, `PhysicalBufferedBatchCollector`, `PhysicalArrowCollector`, `PhysicalArrowBatchCollector`) pass context.shared_from_this() when constructing results.
- C-API: `CClientArrowOptionsWrapper` now wraps the context. The consuming functions use this instead of the options.
  - Tests updated to match the new signatures.
