### PR TITLE
Rework expression rewriter to make it bottom-up and iterative

### DIFF
--- a/extension/core_functions/scalar/generic/alias.cpp
+++ b/extension/core_functions/scalar/generic/alias.cpp
@@ -3,14 +3,37 @@
 
 namespace duckdb {
 
+namespace {
+struct AliasBindData : public FunctionData {
+	explicit AliasBindData(string alias_p) : alias(std::move(alias_p)) {
+	}
+
+	string alias;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<AliasBindData>(alias);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<AliasBindData>();
+		return alias == other.alias;
+	}
+};
+
+unique_ptr<FunctionData> AliasBind(BindScalarFunctionInput &input) {
+	return make_uniq<AliasBindData>(input.GetArguments()[0]->GetName());
+}
+} // namespace
+
 static void AliasFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-	Value v(state.expr.GetAlias().empty() ? func_expr.children[0]->GetName() : state.expr.GetAlias());
+	auto &bind_data = func_expr.bind_info->Cast<AliasBindData>();
+	Value v(state.expr.GetAlias().empty() ? bind_data.alias : state.expr.GetAlias());
 	result.Reference(v, count_t(args.size()));
 }
 
 ScalarFunction AliasFun::GetFunction() {
-	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, AliasFunction);
+	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, AliasFunction, AliasBind);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/src/include/duckdb/optimizer/rule/constant_order_normalization.hpp
+++ b/src/include/duckdb/optimizer/rule/constant_order_normalization.hpp
@@ -12,8 +12,9 @@
 
 namespace duckdb {
 
-// Move constant expression parameters to the left in expression(i.e. x + 2 + y + 2 => 2 + 2 + x + y)
-// for convenience of other rules(i.e. ConstantFoldingRule).
+// Group constant expression parameters together in commutative arithmetic expressions to expose
+// constant folding opportunities. After folding collapses multiplication constants into a single
+// value, keep that constant on the right to match the canonical binary operator shape.
 class ConstantOrderNormalizationRule : public Rule {
 public:
 	explicit ConstantOrderNormalizationRule(ExpressionRewriter &rewriter);

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -10,6 +10,12 @@
 
 namespace duckdb {
 
+struct RewriteFrame {
+	reference<unique_ptr<Expression>> expr;
+	bool is_root;
+	bool children_visited;
+};
+
 static unique_ptr<Expression> ApplyRule(LogicalOperator &op, const vector<reference<Rule>> &rules,
                                         unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
 	for (auto &rule : rules) {
@@ -37,31 +43,40 @@ static unique_ptr<Expression> ApplyRule(LogicalOperator &op, const vector<refere
 	return expr;
 }
 
+static void CollectChildren(Expression &expr, vector<reference<unique_ptr<Expression>>> &children) {
+	children.clear();
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &child) { children.push_back(child); });
+}
+
 unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const vector<reference<Rule>> &rules,
                                                       unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
-	while (true) {
-		bool iteration_made_change = false;
-		// Rewrite the subtree bottom-up so parent rules see already-simplified children.
-		ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
-			bool child_made_change = false;
-			child = ExpressionRewriter::ApplyRules(op, rules, std::move(child), child_made_change);
-			if (child_made_change) {
-				iteration_made_change = true;
-				changes_made = true;
-			}
-		});
+	vector<RewriteFrame> stack;
+	vector<reference<unique_ptr<Expression>>> children;
+	stack.push_back({expr, is_root, false});
 
-		bool node_made_change = false;
-		expr = ApplyRule(op, rules, std::move(expr), node_made_change, is_root);
-		if (node_made_change) {
-			iteration_made_change = true;
-			changes_made = true;
+	while (!stack.empty()) {
+		auto &frame = stack.back();
+		auto &current_expr = frame.expr.get();
+		D_ASSERT(current_expr);
+		if (!frame.children_visited) {
+			frame.children_visited = true;
+			// Rewrite the subtree bottom-up so parent rules see already-simplified children.
+			CollectChildren(*current_expr, children);
+			for (idx_t i = children.size(); i > 0; i--) {
+				stack.push_back({children[i - 1], false, false});
+			}
 			continue;
 		}
-		if (!iteration_made_change) {
-			return expr;
+		bool node_made_change = false;
+		current_expr = ApplyRule(op, rules, std::move(current_expr), node_made_change, frame.is_root);
+		if (node_made_change) {
+			changes_made = true;
+			frame.children_visited = false;
+			continue;
 		}
+		stack.pop_back();
 	}
+	return expr;
 }
 
 unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression> child, Value value) {

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -10,8 +10,8 @@
 
 namespace duckdb {
 
-unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const vector<reference<Rule>> &rules,
-                                                      unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
+static unique_ptr<Expression> ApplyRule(LogicalOperator &op, const vector<reference<Rule>> &rules,
+                                        unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
 	for (auto &rule : rules) {
 		vector<reference<Expression>> bindings;
 		if (rule.get().root->Match(*expr, bindings)) {
@@ -22,26 +22,46 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 			if (result) {
 				changes_made = true;
 				// the base node changed: the rule applied changes
-				// rerun on the new node
 				if (!alias.empty()) {
 					result->SetAlias(std::move(alias));
 				}
-				return ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
+				return result;
 			} else if (rule_made_change) {
 				changes_made = true;
-				// the base node didn't change, but changes were made, rerun
 				return expr;
 			}
 			// else nothing changed, continue to the next rule
 			continue;
 		}
 	}
-	// no changes could be made to this node
-	// recursively run on the children of this node
-	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
-		child = ExpressionRewriter::ApplyRules(op, rules, std::move(child), changes_made);
-	});
 	return expr;
+}
+
+unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const vector<reference<Rule>> &rules,
+                                                      unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
+	while (true) {
+		bool iteration_made_change = false;
+		// Rewrite the subtree bottom-up so parent rules see already-simplified children.
+		ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+			bool child_made_change = false;
+			child = ExpressionRewriter::ApplyRules(op, rules, std::move(child), child_made_change);
+			if (child_made_change) {
+				iteration_made_change = true;
+				changes_made = true;
+			}
+		});
+
+		bool node_made_change = false;
+		expr = ApplyRule(op, rules, std::move(expr), node_made_change, is_root);
+		if (node_made_change) {
+			iteration_made_change = true;
+			changes_made = true;
+			continue;
+		}
+		if (!iteration_made_change) {
+			return expr;
+		}
+	}
 }
 
 unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression> child, Value value) {
@@ -90,11 +110,8 @@ void ExpressionRewriter::VisitOperator(LogicalOperator &op) {
 }
 
 void ExpressionRewriter::VisitExpression(unique_ptr<Expression> *expression) {
-	bool changes_made;
-	do {
-		changes_made = false;
-		*expression = ExpressionRewriter::ApplyRules(*op, to_apply_rules, std::move(*expression), changes_made, true);
-	} while (changes_made);
+	bool changes_made = false;
+	*expression = ExpressionRewriter::ApplyRules(*op, to_apply_rules, std::move(*expression), changes_made, true);
 }
 
 ClientContext &Rule::GetContext() const {

--- a/src/optimizer/rule/constant_order_normalization.cpp
+++ b/src/optimizer/rule/constant_order_normalization.cpp
@@ -6,6 +6,10 @@
 
 namespace duckdb {
 
+static bool MultiplicationConstantBelongsAtEnd(const BoundFunctionExpression &expr) {
+	return expr.function.GetName() == "*";
+}
+
 class RecursiveFunctionExpressionMatcher : public ExpressionMatcher {
 public:
 	explicit RecursiveFunctionExpressionMatcher(vector<unique_ptr<FunctionExpressionMatcher>> func_matchers)
@@ -80,6 +84,7 @@ unique_ptr<Expression> ConstantOrderNormalizationRule::Apply(LogicalOperator &op
                                                              vector<reference<Expression>> &bindings,
                                                              bool &changes_made, bool is_root) {
 	auto &root = bindings.back().get().Cast<BoundFunctionExpression>();
+	const auto expression_count = bindings.size() - 1;
 
 	// Put all constant expressions in front.
 	vector<reference<Expression>> ordered_bindings;
@@ -94,10 +99,25 @@ unique_ptr<Expression> ConstantOrderNormalizationRule::Apply(LogicalOperator &op
 		}
 	}
 
-	if (ordered_bindings.size() <= 1 || last_constant_position == ordered_bindings.size() - 1) {
+	if (ordered_bindings.empty()) {
 		return nullptr;
 	}
-	ordered_bindings.insert(ordered_bindings.end(), remain_bindings.begin(), remain_bindings.end());
+
+	if (ordered_bindings.size() == 1) {
+		// Multiplication trees can lose their folded constant subtree in the bottom-up rewriter
+		// (e.g. 1 * 2 * x -> 2 * x). Normalize that remaining binary form to x * 2 so it
+		// matches the shape produced by the other multiplication variants.
+		if (!MultiplicationConstantBelongsAtEnd(root) || last_constant_position == expression_count - 1) {
+			return nullptr;
+		}
+		remain_bindings.push_back(ordered_bindings[0]);
+		ordered_bindings = std::move(remain_bindings);
+	} else {
+		if (last_constant_position == ordered_bindings.size() - 1) {
+			return nullptr;
+		}
+		ordered_bindings.insert(ordered_bindings.end(), remain_bindings.begin(), remain_bindings.end());
+	}
 
 	// Reconstruct the expression.
 	FunctionBinder binder(rewriter.context);

--- a/src/optimizer/rule/timestamp_comparison.cpp
+++ b/src/optimizer/rule/timestamp_comparison.cpp
@@ -17,10 +17,9 @@
 namespace duckdb {
 
 TimeStampComparison::TimeStampComparison(ExpressionRewriter &rewriter) : Rule(rewriter), context(rewriter.context) {
-	// match on a ComparisonExpression that is an Equality and has a VARCHAR and ENUM as its children
+	// match on an equality comparison between a timestamp column cast to DATE and a foldable DATE constant
 	auto op = make_uniq<ComparisonExpressionMatcher>();
 	op->policy = SetMatcher::Policy::UNORDERED;
-	// Enum requires expression to be root
 	op->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::COMPARE_EQUAL);
 
 	// one side is timestamp cast to date
@@ -31,34 +30,49 @@ TimeStampComparison::TimeStampComparison(ExpressionRewriter &rewriter) : Rule(re
 	left->matcher->type = make_uniq<TypeMatcherId>(LogicalTypeId::TIMESTAMP);
 	op->matchers.push_back(std::move(left));
 
-	// other side is varchar to date?
-	auto right = make_uniq<CastExpressionMatcher>();
+	// other side is any foldable DATE constant expression; bottom-up rewriting can fold CAST(VARCHAR AS DATE)
+	auto right = make_uniq<FoldableConstantMatcher>();
 	right->type = make_uniq<TypeMatcherId>(LogicalTypeId::DATE);
-	right->matcher = make_uniq<FoldableConstantMatcher>();
-	right->matcher->expr_class = ExpressionClass::BOUND_CONSTANT;
-	right->matcher->type = make_uniq<TypeMatcherId>(LogicalTypeId::VARCHAR);
 	op->matchers.push_back(std::move(right));
 
 	root = std::move(op);
 }
 
-static void ExpressionIsConstant(const Expression &root_expr, bool &is_constant) {
-	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
-	    root_expr, [&](const BoundColumnRefExpression &column_ref) { is_constant = false; });
+static BoundCastExpression *GetTimestampCast(Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+		return nullptr;
+	}
+	auto &cast_expr = expr.Cast<BoundCastExpression>();
+	if (cast_expr.GetReturnType().id() != LogicalTypeId::DATE) {
+		return nullptr;
+	}
+	if (cast_expr.child->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
+	    cast_expr.child->GetReturnType().id() != LogicalTypeId::TIMESTAMP) {
+		return nullptr;
+	}
+	return &cast_expr;
 }
 
 unique_ptr<Expression> TimeStampComparison::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                   bool &changes_made, bool is_root) {
-	auto cast_constant = bindings[3].get().Copy();
-	auto cast_columnref = bindings[2].get().Copy();
-	auto is_constant = true;
-	ExpressionIsConstant(*cast_constant, is_constant);
-	if (!is_constant) {
-		// means the matchers are flipped, so we need to flip our bindings
-		// for some reason an extra binding is added in this case.
-		cast_constant = bindings[4].get().Copy();
-		cast_columnref = bindings[3].get().Copy();
+	auto &comparison = bindings[0].get().Cast<BoundFunctionExpression>();
+	D_ASSERT(comparison.children.size() == 2);
+
+	BoundCastExpression *cast_expr = nullptr;
+	Expression *constant_expr = nullptr;
+	for (auto &child : comparison.children) {
+		if (auto timestamp_cast = GetTimestampCast(*child)) {
+			cast_expr = timestamp_cast;
+		} else if (child->IsFoldable() && child->GetReturnType().id() == LogicalTypeId::DATE) {
+			constant_expr = child.get();
+		}
 	}
+	if (!cast_expr || !constant_expr) {
+		return nullptr;
+	}
+
+	auto cast_constant = constant_expr->Copy();
+	auto cast_columnref = cast_expr->child->Copy();
 	auto new_expr = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
 
 	Value result;

--- a/test/sql/optimizer/predicate_factoring.test
+++ b/test/sql/optimizer/predicate_factoring.test
@@ -22,6 +22,19 @@ EXPLAIN SELECT * FROM t WHERE (a=1 AND b>3) OR (a=1 AND c<5)
 ----
 physical_plan	<REGEX>:.*Filters:.*a = 1.*
 
+# Predicate factoring still works when nested conjunctions must be simplified first
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND (b>3 AND TRUE)) OR (a=1 AND (TRUE AND c<5))
+----
+1	2	3
+1	5	11
+1	5	3
+
+query II
+EXPLAIN SELECT * FROM t WHERE (a=1 AND (b>3 AND TRUE)) OR (a=1 AND (TRUE AND c<5))
+----
+physical_plan	<REGEX>:.*Filters:.*a = 1.*
+
 # Predicate factoring on a different common column: b=5
 query III rowsort
 SELECT * FROM t WHERE (a=1 AND b=5) OR (a=2 AND b=5)


### PR DESCRIPTION
This PR does two things:

1. It changes the `ExpressionRewriter` from top-down traversal to bottom-up. This prevents us from re-visiting the expression tree (potentially) many times.
2. It removes recursion by using an explicit post-order stack. The new traversal keeps `reference<unique_ptr<Expression>>` frames, visits children first, then applies rules to the current node, and restarts just that subtree if a rule rewrites the node. That preserves the bottom-up fixed-point behavior without recursive calls.

----

```sql
CREATE SCHEMA vec;
CREATE MACRO vec.make(x, y, z) AS (x, y, z) :: struct(x real, y real, z real);
CREATE MACRO vec.add(a, b) AS vec.make(a.x + b.x, a.y + b.y, a.z + b.z);
CREATE MACRO vec.sub(a, b) AS vec.make(a.x - b.x, a.y - b.y, a.z - b.z);
CREATE MACRO vec.mul(v, f) AS vec.make(v.x * f, v.y * f, v.z * f);
CREATE MACRO vec.div(v, f) AS vec.make(v.x / f, v.y / f, v.z / f);
CREATE MACRO vec.dot(a, b) AS a.x * b.x + a.y * b.y + a.z * b.z;
CREATE MACRO vec.cross(a, b) AS vec.make(a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x);
CREATE MACRO vec.mag(v) AS sqrt(v.x ** 2 + v.y ** 2 + v.z ** 2);
CREATE MACRO vec.norm(v) AS vec.div(v, vec.mag(v));

SELECT vec.norm(vec.add(vec.make(0,0,0), vec.make(0,0,1))) AS a,
       vec.norm(vec.cross(vec.make(0,1,0), a))             AS b,
       vec.add(b, b)                                       AS c;
```

Expression rewriting for this case ☝🏻 is about 4x faster now.

fix: https://github.com/duckdb/duckdb/issues/6936