### PR TITLE
Fix nightly tests and ignore very slow tests for HASH_ZERO=1

### DIFF
--- a/.github/config/extensions/test-utils.cmake
+++ b/.github/config/extensions/test-utils.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(test_utils
   GIT_URL https://github.com/duckdb/bwc-test-utils
-  GIT_TAG df0ca97925bc8b3349ee7b1d0ad7496af077daf8
+  GIT_TAG 7074208283523a3af8b5ddd1c890a03abdba3b9b
   # For local dev:
   # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
 )

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -268,11 +268,11 @@ jobs:
 
   storage-initialization:
      name: Storage Initialization Verification
-     runs-on: ubuntu-22.04
+     runs-on: ubuntu-24.04
      needs: linux-memory-leaks
      env:
-       CC: gcc-10
-       CXX: g++-10
+       CC: gcc
+       CXX: g++
        GEN: ninja
 
      steps:
@@ -300,11 +300,11 @@ jobs:
 
   extension-updating:
     name: Extension updating test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc
+      CXX: g++
       GEN: ninja
 
     steps:
@@ -358,11 +358,11 @@ jobs:
 
   regression-test-memory-safety:
    name: Regression Tests between safe and unsafe builds
-   runs-on: ubuntu-22.04
+   runs-on: ubuntu-24.04
    needs: linux-memory-leaks
    env:
-     CC: gcc-10
-     CXX: g++-10
+     CC: gcc
+     CXX: g++
      GEN: ninja
      BUILD_BENCHMARK: 1
      BUILD_JEMALLOC: 1

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -620,7 +620,10 @@ jobs:
 
      - name: Test
        shell: bash
-       run: python3 scripts/ci/run_tests.py --test-config=test/configs/hash_zero.json build/relassert/test/unittest
+       # HASH_ZERO=1 triggers hash collisions; some test statements can turn
+       # into quadratic runtime and thus very slow. Report tests >30s, but only
+       # fail when a test runtime exceeds 2 minutes.
+       run: make unittest_relassert T="--track-runtime 30 --batch-timeout 120 --test-config=test/configs/hash_zero.json"
 
 
   bwc_build:

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -168,8 +168,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: ./.github/actions/cleanup_runner
-
     - name: Install
       run: python3 scripts/ci/retry.py -- make toolsci
 
@@ -210,8 +208,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-
-    - uses: ./.github/actions/cleanup_runner
 
     - name: Install
       run: python3 scripts/ci/retry.py -- make toolsci
@@ -283,8 +279,6 @@ jobs:
      - uses: actions/checkout@v6
        with:
          fetch-depth: 0
-
-     - uses: ./.github/actions/cleanup_runner
 
      - name: Install
        shell: bash
@@ -379,8 +373,6 @@ jobs:
        uses: actions/checkout@v6
        with:
          fetch-depth: 0
-
-     - uses: ./.github/actions/cleanup_runner
 
      - name: Checkout tools repo
        uses: actions/checkout@v6

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -401,7 +401,8 @@ AggregateFunction GetVectorArgMinMaxFunctionInternal(const LogicalType &by_type,
 	                         AggregateFunction::StateDestroy<STATE, OP>);
 #else
 	auto function = GetGenericArgMinMaxFunction<OP>(null_handling);
-	function.GetArguments() = {type, by_type};
+	function.GetSignature().GetParameter(0).SetType(type);
+	function.GetSignature().GetParameter(1).SetType(by_type);
 	function.SetReturnType(type);
 	return function;
 #endif
@@ -462,7 +463,8 @@ AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &by_type, const
 	function.SetBindCallback(GetBindFunction<OP>(null_handling));
 #else
 	auto function = GetGenericArgMinMaxFunction<OP>(null_handling);
-	function.GetArguments() = {type, by_type};
+	function.GetSignature().GetParameter(0).SetType(type);
+	function.GetSignature().GetParameter(1).SetType(by_type);
 	function.SetReturnType(type);
 #endif
 	return function;

--- a/test/configs/hash_zero.json
+++ b/test/configs/hash_zero.json
@@ -22,7 +22,10 @@
         "test/sql/copy/csv/csv_limit_copy.test",
         "test/sql/aggregate/aggregates/test_mode.test",
         "test/issues/general/test_21431.test",
-        "test/sql/join/inner/test_prefix_range_filter_pushdown.test"
+        "test/sql/join/inner/test_prefix_range_filter_pushdown.test",
+        "test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test",
+        "test/sql/settings/operator_memory_limit.test",
+        "test/sql/table_function/duckdb_eviction_queues.test"
       ]
     },
     {

--- a/test/configs/hash_zero.json
+++ b/test/configs/hash_zero.json
@@ -9,6 +9,7 @@
         "test/optimizer/joins/tpcds_nofail.test",
         "test/fuzzer/duckfuzz/bind_limit_num.test_slow",
         "test/sql/types/enum/test_5983.test",
+        "test/sql/insert/insert_by_name.test",
         "test/sql/insert/insert_from_many_grouping_sets.test",
         "test/sql/subquery/lateral/pg_lateral.test",
         "test/sql/aggregate/aggregates/test_perfect_ht.test",
@@ -19,7 +20,9 @@
         "test/sql/copy/csv/test_8890.test",
         "test/sql/copy/csv/test_15211.test",
         "test/sql/copy/csv/csv_limit_copy.test",
-        "test/sql/aggregate/aggregates/test_mode.test"
+        "test/sql/aggregate/aggregates/test_mode.test",
+        "test/issues/general/test_21431.test",
+        "test/sql/join/inner/test_prefix_range_filter_pushdown.test"
       ]
     },
     {


### PR DESCRIPTION
### Clean up

- Remove duplicate `cleanup_runner` actions.
- Upgrade some nightly tests jobs to `ubuntu:24.04`.

### Fix some CI jobs

- Fix `function.GetArguments()` refactor for `SMALLER_BINARY=1`. Fixes https://github.com/duckdblabs/duckdb-internal/issues/9140.
- Fix missing `iostream` in `test_utils` extension by bumping extension tag.

### Ignore slow tests for `HASH_ZERO=1`

- Ignore 7 very slow tests with expected hash-collisions causing quadratic runtime.
- Report slow (>30 sec) tests for `HASH_ZERO=1` in CI, and fail a test after 2 min.

We can find slow tests locally (or in CI), using:
```
$ make unittest_relassert T="--track-runtime 30 --batch-timeout 120 --test-config=test/configs/hash_zero.json"
found 4105 tests
config: test_flags=--test-config test/configs/hash_zero.json, workers=6, retry=0, max_retries=4, batch_size=1, batch_timeout_seconds=120.0, runtime_threshold_seconds=30
..................................
test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test took 59.97s
.......
test/issues/general/test_21431.test took 120.07s
.
test/sql/settings/operator_memory_limit.test took 120.05s
........ [ 50%]
..........
test/sql/insert/insert_by_name.test took 120.03s
..
test/sql/join/inner/test_prefix_range_filter_pushdown.test took 120.06s
.....................................
test/sql/table_function/duckdb_eviction_queues.test took 58.77s
. [100%]
error: found 4 test batch failures in 279s
```

Some of the ignored tests took more than 10 minutes to run, because 600s is the original test timeout used for `HASH_ZERO=1`. See also these two issues:

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9083.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9103.

### `BWC Test` was skipped because `Build DuckDB` failed

The CI jobs for `BWC Test` were [skipped](https://github.com/duckdb/duckdb/actions/runs/25410966728/job/74533817019) because the job `Build DuckDB` failed for `NightlyTests.yml`.

I'll look into the BWC test job failures another time.