### PR TITLE
Make CTE inlining of correlated CTEs more stable

### DIFF
--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -115,6 +115,23 @@ static bool ContainsDelimGet(const LogicalOperator &op) {
 	return false;
 }
 
+static bool HasCTEReferenceBelowDelimJoin(const LogicalOperator &op, TableIndex cte_index,
+                                          bool below_delim_join = false) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cteref = op.Cast<LogicalCTERef>();
+		if (cteref.cte_index == cte_index) {
+			return below_delim_join;
+		}
+	}
+	auto child_below_delim_join = below_delim_join || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN;
+	for (auto &child : op.children) {
+		if (HasCTEReferenceBelowDelimJoin(*child, cte_index, child_below_delim_join)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 	if (op->type == LogicalOperatorType::LOGICAL_PREPARE) {
 		// we are in a prepare statement, if we have to copy an operator during inlining,
@@ -148,10 +165,11 @@ void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 			// With ref_count>1 and requires_copy, the DML would execute once per copy.
 			return;
 		}
-		if (!cte.correlated_columns.empty() && ContainsDelimGet(*cte.children[0])) {
-			// Correlated CTEs can be decorrelated into DELIM_GET consumers. After that rewrite the CTE definition
-			// must stay scoped to its original duplicate-elimination source; inlining it under a different subtree can
-			// attach those DELIM_GETs to the wrong delim scan.
+		if (!cte.correlated_columns.empty() && ContainsDelimGet(*cte.children[0]) &&
+		    HasCTEReferenceBelowDelimJoin(*op->children[1], cte.table_index)) {
+			// Correlated CTEs can be decorrelated into DELIM_GET consumers. Inlining stays safe while all matching
+			// CTE scans remain outside DELIM_JOIN subtrees, but once a scan is nested below another DELIM_JOIN the
+			// inlined DELIM_GETs can attach to the wrong duplicate-elimination source.
 			return;
 		}
 		if (cte.materialize == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {

--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -103,6 +103,18 @@ static bool EndsInDummyScan(const LogicalOperator &op) {
 	return false;
 }
 
+static bool ContainsDelimGet(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (ContainsDelimGet(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 	if (op->type == LogicalOperatorType::LOGICAL_PREPARE) {
 		// we are in a prepare statement, if we have to copy an operator during inlining,
@@ -134,6 +146,12 @@ void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 			// side reads the modified table.  With ref_count==1, inlining would merge
 			// the DML into the query pipeline so it no longer precedes the scan.
 			// With ref_count>1 and requires_copy, the DML would execute once per copy.
+			return;
+		}
+		if (!cte.correlated_columns.empty() && ContainsDelimGet(*cte.children[0])) {
+			// Correlated CTEs can be decorrelated into DELIM_GET consumers. After that rewrite the CTE definition
+			// must stay scoped to its original duplicate-elimination source; inlining it under a different subtree can
+			// attach those DELIM_GETs to the wrong delim scan.
 			return;
 		}
 		if (cte.materialize == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {

--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -165,11 +165,10 @@ void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 			// With ref_count>1 and requires_copy, the DML would execute once per copy.
 			return;
 		}
-		if (!cte.correlated_columns.empty() && ContainsDelimGet(*cte.children[0]) &&
-		    HasCTEReferenceBelowDelimJoin(*op->children[1], cte.table_index)) {
-			// Correlated CTEs can be decorrelated into DELIM_GET consumers. Inlining stays safe while all matching
-			// CTE scans remain outside DELIM_JOIN subtrees, but once a scan is nested below another DELIM_JOIN the
-			// inlined DELIM_GETs can attach to the wrong duplicate-elimination source.
+		if (ContainsDelimGet(*cte.children[0]) && HasCTEReferenceBelowDelimJoin(*op->children[1], cte.table_index)) {
+			// Inlining a CTE that already contains a DELIM_GET stays safe while all matching CTE scans remain outside
+			// DELIM_JOIN subtrees, but once a scan is nested below another DELIM_JOIN the inlined DELIM_GETs can attach
+			// to the wrong duplicate-elimination source.
 			return;
 		}
 		if (cte.materialize == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {

--- a/test/sql/cte/recursive_cte_complex_pipelines.test
+++ b/test/sql/cte/recursive_cte_complex_pipelines.test
@@ -128,3 +128,30 @@ SELECT * FROM t ORDER BY 1 NULLS LAST;
 4
 8
 16
+
+# recursive CTE inside lateral join with inherited correlations
+query I
+SELECT 1
+FROM (VALUES (1::INT4)) a(v),
+LATERAL (
+	WITH RECURSIVE
+		b AS (
+			SELECT 0::INT4 AS i
+			WHERE a.v IS NOT NULL
+		),
+		c AS (
+			SELECT 0::INT8 AS i
+			UNION ALL
+			SELECT d.i + 1::INT8
+			FROM c d,
+			LATERAL (
+				SELECT 1
+				FROM b e
+				WHERE e.i = d.i
+			) f
+		)
+	SELECT * FROM c
+) g
+LIMIT 1;
+----
+1


### PR DESCRIPTION
We can not always inline correlated CTEs. If the materializing side of a CTE becomes a DELIM JOIN consumer, we can not simply inline this CTE, if the CTE scan is below another DELIM JOIN. This would result in accessing a wrong DELIM SCAN. This PR fixes that.

fix: https://github.com/duckdb/duckdb/issues/22691
fix: https://github.com/duckdblabs/duckdb-internal/issues/9301