### PR TITLE
Run more core extensions with sanitizers in CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1156,7 +1156,7 @@ jobs:
       EXPORT_DYNAMIC_SYMBOLS: 1
       REDUCE_SYMBOLS: 1
       EXTENSION_STATIC_BUILD: 0
-      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
       DISABLE_STRING_INLINE: 1
       DESTROY_UNPINNED_BLOCKS: 1
       ALTERNATIVE_VERIFY: 1
@@ -1274,7 +1274,7 @@ jobs:
       CXX: clang++-20
       GEN: ninja
       BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
       TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt:external_symbolizer_path=/usr/bin/llvm-symbolizer-20
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1172,7 +1172,7 @@ jobs:
           EXPORT_DYNAMIC_SYMBOLS: 1
           REDUCE_SYMBOLS: 1
           EXTENSION_STATIC_BUILD: 0
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
           DISABLE_STRING_INLINE: 1
           DESTROY_UNPINNED_BLOCKS: 1
           ALTERNATIVE_VERIFY: 1
@@ -1297,7 +1297,7 @@ jobs:
       env:
         BUILD_JEMALLOC: 1
         THREADSAN: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
       with:
         build-type: reldebug
         build: python3 scripts/ci/retry.py -- make reldebug

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1147,7 +1147,15 @@ jobs:
       - prepare
       - linux-relassert
     env:
+      CC: clang-20
+      CXX: clang++-20
       GEN: ninja
+      CRASH_ON_ASSERT: 1
+      FORCE_DEBUG: 1
+      FORCE_ASSERT: 1
+      EXPORT_DYNAMIC_SYMBOLS: 1
+      REDUCE_SYMBOLS: 1
+      EXTENSION_STATIC_BUILD: 0
       CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       DISABLE_STRING_INLINE: 1
       DESTROY_UNPINNED_BLOCKS: 1

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -504,8 +504,6 @@ jobs:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'linux-release') }}
     needs: prepare
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
-    env:
-      GEN: ninja
 
     steps:
     - name: "Checkout"
@@ -1149,19 +1147,6 @@ jobs:
     env:
       CC: clang-20
       CXX: clang++-20
-      GEN: ninja
-      CRASH_ON_ASSERT: 1
-      FORCE_DEBUG: 1
-      FORCE_ASSERT: 1
-      EXPORT_DYNAMIC_SYMBOLS: 1
-      REDUCE_SYMBOLS: 1
-      EXTENSION_STATIC_BUILD: 0
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
-      DISABLE_STRING_INLINE: 1
-      DESTROY_UNPINNED_BLOCKS: 1
-      ALTERNATIVE_VERIFY: 1
-      DISABLE_POINTER_SALT: 1
-      DISABLE_GCC_FUNCTION_SECTIONS: 1
       LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
       DUCKDB_TEST_DESCRIPTION: 'Compiled with ALTERNATIVE_VERIFY=1 DISABLE_STRING_INLINE=1 DESTROY_UNPINNED_BLOCKS=1 DISABLE_POINTER_SALT=1. Use require no_alternative_verify to skip.'
 
@@ -1179,7 +1164,26 @@ jobs:
           save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
       - name: Build
-        run: python3 scripts/ci/retry.py -- make relassert
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        env:
+          CRASH_ON_ASSERT: 1
+          FORCE_DEBUG: 1
+          FORCE_ASSERT: 1
+          EXPORT_DYNAMIC_SYMBOLS: 1
+          REDUCE_SYMBOLS: 1
+          EXTENSION_STATIC_BUILD: 0
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+          DISABLE_STRING_INLINE: 1
+          DESTROY_UNPINNED_BLOCKS: 1
+          ALTERNATIVE_VERIFY: 1
+          DISABLE_POINTER_SALT: 1
+          DISABLE_GCC_FUNCTION_SECTIONS: 1
+        with:
+          build-type: relassert
+          build: python3 scripts/ci/retry.py -- make relassert
+          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          cache-suffix: no_string_inline
+          save-cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
       - name: Test
         if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
@@ -1272,9 +1276,6 @@ jobs:
     env:
       CC: clang-20
       CXX: clang++-20
-      GEN: ninja
-      BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
       TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt:external_symbolizer_path=/usr/bin/llvm-symbolizer-20
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 
@@ -1291,8 +1292,18 @@ jobs:
       with:
         save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
