### PR TITLE
Parquet ApplyPendingSkips really skip decode

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -327,7 +327,8 @@ void ColumnReader::ReadData(const data_ptr_t buffer, const uint32_t buffer_size,
 	}
 }
 
-void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter, optional_ptr<TableFilterState> filter_state) {
+void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter, optional_ptr<TableFilterState> filter_state,
+                               idx_t rows_to_skip) {
 	encoding = ColumnEncoding::INVALID;
 	defined_decoder.reset();
 	page_is_filtered_out = false;
@@ -353,8 +354,19 @@ void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter, optional_
 	}
 
 	if (PageIsFilteredOut(page_hdr, filter)) {
-		// this page has been filtered out so we don't need to read it
 		return;
+	}
+
+	if (rows_to_skip > 0 && (page_hdr.type == PageType::DATA_PAGE || page_hdr.type == PageType::DATA_PAGE_V2)) {
+		bool is_v1 = page_hdr.type == PageType::DATA_PAGE;
+		idx_t page_num_values = NumericCast<idx_t>(is_v1 ? page_hdr.data_page_header.num_values
+		                                                  : page_hdr.data_page_header_v2.num_values);
+		if (rows_to_skip >= page_num_values) {
+			trans.Skip(page_hdr.compressed_page_size);
+			page_is_filtered_out = true;
+			page_rows_available = page_num_values;
+			return;
+		}
 	}
 
 	switch (page_hdr.type) {
@@ -635,11 +647,11 @@ void ColumnReader::BeginRead(data_ptr_t define_out, data_ptr_t repeat_out) {
 }
 
 idx_t ColumnReader::ReadPageHeaders(idx_t max_read, optional_ptr<const TableFilter> filter,
-                                    optional_ptr<TableFilterState> filter_state) {
+                                    optional_ptr<TableFilterState> filter_state, idx_t rows_to_skip) {
 	int8_t page_ordinal = 0;
 	while (page_rows_available == 0) {
 		aad_crypto_metadata.page_ordinal = page_ordinal;
-		PrepareRead(filter, filter_state);
+		PrepareRead(filter, filter_state, rows_to_skip);
 		page_ordinal++;
 	}
 	return MinValue<idx_t>(MinValue<idx_t>(max_read, page_rows_available), STANDARD_VECTOR_SIZE);
@@ -861,7 +873,7 @@ void ColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_ou
 	BeginRead(nullptr, nullptr);
 
 	while (to_skip > 0) {
-		auto skip_now = ReadPageHeaders(to_skip);
+		auto skip_now = ReadPageHeaders(to_skip, nullptr, nullptr, to_skip);
 		if (page_is_filtered_out) {
 			// the page has been filtered out entirely - skip
 			page_rows_available -= skip_now;

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -359,8 +359,8 @@ void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter, optional_
 
 	if (rows_to_skip > 0 && (page_hdr.type == PageType::DATA_PAGE || page_hdr.type == PageType::DATA_PAGE_V2)) {
 		bool is_v1 = page_hdr.type == PageType::DATA_PAGE;
-		idx_t page_num_values = NumericCast<idx_t>(is_v1 ? page_hdr.data_page_header.num_values
-		                                                  : page_hdr.data_page_header_v2.num_values);
+		idx_t page_num_values =
+		    NumericCast<idx_t>(is_v1 ? page_hdr.data_page_header.num_values : page_hdr.data_page_header_v2.num_values);
 		if (rows_to_skip >= page_num_values) {
 			trans.Skip(page_hdr.compressed_page_size);
 			page_is_filtered_out = true;

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -246,7 +246,7 @@ private:
 	void BeginRead(data_ptr_t define_out, data_ptr_t repeat_out);
 	void FinishRead(idx_t read_count);
 	idx_t ReadPageHeaders(idx_t max_read, optional_ptr<const TableFilter> filter = nullptr,
-	                      optional_ptr<TableFilterState> filter_state = nullptr);
+	                      optional_ptr<TableFilterState> filter_state = nullptr, idx_t rows_to_skip = 0);
 	idx_t ReadInternal(ColumnReaderInput &input, Vector &result);
 	//! Prepare a read of up to "max_read" rows and read the defines/repeats.
 	//! Returns whether all values are valid (i.e., not NULL)
@@ -353,7 +353,8 @@ protected:
 
 private:
 	void AllocateBlock(idx_t size);
-	void PrepareRead(optional_ptr<const TableFilter> filter, optional_ptr<TableFilterState> filter_state);
+	void PrepareRead(optional_ptr<const TableFilter> filter, optional_ptr<TableFilterState> filter_state,
+	                 idx_t rows_to_skip = 0);
 	void PreparePage(PageHeader &page_hdr);
 	void PrepareDataPage(PageHeader &page_hdr);
 	void PreparePageV2(PageHeader &page_hdr);


### PR DESCRIPTION
Before I implement https://github.com/duckdb/duckdb/pull/22188#issuecomment-4288312713, I'd like to raise this PR first, because without this optimization, the benchmark for https://github.com/duckdb/duckdb/pull/22188#issuecomment-4288312713 may not show an obvious improvement.

This PR can skip page I/O and decoding completely when executing ``ApplyPendingSkips``.