### PR TITLE
Optimize ordered TopN prefixes

### DIFF
--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -713,7 +713,7 @@ void ArgMinMaxNUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t inp
 		auto arg_val = STATE::ARG_TYPE::Create(arg_format, arg_idx);
 		auto val_val = STATE::VAL_TYPE::Create(val_format, val_idx);
 
-		state.heap.Insert(aggr_input.allocator, arg_val, val_val);
+		state.heap.Insert(aggr_input.allocator, arg_val, val_val, bind_data.with_ties);
 	}
 }
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/common/arena_containers/arena_vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/create_sort_key.hpp"
@@ -12,9 +13,12 @@ namespace duckdb {
 
 PhysicalTopN::PhysicalTopN(PhysicalPlan &physical_plan, vector<LogicalType> types, vector<BoundOrderByNode> orders,
                            idx_t limit, idx_t offset, shared_ptr<DynamicFilterData> dynamic_filter_p,
-                           idx_t estimated_cardinality)
+                           shared_ptr<DynamicFilterData> secondary_dynamic_filter_p,
+                           Value secondary_dynamic_filter_prefix_p, idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::TOP_N, std::move(types), estimated_cardinality),
-      orders(std::move(orders)), limit(limit), offset(offset), dynamic_filter(std::move(dynamic_filter_p)) {
+      orders(std::move(orders)), limit(limit), offset(offset), dynamic_filter(std::move(dynamic_filter_p)),
+      secondary_dynamic_filter(std::move(secondary_dynamic_filter_p)),
+      secondary_dynamic_filter_prefix(std::move(secondary_dynamic_filter_prefix_p)) {
 }
 
 PhysicalTopN::~PhysicalTopN() {
@@ -44,9 +48,17 @@ struct TopNScanState {
 };
 
 struct TopNBoundaryValue {
-	explicit TopNBoundaryValue(const PhysicalTopN &op)
+	TopNBoundaryValue(ClientContext &context, const PhysicalTopN &op)
 	    : op(op), boundary_vector(op.orders[0].expression->GetReturnType()),
 	      boundary_modifiers(op.orders[0].type, op.orders[0].null_order) {
+		if (op.secondary_dynamic_filter) {
+			vector<LogicalType> boundary_types;
+			boundary_types.push_back(op.orders[0].expression->GetReturnType());
+			boundary_types.push_back(op.orders[1].expression->GetReturnType());
+			secondary_boundary_values.Initialize(BufferAllocator::Get(context), boundary_types);
+			secondary_boundary_modifiers.emplace_back(op.orders[0].type, op.orders[0].null_order);
+			secondary_boundary_modifiers.emplace_back(op.orders[1].type, op.orders[1].null_order);
+		}
 	}
 
 	const PhysicalTopN &op;
@@ -55,6 +67,8 @@ struct TopNBoundaryValue {
 	bool is_set = false;
 	Vector boundary_vector;
 	OrderModifiers boundary_modifiers;
+	DataChunk secondary_boundary_values;
+	vector<OrderModifiers> secondary_boundary_modifiers;
 
 	string GetBoundaryValue() {
 		lock_guard<mutex> l(lock);
@@ -66,7 +80,24 @@ struct TopNBoundaryValue {
 		if (!is_set || boundary_val < string_t(boundary_value)) {
 			boundary_value = boundary_val.GetString();
 			is_set = true;
-			if (op.dynamic_filter) {
+			if (op.secondary_dynamic_filter) {
+				secondary_boundary_values.Reset();
+				CreateSortKeyHelpers::DecodeSortKey(boundary_val, secondary_boundary_values, 0,
+				                                    secondary_boundary_modifiers);
+				auto new_dynamic_value = secondary_boundary_values.data[0].GetValue(0);
+				auto new_secondary_dynamic_value = secondary_boundary_values.data[1].GetValue(0);
+				const auto set_secondary_filter =
+				    ValueOperations::NotDistinctFrom(new_dynamic_value, op.secondary_dynamic_filter_prefix);
+				l.unlock();
+				if (op.dynamic_filter) {
+					op.dynamic_filter->SetValue(std::move(new_dynamic_value));
+				}
+				if (set_secondary_filter) {
+					op.secondary_dynamic_filter->SetValue(std::move(new_secondary_dynamic_value));
+				} else {
+					op.secondary_dynamic_filter->Reset();
+				}
+			} else if (op.dynamic_filter) {
 				CreateSortKeyHelpers::DecodeSortKey(boundary_val, boundary_vector, 0, boundary_modifiers);
 				auto new_dynamic_value = boundary_vector.GetValue(0);
 				l.unlock();
@@ -470,7 +501,7 @@ void TopNHeap::Scan(TopNScanState &state, DataChunk &chunk, idx_t &pos) {
 class TopNGlobalSinkState : public GlobalSinkState {
 public:
 	TopNGlobalSinkState(ClientContext &context, const PhysicalTopN &op)
-	    : heap(context, op.types, op.orders, op.limit, op.offset), boundary_value(op) {
+	    : heap(context, op.types, op.orders, op.limit, op.offset), boundary_value(context, op) {
 	}
 
 	mutex lock;
@@ -495,6 +526,9 @@ unique_ptr<LocalSinkState> PhysicalTopN::GetLocalSinkState(ExecutionContext &con
 unique_ptr<GlobalSinkState> PhysicalTopN::GetGlobalSinkState(ClientContext &context) const {
 	if (dynamic_filter) {
 		dynamic_filter->Reset();
+	}
+	if (secondary_dynamic_filter) {
+		secondary_dynamic_filter->Reset();
 	}
 	return make_uniq<TopNGlobalSinkState>(context, *this);
 }

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -9,7 +9,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
 	auto &plan = CreatePlan(*op.children[0]);
 	auto &top_n =
 	    Make<PhysicalTopN>(op.types, std::move(op.orders), NumericCast<idx_t>(op.limit), NumericCast<idx_t>(op.offset),
-	                       std::move(op.dynamic_filter), op.estimated_cardinality);
+	                       std::move(op.dynamic_filter), std::move(op.secondary_dynamic_filter),
+	                       std::move(op.secondary_dynamic_filter_prefix), op.estimated_cardinality);
 	top_n.children.push_back(plan);
 	return top_n;
 }

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -22,7 +22,9 @@ public:
 
 public:
 	PhysicalTopN(PhysicalPlan &physical_plan, vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit,
-	             idx_t offset, shared_ptr<DynamicFilterData> dynamic_filter, idx_t estimated_cardinality);
+	             idx_t offset, shared_ptr<DynamicFilterData> dynamic_filter,
+	             shared_ptr<DynamicFilterData> secondary_dynamic_filter, Value secondary_dynamic_filter_prefix,
+	             idx_t estimated_cardinality);
 	~PhysicalTopN() override;
 
 	vector<BoundOrderByNode> orders;
@@ -30,6 +32,9 @@ public:
 	idx_t offset;
 	//! Dynamic table filter (if any)
 	shared_ptr<DynamicFilterData> dynamic_filter;
+	//! Dynamic table filter for the second order key (if any)
+	shared_ptr<DynamicFilterData> secondary_dynamic_filter;
+	Value secondary_dynamic_filter_prefix;
 
 public:
 	// Source interface

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -146,7 +146,7 @@ public:
 		D_ASSERT(std::is_heap(heap, heap + size, Compare));
 	}
 
-	void Insert(ArenaAllocator &allocator, const UnaryAggregateHeap &other) {
+	void Insert(ArenaAllocator &allocator, const UnaryAggregateHeap &other, const bool = false) {
 		for (idx_t slot = 0; slot < other.Size(); slot++) {
 			Insert(allocator, other.heap[slot].value);
 		}
@@ -205,7 +205,7 @@ public:
 		return capacity;
 	}
 
-	void Insert(ArenaAllocator &allocator, const K &key, const V &value) {
+	void Insert(ArenaAllocator &allocator, const K &key, const V &value, const bool with_ties = false) {
 		D_ASSERT(capacity != 0); // must be initialized
 
 		// If the heap is not full, insert the value into a new slot
@@ -221,17 +221,35 @@ public:
 		// If the heap is full, check if the value is greater than the smallest value in the heap
 		// If it is, assign the new value to the slot and re-heapify
 		else if (K_COMPARATOR::Operation(key, heap[0].first.value)) {
-			std::pop_heap(heap, heap + size, Compare);
-			heap[size - 1].first.Assign(allocator, key);
-			heap[size - 1].second.Assign(allocator, value);
+			if (with_ties) {
+				if (size == allocated_capacity) {
+					Grow(allocator, true);
+				}
+				heap[size].first.Assign(allocator, key);
+				heap[size].second.Assign(allocator, value);
+				size++;
+				PruneTies();
+			} else {
+				std::pop_heap(heap, heap + size, Compare);
+				heap[size - 1].first.Assign(allocator, key);
+				heap[size - 1].second.Assign(allocator, value);
+				std::push_heap(heap, heap + size, Compare);
+			}
+		} else if (with_ties && KeysAreEqual(key, heap[0].first.value)) {
+			if (size == allocated_capacity) {
+				Grow(allocator, true);
+			}
+			heap[size].first.Assign(allocator, key);
+			heap[size].second.Assign(allocator, value);
+			size++;
 			std::push_heap(heap, heap + size, Compare);
 		}
 		D_ASSERT(std::is_heap(heap, heap + size, Compare));
 	}
 
-	void Insert(ArenaAllocator &allocator, const BinaryAggregateHeap &other) {
+	void Insert(ArenaAllocator &allocator, const BinaryAggregateHeap &other, const bool with_ties = false) {
 		for (idx_t slot = 0; slot < other.Size(); slot++) {
-			Insert(allocator, other.heap[slot].first.value, other.heap[slot].second.value);
+			Insert(allocator, other.heap[slot].first.value, other.heap[slot].second.value, with_ties);
 		}
 	}
 
@@ -245,15 +263,18 @@ public:
 	}
 
 private:
-	void Grow(ArenaAllocator &allocator) {
-		D_ASSERT(allocated_capacity < capacity);
+	void Grow(ArenaAllocator &allocator, const bool beyond_capacity = false) {
+		D_ASSERT(beyond_capacity || allocated_capacity < capacity);
 		const auto old_allocated_capacity = allocated_capacity;
 		if (allocated_capacity == 0) {
 			allocated_capacity = 1;
-		} else if (allocated_capacity > capacity / 2) {
+		} else if (!beyond_capacity && allocated_capacity > capacity / 2) {
 			allocated_capacity = capacity;
 		} else {
 			allocated_capacity *= 2;
+		}
+		if (!beyond_capacity) {
+			allocated_capacity = MinValue(allocated_capacity, capacity);
 		}
 
 		const auto old_size = old_allocated_capacity * sizeof(STORAGE_TYPE);
@@ -266,6 +287,31 @@ private:
 
 	static bool Compare(const STORAGE_TYPE &left, const STORAGE_TYPE &right) {
 		return K_COMPARATOR::Operation(left.first.value, right.first.value);
+	}
+
+	static bool KeysAreEqual(const K &left, const K &right) {
+		return !K_COMPARATOR::Operation(left, right) && !K_COMPARATOR::Operation(right, left);
+	}
+
+	void PruneTies() {
+		D_ASSERT(size > capacity);
+
+		auto nth = heap + capacity - 1;
+		std::nth_element(heap, nth, heap + size, Compare);
+		const auto threshold = nth->first.value;
+
+		idx_t write_idx = 0;
+		for (idx_t read_idx = 0; read_idx < size; read_idx++) {
+			if (K_COMPARATOR::Operation(threshold, heap[read_idx].first.value)) {
+				continue;
+			}
+			if (write_idx != read_idx) {
+				heap[write_idx] = std::move(heap[read_idx]);
+			}
+			write_idx++;
+		}
+		size = write_idx;
+		std::make_heap(heap, heap + size, Compare);
 	}
 
 	idx_t capacity = 0;
@@ -286,16 +332,18 @@ struct ArgMinMaxFunctionData : FunctionData {
 		auto copy = make_uniq<ArgMinMaxFunctionData>();
 		copy->null_handling = null_handling;
 		copy->nulls_last = nulls_last;
+		copy->with_ties = with_ties;
 		return std::move(copy);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<ArgMinMaxFunctionData>();
-		return other.null_handling == null_handling && other.nulls_last == nulls_last;
+		return other.null_handling == null_handling && other.nulls_last == nulls_last && other.with_ties == with_ties;
 	}
 
 	ArgMinMaxNullHandling null_handling;
 	bool nulls_last;
+	bool with_ties = false;
 };
 
 //------------------------------------------------------------------------------
@@ -445,7 +493,9 @@ struct MinMaxNOperation {
 		}
 
 		// Merge the heaps
-		target.heap.Insert(aggr_input.allocator, source.heap);
+		const bool with_ties =
+		    aggr_input.bind_data ? aggr_input.bind_data->Cast<ArgMinMaxFunctionData>().with_ties : false;
+		target.heap.Insert(aggr_input.allocator, source.heap, with_ties);
 	}
 
 	template <class STATE>

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -43,6 +43,7 @@ public:
 private:
 	bool CanOptimize(LogicalOperator &op);
 	unique_ptr<LogicalOperator> OptimizeInternal(unique_ptr<LogicalOperator> op, ColumnBindingReplacer &replacer);
+	unique_ptr<LogicalOperator> TryOptimizeOrderedRankPrefix(unique_ptr<LogicalOperator> op);
 
 	unique_ptr<LogicalOperator> CreateAggregateOperator(LogicalWindow &window, vector<unique_ptr<Expression>> args,
 	                                                    const TopNWindowEliminationParameters &params) const;

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
@@ -18,6 +19,8 @@ namespace duckdb {
 enum class TopNPayloadType { SINGLE_COLUMN, STRUCT_PACK };
 
 struct TopNWindowEliminationParameters {
+	//! The window function being optimized
+	ExpressionType window_type;
 	//! Whether the sort is ASCENDING or DESCENDING
 	OrderType order_type;
 	//! The number of values in the LIMIT clause
@@ -48,9 +51,18 @@ private:
 	unique_ptr<LogicalOperator> CreateProjectionOperator(unique_ptr<LogicalOperator> op,
 	                                                     const TopNWindowEliminationParameters &params,
 	                                                     const map<idx_t, idx_t> &group_idxs) const;
+	unique_ptr<LogicalOperator> CreateRankWindowOperator(unique_ptr<LogicalOperator> op,
+	                                                     unique_ptr<Expression> rank_expression,
+	                                                     TableIndex window_idx,
+	                                                     const vector<LogicalType> &types,
+	                                                     const map<idx_t, idx_t> &group_idxs,
+	                                                     const vector<ColumnBinding> &topmost_bindings,
+	                                                     vector<ColumnBinding> &new_bindings,
+	                                                     ColumnBindingReplacer &replacer);
 
 	vector<unique_ptr<Expression>> GenerateAggregatePayload(const vector<ColumnBinding> &bindings,
-	                                                        const LogicalWindow &window, map<idx_t, idx_t> &group_idxs);
+	                                                        const LogicalWindow &window, map<idx_t, idx_t> &group_idxs,
+	                                                        bool keep_order_value);
 	bool TraverseProjectionBindings(const vector<ColumnBinding> &old_bindings, reference<LogicalOperator> &op,
 	                                vector<ColumnBinding> &new_bindings);
 	unique_ptr<Expression> CreateAggregateExpression(vector<unique_ptr<Expression>> aggregate_params, bool requires_arg,

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -52,14 +52,11 @@ private:
 	unique_ptr<LogicalOperator> CreateProjectionOperator(unique_ptr<LogicalOperator> op,
 	                                                     const TopNWindowEliminationParameters &params,
 	                                                     const map<idx_t, idx_t> &group_idxs) const;
-	unique_ptr<LogicalOperator> CreateRankWindowOperator(unique_ptr<LogicalOperator> op,
-	                                                     unique_ptr<Expression> rank_expression,
-	                                                     TableIndex window_idx,
-	                                                     const vector<LogicalType> &types,
-	                                                     const map<idx_t, idx_t> &group_idxs,
-	                                                     const vector<ColumnBinding> &topmost_bindings,
-	                                                     vector<ColumnBinding> &new_bindings,
-	                                                     ColumnBindingReplacer &replacer);
+	unique_ptr<LogicalOperator>
+	CreateRankWindowOperator(unique_ptr<LogicalOperator> op, unique_ptr<Expression> rank_expression,
+	                         TableIndex window_idx, const vector<LogicalType> &types,
+	                         const map<idx_t, idx_t> &group_idxs, const vector<ColumnBinding> &topmost_bindings,
+	                         vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer);
 
 	vector<unique_ptr<Expression>> GenerateAggregatePayload(const vector<ColumnBinding> &bindings,
 	                                                        const LogicalWindow &window, map<idx_t, idx_t> &group_idxs,

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -43,7 +43,7 @@ public:
 private:
 	bool CanOptimize(LogicalOperator &op);
 	unique_ptr<LogicalOperator> OptimizeInternal(unique_ptr<LogicalOperator> op, ColumnBindingReplacer &replacer);
-	unique_ptr<LogicalOperator> TryOptimizeOrderedRankPrefix(unique_ptr<LogicalOperator> op);
+	unique_ptr<LogicalOperator> TryOptimizeOrderedRollupPrefix(unique_ptr<LogicalOperator> op);
 
 	unique_ptr<LogicalOperator> CreateAggregateOperator(LogicalWindow &window, vector<unique_ptr<Expression>> args,
 	                                                    const TopNWindowEliminationParameters &params) const;

--- a/src/include/duckdb/planner/operator/logical_top_n.hpp
+++ b/src/include/duckdb/planner/operator/logical_top_n.hpp
@@ -30,6 +30,9 @@ public:
 	idx_t offset;
 	//! Dynamic table filter (if any)
 	shared_ptr<DynamicFilterData> dynamic_filter;
+	//! Secondary dynamic table filter, gated by the first order key reaching the global boundary
+	shared_ptr<DynamicFilterData> secondary_dynamic_filter;
+	Value secondary_dynamic_filter_prefix;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -13,8 +13,82 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/storage/table/row_group_reorderer.hpp"
+#include "duckdb/function/partition_stats.hpp"
+#include "duckdb/common/value_operations/value_operations.hpp"
 
 namespace duckdb {
+
+namespace {
+
+bool TopNDynamicFilterTypeSupported(const LogicalType &type) {
+	return TypeIsNumeric(type.InternalType()) || type.id() == LogicalTypeId::VARCHAR;
+}
+
+ExpressionType TopNComparisonType(const OrderType order_type, const bool single_order) {
+	if (order_type == OrderType::ASCENDING) {
+		return single_order ? ExpressionType::COMPARE_LESSTHAN : ExpressionType::COMPARE_LESSTHANOREQUALTO;
+	}
+	return single_order ? ExpressionType::COMPARE_GREATERTHAN : ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+}
+
+bool TryGetGlobalOrderBoundary(ClientContext &context, LogicalGet &get, const ColumnBinding &binding,
+                               const BoundOrderByNode &order, Value &boundary, idx_t &boundary_groups) {
+	if (!get.function.get_partition_stats || order.null_order != OrderByNullType::NULLS_LAST) {
+		return false;
+	}
+	const auto &type = order.expression->GetReturnType();
+	if (type.id() == LogicalTypeId::VARCHAR || !TypeIsNumeric(type.InternalType())) {
+		return false;
+	}
+
+	const auto &column_index = get.GetColumnIndex(binding);
+	StorageIndex storage_index;
+	if (!get.TryGetStorageIndex(column_index, storage_index)) {
+		return false;
+	}
+
+	GetPartitionStatsInput input(get.function, get.bind_data.get());
+	auto partition_stats = get.function.get_partition_stats(context, input);
+	if (partition_stats.empty()) {
+		return false;
+	}
+
+	const auto order_by = order.type == OrderType::ASCENDING ? OrderByStatistics::MIN : OrderByStatistics::MAX;
+	bool has_boundary = false;
+	for (auto &partition_stat : partition_stats) {
+		if (partition_stat.count_type == CountType::COUNT_APPROXIMATE || !partition_stat.partition_row_group) {
+			return false;
+		}
+		auto stats = partition_stat.partition_row_group->GetColumnStatistics(storage_index);
+		auto value = RowGroupReorderer::RetrieveStat(*stats, order_by, OrderByColumnType::NUMERIC);
+		if (value.IsNull()) {
+			if (order.null_order == OrderByNullType::NULLS_LAST && !stats->CanHaveNoNull()) {
+				continue;
+			}
+			return false;
+		}
+		if (!has_boundary || (order.type == OrderType::ASCENDING && ValueOperations::LessThan(value, boundary)) ||
+		    (order.type == OrderType::DESCENDING && ValueOperations::GreaterThan(value, boundary))) {
+			boundary = std::move(value);
+			has_boundary = true;
+		}
+	}
+	if (!has_boundary) {
+		return false;
+	}
+
+	for (auto &partition_stat : partition_stats) {
+		auto stats = partition_stat.partition_row_group->GetColumnStatistics(storage_index);
+		auto value = RowGroupReorderer::RetrieveStat(*stats, order_by, OrderByColumnType::NUMERIC);
+		if (!value.IsNull() && ValueOperations::NotDistinctFrom(value, boundary)) {
+			boundary_groups++;
+		}
+	}
+	return true;
+}
+
+} // namespace
 
 TopN::TopN(ClientContext &context_p) : context(context_p) {
 }
@@ -67,7 +141,7 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	// pushdown dynamic filters through the Top-N operator
 	bool nulls_first = op.orders[0].null_order == OrderByNullType::NULLS_FIRST;
 	auto &type = op.orders[0].expression->GetReturnType();
-	if (!TypeIsNumeric(type.InternalType()) && type.id() != LogicalTypeId::VARCHAR) {
+	if (!TopNDynamicFilterTypeSupported(type)) {
 		// only supported for numeric and varchar types
 		return;
 	}
@@ -91,18 +165,7 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		return;
 	}
 	// found pushdown targets! generate dynamic filters
-	ExpressionType comparison_type;
-	if (op.orders[0].type == OrderType::ASCENDING) {
-		// for ascending order, we want the lowest N elements, so we filter on C <= [boundary]
-		// if we only have a single order clause, we can filter on C < boundary
-		comparison_type =
-		    op.orders.size() == 1 ? ExpressionType::COMPARE_LESSTHAN : ExpressionType::COMPARE_LESSTHANOREQUALTO;
-	} else {
-		// for descending order, we want the highest N elements, so we filter on C >= [boundary]
-		// if we only have a single order clause, we can filter on C > boundary
-		comparison_type =
-		    op.orders.size() == 1 ? ExpressionType::COMPARE_GREATERTHAN : ExpressionType::COMPARE_GREATERTHANOREQUALTO;
-	}
+	ExpressionType comparison_type = TopNComparisonType(op.orders[0].type, op.orders.size() == 1);
 	Value minimum_value = type.InternalType() == PhysicalType::VARCHAR ? Value("") : Value::MinimumValue(type);
 	auto filter_data = make_shared_ptr<DynamicFilterData>(comparison_type, std::move(minimum_value));
 
@@ -130,6 +193,51 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		    col_binding.column_index,
 		    make_uniq<ExpressionFilter>(CreateOptionalFilterExpression(std::move(pushed_expr), type)));
 	}
+
+	if (op.orders.size() < 2 || op.orders[0].null_order != OrderByNullType::NULLS_LAST ||
+	    op.orders[1].null_order != OrderByNullType::NULLS_LAST ||
+	    op.orders[1].expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return;
+	}
+	auto &second_type = op.orders[1].expression->GetReturnType();
+	if (!TypeIsNumeric(type.InternalType()) || !TypeIsNumeric(second_type.InternalType())) {
+		return;
+	}
+
+	auto &second_colref = op.orders[1].expression->Cast<BoundColumnRefExpression>();
+	vector<JoinFilterPushdownColumn> multi_columns;
+	JoinFilterPushdownColumn first_column;
+	first_column.probe_column_index = colref.binding;
+	multi_columns.push_back(std::move(first_column));
+	JoinFilterPushdownColumn second_column;
+	second_column.probe_column_index = second_colref.binding;
+	multi_columns.push_back(std::move(second_column));
+
+	vector<PushdownFilterTarget> multi_targets;
+	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(*op.children[0], std::move(multi_columns), multi_targets);
+	if (multi_targets.size() != 1 || multi_targets[0].columns.size() != 2) {
+		return;
+	}
+
+	auto &target = multi_targets[0];
+	Value prefix_boundary;
+	idx_t prefix_boundary_groups = 0;
+	if (!TryGetGlobalOrderBoundary(context, target.get, target.columns[0].probe_column_index, op.orders[0],
+	                               prefix_boundary, prefix_boundary_groups) ||
+	    prefix_boundary_groups <= 1) {
+		return;
+	}
+
+	auto second_filter_data = make_shared_ptr<DynamicFilterData>(TopNComparisonType(op.orders[1].type, false),
+	                                                             Value::MinimumValue(second_type));
+	op.secondary_dynamic_filter = second_filter_data;
+	op.secondary_dynamic_filter_prefix = std::move(prefix_boundary);
+
+	auto pushed_expr = CreateDynamicFilterExpression(std::move(second_filter_data), second_type);
+	auto col_binding = target.columns[1].probe_column_index;
+	target.get.table_filters.PushFilter(
+	    col_binding.column_index,
+	    make_uniq<ExpressionFilter>(CreateOptionalFilterExpression(std::move(pushed_expr), second_type)));
 }
 
 unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -146,6 +146,19 @@ bool ExtractPassthroughBinding(const Expression &expr, ColumnBinding &binding) {
 	}
 }
 
+bool ExpressionCanHaveNull(const Expression &expr, const column_binding_map_t<unique_ptr<BaseStatistics>> &stats) {
+	if (expr.GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		return expr.Cast<BoundConstantExpression>().value.IsNull();
+	}
+
+	ColumnBinding binding;
+	if (!ExtractPassthroughBinding(expr, binding)) {
+		return true;
+	}
+	auto column_stats = stats.find(binding);
+	return column_stats == stats.end() || !column_stats->second || column_stats->second->CanHaveNull();
+}
+
 bool IsLeadingAggregateGroup(LogicalOperator &op, ColumnBinding binding) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
@@ -421,6 +434,9 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	if (!HasOrderedPrefixGroupingSets(aggregate)) {
 		return op;
 	}
+	if (!ExpressionCanHaveNull(*aggregate.groups[0], *stats)) {
+		return op;
+	}
 
 	// If the first ORDER BY key is the leading rollup key with NULLS FIRST, the NULL-prefix rollup rows sort
 	// before the rest. Materialize those rows first and only run the fallback branch when they do not fill the LIMIT.
@@ -453,9 +469,9 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	vector<unique_ptr<LogicalOperator>> prefix_children;
 	prefix_children.push_back(std::move(null_prefix));
 	prefix_children.push_back(std::move(grand_total));
-	auto prefix_union = make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(),
-	                                                   first_aggregate_bindings.size(), std::move(prefix_children),
-	                                                   LogicalOperatorType::LOGICAL_UNION, true, true);
+	auto prefix_union =
+	    make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(), first_aggregate_bindings.size(),
+	                                   std::move(prefix_children), LogicalOperatorType::LOGICAL_UNION, true, true);
 	prefix_union->ResolveOperatorTypes();
 	const auto prefix_union_bindings = prefix_union->GetColumnBindings();
 	ColumnBindingReplacer prefix_replacer;
@@ -479,24 +495,22 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	vector<unique_ptr<Expression>> count_expressions;
 	count_expressions.push_back(
 	    function_binder.BindAggregateFunction(count_star_fun, {}, nullptr, AggregateType::NON_DISTINCT));
-	auto count_aggregate = make_uniq<LogicalAggregate>(optimizer.binder.GenerateTableIndex(),
-	                                                   optimizer.binder.GenerateTableIndex(),
-	                                                   std::move(count_expressions));
+	auto count_aggregate = make_uniq<LogicalAggregate>(
+	    optimizer.binder.GenerateTableIndex(), optimizer.binder.GenerateTableIndex(), std::move(count_expressions));
 	count_aggregate->children.push_back(make_cte_ref());
 	count_aggregate->ResolveOperatorTypes();
 	const auto count_binding = count_aggregate->GetColumnBindings()[0];
 	auto count_ref = make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, count_binding);
 	auto count_limit = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(topn.limit)));
-	auto count_filter = make_uniq<LogicalFilter>(
-	    BoundComparisonExpression::Create(ExpressionType::COMPARE_LESSTHAN, std::move(count_ref),
-	                                      std::move(count_limit)));
+	auto count_filter = make_uniq<LogicalFilter>(BoundComparisonExpression::Create(
+	    ExpressionType::COMPARE_LESSTHAN, std::move(count_ref), std::move(count_limit)));
 	count_filter->children.push_back(std::move(count_aggregate));
 	count_filter->ResolveOperatorTypes();
 
 	vector<unique_ptr<Expression>> guard_expressions;
 	guard_expressions.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-	auto guard_projection = make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(),
-	                                                    std::move(guard_expressions));
+	auto guard_projection =
+	    make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(), std::move(guard_expressions));
 	guard_projection->children.push_back(std::move(count_filter));
 	guard_projection->ResolveOperatorTypes();
 
@@ -510,9 +524,8 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	if (!RemoveEmptyGroupingSet(fallback_aggregate)) {
 		return op;
 	}
-	WrapAggregateChildInFilter(fallback_aggregate,
-	                           CreateNullCheck(fallback_aggregate.groups[0]->Copy(),
-	                                           ExpressionType::OPERATOR_IS_NOT_NULL));
+	WrapAggregateChildInFilter(fallback_aggregate, CreateNullCheck(fallback_aggregate.groups[0]->Copy(),
+	                                                               ExpressionType::OPERATOR_IS_NOT_NULL));
 	fallback_aggregate.children[0] =
 	    LogicalCrossProduct::Create(std::move(fallback_aggregate.children[0]), std::move(guard_projection));
 	fallback_aggregate.children[0]->ResolveOperatorTypes();
@@ -521,9 +534,9 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	vector<unique_ptr<LogicalOperator>> union_children;
 	union_children.push_back(std::move(first_rows_ref));
 	union_children.push_back(std::move(fallback));
-	auto result_union = make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(), cte_types.size(),
-	                                                   std::move(union_children),
-	                                                   LogicalOperatorType::LOGICAL_UNION, true, false);
+	auto result_union =
+	    make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(), cte_types.size(),
+	                                   std::move(union_children), LogicalOperatorType::LOGICAL_UNION, true, false);
 	result_union->ResolveOperatorTypes();
 
 	ColumnBindingReplacer topn_replacer;
@@ -532,9 +545,9 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefi
 	topn_replacer.VisitOperator(topn);
 	topn.ResolveOperatorTypes();
 
-	auto result = make_uniq<LogicalMaterializedCTE>("ordered_rollup_prefix", cte_index, cte_types.size(),
-	                                               std::move(first_rows), std::move(op),
-	                                               CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	auto result =
+	    make_uniq<LogicalMaterializedCTE>("ordered_rollup_prefix", cte_index, cte_types.size(), std::move(first_rows),
+	                                      std::move(op), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
 	result->ResolveOperatorTypes();
 	return std::move(result);
 }
@@ -587,8 +600,8 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	// We use an ordered map here because we need to iterate over them in order later
 	map<idx_t, idx_t> group_projection_idxs;
 	const auto window_type = window.expressions[0]->GetExpressionType();
-	auto aggregate_payload =
-	    GenerateAggregatePayload(new_bindings, window, group_projection_idxs, window_type == ExpressionType::WINDOW_RANK);
+	auto aggregate_payload = GenerateAggregatePayload(new_bindings, window, group_projection_idxs,
+	                                                  window_type == ExpressionType::WINDOW_RANK);
 	if (window_type == ExpressionType::WINDOW_RANK && aggregate_payload.empty()) {
 		return op;
 	}
@@ -619,7 +632,8 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	auto params = ExtractOptimizerParameters(window, filter, new_bindings, aggregate_payload);
 
 	unique_ptr<LogicalOperator> late_mat_lhs = nullptr;
-	if (params.window_type == ExpressionType::WINDOW_ROW_NUMBER && params.payload_type == TopNPayloadType::STRUCT_PACK) {
+	if (params.window_type == ExpressionType::WINDOW_ROW_NUMBER &&
+	    params.payload_type == TopNPayloadType::STRUCT_PACK) {
 		// Try circumventing struct-packing with late materialization
 		late_mat_lhs = TryPrepareLateMaterialization(window, aggregate_payload);
 		if (late_mat_lhs && aggregate_payload.size() == 1) {
@@ -687,7 +701,7 @@ TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> 
 		D_ASSERT(bound_aggregate.bind_info);
 		bound_aggregate.bind_info->Cast<ArgMinMaxFunctionData>().with_ties = true;
 	}
-	return aggregate;
+	return unique_ptr_cast<BoundAggregateExpression, Expression>(std::move(aggregate));
 }
 
 unique_ptr<LogicalOperator>
@@ -1143,13 +1157,11 @@ public:
 };
 
 unique_ptr<LogicalOperator>
-TopNWindowElimination::CreateRankWindowOperator(unique_ptr<LogicalOperator> op,
-                                                unique_ptr<Expression> rank_expression, const TableIndex window_idx,
-                                                const vector<LogicalType> &types,
+TopNWindowElimination::CreateRankWindowOperator(unique_ptr<LogicalOperator> op, unique_ptr<Expression> rank_expression,
+                                                const TableIndex window_idx, const vector<LogicalType> &types,
                                                 const map<idx_t, idx_t> &group_idxs,
                                                 const vector<ColumnBinding> &topmost_bindings,
-                                                vector<ColumnBinding> &new_bindings,
-                                                ColumnBindingReplacer &replacer) {
+                                                vector<ColumnBinding> &new_bindings, ColumnBindingReplacer &replacer) {
 	D_ASSERT(rank_expression);
 
 	const auto reduced_bindings = op->GetColumnBindings();

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
@@ -58,16 +59,6 @@ unique_ptr<LogicalOperator> *FindFirstAggregate(unique_ptr<LogicalOperator> &op)
 		return nullptr;
 	}
 	return FindFirstAggregate(op->children[0]);
-}
-
-optional_ptr<LogicalWindow> FindFirstWindow(LogicalOperator &op) {
-	if (op.type == LogicalOperatorType::LOGICAL_WINDOW) {
-		return op.Cast<LogicalWindow>();
-	}
-	if (op.children.size() != 1) {
-		return nullptr;
-	}
-	return FindFirstWindow(*op.children[0]);
 }
 
 bool RemoveEmptyGroupingSet(LogicalAggregate &aggregate) {
@@ -131,6 +122,30 @@ void AddBindingReplacements(ColumnBindingReplacer &replacer, const vector<Column
 	}
 }
 
+bool ExtractPassthroughBinding(const Expression &expr, ColumnBinding &binding) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COLUMN_REF:
+		binding = expr.Cast<BoundColumnRefExpression>().binding;
+		return true;
+	case ExpressionClass::BOUND_CAST:
+		return ExtractPassthroughBinding(*expr.Cast<BoundCastExpression>().child, binding);
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &function_expr = expr.Cast<BoundFunctionExpression>();
+		if (function_expr.children.size() != 1) {
+			return false;
+		}
+		const auto &name = function_expr.function.GetName();
+		if (!StringUtil::StartsWith(name, "__internal_compress_") &&
+		    !StringUtil::StartsWith(name, "__internal_decompress_")) {
+			return false;
+		}
+		return ExtractPassthroughBinding(*function_expr.children[0], binding);
+	}
+	default:
+		return false;
+	}
+}
+
 bool IsLeadingAggregateGroup(LogicalOperator &op, ColumnBinding binding) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
