### PR TITLE
Add dummy cmake target for jemalloc

### DIFF
--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -525,6 +525,11 @@ foreach(EXT IN LISTS BUILD_EXTENSIONS)
     if("${EXT}" STREQUAL "jemalloc")
         message(WARNING "The 'jemalloc' allocator is no longer provided as an extension, use 'ENABLE_JEMALLOC=ON' to include jemalloc instead")
         set(ENABLE_JEMALLOC ON CACHE BOOL "Use jemalloc as the memory allocator for DuckDB" FORCE)
+        # Backward-compat shim: downstream consumers call target_link_libraries(... ${ext}_extension).
+        # We provide an empty INTERFACE target to make sure that doesn't fail.
+        if(NOT TARGET jemalloc_extension)
+            add_library(jemalloc_extension INTERFACE)
+        endif()
         continue()
     endif()
 


### PR DESCRIPTION
Follow up on #22558 and #22594

In python we call `target_link_libraries(${target_name} PRIVATE ${ext}_extension)` for every extension we link in. For jemalloc that target does not exist anymore, so builds fail. By adding a dummy target we make sure that this won't break other consumers.