### PR TITLE
Fix/eviction queue purge correctness

### DIFF
--- a/src/include/duckdb/parallel/concurrentqueue.hpp
+++ b/src/include/duckdb/parallel/concurrentqueue.hpp
@@ -25,12 +25,14 @@ class BlockingConcurrentQueue;
 
 struct ProducerToken {
 	//! Constructor
-	template <typename T, typename Traits>
-	explicit ProducerToken(ConcurrentQueue<T> &);
+	template <typename T>
+	explicit ProducerToken(ConcurrentQueue<T> &) {
+	}
 	//! Constructor
-	template <typename T, typename Traits>
-	explicit ProducerToken(BlockingConcurrentQueue<T> &);
-	//! Constructor
+	template <typename T>
+	explicit ProducerToken(BlockingConcurrentQueue<T> &) {
+	}
+	//! Move constructor
 	ProducerToken(ProducerToken &&) {
 	}
 	//! Is valid token?

--- a/src/include/duckdb/parallel/concurrentqueue.hpp
+++ b/src/include/duckdb/parallel/concurrentqueue.hpp
@@ -39,6 +39,20 @@ struct ProducerToken {
 	}
 };
 
+struct ConsumerToken {
+	//! Constructor
+	template <typename T>
+	explicit ConsumerToken(ConcurrentQueue<T> &) {
+	}
+	//! Constructor
+	template <typename T>
+	explicit ConsumerToken(BlockingConcurrentQueue<T> &) {
+	}
+	//! Move constructor
+	ConsumerToken(ConsumerToken &&) {
+	}
+};
+
 template <typename T>
 class ConcurrentQueue {
 private:
@@ -84,6 +98,11 @@ public:
 		}
 		return max;
 	}
+	//! Dequeues several elements from the queue using a consumer token.
+	template <typename It>
+	size_t try_dequeue_bulk(ConsumerToken &, It itemFirst, size_t max) {
+		return try_dequeue_bulk(itemFirst, max);
+	}
 
 	template <typename It>
 	bool enqueue_bulk(It itemFirst, size_t count) {
@@ -91,6 +110,11 @@ public:
 			q.push(std::move(*itemFirst++));
 		}
 		return true;
+	}
+	//! Enqueues several elements using a producer token.
+	template <typename It>
+	bool enqueue_bulk(ProducerToken const &, It itemFirst, size_t count) {
+		return enqueue_bulk(itemFirst, count);
 	}
 };
 

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -226,6 +226,22 @@ private:
 	const char *unswizzled;
 	//! The eviction queue index, currently only FileBufferType::MANAGED_BUFFER.
 	atomic<idx_t> eviction_queue_idx;
+	//! True iff this block has ever been inserted into an eviction queue.
+	//! Used by ~BlockMemory to decide whether the latest queue entry needs to be marked dead.
+	//! This stays true even after Unload (which resets eviction_seq_num), because the stale
+	//! queue entry from before the unload is still in the queue and must be accounted for
+	//! when this BlockMemory is destroyed.
+	atomic<bool> ever_in_eviction_queue;
+
+public:
+	//! Returns whether this block has ever been added to an eviction queue.
+	bool EverInEvictionQueue() const {
+		return ever_in_eviction_queue.load(std::memory_order_relaxed);
+	}
+	//! Marks this block as having been added to an eviction queue at least once.
+	void MarkAddedToEvictionQueue() {
+		ever_in_eviction_queue.store(true, std::memory_order_relaxed);
+	}
 };
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -226,22 +226,6 @@ private:
 	const char *unswizzled;
 	//! The eviction queue index, currently only FileBufferType::MANAGED_BUFFER.
 	atomic<idx_t> eviction_queue_idx;
