### PR TITLE
Fix bwc test jobs

### DIFF
--- a/.github/config/extensions/test-utils.cmake
+++ b/.github/config/extensions/test-utils.cmake
@@ -1,6 +1,8 @@
 duckdb_extension_load(test_utils
   GIT_URL https://github.com/duckdb/bwc-test-utils
-  GIT_TAG 7074208283523a3af8b5ddd1c890a03abdba3b9b
+  # Use the commit before "Update extensions" (that contains the binaries of
+  # the commit before that).
+  GIT_TAG 5b9c7334949c47cdf69ce11c151139c4c88aa7f8
   # For local dev:
   # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
 )

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -626,13 +626,22 @@ jobs:
        run: make unittest_relassert T="--track-runtime 30 --batch-timeout 120 --test-config=test/configs/hash_zero.json"
 
 
-  bwc_build:
+  bwc-build:
     name: Build DuckDB
     runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.resolve.outputs.groups }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Resolve versions
+        id: resolve
+        run: |
+          groups_json=$(python3 test/bwc/list_versions.py --groups-json)
+          echo "groups=${groups_json}" >> "$GITHUB_OUTPUT"
+          echo "Resolved BWC version groups: ${groups_json}"
 
       - name: Install
         run: python3 scripts/ci/retry.py -- make toolsci
@@ -653,28 +662,13 @@ jobs:
           path: build/release/duckdb
 
   bwc-test:
-    name: BWC Test (DuckDB ${{ matrix.old_duckdb_version }})
+    name: BWC Test (DuckDB ${{ matrix.series.group }})
     runs-on: ubuntu-latest
-    needs: bwc_build
+    needs: bwc-build
     strategy:
       fail-fast: false
       matrix:
