### PR TITLE
Fix NULL format option on json copy

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -19,6 +19,20 @@ static void ThrowJSONCopyParameterException(const string &loption) {
 	throw BinderException("COPY (FORMAT JSON) parameter %s expects a single argument.", loption);
 }
 
+static void ThrowJSONCopyNullException(const string &loption) {
+	throw BinderException("COPY (FORMAT JSON) parameter \"%s\" cannot be NULL.", loption);
+}
+
+static const Value &GetSingleJSONCopyValue(const string &loption, const vector<Value> &values) {
+	if (values.size() != 1) {
+		ThrowJSONCopyParameterException(loption);
+	}
+	if (values.back().IsNull()) {
+		ThrowJSONCopyNullException(loption);
+	}
+	return values.back();
+}
+
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	static const unordered_set<string> SUPPORTED_BASE_OPTIONS {
 	    "compression", "encoding", "use_tmp_file", "overwrite_or_ignore", "overwrite", "append", "filename_pattern",
@@ -37,18 +51,15 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	for (const auto &kv : copy_info.options) {
 		const auto &loption = StringUtil::Lower(kv.first);
 		if (loption == "dateformat" || loption == "date_format") {
-			if (kv.second.size() != 1) {
-				ThrowJSONCopyParameterException(loption);
-			}
-			date_format = StringValue::Get(kv.second.back());
+			date_format = StringValue::Get(GetSingleJSONCopyValue(loption, kv.second));
 		} else if (loption == "timestampformat" || loption == "timestamp_format") {
-			if (kv.second.size() != 1) {
-				ThrowJSONCopyParameterException(loption);
-			}
-			timestamp_format = StringValue::Get(kv.second.back());
+			timestamp_format = StringValue::Get(GetSingleJSONCopyValue(loption, kv.second));
 		} else if (loption == "array") {
 			if (kv.second.size() > 1) {
 				ThrowJSONCopyParameterException(loption);
+			}
+			if (!kv.second.empty() && kv.second.back().IsNull()) {
+				ThrowJSONCopyNullException(loption);
 			}
 			if (kv.second.empty() || BooleanValue::Get(kv.second.back().DefaultCastAs(LogicalTypeId::BOOLEAN))) {
 				csv_copy_options["prefix"] = {"[\n\t"};
@@ -57,7 +68,7 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			}
 		} else if (loption == "file_extension") {
 			// Since we set the file extension to "json" above, we need to override it
-			csv_copy_options["file_extension"] = {StringValue::Get(kv.second.back())};
+			csv_copy_options["file_extension"] = {StringValue::Get(GetSingleJSONCopyValue(loption, kv.second))};
 		} else if (SUPPORTED_BASE_OPTIONS.find(loption) != SUPPORTED_BASE_OPTIONS.end()) {
 			// We support these base options
 			csv_copy_options.insert(kv);

--- a/test/sql/json/copy_json_null_options.test
+++ b/test/sql/json/copy_json_null_options.test
@@ -1,0 +1,35 @@
+# name: test/sql/json/copy_json_null_options.test
+# description: Test that NULL values for COPY (FORMAT JSON) options produce a clean Binder Error (issue #22829)
+# group: [json]
+
+require json
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_dateformat.json' (FORMAT JSON, dateformat NULL);
+----
+<REGEX>:Binder Error.*dateformat.*cannot be NULL.*
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_date_format.json' (FORMAT JSON, date_format NULL);
+----
+<REGEX>:Binder Error.*date_format.*cannot be NULL.*
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_timestampformat.json' (FORMAT JSON, timestampformat NULL);
+----
+<REGEX>:Binder Error.*timestampformat.*cannot be NULL.*
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_timestamp_format.json' (FORMAT JSON, timestamp_format NULL);
+----
+<REGEX>:Binder Error.*timestamp_format.*cannot be NULL.*
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_array.json' (FORMAT JSON, array NULL);
+----
+<REGEX>:Binder Error.*array.*cannot be NULL.*
+
+statement error
+COPY (SELECT 1 AS a) TO '{TEST_DIR}/test_null_file_extension.json' (FORMAT JSON, file_extension NULL);
+----
+<REGEX>:Binder Error.*file_extension.*cannot be NULL.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/22829

The root cause is, for all the options for json copy, we didn't check whether the option is NULL.