### PR TITLE
Fix max file row number

### DIFF
--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -101,9 +101,11 @@ unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_m
 			row_group_offset_min += row_groups[i].num_rows;
 		}
 
-		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
-		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min +
-		                                                                     row_groups[row_group_idx_p].num_rows)));
+		if (row_groups[row_group_idx_p].num_rows > 0) {
+			NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
+			NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(
+			                                row_group_offset_min + row_groups[row_group_idx_p].num_rows - 1)));
+		}
 		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 		return stats.ToUnique();
 	}

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -93,19 +93,21 @@ unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_m
 		return nullptr;
 	}
 	if (schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
-		auto stats = NumericStats::CreateUnknown(type);
 		auto &row_groups = file_meta_data.row_groups;
 		D_ASSERT(row_group_idx_p < row_groups.size());
+		if (row_groups[row_group_idx_p].num_rows == 0) {
+			return NumericStats::CreateEmpty(type).ToUnique();
+		}
+
 		idx_t row_group_offset_min = 0;
 		for (idx_t i = 0; i < row_group_idx_p; i++) {
 			row_group_offset_min += row_groups[i].num_rows;
 		}
 
-		if (row_groups[row_group_idx_p].num_rows > 0) {
-			NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
-			NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(
-			                                row_group_offset_min + row_groups[row_group_idx_p].num_rows - 1)));
-		}
+		auto stats = NumericStats::CreateUnknown(type);
+		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
+		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(
+		                                row_group_offset_min + row_groups[row_group_idx_p].num_rows - 1)));
 		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 		return stats.ToUnique();
 	}

--- a/test/sql/copy/parquet/parquet_row_number.test
+++ b/test/sql/copy/parquet/parquet_row_number.test
@@ -69,7 +69,7 @@ select min(file_row_number), max(file_row_number), count(*) from parquet_scan('{
 query I
 select first(stats(file_row_number)) from parquet_scan('{DATA_DIR}/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1);
 ----
-[Min: 0, Max: 10000][Has Null: false, Has No Null: true]
+[Min: 0, Max: 9999][Has Null: false, Has No Null: true]
 
 statement ok
 PRAGMA explain_output = OPTIMIZED_ONLY;


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22686

The issue is:
- Currently, max = min + row number, which should be max = min + row number - 1
- Actually existing unit tests already surface the issue when returning min/max stats directly (without scanning data)