### PR TITLE
Fix enum type write to parquet

### DIFF
--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -7,6 +7,18 @@
 namespace duckdb {
 using duckdb_parquet::Encoding;
 
+namespace {
+class EnumStatisticsState : public StringStatisticsState {
+public:
+	bool MinIsExact() override {
+		return false;
+	}
+	bool MaxIsExact() override {
+		return false;
+	}
+};
+} // namespace
+
 class EnumWriterPageState : public ColumnWriterPageState {
 public:
 	explicit EnumWriterPageState(uint32_t bit_width) : encoder(bit_width), written_value(false) {
@@ -23,7 +35,7 @@ EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&
 }
 
 unique_ptr<ColumnWriterStatistics> EnumColumnWriter::InitializeStatsState() {
-	return make_uniq<StringStatisticsState>();
+	return make_uniq<EnumStatisticsState>();
 }
 
 template <class T>

--- a/test/sql/copy/parquet/writer/parquet_write_enums.test
+++ b/test/sql/copy/parquet/writer/parquet_write_enums.test
@@ -139,3 +139,19 @@ NULL
 NULL
 NULL
 NULL
+
+statement ok
+CREATE TABLE t AS SELECT 'joy'::mood AS m FROM range(10) t(i);
+
+statement ok
+COPY t TO '__TEST_DIR__/enum_stats_single.parquet' (FORMAT PARQUET);
+
+query I
+SELECT MIN(m) FROM read_parquet('__TEST_DIR__/enum_stats_single.parquet')
+----
+joy
+
+query I
+SELECT MAX(m) FROM read_parquet('__TEST_DIR__/enum_stats_single.parquet')
+----
+joy


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22676

This PR followup on Mark's comment here https://github.com/duckdb/duckdb/pull/22658#issuecomment-4450133718, to split the enum type stats population into two parts:
- This PR fixes an existing bug that, min/max considers all possible enum values, but don't mark them as inexact, which leads to incorrect query result. (v1.5 fix branch)
- I will followup with another PR to improve the stats population (main branch)