### PR TITLE
Make `GetSQLValueFunction` pluggable through a planner extension

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -344,6 +344,8 @@ public:
 
 	void BindDefaultValue(const ColumnDefinition &column, vector<unique_ptr<Expression>> &bound_defaults,
 	                      const string &catalog = "", const string &schema = "");
+	unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
+	string GetExpressionName(const ParsedExpression &expr);
 
 private:
 	//! The parent binder (if any)

--- a/src/include/duckdb/planner/column_qualifier.hpp
+++ b/src/include/duckdb/planner/column_qualifier.hpp
@@ -41,7 +41,6 @@ public:
 	                        const bool within_function_expression = false);
 
 	optional_ptr<CatalogEntry> QualifyFunction(FunctionExpression &function);
-	static unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
 
 private:
 	Binder &binder;

--- a/src/include/duckdb/planner/planner_extension.hpp
+++ b/src/include/duckdb/planner/planner_extension.hpp
@@ -34,7 +34,6 @@ typedef void (*post_bind_function_t)(PlannerExtensionInput &input, BoundStatemen
 
 typedef unique_ptr<ParsedExpression> (*get_sql_value_function_t)(PlannerExtensionInput &input,
                                                                  const string &column_name);
-typedef string (*get_expression_name_t)(PlannerExtensionInput &input, const ParsedExpression &expr);
 
 class PlannerExtension {
 public:
@@ -46,9 +45,6 @@ public:
 
 	//! Override that allows registering a different callback for SQL value functions
 	get_sql_value_function_t get_sql_value_function = nullptr;
-
-	//! Callback for getting a name of an unnamed expression
-	get_expression_name_t get_expression_name = nullptr;
 
 	//! Additional planner info passed to the functions
 	shared_ptr<PlannerExtensionInfo> planner_info;

--- a/src/include/duckdb/planner/planner_extension.hpp
+++ b/src/include/duckdb/planner/planner_extension.hpp
@@ -23,6 +23,8 @@ struct PlannerExtensionInfo {
 	}
 };
 
+enum class GetSQLValueFunctionReturnType { CONTINUE_BINDING, FINISH_BINDING };
+
 struct PlannerExtensionInput {
 	ClientContext &context;
 	Binder &binder;
@@ -32,8 +34,9 @@ struct PlannerExtensionInput {
 //! The post_bind function runs after binding succeeds, allowing modification of the bound statement
 typedef void (*post_bind_function_t)(PlannerExtensionInput &input, BoundStatement &statement);
 
-typedef unique_ptr<ParsedExpression> (*get_sql_value_function_t)(PlannerExtensionInput &input,
-                                                                 const string &column_name);
+typedef GetSQLValueFunctionReturnType (*get_sql_value_function_t)(PlannerExtensionInput &input,
+                                                                  const string &column_name,
+                                                                  unique_ptr<ParsedExpression> &result);
 
 class PlannerExtension {
 public:

--- a/src/include/duckdb/planner/planner_extension.hpp
+++ b/src/include/duckdb/planner/planner_extension.hpp
@@ -32,6 +32,10 @@ struct PlannerExtensionInput {
 //! The post_bind function runs after binding succeeds, allowing modification of the bound statement
 typedef void (*post_bind_function_t)(PlannerExtensionInput &input, BoundStatement &statement);
 
+typedef unique_ptr<ParsedExpression> (*get_sql_value_function_t)(PlannerExtensionInput &input,
+                                                                 const string &column_name);
+typedef string (*get_expression_name_t)(PlannerExtensionInput &input, const ParsedExpression &expr);
+
 class PlannerExtension {
 public:
 	//! The post-bind function of the planner extension.
@@ -39,6 +43,12 @@ public:
 	//! This runs after the binder has successfully bound the statement,
 	//! allowing modification of the plan and result types.
 	post_bind_function_t post_bind_function = nullptr;
+
+	//! Override that allows registering a different callback for SQL value functions
+	get_sql_value_function_t get_sql_value_function = nullptr;
+
+	//! Callback for getting a name of an unnamed expression
+	get_expression_name_t get_expression_name = nullptr;
 
 	//! Additional planner info passed to the functions
 	shared_ptr<PlannerExtensionInfo> planner_info;

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -19,7 +19,7 @@
 namespace duckdb {
 
 unique_ptr<ParsedExpression> ExpressionBinder::GetSQLValueFunction(const string &column_name) {
-	return ColumnQualifier::GetSQLValueFunction(column_name);
+	return binder.GetSQLValueFunction(column_name);
 }
 
 unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<ParsedExpression> base,

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/planner/expression_binder/where_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
+#include "duckdb/planner/planner_extension.hpp"
 
 namespace duckdb {
 
@@ -422,6 +423,19 @@ void Binder::BindWhereStarExpression(unique_ptr<ParsedExpression> &expr) {
 	}
 }
 
+string Binder::GetExpressionName(const ParsedExpression &expr) {
+	if (!expr.GetAlias().empty()) {
+		return expr.GetAlias();
+	}
+	for (auto &ext : PlannerExtension::Iterate(context)) {
+		if (ext.get_expression_name) {
+			PlannerExtensionInput input {context, *this, ext.planner_info.get()};
+			return ext.get_expression_name(input, expr);
+		}
+	}
+	return expr.GetName();
+}
+
 BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from_table) {
 	D_ASSERT(from_table.plan);
 	D_ASSERT(!statement.from_table);
@@ -453,7 +467,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	auto &bind_state = result.bind_state;
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		auto &expr = statement.select_list[i];
-		result.names.push_back(expr->GetName());
+		result.names.push_back(GetExpressionName(*expr));
 		ExpressionBinder::QualifyColumnNames(*this, expr);
 		if (!expr->GetAlias().empty()) {
 			bind_state.alias_map[expr->GetAlias()] = i;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -31,7 +31,6 @@
 #include "duckdb/planner/expression_binder/where_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
-#include "duckdb/planner/planner_extension.hpp"
 
 namespace duckdb {
 
@@ -426,12 +425,6 @@ void Binder::BindWhereStarExpression(unique_ptr<ParsedExpression> &expr) {
 string Binder::GetExpressionName(const ParsedExpression &expr) {
 	if (!expr.GetAlias().empty()) {
 		return expr.GetAlias();
-	}
-	for (auto &ext : PlannerExtension::Iterate(context)) {
-		if (ext.get_expression_name) {
-			PlannerExtensionInput input {context, *this, ext.planner_info.get()};
-			return ext.get_expression_name(input, expr);
-		}
 	}
 	return expr.GetName();
 }

--- a/src/planner/column_qualifier.cpp
+++ b/src/planner/column_qualifier.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/parser/expression/positional_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/having_binder.hpp"
+#include "duckdb/planner/planner_extension.hpp"
 
 namespace duckdb {
 
@@ -45,7 +46,14 @@ string GetSQLValueFunctionName(const string &column_name) {
 	return string();
 }
 
-unique_ptr<ParsedExpression> ColumnQualifier::GetSQLValueFunction(const string &column_name) {
+unique_ptr<ParsedExpression> Binder::GetSQLValueFunction(const string &column_name) {
+	for (auto &ext : PlannerExtension::Iterate(context)) {
+		if (ext.get_sql_value_function) {
+			PlannerExtensionInput input {context, *this, ext.planner_info.get()};
+			return ext.get_sql_value_function(input, column_name);
+		}
+	}
+
 	auto value_function = GetSQLValueFunctionName(column_name);
 	if (value_function.empty()) {
 		return nullptr;

--- a/src/planner/column_qualifier.cpp
+++ b/src/planner/column_qualifier.cpp
@@ -50,7 +50,11 @@ unique_ptr<ParsedExpression> Binder::GetSQLValueFunction(const string &column_na
 	for (auto &ext : PlannerExtension::Iterate(context)) {
 		if (ext.get_sql_value_function) {
 			PlannerExtensionInput input {context, *this, ext.planner_info.get()};
-			return ext.get_sql_value_function(input, column_name);
+			unique_ptr<ParsedExpression> result;
+			auto result_type = ext.get_sql_value_function(input, column_name, result);
+			if (result_type == GetSQLValueFunctionReturnType::FINISH_BINDING || result) {
+				return result;
+			}
 		}
 	}
 


### PR DESCRIPTION
In DuckDB we have the concept of "sql value functions" - which are functions that column references get resolved to if none is found, e.g.:

```sql
SELECT current_timestamp;
```

We have a list of functions that DuckDB supports, but it might be desirable for extensions to modify / change this list. This makes that possible.