### PR TITLE
Allow json ts format variation across columns - issue 22103

### DIFF
--- a/extension/json/include/json_reader_options.hpp
+++ b/extension/json/include/json_reader_options.hpp
@@ -32,6 +32,11 @@ public:
 		return candidate_formats.find(type)->second.back();
 	}
 
+	const vector<StrpTimeFormat> &GetFormats(LogicalTypeId type) const {
+		D_ASSERT(candidate_formats.find(type) != candidate_formats.end());
+		return candidate_formats.find(type)->second;
+	}
+
 public:
 	static void AddFormat(type_id_map_t<vector<StrpTimeFormat>> &candidate_formats, LogicalTypeId type,
 	                      const string &format_string) {
@@ -72,14 +77,6 @@ public:
 		}
 		format = formats[index];
 		return true;
-	}
-
-	void ShrinkFormatsToSize(LogicalTypeId type, idx_t size) {
-		lock_guard<mutex> lock(format_lock);
-		auto &formats = date_format_map.candidate_formats[type];
-		while (formats.size() > size) {
-			formats.pop_back();
-		}
 	}
 
 private:

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -336,7 +336,6 @@ bool JSONStructureNode::EliminateCandidateFormats(const idx_t vec_count, Vector 
 		}
 
 		if (success) {
-			date_format_map.ShrinkFormatsToSize(type, i);
 			return true;
 		}
 	}

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -293,28 +293,22 @@ static bool TransformFromString(yyjson_val *vals[], Vector &result, const idx_t 
 	return success;
 }
 
