### PR TITLE
Optimize TryAddDictionaryGroups

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -412,6 +412,7 @@ optional_idx GroupedAggregateHashTable::TryAddDictionaryGroups(DataChunk &groups
 		}
 		memset(dict_state.found_entry.get(), 0, dict_size * sizeof(bool));
 		dict_state.dictionary_id = dictionary_id;
+		dict_state.resolved_count = 0;
 		dict_state.address_high_bits = ~uint64_t(0);
 		dict_state.address_high_bits_uniform =
 		    (sizeof(uintptr_t) == sizeof(uint64_t)); // only relevant on 64-bits systems
@@ -426,11 +427,15 @@ optional_idx GroupedAggregateHashTable::TryAddDictionaryGroups(DataChunk &groups
 	idx_t unique_count = 0;
 	// for each of the dictionary entries - check if we have already done a look-up into the hash table
 	// if we have, we can just use the cached group pointers
-	for (idx_t i = 0; i < groups.size(); i++) {
-		auto dict_idx = offsets.get_index(i);
-		unique_entries.set_index(unique_count, dict_idx);
-		unique_count += !found_entry[dict_idx];
-		found_entry[dict_idx] = true;
+	// once every dict slot has been seen the walk would produce no new entries - skip it
+	if (dict_state.resolved_count < dict_size) {
+		for (idx_t i = 0; i < groups.size(); i++) {
+			auto dict_idx = offsets.get_index(i);
+			unique_entries.set_index(unique_count, dict_idx);
+			unique_count += !found_entry[dict_idx];
+			found_entry[dict_idx] = true;
+		}
+		dict_state.resolved_count += unique_count;
 	}
 	auto &new_dictionary_pointers = dict_state.new_dictionary_pointers;
 	idx_t new_group_count = 0;

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -146,6 +146,9 @@ private:
 		unique_ptr<Vector> dictionary_addresses;
 		unsafe_unique_array<bool> found_entry;
 		idx_t capacity = 0;
+		//! Cumulative count of dict slots added to found_entry under the current id; the
+		//! unique-entries walk is skipped once it reaches dict_size.
+		idx_t resolved_count = 0;
 		//! For the clustered-aggregate fast path: track whether every state pointer added to this
 		//! dictionary shares the same high (64 - SLOT_GID_BITS) bits. The clustered path stores only
 		//! the low SLOT_GID_BITS of each pointer, so if any two pointers differ in their high bits


### PR DESCRIPTION

# Optimize `TryAddDictionaryGroups`

## Motivation

`GroupedAggregateHashTable::TryAddDictionaryGroups` walks every row of every chunk to discover which dictionary slots appear, even on warm chunks where every slot has already been seen in earlier chunks of the same row group. On those chunks the walk produces `unique_count == 0`, the probe/scatter block short-circuits, but the N-row pass itself still runs.

This is the same wasted work the [compressed probing PR](https://github.com/duckdb/duckdb/pull/22789) eliminated on the join side. This PR ports that gate back to the aggregate side, as called out in step 3 of that PR's description.

## Approach

Mirror the `resolved_count` gate from `TryProbeDictionary`: a new `idx_t resolved_count` field on `AggregateDictionaryState`, reset to `0` at re-bind, with the unique-entries discovery walk wrapped in `if (resolved_count < dict_size)` and `resolved_count += unique_count` accumulated after the walk. Once `resolved_count` reaches `dict_size`, every `offsets.get_index(i)` is already in `found_entry`, so the walk would produce `unique_count == 0` — skipping it is bitwise identical to running it. The downstream `if (unique_count > 0)` short-circuit and the fan-out are unchanged; `dictionary_addresses[offsets[i]]` has been populated by an earlier chunk under the same id for every referenced slot, otherwise `resolved_count` could not have reached `dict_size`.

**When it activates.** The gate fires once the data has cumulatively referenced every slot of the current dictionary id. Two shapes reach that point in practice:

- **Operator-emitted dictionaries** (e.g. from `PerfectHashJoinExecutor::CreateReusableDictionary` or `JoinHashTable::BuildDictionaryArrays`) carry no reserved sentinel, so `dict_size` equals the build cardinality exactly and the cold chunk alone fires the gate. **Correct** because the cold-chunk walk visits and probes every slot the data can ever reference.
- **Storage VARCHAR dictionaries** where the data organically touches every slot — including the reserved NULL sentinel at slot 0, requiring at least one NULL row in practice. **Correct** because firing means an earlier chunk carried each slot through the walk and the probe, so every `dictionary_addresses[i]` is written. NULL-free storage VARCHAR never activates the optimization (`resolved_count` stops one short of `dict_size`); the walk runs every chunk, original behaviour and correctness preserved.

**Why the join-side NULL-sentinel pre-mark is not ported.** The compressed probing PR pre-marks invalid child slots at re-bind so the gate fires even on NULL-free storage VARCHAR. Three structural safeguards make that safe on the join side, none hold here: the join pre-mark is guarded by `!null_values_are_equal[0]` (aggregate semantics are always `COMPARE_NOT_DISTINCT_FROM`-shaped, so a literal port would disable it everywhere it'd actually run); the join cache is zeroed with `nullptr` as a miss sentinel (the aggregate has no miss convention — every group must resolve to a real state row); the join fan-out filters on null pointers, the aggregate fan-out dereferences unconditionally in `UpdateAggregates`.

## Showcase

D = 100, N = 50M, single-threaded:

```sql
SET threads = 1;
CREATE TABLE dim AS
  SELECT i AS k, format('key_{:05d}', i) AS name
  FROM range(100) t(i);
CREATE TABLE fact AS
  SELECT (i % 100)::INTEGER AS k
  FROM range(50000000) t(i);

SELECT d.name, COUNT(*) AS cnt
FROM fact f JOIN dim d ON f.k = d.k
GROUP BY d.name;
```

### Walk behaviour — main vs this PR

| Metric | Main | This PR |
| --- | --- | --- |
| Chunks routed through `TryAddDictionaryGroups` | 24,415 | 24,415 |
| Walks executed | 24,415 | **1** (cold only) |
| Walks skipped (gate fired) | 0 | **24,414** |
| Walk row visits per query | ~50.0 M | ~2,048 |
| **Saved per query** | — | **~49.99 M row visits (~99.996 %)** |

### main vs this PR (D=100, N=50M)

| Metric | Main | Optimized | Wall-time reduction | Speedup |
| --- | --- | --- | --- | --- |
| End-to-end, min | 0.170291 s | 0.154865 s | −9.06% | **1.100×** |
| End-to-end, geomean | 0.173571 s | 0.156852 s | −9.63% | **1.107×** |
| `TryAddDictionaryGroups` (function-local) | — | — | −36% | **1.562×** |

---

The optimization reduced the wall-time of `TryAddDictionaryGroups` by −36%, way higher than my expectations.

@lnkuiper — port of the `resolved_count` gate from the [compressed probing PR](https://github.com/duckdb/duckdb/pull/22789) to the aggregate side, ready for review.

Thank you for taking the time to review!
