### PR TITLE
Retry clangd error 'ValueError: Invalid header end'

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -443,6 +443,14 @@ jobs:
         EOF
         make tidy-check-clangd CLANGD_TIDY_QUERY_DRIVER=/usr/bin/**/g++*,/usr/bin/**/gcc*
 
+    - name: Upload clangd-tidy logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: clangd-tidy-logs
+        path: build/tidy/clangd-tidy-logs
+        if-no-files-found: ignore
+
  extensions:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'extensions') }}
     uses: ./.github/workflows/Extensions.yml

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -4,9 +4,24 @@ import argparse
 import json
 import multiprocessing
 import os
+import random
 import shlex
 import subprocess
 import sys
+import time
+
+
+MAX_CHUNK_CHARS = 100000
+MAX_RETRIES = 2
+RETRY_BACKOFF_MS = 500
+RETRY_PATTERNS = (
+    'invalid header end',
+    'broken pipe',
+    'unexpected eof',
+    'connection reset by peer',
+    'failed to read message',
+    'jsonrpc',
+)
 
 
 def make_absolute(path, directory):
@@ -24,7 +39,7 @@ def is_ignored_file(path, repo_root):
     return relative == 'third_party' or relative.startswith('third_party' + os.sep)
 
 
-def chunk_files(files, max_chars=100000):
+def chunk_files(files, max_chars=MAX_CHUNK_CHARS):
     chunk = []
     current_chars = 0
     for path in files:
@@ -56,12 +71,8 @@ def load_files(build_path):
     return repo_root, files
 
 
