### PR TITLE
Add make targets to run test configs easily

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1320,22 +1320,22 @@ jobs:
         rm -rf build/release
         tar -xzf build/release-artifact.tar.gz -C build
 
-    - name: test_configs
+    - name: Test Configurations
       if: success() || failure()
       run: |
         make test_configs
 
-    - name: test_vector
+    - name: Test Vector Verification
       if: success() || failure()
       run: |
         make test_vector
 
-    - name: test_table_scan
+    - name: Test Synchronous Table Scan
       if: success() || failure()
       run: |
         make test_table_scan
 
-    - name: test_storage
+    - name: Test Storage Compatibility
       if: success() || failure()
       run: |
         make test_storage

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1307,7 +1307,6 @@ jobs:
 
     - name: Install
       timeout-minutes: 10
-      shell: bash
       run: python3 scripts/ci/retry.py -- make toolsci
 
     - name: Download linux release artifact
@@ -1317,232 +1316,29 @@ jobs:
         path: build
 
     - name: Extract linux release artifact
-      shell: bash
       run: |
         rm -rf build/release
         tar -xzf build/release-artifact.tar.gz -C build
 
-    - name: test/configs/verify_statement_copy.json
+    - name: test_configs
       if: success() || failure()
-      shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_copy.json ./build/release/test/unittest
+        make test_configs
 
-    - name: test/configs/verify_statement_to_string.json
+    - name: test_vector
       if: success() || failure()
-      shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_to_string.json ./build/release/test/unittest
+        make test_vector
 
-    - name: test/configs/verify_statement_explain.json
+    - name: test_table_scan
       if: success() || failure()
-      shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_explain.json ./build/release/test/unittest
+        make test_table_scan
 
-    - name: test/configs/verify_statement_prepare.json
+    - name: test_storage
       if: success() || failure()
-      shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_prepare.json ./build/release/test/unittest
-
-    - name: test/configs/verify_serializer.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_serializer.json ./build/release/test/unittest
-
-    - name: test/configs/verify_stats.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_stats.json ./build/release/test/unittest
-
-    - name: test/configs/verify_serialization.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_statement_serialization.json ./build/release/test/unittest
-
-    - name: test/configs/force_storage.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage.json ./build/release/test/unittest
-
-    - name: test/configs/force_storage_restart.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage_restart.json ./build/release/test/unittest
-
-    - name: test/configs/latest_storage.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage.json ./build/release/test/unittest
-
-    - name: test/configs/block_verification.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/block_verification.json ./build/release/test/unittest
-
-    - name: test/configs/disable_optimizer.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/disable_optimizer.json ./build/release/test/unittest
-
-    - name: test/configs/internal_vector_serialization.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/internal_vector_serialization.json ./build/release/test/unittest
-
-    - name: test/configs/internal_vector_verification.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/internal_vector_verification.json ./build/release/test/unittest
-
-    - name: test/configs/force_external.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/force_external.json ./build/release/test/unittest
-
-    - name: test/configs/verify_fetch_row.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_fetch_row.json ./build/release/test/unittest
-
-    - name: test/configs/disable_caching_operators.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/disable_caching_operators.json ./build/release/test/unittest
-
-    - name: test/configs/wal_verification.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/wal_verification.json ./build/release/test/unittest
-
-    - name: test/configs/vacuum_rebuild_indexes_force_storage.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/vacuum_rebuild_indexes_force_storage.json ./build/release/test/unittest
-
-    - name: test/configs/prefetch_all_parquet_files.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_parquet_files.json ./build/release/test/unittest
-
-    - name: test/configs/verification_projection.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verification_projection.json ./build/release/test/unittest
-
-    - name: test/configs/verify_column_bindings.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_column_bindings.json ./build/release/test/unittest
-
-    - name: test/configs/no_local_filesystem.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/no_local_filesystem.json ./build/release/test/unittest
-
-    - name: test/configs/block_size_16kB.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/block_size_16kB.json ./build/release/test/unittest
-
-    - name: test/configs/latest_storage_block_size_16kB.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage_block_size_16kB.json ./build/release/test/unittest
-
-    - name: test/configs/block_allocator_100mib.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/block_allocator_100mib.json ./build/release/test/unittest
-
-    - name: Test dictionary_expression
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_expression --skip-compiled" ./build/release/test/unittest
-
-    - name: Test dictionary_operator
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_operator --skip-compiled" ./build/release/test/unittest
-
-    - name: Test constant_operator
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector constant_operator --skip-compiled" ./build/release/test/unittest
-
-    - name: Test sequence_operator
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector sequence_operator --skip-compiled" ./build/release/test/unittest
-
-    - name: Test nested_shuffle
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector nested_shuffle --skip-compiled" ./build/release/test/unittest
-
-    - name: Test variant_vector
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/variant_vector.json ./build/release/test/unittest
-
-    - name: Test compressed in memory
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/compressed_in_memory.json ./build/release/test/unittest
-
-    - name: Test sycnronous table scan implementation
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags='--on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"' ./build/release/test/unittest
-
-    - name: Test block prefetching
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_storage.json ./build/release/test/unittest
-
-    - name: Forwards compatibility tests
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2|1.4.3" --new-unittest build/release/test/unittest
-
-    - name: test/configs/encryption.json
-      if: success() || failure()
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-config=test/configs/encryption.json ./build/release/test/unittest
+        make test_storage
 
  summary:
     name: Summary

