### PR TITLE
[Dev] Create a `patched` branch in the cloned repo if `APPLY_PATCHES` is set

### DIFF
--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -9,6 +9,8 @@ import tempfile
 directory = sys.argv[1]
 patch_pattern = f"{directory}*.patch"
 
+PATCHED_BRANCH = "patched"
+
 if os.environ.get("DUCKDB_SKIP_APPLYING_PATCHES") == "1":
     exit(0)
 
@@ -39,20 +41,48 @@ if not patches:
     raise_error(error_message)
 
 
+def git(*args, capture_output=False):
+    return subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
 current_dir = os.getcwd()
+
 print(f"Applying patches at '{current_dir}'")
 print(f"Resetting patches in {directory}\n")
 
 # capture the current diff
-diff_proc = subprocess.run(["git", "diff"], capture_output=True, check=True)
+diff_proc = git("diff", capture_output=True)
 prev_diff = diff_proc.stdout
 
-output_proc = subprocess.run(["git", "diff", "--numstat"], capture_output=True, check=True)
-prev_output_lines = output_proc.stdout.decode('utf8').split('\n')
+output_proc = git("diff", "--numstat", capture_output=True)
+prev_output_lines = output_proc.stdout.split('\n')
 prev_output_lines.sort()
 
-subprocess.run(["git", "clean", "-f"], check=True)
-subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
+# reset repository to clean state
+git("clean", "-f")
+git("reset", "--hard", "HEAD")
+
+# create/reset patched branch
+print(f"Creating/resetting branch '{PATCHED_BRANCH}'")
+
+# delete existing branch if present
+existing_branches = git("branch", "--list", PATCHED_BRANCH, capture_output=True).stdout.strip()
+if existing_branches:
+    current_branch = git("rev-parse", "--abbrev-ref", "HEAD", capture_output=True).stdout.strip()
+
+    # switch away before deleting if currently checked out
+    if current_branch == PATCHED_BRANCH:
+        git("checkout", "HEAD", "--detach")
+
+    git("branch", "-D", PATCHED_BRANCH)
+
+# create and checkout fresh branch from current HEAD
+git("checkout", "-b", PATCHED_BRANCH)
 
 
 def apply_patch(patch_file):
@@ -60,37 +90,61 @@ def apply_patch(patch_file):
     arguments = []
     arguments.extend(ARGUMENTS)
     arguments.append(patch_file)
+
     try:
