### PR TITLE
Show skipped test reasons in test runner

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -3,6 +3,7 @@ import argparse
 import concurrent.futures
 import contextlib
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -315,6 +316,41 @@ def normalize_output(output):
     return output or ""
 
 
+SKIPPED_TESTS_PATTERN = re.compile(r"All tests passed \((\d+) skipped tests,")
+SKIP_REASON_PATTERN = re.compile(r"(.+):\s+(\d+)$")
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str):
+    return ANSI_ESCAPE_PATTERN.sub("", text)
+
+
+def parse_skipped_tests_count(output: str):
+    match = SKIPPED_TESTS_PATTERN.search(strip_ansi(output))
+    if not match:
+        return 0
+    return int(match.group(1))
+
+
+def parse_skipped_test_reasons(output: str):
+    reasons = {}
+    lines = strip_ansi(output).splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip() != "Skipped tests for the following reasons:":
+            continue
+
+        for reason_line in lines[idx + 1 :]:
+            reason_line = reason_line.strip()
+            if not reason_line:
+                break
+            match = SKIP_REASON_PATTERN.match(reason_line)
+            if not match:
+                break
+            reasons[match.group(1)] = reasons.get(match.group(1), 0) + int(match.group(2))
+        break
+    return reasons
+
+
 def run_batch(config: TestRunnerConfig, batch):
     failed = False
     stdout = ""
@@ -596,6 +632,8 @@ def run_tests(config: TestRunnerConfig, batches):
     start = time.monotonic()
     state = BatchRunState()
     progress = DotProgressBar(len(batches))
+    total_skipped_tests = 0
+    skipped_reason_counts = {}
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=config.workers) as executor:
         future_to_batch = {}
@@ -623,6 +661,11 @@ def run_tests(config: TestRunnerConfig, batches):
                 if result["failed"]:
                     if handle_failed_batch(ctx, batch_info, result):
                         continue
+                else:
+                    combined_output = "\n".join([result["stdout"], result["stderr"]])
+                    total_skipped_tests += parse_skipped_tests_count(combined_output)
+                    for reason, count in parse_skipped_test_reasons(combined_output).items():
+                        skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 
             if not state.stop_launching:
@@ -634,7 +677,15 @@ def run_tests(config: TestRunnerConfig, batches):
         print(f"error: found {state.failed_count} test batch failures in {elapsed:.0f}s")
         return 1
 
-    print(f"all tests passed in {elapsed:.0f}s")
+    if total_skipped_tests > 0:
+        print(f"all tests passed in {elapsed:.0f}s ({total_skipped_tests} skipped tests)")
+    else:
+        print(f"all tests passed in {elapsed:.0f}s")
+    if skipped_reason_counts:
+        print()
+        print("Skipped tests for the following reasons:")
+        for reason in sorted(skipped_reason_counts):
+            print(f"{reason}: {skipped_reason_counts[reason]}")
     return 0
 
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -27,6 +27,181 @@ def start_runner(cli_args: list[str]):
 
 
 class RunTestsScriptTest(unittest.TestCase):
