### PR TITLE
Fix for SIGABRT in setting size on zero-capacity vector

### DIFF
--- a/src/function/cast/array_casts.cpp
+++ b/src/function/cast/array_casts.cpp
@@ -60,6 +60,7 @@ static bool ArrayToArrayCast(Vector &source, Vector &result, idx_t count, CastPa
 
 		if (ConstantVector::IsNull(source)) {
 			ConstantVector::SetNull(result, true);
+			return true;
 		}
 
 		auto &source_cc = ArrayVector::GetEntry(source);

--- a/test/fuzzer/duckfuzz/vector_size_out_of_range.test
+++ b/test/fuzzer/duckfuzz/vector_size_out_of_range.test
@@ -1,0 +1,10 @@
+# name: test/fuzzer/duckfuzz/vector_size_out_of_range.test
+# description: Coverage for wrong vector size
+# group: [duckfuzz]
+
+require core_functions
+
+statement error
+SELECT DISTINCT OPERATOR ( / ) + ARRAY [ ] :: INTERVAL SECONDS [9] [ ] :: SETOF NCHAR ARRAY :: FLOAT ;
+----
+Binder Error:


### PR DESCRIPTION
We should return early after setting size on a zero capacity vector instead of falling through. 

fixes https://github.com/duckdblabs/duckdb-internal/issues/9071