### PR TITLE
Fix RESET my_global_extension_setting to actually be GLOBAL

### DIFF
--- a/src/execution/operator/helper/physical_reset.cpp
+++ b/src/execution/operator/helper/physical_reset.cpp
@@ -9,10 +9,11 @@ namespace duckdb {
 
 void PhysicalReset::ResetExtensionVariable(ExecutionContext &context, DBConfig &config,
                                            ExtensionOption &extension_option) const {
+	auto effective_scope = scope == SetScope::AUTOMATIC ? extension_option.default_scope : scope;
 	if (extension_option.set_function) {
-		extension_option.set_function(context.client, scope, extension_option.default_value);
+		extension_option.set_function(context.client, effective_scope, extension_option.default_value);
 	}
-	if (scope == SetScope::GLOBAL) {
+	if (effective_scope == SetScope::GLOBAL) {
 		config.ResetOption(extension_option);
 	} else {
 		auto &client_config = ClientConfig::GetConfig(context.client);

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -671,6 +671,11 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	config.AddExtensionOption("add_column_enabled", "enable adding extra column to queries", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(false));
 
+	// Global-default extension option used to exercise RESET on GLOBAL-scoped
+	// extension options across multiple connections.
+	config.AddExtensionOption("demo_global_setting", "demo GLOBAL-default extension option", LogicalType::VARCHAR,
+	                          Value("default"), nullptr, SetScope::GLOBAL);
+
 	// Bounded type
 	auto bounded_type = BoundedType::GetDefault();
 	loader.RegisterType("BOUNDED", bounded_type, BoundedType::Bind);

--- a/test/extension/reset_global_extension_option.test
+++ b/test/extension/reset_global_extension_option.test
@@ -1,0 +1,68 @@
+# name: test/extension/reset_global_extension_option.test
+# description: RESET (without explicit scope) on a GLOBAL-default extension option must reset GLOBAL
+# group: [extension]
+
+require notmingw
+
+require skip_reload
+
+require allow_unsigned_extensions
+
+statement ok
+LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+
+# Both connections see the registered default
+query I con1
+SELECT current_setting('demo_global_setting');
+----
+default
+
+query I con2
+SELECT current_setting('demo_global_setting');
+----
+default
+
+# Plain SET on con1 writes GLOBAL (default_scope) — visible to con2 too
+statement ok con1
+SET demo_global_setting = 'foo';
+
+query I con1
+SELECT current_setting('demo_global_setting');
+----
+foo
+
+query I con2
+SELECT current_setting('demo_global_setting');
+----
+foo
+
+# Plain RESET on con1 must also affect GLOBAL — both connections must see the default again
+statement ok con1
+RESET demo_global_setting;
+
+query I con1
+SELECT current_setting('demo_global_setting');
+----
+default
+
+query I con2
+SELECT current_setting('demo_global_setting');
+----
+default
+
+# Explicit RESET GLOBAL still works
+statement ok con1
+SET demo_global_setting = 'bar';
+
+query I con2
+SELECT current_setting('demo_global_setting');
+----
+bar
+
+statement ok con1
+RESET GLOBAL demo_global_setting;
+
+query I con2
+SELECT current_setting('demo_global_setting');
+----
+default


### PR DESCRIPTION
Currently, `RESET my_global_extension_setting` acts as `RESET SESSION my_global_extension_setting`, even though issuing that explicitly is forbidden.