### PR TITLE
[Dev][ToString] Add type to NULL value, add 'add_alias=true' to BoundFunctionExpression

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1646,7 +1646,7 @@ string Value::ToString() const {
 
 string Value::ToSQLString() const {
 	if (IsNull()) {
-		return ToString();
+		return ToString() + "::" + type_.ToString();
 	}
 	switch (type_.id()) {
 	case LogicalTypeId::UUID:

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1646,7 +1646,11 @@ string Value::ToString() const {
 
 string Value::ToSQLString() const {
 	if (IsNull()) {
-		return ToString() + "::" + type_.ToString();
+		auto res = ToString();
+		if (type_.id() != LogicalTypeId::SQLNULL) {
+			res += "::" + type_.ToString();
+		}
+		return res;
 	}
 	switch (type_.id()) {
 	case LogicalTypeId::UUID:

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -50,8 +50,9 @@ bool BoundFunctionExpression::CanThrow() const {
 }
 
 string BoundFunctionExpression::ToString() const {
-	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), string(), function.name,
-	                                                                         is_operator);
+	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(
+	    *this, string(), string(), function.name, is_operator, false, static_cast<Expression *>(nullptr),
+	    static_cast<OrderModifier *>(nullptr), false, true);
 }
 bool BoundFunctionExpression::PropagatesNullValues() const {
 	return function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING ? false


### PR DESCRIPTION
This PR makes some changes to `ToString` behavior, found as part of debugging in duckdb-iceberg, we create some `remap_struct` expressions there, and those aren't roundtrippable through `ToString`, with these changes they are.

Not sure if desired, but figured I'd make a PR out of it in case it is