### PR TITLE
Move `debug_verify_column_bindings` and `debug_verification_projection` to settings and test configs

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1442,6 +1442,12 @@ jobs:
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_parquet_files.json ./build/release/test/unittest
 
+    - name: test/configs/verification_projection.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/verification_projection.json ./build/release/test/unittest
+
     - name: test/configs/no_local_filesystem.json
       if: success() || failure()
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1448,6 +1448,12 @@ jobs:
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/verification_projection.json ./build/release/test/unittest
 
+    - name: test/configs/verify_column_bindings.json
+      if: success() || failure()
+      shell: bash
+      run: |
+        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_column_bindings.json ./build/release/test/unittest
+
     - name: test/configs/no_local_filesystem.json
       if: success() || failure()
       shell: bash

--- a/extension/json/json_functions/json_serialize_plan.cpp
+++ b/extension/json/json_functions/json_serialize_plan.cpp
@@ -147,7 +147,7 @@ static void JsonSerializePlanFunction(DataChunk &args, ExpressionState &state, V
 				}
 
 				ColumnBindingResolver resolver;
-				resolver.Verify(*plan);
+				resolver.Verify(context, *plan);
 				resolver.VisitOperator(*plan);
 				plan->ResolveOperatorTypes();
 

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -339,6 +339,13 @@
         "custom_implementation": true
     },
     {
+        "name": "debug_verification_projection",
+        "description": "DEBUG SETTING: add internal verification projections to stress optimizers",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "debug_verify_blocks",
         "description": "DEBUG SETTING: verify block metadata during checkpointing",
         "type": "BOOLEAN",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -353,6 +353,13 @@
         "default_value": "false"
     },
     {
+        "name": "debug_verify_column_bindings",
+        "description": "DEBUG SETTING: run extra internal verification of column bindings",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "debug_verify_serializer",
         "description": "DEBUG SETTING: verify logical plan serializer",
         "type": "BOOLEAN",

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/planner/operator/logical_recursive_cte.hpp"
+#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
@@ -244,13 +245,14 @@ unordered_set<TableIndex> ColumnBindingResolver::VerifyInternal(LogicalOperator 
 	return result;
 }
 
-void ColumnBindingResolver::Verify(LogicalOperator &op) {
-#ifdef DEBUG
+void ColumnBindingResolver::Verify(ClientContext &context, LogicalOperator &op) {
+	if (!Settings::Get<DebugVerifyColumnBindingsSetting>(context)) {
+		return;
+	}
 	op.ResolveOperatorTypes();
 	ColumnBindingResolver resolver(true);
 	resolver.VisitOperator(op);
 	VerifyInternal(op);
-#endif
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/column_binding_resolver.hpp
+++ b/src/include/duckdb/execution/column_binding_resolver.hpp
@@ -22,7 +22,7 @@ public:
 	explicit ColumnBindingResolver(bool verify_only = false);
 
 	void VisitOperator(LogicalOperator &op) override;
-	static void Verify(LogicalOperator &op);
+	static void Verify(ClientContext &context, LogicalOperator &op);
 
 protected:
 	vector<ColumnBinding> bindings;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -558,6 +558,17 @@ struct DebugVerificationModeSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct DebugVerificationProjectionSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "debug_verification_projection";
+	static constexpr const char *Description =
+	    "DEBUG SETTING: add internal verification projections to stress optimizers";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct DebugVerifyBlocksSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_verify_blocks";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -579,6 +579,16 @@ struct DebugVerifyBlocksSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct DebugVerifyColumnBindingsSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "debug_verify_column_bindings";
+	static constexpr const char *Description = "DEBUG SETTING: run extra internal verification of column bindings";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct DebugVerifySerializerSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_verify_serializer";

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -789,7 +789,7 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 		}
 
 		ColumnBindingResolver resolver;
-		resolver.Verify(*plan);
+		resolver.Verify(*this, *plan);
 		resolver.VisitOperator(*plan);
 
 		plan->ResolveOperatorTypes();

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -106,6 +106,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
     DUCKDB_GLOBAL(DebugVerificationModeSetting),
+    DUCKDB_SETTING(DebugVerificationProjectionSetting),
     DUCKDB_SETTING(DebugVerifyBlocksSetting),
     DUCKDB_SETTING(DebugVerifySerializerSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyStatementSetting),
@@ -222,12 +223,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 110),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 50),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 131),
-                                                     DUCKDB_SETTING_ALIAS("user", 146),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 111),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 51),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 132),
+                                                     DUCKDB_SETTING_ALIAS("user", 147),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 145),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 146),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -108,6 +108,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(DebugVerificationModeSetting),
     DUCKDB_SETTING(DebugVerificationProjectionSetting),
     DUCKDB_SETTING(DebugVerifyBlocksSetting),
