### PR TITLE
Fix variant write small decimal

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -523,9 +523,18 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 	case VariantLogicalType::DECIMAL: {
 		auto decimal_data = VariantUtils::DecodeDecimalData(variant, row, values_index);
 
-		if (decimal_data.width <= 4 || decimal_data.width > 38) {
+		if (decimal_data.width > 38) {
 			throw InvalidInputException("Can't convert VARIANT DECIMAL(%d, %d) to Parquet VARIANT", decimal_data.width,
 			                            decimal_data.scale);
+		} else if (decimal_data.width <= 4) {
+			// DuckDB uses INT16 to store small decimals, but parquet only supports DECIMAL4 at minimum, so here we
+			// promote to INT32.
+			WritePrimitiveTypeHeader<VariantPrimitiveType::DECIMAL4>(value_data);
+			Store<int8_t>(NumericCast<int8_t>(decimal_data.scale), value_data);
+			value_data++;
+			const int32_t promoted = Load<int16_t>(decimal_data.value_ptr);
+			Store<int32_t>(promoted, value_data);
+			value_data += sizeof(int32_t);
 		} else if (decimal_data.width <= 9) {
 			WritePrimitiveTypeHeader<VariantPrimitiveType::DECIMAL4>(value_data);
 			Store<int8_t>(decimal_data.scale, value_data);

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -45,6 +45,7 @@
         "test/geoparquet/mixed.test",
         "test/parquet/variant/variant_comparison.test",
         "test/parquet/variant/variant_json_copy.test",
+        "test/parquet/variant/variant_small_decimal.test",
         "test/sql/storage/types/variant/index_fetch.test",
         "test/sql/storage/types/variant/update.test",
         "test/sql/types/geo/geometry_crs.test",

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -118,6 +118,7 @@
         "test/parquet/variant/variant_comparison.test",
         "test/parquet/variant/variant_json_copy.test",
         "test/parquet/variant/variant_shredding_reanalysis_bug.test",
+        "test/parquet/variant/variant_small_decimal.test",
         "test/sql/function/variant/variant_typeof.test",
         "test/sql/storage/types/variant/append_shredded.test",
         "test/sql/storage/types/variant/big_table.test_slow",

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -44,6 +44,7 @@
         "test/geoparquet/mixed.test",
         "test/parquet/variant/variant_comparison.test",
         "test/parquet/variant/variant_json_copy.test",
+        "test/parquet/variant/variant_small_decimal.test",
         "test/sql/storage/types/variant/index_fetch.test",
         "test/sql/storage/types/variant/update.test",
         "test/sql/types/geo/geometry_crs.test",

--- a/test/parquet/variant/variant_small_decimal.test
+++ b/test/parquet/variant/variant_small_decimal.test
@@ -1,0 +1,23 @@
+# name: test/parquet/variant/variant_small_decimal.test
+# description: Test write small decimal write to parquet.
+# group: [variant]
+
+require parquet
+
+statement ok
+CREATE TABLE t (data VARIANT);
+
+statement ok
+INSERT INTO t VALUES (1.23::DECIMAL(3, 2)::VARIANT);
+
+statement ok
+INSERT INTO t VALUES (12.345::DECIMAL(5, 3)::VARIANT);
+
+statement ok
+COPY t TO '{TEST_DIR}/small_variant.parquet';
+
+query I
+SELECT * FROM '{TEST_DIR}/small_variant.parquet' ORDER BY data
+----
+1.23
+12.345


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22539

From the error message, it's easy to trace to https://github.com/duckdb/duckdb/blob/01eda16d6e3a6648accda27230b9e30edd8b9703/extension/parquet/writer/variant/convert_variant.cpp#L568-L570

I think it doesn't make too much sense to disallow small decimal; considering parquet only allows decimal4/8/16, so I promote small decimals to big one and store.
Ref: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md#encoding-types

I have ran CI in my fork: https://github.com/dentiny/duckdb/pull/97 (failure unrelated)