### PR TITLE
Internal #9226: Timestamp TimeZone Parsing

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -121,7 +121,6 @@ TimestampCastResult Timestamp::TryConvertTimestamp(const char *str, idx_t len, t
                                                    optional_ptr<int32_t> nanos, bool strict) {
 	string_t tz(nullptr, 0);
 	bool has_offset = false;
-	// We don't understand TZ without an extension, so fail if one was provided.
 	auto success = TryConvertTimestampTZ(str, len, result, use_offset, has_offset, tz, nanos);
 	if (success != TimestampCastResult::SUCCESS) {
 		return success;
@@ -144,7 +143,14 @@ TimestampCastResult Timestamp::TryConvertTimestamp(const char *str, idx_t len, t
 			return TimestampCastResult::SUCCESS;
 		}
 	}
-	return TimestampCastResult::ERROR_NON_UTC_TIMEZONE;
+	// We don't understand TZ without an extension, so fail if one was provided AND we were supposed to use it.
+	if (use_offset && !tz.Empty()) {
+		return TimestampCastResult::ERROR_NON_UTC_TIMEZONE;
+	} else if (strict && !tz.Empty()) {
+		return TimestampCastResult::STRICT_UTC;
+	} else {
+		return TimestampCastResult::SUCCESS;
+	}
 }
 
 bool Timestamp::TryFromTimestampNanos(timestamp_t input, int32_t nanos, timestamp_ns_t &result) {

--- a/test/sql/copy/csv/timestamp_with_tz.test
+++ b/test/sql/copy/csv/timestamp_with_tz.test
@@ -5,11 +5,8 @@
 statement ok
 CREATE TABLE tbl(id int, ts timestamp);
 
-# this fails without ICU loaded
-statement error
+statement ok
 COPY tbl FROM '{DATA_DIR}/csv/timestamp_with_tz.csv' (HEADER)
-----
-Error when converting column "ts". Could not convert string "2021-05-25 04:55:03.382494 EST" to 'TIMESTAMP'
 
 require icu
 
@@ -26,6 +23,9 @@ CREATE TABLE tbl_tz(id int, ts timestamptz);
 
 statement ok
 COPY tbl_tz FROM '{DATA_DIR}/csv/timestamp_with_tz.csv' (HEADER)
+
+statement ok
+SET Calendar='gregorian'
 
 statement ok
 SET TimeZone='UTC'

--- a/test/sql/types/timestamp/timestamp_timezone_cast.test
+++ b/test/sql/types/timestamp/timestamp_timezone_cast.test
@@ -18,18 +18,17 @@ SELECT TIMESTAMP '2021-05-25 04:55:03.382494 uTc';
 ----
 2021-05-25 04:55:03.382494
 
-statement error
+query I
 SELECT TIMESTAMP '2021-05-25 04:55:03.382494 EST';
 ----
-has a timestamp that is not UTC
+2021-05-25 04:55:03.382494
 
 require icu
 
-# FIXME: we should be able to make this work
-statement error
+query I
 SELECT TIMESTAMP '2021-05-25 04:55:03.382494 EST';
 ----
-has a timestamp that is not UTC
+2021-05-25 04:55:03.382494
 
 statement ok
 set Calendar='gregorian';


### PR DESCRIPTION
* Reject time zone fields only when parsing TIMESTAMP with use_offset == true;
* Return STRICT_UTC to flag strings with all time zones (not just UTC);
* Update tests for now valid TZ fields;