### PR TITLE
parser_tools is apparently now a dependency for postgres

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -204,7 +204,7 @@ jobs:
       exclude_archs: ${{ needs.load-extension-configs.outputs.main_extensions_exclude_archs }}
       opt_in_archs: ${{ needs.load-extension-configs.outputs.main_extensions_opt_in_archs }}
       extension_config: ${{ needs.load-extension-configs.outputs.main_extensions_config }}
-      extra_toolchains: 'unixodbc'
+      extra_toolchains: 'unixodbc;parser_tools'
       override_tag: ${{ inputs.override_git_describe }}
       override_duckdb_version: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests == 'true' && true || false }}


### PR DESCRIPTION
See https://github.com/duckdb/duckdb-postgres/blob/6b2b12cad3afef61e8a4637e714e8a88895fed1a/vcpkg_ports/libpq/portfile.cmake#L39.

I am running this vs `linux_arm64_musl` at https://github.com/carlopi/duckdb/actions/runs/25787326251/job/75743965320 to double check.