### PR TITLE
Don't optimize join in Deliminator if any filter has been pushed to table function

### DIFF
--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -42,6 +42,7 @@ public:
 	vector<ProjectionIndex> projection_ids;
 	//! Filters pushed down for table scan
 	TableFilterSet table_filters;
+	bool pushed_any_filter_to_table_function = false;
 	//! The set of input parameters for the table function
 	vector<Value> parameters;
 	//! The set of named input parameters for the table function

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -117,6 +117,9 @@ bool Deliminator::HasSelection(const LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET: {
 		auto &get = op.Cast<LogicalGet>();
+		if (get.pushed_any_filter_to_table_function) {
+			return true;
+		}
 		for (const auto &entry : get.table_filters) {
 			if (entry.Filter().filter_type != TableFilterType::IS_NOT_NULL) {
 				return true;

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -31,7 +31,11 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		}
 		filters.clear();
 
+		const size_t expressions_size = expressions.size();
 		get.function.pushdown_complex_filter(optimizer.context, get, get.bind_data.get(), expressions);
+		if (expressions_size != expressions.size()) {
+			get.pushed_any_filter_to_table_function = true;
+		};
 
 		if (expressions.empty()) {
 			return op;


### PR DESCRIPTION
This is a fix for https://github.com/duckdb/duckdb/issues/22669
as an PoC. Optimizing the join to a hash join may lead to regressions on some benchmarks. This doesn't reproduce on Parquet becase Parquet reader doesn't do complex filter pushdown outside hive columns / filename column reduction.