### PR TITLE
fix: list_zip SEGFAULT with empty / NULL argument

### DIFF
--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -112,7 +112,11 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 		offset += len;
 	}
 	for (idx_t child_idx = 0; child_idx < args_size; child_idx++) {
-		if (args.data[child_idx].GetType() != LogicalType::SQLNULL) {
+		if (args.data[child_idx].GetType() == LogicalType::SQLNULL ||
+			ListVector::GetListSize(args.data[child_idx]) == 0) {
+			struct_entries[child_idx]->SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(*struct_entries[child_idx], true);
+		} else {
 			struct_entries[child_idx]->Slice(ListVector::GetEntry(args.data[child_idx]), selections[child_idx],
 			                                 result_size);
 		}

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -113,7 +113,7 @@ static void ListZipFunction(DataChunk &args, ExpressionState &state, Vector &res
 	}
 	for (idx_t child_idx = 0; child_idx < args_size; child_idx++) {
 		if (args.data[child_idx].GetType() == LogicalType::SQLNULL ||
-			ListVector::GetListSize(args.data[child_idx]) == 0) {
+		    ListVector::GetListSize(args.data[child_idx]) == 0) {
 			struct_entries[child_idx]->SetVectorType(VectorType::CONSTANT_VECTOR);
 			ConstantVector::SetNull(*struct_entries[child_idx], true);
 		} else {

--- a/test/sql/function/list/list_zip.test
+++ b/test/sql/function/list/list_zip.test
@@ -312,6 +312,44 @@ SELECT list_zip([{'a': 1}, {'a': 5}, {'a': 3}])
 ----
 [({'a': 1}), ({'a': 5}), ({'a': 3})]
 
+# nested element types with empty or NULL second arg (previously segfaulted)
+
+query I
+SELECT list_zip([{'a': 1}]::STRUCT(a INT)[], []::STRUCT(a INT)[])
+----
+[({'a': 1}, NULL)]
+
+query I
+SELECT list_zip([{'a': 1}]::STRUCT(a INT)[], NULL::STRUCT(a INT)[])
+----
+[({'a': 1}, NULL)]
+
+query I
+SELECT list_zip(CAST(['123'] AS VARIANT[]), CAST([] AS VARIANT[]))
+----
+[(123, NULL)]
+
+query I
+SELECT list_zip(CAST(['123'] AS VARIANT[]), NULL::VARIANT[])
+----
+[(123, NULL)]
+
+query I
+SELECT MAP_FROM_ENTRIES(LIST_ZIP(CAST(['123'] AS VARIANT[]), CAST([] AS VARIANT[])))
+----
+{123=NULL}
+
+statement ok
+CREATE TABLE variant_zip_test AS SELECT CAST(['123'] AS VARIANT[]) a, CAST([] AS VARIANT[]) b
+
+query I
+SELECT list_zip(a, b) FROM variant_zip_test
+----
+[(123, NULL)]
+
+statement ok
+DROP TABLE variant_zip_test
+
 # Non-list type
 
 statement error

--- a/test/sql/function/list/list_zip.test
+++ b/test/sql/function/list/list_zip.test
@@ -339,17 +339,6 @@ SELECT MAP_FROM_ENTRIES(LIST_ZIP(CAST(['123'] AS VARIANT[]), CAST([] AS VARIANT[
 ----
 {123=NULL}
 
-statement ok
-CREATE TABLE variant_zip_test AS SELECT CAST(['123'] AS VARIANT[]) a, CAST([] AS VARIANT[]) b
-
-query I
-SELECT list_zip(a, b) FROM variant_zip_test
-----
-[(123, NULL)]
-
-statement ok
-DROP TABLE variant_zip_test
-
 # Non-list type
 
 statement error


### PR DESCRIPTION
Based on PR https://github.com/duckdb/duckdb/pull/22654 from @fivetran-kwoodbeck, removing the lines:
```
statement ok
CREATE TABLE variant_zip_test AS SELECT CAST(['123'] AS VARIANT[]) a, CAST([] AS VARIANT[]) b

query I
SELECT list_zip(a, b) FROM variant_zip_test
----
[(123, NULL)]

statement ok
DROP TABLE variant_zip_test
```
that make it unsuitable vs older storage formats.