+    DUCKDB_SETTING(DebugVerifyColumnBindingsSetting),
     DUCKDB_SETTING(DebugVerifySerializerSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyStatementSetting),
     DUCKDB_SETTING(DebugVerifyStatsSetting),
@@ -223,12 +224,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 111),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 51),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 132),
-                                                     DUCKDB_SETTING_ALIAS("user", 147),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 112),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 52),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 133),
+                                                     DUCKDB_SETTING_ALIAS("user", 148),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 146),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 147),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -196,7 +196,9 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 }
 
 void ColumnLifetimeAnalyzer::Verify(LogicalOperator &op) {
-#ifdef DEBUG
+	if (!Settings::Get<DebugVerificationProjectionSetting>(optimizer.context)) {
+		return;
+	}
 	if (everything_referenced) {
 		return;
 	}
@@ -216,7 +218,6 @@ void ColumnLifetimeAnalyzer::Verify(LogicalOperator &op) {
 	default:
 		break;
 	}
-#endif
 }
 
 void ColumnLifetimeAnalyzer::AddVerificationProjection(unique_ptr<LogicalOperator> &child) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -116,7 +116,7 @@ void Optimizer::RunOptimizer(OptimizerType type, const std::function<void()> &ca
 }
 
 void Optimizer::Verify(LogicalOperator &op) {
-	ColumnBindingResolver::Verify(op);
+	ColumnBindingResolver::Verify(context, op);
 }
 
 // Returns true if the plan contains a DML statement (INSERT/UPDATE/DELETE/MERGE INTO)

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -178,17 +178,20 @@ static bool OperatorSupportsSerialization(LogicalOperator &op) {
 
 void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op,
                          optional_ptr<bound_parameter_map_t> map) {
-	auto &config = DBConfig::GetConfig(context);
-	if (!op || !Settings::Get<DebugVerifySerializerSetting>(context)) {
+	if (!op) {
+		return;
+	}
+	// verify the column bindings of the plan
+	ColumnBindingResolver::Verify(context, *op);
+	if (!Settings::Get<DebugVerifySerializerSetting>(context)) {
 		return;
 	}
 	//! SELECT only for now
 	if (!OperatorSupportsSerialization(*op)) {
 		return;
 	}
-	// verify the column bindings of the plan
-	ColumnBindingResolver::Verify(*op);
 
+	auto &config = DBConfig::GetConfig(context);
 	// format (de)serialization of this operator
 	try {
 		MemoryStream stream(Allocator::Get(context));

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -485,7 +485,7 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownCorrelatedNode(unique_ptr<L
 		// check if we have to replace any COUNT aggregates into "CASE WHEN X IS NULL THEN 0 ELSE COUNT END"
 		RewriteCountAggregates::Rewrite(*plan, replacement_map);
 	}
-	ColumnBindingResolver::Verify(*plan);
+	ColumnBindingResolver::Verify(binder.context, *plan);
 	return state;
 }
 
@@ -541,7 +541,7 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownProjection(unique_ptr<Logic
 	AppendCorrelatedColumns(plan->expressions, state, true);
 	auto &proj = plan->Cast<LogicalProjection>();
 	auto correlated_offset = plan->expressions.size() - correlated_columns.size();
-	ColumnBindingResolver::Verify(*plan);
+	ColumnBindingResolver::Verify(binder.context, *plan);
 	return CreateContiguousState(ColumnBinding(proj.table_index, ProjectionIndex(correlated_offset)));
 }
 

--- a/test/configs/verification_projection.json
+++ b/test/configs/verification_projection.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with debug_verification_projection enabled",
+  "on_init": "SET debug_verification_projection=true;",
+  "skip_compiled": "true"
+}

--- a/test/configs/verify_column_bindings.json
+++ b/test/configs/verify_column_bindings.json
@@ -1,0 +1,13 @@
+{
+  "description": "Run with debug_verify_column_bindings enabled",
+  "on_init": "SET debug_verify_column_bindings=true;",
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "FIXME: Internal verification failed after CommonAggregateOptimizer",
+      "paths": [
+        "test/sql/aggregate/having/test_scalar_having.test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Previously these passes were done only in debug mode:

* `ColumnLifetimeAnalyzer` would add a bunch of extra projections to stress test projection maps
* We would call `ColumnBindingResolver::Verify` after planning and after every optimizer pass to ensure we never created broken plans, also not as intermediate optimizer steps

This PR splits these off into separate options and adds test config runs for them. This actually found a problem with the `CommonAggregateOptimizer` that was previously hidden by the verification projections.