-	//! True iff this block has ever been inserted into an eviction queue.
-	//! Used by ~BlockMemory to decide whether the latest queue entry needs to be marked dead.
-	//! This stays true even after Unload (which resets eviction_seq_num), because the stale
-	//! queue entry from before the unload is still in the queue and must be accounted for
-	//! when this BlockMemory is destroyed.
-	atomic<bool> ever_in_eviction_queue;
-
-public:
-	//! Returns whether this block has ever been added to an eviction queue.
-	bool EverInEvictionQueue() const {
-		return ever_in_eviction_queue.load(std::memory_order_relaxed);
-	}
-	//! Marks this block as having been added to an eviction queue at least once.
-	void MarkAddedToEvictionQueue() {
-		ever_in_eviction_queue.store(true, std::memory_order_relaxed);
-	}
 };
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -34,7 +34,7 @@ struct BufferEvictionNode {
 
 	bool CanUnload(BlockMemory &memory);
 	shared_ptr<BlockMemory> TryGetBlockMemory();
-	bool IsDeadNode();
+	bool IsDeadNode(idx_t debug_sleep_micros = 0);
 };
 
 //! The BufferPool is in charge of handling memory management for one or more databases. It defines memory limits

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -34,7 +34,7 @@ struct BufferEvictionNode {
 
 	bool CanUnload(BlockMemory &memory);
 	shared_ptr<BlockMemory> TryGetBlockMemory();
-	bool IsDeadNode(idx_t debug_sleep_micros = 0);
+	bool IsDeadNode(optional_idx debug_sleep_micros = optional_idx());
 };
 
 //! The BufferPool is in charge of handling memory management for one or more databases. It defines memory limits

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -34,6 +34,7 @@ struct BufferEvictionNode {
 
 	bool CanUnload(BlockMemory &memory);
 	shared_ptr<BlockMemory> TryGetBlockMemory();
+	bool IsDeadNode();
 };
 
 //! The BufferPool is in charge of handling memory management for one or more databases. It defines memory limits

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -34,7 +34,7 @@ BlockMemory::~BlockMemory() { // NOLINT: allow internal exceptions
 	// The block memory is being destroyed, meaning that any unswizzled pointers are now binary junk.
 	SetSwizzling(nullptr);
 	D_ASSERT(!GetBuffer() || GetBuffer()->GetBufferType() == GetBufferType());
-	if (GetBuffer() && GetBufferType() != FileBufferType::TINY_BUFFER) {
+	if (GetBufferType() != FileBufferType::TINY_BUFFER) {
 		// Kill the latest version in the eviction queue.
 		GetBufferManager().GetBufferPool().IncrementDeadNodes(*this);
 	}

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -16,7 +16,7 @@ BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, M
       buffer_type(FileBufferType::BLOCK), buffer(nullptr), eviction_seq_num(0), lru_timestamp_msec(),
       destroy_buffer_upon(DestroyBufferUpon::BLOCK), memory_usage(block_alloc_size_p),
       memory_charge(tag, buffer_manager.GetBufferPool()), unswizzled(nullptr),
-      eviction_queue_idx(DConstants::INVALID_INDEX), ever_in_eviction_queue(false) {
+      eviction_queue_idx(DConstants::INVALID_INDEX) {
 }
 
 BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, MemoryTag tag_p,
@@ -26,7 +26,7 @@ BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, M
       buffer_type(buffer_p->GetBufferType()), buffer(std::move(buffer_p)), eviction_seq_num(0), lru_timestamp_msec(),
       destroy_buffer_upon(destroy_buffer_upon_p), memory_usage(size_p),
       memory_charge(tag, buffer_manager.GetBufferPool()), unswizzled(nullptr),
-      eviction_queue_idx(DConstants::INVALID_INDEX), ever_in_eviction_queue(false) {
+      eviction_queue_idx(DConstants::INVALID_INDEX) {
 	memory_charge = std::move(reservation); // Moved to constructor body due to tidy check.
 }
 
@@ -34,13 +34,9 @@ BlockMemory::~BlockMemory() { // NOLINT: allow internal exceptions
 	// The block memory is being destroyed, meaning that any unswizzled pointers are now binary junk.
 	SetSwizzling(nullptr);
 	D_ASSERT(!GetBuffer() || GetBuffer()->GetBufferType() == GetBufferType());
-	if (EverInEvictionQueue() && GetBufferType() != FileBufferType::TINY_BUFFER) {
-		// This BlockMemory was inserted into the eviction queue at least once, so the latest
-		// queue entry referring to it is now dead. Account for it.
-		// We deliberately do NOT predicate this on GetBuffer() being non-null: the queue
-		// entry's lifetime is independent of whether the buffer is currently loaded - only
-		// the dequeue side ever removes it. If the block was evicted (buffer destroyed) and
-		// then this BlockMemory is destroyed, the stale queue entry still needs accounting.
+	if (GetEvictionSequenceNumber() > 0 && GetBufferType() != FileBufferType::TINY_BUFFER) {
+		// eviction_seq_num > 0 means there is a live queue entry for this block (it's reset
+		// to 0 on unload/evict). That entry is now dead — account for it.
 		GetBufferManager().GetBufferPool().IncrementDeadNodes(*this);
 	}
 

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -16,7 +16,7 @@ BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, M
       buffer_type(FileBufferType::BLOCK), buffer(nullptr), eviction_seq_num(0), lru_timestamp_msec(),
       destroy_buffer_upon(DestroyBufferUpon::BLOCK), memory_usage(block_alloc_size_p),
       memory_charge(tag, buffer_manager.GetBufferPool()), unswizzled(nullptr),
-      eviction_queue_idx(DConstants::INVALID_INDEX) {
+      eviction_queue_idx(DConstants::INVALID_INDEX), ever_in_eviction_queue(false) {
 }
 
 BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, MemoryTag tag_p,
@@ -26,7 +26,7 @@ BlockMemory::BlockMemory(BufferManager &buffer_manager, block_id_t block_id_p, M
       buffer_type(buffer_p->GetBufferType()), buffer(std::move(buffer_p)), eviction_seq_num(0), lru_timestamp_msec(),
       destroy_buffer_upon(destroy_buffer_upon_p), memory_usage(size_p),
       memory_charge(tag, buffer_manager.GetBufferPool()), unswizzled(nullptr),
-      eviction_queue_idx(DConstants::INVALID_INDEX) {
+      eviction_queue_idx(DConstants::INVALID_INDEX), ever_in_eviction_queue(false) {
 	memory_charge = std::move(reservation); // Moved to constructor body due to tidy check.
 }
 
@@ -34,8 +34,13 @@ BlockMemory::~BlockMemory() { // NOLINT: allow internal exceptions
 	// The block memory is being destroyed, meaning that any unswizzled pointers are now binary junk.
 	SetSwizzling(nullptr);
 	D_ASSERT(!GetBuffer() || GetBuffer()->GetBufferType() == GetBufferType());
-	if (GetBufferType() != FileBufferType::TINY_BUFFER) {
-		// Kill the latest version in the eviction queue.
+	if (EverInEvictionQueue() && GetBufferType() != FileBufferType::TINY_BUFFER) {
+		// This BlockMemory was inserted into the eviction queue at least once, so the latest
+		// queue entry referring to it is now dead. Account for it.
+		// We deliberately do NOT predicate this on GetBuffer() being non-null: the queue
+		// entry's lifetime is independent of whether the buffer is currently loaded - only
+		// the dequeue side ever removes it. If the block was evicted (buffer destroyed) and
+		// then this BlockMemory is destroyed, the stale queue entry still needs accounting.
 		GetBufferManager().GetBufferPool().IncrementDeadNodes(*this);
 	}
 

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -293,6 +293,7 @@ bool BufferPool::AddToEvictionQueue(shared_ptr<BlockHandle> &handle) {
 	// The block handle is locked during this operation (Unpin),
 	// or the block handle is still a local variable (ConvertToPersistent)
 	D_ASSERT(memory.GetReaders() == 0);
+	memory.MarkAddedToEvictionQueue();
 	auto ts = memory.NextEvictionSequenceNumber();
 	if (track_eviction_timestamps) {
 		memory.SetLRUTimestamp(std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -298,7 +298,6 @@ bool BufferPool::AddToEvictionQueue(shared_ptr<BlockHandle> &handle) {
 	// The block handle is locked during this operation (Unpin),
 	// or the block handle is still a local variable (ConvertToPersistent)
 	D_ASSERT(memory.GetReaders() == 0);
-	memory.MarkAddedToEvictionQueue();
 	auto ts = memory.NextEvictionSequenceNumber();
 	if (track_eviction_timestamps) {
 		memory.SetLRUTimestamp(std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -66,6 +66,17 @@ shared_ptr<BlockMemory> BufferEvictionNode::TryGetBlockMemory() {
 	return shared_memory_p;
 }
 
+bool BufferEvictionNode::IsDeadNode() {
+	auto shared_memory_p = memory_p.lock();
+	if (!shared_memory_p) {
+		return true;
+	}
+	if (handle_sequence_number != shared_memory_p->GetEvictionSequenceNumber()) {
+		return true;
+	}
+	return false;
+}
+
 typedef duckdb_moodycamel::ConcurrentQueue<BufferEvictionNode> eviction_queue_t;
 
 struct EvictionQueue {
@@ -109,7 +120,7 @@ public:
 
 private:
 	//! Bulk purge dead nodes from the eviction queue. Then, enqueue those that are still alive.
-	void PurgeIteration(const idx_t purge_size);
+	void PurgeIteration(const idx_t purge_size, vector<BufferEvictionNode> &alive_nodes_out);
 
 public:
 	//! The type of the buffers in this queue and helper function (both for verification only)
@@ -191,11 +202,19 @@ void EvictionQueue::Purge() {
 	// guaranteeing that we always exit the loop.
 
 	idx_t max_purges = approx_q_size / purge_size;
-	while (max_purges != 0) {
-		PurgeIteration(purge_size);
 
-		// update relevant sizes and potentially early-out
-		approx_q_size = q.size_approx();
+	// Accumulate alive nodes across all iterations and re-enqueue once at the end.
+	// This prevents the purge thread from feeding alive nodes back into its own
+	// moodycamel sub-queue between iterations, which would cause subsequent
+	// try_dequeue_bulk calls to re-drain those same alive nodes instead of
+	// reaching dead entries in worker thread sub-queues.
+	vector<BufferEvictionNode> alive_nodes_to_reenqueue;
+
+	while (max_purges != 0) {
+		PurgeIteration(purge_size, alive_nodes_to_reenqueue);
+
+		// The effective queue size includes alive nodes held in our buffer
+		approx_q_size = q.size_approx() + alive_nodes_to_reenqueue.size();
 
 		// early-out according to (2.1)
 		if (approx_q_size < purge_size * EARLY_OUT_MULTIPLIER) {
@@ -213,9 +232,14 @@ void EvictionQueue::Purge() {
 
 		max_purges--;
 	}
+
+	// Re-enqueue all alive nodes after the purge loop completes
+	if (!alive_nodes_to_reenqueue.empty()) {
+		q.enqueue_bulk(alive_nodes_to_reenqueue.begin(), alive_nodes_to_reenqueue.size());
+	}
 }
 
-void EvictionQueue::PurgeIteration(const idx_t purge_size) {
+void EvictionQueue::PurgeIteration(const idx_t purge_size, vector<BufferEvictionNode> &alive_nodes_out) {
 	// if this purge is significantly smaller or bigger than the previous purge, then
 	// we need to resize the purge_nodes vector. Note that this barely happens, as we
 	// purge queue_insertions * PURGE_SIZE_MULTIPLIER nodes
@@ -227,25 +251,21 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 	// bulk purge
 	const idx_t actually_dequeued = q.try_dequeue_bulk(purge_nodes.begin(), purge_size);
 
-	// retrieve all alive nodes that have been wrongly dequeued
-	idx_t alive_nodes = 0;
+	idx_t dead_count = 0;
 	auto debug_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);
 	for (idx_t i = 0; i < actually_dequeued; i++) {
 		auto &node = purge_nodes[i];
-		auto handle = node.TryGetBlockMemory();
 		if (debug_sleep_micros > 0) {
-			// Debug race conditions regarding the ownership of the BlockMemory.
 			ThreadUtil::SleepMicroSeconds(debug_sleep_micros);
 		}
-		if (handle) {
-			purge_nodes[alive_nodes++] = std::move(node);
+		if (node.IsDeadNode()) {
+			dead_count++;
+		} else {
+			alive_nodes_out.push_back(std::move(node));
 		}
 	}
 
-	// bulk re-add (TODO order them by timestamp to better retain the LRU behavior)
-	q.enqueue_bulk(purge_nodes.begin(), alive_nodes);
-
-	total_dead_nodes -= actually_dequeued - alive_nodes;
+	total_dead_nodes -= dead_count;
 }
 
 BufferPool::BufferPool(BlockAllocator &block_allocator, idx_t maximum_memory, bool track_eviction_timestamps,

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -85,8 +85,8 @@ typedef duckdb_moodycamel::ConcurrentQueue<BufferEvictionNode> eviction_queue_t;
 struct EvictionQueue {
 public:
 	explicit EvictionQueue(const vector<FileBufferType> &file_buffer_types_p)
-	    : file_buffer_types(file_buffer_types_p), purge_consumer_token(q), purge_producer_token(q),
-	      debug_eviction_queue_sleep(0), evict_queue_insertions(0), total_dead_nodes(0) {
+	    : file_buffer_types(file_buffer_types_p), debug_eviction_queue_sleep(0), evict_queue_insertions(0),
+	      total_dead_nodes(0), purge_consumer_token(q), purge_producer_token(q) {
 	}
 
 public:

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -234,6 +234,9 @@ void EvictionQueue::Purge() {
 }
 
 void EvictionQueue::PurgeIteration(const idx_t purge_size) {
+	// if this purge is significantly smaller or bigger than the previous purge, then
+	// we need to resize the purge_nodes vector. Note that this barely happens, as we
+	// purge queue_insertions * PURGE_SIZE_MULTIPLIER nodes
 	idx_t previous_purge_size = purge_nodes.size();
 	if (purge_size < previous_purge_size / 2 || purge_size > previous_purge_size) {
 		purge_nodes.resize(purge_size);

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -85,8 +85,8 @@ typedef duckdb_moodycamel::ConcurrentQueue<BufferEvictionNode> eviction_queue_t;
 struct EvictionQueue {
 public:
 	explicit EvictionQueue(const vector<FileBufferType> &file_buffer_types_p)
-	    : file_buffer_types(file_buffer_types_p), debug_eviction_queue_sleep(0), evict_queue_insertions(0),
-	      total_dead_nodes(0) {
+	    : file_buffer_types(file_buffer_types_p), purge_consumer_token(q), purge_producer_token(q),
+	      debug_eviction_queue_sleep(0), evict_queue_insertions(0), total_dead_nodes(0) {
 	}
 
 public:
@@ -122,8 +122,8 @@ public:
 	}
 
 private:
-	//! Bulk purge dead nodes from the eviction queue. Then, enqueue those that are still alive.
-	void PurgeIteration(const idx_t purge_size, vector<BufferEvictionNode> &alive_nodes_out);
+	//! Bulk purge dead nodes from the eviction queue. Then, re-enqueue those that are still alive.
+	void PurgeIteration(const idx_t purge_size);
 
 public:
 	//! The type of the buffers in this queue and helper function (both for verification only)
@@ -157,6 +157,10 @@ private:
 	mutex purge_lock;
 	//! A pre-allocated vector of eviction nodes. We reuse this to keep the allocation overhead of purges small.
 	vector<BufferEvictionNode> purge_nodes;
+	//! Consumer token for purge dequeuing — progresses through sub-queues sequentially.
+	duckdb_moodycamel::ConsumerToken purge_consumer_token;
+	//! Producer token for re-enqueuing alive nodes into a dedicated sub-queue.
+	duckdb_moodycamel::ProducerToken purge_producer_token;
 };
 
 bool EvictionQueue::AddToEvictionQueue(BufferEvictionNode &&node) {
@@ -206,18 +210,10 @@ void EvictionQueue::Purge() {
 
 	idx_t max_purges = approx_q_size / purge_size;
 
-	// Accumulate alive nodes across all iterations and re-enqueue once at the end.
-	// This prevents the purge thread from feeding alive nodes back into its own
-	// moodycamel sub-queue between iterations, which would cause subsequent
-	// try_dequeue_bulk calls to re-drain those same alive nodes instead of
-	// reaching dead entries in worker thread sub-queues.
-	vector<BufferEvictionNode> alive_nodes_to_reenqueue;
-
 	while (max_purges != 0) {
-		PurgeIteration(purge_size, alive_nodes_to_reenqueue);
+		PurgeIteration(purge_size);
 
-		// The effective queue size includes alive nodes held in our buffer
-		approx_q_size = q.size_approx() + alive_nodes_to_reenqueue.size();
+		approx_q_size = q.size_approx();
 
 		// early-out according to (2.1)
 		if (approx_q_size < purge_size * EARLY_OUT_MULTIPLIER) {
@@ -235,37 +231,43 @@ void EvictionQueue::Purge() {
 
 		max_purges--;
 	}
-
-	// Re-enqueue all alive nodes after the purge loop completes
-	if (!alive_nodes_to_reenqueue.empty()) {
-		q.enqueue_bulk(alive_nodes_to_reenqueue.begin(), alive_nodes_to_reenqueue.size());
-	}
 }
 
-void EvictionQueue::PurgeIteration(const idx_t purge_size, vector<BufferEvictionNode> &alive_nodes_out) {
-	// if this purge is significantly smaller or bigger than the previous purge, then
-	// we need to resize the purge_nodes vector. Note that this barely happens, as we
-	// purge queue_insertions * PURGE_SIZE_MULTIPLIER nodes
+void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 	idx_t previous_purge_size = purge_nodes.size();
 	if (purge_size < previous_purge_size / 2 || purge_size > previous_purge_size) {
 		purge_nodes.resize(purge_size);
 	}
 
-	// bulk purge
-	const idx_t actually_dequeued = q.try_dequeue_bulk(purge_nodes.begin(), purge_size);
+	// Dequeue using consumer token — progresses through sub-queues sequentially
+	const idx_t actually_dequeued = q.try_dequeue_bulk(purge_consumer_token, purge_nodes.begin(), purge_size);
+	if (actually_dequeued == 0) {
+		return;
+	}
 
 	idx_t dead_count = 0;
+	idx_t alive_count = 0;
 	auto debug_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);
 	for (idx_t i = 0; i < actually_dequeued; i++) {
 		auto &node = purge_nodes[i];
 		if (node.IsDeadNode(debug_sleep_micros)) {
 			dead_count++;
 		} else {
-			alive_nodes_out.push_back(std::move(node));
+			// Move alive nodes to the front for bulk re-enqueue
+			if (alive_count != i) {
+				purge_nodes[alive_count] = std::move(node);
+			}
+			alive_count++;
 		}
 	}
 
 	total_dead_nodes -= dead_count;
+
+	// Re-enqueue alive nodes via producer token — goes into a dedicated sub-queue
+	// that the consumer token has already passed
+	if (alive_count > 0) {
+		q.enqueue_bulk(purge_producer_token, purge_nodes.begin(), alive_count);
+	}
 }
 
 BufferPool::BufferPool(BlockAllocator &block_allocator, idx_t maximum_memory, bool track_eviction_timestamps,

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -66,10 +66,10 @@ shared_ptr<BlockMemory> BufferEvictionNode::TryGetBlockMemory() {
 	return shared_memory_p;
 }
 
-bool BufferEvictionNode::IsDeadNode(idx_t debug_sleep_micros) {
+bool BufferEvictionNode::IsDeadNode(optional_idx debug_sleep_micros) {
 	auto shared_memory_p = memory_p.lock();
-	if (debug_sleep_micros > 0) {
-		ThreadUtil::SleepMicroSeconds(debug_sleep_micros);
+	if (debug_sleep_micros.IsValid()) {
+		ThreadUtil::SleepMicroSeconds(debug_sleep_micros.GetIndex());
 	}
 	if (!shared_memory_p) {
 		return true;
@@ -213,6 +213,7 @@ void EvictionQueue::Purge() {
 	while (max_purges != 0) {
 		PurgeIteration(purge_size);
 
+		// update relevant sizes and potentially early-out
 		approx_q_size = q.size_approx();
 
 		// early-out according to (2.1)
@@ -250,7 +251,8 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 
 	idx_t dead_count = 0;
 	idx_t alive_count = 0;
-	auto debug_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);
+	auto raw_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);
+	optional_idx debug_sleep_micros = raw_sleep_micros > 0 ? optional_idx(raw_sleep_micros) : optional_idx();
 	for (idx_t i = 0; i < actually_dequeued; i++) {
 		auto &node = purge_nodes[i];
 		if (node.IsDeadNode(debug_sleep_micros)) {

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -66,8 +66,11 @@ shared_ptr<BlockMemory> BufferEvictionNode::TryGetBlockMemory() {
 	return shared_memory_p;
 }
 
-bool BufferEvictionNode::IsDeadNode() {
+bool BufferEvictionNode::IsDeadNode(idx_t debug_sleep_micros) {
 	auto shared_memory_p = memory_p.lock();
+	if (debug_sleep_micros > 0) {
+		ThreadUtil::SleepMicroSeconds(debug_sleep_micros);
+	}
 	if (!shared_memory_p) {
 		return true;
 	}
@@ -255,10 +258,7 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size, vector<BufferEviction
 	auto debug_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);
 	for (idx_t i = 0; i < actually_dequeued; i++) {
 		auto &node = purge_nodes[i];
-		if (debug_sleep_micros > 0) {
-			ThreadUtil::SleepMicroSeconds(debug_sleep_micros);
-		}
-		if (node.IsDeadNode()) {
+		if (node.IsDeadNode(debug_sleep_micros)) {
 			dead_count++;
 		} else {
 			alive_nodes_out.push_back(std::move(node));

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -259,10 +259,7 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 			dead_count++;
 		} else {
 			// Move alive nodes to the front for bulk re-enqueue
-			if (alive_count != i) {
-				purge_nodes[alive_count] = std::move(node);
-			}
-			alive_count++;
+			purge_nodes[alive_count++] = std::move(node);
 		}
 	}
 

--- a/test/api/test_buffer_pool_eviction.cpp
+++ b/test/api/test_buffer_pool_eviction.cpp
@@ -262,3 +262,139 @@ TEST_CASE("Test buffer pool eviction: failed to allocate space if every page and
 	const auto final_memory_usage = buffer_manager.GetUsedMemory();
 	REQUIRE(final_memory_usage == total_memory_limit);
 }
+
+namespace {
+
+idx_t SumDeadNodes(const vector<EvictionQueueInformation> &info) {
+	idx_t total = 0;
+	for (const auto &q : info) {
+		total += q.dead_nodes;
+	}
+	return total;
+}
+
+idx_t SumApproxSize(const vector<EvictionQueueInformation> &info) {
+	idx_t total = 0;
+	for (const auto &q : info) {
+		total += q.approximate_size;
+	}
+	return total;
+}
+
+} // namespace
+
+// Regression test for an eviction-queue dead-node accounting bug.
+//
+// Each non-tiny BlockMemory placed in the eviction queue stays referenced from there via a
+// weak_ptr<BlockMemory> + sequence number. When the BlockMemory is destroyed, the latest queue
+// entry pointing at it becomes dead and must be reflected in the per-queue dead_nodes counter.
+//
+// Previously, BlockMemory::~BlockMemory only called IncrementDeadNodes when GetBuffer() was
+// non-null. But if the block had already been evicted (buffer destroyed) before the BlockHandle
+// was dropped, the counter was never incremented for it, even though a stale entry still sat in
+// the queue. This systematically under-counted dead_nodes and made the purge-ratio early-out
+// fire too aggressively, letting dead entries accumulate.
+TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruction even after eviction",
+          "[storage][buffer_pool]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
+	const idx_t initial_memory = buffer_pool.GetUsedMemory();
+
+	constexpr idx_t page_size = 1024 * 1024; // 1 MiB
+	constexpr idx_t total_pages = 6;
+	constexpr idx_t held_pages = 2;
+	const idx_t actual_alloc_size = BufferManager::GetAllocSize(page_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
+
+	// Memory limit only large enough to hold `held_pages` blocks at once, so subsequent
+	// allocations evict older destroyable blocks (their buffer becomes nullptr).
+	const idx_t memory_limit = initial_memory + held_pages * actual_alloc_size;
+	buffer_pool.SetLimit(memory_limit, EXCEPTION_POSTSCRIPT);
+
+	vector<shared_ptr<BlockHandle>> handles;
+	handles.reserve(total_pages);
+	for (idx_t i = 0; i < total_pages; ++i) {
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true);
+		handles.emplace_back(pin.GetBlockHandle());
+		// Pin destroyed at scope exit -> block enters the eviction queue.
+	}
+
+	// At this point only the most recent `held_pages` BlockHandles still own a buffer; the
+	// older `total_pages - held_pages` have been evicted (buffer == nullptr) but the
+	// BlockMemory is still alive because we hold the shared_ptr<BlockHandle>.
+	idx_t evicted_observed = 0;
+	idx_t loaded_observed = 0;
+	for (auto &handle : handles) {
+		if (handle->GetMemory().GetState() == BlockState::BLOCK_UNLOADED) {
+			evicted_observed++;
+		} else {
+			loaded_observed++;
+		}
+	}
+	REQUIRE(evicted_observed == total_pages - held_pages);
+	REQUIRE(loaded_observed == held_pages);
+
+	const idx_t dead_before = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
+
+	// Drop all BlockHandles. Every ~BlockMemory must increment dead_nodes once, regardless
+	// of whether the buffer was already null at destruction time.
+	handles.clear();
+
+	const idx_t dead_after = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
+
+	REQUIRE(dead_after - dead_before == total_pages);
+}
+
+// Sanity check the dead_nodes counter never exceeds the queue size and never decrements past
+// zero across a destroyable-block churn workload. This indirectly exercises PurgeIteration:
+// before the fix, pinned-but-current entries dequeued during purge would be both dropped from
+// the queue AND wrongly subtracted from the dead-node counter, leading to underflow on the
+// unsigned counter (observable as an absurdly large dead_nodes value).
+TEST_CASE("Test eviction queue: dead_nodes invariants hold under destroyable block churn", "[storage][buffer_pool]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
+	const idx_t initial_memory = buffer_pool.GetUsedMemory();
+
+	constexpr idx_t page_size = 64 * 1024; // 64 KiB - smaller pages so we can churn many of them
+	constexpr idx_t resident_pages = 32;
+	constexpr idx_t churn_iterations = 20000; // > INSERT_INTERVAL (4096) to trigger purges
+	const idx_t actual_alloc_size = BufferManager::GetAllocSize(page_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
+
+	const idx_t memory_limit = initial_memory + resident_pages * actual_alloc_size;
+	buffer_pool.SetLimit(memory_limit, EXCEPTION_POSTSCRIPT);
+
+	// Keep a small set of pinned blocks that stay resident throughout the test.
+	// Their queue entries (after each unpin/repin cycle below) are alive, latest-version,
+	// and currently unevictable - exactly the case the old PurgeIteration mishandled.
+	vector<BufferHandle> pinned_resident;
+	pinned_resident.reserve(resident_pages / 4);
+	for (idx_t i = 0; i < resident_pages / 4; ++i) {
+		pinned_resident.emplace_back(buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true));
+	}
+
+	// Drive churn: allocate, briefly hold, release. Each unpin enqueues a node; many of
+	// them go stale immediately when the BlockHandle is dropped, generating dead nodes.
+	for (idx_t i = 0; i < churn_iterations; ++i) {
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true);
+		// pin destroyed -> enqueue; BlockHandle dropped -> BlockMemory destroyed -> dead++
+	}
+
+	const auto info = buffer_pool.GetEvictionQueueInfo();
+	const idx_t dead = SumDeadNodes(info);
+	const idx_t approx_size = SumApproxSize(info);
+
+	// Underflow check: total_dead_nodes is an unsigned atomic. If the old PurgeIteration
+	// over-decremented (treating pinned-but-current entries as dead), the counter would wrap
+	// to a value far larger than any plausible queue size.
+	REQUIRE(dead < approx_size + churn_iterations);
+
+	// Every queue must individually satisfy dead_nodes <= total_insertions.
+	for (const auto &q : info) {
+		REQUIRE(q.dead_nodes <= q.total_insertions);
+	}
+}

--- a/test/api/test_buffer_pool_eviction.cpp
+++ b/test/api/test_buffer_pool_eviction.cpp
@@ -303,26 +303,26 @@ TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruc
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 	const idx_t initial_memory = buffer_pool.GetUsedMemory();
 
-	constexpr idx_t page_size = 1024 * 1024; // 1 MiB
-	constexpr idx_t total_pages = 6;
-	constexpr idx_t held_pages = 2;
-	const idx_t actual_alloc_size = BufferManager::GetAllocSize(page_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
+	constexpr idx_t buffer_size = 1024 * 1024; // 1 MiB
+	constexpr idx_t total_buffers = 6;
+	constexpr idx_t held_buffers = 2;
+	const idx_t actual_alloc_size = BufferManager::GetAllocSize(buffer_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
 
-	// Memory limit only large enough to hold `held_pages` blocks at once, so subsequent
+	// Memory limit only large enough to hold `held_buffers` blocks at once, so subsequent
 	// allocations evict older destroyable blocks (their buffer becomes nullptr).
-	const idx_t memory_limit = initial_memory + held_pages * actual_alloc_size;
+	const idx_t memory_limit = initial_memory + held_buffers * actual_alloc_size;
 	buffer_pool.SetLimit(memory_limit, EXCEPTION_POSTSCRIPT);
 
 	vector<shared_ptr<BlockHandle>> handles;
-	handles.reserve(total_pages);
-	for (idx_t i = 0; i < total_pages; ++i) {
-		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true);
+	handles.reserve(total_buffers);
+	for (idx_t i = 0; i < total_buffers; ++i) {
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, buffer_size, /*can_destroy=*/true);
 		handles.emplace_back(pin.GetBlockHandle());
 		// Pin destroyed at scope exit -> block enters the eviction queue.
 	}
 
-	// At this point only the most recent `held_pages` BlockHandles still own a buffer; the
-	// older `total_pages - held_pages` have been evicted (buffer == nullptr) but the
+	// At this point only the most recent `held_buffers` BlockHandles still own a buffer; the
+	// older `total_buffers - held_buffers` have been evicted (buffer == nullptr) but the
 	// BlockMemory is still alive because we hold the shared_ptr<BlockHandle>.
 	idx_t evicted_observed = 0;
 	idx_t loaded_observed = 0;
@@ -333,8 +333,8 @@ TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruc
 			loaded_observed++;
 		}
 	}
-	REQUIRE(evicted_observed == total_pages - held_pages);
-	REQUIRE(loaded_observed == held_pages);
+	REQUIRE(evicted_observed == total_buffers - held_buffers);
+	REQUIRE(loaded_observed == held_buffers);
 
 	const idx_t dead_before = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
 
@@ -344,7 +344,7 @@ TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruc
 
 	const idx_t dead_after = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
 
-	REQUIRE(dead_after - dead_before == total_pages);
+	REQUIRE(dead_after - dead_before == total_buffers);
 }
 
 // Sanity check the dead_nodes counter never exceeds the queue size and never decrements past
@@ -360,27 +360,27 @@ TEST_CASE("Test eviction queue: dead_nodes invariants hold under destroyable blo
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 	const idx_t initial_memory = buffer_pool.GetUsedMemory();
 
-	constexpr idx_t page_size = 64 * 1024; // 64 KiB - smaller pages so we can churn many of them
-	constexpr idx_t resident_pages = 32;
+	constexpr idx_t buffer_size = 64 * 1024; // 64 KiB - smaller buffers so we can churn many of them
+	constexpr idx_t resident_buffers = 32;
 	constexpr idx_t churn_iterations = 20000; // > INSERT_INTERVAL (4096) to trigger purges
-	const idx_t actual_alloc_size = BufferManager::GetAllocSize(page_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
+	const idx_t actual_alloc_size = BufferManager::GetAllocSize(buffer_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
 
-	const idx_t memory_limit = initial_memory + resident_pages * actual_alloc_size;
+	const idx_t memory_limit = initial_memory + resident_buffers * actual_alloc_size;
 	buffer_pool.SetLimit(memory_limit, EXCEPTION_POSTSCRIPT);
 
-	// Keep a small set of pinned blocks that stay resident throughout the test.
+	// Keep a small set of pinned buffers that stay resident throughout the test.
 	// Their queue entries (after each unpin/repin cycle below) are alive, latest-version,
 	// and currently unevictable - exactly the case the old PurgeIteration mishandled.
 	vector<BufferHandle> pinned_resident;
-	pinned_resident.reserve(resident_pages / 4);
-	for (idx_t i = 0; i < resident_pages / 4; ++i) {
-		pinned_resident.emplace_back(buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true));
+	pinned_resident.reserve(resident_buffers / 4);
+	for (idx_t i = 0; i < resident_buffers / 4; ++i) {
+		pinned_resident.emplace_back(buffer_manager.Allocate(MemoryTag::EXTENSION, buffer_size, /*can_destroy=*/true));
 	}
 
 	// Drive churn: allocate, briefly hold, release. Each unpin enqueues a node; many of
 	// them go stale immediately when the BlockHandle is dropped, generating dead nodes.
 	for (idx_t i = 0; i < churn_iterations; ++i) {
-		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, page_size, /*can_destroy=*/true);
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, buffer_size, /*can_destroy=*/true);
 		// pin destroyed -> enqueue; BlockHandle dropped -> BlockMemory destroyed -> dead++
 	}
 

--- a/test/api/test_buffer_pool_eviction.cpp
+++ b/test/api/test_buffer_pool_eviction.cpp
@@ -283,18 +283,12 @@ idx_t SumApproxSize(const vector<EvictionQueueInformation> &info) {
 
 } // namespace
 
-// Regression test for an eviction-queue dead-node accounting bug.
+// Regression test for eviction-queue dead-node accounting.
 //
-// Each non-tiny BlockMemory placed in the eviction queue stays referenced from there via a
-// weak_ptr<BlockMemory> + sequence number. When the BlockMemory is destroyed, the latest queue
-// entry pointing at it becomes dead and must be reflected in the per-queue dead_nodes counter.
-//
-// Previously, BlockMemory::~BlockMemory only called IncrementDeadNodes when GetBuffer() was
-// non-null. But if the block had already been evicted (buffer destroyed) before the BlockHandle
-// was dropped, the counter was never incremented for it, even though a stale entry still sat in
-// the queue. This systematically under-counted dead_nodes and made the purge-ratio early-out
-// fire too aggressively, letting dead entries accumulate.
-TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruction even after eviction",
+// Only blocks with a live queue entry (eviction_seq_num > 0) should increment dead_nodes on
+// destruction. Blocks that were evicted via IterateUnloadableBlocks have their seq_num reset
+// to 0 and their queue entry already consumed — they must NOT inflate the counter.
+TEST_CASE("Test eviction queue: dead_nodes is incremented only for blocks with live queue entries",
           "[storage][buffer_pool]") {
 	DuckDB db;
 	Connection con(db);
@@ -338,13 +332,14 @@ TEST_CASE("Test eviction queue: dead_nodes is incremented on BlockMemory destruc
 
 	const idx_t dead_before = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
 
-	// Drop all BlockHandles. Every ~BlockMemory must increment dead_nodes once, regardless
-	// of whether the buffer was already null at destruction time.
+	// Drop all BlockHandles. Only the still-loaded blocks (which have eviction_seq_num > 0
+	// and a live queue entry) should increment dead_nodes. Evicted blocks had their entries
+	// consumed by IterateUnloadableBlocks and seq_num reset to 0.
 	handles.clear();
 
 	const idx_t dead_after = SumDeadNodes(buffer_pool.GetEvictionQueueInfo());
 
-	REQUIRE(dead_after - dead_before == total_buffers);
+	REQUIRE(dead_after - dead_before == held_buffers);
 }
 
 // Sanity check the dead_nodes counter never exceeds the queue size and never decrements past

--- a/test/sql/storage/test_eviction_queue_no_underflow.test_slow
+++ b/test/sql/storage/test_eviction_queue_no_underflow.test_slow
@@ -1,0 +1,48 @@
+# name: test/sql/storage/test_eviction_queue_no_underflow.test_slow
+# description: Concurrent high-load test ensuring eviction queue dead_nodes never underflows
+# group: [storage]
+
+statement ok
+SET threads=8;
+
+statement ok
+PRAGMA memory_limit='100MB';
+
+statement ok
+CREATE MACRO eviction_queues_sane() AS (
+  SELECT COUNT(*) = 0 FROM duckdb_eviction_queues()
+  WHERE dead_nodes < 0
+    OR dead_nodes > total_insertions
+);
+
+concurrentloop x 0 8
+
+loop i 0 200
+
+statement ok
+CREATE OR REPLACE TABLE t_{x}_{i} AS SELECT range AS id, repeat('x', 1000) AS payload FROM range(10000);
+
+statement ok
+SELECT COUNT(*) FROM t_{x}_{i} WHERE length(payload) > 0;
+
+statement ok
+DROP TABLE IF EXISTS t_{x}_{i};
+
+endloop
+
+endloop
+
+query I
+SELECT eviction_queues_sane();
+----
+1
+
+query I
+SELECT COUNT(*) = 0 FROM duckdb_eviction_queues() WHERE dead_nodes < 0;
+----
+1
+
+query I
+SELECT COUNT(*) = 0 FROM duckdb_eviction_queues() WHERE dead_nodes > total_insertions;
+----
+1


### PR DESCRIPTION
## Summary

This PR fixes three related bugs in the buffer pool's eviction queue purge path. Together they caused dead nodes to silently accumulate in the eviction queue, alive-but-pinned nodes to be dropped (disturbing LRU and corrupting the dead-node counter), and the multi-iteration purge loop to make essentially no progress under contention.

The fix is small (3 files, +37 / −16) but the underlying issues interact and are worth fixing together so the purge accounting becomes self-consistent again.

## Background

`EvictionQueue` uses a `duckdb_moodycamel::ConcurrentQueue<BufferEvictionNode>` where each node holds:

- `weak_ptr<BlockMemory>` — the block this entry refers to.
- `handle_sequence_number` — incremented every time the block is re-added to the queue.

A node is logically *dead* if either:

1. The `weak_ptr` is expired (the `BlockMemory` was destroyed), or
2. The block's current `eviction_seq_num` is newer than the node's recorded sequence number (a newer entry superseded it).

Dead nodes are never proactively removed — they are dequeued lazily by `EvictionQueue::Purge()`, which runs on one thread at a time and tries to keep the queue's dead-node ratio under control.

## Bugs fixed

### 1. `IncrementDeadNodes` was skipped when the buffer was already null

`BlockMemory::~BlockMemory` only called `IncrementDeadNodes` when `GetBuffer()` returned non-null:

```cpp
// before
if (GetBuffer() && GetBufferType() != FileBufferType::TINY_BUFFER) {
    GetBufferManager().GetBufferPool().IncrementDeadNodes(*this);
}
```

But the queue entry's lifetime is independent of whether the buffer is currently loaded — only the dequeue side ever removes it. If the block had previously been evicted (buffer = nullptr) and then the `BlockMemory` itself was destroyed, the queue entry that pointed at it became dead but was never accounted for. This systematically under-counted `total_dead_nodes`, which made the purge ratio early-out (`approx_alive_nodes * (ALIVE_NODE_MULTIPLIER - 1) > approx_dead_nodes`) fire too often and let dead entries accumulate.

**Fix:** drop the `GetBuffer()` guard.

### 2. Pinned-but-current nodes were classified as dead during purge

`PurgeIteration` used `TryGetBlockMemory()` to decide whether a dequeued node was alive:

```cpp
shared_ptr<BlockMemory> BufferEvictionNode::TryGetBlockMemory() {
    auto shared_memory_p = memory_p.lock();
    if (!shared_memory_p) {
        return nullptr;
    }
    if (!CanUnload(*shared_memory_p)) {  // also checks readers / pinning
        return nullptr;
    }
    return shared_memory_p;
}
```

`CanUnload` is **not** a deadness predicate — it also returns `false` when the block is currently pinned (`readers != 0`). So a perfectly valid latest-version node that just happened to be pinned at the moment of the purge was:

- Dropped from the queue (LRU position lost).
- Counted toward `total_dead_nodes -= actually_dequeued - alive_nodes`, decrementing the dead counter for a node that was never dead.

This actively desyncs `total_dead_nodes` from reality and combines badly with bug.

**Fix:** introduce a dedicated `BufferEvictionNode::IsDeadNode()` that checks only the two real deadness conditions (expired weak_ptr or stale sequence number) and use it for purge classification:

```cpp
bool BufferEvictionNode::IsDeadNode() {
    auto shared_memory_p = memory_p.lock();
    if (!shared_memory_p) {
        return true;
    }
    if (handle_sequence_number != shared_memory_p->GetEvictionSequenceNumber()) {
        return true;
    }
    return false;
}
```

`PurgeIteration` now decrements `total_dead_nodes` by an explicit `dead_count`, which can never include pinned-but-current entries.

### 3. Multi-iteration purge churned the purge thread's own moodycamel sub-queue

This is the most impactful bug.

`moodycamel::ConcurrentQueue` is **not** a single FIFO. Internally it maintains one sub-queue per producer thread (implicit producers are created lazily on first enqueue from a given thread). `try_dequeue_bulk` without a token walks the producer list and tends to drain the most recently used sub-queues first.

The previous purge loop re-enqueued alive nodes between iterations using an implicit producer:

```cpp
// PurgeIteration (old)
q.enqueue_bulk(purge_nodes.begin(), alive_nodes);
```

That enqueue happens on the purge thread, which in nearly all interesting scenarios was not previously a producer for this queue (producers are worker threads). It creates an implicit-producer sub-queue owned by the purge thread, and on the **next** `try_dequeue_bulk` call moodycamel preferentially re-drains it — pulling back the very alive nodes the purge just inserted, instead of reaching dead entries sitting in worker producer sub-queues. Under sustained pressure the loop made little to no real progress: it kept "purging" the same alive nodes round and round while real dead entries accumulated elsewhere.

**Fix:** use explicit `ConsumerToken` and `ProducerToken` to separate the dequeue and re-enqueue paths into distinct sub-queues. The `ConsumerToken` remembers which sub-queue it last consumed from and progresses sequentially through the producer list, ensuring forward progress. The `ProducerToken` routes re-enqueued alive nodes into a dedicated sub-queue that the consumer has already passed, preventing the purge thread from immediately re-draining its own output:

```cpp
// EvictionQueue members
duckdb_moodycamel::ConsumerToken purge_consumer_token;
duckdb_moodycamel::ProducerToken purge_producer_token;

void EvictionQueue::PurgeIteration(const idx_t purge_size) {
    // Dequeue using consumer token — progresses through sub-queues sequentially
    const idx_t actually_dequeued = q.try_dequeue_bulk(purge_consumer_token, purge_nodes.begin(), purge_size);
    // ... classify alive vs dead ...
    // Re-enqueue alive nodes via producer token — goes into a dedicated sub-queue
    // that the consumer token has already passed
    if (alive_count > 0) {
        q.enqueue_bulk(purge_producer_token, purge_nodes.begin(), alive_count);
    }
}
```

This guarantees that each purge iteration sees fresh entries from worker sub-queues instead of bouncing the purge thread's own buffer, while keeping alive nodes in the queue at all times (unlike the alternative of holding them aside externally, which would starve the eviction process).

## How they interact

| Bug | Effect on `total_dead_nodes` | Effect on the queue |
|---|---|---|
| 1 — buffer-null skip | Under-counts dead nodes | Dead entries leak in |
| 2 — pinned treated as dead | Decremented for non-dead nodes | Pinned entries are dropped (LRU disturbed) |
| 3 — sub-queue churn | — | Multi-iteration purge does no useful work |

Bugs 1 and 2 push the counter in opposite directions, masking each other intermittently and making the symptom hard to trace. Bug 3 means even when the ratio check correctly demands more aggressive purging, the loop fails to actually purge.

## Files changed

- `src/include/duckdb/storage/buffer/buffer_pool.hpp` — declare `BufferEvictionNode::IsDeadNode`.
- `src/storage/buffer/buffer_pool.cpp` — implement `IsDeadNode`, restructure `Purge` / `PurgeIteration` with consumer/producer tokens.
- `src/storage/buffer/block_handle.cpp` — drop `GetBuffer()` guard before `IncrementDeadNodes`.

## Test plan

- [ ] `make reldebug` builds cleanly.
- [ ] `build/reldebug/test/unittest` passes (full unit suite).
- [ ] Targeted buffer-manager / eviction tests pass (`build/reldebug/test/unittest "[buffermanager]"`).
- [ ] Local repro of dead-node accumulation under heavy churn no longer grows `total_dead_nodes` unboundedly between purges.
- [ ] LRU-sensitive workloads do not show pinned blocks being repeatedly evicted/reloaded after purge.
- [ ] Multi-iteration purge actually shrinks the queue under contention (verified by observing `q.size_approx()` between iterations in a stress harness).

## Notes for reviewers

- `BufferEvictionNode::IsDeadNode()` is intentionally *not* `const` because `weak_ptr::lock()` is a mutating operation only in spirit — happy to mark it `const` if preferred (it would still compile since `lock()` is `const` on the weak_ptr).
- The `ConsumerToken` / `ProducerToken` approach keeps alive nodes in the queue at all times during purge (unlike the earlier "accumulate externally" approach), so concurrent `TryDequeueWithLock` on the same queue can still find evictable entries even while a purge is in progress.
- The producer token's sub-queue will be visited by the consumer token on a subsequent purge cycle, ensuring these re-enqueued nodes are eventually revisited (and purged if they've since become dead).
