### PR TITLE
Fix incorrect profiling results when using `LIMIT`

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -41,7 +41,6 @@ struct TableScanLocalState : public LocalTableFunctionState {
 	//! This includes filter columns, which are immediately removed.
 	DataChunk all_columns;
 
-	idx_t rows_scanned = 0;
 	idx_t rows_in_current_row_group = 0;
 	idx_t row_groups_scanned = 0;
 };
@@ -330,8 +329,6 @@ public:
 				return;
 			}
 
-			// We have fully processed a row group. Add to scanned_rows
-			l_state.rows_scanned += l_state.rows_in_current_row_group;
 			l_state.rows_in_current_row_group = storage.NextParallelScan(context, state, l_state.scan_state);
 			if (l_state.rows_in_current_row_group > 0) {
 				l_state.row_groups_scanned++;
@@ -388,8 +385,8 @@ public:
 	}
 
 	idx_t TableScanRowsScanned(LocalTableFunctionState &state) override {
-		auto &l_state = state.Cast<TableScanLocalState>();
-		return l_state.rows_scanned;
+		const auto &l_state = state.Cast<TableScanLocalState>();
+		return l_state.scan_state.table_state.rows_scanned + l_state.scan_state.local_state.rows_scanned;
 	}
 
 	idx_t TableScanRowGroupsScanned(LocalTableFunctionState &state) override {

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -108,8 +108,8 @@ public:
 public:
 	DUCKDB_API void StartOperator(optional_ptr<const PhysicalOperator> phys_op);
 	DUCKDB_API void EndOperator(optional_ptr<DataChunk> chunk);
-	DUCKDB_API void FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate, const PhysicalOperator &phys_op,
-	                             bool source_exhausted);
+	DUCKDB_API void FinalizeSourceProfiling(GlobalSourceState &gstate, LocalSourceState &lstate,
+	                                        const PhysicalOperator &phys_op, bool source_exhausted);
 
 	//! Adds the timings in the OperatorProfiler (tree) to the QueryProfiler (tree).
 	DUCKDB_API void Flush(const PhysicalOperator &phys_op);

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -108,7 +108,8 @@ public:
 public:
 	DUCKDB_API void StartOperator(optional_ptr<const PhysicalOperator> phys_op);
 	DUCKDB_API void EndOperator(optional_ptr<DataChunk> chunk);
-	DUCKDB_API void FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate);
+	DUCKDB_API void FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate, const PhysicalOperator &phys_op,
+	                             bool source_exhausted);
 
 	//! Adds the timings in the OperatorProfiler (tree) to the QueryProfiler (tree).
 	DUCKDB_API void Flush(const PhysicalOperator &phys_op);

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -113,7 +113,7 @@ private:
 	OperatorPartitionInfo required_partition_info;
 
 	//! Source operator indicated that there is no more output possible
-	bool source_exhausted = false;
+	bool exhausted_source = false;
 	//! Source or intermediate operator indicated that there is no more output possible
 	bool exhausted_pipeline = false;
 	//! Flushing of intermediate operators has started

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -112,6 +112,8 @@ private:
 	//! Partition info that is used by this executor
 	OperatorPartitionInfo required_partition_info;
 
+	//! Source operator indicated that there is no more output possible
+	bool source_exhausted = false;
 	//! Source or intermediate operator indicated that there is no more output possible
 	bool exhausted_pipeline = false;
 	//! Flushing of intermediate operators has started

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -246,6 +246,9 @@ public:
 
 	RandomEngine random;
 
+	//! The amount of tuples considered by a scan, before applying filters
+	idx_t rows_scanned = 0;
+
 	//! Optional state for custom row group ordering
 	unique_ptr<RowGroupReorderer> reorderer;
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -432,8 +432,8 @@ void OperatorProfiler::EndOperator(optional_ptr<DataChunk> chunk) {
 	active_operator = nullptr;
 }
 
