### PR TITLE
Fix variant selection vector index

### DIFF
--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -94,7 +94,7 @@ void VariantUtils::FindChildValues(const UnifiedVariantVectorData &variant, cons
 				continue;
 			}
 			auto value_id = variant.GetValuesIndex(row_index, nested_data_entry.children_idx + child_idx);
-			res[i] = static_cast<uint8_t>(value_id);
+			res[i] = value_id;
 			continue;
 		}
 		bool found_child = false;

--- a/test/sql/function/variant/variant_extract.test
+++ b/test/sql/function/variant/variant_extract.test
@@ -85,3 +85,8 @@ SELECT [
 ]
 ----
 [42, NULL, NULL]
+
+query I
+SELECT variant_extract((SELECT list(i) FROM range(500) t(i))::VARIANT, 300::UINTEGER)::BIGINT;
+----
+299


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22546

Both types are of `uint32_t`, we shouldn't downcast here which leads to incorrect result.