### PR TITLE
Fix parquet stats for enum types

### DIFF
--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -34,6 +34,10 @@ public:
 	~EnumColumnWriter() override = default;
 
 	uint32_t bit_width;
+	// Maps enum index to rank in lexicographic order over the enum's string values.
+	// Precomputed once so the on enum value write hot-path, we could compare integer instead of string comparison when
+	// finding the chunk's lex min/max.
+	vector<uint32_t> lex_rank;
 
 public:
 	unique_ptr<ColumnWriterStatistics> InitializeStatsState() override;

--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -33,13 +33,6 @@ public:
 	EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p);
 	~EnumColumnWriter() override = default;
 
-	uint32_t bit_width;
-	// Maps enum index to rank in lexicographic order over the enum's string values.
-	// Precomputed once so the on enum value write hot-path, we could compare integer instead of string comparison when
-	// finding the chunk's lex min/max.
-	vector<uint32_t> lex_rank;
-
-public:
 	unique_ptr<ColumnWriterStatistics> InitializeStatsState() override;
 
 	void WriteVector(WriteStream &temp_writer, ColumnWriterStatistics *stats_p, ColumnWriterPageState *page_state_p,
@@ -63,6 +56,12 @@ private:
 	template <class T>
 	void WriteEnumInternal(WriteStream &temp_writer, Vector &input_column, idx_t chunk_start, idx_t chunk_end,
 	                       EnumWriterPageState &page_state, StringStatisticsState &stats);
+
+	uint32_t bit_width;
+	// Maps enum index to rank in lexicographic order over the enum's string values.
+	// Precomputed once so the on enum value write hot-path, so we could compare integer instead of string when
+	// finding the chunk's lex min/max.
+	vector<uint32_t> lex_rank;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -23,7 +23,6 @@
 namespace duckdb {
 class EnumWriterPageState;
 class ParquetWriter;
-class StringStatisticsState;
 class Vector;
 class WriteStream;
 struct ParquetColumnSchema;
@@ -55,13 +54,11 @@ public:
 private:
 	template <class T>
 	void WriteEnumInternal(WriteStream &temp_writer, Vector &input_column, idx_t chunk_start, idx_t chunk_end,
-	                       EnumWriterPageState &page_state, StringStatisticsState &stats);
+	                       EnumWriterPageState &page_state);
 
 	uint32_t bit_width;
-	// Maps enum index to rank in lexicographic order over the enum's string values.
-	// Precomputed once so the on enum value write hot-path, so we could compare integer instead of string when
-	// finding the chunk's lex min/max.
-	vector<uint32_t> lex_rank;
+	//! Tracks which enum values have actually been written.
+	vector<bool> seen_enum;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -23,6 +23,7 @@
 namespace duckdb {
 class EnumWriterPageState;
 class ParquetWriter;
+class StringStatisticsState;
 class Vector;
 class WriteStream;
 struct ParquetColumnSchema;
@@ -57,7 +58,7 @@ public:
 private:
 	template <class T>
 	void WriteEnumInternal(WriteStream &temp_writer, Vector &input_column, idx_t chunk_start, idx_t chunk_end,
-	                       EnumWriterPageState &page_state);
+	                       EnumWriterPageState &page_state, StringStatisticsState &stats);
 };
 
 } // namespace duckdb

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -43,9 +43,14 @@ unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {
 
 template <class T>
 void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input_column, idx_t chunk_start,
-                                         idx_t chunk_end, EnumWriterPageState &page_state) {
+                                         idx_t chunk_end, EnumWriterPageState &page_state,
+                                         StringStatisticsState &stats) {
 	auto &mask = FlatVector::ValidityMutable(input_column);
 	auto *ptr = FlatVector::GetData<T>(input_column);
+	// stats are computed from the actual values that appear in the column,
+	// not from the full enum dictionary, so look up each row's string here
+	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
+	auto string_values = FlatVector::GetData<string_t>(enum_values);
 	for (idx_t r = chunk_start; r < chunk_end; r++) {
 		if (mask.RowIsValid(r)) {
 			if (!page_state.written_value) {
@@ -55,6 +60,7 @@ void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input
 				page_state.written_value = true;
 			}
 			page_state.encoder.WriteValue(temp_writer, ptr[r]);
+			stats.Update(string_values[ptr[r]]);
 		}
 	}
 }
