### PR TITLE
Break early when getting cgroupv1 CPU entry

### DIFF
--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -251,7 +251,7 @@ idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
 		for (auto &controller : controller_list) {
 			if (controller == "cpu") {
 				cpu_entry = i;
-				continue;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Found this when I was checking a default thread number issue.