### PR TITLE
Add libatomic for missing __atomic_is_lock_free

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,4 +65,8 @@ else()
   link_extension_libraries(unittest "")
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_link_libraries(unittest atomic)
+endif()
+
 duckdb_codesign_for_debugging(unittest)


### PR DESCRIPTION
Fix NightlyTests CI job `Release Assertions with Clang` linking [failure](https://github.com/duckdb/duckdb/actions/runs/25645238791/job/75274381203#step:8:546):
```

mold: error: undefined symbol: __atomic_is_lock_free
>>> referenced by ub_test_common.cpp
>>>               test/common/CMakeFiles/test_common.dir/ub_test_common.cpp.o:(____C_A_T_C_H____T_E_S_T____40())>>> referenced by ub_test_common.cpp
>>>               test/common/CMakeFiles/test_common.dir/ub_test_common.cpp.o:(____C_A_T_C_H____T_E_S_T____40())
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[17/18] Linking CXX executable duckdb
```

The C++ test `test/common/test_checked_integer.cpp:247` calls `std::atomic<int64_t>().is_lock_free()`:
```c++
TEST_CASE("CheckedInteger atomic operations", "[checked_integer]") {
        SECTION("is_lock_free / is_always_lock_free forward to underlying type") {
                std::atomic<ci64> a(0);
                REQUIRE(a.is_lock_free() == std::atomic<int64_t>().is_lock_free());
                REQUIRE(std::atomic<ci64>::is_always_lock_free == std::atomic<int64_t>::is_always_lock_free);
        }
```

On Linux/clang, `is_lock_free()` can lower to the runtime symbol `__atomic_is_lock_free`, which lives in `libatomic`.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9167.