--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,54 @@ endif
 unittest_release:
 	$(PYTHON) scripts/ci/run_tests.py build/release/$(UNITTEST_BINARY) $(T)
 
+TEST_CONFIGS := \
+	test/configs/verify_statement_copy.json \
+	test/configs/verify_statement_to_string.json \
+	test/configs/verify_statement_explain.json \
+	test/configs/verify_statement_prepare.json \
+	test/configs/verify_serializer.json \
+	test/configs/verify_stats.json \
+	test/configs/verify_statement_serialization.json \
+	test/configs/force_storage.json \
+	test/configs/force_storage_restart.json \
+	test/configs/latest_storage.json \
+	test/configs/block_verification.json \
+	test/configs/disable_optimizer.json \
+	test/configs/internal_vector_serialization.json \
+	test/configs/internal_vector_verification.json \
+	test/configs/force_external.json \
+	test/configs/verify_fetch_row.json \
+	test/configs/disable_caching_operators.json \
+	test/configs/wal_verification.json \
+	test/configs/vacuum_rebuild_indexes_force_storage.json \
+	test/configs/prefetch_all_parquet_files.json \
+	test/configs/verification_projection.json \
+	test/configs/verify_column_bindings.json \
+	test/configs/no_local_filesystem.json \
+	test/configs/block_size_16kB.json \
+	test/configs/latest_storage_block_size_16kB.json \
+	test/configs/block_allocator_100mib.json \
+	test/configs/variant_vector.json \
+	test/configs/compressed_in_memory.json \
+	test/configs/prefetch_all_storage.json \
+	test/configs/encryption.json
+
+test_configs:
+	$(PYTHON) scripts/ci/run_tests.py $(foreach cfg,$(TEST_CONFIGS),--test-config=$(cfg)) ./build/release/$(UNITTEST_BINARY)
+
+test_vector:
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_expression --skip-compiled" ./build/release/$(UNITTEST_BINARY)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_operator --skip-compiled" ./build/release/$(UNITTEST_BINARY)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--verify-vector constant_operator --skip-compiled" ./build/release/$(UNITTEST_BINARY)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--verify-vector sequence_operator --skip-compiled" ./build/release/$(UNITTEST_BINARY)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--verify-vector nested_shuffle --skip-compiled" ./build/release/$(UNITTEST_BINARY)
+
+test_table_scan:
+	$(PYTHON) scripts/ci/run_tests.py --test-flags='--on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"' ./build/release/$(UNITTEST_BINARY)
+
+test_storage:
+	$(PYTHON) scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2|1.4.3" --new-unittest build/release/$(UNITTEST_BINARY)
+
 .PHONY: alltest_release_tag test_release_tag
 alltest_release_tag:
 	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/$(UNITTEST_BINARY) '*' $(T)

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -698,6 +698,7 @@ def main_impl(argv: list[str] | None = None):
 
     test_list_files = [path for path in [args.test_list, args.changed_tests] if path is not None]
     config_invocations = build_config_invocations(args.test_config, args.test_flags)