-        subprocess.run(arguments, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(
+            arguments,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
     except subprocess.CalledProcessError as e:
         arguments[1:1] = ['-d', current_dir]
         command = " ".join(arguments)
+
         print(f"Failed to apply patch, command to reproduce locally:\n{command}")
         print("\nError output:")
         print(e.stderr.decode('utf-8'))
         print("\nStandard output:")
         print(e.stdout.decode('utf-8'))
         print("Exiting")
+
         exit(1)
+
+
+def commit_patch(patch_name):
+    commit_message = f"Apply patch: {patch_name}"
+
+    # stage all changes from the patch
+    git("add", "-A")
+
+    # create commit
+    git("commit", "-m", commit_message)
+
+    print(f"Committed patch: {patch_name}")
 
 
 # Apply each patch file using patch
 for patch in patches:
     print(f"Applying patch: {patch}\n")
+
     apply_patch(os.path.join(directory, patch))
+    commit_patch(patch)
+
 
 # all patches have applied - check the current diff
-output_proc = subprocess.run(["git", "diff", "--numstat"], capture_output=True, check=True)
-output_lines = output_proc.stdout.decode('utf8').split('\n')
+output_proc = git("diff", "--numstat", capture_output=True)
+output_lines = output_proc.stdout.split('\n')
 output_lines.sort()
 
 if len(output_lines) <= len(prev_output_lines) and prev_output_lines != output_lines:
     print("Detected local changes - rolling back patch application")
 
-    subprocess.run(["git", "clean", "-f"], check=True)
-    subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
+    git("clean", "-f")
+    git("reset", "--hard", "HEAD")
+
     with tempfile.NamedTemporaryFile() as f:
-        f.write(prev_diff)
+        f.write(prev_diff.encode("utf-8"))
         f.flush()
         apply_patch(f.name)
 
@@ -101,3 +155,8 @@ if len(output_lines) <= len(prev_output_lines) and prev_output_lines != output_l
     print("--------------------------------------------------")
 
     exit(1)
+
+print("\n--------------------------------------------------")
+print(f"All patches successfully applied to branch '{PATCHED_BRANCH}'")
+print("Working tree is clean.")
+print("--------------------------------------------------")

--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -31,20 +31,17 @@ def apply_patch(patch_file, current_dir):
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:
-        repro_args = args[:]
-        repro_args[1:1] = ["-d", current_dir]
+        args[1:1] = ["-d", current_dir]
+        command = " ".join(args)
 
-        print("Failed to apply patch")
-        print("\nCommand to reproduce locally:")
-        print(" ".join(repro_args))
-
+        print(f"Failed to apply patch, command to reproduce locally:\n{command}")
         print("\nError output:")
         print(e.stderr.decode("utf-8"))
-
         print("\nStandard output:")
         print(e.stdout.decode("utf-8"))
+        print("Exiting")
 
-        sys.exit(1)
+        raise_error("Patch application failed")
 
 
 def commit_patch(patch_name):
@@ -56,24 +53,31 @@ def ensure_clean_repo(directory):
     status = git("status", "--porcelain", capture_output=True).stdout.strip()
 
     if status:
-        print("Detected local changes - aborting patch application\n")
+        print("Detected local changes - aborting patch application")
 
         print("--------------------------------------------------")
+        print("Uncommitted changes detected:")
+        print(status)
+        print("--------------------------------------------------")
+
         print("Generate a patch file using the following command:")
         print("--------------------------------------------------")
-        print(f"(cd {os.getcwd()} && " f"git diff > {os.path.join(directory, 'fix.patch')})")
+        print(f"(cd {os.getcwd()} && git diff > {os.path.join(directory, 'fix.patch')})")
         print("--------------------------------------------------")
 
-        raise_error(
-            "Repository has uncommitted changes. " "Please commit or stash them before running patch application."
-        )
+        raise_error("Repository has uncommitted changes. " "Please commit, stash, or convert them into a patch first.")
 
 
 def ensure_patched_branch():
     existing = git("branch", "--list", PATCHED_BRANCH, capture_output=True).stdout.strip()
 
     if existing:
-        current = git("rev-parse", "--abbrev-ref", "HEAD", capture_output=True).stdout.strip()
+        current = git(
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+            capture_output=True,
+        ).stdout.strip()
 
         if current == PATCHED_BRANCH:
             git("checkout", "HEAD", "--detach")
@@ -99,10 +103,17 @@ def main():
 
     for patch in patches:
         if not patch.endswith(".patch"):
-            raise_error(f'Patch file {patch} found in directory {directory} ' 'does not end in ".patch"')
+            raise_error(
+                f'Patch file {patch} found in directory {directory} does not end in ".patch" - rename the patch file'
+            )
 
     if not patches:
-        raise_error(f"\nERROR: Extension patching enabled, but no patches found in '{directory}'.")
+        error_message = (
+            f"\nERROR: Extension patching enabled, but no patches found in '{directory}'. "
+            "Please make sure APPLY_PATCHES is only enabled when there are actually patches present. "
+            "See .github/patches/extensions/README.md for more details."
+        )
+        raise_error(error_message)
 
     print(f"Applying patches in '{os.getcwd()}'")
 

--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -1,44 +1,14 @@
 #!/usr/bin/env python3
 import sys
-import glob
 import subprocess
 import os
-import tempfile
-
-# Get the directory and construct the patch file pattern
-directory = sys.argv[1]
-patch_pattern = f"{directory}*.patch"
 
 PATCHED_BRANCH = "patched"
 
-if os.environ.get("DUCKDB_SKIP_APPLYING_PATCHES") == "1":
-    exit(0)
-
-# Find patch files matching the pattern
-patches = glob.glob(patch_pattern)
-
 
 def raise_error(error_msg):
-    sys.stderr.write(error_msg + '\n')
+    sys.stderr.write(error_msg + "\n")
     sys.exit(1)
-
-
-patches = sorted(os.listdir(directory))
-for patch in patches:
-    if not patch.endswith('.patch'):
-        raise_error(
-            f'Patch file {patch} found in directory {directory} does not end in ".patch" - rename the patch file'
-        )
-
-
-# Exit if no patches are found
-if not patches:
-    error_message = (
-        f"\nERROR: Extension patching enabled, but no patches found in '{directory}'. "
-        "Please make sure APPLY_PATCHES is only enabled when there are actually patches present. "
-        "See .github/patches/extensions/README.md for more details."
-    )
-    raise_error(error_message)
 
 
 def git(*args, capture_output=False):
@@ -50,113 +20,118 @@ def git(*args, capture_output=False):
     )
 
 
-current_dir = os.getcwd()
-
-print(f"Applying patches at '{current_dir}'")
-print(f"Resetting patches in {directory}\n")
-
-# capture the current diff
-diff_proc = git("diff", capture_output=True)
-prev_diff = diff_proc.stdout
-
-output_proc = git("diff", "--numstat", capture_output=True)
-prev_output_lines = output_proc.stdout.split('\n')
-prev_output_lines.sort()
-
-# reset repository to clean state
-git("clean", "-f")
-git("reset", "--hard", "HEAD")
-
-# create/reset patched branch
-print(f"Creating/resetting branch '{PATCHED_BRANCH}'")
-
-# delete existing branch if present
-existing_branches = git("branch", "--list", PATCHED_BRANCH, capture_output=True).stdout.strip()
-if existing_branches:
-    current_branch = git("rev-parse", "--abbrev-ref", "HEAD", capture_output=True).stdout.strip()
-
-    # switch away before deleting if currently checked out
-    if current_branch == PATCHED_BRANCH:
-        git("checkout", "HEAD", "--detach")
-
-    git("branch", "-D", PATCHED_BRANCH)
-
-# create and checkout fresh branch from current HEAD
-git("checkout", "-b", PATCHED_BRANCH)
-
-
-def apply_patch(patch_file):
-    ARGUMENTS = ["patch", "-p1", "--forward", "-i"]
-    arguments = []
-    arguments.extend(ARGUMENTS)
-    arguments.append(patch_file)
+def apply_patch(patch_file, current_dir):
+    args = ["patch", "-p1", "--forward", "-i", patch_file]
 
     try:
         subprocess.run(
-            arguments,
+            args,
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:
-        arguments[1:1] = ['-d', current_dir]
-        command = " ".join(arguments)
+        repro_args = args[:]
+        repro_args[1:1] = ["-d", current_dir]
 
-        print(f"Failed to apply patch, command to reproduce locally:\n{command}")
+        print("Failed to apply patch")
+        print("\nCommand to reproduce locally:")
+        print(" ".join(repro_args))
+
         print("\nError output:")
-        print(e.stderr.decode('utf-8'))
-        print("\nStandard output:")
-        print(e.stdout.decode('utf-8'))
-        print("Exiting")
+        print(e.stderr.decode("utf-8"))
 
-        exit(1)
+        print("\nStandard output:")
+        print(e.stdout.decode("utf-8"))
+
+        sys.exit(1)
 
 
 def commit_patch(patch_name):
-    commit_message = f"Apply patch: {patch_name}"
-
-    # stage all changes from the patch
     git("add", "-A")
-
-    # create commit
-    git("commit", "-m", commit_message)
-
-    print(f"Committed patch: {patch_name}")
+    git("commit", "-m", f"Apply patch: {patch_name}")
 
 
-# Apply each patch file using patch
-for patch in patches:
-    print(f"Applying patch: {patch}\n")
+def ensure_clean_repo(directory):
+    status = git("status", "--porcelain", capture_output=True).stdout.strip()
 
-    apply_patch(os.path.join(directory, patch))
-    commit_patch(patch)
+    if status:
+        print("Detected local changes - aborting patch application\n")
+
+        print("--------------------------------------------------")
+        print("Generate a patch file using the following command:")
+        print("--------------------------------------------------")
+        print(f"(cd {os.getcwd()} && " f"git diff > {os.path.join(directory, 'fix.patch')})")
+        print("--------------------------------------------------")
+
+        raise_error(
+            "Repository has uncommitted changes. " "Please commit or stash them before running patch application."
+        )
 
 
-# all patches have applied - check the current diff
-output_proc = git("diff", "--numstat", capture_output=True)
-output_lines = output_proc.stdout.split('\n')
-output_lines.sort()
+def ensure_patched_branch():
+    existing = git("branch", "--list", PATCHED_BRANCH, capture_output=True).stdout.strip()
 
-if len(output_lines) <= len(prev_output_lines) and prev_output_lines != output_lines:
-    print("Detected local changes - rolling back patch application")
+    if existing:
+        current = git("rev-parse", "--abbrev-ref", "HEAD", capture_output=True).stdout.strip()
 
-    git("clean", "-f")
-    git("reset", "--hard", "HEAD")
+        if current == PATCHED_BRANCH:
+            git("checkout", "HEAD", "--detach")
 
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(prev_diff.encode("utf-8"))
-        f.flush()
-        apply_patch(f.name)
+        git("branch", "-D", PATCHED_BRANCH)
 
+    git("checkout", "-b", PATCHED_BRANCH)
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise_error("Usage: apply_patches.py <patch_directory>")
+
+    directory = sys.argv[1]
+
+    if os.environ.get("DUCKDB_SKIP_APPLYING_PATCHES") == "1":
+        return
+
+    if not os.path.isdir(directory):
+        raise_error(f"Patch directory does not exist: {directory}")
+
+    patches = sorted(os.listdir(directory))
+
+    for patch in patches:
+        if not patch.endswith(".patch"):
+            raise_error(f'Patch file {patch} found in directory {directory} ' 'does not end in ".patch"')
+
+    if not patches:
+        raise_error(f"\nERROR: Extension patching enabled, but no patches found in '{directory}'.")
+
+    print(f"Applying patches in '{os.getcwd()}'")
+
+    #
+    # Abort if repo is not clean
+    #
+    ensure_clean_repo(directory)
+
+    print(f"Creating branch '{PATCHED_BRANCH}'")
+    ensure_patched_branch()
+
+    #
+    # Apply + commit patches
+    #
+    for patch in patches:
+        patch_path = os.path.join(directory, patch)
+
+        print(f"\nApplying patch: {patch}")
+
+        apply_patch(patch_path, os.getcwd())
+        commit_patch(patch)
+
+        print(f"Committed patch: {patch}")
+
+    print("\n--------------------------------------------------")
+    print(f"All patches successfully applied to branch '{PATCHED_BRANCH}'")
+    print("Working tree is clean")
     print("--------------------------------------------------")
-    print("Generate a patch file using the following command:")
-    print("--------------------------------------------------")
-    print(f"(cd {os.getcwd()} && git diff > {os.path.join(directory, 'fix.patch')})")
-    print("--------------------------------------------------")
 
-    exit(1)
 
-print("\n--------------------------------------------------")
-print(f"All patches successfully applied to branch '{PATCHED_BRANCH}'")
-print("Working tree is clean.")
-print("--------------------------------------------------")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Every patch becomes a commit to the `patched` branch, making it easier to write a new patch, since the working tree will be clean.
It's also easier to develop a patch, all you need is a `git reset HEAD^` to turn the last applied patch back into uncommitted changes in the working tree.

This also makes the script much simpler, as previously we jumped through some weird hoops to determine if the repository had uncommitted local changes not created by patches.

Now that we always leave the working tree clean after applying the patches, this check is much simpler.