### PR TITLE
Normalize db_type to lowercase on ATTACH, apply extension aliases on compare

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1295,7 +1295,10 @@ void Catalog::OnDetach(ClientContext &context) {
 
 bool Catalog::HasConflictingAttachOptions(const string &path, const AttachOptions &options) {
 	auto const db_type = options.db_type.empty() ? "duckdb" : options.db_type;
-	return GetDBPath() != path || GetCatalogType() != db_type;
+	// Normalize through the extension alias table so that equivalent forms
+	auto canonical_actual = ExtensionHelper::ApplyExtensionAlias(GetCatalogType());
+	auto canonical_requested = ExtensionHelper::ApplyExtensionAlias(db_type);
+	return GetDBPath() != path || !StringUtil::CIEquals(canonical_actual, canonical_requested);
 }
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -69,8 +69,10 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 		}
 
 		if (entry.first == "type") {
-			// Extract the database type.
-			db_type = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
+			// Extract the database type. Normalize case so that
+			// `TYPE sqlite` and `TYPE 'SQLite'` are equivalent.
+			// `TYPE sqlite` and `TYPE 'sqlite3'` are NOT equivalent, aliasing to be applied on comparison
+			db_type = StringUtil::Lower(StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR)));
 			continue;
 		}
 

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -12,7 +12,10 @@ void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	if (!extension.empty()) {
 		// path is prefixed with an extension - remove the first occurence of it
 		path = path.substr(extension.length() + 1);
-		db_type = ExtensionHelper::ApplyExtensionAlias(extension);
+		// Store the raw user prefix normalized to lowercase. The alias is
+		// applied only at lookup/comparison sites — symmetric with how the
+		// `TYPE 'xxx'` option preserves the user-supplied value.
+		db_type = StringUtil::Lower(extension);
 	}
 }
 

--- a/test/sql/extensions/attach_type_alias_conflict.test
+++ b/test/sql/extensions/attach_type_alias_conflict.test
@@ -1,0 +1,42 @@
+# name: test/sql/extensions/attach_type_alias_conflict.test
+# description: ATTACH OR REPLACE for the same database under different alias forms must not silently replace the in-flight catalog
+# group: [extensions]
+
+require sqlite_scanner
+
+statement ok
+SET autoinstall_known_extensions=true;
+
+statement ok
+SET autoload_known_extensions=true;
+
+statement ok
+ATTACH '__TEST_DIR__/foo.db' AS d (TYPE sqlite);
+
+statement ok
+CREATE OR REPLACE TABLE d.t(x INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO d.t VALUES (1);
+
+query I
+SELECT count(*) FROM d.t;
+----
+1
+
+# 'sqlite3' is just an alias of 'sqlite' (both resolve to sqlite_scanner).
+# This ATTACH refers to the SAME database; it must not replace the
+# in-flight catalog out from under the open transaction.
+statement ok
+ATTACH OR REPLACE '__TEST_DIR__/foo.db' AS d (TYPE sqlite3);
+
+query I
+SELECT count(*) FROM d.t;
+----
+1
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
Bumped in a weird bug, where:
```sql
ATTACH 'sqlite:file.db';                  --> db_type was sqlite_scanner,  now sqlite
ATTACH 'sqlite3:file.db';                 --> db_type was sqlite_scanner,  now sqlite3
ATTACH 'sqlite_scanner:file.db';          --> db_type was sqlite_scanner,  now sqlite_scanner
ATTACH 'SQLITE:file.db';                  --> db_type was sqlite_scanner,  now sqlite

ATTACH 'file.db' (TYPE sqlite);           --> db_type was sqlite,          now sqlite
ATTACH 'file.db' (TYPE sqlite3);          --> db_type was sqlite3,         now sqlite3
ATTACH 'file.db' (TYPE sqlite_scanner);   --> db_type was sqlite_scanner,  now sqlite_scanner
ATTACH 'file.db' (TYPE SQLITE);           --> db_type was SQLITE,          now sqlite
```
would behave somewhat weirdly, and different between TYPE and `<type>:`

New rule: lower case on entrance, use aliasing only on comparision.

That makes so that information is preserved, and backend could possibly dispatch depending on type (and defer aliasing to after load of the aliased extension).

Test case is somewhat quirky, but shows that ATTACH OR REPLACE mid transaction leads to wrong results.