### PR TITLE
Postgres Compatibility For SETOF Returning Functions

### DIFF
--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -247,6 +247,7 @@ struct ICUTableRange {
 		    RangeDateTimeLocalInit);
 		generate_series_function.in_out_function = ICUTableRangeFunction<true>;
 		generate_series_function.cardinality = Cardinality;
+		generate_series_function.postgres_setof_compat = true;
 		generate_series.AddFunction(generate_series_function);
 
 		loader.RegisterFunction(generate_series);

--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -247,7 +247,7 @@ struct ICUTableRange {
 		    RangeDateTimeLocalInit);
 		generate_series_function.in_out_function = ICUTableRangeFunction<true>;
 		generate_series_function.cardinality = Cardinality;
-		generate_series_function.postgres_setof_compat = true;
+		generate_series_function.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 		generate_series.AddFunction(generate_series_function);
 
 		loader.RegisterFunction(generate_series);

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -406,7 +406,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet generate_series("generate_series");
 	range_function.bind = RangeFunctionBind<true>;
 	range_function.in_out_function = RangeFunction<true>;
-	range_function.postgres_setof_compat = true;
+	range_function.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 	range_function.GetArguments() = {LogicalType::BIGINT};
 	generate_series.AddFunction(range_function);
 	range_function.GetArguments() = {LogicalType::BIGINT, LogicalType::BIGINT};
@@ -417,7 +417,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
 	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
 	generate_series_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
-	generate_series_in_out.postgres_setof_compat = true;
+	generate_series_in_out.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 	generate_series.AddFunction(generate_series_in_out);
 	set.AddFunction(generate_series);
 }

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -406,6 +406,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet generate_series("generate_series");
 	range_function.bind = RangeFunctionBind<true>;
 	range_function.in_out_function = RangeFunction<true>;
+	range_function.postgres_setof_compat = true;
 	range_function.GetArguments() = {LogicalType::BIGINT};
 	generate_series.AddFunction(range_function);
 	range_function.GetArguments() = {LogicalType::BIGINT, LogicalType::BIGINT};
@@ -416,6 +417,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
 	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
 	generate_series_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
+	generate_series_in_out.postgres_setof_compat = true;
 	generate_series.AddFunction(generate_series_in_out);
 	set.AddFunction(generate_series);
 }

--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -92,7 +92,7 @@ static OperatorResultType UnnestFunction(ExecutionContext &context, TableFunctio
 void UnnestTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction unnest_function("unnest", {LogicalType::ANY}, nullptr, UnnestBind, UnnestInit, UnnestLocalInit);
 	unnest_function.in_out_function = UnnestFunction;
-	unnest_function.postgres_setof_compat = true;
+	unnest_function.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;
 	set.AddFunction(unnest_function);
 }
 

--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -92,6 +92,7 @@ static OperatorResultType UnnestFunction(ExecutionContext &context, TableFunctio
 void UnnestTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction unnest_function("unnest", {LogicalType::ANY}, nullptr, UnnestBind, UnnestInit, UnnestLocalInit);
 	unnest_function.in_out_function = UnnestFunction;
+	unnest_function.postgres_setof_compat = true;
 	set.AddFunction(unnest_function);
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -26,7 +26,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false) {
+      sampling_pushdown(false), late_materialization(false), postgres_setof_compat(false) {
 }
 
 TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, std::nullptr_t function_,
@@ -41,7 +41,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false) {
+      sampling_pushdown(false), late_materialization(false), postgres_setof_compat(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
@@ -75,7 +75,7 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
 	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
 	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
-	       global_initialization == rhs.global_initialization;
+	       postgres_setof_compat == rhs.postgres_setof_compat && global_initialization == rhs.global_initialization;
 }
 
 bool TableFunction::operator!=(const TableFunction &rhs) const {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -26,7 +26,8 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false), postgres_setof_compat(false) {
+      sampling_pushdown(false), late_materialization(false),
+      return_type(TableFunctionReturnType::TABLE_RETURNING_FUNCTION) {
 }
 
 TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, std::nullptr_t function_,
@@ -41,7 +42,8 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false), postgres_setof_compat(false) {
+      sampling_pushdown(false), late_materialization(false),
+      return_type(TableFunctionReturnType::TABLE_RETURNING_FUNCTION) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
@@ -75,7 +77,7 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
 	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
 	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
-	       postgres_setof_compat == rhs.postgres_setof_compat && global_initialization == rhs.global_initialization;
+	       return_type == rhs.return_type && global_initialization == rhs.global_initialization;
 }
 
 bool TableFunction::operator!=(const TableFunction &rhs) const {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -368,6 +368,8 @@ typedef void (*table_function_set_partitions_to_scan_t)(vector<idx_t> partition_
 //! When to call init_global to initialize the table function
 enum class TableFunctionInitialization { INITIALIZE_ON_EXECUTE, INITIALIZE_ON_SCHEDULE };
 
+enum class TableFunctionReturnType { TABLE_RETURNING_FUNCTION, SET_RETURNING_FUNCTION };
+
 class TableFunction : public SimpleNamedParameterFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	DUCKDB_API TableFunction();
@@ -506,8 +508,7 @@ public:
 	bool sampling_pushdown;
 	//! Whether or not the table function supports late materialization
 	bool late_materialization;
-	//! Whether a single-column result should inherit an explicit table alias for PostgreSQL SETOF compatibility
-	bool postgres_setof_compat;
+	TableFunctionReturnType return_type;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
 	//! The order preservation type of the table function

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -506,6 +506,8 @@ public:
 	bool sampling_pushdown;
 	//! Whether or not the table function supports late materialization
 	bool late_materialization;
+	//! Whether a single-column result should inherit an explicit table alias for PostgreSQL SETOF compatibility
+	bool postgres_setof_compat;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
 	//! The order preservation type of the table function

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -177,6 +177,15 @@ static string GetAlias(const TableFunctionRef &ref) {
 	return string();
 }
 
+static void ApplyPostgresSetofAliasCompatibility(const TableFunction &table_function, const TableFunctionRef &ref,
+                                                 vector<string> &return_names) {
+	if (!table_function.postgres_setof_compat || ref.alias.empty() || !ref.column_name_alias.empty() ||
+	    return_names.size() != 1) {
+		return;
+	}
+	return_names[0] = ref.alias;
+}
+
 BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, const TableFunctionRef &ref,
                                                  vector<Value> parameters, named_parameter_map_t named_parameters,
                                                  vector<LogicalType> input_table_types,
@@ -210,6 +219,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 						    table_function.name);
 					}
 				}
