### PR TITLE
Fix `WindowSelfJoinOptimizer` ignore exception

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -128,7 +128,7 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		LogicalOperatorDeepCopy deep_copy(optimizer.binder, nullptr);
 		try {
 			copy_child = deep_copy.DeepCopy(window.children[0]);
-		} catch (NotImplementedException &ex) {
+		} catch (std::exception &ex) {
 			// failed to copy the LHS - cannot run this optimizer
 			return op;
 		}


### PR DESCRIPTION
Revert the narrowed `catch (NotImplementedException &)` introduced in https://github.com/duckdb/duckdb/pull/22164. This causes errors leak out of the optimizer instead of "skiping this optimization".

Specifically, pg_duckdb uses a `PostgresScanTableFunction` without registered in the system catalog. `DeepCopy` this operator throws a `CatalogException` instead.