### PR TITLE
Add optional reason to 'mode skip' in tests

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -318,6 +318,7 @@ def normalize_output(output):
 
 SKIPPED_TESTS_PATTERN = re.compile(r"All tests passed \((\d+) skipped tests,")
 SKIP_REASON_PATTERN = re.compile(r"(.+):\s+(\d+)$")
+MODE_SKIP_REASON_PATTERN = re.compile(r"^mode skip(?:\s+(.*\S))?\s*$")
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
@@ -351,15 +352,32 @@ def parse_skipped_test_reasons(output: str):
     return reasons
 
 
+def parse_mode_skip_reasons(output: str):
+    reasons = {}
+    for line in strip_ansi(output).splitlines():
+        stripped = line.strip()
+        if SKIP_REASON_PATTERN.match(stripped):
+            continue
+        match = MODE_SKIP_REASON_PATTERN.match(stripped)
+        if not match:
+            continue
+        reason = match.group(1) or "unspecified"
+        reason_key = f"mode skip {reason}"
+        reasons[reason_key] = reasons.get(reason_key, 0) + 1
+    return reasons
+
+
 def extract_skipped_test_output(stdout: str, stderr: str):
     stdout_count = parse_skipped_tests_count(stdout)
     stdout_reasons = parse_skipped_test_reasons(stdout)
-    if stdout_count > 0 or stdout_reasons:
+    stdout_mode_skip_reasons = parse_mode_skip_reasons(stdout)
+    if stdout_count > 0 or stdout_reasons or stdout_mode_skip_reasons:
         return stdout
 
     stderr_count = parse_skipped_tests_count(stderr)
     stderr_reasons = parse_skipped_test_reasons(stderr)
-    if stderr_count > 0 or stderr_reasons:
+    stderr_mode_skip_reasons = parse_mode_skip_reasons(stderr)
+    if stderr_count > 0 or stderr_reasons or stderr_mode_skip_reasons:
         return stderr
 
     return ""
@@ -679,6 +697,8 @@ def run_tests(config: TestRunnerConfig, batches):
                     skipped_output = extract_skipped_test_output(result["stdout"], result["stderr"])
                     total_skipped_tests += parse_skipped_tests_count(skipped_output)
                     for reason, count in parse_skipped_test_reasons(skipped_output).items():
+                        skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
+                    for reason, count in parse_mode_skip_reasons(skipped_output).items():
                         skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -351,6 +351,20 @@ def parse_skipped_test_reasons(output: str):
     return reasons
 
 
+def extract_skipped_test_output(stdout: str, stderr: str):
+    stdout_count = parse_skipped_tests_count(stdout)
+    stdout_reasons = parse_skipped_test_reasons(stdout)
+    if stdout_count > 0 or stdout_reasons:
+        return stdout
+
+    stderr_count = parse_skipped_tests_count(stderr)
+    stderr_reasons = parse_skipped_test_reasons(stderr)
+    if stderr_count > 0 or stderr_reasons:
+        return stderr
+
+    return ""
+
+
 def run_batch(config: TestRunnerConfig, batch):
     failed = False
     stdout = ""
@@ -662,9 +676,9 @@ def run_tests(config: TestRunnerConfig, batches):
                     if handle_failed_batch(ctx, batch_info, result):
                         continue
                 else:
-                    combined_output = "\n".join([result["stdout"], result["stderr"]])
-                    total_skipped_tests += parse_skipped_tests_count(combined_output)
-                    for reason, count in parse_skipped_test_reasons(combined_output).items():
+                    skipped_output = extract_skipped_test_output(result["stdout"], result["stderr"])
+                    total_skipped_tests += parse_skipped_tests_count(skipped_output)
+                    for reason, count in parse_skipped_test_reasons(skipped_output).items():
                         skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -34,24 +34,38 @@ class RunTestsScriptTest(unittest.TestCase):
                 "stdout": """
 All tests passed (5 skipped tests, 123 assertions in 4 test cases)
 
+mode skip flaky planner
+mode skip unsupported
+
 Skipped tests for the following reasons:
 require longdouble: 2
 require-env SOME_TOKEN: 3
 """,
                 "expected_skip_count": 5,
-                "expected_reasons": ["require longdouble: 2", "require-env SOME_TOKEN: 3"],
+                "expected_reasons": [
+                    "require longdouble: 2",
+                    "require-env SOME_TOKEN: 3",
+                    "mode skip flaky planner: 1",
+                    "mode skip unsupported: 1",
+                ],
             },
             {
                 "name": "ansi",
                 "stdout": (
                     "\x1b[36mAll tests passed (14 skipped tests, 2659 assertions in 86 test cases)\x1b[0m\n\n"
+                    "\x1b[33mmode skip flaky parser\x1b[0m\n"
                     "\x1b[1mSkipped tests for the following reasons:\x1b[0m\n"
                     "\x1b[33mrequire httpfs: 1\x1b[0m\n"
                     "\x1b[33mrequire icu: 2\x1b[0m\n"
                     "\x1b[33mrequire-env LOCAL_EXTENSION_REPO: 5\x1b[0m\n"
                 ),
                 "expected_skip_count": 14,
-                "expected_reasons": ["require httpfs: 1", "require icu: 2", "require-env LOCAL_EXTENSION_REPO: 5"],
+                "expected_reasons": [
+                    "require httpfs: 1",
+                    "require icu: 2",
+                    "require-env LOCAL_EXTENSION_REPO: 5",
+                    "mode skip flaky parser: 1",
+                ],
             },
         ]
 
