### PR TITLE
Fix #22791: nested window self-join leaves stale bindings

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -122,8 +122,18 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 	if (op->type == LogicalOperatorType::LOGICAL_WINDOW) {
 		auto &window = op->Cast<LogicalWindow>();
 
-		// Check recursively
-		window.children[0] = OptimizeInternal(std::move(window.children[0]), replacer);
+		// Check recursively using a local replacer so that any deferred binding replacements
+		// produced by an inner-window rewrite are flushed into this window before we proceed.
+		// Without this, a non-optimizable window sitting between two optimizable windows
+		// would carry stale BoundColumnRef bindings into DeepCopy, leaving references that
+		// point at operators outside the cloned subtree (issue #22791).
+		ColumnBindingReplacer local;
+		window.children[0] = OptimizeInternal(std::move(window.children[0]), local);
+		if (!local.replacement_bindings.empty()) {
+			local.VisitOperator(*op);
+			replacer.replacement_bindings.insert(replacer.replacement_bindings.end(),
+			                                     local.replacement_bindings.begin(), local.replacement_bindings.end());
+		}
 
 		auto &w_expr0 = window.expressions[0]->Cast<BoundWindowExpression>();
 		for (auto &expr : window.expressions) {

--- a/test/sql/optimizer/test_window_self_join.test
+++ b/test/sql/optimizer/test_window_self_join.test
@@ -247,3 +247,32 @@ group by
 order by all;
 ----
 physical_plan	<REGEX>:.*Join Type: INNER.*
+
+# Issue #22791: nested partitioned window with a non-aggregate window function
+# (e.g. LAG) between two aggregate windows previously triggered
+# `unordered_map::at: key not found` because the inner-window rewrite left
+# stale BoundColumnRef bindings in the LAG operator, which were then carried
+# into the DeepCopy of the outer-window's LHS.
+statement ok
+CREATE TABLE t22791(id INTEGER, x DOUBLE);
+
+statement ok
+INSERT INTO t22791 VALUES (1, 10.0), (1, 20.0), (2, 30.0);
+
+query II
+SELECT id, outer_sum
+FROM (
+  SELECT id, SUM(x) OVER (PARTITION BY id) AS outer_sum
+  FROM (
+    SELECT id, x, LAG(total, 1, 0) OVER (PARTITION BY id) AS prev_total
+    FROM (
+      SELECT id, x, COUNT(*) OVER (PARTITION BY id) AS total
+      FROM t22791
+    ) AS a
+  ) AS b
+)
+ORDER BY id, outer_sum;
+----
+1	30.0
+1	30.0
+2	30.0


### PR DESCRIPTION
Closes #22791

cc @DinosL — picking this up as discussed in the issue thread.

The `WindowSelfJoinOptimizer` recurses with a single shared `ColumnBindingReplacer` that is only flushed at the end of `Optimize`. When an inner aggregate window gets rewritten into a join+aggregate, a non-aggregate window above it (e.g. `LAG`) is left with stale `BoundColumnRef` bindings to the removed window operator. `DeepCopy` of that subtree for the outer-window rewrite then carries those stale references into the clone, triggering `unordered_map::at: key not found` on subsequent type resolution.

Fix: use a local replacer per child and flush it into the current operator before any further transformation, mirroring `TopNWindowElimination::OptimizeInternal`.

Regression test added to `test/sql/optimizer/test_window_self_join.test`.