### PR TITLE
Avoid 3 instances of idx_t - idx_t > 0, and avoid unnecessary check on zLine

### DIFF
--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -72,7 +72,7 @@ uint64_t Checksum(uint8_t *buffer, size_t size) {
 	for (i = 0; i < size / 8; i++) {
 		result ^= Checksum(ptr[i]);
 	}
-	if (size - i * 8 > 0) {
+	if (size > i * 8) {
 		// the remaining 0-7 bytes we hash using a string hash
 		result ^= ChecksumRemainder(buffer + i * 8, size - i * 8);
 	}

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -790,7 +790,7 @@ void Linenoise::RefreshMultiLine() {
 	int new_cursor_row, new_cursor_x;
 	PositionToColAndRow(pos, new_cursor_row, new_cursor_x, rows, cols);
 	int col; /* column position, zero-based. */
-	int old_rows = maxrows ? maxrows : 1;
+	idx_t old_rows = maxrows ? maxrows : 1;
 	int fd = ofd;
 	std::string highlight_buffer;
 	auto render_buf = this->buf;
@@ -910,12 +910,12 @@ void Linenoise::RefreshMultiLine() {
 	AppendBuffer append_buffer;
 	if (old_rows > old_cursor_rows) {
 		Linenoise::Log("go down %d\n", old_rows - old_cursor_rows);
-		snprintf(seq, 64, "\x1b[%dB", old_rows - int(old_cursor_rows));
+		snprintf(seq, 64, "\x1b[%lluB", old_rows - old_cursor_rows);
 		append_buffer.Append(seq);
 	}
 
 	/* Now for every row clear it, go up. */
-	for (int j = 0; j < old_rows - 1; j++) {
+	for (int j = 0; j + 1 < old_rows; j++) {
 		Linenoise::Log("clear+up\n");
 		append_buffer.Append("\r\x1b[0K\x1b[1A");
 	}

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -910,12 +910,12 @@ void Linenoise::RefreshMultiLine() {
 	AppendBuffer append_buffer;
 	if (old_rows > old_cursor_rows) {
 		Linenoise::Log("go down %d\n", old_rows - old_cursor_rows);
-		snprintf(seq, 64, "\x1b[%lluB", old_rows - old_cursor_rows);
+		snprintf(seq, 64, "\x1b[%luB", old_rows - old_cursor_rows);
 		append_buffer.Append(seq);
 	}
 
 	/* Now for every row clear it, go up. */
-	for (int j = 0; j + 1 < old_rows; j++) {
+	for (idx_t j = 0; j + 1 < old_rows; j++) {
 		Linenoise::Log("clear+up\n");
 		append_buffer.Append("\r\x1b[0K\x1b[1A");
 	}

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -909,8 +909,9 @@ void Linenoise::RefreshMultiLine() {
 	 * going to the last row. */
 	AppendBuffer append_buffer;
 	if (old_rows > old_cursor_rows) {
-		Linenoise::Log("go down %d\n", old_rows - old_cursor_rows);
-		snprintf(seq, 64, "\x1b[%luB", old_rows - old_cursor_rows);
+		int extra_rows = old_rows - old_cursor_rows;
+		Linenoise::Log("go down %d\n", extra_rows);
+		snprintf(seq, 64, "\x1b[%dB", extra_rows);
 		append_buffer.Append(seq);
 	}
 

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -908,7 +908,7 @@ void Linenoise::RefreshMultiLine() {
 	/* First step: clear all the lines used before. To do so start by
 	 * going to the last row. */
 	AppendBuffer append_buffer;
-	if (old_rows - old_cursor_rows > 0) {
+	if (old_rows > old_cursor_rows) {
 		Linenoise::Log("go down %d\n", old_rows - old_cursor_rows);
 		snprintf(seq, 64, "\x1b[%dB", old_rows - int(old_cursor_rows));
 		append_buffer.Append(seq);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2822,12 +2822,12 @@ int ShellState::ProcessInput(InputMode mode) {
 			}
 			continue;
 		}
-		if (zLine && (zLine[0] == '.' || zLine[0] == '#') && nSql == 0) {
+		if ((zLine[0] == '.' || zLine[0] == '#') && nSql == 0) {
 			if (ShellHasFlag(ShellFlags::SHFLG_Echo)) {
 				printf("%s\n", zLine);
 			}
 			if (zLine[0] == '.') {
-				if (mode == InputMode::STANDARD && zLine && *zLine && *zLine != '\3') {
+				if (mode == InputMode::STANDARD && *zLine && *zLine != '\3') {
 					ShellAddHistory(zLine);
 				}
 				rc = DoMetaCommand(zLine);

--- a/tools/shell/shell_highlight.cpp
+++ b/tools/shell/shell_highlight.cpp
@@ -222,7 +222,7 @@ void ShellHighlight::PrintError(string error_msg) {
 		}
 		idx_t start = tokens[i].start;
 		idx_t end = i + 1 == tokens.size() ? error_msg.size() : tokens[i + 1].start;
-		if (end - start > 0) {
+		if (end > start) {
 			string error_print = error_msg.substr(tokens[i].start, end - start);
 			PrintText(error_print, PrintOutput::STDERR, element_type);
 		}


### PR DESCRIPTION
Cleanups some warnings raised by tooling. I tested the checksum, has no effect on compatibility, since previous code was already correct (due to the presence of iteration). Nevertheless, the more formally correct form is better, clearer and robust to code changes.