### PR TITLE
append to new row group if vacuum_rebuild_indexes is enabled

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -26,6 +26,19 @@
 
 namespace duckdb {
 
+static bool CanRebuildExistingIndexesAfterVacuum(DataTableInfo &info, DatabaseInstance &db, idx_t total_rows) {
+	auto &indexes = info.GetIndexes();
+	if (indexes.Empty() || indexes.HasUnbound()) {
+		return false;
+	}
+	auto vacuum_rebuild_threshold = Settings::Get<VacuumRebuildIndexesSetting>(db);
+	if (vacuum_rebuild_threshold == 0 || total_rows > vacuum_rebuild_threshold) {
+		return false;
+	}
+	auto index_types = indexes.DistinctIndexTypes();
+	return index_types.size() == 1 && index_types.count(ART::TYPE_NAME);
+}
+
 //===--------------------------------------------------------------------===//
 // Row Group Segment Tree
 //===--------------------------------------------------------------------===//
@@ -504,12 +517,13 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 	bool needs_new_row_group = state.row_groups->IsEmpty(l) || row_group_append_mode == RowGroupAppendMode::REQUIRE_NEW;
 	// Otherwise we evaluate the row_group_append_mode
 	if (!needs_new_row_group) {
-		if (info->GetIndexes().Empty()) {
-			// We honor SUGGEST_NEW unless the table has indexes because there is no vacuuming for indexed tables...
+		if (info->GetIndexes().Empty() || CanRebuildExistingIndexesAfterVacuum(*info, GetDatabase(), GetTotalRows())) {
+			// Honor SUGGEST_NEW if vacuum can compact the table later, either because there are no indexes or because
+			// the existing indexes can be rebuilt after vacuuming.
 			needs_new_row_group = row_group_append_mode == RowGroupAppendMode::SUGGEST_NEW;
 		} else {
-			// ... and if it has indexes we will ignore row_group_append_mode and try to append, unless the last row
-			// group is full already.
+			// If the table has indexes that vacuum cannot rebuild, ignore row_group_append_mode and try to append,
+			// unless the last row group is full already.
 			needs_new_row_group = row_group_size < state.row_groups->GetLastSegment(l)->GetNode().count;
 		}
 	}
@@ -1356,11 +1370,8 @@ void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkp
 	// *unless* vacuum_rebuild_indexes threshold is set, the table's row count
 	// is within the threshold, and all indexes are bound ART indexes,
 	// in which case we allow vacuuming and rebuild the indexes afterward.
-	auto vacuum_rebuild_threshold = Settings::Get<VacuumRebuildIndexesSetting>(checkpoint_state.writer.GetDatabase());
-	auto index_types = info->GetIndexes().DistinctIndexTypes();
-	state.can_rebuild_indexes = has_indexes && !info->GetIndexes().HasUnbound() && index_types.size() == 1 &&
-	                            index_types.count(ART::TYPE_NAME) && vacuum_rebuild_threshold > 0 &&
-	                            GetTotalRows() <= vacuum_rebuild_threshold;
+	state.can_rebuild_indexes =
+	    CanRebuildExistingIndexesAfterVacuum(*info, checkpoint_state.writer.GetDatabase(), GetTotalRows());
 
 	// We can move around rowids if we either 1) don't have any indexes at all or 2) can_rebuild_indexes is true (in
 	// which case indexes are entirely rebuilt after vacuuming).

--- a/test/configs/vacuum_rebuild_indexes_force_storage.json
+++ b/test/configs/vacuum_rebuild_indexes_force_storage.json
@@ -19,6 +19,12 @@
         "test/sql/index/art/constraints/test_art_eager_constraint_checking.test",
         "test/sql/index/art/constraints/test_art_tx_deletes_list.test"
       ]
+    },
+    {
+      "reason": "Test expects an out-of-memory error from a specific persistent index loading pattern.",
+      "paths": [
+        "test/sql/storage/constraints/foreignkey/foreign_key_persistent_memory_limit.test"
+      ]
     }
   ]
 }

--- a/test/sql/storage/vacuum/vacuum_rebuild_indexes.test_slow
+++ b/test/sql/storage/vacuum/vacuum_rebuild_indexes.test_slow
@@ -10,6 +10,12 @@ statement ok
 SET wal_autocheckpoint='100GB'
 
 statement ok
+SET index_scan_percentage = 1.0
+
+statement ok
+SET index_scan_max_count = 0
+
+statement ok
 CREATE TABLE t(i INTEGER);
 
 statement ok
@@ -62,6 +68,64 @@ query I
 SELECT COUNT(*) FROM t
 ----
 122880
+
+# verify that indexed appends honor SUGGEST_NEW when vacuum_rebuild_indexes is enabled
+statement ok
+CREATE TABLE append_test(i INTEGER);
+
+statement ok
+CREATE INDEX append_idx ON append_test(i);
+
+statement ok
+INSERT INTO append_test SELECT i FROM range(100000) tbl(i);
+
+statement ok
+CHECKPOINT
+
+query II
+SELECT row_group_id, max(count) FROM pragma_storage_info('append_test') GROUP BY row_group_id ORDER BY row_group_id
+----
+0	100000
+
+statement ok
+INSERT INTO append_test SELECT i FROM range(100000, 100100) tbl(i);
+
+statement ok
+CHECKPOINT
+
+# the append starts a new row group instead of filling the existing indexed row group
+query II
+SELECT row_group_id, max(count) FROM pragma_storage_info('append_test') GROUP BY row_group_id ORDER BY row_group_id
+----
+0	100000
+1	100
+
+statement ok
+DELETE FROM append_test WHERE i < 100000
+
+statement ok
+CHECKPOINT
+
+# vacuum drops the deleted row group and rebuilds the index with shifted row IDs
+query II
+SELECT row_group_id, max(count) FROM pragma_storage_info('append_test') GROUP BY row_group_id ORDER BY row_group_id
+----
+0	100
+
+query II
+EXPLAIN ANALYZE SELECT i, rowid FROM append_test WHERE i = 100000
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query II
+SELECT i, rowid FROM append_test WHERE i = 100000
+----
+100000	0
+
+query II
+SELECT i, rowid FROM append_test WHERE i = 100099
+----
+100099	99
 
 # verify that the setting cannot be changed while the database is running
 statement error


### PR DESCRIPTION
In RowGroupCollection::InitializeAppend, if there were no indexes present we would honor SUGGEST_NEW, i.e. try to append to a new row group, or if there are indexes present and space in the last row group, we would append to an existing row group (to mitigate the current limitation of no vacuuming with indexes). 

Modify this so that if the vacuum_rebuild_indexes setting is enabled, we append to a new row group (since vacuuming will happen assuming the row count is below the threshold). 

Temporary workaround while I am working on vacuuming in the presence of indexes by default, at which point we can remove the vacuum_rebuild_indexes and related logic around it. 