### PR TITLE
Fix jemalloc packaging for JDBC/ODBC

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -39,6 +39,7 @@ def third_party_includes():
     includes += [os.path.join('third_party', 'vergesort')]
     includes += [os.path.join('third_party', 'yyjson', 'include')]
     includes += [os.path.join('third_party', 'zstd', 'include')]
+    includes += [os.path.join('third_party', 'jemalloc', 'include')]
     return includes
 
 
@@ -55,6 +56,7 @@ def third_party_sources():
     sources += [os.path.join('third_party', 'mbedtls')]
     sources += [os.path.join('third_party', 'yyjson')]
     sources += [os.path.join('third_party', 'zstd')]
+    sources += [os.path.join('third_party', 'jemalloc')]
     return sources
 
 

--- a/src/common/allocator/allocator_jemalloc.cpp
+++ b/src/common/allocator/allocator_jemalloc.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include <thread>
 #include <cstdint>

--- a/tools/swift/create_package.py
+++ b/tools/swift/create_package.py
@@ -39,6 +39,9 @@ import package_build
 source_list = [os.path.relpath(x, target_dir) if os.path.isabs(x) else x for x in source_list]
 include_list = [os.path.join(src_dir_name, x) for x in include_list]
 define_list = ['DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()) for ext in extensions]
+# filter out jemalloc
+source_list = [x for x in source_list if not x.startswith("duckdb/third_party/jemalloc/")]
+include_list = [x for x in include_list if not x.startswith("duckdb/third_party/jemalloc/")]
 # write Package.swift
 os.chdir(base_dir)
 


### PR DESCRIPTION
This PR adds a fix to a packaging script that is used when importing sources into JDBC and ODBC repos.

It also adds a missing header for `StringUtil` usage.