-void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate,
-                                    const PhysicalOperator &phys_op, const bool source_exhausted) {
+void OperatorProfiler::FinalizeSourceProfiling(GlobalSourceState &gstate, LocalSourceState &lstate,
+                                               const PhysicalOperator &phys_op, const bool source_exhausted) {
 	if (!enabled) {
 		return;
 	}

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -442,16 +442,18 @@ void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState 
 	}
 
 	if (ProfilingInfo::Enabled(settings, MetricType::EXTRA_INFO)) {
-		auto &info = GetOperatorInfo(phys_op);
 		auto extra_info = phys_op.ExtraSourceParams(gstate, lstate);
-		for (auto &new_info : extra_info) {
-			auto entry = info.extra_info.find(new_info.first);
-			if (entry != info.extra_info.end()) {
-				// entry exists - override
-				entry->second = std::move(new_info.second);
-			} else {
-				// entry does not exist yet - insert
-				info.extra_info.insert(std::move(new_info));
+		if (!extra_info.empty()) {
+			auto &info = GetOperatorInfo(phys_op);
+			for (auto &new_info : extra_info) {
+				const auto entry = info.extra_info.find(new_info.first);
+				if (entry != info.extra_info.end()) {
+					// entry exists - override
+					entry->second = std::move(new_info.second);
+				} else {
+					// entry does not exist yet - insert
+					info.extra_info.insert(std::move(new_info));
+				}
 			}
 		}
 	}
@@ -504,6 +506,25 @@ void OperatorProfiler::Flush(const PhysicalOperator &phys_op) {
 	info.name = phys_op.GetName();
 }
 
+static void MergeOperatorExtraInfo(const InsertionOrderPreservingMap<string> &local_extra_info,
+                                   Value &global_extra_info) {
+	InsertionOrderPreservingMap<string> merged;
+	const auto &children = MapValue::GetChildren(global_extra_info);
+	for (const auto &child : children) {
+		const auto &struct_children = StructValue::GetChildren(child);
+		const auto key = struct_children[0].GetValue<string>();
+		const auto value = struct_children[1].GetValue<string>();
+
+		merged[key] = value;
+	}
+
+	for (const auto &[key, value] : local_extra_info) {
+		merged[key] = value;
+	}
+
+	global_extra_info = Value::MAP(merged);
+}
+
 void QueryProfiler::Flush(OperatorProfiler &profiler) {
 	lock_guard<std::mutex> guard(lock);
 	if (!IsEnabled() || !running) {
@@ -537,8 +558,8 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 		if (ProfilingInfo::Enabled(profiler.settings, MetricType::RESULT_SET_SIZE)) {
 			info.MetricSum<idx_t>(MetricType::RESULT_SET_SIZE, node.second.result_set_size);
 		}
-		if (ProfilingInfo::Enabled(profiler.settings, MetricType::EXTRA_INFO)) {
-			info.metrics[MetricType::EXTRA_INFO] = Value::MAP(node.second.extra_info);
+		if (ProfilingInfo::Enabled(profiler.settings, MetricType::EXTRA_INFO) && !node.second.extra_info.empty()) {
+			MergeOperatorExtraInfo(node.second.extra_info, info.metrics[MetricType::EXTRA_INFO]);
 		}
 		if (ProfilingInfo::Enabled(profiler.settings, MetricType::SYSTEM_PEAK_BUFFER_MEMORY)) {
 			query_metrics.query_global_info.MetricMax(MetricType::SYSTEM_PEAK_BUFFER_MEMORY,

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -432,47 +432,48 @@ void OperatorProfiler::EndOperator(optional_ptr<DataChunk> chunk) {
 	active_operator = nullptr;
 }
 
-void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate) {
+void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate,
+                                    const PhysicalOperator &phys_op, const bool source_exhausted) {
 	if (!enabled) {
 		return;
 	}
-	if (!active_operator) {
-		throw InternalException("OperatorProfiler: Attempting to call FinishSource while no operator is active");
+	if (settings.empty()) {
+		return;
 	}
-	if (!settings.empty()) {
-		if (ProfilingInfo::Enabled(settings, MetricType::EXTRA_INFO)) {
-			// we're emitting extra info - get the extra source info
-			auto &info = GetOperatorInfo(*active_operator);
-			auto extra_info = active_operator->ExtraSourceParams(gstate, lstate);
-			for (auto &new_info : extra_info) {
-				auto entry = info.extra_info.find(new_info.first);
-				if (entry != info.extra_info.end()) {
-					// entry exists - override
-					entry->second = std::move(new_info.second);
-				} else {
-					// entry does not exist yet - insert
-					info.extra_info.insert(std::move(new_info));
-				}
+
+	if (ProfilingInfo::Enabled(settings, MetricType::EXTRA_INFO)) {
+		auto &info = GetOperatorInfo(phys_op);
+		auto extra_info = phys_op.ExtraSourceParams(gstate, lstate);
+		for (auto &new_info : extra_info) {
+			auto entry = info.extra_info.find(new_info.first);
+			if (entry != info.extra_info.end()) {
+				// entry exists - override
+				entry->second = std::move(new_info.second);
+			} else {
+				// entry does not exist yet - insert
+				info.extra_info.insert(std::move(new_info));
 			}
 		}
-		if (active_operator.get()->type == PhysicalOperatorType::TABLE_SCAN && TableScanMetricsEnabled(settings)) {
-			const auto &table_scan = active_operator->Cast<PhysicalTableScan>();
-			profiler_metrics_t metrics;
-			table_scan.GetMetrics(context, gstate, lstate, settings, metrics);
-			auto &info = GetOperatorInfo(*active_operator);
-			for (const auto metric_type : TABLE_SCAN_METRICS) {
-				if (!ProfilingInfo::Enabled(settings, metric_type)) {
-					continue;
-				}
-				if (metric_type == MetricType::OPERATOR_ROWS_SCANNED) {
-					if (!TryAddTableScanMetric(info, metrics, metric_type)) {
-						// Use the cardinality estimate if no exact rows-scanned metric is available.
-						AddEstimatedTableScanRowsScanned(context, info, table_scan);
-					}
-					continue;
-				}
-				TryAddTableScanMetric(info, metrics, metric_type);
+	}
+
+	if (phys_op.type == PhysicalOperatorType::TABLE_SCAN && TableScanMetricsEnabled(settings)) {
+		const auto &table_scan = phys_op.Cast<PhysicalTableScan>();
+		profiler_metrics_t metrics;
+		table_scan.GetMetrics(context, gstate, lstate, settings, metrics);
+		auto &info = GetOperatorInfo(phys_op);
+		for (const auto metric_type : TABLE_SCAN_METRICS) {
+			if (!ProfilingInfo::Enabled(settings, metric_type)) {
+				continue;
 			}
+			if (metric_type == MetricType::OPERATOR_ROWS_SCANNED) {
+				// If the source is not exhausted we cannot make a reliable guess based on the cardinality estimate.
+				if (!TryAddTableScanMetric(info, metrics, metric_type) && source_exhausted) {
+					// Use the cardinality estimate if no exact rows-scanned metric is available.
+					AddEstimatedTableScanRowsScanned(context, info, table_scan);
+				}
+				continue;
+			}
+			TryAddTableScanMetric(info, metrics, metric_type);
 		}
 	}
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -506,6 +506,8 @@ void OperatorProfiler::Flush(const PhysicalOperator &phys_op) {
 	info.name = phys_op.GetName();
 }
 
+// MetricType::EXTRA_INFO is metadata rather than a delta metric, so we do not overwrite the entire object.
+// Instead, we merge with the global object instance so subsequent flushes do not erase existing metadata.
 static void MergeOperatorExtraInfo(const InsertionOrderPreservingMap<string> &local_extra_info,
                                    Value &global_extra_info) {
 	InsertionOrderPreservingMap<string> merged;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -518,8 +518,8 @@ static void MergeOperatorExtraInfo(const InsertionOrderPreservingMap<string> &lo
 		merged[key] = value;
 	}
 
-	for (const auto &[key, value] : local_extra_info) {
-		merged[key] = value;
+	for (const auto &entry : local_extra_info) {
+		merged[entry.first] = entry.second;
 	}
 
 	global_extra_info = Value::MAP(merged);

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -382,10 +382,8 @@ PipelineExecuteResult PipelineExecutor::PushFinalize() {
 
 	finalized = true;
 
-	if (pipeline.GetSource()) {
-		context.thread.profiler.FinalizeSourceProfiling(*pipeline.source_state, *local_source_state, *pipeline.source,
+	context.thread.profiler.FinalizeSourceProfiling(*pipeline.source_state, *local_source_state, *pipeline.source,
 		                                                exhausted_source);
-	}
 
 	// flush all query profiler info
 	for (idx_t i = 0; i < intermediate_states.size(); i++) {

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -383,8 +383,8 @@ PipelineExecuteResult PipelineExecutor::PushFinalize() {
 	finalized = true;
 
 	if (pipeline.GetSource()) {
-		context.thread.profiler.FinishSource(*pipeline.source_state, *local_source_state, *pipeline.source,
-		                                     exhausted_source);
+		context.thread.profiler.FinalizeSourceProfiling(*pipeline.source_state, *local_source_state, *pipeline.source,
+		                                                exhausted_source);
 	}
 
 	// flush all query profiler info

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -232,7 +232,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 					return PipelineExecuteResult::INTERRUPTED;
 				}
 				if (source_result == SourceResultType::FINISHED) {
-					source_exhausted = true;
+					exhausted_source = true;
 					exhausted_pipeline = true;
 				}
 			}
@@ -384,7 +384,7 @@ PipelineExecuteResult PipelineExecutor::PushFinalize() {
 
 	if (pipeline.GetSource()) {
 		context.thread.profiler.FinishSource(*pipeline.source_state, *local_source_state, *pipeline.source,
-		                                     source_exhausted);
+		                                     exhausted_source);
 	}
 
 	// flush all query profiler info

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -232,6 +232,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 					return PipelineExecuteResult::INTERRUPTED;
 				}
 				if (source_result == SourceResultType::FINISHED) {
+					source_exhausted = true;
 					exhausted_pipeline = true;
 				}
 			}
@@ -380,6 +381,12 @@ PipelineExecuteResult PipelineExecutor::PushFinalize() {
 	}
 
 	finalized = true;
+
+	if (pipeline.GetSource()) {
+		context.thread.profiler.FinishSource(*pipeline.source_state, *local_source_state, *pipeline.source,
+		                                     source_exhausted);
+	}
+
 	// flush all query profiler info
 	for (idx_t i = 0; i < intermediate_states.size(); i++) {
 		intermediate_states[i]->Finalize(pipeline.operators[i].get(), context);
@@ -531,10 +538,6 @@ SourceResultType PipelineExecutor::FetchFromSource(DataChunk &result) {
 
 	// Ensures sources only return empty results when Blocking or Finished
 	D_ASSERT(res != SourceResultType::BLOCKED || result.size() == 0);
-	if (res == SourceResultType::FINISHED) {
-		// final call into the source - finish source execution
-		context.thread.profiler.FinishSource(*pipeline.source_state, *local_source_state);
-	}
 	EndOperator(*pipeline.source, &result);
 
 	return res;

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -383,7 +383,7 @@ PipelineExecuteResult PipelineExecutor::PushFinalize() {
 	finalized = true;
 
 	context.thread.profiler.FinalizeSourceProfiling(*pipeline.source_state, *local_source_state, *pipeline.source,
-		                                                exhausted_source);
+	                                                exhausted_source);
 
 	// flush all query profiler info
 	for (idx_t i = 0; i < intermediate_states.size(); i++) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -625,6 +625,8 @@ void RowGroup::Scan(ScanOptions options, CollectionScanState &state, DataChunk &
 			NextVector(state);
 			continue;
 		}
+		state.rows_scanned += count;
+
 		auto &block_manager = GetBlockManager();
 		if (block_manager.Prefetch()) {
 			PrefetchState prefetch_state;

--- a/test/sql/pragma/profiling/test_custom_profiling_row_group_metrics.test_slow
+++ b/test/sql/pragma/profiling/test_custom_profiling_row_group_metrics.test_slow
@@ -378,7 +378,7 @@ SELECT * FROM cumulative_metrics;
 statement ok
 ROLLBACK;
 
-# --- LIMITation: rows scanned is not flushed when the scan is stopped early ---
+# --- Execution stopped early: statistics should reflect work done until stop trigger (operator) ---
 
 statement ok
 PRAGMA enable_profiling = 'json';
@@ -387,7 +387,7 @@ statement ok
 PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
 
 statement ok
-PRAGMA custom_profiling_settings='{"OPERATOR_ROWS_SCANNED": "true", "OPERATOR_TYPE": "true"}';
+PRAGMA custom_profiling_settings='{"OPERATOR_ROW_GROUPS_SCANNED": "true", "OPERATOR_TOTAL_ROW_GROUPS_TO_SCAN": "true", "OPERATOR_TYPE": "true"}';
 
 statement ok
 SELECT * FROM t LIMIT 1;
@@ -396,22 +396,43 @@ statement ok
 PRAGMA disable_profiling;
 
 statement ok
-CREATE VIEW rows_scanned_operator_metrics AS
+CREATE VIEW row_groups_scanned_operator_metrics AS
 WITH RECURSIVE ops AS (
     SELECT unnest(children) AS op FROM '__TEST_DIR__/profiling_output.json'
     UNION ALL
     SELECT unnest(op.children) FROM ops WHERE len(op.children) > 0
 )
 SELECT op.operator_type,
-       op.operator_rows_scanned AS rows_scanned
+       op.operator_row_groups_scanned AS row_groups_scanned,
+       op.operator_total_row_groups_to_scan AS total_row_groups_to_scan
 FROM ops;
 
-# The table scan starts, but the downstream LIMIT prevents FinishSource from
-# flushing OPERATOR_ROWS_SCANNED. Once fixed, this should report the started row group.
-query II
-SELECT * FROM rows_scanned_operator_metrics WHERE operator_type = 'TABLE_SCAN';
+query III
+SELECT * FROM row_groups_scanned_operator_metrics WHERE operator_type = 'TABLE_SCAN';
 ----
-TABLE_SCAN	0
+TABLE_SCAN	1	4
+
+# --- Execution stopped early: statistics should reflect work done until stop trigger (cumulative) ---
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_ROW_GROUPS_SCANNED": "true", "CUMULATIVE_TOTAL_ROW_GROUPS_TO_SCAN": "true"}';
+
+statement ok
+SELECT * FROM t LIMIT 1;
+
+statement ok
+PRAGMA disable_profiling;
+
+query II
+SELECT * FROM cumulative_metrics;
+----
+1	4
 
 # --- Transaction-local append: pruning covers distinct persistent and local ranges ---
 

--- a/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
@@ -69,3 +69,121 @@ SELECT
 FROM metrics_output;
 ----
 true
+
+# Show nonzero count when using LIMIT below late-materialization threshold.
+
+statement ok
+CREATE TABLE t AS SELECT range i FROM range(400000);
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true", "BLOCKED_THREAD_TIME": "true"}';
+
+statement ok
+SELECT * FROM t LIMIT 1;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json'
+
+query I
+SELECT
+	CASE WHEN cumulative_rows_scanned > 0 THEN 'true'
+	ELSE 'false' END
+FROM metrics_output;
+----
+true
+
+# Show nonzero count when using LIMIT above late-materialization threshold.
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true", "BLOCKED_THREAD_TIME": "true"}';
+
+statement ok
+SELECT * FROM t LIMIT 1024;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json'
+
+query I
+SELECT
+	CASE WHEN cumulative_rows_scanned > 0 THEN 'true'
+	ELSE 'false' END
+FROM metrics_output;
+----
+true
+
+# Show nonzero count when no metrics available (use estimate).
+
+statement ok
+PRAGMA disabled_optimizers='late_materialization';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true", "BLOCKED_THREAD_TIME": "true"}';
+
+statement ok
+SELECT * FROM range(10);
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json'
+
+query I
+SELECT
+	CASE WHEN cumulative_rows_scanned > 0 THEN 'true'
+	ELSE 'false' END
+FROM metrics_output;
+----
+true
+
+# Show zero count when using LIMIT, no metrics available and source is not exhausted.
+
+statement ok
+PRAGMA disabled_optimizers='late_materialization';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true", "BLOCKED_THREAD_TIME": "true"}';
+
+statement ok
+SELECT * FROM range(1000) LIMIT 10;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json'
+
+query I
+SELECT cumulative_rows_scanned FROM metrics_output;
+----
+0

--- a/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
@@ -187,3 +187,32 @@ query I
 SELECT cumulative_rows_scanned FROM metrics_output;
 ----
 0
+
+# Limitation: LIMIT stops the query pipeline before source is exhausted, so when no metrics are available
+# a zero count is returned.
+
+statement ok
+PRAGMA disabled_optimizers='late_materialization';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true", "BLOCKED_THREAD_TIME": "true"}';
+
+statement ok
+SELECT * FROM range(10) LIMIT 10;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json'
+
+query I
+SELECT cumulative_rows_scanned FROM metrics_output;
+----
+0


### PR DESCRIPTION
This PR resolves https://github.com/duckdblabs/duckdb-internal/issues/9085.

The bug originated from the fact that the placement of `FinishSource` assumed that a pipeline would only finish when the source was exhausted. However `LIMIT` (among others) is an intermediate operator which can trigger an early finish of the pipeline, in these cases `FinishSource` would never trigger.

As a fix the `FinishSource` has been refactored to take any operator, irrespective of if it is active or not, and `FinishSource` has been placed in the finalize phase that catches all finish reasons. Because the meaning of the function has changed slightly it has been renamed to `FinalizeSourceProfiling`.

Because the above changed the context of `FinalizeSourceProfiling` from operator scoped to pipeline scoped a change was made in how `extra_info` metadata is managed. Where we now update the global property instead of overwriting with the local object to account for multiple flushes.

Finally, we made row counting more granular (before it was either 0 or row group size). Such that it in case of for example `CUMULATIVE_ROWS_SCANNED`, the amount of rows positions processed by the table scan is returned, before filters are applied.

### Limitation

The current patch will result in a zero count in profiling for the following query:

```sql
SELECT * FROM range(10) LIMIT 10;
```

This happens because `LIMIT` stops the pipeline before the source can emit a chunk with zero rows. This leads to a situation where there are no metrics, and the source is not exhausted, so we return `0`. After discussion with @lnkuiper this limitation is left as-is, documented through a test.