### PR TITLE
Fix fuzzer issue on empty subscript expression

### DIFF
--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -1617,6 +1617,9 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformSliceExpression(PEG
                                                                              ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto slice_bound = transformer.Transform<vector<unique_ptr<ParsedExpression>>>(list_pr.Child<ListParseResult>(1));
+	if (slice_bound.size() == 0) {
+		throw ParserException("Empty subscript '[]' is not allowed");
+	}
 	if (slice_bound.size() == 1) {
 		return make_uniq<OperatorExpression>(ExpressionType::ARRAY_EXTRACT, std::move(slice_bound));
 	}

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -1617,7 +1617,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformSliceExpression(PEG
                                                                              ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto slice_bound = transformer.Transform<vector<unique_ptr<ParsedExpression>>>(list_pr.Child<ListParseResult>(1));
-	if (slice_bound.size() == 0) {
+	if (slice_bound.empty()) {
 		throw ParserException("Empty subscript '[]' is not allowed");
 	}
 	if (slice_bound.size() == 1) {

--- a/test/sql/peg_parser/fuzzer/fuzzer_4434.test
+++ b/test/sql/peg_parser/fuzzer/fuzzer_4434.test
@@ -1,0 +1,9 @@
+# name: test/sql/peg_parser/fuzzer/fuzzer_4434.test
+# description: Fix empty subscript expression leading to internal error
+# group: [fuzzer]
+
+statement error
+n''''+ST�&6>ttacrotablesampimportleT�&6>tta�rordeT�Niqeger[], e�tfilter%
+                  t_not_currorderent;
+----
+Parser Error: Empty subscript '[]' is not allowed

--- a/test/sql/peg_parser/fuzzer/fuzzer_4434.test
+++ b/test/sql/peg_parser/fuzzer/fuzzer_4434.test
@@ -7,3 +7,8 @@ n''''+ST�&6>ttacrotablesampimportleT�&6>tta�rordeT�Niqeger[], e�tfilte
                   t_not_currorderent;
 ----
 Parser Error: Empty subscript '[]' is not allowed
+
+statement error
+[1,2,3][];
+----
+Parser Error: Empty subscript '[]' is not allowed


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/9063

The following query failed with an internal exception, while this was previously a parser error: 
```sql
n''''+ST�&6>ttacrotablesampimportleT�&6>tta�rordeT�Niqeger[], e�tfilter%
t_not_currorderent;
;
```

It looks like an odd query, but it seems to be caused by the `[]` which matches a `SliceExpression`. Every element of this subrule is optional: 
`SliceBound <- Expression? EndSliceBound? StepSliceBound?`
But a completely empty `SliceExpression` should not be accepted (Previously led to a generic `syntax error`). So now we check if the result is empty and throw a descriptive error if this happens. 

I am surprised this wasn't previously caught in other tests