### PR TITLE
Fix timer lifetime/timing issues

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -147,14 +147,13 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 
 	if (requires_tracking_attaches) {
 		// Start timing the ATTACH-delay step.
-		auto profiler = context.client_data->profiler->StartTimer(MetricType::WAITING_TO_ATTACH_LATENCY);
-
+		auto timer = context.client_data->profiler->StartTimer(MetricType::WAITING_TO_ATTACH_LATENCY);
+		// Start trying to attach.
 		while (InsertDatabasePath(info, options) == InsertDatabasePathResult::ALREADY_EXISTS) {
 			// database with this name and path already exists
 			// first check if it exists within this transaction
 			auto &meta_transaction = MetaTransaction::Get(context);
-			auto existing_db = meta_transaction.GetReferencedDatabaseOwning(info.name);
-			if (existing_db) {
+			if (auto existing_db = meta_transaction.GetReferencedDatabaseOwning(info.name)) {
 				// it does! return it
 				return existing_db;
 			}
@@ -171,6 +170,8 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 				throw InterruptException();
 			}
 		}
+		// Returning in the loop above will also end the timer, otherwise, do it explicitly here.
+		timer.EndTimer();
 	}
 	auto &config = DBConfig::GetConfig(context);
 	GetDatabaseType(context, info, config, options);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1821,12 +1821,13 @@ void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 	row_groups->Checkpoint(writer, global_stats);
 	row_groups->SetRowGroupAppendMode(RowGroupAppendMode::SUGGEST_NEW);
 	if (writer.GetRebuildIndexes()) {
-		ActiveTimer rebuild_indexes_timer;
+		ActiveTimer timer;
 		auto context = writer.TryGetClientContext();
 		if (context) {
-			rebuild_indexes_timer = QueryProfiler::Get(*context).StartTimer(MetricType::CUMULATIVE_VACUUM_TIME);
+			timer = QueryProfiler::Get(*context).StartTimer(MetricType::CUMULATIVE_VACUUM_TIME);
 		}
 		RebuildIndexes();
+		timer.EndTimer();
 	}
 	// The row group payload data has been written. Now write:
 	//   sample

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -516,7 +516,8 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		// Replay the WAL.
 		wal_path = GetWALPath();
 		wal = WriteAheadLog::Replay(context, *this, wal_path);
-		timer->EndTimer();
+
+		// Timer will go out of scope here, if set.
 	}
 
 	if (row_group_size > 122880ULL && GetStorageVersion() < 4) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -502,9 +502,8 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		auto checkpoint_reader = SingleFileCheckpointReader(*this);
 		checkpoint_reader.LoadFromStorage();
 
-		// End timing the storage load step.
+		// Reset the timer (also ends it).
 		if (timer) {
-			timer->EndTimer();
 			timer = nullptr;
 		}
 
@@ -517,11 +516,7 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		// Replay the WAL.
 		wal_path = GetWALPath();
 		wal = WriteAheadLog::Replay(context, *this, wal_path);
-
-		// End timing the WAL replay step.
-		if (timer) {
-			timer->EndTimer();
-		}
+		timer->EndTimer();
 	}
 
 	if (row_group_size > 122880ULL && GetStorageVersion() < 4) {
@@ -697,14 +692,15 @@ void SingleFileStorageManager::CreateCheckpoint(QueryContext context, Checkpoint
 		try {
 			// Start timing the checkpoint.
 			auto client_context = context.GetClientContext();
-			ActiveTimer profiler;
+			ActiveTimer timer;
 			if (client_context) {
-				profiler = client_context->client_data->profiler->StartTimer(MetricType::CHECKPOINT_LATENCY);
+				timer = client_context->client_data->profiler->StartTimer(MetricType::CHECKPOINT_LATENCY);
 			}
 
 			// Write the checkpoint.
 			auto checkpointer = CreateCheckpointWriter(context, options);
 			checkpointer->CreateCheckpoint();
+			timer.EndTimer();
 
 		} catch (std::exception &ex) {
 			ErrorData error(ex);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1200,14 +1200,16 @@ public:
 	}
 
 	void ExecuteTask() override {
-		ActiveTimer vacuum_task_timer;
+		ActiveTimer timer;
 		auto context = checkpoint_state.writer.TryGetClientContext();
 		if (context) {
-			vacuum_task_timer = QueryProfiler::Get(*context).StartTimer(MetricType::CUMULATIVE_VACUUM_TIME);
+			timer = QueryProfiler::Get(*context).StartTimer(MetricType::CUMULATIVE_VACUUM_TIME);
 		}
+
 		auto &collection = checkpoint_state.collection;
 		const idx_t row_group_size = collection.GetRowGroupSize();
 		auto &types = collection.GetTypes();
+
 		// create the new set of target row groups (initially empty)
 		vector<unique_ptr<RowGroup>> new_row_groups;
 		vector<idx_t> append_counts;
@@ -1218,7 +1220,6 @@ public:
 			new_row_group->InitializeEmpty(types, ColumnDataType::MAIN_TABLE);
 			new_row_groups.push_back(std::move(new_row_group));
 			append_counts.push_back(0);
-
 			row_group_rows -= current_row_group_rows;
 		}
 
@@ -1301,7 +1302,10 @@ public:
 			    "Mismatch in row group count %d vs verify count %d in RowGroupCollection::Checkpoint", merge_rows,
 			    total_append_count);
 		}
-		vacuum_task_timer.EndTimer();
+
+		// Explicitly end the timer for the vacuum tasks here.
+		timer.EndTimer();
+
 		// merging is complete - execute checkpoint tasks of the target row groups
 		for (idx_t i = 0; i < target_count; i++) {
 			auto checkpoint_task = collection.GetCheckpointTask(checkpoint_state, segment_idx + i);

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -221,9 +221,9 @@ ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &
 		commit_state = storage_manager.GenStorageCommitState(*wal);
 
 		auto &profiler = *context.client_data->profiler;
-
 		auto commit_timer = profiler.StartTimer(MetricType::COMMIT_LOCAL_STORAGE_LATENCY);
 		storage->Commit(commit_state.get());
+		commit_timer.EndTimer();
 
 		auto wal_timer = profiler.StartTimer(MetricType::WRITE_TO_WAL_LATENCY);
 		undo_buffer.WriteToWAL(*wal, commit_state.get());
@@ -233,6 +233,8 @@ ErrorData DuckTransaction::WriteToWAL(ClientContext &context, AttachedDatabase &
 			// hence we need to ensure those optimistically written blocks are persisted
 			storage_manager.GetBlockManager().FileSync();
 		}
+		wal_timer.EndTimer();
+
 	} catch (std::exception &ex) {
 		// Call RevertCommit() outside this try-catch as it itself may throw
 		error_data = ErrorData(ex);


### PR DESCRIPTION
Mainly, this disentangles the timers for `commit_local_storage_latency` and `write_to_wal_latency`, of which `commit_local_storage_latency` is currently also timing the WAL writes.