### PR TITLE
parser: make coalesce/ifnull (and other parser-level rewrites) work with dot-chaining

### DIFF
--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -19,8 +19,8 @@
 
 namespace duckdb {
 
-static unique_ptr<ParsedExpression>
-TryRewriteSpecialFunctionCall(const string &lowercase_name, vector<unique_ptr<ParsedExpression>> &children);
+static unique_ptr<ParsedExpression> TryRewriteSpecialFunctionCall(const string &lowercase_name,
+                                                                  vector<unique_ptr<ParsedExpression>> &children);
 static bool IsParserLevelRewriteName(const string &lowercase_name);
 
 unique_ptr<SQLStatement> PEGTransformerFactory::TransformExpressionStatement(PEGTransformer &transformer,
@@ -199,9 +199,8 @@ string PEGTransformerFactory::TransformReservedTableQualification(PEGTransformer
 // (CASE, COALESCE, UNPACK, TRY, ARRAY_CONSTRUCTOR, CAST). Returns the rewritten expression on
 // success, or nullptr if `lowercase_name` is not a special-cased name. On success, elements of
 // `children` are moved out.
-static unique_ptr<ParsedExpression>
-TryRewriteSpecialFunctionCall(const string &lowercase_name,
-                              vector<unique_ptr<ParsedExpression>> &children) {
+static unique_ptr<ParsedExpression> TryRewriteSpecialFunctionCall(const string &lowercase_name,
+                                                                  vector<unique_ptr<ParsedExpression>> &children) {
 	if (lowercase_name == "if") {
 		if (children.size() != 3) {
 			throw ParserException("Wrong number of arguments to IF.");
@@ -263,8 +262,8 @@ TryRewriteSpecialFunctionCall(const string &lowercase_name,
 
 static bool IsParserLevelRewriteName(const string &lowercase_name) {
 	return lowercase_name == "if" || lowercase_name == "unpack" || lowercase_name == "try" ||
-	       lowercase_name == "construct_array" || lowercase_name == "ifnull" ||
-	       lowercase_name == "coalesce" || lowercase_name == "date";
+	       lowercase_name == "construct_array" || lowercase_name == "ifnull" || lowercase_name == "coalesce" ||
+	       lowercase_name == "date";
 }
 
 unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(PEGTransformer &transformer,
@@ -340,8 +339,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 	// behave like `ifnull(x, y)`.
 	if (!qualified_function.schema.empty() && qualified_function.catalog.empty() &&
 	    IsParserLevelRewriteName(lowercase_name)) {
-		function_children.insert(function_children.begin(),
-		                         make_uniq<ColumnRefExpression>(qualified_function.schema));
+		function_children.insert(function_children.begin(), make_uniq<ColumnRefExpression>(qualified_function.schema));
 		qualified_function.schema = "";
 	}
 

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -19,6 +19,10 @@
 
 namespace duckdb {
 
+static unique_ptr<ParsedExpression>
+TryRewriteSpecialFunctionCall(const string &lowercase_name, vector<unique_ptr<ParsedExpression>> &children);
+static bool IsParserLevelRewriteName(const string &lowercase_name);
+
 unique_ptr<SQLStatement> PEGTransformerFactory::TransformExpressionStatement(PEGTransformer &transformer,
                                                                              ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
@@ -117,7 +121,12 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformBaseExpression(PEGT
 		} else if (indirection_expr->GetExpressionClass() == ExpressionClass::FUNCTION) {
 			auto function_expr = unique_ptr_cast<ParsedExpression, FunctionExpression>(std::move(indirection_expr));
 			function_expr->children.insert(function_expr->children.begin(), std::move(expr));
-			expr = std::move(function_expr);
+			auto lowercase_name = StringUtil::Lower(function_expr->function_name);
+			if (auto rewritten = TryRewriteSpecialFunctionCall(lowercase_name, function_expr->children)) {
+				expr = std::move(rewritten);
+			} else {
+				expr = std::move(function_expr);
+			}
 			prev_indirection_was_cast = false;
 		} else if (indirection_expr->GetExpressionClass() == ExpressionClass::CONSTANT) {
 			vector<unique_ptr<ParsedExpression>> struct_children;
@@ -184,6 +193,78 @@ string PEGTransformerFactory::TransformReservedTableQualification(PEGTransformer
                                                                   ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	return list_pr.Child<IdentifierParseResult>(0).identifier;
+}
+
+// Apply parser-level rewrites for function names that resolve to a non-FunctionExpression AST node
+// (CASE, COALESCE, UNPACK, TRY, ARRAY_CONSTRUCTOR, CAST). Returns the rewritten expression on
+// success, or nullptr if `lowercase_name` is not a special-cased name. On success, elements of
+// `children` are moved out.
+static unique_ptr<ParsedExpression>
+TryRewriteSpecialFunctionCall(const string &lowercase_name,
+                              vector<unique_ptr<ParsedExpression>> &children) {
+	if (lowercase_name == "if") {
+		if (children.size() != 3) {
+			throw ParserException("Wrong number of arguments to IF.");
+		}
+		auto expr = make_uniq<CaseExpression>();
+		CaseCheck check;
+		check.when_expr = std::move(children[0]);
+		check.then_expr = std::move(children[1]);
+		expr->case_checks.push_back(std::move(check));
+		expr->else_expr = std::move(children[2]);
+		return std::move(expr);
+	}
+	if (lowercase_name == "unpack") {
+		if (children.size() != 1) {
+			throw ParserException("Wrong number of arguments to the UNPACK operator");
+		}
+		auto expr = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_UNPACK);
+		expr->children = std::move(children);
+		return std::move(expr);
+	}
+	if (lowercase_name == "try") {
+		if (children.size() != 1) {
+			throw ParserException("Wrong number of arguments provided to TRY expression");
+		}
+		auto try_expression = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_TRY);
+		try_expression->children = std::move(children);
+		return std::move(try_expression);
+	}
+	if (lowercase_name == "construct_array") {
+		auto construct_array = make_uniq<OperatorExpression>(ExpressionType::ARRAY_CONSTRUCTOR);
+		construct_array->children = std::move(children);
+		return std::move(construct_array);
+	}
+	if (lowercase_name == "ifnull") {
+		if (children.size() != 2) {
+			throw ParserException("Wrong number of arguments to IFNULL.");
+		}
+		auto coalesce_op = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+		coalesce_op->children.push_back(std::move(children[0]));
+		coalesce_op->children.push_back(std::move(children[1]));
+		return std::move(coalesce_op);
+	}
+	if (lowercase_name == "coalesce") {
+		if (children.empty()) {
+			throw ParserException("Wrong number of arguments to COALESCE.");
+		}
+		auto coalesce_op = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+		coalesce_op->children = std::move(children);
+		return std::move(coalesce_op);
+	}
+	if (lowercase_name == "date") {
+		if (children.size() != 1) {
+			throw ParserException("Wrong number of arguments provided to DATE function");
+		}
+		return make_uniq_base<ParsedExpression, CastExpression>(LogicalType::DATE, std::move(children[0]));
+	}
+	return nullptr;
+}
+
+static bool IsParserLevelRewriteName(const string &lowercase_name) {
+	return lowercase_name == "if" || lowercase_name == "unpack" || lowercase_name == "try" ||
+	       lowercase_name == "construct_array" || lowercase_name == "ifnull" ||
+	       lowercase_name == "coalesce" || lowercase_name == "date";
 }
 
 unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(PEGTransformer &transformer,
@@ -253,50 +334,19 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 		lowercase_name = "count_star";
 	}
 
-	if (lowercase_name == "if") {
-		if (function_children.size() != 3) {
-			throw ParserException("Wrong number of arguments to IF.");
-		}
-		auto expr = make_uniq<CaseExpression>();
-		CaseCheck check;
-		check.when_expr = std::move(function_children[0]);
-		check.then_expr = std::move(function_children[1]);
-		expr->case_checks.push_back(std::move(check));
-		expr->else_expr = std::move(function_children[2]);
-		return std::move(expr);
-	} else if (lowercase_name == "unpack") {
-		if (function_children.size() != 1) {
-			throw ParserException("Wrong number of arguments to the UNPACK operator");
-		}
-		auto expr = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_UNPACK);
-		expr->children = std::move(function_children);
-		return std::move(expr);
-	} else if (lowercase_name == "try") {
-		if (function_children.size() != 1) {
-			throw ParserException("Wrong number of arguments provided to TRY expression");
-		}
-		auto try_expression = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_TRY);
-		try_expression->children = std::move(function_children);
-		return std::move(try_expression);
-	} else if (lowercase_name == "construct_array") {
-		auto construct_array = make_uniq<OperatorExpression>(ExpressionType::ARRAY_CONSTRUCTOR);
-		construct_array->children = std::move(function_children);
-		return std::move(construct_array);
-	} else if (lowercase_name == "ifnull") {
-		if (function_children.size() != 2) {
-			throw ParserException("Wrong number of arguments to IFNULL.");
-		}
+	// `x.f(args)` parses as a schema-qualified call (schema=x, name=f). For names that map to
+	// parser-level rewrites (and thus have no catalog entry), the binder's `schema.func ->
+	// func(col)` fallback can never fire. Demote here so dot-chained calls like `x.ifnull(y)`
+	// behave like `ifnull(x, y)`.
+	if (!qualified_function.schema.empty() && qualified_function.catalog.empty() &&
+	    IsParserLevelRewriteName(lowercase_name)) {
+		function_children.insert(function_children.begin(),
+		                         make_uniq<ColumnRefExpression>(qualified_function.schema));
+		qualified_function.schema = "";
+	}
 
-		//  Two-argument COALESCE
-		auto coalesce_op = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
-		coalesce_op->children.push_back(std::move(function_children[0]));
-		coalesce_op->children.push_back(std::move(function_children[1]));
-		return std::move(coalesce_op);
-	} else if (lowercase_name == "date") {
-		if (function_children.size() != 1) {
-			throw ParserException("Wrong number of arguments provided to DATE function");
-		}
-		return std::move(make_uniq<CastExpression>(LogicalType::DATE, std::move(function_children[0])));
+	if (auto rewritten = TryRewriteSpecialFunctionCall(lowercase_name, function_children)) {
+		return rewritten;
 	}
 	if (has_ignore_nulls_result) {
 		throw ParserException("RESPECT/IGNORE NULLS is not supported for non-window functions");

--- a/test/sql/parser/function_chaining.test
+++ b/test/sql/parser/function_chaining.test
@@ -106,3 +106,60 @@ query I
 EXECUTE v1('Hello World')
 ----
 hello
+
+# Issue #17788: parser-level rewrites must apply through dot-chaining as well.
+# These functions (coalesce, ifnull, if, try, construct_array, date, unpack) have no
+# scalar-function counterpart, so x.<name>(...) must be rewritten the same way as <name>(x, ...).
+
+query I
+SELECT col.ifnull('b') FROM (SELECT 'a' AS col)
+----
+a
+
+query I
+SELECT col.ifnull('b') FROM (SELECT NULL::VARCHAR AS col)
+----
+b
+
+query I
+SELECT col.coalesce('b') FROM (SELECT 'a' AS col)
+----
+a
+
+query I
+SELECT col.coalesce('b', 'c') FROM (SELECT NULL::VARCHAR AS col)
+----
+b
+
+# col.len() = 1, then 1.coalesce('b') = 1 (cast to first non-null result type)
+query I
+SELECT col.len().coalesce(99) FROM (SELECT 'a' AS col)
+----
+1
+
+# Wrong number of arguments to IFNULL must error consistently in both paths.
+statement error
+SELECT col.ifnull('a', 'b') FROM (SELECT 'a' AS col)
+----
+Wrong number of arguments to IFNULL
+
+statement error
+SELECT col.len().ifnull('b','c') FROM (SELECT 'a' AS col)
+----
+Wrong number of arguments to IFNULL
+
+# Other parser-level rewrites should also work through dot-chaining.
+query I
+SELECT (TRUE).if(1, 2)
+----
+1
+
+query I
+SELECT (FALSE).if(1, 2)
+----
+2
+
+query I
+SELECT ('2024-01-15').date()
+----
+2024-01-15


### PR DESCRIPTION
Fixes #17788.

### Problem

The four broken cases from the issue all stem from the PEG grammar matching `col.f(args)` as a schema-qualified function call (`SchemaReservedFunctionName <- SchemaQualification ReservedFunctionName`) *before* it tries the dot-chain path (`BaseExpression <- SingleExpression Indirection*`).

For names like `lower`, this is harmless: the binder has a fallback in `bind_function_expression.cpp` that, if `schema.func` doesn't bind, checks whether `func` exists in the system catalog and demotes `schema.func(args)` to `func(schema_as_col, args)`. That's why `v.lower()` works.

But several names (`coalesce`, `ifnull`, `if`, `try`, `unpack`, `construct_array`, `date`) are not catalog functions at all — they're rewritten to AST nodes during parsing (`OperatorExpression(OPERATOR_COALESCE)`, `CaseExpression`, `CastExpression`, ...). The catalog fallback can never fire for them, so the parser-level rewrite ran with the wrong arity (no receiver prepended) and produced confusing errors:
SELECT col.ifnull('b') FROM (SELECT 'a' AS col);
Parser Error: Wrong number of arguments to IFNULL.

SELECT col.coalesce('b') FROM (SELECT 'a' AS col);
Catalog Error: Scalar Function with name coalesce does not exist!

### Fix

Three changes in `src/parser/peg/transformer/transform_expression.cpp`:

1. Extract the inline parser-level rewrites in `TransformFunctionExpression` into a static helper `TryRewriteSpecialFunctionCall`, and add `coalesce` to the set it handles.
2. Before invoking the helper, mirror the binder's `schema.func -> func(col)` fallback for parser-level rewrite names: if the function call has a non-empty `schema` and the name is one of `{if, unpack, try, construct_array, ifnull, coalesce, date}`, prepend the schema as a `ColumnRefExpression` and clear the schema. The helper then sees the right arity.
3. Call the same helper from `TransformBaseExpression`'s indirection branch so dot-chains that *do* reach it (e.g. `col.len().ifnull(...)`) are also rewritten consistently.

### Behavior after the fix
SELECT col.ifnull('b') FROM (SELECT 'a' AS col); -- a
SELECT col.coalesce('b') FROM (SELECT 'a' AS col); -- a
SELECT col.ifnull('a','b') FROM ...; -- error (correct arity msg)
SELECT col.len().ifnull('b','c') FROM ...; -- error (correct arity msg)


### Tests

Added cases to `test/sql/parser/function_chaining.test` covering both schema-qualified parsing (`col.ifnull(...)`) and explicit dot-chain parsing (`(col).coalesce(...)`, `col.len().coalesce(...)`), plus the arity-error cases and `(TRUE).if(1,2)` / `('2024-01-15').date()` for the other rewrite names.

Locally on macOS arm64: `[parser]` (732 assertions), `[binder]` (781 assertions), and the new `function_chaining.test` (37 assertions) all pass with no regressions.