### PR TITLE
Add compressed probing hash join

### DIFF
--- a/benchmark/micro/join/hashjoin_constant_probe.benchmark
+++ b/benchmark/micro/join/hashjoin_constant_probe.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/join/hashjoin_constant_probe.benchmark
+# description: Hash join probe over a numeric constant-compressed key (small build, 1M-row probe)
+# group: [join]
+
+name Hash Join Constant Probe
+group join
+storage persistent
+
+# fact.k is physically clustered so each row group holds a single value - the segment is
+# constant-compressed and scanned as a CONSTANT_VECTOR. Keys span a wide range to avoid a
+# perfect hash join, keeping the probe on the regular hash-join path.
+load
+CREATE TABLE dim AS SELECT i * 1000000 AS k FROM range(9) t(i);
+CREATE TABLE fact AS SELECT (i // 122880) * 1000000 AS k FROM range(1000000) t(i);
+
+run
+SELECT COUNT(*) FROM fact f JOIN dim d ON f.k = d.k
+
+result I
+1000000

--- a/benchmark/micro/join/hashjoin_dictionary_emit_probe.benchmark
+++ b/benchmark/micro/join/hashjoin_dictionary_emit_probe.benchmark
@@ -1,0 +1,28 @@
+# name: benchmark/micro/join/hashjoin_dictionary_emit_probe.benchmark
+# description: Hash join chain combining dictionary emission (build side) and dictionary probing (probe side)
+# group: [join]
+
+name Hash Join Dictionary Emit + Probe
+group join
+storage persistent
+
+# join1: small build side triggers operator-created dictionary emission for d.code
+# join2: d.code arrives as a dictionary vector, triggering dictionary probing
+load
+CREATE TABLE dim AS SELECT 'K' || i AS dim_key, 'C' || (i % 10) AS code FROM range(50) t(i);
+CREATE TABLE dim2 AS SELECT 'C' || i AS code, 'label_' || i AS label FROM range(10) t(i);
+CREATE TABLE fact AS SELECT 'K' || (i % 50) AS dim_key, i AS amount FROM range(500000) t(i);
+
+# single thread keeps the dictionary path deterministic; no join reordering
+init
+SET threads TO 1;
+SET disabled_optimizers TO 'join_order';
+
+run
+SELECT count(*), count(d2.label), min(d2.label), max(d2.label)
+FROM fact f
+JOIN dim d ON f.dim_key = d.dim_key
+JOIN dim2 d2 ON d.code = d2.code
+
+result IIII
+500000	500000	label_0	label_9

--- a/benchmark/micro/join/hashjoin_dictionary_probe.benchmark
+++ b/benchmark/micro/join/hashjoin_dictionary_probe.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/join/hashjoin_dictionary_probe.benchmark
+# description: Hash join probe over a dictionary-encoded VARCHAR key (small build, 1M-row probe)
+# group: [join]
+
+name Hash Join Dictionary Probe
+group join
+storage persistent
+
+load
+CREATE TABLE dim AS SELECT format('key_{:03d}', i) AS k FROM range(10) t(i);
+CREATE TABLE fact AS SELECT format('key_{:03d}', i % 10) AS k FROM range(1000000) t(i);
+
+run
+SELECT COUNT(*) FROM fact f JOIN dim d ON f.k = d.k
+
+result I
+1000000

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/join_hashtable.hpp"
 
 #include "duckdb/common/enums/join_type.hpp"
+#include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -27,6 +28,11 @@ JoinHashTable::SharedState::SharedState()
 JoinHashTable::ProbeState::ProbeState()
     : SharedState(), ht_offsets_and_salts_v(LogicalType::UBIGINT), hashes_dense_v(LogicalType::HASH),
       non_empty_sel(STANDARD_VECTOR_SIZE) {
+}
+
+JoinHashTable::ProbeDictionaryState::ProbeDictionaryState()
+    : hashes(LogicalType::HASH), new_dictionary_pointers(LogicalType::POINTER), unique_entries(STANDARD_VECTOR_SIZE),
+      match_sel(STANDARD_VECTOR_SIZE) {
 }
 
 JoinHashTable::InsertState::InsertState(const JoinHashTable &ht)
@@ -889,6 +895,214 @@ void JoinHashTable::Probe(ScanStructure &scan_structure, DataChunk &keys, TupleD
 		GetRowPointers(keys, key_state, probe_state, hashes, current_sel, scan_structure.count, scan_structure.pointers,
 		               scan_structure.sel_vector, scan_structure.has_null_value_filter);
 	}
+}
+
+bool JoinHashTable::TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+                                       ProbeState &probe_state) {
+	static constexpr idx_t MAX_DICTIONARY_SIZE_THRESHOLD = 20000;
+	static constexpr idx_t DICTIONARY_THRESHOLD = 2;
+
+	D_ASSERT(equality_types.size() == 1);
+	D_ASSERT(Count() > 0);
+	D_ASSERT(finalized);
+
+	auto &dict_col = keys.data[0];
+	if (dict_col.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
+		return false;
+	}
+	const auto opt_dict_size = DictionaryVector::DictionarySize(dict_col);
+	if (!opt_dict_size.IsValid()) {
+		// dict size not known - this is not a dictionary that comes from the storage
+		return false;
+	}
+	const idx_t dict_size = opt_dict_size.GetIndex();
+	const auto &dictionary_id = DictionaryVector::DictionaryId(dict_col);
+	if (dictionary_id.empty()) {
+		// no id - can't cache across vectors, only use dict path if it is much smaller than the chunk
+		if (dict_size * DICTIONARY_THRESHOLD >= keys.size()) {
+			return false;
+		}
+	} else if (dict_size >= MAX_DICTIONARY_SIZE_THRESHOLD) {
+		return false;
+	}
+	if (dict_size == 0) {
+		// the cache below is never allocated for an empty dictionary - avoid dereferencing a null Vector
+		return false;
+	}
+
+	auto &dictionary_vector = DictionaryVector::Child(dict_col);
+	auto &offsets = DictionaryVector::SelVector(dict_col);
+	auto &dict_state = probe_state.dict_state;
+
+	if (dict_state.dictionary_id.empty() || dict_state.dictionary_id != dictionary_id) {
+		// new dictionary - initialize the per-id cache
+		if (dict_size > dict_state.capacity) {
+			dict_state.dictionary_pointers = make_uniq<Vector>(LogicalType::POINTER, dict_size);
+			dict_state.found_entry = make_unsafe_uniq_array<bool>(dict_size);
+			dict_state.capacity = dict_size;
+		}
+		memset(dict_state.found_entry.get(), 0, dict_size * sizeof(bool));
+		// zero the cache - an unresolved slot reads back as nullptr, the miss sentinel
+		memset(FlatVector::GetDataMutable(*dict_state.dictionary_pointers), 0, dict_size * sizeof(data_ptr_t));
+		dict_state.dictionary_id = dictionary_id;
+		dict_state.resolved_count = 0;
+		// storage dictionaries reserve a NULL sentinel slot that non-NULL probe rows never
+		// reference; pre-mark NULL child slots resolved so resolved_count can still reach dict_size.
+		// Equality joins only: PrepareKeys drops NULL probe rows, so the NULL slot is never probed.
+		// Under NOT DISTINCT FROM those rows are kept and the walk below must probe it itself.
+		if (!null_values_are_equal[0] && dictionary_vector.GetVectorType() == VectorType::FLAT_VECTOR) {
+			const auto &child_validity = FlatVector::Validity(dictionary_vector);
+			if (child_validity.CanHaveNull()) {
+				for (idx_t i = 0; i < dict_size; i++) {
+					if (!child_validity.RowIsValid(i)) {
+						dict_state.found_entry[i] = true;
+						dict_state.resolved_count++;
+					}
+				}
+			}
+		}
+	} else if (dict_size > dict_state.capacity) {
+		throw InternalException("JoinHashTable - using cached dictionary data but dictionary has changed (dictionary "
+		                        "id %s - dict size %d, current capacity %d)",
+		                        dict_state.dictionary_id, dict_size, dict_state.capacity);
+	}
+
+	// collect each dict slot once - skip the walk entirely once every slot is resolved
+	auto &found_entry = dict_state.found_entry;
+	auto &unique_entries = dict_state.unique_entries;
+	idx_t unique_count = 0;
+	if (dict_state.resolved_count < dict_size) {
+		for (idx_t i = 0; i < keys.size(); i++) {
+			const auto dict_idx = offsets.get_index(i);
+			unique_entries.set_index(unique_count, dict_idx);
+			unique_count += !found_entry[dict_idx];
+			found_entry[dict_idx] = true;
+		}
+		dict_state.resolved_count += unique_count;
+	}
+
+	if (unique_count > 0) {
+		auto &unique_values = dict_state.unique_values;
+		if (unique_values.ColumnCount() == 0) {
+			unique_values.InitializeEmpty(vector<LogicalType> {equality_types[0]});
+			TupleDataCollection::InitializeChunkState(dict_state.unique_key_state, {equality_types[0]});
+		}
+		unique_values.data[0].Slice(dictionary_vector, unique_entries, unique_count);
+		unique_values.SetCardinality(unique_count);
+
+		TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
+
+		auto &hashes = dict_state.hashes;
+		VectorOperations::Hash(unique_values.data[0], hashes, unique_count);
+
+		idx_t count = unique_count;
+		GetRowPointers(unique_values, dict_state.unique_key_state, probe_state, hashes, nullptr, count,
+		               dict_state.new_dictionary_pointers, dict_state.match_sel, false);
+
+		// remap hits from position to dict slot; missed slots stay nullptr from the rebind memset
+		const auto new_dict_ptrs = FlatVector::GetData<data_ptr_t>(dict_state.new_dictionary_pointers);
+		auto unique_dict_ptrs = FlatVector::GetDataMutable<data_ptr_t>(*dict_state.dictionary_pointers);
+		for (idx_t i = 0; i < count; i++) {
+			const auto position = dict_state.match_sel.get_index(i);
+			const auto dict_idx = unique_entries.get_index(position);
+			unique_dict_ptrs[dict_idx] = new_dict_ptrs[position];
+		}
+	}
+
+	// fan out the cache into the scan_structure shape that Probe() produces
+	scan_structure.is_null = false;
+	scan_structure.finished = false;
+	if (join_type != JoinType::INNER) {
+		memset(scan_structure.found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+	}
+	TupleDataCollection::ToUnifiedFormat(key_state, keys);
+	optional_ptr<const SelectionVector> current_sel;
+	const idx_t prepared_count =
+	    PrepareKeys(keys, key_state.vector_data, current_sel, scan_structure.sel_vector, false);
+	scan_structure.has_null_value_filter = prepared_count < keys.size();
+
+	auto scan_structure_ptrs = FlatVector::GetDataMutable<data_ptr_t>(scan_structure.pointers);
+	const auto unique_dict_ptrs = FlatVector::GetData<data_ptr_t>(*dict_state.dictionary_pointers);
+	idx_t kept = 0;
+	for (idx_t i = 0; i < prepared_count; i++) {
+		const auto row_index = current_sel->get_index(i);
+		const auto dict_idx = offsets.get_index(row_index);
+		const auto ptr = unique_dict_ptrs[dict_idx];
+		scan_structure_ptrs[row_index] = ptr;
+		scan_structure.sel_vector.set_index(kept, row_index);
+		// miss rows leave a stale pointer, but Next() only reads pointers at positions in sel_vector[0..count)
+		kept += (ptr != nullptr);
+	}
+	scan_structure.count = kept;
+	return true;
+}
+
+bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+                                     ProbeState &probe_state) {
+	D_ASSERT(equality_types.size() == 1);
+	D_ASSERT(Count() > 0);
+	D_ASSERT(finalized);
+
+	auto &constant_col = keys.data[0];
+	if (constant_col.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		return false;
+	}
+#ifndef DEBUG
+	if (keys.size() <= 1) {
+		// resolving once only pays off when the result fans out to multiple probe rows
+		return false;
+	}
+#endif
+
+	// constant vectors carry no dictionary id, so there is no cross-chunk cache - resolve the
+	// single distinct key with one hash-table lookup per chunk
+	auto &dict_state = probe_state.dict_state;
+	auto &unique_values = dict_state.unique_values;
+	if (unique_values.ColumnCount() == 0) {
+		unique_values.InitializeEmpty(vector<LogicalType> {equality_types[0]});
+		TupleDataCollection::InitializeChunkState(dict_state.unique_key_state, {equality_types[0]});
+	}
+	unique_values.data[0].Reference(constant_col);
+	unique_values.SetCardinality(1);
+	unique_values.Flatten();
+
+	TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
+
+	auto &hashes = dict_state.hashes;
+	VectorOperations::Hash(unique_values.data[0], hashes, 1);
+
+	// resolved_ptr is a chain-head, not a confirmed match - a real key-miss is still rejected by
+	// the chain walk in Next(). A NULL constant key resolves correctly via RowMatcher null equality.
+	idx_t count = 1;
+	GetRowPointers(unique_values, dict_state.unique_key_state, probe_state, hashes, nullptr, count,
+	               dict_state.new_dictionary_pointers, dict_state.match_sel, false);
+	const auto resolved_ptr =
+	    count == 0 ? nullptr : FlatVector::GetData<data_ptr_t>(dict_state.new_dictionary_pointers)[0];
+
+	// fan out the resolved pointer into the scan_structure shape that Probe() produces
+	scan_structure.is_null = false;
+	scan_structure.finished = false;
+	if (join_type != JoinType::INNER) {
+		memset(scan_structure.found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+	}
+	TupleDataCollection::ToUnifiedFormat(key_state, keys);
+	optional_ptr<const SelectionVector> current_sel;
+	const idx_t prepared_count =
+	    PrepareKeys(keys, key_state.vector_data, current_sel, scan_structure.sel_vector, false);
+	scan_structure.has_null_value_filter = prepared_count < keys.size();
+
+	auto scan_structure_ptrs = FlatVector::GetDataMutable<data_ptr_t>(scan_structure.pointers);
+	idx_t kept = 0;
+	if (resolved_ptr) {
+		// PrepareKeys dropped NULL probe rows - the rest all share the one resolved chain-head
+		for (idx_t i = 0; i < prepared_count; i++) {
+			const auto row_index = current_sel->get_index(i);
+			scan_structure_ptrs[row_index] = resolved_ptr;
+			scan_structure.sel_vector.set_index(kept++, row_index);
+		}
+	}
+	scan_structure.count = kept;
+	return true;
 }
 
 ScanStructure::ScanStructure(JoinHashTable &ht_p, TupleDataChunkState &key_state_p)

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -876,8 +876,33 @@ void JoinHashTable::InitializeScanStructure(ScanStructure &scan_structure, DataC
 	}
 }
 
