### PR TITLE
Reject MERGE clauses that follow an unconditional clause of the same condition

### DIFF
--- a/src/parser/peg/transformer/transform_merge_into.cpp
+++ b/src/parser/peg/transformer/transform_merge_into.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/set.hpp"
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
 #include "duckdb/parser/statement/merge_into_statement.hpp"
 
@@ -18,28 +19,25 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformMergeIntoStatement(PEGT
 	}
 
 	auto &merge_match_repeat = list_pr.Child<RepeatParseResult>(6);
-	map<MergeActionCondition, unique_ptr<MergeIntoAction>> unconditional_actions;
+	set<MergeActionCondition> unconditional_actions;
 	for (auto merge_match : merge_match_repeat.GetChildren()) {
 		auto merge_match_result =
 		    transformer.Transform<pair<MergeActionCondition, unique_ptr<MergeIntoAction>>>(merge_match);
 		auto action_condition = merge_match_result.first;
 		auto &action = merge_match_result.second;
+		// once an unconditional clause has been seen for a given condition type, no further clauses
+		// of the same condition type are allowed - they would be unreachable. preserve declaration
+		// order so that the first matching clause wins, matching the SQL standard.
+		if (unconditional_actions.count(action_condition)) {
+			string action_condition_str = MergeIntoStatement::ActionConditionToString(action_condition);
+			throw ParserException(
+			    "Unconditional %s clause was already defined - any following %s clause would be unreachable",
+			    action_condition_str, action_condition_str);
+		}
 		if (!action->condition) {
-			auto entry = unconditional_actions.find(action_condition);
-			if (entry != unconditional_actions.end()) {
-				string action_condition_str = MergeIntoStatement::ActionConditionToString(action_condition);
-				throw ParserException(
-				    "Unconditional %s clause was already defined - only one unconditional %s clause is supported",
-				    action_condition_str, action_condition_str);
-			}
-			unconditional_actions.emplace(action_condition, std::move(action));
-			continue;
+			unconditional_actions.insert(action_condition);
 		}
 		result->actions[action_condition].push_back(std::move(action));
-	}
-	// finally add the unconditional actions
-	for (auto &entry : unconditional_actions) {
-		result->actions[entry.first].push_back(std::move(entry.second));
 	}
 	transformer.TransformOptional<vector<unique_ptr<ParsedExpression>>>(list_pr, 7, result->returning_list);
 	return std::move(result);

--- a/test/issues/general/test_22624.test
+++ b/test/issues/general/test_22624.test
@@ -1,0 +1,36 @@
+# name: test/issues/general/test_22624.test
+# description: Issue 22624 - MERGE silently reordered WHEN MATCHED clauses when catch-all preceded a conditional clause
+# group: [general]
+
+statement ok
+CREATE TABLE t (id int primary key, val text);
+
+statement ok
+INSERT INTO t (id) VALUES (1),(2),(3),(4);
+
+# A conditional WHEN MATCHED clause that follows an unconditional WHEN MATCHED clause is unreachable.
+# Previously the parser silently reordered the clauses, causing the conditional clause to fire instead.
+# We now reject the query at parse time so the unreachable clause cannot go unnoticed.
+statement error
+MERGE INTO t
+USING (SELECT 1)
+ON t.id > 2
+WHEN MATCHED THEN UPDATE SET val = 'x'
+WHEN MATCHED AND id = 4 THEN DELETE;
+----
+Unconditional WHEN MATCHED clause was already defined
+
+# Writing the catch-all last continues to work and follows declaration order.
+statement ok
+MERGE INTO t
+USING (SELECT 1)
+ON t.id > 2
+WHEN MATCHED AND id = 4 THEN DELETE
+WHEN MATCHED THEN UPDATE SET val = 'x';
+
+query IT
+FROM t ORDER BY id
+----
+1	NULL
+2	NULL
+3	x

--- a/test/sql/merge/merge_into.test
+++ b/test/sql/merge/merge_into.test
@@ -101,7 +101,7 @@ MERGE INTO Stock USING initial_stocks ON (Stock.item_id = initial_stocks.item_id
 WHEN NOT MATCHED THEN INSERT VALUES (initial_stocks.item_id, initial_stocks.balance)
 WHEN NOT MATCHED THEN ERROR;
 ----
-only one unconditional WHEN NOT MATCHED clause
+Unconditional WHEN NOT MATCHED clause was already defined
 
 # we cannot merge into views
 statement ok


### PR DESCRIPTION
A conditional WHEN [NOT] MATCHED clause that follows an unconditional clause of the same condition type is unreachable, but the parser was silently reordering all unconditional clauses to the end of their condition group. In the example from #22624, an unconditional UPDATE got reordered behind a conditional DELETE, so a row that should have been updated was deleted instead.

This change rejects the query at parse time so the unreachable clause cannot go unnoticed, and removes the reorder pass so the remaining clauses execute in declaration order. The error message also points at the unreachable clause rather than only mentioning duplicate unconditional clauses, since the same situation now covers both cases. Existing tests in test/sql/merge already place catch-all clauses last and continue to pass; the existing duplicate-unconditional test in test/sql/merge/merge_into.test was updated to match the new wording.

The new regression test in test/issues/general/test_22624.test covers both the rejection of the original reproducer and that the equivalent declaration-order form still runs and produces the expected rows.

Closes #22624