### PR TITLE
Add COPY TO sink result callback

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -1736,8 +1736,8 @@ SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, DataChunk &ch
 	if (batch_analyzer.MeetsFlushCriteria()) {
 		lstate.batch_append_state.current_chunk_state.handles.clear();
 		auto &file_state_ptr = per_thread_output ? lstate.global_file_state : gstate.global_state;
-		PrepareAndFlushBatch(context.client, gstate, file_state_ptr, gstate.create_file_state_fun,
-		                     std::move(lstate.batch));
+		return PrepareAndFlushBatch(context.client, gstate, file_state_ptr, gstate.create_file_state_fun,
+		                            std::move(lstate.batch));
 	}
 
 	return SinkResultType::NEED_MORE_INPUT;
@@ -1849,13 +1849,15 @@ SinkFinalizeType PhysicalCopyToFile::Finalize(Pipeline &pipeline, Event &event, 
 	return SinkFinalizeType::READY;
 }
 
-void PhysicalCopyToFile::PrepareAndFlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
-                                              unique_ptr<GlobalFileState> &file_state_ptr,
-                                              const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
-                                              unique_ptr<ColumnDataCollection> batch) const {
+SinkResultType
+PhysicalCopyToFile::PrepareAndFlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
+                                         unique_ptr<GlobalFileState> &file_state_ptr,
+                                         const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
+                                         unique_ptr<ColumnDataCollection> batch) const {
 	auto [batch_analyzer, prepared_batch] =
 	    PrepareBatch(context, gstate_p, file_state_ptr, create_file_state_fun, std::move(batch));
-	FlushBatch(context, gstate_p, file_state_ptr, create_file_state_fun, batch_analyzer, std::move(prepared_batch));
+	return FlushBatch(context, gstate_p, file_state_ptr, create_file_state_fun, batch_analyzer,
+	                  std::move(prepared_batch));
 }
 
 //===--------------------------------------------------------------------===//
@@ -1883,9 +1885,11 @@ static unique_ptr<PreparedBatchData> PrepareLegacyCopyBatch(unique_ptr<ColumnDat
 	return make_uniq<LegacyCopyPreparedBatch>(std::move(batch));
 }
 
-static void FlushLegacyCopyBatch(ClientContext &context, const CopyFunction &function, FunctionData &bind_data,
-                                 GlobalFunctionData &gstate, PreparedBatchData &prepared_batch) {
-	if (!function.copy_to_initialize_local || !function.copy_to_sink || !function.copy_to_combine) {
+static SinkResultType FlushLegacyCopyBatch(ClientContext &context, const CopyFunction &function,
+                                           FunctionData &bind_data, GlobalFunctionData &gstate,
+                                           PreparedBatchData &prepared_batch) {
+	if (!function.copy_to_initialize_local || (!function.copy_to_sink && !function.copy_to_sink_with_result) ||
+	    !function.copy_to_combine) {
 		throw InternalException("Legacy copy function is missing required sink/combine callbacks");
 	}
 
@@ -1893,10 +1897,19 @@ static void FlushLegacyCopyBatch(ClientContext &context, const CopyFunction &fun
 	ThreadContext thread_context(context);
 	ExecutionContext execution_context(context, thread_context, nullptr);
 	auto local_state = function.copy_to_initialize_local(execution_context, bind_data);
+	auto result = SinkResultType::NEED_MORE_INPUT;
 	for (auto &chunk : legacy_batch.collection->Chunks()) {
-		function.copy_to_sink(execution_context, bind_data, gstate, *local_state, chunk);
+		if (function.copy_to_sink_with_result) {
+			result = function.copy_to_sink_with_result(execution_context, bind_data, gstate, *local_state, chunk);
+			if (result != SinkResultType::NEED_MORE_INPUT) {
+				break;
+			}
+		} else {
+			function.copy_to_sink(execution_context, bind_data, gstate, *local_state, chunk);
+		}
 	}
 	function.copy_to_combine(execution_context, bind_data, gstate, *local_state);
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -1931,12 +1944,13 @@ PhysicalCopyToFile::PrepareBatch(ClientContext &context, GlobalSinkState &gstate
 	return {batch_analyzer, function.prepare_batch(context, *bind_data, *prepare_global_state->data, std::move(batch))};
 }
 
-void PhysicalCopyToFile::FlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
-                                    unique_ptr<GlobalFileState> &file_state_ptr,
-                                    const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
-                                    const CopyFunctionBatchAnalyzer &batch_analyzer,
-                                    unique_ptr<PreparedBatchData> prepared_batch) const {
+SinkResultType PhysicalCopyToFile::FlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
+                                              unique_ptr<GlobalFileState> &file_state_ptr,
+                                              const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
+                                              const CopyFunctionBatchAnalyzer &batch_analyzer,
+                                              unique_ptr<PreparedBatchData> prepared_batch) const {
 	auto &gstate = gstate_p.Cast<CopyToFileGlobalState>();
+	auto result = SinkResultType::NEED_MORE_INPUT;
 
 	while (true) {
 		// Decide which file to flush to
@@ -1965,13 +1979,14 @@ void PhysicalCopyToFile::FlushBatch(ClientContext &context, GlobalSinkState &gst
 			            {"size", to_string(batch_analyzer.current_batch_size_bytes)},
 			            {"reason", EnumUtil::ToString(batch_analyzer.ToReason())}});
 			if (UsesLegacyCopyBatchAPI(function)) {
-				FlushLegacyCopyBatch(context, function, *bind_data, *file_state_ptr->data, *prepared_batch);
+				result = FlushLegacyCopyBatch(context, function, *bind_data, *file_state_ptr->data, *prepared_batch);
 			} else {
 				function.flush_batch(context, *bind_data, *file_state_ptr->data, *prepared_batch);
 			}
 			break;
 		}
 	}
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/function/copy_function.cpp
+++ b/src/function/copy_function.cpp
@@ -7,9 +7,10 @@ namespace duckdb {
 CopyFunction::CopyFunction(const string &name)
     : Function(name), plan(nullptr), copy_to_select(nullptr), copy_to_bind(nullptr), copy_options(nullptr),
       copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr), copy_to_get_written_statistics(nullptr),
-      copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), execution_mode(nullptr),
-      initialize_operator(nullptr), prepare_batch(nullptr), flush_batch(nullptr), file_size_bytes(nullptr),
-      desired_batch_size(nullptr), serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
+      copy_to_sink(nullptr), copy_to_sink_with_result(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr),
+      execution_mode(nullptr), initialize_operator(nullptr), prepare_batch(nullptr), flush_batch(nullptr),
+      file_size_bytes(nullptr), desired_batch_size(nullptr), serialize(nullptr), deserialize(nullptr),
+      copy_from_bind(nullptr) {
 }
 
 CopyOption::CopyOption() : type(LogicalType::ANY), mode(CopyOptionMode::READ_WRITE) {

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -50,18 +50,19 @@ public:
 
 	bool Rotate() const;
 
-	void PrepareAndFlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
-	                          unique_ptr<GlobalFileState> &file_state_ptr,
-	                          const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
-	                          unique_ptr<ColumnDataCollection> batch) const;
+	SinkResultType PrepareAndFlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
+	                                    unique_ptr<GlobalFileState> &file_state_ptr,
+	                                    const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
+	                                    unique_ptr<ColumnDataCollection> batch) const;
 	pair<const CopyFunctionBatchAnalyzer, unique_ptr<PreparedBatchData>>
 	PrepareBatch(ClientContext &context, GlobalSinkState &gstate_p, unique_ptr<GlobalFileState> &file_state_ptr,
 	             const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
 	             unique_ptr<ColumnDataCollection> batch) const;