-    - name: Build
-      run: THREADSAN=1 make reldebug
+    - name: Build threadsan
+      uses: duckdb/duckdb-ci/build-duckdb@main
+      env:
+        BUILD_JEMALLOC: 1
+        THREADSAN: 1
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+      with:
+        build-type: reldebug
+        build: python3 scripts/ci/retry.py -- make reldebug
+        vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+        cache-suffix: threadsan
+        save-cache: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
     - name: Test
       if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -963,9 +963,6 @@ if (NOT EXTENSION_CONFIG_BUILD)
   add_third_party(utf8proc)
   add_third_party(yyjson)
   add_third_party(zstd)
-endif()
-
-if (NOT EXTENSION_CONFIG_BUILD)
   if(NOT DUCKDB_EXPLICIT_PLATFORM)
     set(VERSION_SOURCES tools/utils/test_platform.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -918,6 +918,15 @@ endfunction()
 # this depends on disable_target_warnings so the order matters
 include(${PROJECT_SOURCE_DIR}/extension/extension_build_tools.cmake)
 
+# These compile definitions/paths are consumed by sources in src/ (e.g. extension_helper.cpp, allocator.cpp),
+# so they must be configured before add_subdirectory(src).
+include_directories("${PROJECT_BINARY_DIR}/codegen/include/")
+add_extension_definitions()
+add_definitions(-DGENERATED_EXTENSION_HEADERS=1)
+add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
+add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
+add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
+
 if(ENABLE_JEMALLOC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT EMSCRIPTEN AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT BSD AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
   set(JEMALLOC_ENABLED TRUE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_ENABLE_JEMALLOC")

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ EXE_SUFFIX := .exe
 endif
 UNITTEST_BINARY ?= test/unittest$(EXE_SUFFIX)
 SMOKE_UNITTEST ?= build/relassert/$(UNITTEST_BINARY)
-UNITTEST_SLOW_FLAGS ?= --batch-timeout=300 --track-runtime=100
-UNITTEST_HUGE_FLAGS ?= --batch-size=5 --workers=50% $(UNITTEST_SLOW_FLAGS)
+UNITTEST_SLOW_FLAGS ?= --batch-size=5 --batch-timeout=300 --track-runtime=100
+UNITTEST_HUGE_FLAGS ?= --workers=50% $(UNITTEST_SLOW_FLAGS)
 
 # Allow setting extra unit test parameters using `make smoke T=...`.
 T ?=
@@ -496,7 +496,7 @@ unittest: debug
 	$(PYTHON) scripts/ci/run_tests.py build/debug/$(UNITTEST_BINARY) $(T)
 
 unittest_reldebug:
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/$(UNITTEST_BINARY) $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_SLOW_FLAGS) build/reldebug/$(UNITTEST_BINARY) $(T)
 
 ifneq ($(SKIP_BUILD),1)
 unittest_release: release

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ EXE_SUFFIX := .exe
 endif
 UNITTEST_BINARY ?= test/unittest$(EXE_SUFFIX)
 SMOKE_UNITTEST ?= build/relassert/$(UNITTEST_BINARY)
-UNITTEST_SLOW_FLAGS ?= --batch-timeout=1800 --track-runtime=300
-UNITTEST_HUGE_FLAGS ?= --batch-size=1 --workers=50% $(UNITTEST_SLOW_FLAGS)
+UNITTEST_SLOW_FLAGS ?= --batch-timeout=300 --track-runtime=100
+UNITTEST_HUGE_FLAGS ?= --batch-size=5 --workers=50% $(UNITTEST_SLOW_FLAGS)
 
 # Allow setting extra unit test parameters using `make smoke T=...`.
 T ?=
@@ -583,7 +583,7 @@ unittest_threadsan: unittest_reldebug
 .PHONY: unittest_threadsan_extra
 unittest_threadsan_extra: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
 unittest_threadsan_extra: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 --test-flags="--force-storage" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -6,9 +6,6 @@
 # then use `configure_file` again the advantage of this is that we don't change
 # modification time if nothing changed
 
-# include generated includes
-include_directories("${PROJECT_BINARY_DIR}/codegen/include/")
-
 add_library(dummy_static_extension_loader STATIC
             loader/dummy_static_extension_loader.cpp)
 
@@ -17,8 +14,6 @@ install(
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
-
-add_extension_definitions()
 
 configure_file(
   generated_extension_headers.hpp.in
@@ -92,11 +87,6 @@ endif()
 set(GENERATED_CPP_FILE
     ${PROJECT_BINARY_DIR}/codegen/src/generated_extension_loader.cpp)
 configure_file(generated_extension_loader.cpp.in "${GENERATED_CPP_FILE}")
-add_definitions(-DGENERATED_EXTENSION_HEADERS=1)
-add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
-add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
-add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
-
 add_library(duckdb_generated_extension_loader STATIC ${GENERATED_CPP_FILE})
 
 set(ALL_OBJECT_FILES

--- a/extension/loader/dummy_static_extension_loader.cpp
+++ b/extension/loader/dummy_static_extension_loader.cpp
@@ -4,6 +4,10 @@
 // Link this to libduckdb_static.a to get a working system.
 
 namespace duckdb {
+ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const string &extension) {
+	return ExtensionLoadResult::NOT_LOADED;
+}
+
 void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
 	// nop
 }

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -57,6 +57,7 @@ class TestRunnerConfig:
     rss_memory_threshold_mib: int | None
     runtime_threshold_seconds: int | None
     max_failures: int | None
+    fail_require_skip: bool
 
 
 @dataclass(frozen=True)
@@ -386,6 +387,7 @@ def run_batch(config: TestRunnerConfig, batch):
     stdout = ""
     stderr = ""
     message = None
+    allow_retry = True
     peak_rss_bytes = 0
 
     # On Windows the child process cannot reopen a NamedTemporaryFile while it
@@ -431,6 +433,12 @@ def run_batch(config: TestRunnerConfig, batch):
             if rss_bytes is not None:
                 peak_rss_bytes = max(peak_rss_bytes, rss_bytes)
             failed = proc.returncode != 0
+            if not failed and config.fail_require_skip:
+                require_skip_lines = find_require_skip_lines(stdout)
+                if require_skip_lines:
+                    failed = True
+                    message = "error: detected require-based skipped tests: " + require_skip_lines[0]
+                    allow_retry = False
     except OSError as exc:
         failed = True
         stderr = str(exc)
@@ -444,7 +452,14 @@ def run_batch(config: TestRunnerConfig, batch):
         "stderr": stderr,
         "message": message,
         "peak_rss_bytes": peak_rss_bytes,
+        "allow_retry": allow_retry,
     }
+
+
+def find_require_skip_lines(output: str):
+    ansi = r"(?:\x1b\[[0-9;]*m)*"
+    pattern = rf"^{ansi}(require\s+\S+:\s+\d+){ansi}\s*$"
+    return re.findall(pattern, output, flags=re.MULTILINE)
 
 
 def submit_batch(executor, config: TestRunnerConfig, batch, future_to_batch, batch_idx: int, attempt: int):
@@ -477,7 +492,7 @@ def handle_failed_batch(ctx: RunContext, batch_info, result):
         ),
     )
     ctx.progress.print_message("========================")
-    if ctx.state.can_retry(batch_info, ctx.config):
+    if result.get("allow_retry", True) and ctx.state.can_retry(batch_info, ctx.config):
         ctx.state.record_retry()
         next_attempt = batch_info["attempt"] + 1
         ctx.progress.print_message(
@@ -494,7 +509,7 @@ def handle_failed_batch(ctx: RunContext, batch_info, result):
         )
         return True
 
-    if batch_info["attempt"] < ctx.config.retry:
+    if result.get("allow_retry", True) and batch_info["attempt"] < ctx.config.retry:
         ctx.progress.print_message(
             f"not retrying failed test batch {batch_info['batch_idx']} after reaching {ctx.config.max_retries} retries"
         )
@@ -563,6 +578,11 @@ def parse_args(argv: list[str] | None = None):
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--batch-timeout", type=float, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--fail-require-skip",
+        action="store_true",
+        help="fail a batch if unittest output reports skipped tests for `require ...` reasons",
+    )
     # Accept options interleaved with positional patterns, e.g.:
     #   run_tests.py bin "[tag]" --fail-fast test/sql/foo.test
     return parser.parse_intermixed_args(argv)