-        old_duckdb_version:
-          - v1.1.0
-          - v1.1.1
-          - v1.1.2
-          - v1.1.3
-          - v1.2.0
-          - v1.2.1
-          - v1.2.2
-          - v1.3.0
-          - v1.3.1
-          - v1.3.2
-          - v1.4.0
-          - v1.4.1
-          - v1.4.2
-          - v1.4.3
-          - v1.4.4
+        series: ${{ fromJSON(needs.bwc-build.outputs.groups) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -696,46 +690,64 @@ jobs:
       - name: Install Python dependencies
         run: python3 scripts/ci/retry.py -- pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
 
-      - name: Download BWC cache
-        if: ${{ vars.ENABLE_BWC_CACHE_DOWNLOAD == 'true' }}
+      - name: Run BWC series
         run: |
-          VERSION=${{ matrix.old_duckdb_version }}
-          CACHE_ARCHIVE="runtime_${VERSION}.tar.gz"
+          versions='${{ toJson(matrix.series.versions) }}'
+          mapfile -t VERSION_LIST < <(python3 -c 'import json,sys; [print(v) for v in json.loads(sys.argv[1])]' "$versions")
+          FAILED=0
+          FAILED_VERSIONS=""
           RUNTIME_DIR="duckdb_unittest_tempdir/bwc/runtime"
           mkdir -p "${RUNTIME_DIR}"
+          mkdir -p duckdb_unittest_tempdir/bwc/cache
 
-          # Download the cache archive from test-utils repo
-          DOWNLOAD_URL="https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/cache/${CACHE_ARCHIVE}"
-          HTTP_CODE=$(curl -sL -w '%{http_code}' -o "/tmp/${CACHE_ARCHIVE}" "${DOWNLOAD_URL}" || true)
+          for VERSION in "${VERSION_LIST[@]}"; do
+            echo "============================================================"
+            echo "Running BWC for ${VERSION} (group: ${{ matrix.series.group }})"
+            echo "============================================================"
 
-          if [ "${HTTP_CODE}" != "200" ]; then
-            echo "Failed to download cache for ${VERSION} (HTTP ${HTTP_CODE})"
+            if [ "${{ vars.ENABLE_BWC_CACHE_DOWNLOAD }}" = "true" ]; then
+              CACHE_ARCHIVE="runtime_${VERSION}.tar.gz"
+              DOWNLOAD_URL="https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/cache/${CACHE_ARCHIVE}"
+              HTTP_CODE=$(curl -sL -w '%{http_code}' -o "/tmp/${CACHE_ARCHIVE}" "${DOWNLOAD_URL}" || true)
+              if [ "${HTTP_CODE}" = "200" ]; then
+                tar xzf "/tmp/${CACHE_ARCHIVE}" -C "${RUNTIME_DIR}"
+                CACHED=$(find "${RUNTIME_DIR}/${VERSION}" -name "*.plan.bin" | wc -l)
+                echo "Extracted cache for ${VERSION}: ${CACHED} cached test plans"
+              else
+                echo "Failed to download cache for ${VERSION} (HTTP ${HTTP_CODE})"
+                FAILED=1
+                FAILED_VERSIONS="${FAILED_VERSIONS} ${VERSION}(cache)"
+              fi
+            fi
+
+            if ! python3.11 test/bwc/runner.py --old_duckdb_version="${VERSION}"; then
+              FAILED=1
+              FAILED_VERSIONS="${FAILED_VERSIONS} ${VERSION}(tests)"
+            fi
+
+            if ! python3.11 test/bwc/export_cache.py --version "${VERSION}" --output-dir duckdb_unittest_tempdir/bwc/cache; then
+              FAILED=1
+              FAILED_VERSIONS="${FAILED_VERSIONS} ${VERSION}(export)"
+            fi
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "BWC series had failures:${FAILED_VERSIONS}"
             exit 1
           fi
-
-          tar xzf "/tmp/${CACHE_ARCHIVE}" -C "${RUNTIME_DIR}"
-          CACHED=$(find "${RUNTIME_DIR}/${VERSION}" -name "*.plan.bin" | wc -l)
-          echo "Extracted cache for ${VERSION}: ${CACHED} cached test plans"
-
-      - name: Run BWC tests
-        run: python3.11 test/bwc/runner.py --old_duckdb_version=${{ matrix.old_duckdb_version }}
-
-      - name: Export BWC cache
-        if: always()
-        run: python3.11 test/bwc/export_cache.py --version ${{ matrix.old_duckdb_version }} --output-dir duckdb_unittest_tempdir/bwc/cache
 
       - name: Upload BWC cache
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: bwc-cache-${{ matrix.old_duckdb_version }}
-          path: duckdb_unittest_tempdir/bwc/cache/runtime_${{ matrix.old_duckdb_version }}.tar.gz
+          name: bwc-cache-${{ matrix.series.group }}
+          path: duckdb_unittest_tempdir/bwc/cache/runtime_*.tar.gz
 
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: bwc-test-results-${{ matrix.old_duckdb_version }}
+          name: bwc-test-results-${{ matrix.series.group }}
           path: |
             duckdb_unittest_tempdir/bwc/tests_summary_*.txt
             duckdb_unittest_tempdir/bwc/reports/test_report_*.duckdb

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
 
 PYTHON ?= python3
-FORMAT_VENV ?= build/format-venv
+FORMAT_VENV ?= .cache/format-venv
 FORMAT_PYTHON := $(FORMAT_VENV)/bin/python
 FORMAT_SETUP_DEPS := format_venv
 

--- a/test/bwc/list_versions.py
+++ b/test/bwc/list_versions.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from os.path import abspath, dirname
+import sys
+
+sys.path.insert(0, dirname(abspath(__file__)))
+from utils.version_list import list_supported_duckdb_version_groups, list_supported_duckdb_versions
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List supported DuckDB versions for BWC")
+    parser.add_argument("--json", action="store_true", help="Output JSON array")
+    parser.add_argument("--groups-json", action="store_true", help="Output JSON array grouped by vX.Y series")
+    args = parser.parse_args()
+
+    if args.groups_json:
+        print(json.dumps(list_supported_duckdb_version_groups()))
+        return
+
+    versions = list_supported_duckdb_versions()
+    if args.json:
+        print(json.dumps(versions))
+    else:
+        for version in versions:
+            print(version)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -5,6 +5,7 @@ from utils.duckdb_installer import install_assets, install_extensions, make_cli_
 from utils.test_files_parser import load_test_files
 from utils.test_report import TestReport
 from utils.logger import make_logger
+from utils.version_list import list_supported_duckdb_versions
 import time
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock, Event
@@ -317,25 +318,7 @@ def cleanup_runtime_dir(bwc_tests_base_dir, dry_run=True):
 
 if __name__ == "__main__":
     supported_duckdb_versions = (
-        [args.old_duckdb_version]
-        if args.old_duckdb_version
-        else [
-            "v1.1.0",
-            "v1.1.2",
-            "v1.1.1",
-            "v1.2.0",
-            "v1.1.3",
-            "v1.2.2",
-            "v1.2.1",
-            "v1.3.0",
-            "v1.3.1",
-            "v1.3.2",
-            "v1.4.0",
-            "v1.4.1",
-            "v1.4.2",
-            "v1.4.3",
-            "v1.4.4",
-        ]
+        [args.old_duckdb_version] if args.old_duckdb_version else list_supported_duckdb_versions()
     )
 
     duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))