+//! Per-chunk fast-reject so non-dictionary chunks skip the TryProbeDictionary call entirely
+static bool LHSChunkIsDictionaryEligible(const Vector &lhs_key) {
+	if (lhs_key.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
+		return false;
+	}
+	return DictionaryVector::DictionarySize(lhs_key).IsValid();
+}
+
+//! Per-chunk fast-reject so non-constant chunks skip the TryProbeConstant call entirely
+static bool LHSChunkIsConstant(const Vector &lhs_key) {
+	return lhs_key.GetVectorType() == VectorType::CONSTANT_VECTOR;
+}
+
 void JoinHashTable::Probe(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
                           ProbeState &probe_state, optional_ptr<Vector> precomputed_hashes) {
+	// dispatch into the compressed-vector fast paths when the operator gated them on. precomputed_hashes
+	// is incompatible: the caller hashed the full N-row chunk; the fast paths re-hash a sliced D-row chunk.
+	if (probe_state.dict_state && !precomputed_hashes) {
+		auto &lhs_key = keys.data[0];
+		if (LHSChunkIsConstant(lhs_key) && TryProbeConstant(scan_structure, keys, key_state, probe_state)) {
+			return;
+		}
+		if (LHSChunkIsDictionaryEligible(lhs_key) && TryProbeDictionary(scan_structure, keys, key_state, probe_state)) {
+			return;
+		}
+	}
+
 	optional_ptr<const SelectionVector> current_sel;
 	InitializeScanStructure(scan_structure, keys, key_state, current_sel);
 	if (scan_structure.count == 0) {
@@ -932,7 +957,8 @@ bool JoinHashTable::TryProbeDictionary(ScanStructure &scan_structure, DataChunk 
 
 	auto &dictionary_vector = DictionaryVector::Child(dict_col);
 	auto &offsets = DictionaryVector::SelVector(dict_col);
-	auto &dict_state = probe_state.dict_state;
+	D_ASSERT(probe_state.dict_state);
+	auto &dict_state = *probe_state.dict_state;
 
 	if (dict_state.dictionary_id.empty() || dict_state.dictionary_id != dictionary_id) {
 		// new dictionary - initialize the per-id cache
@@ -1056,7 +1082,8 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
 
 	// constant vectors carry no dictionary id, so there is no cross-chunk cache - resolve the
 	// single distinct key with one hash-table lookup per chunk
-	auto &dict_state = probe_state.dict_state;
+	D_ASSERT(probe_state.dict_state);
+	auto &dict_state = *probe_state.dict_state;
 	auto &unique_values = dict_state.unique_values;
 	if (unique_values.ColumnCount() == 0) {
 		unique_values.InitializeEmpty(vector<LogicalType> {equality_types[0]});

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1645,6 +1645,10 @@ public:
 		} else {
 			spill_chunk.Reset();
 		}
+		// discard cached build-side pointers; the HT may have been reset between iterations (e.g. recursive CTE)
+		if (probe_state.dict_state) {
+			probe_state.dict_state = make_uniq<JoinHashTable::ProbeDictionaryState>();
+		}
 		// perfect_hash_join_state will be lazily initialized on first Execute when we have a real ExecutionContext
 	}
 };

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
+#include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/common/uhugeint.hpp"
@@ -1575,6 +1576,44 @@ SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 //===--------------------------------------------------------------------===//
 // Operator
 //===--------------------------------------------------------------------===//
+//! Structural gate for the compressed-vector probe paths; evaluated once per operator state
+static bool CanUseCompressedProbe(const HashJoinGlobalSinkState &sink, const vector<JoinCondition> &conditions) {
+	if (sink.external) {
+		// external joins re-finalize the HT mid-probe, invalidating the per-id pointer cache
+		return false;
+	}
+	if (sink.perfect_join_executor) {
+		return false;
+	}
+	if (conditions.size() != 1) {
+		return false;
+	}
+	const auto cmp = conditions[0].GetComparisonType();
+	if (cmp != ExpressionType::COMPARE_EQUAL && cmp != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		return false;
+	}
+	if (conditions[0].GetLHS().GetExpressionClass() != ExpressionClass::BOUND_REF) {
+		return false;
+	}
+	if (conditions[0].GetLHS().GetReturnType().InternalType() == PhysicalType::STRUCT) {
+		return false;
+	}
+	return true;
+}
+
+//! Per-chunk fast-reject so non-dictionary chunks skip the TryProbeDictionary call entirely
+static bool LHSChunkIsDictionaryEligible(const Vector &lhs_key) {
+	if (lhs_key.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
+		return false;
+	}
+	return DictionaryVector::DictionarySize(lhs_key).IsValid();
+}
+
+//! Per-chunk fast-reject so non-constant chunks skip the TryProbeConstant call entirely
+static bool LHSChunkIsConstant(const Vector &lhs_key) {
+	return lhs_key.GetVectorType() == VectorType::CONSTANT_VECTOR;
+}
+
 class HashJoinOperatorState : public CachingOperatorState {
 public:
 	HashJoinOperatorState(ClientContext &context, const PhysicalHashJoin &op_p, HashJoinGlobalSinkState &sink)
@@ -1594,6 +1633,8 @@ public:
 	JoinHashTable::ProbeState probe_state;
 	//! Chunk to sink data into for external join
 	DataChunk spill_chunk;
+	//! Cached result of CanUseCompressedProbe for this operator state
+	bool compressed_probe_enabled = false;
 
 public:
 	void Finalize(const PhysicalOperator &op, ExecutionContext &context) override {
@@ -1647,6 +1688,8 @@ unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ExecutionContext &c
 		sink.InitializeProbeSpill();
 	}
 
+	state->compressed_probe_enabled = CanUseCompressedProbe(sink, conditions);
+
 	return std::move(state);
 }
 
@@ -1698,6 +1741,14 @@ OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, 
 			sink.hash_table->ProbeAndSpill(state.scan_structure, state.lhs_join_keys, state.join_key_state,
 			                               state.probe_state, input, *sink.probe_spill, state.spill_state,
 			                               state.spill_chunk);
+		} else if (state.compressed_probe_enabled && LHSChunkIsConstant(state.lhs_join_keys.data[0]) &&
+		           sink.hash_table->TryProbeConstant(state.scan_structure, state.lhs_join_keys, state.join_key_state,
+		                                             state.probe_state)) {
+			// scan_structure populated by the constant-vector fast path
+		} else if (state.compressed_probe_enabled && LHSChunkIsDictionaryEligible(state.lhs_join_keys.data[0]) &&
+		           sink.hash_table->TryProbeDictionary(state.scan_structure, state.lhs_join_keys, state.join_key_state,
+		                                               state.probe_state)) {
+			// scan_structure populated by the dictionary-aware path
 		} else {
 			sink.hash_table->Probe(state.scan_structure, state.lhs_join_keys, state.join_key_state, state.probe_state);
 		}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -3,7 +3,6 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
-#include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/common/uhugeint.hpp"
@@ -1576,7 +1575,9 @@ SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 //===--------------------------------------------------------------------===//
 // Operator
 //===--------------------------------------------------------------------===//
-//! Structural gate for the compressed-vector probe paths; evaluated once per operator state
+//! Structural gate for the compressed-vector probe paths; evaluated once per operator state.
+//! Decides whether to allocate ProbeState::dict_state; Probe() dispatches into the fast paths
+//! whenever that allocation is present.
 static bool CanUseCompressedProbe(const HashJoinGlobalSinkState &sink, const vector<JoinCondition> &conditions) {
 	if (sink.external) {
 		// external joins re-finalize the HT mid-probe, invalidating the per-id pointer cache
@@ -1601,19 +1602,6 @@ static bool CanUseCompressedProbe(const HashJoinGlobalSinkState &sink, const vec
 	return true;
 }
 
-//! Per-chunk fast-reject so non-dictionary chunks skip the TryProbeDictionary call entirely
-static bool LHSChunkIsDictionaryEligible(const Vector &lhs_key) {
-	if (lhs_key.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
-		return false;
-	}
-	return DictionaryVector::DictionarySize(lhs_key).IsValid();
-}
-
-//! Per-chunk fast-reject so non-constant chunks skip the TryProbeConstant call entirely
-static bool LHSChunkIsConstant(const Vector &lhs_key) {
-	return lhs_key.GetVectorType() == VectorType::CONSTANT_VECTOR;
-}
-
 class HashJoinOperatorState : public CachingOperatorState {
 public:
 	HashJoinOperatorState(ClientContext &context, const PhysicalHashJoin &op_p, HashJoinGlobalSinkState &sink)
@@ -1633,8 +1621,6 @@ public:
 	JoinHashTable::ProbeState probe_state;
 	//! Chunk to sink data into for external join
 	DataChunk spill_chunk;
-	//! Cached result of CanUseCompressedProbe for this operator state
-	bool compressed_probe_enabled = false;
 
 public:
 	void Finalize(const PhysicalOperator &op, ExecutionContext &context) override {
@@ -1688,7 +1674,10 @@ unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ExecutionContext &c
 		sink.InitializeProbeSpill();
 	}
 
-	state->compressed_probe_enabled = CanUseCompressedProbe(sink, conditions);
+	if (CanUseCompressedProbe(sink, conditions)) {
+		// non-null dict_state is the enabling signal for the compressed-vector probe paths in Probe()
+		state->probe_state.dict_state = make_uniq<JoinHashTable::ProbeDictionaryState>();
+	}
 
 	return std::move(state);
 }
@@ -1741,14 +1730,6 @@ OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, 
 			sink.hash_table->ProbeAndSpill(state.scan_structure, state.lhs_join_keys, state.join_key_state,
 			                               state.probe_state, input, *sink.probe_spill, state.spill_state,
 			                               state.spill_chunk);
-		} else if (state.compressed_probe_enabled && LHSChunkIsConstant(state.lhs_join_keys.data[0]) &&
-		           sink.hash_table->TryProbeConstant(state.scan_structure, state.lhs_join_keys, state.join_key_state,
-		                                             state.probe_state)) {
-			// scan_structure populated by the constant-vector fast path
-		} else if (state.compressed_probe_enabled && LHSChunkIsDictionaryEligible(state.lhs_join_keys.data[0]) &&
-		           sink.hash_table->TryProbeDictionary(state.scan_structure, state.lhs_join_keys, state.join_key_state,
-		                                               state.probe_state)) {
-			// scan_structure populated by the dictionary-aware path
 		} else {
 			sink.hash_table->Probe(state.scan_structure, state.lhs_join_keys, state.join_key_state, state.probe_state);
 		}

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -202,7 +202,8 @@ public:
 		Vector ht_offsets_and_salts_v;
 		Vector hashes_dense_v;
 		SelectionVector non_empty_sel;
-		ProbeDictionaryState dict_state;
+		//! Allocated only when the operator gates the compressed-probe paths on; null otherwise
+		unique_ptr<ProbeDictionaryState> dict_state;
 	};
 
 	struct InsertState : SharedState {
@@ -243,12 +244,6 @@ public:
 	//! Probe the HT with the given input chunk, resulting in the given result
 	void Probe(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state, ProbeState &probe_state,
 	           optional_ptr<Vector> precomputed_hashes = nullptr);
-	//! Dictionary-aware variant of Probe. Returns false if the LHS keys are not dictionary-eligible.
-	bool TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
-	                        ProbeState &probe_state);
-	//! Constant-vector variant of Probe. Returns false if the LHS keys are not a constant vector.
-	bool TryProbeConstant(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
-	                      ProbeState &probe_state);
 	//! Scan the HT to construct the full outer join result
 	void ScanFullOuter(JoinHTScanState &state, Vector &addresses, DataChunk &result) const;
 
@@ -406,6 +401,13 @@ private:
 	void InitializeScanStructure(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
 	                             optional_ptr<const SelectionVector> &current_sel);
 	void Hash(DataChunk &keys, const SelectionVector &sel, idx_t count, Vector &hashes);
+
+	//! Dictionary-aware variant of Probe. Returns false if the LHS keys are not dictionary-eligible.
+	bool TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+	                        ProbeState &probe_state);
+	//! Constant-vector variant of Probe. Returns false if the LHS keys are not a constant vector.
+	bool TryProbeConstant(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+	                      ProbeState &probe_state);
 
 	bool UseSalt() const;
 

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -176,12 +176,33 @@ public:
 		SelectionVector keys_no_match_sel;
 	};
 