+    is_github_ci = bool(os.environ.get("CI"))
     max_failures = args.max_failures
     if args.fail_fast:
         max_failures = 1
@@ -716,12 +717,17 @@ def main_impl(argv: list[str] | None = None):
     else:
         batch_size = args.batch_size
     failed_configs = []
+    keep_groups_open = False
     if len(config_invocations) > 1:
         print(f"running {len(config_invocations)} configs")
     for invocation in config_invocations:
         if stop_requested():
             print("interrupted")
             return 130
+        group_open = False
+        if is_github_ci:
+            print(f"::group::test config: {invocation.label}")
+            group_open = True
         try:
             returncode = run_single_config(
                 args,
@@ -737,6 +743,11 @@ def main_impl(argv: list[str] | None = None):
         except Exception as exc:
             print(f"[{invocation.label}] error: {exc}")
             returncode = 1
+        failed = returncode not in (0, 130)
+        if failed:
+            keep_groups_open = True
+        if group_open and not keep_groups_open:
+            print("::endgroup::")
         if returncode == 130:
             print("interrupted")
             return 130

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -5,9 +5,11 @@ import contextlib
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import asdict, dataclass
@@ -22,6 +24,7 @@ DEFAULT_RSS_POLL_INTERVAL_SECONDS = 0.05
 # Leave some CPU headroom so parallel test execution does not fully saturate CI runners.
 DEFAULT_WORKERS = "75%"
 DEFAULT_MAX_RETRIES = 4
+STOP_REQUESTED = threading.Event()
 
 
 def enable_line_buffering():
@@ -29,6 +32,14 @@ def enable_line_buffering():
         sys.stdout.reconfigure(line_buffering=True, write_through=True)
     if hasattr(sys.stderr, "reconfigure"):
         sys.stderr.reconfigure(line_buffering=True, write_through=True)
+
+
+def signal_stop_requested(signum, frame):
+    STOP_REQUESTED.set()
+
+
+def stop_requested():
+    return STOP_REQUESTED.is_set()
 
 
 @dataclass(frozen=True)
@@ -517,7 +528,7 @@ def parse_args(argv: list[str] | None = None):
         "--test-config",
         action="append",
         default=[],
-        help="path to test config; may be passed multiple times and is appended to test flags",
+        help="path to test config; may be passed multiple times and runs each config independently",
     )
     parser.add_argument(
         "--test-flags",
@@ -564,19 +575,129 @@ class InvocationResult:
     stderr: str
 
 
+@dataclass(frozen=True)
+class ConfigInvocation:
+    label: str
+    test_flags: str
+    test_config: str | None
+
+
+def build_test_flags(base_flags: str, test_config: str | None):
+    if not test_config:
+        return base_flags
+    config_flag = f"--test-config {shlex.quote(test_config)}"
+    return " ".join(flag for flag in [base_flags, config_flag] if flag)
+
+
+def build_config_invocations(test_configs: list[str], base_flags: str):
+    if not test_configs:
+        return [ConfigInvocation(label="default", test_flags=base_flags, test_config=None)]
+    return [
+        ConfigInvocation(
+            label=test_config, test_flags=build_test_flags(base_flags, test_config), test_config=test_config
+        )
+        for test_config in test_configs
+    ]
+
+
+def create_temp_test_list(
+    unittest_bin: str,
+    test_flags: str,
+    patterns: list[str],
+    test_list_files: list[Path] | None,
+):
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_file:
+        generate_test_list(test_file, unittest_bin, test_flags, patterns, test_list_files)
+        return Path(test_file.name)
+
+
+def run_single_config(
+    args,
+    unittest_bin: str,
+    workers: int,
+    retry: int,
+    max_retries: int,
+    max_failures: int | None,
+    batch_size: int,
+    test_list_files: list[Path],
+    invocation: ConfigInvocation,
+):
+    if stop_requested():
+        return 130
+    print(f"=== config run: {invocation.label} ===")
+    generated_test_list: Path | None = None
+    try:
+        if args.test_list is not None and len(test_list_files) == 1:
+            test_list_path = args.test_list
+        else:
+            generated_test_list = create_temp_test_list(
+                unittest_bin, invocation.test_flags, args.patterns, test_list_files
+            )
+            test_list_path = generated_test_list
+        config = TestRunnerConfig(
+            test_list=test_list_path,
+            unittest_bin=unittest_bin,
+            test_flags=invocation.test_flags,
+            patterns=args.patterns,
+            test_command=args.test_command,
+            workers=workers,
+            retry=retry,
+            max_retries=max_retries,
+            batch_size=batch_size,
+            batch_timeout_seconds=args.batch_timeout,
+            rss_memory_threshold_mib=args.track_rss_memory,
+            runtime_threshold_seconds=args.track_runtime,
+            max_failures=max_failures,
+        )
+
+        tests = load_tests(config.test_list)
+        if stop_requested():
+            return 130
+        if args.changed_tests is not None:
+            merged_names = {test.name for test in tests}
+            base_names = {test.name for test in load_tests(args.test_list)}
+            added_test_count = len(merged_names - base_names)
+            print(
+                f"[{invocation.label}] added {added_test_count} tests from --changed-tests file to the smoke test run"
+            )
+        computed_batch_size = compute_batch_size(len(tests), config)
+
+        print(f"[{invocation.label}] found {len(tests)} tests")
+        config_values = asdict(config)
+        config_values["batch_size"] = computed_batch_size
+        config_values.pop("test_list", None)
+        config_values.pop("unittest_bin", None)
+        config_values.pop("test_command", None)
+        config_values = {k: v for k, v in config_values.items() if v is not None and v != "" and v != []}
+        config_output = ", ".join(f"{key}={value}" for key, value in config_values.items())
+        print(f"[{invocation.label}] config: {config_output}")
+
+        batches = list(chunked(tests, computed_batch_size))
+        return run_tests(config, batches)
+    finally:
+        if generated_test_list is not None:
+            generated_test_list.unlink(missing_ok=True)
+
+
 def main(argv: list[str] | None = None):
     enable_line_buffering()
+    STOP_REQUESTED.clear()
+    previous_sigint_handler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, signal_stop_requested)
+    try:
+        return main_impl(argv)
+    finally:
+        signal.signal(signal.SIGINT, previous_sigint_handler)
+
+
+def main_impl(argv: list[str] | None = None):
     args = parse_args(argv)
     if args.changed_tests is not None and args.test_list is None:
         print("error: --changed-tests requires --test-list", file=sys.stderr)
         return 1
 
     test_list_files = [path for path in [args.test_list, args.changed_tests] if path is not None]
