### PR TITLE
Follow-up fix: use CheckExecuteCount instead of getting count of non-const member

### DIFF
--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -102,7 +102,7 @@ bool ExecuteFunctionState::TryExecuteDictionaryExpression(const BoundFunctionExp
 			// Offset the input dictionary
 			Vector offset_input(DictionaryVector::Child(unary_input), offset, offset + count);
 			input_chunk.data[input_col_idx.GetIndex()].Reference(offset_input);
-			input_chunk.SetCardinality(count);
+			input_chunk.SetChildCardinality(count);
 
 			// Execute, storing the result in an intermediate vector, and copying it to the output dictionary
 			Vector output_intermediate(result.GetType());

--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -280,35 +280,32 @@ public:
 	}
 
 private:
-	static idx_t GetExecuteCount(const Vector &left, const Vector &right) {
-		const bool left_const = left.GetVectorType() == VectorType::CONSTANT_VECTOR;
-		const bool right_const = right.GetVectorType() == VectorType::CONSTANT_VECTOR;
-		if (!left_const && !right_const && left.size() != right.size()) {
+	static idx_t CheckExecuteCount(const Vector &left, const Vector &right) {
+		if (left.size() != right.size()) {
 			throw InternalException(
 			    "Mismatch in input vector sizes for BinaryExecutor - left has %d rows but right has %d", left.size(),
 			    right.size());
 		}
-		return left_const ? right.size() : left.size();
+		return left.size();
 	}
 
 public:
 	//! Convenience overloads without explicit count - count is derived from the input vectors.
-	//! These add a size-mismatch check for non-constant vectors.
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE,
 	          class FUNC = std::function<RESULT_TYPE(LEFT_TYPE, RIGHT_TYPE)>>
 	static void Execute(const Vector &left, const Vector &right, Vector &result, FUNC fun) {
-		Execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result, GetExecuteCount(left, right), fun);
+		Execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result, CheckExecuteCount(left, right), fun);
 	}
 
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP,
 	          class OPWRAPPER = BinarySingleArgumentOperatorWrapper>
 	static void Execute(const Vector &left, const Vector &right, Vector &result) {
-		Execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP, OPWRAPPER>(left, right, result, GetExecuteCount(left, right));
+		Execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP, OPWRAPPER>(left, right, result, CheckExecuteCount(left, right));
 	}
 
 	template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
 	static void ExecuteStandard(const Vector &left, const Vector &right, Vector &result) {
-		ExecuteStandard<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, GetExecuteCount(left, right));
+		ExecuteStandard<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, CheckExecuteCount(left, right));
 	}
 
 public:

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -386,23 +386,16 @@ private:
 		}
 	}
 
-	static idx_t GetExecuteCount(std::initializer_list<const Vector *> inputs) {
-		idx_t result = 0;
+	static idx_t CheckExecuteCount(std::initializer_list<const Vector *> inputs) {
+		idx_t count = (*inputs.begin())->size();
 		for (auto *v : inputs) {
-			if (v->GetVectorType() != VectorType::CONSTANT_VECTOR) {
-				if (result != 0 && result != v->size()) {
-					throw InternalException("Mismatch in input vector sizes for GenericExecutor - "
-					                        "expected %d rows but got %d",
-					                        result, v->size());
-				}
-				result = v->size();
+			if (v->size() != count) {
+				throw InternalException("Mismatch in input vector sizes for GenericExecutor - "
+				                        "expected %d rows but got %d",
+				                        count, v->size());
 			}
 		}
-		if (result == 0) {
-			// all constant - use the first one's size
-			result = (*inputs.begin())->size();
-		}
-		return result;
+		return count;
 	}
 
 public:
@@ -420,7 +413,7 @@ public:
 	}
 	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
 	static void ExecuteBinary(const Vector &a, const Vector &b, Vector &result, FUNC fun) {
-		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, FUNC>(a, b, result, GetExecuteCount({&a, &b}), fun);
+		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, FUNC>(a, b, result, CheckExecuteCount({&a, &b}), fun);
 	}
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE,
 	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
@@ -432,7 +425,7 @@ public:
 	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
 	static void ExecuteTernary(const Vector &a, const Vector &b, const Vector &c, Vector &result, FUNC fun) {
 		ExecuteTernaryInternal<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(a, b, c, result,
-		                                                                  GetExecuteCount({&a, &b, &c}), fun);
+		                                                                  CheckExecuteCount({&a, &b, &c}), fun);
 	}
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE,
 	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
