### PR TITLE
Remove time-out waiting for terminal background color

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -478,11 +478,6 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 		char read_buf[1];
 		while (true) {
 			// check if we have data to read
-			// wait up till 1s
-			if (!HasMoreData(ifd, 1000000)) {
-				// no more data available - done
-				break;
-			}
 			if (read(ifd, read_buf, 1) != 1) {
 				break;
 			}


### PR DESCRIPTION
Hopefully fixes https://github.com/duckdb/duckdb/issues/22810

This time-out was added as a work-around for the color detection being broken in some terminals - but it can itself break terminals if we exceed this time-out. We should just remove it and wait until a full response is returned.

