### PR TITLE
Fix invalid access for file row number

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1348,6 +1348,12 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 		D_ASSERT(metadata.row_groups.size() > row_group_idx);
 		D_ASSERT(root_schema->children.size() > primary_index);
 
+		// Special handle generated columns.
+		const auto &column_schema = root_schema->children[primary_index];
+		if (column_schema.schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
+			return true;
+		}
+
 		const auto &row_group = metadata.row_groups[row_group_idx];
 		const auto &column_chunk = row_group.columns[primary_index];
 

--- a/test/sql/copy/parquet/parquet_row_number.test
+++ b/test/sql/copy/parquet/parquet_row_number.test
@@ -8,6 +8,11 @@ PRAGMA enable_verification
 
 require parquet
 
+query I
+select min(file_row_number) from parquet_scan('{DATA_DIR}/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1);
+----
+0
+
 query IIII
 select min(file_row_number), max(file_row_number), avg(file_row_number),  count(*) from parquet_scan('{DATA_DIR}/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1);
 ----


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22661

The out-of-bound access happens [here](https://github.com/duckdb/duckdb/blob/2957fd1e3fd608a6b03fd63795aea3cb7abad40f/extension/parquet/parquet_reader.cpp#L1430-L1441), when optimizer tries to decide whether the stats value for `file_row_number` is exact or not.

Here's the root cause:
- When `file_row_number` requested in the query, DuckDB adds it as a generated column to the root schema [here](https://github.com/duckdb/duckdb/blob/2957fd1e3fd608a6b03fd63795aea3cb7abad40f/extension/parquet/parquet_reader.cpp#L809-L819), but row group columns only contain physical columns
- So in this PR, I treat file row number as a special column and return early at exact stats check

A related thing:
- In the unit test, we already have test cases to get min/max/avg/count for the file row number [here](https://github.com/duckdb/duckdb/blob/2957fd1e3fd608a6b03fd63795aea3cb7abad40f/test/sql/copy/parquet/parquet_row_number.test#L8-L11), but it doesn't trigger the bug
- The reason is, we [return early](https://github.com/duckdb/duckdb/blob/2957fd1e3fd608a6b03fd63795aea3cb7abad40f/src/optimizer/statistics/operator/propagate_aggregate.cpp#L160-L161) if the queried items include ones that are not min/max/count