### PR TITLE
fix progress bar output and crash when piping SQL

### DIFF
--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -73,8 +73,11 @@ idx_t Printer::TerminalWidth() {
 	rows = csbi.srWindow.Right - csbi.srWindow.Left + 1;
 	return rows;
 #else
-	struct winsize w;
+	struct winsize w = {};
 	ioctl(0, TIOCGWINSZ, &w);
+	if (w.ws_col == 0) {
+		return 120;
+	}
 	return w.ws_col;
 #endif
 #else

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1192,7 +1192,9 @@ void ShellState::OpenDB(ShellOpenFlags flags) {
 			}
 		}
 		auto &client_config = duckdb::ClientConfig::GetConfig(*conn->context);
-		client_config.display_create_func = CreateProgressBar;
+		if (stdout_is_console) {
+			client_config.display_create_func = CreateProgressBar;
+		}
 #ifdef SHELL_INLINE_AUTOCOMPLETE
 		db->LoadStaticExtension<duckdb::AutocompleteExtension>();
 #endif


### PR DESCRIPTION
When running `duckdb < query.sql`, the progress bar produced a lot of trailing spaces per update line and on some occasions crashed with a floating point exception. When stdin is a pipe or file, `ioctl` fails and leaves the width uninitialized, returning a garbage value (or zero). The progress bar then attempted to render a line of that width, causing an arithmetic overflow and SIGFPE.

Using a default value of 120 feels a bit hacky, but we already follow the same approach in `BoxRendererImplementation::Initialize()`, so I applied it here as well for consistency.

Fixes: https://github.com/duckdb/duckdb/issues/22716