### PR TITLE
RowGroupPruner: treat UNSET LIMIT as unbounded

### DIFF
--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -90,10 +90,9 @@ bool RowGroupPruner::TryOptimize(LogicalOperator &op) const {
 
 void RowGroupPruner::GetLimitAndOffset(const LogicalLimit &logical_limit, optional_idx &row_limit,
                                        optional_idx &row_offset) const {
+	// UNSET = no LIMIT = unbounded; leave row_limit invalid.
 	if (logical_limit.limit_val.Type() == LimitNodeType::CONSTANT_VALUE) {
 		row_limit = logical_limit.limit_val.GetConstantValue();
-	} else if (logical_limit.limit_val.Type() == LimitNodeType::UNSET) {
-		row_limit = 0;
 	}
 
 	if (logical_limit.offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {

--- a/test/sql/topn/test_top_n_offset_no_limit_pruner.test
+++ b/test/sql/topn/test_top_n_offset_no_limit_pruner.test
@@ -1,0 +1,35 @@
+# name: test/sql/topn/test_top_n_offset_no_limit_pruner.test
+# description: RowGroupPruner must not truncate scan when LIMIT is unset
+# group: [topn]
+
+load {TEST_DIR}/top_n_offset_no_limit_pruner.duckdb
+
+# 300,000 rows -> 3 default-size row groups (122880 / 122880 / 54240)
+statement ok
+CREATE TABLE t AS SELECT range AS id FROM range(300000)
+
+restart
+
+# OFFSET 0 with no LIMIT must return all rows (previously returned 0)
+query I
+SELECT COUNT(*) FROM (SELECT id FROM t ORDER BY id OFFSET 0)
+----
+300000
+
+# OFFSET past a row-group boundary with no LIMIT must keep trailing groups
+query I
+SELECT COUNT(*) FROM (SELECT id FROM t ORDER BY id OFFSET 200000)
+----
+100000
+
+# Trailing values must be present (regression: group 2 was being dropped)
+query I
+SELECT MAX(id) FROM (SELECT id FROM t ORDER BY id OFFSET 200000)
+----
+299999
+
+# Sanity: large LIMIT + OFFSET still correct
+query I
+SELECT COUNT(*) FROM (SELECT id FROM t ORDER BY id LIMIT 100000000 OFFSET 200000)
+----
+100000


### PR DESCRIPTION
Fixes #22656.

`GetLimitAndOffset` treated `LimitNodeType::UNSET` as `row_limit = 0`.
Combined with `combined_limit = row_limit + row_offset`, this told the scan to stop after ~`row_offset` rows; the user-level OFFSET then skipped almost everything that was actually scanned — silently dropping the tail row groups, or returning zero rows for `OFFSET 0`.

Repro from the issue, on a persisted table with 3 row groups
(122880 / 122880 / 54240):

| Query                                | Expected | Before | After  |
|--------------------------------------|---------:|-------:|-------:|
| `... ORDER BY id OFFSET 0`           |   300000 |      0 | 300000 |
| `... ORDER BY id OFFSET 200000`      |   100000 |  45760 | 100000 |

Fix: drop the UNSET branch so `row_limit` stays invalid and `combined_limit` stays unbounded. The `offset_val` UNSET → 0 is correct and untouched (no OFFSET == OFFSET 0).

Out of scope: the related MotherDuck-only `get_partition_stats` offset-pruning bug noted in the issue.
