### PR TITLE
Fix case-insensitive column match in INSERT ... SELECT ON CONFLICT

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -432,7 +432,7 @@ unique_ptr<MergeIntoStatement> Binder::GenerateMergeInto(InsertStatement &stmt, 
 			// now push another subquery that adds the default columns
 			auto select_stmt = make_uniq<SelectStatement>();
 			auto select_node = make_uniq<SelectNode>();
-			unordered_set<string> set_columns;
+			case_insensitive_set_t set_columns;
 			for (auto &set_col : stmt.columns) {
 				set_columns.insert(set_col);
 			}

--- a/test/sql/upsert/upsert_default.test
+++ b/test/sql/upsert/upsert_default.test
@@ -42,3 +42,50 @@ query I
 insert into t values (1, 1) on conflict (i) do update set j = excluded.i;
 ----
 1
+
+statement ok
+create table t_case (i int not null primary key);
+
+query I
+insert into t_case (I) select 1 on conflict do nothing;
+----
+1
+
+query I
+select * from t_case;
+----
+1
+
+query I
+insert into t_case (I) select 1 on conflict do nothing;
+----
+0
+
+# nullable column, mismatched case: value must survive, not become NULL
+statement ok
+create table t_case_nullable (i int, j int unique);
+
+statement ok
+insert into t_case_nullable (I, J) select 7, 9 on conflict do nothing;
+
+query II
+select i, j from t_case_nullable;
+----
+7	9
+
+# mismatched case on both insert columns and explicit ON CONFLICT target
+statement ok
+create table t_case_upd (i int primary key, j int);
+
+statement ok
+insert into t_case_upd (I, J) select 1, 10 on conflict do nothing;
+
+query I
+insert into t_case_upd (I, J) select 1, 20 on conflict (I) do update set j = excluded.j;
+----
+1
+
+query II
+select i, j from t_case_upd;
+----
+1	20


### PR DESCRIPTION
Fixes #22641.

Cause: The `INSERT ... ON CONFLICT` rewrite compared column names case-sensitively, so `INSERT INTO t (I) SELECT ...` didn't match column `i` and filled it with NULL. 1.4.4 fixed this for the VALUES form but missed the `INSERT ... SELECT` form.

Fix: compare case-insensitively. 

Tests: added to `upsert_default.test`, ran the upsert/merge/insert suites and all passed