@@ -100,6 +114,8 @@ require-env SOME_TOKEN: 3
                 "stdout": """
 All tests passed (2 skipped tests, 100 assertions in 1 test cases)
 
+mode skip flaky planner
+
 Skipped tests for the following reasons:
 require windows: 1
 require-env A: 1
@@ -112,6 +128,9 @@ require-env A: 1
                 "failed": False,
                 "stdout": """
 All tests passed (3 skipped tests, 100 assertions in 1 test cases)
+
+mode skip flaky planner
+mode skip unsupported
 
 Skipped tests for the following reasons:
 require-env A: 2
@@ -145,6 +164,8 @@ require-env B: 1
         self.assertIn("require windows: 1", proc.stdout)
         self.assertIn("require-env A: 3", proc.stdout)
         self.assertIn("require-env B: 1", proc.stdout)
+        self.assertIn("mode skip flaky planner: 2", proc.stdout)
+        self.assertIn("mode skip unsupported: 1", proc.stdout)
 
     def test_does_not_double_count_summary_when_in_stdout_and_stderr(self):
         test_list_path = create_temp_file("test/sql/a.test\n")

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -146,6 +146,47 @@ require-env B: 1
         self.assertIn("require-env A: 3", proc.stdout)
         self.assertIn("require-env B: 1", proc.stdout)
 