-def create_clangd_wrapper(build_path, clangd_binary):
-    build_path = os.path.abspath(build_path)
-    pch_dir = os.path.join(build_path, 'pchs')
-    os.makedirs(pch_dir, exist_ok=True)
-
-    wrapper_path = os.path.join(build_path, 'clangd-tidy-clangd-wrapper.sh')
+def create_attempt_clangd_wrapper(log_dir, clangd_binary, pch_dir, attempt_id):
+    wrapper_path = os.path.join(log_dir, f'clangd-wrapper-attempt-{attempt_id}.sh')
     wrapper = f"""#!/bin/sh
 set -eu
 export TMPDIR={shlex.quote(pch_dir)}
@@ -73,6 +84,62 @@ exec {shlex.quote(clangd_binary)} "$@" --pch-storage=disk
         handle.write(wrapper)
     os.chmod(wrapper_path, 0o755)
     return wrapper_path
+
+
+def is_retryable_failure(result):
+    if result.returncode == 0:
+        return False
+    text = (result.stdout or '') + '\n' + (result.stderr or '')
+    lower = text.lower()
+    return any(pattern in lower for pattern in RETRY_PATTERNS)
+
+
+def write_attempt_logs(log_dir, attempt_id, chunk, result):
+    with open(os.path.join(log_dir, f'attempt-{attempt_id}.stdout.log'), 'w', encoding='utf-8') as handle:
+        handle.write(result.stdout or '')
+    with open(os.path.join(log_dir, f'attempt-{attempt_id}.stderr.log'), 'w', encoding='utf-8') as handle:
+        handle.write(result.stderr or '')
+    with open(os.path.join(log_dir, f'attempt-{attempt_id}.files.txt'), 'w', encoding='utf-8') as handle:
+        for entry in chunk:
+            handle.write(entry + '\n')
+
+
+def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter):
+    retries = 0
+    while True:
+        attempt_counter[0] += 1
+        attempt_id = attempt_counter[0]
+        attempt_pch_dir = os.path.join(pch_root, f'attempt-{attempt_id}')
+        os.makedirs(attempt_pch_dir, exist_ok=True)
+        clangd_wrapper = create_attempt_clangd_wrapper(log_dir, clangd_binary, attempt_pch_dir, attempt_id)
+        command = base_command + ['--clangd-executable', clangd_wrapper] + chunk
+        result = subprocess.run(command, check=False, cwd=repo_root, env=env, text=True, capture_output=True)
+        write_attempt_logs(log_dir, attempt_id, chunk, result)
+        if result.returncode == 0:
+            return True
+        if retries >= MAX_RETRIES or not is_retryable_failure(result):
+            return False
+        delay = (RETRY_BACKOFF_MS / 1000.0) * (2**retries) + random.uniform(0.0, 0.2)
+        time.sleep(delay)
+        retries += 1
+
+
+def process_chunk(
+    base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
+):
+    ok = run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter)
+    if ok:
+        return
+    if len(chunk) == 1:
+        hard_failures.append(chunk[0])
+        return
+    mid = len(chunk) // 2
+    process_chunk(
+        base_command, chunk[:mid], repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
+    )
+    process_chunk(
+        base_command, chunk[mid:], repo_root, env, log_dir, pch_root, clangd_binary, attempt_counter, hard_failures
+    )
 
 
 def main():
@@ -113,26 +180,46 @@ def main():
     print(f'Using clangd-tidy: {clangd_tidy_version}')
     print(f'Using clangd: {clangd_version}')
 
-    clangd_wrapper = create_clangd_wrapper(build_path, args.clangd_binary)
+    log_dir = os.path.join(build_path, 'clangd-tidy-logs')
+    os.makedirs(log_dir, exist_ok=True)
+    pch_root = os.path.join(build_path, 'pchs')
+    os.makedirs(pch_root, exist_ok=True)
     base_command = [
         args.clangd_tidy_binary,
         '--compile-commands-dir',
         build_path,
         '--jobs',
         str(jobs),
-        '--clangd-executable',
-        clangd_wrapper,
     ]
     if args.query_driver:
         base_command.extend(['--query-driver', args.query_driver])
 
-    return_code = 0
-    for chunk in chunk_files(files):
-        result = subprocess.run(base_command + chunk, check=False, cwd=repo_root)
-        if result.returncode != 0:
-            return_code = result.returncode
+    run_env = os.environ.copy()
+    run_env['LC_ALL'] = 'C'
+    run_env['PYTHONUNBUFFERED'] = '1'
 
-    return return_code
+    attempt_counter = [0]
+    hard_failures = []
+    for chunk in chunk_files(files):
+        process_chunk(
+            base_command,
+            chunk,
+            repo_root,
+            run_env,
+            log_dir,
+            pch_root,
+            args.clangd_binary,
+            attempt_counter,
+            hard_failures,
+        )
+
+    if hard_failures:
+        print('clangd-tidy hard failures after retries:', file=sys.stderr)
+        for failed in hard_failures:
+            print(f'  {failed}', file=sys.stderr)
+    print(f'clangd-tidy logs written to: {log_dir}')
+
+    return 1 if hard_failures else 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Clangd tidy can [fail](https://github.com/duckdb/duckdb/actions/runs/26159255962/job/76946843482) with `ValueError: Invalid header end`:
```
Using clangd-tidy: clangd-tidy 1.1.1
Using clangd: Ubuntu clangd version 20.1.2 (0ubuntu1~24.04.2)
Traceback (most recent call last):
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/bin/clangd-tidy", line 8, in <module>
    sys.exit(main_cli())
             ^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/main_cli.py", line 174, in main_cli
    ).acquire_diagnostics()
      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/main_cli.py", line 78, in acquire_diagnostics
    return asyncio.run(self._acquire_diagnostics())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/main_cli.py", line 142, in _acquire_diagnostics
    _, file_diagnostics = await asyncio.gather(
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/main_cli.py", line 101, in _collect_diagnostics
    resp = await self._clangd.recv_response_or_notification()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/lsp/clangd.py", line 61, in recv_response_or_notification
    return await self._client.recv()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/lsp/client.py", line 50, in recv
    content = await self._rpc.recv()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/lsp/rpc.py", line 67, in recv
    Protocol.parse_header(header_line, header)
  File "/home/runner/work/duckdb/duckdb/build/clangd-tidy-venv/lib/python3.12/site-packages/clangd_tidy/lsp/rpc.py", line 35, in parse_header
    raise ValueError("Invalid header end")
ValueError: Invalid header end
make: *** [Makefile:727: tidy-check-clangd] Error 1
Error: Process completed with exit code 2.
```

The python script can now retry the chunks so it's not failing the CI run when the LSP and RPC communication logic fails.

I did not look deeply into whether this solution solves the problem. I used codex to analyse the problem and I think retrying as a solution could help increase robustness of the CI pipelines.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9312.