+				ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
 				BoundStatement result;
 				bind_context.AddGenericBinding(bind_index, function_name, return_names, new_plan->types);
 				result.names = return_names;
@@ -270,6 +280,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
 		                        table_function.name);
 	}
+	ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
 	// overwrite the names with any supplied aliases
 	for (idx_t i = 0; i < column_name_alias.size() && i < return_names.size(); i++) {
 		return_names[i] = column_name_alias[i];

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -179,8 +179,8 @@ static string GetAlias(const TableFunctionRef &ref) {
 
 static void ApplyPostgresSetofAliasCompatibility(const TableFunction &table_function, const TableFunctionRef &ref,
                                                  vector<string> &return_names) {
-	if (!table_function.postgres_setof_compat || ref.alias.empty() || !ref.column_name_alias.empty() ||
-	    return_names.size() != 1) {
+	if (table_function.return_type != TableFunctionReturnType::SET_RETURNING_FUNCTION || ref.alias.empty() ||
+	    !ref.column_name_alias.empty() || return_names.size() != 1) {
 		return;
 	}
 	return_names[0] = ref.alias;

--- a/test/sql/table_function/postgres_setof_compatibility.test
+++ b/test/sql/table_function/postgres_setof_compatibility.test
@@ -1,0 +1,48 @@
+# name: test/sql/table_function/postgres_setof_compatibility.test
+# description: Test PostgreSQL SETOF compatibility for table functions
+# group: [table_function]
+
+query I
+select i from generate_series(1, 2) i;
+----
+1
+2
+
+query TT
+select column_name, column_type from (describe select * from generate_series(1, 2) i);
+----
+i	BIGINT
+
+query TT
+select column_name, column_type from (describe select * from generate_series(1, 2) t(i));
+----
+i	BIGINT
+
+query I
+select r from range(1, 3) r;
+----
+{'range': 1}
+{'range': 2}
+
+query I
+select i from range(1, 3) r(i);
+----
+1
+2
+
+query I
+select i from unnest([1, 2]) i;
+----
+1
+2
+
+query TT
+select column_name, column_type from (describe select * from unnest([1, 2]) i);
+----
+i	INTEGER
+
+query TT
+select column_name, column_type from (describe select * from unnest([1, 2]) t(i));
+----
+i	INTEGER
+

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -230,37 +230,3 @@ select * FROM generate_series(1, 3, 1) AS _(x), generate_series(x, 2, 1) AS __(y
 1	2
 2	2
 
-query I
-select i from generate_series(1, 2) i;
-----
-1
-2
-
-query I
-select * from generate_series(1, 2) i;
-----
-1
-2
-
-query TT
-select column_name, column_type from (describe select * from generate_series(1, 2) i);
-----
-i	BIGINT
-
-query I
-select x from generate_series(1, 2) t(x);
-----
-1
-2
-
-query I
-select r from range(1, 3) r;
-----
-{'range': 1}
-{'range': 2}
-
-query I
-select u from unnest([1, 2]) u;
-----
-1
-2

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -229,4 +229,3 @@ select * FROM generate_series(1, 3, 1) AS _(x), generate_series(x, 2, 1) AS __(y
 1	1
 1	2
 2	2
-

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -229,3 +229,32 @@ select * FROM generate_series(1, 3, 1) AS _(x), generate_series(x, 2, 1) AS __(y
 1	1
 1	2
 2	2
+
+query I
+select i from generate_series(1, 2) i;
+----
+1
+2
+
+query I
+select * from generate_series(1, 2) i;
+----
+1
+2
+
+query TT
+select column_name, column_type from (describe select * from generate_series(1, 2) i);
+----
+i	BIGINT
+
+query I
+select x from generate_series(1, 2) t(x);
+----
+1
+2
+
+query I
+select r from range(1, 3) r;
+----
+{'range': 1}
+{'range': 2}

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -258,3 +258,9 @@ select r from range(1, 3) r;
 ----
 {'range': 1}
 {'range': 2}
+
+query I
+select u from unnest([1, 2]) u;
+----
+1
+2


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/8675

This PR aligns aliasing behavior with Postgres for `generate_series`, and `unnest`. With that, both `generate_series(...) t` and `generate_series(...) t(i)` are interpreted with `i` being the column name.

Previously:
```sql
select i from generate_series(1, 2) i;
┌────────────────────────────────┐
│               i                │
│ struct(generate_series bigint) │
├────────────────────────────────┤
│ {'generate_series': 1}         │
│ {'generate_series': 2}         │
└────────────────────────────────┘
```

This PR/Postgres:
```sql
select i from generate_series(1, 2) i;
 
┌───────┐
│   i   │
│ int64 │
├───────┤
│     1 │
│     2 │
│     3 │
└───────┘
```