### PR TITLE
Add `write_buffer_row_group_memory_limit` setting which controls when to flush row groups based on memory instead of only based on row group count

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1122,6 +1122,13 @@
         "default_value": "5"
     },
     {
+        "name": "write_buffer_row_group_memory_limit",
+        "description": "The maximum data to buffer in row groups (in bytes) to buffer prior to flushing them together. When either this limit is reached, or write_buffer_row_group_count is reached, we flush the data to disk. Defaults to 20% of memory limit divided by thread count.",
+        "type": "VARCHAR",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "zstd_min_string_length",
         "description": "The (average) length at which to enable ZSTD compression, defaults to 4096",
         "type": "UBIGINT",

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -169,6 +169,9 @@ struct DBConfigOptions {
 	LogConfig log_config = LogConfig();
 	//! Physical memory that the block allocator is allowed to use (this memory is never freed and cannot be reduced)
 	idx_t block_allocator_size = 0;
+	//! The maximum data to buffer in row groups (in bytes) to buffer prior to flushing.
+	//! When inserting large chunks of data we
+	optional_idx write_buffer_row_group_memory_limit;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1628,6 +1628,20 @@ struct WriteBufferRowGroupCountSetting {
 	static constexpr idx_t SettingIndex = 94;
 };
 
+struct WriteBufferRowGroupMemoryLimitSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "write_buffer_row_group_memory_limit";
+	static constexpr const char *Description =
+	    "The maximum data to buffer in row groups (in bytes) to buffer prior to flushing them together. When either "
+	    "this limit is reached, or write_buffer_row_group_count is reached, we flush the data to disk. Defaults to 20% "
+	    "of "
+	    "memory limit divided by thread count.";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct ZstdMinStringLengthSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "zstd_min_string_length";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1634,8 +1634,7 @@ struct WriteBufferRowGroupMemoryLimitSetting {
 	static constexpr const char *Description =
 	    "The maximum data to buffer in row groups (in bytes) to buffer prior to flushing them together. When either "
 	    "this limit is reached, or write_buffer_row_group_count is reached, we flush the data to disk. Defaults to 20% "
-	    "of "
-	    "memory limit divided by thread count.";
+	    "of memory limit divided by thread count.";
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -19,6 +19,8 @@ struct OptimisticWriteCollection {
 
 	shared_ptr<RowGroupCollection> collection;
 	set<idx_t> unflushed_row_groups;
+	idx_t unflushed_data_size = 0;
+	idx_t prev_allocated_size = 0;
 	idx_t complete_row_groups = 0;
 	vector<unique_ptr<PartialBlockManager>> partial_block_managers;
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -206,6 +206,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(WalAutocheckpointEntriesSetting),
     DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),
     DUCKDB_SETTING(WriteBufferRowGroupCountSetting),
+    DUCKDB_GLOBAL(WriteBufferRowGroupMemoryLimitSetting),
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1699,6 +1699,32 @@ void WarningsAsErrorsSetting::OnSet(SettingCallbackInfo &info, Value &input) {
 	}
 }
 
+//===----------------------------------------------------------------------===//
+// Streaming Buffer Size
+//===----------------------------------------------------------------------===//
+void WriteBufferRowGroupMemoryLimitSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	if (input.IsNull() || input.ToString().empty()) {
+		config.options.write_buffer_row_group_memory_limit = optional_idx();
+	} else {
+		config.options.write_buffer_row_group_memory_limit = DBConfig::ParseMemoryLimit(input.ToString());
+	}
+}
+
+void WriteBufferRowGroupMemoryLimitSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.write_buffer_row_group_memory_limit = optional_idx();
+}
+
+Value WriteBufferRowGroupMemoryLimitSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	idx_t bytes = 0;
+	if (config.options.write_buffer_row_group_memory_limit.IsValid()) {
+		bytes = config.options.write_buffer_row_group_memory_limit.GetIndex();
+	} else {
+		bytes = config.options.maximum_memory / 5 / (config.options.maximum_threads + 1);
+	}
+	return Value(StringUtil::BytesToHumanReadableString(bytes));
+}
+
 void CurrentTransactionInvalidationPolicySetting::OnSet(SettingCallbackInfo &info, Value &input) {
 	if (!info.context) {
 		throw InvalidInputException(

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -68,7 +68,23 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 	row_groups.unflushed_row_groups.insert(row_groups.complete_row_groups);
 	row_groups.complete_row_groups++;
 	auto unflushed_row_groups = row_groups.unflushed_row_groups.size();
-	if (unflushed_row_groups >= Settings::Get<WriteBufferRowGroupCountSetting>(context)) {
+	// check if we should flush the row groups
+	// first check the amount of row groups
+	bool need_to_flush = unflushed_row_groups >= Settings::Get<WriteBufferRowGroupCountSetting>(context);
+	if (!need_to_flush) {
+		// we don't need to flush based on the amount of row groups - but we still might need to flush based on the
+		// amount of
+		auto &config = DBConfig::GetConfig(context);
+		auto memory_limit = config.options.write_buffer_row_group_memory_limit;
+		if (!memory_limit.IsValid()) {
+			memory_limit = config.options.maximum_memory / 5 / (config.options.maximum_threads + 1);
+		}
+		if (row_groups.collection->GetAllocationSize() >= memory_limit.GetIndex()) {
+			// we exhausted our memory available for buffering - flush
+			need_to_flush = true;
+		}
+	}
+	if (need_to_flush) {
 		// we have crossed our flush threshold - flush any unwritten row groups to disk
 		vector<const_reference<RowGroup>> to_flush;
 		vector<int64_t> segment_indexes;

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -67,6 +67,12 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 
 	row_groups.unflushed_row_groups.insert(row_groups.complete_row_groups);
 	row_groups.complete_row_groups++;
+	auto allocated_size = row_groups.collection->GetAllocationSize();
+	if (row_groups.prev_allocated_size > allocated_size) {
+		throw InternalException("Row group prev allocated size is larger than currently allocated size");
+	}
+	row_groups.unflushed_data_size += allocated_size - row_groups.prev_allocated_size;
+	row_groups.prev_allocated_size = allocated_size;
 	auto unflushed_row_groups = row_groups.unflushed_row_groups.size();
 	// check if we should flush the row groups
 	// first check the amount of row groups
@@ -79,7 +85,7 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 		if (!memory_limit.IsValid()) {
 			memory_limit = config.options.maximum_memory / 5 / (config.options.maximum_threads + 1);
 		}
-		if (row_groups.collection->GetAllocationSize() >= memory_limit.GetIndex()) {
+		if (row_groups.unflushed_data_size >= memory_limit.GetIndex()) {
 			// we exhausted our memory available for buffering - flush
 			need_to_flush = true;
 		}
@@ -95,6 +101,7 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 		}
 		FlushToDisk(row_groups, to_flush, segment_indexes);
 		row_groups.unflushed_row_groups.clear();
+		row_groups.unflushed_data_size = 0;
 	}
 }
 

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -88,6 +88,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"extension_directory", {"test"}},
 	    {"extension_directories", {"[test]"}},
 	    {"max_expression_depth", {50}},
+	    {"write_buffer_row_group_memory_limit", {"4.0 GiB"}},
 	    {"max_memory", {"4.0 GiB"}},
 	    {"max_temp_directory_size", {"10.0 GiB"}},
 	    {"merge_join_threshold", {73}},


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/19118 introduced new behavior where we gather row groups prior to writing them out in order to create "better" files that are faster to read by co-locating the same column also across separate row groups when possible, reducing the number of distinct blocks we need to read when reading individual columns. However, this batching comes at the expense of increased memory usage.

Currently we naively buffer 5 row groups by default (configurable by `write_buffer_row_group_count`). This PR extends this to also take the *size* of the row groups into account. The `write_buffer_row_group_memory_limit` controls how much memory we are allowed to buffer prior to flushing. We will then flush when **either** the amount of row groups exceeds `write_buffer_row_group_count` is exceeded **or** the unflushed memory exceeds `write_buffer_row_group_memory_limit`.

The default limit is set to 20% of the max memory divided by the number of threads.

This should reduce memory pressure from this new feature especially when writing wide row groups, while still allowing it to be beneficial in most use cases.