### PR TITLE
Gate #22630 for musl

### DIFF
--- a/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -201,13 +201,17 @@
 /* #undef JEMALLOC_EXPERIMENTAL_SMALLOCX_API */
 
 /* JEMALLOC_PROF enables allocation profiling. */
+#if defined(__GLIBC__) && !defined(__MUSL__)
 #define JEMALLOC_PROF
+#endif
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
 
 /* Use libgcc for profile backtracing if defined. */
+#if defined(__GLIBC__) && !defined(__MUSL__)
 #define JEMALLOC_PROF_LIBGCC
+#endif
 
 /* Use gcc intrinsics for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_GCC */


### PR DESCRIPTION
This fixup commit https://github.com/duckdb/duckdb/commit/031565bba3561e2074bf50a2ec5b130d4ad819d0, by avoiding inclusion in case of `MUSL`.

Alternative to  https://github.com/duckdb/duckdb/pull/22740