--- a/test/bwc/update_cache.py
+++ b/test/bwc/update_cache.py
@@ -17,6 +17,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from os.path import abspath, dirname
+
+sys.path.insert(0, dirname(abspath(__file__)))
+from utils.version_list import list_supported_duckdb_versions
 
 parser = argparse.ArgumentParser(description='Update BWC test cache in test-utils from CI artifacts')
 parser.add_argument(
@@ -28,24 +32,6 @@ parser.add_argument('--repo', dest='repo', default='duckdb/duckdb', help='GitHub
 parser.add_argument('--commit', dest='commit', action='store_true', help='Commit the updated cache files in test-utils')
 
 args = parser.parse_args()
-
-SUPPORTED_VERSIONS = [
-    "v1.1.0",
-    "v1.1.1",
-    "v1.1.2",
-    "v1.1.3",
-    "v1.2.0",
-    "v1.2.1",
-    "v1.2.2",
-    "v1.3.0",
-    "v1.3.1",
-    "v1.3.2",
-    "v1.4.0",
-    "v1.4.1",
-    "v1.4.2",
-    "v1.4.3",
-    "v1.4.4",
-]
 
 
 def download_artifact(run_id, artifact_name, dest_dir, repo):
@@ -69,7 +55,7 @@ if __name__ == '__main__':
     if args.version:
         versions = [args.version]
     else:
-        versions = SUPPORTED_VERSIONS
+        versions = list_supported_duckdb_versions()
 
     print(f"Downloading cache artifacts from run {args.run_id} ({args.repo})")
     print(f"Updating {len(versions)} version(s) in {cache_dir}\n")

--- a/test/bwc/utils/version_list.py
+++ b/test/bwc/utils/version_list.py
@@ -1,0 +1,51 @@
+import re
+import subprocess
+from collections import OrderedDict
+
+
+SEMVER_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version_tag(tag):
+    match = SEMVER_TAG_RE.match(tag)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def list_supported_duckdb_versions(min_version="v1.1.0"):
+    min_tuple = parse_version_tag(min_version)
+    if min_tuple is None:
+        raise ValueError(f"Invalid minimum version tag: {min_version}")
+
+    result = subprocess.run(
+        ["git", "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    raw_tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    versions = []
+    for tag in raw_tags:
+        parsed = parse_version_tag(tag)
+        if parsed is None:
+            continue
+        if parsed >= min_tuple:
+            versions.append((parsed, tag))
+
+    versions.sort(key=lambda entry: entry[0])
+    return [tag for _, tag in versions]
+
+
+def list_supported_duckdb_version_groups(min_version="v1.1.0"):
+    grouped = OrderedDict()
+    for version in list_supported_duckdb_versions(min_version=min_version):
+        parsed = parse_version_tag(version)
+        assert parsed is not None
+        major, minor, _ = parsed
+        group = f"v{major}.{minor}"
+        if group not in grouped:
+            grouped[group] = []
+        grouped[group].append(version)
+    return [{"group": group, "versions": versions} for group, versions in grouped.items()]

--- a/test/configs/hash_zero.json
+++ b/test/configs/hash_zero.json
@@ -24,8 +24,12 @@
         "test/issues/general/test_21431.test",
         "test/sql/join/inner/test_prefix_range_filter_pushdown.test",
         "test/sql/join/inner/test_prefix_range_filter_pushdown_strinline.test",
+        "test/sql/join/left_outer/unique_left_join.test",
+        "test/sql/limit/streaming_limit_pipeline_flush.test",
+        "test/sql/settings/max_execution_time.test",
         "test/sql/settings/operator_memory_limit.test",
-        "test/sql/table_function/duckdb_eviction_queues.test"
+        "test/sql/table_function/duckdb_eviction_queues.test",
+        "test/sql/pragma/profiling/test_custom_profiling_total_memory_allocated.test"
       ]
     },
     {


### PR DESCRIPTION
- Compute version matrix using git tags instead of using hardcoded version list.
- Group bwc test jobs by minor duckdb version.
- Fix test-utils commit.

We should not use `Update extension` commits because that [fails](https://github.com/duckdb/duckdb/actions/runs/25500841929/job/74839369343#step:8:111):
```
  File "/home/runner/work/duckdb/duckdb/test/bwc/runner.py", line 201, in do_run_test
    raise RuntimeError(
RuntimeError: test-utils extension version mismatch:
v1.1.0 is @ 5b9c733 and v1.6.0-dev5484 is @ 7074208
Error: Process completed with exit code 1.
```

### CI failure is unrelated

```
Run python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
tcache_thread_shutdown(): unaligned tcache chunk detected
Aborted (core dumped)
```