### PR TITLE
Fix `TemporaryFileManager` reported size to reflect live blocks

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -97,6 +97,8 @@ public:
 	idx_t GetMaxIndex() const;
 	//! Whether there are free blocks available within the file
 	bool HasFreeBlocks() const;
+	//! Get the count of blocks currently holding data
+	idx_t GetUsedBlockCount() const;
 
 private:
 	//! Get/set max block index

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -142,6 +142,10 @@ idx_t BlockIndexManager::GetMaxIndex() const {
 	return max_index;
 }
 
+idx_t BlockIndexManager::GetUsedBlockCount() const {
+	return indexes_in_use.size();
+}
+
 bool BlockIndexManager::HasFreeBlocks() const {
 	return !free_indexes.empty();
 }
@@ -318,7 +322,7 @@ TemporaryFileInformation TemporaryFileHandle::GetTemporaryFile() {
 	TemporaryFileLock lock(file_lock);
 	TemporaryFileInformation info;
 	info.path = path;
-	info.size = GetPositionInFile(index_manager.GetMaxIndex());
+	info.size = GetPositionInFile(index_manager.GetUsedBlockCount());
 	return info;
 }
 


### PR DESCRIPTION
Currently, `duckdb_temporary_files()` reports the allocated file space using `max_index`, which reflects the highest allocated block index rather than the actual live data in the file. When a table is dropped, its blocks are freed, but `max_index` remains unchanged if other live blocks still exist in the file. As a result, `GetTemporaryFile()` can over-report the file size. This PR changes that to report sizes based on the current number of active blocks.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/9296#event-25701818741
Fixes: https://github.com/duckdb/duckdb/issues/22584