-	void FlushBatch(ClientContext &context, GlobalSinkState &gstate_p, unique_ptr<GlobalFileState> &file_state_ptr,
-	                const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
-	                const CopyFunctionBatchAnalyzer &batch_analyzer,
-	                unique_ptr<PreparedBatchData> prepared_batch) const;
+	SinkResultType FlushBatch(ClientContext &context, GlobalSinkState &gstate_p,
+	                          unique_ptr<GlobalFileState> &file_state_ptr,
+	                          const std::function<unique_ptr<GlobalFileState>()> &create_file_state_fun,
+	                          const CopyFunctionBatchAnalyzer &batch_analyzer,
+	                          unique_ptr<PreparedBatchData> prepared_batch) const;
 
 public:
 	//===--------------------------------------------------------------------===//

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -142,6 +142,9 @@ typedef unique_ptr<GlobalFunctionData> (*copy_to_initialize_global_t)(ClientCont
                                                                       const string &file_path);
 typedef void (*copy_to_sink_t)(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
                                LocalFunctionData &lstate, DataChunk &input);
+typedef SinkResultType (*copy_to_sink_with_result_t)(ExecutionContext &context, FunctionData &bind_data,
+                                                     GlobalFunctionData &gstate, LocalFunctionData &lstate,
+                                                     DataChunk &input);
 typedef void (*copy_to_combine_t)(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
                                   LocalFunctionData &lstate);
 typedef void (*copy_to_finalize_t)(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate);
@@ -243,6 +246,7 @@ public:
 	copy_to_initialize_global_t copy_to_initialize_global;
 	copy_to_get_written_statistics_t copy_to_get_written_statistics;
 	copy_to_sink_t copy_to_sink;
+	copy_to_sink_with_result_t copy_to_sink_with_result;
 	copy_to_combine_t copy_to_combine;
 	copy_to_finalize_t copy_to_finalize;
 	copy_to_execution_mode_t execution_mode;

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_API_OBJECTS
     test_uuid.cpp
     test_insertion_order_preserving_map.cpp
     test_bignum.cpp
+    test_copy_function.cpp
     test_threads.cpp
     test_windows_header_compatibility.cpp
     test_windows_unicode_path.cpp

