### PR TITLE
Reuse identical aggregate filters

### DIFF
--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -72,18 +72,48 @@ void AggregateFilterDataSet::Initialize(ClientContext &context, const vector<Agg
 		// no filters: nothing to do
 		return;
 	}
-	filter_data.resize(aggregates.size());
+	filter_map.resize(aggregates.size());
 	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
 		auto &aggr = aggregates[aggr_idx];
 		if (aggr.filter) {
-			filter_data[aggr_idx] = make_uniq<AggregateFilterData>(context, *aggr.filter, payload_types);
+			for (idx_t other_idx = 0; other_idx < aggr_idx; other_idx++) {
+				auto &other = aggregates[other_idx];
+				if (other.filter && Expression::Equals(*aggr.filter, *other.filter)) {
+					filter_map[aggr_idx] = filter_map[other_idx];
+					break;
+				}
+			}
+			if (!filter_map[aggr_idx].IsValid()) {
+				filter_map[aggr_idx] = filter_data.size();
+				filter_data.push_back(make_uniq<AggregateFilterData>(context, *aggr.filter, payload_types));
+			}
 		}
+	}
+	cached_counts.resize(filter_data.size());
+}
+
+void AggregateFilterDataSet::BeginChunk() {
+	for (auto &count : cached_counts) {
+		count.SetInvalid();
 	}
 }
 
+idx_t AggregateFilterDataSet::ApplyFilter(idx_t aggr_idx, DataChunk &payload) {
+	auto filter_idx = filter_map[aggr_idx].GetIndex();
+	if (cached_counts[filter_idx].IsValid()) {
+		return cached_counts[filter_idx].GetIndex();
+	}
+	auto count = filter_data[filter_idx]->ApplyFilter(payload);
+	cached_counts[filter_idx] = count;
+	return count;
+}
+
 AggregateFilterData &AggregateFilterDataSet::GetFilterData(idx_t aggr_idx) {
-	D_ASSERT(aggr_idx < filter_data.size());
-	D_ASSERT(filter_data[aggr_idx]);
-	return *filter_data[aggr_idx];
+	D_ASSERT(aggr_idx < filter_map.size());
+	D_ASSERT(filter_map[aggr_idx].IsValid());
+	auto filter_idx = filter_map[aggr_idx].GetIndex();
+	D_ASSERT(filter_idx < filter_data.size());
+	D_ASSERT(filter_data[filter_idx]);
+	return *filter_data[filter_idx];
 }
 } // namespace duckdb

--- a/src/execution/operator/aggregate/physical_partitioned_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_partitioned_aggregate.cpp
@@ -112,6 +112,7 @@ SinkResultType PhysicalPartitionedAggregate::Sink(ExecutionContext &context, Dat
 	}
 
 	// perform the aggregation
