### PR TITLE
Fix: check if `ParseFormatSpecifier` returns unrecognized format

### DIFF
--- a/extension/json/include/json_reader_options.hpp
+++ b/extension/json/include/json_reader_options.hpp
@@ -43,7 +43,11 @@ public:
 		auto &formats = candidate_formats[type];
 		formats.emplace_back();
 		formats.back().format_specifier = format_string;
-		StrpTimeFormat::ParseFormatSpecifier(formats.back().format_specifier, formats.back());
+		const auto error = StrpTimeFormat::ParseFormatSpecifier(formats.back().format_specifier, formats.back());
+		if (!error.empty()) {
+			formats.pop_back();
+			throw InvalidInputException(error);
+		}
 	}
 
 	static bool HasFormats(const type_id_map_t<vector<StrpTimeFormat>> &candidate_formats, LogicalTypeId type) {

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -250,3 +250,17 @@ query I
 select ts from '{TEMP_DIR}/my_file.json';
 ----
 2026-01-01 +00
+
+# invalid timestampformat must produce a clear error
+statement ok
+CREATE TABLE t (ts TIMESTAMP[])
+
+statement error
+COPY t FROM '{DATA_DIR}/json/simple_timestamp.json' (FORMAT JSON, TIMESTAMPFORMAT '%Q')
+----
+Unrecognized format for strftime/strptime: %Q
+
+statement error
+SELECT * FROM read_json('{DATA_DIR}/json/simple_timestamp.json', timestampformat='%Q')
+----
+Unrecognized format for strftime/strptime: %Q


### PR DESCRIPTION
The return value of `ParseFormatSpecifier` was silently disregarded in `DateFormatMap::AddFormat`, which is a problem when an unrecognized format is passed to `timestampformat`. 


fixes: https://github.com/duckdb/duckdb/issues/22826
