### PR TITLE
Keep stats at unsigned integer cast

### DIFF
--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -38,6 +38,11 @@ bool StatisticsPropagator::CanPropagateCast(const LogicalType &source, const Log
 	case PhysicalType::INT32:
 	case PhysicalType::INT64:
 	case PhysicalType::INT128:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::UINT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
 		break;
@@ -50,6 +55,11 @@ bool StatisticsPropagator::CanPropagateCast(const LogicalType &source, const Log
 	case PhysicalType::INT32:
 	case PhysicalType::INT64:
 	case PhysicalType::INT128:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::UINT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
 		break;

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -31,6 +31,9 @@ bool StatisticsPropagator::CanPropagateCast(const LogicalType &source, const Log
 	if (source == target) {
 		return true;
 	}
+	if (source.id() == LogicalTypeId::ENUM || target.id() == LogicalTypeId::ENUM) {
+		return false;
+	}
 	// we can only propagate numeric -> numeric
 	switch (source.InternalType()) {
 	case PhysicalType::INT8:

--- a/test/optimizer/pushdown/join_filter_pushdown_cast.test
+++ b/test/optimizer/pushdown/join_filter_pushdown_cast.test
@@ -167,11 +167,10 @@ CREATE TABLE probe_ubigint AS SELECT v::UBIGINT AS a FROM (VALUES (1), (5), (10)
 statement ok
 CREATE TABLE build_neg AS SELECT b::BIGINT AS b FROM (VALUES (5), (-1), (10)) t(b);
 
-# TODO HERE
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM (SELECT a::BIGINT AS a FROM probe_ubigint) t JOIN build_neg ON t.a = build_neg.b;
 ----
-analyzed_plan	<!REGEX>:.*Dynamic Filters:.*
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*
 
 # -1 cannot be cast to UBIGINT — only 5 and 10 match
 query I

--- a/test/optimizer/statistics/statistics_unsigned_cast.test
+++ b/test/optimizer/statistics/statistics_unsigned_cast.test
@@ -1,0 +1,22 @@
+# name: test/optimizer/statistics/statistics_unsigned_cast.test
+# description: Statistics propagation across casts involving unsigned integer types
+# group: [statistics]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE t_signed AS SELECT i::INT AS id FROM range(0, 100) t(i);
+
+query II
+EXPLAIN SELECT * FROM t_signed WHERE id::BIGINT > 100;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+statement ok
+CREATE TABLE t_unsigned AS SELECT i::UINTEGER AS id FROM range(0, 100) t(i);
+
+query II
+EXPLAIN SELECT * FROM t_unsigned WHERE id::BIGINT > 100;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*


### PR DESCRIPTION
Hi team, I found for unsigned integer cast, stats are not applied as expected, which leads to unnecessary table scan.
```sql
memory D CREATE TABLE t_signed AS SELECT i::INT AS id FROM range(0, 100) t(i);
memory D EXPLAIN SELECT * FROM t_signed WHERE id::BIGINT > 100;

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│        EMPTY_RESULT       │
└───────────────────────────┘
memory D CREATE TABLE t_unsigned AS SELECT i::UINTEGER AS id FROM range(0, 100) t(i);
memory D EXPLAIN SELECT * FROM t_unsigned WHERE id::BIGINT > 100;

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│          SEQ_SCAN         │
│    ────────────────────   │
│           Table:          │
│   memory.main.t_unsigned  │
│                           │
│   Type: Sequential Scan   │
│      Projections: id      │
│                           │
│          Filters:         │
│ (CAST(id AS BIGINT) > 100)│
│                           │
│          ~20 rows         │
└───────────────────────────┘
```
In the above example, table `t_unsigned`'s min/max stats should be kept IMO, which could avoid the scan. 