### PR TITLE
Bump avro, azure, delta, ducklake, spatial, unity_catalog and vortex

### DIFF
--- a/.github/config/extensions/avro.cmake
+++ b/.github/config/extensions/avro.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW)
     duckdb_extension_load(avro
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-avro
-            GIT_TAG a73b60d629a92146cfd71c210936144a971783bd
+            GIT_TAG 0535350850786be8a8bc03b9ffc59e29dd32ecf7
     )
 endif()

--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(azure
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
-        GIT_TAG ea6ffae3710ec568ce08579dbfc0cddc8c759227
+        GIT_TAG 2ad247d4ca090cd2110f2e35531ab6fcdb80c186
   )
 endif()

--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -1,7 +1,7 @@
 if(NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 776be7ac2c51211e12bcd46c911ab11267cc44f3
+            GIT_TAG 2d76d40cffa5a8cee04e6fbfb9131c170e471129
             SUBMODULES extension-ci-tools
   )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,4 +1,4 @@
 duckdb_extension_load(ducklake
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 6c69da796c95976eefd6e86856a18769afd0c5ac
+    GIT_TAG fa50211d4e2faef348b14f220aa32a7d4b8a76a9
 )

--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -3,7 +3,7 @@ if (${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG dc1996bfd16bd8614fb4ccb5895b3ee0dbd4298e
+    GIT_TAG b5ea138c2517795cb2de62142d33bf7eeba29f7e
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     )

--- a/.github/config/extensions/unity_catalog.cmake
+++ b/.github/config/extensions/unity_catalog.cmake
@@ -1,7 +1,7 @@
 if(NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
   duckdb_extension_load(unity_catalog
             GIT_URL https://github.com/duckdb/unity_catalog
-            GIT_TAG 02024095fe6eeed6f53e78dce43e83c7424abec2
+            GIT_TAG ad54a347dba6a1da2167c716b2c67fdfb69cd499
             LOAD_TESTS
   )
 endif()

--- a/.github/config/extensions/vortex.cmake
+++ b/.github/config/extensions/vortex.cmake
@@ -1,7 +1,7 @@
 if (NOT WIN32 AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
     duckdb_extension_load(vortex
             GIT_URL https://github.com/vortex-data/duckdb-vortex
-            GIT_TAG 6ea8bd77fe8e6e814bde11b6981f934fa82ab961
+            GIT_TAG 5a78c9abd3b8f45a99dded142fb985dfb111a0a4
             SUBMODULES vortex
             APPLY_PATCHES
             LOAD_TESTS

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -722,6 +722,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"st_simplify", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_simplifypreservetopology", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_startpoint", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"st_symdifference", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_tileenvelope", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_touches", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_transform", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},


### PR DESCRIPTION
Generated via `extension_util.py` script, bumping extensions that have a v1.5-variegata.