### PR TITLE
Fix miscount of pinned row handles and allocator row blocks

### DIFF
--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -529,19 +529,26 @@ void TupleDataCollection::Reset() {
 	for (idx_t i = 0; i < segments.size(); i++) {
 		if (segments[i]) {
 			live_idx = i;
-			segments[i]->Reset();
 			break;
 		}
 	}
 
 	if (live_idx < segments.size()) {
-		// At least one live segment found: reset in-place to avoid per-iteration mutex create/destroy.
-		// We own all the blocks, so it is safe to clear the allocator's block list directly.
+		// At least one live segment found. Keep exactly one live segment and make the collection-level allocator
+		// match that segment allocator before resetting to preserve segment/allocator consistency.
 		if (live_idx > 0) {
 			segments[0] = std::move(segments[live_idx]);
 		}
 		segments.resize(1);
+		allocator = segments[0]->allocator;
+		segments[0]->Reset();
 		allocator->Reset();
+#ifdef D_ASSERT_IS_ENABLED
+		D_ASSERT(segments[0]->allocator.get() == allocator.get());
+		D_ASSERT(segments[0]->count == 0);
+		D_ASSERT(segments[0]->chunks.empty());
+		D_ASSERT(segments[0]->chunk_parts.empty());
+#endif
 	} else {
 		// All segments were null (moved out by Combine).  The old allocator is still shared by
 		// those moved-out segments and must keep its row_blocks intact.  Create a fresh allocator.

--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -543,12 +543,10 @@ void TupleDataCollection::Reset() {
 		allocator = segments[0]->allocator;
 		segments[0]->Reset();
 		allocator->Reset();
-#ifdef D_ASSERT_IS_ENABLED
 		D_ASSERT(segments[0]->allocator.get() == allocator.get());
 		D_ASSERT(segments[0]->count == 0);
 		D_ASSERT(segments[0]->chunks.empty());
 		D_ASSERT(segments[0]->chunk_parts.empty());
-#endif
 	} else {
 		// All segments were null (moved out by Combine).  The old allocator is still shared by
 		// those moved-out segments and must keep its row_blocks intact.  Create a fresh allocator.


### PR DESCRIPTION
### Assertion failure for pinned row handles and row block count

The nightly CI job `Release Assertions with Clang` [failed](https://github.com/duckdb/duckdb/actions/runs/26199676309/job/77088829080#step:9:53) with:
```
-------------------------------------------------------------------------------
Test TPCH arrow roundtrip
-------------------------------------------------------------------------------
/home/runner/work/duckdb/duckdb/test/arrow/arrow_roundtrip.cpp:282
...............................................................................

/home/runner/work/duckdb/duckdb/test/arrow/arrow_roundtrip.cpp:282: FAILED:
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal

ABORT THROWN BY INTERNAL EXCEPTION: Assertion triggered in file
"/home/runner/work/duckdb/duckdb/src/common/types/row/tuple_data_segment.cpp"
on line 170: pinned_row_handles.size() == allocator->RowBlockCount()
```

I was able to reproduce it locally on macOS:
```
$ UNSAFE_NUMERIC_CAST=1 RUN_SLOW_VERIFIERS=1 DISABLE_SANITIZER=1 CORE_EXTENSIONS="tpch;tpcds" make relassert
$ ./build/relassert/test/unittest 'Test TPCH arrow roundtrip[.]'                                           
Filters: Test TPCH arrow roundtrip[.]
[0/1] (0%): Test TPCH arrow roundtrip                                                                                                                           -------------------------------------
Arrow round-trip type comparison failed
-------------------------------------
Query: SELECT l_orderkey, l_shipdate, l_comment FROM lineitem_no_constraint ORDER BY l_orderkey DESC;
-------------------------------------
Query failed to execute:
INTERNAL Error: Assertion triggered in file "/Users/sander/dev/duckdb/duckdb/src/common/types/row/tuple_data_segment.cpp" on line 170: pinned_row_handles.size() == allocator->RowBlockCount()

Stack Trace:

0        duckdb::Exception::ToJSON(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 48
1        duckdb::InternalException::InternalException<char const*&, int&, char const*&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*&, int&, char const*&) + 140
2        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 108
3        duckdb::TupleDataCollection::VerifyEverythingPinned() const + 128
4        duckdb::HashJoinGlobalSourceState::TryPrepareNextStage(duckdb::HashJoinGlobalSinkState&) + 88
5        duckdb::PhysicalHashJoin::GetDataInternal(duckdb::ExecutionContext&, duckdb::DataChunk&, duckdb::OperatorSourceInput&) const + 348
6        duckdb::PipelineExecutor::FetchFromSource(duckdb::DataChunk&) + 136
7        duckdb::PipelineExecutor::Execute(unsigned long long) + 400
8        duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode) + 328
9        duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 288
10       duckdb::TaskScheduler::ExecuteForever(std::__1::atomic<bool>*) + 508
11       void* std::__1::__thread_proxy[abi:nqe210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(duckdb::TaskScheduler*, std::__1::atomic<bool>*), duckdb::TaskScheduler*, std::__1::atomic<bool>*>>(void*) + 56
12       _pthread_start + 136
13       thread_start + 8

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/current/dev/internal_errors-------------------------------------

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
Test TPCH arrow roundtrip
-------------------------------------------------------------------------------
/Users/sander/dev/duckdb/duckdb/test/arrow/arrow_roundtrip.cpp:282
...............................................................................

/Users/sander/dev/duckdb/duckdb/test/arrow/arrow_roundtrip.cpp:301: FAILED:
  REQUIRE( ArrowTestHelper::RunArrowComparison( con, "SELECT l_orderkey, l_shipdate, l_comment FROM lineitem_no_constraint ORDER BY l_orderkey DESC;", true) )
with expansion:
  false

[1/1] (100%): Test TPCH arrow roundtrip                                                                                                                         
===============================================================================
test cases: 1 | 1 failed
assertions: 1 | 1 failed
```

## Why `Reset()` doesn’t clear all segment objects anymore

I asked Codex what caused it and how it can be fixed:

- `Reset()` is designed to reuse one segment object for performance (avoid repeated allocation/mutex churn).
- It still clears all logical data:
    - count / data_size
    - chunk/part contents
    - allocator block state
- The bug was allocator/segment mismatch after Combine:
    - retained segment could point to allocator A
    - collection could reset allocator B
    - this caused `pinned_row_handles.size()` vs `RowBlockCount()` assertion failure.
- Fix: when keeping one segment, first make `collection.allocator = retained_segment.allocator`, then reset both consistently.

### Passing tests

The initial and the other 7 failing test are now passing locally:
```
$ ./build/relassert/test/unittest test/sql/storage/external_file_cache/external_file_cache_low_mem.test_slow,test/sql/logging/physical_operator_logging.test_slow,test/sql/join/external/many_external_joins.test_slow,test/sql/join/external/simple_external_join.test_slow,test/sql/join/external/tpch_all_tables.test_slow,test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow,test/sql/copy/parquet/batched_write/lineitem_memory_usage.test_slow
[7/7] (100%): test/sql/logging/physical_operator_logging.test_slow                                                                                              
===============================================================================
All tests passed (135 assertions in 7 test cases)
```