### PR TITLE
Render MAP values as valid SQL in Value::ToSQLString()

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1743,6 +1743,24 @@ string Value::ToSQLString() const {
 		ret += "]";
 		return ret;
 	}
+	case LogicalTypeId::MAP: {
+		// A bare `MAP {...}` literal infers its element types from the entries
+		// (and `MAP {}` infers MAP(INTEGER, INTEGER)), so it does not faithfully
+		// round-trip on its own. Append an explicit cast to the real type
+		auto &entries = MapValue::GetChildren(*this);
+		string ret = "MAP {";
+		for (idx_t i = 0; i < entries.size(); i++) {
+			auto &kv = StructValue::GetChildren(entries[i]);
+			if (i > 0) {
+				ret += ", ";
+			}
+			ret += kv[0].ToSQLString();
+			ret += ": ";
+			ret += kv[1].ToSQLString();
+		}
+		ret += "}::" + type_.ToString();
+		return ret;
+	}
 	case LogicalTypeId::UNION: {
 		string ret = "union_value(";
 		auto union_tag = UnionValue::GetTag(*this);

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library_unity(
   test_allocator_debug_info.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
-  test_string_util.cpp)
+  test_string_util.cpp
+  test_value_to_sql_string.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_common>

--- a/test/common/test_value_to_sql_string.cpp
+++ b/test/common/test_value_to_sql_string.cpp
@@ -1,0 +1,47 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+// Evaluates `SELECT <expr>` and returns the resulting scalar Value.
+static Value EvalScalar(Connection &con, const string &expr) {
+	auto result = con.Query("SELECT " + expr);
+	REQUIRE_NO_FAIL(*result);
+	return result->GetValue(0, 0);
+}
+
+// Asserts the round-trip contract of Value::ToSQLString(): rendering a Value to
+// SQL and re-parsing it yields a Value with the same type and contents.
+static void RequireRoundTrip(Connection &con, const string &expr) {
+	auto original = EvalScalar(con, expr);
+	auto sql = original.ToSQLString();
+	INFO("expr=" << expr << " ToSQLString=" << sql);
+	auto roundtripped = EvalScalar(con, sql);
+	REQUIRE(roundtripped.type() == original.type());
+	REQUIRE(roundtripped.ToString() == original.ToString());
+}
+
+TEST_CASE("Value::ToSQLString round-trips MAP values", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// flat string-keyed map
+	RequireRoundTrip(con, "MAP {'a': 'b', 'c': 'd'}");
+	// integer-keyed / integer-valued map
+	RequireRoundTrip(con, "MAP {1: 10, 2: 20}");
+	// empty map needs an explicit cast to keep its element types
+	RequireRoundTrip(con, "MAP {}::MAP(VARCHAR, VARCHAR)");
+	// nested map
+	RequireRoundTrip(con, "MAP {'a': MAP {'b': 1}}");
+	// map with LIST values
+	RequireRoundTrip(con, "MAP {'a': [1, 2, 3]}");
+	// map with STRUCT values
+	RequireRoundTrip(con, "MAP {'a': {'x': 1, 'y': 2}}");
+	// map with a NULL value
+	RequireRoundTrip(con, "MAP {'k': NULL}::MAP(VARCHAR, VARCHAR)");
+	// keys/values that require single-quote escaping
+	RequireRoundTrip(con, "MAP {'it''s': 'a''b'}");
+	// the explicit cast also preserves narrower integer subtypes
+	RequireRoundTrip(con, "MAP {1::SMALLINT: 2::SMALLINT}");
+}


### PR DESCRIPTION
Add a MAP case that emits the `MAP {k: v, ...}::MAP(...)` constructor literal, recursing through ToSQLString() on each key and value so nested MAPs/STRUCTs/LISTs are handled. The explicit `::type` cast is always appended (mirroring the DATE/BLOB cases) because a bare `MAP {...}` literal infers its element types from the entries -- and `MAP {}` infers MAP(INTEGER, INTEGER) -- so it does not faithfully round-trip on its own.

Bumped on this working on `quack`, have a workaround, but this seems generally a nice to have.