### PR TITLE
Parse mode skip/require reasons once and summarize

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -333,54 +333,41 @@ def parse_skipped_tests_count(output: str):
     return int(match.group(1))
 
 
-def parse_skipped_test_reasons(output: str):
+def parse_skipped_test_summary(output: str):
+    skipped_count = 0
     reasons = {}
-    lines = strip_ansi(output).splitlines()
-    for idx, line in enumerate(lines):
-        if line.strip() != "Skipped tests for the following reasons:":
-            continue
-
-        for reason_line in lines[idx + 1 :]:
-            reason_line = reason_line.strip()
-            if not reason_line:
-                break
-            match = SKIP_REASON_PATTERN.match(reason_line)
-            if not match:
-                break
-            reasons[match.group(1)] = reasons.get(match.group(1), 0) + int(match.group(2))
-        break
-    return reasons
-
-
-def parse_mode_skip_reasons(output: str):
-    reasons = {}
+    in_skip_summary = False
     for line in strip_ansi(output).splitlines():
         stripped = line.strip()
-        if SKIP_REASON_PATTERN.match(stripped):
+        if skipped_count == 0:
+            count_match = SKIPPED_TESTS_PATTERN.search(stripped)
+            if count_match:
+                skipped_count = int(count_match.group(1))
+        if stripped == "Skipped tests for the following reasons:":
+            in_skip_summary = True
             continue
-        match = MODE_SKIP_REASON_PATTERN.match(stripped)
-        if not match:
-            continue
-        reason = match.group(1) or "unspecified"
-        reason_key = f"mode skip {reason}"
-        reasons[reason_key] = reasons.get(reason_key, 0) + 1
-    return reasons
+        if in_skip_summary:
+            if not stripped:
+                in_skip_summary = False
+                continue
+            reason_match = SKIP_REASON_PATTERN.match(stripped)
+            if not reason_match:
+                in_skip_summary = False
+                continue
+            reasons[reason_match.group(1)] = reasons.get(reason_match.group(1), 0) + int(reason_match.group(2))
+    return skipped_count, reasons
 
 
 def extract_skipped_test_output(stdout: str, stderr: str):
-    stdout_count = parse_skipped_tests_count(stdout)
-    stdout_reasons = parse_skipped_test_reasons(stdout)
-    stdout_mode_skip_reasons = parse_mode_skip_reasons(stdout)
-    if stdout_count > 0 or stdout_reasons or stdout_mode_skip_reasons:
-        return stdout
+    stdout_summary = parse_skipped_test_summary(stdout)
+    if stdout_summary[0] > 0 or stdout_summary[1]:
+        return stdout_summary
 
-    stderr_count = parse_skipped_tests_count(stderr)
-    stderr_reasons = parse_skipped_test_reasons(stderr)
-    stderr_mode_skip_reasons = parse_mode_skip_reasons(stderr)
-    if stderr_count > 0 or stderr_reasons or stderr_mode_skip_reasons:
-        return stderr
+    stderr_summary = parse_skipped_test_summary(stderr)
+    if stderr_summary[0] > 0 or stderr_summary[1]:
+        return stderr_summary
 
-    return ""
+    return 0, {}
 
 
 def run_batch(config: TestRunnerConfig, batch):
@@ -694,11 +681,9 @@ def run_tests(config: TestRunnerConfig, batches):
                     if handle_failed_batch(ctx, batch_info, result):
                         continue
                 else:
-                    skipped_output = extract_skipped_test_output(result["stdout"], result["stderr"])
-                    total_skipped_tests += parse_skipped_tests_count(skipped_output)
-                    for reason, count in parse_skipped_test_reasons(skipped_output).items():
-                        skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
-                    for reason, count in parse_mode_skip_reasons(skipped_output).items():
+                    skipped_count, skipped_reasons = extract_skipped_test_output(result["stdout"], result["stderr"])
+                    total_skipped_tests += skipped_count
+                    for reason, count in skipped_reasons.items():
                         skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -34,18 +34,17 @@ class RunTestsScriptTest(unittest.TestCase):
                 "stdout": """
 All tests passed (5 skipped tests, 123 assertions in 4 test cases)
 
-mode skip flaky planner
-mode skip unsupported
-
 Skipped tests for the following reasons:
 require longdouble: 2
 require-env SOME_TOKEN: 3
+mode skip flaky planner: 2
+mode skip unsupported: 1
 """,
                 "expected_skip_count": 5,
                 "expected_reasons": [
                     "require longdouble: 2",
                     "require-env SOME_TOKEN: 3",
-                    "mode skip flaky planner: 1",
+                    "mode skip flaky planner: 2",
                     "mode skip unsupported: 1",
                 ],
             },
