### PR TITLE
Fix file log CSV writer state and header after truncate_duckdb_logs

### DIFF
--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -356,8 +356,11 @@ void FileLogStorage::Truncate() {
 		}
 		// Truncate the file writer
 		file_writer->Truncate(0);
-		// Re-initialize the corresponding CSVWriter
-		GetWriter(it.first).Initialize(true);
+		auto &writer = GetWriter(it.first);
+		// Reset writer and header option, then re-initialize
+		writer.Reset(nullptr);
+		writer.options.dialect_options.header = CSVOption<bool>(true);
+		writer.Initialize(true);
 	}
 }
 

--- a/test/configs/verify_statement_explain.json
+++ b/test/configs/verify_statement_explain.json
@@ -14,7 +14,8 @@
         "test/sql/logging/logging_types.test",
         "test/sql/logging/logging.test",
         "test/sql/logging/logging_context_ids.test",
-        "test/sql/logging/logging_csv.test"
+        "test/sql/logging/logging_csv.test",
+        "test/sql/logging/logging_file_truncate_rewrite.test"
       ]
     },
     {

--- a/test/configs/verify_statement_prepare.json
+++ b/test/configs/verify_statement_prepare.json
@@ -34,6 +34,7 @@
         "test/sql/logging/logging.test",
         "test/sql/logging/logging_context_ids.test",
         "test/sql/logging/logging_csv.test",
+        "test/sql/logging/logging_file_truncate_rewrite.test",
         "test/sql/logging/http_log_timing.test"
       ]
     },

--- a/test/sql/logging/logging_file_truncate_rewrite.test
+++ b/test/sql/logging/logging_file_truncate_rewrite.test
@@ -1,0 +1,63 @@
+# name: test/sql/logging/logging_file_truncate_rewrite.test
+# description: File log truncate must rewrite a valid header (no leading blank; append mode reset)
+# group: [logging]
+
+require noforcestorage
+
+# Due to different file locking behaviour, this currently fails on windows
+require notwindows
+
+statement ok
+CALL enable_logging(['FileSystem'], storage='file', storage_config={'path': '{TEMP_DIR}/logging_truncate_rewrite.csv', 'normalize': false});
+
+statement ok
+FROM "{DATA_DIR}/csv/big_number.csv"
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Only the header row exists as data; count should still be zero
+query I
+SELECT COUNT(*) FROM "{TEMP_DIR}/logging_truncate_rewrite.csv";
+----
+0
+
+# CSV must still parse with the expected schema (no blank line before header)
+query IIIIII
+DESCRIBE FROM '{TEMP_DIR}/logging_truncate_rewrite.csv';
+----
+context_id	BIGINT	YES	NULL	NULL	NULL
+scope	VARCHAR	YES	NULL	NULL	NULL
+connection_id	BIGINT	YES	NULL	NULL	NULL
+transaction_id	BIGINT	YES	NULL	NULL	NULL
+query_id	BIGINT	YES	NULL	NULL	NULL
+thread_id	VARCHAR	YES	NULL	NULL	NULL
+timestamp	TIMESTAMP WITH TIME ZONE	YES	NULL	NULL	NULL
+type	VARCHAR	YES	NULL	NULL	NULL
+log_level	VARCHAR	YES	NULL	NULL	NULL
+message	VARCHAR	YES	NULL	NULL	NULL
+
+statement ok
+CALL truncate_duckdb_logs();
+
+query I
+SELECT COUNT(*) FROM "{TEMP_DIR}/logging_truncate_rewrite.csv";
+----
+0
+
+query IIIIII
+DESCRIBE FROM '{TEMP_DIR}/logging_truncate_rewrite.csv';
+----
+context_id	BIGINT	YES	NULL	NULL	NULL
+scope	VARCHAR	YES	NULL	NULL	NULL
+connection_id	BIGINT	YES	NULL	NULL	NULL
+transaction_id	BIGINT	YES	NULL	NULL	NULL
+query_id	BIGINT	YES	NULL	NULL	NULL
+thread_id	VARCHAR	YES	NULL	NULL	NULL
+timestamp	TIMESTAMP WITH TIME ZONE	YES	NULL	NULL	NULL
+type	VARCHAR	YES	NULL	NULL	NULL
+log_level	VARCHAR	YES	NULL	NULL	NULL
+message	VARCHAR	YES	NULL	NULL	NULL
+
+statement ok
+CALL disable_logging();


### PR DESCRIPTION
Fixes #22585 

File-backed logging could leave the CSV in a bad shape after `CALL truncate_duckdb_logs()`

  * In one process, a blank line could appear before the header row when the log file was truncated and the header was written again.
  * After restarting DuckDB, truncating could clear the file but skip writing a new header row when the path had been opened in append mode.

This PR fixes both by resetting `CSVWriter` state and the CSV `header` dialect option after truncating the on-disk file to length zero, before calling `Initialize(true)`.


Issue
---
1. Same session - leading blank line

   File log storage uses `CSVWriter` with newline mode `WRITE_BEFORE`. After any log lines were flushed, `written_anything` stayed true. `FileLogStorage::Truncate()` truncated the file and called `Initialize(true)` to emit the header again, but did not reset the writer. On the header replay, `FlushInternal` still treated the writer as mid-stream and emitted a newline before the header bytes.

2. After restart - empty file, no header

   When `InitializeFile` opens a path that already has bytes on disk, it sets `dialect_options.header` to “do not write a header” (append semantics) so duplicate headers are not inserted mid-file. That flag stayed set on the writer. After truncate, the file was empty on disk, but `Initialize(true)` still skipped `WriteHeader()` because of that append-style header option.


Solution
---
In `FileLogStorage::Truncate()`, after `BufferedFileWriter::Truncate(0)` and before `CSVWriter::Initialize(true)`:

  * `writer.Reset(nullptr)` - clears writer bookkeeping (including `written_anything`) so the replayed header is written as the first output, consistent with an empty file.
  * `writer.options.dialect_options.header = CSVOption<bool>(true)` - allows `WriteHeader()` on the next `Initialize` for the now-empty file, independent of append-open having disabled headers.

Test
---
  ./build/reldebug/test/unittest test/sql/logging/logging_file_truncate_rewrite.test
