### PR TITLE
Optimize key-existence self joins

### DIFF
--- a/src/include/duckdb/optimizer/materialized_cte_optimizer.hpp
+++ b/src/include/duckdb/optimizer/materialized_cte_optimizer.hpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/materialized_cte_optimizer.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/logical_operator.hpp"
+
+namespace duckdb {
+
+class Optimizer;
+
+class MaterializedCTEOptimizer {
+public:
+	explicit MaterializedCTEOptimizer(Optimizer &optimizer);
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+
+private:
+	void VisitOperator(LogicalOperator &op);
+
+private:
+	Optimizer &optimizer;
+};
+
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library_unity(
   join_filter_pushdown_optimizer.cpp
   late_materialization.cpp
   late_materialization_helper.cpp
+  materialized_cte_optimizer.cpp
   optimizer.cpp
   outer_join_simplification.cpp
   partitioned_execution.cpp

--- a/src/optimizer/materialized_cte_optimizer.cpp
+++ b/src/optimizer/materialized_cte_optimizer.cpp
@@ -1,0 +1,606 @@
+#include "duckdb/optimizer/materialized_cte_optimizer.hpp"
+
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/function/aggregate/distributive_function_utils.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_join.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static idx_t CountMaterializedCTEReferences(const LogicalOperator &op, TableIndex cte_index) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cte = op.Cast<LogicalCTERef>();
+		if (cte.cte_index == cte_index) {
+			return 1;
+		}
+	}
+	idx_t number_of_references = 0;
+	for (auto &child : op.children) {
+		number_of_references += CountMaterializedCTEReferences(*child, cte_index);
+	}
+
+	return number_of_references;
+}
+
+static void GatherCTERefBindings(const LogicalOperator &op, TableIndex cte_index, unordered_set<TableIndex> &bindings) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cte = op.Cast<LogicalCTERef>();
+		if (cte.cte_index == cte_index) {
+			bindings.insert(cte.table_index);
+		}
+	}
+	for (auto &child : op.children) {
+		GatherCTERefBindings(*child, cte_index, bindings);
+	}
+}
+
+static bool CTEExpressionsUseOnlyKeys(const LogicalOperator &op, const unordered_set<TableIndex> &cte_bindings,
+                                      const unordered_set<ProjectionIndex> &key_columns) {
+	for (auto &expr : op.expressions) {
+		bool valid = true;
+		ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+		    *expr, [&](const BoundColumnRefExpression &colref) {
+			    if (cte_bindings.find(colref.binding.table_index) != cte_bindings.end() &&
+			        key_columns.find(colref.binding.column_index) == key_columns.end()) {
+				    valid = false;
+			    }
+		    });
+		if (!valid) {
+			return false;
+		}
+	}
+	for (auto &child : op.children) {
+		if (!CTEExpressionsUseOnlyKeys(*child, cte_bindings, key_columns)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool JoinRHSIsDuplicateInsensitive(JoinType join_type) {
+	return join_type == JoinType::MARK || join_type == JoinType::SEMI || join_type == JoinType::ANTI;
+}
+
+static bool JoinLHSIsDuplicateInsensitive(JoinType join_type) {
+	return join_type == JoinType::RIGHT_SEMI || join_type == JoinType::RIGHT_ANTI;
+}
+
+static bool IsLogicalJoin(const LogicalOperator &op) {
+	return op.type == LogicalOperatorType::LOGICAL_JOIN || op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	       op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN ||
+	       op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN || op.type == LogicalOperatorType::LOGICAL_ANY_JOIN;
+}
+
+static bool CTERefsAreDuplicateInsensitive(const LogicalOperator &op, TableIndex cte_index,
+                                           bool duplicate_insensitive) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cte = op.Cast<LogicalCTERef>();
+		return cte.cte_index != cte_index || duplicate_insensitive;
+	}
+
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+	case LogicalOperatorType::LOGICAL_WINDOW:
+	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		duplicate_insensitive = false;
+		break;
+	default:
+		break;
+	}
+
+	if (IsLogicalJoin(op)) {
+		auto &join = op.Cast<LogicalJoin>();
+		D_ASSERT(op.children.size() == 2);
+		auto lhs_duplicate_insensitive = JoinLHSIsDuplicateInsensitive(join.join_type);
+		auto rhs_duplicate_insensitive = JoinRHSIsDuplicateInsensitive(join.join_type);
+		if (join.join_type == JoinType::INNER) {
+			lhs_duplicate_insensitive = duplicate_insensitive;
+			rhs_duplicate_insensitive = duplicate_insensitive;
+		}
+		return CTERefsAreDuplicateInsensitive(*op.children[0], cte_index, lhs_duplicate_insensitive) &&
+		       CTERefsAreDuplicateInsensitive(*op.children[1], cte_index, rhs_duplicate_insensitive);
+	}
+
+	for (auto &child : op.children) {
+		if (!CTERefsAreDuplicateInsensitive(*child, cte_index, duplicate_insensitive)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool CTEIsOnlyUsedForKeyExistence(const LogicalMaterializedCTE &cte,
+                                         const unordered_set<ProjectionIndex> &key_columns) {
+	unordered_set<TableIndex> cte_bindings;
+	GatherCTERefBindings(*cte.children[1], cte.table_index, cte_bindings);
+	if (cte_bindings.empty()) {
+		return false;
+	}
+	return CTEExpressionsUseOnlyKeys(*cte.children[1], cte_bindings, key_columns) &&
+	       CTERefsAreDuplicateInsensitive(*cte.children[1], cte.table_index, false);
+}
+
+static bool SameTableScan(const LogicalGet &lhs, const LogicalGet &rhs) {
+	auto left_table = lhs.GetTable();
+	auto right_table = rhs.GetTable();
+	if (left_table || right_table) {
+		return left_table && right_table && left_table.get() == right_table.get();
+	}
+	if (lhs.function.name != rhs.function.name || lhs.returned_types != rhs.returned_types || lhs.names != rhs.names ||
+	    lhs.parameters.size() != rhs.parameters.size() || lhs.named_parameters.size() != rhs.named_parameters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < lhs.parameters.size(); i++) {
+		if (lhs.parameters[i] != rhs.parameters[i]) {
+			return false;
+		}
+	}
+	for (auto &entry : lhs.named_parameters) {
+		auto rhs_entry = rhs.named_parameters.find(entry.first);
+		if (rhs_entry == rhs.named_parameters.end() || entry.second != rhs_entry->second) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static optional_ptr<const BoundColumnRefExpression> GetColumnRef(const Expression &expr);
+
+static optional_ptr<const LogicalGet> GetUnderlyingGet(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		return &op.Cast<LogicalGet>();
+	}
+	if (op.type != LogicalOperatorType::LOGICAL_PROJECTION || op.children.size() != 1) {
+		return nullptr;
+	}
+	return GetUnderlyingGet(*op.children[0]);
+}
+
+static bool SameProjectionShape(const LogicalProjection &lhs, const LogicalProjection &rhs) {
+	if (lhs.expressions.size() != rhs.expressions.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < lhs.expressions.size(); i++) {
+		auto lhs_colref = GetColumnRef(*lhs.expressions[i]);
+		auto rhs_colref = GetColumnRef(*rhs.expressions[i]);
+		if (!lhs_colref || !rhs_colref || lhs_colref->binding.column_index != rhs_colref->binding.column_index) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool SameSourceOperator(const LogicalOperator &lhs, const LogicalOperator &rhs) {
+	auto lhs_get = GetUnderlyingGet(lhs);
+	auto rhs_get = GetUnderlyingGet(rhs);
+	if (!lhs_get || !rhs_get || !SameTableScan(*lhs_get, *rhs_get)) {
+		return false;
+	}
+	if (lhs.type == LogicalOperatorType::LOGICAL_GET || rhs.type == LogicalOperatorType::LOGICAL_GET) {
+		return lhs.type == rhs.type;
+	}
+	if (lhs.type != rhs.type || lhs.type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return false;
+	}
+	return SameProjectionShape(lhs.Cast<LogicalProjection>(), rhs.Cast<LogicalProjection>());
+}
+
+static optional_ptr<const BoundColumnRefExpression> GetColumnRef(const Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		return nullptr;
+	}
+	return &expr.Cast<BoundColumnRefExpression>();
+}
+
+struct ColumnComparison {
+	ExpressionType comparison_type;
+	ColumnBinding left_binding;
+	ColumnBinding right_binding;
+	LogicalType left_type;
+	LogicalType right_type;
+};
+
+enum class KeyVariationProjectionType : uint8_t { KEY, MIN_VALUE, MAX_VALUE };
+
+struct KeyVariationProjectionColumn {
+	KeyVariationProjectionType type;
+	idx_t key_index = DConstants::INVALID_INDEX;
+};
+
+struct KeyVariationCTEInfo {
+	vector<ColumnBinding> key_bindings;
+	vector<ColumnBinding> right_key_bindings;
+	vector<LogicalType> key_types;
+	vector<KeyVariationProjectionColumn> projection_columns;
+	unordered_set<ProjectionIndex> key_columns;
+	ColumnBinding value_binding;
+	LogicalType value_type;
+	optional_ptr<unique_ptr<LogicalOperator>> scan_ref;
+};
+
+static bool GetComparisonBindings(const Expression &expr, ColumnComparison &result) {
+	if (!BoundComparisonExpression::IsComparison(expr)) {
+		return false;
+	}
+	auto &comparison = expr.Cast<BoundFunctionExpression>();
+	auto &left_expr = BoundComparisonExpression::Left(comparison);
+	auto &right_expr = BoundComparisonExpression::Right(comparison);
+	auto left = GetColumnRef(left_expr);
+	auto right = GetColumnRef(right_expr);
+	if (!left || !right) {
+		return false;
+	}
+	result.comparison_type = comparison.GetExpressionType();
+	result.left_binding = left->binding;
+	result.right_binding = right->binding;
+	result.left_type = left_expr.GetReturnType();
+	result.right_type = right_expr.GetReturnType();
+	return true;
+}
+
+static bool GetComparisonBindings(const JoinCondition &condition, ColumnComparison &result) {
+	if (!condition.IsComparison()) {
+		return false;
+	}
+	auto left = GetColumnRef(condition.GetLHS());
+	auto right = GetColumnRef(condition.GetRHS());
+	if (!left || !right) {
+		return false;
+	}
+	result.comparison_type = condition.GetComparisonType();
+	result.left_binding = left->binding;
+	result.right_binding = right->binding;
+	result.left_type = condition.GetLHS().GetReturnType();
+	result.right_type = condition.GetRHS().GetReturnType();
+	return true;
+}
+
+static bool AddFilterComparisons(LogicalFilter &filter, vector<ColumnComparison> &comparisons) {
+	for (auto &expr : filter.expressions) {
+		ColumnComparison comparison;
+		if (!GetComparisonBindings(*expr, comparison)) {
+			return false;
+		}
+		comparisons.push_back(std::move(comparison));
+	}
+	return true;
+}
+
+static bool AddJoinComparisons(const LogicalComparisonJoin &join, vector<ColumnComparison> &comparisons) {
+	for (auto &condition : join.conditions) {
+		ColumnComparison comparison;
+		if (!GetComparisonBindings(condition, comparison)) {
+			return false;
+		}
+		comparisons.push_back(std::move(comparison));
+	}
+	return true;
+}
+
+static bool ExtractSelfJoinInput(unique_ptr<LogicalOperator> &input, vector<ColumnComparison> &comparisons,
+                                 optional_ptr<unique_ptr<LogicalOperator>> &left_ref,
+                                 optional_ptr<unique_ptr<LogicalOperator>> &right_ref) {
+	if (input->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = input->Cast<LogicalComparisonJoin>();
+		if (join.join_type != JoinType::INNER || join.children.size() != 2 || !AddJoinComparisons(join, comparisons)) {
+			return false;
+		}
+		left_ref = &join.children[0];
+		right_ref = &join.children[1];
+		return true;
+	}
+
+	if (input->type != LogicalOperatorType::LOGICAL_FILTER) {
+		return false;
+	}
+	auto &filter = input->Cast<LogicalFilter>();
+	if (!AddFilterComparisons(filter, comparisons) || filter.children.size() != 1) {
+		return false;
+	}
+
+	auto &child = filter.children[0];
+	if (child->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		auto &cross_product = child->Cast<LogicalCrossProduct>();
+		if (cross_product.children.size() != 2) {
+			return false;
+		}
+		left_ref = &cross_product.children[0];
+		right_ref = &cross_product.children[1];
+		return true;
+	}
+	if (child->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = child->Cast<LogicalComparisonJoin>();
+		if (join.join_type != JoinType::INNER || join.children.size() != 2 || !AddJoinComparisons(join, comparisons)) {
+			return false;
+		}
+		left_ref = &join.children[0];
+		right_ref = &join.children[1];
+		return true;
+	}
+	return false;
+}
+
+static bool OperatorOutputsBinding(LogicalOperator &op, ColumnBinding binding) {
+	for (auto &op_binding : op.GetColumnBindings()) {
+		if (op_binding == binding) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool GetChildBindingPair(LogicalOperator &left_op, LogicalOperator &right_op, const ColumnComparison &comparison,
+                                ColumnBinding &left_binding, ColumnBinding &right_binding, LogicalType &left_type,
+                                LogicalType &right_type) {
+	auto comparison_left_is_left = OperatorOutputsBinding(left_op, comparison.left_binding);
+	auto comparison_left_is_right = OperatorOutputsBinding(right_op, comparison.left_binding);
+	auto comparison_right_is_left = OperatorOutputsBinding(left_op, comparison.right_binding);
+	auto comparison_right_is_right = OperatorOutputsBinding(right_op, comparison.right_binding);
+
+	if (comparison_left_is_left && comparison_right_is_right && !comparison_left_is_right &&
+	    !comparison_right_is_left) {
+		left_binding = comparison.left_binding;
+		right_binding = comparison.right_binding;
+		left_type = comparison.left_type;
+		right_type = comparison.right_type;
+		return true;
+	}
+	if (comparison_left_is_right && comparison_right_is_left && !comparison_left_is_left &&
+	    !comparison_right_is_right) {
+		left_binding = comparison.right_binding;
+		right_binding = comparison.left_binding;
+		left_type = comparison.right_type;
+		right_type = comparison.left_type;
+		return true;
+	}
+	return false;
+}
+
+static bool KeyAlreadyMatched(const vector<ColumnBinding> &key_bindings, ColumnBinding binding) {
+	for (auto &key_binding : key_bindings) {
+		if (key_binding == binding) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool FindKeyBinding(const KeyVariationCTEInfo &info, ColumnBinding binding, idx_t &key_index) {
+	for (idx_t i = 0; i < info.key_bindings.size(); i++) {
+		if (info.key_bindings[i] == binding || info.right_key_bindings[i] == binding) {
+			key_index = i;
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool MatchKeyVariationSelfJoinCTE(unique_ptr<LogicalOperator> &definition, KeyVariationCTEInfo &result) {
+	if (definition->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return false;
+	}
+	auto &projection = definition->Cast<LogicalProjection>();
+	if (projection.children.size() != 1) {
+		return false;
+	}
+
+	vector<ColumnComparison> comparisons;
+	optional_ptr<unique_ptr<LogicalOperator>> left_ref;
+	optional_ptr<unique_ptr<LogicalOperator>> right_ref;
+	if (!ExtractSelfJoinInput(projection.children[0], comparisons, left_ref, right_ref)) {
+		return false;
+	}
+	if (!left_ref || !right_ref || !SameSourceOperator(**left_ref, **right_ref)) {
+		return false;
+	}
+
+	bool found_value_inequality = false;
+	ColumnBinding left_value_binding;
+	ColumnBinding right_value_binding;
+	LogicalType left_value_type;
+	for (auto &comparison : comparisons) {
+		if (comparison.comparison_type != ExpressionType::COMPARE_NOTEQUAL) {
+			continue;
+		}
+		ColumnBinding left_binding;
+		ColumnBinding right_binding;
+		LogicalType left_type;
+		LogicalType right_type;
+		if (!GetChildBindingPair(**left_ref, **right_ref, comparison, left_binding, right_binding, left_type,
+		                         right_type) ||
+		    left_binding.column_index != right_binding.column_index || left_type != right_type ||
+		    found_value_inequality) {
+			return false;
+		}
+		found_value_inequality = true;
+		left_value_binding = left_binding;
+		right_value_binding = right_binding;
+		left_value_type = left_type;
+	}
+	if (!found_value_inequality) {
+		return false;
+	}
+
+	for (auto &comparison : comparisons) {
+		if (comparison.comparison_type == ExpressionType::COMPARE_NOTEQUAL) {
+			continue;
+		}
+		if (comparison.comparison_type != ExpressionType::COMPARE_EQUAL) {
+			return false;
+		}
+		ColumnBinding left_binding;
+		ColumnBinding right_binding;
+		LogicalType left_type;
+		LogicalType right_type;
+		if (!GetChildBindingPair(**left_ref, **right_ref, comparison, left_binding, right_binding, left_type,
+		                         right_type) ||
+		    left_binding.column_index != right_binding.column_index || left_type != right_type) {
+			return false;
+		}
+		if (left_binding == left_value_binding || KeyAlreadyMatched(result.key_bindings, left_binding)) {
+			continue;
+		}
+		result.key_bindings.push_back(left_binding);
+		result.right_key_bindings.push_back(right_binding);
+		result.key_types.push_back(left_type);
+	}
+	if (result.key_bindings.empty()) {
+		return false;
+	}
+
+	vector<bool> projected_keys(result.key_bindings.size(), false);
+	result.projection_columns.reserve(projection.expressions.size());
+	for (idx_t projection_idx = 0; projection_idx < projection.expressions.size(); projection_idx++) {
+		auto colref = GetColumnRef(*projection.expressions[projection_idx]);
+		if (!colref) {
+			return false;
+		}
+
+		KeyVariationProjectionColumn projection_column;
+		if (colref->binding == left_value_binding) {
+			projection_column.type = KeyVariationProjectionType::MIN_VALUE;
+		} else if (colref->binding == right_value_binding) {
+			projection_column.type = KeyVariationProjectionType::MAX_VALUE;
+		} else {
+			idx_t key_index;
+			if (!FindKeyBinding(result, colref->binding, key_index)) {
+				return false;
+			}
+			projection_column.type = KeyVariationProjectionType::KEY;
+			projection_column.key_index = key_index;
+			projected_keys[key_index] = true;
+			result.key_columns.insert(ProjectionIndex(projection_idx));
+		}
+		result.projection_columns.push_back(projection_column);
+	}
+	for (auto projected : projected_keys) {
+		if (!projected) {
+			return false;
+		}
+	}
+	result.value_binding = left_value_binding;
+	result.value_type = left_value_type;
+	result.scan_ref = left_ref;
+	return true;
+}
+
+static unique_ptr<LogicalOperator> CreateGroupedKeyVariationCTE(Optimizer &optimizer, KeyVariationCTEInfo &info,
+                                                                TableIndex projection_index) {
+	auto value_expr = make_uniq<BoundColumnRefExpression>(info.value_type, info.value_binding);
+
+	vector<unique_ptr<Expression>> aggregate_expressions;
+	FunctionBinder function_binder(optimizer.GetContext());
+	vector<unique_ptr<Expression>> min_children;
+	min_children.push_back(value_expr->Copy());
+	aggregate_expressions.push_back(function_binder.BindAggregateFunction(
+	    MinFunction::GetFunction(), std::move(min_children), nullptr, AggregateType::NON_DISTINCT));
+	vector<unique_ptr<Expression>> max_children;
+	max_children.push_back(std::move(value_expr));
+	aggregate_expressions.push_back(function_binder.BindAggregateFunction(
+	    MaxFunction::GetFunction(), std::move(max_children), nullptr, AggregateType::NON_DISTINCT));
+
+	auto group_index = optimizer.binder.GenerateTableIndex();
+	auto aggregate_index = optimizer.binder.GenerateTableIndex();
+	auto aggregate = make_uniq<LogicalAggregate>(group_index, aggregate_index, std::move(aggregate_expressions));
+	for (idx_t i = 0; i < info.key_bindings.size(); i++) {
+		aggregate->groups.push_back(make_uniq<BoundColumnRefExpression>(info.key_types[i], info.key_bindings[i]));
+	}
+	D_ASSERT(info.scan_ref);
+	auto input = std::move(*info.scan_ref);
+	auto key_filter = make_uniq<LogicalFilter>();
+	for (idx_t i = 0; i < info.key_bindings.size(); i++) {
+		auto key_not_null =
+		    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
+		key_not_null->children.push_back(make_uniq<BoundColumnRefExpression>(info.key_types[i], info.key_bindings[i]));
+		key_filter->expressions.push_back(std::move(key_not_null));
+	}
+	key_filter->children.push_back(std::move(input));
+	aggregate->children.push_back(std::move(key_filter));
+
+	auto min_binding = ColumnBinding(aggregate_index, ProjectionIndex(0));
+	auto max_binding = ColumnBinding(aggregate_index, ProjectionIndex(1));
+	auto filter = make_uniq<LogicalFilter>(BoundComparisonExpression::Create(
+	    ExpressionType::COMPARE_NOTEQUAL, make_uniq<BoundColumnRefExpression>(info.value_type, min_binding),
+	    make_uniq<BoundColumnRefExpression>(info.value_type, max_binding)));
+	filter->children.push_back(std::move(aggregate));
+
+	vector<unique_ptr<Expression>> projection_expressions;
+	for (auto &projection_column : info.projection_columns) {
+		switch (projection_column.type) {
+		case KeyVariationProjectionType::KEY:
+			projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(
+			    info.key_types[projection_column.key_index],
+			    ColumnBinding(group_index, ProjectionIndex(projection_column.key_index))));
+			break;
+		case KeyVariationProjectionType::MIN_VALUE:
+			projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(info.value_type, min_binding));
+			break;
+		case KeyVariationProjectionType::MAX_VALUE:
+			projection_expressions.push_back(make_uniq<BoundColumnRefExpression>(info.value_type, max_binding));
+			break;
+		default:
+			throw InternalException("Unsupported key variation projection type");
+		}
+	}
+	auto projection = make_uniq<LogicalProjection>(projection_index, std::move(projection_expressions));
+	projection->children.push_back(std::move(filter));
+	return std::move(projection);
+}
+
+static bool TryRewriteKeyExistenceSelfJoin(Optimizer &optimizer, LogicalMaterializedCTE &cte) {
+	if (cte.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return false;
+	}
+	auto projection_index = cte.children[0]->Cast<LogicalProjection>().table_index;
+	KeyVariationCTEInfo info;
+	if (!MatchKeyVariationSelfJoinCTE(cte.children[0], info)) {
+		return false;
+	}
+	if (!CTEIsOnlyUsedForKeyExistence(cte, info.key_columns)) {
+		return false;
+	}
+	cte.children[0] = CreateGroupedKeyVariationCTE(optimizer, info, projection_index);
+	return true;
+}
+
+} // namespace
+
+MaterializedCTEOptimizer::MaterializedCTEOptimizer(Optimizer &optimizer_p) : optimizer(optimizer_p) {
+}
+
+unique_ptr<LogicalOperator> MaterializedCTEOptimizer::Optimize(unique_ptr<LogicalOperator> op) {
+	VisitOperator(*op);
+	return op;
+}
+
+void MaterializedCTEOptimizer::VisitOperator(LogicalOperator &op) {
+	for (auto &child : op.children) {
+		VisitOperator(*child);
+	}
+	if (op.type != LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
+		return;
+	}
+	auto &cte = op.Cast<LogicalMaterializedCTE>();
+	if (cte.children[0]->HasSideEffects() || CountMaterializedCTEReferences(op, cte.table_index) == 0) {
+		return;
+	}
+	TryRewriteKeyExistenceSelfJoin(optimizer, cte);
+}
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 #include "duckdb/optimizer/join_order/join_order_optimizer.hpp"
 #include "duckdb/optimizer/limit_pushdown.hpp"
+#include "duckdb/optimizer/materialized_cte_optimizer.hpp"
 #include "duckdb/optimizer/regex_range_filter.hpp"
 #include "duckdb/optimizer/remove_duplicate_groups.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
@@ -162,6 +163,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	// first we perform expression rewrites using the ExpressionRewriter
 	// this does not change the logical plan structure, but only simplifies the expression trees
 	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
+
+	// optimize materialized CTE definitions before inlining them
+	RunOptimizer(OptimizerType::MATERIALIZED_CTE, [&]() {
+		MaterializedCTEOptimizer materialized_cte_optimizer(*this);
+		plan = materialized_cte_optimizer.Optimize(std::move(plan));
+	});
 
 	// try to inline CTEs instead of materialization
 	RunOptimizer(OptimizerType::CTE_INLINING, [&]() {

--- a/test/optimizer/materialized_cte_optimizer.test
+++ b/test/optimizer/materialized_cte_optimizer.test
@@ -1,0 +1,151 @@
+# name: test/optimizer/materialized_cte_optimizer.test
+# description: Test the materialized CTE optimizer
+# group: [optimizer]
+
+statement ok
+SET default_null_order='nulls_first';
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY
+
+statement ok
+SET disabled_optimizers = 'cte_inlining'
+
+statement ok
+create table web_sales(ws_order_number integer, ws_warehouse_sk integer, ws_ext_ship_cost integer, ws_net_profit integer);
+
+statement ok
+insert into web_sales values
+	(1, 10, 5, 5), (1, 10, 7, 7), (1, 20, 11, 11),
+	(2, 30, 13, 13), (2, 30, 17, 17),
+	(3, NULL, 19, 19), (3, 40, 23, 23),
+	(4, NULL, 29, 29), (4, NULL, 31, 31),
+	(5, 50, 37, 37), (5, 60, 41, 41);
+
+statement ok
+create table web_returns(wr_order_number integer);
+
+statement ok
+insert into web_returns values (1), (2), (3), (4), (5), (5);
+
+query III
+with ws_wh as (
+	select ws1.ws_order_number, ws1.ws_warehouse_sk wh1, ws2.ws_warehouse_sk wh2
+	from web_sales ws1, web_sales ws2
+	where ws1.ws_order_number = ws2.ws_order_number
+	  and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk
+)
+select count(distinct ws1.ws_order_number), sum(ws1.ws_ext_ship_cost), sum(ws1.ws_net_profit)
+from web_sales ws1
+where ws1.ws_order_number in (select ws_order_number from ws_wh)
+  and ws1.ws_order_number in (
+	select wr_order_number
+	from web_returns, ws_wh
+	where wr_order_number = ws_wh.ws_order_number
+);
+----
+2	101	101
+
+query I
+with ws_wh as (
+	select ws1.ws_order_number, ws1.ws_warehouse_sk wh1, ws2.ws_warehouse_sk wh2
+	from web_sales ws1, web_sales ws2
+	where ws1.ws_order_number = ws2.ws_order_number
+	  and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk
+)
+select count(*) from ws_wh;
+----
+6
+
+query II
+explain
+with ws_wh as (
+	select ws1.ws_order_number, ws1.ws_warehouse_sk wh1, ws2.ws_warehouse_sk wh2
+	from web_sales ws1, web_sales ws2
+	where ws1.ws_order_number = ws2.ws_order_number
+	  and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk
+)
+select count(distinct ws1.ws_order_number)
+from web_sales ws1
+where ws1.ws_order_number in (select ws_order_number from ws_wh)
+  and ws1.ws_order_number in (
+	select wr_order_number
+	from web_returns, ws_wh
+	where wr_order_number = ws_wh.ws_order_number
+);
+----
+logical_opt	<REGEX>:.*CTE.*min.*max.*
+
+statement ok
+create table shipments(order_id integer, line_id integer, warehouse_id integer);
+
+statement ok
+insert into shipments values
+	(1, 1, 10), (1, 1, 20),
+	(1, 2, 30), (1, 2, 30),
+	(2, 1, 40), (2, 1, 50), (2, 1, 60),
+	(3, 1, NULL), (3, 1, 70),
+	(NULL, 1, 80), (NULL, 1, 90);
+
+statement ok
+create table shipment_lines(order_id integer, line_id integer);
+
+statement ok
+insert into shipment_lines values (1, 1), (1, 2), (2, 1), (3, 1), (NULL, 1);
+
+query I
+with moved_lines as (
+	select s2.order_id, s1.line_id, s1.warehouse_id wh1, s2.warehouse_id wh2
+	from shipments s1
+	join shipments s2
+	  on s1.order_id = s2.order_id
+	 and s1.line_id = s2.line_id
+	 and s1.warehouse_id <> s2.warehouse_id
+)
+select count(*)
+from shipment_lines l
+where exists (
+	select 1
+	from moved_lines m
+	where m.order_id = l.order_id
+	  and m.line_id = l.line_id
+);
+----
+2
+
+query II
+explain
+with moved_lines as (
+	select s2.order_id, s1.line_id, s1.warehouse_id wh1, s2.warehouse_id wh2
+	from shipments s1
+	join shipments s2
+	  on s1.order_id = s2.order_id
+	 and s1.line_id = s2.line_id
+	 and s1.warehouse_id <> s2.warehouse_id
+)
+select count(*)
+from shipment_lines l
+where exists (
+	select 1
+	from moved_lines m
+	where m.order_id = l.order_id
+	  and m.line_id = l.line_id
+);
+----
+logical_opt	<REGEX>:.*min.*max.*
+
+query I
+with moved_lines as (
+	select s2.order_id, s1.line_id, s1.warehouse_id wh1, s2.warehouse_id wh2
+	from shipments s1
+	join shipments s2
+	  on s1.order_id = s2.order_id
+	 and s1.line_id = s2.line_id
+	 and s1.warehouse_id <> s2.warehouse_id
+)
+select count(*) from moved_lines;
+----
+8
+
+statement ok
+SET disabled_optimizers = ''


### PR DESCRIPTION
This adds a conservative CTE rewrite for key-existence self joins.

If a materialized CTE builds pairs from the same input with matching key columns and a differing value column, and all CTE consumers only use the key columns in duplicate-insensitive contexts, the pair relation can be reduced to a grouped key-variation check:

- group by the key columns
- compute `min(value)` and `max(value)`
- keep keys where `min(value) <> max(value)`

The rewrite only fires for the same logical source on both sides, equality predicates on matching key columns, a single same-column inequality predicate, and key-only CTE consumers. It also filters null keys before grouping to preserve the original `key = key` join semantics.

Validation:
- `cmake --build build/release --target unittest -j4`
- `build/release/test/unittest test/optimizer/cte_inlining.test`
- TPC-DS SF100 sorted Parquet Q95 on current `main`: `17.52s -> 2.22s`, same output hash
