### PR TITLE
Backport windows-32bit test fix to 1.4

### DIFF
--- a/test/sql/join/test_hash_join_many_columns.test
+++ b/test/sql/join/test_hash_join_many_columns.test
@@ -2,6 +2,8 @@
 # description: Divide by 0 in GetPartitioningSpaceRequirement, inlined by PhysicalHashJoin::PrepareFinalize when running a query with 20k columns (PR #21271)
 # group: [join]
 
+require 64bit
+
 statement ok
 SET threads=1;
 


### PR DESCRIPTION
Backporting a test fix #21432 to `v1.4-andium` just in case.

Ref: duckdblabs/duckdb-internal#8404