### PR TITLE
fix: duplicated "the" in update_settings_header_file and distinct_statistics comments

### DIFF
--- a/scripts/settings_scripts/update_settings_header_file.py
+++ b/scripts/settings_scripts/update_settings_header_file.py
@@ -60,7 +60,7 @@ def extract_declarations(setting) -> str:
     return definition
 
 
-# generate code for all the settings for the the header file
+# generate code for all the settings for the header file
 def generate_content(header_file_path):
     with open(header_file_path, 'r') as source_file:
         source_code = source_file.read()

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -59,7 +59,7 @@ idx_t DistinctStatistics::GetCount() const {
 	double s = static_cast<double>(sample_count.load());
 	double n = static_cast<double>(total_count.load());
 
-	// Assume this proportion of the the sampled values occurred only once
+	// Assume this proportion of the sampled values occurred only once
 	double u1 = pow(u / s, 2) * u;
 
 	// Estimate total uniques using Good Turing Estimation


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in comments:
- `scripts/settings_scripts/update_settings_header_file.py` — "# generate code for all the settings for the the header file" → "...for the header file"
- `src/storage/statistics/distinct_statistics.cpp` — "// Assume this proportion of the the sampled values" → "...of the sampled values"

No code/behavior change.