### PR TITLE
Fix alias propagation when replacement scan is wrapped in SubqueryRef

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -55,6 +55,13 @@ BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTable
 		if (!replacement_function) {
 			continue;
 		}
+		if (!ref.alias.empty()) {
+			// user-provided alias overrides the default alias
+			replacement_function->alias = ref.alias;
+		} else if (replacement_function->alias.empty()) {
+			// if the replacement scan itself did not provide an alias we use the table name
+			replacement_function->alias = ref.table_name;
+		}
 		if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
 			auto &table_function = replacement_function->Cast<TableFunctionRef>();
 			table_function.column_name_alias = ref.column_name_alias;
@@ -62,23 +69,18 @@ BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTable
 			auto &subquery = replacement_function->Cast<SubqueryRef>();
 			subquery.column_name_alias = ref.column_name_alias;
 		} else {
+			// carry the alias to the wrapping SubqueryRef so qualified references
+			// like `SELECT d.x FROM _ AS d` can resolve against the outer ref
+			auto inner_alias = replacement_function->alias;
 			auto select_node = make_uniq<SelectNode>();
 			select_node->select_list.push_back(make_uniq<StarExpression>());
 			select_node->from_table = std::move(replacement_function);
 			auto select_stmt = make_uniq<SelectStatement>();
 			select_stmt->node = std::move(select_node);
 			auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
+			subquery->alias = std::move(inner_alias);
 			subquery->column_name_alias = ref.column_name_alias;
 			replacement_function = std::move(subquery);
-		}
-		// Apply the user-provided alias to the outermost ref so it survives
-		// the wrap above. If the replacement scan itself supplied a default
-		// alias (e.g. the extracted basename of a parquet/csv path), preserve
-		// it when the user did not specify one.
-		if (!ref.alias.empty()) {
-			replacement_function->alias = ref.alias;
-		} else if (replacement_function->alias.empty()) {
-			replacement_function->alias = ref.table_name;
 		}
 		if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
 			AddReplacementScan(ref.table_name, replacement_function->Copy());

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -55,13 +55,6 @@ BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTable
 		if (!replacement_function) {
 			continue;
 		}
-		if (!ref.alias.empty()) {
-			// user-provided alias overrides the default alias
-			replacement_function->alias = ref.alias;
-		} else if (replacement_function->alias.empty()) {
-			// if the replacement scan itself did not provide an alias we use the table name
-			replacement_function->alias = ref.table_name;
-		}
 		if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
 			auto &table_function = replacement_function->Cast<TableFunctionRef>();
 			table_function.column_name_alias = ref.column_name_alias;
@@ -77,6 +70,15 @@ BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTable
 			auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
 			subquery->column_name_alias = ref.column_name_alias;
 			replacement_function = std::move(subquery);
+		}
+		// Apply the user-provided alias to the outermost ref so it survives
+		// the wrap above. If the replacement scan itself supplied a default
+		// alias (e.g. the extracted basename of a parquet/csv path), preserve
+		// it when the user did not specify one.
+		if (!ref.alias.empty()) {
+			replacement_function->alias = ref.alias;
+		} else if (replacement_function->alias.empty()) {
+			replacement_function->alias = ref.table_name;
 		}
 		if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
 			AddReplacementScan(ref.table_name, replacement_function->Copy());

--- a/tools/shell/tests/test_last_result.py
+++ b/tools/shell/tests/test_last_result.py
@@ -50,5 +50,26 @@ def test_last_result_error(shell):
     result = test.run()
     assert '420' in result.stdout
 
+# alias on _ is reachable from a qualified column reference
+def test_last_result_alias(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 'a' AS x")
+        .statement("SELECT d.x FROM _ AS d")
+    )
+    result = test.run()
+    result.check_stdout("a")
+
+# self-join over _ via two aliases (regression for #22841)
+def test_last_result_alias_self_join(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 'a' AS x")
+        .statement("SELECT d1.x, d2.x FROM _ AS d1, _ AS d2")
+    )
+    result = test.run()
+    assert 'd1' not in result.stderr
+    result.check_stdout("a")
+
 
 # fmt: on


### PR DESCRIPTION
Closes #22841.

The `_` replacement scan in the shell extension returns a `ColumnDataRef`, which falls through the `TABLE_FUNCTION` / `SUBQUERY` branches in `BindWithReplacementScan` and gets wrapped in a fresh `SubqueryRef`. The alias was applied to the inner `replacement_function` before the wrap, but never carried onto the outer `SubqueryRef`, so the wrap ended up unaliased — hence the `unnamed_subquery` fallback when running `SELECT d.x FROM _ AS d`.

In the else-branch wrap, save the inner ref's alias into a local before the move and assign it onto the wrapping `SubqueryRef` afterward. The inner ref's alias is left intact (the binder needs it set for scope resolution) and the outer wrap now carries the same alias, so qualified references resolve as expected. `TABLE_FUNCTION` and `SUBQUERY` are unaffected.

Added two shell tests covering qualified column references and self-join over `_`.