+    def test_does_not_double_count_summary_when_in_stdout_and_stderr(self):
+        test_list_path = create_temp_file("test/sql/a.test\n")
+        skip_summary = """
+All tests passed (4 skipped tests, 100 assertions in 1 test cases)
+
+Skipped tests for the following reasons:
+require json: 3
+require-env FOO: 1
+"""
+        try:
+            with mock.patch(
+                "scripts.ci.run_tests.run_batch",
+                return_value={
+                    "failed": False,
+                    "stdout": skip_summary,
+                    "stderr": skip_summary,
+                    "message": None,
+                    "peak_rss_bytes": 0,
+                },
+            ):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("(4 skipped tests)", proc.stdout)
+        self.assertIn("require json: 3", proc.stdout)
+        self.assertIn("require-env FOO: 1", proc.stdout)
+
     def test_retry_only_counts_skips_from_successful_attempt(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
         try:

--- a/test/extension/autoloading_encodings.test
+++ b/test/extension/autoloading_encodings.test
@@ -2,7 +2,7 @@
 # description: Test autoloading of encodings.
 # group: [extension]
 
-mode skip
+mode skip instable
 
 require-env LOCAL_EXTENSION_REPO
 

--- a/test/extension/test_loadable_optimizer.test
+++ b/test/extension/test_loadable_optimizer.test
@@ -6,7 +6,7 @@ require skip_reload
 
 require notmingw
 
-mode skip
+mode skip instable
 
 # FIXME: not going to do this now
 statement ok

--- a/test/fuzzer/afl/issue_7551.test
+++ b/test/fuzzer/afl/issue_7551.test
@@ -3,7 +3,7 @@
 # group: [afl]
 
 # FIXME - internal exception is thrown
-mode skip
+mode skip flaky
 
 statement ok
 CREATE TABLE t0(c0 VARCHAR);

--- a/test/fuzzer/pedro/another_binder_error.test
+++ b/test/fuzzer/pedro/another_binder_error.test
@@ -2,7 +2,7 @@
 # description: Issue #4978 (issue 48): Another Binder Issue
 # group: [pedro]
 
-mode skip
+mode skip flaky
 
 statement error
 SELECT avg(0) c0, (SELECT 0 OFFSET c0);

--- a/test/fuzzer/pedro/parser_roundtrip.test
+++ b/test/fuzzer/pedro/parser_roundtrip.test
@@ -14,7 +14,7 @@ statement ok
 SELECT "x-x"."y-y" FROM (SELECT 42) AS "x-x"("y-y");
 
 # FIXME: explicit cross joins not rendered correctly (yet)
-mode skip
+mode skip flaky
 
 query I
 SELECT 1 FROM ((SELECT 2) t0(c0) JOIN (SELECT 3) t1(c0) ON TRUE), ((SELECT 4) t2(c0) JOIN ((SELECT 5) t3(c0) CROSS JOIN (SELECT 6) t4(c0)) ON TRUE);

--- a/test/fuzzer/sqlsmith/statistics_assertion_trigger.test
+++ b/test/fuzzer/sqlsmith/statistics_assertion_trigger.test
@@ -3,7 +3,7 @@
 # group: [sqlsmith]
 
 # FIXME
-mode skip
+mode skip flaky
 
 statement ok
 create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();

--- a/test/fuzzer/sqlsmith/subquery_binding_error.test
+++ b/test/fuzzer/sqlsmith/subquery_binding_error.test
@@ -3,7 +3,7 @@
 # group: [sqlsmith]
 
 # FIXME
-mode skip
+mode skip flaky
 
 statement ok
 CREATE TABLE all_types("varchar" VARCHAR);

--- a/test/ldbc/ldbc-empty.test
+++ b/test/ldbc/ldbc-empty.test
@@ -201,7 +201,7 @@ SELECT messageYear, isComment, lengthCategory
 
 # Q2. Top tags for country, age, gender, time
 # FIXME: date_part from interval
-mode skip
+mode skip unsupported
 
 statement ok
 SELECT co.pl_name AS "country.name"
@@ -522,7 +522,7 @@ SELECT p.personid AS "person.id"
 ;
 
 
-mode skip
+mode skip unsupported
 #  Q11. Unrelated replies
 # not supported: several array/string array stuff
 statement ok
@@ -637,7 +637,7 @@ HAVING count(*) > 400
  LIMIT 100
 ;
 
-mode skip
+mode skip unsupported
 # Q13. Popular Tags per month in a country
 # unsupported: ARRAY syntax
 statement ok
@@ -761,7 +761,7 @@ SELECT personid AS "person.id"
  LIMIT 100
 ;
 
-mode skip
+mode skip unsupported
 # Q16. Experts in social circle
 # FIXME: array syntax, ROW syntax
 statement ok

--- a/test/optimizer/move_constants.test
+++ b/test/optimizer/move_constants.test
@@ -106,7 +106,7 @@ query I nosort mult_left_negative_flip
 EXPLAIN SELECT X>5 FROM test
 ----
 
-mode skip
+mode skip instable
 
 # FIXME
 # negation

--- a/test/optimizer/pushdown/parquet_or_pushdown.test
+++ b/test/optimizer/pushdown/parquet_or_pushdown.test
@@ -5,7 +5,7 @@
 require parquet
 
 # FIXME: re-enable when or pushdown is fixed
-mode skip
+mode skip instable
 
 # Multiple column in the root OR node, don't push down
 query II

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -335,7 +335,7 @@ select * from t0 where (NULL OR cast(t0.c1 as bool)) order by all;
 2
 
 
-mode skip
+mode skip instable
 
 #### numeric statistics
 # notequal and constant > max
@@ -361,7 +361,7 @@ SELECT * FROM integers WHERE a!=10 OR a>3
 statement ok
 PRAGMA enable_profiling
 
-mode skip
+mode skip instable
 
 # should return 2 rows: 1 and 5
 query II

--- a/test/optimizer/statistics/statistics_is_null.test
+++ b/test/optimizer/statistics/statistics_is_null.test
@@ -108,7 +108,7 @@ SELECT i1.i IS NULL FROM integers i1 FULL OUTER JOIN integers i2 ON (false) ORDE
 0
 
 # FIXME: we don't yet correctly track when columns don't contain valid values
-mode skip
+mode skip instable
 
 statement ok
 CREATE TABLE integers3 AS SELECT * FROM (VALUES (NULL), (NULL), (NULL)) tbl(i);

--- a/test/optimizer/transitive_filters.test
+++ b/test/optimizer/transitive_filters.test
@@ -139,7 +139,7 @@ logical_opt	<REGEX>:.*\(col1 < 5\).*
 
 
 # FIXME - disabled because of bugs in the filter combiner
-mode skip
+mode skip instable
 
 ### Complex transitive filters #################################################
 #columns i and j correspond to columns: col0 and col1 in the optimized logical plan

--- a/test/optimizer/zonemaps.test
+++ b/test/optimizer/zonemaps.test
@@ -19,7 +19,7 @@ explain select count(*) from t where b <=3 and b>=0;
 ----
 physical_plan	<REGEX>:.*Filters:.*
 
-mode skip
+mode skip instable
 # FIXME
 
 #   2) In-clause based on in-clause range/boundary zonemap check

--- a/test/parquet/encrypted_parquet.test
+++ b/test/parquet/encrypted_parquet.test
@@ -4,7 +4,7 @@
 
 # TODO: re-enable these tests once we encrypt the full Parquet Encryption spec
 # for now, parquet crypto tests are in test/sql/copy/parquet/parquet_encryption.test_slow
-mode skip
+mode skip instable
 
 require parquet
 

--- a/test/parquet/test_parquet_reader.test_slow
+++ b/test/parquet/test_parquet_reader.test_slow
@@ -879,7 +879,7 @@ SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/bug1589.parquet') limit 5
 200	NULL	
 300	NULL	
 
-mode skip
+mode skip instable
 
 query I
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/arrow/hadoop_lz4_compressed_larger.parquet') limit 50;
@@ -935,7 +935,7 @@ f2807544-a424-444a-add3-3d5d486b70e2
 d0018041-41e3-4013-ba90-535ba03d46c3	
 c50e8ade-6051-436f-a26e-acc9c0594be5	
 
-mode skip
+mode skip instable
 
 query III
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/arrow/non_hadoop_lz4_compressed.parquet') limit 50;
@@ -1045,7 +1045,7 @@ SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/arrow/nullable.impala.par
 6	NULL	NULL	NULL	NULL	NULL
 7	NULL	[NULL, [5, 6]]	{k1=NULL, k3=NULL}	NULL	{'A': 7, 'b': [2, 3, NULL], 'C': {'d': [[], [NULL], NULL]}, 'g': NULL}
 
-mode skip
+mode skip instable
 
 query III
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/arrow/hadoop_lz4_compressed.parquet') limit 50;

--- a/test/parquet/variant/variant_multiple_files.test
+++ b/test/parquet/variant/variant_multiple_files.test
@@ -46,7 +46,7 @@ Not implemented Error: ColumnWriter of type 'VARIANT' requires a transform, but 
 
 # Enable these when the above statement no longer fails
 # These tests are added to help remind that the multiple-file-scanning logic likely needs adjusting when variants are allowed in non-root columns
-mode skip
+mode skip instable
 
 query I
 select count(*)

--- a/test/sql/aggregate/aggregates/histogram_table_function.test
+++ b/test/sql/aggregate/aggregates/histogram_table_function.test
@@ -114,7 +114,7 @@ SELECT * FROM histogram_values(booleans, b::INTEGER)
 0	75
 1	25
 
-mode skip
+mode skip instable
 
 # FIXME: booleans do not work yet because of quantile turning any unsupported type into VARCHAR
 query II

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -306,7 +306,7 @@ SELECT g, FINALIZE(favg(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 
 # we skip these for now as argmin/argmax now has a custom binder (so that it can work with extension types like JSON)
 # otherwise we get "Binder Error: Cannot use EXPORT_STATE on aggregate functions with custom binders"
-mode skip
+mode skip instable
 
 query II nosort res7
 select argmin(a,b), argmax(a,b) from (values (1,1), (2,2), (8,8), (10,10)) s(a,b);

--- a/test/sql/alter/alter_col/test_not_null_in_tran.test
+++ b/test/sql/alter/alter_col/test_not_null_in_tran.test
@@ -226,7 +226,7 @@ COMMIT
 statement ok
 INSERT INTO t VALUES(NULL)
 
-mode skip
+mode skip instable
 # Scenario #5, Insert null, delete null locally, then alter
 statement ok
 DROP TABLE IF EXISTS t

--- a/test/sql/attach/attach_encryption_fallback_readonly.test
+++ b/test/sql/attach/attach_encryption_fallback_readonly.test
@@ -2,7 +2,7 @@
 # description: Ensure the fallback crypto implementation is read-only
 # group: [attach]
 
-mode skip
+mode skip instable
 
 require vector_size 2048
 

--- a/test/sql/attach/reattach_schema.test
+++ b/test/sql/attach/reattach_schema.test
@@ -100,7 +100,7 @@ SELECT one()
 1
 
 # FIXME - this leads to infinite recursion
-mode skip
+mode skip instable
 
 query I
 SELECT * FROM range(3)

--- a/test/sql/catalog/dependencies/test_concurrent_index_creation.test
+++ b/test/sql/catalog/dependencies/test_concurrent_index_creation.test
@@ -2,7 +2,7 @@
 # description: Test concurrent alter and rename of tables
 # group: [dependencies]
 
-mode skip
+mode skip flaky
 
 require skip_reload
 

--- a/test/sql/catalog/function/struct_extract_macro.test
+++ b/test/sql/catalog/function/struct_extract_macro.test
@@ -10,7 +10,7 @@ SELECT my_extract({'a': {'b': 42}})
 ----
 42
 
-mode skip
+mode skip instable
 # FIXME: this does not work yet due to the way in which macro functions are bound
 # as it is not trivial to fix, for now we leave it as is
 

--- a/test/sql/copy/csv/14874.test
+++ b/test/sql/copy/csv/14874.test
@@ -2,7 +2,7 @@
 # description: Test for issue #14784
 # group: [csv]
 
-mode skip
+mode skip instable
 
 query I
 SELECT count(*) FROM read_csv('{DATA_DIR}/csv/drug_exposure.csv');

--- a/test/sql/copy/csv/parallel/csv_parallel_clickbench.test_slow
+++ b/test/sql/copy/csv/parallel/csv_parallel_clickbench.test_slow
@@ -2,7 +2,7 @@
 # description: Test parallel read CSV function on Clickbench
 # group: [parallel]
 
-mode skip
+mode skip flaky
 
 require httpfs
 

--- a/test/sql/copy/csv/parallel/parallel_csv_union_by_name.test
+++ b/test/sql/copy/csv/parallel/parallel_csv_union_by_name.test
@@ -57,7 +57,7 @@ LIMIT 1;
 ----
 VARCHAR	BIGINT	BIGINT	VARCHAR	BIGINT
 
-mode skip
+mode skip flaky
 
 # projection pushdown
 query II

--- a/test/sql/copy/csv/parallel/test_7578.test
+++ b/test/sql/copy/csv/parallel/test_7578.test
@@ -26,7 +26,7 @@ from  read_csv('{DATA_DIR}/csv/bug_7578.csv', delim='\t', quote = '`', columns={
 
 
 # FIXME: this fails randomly
-mode skip
+mode skip flaky
 
 statement ok
 pragma threads=2

--- a/test/sql/copy/csv/parallel/test_parallel_error_messages.test
+++ b/test/sql/copy/csv/parallel/test_parallel_error_messages.test
@@ -34,7 +34,7 @@ SELECT * FROM read_csv('{DATA_DIR}/csv/wrongtype.csv', sep=',', columns={'h1': i
 Column at position: 0 Set type: INTEGER Sniffed type: VARCHAR
 
 # FIXME sporadically a few of these succeed
-mode skip
+mode skip flaky
 
 # the first error is on line 10002
 statement error

--- a/test/sql/copy/csv/test_big_compressed.test_slow
+++ b/test/sql/copy/csv/test_big_compressed.test_slow
@@ -4,7 +4,7 @@
 
 # This test is way too slow to run on CI, generating a SF100 TPC-H lineitem file takes a LOT of time.
 # Still useful to check for problems locally.
-mode skip
+mode skip instable
 
 require tpch
 

--- a/test/sql/copy/csv/test_lineitem_gz.test
+++ b/test/sql/copy/csv/test_lineitem_gz.test
@@ -3,7 +3,7 @@
 # group: [csv]
 
 # No way CI can handle this
-mode skip
+mode skip instable
 
 
 require tpch

--- a/test/sql/copy/csv/test_skip.test_slow
+++ b/test/sql/copy/csv/test_skip.test_slow
@@ -185,7 +185,7 @@ from read_csv('{TEST_DIR}/skip_2.csv',skip=10000, buffer_size = {buffer_size})
 endloop
 
 # Skipping to make it not fail OSX Release
-mode skip
+mode skip instable
 
 # Multifile Testing
 

--- a/test/sql/copy/parquet/afl.test
+++ b/test/sql/copy/parquet/afl.test
@@ -2,7 +2,7 @@
 # description: Read afl-generated parquet files
 # group: [parquet]
 
-mode skip
+mode skip instable
 
 require parquet
 

--- a/test/sql/copy/parquet/broken_parquet.test
+++ b/test/sql/copy/parquet/broken_parquet.test
@@ -32,7 +32,7 @@ statement error
 select count(*) from parquet_scan('test/sql/copy/parquet/broken/garbledfooter.parquet')
 ----
 
-mode skip
+mode skip instable
 
 statement error
 from parquet_scan('test/sql/copy/parquet/broken/broken_structure.parquet')

--- a/test/sql/copy/parquet/parquet2strings.test
+++ b/test/sql/copy/parquet/parquet2strings.test
@@ -17,7 +17,7 @@
 # ref2.write.csv("p2strings.csv")
 
 # for now
-mode skip
+mode skip instable
 
 require parquet
 

--- a/test/sql/copy/parquet/test_parquet_stats.test
+++ b/test/sql/copy/parquet/test_parquet_stats.test
@@ -83,7 +83,7 @@ statement ok
 SET parquet_metadata_cache=true;
 
 # we no longer gather stats with parquet_metadata_cache=true (for now?)
-mode skip
+mode skip instable
 
 # no stats since there are two files and the cache is on but we have not read all files yet
 query I nosort nostats

--- a/test/sql/copy_database/copy_database_different_types.test
+++ b/test/sql/copy_database/copy_database_different_types.test
@@ -15,7 +15,7 @@ statement ok
 INSERT INTO test VALUES (42, 88, 'hello');
 
 # FIXME - (unique) indexes aren't copied currently
-mode skip
+mode skip instable
 
 statement ok
 CREATE UNIQUE INDEX i_unique ON test(a);
@@ -75,7 +75,7 @@ SELECT * FROM v1;
 42	88	hello
 
 # FIXME - unique indexes aren't copied currently
-mode skip
+mode skip instable
 
 statement error
 INSERT INTO test VALUES (42, 88, 'hello');

--- a/test/sql/copy_database/copy_database_fk.test
+++ b/test/sql/copy_database/copy_database_fk.test
@@ -3,7 +3,7 @@
 # group: [copy_database]
 
 # FIXME - this is not working right now - we need to correctly take dependencies into account for COPY FROM DATABASE
-mode skip
+mode skip instable
 
 statement ok
 CREATE TABLE pk_integers(i INTEGER PRIMARY KEY)

--- a/test/sql/export/export_types.test
+++ b/test/sql/export/export_types.test
@@ -3,7 +3,7 @@
 # group: [export]
 
 # Because of ordering issues in EXPORT DATABASE we can't IMPORT this database
-mode skip
+mode skip instable
 
 statement ok
 BEGIN TRANSACTION

--- a/test/sql/filter/test_zonemap.test_slow
+++ b/test/sql/filter/test_zonemap.test_slow
@@ -4,7 +4,7 @@
 
 # FIXME: temporarily removed because of too much memory usage on 32-bit
 # should be re-enabled when validity segments are no longer limited to 80 vectors
-mode skip
+mode skip instable
 
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;

--- a/test/sql/index/art/constraints/test_art_tx_same_row_id.test
+++ b/test/sql/index/art/constraints/test_art_tx_same_row_id.test
@@ -3,7 +3,7 @@
 # group: [constraints]
 
 # FIXME: We need to fix the internal issue #3702
-mode skip
+mode skip instable
 
 statement ok
 SET immediate_transaction_mode = true;

--- a/test/sql/index/art/nodes/test_art_prefix_transform_deprecated_create.test
+++ b/test/sql/index/art/nodes/test_art_prefix_transform_deprecated_create.test
@@ -3,7 +3,7 @@
 # group: [nodes]
 
 # FIXME: sporadically breaks
-mode skip
+mode skip instable
 
 statement ok
 SET checkpoint_threshold = '10.0 GB';

--- a/test/sql/index/art/storage/test_upsert_reclaim_space.test_slow
+++ b/test/sql/index/art/storage/test_upsert_reclaim_space.test_slow
@@ -2,7 +2,7 @@
 # description: Test that the block manager reclaims index memory after UPSERT.
 # group: [storage]
 
-mode skip
+mode skip instable
 
 load {TEST_DIR}/test_reclaim_upsert_space.db
 

--- a/test/sql/join/inner/join_cross_product.test
+++ b/test/sql/join/inner/join_cross_product.test
@@ -32,7 +32,7 @@ select * from t1 join t2 on (i=j), t3 join t4 on (k=l) order by 1, 2, 3, 4;
 1	1	2	2
 1	1	3	3
 
-mode skip
+mode skip instable
 
 # lateral join
 query IIII rowsort

--- a/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
+++ b/test/sql/outofcore/leftover_temp_files_issue_6420.test_slow
@@ -28,7 +28,7 @@ CREATE OR REPLACE TEMPORARY TABLE ans AS SELECT l1.* FROM lineitem1 l1;
 # FIXME: This is a significant regression because we no longer evict "tiny buffers", of which we're
 # FIXME: allocating plenty here. That means no temporary files are showing up.
 
-mode skip
+mode skip instable
 
 query I
 SELECT COUNT(*) > 0 FROM duckdb_temporary_files()

--- a/test/sql/parallelism/interquery/parallel_dependencies_catalog_operations.test_slow
+++ b/test/sql/parallelism/interquery/parallel_dependencies_catalog_operations.test_slow
@@ -3,7 +3,7 @@
 # group: [interquery]
 
 # # FIXME: this test triggers an internal exception
-mode skip
+mode skip flaky
 
 concurrentloop threadid 0 11
 

--- a/test/sql/peg_parser/transformer/load_statement.test
+++ b/test/sql/peg_parser/transformer/load_statement.test
@@ -2,7 +2,7 @@
 # description: Test analyze and vacuum statements in peg parser
 # group: [transformer]
 
-mode skip
+mode skip instable
 
 require autocomplete
 

--- a/test/sql/pg_catalog/sqlalchemy.test
+++ b/test/sql/pg_catalog/sqlalchemy.test
@@ -315,7 +315,7 @@ ORDER BY
 	t.relname,
 	i.relname
 
-mode skip
+mode skip instable
 # FIXME: ANY(list) in left outer join
 # this will be fixed by either allowing subqueries in left-outer joins
 # or by modifying ANY(list) to be a function instead of a rewrite to a subquery

--- a/test/sql/sample/table_samples/basic_sample_tests.test
+++ b/test/sql/sample/table_samples/basic_sample_tests.test
@@ -1,7 +1,7 @@
 # name: test/sql/sample/table_samples/basic_sample_tests.test
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # currently require fixed vector size since the "randomness" of the sample depends on
 # the vector size. If the vector size decreases, the randomness of the sample decreases

--- a/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
+++ b/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
@@ -2,7 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048

--- a/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
+++ b/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
@@ -2,7 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048

--- a/test/sql/sample/table_samples/table_sample_is_stored.test_slow
+++ b/test/sql/sample/table_samples/table_sample_is_stored.test_slow
@@ -2,7 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048

--- a/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
+++ b/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
@@ -2,7 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048

--- a/test/sql/sample/table_samples/test_sample_types.test
+++ b/test/sql/sample/table_samples/test_sample_types.test
@@ -2,7 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 # test valid sampling types (for now only integral types)
 

--- a/test/sql/sample/table_samples/test_table_sample_errors.test
+++ b/test/sql/sample/table_samples/test_table_sample_errors.test
@@ -2,7 +2,7 @@
 # description: test table sampl[e errors
 # group: [table_samples]
 
-mode skip
+mode skip flaky
 
 statement ok
 create table t1 as select range a from range(204800);

--- a/test/sql/setops/test_pg_union.test
+++ b/test/sql/setops/test_pg_union.test
@@ -249,7 +249,7 @@ ORDER BY 1;
 123456.0
 
 # disabled due to the lack of CHAR() in DuckDB
-mode skip
+mode skip instable
 
 query I
 SELECT CAST(f1 AS char(4)) AS three FROM VARCHAR_TBL
@@ -440,7 +440,7 @@ query I
 #-- In this syntax, ORDER BY/LIMIT apply to the result of the EXCEPT
 
 # Bug in DuckDB
-mode skip
+mode skip instable
 
 query II
 SELECT q1,q2 FROM int8_tbl EXCEPT SELECT q2,q1 FROM int8_tbl

--- a/test/sql/storage/compression/roaring/roaring_bool_various_distributions.test_slow
+++ b/test/sql/storage/compression/roaring/roaring_bool_various_distributions.test_slow
@@ -2,7 +2,7 @@
 # description: Test bitpacking with nulls
 # group: [roaring]
 
-mode skip
+mode skip instable
 
 foreach ratio 0.01 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 0.99
 

--- a/test/sql/storage/concurrent_table_insertion.test_slow
+++ b/test/sql/storage/concurrent_table_insertion.test_slow
@@ -7,7 +7,7 @@
 # This is spurious and I cannot reproduce it locally.
 require no_vector_verification
 
-mode skip
+mode skip flaky
 
 load {TEST_DIR}/concurrent_table_insertions.db
 

--- a/test/sql/storage/parallel/insert_many_compressible_batches.test_slow
+++ b/test/sql/storage/parallel/insert_many_compressible_batches.test_slow
@@ -106,7 +106,7 @@ COMMIT
 # NULLs are RLE compressed (with Roaring)
 # So even with nulls we reach a similar compression ratio
 
-mode skip
+mode skip instable
 
 query I
 SELECT COUNT(DISTINCT block_id) < 8 FROM pragma_storage_info('integers_batched_load_nulls');

--- a/test/sql/storage/reclaim_space/test_reclaim_space_update_large_string.test
+++ b/test/sql/storage/reclaim_space/test_reclaim_space_update_large_string.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA force_checkpoint;
 
 # FIXME: overflow strings are not reclaimed yet when overwritten on updates
-mode skip
+mode skip instable
 
 # create a big string
 statement ok

--- a/test/sql/storage/temp_directory/max_swap_space_error.test
+++ b/test/sql/storage/temp_directory/max_swap_space_error.test
@@ -5,7 +5,7 @@
 # FIXME: This is a significant regression because we no longer evict "tiny buffers", of which we're
 # FIXME: allocating plenty here.
 # FIXME: I am skipping the test temporarily because if fails for a bunch of configurations.
-mode skip
+mode skip unsupported
 
 require noforcestorage
 

--- a/test/sql/storage/types/variant/variant_index.test
+++ b/test/sql/storage/types/variant/variant_index.test
@@ -9,7 +9,7 @@ CREATE TABLE tbl(col VARIANT UNIQUE, b INTEGER)
 Invalid type Error: Invalid Type [VARIANT]: Invalid type for index key.
 
 # See FIXME in art.cpp:ART::ART to support nested types
-mode skip
+mode skip instable
 
 statement ok
 INSERT into tbl select {'a': i, 'b': i % 5} col, i from range(1000) t(i)

--- a/test/sql/storage/types/variant/variant_stats_merging.test_slow
+++ b/test/sql/storage/types/variant/variant_stats_merging.test_slow
@@ -35,7 +35,7 @@ select count(*) from tbl where col is null
 122880
 
 # FIXME: this is wrong
-mode skip
+mode skip instable
 
 query I
 select s.has_null from (select s.fully_shredded.child_stats.stats s from (select stats(col) s from tbl limit 1));

--- a/test/sql/subquery/lateral/lateral_unnest.test_slow
+++ b/test/sql/subquery/lateral/lateral_unnest.test_slow
@@ -2,7 +2,7 @@
 # description: Test LATERAL UNNEST
 # group: [lateral]
 
-mode skip
+mode skip instable
 
 # FIXME: this causes an internal exception to be thrown
 statement ok

--- a/test/sql/subquery/lateral/pg_lateral.test
+++ b/test/sql/subquery/lateral/pg_lateral.test
@@ -274,7 +274,7 @@ where t1.f1 = ss.f1;
 doh!	4567890123456789	123	4567890123456789	doh!
 
 # FIXME: lateral chain with star
-mode skip
+mode skip instable
 
 query IIIIIII
 select * from
@@ -346,7 +346,7 @@ NULL	123456
 NULL	2147483647
 
 # FIXME: INTERNAL Error: Logical operator type "DELIM_JOIN" for dependent join
-mode skip
+mode skip instable
 
 query IIII rowsort qlateral
 select *, (select r from (select q1 as q2) x, (select q2 as r) y) from int8_tbl;
@@ -359,7 +359,7 @@ select *, (select r from (select q1 as q2) x, lateral (select q2 as r) y) from i
 mode unskip
 
 # FIXME: Not implemented Error: LATERAL not implemented
-mode skip
+mode skip instable
 
 query I
 select count(*) from tenk1 a, lateral generate_series(1,two) g;
@@ -413,7 +413,7 @@ select * from ((select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1) 
 0	0	0
 
 # FIXME: Not implemented Error: LATERAL not implemented
-mode skip
+mode skip instable
 
 query II
 select * from (values(1)) x(lb),

--- a/test/sql/subquery/scalar/subquery_row_in_any.test
+++ b/test/sql/subquery/scalar/subquery_row_in_any.test
@@ -68,7 +68,7 @@ FROM integers i1
 ----
 not yet supported
 
-mode skip
+mode skip instable
 
 # correlated
 query I

--- a/test/sql/subquery/scalar/test_correlated_grouping_set.test
+++ b/test/sql/subquery/scalar/test_correlated_grouping_set.test
@@ -49,7 +49,7 @@ NULL	16
 
 # aggregate with correlation in GROUPING SET and HAVING
 # FIXME: this is borked, related to #2335
-mode skip
+mode skip instable
 
 query II
 SELECT i, (SELECT MIN(i) FROM integers GROUP BY GROUPING SETS(i1.i, i) HAVING i1.i=i) AS j FROM integers i1 ORDER BY i;

--- a/test/sql/subquery/scalar/test_correlated_side_effects.test
+++ b/test/sql/subquery/scalar/test_correlated_side_effects.test
@@ -4,7 +4,7 @@
 
 # FIXME: we should not perform duplicate elimination for subqueries that have side-effects
 
-mode skip
+mode skip instable
 
 query I
 SELECT COUNT(DISTINCT

--- a/test/sql/tpch/tpch_power_test.test_slow
+++ b/test/sql/tpch/tpch_power_test.test_slow
@@ -3,7 +3,7 @@
 # group: [tpch]
 
 # TPC-H power test
-mode skip
+mode skip instable
 
 require parquet
 

--- a/test/sql/types/bignum/test_bignum_sum.test_slow
+++ b/test/sql/types/bignum/test_bignum_sum.test_slow
@@ -2,7 +2,7 @@
 # description: Test TPC-H Bignum Sum
 # group: [bignum]
 
-mode skip
+mode skip unsupported
 
 require parquet
 

--- a/test/sql/types/bignum/test_int_varchar_bignum_compatibility.test_slow
+++ b/test/sql/types/bignum/test_int_varchar_bignum_compatibility.test_slow
@@ -3,7 +3,7 @@
 # group: [bignum]
 
 # We skip this test since it tests a full integer range, only meant for local - release execution
-mode skip
+mode skip unsupported
 
 query I
 select distinct i::varchar::bignum = i::bignum from range(0, 2147483646) t(i);

--- a/test/sql/types/enum/test_alter_enum.test
+++ b/test/sql/types/enum/test_alter_enum.test
@@ -44,7 +44,7 @@ select typeof(name) from person limit 1
 ENUM('Pedro', 'Mark', 'Hannes')
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 # This should not be possible
 statement error

--- a/test/sql/types/enum/test_enum.test
+++ b/test/sql/types/enum/test_enum.test
@@ -59,7 +59,7 @@ CREATE TYPE bla AS ENUM ('sad','sad');
 statement ok
 CREATE TYPE mood_2 AS ENUM ('sad','Sad','SAD');
 
-mode skip
+mode skip unsupported
 #We should be able to update enums eventually
 statement ok
 ALTER TYPE mood ADD VALUE 'depressive';

--- a/test/sql/types/enum/test_enum_constraints.test
+++ b/test/sql/types/enum/test_enum_constraints.test
@@ -3,7 +3,7 @@
 # group: [enum]
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 statement ok
 CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');

--- a/test/sql/types/enum/test_enum_storage.test
+++ b/test/sql/types/enum/test_enum_storage.test
@@ -69,7 +69,7 @@ loop i 0 2
 restart
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 # We cant drop mood and we verify the constraint is still there after reloading the database
 statement error

--- a/test/sql/types/enum/test_enum_structs.test
+++ b/test/sql/types/enum/test_enum_structs.test
@@ -37,7 +37,7 @@ FROM person
 1	{'name': Mark, 'current_mood': happy}
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 statement error
 DROP TYPE mood
@@ -70,7 +70,7 @@ ALTER TABLE person ADD COLUMN c STRUCT(
     )
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 # we cannot drop the type after adding it back
 statement error
@@ -104,7 +104,7 @@ FROM person
 1	NULL
 
 # FIXME: dependencies between enums and tables are currently disabled
-mode skip
+mode skip unsupported
 
 # we cannot drop the type after adding it using an alter type
 statement error

--- a/test/sql/types/float/nan_aggregate.test
+++ b/test/sql/types/float/nan_aggregate.test
@@ -39,7 +39,7 @@ DROP TABLE floats
 endloop
 
 # still need to catch overflows during sum operation
-mode skip
+mode skip instable
 
 statement ok
 create table floats_doubles (f FLOAT, d DOUBLE);

--- a/test/sql/types/struct/struct_operations.test
+++ b/test/sql/types/struct/struct_operations.test
@@ -38,7 +38,7 @@ NULL	NULL	1	hello
 
 # unsupported operations
 # TODO
-mode skip
+mode skip instable
 
 # subquery
 query I

--- a/test/sql/update/test_update_from.test
+++ b/test/sql/update/test_update_from.test
@@ -103,7 +103,7 @@ SELECT * FROM test
 # test with multiple updates per row (which is undefined),
 # but in this case the last value in the table will win
 # FIXME:
-mode skip
+mode skip instable
 
 statement ok
 INSERT INTO src VALUES (7)

--- a/test/sql/upsert/test_problematic_conditional_do_update.test
+++ b/test/sql/upsert/test_problematic_conditional_do_update.test
@@ -9,7 +9,7 @@ CREATE TABLE users (
 );
 
 # FIXME: not consistent
-mode skip
+mode skip instable
 
 # The condition skips the last tuple
 statement error

--- a/test/sql/upsert/upsert_returning.test
+++ b/test/sql/upsert/upsert_returning.test
@@ -52,7 +52,7 @@ RETURNING *;
 
 
 # FIXME: not consistent
-mode skip
+mode skip instable
 
 # Here we have conflicts within the inserted data
 # Only the last occurrence of this conflict should be present in the returning clause.

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -851,11 +851,19 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_HALT) {
 			break;
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_MODE) {
-			if (token.parameters.size() != 1) {
-				parser.Fail("mode requires one parameter");
+			if (token.parameters.empty()) {
+				parser.Fail("mode requires at least one parameter");
 			}
 			string parameter = token.parameters[0];
 			if (parameter == "skip") {
+				string reason = "unspecified";
+				if (token.parameters.size() > 1) {
+					reason = token.parameters[1];
+					for (idx_t i = 2; i < token.parameters.size(); i++) {
+						reason += " " + token.parameters[i];
+					}
+				}
+				Printer::PrintF("mode skip %s", reason);
 				skip_level++;
 			} else if (parameter == "unskip") {
 				skip_level--;


### PR DESCRIPTION
@Tishj asked in #22618 if we could show and group `mode skip` reasons at the end of a test run.

This PR summarizes `mode skip` reasons:
```shell
$ make unittest_release
generated test list using: build/release/test/unittest --list-tests
found 4643 tests
config: workers=6, retry=0, max_retries=4, batch_size=10, batch_timeout_seconds=600
.................................................. [ 50%]
.................................................. [100%]
all tests passed in 39s (185 skipped tests)

Skipped tests for the following reasons:
mode skip flaky: 12
mode skip instable: 27
mode skip unsupported: 7
require autocomplete: 72
require block_size: 2
require exact_vector_size: 2
...
```