### PR TITLE
Skip colref projection pullup over LOGICAL_DISTINCT

### DIFF
--- a/src/optimizer/projection_pullup.cpp
+++ b/src/optimizer/projection_pullup.cpp
@@ -80,6 +80,15 @@ void ProjectionPullup::InsertProjectionBelowOp(unique_ptr<LogicalOperator> &op, 
 
 void ProjectionPullup::PullUpColrefProjection(unique_ptr<LogicalOperator> &op, LogicalProjection &proj,
                                               vector<ColumnBinding> &proj_bindings) {
+	// LOGICAL_DISTINCT sets `everything_referenced = true` in RemoveUnusedColumns
+	// for its subtree. The projection above it acts as a binding barrier; removing
+	// it lets upstream references point past DISTINCT and breaks column pruning
+	// down to READ_PARQUET. Repro: TPC-DS Q54 regresses 4-5x without this guard.
+	if (proj.children[0]->type == LogicalOperatorType::LOGICAL_DISTINCT) {
+		ProjectionPullup next(optimizer, root);
+		next.Optimize(proj.children[0]);
+		return;
+	}
 	ColumnBindingReplacer replacer;
 	for (idx_t i = 0; i < proj.expressions.size(); i++) {
 		auto &colref = proj.expressions[i]->Cast<BoundColumnRefExpression>();


### PR DESCRIPTION
`PullUpColrefProjection` removes a colref-only `LOGICAL_PROJECTION` and rewrites its outputs to the child's bindings. When the child is `LOGICAL_DISTINCT`, that projection was acting as a binding barrier: its table_index relabels DISTINCT's outputs so upstream operators reference the projection rather than DISTINCT's child directly.

After the pullup, upstream references point past DISTINCT. `RemoveUnusedColumns` later visits DISTINCT and sets `everything_referenced = true` for the subtree, but by then upstream operators have already added DISTINCT's child bindings to `column_references`. Column pruning can no longer push back to `READ_PARQUET`.

In TPC-DS Q54 this produces a `PROJECTION` operator at depth 9 that emits 31 columns instead of 4. The `store_sales` parquet scan reads ~5x more bytes and the query regresses 4-5x against v1.5.2.

The fix bails out of `PullUpColrefProjection` when the projection's child is `LOGICAL_DISTINCT` and recurses into the DISTINCT subtree with fresh state. Other pullup paths are unchanged.

TPC-DS SF100 parquet views, 8 threads, 32GB memory, 5-trial median per binary:

| Query | v1.5.2 | main | this PR |
|---|---:|---:|---:|
| Q54 | 1.17s | 4.77s | 1.21s |

Plan classification across all 99 TPC-DS queries: only Q54 has a different plan with this PR. The other 98 queries produce byte-identical EXPLAIN output and are timing-neutral against main.

Tests:
- `./build/release/test/unittest '[optimizer]'`
- Q54 output hash matches `main` and v1.5.2