@@ -445,7 +438,7 @@ public:
 	static void ExecuteQuaternary(const Vector &a, const Vector &b, const Vector &c, const Vector &d, Vector &result,
 	                              FUNC fun) {
 		ExecuteQuaternaryInternal<A_TYPE, B_TYPE, C_TYPE, D_TYPE, RESULT_TYPE, FUNC>(
-		    a, b, c, d, result, GetExecuteCount({&a, &b, &c, &d}), fun);
+		    a, b, c, d, result, CheckExecuteCount({&a, &b, &c, &d}), fun);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/variadic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/variadic_executor.hpp
@@ -213,26 +213,18 @@ private:
 
 private:
 	//-------------------------------------------------------------------
-	// Derive count from inputs: first non-constant vector's size, or first vector's size if all constant.
-	// Also checks that all non-constant vectors agree on size.
+	// Verify all inputs have the same size and return that size.
 	//-------------------------------------------------------------------
 	template <size_t N>
-	static idx_t GetCount(const std::array<VectorRef, N> &inputs) {
-		idx_t count = 0;
-		for (size_t i = 0; i < N; i++) {
-			if (inputs[i].get().GetVectorType() != VectorType::CONSTANT_VECTOR) {
-				if (count == 0) {
-					count = inputs[i].get().size();
-				} else if (inputs[i].get().size() != count) {
-					throw InternalException(
-					    "Mismatch in input vector sizes for VariadicExecutor - expected %d rows but got %d", count,
-					    inputs[i].get().size());
-				}
+	static idx_t CheckExecuteCount(const std::array<VectorRef, N> &inputs) {
+		static_assert(N > 0, "VariadicExecutor requires at least one input");
+		idx_t count = inputs[0].get().size();
+		for (size_t i = 1; i < N; i++) {
+			if (inputs[i].get().size() != count) {
+				throw InternalException(
+				    "Mismatch in input vector sizes for VariadicExecutor - expected %d rows but got %d", count,
+				    inputs[i].get().size());
 			}
-		}
-		if (count == 0 && N > 0) {
-			// All inputs are constant vectors; use the first vector's size (set to the chunk size by execute_constant)
-			count = inputs[0].get().size();
 		}
 		return count;
 	}
@@ -244,7 +236,7 @@ public:
 	template <class RESULT_TYPE, class... ARGS, class FUN>
 	static void Execute(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result, FUN fun) {
 		constexpr size_t N = sizeof...(ARGS);
-		const idx_t count = GetCount<N>(inputs);
+		const idx_t count = CheckExecuteCount<N>(inputs);
 		ExecuteImplWithIndices<RESULT_TYPE, VariadicLambdaWrapper, FUN, ARGS...>(inputs, result, count, fun,
 		                                                                         std::index_sequence_for<ARGS...> {});
 	}
@@ -265,7 +257,7 @@ public:
 	template <class RESULT_TYPE, class OP, class... ARGS>
 	static void ExecuteStandard(std::array<VectorRef, sizeof...(ARGS)> inputs, Vector &result) {
 		constexpr size_t N = sizeof...(ARGS);
-		const idx_t count = GetCount<N>(inputs);
+		const idx_t count = CheckExecuteCount<N>(inputs);
 		bool dummy = false;
 		ExecuteImplWithIndices<RESULT_TYPE, VariadicStandardOperatorWrapper<OP>, bool, ARGS...>(
 		    inputs, result, count, dummy, std::index_sequence_for<ARGS...> {});


### PR DESCRIPTION
Follow-up fix to https://github.com/duckdb/duckdb/pull/22695