### PR TITLE
optimizer: don't return truncated VARCHAR MIN/MAX from statistics

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -91,14 +91,8 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 			// No min/max statistics availabe
 			return false;
 		}
-		// String statistics store at most an 8-byte prefix of the min/max
-		// values (see StringStatsData::MAX_STRING_MINMAX_SIZE). If the
-		// actual maximum string length exceeds that prefix, the stored
-		// prefix is not the true min/max even when the underlying source
-		// (e.g. Parquet `is_min_value_exact` / `is_max_value_exact`)
-		// reports the bounds as exact. Returning the prefix in that case
-		// silently truncates MIN()/MAX() results for VARCHAR aggregates
-		// over Parquet (issue #22515).
+		// String statistics store at most an 8-byte prefix of the min/max values.
+		// If the actual maximum string length exceeds that prefix, the stored prefix is not the true min/max
 		if (!StringStats::HasMaxStringLength(*column_stats) ||
 		    StringStats::MaxStringLength(*column_stats) > StringStatsData::MAX_STRING_MINMAX_SIZE) {
 			return false;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -91,6 +91,18 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 			// No min/max statistics availabe
 			return false;
 		}
+		// String statistics store at most an 8-byte prefix of the min/max
+		// values (see StringStatsData::MAX_STRING_MINMAX_SIZE). If the
+		// actual maximum string length exceeds that prefix, the stored
+		// prefix is not the true min/max even when the underlying source
+		// (e.g. Parquet `is_min_value_exact` / `is_max_value_exact`)
+		// reports the bounds as exact. Returning the prefix in that case
+		// silently truncates MIN()/MAX() results for VARCHAR aggregates
+		// over Parquet (issue #22515).
+		if (!StringStats::HasMaxStringLength(*column_stats) ||
+		    StringStats::MaxStringLength(*column_stats) > StringStatsData::MAX_STRING_MINMAX_SIZE) {
+			return false;
+		}
 	}
 	result = comparator.GetVal(*column_stats);
 	return true;

--- a/test/parquet/min_max_long_varchar_22515.test
+++ b/test/parquet/min_max_long_varchar_22515.test
@@ -1,0 +1,47 @@
+# name: test/parquet/min_max_long_varchar_22515.test
+# description: Issue #22515 - MIN/MAX(VARCHAR) over read_parquet() must not be truncated to 8 bytes by statistics propagation.
+# group: [parquet]
+
+require parquet
+
+# Strings longer than the 8-byte StringStats prefix.
+statement ok
+COPY (SELECT 'A123456789' AS v UNION ALL SELECT 'B123456789') TO '{TEST_DIR}/min_max_long_varchar.parquet' (FORMAT PARQUET);
+
+query I
+SELECT MIN(v) FROM read_parquet('{TEST_DIR}/min_max_long_varchar.parquet');
+----
+A123456789
+
+query I
+SELECT MAX(v) FROM read_parquet('{TEST_DIR}/min_max_long_varchar.parquet');
+----
+B123456789
+
+# Strings within the 8-byte prefix should still be answered from stats.
+statement ok
+COPY (SELECT 'aa' AS v UNION ALL SELECT 'bb') TO '{TEST_DIR}/min_max_short_varchar.parquet' (FORMAT PARQUET);
+
+query I
+SELECT MIN(v) FROM read_parquet('{TEST_DIR}/min_max_short_varchar.parquet');
+----
+aa
+
+query I
+SELECT MAX(v) FROM read_parquet('{TEST_DIR}/min_max_short_varchar.parquet');
+----
+bb
+
+# Mix of short and long values: the long max must not be truncated.
+statement ok
+COPY (SELECT 'short' AS v UNION ALL SELECT 'A123456789') TO '{TEST_DIR}/min_max_mixed_varchar.parquet' (FORMAT PARQUET);
+
+query I
+SELECT MAX(v) FROM read_parquet('{TEST_DIR}/min_max_mixed_varchar.parquet');
+----
+short
+
+query I
+SELECT MIN(v) FROM read_parquet('{TEST_DIR}/min_max_mixed_varchar.parquet');
+----
+A123456789


### PR DESCRIPTION
Fixes #22515.

### Problem

```python
con.execute("COPY (SELECT 'A123456789' AS v) TO '/tmp/bug.parquet' (FORMAT PARQUET)")
con.execute("SELECT MIN(v) FROM read_parquet('/tmp/bug.parquet')").fetchone()
# -> ('A1234567',)   # truncated to 8 bytes
```

The optimizer takes a shortcut: when partition statistics report `MinMaxIsExact`, `StatisticsPropagator::TryGetValueFromStats` returns the stats' min/max directly as the result of `MIN()` / `MAX()`. The Parquet reader's `MinMaxIsExact` (`extension/parquet/parquet_reader.cpp:1434`) trusts the file-level `is_min_value_exact` / `is_max_value_exact` flags introduced in PARQUET-2352.

But DuckDB's `StringStatsData` stores only the first 8 bytes of each min/max:

```cpp
constexpr static uint32_t MAX_STRING_MINMAX_SIZE = 8;
data_t min[MAX_STRING_MINMAX_SIZE];
data_t max[MAX_STRING_MINMAX_SIZE];
```

So even when Parquet says "the bounds are exact", once the bytes flow through our stats they're truncated, and the shortcut returns the truncated prefix as the user-visible result.

This is a regression in 1.5.x — the workaround documented in the issue is `SET disabled_optimizers = 'statistics_propagation'`.

### Fix

In `TryGetValueFromStats`, after `MinMaxIsExact` returns true, additionally require that the column's known max string length does **not** exceed the prefix size. If it does (or if the max length is unknown), the stats may be a truncated prefix and we can't use them as the aggregate result; the optimizer falls back to scanning the column, which produces the correct value.

```cpp
if (!StringStats::HasMaxStringLength(*column_stats) ||
    StringStats::MaxStringLength(*column_stats) > StringStatsData::MAX_STRING_MINMAX_SIZE) {
    return false;
}
```

The row-group implementation of `MinMaxIsExact` (in `src/storage/table/row_group.cpp`) already encodes the same invariant (`max_length == StringStats::Max(stats).length()`), so this is effectively making the consumer side enforce it regardless of which `PartitionStatistics` source provided the stats.

### Tests

Added `test/parquet/min_max_long_varchar_22515.test` covering:
- `MIN`/`MAX` over Parquet of strings >8 bytes (the bug)
- `MIN`/`MAX` over Parquet of strings ≤8 bytes (still optimized via stats)
- Mixed short + long values

All `[parquet]` tests pass locally (23080 assertions, 162 cases).