### PR TITLE
mark join: refine NULL handling for multi-column NOT IN

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/ht_entry.hpp"
 #include "duckdb/logging/log_manager.hpp"
@@ -150,6 +151,16 @@ void JoinHashTable::Merge(JoinHashTable &other) {
 	}
 
 	sink_collection->Combine(*other.sink_collection);
+
+	// Combine null-bearing keys captured for non-correlated MARK joins.
+	if (other.mark_join_null_keys) {
+		lock_guard<mutex> guard(mark_join_null_keys_lock);
+		if (!mark_join_null_keys) {
+			mark_join_null_keys = std::move(other.mark_join_null_keys);
+		} else {
+			mark_join_null_keys->Combine(*other.mark_join_null_keys);
+		}
+	}
 }
 
 static void ApplyBitmaskAndGetSaltBuild(Vector &hashes_v, Vector &salt_v, const idx_t &count, const idx_t &bitmask) {
@@ -435,6 +446,36 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 	idx_t added_count = PrepareKeys(keys, append_state.chunk_state.vector_data, current_sel, sel, true);
 	if (added_count < keys.size()) {
 		has_null = true;
+		// For non-correlated MARK joins, preserve the keys of the rows that were filtered for
+		// NULL so we can refine "is the probe potentially matched through NULL" decisions in
+		// ConstructMarkJoinResult. The hash table itself can't carry these (NULLs can't hash-
+		// match anything); without them we'd have to fall back to the over-conservative
+		// "any right NULL → all non-matched probes become NULL" rule.
+		if (join_type == JoinType::MARK && correlated_mark_join_info.correlated_types.empty()) {
+			// current_sel is the kept-rows selection (sorted ascending); compute the inverse.
+			SelectionVector dropped_sel(keys.size() - added_count);
+			idx_t kept_idx = 0;
+			idx_t dropped_count = 0;
+			for (idx_t i = 0; i < keys.size(); i++) {
+				if (kept_idx < added_count && current_sel->get_index(kept_idx) == i) {
+					kept_idx++;
+				} else {
+					dropped_sel.set_index(dropped_count++, i);
+				}
+			}
+			D_ASSERT(dropped_count == keys.size() - added_count);
+
+			DataChunk null_keys_chunk;
+			null_keys_chunk.InitializeEmpty(keys.GetTypes());
+			null_keys_chunk.Slice(keys, dropped_sel, dropped_count);
+			null_keys_chunk.Flatten();
+
+			lock_guard<mutex> guard(mark_join_null_keys_lock);
+			if (!mark_join_null_keys) {
+				mark_join_null_keys = make_uniq<ColumnDataCollection>(buffer_manager, keys.GetTypes());
+			}
+			mark_join_null_keys->Append(null_keys_chunk);
+		}
 	}
 	if (added_count == 0) {
 		return;
@@ -1344,6 +1385,95 @@ void ScanStructure::NextRightSemiOrAntiJoin(DataChunk &keys, DataChunk &probe_da
 	finished = true;
 }
 
+// Helper: refine the mark vector for non-matched probes by checking against build-side rows
+// whose keys had NULL in some column (and were therefore filtered out of the hash table). A
+// non-matched probe is reported as NULL only if it could plausibly match one of these rows
+// through their NULL columns; otherwise it stays FALSE. Without this check we'd fall back to
+// the over-conservative "any rhs NULL → all non-matched probes are NULL" rule.
+//
+// Preconditions: mark_vector is FLAT BOOLEAN. mask must already reflect probe-side NULL keys
+// (those rows are skipped). bool_result[i] reflects whether probe i found an exact match.
+static void RefineMarkResultWithNullKeys(DataChunk &join_keys, ColumnDataCollection &null_keys, Vector &mark_vector,
+                                         idx_t count) {
+	if (null_keys.Count() == 0) {
+		return;
+	}
+	auto bool_result = FlatVector::GetDataMutable<bool>(mark_vector);
+	auto &mask = FlatVector::ValidityMutable(mark_vector);
+
+	const idx_t key_count = join_keys.ColumnCount();
+	vector<UnifiedVectorFormat> probe_formats(key_count);
+	for (idx_t c = 0; c < key_count; c++) {
+		join_keys.data[c].ToUnifiedFormat(probe_formats[c]);
+	}
+
+	ColumnDataScanState scan_state;
+	DataChunk null_keys_chunk;
+	null_keys.InitializeScan(scan_state);
+	null_keys.InitializeScanChunk(null_keys_chunk);
+
+	while (null_keys.Scan(scan_state, null_keys_chunk)) {
+		const idx_t null_count = null_keys_chunk.size();
+		vector<UnifiedVectorFormat> null_formats(key_count);
+		for (idx_t c = 0; c < key_count; c++) {
+			null_keys_chunk.data[c].ToUnifiedFormat(null_formats[c]);
+		}
+		for (idx_t i = 0; i < count; i++) {
+			if (bool_result[i] || !mask.RowIsValid(i)) {
+				continue;
+			}
+			bool potential_match = false;
+			for (idx_t j = 0; j < null_count; j++) {
+				bool ok = true;
+				for (idx_t c = 0; c < key_count; c++) {
+					auto &nfmt = null_formats[c];
+					auto nidx = nfmt.sel->get_index(j);
+					if (!nfmt.validity.RowIsValid(nidx)) {
+						// Build value is NULL → column unconstrained for matching.
+						continue;
+					}
+					auto &pfmt = probe_formats[c];
+					auto pidx = pfmt.sel->get_index(i);
+					D_ASSERT(pfmt.validity.RowIsValid(pidx));
+					if (!(join_keys.data[c].GetValue(pidx) == null_keys_chunk.data[c].GetValue(nidx))) {
+						ok = false;
+						break;
+					}
+				}
+				if (ok) {
+					potential_match = true;
+					break;
+				}
+			}
+			if (potential_match) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+// Apply probe-side NULL handling: probes with NULL in any join key column produce a NULL
+// mark result regardless of any matches.
+static void ApplyProbeSideNullMask(DataChunk &join_keys, Vector &mark_vector, idx_t count,
+                                   const vector<bool> &null_values_are_equal) {
+	auto &mask = FlatVector::ValidityMutable(mark_vector);
+	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
+		if (null_values_are_equal[col_idx]) {
+			continue;
+		}
+		UnifiedVectorFormat jdata;
+		join_keys.data[col_idx].ToUnifiedFormat(jdata);
+		if (jdata.validity.CanHaveNull()) {
+			for (idx_t i = 0; i < count; i++) {
+				auto jidx = jdata.sel->get_index(i);
+				if (!jdata.validity.RowIsValidUnsafe(jidx)) {
+					mask.SetInvalid(i);
+				}
+			}
+		}
+	}
+}
+
 void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &probe_data, DataChunk &result) {
 	// extract OUTPUT columns from probe_data
 	result.SetCardinality(probe_data.size());
@@ -1356,35 +1486,59 @@ void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &pro
 	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
 	FlatVector::SetSize(mark_vector, count_t(probe_data.size()));
 
-	// first we set the NULL values from the join keys
-	// if there is any NULL in the keys, the result is NULL
 	auto bool_result = FlatVector::GetDataMutable<bool>(mark_vector);
 	auto &mask = FlatVector::ValidityMutable(mark_vector);
-	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
-		if (ht.null_values_are_equal[col_idx]) {
-			continue;
-		}
-		UnifiedVectorFormat jdata;
-		join_keys.data[col_idx].ToUnifiedFormat(jdata);
-		if (jdata.validity.CanHaveNull()) {
-			for (idx_t i = 0; i < join_keys.size(); i++) {
-				auto jidx = jdata.sel->get_index(i);
-				if (!jdata.validity.RowIsValidUnsafe(jidx)) {
-					mask.SetInvalid(i);
-				}
-			}
-		}
-	}
 
-	// now set the remaining entries to either true or false based on whether a match was found
+	// probe-side NULL handling: rows with NULL keys produce NULL regardless of matches
+	ApplyProbeSideNullMask(join_keys, mark_vector, probe_data.size(), ht.null_values_are_equal);
+
+	// initialize bool_result from found_match (set by ScanKeyMatches)
 	D_ASSERT(found_match);
 	for (idx_t i = 0; i < probe_data.size(); i++) {
 		bool_result[i] = found_match[i];
 	}
 
-	// if the right side contains NULL values, the result of any FALSE becomes NULL
-	if (ht.has_null) {
+	// refine non-matched probes against build-side rows that had NULL keys
+	if (ht.mark_join_null_keys) {
+		RefineMarkResultWithNullKeys(join_keys, *ht.mark_join_null_keys, mark_vector, probe_data.size());
+	} else if (ht.has_null) {
+		// fallback for paths that don't populate mark_join_null_keys (e.g. correlated MARK)
 		for (idx_t i = 0; i < probe_data.size(); i++) {
+			if (!bool_result[i]) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+void JoinHashTable::ConstructEmptyMarkJoinResult(DataChunk &join_keys, DataChunk &input, DataChunk &result) {
+	D_ASSERT(join_type == JoinType::MARK);
+	D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
+
+	result.SetCardinality(input);
+	for (idx_t i = 0; i < input.ColumnCount(); i++) {
+		result.data[i].Reference(input.data[i]);
+	}
+
+	auto &mark_vector = result.data.back();
+	D_ASSERT(mark_vector.GetType() == LogicalType::BOOLEAN);
+	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	FlatVector::SetSize(mark_vector, count_t(input.size()));
+
+	// HT has no rows → no exact matches; initialize all to false
+	auto bool_result = FlatVector::GetDataMutable<bool>(mark_vector);
+	for (idx_t i = 0; i < input.size(); i++) {
+		bool_result[i] = false;
+	}
+
+	// probe-side NULL handling
+	ApplyProbeSideNullMask(join_keys, mark_vector, input.size(), null_values_are_equal);
+
+	if (mark_join_null_keys) {
+		RefineMarkResultWithNullKeys(join_keys, *mark_join_null_keys, mark_vector, input.size());
+	} else if (has_null) {
+		auto &mask = FlatVector::ValidityMutable(mark_vector);
+		for (idx_t i = 0; i < input.size(); i++) {
 			if (!bool_result[i]) {
 				mask.SetInvalid(i);
 			}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1429,9 +1429,19 @@ OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, 
 		if (EmptyResultIfRHSIsEmpty()) {
 			return OperatorResultType::FINISHED;
 		}
-		// for empty result, only need output columns (no predicate evaluation)
 		state.lhs_probe_data.ReferenceColumns(input, lhs_output_columns.col_idxs);
-		ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, state.lhs_probe_data, chunk);
+		// MARK joins with build-side NULL keys need the probe-side keys to refine NULL-vs-FALSE
+		// per probe row; the generic empty-result path falls back to the over-conservative
+		// "any rhs NULL → all probes NULL" rule.
+		if (sink.hash_table->join_type == JoinType::MARK && sink.hash_table->mark_join_null_keys &&
+		    sink.hash_table->mark_join_null_keys->Count() > 0) {
+			state.lhs_join_keys.Reset();
+			state.probe_executor.Execute(input, state.lhs_join_keys);
+			sink.hash_table->ConstructEmptyMarkJoinResult(state.lhs_join_keys, state.lhs_probe_data, chunk);
+		} else {
+			ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, state.lhs_probe_data,
+			                         chunk);
+		}
 		return OperatorResultType::NEED_MORE_INPUT;
 	}
 
@@ -1859,8 +1869,14 @@ void HashJoinLocalSourceState::ExternalProbe(HashJoinGlobalSinkState &sink, Hash
 	if (sink.hash_table->Count() == 0 && !gstate.op.EmptyResultIfRHSIsEmpty()) {
 		// for empty result, only need output columns (no predicate evaluation)
 		lhs_probe_data.ReferenceColumns(lhs_probe_chunk, gstate.op.lhs_output_columns.col_idxs);
-		gstate.op.ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, lhs_probe_data,
-		                                   chunk);
+		if (sink.hash_table->join_type == JoinType::MARK && sink.hash_table->mark_join_null_keys &&
+		    sink.hash_table->mark_join_null_keys->Count() > 0) {
+			// lhs_join_keys was populated above by lhs_join_key_executor.Execute
+			sink.hash_table->ConstructEmptyMarkJoinResult(lhs_join_keys, lhs_probe_data, chunk);
+		} else {
+			gstate.op.ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, lhs_probe_data,
+			                                   chunk);
+		}
 		empty_ht_probe_in_progress = true;
 		return;
 	}

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -327,6 +327,14 @@ public:
 	bool finalized;
 	//! Whether or not any of the key elements contain NULL
 	bool has_null;
+	//! For non-correlated MARK joins: keys of build-side rows that have NULL in any equality
+	//! key column. Such rows are filtered out of the hash table itself (they can never produce a
+	//! hash match), but in mark-join semantics a probe row that finds no exact match must be
+	//! reported as NULL iff some build row could have matched through the NULLs (i.e., for every
+	//! non-NULL key column of that build row, the value equals the probe's). Replaces an
+	//! over-conservative "any right NULL → all non-matched probes become NULL" approximation.
+	unique_ptr<ColumnDataCollection> mark_join_null_keys;
+	mutex mark_join_null_keys_lock;
 	//! Bitmask for getting relevant bits from the hashes to determine the position
 	uint64_t bitmask = DConstants::INVALID_INDEX;
 	//! Whether or not we error on multiple rows found per match in a SINGLE join
@@ -385,6 +393,13 @@ private:
 	void GetRowPointers(DataChunk &keys, TupleDataChunkState &key_state, ProbeState &state, Vector &hashes_v,
 	                    const SelectionVector *sel, idx_t &count, Vector &pointers_result_v, SelectionVector &match_sel,
 	                    bool has_sel);
+
+public:
+	//! Construct the MARK join result for the case where the hash table is empty (no probe-side
+	//! ScanKeyMatches has run). Mirrors ScanStructure::ConstructMarkJoinResult but with all
+	//! found_match values implicitly false, and refines the rhs-NULL handling using
+	//! mark_join_null_keys when available.
+	void ConstructEmptyMarkJoinResult(DataChunk &join_keys, DataChunk &input, DataChunk &result);
 
 private:
 	//! Insert the given set of locations into the HT with the given set of hashes_v

--- a/test/sql/subquery/any_all/test_multi_column_not_in_null_22418.test
+++ b/test/sql/subquery/any_all/test_multi_column_not_in_null_22418.test
@@ -1,0 +1,103 @@
+# name: test/sql/subquery/any_all/test_multi_column_not_in_null_22418.test
+# description: Multi-column NOT IN over a subquery must follow SQL three-valued logic when the
+# group: [any_all]
+
+#              subquery contains rows with NULL key columns. Specifically, a probe row that has
+#              a non-NULL value definitively differing from a non-NULL key column of every NULL-
+#              bearing build row should evaluate to TRUE for NOT IN (not NULL).
+
+# Issue #22418
+
+statement ok
+CREATE TABLE t_a(i INT, j INT);
+
+statement ok
+CREATE TABLE t_b(i INT, j INT);
+
+statement ok
+INSERT INTO t_a VALUES (1,1), (2,2), (3,NULL), (NULL,4);
+
+statement ok
+INSERT INTO t_b VALUES (1,1), (NULL,4);
+
+# Per SQL ternary logic over rows of t_a:
+#   (1,1) — exact match with t_b's (1,1)            → IN = TRUE       → NOT IN = FALSE
+#   (2,2) — vs (1,1) FALSE; vs (NULL,4) FALSE       → IN = FALSE      → NOT IN = TRUE
+#                  (NULL,4): j component 2 != 4 is FALSE; AND with NULL stays FALSE.
+#   (3,NULL) — probe has NULL key                   → result is NULL
+#   (NULL,4) — probe has NULL key                   → result is NULL
+#
+# Therefore the count partition (T, F, N) must be (1, 1, 2) and sum to 4.
+
+query I
+SELECT COUNT(*) FROM t_a WHERE ((i, j) NOT IN (SELECT i, j FROM t_b));
+----
+1
+
+query I
+SELECT COUNT(*) FROM t_a WHERE NOT (((i, j) NOT IN (SELECT i, j FROM t_b)));
+----
+1
+
+query I
+SELECT COUNT(*) FROM t_a WHERE (((i, j) NOT IN (SELECT i, j FROM t_b))) IS NULL;
+----
+2
+
+# row-level visibility of the predicate
+query IIT
+SELECT i, j, ((i, j) NOT IN (SELECT i, j FROM t_b)) AS not_in
+FROM t_a
+ORDER BY i NULLS LAST, j NULLS LAST;
+----
+1	1	false
+2	2	true
+3	NULL	NULL
+NULL	4	NULL
+
+# Symmetric: build-side NULL row whose non-NULL columns match the probe's row -> result NULL.
+statement ok
+CREATE TABLE t_c(i INT, j INT);
+
+statement ok
+INSERT INTO t_c VALUES (NULL, 2);
+
+query T
+SELECT (2, 2) IN (SELECT i, j FROM t_c);
+----
+NULL
+
+# Build-side NULL row whose non-NULL column definitively differs from probe -> result FALSE.
+query T
+SELECT (2, 2) IN (SELECT i, j FROM t_b WHERE j = 4);
+----
+false
+
+# Build side has only fully-non-matching rows -> NOT IN is TRUE.
+statement ok
+CREATE TABLE t_d(i INT, j INT);
+
+statement ok
+INSERT INTO t_d VALUES (10, 10), (20, 20);
+
+query T
+SELECT (2, 2) NOT IN (SELECT i, j FROM t_d);
+----
+true
+
+# Single-column NOT IN with NULLs on the right - existing semantics preserved.
+statement ok
+CREATE TABLE t_single(x INT);
+
+statement ok
+INSERT INTO t_single VALUES (1), (NULL);
+
+query T
+SELECT 5 NOT IN (SELECT x FROM t_single);
+----
+NULL
+
+query T
+SELECT 1 NOT IN (SELECT x FROM t_single);
+----
+false


### PR DESCRIPTION
## Summary
- `(probe) NOT IN (subquery)` evaluated by a hash MARK join was using a global `has_null` flag to mark every non-matched probe as NULL whenever the build side had a NULL in any join key column. This is too coarse — per SQL ternary logic the result is FALSE when, for every NULL-bearing build row, some non-NULL build column definitively differs from the probe.
- Capture the keys that `PrepareKeys` filters for NULL into a per-HT `mark_join_null_keys` `ColumnDataCollection`; when constructing the mark vector, refine non-matched probes by checking whether they could plausibly match any of those rows (every non-NULL build column equals the corresponding probe value). Falls back to the prior approximation when the collection isn't populated (correlated MARK joins don't reach this path).
- Applied at both the regular probe path (`ScanStructure::ConstructMarkJoinResult`) and the empty-HT shortcut (`ConstructEmptyJoinResult`, including the case where every build row was filtered for NULL — which makes the HT empty but the result is still well-defined).

Fixes #22418.

## Reproducer (from the issue)

```sql
CREATE TABLE t_a(i INT, j INT);
CREATE TABLE t_b(i INT, j INT);
INSERT INTO t_a VALUES (1,1), (2,2), (3,NULL), (NULL,4);
INSERT INTO t_b VALUES (1,1), (NULL,4);

-- T = predicate true, F = predicate false, N = predicate null
-- Expected: (T, F, N) = (1, 1, 2). Sum = 4 = |t_a|.
SELECT COUNT(*) FROM t_a WHERE      ((i,j) NOT IN (SELECT i,j FROM t_b));     -- before: 0  after: 1
SELECT COUNT(*) FROM t_a WHERE  NOT (((i,j) NOT IN (SELECT i,j FROM t_b)));   -- before: 1  after: 1
SELECT COUNT(*) FROM t_a WHERE      (((i,j) NOT IN (SELECT i,j FROM t_b))) IS NULL;  -- before: 3  after: 2
```

Row `(2,2)` should be TRUE for `NOT IN` because `(2,2) = (NULL,4)` is FALSE (`j=2` ≠ `j=4`, AND with the NULL stays FALSE) and `(2,2) = (1,1)` is FALSE — neither build row matches and there is no path through the NULL that could.

## What changed

| | before | after |
|---|---|---|
| build path | rows with NULL in any join column dropped from HT, only `has_null=true` recorded | dropped rows are also appended to a new per-HT `ColumnDataCollection mark_join_null_keys` |
| `Merge` | combines `data_collection` and `sink_collection` | also combines `mark_join_null_keys` from per-thread HTs |
| `ConstructMarkJoinResult` | non-match + `has_null` → NULL (any rhs NULL → all probes NULL) | non-match → check if any null-bearing row could match through its NULLs; only those probes become NULL, others stay FALSE |
| empty HT for MARK | all probes NULL if `has_null` set | same per-row null-key check via new `JoinHashTable::ConstructEmptyMarkJoinResult` (called from both empty-HT call sites in `physical_hash_join.cpp`) |

The check itself: for each non-matched probe `P`, walk the null-bearing collection; a build row `R` is a "potential match" iff for every column `c`, either `R[c]` is NULL or `R[c] == P[c]`. If any such `R` exists, mark the probe NULL; otherwise it stays FALSE.

Probe-side NULL handling is unchanged — probes with any NULL key column still produce NULL regardless.

The literal-IN-list form (`(2,2) IN ((NULL, 2))`) goes through STRUCT-equality lexicographic comparison and has a related but distinct bug — not addressed here.

## Test plan
- [x] New regression test `test/sql/subquery/any_all/test_multi_column_not_in_null_22418.test` covering the issue's exact scenario plus boundary cases (build-side NULL row that *can* match → NULL; that *cannot* match → FALSE; single-column NOT IN unchanged).
- [x] `test/sql/subquery/any_all/*` — 442 assertions / 11 cases pass.
- [x] `[mark]` filter — 564 assertions / 2 cases pass.
- [x] `test/sql/join/*` — 15594 assertions / 121 cases pass.
- [x] Edge cases (empty rhs, all-NULL rhs, multiple NULL-bearing rows, probe-side NULL, large dataset) verified manually.
- [x] Same suites pass under `make relassert` (no assertion failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
