### PR TITLE
Fix free block for temporary file manageer

### DIFF
--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -197,7 +197,7 @@ TemporaryFileHandle::TemporaryFileLock::TemporaryFileLock(mutex &mutex) : lock(m
 
 TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size) {
 	TemporaryFileLock lock(file_lock);
-	if (index_manager.GetMaxIndex() >= max_allowed_index && index_manager.HasFreeBlocks()) {
+	if (index_manager.GetMaxIndex() >= max_allowed_index && !index_manager.HasFreeBlocks()) {
 		// file is at capacity
 		return TemporaryFileIndex();
 	}


### PR DESCRIPTION
Related to https://github.com/duckdb/duckdb/issues/22584

Hi team, current code reads to me: even there're free blocks in any of the temporary files, we still allocate new file
But I don't think the current implementation (first-fit) is perfect, see [here](https://github.com/duckdb/duckdb/issues/22584#issuecomment-4428682699); I'm thinking a better way might be iterating through all existing temporary files and find the best fit one, might be a followup PR in the main branch.