-    test_flags = args.test_flags
-    for config in args.test_config:
-        # The unittest binary parses "--test-config" as a separate option + value pair.
-        config_flag = f"--test-config {shlex.quote(config)}"
-        test_flags = " ".join(flag for flag in [test_flags, config_flag] if flag)
+    config_invocations = build_config_invocations(args.test_config, args.test_flags)
     max_failures = args.max_failures
     if args.fail_fast:
         max_failures = 1
@@ -594,43 +715,39 @@ def main(argv: list[str] | None = None):
         batch_size = 1
     else:
         batch_size = args.batch_size
-    with open_test_list(args.test_list, unittest_bin, test_flags, args.patterns, test_list_files) as test_file:
-        config = TestRunnerConfig(
-            test_list=test_file,
-            unittest_bin=unittest_bin,
-            test_flags=test_flags,
-            patterns=args.patterns,
-            test_command=args.test_command,
-            workers=workers,
-            retry=retry,
-            max_retries=max_retries,
-            batch_size=batch_size,
-            batch_timeout_seconds=args.batch_timeout,
-            rss_memory_threshold_mib=args.track_rss_memory,
-            runtime_threshold_seconds=args.track_runtime,
-            max_failures=max_failures,
-        )
+    failed_configs = []
+    if len(config_invocations) > 1:
+        print(f"running {len(config_invocations)} configs")
+    for invocation in config_invocations:
+        if stop_requested():
+            print("interrupted")
+            return 130
+        try:
+            returncode = run_single_config(
+                args,
+                unittest_bin,
+                workers,
+                retry,
+                max_retries,
+                max_failures,
+                batch_size,
+                test_list_files,
+                invocation,
+            )
+        except Exception as exc:
+            print(f"[{invocation.label}] error: {exc}")
+            returncode = 1
+        if returncode == 130:
+            print("interrupted")
+            return 130
+        if returncode != 0:
+            failed_configs.append(invocation.label)
 
