### PR TITLE
Improve IsValid decision for parquet metadata cache

### DIFF
--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -57,7 +57,6 @@ public:
 	ParquetCacheValidity IsValid(const OpenFileInfo &info, ClientContext &context) const;
 
 private:
-	bool validate;
 	timestamp_t last_modified;
 	string version_tag;
 };

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -60,7 +60,7 @@ optional_idx ParquetFileMetadataCache::GetEstimatedCacheMemory() const {
 }
 
 bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) const {
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
+	return ExternalFileCache::IsValid(new_handle.Validate(), version_tag, last_modified, new_handle.GetVersionTag(),
 	                                  new_handle.GetLastModifiedTime());
 }
 

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -22,7 +22,7 @@ ParquetFileMetadataCache::ParquetFileMetadataCache(unique_ptr<duckdb_parquet::Fi
                                                    unique_ptr<GeoParquetFileMetadata> geo_metadata,
                                                    unique_ptr<FileCryptoMetaData> crypto_metadata, idx_t footer_size)
     : metadata(std::move(file_metadata)), geo_metadata(std::move(geo_metadata)),
-      crypto_metadata(std::move(crypto_metadata)), footer_size(footer_size), validate(handle.Validate()),
+      crypto_metadata(std::move(crypto_metadata)), footer_size(footer_size),
       last_modified(handle.GetLastModifiedTime()), version_tag(handle.GetVersionTag()) {
 }
 


### PR DESCRIPTION
In the current implementation, whether a cache entry needs to be validated is decided on its construction, even if later users flip [`validate_external_file_cache`](https://github.com/duckdb/duckdb/blob/c7a9c8fe3bcd10a923037b8e03ab7936515e47c4/src/include/duckdb/main/settings.hpp#L1757) it won't take affect. This PR decides whether to validation based on the [caching file handle](https://github.com/duckdb/duckdb/blob/c7a9c8fe3bcd10a923037b8e03ab7936515e47c4/src/storage/external_file_cache/caching_file_system.cpp#L148-L149) (decides validation on handle constructor).

I target this PR against main instead v1.5 since it's a half fix, half improvement -- we didn't check the latest setting on each `IsValid` call anyway, the purpose for this PR  is to prevent situations where user flips from "no check" -> "check" but cache always be kept in memory.

I have already ran CI on my fork: https://github.com/dentiny/duckdb/pull/100, failed CI unrelated