### PR TITLE
Propagate parent query text to MultiStatement sub-statements

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/statement/extension_statement.hpp"
+#include "duckdb/parser/statement/multi_statement.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/tableref/expressionlistref.hpp"
@@ -366,6 +367,19 @@ void Parser::ParseQuery(const string &query) {
 			if (statement->type == StatementType::CREATE_STATEMENT) {
 				auto &create = statement->Cast<CreateStatement>();
 				create.info->sql = statement->query;
+			}
+			// Synthetic sub-statements inside a MultiStatement (e.g. CREATE TYPE generated for
+			// a PIVOT, or the ALTER+UPDATE+ALTER rewrite for ADD COLUMN ... DEFAULT
+			// <non-literal>) inherit no source offsets. Propagate the parent query text so
+			// downstream readers (current_query(), active_query->query, query history) see the
+			// SQL the user actually typed during each child's execution.
+			if (statement->type == StatementType::MULTI_STATEMENT) {
+				auto &multi = statement->Cast<MultiStatement>();
+				for (auto &child : multi.statements) {
+					child->query = statement->query;
+					child->stmt_location = 0;
+					child->stmt_length = statement->query.size();
+				}
 			}
 		}
 	}

--- a/test/sql/pivot/pivot_query_text.test
+++ b/test/sql/pivot/pivot_query_text.test
@@ -1,0 +1,16 @@
+# name: test/sql/pivot/pivot_query_text.test
+# description: PIVOT is rewritten into a MultiStatement; child statements must inherit the parent query text.
+# group: [pivot]
+
+statement ok
+CREATE TABLE t(c VARCHAR, v INTEGER);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2);
+
+# current_query() inside the PIVOT's SELECT child returns the parent PIVOT SQL.
+query III
+PIVOT (SELECT c, v, current_query() AS q FROM t) ON c USING ANY_VALUE(q) ORDER BY v;
+----
+1	PIVOT (SELECT c, v, current_query() AS q FROM t) ON c USING ANY_VALUE(q) ORDER BY v;	NULL
+2	NULL	PIVOT (SELECT c, v, current_query() AS q FROM t) ON c USING ANY_VALUE(q) ORDER BY v;


### PR DESCRIPTION
We rely on the equivalent of `current_query()` in our infra and we noticed that statements that are re-written to a multi-statement transaction (example `ALTER TABLE ADD COLUMN <c> DEFAULT <non-literal>`, see test)  don't have the query information populated (and thus `current_query()` fails - in some of the paths, the statement [query is used](https://github.com/duckdb/duckdb/blob/6ff3b4f26cc9a916896f89167922704296ef9b6a/src/main/client_context.cpp#L1169) ) . 

This PR propagates the parent MultiStatement's query text to each child during the same wrap-up loop. It also adds a regression test that uses current_query() as the non-literal default; the test fails (empty result) without the fix and passes with it.

It is debatable if one should propagate the original query when that happens, or the underlying query that led to this (relying on statement ToString). I chose the former because it's closer to what the user types, but would like advice. 