@@ -659,6 +679,7 @@ def run_single_config(
             rss_memory_threshold_mib=args.track_rss_memory,
             runtime_threshold_seconds=args.track_runtime,
             max_failures=max_failures,
+            fail_require_skip=args.fail_require_skip,
         )
 
         tests = load_tests(config.test_list)
@@ -860,8 +881,14 @@ def run_tests(config: TestRunnerConfig, batches, total_tests: int):
     elapsed = time.monotonic() - start
     if stop_requested():
         return ConfigRunResult(returncode=130, passed_tests=0, failed_tests=0, skipped_tests=0, elapsed_seconds=elapsed)
+    exit_code = 0
     if state.failed_count:
         print(f"error: found {state.failed_count} test batch failures in {elapsed:.0f}s")
+        exit_code = 1
+    elif total_skipped_tests:
+        print(f"all tests passed in {elapsed:.0f}s ({total_skipped_tests} skipped tests)")
+    else:
+        print(f"all tests passed in {elapsed:.0f}s")
     if skipped_reason_counts:
         print()
         print("Skipped tests for the following reasons:")
@@ -870,7 +897,7 @@ def run_tests(config: TestRunnerConfig, batches, total_tests: int):
     failed_tests = state.failed_count
     passed_tests = max(0, total_tests - failed_tests - total_skipped_tests)
     return ConfigRunResult(
-        returncode=1 if state.failed_count else 0,
+        returncode=exit_code,
         passed_tests=passed_tests,
         failed_tests=failed_tests,
         skipped_tests=total_skipped_tests,

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -261,6 +261,46 @@ require windows: 2
         self.assertIn("require windows: 2", summary_block)
         self.assertNotIn("require windows: 7", summary_block)
 
+    def test_fail_require_skip_enabled_fails(self):
+        test_list_path = create_temp_file("test/sql/a.test\n")
+        helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            cat <<'EOF'
+            Skipped tests for the following reasons:
+            require mysql_scanner: 56
+            require postgres_scanner: 2
+            require spatial: 124
+            EOF
+            exit 0
+            """
+        )
+        os.chmod(helper_path, 0o755)
+
+        try:
+            proc = start_runner(
+                [
+                    "--workers",
+                    "1",
+                    "--batch-size",
+                    "1",
+                    "--fail-require-skip",
+                    "--test-list",
+                    str(test_list_path),
+                    "--test-command",
+                    f"{helper_path} {{test_list}}",
+                    "unused-binary",
+                ]
+            )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+            helper_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("require mysql_scanner: 56", proc.stdout)
+        self.assertIn("require postgres_scanner: 2", proc.stdout)
+        self.assertIn("require spatial: 124", proc.stdout)
+
     def test_generate_list(self):
         listed_tests_path = create_temp_file(
             """

--- a/src/common/allocator/allocator_jemalloc.cpp
+++ b/src/common/allocator/allocator_jemalloc.cpp
@@ -18,7 +18,7 @@ extern "C" {
 
 unsigned duckdb_malloc_ncpus() {
 #ifdef DUCKDB_NO_THREADS
-	return 1
+	return 1;
 #else
 	unsigned concurrency = duckdb::NumericCast<unsigned>(std::thread::hardware_concurrency());
 	return std::max(concurrency, 1u);

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -608,6 +608,26 @@ string ExtensionHelper::GetExtensionName(const string &original_name) {
 }
 
 void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, FileSystem &fs, const ExtensionLoadOptions &options) {
+	// If this is a logical extension name (not an explicit path), prefer the
+	// statically linked implementation for built-in linked extensions only.
+	// This avoids loading a second copy from disk (ASan ODR violation) while
+	// keeping externally installed/autoloaded extensions on the normal path.
+	auto logical_name = ExtensionHelper::GetExtensionName(options.extension_name);
+	if (!ExtensionHelper::IsFullPath(options.extension_name)) {
+		for (idx_t i = 0; i < ExtensionHelper::DefaultExtensionCount(); i++) {
+			auto default_extension = ExtensionHelper::GetDefaultExtension(i);
+			if (!default_extension.statically_loaded || logical_name != default_extension.name) {
+				continue;
+			}
+			DuckDB db_wrapper(db);
+			auto load_result = ExtensionHelper::LoadExtension(db_wrapper, logical_name);
+			if (load_result == ExtensionLoadResult::LOADED_EXTENSION) {
+				return;
+			}
+			break;
+		}
+	}
+
 	auto &manager = ExtensionManager::Get(db);
 	auto info = manager.BeginLoad(options);
 	if (!info) {

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -239,6 +239,14 @@ void TestConfiguration::ParseOption(const string &name, const Value &value) {
 	}
 }
 
+void TestConfiguration::SetLocalExtensionRepository(const string &repo) {
+	local_extension_repo = repo;
+}
+
+string TestConfiguration::GetLocalExtensionRepository() const {
+	return local_extension_repo;
+}
+
 TestConfiguration::ExtensionAutoLoadingMode TestConfiguration::GetExtensionAutoLoadingMode() {
 	string res = StringUtil::Lower(GetOptionOrDefault("autoloading", string("default")));
 	if (res == "none" || res == "default") {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -96,6 +96,9 @@ public:
 	static void AppendSelectTagSet(const Value &tag_set);
 	static void AppendSkipTagSet(const Value &tag_set);
 
+	string GetLocalExtensionRepository() const;
+	void SetLocalExtensionRepository(const string &repo);
+
 private:
 	//! Give preference to settings from loaded configs
 	bool test_env_from_config_loaded = false;
@@ -110,6 +113,8 @@ private:
 
 	vector<unordered_set<string>> select_tag_sets;
 	vector<unordered_set<string>> skip_tag_sets;
+
+	string local_extension_repo;
 
 private:
 	template <class T, class VAL_T = T>

--- a/test/sql/tpch/dbgen_error.test_slow
+++ b/test/sql/tpch/dbgen_error.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/tpch/dbgen_error.test
+# name: test/sql/tpch/dbgen_error.test_slow
 # description: Test error thrown during dbgen
 # group: [tpch]
 

--- a/test/sql/transactions/statement-preprocessor/copy_from_database_is_transactional.test_slow
+++ b/test/sql/transactions/statement-preprocessor/copy_from_database_is_transactional.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/transactions/statement-preprocessor/copy_from_database_is_transactional.test
+# name: test/sql/transactions/statement-preprocessor/copy_from_database_is_transactional.test_slow
 # group: [statement-preprocessor]
 
 require tpch

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -54,14 +54,16 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 	}
 	}
 
+	auto repo = string(DUCKDB_BUILD_DIRECTORY) + "/repository";
 	auto env_var = std::getenv("LOCAL_EXTENSION_REPO");
 	if (env_var) {
 		local_extension_repo = env_var;
 		autoload_known_extensions = true;
 		autoinstall_known_extensions = true;
 	} else if (autoload_known_extensions) {
-		local_extension_repo = string(DUCKDB_BUILD_DIRECTORY) + "/repository";
+		local_extension_repo = repo;
 	}
+	test_config.SetLocalExtensionRepository(repo);
 	config->SetOptionByName("autoinstall_known_extensions", autoinstall_known_extensions);
 	config->SetOptionByName("autoload_known_extensions", autoload_known_extensions);
 	for (auto &entry : test_config.GetConfigSettings()) {
@@ -145,16 +147,32 @@ void SQLLogicTestRunner::EndLoop() {
 }
 
 ExtensionLoadResult SQLLogicTestRunner::LoadExtension(DuckDB &db, const std::string &extension) {
-	auto &test_config = TestConfiguration::Get();
-	if (test_config.GetExtensionAutoLoadingMode() != TestConfiguration::ExtensionAutoLoadingMode::NONE) {
-		// try LOAD extension
-		Connection con(db);
-		auto result = con.Query("LOAD " + extension);
-		if (!result->HasError()) {
-			return ExtensionLoadResult::LOADED_EXTENSION;
-		}
+	if (db.ExtensionIsLoaded(extension)) {
+		return ExtensionLoadResult::LOADED_EXTENSION;
 	}
-	return ExtensionHelper::LoadExtension(db, extension);
+
+	// Prefer built-in/static extension loading first. Otherwise we can end up loading the same extension
+	// from the local extension repo as well, which causes duplicate symbols in sanitizer builds.
+	auto linked_result = ExtensionHelper::LoadExtension(db, extension);
+	if (linked_result == ExtensionLoadResult::LOADED_EXTENSION) {
+		return linked_result;
+	}
+
+	auto &test_config = TestConfiguration::Get();
+	Connection con(db);
+	if (test_config.GetExtensionAutoLoadingMode() == TestConfiguration::ExtensionAutoLoadingMode::NONE) {
+		// try INSTALL extension
+		auto repo = test_config.GetLocalExtensionRepository();
+		con.Query("INSTALL " + extension + " FROM '" + repo + "'");
+	}
+
+	// try LOAD extension
+	auto result = con.Query("LOAD " + extension);
+	if (!result->HasError()) {
+		return ExtensionLoadResult::LOADED_EXTENSION;
+	}
+
+	return linked_result;
 }
 
 void SQLLogicTestRunner::LoadDatabase(string dbpath, bool load_extensions) {


### PR DESCRIPTION
Run more core extensions under:
- thread sanitizer
- no-string-inline that also runs sanitizers

This PR is based on https://github.com/duckdb/duckdb/pull/22498.

CI failure in main extensions linux_amd64 seems unrelated.