### PR TITLE
Fix adaptive segment allocation resetting after checkpoint

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -505,9 +505,7 @@ void ColumnData::InitializeAppend(ColumnAppendState &state) {
 	    !last_segment.GetCompressionFunction().init_append) {
 		// we cannot append to this segment - append a new segment
 		auto total_rows = segment->GetRowStart() + last_segment.count;
-		// Persistent segments are resized to block_size during checkpoint, wo we pass nullptr to start fresh
-		const bool is_persistent = last_segment.segment_type == ColumnSegmentType::PERSISTENT;
-		AppendTransientSegment(l, total_rows, is_persistent ? nullptr : &last_segment);
+		AppendTransientSegment(l, total_rows, last_segment);
 		state.current = data.GetLastSegment(l);
 	} else {
 		state.current = segment;
@@ -642,7 +640,7 @@ void ColumnData::AppendTransientSegment(SegmentLock &l, idx_t start_row, optiona
 	auto &config = DBConfig::GetConfig(db);
 
 	idx_t segment_size;
-	if (!prev_segment) {
+	if (!prev_segment || prev_segment->segment_type == ColumnSegmentType::PERSISTENT) {
 		// We start with the `initial_bytes` setting, but we ensure that we have enough space for at least one row.
 		const auto initial_bytes = Settings::Get<InitialColumnSegmentSizeSetting>(config);
 		segment_size = MaxValue<idx_t>(GetTypeIdSize(type.InternalType()), initial_bytes);

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -505,7 +505,9 @@ void ColumnData::InitializeAppend(ColumnAppendState &state) {
 	    !last_segment.GetCompressionFunction().init_append) {
 		// we cannot append to this segment - append a new segment
 		auto total_rows = segment->GetRowStart() + last_segment.count;
-		AppendTransientSegment(l, total_rows, last_segment);
+		// Persistent segments are resized to block_size during checkpoint, wo we pass nullptr to start fresh
+		const bool is_persistent = last_segment.segment_type == ColumnSegmentType::PERSISTENT;
+		AppendTransientSegment(l, total_rows, is_persistent ? nullptr : &last_segment);
 		state.current = data.GetLastSegment(l);
 	} else {
 		state.current = segment;

--- a/test/sql/storage/adaptive_segment_allocation.test
+++ b/test/sql/storage/adaptive_segment_allocation.test
@@ -189,3 +189,38 @@ query I
 SELECT len(s) FROM string_test WHERE s = repeat('x', 50) || '1'
 ----
 51
+
+# after checkpoint, new appends must also start from initial_column_segment_size
+statement ok
+DROP TABLE validity_test
+
+statement ok
+DROP TABLE string_test
+
+statement ok
+CHECKPOINT
+
+statement ok
+CREATE TABLE post_checkpoint_mem (a INT NOT NULL, b INT NOT NULL, c INT NOT NULL, d INT NOT NULL, e INT NOT NULL)
+
+statement ok
+INSERT INTO post_checkpoint_mem VALUES (1, 2, 3, 4, 5)
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO post_checkpoint_mem VALUES (6, 7, 8, 9, 10)
+
+query I
+SELECT CASE WHEN memory_usage_bytes < 2000
+            THEN 'ok'
+            ELSE error(concat('expected < 2000 bytes after checkpoint, got ', memory_usage_bytes))
+       END
+FROM duckdb_memory()
+WHERE tag = 'IN_MEMORY_TABLE'
+----
+ok
+
+statement ok
+DROP TABLE post_checkpoint_mem


### PR DESCRIPTION
## Summary
After a checkpoint, `InitializeAppend` was passing the last persistent segment as `prev_segment` to `AppendTransientSegment`.
Since segments are resized to `block_size` during checkpoint, the first new transient segment started at `block_size` instead of the configured `initial_column_segment_size`.

- Fix: pass `nullptr` when the last segment is persistent, so the initial size is respected.
- Adds a regression test that verifies memory stays small after a CHECKPOINT + re-insert cycle.