@@ -63,15 +69,16 @@ void EnumColumnWriter::WriteVector(WriteStream &temp_writer, ColumnWriterStatist
                                    ColumnWriterPageState *page_state_p, Vector &input_column, idx_t chunk_start,
                                    idx_t chunk_end) {
 	auto &page_state = page_state_p->Cast<EnumWriterPageState>();
+	auto &stats = stats_p->Cast<StringStatisticsState>();
 	switch (Type().InternalType()) {
 	case PhysicalType::UINT8:
-		WriteEnumInternal<uint8_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
+		WriteEnumInternal<uint8_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
 		break;
 	case PhysicalType::UINT16:
-		WriteEnumInternal<uint16_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
+		WriteEnumInternal<uint16_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
 		break;
 	case PhysicalType::UINT32:
-		WriteEnumInternal<uint32_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
+		WriteEnumInternal<uint32_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
 		break;
 	default:
 		throw InternalException("Unsupported internal enum type");
@@ -107,8 +114,6 @@ idx_t EnumColumnWriter::DictionarySize(PrimitiveColumnWriterState &state_p) {
 }
 
 void EnumColumnWriter::FlushDictionary(PrimitiveColumnWriterState &state, ColumnWriterStatistics *stats_p) {
-	auto &stats = stats_p->Cast<StringStatisticsState>();
-	// write the enum values to a dictionary page
 	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
 	auto enum_count = EnumType::GetSize(Type());
 	auto string_values = FlatVector::GetData<string_t>(enum_values);
@@ -116,8 +121,6 @@ void EnumColumnWriter::FlushDictionary(PrimitiveColumnWriterState &state, Column
 	auto temp_writer = make_uniq<MemoryStream>(BufferAllocator::Get(writer.GetContext()));
 	for (idx_t r = 0; r < enum_count; r++) {
 		D_ASSERT(!FlatVector::IsNull(enum_values, r));
-		// update the statistics
-		stats.Update(string_values[r]);
 		// write this string value to the dictionary
 		temp_writer->Write<uint32_t>(string_values[r].GetSize());
 		temp_writer->WriteData(const_data_ptr_cast(string_values[r].GetData()), string_values[r].GetSize());

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -10,16 +10,12 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "parquet_column_schema.hpp"
-
-#include <algorithm>
-#include <numeric>
 
 namespace duckdb {
 class Vector;
@@ -39,19 +35,7 @@ EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&
                                    vector<string> schema_path_p)
     : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 	bit_width = RleBpDecoder::ComputeBitWidthFromValueCount(EnumType::GetSize(Type()));
-
-	// Precompute lex_rank.
-	auto enum_count = EnumType::GetSize(Type());
-	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
-	auto string_values = FlatVector::GetData<string_t>(enum_values);
-	vector<uint32_t> order(enum_count);
-	std::iota(order.begin(), order.end(), 0);
-	std::sort(order.begin(), order.end(),
-	          [&](uint32_t a, uint32_t b) { return LessThan::Operation(string_values[a], string_values[b]); });
-	lex_rank.resize(enum_count);
-	for (uint32_t rank = 0; rank < enum_count; ++rank) {
-		lex_rank[order[rank]] = rank;
-	}
+	seen_enum.resize(EnumType::GetSize(Type()), false);
 }
 
 unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {
@@ -60,18 +44,9 @@ unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {
 
 template <class T>
 void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input_column, idx_t chunk_start,
-                                         idx_t chunk_end, EnumWriterPageState &page_state,
-                                         StringStatisticsState &stats) {
+                                         idx_t chunk_end, EnumWriterPageState &page_state) {
 	auto &mask = FlatVector::ValidityMutable(input_column);
 	auto *ptr = FlatVector::GetData<T>(input_column);
-
-	// Track the lex min/max enum index seen in this chunk.
-	uint32_t best_min_idx = 0;
-	uint32_t best_max_idx = 0;
-	uint32_t best_min_rank = std::numeric_limits<uint32_t>::max();
-	uint32_t best_max_rank = 0;
-	bool any_seen = false;
-
 	for (idx_t r = chunk_start; r < chunk_end; r++) {
 		if (mask.RowIsValid(r)) {
 			if (!page_state.written_value) {
@@ -80,27 +55,8 @@ void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input
 				page_state.encoder.BeginWrite();
 				page_state.written_value = true;
 			}
-			const auto enum_idx = ptr[r];
-			page_state.encoder.WriteValue(temp_writer, enum_idx);
-			auto rank = lex_rank[enum_idx];
-			if (!any_seen || rank < best_min_rank) {
-				best_min_rank = rank;
-				best_min_idx = enum_idx;
-			}
-			if (!any_seen || rank > best_max_rank) {
-				best_max_rank = rank;
-				best_max_idx = enum_idx;
-			}
-			any_seen = true;
-		}
-	}
-
-	if (any_seen) {
-		auto &enum_values = EnumType::GetValuesInsertOrder(Type());
-		auto string_values = FlatVector::GetData<string_t>(enum_values);
-		stats.Update(string_values[best_min_idx]);
-		if (best_max_idx != best_min_idx) {
-			stats.Update(string_values[best_max_idx]);
+			page_state.encoder.WriteValue(temp_writer, ptr[r]);
+			seen_enum[ptr[r]] = true;
 		}
 	}
 }
@@ -109,16 +65,15 @@ void EnumColumnWriter::WriteVector(WriteStream &temp_writer, ColumnWriterStatist
                                    ColumnWriterPageState *page_state_p, Vector &input_column, idx_t chunk_start,
                                    idx_t chunk_end) {
 	auto &page_state = page_state_p->Cast<EnumWriterPageState>();
-	auto &stats = stats_p->Cast<StringStatisticsState>();
 	switch (Type().InternalType()) {
 	case PhysicalType::UINT8:
-		WriteEnumInternal<uint8_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
+		WriteEnumInternal<uint8_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
 		break;
 	case PhysicalType::UINT16:
-		WriteEnumInternal<uint16_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
+		WriteEnumInternal<uint16_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
 		break;
 	case PhysicalType::UINT32:
-		WriteEnumInternal<uint32_t>(temp_writer, input_column, chunk_start, chunk_end, page_state, stats);
+		WriteEnumInternal<uint32_t>(temp_writer, input_column, chunk_start, chunk_end, page_state);
 		break;
 	default:
 		throw InternalException("Unsupported internal enum type");
@@ -154,6 +109,7 @@ idx_t EnumColumnWriter::DictionarySize(PrimitiveColumnWriterState &state_p) {
 }
 
 void EnumColumnWriter::FlushDictionary(PrimitiveColumnWriterState &state, ColumnWriterStatistics *stats_p) {
+	auto &stats = stats_p->Cast<StringStatisticsState>();
 	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
 	auto enum_count = EnumType::GetSize(Type());
 	auto string_values = FlatVector::GetData<string_t>(enum_values);
@@ -161,9 +117,13 @@ void EnumColumnWriter::FlushDictionary(PrimitiveColumnWriterState &state, Column
 	auto temp_writer = make_uniq<MemoryStream>(BufferAllocator::Get(writer.GetContext()));
 	for (idx_t r = 0; r < enum_count; r++) {
 		D_ASSERT(!FlatVector::IsNull(enum_values, r));
-		// write this string value to the dictionary
-		temp_writer->Write<uint32_t>(string_values[r].GetSize());
-		temp_writer->WriteData(const_data_ptr_cast(string_values[r].GetData()), string_values[r].GetSize());
+		if (seen_enum[r]) {
+			stats.Update(string_values[r]);
+			temp_writer->Write<uint32_t>(string_values[r].GetSize());
+			temp_writer->WriteData(const_data_ptr_cast(string_values[r].GetData()), string_values[r].GetSize());
+		} else {
+			temp_writer->Write<uint32_t>(0);
+		}
 	}
 	// flush the dictionary page and add it to the to-be-written pages
 	WriteDictionary(state, std::move(temp_writer), enum_count);

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -10,12 +10,16 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "parquet_column_schema.hpp"
+
+#include <algorithm>
+#include <numeric>
 
 namespace duckdb {
 class Vector;
@@ -35,6 +39,19 @@ EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&
                                    vector<string> schema_path_p)
     : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 	bit_width = RleBpDecoder::ComputeBitWidthFromValueCount(EnumType::GetSize(Type()));
+
+	// Precompute lex_rank.
+	auto enum_count = EnumType::GetSize(Type());
+	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
+	auto string_values = FlatVector::GetData<string_t>(enum_values);
+	vector<uint32_t> order(enum_count);
+	std::iota(order.begin(), order.end(), 0);
+	std::sort(order.begin(), order.end(),
+	          [&](uint32_t a, uint32_t b) { return LessThan::Operation(string_values[a], string_values[b]); });
+	lex_rank.resize(enum_count);
+	for (uint32_t rank = 0; rank < enum_count; rank++) {
+		lex_rank[order[rank]] = rank;
+	}
 }
 
 unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {
@@ -47,10 +64,14 @@ void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input
                                          StringStatisticsState &stats) {
 	auto &mask = FlatVector::ValidityMutable(input_column);
 	auto *ptr = FlatVector::GetData<T>(input_column);
-	// stats are computed from the actual values that appear in the column,
-	// not from the full enum dictionary, so look up each row's string here
-	auto &enum_values = EnumType::GetValuesInsertOrder(Type());
-	auto string_values = FlatVector::GetData<string_t>(enum_values);
+
+	// Track the lex min/max enum index seen in this chunk.
+	uint32_t best_min_idx = 0;
+	uint32_t best_max_idx = 0;
+	uint32_t best_min_rank = std::numeric_limits<uint32_t>::max();
+	uint32_t best_max_rank = 0;
+	bool any_seen = false;
+
 	for (idx_t r = chunk_start; r < chunk_end; r++) {
 		if (mask.RowIsValid(r)) {
 			if (!page_state.written_value) {
@@ -59,8 +80,27 @@ void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input
 				page_state.encoder.BeginWrite();
 				page_state.written_value = true;
 			}
-			page_state.encoder.WriteValue(temp_writer, ptr[r]);
-			stats.Update(string_values[ptr[r]]);
+			auto idx = ptr[r];
+			page_state.encoder.WriteValue(temp_writer, idx);
+			auto rank = lex_rank[idx];
+			if (!any_seen || rank < best_min_rank) {
+				best_min_rank = rank;
+				best_min_idx = idx;
+			}
+			if (!any_seen || rank > best_max_rank) {
+				best_max_rank = rank;
+				best_max_idx = idx;
+			}
+			any_seen = true;
+		}
+	}
+
+	if (any_seen) {
+		auto &enum_values = EnumType::GetValuesInsertOrder(Type());
+		auto string_values = FlatVector::GetData<string_t>(enum_values);
+		stats.Update(string_values[best_min_idx]);
+		if (best_max_idx != best_min_idx) {
+			stats.Update(string_values[best_max_idx]);
 		}
 	}
 }

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -49,7 +49,7 @@ EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&
 	std::sort(order.begin(), order.end(),
 	          [&](uint32_t a, uint32_t b) { return LessThan::Operation(string_values[a], string_values[b]); });
 	lex_rank.resize(enum_count);
-	for (uint32_t rank = 0; rank < enum_count; rank++) {
+	for (uint32_t rank = 0; rank < enum_count; ++rank) {
 		lex_rank[order[rank]] = rank;
 	}
 }
@@ -80,16 +80,16 @@ void EnumColumnWriter::WriteEnumInternal(WriteStream &temp_writer, Vector &input
 				page_state.encoder.BeginWrite();
 				page_state.written_value = true;
 			}
-			auto idx = ptr[r];
-			page_state.encoder.WriteValue(temp_writer, idx);
-			auto rank = lex_rank[idx];
+			const auto enum_idx = ptr[r];
+			page_state.encoder.WriteValue(temp_writer, enum_idx);
+			auto rank = lex_rank[enum_idx];
 			if (!any_seen || rank < best_min_rank) {
 				best_min_rank = rank;
-				best_min_idx = idx;
+				best_min_idx = enum_idx;
 			}
 			if (!any_seen || rank > best_max_rank) {
 				best_max_rank = rank;
-				best_max_idx = idx;
+				best_max_idx = enum_idx;
 			}
 			any_seen = true;
 		}

--- a/test/sql/copy/parquet/writer/parquet_write_enums.test
+++ b/test/sql/copy/parquet/writer/parquet_write_enums.test
@@ -145,10 +145,10 @@ statement ok
 CREATE TABLE t1 AS SELECT 'a'::myenum AS m FROM range(10) t(i);
 
 statement ok
-COPY t1 TO '__TEST_DIR__/enum_stats_single_1.parquet' (FORMAT PARQUET);
+COPY t1 TO '{TEST_DIR}/enum_stats_single_1.parquet' (FORMAT PARQUET);
 
 query II
-SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single_1.parquet')
+SELECT stats_min, stats_max FROM parquet_metadata('{TEST_DIR}/enum_stats_single_1.parquet')
 ----
 a	a
 
@@ -156,9 +156,9 @@ statement ok
 CREATE TABLE t2 AS SELECT 'c'::myenum AS m FROM range(10) t(i);
 
 statement ok
-COPY t2 TO '__TEST_DIR__/enum_stats_single_2.parquet' (FORMAT PARQUET);
+COPY t2 TO '{TEST_DIR}/enum_stats_single_2.parquet' (FORMAT PARQUET);
 
 query II
-SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single_2.parquet')
+SELECT stats_min, stats_max FROM parquet_metadata('{TEST_DIR}/enum_stats_single_2.parquet')
 ----
 c	c

--- a/test/sql/copy/parquet/writer/parquet_write_enums.test
+++ b/test/sql/copy/parquet/writer/parquet_write_enums.test
@@ -137,7 +137,7 @@ NULL
 NULL
 NULL
 
-# regression test for https://github.com/duckdb/duckdb/issues/22548
+# Regression test for https://github.com/duckdb/duckdb/issues/22548
 statement ok
 CREATE TYPE myenum AS ENUM ('a', 'b', 'c');
 
@@ -145,9 +145,20 @@ statement ok
 CREATE TABLE t1 AS SELECT 'a'::myenum AS m FROM range(10) t(i);
 
 statement ok
-COPY t1 TO '__TEST_DIR__/enum_stats_single.parquet' (FORMAT PARQUET);
+COPY t1 TO '__TEST_DIR__/enum_stats_single_1.parquet' (FORMAT PARQUET);
 
 query II
-SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single.parquet')
+SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single_1.parquet')
 ----
 a	a
+
+statement ok
+CREATE TABLE t2 AS SELECT 'c'::myenum AS m FROM range(10) t(i);
+
+statement ok
+COPY t2 TO '__TEST_DIR__/enum_stats_single_2.parquet' (FORMAT PARQUET);
+
+query II
+SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single_2.parquet')
+----
+c	c

--- a/test/sql/copy/parquet/writer/parquet_write_enums.test
+++ b/test/sql/copy/parquet/writer/parquet_write_enums.test
@@ -136,3 +136,18 @@ NULL
 NULL
 NULL
 NULL
+
+# regression test for https://github.com/duckdb/duckdb/issues/22548
+statement ok
+CREATE TYPE myenum AS ENUM ('a', 'b', 'c');
+
+statement ok
+CREATE TABLE t1 AS SELECT 'a'::myenum AS m FROM range(10) t(i);
+
+statement ok
+COPY t1 TO '__TEST_DIR__/enum_stats_single.parquet' (FORMAT PARQUET);
+
+query II
+SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/enum_stats_single.parquet')
+----
+a	a


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22548

In the current implementation we updates stats with all possible enum values, fixed by only updating min/max after all enum rows written. ~~To avoid frequently string comparison, lex ordering are pre-computed in advance.~~ Boolean array is used to indicate whether an enum type exists or not.