### PR TITLE
Allow collation for VARCHAR alias column types (e.g. CHAR, BPCHAR, STRING, TEXT)

### DIFF
--- a/src/parser/peg/transformer/transform_create_table.cpp
+++ b/src/parser/peg/transformer/transform_create_table.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/expression/type_expression.hpp"
+#include "duckdb/catalog/default/default_types.hpp"
 
 namespace duckdb {
 
@@ -310,7 +311,7 @@ ConstraintColumnDefinition PEGTransformerFactory::TransformColumnDefinition(PEGT
 						throw InternalException("Expected a type expression");
 					}
 					auto &type_expr = expr->Cast<TypeExpression>();
-					if (!StringUtil::CIEquals(type_expr.GetTypeName(), "VARCHAR")) {
+					if (DefaultTypeGenerator::GetDefaultType(type_expr.GetTypeName()) != LogicalTypeId::VARCHAR) {
 						throw ParserException("Only VARCHAR columns can have collations!");
 					}
 				} else {

--- a/test/sql/collate/collate_string_col.test
+++ b/test/sql/collate/collate_string_col.test
@@ -1,0 +1,18 @@
+# name: test/sql/collate/collate_string_col.test
+# group: [collate]
+
+statement ok
+CREATE TABLE tbl (
+	col1 STRING COLLATE NOCASE
+);
+
+statement ok
+INSERT INTO tbl VALUES ('Hello'), ('hello'), ('HELLO'), ('hElLo');
+
+query I
+SELECT * FROM tbl WHERE col1 = 'hello';
+----
+Hello
+hello
+HELLO
+hElLo


### PR DESCRIPTION
Previously this would throw: Only VARCHAR columns can have collations!