### PR TITLE
Bump HTTPFS

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 52afb4204a3238d6ee132e83340f8d68c40ee91c
+    GIT_TAG 53c5b032f6c368cfcc1a1ac3819118e86d3286a6
     APPLY_PATCHES
 )

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -30,11 +30,6 @@ const char MainHeader::MAGIC_BYTES[] = "DUCK";
 const char MainHeader::CANARY[] = "DUCKKEY";
 static constexpr idx_t ENCRYPTION_METADATA_LEN = 8;
 
-static mutex &CanaryCryptoLock() {
-	static mutex lock;
-	return lock;
-}
-
 void SerializeVersionNumber(WriteStream &ser, const string &version_str) {
 	data_t version[MainHeader::MAX_VERSION_SIZE];
 	memset(version, 0, MainHeader::MAX_VERSION_SIZE);
@@ -105,7 +100,6 @@ void GenerateDBIdentifier(uint8_t *db_identifier) {
 
 void EncryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &encryption_state,
                    const_data_ptr_t derived_key) {
-	lock_guard<mutex> canary_lock(CanaryCryptoLock());
 	EncryptionCanary canary;
 	EncryptionNonce nonce(EncryptionTypes::CipherType::GCM, encryption_state->metadata->GetVersion());
 	memset(nonce.data(), 0, nonce.size());
@@ -138,7 +132,6 @@ void EncryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &e
 
 bool DecryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &encryption_state,
                    data_ptr_t derived_key) {
-	lock_guard<mutex> canary_lock(CanaryCryptoLock());
 	auto encryption_version = encryption_state->metadata->GetVersion();
 	EncryptionNonce nonce(EncryptionTypes::CipherType::GCM, encryption_version);
 	EncryptionTag tag;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -30,6 +30,11 @@ const char MainHeader::MAGIC_BYTES[] = "DUCK";
 const char MainHeader::CANARY[] = "DUCKKEY";
 static constexpr idx_t ENCRYPTION_METADATA_LEN = 8;
 
+static mutex &CanaryCryptoLock() {
+	static mutex lock;
+	return lock;
+}
+
 void SerializeVersionNumber(WriteStream &ser, const string &version_str) {
 	data_t version[MainHeader::MAX_VERSION_SIZE];
 	memset(version, 0, MainHeader::MAX_VERSION_SIZE);
@@ -100,6 +105,7 @@ void GenerateDBIdentifier(uint8_t *db_identifier) {
 
 void EncryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &encryption_state,
                    const_data_ptr_t derived_key) {
+	lock_guard<mutex> canary_lock(CanaryCryptoLock());
 	EncryptionCanary canary;
 	EncryptionNonce nonce(EncryptionTypes::CipherType::GCM, encryption_state->metadata->GetVersion());
 	memset(nonce.data(), 0, nonce.size());
@@ -132,6 +138,7 @@ void EncryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &e
 
 bool DecryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &encryption_state,
                    data_ptr_t derived_key) {
+	lock_guard<mutex> canary_lock(CanaryCryptoLock());
 	auto encryption_version = encryption_state->metadata->GetVersion();
 	EncryptionNonce nonce(EncryptionTypes::CipherType::GCM, encryption_version);
 	EncryptionTag tag;


### PR DESCRIPTION
I got a threadsan data race [warning](https://github.com/duckdb/duckdb/actions/runs/26271430486/job/77325736063?pr=22832#step:7:36) in another [PR](https://github.com/duckdb/duckdb/pull/22832):
```
[0/1] (0%): test/sql/copy/encryption/concurrent_encrypted_attach.test
[1/1] (100%): test/sql/copy/encryption/concurrent_encrypted_attach.test
===============================================================================
All tests passed (10 assertions in 1 test case)

WARNING: ThreadSanitizer: data race (pid=92574)
  Read of size 8 at 0x721c0003c158 by thread T22 (mutexes: write M0):
    #0 bcmp <null> (unittest+0x29683e) (BuildId: 4a71c7e25393c04f8fb25aecb86e6508425b3ef1)
    #1 ossl_ht_get <null> (libduckdb.so+0x634377b) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #2 duckdb::EncryptCanary(duckdb::MainHeader&, duckdb::shared_ptr<duckdb::EncryptionState, true> const&, unsigned char const*) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:118:21 (libduckdb.so+0x4846ca8) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #3 duckdb::SingleFileBlockManager::StoreEncryptedCanary(duckdb::AttachedDatabase&, duckdb::MainHeader&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:456:2 (libduckdb.so+0x484b4b0) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #4 duckdb::SingleFileBlockManager::CreateNewDatabase(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:597:3 (libduckdb.so+0x4830bad) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #5 duckdb::SingleFileStorageManager::LoadDatabase(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/storage_manager.cpp:474:21 (libduckdb.so+0x482f845) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #6 duckdb::StorageManager::Initialize(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/storage_manager.cpp:356:2 (libduckdb.so+0x482de39) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
...
  Previous write of size 8 at 0x721c0003c158 by thread T18 (mutexes: write M1, write M2, write M3):
    #0 memcpy <null> (unittest+0x2857b2) (BuildId: 4a71c7e25393c04f8fb25aecb86e6508425b3ef1)
    #1 ossl_ht_insert <null> (libduckdb.so+0x6342ab1) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #2 duckdb::EncryptCanary(duckdb::MainHeader&, duckdb::shared_ptr<duckdb::EncryptionState, true> const&, unsigned char const*) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:118:21 (libduckdb.so+0x4846ca8) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #3 duckdb::SingleFileBlockManager::StoreEncryptedCanary(duckdb::AttachedDatabase&, duckdb::MainHeader&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:456:2 (libduckdb.so+0x484b4b0) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #4 duckdb::SingleFileBlockManager::CreateNewDatabase(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/single_file_block_manager.cpp:597:3 (libduckdb.so+0x4830bad) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #5 duckdb::SingleFileStorageManager::LoadDatabase(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/storage_manager.cpp:474:21 (libduckdb.so+0x482f845) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #6 duckdb::StorageManager::Initialize(duckdb::QueryContext) /home/runner/work/duckdb/duckdb/src/storage/storage_manager.cpp:356:2 (libduckdb.so+0x482de39) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #7 duckdb::AttachedDatabase::Initialize(duckdb::optional_ptr<duckdb::ClientContext, true>) /home/runner/work/duckdb/duckdb/src/main/attached_database.cpp:242:12 (libduckdb.so+0x43f099f) (BuildId: 1933a57ba8cd5721b7a93b4b0bb4d66d4448190c)
    #8 duckdb::DatabaseManager::AttachDatabase(duckdb::ClientContext&, duckdb::AttachInfo&, duckdb::AttachOptions&) /home/runner/work/duckdb/duckdb/src/main/database_manager.cpp:204:16 (libduckdb.so+0x43f099f)
```

TSAN found two threads entering the canary encryption path at the same time (`EncryptCanary` / `DecryptCanary` during parallel ATTACH/open).

Inside that path, OpenSSL internals performed concurrent read/write access to the same heap-backed crypto state (reported around `ossl_ht_insert` / `memcpy` / `bcmp`) and that caused the data race warning.

~~Adding a lock to `EncryptCanary` and `DecryptCanary` avoids concurrent read/writes to the internal crypto state.~~

I added Mark/Claude's suggestion to `httpfs` and merged that [PR](https://github.com/duckdb/duckdb-httpfs/pull/330). So, this PR bumps `httpfs` and that should resolve the threadsan data race.