+	//! Mirrors GroupedAggregateHashTable::AggregateDictionaryState for the join probe path
+	struct ProbeDictionaryState {
+		ProbeDictionaryState();
+
+		//! The current dictionary vector id (if any)
+		string dictionary_id;
+		DataChunk unique_values;
+		TupleDataChunkState unique_key_state;
+		Vector hashes;
+		Vector new_dictionary_pointers;
+		SelectionVector unique_entries;
+		//! Per-slot head-of-chain pointer cache; nullptr marks a miss
+		unique_ptr<Vector> dictionary_pointers;
+		unsafe_unique_array<bool> found_entry;
+		idx_t capacity = 0;
+		SelectionVector match_sel;
+		//! Number of dict slots already resolved; the unique-entries walk is skipped once it reaches dict_size
+		idx_t resolved_count = 0;
+	};
+
 	struct ProbeState : SharedState {
 		ProbeState();
 
 		Vector ht_offsets_and_salts_v;
 		Vector hashes_dense_v;
 		SelectionVector non_empty_sel;
+		ProbeDictionaryState dict_state;
 	};
 
 	struct InsertState : SharedState {
@@ -222,6 +243,12 @@ public:
 	//! Probe the HT with the given input chunk, resulting in the given result
 	void Probe(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state, ProbeState &probe_state,
 	           optional_ptr<Vector> precomputed_hashes = nullptr);
+	//! Dictionary-aware variant of Probe. Returns false if the LHS keys are not dictionary-eligible.
+	bool TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+	                        ProbeState &probe_state);
+	//! Constant-vector variant of Probe. Returns false if the LHS keys are not a constant vector.
+	bool TryProbeConstant(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
+	                      ProbeState &probe_state);
 	//! Scan the HT to construct the full outer join result
 	void ScanFullOuter(JoinHTScanState &state, Vector &addresses, DataChunk &result) const;
 

