### PR TITLE
[Dev] Fix behavior for the `force_full_download` open-file-info option, with the new workings of the ExternalFileCache

### DIFF
--- a/src/include/duckdb/planner/filter/expression_filter.hpp
+++ b/src/include/duckdb/planner/filter/expression_filter.hpp
@@ -64,6 +64,7 @@ public:
 
 	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const;
 	string ToString(const string &column_name) const;
+	string DebugToString() const;
 	bool Equals(const ExpressionFilter &other) const;
 	unique_ptr<ExpressionFilter> Copy() const;
 	unique_ptr<Expression> ToExpression(const Expression &column) const override;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -60,6 +60,10 @@ public:
 	DUCKDB_API void Seek(idx_t location);
 
 private:
+	//! Remove the 'force_full_download' option from the file handle if present, and return whether it was present
+	bool StripForceFullDownloadIfPresent();
+
+private:
 	QueryContext context;
 
 	//! The client caching file system that was used to create this CachingFileHandle

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -510,6 +510,10 @@ string ExpressionFilter::ToString(const string &column_name) const {
 	return ExpressionToFriendlyString(*expr, column_name);
 }
 
+string ExpressionFilter::DebugToString() const {
+	return ExpressionToFriendlyString(*expr, "c1");
+}
+
 void ExpressionFilter::ReplaceExpressionRecursive(unique_ptr<Expression> &expr, const Expression &column,
                                                   ExpressionType replace_type) {
 	if (expr->GetExpressionType() == replace_type) {

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -140,6 +140,29 @@ unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, 
 // CachingFileHandle
 //===----------------------------------------------------------------------===//
 
+bool CachingFileHandle::StripForceFullDownloadIfPresent() {
+	auto &extended_info_p = path.extended_info;
+	if (!extended_info_p) {
+		return false;
+	}
+
+	auto &extended_info = *extended_info_p;
+	const bool contains_force_full_download = extended_info.options.count("force_full_download");
+	if (!contains_force_full_download) {
+		return false;
+	}
+
+	//! We do have 'force_full_download' - strip it
+	auto new_extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	*new_extended_info = extended_info;
+	new_extended_info->options.erase("force_full_download");
+	if (!new_extended_info->options.count("file_size")) {
+		new_extended_info->options["file_size"] = Value::UBIGINT(GetFileSize());
+	}
+	path.extended_info = new_extended_info;
+	return true;
+}
+
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
                                      optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
@@ -161,6 +184,10 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 	}
 	if (needs_open) {
 		GetFileHandle();
+	}
+	auto needs_full_download = StripForceFullDownloadIfPresent();
+	if (needs_full_download) {
+		Read(GetFileSize(), 0);
 	}
 }
 


### PR DESCRIPTION
This PR fixes the intended behavior of this PR to duckdb-httpfs: https://github.com/duckdb/duckdb-httpfs/pull/67

The `force_full_download` performs a GET request to cache the entire files contents and get the file size, without the need to first make a HEAD request.

`force_full_download` is acted on inside of `FileHandle::Initialize`, which is now called multiple times.
To make sure we don't perform a GET request every time, we strip the option and add a cache entry covering the entire file instead.

Also add back `ExpressionFilter::DebugToString`, for debugging. 
