### PR TITLE
Fix GCC jemalloc symbol leakage CI failure

### DIFF
--- a/scripts/exported_symbols_check.py
+++ b/scripts/exported_symbols_check.py
@@ -14,6 +14,7 @@ culprits = []
 
 whitelist = [
     '@GLIBC',
+    '@GCC',
     '@CXXABI',
     '__gnu_cxx::',
     'std::',


### PR DESCRIPTION
Introduced by https://github.com/duckdb/duckdb/pull/22630 but not found due to a hidden merge conflict