### PR TITLE
Prefer filtered build sides for runtime filters

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -8,6 +8,7 @@ benchmark/micro/copy/to_parquet_partition_by_few.benchmark
 benchmark/micro/copy/to_parquet_partition_by_many.benchmark
 benchmark/micro/limit/parallel_limit.benchmark
 benchmark/micro/filter/parallel_complex_filter.benchmark
+benchmark/micro/join/join_filter_build_side.benchmark
 benchmark/micro/catalog/add_column_empty.benchmark
 benchmark/micro/groupby-parallel/many_groups_large_values_small.benchmark
 benchmark/tpch/csv/lineitem_csv_auto_detect.benchmark

--- a/benchmark/micro/join/join_filter_build_side.benchmark
+++ b/benchmark/micro/join/join_filter_build_side.benchmark
@@ -1,0 +1,28 @@
+# name: benchmark/micro/join/join_filter_build_side.benchmark
+# description: Prefer a filtered build side when it can produce a join filter for a large probe scan
+# group: [join]
+
+name Join Filter Build Side
+group micro
+subgroup join
+
+require parquet
+
+cache join_filter_build_side.duckdb
+
+load
+CREATE TABLE build_payload AS PIVOT (
+	SELECT i, 'c' || j::VARCHAR AS name, NULL::VARCHAR AS val
+	FROM range(200000) _(i), range(400) __(j)
+) ON name USING first(val) GROUP BY i;
+CREATE TABLE build AS SELECT (i * 50)::INTEGER AS id, i < 100 AS keep, * EXCLUDE(i) FROM build_payload;
+DROP TABLE build_payload;
+COPY (SELECT i::INTEGER AS id FROM range(10000000) _(i)) TO '${BENCHMARK_DIR}/join_filter_build_side_probe.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 50000);
+CREATE VIEW probe AS SELECT * FROM read_parquet('${BENCHMARK_DIR}/join_filter_build_side_probe.parquet');
+ANALYZE build;
+
+run
+SELECT *
+FROM probe p
+JOIN build b ON p.id = b.id
+WHERE b.keep;

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/column_binding.hpp"
@@ -59,6 +60,11 @@ struct PushdownFilterTarget {
 
 	LogicalGet &get;
 	vector<JoinFilterPushdownColumn> columns;
+};
+
+struct JoinFilterPushdownUtil {
+	static bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter);
+	static bool JoinTypeIsSupported(JoinType join_type);
 };
 
 struct JoinFilterPushdownInfo {

--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -4,18 +4,25 @@
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/row/tuple_data_layout.hpp"
 #include "duckdb/execution/ht_entry.hpp"
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
+#include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/main/settings.hpp"
 
 namespace duckdb {
+
+struct JoinFilterBuildSideHeuristics {
+	static constexpr idx_t MIN_FILTER_TARGET_CARDINALITY = 1000000;
+	static constexpr idx_t MAX_BUILD_TO_TARGET_RATIO = 64;
+};
 
 static void GetRowidBindings(LogicalOperator &op, vector<ColumnBinding> &bindings) {
 	if (op.type == LogicalOperatorType::LOGICAL_GET) {
@@ -98,6 +105,51 @@ static inline idx_t ComputeOverlappingBindings(const vector<ColumnBinding> &hays
 	return result;
 }
 
+static idx_t MaxDynamicFilterTargetCardinality(LogicalOperator &op, const Expression &expr) {
+	JoinFilterPushdownColumn column;
+	if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, column)) {
+		return 0;
+	}
+
+	vector<JoinFilterPushdownColumn> columns {std::move(column)};
+	vector<PushdownFilterTarget> targets;
+	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(op, std::move(columns), targets);
+
+	// Dynamic filters are applied at the scan target found here. Estimate the work that the
+	// filter can avoid at that point, even if later filters reduce the cardinality at the join.
+	idx_t result = 0;
+	for (auto &target : targets) {
+		auto &get = target.get;
+		result = MaxValue(result, get.has_estimated_cardinality ? get.estimated_cardinality : idx_t(0));
+	}
+	return result;
+}
+
+static double DynamicFilterBuildBonus(LogicalComparisonJoin &join, const idx_t probe_idx, const idx_t build_idx,
+                                      const idx_t build_cardinality) {
+	if (!JoinFilterPushdownOptimizer::IsFiltering(join.children[build_idx])) {
+		return 1;
+	}
+
+	idx_t max_target_cardinality = 0;
+	for (auto &cond : join.conditions) {
+		if (!cond.IsComparison() || cond.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
+			continue;
+		}
+		auto &probe_expr = probe_idx == 0 ? cond.GetLHS() : cond.GetRHS();
+		max_target_cardinality =
+		    MaxValue(max_target_cardinality, MaxDynamicFilterTargetCardinality(*join.children[probe_idx], probe_expr));
+	}
+	if (max_target_cardinality < JoinFilterBuildSideHeuristics::MIN_FILTER_TARGET_CARDINALITY) {
+		return 1;
+	}
+	if (build_cardinality > 0 &&
+	    build_cardinality > max_target_cardinality / JoinFilterBuildSideHeuristics::MAX_BUILD_TO_TARGET_RATIO) {
+		return 1;
+	}
+	return static_cast<double>(max_target_cardinality) / static_cast<double>(MaxValue<idx_t>(build_cardinality, 1));
+}
+
 BuildSize BuildProbeSideOptimizer::GetBuildSizes(const LogicalOperator &op, const idx_t lhs_cardinality,
                                                  const idx_t rhs_cardinality) {
 	BuildSize ret;
@@ -177,6 +229,17 @@ bool BuildProbeSideOptimizer::TryFlipJoinChildren(LogicalOperator &op) const {
 
 	bool swap = false;
 
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (JoinFilterPushdownUtil::JoinTypeIsSupported(join.join_type)) {
+			right_side_build_cost /= DynamicFilterBuildBonus(join, 0, 1, rhs_cardinality);
+		}
+		if (HasInverseJoinType(join.join_type) &&
+		    JoinFilterPushdownUtil::JoinTypeIsSupported(InverseJoinType(join.join_type))) {
+			left_side_build_cost /= DynamicFilterBuildBonus(join, 1, 0, lhs_cardinality);
+		}
+	}
+
 	idx_t left_child_joins = ChildHasJoins(*op.children[0]);
 	idx_t right_child_joins = ChildHasJoins(*op.children[1]);
 	// if the right child is a table scan, and the left child has joins, we should prefer the left child
@@ -219,7 +282,8 @@ bool BuildProbeSideOptimizer::TryFlipJoinChildren(LogicalOperator &op) const {
 }
 
 void BuildProbeSideOptimizer::VisitOperator(LogicalOperator &op) {
-	// then the currentoperator
+	VisitOperatorChildren(op);
+
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN: {
 		auto &join = op.Cast<LogicalComparisonJoin>();
@@ -273,8 +337,6 @@ void BuildProbeSideOptimizer::VisitOperator(LogicalOperator &op) {
 	default:
 		break;
 	}
-
-	VisitOperatorChildren(op);
 }
 
 } // namespace duckdb

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -20,7 +20,7 @@ namespace duckdb {
 JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
 }
 
-bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter) {
+bool JoinFilterPushdownUtil::PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColumn &filter) {
 	if (expr.GetReturnType().IsNested()) {
 		// nested columns are not supported for pushdown
 		return false;
@@ -48,10 +48,28 @@ bool PushdownJoinFilterExpression(const Expression &expr, JoinFilterPushdownColu
 		    GetTypeIdSize(tgt.InternalType()) > GetTypeIdSize(PhysicalType::INT64)) {
 			return false; // Only do this for (u)bigint and smaller
 		}
-		return PushdownJoinFilterExpression(*bound_cast.child, filter);
+		return JoinFilterPushdownUtil::PushdownJoinFilterExpression(*bound_cast.child, filter);
 	}
 	default:
 		return false;
+	}
+}
+
+bool JoinFilterPushdownUtil::JoinTypeIsSupported(JoinType join_type) {
+	switch (join_type) {
+	case JoinType::MARK:
+	case JoinType::SINGLE:
+	case JoinType::LEFT:
+	case JoinType::OUTER:
+	case JoinType::ANTI:
+	case JoinType::RIGHT_ANTI:
+		// cannot generate join filters for these join types
+		// mark/single - cannot change cardinality of probe side
+		// left/outer always need to include every row from probe side
+		// FIXME: anti/right_anti - we could do this, but need to invert the join conditions
+		return false;
+	default:
+		return true;
 	}
 }
 
@@ -150,7 +168,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 			auto &expr = proj.GetExpression(filter.probe_column_index);
-			if (!PushdownJoinFilterExpression(expr, filter)) {
+			if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, filter)) {
 				// cannot push through this expression - bail-out
 				return;
 			}
