### PR TITLE
Fix small-build dictionary emission activation gate

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -2165,6 +2165,12 @@ void JoinHashTable::ResetForNewIterationSinglePartition() {
 	prefix_range_filter.reset();
 	should_build_prefix_range_filter = false;
 	ResetCorrelatedMarkJoinInfo(*this);
+	// The next iteration may rebuild a different small build side, so this iteration's dictionary
+	// state is stale. Keep in lock-step with BuildDictionaryArrays, which sets these four fields.
+	dict_arrays.clear();
+	aux_next_ptrs.Reset();
+	aux_next_ptrs_data = nullptr;
+	use_dict_emission = false;
 }
 
 bool JoinHashTable::PrepareExternalFinalize(const idx_t max_ht_size) {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -898,7 +898,7 @@ public:
 		auto &ht = *sink.hash_table;
 		auto prefix_range_state = ht.ShouldBuildPrefixRangeFilter() ? RegisterPrefixRangeState(ht) : nullptr;
 		ExecuteHashJoinFinalizeTask(sink, optional_idx(), prefix_range_state);
-		FinishTasks(false);
+		FinishTasks();
 	}
 
 	void Schedule() override {
@@ -906,21 +906,22 @@ public:
 	}
 
 	void FinishEvent() override {
-		FinishTasks(true);
+		FinishTasks();
 	}
 
 	static constexpr idx_t CHUNKS_PER_TASK = 64;
 
 private:
