### PR TITLE
Remove redundant part lock guard for sort_key_payload_state

### DIFF
--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -1,5 +1,4 @@
 deadlock:InitializeIndexes
-deadlock:TemplatedSortKeySetPayload
 race:InsertMatchesAndIncrementMisses
 race:NextInnerJoin
 race:NextRightSemiOrAntiJoin

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -423,7 +423,8 @@ void TupleDataAllocator::InitializeChunkStateInternal(TupleDataPinState &pin_sta
 
 		if (sort_key_payload_state) {
 			D_ASSERT(!layout.IsSortKeyLayout()); // This must be the payload collection
-			lock_guard<mutex> guard(part.lock);
+			// SortKeySetPayload() guards sort-key payload mutations with the sort-key chunk lock.
+			// Avoid nesting part.lock with that lock, which can introduce lock-order inversions.
 			SortKeySetPayload(row_locations, offset, next, *sort_key_payload_state);
 		}
 


### PR DESCRIPTION
Fix this threadsan warning:
```
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=77147)
  Cycle in lock order graph: M0 (0x7f693220b108) => M1 (0x7f693220d108) => M0
```
instead of suppressing the warning.

See threadsan full error in CI log: https://github.com/duckdb/duckdb/actions/runs/25797353015/job/75778737814?pr=22498#step:7:876