@@ -167,7 +185,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 				return;
 			}
 			auto &expr = aggr.GetExpression(filter.probe_column_index);
-			if (!PushdownJoinFilterExpression(expr, filter)) {
+			if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(expr, filter)) {
 				// cannot push through this expression - bail-out
 				return;
 			}
@@ -204,20 +222,8 @@ bool JoinFilterPushdownOptimizer::IsFiltering(const unique_ptr<LogicalOperator> 
 }
 
 void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &join) {
-	switch (join.join_type) {
-	case JoinType::MARK:
-	case JoinType::SINGLE:
-	case JoinType::LEFT:
-	case JoinType::OUTER:
-	case JoinType::ANTI:
-	case JoinType::RIGHT_ANTI:
-		// cannot generate join filters for these join types
-		// mark/single - cannot change cardinality of probe side
-		// left/outer always need to include every row from probe side
-		// FIXME: anti/right_anti - we could do this, but need to invert the join conditions
+	if (!JoinFilterPushdownUtil::JoinTypeIsSupported(join.join_type)) {
 		return;
-	default:
-		break;
 	}
 	// re-order conditions here - otherwise this will happen later on and invalidate the indexes we generate
 	PhysicalComparisonJoin::ReorderConditions(join.conditions);
@@ -244,7 +250,7 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		}
 
 		JoinFilterPushdownColumn pushdown_col;
-		if (!PushdownJoinFilterExpression(cond.GetLHS(), pushdown_col)) {
+		if (!JoinFilterPushdownUtil::PushdownJoinFilterExpression(cond.GetLHS(), pushdown_col)) {
 			continue;
 		}
 

--- a/test/optimizer/joins/join_filter_build_side.test
+++ b/test/optimizer/joins/join_filter_build_side.test
@@ -1,0 +1,42 @@
+# name: test/optimizer/joins/join_filter_build_side.test
+# description: Prefer filtered build sides when they can drive join filter pushdown
+# group: [joins]
+
+statement ok
+CREATE TABLE jf_probe AS SELECT range::INTEGER AS id FROM range(1000000);
+
+statement ok
+CREATE TABLE jf_build AS SELECT
+	range::INTEGER AS id,
+	range < 10 AS keep,
+	(range::VARCHAR || '1111') a,
+	(range::VARCHAR || '2222') b,
+	(range::VARCHAR || '3333') c,
+	(range::VARCHAR || '4444') d,
+	(range::VARCHAR || '5555') e,
+	(range::VARCHAR || '6666') f,
+	(range::VARCHAR || '7777') g,
+	(range::VARCHAR || '8888') h,
+	(range::VARCHAR || '9999') i,
+	(range::VARCHAR || '0000') j
+FROM range(100000);
+
+statement ok
+ANALYZE jf_probe;
+
+statement ok
+ANALYZE jf_build;
+
+statement ok
+PRAGMA explain_output='physical_only';
+
+# jf_build is wide enough that the normal build-side cost prefers jf_probe.
+# The filter on jf_build can generate a dynamic filter for the large jf_probe scan,
+# so jf_build should remain on the build side.
+query II
+EXPLAIN SELECT *
+FROM jf_probe p
+JOIN jf_build b ON p.id = b.id
+WHERE b.keep;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*jf_probe.*jf_build.*


### PR DESCRIPTION
This keeps the runtime-filter change local to build/probe-side optimization. When a filtered join side can produce a join filter for a large scan on the other side, the optimizer gives that build side a guarded bonus on top of the existing build-side cost.

The bonus uses the estimated cardinality of the scan that would receive the dynamic filter, and is only applied when the build side is small relative to that target. The expression and join-type checks are shared with `JoinFilterPushdownUtil`, so the cost signal stays aligned with the runtime filters the engine can actually produce.

I removed the broader join-order cost-model change after CI showed IMDB benchmark regressions. This PR no longer changes `cost_model.cpp`.

Impact:

SF100 TPC-DS on sorted Parquet, Azure `Standard_D4ads_v5` (4 vCPU), `threads=4`, `memory_limit='12GB'`, Linux page cache dropped before every query.

Base `3dd09a1d53` -> this PR `ca08677d10`:

- 99-query total: 1172.13s -> 1135.69s (1.03x, -3.1%)
- geomean query-time ratio: 0.985 (1.016x)
- Q13: 56.91s -> 11.41s (4.99x)
- Q85: 13.37s -> 4.45s (3.00x)
- Q72 is neutral in this reduced PR: 31.72s -> 31.82s

Raw output hashes match for 96/99 queries. The remaining Q18/Q65/Q71 results differ only by row order; sorted outputs match.

I also repeated Q13/Q23/Q44/Q46/Q48/Q85 in the opposite order (`PR` first, `base` second). Q44/Q46/Q48 were neutral there, and Q23 was neutral as well (58.47s vs 58.37s). Q13/Q85 retained the same large wins.

Tests:

- `ninja -C build/release duckdb unittest`
- `python3 scripts/ci/run_tests.py build/release/test/unittest test/optimizer/joins/join_filter_build_side.test`
- `python3 scripts/ci/run_tests.py build/release/test/unittest test/optimizer/*`
- `build/release/test/unittest`
- `PATH=/tmp/duckdb-format-venv/bin:$PATH python3 scripts/format.py origin/main --check --silent`
- `git diff --check`
