### PR TITLE
Throw error if last token is unterminated string or quoted identifier

### DIFF
--- a/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/parser_tokenizer.hpp
@@ -10,6 +10,7 @@ public:
 	~ParserTokenizer() override = default;
 
 	void OnStatementEnd(idx_t pos) override;
+	void OnLastToken(TokenizeState state, string last_word, idx_t last_pos) override;
 };
 
 } // namespace duckdb

--- a/src/parser/peg/tokenizer/parser_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/parser_tokenizer.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/peg/tokenizer/parser_tokenizer.hpp"
+#include "duckdb/common/exception/parser_exception.hpp"
 
 namespace duckdb {
 
@@ -9,6 +10,18 @@ void ParserTokenizer::OnStatementEnd(idx_t pos) {
 	// Always emit ';' as a TERMINATOR token so the grammar can consume it.
 	// Statement boundaries are determined by the PEG grammar (Program rule), not the tokenizer.
 	tokens.emplace_back(";", pos, TokenType::TERMINATOR);
+}
+
+void ParserTokenizer::OnLastToken(TokenizeState state, string last_word, idx_t last_pos) {
+	switch (state) {
+	case TokenizeState::STRING_LITERAL:
+		throw ParserException::SyntaxError(sql, "unterminated string literal", optional_idx(last_pos));
+	case TokenizeState::QUOTED_IDENTIFIER:
+		throw ParserException::SyntaxError(sql, "unterminated quoted identifier", optional_idx(last_pos));
+	default:
+		break;
+	}
+	BaseTokenizer::OnLastToken(state, std::move(last_word), last_pos);
 }
 
 } // namespace duckdb

--- a/test/sql/peg_parser/fuzzer/internal_0208.test
+++ b/test/sql/peg_parser/fuzzer/internal_0208.test
@@ -4,4 +4,4 @@
 statement error
 INSTALL 'CWQqtzCCq9' FROM ''''' 'bj7OGvEqL'
 ----
-Parser Error: syntax error at or near "bj7OGvEqL"
+Parser Error: unterminated string literal

--- a/test/sql/peg_parser/unterminated_literals.test
+++ b/test/sql/peg_parser/unterminated_literals.test
@@ -1,0 +1,23 @@
+# name: test/sql/peg_parser/unterminated_literals.test
+# description: Test that unterminated string literals and quoted identifiers are rejected
+# group: [peg_parser]
+
+statement error
+SELECT 'hello
+----
+Parser Error: unterminated string literal
+
+statement error
+SELECT 'CONCAT_WS(',', ''''
+----
+Parser Error: unterminated string literal
+
+statement error
+SELECT 'abc
+----
+Parser Error: unterminated string literal
+
+statement error
+SELECT "my_col
+----
+Parser Error: unterminated quoted identifier


### PR DESCRIPTION
Thanks @carlopi 

Reference issue: https://github.com/duckdblabs/duckdb-internal/issues/9376

If a query was being executed directly, using `-c` or `-cmd` we would not catch unterminated string literals or quoted identifiers properly during tokenization.