### PR TITLE
Print one-line test summary after log group

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -582,6 +582,15 @@ class ConfigInvocation:
     test_config: str | None
 
 
+@dataclass(frozen=True)
+class ConfigRunResult:
+    returncode: int
+    passed_tests: int
+    failed_tests: int
+    skipped_tests: int
+    elapsed_seconds: float
+
+
 def build_test_flags(base_flags: str, test_config: str | None):
     if not test_config:
         return base_flags
@@ -621,10 +630,12 @@ def run_single_config(
     batch_size: int,
     test_list_files: list[Path],
     invocation: ConfigInvocation,
+    print_config_header: bool,
 ):
     if stop_requested():
-        return 130
-    print(f"=== config run: {invocation.label} ===")
+        return ConfigRunResult(returncode=130, passed_tests=0, failed_tests=0, skipped_tests=0, elapsed_seconds=0.0)
+    if print_config_header:
+        print(f"=== config run: {invocation.label} ===")
     generated_test_list: Path | None = None
     try:
         if args.test_list is not None and len(test_list_files) == 1:
@@ -652,7 +663,7 @@ def run_single_config(
 
         tests = load_tests(config.test_list)
         if stop_requested():
-            return 130
+            return ConfigRunResult(returncode=130, passed_tests=0, failed_tests=0, skipped_tests=0, elapsed_seconds=0.0)
         if args.changed_tests is not None:
             merged_names = {test.name for test in tests}
             base_names = {test.name for test in load_tests(args.test_list)}
@@ -660,7 +671,6 @@ def run_single_config(
             print(f"added {added_test_count} tests from --changed-tests file to the smoke test run")
         computed_batch_size = compute_batch_size(len(tests), config)
 
-        print(f"found {len(tests)} tests")
         config_values = asdict(config)
         config_values["batch_size"] = computed_batch_size
         config_values.pop("test_list", None)
@@ -671,7 +681,7 @@ def run_single_config(
         print(f"config: {config_output}")
 
         batches = list(chunked(tests, computed_batch_size))
-        return run_tests(config, batches)
+        return run_tests(config, batches, len(tests))
     finally:
         if generated_test_list is not None:
             generated_test_list.unlink(missing_ok=True)
@@ -716,7 +726,6 @@ def main_impl(argv: list[str] | None = None):
     else:
         batch_size = args.batch_size
     failed_configs = []
-    keep_groups_open = False
     if len(config_invocations) > 1:
         print(f"running {len(config_invocations)} configs")
     for invocation in config_invocations:
@@ -727,8 +736,11 @@ def main_impl(argv: list[str] | None = None):
         if use_config_groups:
             print(f"::group::test config: {invocation.label}")
             group_open = True
+        print_config_header = not use_config_groups and not (
+            len(config_invocations) == 1 and invocation.label == "default"
+        )
         try:
-            returncode = run_single_config(
+            run_result = run_single_config(
                 args,
                 unittest_bin,
                 workers,
@@ -738,15 +750,29 @@ def main_impl(argv: list[str] | None = None):
                 batch_size,
                 test_list_files,
                 invocation,
+                print_config_header,
             )
         except Exception as exc:
             print(f"error: {exc}")
-            returncode = 1
-        failed = returncode not in (0, 130)
-        if failed:
-            keep_groups_open = True
-        if group_open and not keep_groups_open:
+            run_result = ConfigRunResult(
+                returncode=1, passed_tests=0, failed_tests=1, skipped_tests=0, elapsed_seconds=0.0
+            )
+        returncode = run_result.returncode
+        if group_open:
             print("::endgroup::")
+        if returncode in (0, 1):
+            if run_result.failed_tests > 0:
+                print(
+                    "❌ ran tests: "
+                    f"{run_result.passed_tests} passed, {run_result.failed_tests} failed, "
+                    f"{run_result.skipped_tests} skipped in {run_result.elapsed_seconds:.0f}s"
+                )
+            else:
+                print(
+                    "ran tests: "
+                    f"{run_result.passed_tests} passed, {run_result.skipped_tests} skipped "
+                    f"in {run_result.elapsed_seconds:.0f}s"
+                )
         if returncode == 130:
             print("interrupted")
             return 130
@@ -756,7 +782,8 @@ def main_impl(argv: list[str] | None = None):
     if failed_configs:
         print(f"error: {len(failed_configs)} config runs failed: {', '.join(failed_configs)}")
         return 1
-    print(f"all {len(config_invocations)} config runs passed")
+    if len(config_invocations) > 1:
+        print(f"all {len(config_invocations)} config runs passed")
     return 0
 
 
@@ -774,7 +801,7 @@ def invoke(argv: list[str], cwd: Path | None = None) -> InvocationResult:
     return InvocationResult(returncode=returncode, stdout=stdout_buffer.getvalue(), stderr=stderr_buffer.getvalue())
 
 
-def run_tests(config: TestRunnerConfig, batches):
+def run_tests(config: TestRunnerConfig, batches, total_tests: int):
     start = time.monotonic()
     state = BatchRunState()
     progress = DotProgressBar(len(batches))
@@ -820,11 +847,10 @@ def run_tests(config: TestRunnerConfig, batches):
                 if result["failed"]:
                     if handle_failed_batch(ctx, batch_info, result):
                         continue
-                else:
-                    skipped_count, skipped_reasons = extract_skipped_test_output(result["stdout"], result["stderr"])
-                    total_skipped_tests += skipped_count
-                    for reason, count in skipped_reasons.items():
-                        skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
+                skipped_count, skipped_reasons = extract_skipped_test_output(result["stdout"], result["stderr"])
+                total_skipped_tests += skipped_count
+                for reason, count in skipped_reasons.items():
+                    skipped_reason_counts[reason] = skipped_reason_counts.get(reason, 0) + count
                 progress.advance(next_batch_idx - len(future_to_batch))
 
             if not state.stop_launching and not stop_requested():
@@ -833,21 +859,23 @@ def run_tests(config: TestRunnerConfig, batches):
     progress.flush_line()
     elapsed = time.monotonic() - start
     if stop_requested():
-        return 130
+        return ConfigRunResult(returncode=130, passed_tests=0, failed_tests=0, skipped_tests=0, elapsed_seconds=elapsed)
     if state.failed_count:
         print(f"error: found {state.failed_count} test batch failures in {elapsed:.0f}s")
-        return 1
-
-    if total_skipped_tests > 0:
-        print(f"all tests passed in {elapsed:.0f}s ({total_skipped_tests} skipped tests)")
-    else:
-        print(f"all tests passed in {elapsed:.0f}s")
     if skipped_reason_counts:
         print()
         print("Skipped tests for the following reasons:")
         for reason in sorted(skipped_reason_counts):
             print(f"{reason}: {skipped_reason_counts[reason]}")
-    return 0
+    failed_tests = state.failed_count
+    passed_tests = max(0, total_tests - failed_tests - total_skipped_tests)
+    return ConfigRunResult(
+        returncode=1 if state.failed_count else 0,
+        passed_tests=passed_tests,
+        failed_tests=failed_tests,
+        skipped_tests=total_skipped_tests,
+        elapsed_seconds=elapsed,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -99,8 +99,8 @@ mode skip unsupported: 1
                     test_list_path.unlink(missing_ok=True)
 
                 self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-                self.assertIn("all tests passed in ", proc.stdout)
-                self.assertIn(f"({case['expected_skip_count']} skipped tests)", proc.stdout)
+                self.assertIn("ran tests: ", proc.stdout)
+                self.assertIn(f", {case['expected_skip_count']} skipped in ", proc.stdout)
                 self.assertIn("Skipped tests for the following reasons:", proc.stdout)
                 for expected_reason in case["expected_reasons"]:
                     self.assertIn(expected_reason, proc.stdout)
@@ -157,7 +157,7 @@ mode skip unsupported: 1
             test_list_path.unlink(missing_ok=True)
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-        self.assertIn("(5 skipped tests)", proc.stdout)
+        self.assertIn(", 5 skipped in ", proc.stdout)
         self.assertIn("require windows: 1", proc.stdout)
         self.assertIn("require-env A: 3", proc.stdout)
         self.assertIn("require-env B: 1", proc.stdout)
@@ -201,7 +201,7 @@ require-env FOO: 1
             test_list_path.unlink(missing_ok=True)
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-        self.assertIn("(4 skipped tests)", proc.stdout)
+        self.assertIn(", 4 skipped in ", proc.stdout)
         self.assertIn("require json: 3", proc.stdout)
         self.assertIn("require-env FOO: 1", proc.stdout)
 
@@ -256,7 +256,7 @@ require windows: 2
             test_list_path.unlink(missing_ok=True)
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-        self.assertIn("(2 skipped tests)", proc.stdout)
+        self.assertIn(", 2 skipped in ", proc.stdout)
         summary_block = proc.stdout.rsplit("Skipped tests for the following reasons:", 1)[-1]
         self.assertIn("require windows: 2", summary_block)
         self.assertNotIn("require windows: 7", summary_block)
@@ -305,10 +305,10 @@ require windows: 2
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("generated test list using:", proc.stdout)
-        self.assertIn("found 2 tests", proc.stdout)
+        self.assertNotIn("found 2 tests", proc.stdout)
         self.assertIn("test/sql/slow.test took", proc.stdout)
         self.assertIn("test/sql/fast.test took", proc.stdout)
-        self.assertIn("all tests passed in ", proc.stdout)
+        self.assertIn("ran tests: ", proc.stdout)
 
     def test_runs_with_echo_test_command(self):
         test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
@@ -331,8 +331,10 @@ require windows: 2
             test_list_path.unlink(missing_ok=True)
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-        self.assertIn("found 2 tests", proc.stdout)
-        self.assertIn("all tests passed in ", proc.stdout)
+        self.assertNotIn("found 2 tests", proc.stdout)
+        self.assertIn("ran tests: ", proc.stdout)
+        self.assertNotIn("=== config run: default ===", proc.stdout)
+        self.assertNotIn("all 1 config runs passed", proc.stdout)
 
     def test_changed_tests_flag_uses_second_list_file(self):
         base_test_list_path = create_temp_file(
@@ -393,7 +395,7 @@ require windows: 2
         self.assertIn(f"-f {base_test_list_path}", proc.stdout)
         self.assertIn(f"-f {changed_test_list_path}", proc.stdout)
         self.assertIn("added 1 tests from --changed-tests file to the smoke test run", proc.stdout)
-        self.assertIn("all tests passed in ", proc.stdout)
+        self.assertIn("ran tests: ", proc.stdout)
 
     def test_retries_failed_fake_job(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
@@ -441,7 +443,7 @@ require windows: 2
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("retrying failed test batch 0 (attempt 1/1, retry 1/4)", proc.stdout)
         self.assertIn("fake failure", proc.stdout)
-        self.assertIn("all tests passed in ", proc.stdout)
+        self.assertIn("ran tests: ", proc.stdout)
 
     def test_retries_timed_out_sleep_job(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
@@ -488,7 +490,7 @@ require windows: 2
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn(f"batch timed out after {batch_timeout} seconds", proc.stdout)
         self.assertIn("retrying failed test", proc.stdout)
-        self.assertIn("all tests passed in ", proc.stdout)
+        self.assertIn("ran tests: ", proc.stdout)
 
     def test_multiple_test_configs_run_independently(self):
         listed_tests_path = create_temp_file(
@@ -539,7 +541,7 @@ require windows: 2
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("running 2 configs", proc.stdout)
-        self.assertEqual(proc.stdout.count("found 1 tests"), 2)
+        self.assertEqual(proc.stdout.count("ran tests: "), 2)
         self.assertIn("all 2 config runs passed", proc.stdout)
 
     def test_multiple_test_configs_aggregate_failure(self):
@@ -625,7 +627,10 @@ require windows: 2
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("::group::test config: test/configs/a.json", proc.stdout)
         self.assertIn("::group::test config: test/configs/b.json", proc.stdout)
+        self.assertNotIn("=== config run: test/configs/a.json ===", proc.stdout)
+        self.assertNotIn("=== config run: test/configs/b.json ===", proc.stdout)
         self.assertEqual(proc.stdout.count("::endgroup::"), 2)
+        self.assertGreaterEqual(proc.stdout.count("ran tests: "), 2)
 
     def test_ci_groups_stay_open_after_first_failed_config(self):
         failing_helper = create_temp_file(
@@ -667,7 +672,8 @@ require windows: 2
         self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
         self.assertIn("::group::test config: test/configs/fail.json", proc.stdout)
         self.assertIn("::group::test config: test/configs/pass.json", proc.stdout)
-        self.assertEqual(proc.stdout.count("::endgroup::"), 0)
+        self.assertEqual(proc.stdout.count("::endgroup::"), 2)
+        self.assertIn("❌ ran tests: ", proc.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Turn the test run CI logs:
```
CI detected, enabling retry=2 per batch
running 31 configs
▶ test config: test/configs/verify_statement_copy.json
▶ test config: test/configs/verify_statement_to_string.json
▶ test config: test/configs/verify_statement_explain.json
▶ test config: test/configs/verify_statement_prepare.json
▶ test config: test/configs/verify_serializer.json
▶ test config: test/configs/verify_stats.json
...
```
into
```
CI detected, enabling retry=2 per batch
running 31 configs
▶ test config: test/configs/verify_statement_copy.json
ran tests: 4147 passed, 12 skipped in 34s
▶ test config: test/configs/verify_statement_to_string.json
ran tests: 4135 passed, 14 skipped in 26s
▶ test config: test/configs/verify_statement_explain.json
ran tests: 4117 passed, 14 skipped in 28s
▶ test config: test/configs/verify_statement_prepare.json
ran tests: 4098 passed, 44 skipped in 27s
▶ test config: test/configs/verify_serializer.json
ran tests: 4118 passed, 11 skipped in 23s
▶ test config: test/configs/verify_stats.json
ran tests: 4147 passed, 12 skipped in 23s
...
```

This allows us to easily see:
- what failed and passed,
- how many tests where skipped,
- how long the test config run took.

Details (like what was skipped or any retried failures) are listed in the log group of each test config run.

The log group does not close when a test failure (after retries) is found.