+    def test_reports_skipped_tests_summary(self):
+        cases = [
+            {
+                "name": "plain",
+                "stdout": """
+All tests passed (5 skipped tests, 123 assertions in 4 test cases)
+
+Skipped tests for the following reasons:
+require longdouble: 2
+require-env SOME_TOKEN: 3
+""",
+                "expected_skip_count": 5,
+                "expected_reasons": ["require longdouble: 2", "require-env SOME_TOKEN: 3"],
+            },
+            {
+                "name": "ansi",
+                "stdout": (
+                    "\x1b[36mAll tests passed (14 skipped tests, 2659 assertions in 86 test cases)\x1b[0m\n\n"
+                    "\x1b[1mSkipped tests for the following reasons:\x1b[0m\n"
+                    "\x1b[33mrequire httpfs: 1\x1b[0m\n"
+                    "\x1b[33mrequire icu: 2\x1b[0m\n"
+                    "\x1b[33mrequire-env LOCAL_EXTENSION_REPO: 5\x1b[0m\n"
+                ),
+                "expected_skip_count": 14,
+                "expected_reasons": ["require httpfs: 1", "require icu: 2", "require-env LOCAL_EXTENSION_REPO: 5"],
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                test_list_path = create_temp_file("test/sql/a.test\n")
+                try:
+                    with mock.patch(
+                        "scripts.ci.run_tests.run_batch",
+                        return_value={
+                            "failed": False,
+                            "stdout": case["stdout"],
+                            "stderr": "",
+                            "message": None,
+                            "peak_rss_bytes": 0,
+                        },
+                    ):
+                        proc = start_runner(
+                            [
+                                "--workers",
+                                "1",
+                                "--batch-size",
+                                "1",
+                                "--test-list",
+                                str(test_list_path),
+                                "--test-command",
+                                "echo fake-run {test_list}",
+                                "unused-binary",
+                            ]
+                        )
+                finally:
+                    test_list_path.unlink(missing_ok=True)
+
+                self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+                self.assertIn("all tests passed in ", proc.stdout)
+                self.assertIn(f"({case['expected_skip_count']} skipped tests)", proc.stdout)
+                self.assertIn("Skipped tests for the following reasons:", proc.stdout)
+                for expected_reason in case["expected_reasons"]:
+                    self.assertIn(expected_reason, proc.stdout)
+
+    def test_aggregates_skipped_tests_from_multiple_batches(self):
+        test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
+        batch_outputs = [
+            {
+                "failed": False,
+                "stdout": """
+All tests passed (2 skipped tests, 100 assertions in 1 test cases)
+
+Skipped tests for the following reasons:
+require windows: 1
+require-env A: 1
+""",
+                "stderr": "",
+                "message": None,
+                "peak_rss_bytes": 0,
+            },
+            {
+                "failed": False,
+                "stdout": """
+All tests passed (3 skipped tests, 100 assertions in 1 test cases)
+
+Skipped tests for the following reasons:
+require-env A: 2
+require-env B: 1
+""",
+                "stderr": "",
+                "message": None,
+                "peak_rss_bytes": 0,
+            },
+        ]
+        try:
+            with mock.patch("scripts.ci.run_tests.run_batch", side_effect=batch_outputs):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("(5 skipped tests)", proc.stdout)
+        self.assertIn("require windows: 1", proc.stdout)
+        self.assertIn("require-env A: 3", proc.stdout)
+        self.assertIn("require-env B: 1", proc.stdout)
+
+    def test_retry_only_counts_skips_from_successful_attempt(self):
+        test_list_path = create_temp_file("test/sql/a.test\n")
+        try:
+            with mock.patch(
+                "scripts.ci.run_tests.run_batch",
+                side_effect=[
+                    {
+                        "failed": True,
+                        "stdout": """
+All tests passed (7 skipped tests, 100 assertions in 1 test cases)
+
+Skipped tests for the following reasons:
+require windows: 7
+""",
+                        "stderr": "",
+                        "message": "first attempt failed",
+                        "peak_rss_bytes": 0,
+                    },
+                    {
+                        "failed": False,
+                        "stdout": """
+All tests passed (2 skipped tests, 100 assertions in 1 test cases)
+
+Skipped tests for the following reasons:
+require windows: 2
+""",
+                        "stderr": "",
+                        "message": None,
+                        "peak_rss_bytes": 0,
+                    },
+                ],
+            ):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--retry",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("(2 skipped tests)", proc.stdout)
+        summary_block = proc.stdout.rsplit("Skipped tests for the following reasons:", 1)[-1]
+        self.assertIn("require windows: 2", summary_block)
+        self.assertNotIn("require windows: 7", summary_block)
+
     def test_generate_list(self):
         listed_tests_path = create_temp_file(
             """


### PR DESCRIPTION
Print the combined skipped test reasons at the end of the test run:
```
$ python3 scripts/ci/run_tests.py build/release/test/unittest 
generated test list using: build/release/test/unittest --list-tests
found 4643 tests
config: workers=6, retry=0, max_retries=4, batch_size=10, batch_timeout_seconds=600
.................................................. [ 50%]
.................................................. [100%]
all tests passed in 37s (261 skipped tests)

Skipped tests for the following reasons:
require autocomplete: 72
require block_size: 2
require exact_vector_size: 2
require httpfs: 21
require icu: 55
require inet: 2
require json: 139
require longdouble: 2
require parquet: 291
require sqlite_scanner: 1
require tpcds: 8
require tpch: 38
require windows: 3
require-env LOCAL_EXTENSION_REPO: 7
require-env RUN_EXTENSION_UPDATE_TEST: 1
require-env TEST_PERSISTENT_SECRETS_AVAILABLE: 1
require-env VALIDATE_TAGS: 3
```