### PR TITLE
Fix iterator invalidation in ConnectionManager::GetConnectionList

### DIFF
--- a/src/main/connection_manager.cpp
+++ b/src/main/connection_manager.cpp
@@ -38,17 +38,16 @@ void ConnectionManager::AssignConnectionId(Connection &connection) {
 vector<shared_ptr<ClientContext>> ConnectionManager::GetConnectionList() {
 	lock_guard<mutex> lock(connections_lock);
 	vector<shared_ptr<ClientContext>> result;
-	for (auto &it : connections) {
-		auto connection = it.second.lock();
+	for (auto it = connections.begin(); it != connections.end();) {
+		auto connection = it->second.lock();
 		if (!connection) {
-			connections.erase(it.first);
-			connection_count = connections.size();
-			continue;
+			it = connections.erase(it);
 		} else {
 			result.push_back(std::move(connection));
+			++it;
 		}
 	}
-
+	connection_count = connections.size();
 	return result;
 }
 


### PR DESCRIPTION
The previous range-based for loop called connections.erase(it.first) on the current element and then continued iterating - undefined behavior, because erase invalidates the iterator the range-based for is holding. Switch to a manual iterator loop that uses erase's return value to advance past the removed element. Update connection_count once at the end instead of on every erase.