### PR TITLE
Fix MVCC visibility during unique index creation after DELETE

### DIFF
--- a/src/execution/index/art/art_index.cpp
+++ b/src/execution/index/art/art_index.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/storage/table/append_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 namespace duckdb {
 namespace {
@@ -22,6 +23,7 @@ namespace {
 class ARTBuildBindData : public IndexBuildBindData {
 public:
 	bool sorted = false;
+	bool has_deletes = false;
 };
 
 unique_ptr<IndexBuildBindData> ARTBuildBind(IndexBuildBindInput &input) {
@@ -32,6 +34,11 @@ unique_ptr<IndexBuildBindData> ARTBuildBind(IndexBuildBindInput &input) {
 	// We used to not sort for VARCHAR and multi-column indexes with the old sort implementation
 	// The new sorting implementation handles these cases much better and sorting improves performance now
 	bind_data->sorted = true;
+	if (input.info.constraint_type == IndexConstraintType::UNIQUE ||
+	    input.info.constraint_type == IndexConstraintType::PRIMARY) {
+		auto &transaction = DuckTransaction::Get(input.context, input.table.catalog);
+		bind_data->has_deletes = transaction.GetUndoProperties().has_deletes;
+	}
 
 	return std::move(bind_data);
 }
@@ -47,6 +54,8 @@ bool ARTBuildSort(IndexBuildSortInput &input) {
 class ARTBuildGlobalState : public IndexBuildGlobalState {
 public:
 	unique_ptr<BoundIndex> global_index;
+	unique_ptr<BoundIndex> delete_index;
+	bool has_delete_index = false;
 };
 
 unique_ptr<IndexBuildGlobalState> ARTBuildGlobalInit(IndexBuildInitGlobalStateInput &input) {
@@ -55,6 +64,10 @@ unique_ptr<IndexBuildGlobalState> ARTBuildGlobalInit(IndexBuildInitGlobalStateIn
 	auto &storage = input.table.GetStorage();
 	state->global_index = make_uniq<ART>(input.info.index_name, input.info.constraint_type, input.storage_ids,
 	                                     TableIOManager::Get(storage), input.expressions, storage.db);
+	auto &bind_data = input.bind_data->Cast<ARTBuildBindData>();
+	if (bind_data.has_deletes) {
+		state->delete_index = state->global_index->Cast<ART>().CreateDeltaIndex(DeltaIndexType::LOCAL_DELETE);
+	}
 
 	return std::move(state);
 }
@@ -65,21 +78,33 @@ unique_ptr<IndexBuildGlobalState> ARTBuildGlobalInit(IndexBuildInitGlobalStateIn
 class ARTBuildLocalState : public IndexBuildLocalState {
 public:
 	unique_ptr<BoundIndex> local_index;
+	unique_ptr<BoundIndex> delete_index;
 	ArenaAllocator arena_allocator;
+	reference<DuckTransaction> transaction;
+	bool has_delete_index = false;
 
 	unsafe_vector<ARTKey> keys;
 	unsafe_vector<ARTKey> row_ids;
+	unsafe_vector<ARTKey> visible_keys;
+	unsafe_vector<ARTKey> visible_row_ids;
+	unsafe_vector<ARTKey> deleted_keys;
+	unsafe_vector<ARTKey> deleted_row_ids;
 
-	explicit ARTBuildLocalState(ClientContext &context) : arena_allocator(Allocator::Get(context)) {};
+	ARTBuildLocalState(ClientContext &context, DuckTableEntry &table)
+	    : arena_allocator(Allocator::Get(context)), transaction(DuckTransaction::Get(context, table.catalog)) {};
 };
 
 unique_ptr<IndexBuildLocalState> ARTBuildLocalInit(IndexBuildInitLocalStateInput &input) {
 	// Create the local sink state and add the local index.
-	auto state = make_uniq<ARTBuildLocalState>(input.context);
+	auto state = make_uniq<ARTBuildLocalState>(input.context, input.table);
 
 	auto &storage = input.table.GetStorage();
 	state->local_index = make_uniq<ART>(input.info.index_name, input.info.constraint_type, input.storage_ids,
 	                                    TableIOManager::Get(storage), input.expressions, storage.db);
+	auto &bind_data = input.bind_data->Cast<ARTBuildBindData>();
+	if (bind_data.has_deletes) {
+		state->delete_index = state->local_index->Cast<ART>().CreateDeltaIndex(DeltaIndexType::LOCAL_DELETE);
+	}
 
 	// Initialize the local sink state.
 	state->keys.resize(STANDARD_VECTOR_SIZE);
@@ -91,17 +116,16 @@ unique_ptr<IndexBuildLocalState> ARTBuildLocalInit(IndexBuildInitLocalStateInput
 //----------------------------------------------------------------------------------------------------------------------
 // Sink
 //----------------------------------------------------------------------------------------------------------------------
-void ARTBuildSinkUnsorted(IndexBuildSinkInput &input, DataChunk &key_chunk, DataChunk &row_chunk) {
+void ARTBuildSinkUnsorted(IndexBuildSinkInput &input, DataChunk &key_chunk, DataChunk &row_chunk,
+                          unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &row_ids, const idx_t row_count) {
 	auto &l_state = input.local_state.Cast<ARTBuildLocalState>();
-	auto row_count = key_chunk.size();
 	auto &art = l_state.local_index->Cast<ART>();
 
 	// Insert each key and its corresponding row ID.
 	for (idx_t i = 0; i < row_count; i++) {
 		auto status = art.tree.GetGateStatus();
-		auto conflict_type =
-		    ARTOperator::Insert(l_state.arena_allocator, art, art.tree, l_state.keys[i], 0, l_state.row_ids[i], status,
-		                        DeleteIndexInfo(), IndexAppendMode::DEFAULT);
+		auto conflict_type = ARTOperator::Insert(l_state.arena_allocator, art, art.tree, keys[i], 0, row_ids[i], status,
+		                                         DeleteIndexInfo(), IndexAppendMode::DEFAULT);
 		D_ASSERT(conflict_type != ARTConflictType::TRANSACTION);
 		if (conflict_type == ARTConflictType::CONSTRAINT) {
 			throw ConstraintException("Data contains duplicates on indexed column(s)");
@@ -109,7 +133,8 @@ void ARTBuildSinkUnsorted(IndexBuildSinkInput &input, DataChunk &key_chunk, Data
 	}
 }
 
-void ARTBuildSinkSorted(IndexBuildSinkInput &input, DataChunk &key_chunk, DataChunk &row_chunk) {
+void ARTBuildSinkSorted(IndexBuildSinkInput &input, DataChunk &key_chunk, DataChunk &row_chunk,
+                        unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &row_ids, const idx_t row_count) {
 	auto &l_state = input.local_state.Cast<ARTBuildLocalState>();
 	auto &storage = input.table.GetStorage();
 	auto &l_index = l_state.local_index;
@@ -118,13 +143,28 @@ void ARTBuildSinkSorted(IndexBuildSinkInput &input, DataChunk &key_chunk, DataCh
 	auto art = make_uniq<ART>(input.info.index_name, l_index->GetConstraintType(), l_index->GetColumnIds(),
 	                          l_index->table_io_manager, l_index->unbound_expressions, storage.db,
 	                          l_index->Cast<ART>().allocators);
-	if (art->Build(l_state.keys, l_state.row_ids, key_chunk.size()) != ARTConflictType::NO_CONFLICT) {
+	if (art->Build(keys, row_ids, row_count) != ARTConflictType::NO_CONFLICT) {
 		throw ConstraintException("Data contains duplicates on indexed column(s)");
 	}
 
 	// Merge the ART into the local ART.
 	if (!l_index->MergeIndexes(*art)) {
 		throw ConstraintException("Data contains duplicates on indexed column(s)");
+	}
+}
+
+void ARTBuildSinkDeletes(ARTBuildLocalState &lstate) {
+	if (lstate.deleted_keys.empty()) {
+		return;
+	}
+	D_ASSERT(lstate.delete_index);
+	lstate.has_delete_index = true;
+	auto &delete_index = lstate.delete_index->Cast<ART>();
+	auto error = delete_index.InsertKeys(lstate.arena_allocator, lstate.deleted_keys, lstate.deleted_row_ids,
+	                                     lstate.deleted_keys.size(), DeleteIndexInfo(),
+	                                     IndexAppendMode::INSERT_DUPLICATES, nullptr);
+	if (error.HasError()) {
+		error.Throw();
 	}
 }
 
@@ -137,10 +177,39 @@ void ARTBuildSink(IndexBuildSinkInput &input, DataChunk &key_chunk, DataChunk &r
 	lstate.local_index->Cast<ART>().GenerateKeyVectors(lstate.arena_allocator, key_chunk, row_chunk.data[0],
 	                                                   lstate.keys, lstate.row_ids);
 
-	if (bind_data.sorted) {
-		return ARTBuildSinkSorted(input, key_chunk, row_chunk);
+	auto keys = &lstate.keys;
+	auto row_ids = &lstate.row_ids;
+	auto row_count = key_chunk.size();
+	if (bind_data.has_deletes) {
+		lstate.visible_keys.clear();
+		lstate.visible_row_ids.clear();
+		lstate.deleted_keys.clear();
+		lstate.deleted_row_ids.clear();
+
+		row_chunk.data[0].Flatten();
+		auto row_id_data = FlatVector::GetData<row_t>(row_chunk.data[0]);
+		auto &storage = input.table.GetStorage();
+		for (idx_t i = 0; i < row_count; i++) {
+			if (row_id_data[i] < MAX_ROW_ID && !storage.CanFetch(lstate.transaction, row_id_data[i])) {
+				lstate.deleted_keys.push_back(lstate.keys[i]);
+				lstate.deleted_row_ids.push_back(lstate.row_ids[i]);
+			} else {
+				lstate.visible_keys.push_back(lstate.keys[i]);
+				lstate.visible_row_ids.push_back(lstate.row_ids[i]);
+			}
+		}
+		ARTBuildSinkDeletes(lstate);
+		keys = &lstate.visible_keys;
+		row_ids = &lstate.visible_row_ids;
+		row_count = keys->size();
 	}
-	return ARTBuildSinkUnsorted(input, key_chunk, row_chunk);
+	if (row_count == 0) {
+		return;
+	}
+	if (bind_data.sorted) {
+		return ARTBuildSinkSorted(input, key_chunk, row_chunk, *keys, *row_ids, row_count);
+	}
+	return ARTBuildSinkUnsorted(input, key_chunk, row_chunk, *keys, *row_ids, row_count);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -153,6 +222,15 @@ void ARTBuildCombine(IndexBuildCombineInput &input) {
 	if (!gstate.global_index->MergeIndexes(*lstate.local_index)) {
 		throw ConstraintException("Data contains duplicates on indexed column(s)");
 	}
+	if (lstate.has_delete_index) {
+		D_ASSERT(gstate.delete_index);
+		gstate.has_delete_index = true;
+		auto error =
+		    gstate.delete_index->Cast<ART>().InsertMerge(*lstate.delete_index, IndexAppendMode::INSERT_DUPLICATES);
+		if (error.HasError()) {
+			error.Throw();
+		}
+	}
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -160,6 +238,13 @@ void ARTBuildCombine(IndexBuildCombineInput &input) {
 //----------------------------------------------------------------------------------------------------------------------
 unique_ptr<BoundIndex> ARTBuildFinalize(IndexBuildFinalizeInput &input) {
 	auto &gstate = input.global_state.Cast<ARTBuildGlobalState>();
+	if (gstate.has_delete_index) {
+		auto error =
+		    gstate.global_index->Cast<ART>().InsertMerge(*gstate.delete_index, IndexAppendMode::INSERT_DUPLICATES);
+		if (error.HasError()) {
+			error.Throw();
+		}
+	}
 	return std::move(gstate.global_index);
 }
 

--- a/test/sql/alter/add_pk/test_add_pk_tx_delete_visibility.test
+++ b/test/sql/alter/add_pk/test_add_pk_tx_delete_visibility.test
@@ -1,0 +1,26 @@
+# name: test/sql/alter/add_pk/test_add_pk_tx_delete_visibility.test
+# description: ADD PRIMARY KEY validates against transaction-visible rows after DELETE
+# group: [add_pk]
+
+statement ok
+CREATE TABLE tx_delete_add_pk (id INTEGER, x INTEGER)
+
+statement ok
+INSERT INTO tx_delete_add_pk VALUES (1, 10), (2, 10)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM tx_delete_add_pk WHERE id = 1
+
+query I
+SELECT COUNT(*) FROM tx_delete_add_pk
+----
+1
+
+statement ok
+ALTER TABLE tx_delete_add_pk ADD PRIMARY KEY (x)
+
+statement ok
+ROLLBACK

--- a/test/sql/index/art/create_drop/test_art_create_unique.test
+++ b/test/sql/index/art/create_drop/test_art_create_unique.test
@@ -37,3 +37,28 @@ statement error
 CREATE UNIQUE INDEX idx ON merge_violation(id);
 ----
 <REGEX>:.*Constraint Error.*contains duplicates on indexed column.*
+
+# CREATE UNIQUE INDEX should build over the rows visible to the current transaction.
+# A row deleted earlier in the transaction must not participate in duplicate validation.
+statement ok
+CREATE TABLE tx_delete_unique_index (id INT, x INT);
+
+statement ok
+INSERT INTO tx_delete_unique_index VALUES (1, 10), (2, 10);
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+DELETE FROM tx_delete_unique_index WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM tx_delete_unique_index;
+----
+1
+
+statement ok
+CREATE UNIQUE INDEX tx_delete_unique_index_u ON tx_delete_unique_index(x);
+
+statement ok
+COMMIT;


### PR DESCRIPTION
This change makes `CREATE UNIQUE INDEX` and `ALTER TABLE ADD PRIMARY KEY` respect rows deleted earlier in the same transaction during uniqueness validation.

### Testing

  - Added regression coverage for `CREATE UNIQUE INDEX` after same-transaction `DELETE`.
  - Added regression coverage for `ALTER TABLE ADD PRIMARY KEY` after same-transaction `DELETE`.
  - Verified both focused sqllogictests pass locally.


Fixes #22420 