### PR TITLE
Fix new jemalloc plumbing

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -69,7 +69,10 @@ jobs:
       CXX: g++-10
       GEN: ninja
       BUILD_BENCHMARK: 1
-      BUILD_JEMALLOC: 1
+      # Regression compares against the base branch binary. Keep this on the
+      # standard allocator so allocator changes do not look like query
+      # performance regressions.
+      BUILD_JEMALLOC: 0
       CORE_EXTENSIONS: "json;tpch;tpcds;httpfs;inet;icu"
 
     steps:
@@ -360,5 +363,4 @@ jobs:
         shell: bash
         run: |
           python scripts/plan_cost_runner.py --old duckdb/build/release/duckdb --new build/release/duckdb --dir=benchmark/tpch_plan_cost
-
 

--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -1,4 +1,5 @@
 deadlock:InitializeIndexes
+deadlock:TemplatedSortKeySetPayload
 race:InsertMatchesAndIncrementMisses
 race:NextInnerJoin
 race:NextRightSemiOrAntiJoin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,6 +833,13 @@ endfunction()
 # this depends on disable_target_warnings so the order matters
 include(${PROJECT_SOURCE_DIR}/extension/extension_build_tools.cmake)
 
+if(ENABLE_JEMALLOC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT EMSCRIPTEN AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT BSD AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
+  set(JEMALLOC_ENABLED TRUE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_ENABLE_JEMALLOC")
+  include_directories(third_party/jemalloc/include)
+  add_third_party(jemalloc)
+endif()
+
 if(PREBUILT_BINARY)
   message("Using pre-built static library from file ${PREBUILT_BINARY}")
   add_library(duckdb_static STATIC IMPORTED GLOBAL)
@@ -862,13 +869,6 @@ add_third_party(skiplist)
 add_third_party(utf8proc)
 add_third_party(yyjson)
 add_third_party(zstd)
-
-if(ENABLE_JEMALLOC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT EMSCRIPTEN AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT BSD AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
-  set(JEMALLOC_ENABLED TRUE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_ENABLE_JEMALLOC")
-  include_directories(third_party/jemalloc/include)
-  add_third_party(jemalloc)
-endif()
 
 if(NOT DUCKDB_EXPLICIT_PLATFORM)
   set(VERSION_SOURCES tools/utils/test_platform.cpp)

--- a/src/common/allocator/allocator_jemalloc.cpp
+++ b/src/common/allocator/allocator_jemalloc.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/allocator.hpp"
-#include "duckdb/common/operator/numeric_cast.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 
 #include <thread>
 #include <cstdint>

--- a/src/common/allocator/allocator_jemalloc.cpp
+++ b/src/common/allocator/allocator_jemalloc.cpp
@@ -32,6 +32,14 @@ static string PurgeArenaString(idx_t arena_idx) {
 	return StringUtil::Format("arena.%llu.purge", arena_idx);
 }
 
+static void JemallocCTL(const char *name, void *old_ptr, size_t *old_len, void *new_ptr, size_t new_len) {
+	if (duckdb_je_mallctl(name, old_ptr, old_len, new_ptr, new_len) != 0) {
+#ifdef DEBUG
+		throw InternalException("je_mallctl failed for setting \"%s\"", name);
+#endif
+	}
+}
+
 template <class T>
 static void SetJemallocCTL(const char *name, T &val) {
 	JemallocCTL(name, nullptr, nullptr, &val, sizeof(T));

--- a/third_party/jemalloc/README.md
+++ b/third_party/jemalloc/README.md
@@ -215,6 +215,7 @@ The `exported_symbols_check.py` script still found a few, so these lines need to
 #define opt_malloc_conf_symlink JEMALLOC_N(opt_malloc_conf_symlink)
 #define opt_prof_bt_max JEMALLOC_N(opt_prof_bt_max)
 #define opt_prof_pid_namespace JEMALLOC_N(opt_prof_pid_namespace)
+#define prof_get_pid_namespace JEMALLOC_N(prof_get_pid_namespace)
 #define os_page JEMALLOC_N(os_page)
 #define pa_shard_nactive JEMALLOC_N(pa_shard_nactive)
 #define pa_shard_ndirty JEMALLOC_N(pa_shard_ndirty)

--- a/third_party/jemalloc/include/jemalloc/internal/private_namespace.h
+++ b/third_party/jemalloc/include/jemalloc/internal/private_namespace.h
@@ -748,6 +748,7 @@
 #define opt_malloc_conf_symlink JEMALLOC_N(opt_malloc_conf_symlink)
 #define opt_prof_bt_max JEMALLOC_N(opt_prof_bt_max)
 #define opt_prof_pid_namespace JEMALLOC_N(opt_prof_pid_namespace)
+#define prof_get_pid_namespace JEMALLOC_N(prof_get_pid_namespace)
 #define os_page JEMALLOC_N(os_page)
 #define pa_shard_nactive JEMALLOC_N(pa_shard_nactive)
 #define pa_shard_ndirty JEMALLOC_N(pa_shard_ndirty)


### PR DESCRIPTION
This fixes two bugs (CMake ordering, missing `JemallocCTL`) I ran into while trying to get jemalloc profiling to work in duckdb-go (https://github.com/duckdblabs/duckdb-internal/issues/9148)

I guess this also means we're missing important CI steps?

Related:

- https://github.com/duckdb/duckdb/pull/22558
- https://github.com/duckdb/duckdb/pull/22594
