### PR TITLE
Add vacuum_rebuild_indexes as an (experimental) ATTACH option

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1082,7 +1082,7 @@
     },
     {
         "name": "vacuum_rebuild_indexes",
-        "description": "(Experimental) Allow vacuum to compact row groups on tables with bound ART indexes, rebuilding the indexes afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled.",
+        "description": "(Experimental) Allow vacuum to compact row groups on tables with bound ART indexes, rebuilding the indexes afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled. Can also be set per-database via the 'vacuum_rebuild_indexes' ATTACH option, which overrides this default.",
         "type": "UBIGINT",
         "default_scope": "global",
         "default_value": "0",

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -723,8 +723,8 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 	// row groups while we hold row IDs from the ART, ensuring we always see a consistent
 	// <ART index, SegmentTree<RowGroup> pairing.
 	unique_ptr<StorageLockKey> vacuum_lock;
-	auto &db = DatabaseInstance::GetDatabase(context);
-	if (Settings::Get<VacuumRebuildIndexesSetting>(db) > 0) {
+	const auto &attached = storage.GetAttached();
+	if (attached.GetVacuumRebuildIndexThreshold() > 0) {
 		auto &transaction_manager = DuckTransactionManager::Get(storage.GetAttached());
 		vacuum_lock = transaction_manager.SharedVacuumLock();
 	}

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/main/settings.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
 
@@ -57,7 +58,7 @@ struct StoredDatabasePath {
 //! they have to apply to any database file type (duckdb, sqlite, etc.).
 struct AttachOptions {
 	//! Constructor for databases we attach outside of the ATTACH DATABASE statement.
-	explicit AttachOptions(const DBConfigOptions &options);
+	explicit AttachOptions(const DBConfig &config);
 	//! Constructor for databases we attach when using ATTACH DATABASE.
 	AttachOptions(const unordered_map<string, Value> &options, const AccessMode default_access_mode);
 
@@ -77,6 +78,8 @@ struct AttachOptions {
 	AttachVisibility visibility = AttachVisibility::SHOWN;
 	//! The stored database path (in the path manager)
 	unique_ptr<StoredDatabasePath> stored_database_path;
+	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
+	optional_idx vacuum_rebuild_indexes_threshold;
 };
 
 //! The AttachedDatabase represents an attached database instance.
@@ -131,6 +134,14 @@ public:
 	AttachVisibility GetVisibility() const {
 		return visibility;
 	}
+	//! vacuum_rebuild_indexes threshold for this attached database.
+	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
+	idx_t GetVacuumRebuildIndexThreshold() const {
+		if (vacuum_rebuild_threshold.IsValid()) {
+			return vacuum_rebuild_threshold.GetIndex();
+		}
+		return Settings::Get<VacuumRebuildIndexesSetting>(db);
+	}
 	const unordered_map<string, Value> &GetAttachOptions() const {
 		return attach_options;
 	}
@@ -156,6 +167,7 @@ private:
 	bool is_initial_database = false;
 	bool is_closed = false;
 	shared_ptr<mutex> close_lock;
+	optional_idx vacuum_rebuild_threshold;
 	unordered_map<string, Value> attach_options;
 
 private:

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -136,7 +136,6 @@ public:
 	//! vacuum_rebuild_indexes threshold for this attached database.
 	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
 	idx_t GetVacuumRebuildIndexThreshold() const;
-	void SetVacuumRebuildIndexThreshold(idx_t threshold);
 	const unordered_map<string, Value> &GetAttachOptions() const {
 		return attach_options;
 	}

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/main/settings.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry.hpp"
 
@@ -58,7 +57,7 @@ struct StoredDatabasePath {
 //! they have to apply to any database file type (duckdb, sqlite, etc.).
 struct AttachOptions {
 	//! Constructor for databases we attach outside of the ATTACH DATABASE statement.
-	explicit AttachOptions(const DBConfig &config);
+	explicit AttachOptions(const DBConfigOptions &options);
 	//! Constructor for databases we attach when using ATTACH DATABASE.
 	AttachOptions(const unordered_map<string, Value> &options, const AccessMode default_access_mode);
 
@@ -136,12 +135,8 @@ public:
 	}
 	//! vacuum_rebuild_indexes threshold for this attached database.
 	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
-	idx_t GetVacuumRebuildIndexThreshold() const {
-		if (vacuum_rebuild_threshold.IsValid()) {
-			return vacuum_rebuild_threshold.GetIndex();
-		}
-		return Settings::Get<VacuumRebuildIndexesSetting>(db);
-	}
+	idx_t GetVacuumRebuildIndexThreshold() const;
+	void SetVacuumRebuildIndexThreshold(idx_t threshold);
 	const unordered_map<string, Value> &GetAttachOptions() const {
 		return attach_options;
 	}

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1575,7 +1575,8 @@ struct VacuumRebuildIndexesSetting {
 	static constexpr const char *Name = "vacuum_rebuild_indexes";
 	static constexpr const char *Description =
 	    "(Experimental) Allow vacuum to compact row groups on tables with bound ART indexes, rebuilding the indexes "
-	    "afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled.";
+	    "afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled. Can also be set "
+	    "per-database via the 'vacuum_rebuild_indexes' ATTACH option, which overrides this default.";
 	static constexpr const char *InputType = "UBIGINT";
 	static constexpr const char *DefaultValue = "0";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/database_path_and_type.hpp"
 #include "duckdb/main/valid_checker.hpp"
 #include "duckdb/storage/block_allocator.hpp"
+#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
@@ -31,8 +32,12 @@ void StoredDatabasePath::OnDetach() {
 //===--------------------------------------------------------------------===//
 // Attach Options
 //===--------------------------------------------------------------------===//
-AttachOptions::AttachOptions(const DBConfigOptions &options)
-    : access_mode(options.access_mode), db_type(options.database_type) {
+AttachOptions::AttachOptions(const DBConfig &config)
+    : access_mode(config.options.access_mode), db_type(config.options.database_type) {
+	auto threshold = Settings::Get<VacuumRebuildIndexesSetting>(config);
+	if (threshold > 0) {
+		vacuum_rebuild_indexes_threshold = threshold;
+	}
 }
 
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)
@@ -85,6 +90,11 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 			}
 			continue;
 		}
+
+		if (entry.first == "vacuum_rebuild_indexes") {
+			vacuum_rebuild_indexes_threshold = UBigIntValue::Get(entry.second.DefaultCastAs(LogicalType::UBIGINT));
+			continue;
+		}
 		options.emplace(entry.first, entry.second);
 	}
 }
@@ -121,6 +131,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
 	catalog = make_uniq<DuckCatalog>(*this);
@@ -142,6 +153,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
 	catalog = storage_extension->attach(storage_info, context, *this, name, info, options);

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -32,12 +32,8 @@ void StoredDatabasePath::OnDetach() {
 //===--------------------------------------------------------------------===//
 // Attach Options
 //===--------------------------------------------------------------------===//
-AttachOptions::AttachOptions(const DBConfig &config)
-    : access_mode(config.options.access_mode), db_type(config.options.database_type) {
-	auto threshold = Settings::Get<VacuumRebuildIndexesSetting>(config);
-	if (threshold > 0) {
-		vacuum_rebuild_indexes_threshold = threshold;
-	}
+AttachOptions::AttachOptions(const DBConfigOptions &options)
+    : access_mode(options.access_mode), db_type(options.database_type) {
 }
 
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)
@@ -92,7 +88,14 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 		}
 
 		if (entry.first == "vacuum_rebuild_indexes") {
-			vacuum_rebuild_indexes_threshold = UBigIntValue::Get(entry.second.DefaultCastAs(LogicalType::UBIGINT));
+			const auto threshold = UBigIntValue::Get(entry.second.DefaultCastAs(LogicalType::UBIGINT));
+			try {
+				vacuum_rebuild_indexes_threshold = threshold;
+			} catch (InternalException &e) {
+				throw InvalidInputException("Invalid setting for vacuum_rebuild_indexes: %d (valid range is 0 - %d)",
+				                            threshold,
+				                            UBigIntValue::Get(Value::MaximumValue(LogicalType::UBIGINT)) - 1);
+			}
 			continue;
 		}
 		options.emplace(entry.first, entry.second);
@@ -195,6 +198,17 @@ bool AttachedDatabase::IsReadOnly() const {
 
 bool AttachedDatabase::NameIsReserved(const string &name) {
 	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG || name == SYSTEM_CATALOG;
+}
+
+idx_t AttachedDatabase::GetVacuumRebuildIndexThreshold() const {
+	if (vacuum_rebuild_threshold.IsValid()) {
+		return vacuum_rebuild_threshold.GetIndex();
+	}
+	return Settings::Get<VacuumRebuildIndexesSetting>(db);
+}
+
+void AttachedDatabase::SetVacuumRebuildIndexThreshold(idx_t threshold) {
+	vacuum_rebuild_threshold = threshold;
 }
 
 string AttachedDatabase::StoredPath() const {

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -207,10 +207,6 @@ idx_t AttachedDatabase::GetVacuumRebuildIndexThreshold() const {
 	return Settings::Get<VacuumRebuildIndexesSetting>(db);
 }
 
-void AttachedDatabase::SetVacuumRebuildIndexThreshold(idx_t threshold) {
-	vacuum_rebuild_threshold = threshold;
-}
-
 string AttachedDatabase::StoredPath() const {
 	if (stored_database_path) {
 		return stored_database_path->path;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -206,7 +206,7 @@ void DatabaseInstance::CreateMainDatabase() {
 
 	Connection con(*this);
 	con.BeginTransaction();
-	AttachOptions options(config.options);
+	AttachOptions options(config);
 	options.is_main_database = true;
 	db_manager->AttachDatabase(*con.context, info, options);
 	con.Commit();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -206,7 +206,7 @@ void DatabaseInstance::CreateMainDatabase() {
 
 	Connection con(*this);
 	con.BeginTransaction();
-	AttachOptions options(config);
+	AttachOptions options(config.options);
 	options.is_main_database = true;
 	db_manager->AttachDatabase(*con.context, info, options);
 	con.Commit();

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,6 +134,11 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 			if (!options.default_table.name.empty()) {
 				existing_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 			}
+			if (!options.vacuum_rebuild_indexes_threshold.IsValid()) {
+				existing_db->SetVacuumRebuildIndexThreshold(Settings::Get<VacuumRebuildIndexesSetting>(db));
+			} else {
+				existing_db->SetVacuumRebuildIndexThreshold(options.vacuum_rebuild_indexes_threshold.GetIndex());
+			}
 			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 				// allow custom catalogs to override this behavior
 				if (!existing_db->GetCatalog().HasConflictingAttachOptions(info.path, options)) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,12 +134,17 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 			if (!options.default_table.name.empty()) {
 				existing_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 			}
-			if (!options.vacuum_rebuild_indexes_threshold.IsValid()) {
-				existing_db->SetVacuumRebuildIndexThreshold(Settings::Get<VacuumRebuildIndexesSetting>(db));
-			} else {
-				existing_db->SetVacuumRebuildIndexThreshold(options.vacuum_rebuild_indexes_threshold.GetIndex());
-			}
 			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+				// we require the vacuuming threshold for indexed tables to be the same as the already attached db
+				if (options.vacuum_rebuild_indexes_threshold.IsValid()) {
+					auto previous_setting = existing_db->GetVacuumRebuildIndexThreshold();
+					auto new_setting = options.vacuum_rebuild_indexes_threshold.GetIndex();
+					if (previous_setting != new_setting) {
+						throw BinderException("Cannot re-attach with a different vacuum_rebuild_indexes setting "
+						                      "(previous: %d, new: %d)",
+						                      previous_setting, new_setting);
+					}
+				}
 				// allow custom catalogs to override this behavior
 				if (!existing_db->GetCatalog().HasConflictingAttachOptions(info.path, options)) {
 					return existing_db;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1344,7 +1344,7 @@ void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkp
 	// *unless* vacuum_rebuild_indexes threshold is set, the table's row count
 	// is within the threshold, and all indexes are bound ART indexes,
 	// in which case we allow vacuuming and rebuild the indexes afterward.
-	auto vacuum_rebuild_threshold = Settings::Get<VacuumRebuildIndexesSetting>(checkpoint_state.writer.GetDatabase());
+	auto vacuum_rebuild_threshold = checkpoint_state.writer.GetAttached().GetVacuumRebuildIndexThreshold();
 	auto index_types = info->GetIndexes().DistinctIndexTypes();
 	state.can_rebuild_indexes = has_indexes && !info->GetIndexes().HasUnbound() && index_types.size() == 1 &&
 	                            index_types.count(ART::TYPE_NAME) && vacuum_rebuild_threshold > 0 &&

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
@@ -1,0 +1,64 @@
+# name: test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+# description: Test that setting the ATTACH option vacuum_rebuild_indexes correctly rebuilds indexes when empty row groups are dropped
+# group: [vacuum]
+
+# set threshold at 5 X rowgroup size
+statement ok
+ATTACH '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
+
+statement ok
+CREATE TABLE db1.t(i INTEGER);
+
+statement ok
+CREATE INDEX idx ON db1.t(i);
+
+# insert enough rows for 2 row groups (122880 rows each)
+statement ok
+INSERT INTO db1.t SELECT i FROM range(245760) t(i);
+
+statement ok
+CHECKPOINT db1
+
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
+----
+2
+
+# delete all rows in the first row group
+statement ok
+DELETE FROM db1.t WHERE i < 122880
+
+statement ok
+CHECKPOINT db1
+
+# the empty first row group is dropped, shifting row IDs of the second group
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
+----
+1
+
+# verify index scan is used after rebuild
+query II
+EXPLAIN ANALYZE SELECT i, rowid FROM db1.t WHERE i = 122880
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+# verify index lookups return correct row IDs after shift
+# RG0 dropped, RG1 shifts to rowid 0
+query II
+SELECT i, rowid FROM db1.t WHERE i = 122880
+----
+122880	0
+
+query II
+SELECT i, rowid FROM db1.t WHERE i = 245759
+----
+245759	122879
+
+query I
+SELECT COUNT(*) FROM db1.t
+----
+122880
+
+statement ok
+DETACH db1

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
@@ -60,22 +60,32 @@ SELECT COUNT(*) FROM db1.t
 ----
 245760
 
-# Disable the setting on ATTACH OR REPLACE should work
-statement ok
+# ATTACH OR REPLACE with a different vacuum_rebuild_indexes value should fail
+statement error
 ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+----
+Cannot re-attach with a different vacuum_rebuild_indexes setting
 
-# delete all rows in the first row group
+# ATTACH OR REPLACE with the same value is a no-op
+statement ok
+ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 614400)
+
+# ATTACH IF NOT EXISTS ignores the supplied options; the existing threshold (614400) remains in effect
+statement ok
+ATTACH IF NOT EXISTS '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+
+# delete all rows in the (now) first row group
 statement ok
 DELETE FROM db1.t WHERE i < 245760
 
 statement ok
 CHECKPOINT db1
 
-# the empty first row group is NOT dropped
+# the original threshold (614400) is still active, so the empty row group is dropped
 query I
 SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
 ----
-2
+1
 
 statement ok
 DETACH db1

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
@@ -60,7 +60,7 @@ SELECT COUNT(*) FROM db1.t
 ----
 245760
 
-# ATTACH OR REPLACE with a different vacuum_rebuild_indexes value should fail
+# ATTACH OR REPLACE with a different vacuum_rebuild_indexes value fails
 statement error
 ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
 ----

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach.test_slow
@@ -12,9 +12,9 @@ CREATE TABLE db1.t(i INTEGER);
 statement ok
 CREATE INDEX idx ON db1.t(i);
 
-# insert enough rows for 2 row groups (122880 rows each)
+# insert enough rows for 3 row groups (122880 rows each)
 statement ok
-INSERT INTO db1.t SELECT i FROM range(245760) t(i);
+INSERT INTO db1.t SELECT i FROM range(368640) t(i);
 
 statement ok
 CHECKPOINT db1
@@ -22,7 +22,7 @@ CHECKPOINT db1
 query I
 SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
 ----
-2
+3
 
 # delete all rows in the first row group
 statement ok
@@ -35,7 +35,7 @@ CHECKPOINT db1
 query I
 SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
 ----
-1
+2
 
 # verify index scan is used after rebuild
 query II
@@ -58,7 +58,24 @@ SELECT i, rowid FROM db1.t WHERE i = 245759
 query I
 SELECT COUNT(*) FROM db1.t
 ----
-122880
+245760
+
+# Disable the setting on ATTACH OR REPLACE should work
+statement ok
+ATTACH OR REPLACE '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+
+# delete all rows in the first row group
+statement ok
+DELETE FROM db1.t WHERE i < 245760
+
+statement ok
+CHECKPOINT db1
+
+# the empty first row group is NOT dropped
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
+----
+2
 
 statement ok
 DETACH db1

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach_overrides_global.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes_attach_overrides_global.test_slow
@@ -1,0 +1,54 @@
+# name: test/sql/storage/vacuum/vacuum_rebuild_indexes_attach_overrides_global.test_slow
+# description: Test that setting the ATTACH option vacuum_rebuild_indexes overrides the global setting
+# group: [vacuum]
+
+require vacuum_rebuild_indexes
+
+# set threshold at 0
+statement ok
+ATTACH '__TEST_DIR__/attach_vacuum_indexed.db' AS db1 (vacuum_rebuild_indexes 0)
+
+statement ok
+CREATE TABLE db1.t(i INTEGER);
+
+statement ok
+CREATE INDEX idx ON db1.t(i);
+
+# insert enough rows for 2 row groups (122880 rows each)
+statement ok
+INSERT INTO db1.t SELECT i FROM range(245760) t(i);
+
+statement ok
+CHECKPOINT db1
+
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
+----
+2
+
+# delete all rows in the first row group
+statement ok
+DELETE FROM db1.t WHERE i < 122880
+
+statement ok
+CHECKPOINT db1
+
+# the empty first row group is not dropped
+query I
+SELECT COUNT(DISTINCT row_group_id) FROM pragma_storage_info('db1.t')
+----
+2
+
+# verify index lookups still return the original row IDs
+query II
+SELECT i, rowid FROM db1.t WHERE i = 122880
+----
+122880	122880
+
+query II
+SELECT i, rowid FROM db1.t WHERE i = 245759
+----
+245759	245759
+
+statement ok
+DETACH db1


### PR DESCRIPTION
This adds `vacuum_rebuild_indexes` as an ATTACH option in addition to the global setting.

This allows users to enable vacuuming of indexed tables per-table rather than as a global setting.

Note that the setting (both as attach and as global option) is experimental. We should revisit it before v2.0 and see in what form we want to keep it, if at all.