### PR TITLE
Fix eviction queue dead_nodes counter 

### DIFF
--- a/src/function/table/system/duckdb_eviction_queues.cpp
+++ b/src/function/table/system/duckdb_eviction_queues.cpp
@@ -61,7 +61,7 @@ void DuckDBEvictionQueuesFunction(ClientContext &context, TableFunctionInput &da
 		queue_index.Append(Value::BIGINT(UnsafeNumericCast<int64_t>(entry.queue_index)));
 		queue_type.Append(Value(entry.queue_type));
 		approximate_size.Append(Value::BIGINT(UnsafeNumericCast<int64_t>(entry.approximate_size)));
-		dead_nodes.Append(Value::BIGINT(UnsafeNumericCast<int64_t>(entry.dead_nodes)));
+		dead_nodes.Append(Value::BIGINT(entry.dead_nodes));
 		total_insertions.Append(Value::BIGINT(UnsafeNumericCast<int64_t>(entry.total_insertions)));
 		count++;
 	}

--- a/src/include/duckdb/storage/buffer/temporary_file_information.hpp
+++ b/src/include/duckdb/storage/buffer/temporary_file_information.hpp
@@ -35,7 +35,7 @@ struct EvictionQueueInformation {
 	idx_t queue_index;
 	string queue_type;
 	idx_t approximate_size;
-	idx_t dead_nodes;
+	int64_t dead_nodes;
 	idx_t total_insertions;
 };
 

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -100,7 +100,7 @@ public:
 	idx_t GetApproximateSize() const {
 		return q.size_approx();
 	}
-	idx_t GetDeadNodes() const {
+	int64_t GetDeadNodes() const {
 		return total_dead_nodes.load(std::memory_order_relaxed);
 	}
 	idx_t GetTotalInsertions() const {
@@ -136,7 +136,8 @@ private:
 	atomic<idx_t> evict_queue_insertions;
 	//! Total dead nodes in the eviction queue. There are two scenarios in which a node dies: (1) we destroy its block
 	//! handle, or (2) we insert a newer version into the eviction queue.
-	atomic<idx_t> total_dead_nodes;
+	//! Signed because decrements can exceed increments (nodes dying without being superseded).
+	atomic<int64_t> total_dead_nodes;
 
 	//! Locked, if a queue purge is currently active or we're trying to forcefully evict a node.
 	//! Only lets a single thread enter the purge phase.
@@ -202,8 +203,8 @@ void EvictionQueue::Purge() {
 			break;
 		}
 
-		idx_t approx_dead_nodes = total_dead_nodes;
-		approx_dead_nodes = approx_dead_nodes > approx_q_size ? approx_q_size : approx_dead_nodes;
+		auto raw_dead_nodes = total_dead_nodes.load(std::memory_order_relaxed);
+		idx_t approx_dead_nodes = raw_dead_nodes > 0 ? MinValue<idx_t>(static_cast<idx_t>(raw_dead_nodes), approx_q_size) : 0;
 		idx_t approx_alive_nodes = approx_q_size - approx_dead_nodes;
 
 		// early-out according to (2.2)
@@ -245,7 +246,7 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 	// bulk re-add (TODO order them by timestamp to better retain the LRU behavior)
 	q.enqueue_bulk(purge_nodes.begin(), alive_nodes);
 
-	total_dead_nodes -= actually_dequeued - alive_nodes;
+	total_dead_nodes -= static_cast<int64_t>(actually_dequeued - alive_nodes);
 }
 
 BufferPool::BufferPool(BlockAllocator &block_allocator, idx_t maximum_memory, bool track_eviction_timestamps,

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -204,7 +204,8 @@ void EvictionQueue::Purge() {
 		}
 
 		auto raw_dead_nodes = total_dead_nodes.load(std::memory_order_relaxed);
-		idx_t approx_dead_nodes = raw_dead_nodes > 0 ? MinValue<idx_t>(static_cast<idx_t>(raw_dead_nodes), approx_q_size) : 0;
+		idx_t approx_dead_nodes =
+		    raw_dead_nodes > 0 ? MinValue<idx_t>(static_cast<idx_t>(raw_dead_nodes), approx_q_size) : 0;
 		idx_t approx_alive_nodes = approx_q_size - approx_dead_nodes;
 
 		// early-out according to (2.2)


### PR DESCRIPTION
```json
{
    "data": [
        {
            "approximate_size": 5098963,
            "dead_nodes": 3873616,
            "queue_index": 0,
            "queue_type": "BLOCK_AND_EXTERNAL_FILE",
            "total_insertions": 605198908
        },
        {
            "approximate_size": 224455537,
            "dead_nodes": 163476417,
            "queue_index": 1,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 1977873276
        },
        {
            "approximate_size": 29715,
            "dead_nodes": -107922767,
            "queue_index": 2,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 108300237
        },
        {
            "approximate_size": 32337,
            "dead_nodes": -134953305,
            "queue_index": 3,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 135275557
        },
        {
            "approximate_size": 30044,
            "dead_nodes": -73130179,
            "queue_index": 4,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 73253127
        },
        {
            "approximate_size": 28361,
            "dead_nodes": -32992668,
            "queue_index": 5,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 33069332
        },
        {
            "approximate_size": 33218,
            "dead_nodes": -171896118,
            "queue_index": 6,
            "queue_type": "MANAGED_BUFFER",
            "total_insertions": 172673075
        },
        {
            "approximate_size": 0,
            "dead_nodes": 0,
            "queue_index": 7,
            "queue_type": "TINY_BUFFER",
            "total_insertions": 0
        }
    ]
}


```



The total_dead_nodes counter in EvictionQueue was an unsigned atomic (idx_t) that could underflow when decrements exceeded increments — nodes dying without being superseded were never counted by IncrementDeadNodes but still decremented by DecrementDeadNodes. This caused two problems:

1. The Purge() loop's early-out condition (2.2) never triggered when the counter underflowed, because the massive unsigned value clamped approx_dead_nodes to approx_q_size, making approx_alive_nodes=0, and 0*3 > dead is always false. This caused the loop to run all max_purges iterations unnecessarily.

2. The duckdb_eviction_queues function reported misleading negative values.

Fix: change total_dead_nodes from atomic<idx_t> to atomic<int64_t>. The Purge() comparison now treats negative values as zero dead nodes, allowing condition 2.2 to fire immediately and exit the loop.