-	void FinishTasks(bool build_dictionary_arrays) {
+	void FinishTasks() {
 		for (auto &prefix_range_state : prefix_range_states) {
 			sink.hash_table->MergePrefixRangeBuildState(*prefix_range_state);
 		}
 		sink.hash_table->GetDataCollection().VerifyEverythingPinned();
 
-		// chains are final; materialize dict_arrays and overwrite NEXT_PTR with the dict index
-		if (build_dictionary_arrays && sink.hash_table->CanUseDictionaryEmission(
-		                                   sink.op, sink.external, sink.op.children[0].get().estimated_cardinality)) {
+		// both finalize paths finish writing the chains before reaching here,
+		// so dictionary emission is safe on either path
+		if (sink.hash_table->CanUseDictionaryEmission(sink.op, sink.external,
+		                                              sink.op.children[0].get().estimated_cardinality)) {
 			sink.hash_table->BuildDictionaryArrays(sink.op);
 		}
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -918,7 +918,7 @@ private:
 		}
 		sink.hash_table->GetDataCollection().VerifyEverythingPinned();
 
-		// both finalize paths finish writing the chains before reaching here,
+		// Both finalize paths finish writing the chains before reaching here,
 		// so dictionary emission is safe on either path
 		if (sink.hash_table->CanUseDictionaryEmission(sink.op, sink.external,
 		                                              sink.op.children[0].get().estimated_cardinality)) {

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -45,7 +45,8 @@
         "test/optimizer/joins/no_duplicate_elimination_join.test",
         "test/optimizer/joins/tpcds_nofail.test",
         "test/sql/limit/test_limit0.test",
-        "test/sql/optimizer/plan/test_filter_pushdown_large.test"
+        "test/sql/optimizer/plan/test_filter_pushdown_large.test",
+        "test/optimizer/joins/denominator_cardinality_estimation.test"
       ]
     },
     {

--- a/test/sql/join/hash_join/hash_join_dictionary_emission.test_slow
+++ b/test/sql/join/hash_join/hash_join_dictionary_emission.test_slow
@@ -532,6 +532,51 @@ GROUP BY b.v;
 ----
 only-five	26220
 
+# recursive CTE reusing the hash table: each iteration rebuilds the small build, so dict_arrays
+# must be reset between iterations - otherwise stale dictionaries corrupt the aggregated total
+query II
+WITH RECURSIVE r(step, total) AS (
+    SELECT 0::INTEGER, 0::BIGINT
+    UNION ALL
+    SELECT step + 1,
+           (SELECT SUM(b.v)
+            FROM big_probe p JOIN (
+                SELECT 'K' || (i + 1)::VARCHAR AS k, (step * 1000 + i)::BIGINT AS v
+                FROM range(10) t(i)
+            ) b USING (k))
+    FROM r WHERE step < 4
+)
+SELECT step, total FROM r ORDER BY step;
+----
+0	0
+1	1179900
+2	263379900
+3	525579900
+4	787779900
+
+# multi-column build: the reset must clear every column of dict_arrays, not just the first
+query II
+WITH RECURSIVE r(step, total) AS (
+    SELECT 0::INTEGER, 0::BIGINT
+    UNION ALL
+    SELECT step + 1,
+           (SELECT SUM(b.v)
+            FROM big_probe p JOIN (
+                SELECT 'K' || (i + 1)::VARCHAR AS k, 'name_' || (step * 1000 + i) AS name,
+                       (step * 1000 + i)::BIGINT AS v
+                FROM range(10) t(i)
+            ) b USING (k)
+            WHERE b.name IS NOT NULL)
+    FROM r WHERE step < 4
+)
+SELECT step, total FROM r ORDER BY step;
+----
+0	0
+1	1179900
+2	263379900
+3	525579900
+4	787779900
+
 # fallback path: exactly one activation condition violated per test
 
 # fallback: small probe side (below min-probe-rows threshold)


### PR DESCRIPTION
# Fix small-build dictionary emission activation gate

Small-build dictionary emission ([#22340](https://github.com/duckdb/duckdb/pull/22340)) is silently inactive on `main`. The optimization targets *small* build sides (≤ 100K rows after the 8 MiB payload cap), and any build under `PARALLEL_CONSTRUCT_THRESHOLD = 1,048,576` rows finalizes single-threaded — so every workload it was designed for hits a finalize path that bypasses it.

The gates in `CanUseDictionaryEmission` still work; they just aren't consulted. A later finalize refactor (`08c2bb766c`, "Remove code duplication of fast-path") added a `build_dictionary_arrays` parameter to `FinishTasks` — `false` on the single-threaded `ExecuteDirectly()` path, `true` on the parallel `FinishEvent()` path — which short-circuits the activation call before the gates run on small builds. Confirmed with the original author as an oversight.

**Safety.** `BuildDictionaryArrays` depends only on invariants both finalize paths satisfy at the call site — all finalize work complete, `chains_longer_than_one` finalized, every `NEXT_PTR` written, data collection pinned (`VerifyEverythingPinned()` runs inside `FinishTasks` on both paths). External joins remain excluded (`CanUseDictionaryEmission` returns `false` when `external`); perfect hash join never reaches `ScheduleFinalize` / `FinishEvent`; the `aux_next_ptrs` allocation path inside `BuildDictionaryArrays` is identical regardless of caller. The forced-parallel run already exercises the same activation on the same data shape and produces correct results; this fix routes the single-threaded path through the same gate and builder, on hash tables that have already passed the same pinning check.

## Update: recursive-CTE regression fix

While verifying this branch under recursive CTEs, I found a separate latent bug that surfaced once the gate fix re-enabled dictionary emission on the single-threaded finalize path. Commit b50745ef83 (recursive-CTE state-reuse) added `ResetForNewIterationSinglePartition` but didn't clear the build-side dict-emission state (`dict_arrays`, `aux_next_ptrs`, `aux_next_ptrs_data`, `use_dict_emission`). As a result, `dict_arrays` accumulated across iterations, which blew up runtime (`aoc24.test_slow` went from single-digit seconds to >25 minutes) and, in release builds, produced wrong values as later iterations indexed into stale dictionaries from earlier iterations.

The fix is a four-line teardown at the end of `ResetForNewIterationSinglePartition`, kept in lock-step with `BuildDictionaryArrays`. Added two recursive-CTE regression cases to `hash_join_dictionary_emission.test_slow` that fail without the fix and pass with it.

---

@kryonix — as discussed on Discord, this restores activation of [#22340](https://github.com/duckdb/duckdb/pull/22340). @lnkuiper for visibility.