### PR TITLE
Explicitly handle `nan/inf/-inf` in JSON serializer and deserializer

### DIFF
--- a/extension/json/json_deserializer.cpp
+++ b/extension/json/json_deserializer.cpp
@@ -224,15 +224,19 @@ uint64_t JsonDeserializer::ReadUnsignedInt64() {
 }
 
 float JsonDeserializer::ReadFloat() {
-	auto val = GetNextValue();
-	if (!yyjson_is_real(val)) {
-		ThrowTypeError(val, "float");
-	}
-	return yyjson_get_real(val);
+	return LossyNumericCast<float>(ReadDouble());
 }
 
 double JsonDeserializer::ReadDouble() {
 	auto val = GetNextValue();
+	if (yyjson_is_raw(val)) {
+		double res;
+		string_t input(yyjson_get_raw(val));
+		if (!TryCast::Operation<string_t, double>(input, res)) {
+			throw InvalidInputException("Expected a floating point number, but got the string %s", input.GetString());
+		}
+		return res;
+	}
 	if (!yyjson_is_real(val)) {
 		ThrowTypeError(val, "double");
 	}

--- a/extension/json/json_serializer.cpp
+++ b/extension/json/json_serializer.cpp
@@ -171,13 +171,28 @@ void JsonSerializer::WriteValue(uhugeint_t value) {
 	stack.pop_back();
 }
 
+yyjson_mut_val *DoubleToJSONValue(yyjson_mut_doc *doc, double value) {
+	if (Value::FloatIsFinite(value)) {
+		// simple - finite json
+		return yyjson_mut_real(doc, value);
+	}
+	// represent infinities as strings
+	const char *str;
+	if (!Value::IsNan(value)) {
+		str = value < 0 ? "-Infinity" : "Infinity";
+	} else {
+		str = "NAN";
+	}
+	return yyjson_mut_raw(doc, str);
+}
+
 void JsonSerializer::WriteValue(float value) {
-	auto val = yyjson_mut_real(doc, value);
+	auto val = DoubleToJSONValue(doc, value);
 	PushValue(val);
 }
 
 void JsonSerializer::WriteValue(double value) {
-	auto val = yyjson_mut_real(doc, value);
+	auto val = DoubleToJSONValue(doc, value);
 	PushValue(val);
 }
 

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -54,6 +54,12 @@ SELECT json_deserialize_sql(json_serialize_sql('SELECT AND LAUNCH ROCKETS WHERE 
 ----
 Parser Error: Error parsing json: parser: syntax error at or near "AND"
 
+# Deserialize large double constants
+query I
+SELECT json_deserialize_sql(json_serialize_sql('SELECT 1e10000'));
+----
+SELECT 1e1000
+
 # Test Execute JSON Serialized SQL
 query I
 SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT 1 + 2'));


### PR DESCRIPTION
These aren't supported in JSON, so we shouldn't write them as floats. Instead write these values out as strings and parse them back on deserialization.