### PR TITLE
feat: Add duckdb_secret_type_parameters system view

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library_unity(
   duckdb_schemas.cpp
   duckdb_secrets.cpp
   duckdb_prepared_statements.cpp
-  duckdb_which_secret.cpp
+  duckdb_which_secret.cpp 
+  duckdb_secret_type_parameters.cpp
   duckdb_secret_types.cpp
   duckdb_sequences.cpp
   duckdb_triggers.cpp

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -28,7 +28,8 @@ add_library_unity(
   duckdb_schemas.cpp
   duckdb_secrets.cpp
   duckdb_prepared_statements.cpp
-  duckdb_which_secret.cpp
+  duckdb_which_secret.cpp 
+  duckdb_secret_type_parameters.cpp
   duckdb_secret_types.cpp
   duckdb_sequences.cpp
   duckdb_triggers.cpp

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library_unity(
   duckdb_schemas.cpp
   duckdb_secrets.cpp
   duckdb_prepared_statements.cpp
-  duckdb_which_secret.cpp 
+  duckdb_which_secret.cpp
   duckdb_secret_type_parameters.cpp
   duckdb_secret_types.cpp
   duckdb_sequences.cpp

--- a/src/function/table/system/duckdb_secret_type_parameters.cpp
+++ b/src/function/table/system/duckdb_secret_type_parameters.cpp
@@ -1,0 +1,100 @@
+
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/secret/secret.hpp"
+
+namespace duckdb {
+
+struct SecretTypeParameterRow {
+	string secret_type;
+	string provider;
+	string parameter_name;
+	string parameter_type;
+};
+
+struct DuckDBSecretTypeParametersData : public GlobalTableFunctionState {
+	DuckDBSecretTypeParametersData() : offset(0) {
+	}
+
+	vector<SecretTypeParameterRow> rows;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBSecretTypeParametersBind(ClientContext &context, TableFunctionBindInput &input,
+                                                               vector<LogicalType> &return_types,
+                                                               vector<string> &names) {
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("provider");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("parameter_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBSecretTypeParametersInit(ClientContext &context,
+                                                                    TableFunctionInitInput &input) {
+	auto result = make_uniq<DuckDBSecretTypeParametersData>();
+
+	auto &secret_manager = SecretManager::Get(context);
+	auto all_functions = secret_manager.AllSecretFunctions();
+	for (const auto &func : all_functions) {
+		for (const auto &param_pairs : func.named_parameters) {
+			SecretTypeParameterRow row;
+			row.secret_type = func.secret_type;
+			row.provider = func.provider;
+			row.parameter_name = param_pairs.first;
+			row.parameter_type = param_pairs.second.ToString();
+			result->rows.push_back(row);
+		}
+	}
+
+	return std::move(result);
+}
+
+void DuckDBSecretTypeParametersFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DuckDBSecretTypeParametersData>();
+	if (data.offset >= data.rows.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+
+	while (data.offset < data.rows.size() && count < STANDARD_VECTOR_SIZE) {
+		// Get the current row from our State
+		auto &entry = data.rows[data.offset++];
+
+		// Fill the 5 columns for this row
+		output.SetValue(0, count, Value(entry.secret_type));
+		output.SetValue(1, count, Value(entry.provider));
+		output.SetValue(2, count, Value(entry.parameter_name));
+		output.SetValue(3, count, Value(entry.parameter_type));
+		// Null value
+		output.SetValue(4, count, Value());
+
+		count++;
+	}
+
+	output.SetCardinality(count);
+}
+
+void DuckDBSecretTypeParametersFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_secret_type_parameters", {}, DuckDBSecretTypeParametersFunction,
+	                              DuckDBSecretTypeParametersBind, DuckDBSecretTypeParametersInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system/duckdb_secret_type_parameters.cpp
+++ b/src/function/table/system/duckdb_secret_type_parameters.cpp
@@ -25,7 +25,7 @@ struct DuckDBSecretTypeParametersData : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> DuckDBSecretTypeParametersBind(ClientContext &context, TableFunctionBindInput &input,
                                                                vector<LogicalType> &return_types,
-                                                               vector<string> &names) {
+                                                               vector<Identifier> &names) {
 	names.emplace_back("type");
 	return_types.emplace_back(LogicalType::VARCHAR);
 

--- a/src/function/table/system/duckdb_secret_type_parameters.cpp
+++ b/src/function/table/system/duckdb_secret_type_parameters.cpp
@@ -54,8 +54,8 @@ unique_ptr<GlobalTableFunctionState> DuckDBSecretTypeParametersInit(ClientContex
 		for (const auto &param_pairs : func.named_parameters) {
 			SecretTypeParameterRow row;
 			row.secret_type = func.secret_type;
-			row.provider = func.provider;
-			row.parameter_name = param_pairs.first;
+			row.provider = func.provider.GetIdentifierName();
+			row.parameter_name = param_pairs.first.GetIdentifierName();
 			row.parameter_type = param_pairs.second.ToString();
 			result->rows.push_back(row);
 		}
@@ -74,22 +74,28 @@ void DuckDBSecretTypeParametersFunction(ClientContext &context, TableFunctionInp
 	// either fill up the chunk or return all the remaining columns
 	idx_t count = 0;
 
+	// type, VARCHAR
+	auto &type = output.data[0];
+	// provider, VARCHAR
+	auto &provider = output.data[1];
+	// name, VARCHAR
+	auto &name = output.data[2];
+	// parameter_type, VARCHAR
+	auto &parameter_type = output.data[3];
+	// description, VARCHAR
+	auto &description = output.data[4];
+
 	while (data.offset < data.rows.size() && count < STANDARD_VECTOR_SIZE) {
-		// Get the current row from our State
 		auto &entry = data.rows[data.offset++];
 
-		// Fill the 5 columns for this row
-		output.SetValue(0, count, Value(entry.secret_type));
-		output.SetValue(1, count, Value(entry.provider));
-		output.SetValue(2, count, Value(entry.parameter_name));
-		output.SetValue(3, count, Value(entry.parameter_type));
-		// Null value
-		output.SetValue(4, count, Value());
+		type.Append(Value(entry.secret_type));
+		provider.Append(Value(entry.provider));
+		name.Append(Value(entry.parameter_name));
+		parameter_type.Append(Value(entry.parameter_type));
+		description.Append(Value());
 
 		count++;
 	}
-
-	output.SetCardinality(count);
 }
 
 void DuckDBSecretTypeParametersFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -40,7 +40,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBOptimizersFun::RegisterFunction(*this);
 	DuckDBSecretsFun::RegisterFunction(*this);
 	DuckDBWhichSecretFun::RegisterFunction(*this);
-	DuckDBSecretTypesFun::RegisterFunction(*this);
+	DuckDBSecretTypeParametersFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBTriggersFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -50,7 +50,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBOptimizersFun::RegisterFunction(*this);
 	DuckDBSecretsFun::RegisterFunction(*this);
 	DuckDBWhichSecretFun::RegisterFunction(*this);
-	DuckDBSecretTypesFun::RegisterFunction(*this);
+	DuckDBSecretTypeParametersFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBTriggersFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -51,6 +51,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBSecretsFun::RegisterFunction(*this);
 	DuckDBWhichSecretFun::RegisterFunction(*this);
 	DuckDBSecretTypeParametersFun::RegisterFunction(*this);
+	DuckDBSecretTypesFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBTriggersFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -131,6 +131,10 @@ struct DuckDBOptimizersFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBSecretTypeParametersFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBSecretTypesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -177,6 +177,10 @@ struct DuckDBOptimizersFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBSecretTypeParametersFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBSecretTypesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -62,6 +62,9 @@ public:
 class CreateSecretFunctionSet {
 public:
 	explicit CreateSecretFunctionSet(string &name) : name(name) {};
+	case_insensitive_map_t<CreateSecretFunction> &GetFunctions() {
+		return functions;
+	}
 
 public:
 	bool ProviderExists(const Identifier &provider_name);

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -62,7 +62,7 @@ public:
 class CreateSecretFunctionSet {
 public:
 	explicit CreateSecretFunctionSet(string &name) : name(name) {};
-	case_insensitive_map_t<CreateSecretFunction> &GetFunctions() {
+	identifier_map_t<CreateSecretFunction> &GetFunctions() {
 		return functions;
 	}
 

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -140,6 +140,8 @@ public:
 
 	//! List all secret types
 	DUCKDB_API vector<SecretType> AllSecretTypes();
+	//! List all secret functions
+	DUCKDB_API vector<CreateSecretFunction> AllSecretFunctions();
 
 	//! Secret Manager settings
 	DUCKDB_API virtual void SetEnablePersistentSecrets(bool enabled);

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -143,6 +143,8 @@ public:
 
 	//! List all secret types
 	DUCKDB_API vector<SecretType> AllSecretTypes();
+	//! List all secret functions
+	DUCKDB_API vector<CreateSecretFunction> AllSecretFunctions();
 
 	//! Secret Manager settings
 	DUCKDB_API virtual void SetEnablePersistentSecrets(bool enabled);

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -509,6 +509,20 @@ vector<SecretType> SecretManager::AllSecretTypes() {
 	return result;
 }
 
+vector<CreateSecretFunction> SecretManager::AllSecretFunctions() {
+	unique_lock<mutex> lck(manager_lock);
+	vector<CreateSecretFunction> result;
+
+	for (auto &secret_set : secret_functions) {
+		auto &inner_functions = secret_set.second.GetFunctions();
+		for (auto &func_pair : inner_functions) {
+			result.push_back(func_pair.second);
+		}
+	}
+
+	return result;
+}
+
 void SecretManager::ThrowOnSettingChangeIfInitialized() {
 	if (initialized) {
 		throw InvalidInputException(

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -562,6 +562,20 @@ vector<SecretType> SecretManager::AllSecretTypes() {
 	return result;
 }
 
+vector<CreateSecretFunction> SecretManager::AllSecretFunctions() {
+	unique_lock<mutex> lck(manager_lock);
+	vector<CreateSecretFunction> result;
+
+	for (auto &secret_set : secret_functions) {
+		auto &inner_functions = secret_set.second.GetFunctions();
+		for (auto &func_pair : inner_functions) {
+			result.push_back(func_pair.second);
+		}
+	}
+
+	return result;
+}
+
 void SecretManager::ThrowOnSettingChangeIfInitialized() {
 	if (initialized) {
 		throw InvalidInputException(

--- a/test/optimizer/aggregate_rewrite.cpp
+++ b/test/optimizer/aggregate_rewrite.cpp
@@ -147,16 +147,16 @@ TEST_CASE("Aggregate rewrite plans support fan-out and branch joins", "[optimize
 	                        "FROM (VALUES (1, 2), (1, 4), (1, 4), (2, 3), (NULL, 2), (NULL, 5)) t(g, v) "
 	                        "GROUP BY g ORDER BY g NULLS LAST");
 	REQUIRE_NO_FAIL(*result);
-	REQUIRE(result->GetValue(1, 0) == Value::BIGINT(6));
-	REQUIRE(result->GetValue(1, 1) == Value::BIGINT(6));
-	REQUIRE(result->GetValue(1, 2) == Value::BIGINT(7));
+	REQUIRE(result->GetValue(1, 0).GetValue<int64_t>() == 6);
+	REQUIRE(result->GetValue(1, 1).GetValue<int64_t>() == 6);
+	REQUIRE(result->GetValue(1, 2).GetValue<int64_t>() == 7);
 	REQUIRE(rewrite_calls == 1);
 
 	rewrite_calls = 0;
 	REQUIRE_NO_FAIL(*con.Query("SET enable_optimizer=false"));
 	result = con.Query("SELECT test_dag_aggregate(v::BIGINT) FROM (VALUES (2), (4), (4)) t(v)");
 	REQUIRE_NO_FAIL(*result);
-	REQUIRE(result->GetValue(0, 0) == Value::BIGINT(6));
+	REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 6);
 	REQUIRE(rewrite_calls == 1);
 }
 
@@ -171,7 +171,7 @@ TEST_CASE("Aggregate rewrite policies own strategy selection", "[optimizer][aggr
 	cost_saw_cardinality = false;
 	auto result = con.Query("SELECT test_costed_dag_aggregate(i::BIGINT) FROM range(2, 5) t(i)");
 	REQUIRE_NO_FAIL(*result);
-	REQUIRE(result->GetValue(0, 0) == Value::BIGINT(6));
+	REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 6);
 	REQUIRE(cost_calls == 1);
 	REQUIRE(cost_saw_cardinality);
 	REQUIRE(rewrite_calls == 1);
@@ -181,7 +181,7 @@ TEST_CASE("Aggregate rewrite policies own strategy selection", "[optimizer][aggr
 	cost_calls = 0;
 	result = con.Query("SELECT test_costed_dag_aggregate(i::BIGINT) FROM range(2, 5) t(i)");
 	REQUIRE_NO_FAIL(*result);
-	REQUIRE(result->GetValue(0, 0) == Value::BIGINT(3));
+	REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 3);
 	REQUIRE(cost_calls == 0);
 	REQUIRE(rewrite_calls == 0);
 }

--- a/test/sql/secrets/test_secret_type_parameters.test
+++ b/test/sql/secrets/test_secret_type_parameters.test
@@ -1,0 +1,4 @@
+query I
+SELECT count(*) > 0 FROM duckdb_secret_type_parameters();
+----
+true

--- a/test/sql/secrets/test_secret_type_parameters.test
+++ b/test/sql/secrets/test_secret_type_parameters.test
@@ -1,3 +1,6 @@
+# name: test/sql/secrets/test_secret_type_parameters.test
+# group: [secrets]
+
 query I
 SELECT count(*) > 0 FROM duckdb_secret_type_parameters();
 ----

--- a/test/sql/secrets/test_secret_type_parameters.test
+++ b/test/sql/secrets/test_secret_type_parameters.test
@@ -5,3 +5,4 @@ query I
 SELECT count(*) > 0 FROM duckdb_secret_type_parameters();
 ----
 true
+


### PR DESCRIPTION
This PR implements **Option 2** requested in issue #22308 by @rustyconover.

### Problem
Currently, `duckdb_secret_types()` only returns the existence of a secret type and its provider, but there is no SQL-accessible way to inspect the required parameters (names, types) for a given secret type. 

### Solution
This PR adds a new system table function: `duckdb_secret_type_parameters()`.
It exposes the internal `named_parameters` of registered secret types, returning one row per (name, type, provider, parameter, description).

Closes #22308