-        tests = load_tests(config.test_list)
-        if args.changed_tests is not None:
-            merged_names = {test.name for test in tests}
-            base_names = {test.name for test in load_tests(args.test_list)}
-            added_test_count = len(merged_names - base_names)
-            print(f"added {added_test_count} tests from --changed-tests file to the smoke test run")
-        batch_size = compute_batch_size(len(tests), config)
-
-        print(f"found {len(tests)} tests")
-        config_values = asdict(config)
-        config_values["batch_size"] = batch_size
-        config_values.pop("test_list", None)
-        config_values.pop("unittest_bin", None)
-        config_values.pop("test_command", None)
-        config_values = {k: v for k, v in config_values.items() if v is not None and v != "" and v != []}
-        config_output = ", ".join(f"{key}={value}" for key, value in config_values.items())
-        print(f"config: {config_output}")
-
-        batches = list(chunked(tests, batch_size))
-        return run_tests(config, batches)
+    if failed_configs:
+        print(f"error: {len(failed_configs)} config runs failed: {', '.join(failed_configs)}")
+        return 1
+    print(f"all {len(config_invocations)} config runs passed")
+    return 0
 
 
 def invoke(argv: list[str], cwd: Path | None = None) -> InvocationResult:
@@ -665,13 +782,26 @@ def run_tests(config: TestRunnerConfig, batches):
             progress=progress,
         )
 
+        if stop_requested():
+            return 130
         next_batch_idx = submit_batches(executor, config, batches, future_to_batch, next_batch_idx)
 
         while future_to_batch:
+            if stop_requested():
+                state.stop_launching = True
+                for future in future_to_batch:
+                    future.cancel()
+                break
             done, _ = concurrent.futures.wait(
                 future_to_batch,
+                timeout=0.2,
                 return_when=concurrent.futures.FIRST_COMPLETED,
             )
+            if not done and stop_requested():
+                state.stop_launching = True
+                for future in future_to_batch:
+                    future.cancel()
+                break
             for future in done:
                 batch_info = future_to_batch.pop(future)
                 result = future.result()
@@ -687,11 +817,13 @@ def run_tests(config: TestRunnerConfig, batches):
                         skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 
-            if not state.stop_launching:
+            if not state.stop_launching and not stop_requested():
                 next_batch_idx = submit_batches(executor, config, batches, future_to_batch, next_batch_idx)
 
     progress.flush_line()
     elapsed = time.monotonic() - start
