### PR TITLE
Improve join costing for imbalanced equality joins

### DIFF
--- a/src/optimizer/join_order/cost_model.cpp
+++ b/src/optimizer/join_order/cost_model.cpp
@@ -1,8 +1,48 @@
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "duckdb/optimizer/join_order/join_order_optimizer.hpp"
 #include "duckdb/optimizer/join_order/cost_model.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 
 namespace duckdb {
+
+struct ImbalancedJoinHeuristics {
+	static constexpr idx_t LARGE_INPUT_THRESHOLD = 1000000;
+	static constexpr idx_t TINY_INPUT_LOWER_BOUND = 10;
+	static constexpr idx_t SMALL_INPUT_CONTEXT_THRESHOLD = 100;
+	static constexpr idx_t SMALL_INPUT_THRESHOLD = 10000;
+	static constexpr double INPUT_RATIO_THRESHOLD = 100;
+};
+
+static bool HasEqualityFilter(NeighborInfo &connection) {
+	for (auto &filter : connection.filters) {
+		if (filter->filter && filter->filter->GetExpressionType() == ExpressionType::COMPARE_EQUAL &&
+		    BoundComparisonExpression::IsComparison(*filter->filter)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool HasEqualityConnection(const vector<reference<NeighborInfo>> &connections) {
+	for (auto &connection : connections) {
+		if (HasEqualityFilter(connection.get())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool HasOtherEqualityConnection(const QueryGraphEdges &edges, JoinRelationSet &node, JoinRelationSet &other) {
+	bool has_connection = false;
+	edges.EnumerateNeighbors(node, [&](NeighborInfo &connection) {
+		if (!JoinRelationSet::IsSubset(other, *connection.neighbor) && HasEqualityFilter(connection)) {
+			has_connection = true;
+			return true;
+		}
+		return false;
+	});
+	return has_connection;
+}
 
 CostModel::CostModel(QueryGraphManager &query_graph_manager)
     : query_graph_manager(query_graph_manager), cardinality_estimator() {
@@ -14,6 +54,25 @@ double CostModel::ComputeCost(DPJoinNode &left, DPJoinNode &right) {
 	auto &combination = query_graph_manager.set_manager.Union(left.set, right.set);
 	auto join_card = cardinality_estimator.EstimateCardinalityWithSet<double>(combination);
 	auto join_cost = join_card;
+	if (left.set.count == 1 && right.set.count == 1) {
+		auto &edges = query_graph_manager.GetQueryGraphEdges();
+		auto connections = edges.GetConnections(left.set, right.set);
+		auto min_card = MinValue(left.cardinality, right.cardinality);
+		auto max_card = MaxValue(left.cardinality, right.cardinality);
+		auto has_other_connection = HasOtherEqualityConnection(edges, left.set, right.set) &&
+		                            HasOtherEqualityConnection(edges, right.set, left.set);
+		auto small_side_is_tiny = min_card >= ImbalancedJoinHeuristics::TINY_INPUT_LOWER_BOUND &&
+		                          min_card < ImbalancedJoinHeuristics::SMALL_INPUT_CONTEXT_THRESHOLD;
+		auto small_side_has_context =
+		    min_card >= ImbalancedJoinHeuristics::SMALL_INPUT_CONTEXT_THRESHOLD && has_other_connection;
+		if (HasEqualityConnection(connections) && (small_side_is_tiny || small_side_has_context) &&
+		    min_card <= ImbalancedJoinHeuristics::SMALL_INPUT_THRESHOLD &&
+		    max_card > ImbalancedJoinHeuristics::LARGE_INPUT_THRESHOLD &&
+		    static_cast<double>(max_card) / static_cast<double>(min_card) >
+		        ImbalancedJoinHeuristics::INPUT_RATIO_THRESHOLD) {
+			join_cost = MinValue(join_cost, static_cast<double>(min_card));
+		}
+	}
 	return join_cost + left.cost + right.cost;
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -10,7 +10,9 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/execution/adaptive_filter.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/checkpoint/table_data_writer.hpp"
 #include "duckdb/storage/metadata/metadata_reader.hpp"
@@ -603,6 +605,32 @@ FilterPropagateResult RowGroup::CheckRowIdFilter(const TableFilter &filter, idx_
 	return expr_filter.CheckStatistics(dummy_stats);
 }
 
+static bool IsRootStatisticsOnlyOptionalFilter(const TableFilter &filter) {
+	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "RowGroup::IsRootStatisticsOnlyOptionalFilter");
+	if (expr_filter.expr->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
+	auto &function_name = func.function.GetName();
+	if (function_name == OptionalFilterScalarFun::NAME) {
+		return true;
+	}
+	if (function_name != SelectivityOptionalFilterScalarFun::NAME) {
+		return false;
+	}
+	if (!func.bind_info) {
+		return true;
+	}
+	auto &data = func.bind_info->Cast<SelectivityOptionalFilterFunctionData>();
+	if (!data.child_filter_expr) {
+		return true;
+	}
+	return ExpressionFilter::ContainsInternalFunction(*data.child_filter_expr, BloomFilterScalarFun::NAME) ||
+	       ExpressionFilter::ContainsInternalFunction(*data.child_filter_expr, PerfectHashJoinScalarFun::NAME) ||
+	       ExpressionFilter::ContainsInternalFunction(*data.child_filter_expr, PrefixRangeScalarFun::NAME) ||
+	       ExpressionFilter::ContainsInternalFunction(*data.child_filter_expr, DynamicFilterScalarFun::NAME);
+}
+
 bool RowGroup::CheckZonemap(ScanFilterInfo &filters) {
 	auto &filter_list = filters.GetFilterList();
 	// new row group - label all filters as up for grabs again
@@ -616,7 +644,7 @@ bool RowGroup::CheckZonemap(ScanFilterInfo &filters) {
 		if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			return false;
 		}
-		if (ExpressionFilter::IsRootOptionalFilter(filter)) {
+		if (IsRootStatisticsOnlyOptionalFilter(filter)) {
 			// these are only for row group checking, set as always true so we don't check it
 			filters.SetFilterAlwaysTrue(i);
 		} else if (prune_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {


### PR DESCRIPTION
The join order cost model currently prices a join by estimated output cardinality. For highly imbalanced leaf equality joins, this can miss useful plans where attaching a small relation to a very large relation early enables better downstream runtime filtering.

This patch adds a narrow cost adjustment for leaf/leaf equality joins where one side is tiny/small and the other side is large. The adjustment is guarded by absolute size and ratio thresholds. For non-tiny small inputs, both sides must have additional equality join context so ordinary one-spoke dimension joins keep using the existing cost logic.

The patch also keeps cheap selectivity-optional min/max filters active during native row-group scans. Heavy optional runtime filters remain statistics-only at this point. This fixes the native Q72 regression without changing the sorted-Parquet plan improvement.

TPC-DS SF100 sorted Parquet, hot comparison:

| Query | Before | After |
|---|---:|---:|
| Q64 | 25.72s | 11.31s |
| Q72 | 16.68s | 2.81s |

TPC-DS SF100 native, hot comparison:

| Query | Before | After |
|---|---:|---:|
| Q64 | 57.73s | 57.49s |
| Q72 | 2.82s | 2.43s |

Validation:
- TPC-DS SF100 sorted Parquet Q64/Q72: same result hashes.
- TPC-DS SF100 native Q64/Q72: same result hashes.
- TPC-DS SF10 native all 99 queries executed; warmed reruns of apparent regressions were neutral or faster.
- `python3 scripts/ci/run_tests.py --workers 4 build/release/test/unittest`
- `make format-check-silent enum-integrity-check -j4`