### PR TITLE
Add Arrow export support for VARIANT

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -281,6 +281,7 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 		InitializeAppenderForType<ArrowUnionData>(append_data);
 		break;
 	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::VARIANT:
 		InitializeAppenderForType<ArrowStructData>(append_data);
 		break;
 	case LogicalTypeId::ARRAY:

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -333,6 +333,10 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		SetArrowStructFormat(root_holder, child, type, options, context);
 		break;
 	}
+	case LogicalTypeId::VARIANT: {
+		SetArrowStructFormat(root_holder, child, type, options, context);
+		break;
+	}
 	case LogicalTypeId::ARRAY: {
 		auto array_size = ArrayType::GetSize(type);
 		auto &child_type = ArrayType::GetChildType(type);

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -179,6 +179,40 @@ TEST_CASE("ADBC - Select 42", "[adbc]") {
 	REQUIRE(db.QueryAndCheck("SELECT 42"));
 }
 
+TEST_CASE("ADBC - Query VARIANT", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	auto create_result = db.Query("CREATE TABLE events(id INTEGER, payload VARIANT)");
+	REQUIRE(!create_result->HasError());
+	auto insert_result = db.Query("INSERT INTO events VALUES (1, 42::VARIANT), (2, 'hello world'::VARIANT), "
+	                              "(3, [1, 2, 3]::VARIANT), (4, {'name':'Alice'}::VARIANT)");
+	REQUIRE(!insert_result->HasError());
+
+	auto &stream = db.QueryArrow("SELECT payload FROM events ORDER BY id");
+	ArrowSchema schema;
+	std::memset(&schema, 0, sizeof(schema));
+	REQUIRE(stream.get_schema(&stream, &schema) == 0);
+	REQUIRE(schema.n_children == 1);
+	REQUIRE(string(schema.children[0]->format) == "+s");
+	REQUIRE(schema.children[0]->n_children == 4);
+	REQUIRE(string(schema.children[0]->children[0]->name) == "keys");
+	REQUIRE(string(schema.children[0]->children[1]->name) == "children");
+	REQUIRE(string(schema.children[0]->children[2]->name) == "values");
+	REQUIRE(string(schema.children[0]->children[3]->name) == "data");
+	schema.release(&schema);
+
+	ArrowArray array;
+	std::memset(&array, 0, sizeof(array));
+	REQUIRE(stream.get_next(&stream, &array) == 0);
+	REQUIRE(array.release != nullptr);
+	REQUIRE(array.n_children == 1);
+	REQUIRE(array.children[0]->n_children == 4);
+	array.release(&array);
+}
+
 TEST_CASE("ADBC - non-empty query without actual statements", "[adbc]") {
 	if (!duckdb_lib) {
 		return;

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -206,6 +206,39 @@ TEST_CASE("Test Arrow UNION type roundtrip", "[arrow]") {
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT * FROM union_tbl3", false));
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT * FROM union_tbl3", true));
 }
+
+TEST_CASE("Test Arrow VARIANT export", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+
+	auto result = con.Query("SELECT * FROM (VALUES (42::VARIANT), ({'name':'Alice'}::VARIANT)) AS t(payload)");
+	REQUIRE(!result->HasError());
+	auto chunk = result->Fetch();
+	REQUIRE(chunk);
+	REQUIRE(chunk->size() == 2);
+
+	auto client_properties = con.context->GetClientProperties();
+	ArrowSchema schema;
+	schema.Init();
+	ArrowConverter::ToArrowSchema(&schema, result->types, result->names, client_properties);
+	REQUIRE(schema.n_children == 1);
+	REQUIRE(string(schema.children[0]->format) == "+s");
+	REQUIRE(schema.children[0]->n_children == 4);
+	REQUIRE(string(schema.children[0]->children[0]->name) == "keys");
+	REQUIRE(string(schema.children[0]->children[1]->name) == "children");
+	REQUIRE(string(schema.children[0]->children[2]->name) == "values");
+	REQUIRE(string(schema.children[0]->children[3]->name) == "data");
+
+	ArrowArray array;
+	unordered_map<idx_t, const duckdb::shared_ptr<ArrowTypeExtensionData>> extension_type_cast;
+	ArrowConverter::ToArrowArray(*chunk, &array, client_properties, extension_type_cast);
+	REQUIRE(array.n_children == 1);
+	REQUIRE(array.children[0]->n_children == 4);
+
+	array.release(&array);
+	schema.release(&schema);
+}
+
 TEST_CASE("Test Arrow Extension Types", "[arrow][.]") {
 	// UUID
 	TestArrowRoundtrip("SELECT '2d89ebe6-1e13-47e5-803a-b81c87660b66'::UUID str FROM range(5) tbl(i)", false, true);


### PR DESCRIPTION
## Summary
- handle `LogicalTypeId::VARIANT` in Arrow schema generation by exposing DuckDB's existing struct-backed VARIANT layout
- use the struct Arrow appender for VARIANT vectors so Arrow/ADBC result batches can be materialized
- add direct Arrow export coverage plus an ADBC regression using a stored VARIANT column

Fixes #21471.

## Tests
- `make debug`
- `build/debug/test/unittest "Test Arrow VARIANT export"`
- `DUCKDB_INSTALL_LIB=/Users/geoheil/development/forked-oss/duckdb/build/debug/src/libduckdb.dylib build/debug/test/unittest "ADBC - Query VARIANT"`