+    if stop_requested():
+        return 130
     if state.failed_count:
         print(f"error: found {state.failed_count} test batch failures in {elapsed:.0f}s")
         return 1

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -657,12 +657,10 @@ def run_single_config(
             merged_names = {test.name for test in tests}
             base_names = {test.name for test in load_tests(args.test_list)}
             added_test_count = len(merged_names - base_names)
-            print(
-                f"[{invocation.label}] added {added_test_count} tests from --changed-tests file to the smoke test run"
-            )
+            print(f"added {added_test_count} tests from --changed-tests file to the smoke test run")
         computed_batch_size = compute_batch_size(len(tests), config)
 
-        print(f"[{invocation.label}] found {len(tests)} tests")
+        print(f"found {len(tests)} tests")
         config_values = asdict(config)
         config_values["batch_size"] = computed_batch_size
         config_values.pop("test_list", None)
@@ -670,7 +668,7 @@ def run_single_config(
         config_values.pop("test_command", None)
         config_values = {k: v for k, v in config_values.items() if v is not None and v != "" and v != []}
         config_output = ", ".join(f"{key}={value}" for key, value in config_values.items())
-        print(f"[{invocation.label}] config: {config_output}")
+        print(f"config: {config_output}")
 
         batches = list(chunked(tests, computed_batch_size))
         return run_tests(config, batches)
@@ -698,7 +696,8 @@ def main_impl(argv: list[str] | None = None):
 
     test_list_files = [path for path in [args.test_list, args.changed_tests] if path is not None]
     config_invocations = build_config_invocations(args.test_config, args.test_flags)
-    is_github_ci = bool(os.environ.get("CI"))
+    is_ci = bool(os.environ.get("CI"))
+    use_config_groups = is_ci and len(config_invocations) > 1
     max_failures = args.max_failures
     if args.fail_fast:
         max_failures = 1
@@ -725,7 +724,7 @@ def main_impl(argv: list[str] | None = None):
             print("interrupted")
             return 130
         group_open = False
-        if is_github_ci:
+        if use_config_groups:
             print(f"::group::test config: {invocation.label}")
             group_open = True
         try:
@@ -741,7 +740,7 @@ def main_impl(argv: list[str] | None = None):
                 invocation,
             )
         except Exception as exc:
-            print(f"[{invocation.label}] error: {exc}")
+            print(f"error: {exc}")
             returncode = 1
         failed = returncode not in (0, 130)
         if failed:

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -490,6 +490,98 @@ require windows: 2
         self.assertIn("retrying failed test", proc.stdout)
         self.assertIn("all tests passed in ", proc.stdout)
 
+    def test_multiple_test_configs_run_independently(self):
+        listed_tests_path = create_temp_file(
+            """
+            name\tgroup
+            test/sql/fast.test\t[fast]
+            """
+        )
+
+        list_helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            if [ "$1" = "--test-config" ] && [ "$2" = "test/configs/a.json" ] && [ "$3" = "--list-tests" ]; then
+              echo "name\tgroup"
+              echo "test/sql/a.test\t[fast]"
+              exit 0
+            fi
+            if [ "$1" = "--test-config" ] && [ "$2" = "test/configs/b.json" ] && [ "$3" = "--list-tests" ]; then
+              echo "name\tgroup"
+              echo "test/sql/b.test\t[fast]"
+              exit 0
+            fi
+            exit 2
+            """
+        )
+        os.chmod(list_helper_path, 0o755)
+
+        try:
+            proc = start_runner(
+                [
+                    "--workers",
+                    "1",
+                    "--batch-size",
+                    "1",
+                    "--test-command",
+                    "echo fake-run {test_list}",
+                    "--test-config",
+                    "test/configs/a.json",
+                    "--test-config",
+                    "test/configs/b.json",
+                    str(list_helper_path),
+                    str(listed_tests_path),
+                ]
+            )
+        finally:
+            list_helper_path.unlink(missing_ok=True)
+            listed_tests_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("running 2 configs", proc.stdout)
+        self.assertIn("[test/configs/a.json] found 1 tests", proc.stdout)
+        self.assertIn("[test/configs/b.json] found 1 tests", proc.stdout)
+        self.assertIn("all 2 config runs passed", proc.stdout)
+
+    def test_multiple_test_configs_aggregate_failure(self):
+        failing_helper = create_temp_file(
+            """
+            #!/bin/sh
+            if [ "$1" = "--test-config" ] && [ "$2" = "test/configs/fail.json" ] && [ "$3" = "--list-tests" ]; then
+              exit 1
+            fi
+            if [ "$1" = "--test-config" ] && [ "$3" = "--list-tests" ]; then
+              echo "name\tgroup"
+              echo "test/sql/a.test\t[fast]"
+              exit 0
+            fi
+            exit 2
+            """
+        )
+        os.chmod(failing_helper, 0o755)
+        try:
+            proc = start_runner(
+                [
+                    "--workers",
+                    "1",
+                    "--batch-size",
+                    "1",
+                    "--test-command",
+                    "echo fake-run {test_list}",
+                    "--test-config",
+                    "test/configs/pass.json",
+                    "--test-config",
+                    "test/configs/fail.json",
+                    str(failing_helper),
+                    "ignored-pattern",
+                ]
+            )
+        finally:
+            failing_helper.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("error: 1 config runs failed: test/configs/fail.json", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -582,6 +582,94 @@ require windows: 2
         self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
         self.assertIn("error: 1 config runs failed: test/configs/fail.json", proc.stdout)
 
+    def test_ci_groups_close_when_all_configs_pass(self):
+        listed_tests_path = create_temp_file(
+            """
+            name\tgroup
+            test/sql/fast.test\t[fast]
+            """
+        )
+        list_helper_path = create_temp_file(
+            """
+            #!/bin/sh
+            if [ "$1" = "--test-config" ] && [ "$3" = "--list-tests" ]; then
+              echo "name\tgroup"
+              echo "test/sql/a.test\t[fast]"
+              exit 0
+            fi
+            exit 2
+            """
+        )
+        os.chmod(list_helper_path, 0o755)
+        try:
+            with mock.patch.dict(os.environ, {"CI": "1"}, clear=False):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "--test-config",
+                        "test/configs/a.json",
+                        "--test-config",
+                        "test/configs/b.json",
+                        str(list_helper_path),
+                        str(listed_tests_path),
+                    ]
+                )
+        finally:
+            list_helper_path.unlink(missing_ok=True)
+            listed_tests_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("::group::test config: test/configs/a.json", proc.stdout)
+        self.assertIn("::group::test config: test/configs/b.json", proc.stdout)
+        self.assertEqual(proc.stdout.count("::endgroup::"), 2)
+
+    def test_ci_groups_stay_open_after_first_failed_config(self):
+        failing_helper = create_temp_file(
+            """
+            #!/bin/sh
+            if [ "$1" = "--test-config" ] && [ "$2" = "test/configs/fail.json" ] && [ "$3" = "--list-tests" ]; then
+              exit 1
+            fi
+            if [ "$1" = "--test-config" ] && [ "$3" = "--list-tests" ]; then
+              echo "name\tgroup"
+              echo "test/sql/a.test\t[fast]"
+              exit 0
+            fi
+            exit 2
+            """
+        )
+        os.chmod(failing_helper, 0o755)
+        try:
+            with mock.patch.dict(os.environ, {"CI": "1"}, clear=False):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "--test-config",
+                        "test/configs/fail.json",
+                        "--test-config",
+                        "test/configs/pass.json",
+                        str(failing_helper),
+                        "ignored-pattern",
+                    ]
+                )
+        finally:
+            failing_helper.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("::group::test config: test/configs/fail.json", proc.stdout)
+        self.assertIn("::group::test config: test/configs/pass.json", proc.stdout)
+        self.assertEqual(proc.stdout.count("::endgroup::"), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -539,8 +539,7 @@ require windows: 2
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("running 2 configs", proc.stdout)
-        self.assertIn("[test/configs/a.json] found 1 tests", proc.stdout)
-        self.assertIn("[test/configs/b.json] found 1 tests", proc.stdout)
+        self.assertEqual(proc.stdout.count("found 1 tests"), 2)
         self.assertIn("all 2 config runs passed", proc.stdout)
 
     def test_multiple_test_configs_aggregate_failure(self):


### PR DESCRIPTION
- Add separated make targets for test configs.
- Use log groups and keep them opened if a test config run failed.

<img width="862" height="593" alt="Screenshot 2026-05-15 at 16 55 15" src="https://github.com/user-attachments/assets/038e94c5-4ded-4596-818e-ea198c531553" />

The log groups stay open when one test config failed so it's easy to spot failures in the CI logs.