### PR TITLE
Bump AWS extension

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG b2649e68341a9ee717588dd23f277904727ce793
+            GIT_TAG 4bb2f0333ae38bc5ba0d61e503d3a2bbf240582d
             )
 endif()

--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -871,6 +871,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {{"s3/config", "h
                                                                 {"gcs/credential_chain", "aws"},
                                                                 {"r2/credential_chain", "aws"},
                                                                 {"aws/credential_chain", "aws"},
+                                                                {"rds/credential_chain", "aws"},
                                                                 {"azure/access_token", "azure"},
                                                                 {"azure/config", "azure"},
                                                                 {"azure/credential_chain", "azure"},

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1253,6 +1253,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"gcs/credential_chain", "aws"},
     {"r2/credential_chain", "aws"},
     {"aws/credential_chain", "aws"},
+    {"rds/credential_chain", "aws"},
     {"azure/access_token", "azure"},
     {"azure/config", "azure"},
     {"azure/credential_chain", "azure"},


### PR DESCRIPTION
This PR updates `duckdb-aws` extension to include
duckdb/duckdb-aws#144 change. This change introduces new `rds` secret type.

The same way like with other secret types (`s3`, `r2` etc) in `duckdb-aws`, the type itself is registered on consumer side in `duckdb-postgres` extension (added to `extension_entries.hpp` in #22579) and the provider for it is registered in `duckdb-aws`.

Unlike existing secret types (`s3`, `r2` etc) there is no `config` provider registered for `rds` in `duckdb-postgres` - only the `credential_chain` provider (in `duckdb-aws`) is used for this type.