### PR TITLE
Add libduckdb_static.a to build artifact in CI

### DIFF
--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -37,6 +37,13 @@ else
 	echo "No $BUILD_DIR/src/libduckdb.so* files found"
 fi
 
+# Required by jobs that link against the prebuilt static library.
+if [[ -f "$BUILD_DIR/src/libduckdb_static.a" ]]; then
+	cp -av "$BUILD_DIR/src/libduckdb_static.a" "$ARTIFACT_DIR"/src/
+else
+	echo "No $BUILD_DIR/src/libduckdb_static.a file found"
+fi
+
 # Required by regression jobs that run the prebuilt benchmark runner.
 if [[ -f "$BUILD_DIR/benchmark/benchmark_runner" ]]; then
 	mkdir -p "$ARTIFACT_DIR"/benchmark "$ARTIFACT_DIR"/scripts


### PR DESCRIPTION
Currently, only `src/libduckdb.so` exists in the uploaded artifact:
```
release artifact includes:
  duckdb
  repository/c3d4868dfa/linux_amd64/core_functions.duckdb_extension
  repository/c3d4868dfa/linux_amd64/parquet.duckdb_extension
  src/libduckdb.so
  test/extension/loadable_extension_demo.duckdb_extension
  test/extension/loadable_extension_optimizer_demo.duckdb_extension
  test/unittest
```
but `src/libduckdb_static.a` is missing.

This PR adds the static archive file also to the uploaded artifact file. 