### PR TITLE
Enable jemalloc heap profiling with the libgcc unwinder

### DIFF
--- a/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -201,13 +201,13 @@
 /* #undef JEMALLOC_EXPERIMENTAL_SMALLOCX_API */
 
 /* JEMALLOC_PROF enables allocation profiling. */
-/* #undef JEMALLOC_PROF */
+#define JEMALLOC_PROF
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
 
 /* Use libgcc for profile backtracing if defined. */
-/* #undef JEMALLOC_PROF_LIBGCC */
+#define JEMALLOC_PROF_LIBGCC
 
 /* Use gcc intrinsics for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_GCC */


### PR DESCRIPTION
This PR is required to get jemalloc profiling to work reliably in duckdb-go (https://github.com/duckdblabs/duckdb-internal/issues/9148)

The change supersedes the `PROF_GCC` choice made on main in #21063.

Why not `PROF_GCC`:

- `PROF_GCC` walks the stack via `__builtin_frame_address(N)` / `__builtin_return_address(N)` with N up to 127. GCC documents both as having "unpredictable effects, including crashing the calling program" for nonzero N. (https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html)
- jemalloc itself treats `PROF_GCC` as the last-resort fallback. Its configure script picks the first working backend in the order: libunwind > frame pointer > libgcc > gcc intrinsics. (https://github.com/jemalloc/jemalloc/blob/master/INSTALL.md)
- jemalloc/jemalloc#2328 documents the same `__builtin_return_address` segfault in a plain-C program with no cgo, resolved by switching off `PROF_GCC`.

Why it crashes under Go/cgo:

- In pure C the walker silently samples garbage frames past the top of the stack.
- Under cgo the C stack is adjacent to Go memory, so those out-of-bounds reads dereference real mapped pages and the sample crashes inside `prof_backtrace_impl`.

Reproduced on Ubuntu 24.04 / glibc 2.39 / x86_64 with duckdb-go v2.5.5 against a static build of v1.4.4 patched per #21063:

    SIGSEGV: segmentation violation
    PC=0x1e09a4b m=0 sigcode=1
    signal arrived during cgo execution
    github.com/duckdb/duckdb-go-bindings._Cfunc_duckdb_open_ext(...)

Note: `_Unwind_Backtrace()` is provided by the existing compiler unwind runtime already pulled in by the C++ toolchain, so this does not add a new DuckDB link dependency.

Blocked by https://github.com/duckdb/duckdb/pull/22628