### PR TITLE
Don't allow identifiers to start with numbers

### DIFF
--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -457,6 +457,9 @@ public:
 		if (IsQuoted(text)) {
 			return true;
 		}
+		if (BaseTokenizer::CharacterIsInitialNumber(text[0])) {
+			return false;
+		}
 		return BaseTokenizer::CharacterIsKeyword(text[0]);
 	}
 

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -412,7 +412,8 @@ bool BaseTokenizer::TokenizeInput() {
 			break;
 		case TokenizeState::KEYWORD:
 			// keyword - check if this is still a keyword
-			if (!CharacterIsKeyword(c)) {
+			// '$' is valid as a non-initial identifier character in PostgreSQL
+			if (c != '$' && !CharacterIsKeyword(c)) {
 				// not a keyword - return to standard state
 				auto word = sql.substr(last_pos, i - last_pos);
 				auto token_type = keyword_helper.IsKeyword(word) ? TokenType::KEYWORD : TokenType::IDENTIFIER;

--- a/test/sql/peg_parser/identifier.test
+++ b/test/sql/peg_parser/identifier.test
@@ -1,0 +1,58 @@
+# name: test/sql/peg_parser/identifier.test
+# description: Test SQL identifier rules: must start with a letter or underscore
+# group: [peg_parser]
+
+query I
+SELECT 1 a;
+----
+1
+
+query I
+SELECT 1 A1;
+----
+1
+
+query I
+SELECT 1 _abc;
+----
+1
+
+query I
+SELECT 1 _;
+----
+1
+
+query I
+SELECT 1 a1;
+----
+1
+
+query I
+SELECT 1 a_1;
+----
+1
+
+query I
+SELECT 1 a_b;
+----
+1
+
+query I
+SELECT 1 abc123;
+----
+1
+
+statement error
+SELECT 1 1abc;
+----
+Parser Error: syntax error at or near "1"
+
+statement error
+SELECT 1 123;
+----
+Parser Error: syntax error at or near "123"
+
+statement error
+SELECT 1 $col;
+----
+Parser Error: syntax error at or near "$"

--- a/test/sql/peg_parser/identifier.test
+++ b/test/sql/peg_parser/identifier.test
@@ -42,6 +42,16 @@ SELECT 1 abc123;
 ----
 1
 
+query I
+SELECT 1 a$c;
+----
+1
+
+query I
+SELECT 1 a$1;
+----
+1
+
 statement error
 SELECT 1 1abc;
 ----

--- a/test/sql/peg_parser/peg_syntax_error.test
+++ b/test/sql/peg_parser/peg_syntax_error.test
@@ -115,3 +115,28 @@ query I
 SELECT ('abcd'::VARCHAR)[1:3];
 ----
 abc
+
+# Identifiers must not start with a digit
+statement error
+SELECT * FROM 1e5;
+----
+Parser Error: syntax error at or near "1e5"
+
+statement error
+CREATE TABLE 1 (id INTEGER);
+----
+Parser Error: syntax error at or near "1"
+
+statement error
+SELECT 1 AS 1col;
+----
+Parser Error: syntax error at or near "1"
+
+statement error
+SELECT 0 10;
+----
+Parser Error: syntax error at or near "10"
+
+# Quoted identifiers starting with a digit are allowed
+statement ok
+CREATE TABLE "1abc" (id INTEGER);


### PR DESCRIPTION
thanks @carlopi 
Reference issue: https://github.com/duckdblabs/duckdb-internal/issues/9376

This PR disallows identifiers to start with a number. This is in line with the SQL standard and what PostgreSQL defines ([PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)):

> SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($). Note that dollar signs are not allowed in identifiers according to the letter of the SQL standard, so their use might render applications less portable. The SQL standard will not define a key word that contains digits or starts or ends with an underscore, so identifiers of this form are safe against possible conflict with future extensions of the standard.
