### PR TITLE
Fix jemalloc thread flush threshold check

### DIFF
--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -68,7 +68,7 @@ int64_t JemallocExtension::DecayDelay() {
 
 void JemallocExtension::ThreadFlush(idx_t threshold) {
 	// We flush after exceeding the threshold
-	if (GetJemallocCTL<uint64_t>("thread.peak.read") > threshold) {
+	if (GetJemallocCTL<uint64_t>("thread.peak.read") <= threshold) {
 		return;
 	}
 


### PR DESCRIPTION
This appears to be a typo. On my machine this results in many madvise syscalls.