@@ -144,11 +159,11 @@ bool IsLeadingAggregateGroup(LogicalOperator &op, ColumnBinding binding) {
 			return false;
 		}
 		auto &expr = projection.expressions[binding.column_index.GetIndex()];
-		if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		ColumnBinding child_binding;
+		if (!ExtractPassthroughBinding(*expr, child_binding)) {
 			return false;
 		}
-		auto &column_ref = expr->Cast<BoundColumnRefExpression>();
-		return IsLeadingAggregateGroup(*op.children[0], column_ref.binding);
+		return IsLeadingAggregateGroup(*op.children[0], child_binding);
 	}
 	case LogicalOperatorType::LOGICAL_FILTER:
 	case LogicalOperatorType::LOGICAL_ORDER_BY: {
@@ -169,6 +184,49 @@ bool IsLeadingAggregateGroup(LogicalOperator &op, ColumnBinding binding) {
 	default:
 		return false;
 	}
+}
+
+bool WindowPartitionsOnLeadingAggregateGroup(LogicalWindow &window) {
+	for (const auto &expr : window.expressions) {
+		auto &window_expr = expr->Cast<BoundWindowExpression>();
+		bool found_leading_group = false;
+		for (const auto &partition : window_expr.partitions) {
+			if (partition->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+				continue;
+			}
+			auto &column_ref = partition->Cast<BoundColumnRefExpression>();
+			if (IsLeadingAggregateGroup(*window.children[0], column_ref.binding)) {
+				found_leading_group = true;
+				break;
+			}
+		}
+		if (!found_leading_group) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CanSplitOrderedPrefixAtAggregate(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return true;
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+	case LogicalOperatorType::LOGICAL_FILTER:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		break;
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		if (!WindowPartitionsOnLeadingAggregateGroup(op.Cast<LogicalWindow>())) {
+			return false;
+		}
+		break;
+	default:
+		return false;
+	}
+	if (op.children.size() != 1) {
+		return false;
+	}
+	return CanSplitOrderedPrefixAtAggregate(*op.children[0]);
 }
 
 TableIndex GetAggregateIdx(const unique_ptr<LogicalOperator> &op) {
@@ -319,7 +377,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::Optimize(unique_ptr<LogicalOp
 	return op;
 }
 
-unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(unique_ptr<LogicalOperator> op) {
+unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRollupPrefix(unique_ptr<LogicalOperator> op) {
 	if (op->type != LogicalOperatorType::LOGICAL_TOP_N) {
 		return op;
 	}
@@ -345,17 +403,10 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(
 	if (!IsLeadingAggregateGroup(*topn.children[0], first_order.binding)) {
 		return op;
 	}
-
-	auto window = FindFirstWindow(*topn.children[0]);
-	if (!window || window->expressions.empty()) {
+	if (!CanSplitOrderedPrefixAtAggregate(*topn.children[0])) {
 		return op;
 	}
-	auto &window_expr = window->expressions[0]->Cast<BoundWindowExpression>();
-	if (window_expr.GetExpressionType() != ExpressionType::WINDOW_RANK || window_expr.partitions.size() != 1 ||
-	    window_expr.orders.size() != 1) {
-		return op;
-	}
-	if (window_expr.partitions[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+	if (HasExternalCTEReferences(*topn.children[0])) {
 		return op;
 	}
 
@@ -371,7 +422,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(
 		return op;
 	}
 
-	// If the first ORDER BY key is the leading rollup key with NULLS FIRST, all rows with a NULL prefix sort
+	// If the first ORDER BY key is the leading rollup key with NULLS FIRST, the NULL-prefix rollup rows sort
 	// before the rest. Materialize those rows first and only run the fallback branch when they do not fill the LIMIT.
 	LogicalOperatorDeepCopy first_rows_copier(optimizer.binder, nullptr);
 	auto first_rows = first_rows_copier.DeepCopy(topn.children[0]);
@@ -481,7 +532,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(
 	topn_replacer.VisitOperator(topn);
 	topn.ResolveOperatorTypes();
 
-	auto result = make_uniq<LogicalMaterializedCTE>("ordered_rank_prefix", cte_index, cte_types.size(),
+	auto result = make_uniq<LogicalMaterializedCTE>("ordered_rollup_prefix", cte_index, cte_types.size(),
 	                                               std::move(first_rows), std::move(op),
 	                                               CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
 	result->ResolveOperatorTypes();
@@ -491,7 +542,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(
 unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<LogicalOperator> op,
                                                                     ColumnBindingReplacer &replacer) {
 	if (op->type == LogicalOperatorType::LOGICAL_TOP_N) {
-		op = TryOptimizeOrderedRankPrefix(std::move(op));
+		op = TryOptimizeOrderedRollupPrefix(std::move(op));
 	}
 	if (!CanOptimize(*op)) {
 		// Traverse through query plan to find grouped top-n pattern

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/aggregate/minmax_n_helpers.hpp"
 #include "duckdb/main/database.hpp"
 
 namespace duckdb {
@@ -234,17 +235,48 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	// Map the input column offsets of the group columns to the output offset if there are projections on the group
 	// We use an ordered map here because we need to iterate over them in order later
 	map<idx_t, idx_t> group_projection_idxs;
-	auto aggregate_payload = GenerateAggregatePayload(new_bindings, window, group_projection_idxs);
+	const auto window_type = window.expressions[0]->GetExpressionType();
+	auto aggregate_payload =
+	    GenerateAggregatePayload(new_bindings, window, group_projection_idxs, window_type == ExpressionType::WINDOW_RANK);
+	if (window_type == ExpressionType::WINDOW_RANK && aggregate_payload.empty()) {
+		return op;
+	}
+	if (window_type == ExpressionType::WINDOW_RANK) {
+		auto has_binding = [&](const ColumnBinding &binding) {
+			for (const auto &new_binding : new_bindings) {
+				if (new_binding == binding) {
+					return true;
+				}
+			}
+			return false;
+		};
+		auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
+		for (auto &partition : window_expr.partitions) {
+			VisitExpression(&partition);
+		}
+		for (auto &order : window_expr.orders) {
+			VisitExpression(&order.expression);
+		}
+		for (const auto &column_ref : column_references) {
+			if (!has_binding(column_ref.first)) {
+				column_references.clear();
+				return op;
+			}
+		}
+		column_references.clear();
+	}
 	auto params = ExtractOptimizerParameters(window, filter, new_bindings, aggregate_payload);
 
 	unique_ptr<LogicalOperator> late_mat_lhs = nullptr;
-	if (params.payload_type == TopNPayloadType::STRUCT_PACK) {
+	if (params.window_type == ExpressionType::WINDOW_ROW_NUMBER && params.payload_type == TopNPayloadType::STRUCT_PACK) {
 		// Try circumventing struct-packing with late materialization
 		late_mat_lhs = TryPrepareLateMaterialization(window, aggregate_payload);
 		if (late_mat_lhs && aggregate_payload.size() == 1) {
 			params.payload_type = TopNPayloadType::SINGLE_COLUMN;
 		}
 	}
+
+	auto rank_expression = params.window_type == ExpressionType::WINDOW_RANK ? window.expressions[0]->Copy() : nullptr;
 
 	// Optimize window children
 	window.children[0] = Optimize(std::move(window.children[0]));
@@ -259,8 +291,13 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 		op = ConstructJoin(std::move(late_mat_lhs), std::move(op), group_projection_idxs.size(), params);
 	}
 
-	op = UpdateTopmostBindings(window_idx, std::move(op), topmost_types, group_projection_idxs, topmost_bindings,
-	                           new_bindings, replacer);
+	if (params.window_type == ExpressionType::WINDOW_RANK) {
+		op = CreateRankWindowOperator(std::move(op), std::move(rank_expression), window_idx, topmost_types,
+		                              group_projection_idxs, topmost_bindings, new_bindings, replacer);
+	} else {
+		op = UpdateTopmostBindings(window_idx, std::move(op), topmost_types, group_projection_idxs, topmost_bindings,
+		                           new_bindings, replacer);
+	}
 
 	replacer.stop_operator = op.get();
 
@@ -293,7 +330,13 @@ TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> 
 
 	auto &fun_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(context, DEFAULT_SCHEMA, fun_name);
 	const auto &fun = fun_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(aggregate_params));
-	return function_binder.BindAggregateFunction(fun, std::move(aggregate_params));
+	auto aggregate = function_binder.BindAggregateFunction(fun, std::move(aggregate_params));
+	if (params.window_type == ExpressionType::WINDOW_RANK) {
+		auto &bound_aggregate = aggregate->Cast<BoundAggregateExpression>();
+		D_ASSERT(bound_aggregate.bind_info);
+		bound_aggregate.bind_info->Cast<ArgMinMaxFunctionData>().with_ties = true;
+	}
+	return aggregate;
 }
 
 unique_ptr<LogicalOperator>
@@ -606,7 +649,8 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 			}
 		}
 	}
-	if (window.expressions[0]->GetExpressionType() != ExpressionType::WINDOW_ROW_NUMBER) {
+	const auto window_type = window.expressions[0]->GetExpressionType();
+	if (window_type != ExpressionType::WINDOW_ROW_NUMBER && window_type != ExpressionType::WINDOW_RANK) {
 		return false;
 	}
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
@@ -627,7 +671,8 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 
 vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(const vector<ColumnBinding> &bindings,
                                                                                const LogicalWindow &window,
-                                                                               map<idx_t, idx_t> &group_idxs) {
+                                                                               map<idx_t, idx_t> &group_idxs,
+                                                                               const bool keep_order_value) {
 	vector<unique_ptr<Expression>> aggregate_args;
 	aggregate_args.reserve(bindings.size());
 
@@ -671,7 +716,7 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 		}
 	}
 
-	if (aggregate_args.size() == 1) {
+	if (aggregate_args.size() == 1 && !keep_order_value) {
 		// If we only project the aggregate value itself, we do not need it as an arg
 		VisitExpression(&window_expr.orders[0].expression);
 		if (column_references.size() != 1) {
@@ -727,7 +772,14 @@ public:
 			for (idx_t i = 0; i < bindings.size(); ++i) {
 				const auto &binding = bindings[i];
 				if (binding.table_index == table_index) {
-					types[i] = op.types[binding.column_index];
+					if (op.type == LogicalOperatorType::LOGICAL_WINDOW) {
+						const auto &window = op.Cast<LogicalWindow>();
+						const auto window_offset = window.children[0]->types.size();
+						D_ASSERT(binding.column_index < window.expressions.size());
+						types[i] = op.types[window_offset + binding.column_index];
+					} else {
+						types[i] = op.types[binding.column_index];
+					}
 				}
 			}
 		}
@@ -738,6 +790,94 @@ public:
 	const vector<ColumnBinding> &bindings;
 	vector<LogicalType> types;
 };
+
+unique_ptr<LogicalOperator>
+TopNWindowElimination::CreateRankWindowOperator(unique_ptr<LogicalOperator> op,
+                                                unique_ptr<Expression> rank_expression, const TableIndex window_idx,
+                                                const vector<LogicalType> &types,
+                                                const map<idx_t, idx_t> &group_idxs,
+                                                const vector<ColumnBinding> &topmost_bindings,
+                                                vector<ColumnBinding> &new_bindings,
+                                                ColumnBindingReplacer &replacer) {
+	D_ASSERT(rank_expression);
+
+	const auto reduced_bindings = op->GetColumnBindings();
+	ColumnBindingReplacer child_replacer;
+
+	set<idx_t> ordered_group_projection_idxs;
+	for (const auto &group_idx : group_idxs) {
+		ordered_group_projection_idxs.insert(group_idx.second);
+	}
+	map<idx_t, idx_t> compact_group_projection_idxs;
+	idx_t compact_idx = 0;
+	for (const auto group_projection_idx : ordered_group_projection_idxs) {
+		compact_group_projection_idxs[group_projection_idx] = compact_idx++;
+	}
+
+	idx_t current_column_idx = 0;
+	for (auto group_idx : group_idxs) {
+		const auto group_referencing_idx = group_idx.first;
+		const auto column_idx = compact_group_projection_idxs[group_idx.second];
+		auto &binding = new_bindings[group_referencing_idx];
+		const auto replacement = reduced_bindings[column_idx];
+		child_replacer.replacement_bindings.emplace_back(binding, replacement);
+		binding = replacement;
+		current_column_idx++;
+	}
+
+	set<idx_t> rank_binding_idxs;
+	for (idx_t i = 0; i < new_bindings.size(); i++) {
+		if (group_idxs.find(i) != group_idxs.end()) {
+			continue;
+		}
+		auto &binding = new_bindings[i];
+		if (binding.table_index == window_idx) {
+			rank_binding_idxs.insert(i);
+			continue;
+		}
+		D_ASSERT(current_column_idx < reduced_bindings.size());
+		const auto replacement = reduced_bindings[current_column_idx++];
+		child_replacer.replacement_bindings.emplace_back(binding, replacement);
+		binding = replacement;
+	}
+
+	child_replacer.VisitExpression(&rank_expression);
+
+	auto rank_window = make_uniq<LogicalWindow>(optimizer.binder.GenerateTableIndex());
+	rank_window->expressions.push_back(std::move(rank_expression));
+	rank_window->children.push_back(std::move(op));
+	rank_window->ResolveOperatorTypes();
+
+	const auto rank_window_bindings = rank_window->GetColumnBindings();
+	D_ASSERT(!rank_window_bindings.empty());
+	const auto rank_binding = rank_window_bindings.back();
+	for (const auto rank_binding_idx : rank_binding_idxs) {
+		new_bindings[rank_binding_idx] = rank_binding;
+	}
+
+	replacer.replacement_bindings.reserve(new_bindings.size());
+	ColumnBindingTyper original(new_bindings);
+	original.VisitOperator(*rank_window);
+	const auto proj_table = optimizer.binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> proj_exprs;
+	for (idx_t i = 0; i < topmost_bindings.size(); ++i) {
+		auto &new_binding = new_bindings[i];
+		unique_ptr<Expression> proj_expr = make_uniq<BoundColumnRefExpression>(original.types[i], new_binding);
+		if (original.types[i] != types[i]) {
+			proj_expr = BoundCastExpression::AddDefaultCastToType(std::move(proj_expr), types[i]);
+		}
+		proj_exprs.emplace_back(std::move(proj_expr));
+		new_binding.table_index = proj_table;
+		new_binding.column_index = ProjectionIndex(i);
+		replacer.replacement_bindings.emplace_back(topmost_bindings[i], new_binding);
+	}
+
+	auto set_projection = make_uniq<LogicalProjection>(proj_table, std::move(proj_exprs));
+	set_projection->children.push_back(std::move(rank_window));
+	set_projection->ResolveOperatorTypes();
+
+	return unique_ptr<LogicalOperator>(std::move(set_projection));
+}
 
 unique_ptr<LogicalOperator>
 TopNWindowElimination::UpdateTopmostBindings(TableIndex window_idx, unique_ptr<LogicalOperator> op,
@@ -847,7 +987,9 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	if (filter_expr.GetExpressionType() == ExpressionType::COMPARE_LESSTHAN) {
 		--params.limit;
 	}
-	params.include_row_number = BindingsReferenceRowNumber(bindings, window);
+	params.window_type = window.expressions[0]->GetExpressionType();
+	params.include_row_number =
+	    params.window_type == ExpressionType::WINDOW_ROW_NUMBER && BindingsReferenceRowNumber(bindings, window);
 	params.payload_type = aggregate_payload.size() > 1 ? TopNPayloadType::STRUCT_PACK : TopNPayloadType::SINGLE_COLUMN;
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
 	params.order_type = window_expr.orders[0].type;

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -12,19 +12,26 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_cte.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+#include "duckdb/planner/operator/logical_top_n.hpp"
 #include "duckdb/planner/operator/logical_unnest.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
+#include "duckdb/planner/logical_operator_deep_copy.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/aggregate/minmax_n_helpers.hpp"
 #include "duckdb/main/database.hpp"
@@ -41,6 +48,127 @@ TableIndex GetGroupIdx(const unique_ptr<LogicalOperator> &op) {
 		return op->children[0]->GetTableIndex()[0];
 	}
 	return op->GetTableIndex()[0];
+}
+
+unique_ptr<LogicalOperator> *FindFirstAggregate(unique_ptr<LogicalOperator> &op) {
+	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+		return &op;
+	}
+	if (op->children.size() != 1) {
+		return nullptr;
+	}
+	return FindFirstAggregate(op->children[0]);
+}
+
+optional_ptr<LogicalWindow> FindFirstWindow(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_WINDOW) {
+		return op.Cast<LogicalWindow>();
+	}
+	if (op.children.size() != 1) {
+		return nullptr;
+	}
+	return FindFirstWindow(*op.children[0]);
+}
+
+bool RemoveEmptyGroupingSet(LogicalAggregate &aggregate) {
+	bool removed_empty = false;
+	vector<GroupingSet> grouping_sets;
+	grouping_sets.reserve(aggregate.grouping_sets.size());
+	for (auto &grouping_set : aggregate.grouping_sets) {
+		if (grouping_set.empty()) {
+			removed_empty = true;
+			continue;
+		}
+		grouping_sets.push_back(std::move(grouping_set));
+	}
+	aggregate.grouping_sets = std::move(grouping_sets);
+	return removed_empty && !aggregate.grouping_sets.empty();
+}
+
+bool HasOrderedPrefixGroupingSets(const LogicalAggregate &aggregate) {
+	bool has_empty = false;
+	const auto first_group = ProjectionIndex(0);
+	for (const auto &grouping_set : aggregate.grouping_sets) {
+		if (grouping_set.empty()) {
+			has_empty = true;
+			continue;
+		}
+		if (!grouping_set.count(first_group)) {
+			return false;
+		}
+	}
+	return has_empty;
+}
+
+void WrapAggregateChildInFilter(LogicalAggregate &aggregate, unique_ptr<Expression> filter_expr) {
+	auto filter = make_uniq<LogicalFilter>(std::move(filter_expr));
+	filter->children.push_back(std::move(aggregate.children[0]));
+	filter->ResolveOperatorTypes();
+	aggregate.children[0] = std::move(filter);
+}
+
+unique_ptr<Expression> CreateNullCheck(unique_ptr<Expression> child, ExpressionType type) {
+	D_ASSERT(type == ExpressionType::OPERATOR_IS_NULL || type == ExpressionType::OPERATOR_IS_NOT_NULL);
+	auto result = make_uniq<BoundOperatorExpression>(type, LogicalType::BOOLEAN);
+	result->children.push_back(std::move(child));
+	return std::move(result);
+}
+
+vector<string> CreateColumnNames(const idx_t count) {
+	vector<string> names;
+	names.reserve(count);
+	for (idx_t i = 0; i < count; i++) {
+		names.push_back(StringUtil::Format("c%llu", i));
+	}
+	return names;
+}
+
+void AddBindingReplacements(ColumnBindingReplacer &replacer, const vector<ColumnBinding> &old_bindings,
+                            const vector<ColumnBinding> &new_bindings) {
+	D_ASSERT(old_bindings.size() == new_bindings.size());
+	for (idx_t i = 0; i < old_bindings.size(); i++) {
+		replacer.replacement_bindings.emplace_back(old_bindings[i], new_bindings[i]);
+	}
+}
+
+bool IsLeadingAggregateGroup(LogicalOperator &op, ColumnBinding binding) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggregate = op.Cast<LogicalAggregate>();
+		return binding == ColumnBinding(aggregate.group_index, ProjectionIndex(0));
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		auto &projection = op.Cast<LogicalProjection>();
+		if (binding.table_index != projection.table_index ||
+		    binding.column_index.GetIndex() >= projection.expressions.size()) {
+			return false;
+		}
+		auto &expr = projection.expressions[binding.column_index.GetIndex()];
+		if (expr->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			return false;
+		}
+		auto &column_ref = expr->Cast<BoundColumnRefExpression>();
+		return IsLeadingAggregateGroup(*op.children[0], column_ref.binding);
+	}
+	case LogicalOperatorType::LOGICAL_FILTER:
+	case LogicalOperatorType::LOGICAL_ORDER_BY: {
+		if (op.children.size() != 1) {
+			return false;
+		}
+		return IsLeadingAggregateGroup(*op.children[0], binding);
+	}
+	case LogicalOperatorType::LOGICAL_WINDOW: {
+		const auto child_bindings = op.children[0]->GetColumnBindings();
+		for (const auto &child_binding : child_bindings) {
+			if (child_binding == binding) {
+				return IsLeadingAggregateGroup(*op.children[0], binding);
+			}
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
 }
 
 TableIndex GetAggregateIdx(const unique_ptr<LogicalOperator> &op) {
@@ -191,8 +319,180 @@ unique_ptr<LogicalOperator> TopNWindowElimination::Optimize(unique_ptr<LogicalOp
 	return op;
 }
 
+unique_ptr<LogicalOperator> TopNWindowElimination::TryOptimizeOrderedRankPrefix(unique_ptr<LogicalOperator> op) {
+	if (op->type != LogicalOperatorType::LOGICAL_TOP_N) {
+		return op;
+	}
+	auto &topn = op->Cast<LogicalTopN>();
+	if (topn.offset != 0 || topn.limit == 0 || topn.orders.empty() || topn.children.size() != 1) {
+		return op;
+	}
+	if (topn.orders[0].type != OrderType::ASCENDING || topn.orders[0].null_order != OrderByNullType::NULLS_FIRST) {
+		return op;
+	}
+	if (topn.orders[0].expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return op;
+	}
+
+	auto child_bindings = topn.children[0]->GetColumnBindings();
+	if (child_bindings.empty()) {
+		return op;
+	}
+	auto &first_order = topn.orders[0].expression->Cast<BoundColumnRefExpression>();
+	if (first_order.binding != child_bindings[0]) {
+		return op;
+	}
+	if (!IsLeadingAggregateGroup(*topn.children[0], first_order.binding)) {
+		return op;
+	}
+
+	auto window = FindFirstWindow(*topn.children[0]);
+	if (!window || window->expressions.empty()) {
+		return op;
+	}
+	auto &window_expr = window->expressions[0]->Cast<BoundWindowExpression>();
+	if (window_expr.GetExpressionType() != ExpressionType::WINDOW_RANK || window_expr.partitions.size() != 1 ||
+	    window_expr.orders.size() != 1) {
+		return op;
+	}
+	if (window_expr.partitions[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return op;
+	}
+
+	auto *aggregate_ptr = FindFirstAggregate(topn.children[0]);
+	if (!aggregate_ptr) {
+		return op;
+	}
+	auto &aggregate = (*aggregate_ptr)->Cast<LogicalAggregate>();
+	if (aggregate.groups.empty() || aggregate.grouping_sets.size() <= 1 || !aggregate.grouping_functions.empty()) {
+		return op;
+	}
+	if (!HasOrderedPrefixGroupingSets(aggregate)) {
+		return op;
+	}
+
+	// If the first ORDER BY key is the leading rollup key with NULLS FIRST, all rows with a NULL prefix sort
+	// before the rest. Materialize those rows first and only run the fallback branch when they do not fill the LIMIT.
+	LogicalOperatorDeepCopy first_rows_copier(optimizer.binder, nullptr);
+	auto first_rows = first_rows_copier.DeepCopy(topn.children[0]);
+	auto *first_aggregate_ptr = FindFirstAggregate(first_rows);
+	if (!first_aggregate_ptr) {
+		return op;
+	}
+	const auto first_aggregate_bindings = (*first_aggregate_ptr)->GetColumnBindings();
+
+	LogicalOperatorDeepCopy null_prefix_copier(optimizer.binder, nullptr);
+	auto null_prefix = null_prefix_copier.DeepCopy(*first_aggregate_ptr);
+	LogicalOperatorDeepCopy grand_total_copier(optimizer.binder, nullptr);
+	auto grand_total = grand_total_copier.DeepCopy(*first_aggregate_ptr);
+
+	auto &null_aggregate = null_prefix->Cast<LogicalAggregate>();
+	if (!RemoveEmptyGroupingSet(null_aggregate)) {
+		return op;
+	}
+	WrapAggregateChildInFilter(null_aggregate,
+	                           CreateNullCheck(null_aggregate.groups[0]->Copy(), ExpressionType::OPERATOR_IS_NULL));
+	null_prefix->ResolveOperatorTypes();
+
+	auto &grand_aggregate = grand_total->Cast<LogicalAggregate>();
+	grand_aggregate.grouping_sets.clear();
+	grand_aggregate.grouping_sets.emplace_back();
+	grand_total->ResolveOperatorTypes();
+
+	vector<unique_ptr<LogicalOperator>> prefix_children;
+	prefix_children.push_back(std::move(null_prefix));
+	prefix_children.push_back(std::move(grand_total));
+	auto prefix_union = make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(),
+	                                                   first_aggregate_bindings.size(), std::move(prefix_children),
+	                                                   LogicalOperatorType::LOGICAL_UNION, true, true);
+	prefix_union->ResolveOperatorTypes();
+	const auto prefix_union_bindings = prefix_union->GetColumnBindings();
+	ColumnBindingReplacer prefix_replacer;
+	AddBindingReplacements(prefix_replacer, first_aggregate_bindings, prefix_union_bindings);
+	*first_aggregate_ptr = std::move(prefix_union);
+	prefix_replacer.VisitOperator(*first_rows);
+	first_rows->ResolveOperatorTypes();
+
+	const auto cte_index = optimizer.binder.GenerateTableIndex();
+	const auto cte_types = first_rows->types;
+	const auto cte_names = CreateColumnNames(cte_types.size());
+
+	auto make_cte_ref = [&]() {
+		return make_uniq<LogicalCTERef>(optimizer.binder.GenerateTableIndex(), cte_index, cte_types, cte_names);
+	};
+
+	auto first_rows_ref = make_cte_ref();
+
+	auto count_star_fun = CountStarFun::GetFunction();
+	FunctionBinder function_binder(context);
+	vector<unique_ptr<Expression>> count_expressions;
+	count_expressions.push_back(
+	    function_binder.BindAggregateFunction(count_star_fun, {}, nullptr, AggregateType::NON_DISTINCT));
+	auto count_aggregate = make_uniq<LogicalAggregate>(optimizer.binder.GenerateTableIndex(),
+	                                                   optimizer.binder.GenerateTableIndex(),
+	                                                   std::move(count_expressions));
+	count_aggregate->children.push_back(make_cte_ref());
+	count_aggregate->ResolveOperatorTypes();
+	const auto count_binding = count_aggregate->GetColumnBindings()[0];
+	auto count_ref = make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, count_binding);
+	auto count_limit = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(topn.limit)));
+	auto count_filter = make_uniq<LogicalFilter>(
+	    BoundComparisonExpression::Create(ExpressionType::COMPARE_LESSTHAN, std::move(count_ref),
+	                                      std::move(count_limit)));
+	count_filter->children.push_back(std::move(count_aggregate));
+	count_filter->ResolveOperatorTypes();
+
+	vector<unique_ptr<Expression>> guard_expressions;
+	guard_expressions.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+	auto guard_projection = make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(),
+	                                                    std::move(guard_expressions));
+	guard_projection->children.push_back(std::move(count_filter));
+	guard_projection->ResolveOperatorTypes();
+
+	LogicalOperatorDeepCopy fallback_copier(optimizer.binder, nullptr);
+	auto fallback = fallback_copier.DeepCopy(topn.children[0]);
+	auto *fallback_aggregate_ptr = FindFirstAggregate(fallback);
+	if (!fallback_aggregate_ptr) {
+		return op;
+	}
+	auto &fallback_aggregate = (*fallback_aggregate_ptr)->Cast<LogicalAggregate>();
+	if (!RemoveEmptyGroupingSet(fallback_aggregate)) {
+		return op;
+	}
+	WrapAggregateChildInFilter(fallback_aggregate,
+	                           CreateNullCheck(fallback_aggregate.groups[0]->Copy(),
+	                                           ExpressionType::OPERATOR_IS_NOT_NULL));
+	fallback_aggregate.children[0] =
+	    LogicalCrossProduct::Create(std::move(fallback_aggregate.children[0]), std::move(guard_projection));
+	fallback_aggregate.children[0]->ResolveOperatorTypes();
+	fallback->ResolveOperatorTypes();
+
+	vector<unique_ptr<LogicalOperator>> union_children;
+	union_children.push_back(std::move(first_rows_ref));
+	union_children.push_back(std::move(fallback));
+	auto result_union = make_uniq<LogicalSetOperation>(optimizer.binder.GenerateTableIndex(), cte_types.size(),
+	                                                   std::move(union_children),
+	                                                   LogicalOperatorType::LOGICAL_UNION, true, false);
+	result_union->ResolveOperatorTypes();
+
+	ColumnBindingReplacer topn_replacer;
+	AddBindingReplacements(topn_replacer, child_bindings, result_union->GetColumnBindings());
+	topn.children[0] = std::move(result_union);
+	topn_replacer.VisitOperator(topn);
+	topn.ResolveOperatorTypes();
+
+	auto result = make_uniq<LogicalMaterializedCTE>("ordered_rank_prefix", cte_index, cte_types.size(),
+	                                               std::move(first_rows), std::move(op),
+	                                               CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	result->ResolveOperatorTypes();
+	return std::move(result);
+}
+
 unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<LogicalOperator> op,
                                                                     ColumnBindingReplacer &replacer) {
+	if (op->type == LogicalOperatorType::LOGICAL_TOP_N) {
+		op = TryOptimizeOrderedRankPrefix(std::move(op));
+	}
 	if (!CanOptimize(*op)) {
 		// Traverse through query plan to find grouped top-n pattern
 		if (op->children.size() > 1) {

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -468,6 +468,71 @@ ORDER BY ALL
 1	100	1	1
 
 statement ok
+CREATE TABLE ordered_rollup_prefix(k VARCHAR, c VARCHAR, v INT)
+
+statement ok
+INSERT INTO ordered_rollup_prefix VALUES (NULL, 'a', 10), (NULL, 'b', 5), ('A', 'x', 7), ('B', 'y', 6)
+
+query III
+SELECT k, c, sum(v) s
+FROM ordered_rollup_prefix
+GROUP BY rollup(k, c)
+ORDER BY k NULLS FIRST, c NULLS FIRST, s DESC
+LIMIT 3
+----
+NULL	NULL	28
+NULL	NULL	15
+NULL	a	10
+
+statement ok
+CREATE TABLE ordered_rollup_prefix_with_optimizer AS
+SELECT k, c, sum(v) s
+FROM ordered_rollup_prefix
+GROUP BY rollup(k, c)
+ORDER BY k NULLS FIRST, c NULLS FIRST, s DESC
+LIMIT 8
+
+statement ok
+SET disabled_optimizers = 'top_n_window_elimination'
+
+statement ok
+CREATE TABLE ordered_rollup_prefix_without_optimizer AS
+SELECT k, c, sum(v) s
+FROM ordered_rollup_prefix
+GROUP BY rollup(k, c)
+ORDER BY k NULLS FIRST, c NULLS FIRST, s DESC
+LIMIT 8
+
+query III
+SELECT * FROM ordered_rollup_prefix_with_optimizer
+EXCEPT ALL
+SELECT * FROM ordered_rollup_prefix_without_optimizer
+----
+
+query III
+SELECT * FROM ordered_rollup_prefix_without_optimizer
+EXCEPT ALL
+SELECT * FROM ordered_rollup_prefix_with_optimizer
+----
+
+query IIII
+SELECT k, c, s, sum(s) OVER (PARTITION BY k) ws
+FROM (
+	SELECT k, c, sum(v) s
+	FROM ordered_rollup_prefix
+	GROUP BY rollup(k, c)
+) rollup_rows
+ORDER BY k NULLS FIRST, c NULLS FIRST, s DESC, ws DESC
+LIMIT 3
+----
+NULL	NULL	28	58
+NULL	NULL	15	58
+NULL	a	10	58
+
+statement ok
+SET disabled_optimizers = ''
+
+statement ok
 CREATE TABLE rank_rollup_prefix(k VARCHAR, c VARCHAR, v INT)
 
 statement ok

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -467,6 +467,110 @@ ORDER BY ALL
 1	95	4	2
 1	100	1	1
 
+statement ok
+CREATE TABLE rank_rollup_prefix(k VARCHAR, c VARCHAR, v INT)
+
+statement ok
+INSERT INTO rank_rollup_prefix VALUES (NULL, 'a', 10), (NULL, 'b', 5), ('A', 'x', 7), ('B', 'y', 6)
+
+query IIII
+SELECT *
+FROM (
+	SELECT k, c, sum(v) s, rank() OVER (PARTITION BY k ORDER BY sum(v) DESC) rk
+	FROM rank_rollup_prefix
+	GROUP BY rollup(k, c)
+) ranked
+WHERE rk <= 2
+ORDER BY k NULLS FIRST, c NULLS FIRST, s NULLS FIRST, rk NULLS FIRST
+LIMIT 2
+----
+NULL	NULL	15	2
+NULL	NULL	28	1
+
+statement ok
+CREATE TABLE rank_rollup_prefix_with_optimizer AS
+SELECT *
+FROM (
+	SELECT k, c, sum(v) s, rank() OVER (PARTITION BY k ORDER BY sum(v) DESC) rk
+	FROM rank_rollup_prefix
+	GROUP BY rollup(k, c)
+) ranked
+WHERE rk <= 2
+ORDER BY k NULLS FIRST, c NULLS FIRST, s NULLS FIRST, rk NULLS FIRST
+LIMIT 5
+
+statement ok
+SET disabled_optimizers = 'top_n_window_elimination'
+
+statement ok
+CREATE TABLE rank_rollup_prefix_without_optimizer AS
+SELECT *
+FROM (
+	SELECT k, c, sum(v) s, rank() OVER (PARTITION BY k ORDER BY sum(v) DESC) rk
+	FROM rank_rollup_prefix
+	GROUP BY rollup(k, c)
+) ranked
+WHERE rk <= 2
+ORDER BY k NULLS FIRST, c NULLS FIRST, s NULLS FIRST, rk NULLS FIRST
+LIMIT 5
+
+query IIII
+SELECT * FROM rank_rollup_prefix_with_optimizer
+EXCEPT ALL
+SELECT * FROM rank_rollup_prefix_without_optimizer
+----
+
+query IIII
+SELECT * FROM rank_rollup_prefix_without_optimizer
+EXCEPT ALL
+SELECT * FROM rank_rollup_prefix_with_optimizer
+----
+
+statement ok
+SET disabled_optimizers = ''
+
+statement ok
+CREATE TABLE rank_grouping_sets_prefix(k VARCHAR, c VARCHAR, v INT)
+
+statement ok
+INSERT INTO rank_grouping_sets_prefix VALUES (NULL, 'z', 10), ('A', 'a', 100)
+
+query IIII
+SELECT *
+FROM (
+	SELECT k, c, sum(v) s, rank() OVER (PARTITION BY k ORDER BY sum(v) DESC) rk
+	FROM rank_grouping_sets_prefix
+	GROUP BY GROUPING SETS ((k), (c), ())
+) ranked
+WHERE rk <= 10
+ORDER BY k NULLS FIRST, c NULLS FIRST, s DESC, rk NULLS FIRST
+LIMIT 3
+----
+NULL	NULL	110	1
+NULL	NULL	10	3
+NULL	a	100	2
+
+statement ok
+CREATE TABLE rank_rollup_prefix_reordered(k VARCHAR, c VARCHAR, v INT)
+
+statement ok
+INSERT INTO rank_rollup_prefix_reordered VALUES (NULL, 'z', 10), ('A', 'a', 100)
+
+query IIII
+SELECT *
+FROM (
+	SELECT c, k, sum(v) s, rank() OVER (PARTITION BY k ORDER BY sum(v) DESC) rk
+	FROM rank_rollup_prefix_reordered
+	GROUP BY rollup(k, c)
+) ranked
+WHERE rk <= 10
+ORDER BY c NULLS FIRST, k NULLS FIRST, s DESC, rk NULLS FIRST
+LIMIT 3
+----
+NULL	NULL	110	1
+NULL	NULL	10	2
+NULL	A	100	1
+
 # Left projection map corruption issue #21650
 statement ok
 CREATE TABLE s (s1 VARCHAR)

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -356,6 +356,117 @@ SELECT c, avg(b) FROM sub GROUP BY c ORDER BY ALL;
 x	100.0
 y	200.0
 
+statement ok
+CREATE TABLE rank_ties(p INT, v INT, id INT)
+
+statement ok
+INSERT INTO rank_ties VALUES (1, 10, 1), (1, 9, 2), (1, 9, 3), (1, 8, 4), (2, 5, 5), (2, 5, 6), (2, 4, 7)
+
+query II
+EXPLAIN SELECT *
+FROM (
+	SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+	FROM rank_ties
+) ranked
+WHERE rk <= 2
+ORDER BY ALL
+----
+logical_opt	<REGEX>:.*WINDOW.*AGGREGATE.*
+
+statement ok
+CREATE TABLE rank_ties_with_optimizer AS
+SELECT *
+FROM (
+	SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+	FROM rank_ties
+) ranked
+WHERE rk <= 2
+ORDER BY ALL
+
+statement ok
+SET disabled_optimizers = 'top_n_window_elimination'
+
+query IIII
+SELECT * FROM rank_ties_with_optimizer
+EXCEPT
+SELECT *
+FROM (
+	SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+	FROM rank_ties
+) ranked
+WHERE rk <= 2
+ORDER BY ALL
+----
+
+query IIII
+SELECT *
+FROM (
+	SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+	FROM rank_ties
+) ranked
+WHERE rk <= 2
+EXCEPT
+SELECT * FROM rank_ties_with_optimizer
+ORDER BY ALL
+----
+
+statement ok
+SET disabled_optimizers = ''
+
+query IIII
+SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+FROM rank_ties
+QUALIFY rk <= 2
+ORDER BY ALL
+----
+1	9	2	2
+1	9	3	2
+1	10	1	1
+2	5	5	1
+2	5	6	1
+
+query IIIII
+SELECT p, v, id,
+       rank() OVER (PARTITION BY p ORDER BY v DESC) rk,
+       rank() OVER (PARTITION BY p ORDER BY v DESC) rk2
+FROM rank_ties
+QUALIFY rk <= 2
+ORDER BY ALL
+----
+1	9	2	2	2
+1	9	3	2	2
+1	10	1	1	1
+2	5	5	1	1
+2	5	6	1	1
+
+statement ok
+CREATE TABLE rank_late_ties(p INT, v INT, id INT)
+
+statement ok
+INSERT INTO rank_late_ties VALUES (1, 100, 1), (1, 90, 2), (1, 90, 3), (1, 95, 4)
+
+query II
+EXPLAIN SELECT *
+FROM (
+	SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+	FROM rank_late_ties
+) ranked
+WHERE rk <= 3
+ORDER BY ALL
+----
+logical_opt	<REGEX>:.*WINDOW.*AGGREGATE.*
+
+query IIII
+SELECT p, v, id, rank() OVER (PARTITION BY p ORDER BY v DESC) rk
+FROM rank_late_ties
+QUALIFY rk <= 3
+ORDER BY ALL
+----
+1	90	2	3
+1	90	3	3
+1	95	4	2
+1	100	1	1
+
 # Left projection map corruption issue #21650
 statement ok
 CREATE TABLE s (s1 VARCHAR)

--- a/test/sql/topn/top_n_pruning.test
+++ b/test/sql/topn/top_n_pruning.test
@@ -177,3 +177,56 @@ SELECT i FROM t ORDER BY i DESC LIMIT 3
 10
 9
 8
+
+statement ok
+CREATE TABLE multi_key_t(a INT, b INT)
+
+statement ok
+INSERT INTO multi_key_t SELECT 0, range::INT FROM range(0, 2048)
+
+statement ok
+INSERT INTO multi_key_t SELECT 0, (100000 + range)::INT FROM range(0, 2048)
+
+statement ok
+INSERT INTO multi_key_t SELECT 0, (200000 + range)::INT FROM range(0, 2048)
+
+statement ok
+INSERT INTO multi_key_t SELECT 0, (300000 + range)::INT FROM range(0, 2048)
+
+statement ok
+INSERT INTO multi_key_t SELECT 0, (400000 + range)::INT FROM range(0, 2048)
+
+statement ok
+CHECKPOINT
+
+statement ok
+ATTACH '{TEST_DIR}/tmp2.duckdb' AS tmp2
+
+statement ok
+USE tmp2
+
+statement ok
+DETACH db
+
+statement ok
+ATTACH '{TEST_DIR}/top_n_hard_limit.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE db
+
+statement ok
+DETACH tmp2
+
+query II
+EXPLAIN ANALYZE SELECT a, b FROM multi_key_t ORDER BY a NULLS LAST, b NULLS LAST LIMIT 5
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query II
+SELECT a, b FROM multi_key_t ORDER BY a NULLS LAST, b NULLS LAST LIMIT 5
+----
+0	0
+0	1
+0	2
+0	3
+0	4


### PR DESCRIPTION
This improves two related TopN cases.

For ordered rollup/rank queries, the optimizer can now split the ordered NULL-prefix rows from the remaining rollup rows when that prefix is guaranteed to sort first. The remaining branch is guarded by the prefix count, so the full rollup input is only materialized if the prefix does not satisfy the limit.

For multi-key TopN scans, the existing dynamic filter is extended with a stats-gated secondary filter. When row-group stats prove that the first order key has reached the global boundary, and multiple row groups share that boundary, the scan can also receive an optional dynamic filter for the second order key.

Impact measured on the Azure SF100 sorted-Parquet setup:

- TPC-DS Q67: ~49s on main to ~7s with this branch, same result hash
- Full TPC-DS SF100 sorted Parquet: 99/99, Q67 6.99s in the final run
- Existing TPC-H TopN benchmark shape (`lineitem ORDER BY l_shipdate, l_orderkey LIMIT 5`): ~2.5-3.7x faster on SF10
- Standard TPC-H queries tested were effectively neutral

Validation:

- `python3 scripts/ci/run_tests.py --workers 4 build/release/test/unittest`
- Focused TopN optimizer tests
- Full TPC-DS SF100 sorted-Parquet run: 99/99