@@ -53,18 +52,18 @@ require-env SOME_TOKEN: 3
                 "name": "ansi",
                 "stdout": (
                     "\x1b[36mAll tests passed (14 skipped tests, 2659 assertions in 86 test cases)\x1b[0m\n\n"
-                    "\x1b[33mmode skip flaky parser\x1b[0m\n"
                     "\x1b[1mSkipped tests for the following reasons:\x1b[0m\n"
                     "\x1b[33mrequire httpfs: 1\x1b[0m\n"
                     "\x1b[33mrequire icu: 2\x1b[0m\n"
                     "\x1b[33mrequire-env LOCAL_EXTENSION_REPO: 5\x1b[0m\n"
+                    "\x1b[33mmode skip flaky parser: 2\x1b[0m\n"
                 ),
                 "expected_skip_count": 14,
                 "expected_reasons": [
                     "require httpfs: 1",
                     "require icu: 2",
                     "require-env LOCAL_EXTENSION_REPO: 5",
-                    "mode skip flaky parser: 1",
+                    "mode skip flaky parser: 2",
                 ],
             },
         ]
@@ -114,11 +113,10 @@ require-env SOME_TOKEN: 3
                 "stdout": """
 All tests passed (2 skipped tests, 100 assertions in 1 test cases)
 
-mode skip flaky planner
-
 Skipped tests for the following reasons:
 require windows: 1
 require-env A: 1
+mode skip flaky planner: 2
 """,
                 "stderr": "",
                 "message": None,
@@ -129,12 +127,11 @@ require-env A: 1
                 "stdout": """
 All tests passed (3 skipped tests, 100 assertions in 1 test cases)
 
-mode skip flaky planner
-mode skip unsupported
-
 Skipped tests for the following reasons:
 require-env A: 2
 require-env B: 1
+mode skip flaky planner: 1
+mode skip unsupported: 1
 """,
                 "stderr": "",
                 "message": None,
@@ -164,7 +161,7 @@ require-env B: 1
         self.assertIn("require windows: 1", proc.stdout)
         self.assertIn("require-env A: 3", proc.stdout)
         self.assertIn("require-env B: 1", proc.stdout)
-        self.assertIn("mode skip flaky planner: 2", proc.stdout)
+        self.assertIn("mode skip flaky planner: 3", proc.stdout)
         self.assertIn("mode skip unsupported: 1", proc.stdout)
 
     def test_does_not_double_count_summary_when_in_stdout_and_stderr(self):

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -20,6 +20,9 @@
 
 namespace duckdb {
 
+mutex SQLLogicTestRunner::skip_reason_lock;
+map<string, idx_t> SQLLogicTestRunner::skip_reason_counts;
+
 SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)), finished_processing_file(false) {
 	config = GetTestConfig();
 	config->SetOptionByName("allow_unredacted_secrets", true);
@@ -80,6 +83,28 @@ SQLLogicTestRunner::~SQLLogicTestRunner() {
 		}
 		DeleteDatabase(loaded_path);
 	}
+}
+
+void SQLLogicTestRunner::AddSkipReason(const string &reason) {
+	lock_guard<mutex> guard(skip_reason_lock);
+	skip_reason_counts[reason]++;
+}
+
+void SQLLogicTestRunner::SkipTest(const string &reason) {
+	AddSkipReason(reason);
+	SKIP_TEST(reason);
+}
+
+string SQLLogicTestRunner::GetSkipReasonSummary() {
+	lock_guard<mutex> guard(skip_reason_lock);
+	if (skip_reason_counts.empty()) {
+		return string();
+	}
+	std::ostringstream oss;
+	for (auto &entry : skip_reason_counts) {
+		oss << entry.first << ": " << entry.second << "\n";
+	}
+	return oss.str();
 }
 
 void SQLLogicTestRunner::ExecuteCommand(duckdb::unique_ptr<Command> command) {
@@ -625,7 +650,7 @@ void add_env_tag(vector<string> &tags, const string &name, const string *value =
 void SQLLogicTestRunner::ExecuteFile(string script) {
 	auto &test_config = TestConfiguration::Get();
 	if (test_config.ShouldSkipTest(script)) {
-		SKIP_TEST("config skip_tests");
+		SkipTest("config skip_tests");
 		return;
 	}
 
@@ -684,7 +709,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		// Check tags first time we hit test statements, since all explicit & implicit tags now present
 		if (parser.IsTestCommand(token.type) && !test_expr_executed) {
 			if (test_config.GetPolicyForTagSet(file_tags) == TestConfiguration::SelectPolicy::SKIP) {
-				SKIP_TEST("select tag-set");
+				SkipTest("select tag-set");
 				return;
 			}
 			test_expr_executed = true;
@@ -863,6 +888,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 						reason += " " + token.parameters[i];
 					}
 				}
+				AddSkipReason("mode skip " + reason);
 				skip_level++;
 			} else if (parameter == "unskip") {
 				skip_level--;
@@ -981,7 +1007,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 					// This extension / setting was explicitly required
 					parser.Fail(StringUtil::Format("require %s: FAILED", param));
 				}
-				SKIP_TEST("require " + token.parameters[0]);
+				SkipTest("require " + token.parameters[0]);
 				return;
 			}
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_TEST_ENV) {
@@ -1025,7 +1051,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			}
 			if (env_actual == nullptr) {
 				// Environment variable was not found, this test should not be run
-				SKIP_TEST("require-env " + token.parameters[0]);
+				SkipTest("require-env " + token.parameters[0]);
 				return;
 			}
 
