### PR TITLE
Add test_utils to linux-release and use 30s apt timeout

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -524,7 +524,7 @@ jobs:
       env:
         BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
         DISABLE_SANITIZER: 1
         SMOKE_UNITTEST: build/release/test/unittest
       with:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -524,6 +524,7 @@ jobs:
       env:
         BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
+        EXTENSION_CONFIGS: '.github/config/in_tree_extensions.cmake;.github/config/extensions/fts.cmake;.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake'
         CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
         DISABLE_SANITIZER: 1
         SMOKE_UNITTEST: build/release/test/unittest

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -524,7 +524,6 @@ jobs:
       env:
         BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
-        EXTENSION_CONFIGS: '.github/config/in_tree_extensions.cmake;.github/config/extensions/fts.cmake;.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake'
         CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
         DISABLE_SANITIZER: 1
         SMOKE_UNITTEST: build/release/test/unittest

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -524,7 +524,7 @@ jobs:
       env:
         BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
         DISABLE_SANITIZER: 1
         SMOKE_UNITTEST: build/release/test/unittest
       with:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release
@@ -129,7 +129,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release
@@ -129,7 +129,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release
@@ -129,7 +129,7 @@ jobs:
         env:
           BUILD_BENCHMARK: 1
           BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test_utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
           DISABLE_SANITIZER: 1
         with:
           build: python3 scripts/ci/retry.py -- make release

--- a/Makefile
+++ b/Makefile
@@ -575,8 +575,8 @@ define ensure_apt_commands
 		command -v $$cmd >/dev/null 2>&1 || missing=1; \
 	done; \
 	if [ $$missing -eq 1 ]; then \
-		sudo apt-get update -y -q; \
-		sudo apt-get install -y -q $(2); \
+		sudo apt-get $(APT_TIMEOUT_OPTS) update -y -q && \
+		sudo apt-get $(APT_TIMEOUT_OPTS) install -y -q $(2); \
 	fi
 endef
 
@@ -586,10 +586,12 @@ define ensure_apt_packages
 		dpkg-query -W -f='$${Status}' $$pkg 2>/dev/null | grep -q "install ok installed" || missing=1; \
 	done; \
 	if [ $$missing -eq 1 ]; then \
-		sudo apt-get update -y -q; \
-		sudo apt-get install -y -q $(1); \
+		sudo apt-get $(APT_TIMEOUT_OPTS) update -y -q && \
+		sudo apt-get $(APT_TIMEOUT_OPTS) install -y -q $(1); \
 	fi
 endef
+
+APT_TIMEOUT_OPTS=-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30
 
 .PHONY: toolsci
 


### PR DESCRIPTION
- Add test_utils to linux-release
- Use 30s fetch timeout for `apt`. This is a timeout per HTTP fetch call.