+	lstate.execute_state.Reset();
 	lstate.execute_state.Sink(*lstate.state, chunk);
 	return SinkResultType::NEED_MORE_INPUT;
 }

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -182,6 +182,7 @@ UngroupedAggregateExecuteState::UngroupedAggregateExecuteState(ClientContext &co
 
 void UngroupedAggregateExecuteState::Reset() {
 	aggregate_input_chunk.Reset();
+	filter_set.BeginChunk();
 }
 
 void UngroupedAggregateExecuteState::Sink(LocalUngroupedAggregateState &state, DataChunk &input) {
@@ -204,7 +205,7 @@ void UngroupedAggregateExecuteState::Sink(LocalUngroupedAggregateState &state, D
 		// resolve the filter (if any)
 		if (aggregate.filter) {
 			auto &filtered_data = filter_set.GetFilterData(aggr_idx);
-			auto count = filtered_data.ApplyFilter(input);
+			auto count = filter_set.ApplyFilter(aggr_idx, input);
 
 			child_executor.SetChunk(filtered_data.filtered_payload);
 			payload_chunk.SetCardinality(count);
@@ -330,7 +331,7 @@ void PhysicalUngroupedAggregate::SinkDistinct(ExecutionContext &context, DataChu
 
 			// Apply the filter before inserting into the hashtable
 			auto &filtered_data = sink.execute_state.filter_set.GetFilterData(idx);
-			idx_t count = filtered_data.ApplyFilter(chunk);
+			idx_t count = sink.execute_state.filter_set.ApplyFilter(idx, chunk);
 			filtered_data.filtered_payload.SetCardinality(count);
 
 			radix_table.Sink(context, filtered_data.filtered_payload, sink_input, empty_chunk, distinct_filter);

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -327,10 +327,23 @@ PhysicalOperator &PhysicalPlanGenerator::ExtractAggregateExpressions(PhysicalOpe
 		}
 		if (bound_aggr.filter) {
 			auto &filter = bound_aggr.filter;
-			auto ref = make_uniq<BoundReferenceExpression>(filter->GetReturnType(), expressions.size());
-			types.push_back(filter->GetReturnType());
-			expressions.push_back(std::move(filter));
-			bound_aggr.filter = std::move(ref);
+			optional_idx existing_idx;
+			if (!filter->IsVolatile()) {
+				for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
+					if (Expression::Equals(*expressions[expr_idx], *filter)) {
+						existing_idx = expr_idx;
+						break;
+					}
+				}
+			}
+			if (existing_idx.IsValid()) {
+				bound_aggr.filter = make_uniq<BoundReferenceExpression>(filter->GetReturnType(), existing_idx.GetIndex());
+			} else {
+				auto ref = make_uniq<BoundReferenceExpression>(filter->GetReturnType(), expressions.size());
+				types.push_back(filter->GetReturnType());
+				expressions.push_back(std::move(filter));
+				bound_aggr.filter = std::move(ref);
+			}
 		}
 	}
 	if (expressions.empty()) {

--- a/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
@@ -63,11 +63,15 @@ struct AggregateFilterDataSet {
 	AggregateFilterDataSet();
 
 	vector<unique_ptr<AggregateFilterData>> filter_data;
+	vector<optional_idx> filter_map;
+	vector<optional_idx> cached_counts;
 
 public:
 	void Initialize(ClientContext &context, const vector<AggregateObject> &aggregates,
 	                const vector<LogicalType> &payload_types);
 
+	void BeginChunk();
+	idx_t ApplyFilter(idx_t aggr_idx, DataChunk &payload);
 	AggregateFilterData &GetFilterData(idx_t aggr_idx);
 };
 

--- a/test/sql/filter/test_filter_clause.test_slow
+++ b/test/sql/filter/test_filter_clause.test_slow
@@ -91,6 +91,16 @@ FROM t;
 ----
 45	10
 
+query IIII
+SELECT
+ COUNT(*) FILTER (WHERE i < 10),
+ SUM(i) FILTER (WHERE i < 10),
+ SUM(j) FILTER (WHERE i < 10),
+ COUNT(DISTINCT j) FILTER (WHERE i < 10)
+FROM t;
+----
+10	45	45	10
+
 query II
  SELECT
   sum(i) AS unfiltered,


### PR DESCRIPTION
Filtered aggregates currently build a separate filtered payload for every aggregate. When several aggregates use the same `FILTER` expression, the input projection can contain repeated references to the same boolean value and execution applies the same selection repeatedly.

This reuses identical non-volatile aggregate filter expressions while extracting aggregate inputs, and caches the filtered payload for the current input chunk in `AggregateFilterDataSet`. Volatile filters are left separate.

On a 50M-row generated query with five filters shared across `count`/`avg`/`avg` aggregates:

- main: 2.067s median
- this PR: 0.920s median

A same-size query with unique filters was neutral: 2.283s vs 2.299s median.

Validation:

- `python3 scripts/ci/run_tests.py --workers 4 build/release/test/unittest test/sql/filter/test_filter_clause.test_slow`
- `python3 scripts/ci/run_tests.py --workers 1 build/release/test/unittest test/sql/copy/partitioned/partitioned_group_by.test`
- `python3 scripts/ci/run_tests.py --workers 8 --test-list /tmp/duckdb_non_extension_tests.txt build/release/test/unittest`