@@ -1034,7 +1060,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				auto env_value = token.parameters[1];
 				if (std::strcmp(env_actual, env_value.c_str()) != 0) {
 					// It's not, check the test
-					SKIP_TEST("require-env " + token.parameters[0] + " " + token.parameters[1]);
+					SkipTest("require-env " + token.parameters[0] + " " + token.parameters[1]);
 					return;
 				}
 
@@ -1050,7 +1076,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_LOAD) {
 			auto &test_config = TestConfiguration::Get();
 			if (test_config.OnLoadCommand() == "skip") {
-				SKIP_TEST("config on_load skip");
+				SkipTest("config on_load skip");
 				return;
 			}
 			bool is_read_only = false;

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/common/map.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "sqllogic_command.hpp"
 #include "test_config.hpp"
@@ -96,9 +97,16 @@ public:
 	string ReplaceLoopIterator(string text, string loop_iterator_name, string replacement);
 	string LoopReplacement(string text, const vector<LoopDefinition> &loops);
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
+	void SkipTest(const string &reason);
+	static string GetSkipReasonSummary();
 
 private:
 	RequireResult CheckRequire(SQLLogicParser &parser, const vector<string> &params);
+	static void AddSkipReason(const string &reason);
+
+private:
+	static mutex skip_reason_lock;
+	static map<string, idx_t> skip_reason_counts;
 };
 
 } // namespace duckdb

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "sqlite/sqllogic_test_logger.hpp"
+#include "sqlite/sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
 #include "test_config.hpp"
 
@@ -85,6 +86,12 @@ int main(int argc_in, char *argv[]) {
 		std::cerr << "================  FAILURES SUMMARY  ================" << std::endl;
 		std::cerr << "====================================================\n" << std::endl;
 		std::cerr << failures_summary;
+	}
+	std::string skip_reason_summary = SQLLogicTestRunner::GetSkipReasonSummary();
+	if (!skip_reason_summary.empty()) {
+		std::cerr << "\n"
+		          << "Skipped tests for the following reasons:" << std::endl;
+		std::cerr << skip_reason_summary;
 	}
 
 	if (DeleteTestPath()) {

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -16996,13 +16996,6 @@ void ConsoleReporter::printTotals( Totals const& totals ) {
         printSummaryRow("test cases", columns, 0);
         printSummaryRow("assertions", columns, 1);
     }
-    if (!totals.skippedTestReasons.empty()) {
-        stream << '\n';
-        stream << Colour(Colour::Warning) << "Skipped tests for the following reasons:" << '\n';
-        for(auto &entry : totals.skippedTestReasons) {
-            stream << Colour(Colour::Warning) << entry.first << ": " << entry.second << '\n';
-        }
-    }
 }
 void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row) {
     for (auto col : cols) {


### PR DESCRIPTION
Print summarized `mode skip ...` only at the end of test run:
```shell
$ build/debug/test/unittest '[afl]' 
Filters: [afl]
[30/30] (100%): test/sql/copy/csv/afl/fuzz_20250226.test                                                                                                        
====================================================================
All tests passed (5 skipped tests, 347 assertions in 25 test cases)


Skipped tests for the following reasons:
mode skip flaky: 1
require json: 5
```

(It was printed after each test that had one or more mode skip statements.)