### PR TITLE
Revert "Enable jemalloc heap profiling with the libgcc unwinder"

### DIFF
--- a/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -201,13 +201,13 @@
 /* #undef JEMALLOC_EXPERIMENTAL_SMALLOCX_API */
 
 /* JEMALLOC_PROF enables allocation profiling. */
-#define JEMALLOC_PROF
+/* #undef JEMALLOC_PROF */
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
 
 /* Use libgcc for profile backtracing if defined. */
-#define JEMALLOC_PROF_LIBGCC
+/* #undef JEMALLOC_PROF_LIBGCC */
 
 /* Use gcc intrinsics for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_GCC */


### PR DESCRIPTION
This reverts commit 031565bba3561e2074bf50a2ec5b130d4ad819d0.

CI will fail like:
```
/duckdb_build_dir/duckdb/third_party/jemalloc/src/prof_sys.c: In function 'prof_backtrace_impl':
/duckdb_build_dir/duckdb/third_party/jemalloc/src/prof_sys.c:22:46: error: implicit declaration of function '_Unwind_Backtrace' [-Wimplicit-function-declaration]
   22 | #define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
      |                                              ^~~~~~~~~~~~~~~~~
/duckdb_build_dir/duckdb/third_party/jemalloc/src/prof_sys.c:22:27: note: in expansion of macro 'JEMALLOC_TEST_HOOK'
   22 | #define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
      |                           ^~~~~~~~~~~~~~~~~~
/duckdb_build_dir/duckdb/third_party/jemalloc/src/prof_sys.c:99:9: note: in expansion of macro '_Unwind_Backtrace'
   99 |         _Unwind_Backtrace(prof_unwind_callback, &data);
      |         ^~~~~~~~~~~~~~~~~
```

I could see an alternative is gating those via `#if defined(__GLIBC__) && !defined(__MUSL__)` or similar, but I think revert is the proper safe alternative.