### PR TITLE
[Dev] Add method to `BoundCastInfo` to check if the function is `TryVectorNullCast`

### DIFF
--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -104,6 +104,10 @@ bool BoundCastInfo::IsNopCast() const {
 	return function == DefaultCasts::NopCast;
 }
 
+bool BoundCastInfo::IsTryNullCast() const {
+	return function == DefaultCasts::TryVectorNullCast;
+}
+
 static BoundCastInfo AggregateStateCast(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	D_ASSERT(source.IsAggregateStateStructType());
 

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -133,6 +133,7 @@ public:
 		return function;
 	}
 	bool IsNopCast() const;
+	bool IsTryNullCast() const;
 	void SetFunction(cast_function_t new_function) {
 		function = new_function;
 	}


### PR DESCRIPTION
This is used by duckdb-iceberg, necessary for bump to current duckdb/main