--- a/test/sql/join/hash_join/hash_join_constant_probe.test
+++ b/test/sql/join/hash_join/hash_join_constant_probe.test
@@ -1,0 +1,161 @@
+# name: test/sql/join/hash_join/hash_join_constant_probe.test
+# description: Test constant-vector hash-join probing (TryProbeConstant)
+# group: [hash_join]
+
+statement ok
+PRAGMA enable_verification
+
+# build side - small dimension table
+statement ok
+CREATE TABLE dim (k VARCHAR PRIMARY KEY, name VARCHAR)
+
+statement ok
+INSERT INTO dim VALUES ('EUR','Euro'), ('USD','Dollar'), ('GBP','Pound')
+
+statement ok
+CREATE TABLE fact (id INTEGER)
+
+statement ok
+INSERT INTO fact SELECT i FROM range(5000) t(i)
+
+# a literal projected into the probe key arrives as a CONSTANT_VECTOR - hit
+query I
+SELECT count(*) FROM (SELECT 'EUR' AS ccy, id FROM fact) t JOIN dim d ON t.ccy = d.k
+----
+5000
+
+# constant probe key - miss (value not in the build side)
+query I
+SELECT count(*) FROM (SELECT 'CHF' AS ccy, id FROM fact) t JOIN dim d ON t.ccy = d.k
+----
+0
+
+# numeric constant probe key from a constant-compressed storage column.
+# A numeric literal probe key is constant-folded into a build-side filter and picks a Perfect
+# Hash Join, so the key must instead come from a real constant-compressed column. Build keys
+# span a range wider than the Perfect Hash Join threshold (1 << 20) to stay on the probe path.
+
+# storage only constant-compresses checkpointed segments, so a persistent database is needed
+statement ok
+ATTACH '{TEST_DIR}/hash_join_constant_probe.db' AS cdb
+
+# build-side keys 0 and 2000000 span a range > 1 << 20 - too wide for a Perfect Hash Join
+statement ok
+CREATE OR REPLACE TABLE cdb.dim_i (k INTEGER PRIMARY KEY, name VARCHAR)
+
+statement ok
+INSERT INTO cdb.dim_i VALUES (0,'zero'), (2000000,'twomillion')
+
+# fact_num.k is physically clustered: each 122880-row group (the row group size) holds a
+# single value, so the segment is constant-compressed and scanned as a CONSTANT_VECTOR
+statement ok
+CREATE OR REPLACE TABLE cdb.fact_num (k INTEGER)
+
+statement ok
+INSERT INTO cdb.fact_num SELECT (i // 122880) * 2000000 FROM range(245760) t(i)
+
+# fact_num_miss.k is clustered to values that bracket the build keys but match none of them
+statement ok
+CREATE OR REPLACE TABLE cdb.fact_num_miss (k INTEGER)
+
+statement ok
+INSERT INTO cdb.fact_num_miss SELECT (i // 122880) * 2200000 - 100000 FROM range(245760) t(i)
+
+# flush to storage so the clustered segments are constant-compressed
+statement ok
+CHECKPOINT cdb
+
+# numeric constant probe key - hit (every row group's value is a build-side key)
+query I
+SELECT count(*) FROM cdb.fact_num f JOIN cdb.dim_i d ON f.k = d.k
+----
+245760
+
+# numeric constant probe key - miss (no row group's value is a build-side key); a LEFT
+# join keeps every probe row, so the constant keys still reach TryProbeConstant
+query I
+SELECT count(*) FROM cdb.fact_num_miss f LEFT JOIN cdb.dim_i d ON f.k = d.k WHERE d.k IS NULL
+----
+245760
+
+# constant NULL probe key under equality - NULL = anything is never true
+query I
+SELECT count(*) FROM (SELECT CAST(NULL AS VARCHAR) AS ccy, id FROM fact) t JOIN dim d ON t.ccy = d.k
+----
+0
+
+# constant NULL probe key under IS NOT DISTINCT FROM, build side has no NULL key - no match
+query I
+SELECT count(*) FROM (SELECT CAST(NULL AS VARCHAR) AS ccy, id FROM fact) t JOIN dim d ON t.ccy IS NOT DISTINCT FROM d.k
+----
+0
+
+# constant NULL probe key under IS NOT DISTINCT FROM, build side has a NULL key - matches it
+statement ok
+CREATE TABLE dim_nd (k VARCHAR, name VARCHAR)
+
+statement ok
+INSERT INTO dim_nd VALUES ('EUR','Euro'), (NULL,'Unknown')
+
+query I
+SELECT count(*) FROM (SELECT CAST(NULL AS VARCHAR) AS ccy, id FROM fact) t JOIN dim_nd d ON t.ccy IS NOT DISTINCT FROM d.k
+----
+5000
+
+# non-NULL constant key under IS NOT DISTINCT FROM
+query I
+SELECT count(*) FROM (SELECT 'EUR' AS ccy, id FROM fact) t JOIN dim_nd d ON t.ccy IS NOT DISTINCT FROM d.k
+----
+5000
+
+# LEFT join - non-INNER, every probe row is emitted; found_match must be reset
+query II
+SELECT d.name, count(*) FROM (SELECT 'EUR' AS ccy, id FROM fact) t LEFT JOIN dim d ON t.ccy = d.k GROUP BY d.name ORDER BY d.name
+----
+Euro	5000
+
+query I
+SELECT count(*) FROM (SELECT 'CHF' AS ccy, id FROM fact) t LEFT JOIN dim d ON t.ccy = d.k WHERE d.k IS NULL
+----
+5000
+
+# SEMI join (constant key hit / miss)
+query I
+SELECT count(*) FROM (SELECT 'USD' AS ccy, id FROM fact) t WHERE ccy IN (SELECT k FROM dim)
+----
+5000
+
+query I
+SELECT count(*) FROM (SELECT 'CHF' AS ccy, id FROM fact) t WHERE ccy IN (SELECT k FROM dim)
+----
+0
+
+# ANTI join
+query I
+SELECT count(*) FROM (SELECT 'CHF' AS ccy, id FROM fact) t WHERE ccy NOT IN (SELECT k FROM dim)
+----
+5000
+
+# MARK join - constant key feeds an IN expression projected as a column
+query I
+SELECT count(*) FROM (SELECT 'GBP' AS ccy, id FROM fact) t WHERE (ccy IN (SELECT k FROM dim))
+----
+5000
+
+# probe chunk of a single row - fast path declines, ordinary probe still correct
+query I
+SELECT count(*) FROM (SELECT 'EUR' AS ccy) t JOIN dim d ON t.ccy = d.k
+----
+1
+
+# a probe side mixing dictionary-encoded and constant chunks must stay correct
+statement ok
+CREATE TABLE fact_mixed (k VARCHAR)
+
+statement ok
+INSERT INTO fact_mixed SELECT CASE i%3 WHEN 0 THEN 'EUR' WHEN 1 THEN 'USD' ELSE 'GBP' END FROM range(3000) t(i)
+
+query I
+SELECT count(*) FROM (SELECT k FROM fact_mixed UNION ALL SELECT 'EUR' FROM range(3000)) t JOIN dim d ON t.k = d.k
+----
+6000

--- a/test/sql/join/hash_join/hash_join_dictionary_probe.test
+++ b/test/sql/join/hash_join/hash_join_dictionary_probe.test
@@ -212,7 +212,8 @@ statement ok
 CREATE OR REPLACE TABLE fact_s (k STRUCT(a VARCHAR))
 
 statement ok
-INSERT INTO fact_s SELECT {'a': k} FROM fact WHERE k IS NOT NULL
+INSERT INTO fact_s SELECT {'a': CASE i%4 WHEN 0 THEN 'A' WHEN 1 THEN 'B' WHEN 2 THEN 'C' ELSE 'D' END}
+FROM range(5000) t(i)
 
 statement ok
 CHECKPOINT

--- a/test/sql/join/hash_join/hash_join_dictionary_probe.test
+++ b/test/sql/join/hash_join/hash_join_dictionary_probe.test
@@ -1,0 +1,274 @@
+# name: test/sql/join/hash_join/hash_join_dictionary_probe.test
+# description: Test dictionary-aware hash-join probing on storage dict-encoded VARCHAR keys
+# group: [hash_join]
+
+statement ok
+PRAGMA enable_verification
+
+# persistent + dictionary compression so probe-side VARCHAR keys arrive as DICTIONARY_VECTOR with a non-empty id
+load {TEST_DIR}/dictionary_probe.db
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+statement ok
+CREATE OR REPLACE TABLE dim (k VARCHAR PRIMARY KEY, name VARCHAR);
+
+statement ok
+INSERT INTO dim VALUES ('A','Alpha'), ('B','Beta'), ('C','Gamma'), ('D','Delta')
+
+statement ok
+CREATE OR REPLACE TABLE fact (id INTEGER, k VARCHAR)
+
+statement ok
+INSERT INTO fact SELECT i, CASE i%4 WHEN 0 THEN 'A' WHEN 1 THEN 'B' WHEN 2 THEN 'C' ELSE 'D' END FROM range(5000) t(i)
+
+statement ok
+CHECKPOINT
+
+# baseline: inner join on a dict-encoded VARCHAR probe key
+query I
+SELECT count(*) FROM fact f JOIN dim d ON f.k = d.k
+----
+5000
+
+# verify per-key matches
+query II
+SELECT d.name, count(*) FROM fact f JOIN dim d ON f.k = d.k GROUP BY d.name ORDER BY d.name
+----
+Alpha	1250
+Beta	1250
+Delta	1250
+Gamma	1250
+
+# IS NOT DISTINCT FROM is also dict-eligible
+query I
+SELECT count(*) FROM fact f JOIN dim d ON f.k IS NOT DISTINCT FROM d.k
+----
+5000
+
+# probe keys with no matching build row exercise the dict-slot miss path
+statement ok
+INSERT INTO fact VALUES (10001, 'X'), (10002, 'Y'), (10003, 'Z')
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT count(*) FROM fact f JOIN dim d ON f.k = d.k
+----
+5000
+
+# NULL probe keys: filtered out under =, matched under IS NOT DISTINCT FROM
+statement ok
+INSERT INTO fact VALUES (10004, NULL), (10005, NULL)
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT count(*) FROM fact f JOIN dim d ON f.k = d.k
+----
+5000
+
+# NULL=NULL under IS NOT DISTINCT FROM; build table has no PRIMARY KEY so NULL is allowed
+statement ok
+CREATE OR REPLACE TABLE dim_nd AS SELECT * FROM dim
+
+statement ok
+INSERT INTO dim_nd VALUES (NULL, 'Null')
+
+query II
+SELECT d.name, count(*) FROM fact f JOIN dim_nd d ON f.k IS NOT DISTINCT FROM d.k GROUP BY d.name ORDER BY d.name
+----
+Alpha	1250
+Beta	1250
+Delta	1250
+Gamma	1250
+Null	2
+
+# duplicate build keys force chain walking through the cached head-of-chain pointer
+statement ok
+CREATE OR REPLACE TABLE dim_dup (k VARCHAR, v INTEGER)
+
+statement ok
+INSERT INTO dim_dup VALUES ('A',1),('A',2),('B',10),('B',20),('B',30),('C',100)
+
+query I
+SELECT count(*) FROM fact f JOIN dim_dup d ON f.k = d.k
+----
+7500
+
+query II
+SELECT d.k, sum(d.v) FROM fact f JOIN dim_dup d ON f.k = d.k GROUP BY d.k ORDER BY d.k
+----
+A	3750
+B	75000
+C	125000
+
+# LEFT OUTER: unmatched probe rows must emit NULL on the build side
+query I
+SELECT count(*) FROM fact f LEFT JOIN dim d ON f.k = d.k WHERE d.name IS NULL
+----
+5
+
+# RIGHT OUTER: unmatched build rows must surface even when every probe key hits
+statement ok
+INSERT INTO dim VALUES ('E','Epsilon')
+
+query II
+SELECT d.name, count(f.id) FROM fact f RIGHT JOIN dim d ON f.k = d.k GROUP BY d.name ORDER BY d.name
+----
+Alpha	1250
+Beta	1250
+Delta	1250
+Epsilon	0
+Gamma	1250
+
+# SEMI: probe rows whose key matches the build
+query I
+SELECT count(*) FROM fact f WHERE f.k IN (SELECT k FROM dim WHERE name IN ('Alpha','Beta'))
+----
+2500
+
+# ANTI: explicit syntax keeps the dict-encoded probe on the left; NULL probe keys also survive
+query I
+SELECT count(*) FROM fact f ANTI JOIN dim d ON f.k = d.k
+----
+5
+
+# FULL OUTER: unmatched rows on both sides must surface
+query II
+SELECT coalesce(d.name, '<no-dim>') AS dim_name, count(*) AS rows
+FROM fact f FULL OUTER JOIN dim d ON f.k = d.k
+GROUP BY dim_name ORDER BY dim_name
+----
+<no-dim>	5
+Alpha	1250
+Beta	1250
+Delta	1250
+Epsilon	1
+Gamma	1250
+
+# MARK: IN-subquery in a non-eliminating context
+query II
+SELECT in_dim, count(*) FROM (
+    SELECT f.id, f.k IN (SELECT k FROM dim WHERE name IN ('Alpha','Beta')) AS in_dim FROM fact f
+) GROUP BY in_dim ORDER BY in_dim NULLS FIRST
+----
+NULL	2
+0	2503
+1	2500
+
+# RIGHT_SEMI: optimizer flips sides so the dict-encoded fact stays on the probe side
+query I
+SELECT count(*) FROM dim WHERE k IN (SELECT k FROM fact WHERE k IS NOT NULL)
+----
+4
+
+# RIGHT_ANTI: optimizer flips sides so the dict-encoded fact stays on the probe side
+query I
+SELECT count(*) FROM dim d ANTI JOIN fact f ON d.k = f.k
+----
+1
+
+# SINGLE: correlated scalar subquery folds into a SINGLE hash join
+query I
+SELECT count(*) FROM (
+    SELECT f.id, (SELECT d.name FROM dim d WHERE d.k = f.k) AS dim_name FROM fact f
+) WHERE dim_name IS NOT NULL
+----
+5000
+
+# fallback: multi-condition join disables the structural gate
+statement ok
+CREATE OR REPLACE TABLE fact2 (id INTEGER, k VARCHAR, t INTEGER)
+
+statement ok
+INSERT INTO fact2 SELECT id, k, id % 3 FROM fact WHERE k IS NOT NULL
+
+statement ok
+CHECKPOINT
+
+statement ok
+CREATE OR REPLACE TABLE dim2 (k VARCHAR, t INTEGER, name VARCHAR)
+
+statement ok
+INSERT INTO dim2 VALUES ('A',0,'A0'),('A',1,'A1'),('B',2,'B2')
+
+query I
+SELECT count(*) FROM fact2 f JOIN dim2 d ON f.k = d.k AND f.t = d.t
+----
+1251
+
+# fallback: expression LHS (not a bound reference) - structural gate rejects
+query I
+SELECT count(*) FROM fact f JOIN dim d ON lower(f.k) = lower(d.k)
+----
+5000
+
+# fallback: STRUCT join key - structural gate rejects
+statement ok
+CREATE OR REPLACE TABLE fact_s (k STRUCT(a VARCHAR))
+
+statement ok
+INSERT INTO fact_s SELECT {'a': k} FROM fact WHERE k IS NOT NULL
+
+statement ok
+CHECKPOINT
+
+statement ok
+CREATE OR REPLACE TABLE dim_s (k STRUCT(a VARCHAR), name VARCHAR)
+
+statement ok
+INSERT INTO dim_s VALUES ({'a':'A'},'Alpha'),({'a':'B'},'Beta')
+
+query I
+SELECT count(*) FROM fact_s f JOIN dim_s d ON f.k = d.k
+----
+2500
+
+# fallback: external mode skips the dict path
+statement ok
+SET debug_force_external=true
+
+query I
+SELECT count(*) FROM fact f JOIN dim d ON f.k = d.k
+----
+5000
+
+statement ok
+SET debug_force_external=false
+
+# fallback: in-memory VARCHAR keys arrive flat - per-chunk gate rejects
+statement ok
+ATTACH ':memory:' AS mem
+
+statement ok
+CREATE TABLE mem.dim AS SELECT * FROM dim
+
+statement ok
+CREATE TABLE mem.fact AS SELECT id, k FROM fact LIMIT 100
+
+query I
+SELECT count(*) FROM mem.fact f JOIN mem.dim d ON f.k = d.k
+----
+100
+
+# fallback: perfect-hash join takes over for small contiguous INTEGER keys
+statement ok
+CREATE TABLE mem.dim_i (k INTEGER PRIMARY KEY, name VARCHAR)
+
+statement ok
+INSERT INTO mem.dim_i VALUES (1,'one'),(2,'two'),(3,'three')
+
+statement ok
+CREATE TABLE mem.fact_i (k INTEGER)
+
+statement ok
+INSERT INTO mem.fact_i SELECT (i % 3) + 1 FROM range(300) t(i)
+
+query I
+SELECT count(*) FROM mem.fact_i f JOIN mem.dim_i d ON f.k = d.k
+----
+300


### PR DESCRIPTION
# Add Compressed Probing to Hash Joins

## Motivation

A regular hash join probe pays a fixed per-row cost: hash the key, look it up in the pointer table, salt-compare, re-check key bytes. On a 2048-row chunk that’s 2048 hashes, 2048 cache-missing lookups, 2048 key compares.

When the probe key arrives dictionary-compressed, this is wasted work. If we probe only the distinct dictionary values instead of every row, we eliminate redundant hashing, redundant pointer-table lookups, and redundant key-byte comparisons — reducing the per-chunk cost from N down to D, where D is the dictionary size.

## Approach

We mirror the optimization that `GroupedAggregateHashTable::TryAddDictionaryGroups` already applies on the aggregate side, this time for single-column hash joins. When the LHS join-key column arrives as a `DICTIONARY_VECTOR` with a stable `dictionary_id`, we route into a new `JoinHashTable::TryProbeDictionary` that does the work once per distinct dictionary slot, not once per probe row, and caches the results across chunks so subsequent chunks under the same id pay almost nothing.

The cache lives on the per-thread `ProbeState` as a `ProbeDictionaryState` with three fields:

- `dictionary_pointers` — one slot per dictionary entry, holding the head-of-chain pointer for hits and `nullptr` for misses.
- `found_entry` — one bool per dictionary entry, marking whether we’ve already tried to resolve that slot.
- `dictionary_id` — the id this cache is currently bound to.

On each eligible chunk, `TryProbeDictionary` does six things:

1. **Eligibility check** — confirm the dictionary size and id pass the gates.
2. **Rebind** — if the `dictionary_id` rotated, reset the cache; otherwise reuse it as-is.
3. **Collect unseen slots** — walk the chunk’s selection vector once and gather the distinct dictionary slots we haven’t resolved yet. We improved this step compared to the hash aggregate version by adding a `resolved_count` variable that tracks how many distinct slots have already been resolved under the current id; once it reaches `dict_size`, the walk is skipped entirely on warm chunks, eliminating an O(N) operation. This improvement will be ported back to the hash aggregate side in a separate PR.
4. **Probe the unseen slots** — slice those D keys out of the child vector, hash them, and call `GetRowPointers` on D rows instead of N.
5. **Populate the cache** — write the resolved head pointers into `dictionary_pointers` at their slot positions.
6. **Fan out to N rows** — for each probe row, look up its dictionary slot and copy the cached head pointer into the `ScanStructure`. Then the existing chain walker takes over, unchanged.

The first chunk under a new id pays the full D-row probe cost. Every chunk after that, for as long as the id holds, skips steps 3–5 entirely and only pays for the O(N) fan-out in step 6 — no hashing, no hash-table touch, no key comparison.

## Activation conditions

Three layers; any failure falls through to `Probe()` unchanged.

**Layer 1 — once per operator state (`CanUseCompressedProbe`):** not external, not perfect-hash, `conditions.size() == 1`, comparison is `COMPARE_EQUAL` or `COMPARE_NOT_DISTINCT_FROM`, LHS is `BOUND_REF`, LHS type is not `STRUCT`.

**Layer 2 — once per chunk (`LHSChunkIsDictionaryEligible`):** LHS vector is `DICTIONARY_VECTOR` with a valid `DictionarySize`.

**Layer 3 — inside `TryProbeDictionary` (source of truth):** `dict_size != 0`; if `dictionary_id` is non-empty then `dict_size < 20000`; if empty then `dict_size * 2 < keys.size()` (no cross-chunk reuse, only worth it when D ≪ N).
<h2>Showcase</h2>
<pre><code class="language-sql">SET threads = 1;
CREATE TABLE dim  AS SELECT format('key_{:05d}', i)       AS k, i AS v      FROM range(100)       t(i);
CREATE TABLE fact AS SELECT format('key_{:05d}', i % 100) AS k, i AS amount FROM range(50000000)  t(i);

SELECT COUNT(*) FROM fact f JOIN dim d ON f.k = d.k;
</code></pre>
<h3>Workload shape</h3>

Property | Value
-- | --
D (dim table size) | 100
N (probe rows) | 50,000,000
Global N/D | 500,000
Per-row-group D | 101 (100 + 1 sentinel slot)
Per-row-group N | 122,880
Per-row-group N/D | ~1,217
Number of vectors (chunks) | 24,414

<h3>Cache behaviour — expected vs observed</h3>

Mechanism | Expected | Observed
-- | -- | --
Activations per chunk | 24,414 (50M ÷ 2048) | 24,414 ✓
Rebinds (first bind + one per row group rotation) | 407 | 407 ✓
Walk executed (cold chunks) | 407 | 407 ✓
Walk SKIPPED (FULL CACHE HIT) | 24,007 (= 24,414 − 407) | 24,007 ✓
GetRowPointers probes D, not N | D=100, not N=2048 | D=100 every time ✓

<p><code>GetRowPointers</code> runs on <strong>D=100 keys per row group instead of N=2048 per chunk</strong> — one cold walk per row group (407 row groups total) gives ~41K HT lookups versus ~50M on <code>main</code>.</p>
<h3>main vs dict-probing (D=100, N=50M)</h3>

Metric | Main | Dict-probing | Wall-time reduction | Speedup
-- | -- | -- | -- | --
End-to-end, min | 0.286658 s | 0.119606 s | −58.28% | 2.397×
End-to-end, geomean | 0.291225 s | 0.122105 s | −58.07% | 2.385×
Probe path (PhysicalHashJoin::ExecuteInternal) | — | — | −62.8% | 2.688×


<h2>Benchmarks</h2>
<h3>TPC-H</h3>
<p><strong>No activation at SF=1, 10, 20, 50, 100.</strong></p>
<h3>TPC-DS</h3>
<p>One query activates:</p>

Query | SF1 | SF10 | SF100
-- | -- | -- | --
Q95 | yes | yes | yes
all others | no | no | no

<p><strong>SF100 Q95:</strong></p>

Metric | Main | Dict-probing | Wall-time reduction | Speedup
-- | -- | -- | -- | --
End-to-end, min | 11.428301 s | 11.256842 s | −1.50% | 1.015×
End-to-end, geomean | 11.449038 s | 11.314315 s | −1.18% | 1.012×

<h2>Constant-vector extension</h2>
<p><code>TryProbeDictionary</code> resolves D distinct keys per chunk and fans them out to N rows. A <strong>constant vector</strong> is the degenerate case D = 1 — the whole chunk is one value, produced by a literal projected into the key column or by storage’s constant-compressed numeric segments. This PR also adds <code>JoinHashTable::TryProbeConstant</code>, a smaller sibling: one <code>GetRowPointers</code> call with <code>count = 1</code>, fan the single resolved chain-head pointer out into every kept row’s slot. No cache, no rebind, no <code>dictionary_id</code> lifecycle — D = 1 collapses the per-id machinery to a single lookup per chunk. NULL handling falls out of the existing <code>RowMatcher</code> and <code>PrepareKeys</code> behaviour, so no special-casing is needed. The constant branch is dispatched before the dictionary branch in <code>ExecuteInternal</code>; the two are mutually exclusive by vector type and share the structural gate <code>CanUseCompressedProbe</code>.</p>
<hr>
<p>@lnkuiper — implementation of Compressed probing, constant vector probing is also included, ready for review.</p>
<p>Thank you for taking the time to review! I’m looking forward to your feedback.</p>
<!-- notionvc: 60660e43-17f3-473b-92b9-f72121ae4ad2 -->