### PR TITLE
Bump Postgres, MySQL and ODBC

### DIFF
--- a/.github/config/extensions/mysql_scanner.cmake
+++ b/.github/config/extensions/mysql_scanner.cmake
@@ -1,9 +1,9 @@
-if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(mysql_scanner
             DONT_LINK
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-mysql
-            GIT_TAG e2760cb11f13a12ce74e8c798c07c48deb97a577
+            GIT_TAG 496ac9e3cb61bd8d6d1255f73cf69b958a311525
             SUBMODULES database-connector
             )
 endif()

--- a/.github/config/extensions/odbc_scanner.cmake
+++ b/.github/config/extensions/odbc_scanner.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(odbc_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/odbc-scanner
-            GIT_TAG 2f70a4b34c7b5aba795caa3300b208806cde24c9
+            GIT_TAG 8a3266017af8a9abf14a49e2fd5df83d64eb5520
             )
 endif()

--- a/.github/config/extensions/postgres_scanner.cmake
+++ b/.github/config/extensions/postgres_scanner.cmake
@@ -4,7 +4,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-postgres
-            GIT_TAG c89234f0b1985f4ee0f52f16e742a1ab2d4ae4f0
+            GIT_TAG 6b2b12cad3afef61e8a4637e714e8a88895fed1a
             SUBMODULES database-connector
             )
 endif()

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -520,6 +520,8 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"postgres_attach", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
     {"postgres_configure_pool", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
     {"postgres_execute", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
+    {"postgres_hstore_get", "postgres_scanner", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"postgres_hstore_to_json", "postgres_scanner", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"postgres_query", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
     {"postgres_scan", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
     {"postgres_scan_pushdown", "postgres_scanner", CatalogType::TABLE_FUNCTION_ENTRY},
@@ -1128,7 +1130,9 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"pg_experimental_filter_pushdown", "postgres_scanner"},
     {"pg_idle_in_transaction_timeout_millis", "postgres_scanner"},
     {"pg_null_byte_replacement", "postgres_scanner"},
+    {"pg_oauth_token", "postgres_scanner"},
     {"pg_pages_per_task", "postgres_scanner"},
+    {"pg_pool_acquire_mode", "postgres_scanner"},
     {"pg_pool_enable_reaper_thread", "postgres_scanner"},
     {"pg_pool_enable_thread_local_cache", "postgres_scanner"},
     {"pg_pool_health_check_query", "postgres_scanner"},
@@ -1168,9 +1172,12 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
 }; // END_OF_EXTENSION_SETTINGS
 
 static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
-    {"aws", "httpfs"},         {"azure", "azure"},     {"ducklake", "ducklake"},   {"gcs", "httpfs"},
-    {"huggingface", "httpfs"}, {"iceberg", "iceberg"}, {"mysql", "mysql_scanner"}, {"postgres", "postgres_scanner"},
-    {"r2", "httpfs"},          {"s3", "httpfs"},
+    {"aws", "httpfs"},          {"azure", "azure"},
+    {"ducklake", "ducklake"},   {"gcs", "httpfs"},
+    {"huggingface", "httpfs"},  {"iceberg", "iceberg"},
+    {"mysql", "mysql_scanner"}, {"postgres", "postgres_scanner"},
+    {"r2", "httpfs"},           {"rds", "postgres_scanner"},
+    {"s3", "httpfs"},
 }; // END_OF_EXTENSION_SECRET_TYPES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py


### PR DESCRIPTION
This PR updates Postgres, MySQL and ODBC extensions for 1.5.3.

There were no changes to SQLite extension.

Besides the changes to function and settings entries, new `rds` secret type is added to Postgres extension. Corresponding change to `EXTENSION_SECRET_PROVIDERS` is intended to be added along with the `aws` extension bump.

MySQL CMake script update also enables MySQL extension for `linux_amd64_musl` bringing in the change from #21162.