-template <class OP, class T>
-static bool TransformStringWithFormat(Vector &string_vector, const StrpTimeFormat &format, const idx_t count,
-                                      Vector &result, JSONTransformOptions &options) {
-	const auto source_strings = FlatVector::GetData<string_t>(string_vector);
-	const auto &source_validity = FlatVector::Validity(string_vector);
-
-	auto target_vals = FlatVector::GetData<T>(result);
-	auto &target_validity = FlatVector::Validity(result);
-
-	bool success = true;
-	for (idx_t i = 0; i < count; i++) {
-		if (!source_validity.RowIsValid(i)) {
-			target_validity.SetInvalid(i);
-		} else if (!OP::template Operation<T>(format, source_strings[i], target_vals[i], options.error_message)) {
-			target_validity.SetInvalid(i);
-			if (success && options.strict_cast) {
-				options.object_index = i;
-				success = false;
-			}
+static bool TryOneFormat(const StrpTimeFormat &fmt, LogicalTypeId type_id, const string_t &input, Vector &result,
+                         idx_t i, string &error_message) {
+	if (type_id == LogicalTypeId::DATE) {
+		date_t val;
+		if (!TryParseDate::Operation<date_t>(fmt, input, val, error_message)) {
+			return false;
 		}
+		FlatVector::GetData<date_t>(result)[i] = val;
+	} else {
+		timestamp_t val;
+		if (!TryParseTimeStamp::Operation<timestamp_t>(fmt, input, val, error_message)) {
+			return false;
+		}
+		FlatVector::GetData<timestamp_t>(result)[i] = val;
 	}
-	return success;
+	return true;
 }
 
 static bool TransformFromStringWithFormat(yyjson_val *vals[], Vector &result, const idx_t count,
@@ -325,22 +319,47 @@ static bool TransformFromStringWithFormat(yyjson_val *vals[], Vector &result, co
 		success = false;
 	}
 
-	const auto &result_type = result.GetType().id();
-	auto &format = options.date_format_map->GetFormat(result_type);
+	const auto result_type_id = result.GetType().id();
+	D_ASSERT(result_type_id == LogicalTypeId::DATE || result_type_id == LogicalTypeId::TIMESTAMP);
+	const auto &formats = options.date_format_map->GetFormats(result_type_id);
+	const auto source_strings = FlatVector::GetData<string_t>(string_vector);
+	const auto &source_validity = FlatVector::Validity(string_vector);
+	auto &target_validity = FlatVector::Validity(result);
 
-	switch (result_type) {
-	case LogicalTypeId::DATE:
-		if (!TransformStringWithFormat<TryParseDate, date_t>(string_vector, format, count, result, options)) {
-			success = false;
+	// Probe first non-null value to find the most-specific matching format for this vector
+	idx_t matched_idx = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < count && matched_idx == DConstants::INVALID_INDEX; i++) {
+		if (!source_validity.RowIsValid(i)) {
+			continue;
 		}
-		break;
-	case LogicalTypeId::TIMESTAMP:
-		if (!TransformStringWithFormat<TryParseTimeStamp, timestamp_t>(string_vector, format, count, result, options)) {
-			success = false;
+		string error_message;
+		for (idx_t j = formats.size(); j > 0; j--) {
+			if (TryOneFormat(formats[j - 1], result_type_id, source_strings[i], result, i, error_message)) {
+				matched_idx = j - 1;
+				break;
+			}
 		}
-		break;
-	default:
-		throw InternalException("No date/timestamp formats for %s", EnumUtil::ToString(result.GetType().id()));
+	}
+
+	const idx_t parse_limit = (matched_idx != DConstants::INVALID_INDEX) ? matched_idx + 1 : formats.size();
+	for (idx_t i = 0; i < count; i++) {
+		if (!source_validity.RowIsValid(i)) {
+			target_validity.SetInvalid(i);
+			continue;
+		}
+		bool parsed = false;
+		string error_message;
+		// Reverse iter formats, beginning at matched_idx until one parses
+		for (idx_t j = parse_limit; j > 0 && !parsed; j--) {
+			parsed = TryOneFormat(formats[j - 1], result_type_id, source_strings[i], result, i, error_message);
+		}
+		if (!parsed) {
+			target_validity.SetInvalid(i);
+			if (success && options.strict_cast) {
+				options.object_index = i;
+				success = false;
+			}
+		}
 	}
 	return success;
 }

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -33,7 +33,7 @@ void JSONScanData::InitializeFormats(bool auto_detect_p) {
 		    {LogicalTypeId::DATE, {"%m-%d-%Y", "%m-%d-%y", "%d-%m-%Y", "%d-%m-%y", "%Y-%m-%d", "%y-%m-%d"}},
 		    {LogicalTypeId::TIMESTAMP,
 		     {"%Y-%m-%d %H:%M:%S.%f", "%m-%d-%Y %I:%M:%S %p", "%m-%d-%y %I:%M:%S %p", "%d-%m-%Y %H:%M:%S",
-		      "%d-%m-%y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%SZ",
+		      "%d-%m-%y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ",
 		      "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S.%f%z"}},
 		};
 

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -177,6 +177,48 @@ select typeof(ts), ts from read_json_auto('{TEMP_DIR}/iso8601_neg_offset.json')
 ----
 TIMESTAMP	2023-02-08 02:12:28.789
 
+# Multiple timestamp formats in single JSON (issue 22103)
+statement ok
+copy (select * from (values ('{"ts1":"2026-04-01T06:01:00.010000+00:00", "ts2":"2026-04-02T06:03:00+00:01", "ts3":"2026-04-03T06:03:00Z", "ts4":"2026-04-04T06:04:00"}'))) to '{TEMP_DIR}/issue_22103.json' (format csv, quote '', header 0)
+
+query IIIIIIII
+SELECT typeof(ts1), ts1, typeof(ts2), ts2, typeof(ts3), ts3, typeof(ts4), ts4
+FROM read_json_auto('{TEMP_DIR}/issue_22103.json')
+----
+TIMESTAMP	2026-04-01 06:01:00.01	TIMESTAMP	2026-04-02 06:02:00	TIMESTAMP	2026-04-03 06:03:00	TIMESTAMP	2026-04-04 06:04:00
+
+# -----------------------------------------------------------------------------
+# Named timestamp_format produces a single-format list: only matching values
+# are typed as TIMESTAMP; others remain VARCHAR, confirming that default list
+# is ignored.
+#
+
+statement ok
+copy (select * from (values ('{"ts": "2026-04-04T06:04:00", "ts_tz": "2026-04-04T06:04:00Z"}'))) to '{TEMP_DIR}/ts_explicit_fmt.json' (format csv, quote '', header 0)
+
+query IIII
+SELECT typeof(ts), ts, typeof(ts_tz), ts_tz
+FROM read_json_auto('{TEMP_DIR}/ts_explicit_fmt.json', timestamp_format='%Y-%m-%dT%H:%M:%S')
+----
+TIMESTAMP	2026-04-04 06:04:00	VARCHAR	2026-04-04T06:04:00Z
+
+# -----------------------------------------------------------------------------
+# Safety: %Y-%m-%dT%H:%M:%S must reject trailing TZ content
+# The format fallback chain in TransformFromStringWithFormat relies on this —
+# if strptime ever accepts trailing characters, TZ offsets would be silently
+# dropped instead of being parsed by a TZ-aware format.
+#
+
+statement error
+SELECT strptime('2026-04-01T06:03:00+00:01', '%Y-%m-%dT%H:%M:%S');
+----
+trailing
+
+statement error
+SELECT strptime('2026-04-01T06:03:00Z', '%Y-%m-%dT%H:%M:%S');
+----
+trailing
+
 # test that TIMESTAMPFORMAT also applies to TIMESTAMPTZ columns
 statement ok
 create table timestamptz_test as select '1996-03-27 07:42:33+00'::TIMESTAMPTZ t


### PR DESCRIPTION
Fix issue #22103 -- timestamp format inputs bound per-scan (!per-column)

Currently the JSON parser chooses a format when handling a TIMESTAMP,
and keeps that format throughout the scan; instead move to a per-column
model where each column is probed individually, and the matching format
kept.

Also

- add explicit (previously breaking) test to confirm.
- add missing ISO format without TZ
- add safety test to confirm not unintentionally swallowing trailing TZ info