--- a/test/api/test_copy_function.cpp
+++ b/test/api/test_copy_function.cpp
@@ -1,0 +1,88 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/function/copy_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/extension_manager.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct FinishCopyBindData : public FunctionData {
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<FinishCopyBindData>();
+	}
+
+	bool Equals(const FunctionData &) const override {
+		return true;
+	}
+};
+
+struct FinishCopyLocalState : public LocalFunctionData {
+};
+
+struct FinishCopyGlobalState : public GlobalFunctionData {
+	idx_t chunks_seen = 0;
+};
+
+static unique_ptr<FunctionData> FinishCopyBind(ClientContext &, CopyFunctionBindInput &, const vector<string> &,
+                                               const vector<LogicalType> &) {
+	return make_uniq<FinishCopyBindData>();
+}
+
+static unique_ptr<LocalFunctionData> FinishCopyInitializeLocal(ExecutionContext &, FunctionData &) {
+	return make_uniq<FinishCopyLocalState>();
+}
+
+static unique_ptr<GlobalFunctionData> FinishCopyInitializeGlobal(ClientContext &, FunctionData &, const string &) {
+	return make_uniq<FinishCopyGlobalState>();
+}
+
+static SinkResultType FinishCopySink(ExecutionContext &, FunctionData &, GlobalFunctionData &gstate,
+                                     LocalFunctionData &, DataChunk &) {
+	auto &state = gstate.Cast<FinishCopyGlobalState>();
+	state.chunks_seen++;
+	return SinkResultType::FINISHED;
+}
+
+static void FinishCopyCombine(ExecutionContext &, FunctionData &, GlobalFunctionData &, LocalFunctionData &) {
+}
+
+static void FinishCopyFinalize(ClientContext &, FunctionData &, GlobalFunctionData &gstate) {
+	auto &state = gstate.Cast<FinishCopyGlobalState>();
+	REQUIRE(state.chunks_seen == 1);
+}
+
+static void RegisterFinishCopyFunction(DuckDB &db) {
+	CopyFunction function("finish_copy");
+	function.copy_to_bind = FinishCopyBind;
+	function.copy_to_initialize_local = FinishCopyInitializeLocal;
+	function.copy_to_initialize_global = FinishCopyInitializeGlobal;
+	function.copy_to_sink_with_result = FinishCopySink;
+	function.copy_to_combine = FinishCopyCombine;
+	function.copy_to_finalize = FinishCopyFinalize;
+
+	ExtensionInfo extension_info {};
+	ExtensionActiveLoad load_info {*db.instance, extension_info, "finish_copy_extension", ""};
+	ExtensionLoader loader {load_info};
+	loader.RegisterFunction(std::move(function));
+}
+
+} // namespace
+
+TEST_CASE("COPY TO supports sink result callbacks", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	RegisterFinishCopyFunction(db);
+
+	auto result =
+	    con.Query("COPY (SELECT i FROM range(8192) tbl(i)) TO 'unused' (FORMAT finish_copy, USE_TMP_FILE false)");
+	REQUIRE_NO_FAIL(*result);
+	auto chunk = result->Fetch();
+	REQUIRE(chunk);
+	auto copied_rows = chunk->GetValue(0, 0).GetValue<int64_t>();
+	REQUIRE(copied_rows > 0);
+	REQUIRE(copied_rows < 8192);
+}


### PR DESCRIPTION
## Summary

This PR adds an optional `copy_to_sink_with_result` callback for `COPY TO` functions that use the legacy sink/combine API.

The existing legacy `copy_to_sink` callback returns `void`, so `PhysicalCopyToFile::Sink` always reports `SinkResultType::NEED_MORE_INPUT` after flushing a legacy COPY batch. That makes it impossible for a COPY implementation to propagate `FINISHED` or `BLOCKED` through the physical sink contract. The new callback keeps the existing API intact and gives copy functions an opt-in path when they need to return a sink result.

## Behavior

- Adds `copy_to_sink_with_result_t` to `CopyFunction`.
- Initializes the new callback to `nullptr`, so existing copy functions keep their current behavior.
- Uses `copy_to_sink_with_result` in the legacy COPY batch path when it is set.
- Falls back to the existing `copy_to_sink` callback and returns `NEED_MORE_INPUT` when the new callback is not set.
- Propagates the returned `SinkResultType` back through `PhysicalCopyToFile::Sink`.
- Still runs the legacy combine callback for the local copy state after flushing the batch.

## Testing

- Adds a C++ API test that registers a custom `COPY TO` function using `copy_to_sink_with_result` instead of `copy_to_sink`. The callback returns `FINISHED` on the first chunk, and the test verifies that COPY stops before consuming the full input.
- Runs the existing C API COPY function test to verify the old `copy_to_sink` path remains unchanged.

Commands run:

```text
cmake --build build/debug --target unittest -j 8
build/debug/test/unittest "COPY TO supports sink result callbacks"
build/debug/test/unittest "Test Copy Functions in C API"
```