### PR TITLE
Set query text on PIVOT MultiStatement sub-statements at construction

### DIFF
--- a/extension/autocomplete/transformer/peg_transformer.cpp
+++ b/extension/autocomplete/transformer/peg_transformer.cpp
@@ -113,10 +113,13 @@ unique_ptr<SQLStatement> PEGTransformer::CreatePivotStatement(unique_ptr<SQLStat
 			    "PIVOT ... ON %s IN (val1, val2, ...)",
 			    pivot->column->ToString());
 		}
-		result->statements.push_back(GenerateCreateEnumStmt(std::move(pivot)));
+		auto enum_stmt = GenerateCreateEnumStmt(std::move(pivot));
+		enum_stmt->query = enum_stmt->ToString();
+		result->statements.push_back(std::move(enum_stmt));
 	}
 	result->stmt_location = statement->stmt_location;
 	result->stmt_length = statement->stmt_length;
+	statement->query = statement->ToString();
 	result->statements.push_back(std::move(statement));
 	return std::move(result);
 }

--- a/src/parser/transform/statement/transform_pivot_stmt.cpp
+++ b/src/parser/transform/statement/transform_pivot_stmt.cpp
@@ -123,10 +123,13 @@ unique_ptr<SQLStatement> Transformer::CreatePivotStatement(unique_ptr<SQLStateme
 			    "PIVOT ... ON %s IN (val1, val2, ...)",
 			    pivot->column->ToString());
 		}
-		result->statements.push_back(GenerateCreateEnumStmt(std::move(pivot)));
+		auto enum_stmt = GenerateCreateEnumStmt(std::move(pivot));
+		enum_stmt->query = enum_stmt->ToString();
+		result->statements.push_back(std::move(enum_stmt));
 	}
 	result->stmt_location = statement->stmt_location;
 	result->stmt_length = statement->stmt_length;
+	statement->query = statement->ToString();
 	result->statements.push_back(std::move(statement));
 	// FIXME: drop the types again!?
 	//	for(auto &pivot : pivot_entries) {

--- a/test/sql/pivot/pivot_query_text.test
+++ b/test/sql/pivot/pivot_query_text.test
@@ -8,13 +8,15 @@ CREATE TABLE t(c VARCHAR, v INTEGER);
 statement ok
 INSERT INTO t VALUES ('a', 1), ('b', 2);
 
-# current_query() inside the PIVOT's SELECT child returns that child's own ToString(). The
-# auto-generated enum name (a UUID) is stripped with regexp_replace so the expected text is
-# deterministic.
+statement ok
+CREATE TABLE captured AS
+PIVOT (SELECT c, v, current_query() AS q FROM t) ON c USING ANY_VALUE(q) ORDER BY v;
+
 query III
-PIVOT (SELECT c, v,
-              regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q
-       FROM t) ON c USING ANY_VALUE(q) ORDER BY v;
+SELECT v,
+       regexp_replace(a, '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS a,
+       regexp_replace(b, '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS b
+FROM captured ORDER BY v;
 ----
-1	SELECT * FROM (SELECT c, v, regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v	NULL
-2	NULL	SELECT * FROM (SELECT c, v, regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v
+1	CREATE TABLE captured AS SELECT * FROM (SELECT c, v, current_query() AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v	NULL
+2	NULL	CREATE TABLE captured AS SELECT * FROM (SELECT c, v, current_query() AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v

--- a/test/sql/pivot/pivot_query_text.test
+++ b/test/sql/pivot/pivot_query_text.test
@@ -1,0 +1,20 @@
+# name: test/sql/pivot/pivot_query_text.test
+# description: PIVOT MultiStatement sub-statements should have their query field populated at construction
+# group: [pivot]
+
+statement ok
+CREATE TABLE t(c VARCHAR, v INTEGER);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2);
+
+# current_query() inside the PIVOT's SELECT child returns that child's own ToString(). The
+# auto-generated enum name (a UUID) is stripped with regexp_replace so the expected text is
+# deterministic.
+query III
+PIVOT (SELECT c, v,
+              regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q
+       FROM t) ON c USING ANY_VALUE(q) ORDER BY v;
+----
+1	SELECT * FROM (SELECT c, v, regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v	NULL
+2	NULL	SELECT * FROM (SELECT c, v, regexp_replace(current_query(), '__pivot_enum_[0-9a-f\-]+', '__pivot_enum_X') AS q FROM t) PIVOT (any_value(q) FOR (c) IN "__pivot_enum_X") ORDER BY v


### PR DESCRIPTION
PIVOT is rewritten into a MultiStatement whose children (synthetic CREATE TYPE enum(s) plus the rewritten SELECT) inherit no query text. Any read of current_query() / active_query->query from inside a child saw an empty string.

Populate each child's query field at construction in CreatePivotStatement using the child's own ToString()