### PR TITLE
Test runner: allow to run without changing HOME

### DIFF
--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -17,7 +17,7 @@ int main(int argc_in, char *argv[]) {
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
-	bool isolate_tests = false;
+	bool keep_home = false;
 
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
@@ -37,8 +37,8 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
-		} else if (argument == "--isolate-tests") {
-			isolate_tests = true;
+		} else if (argument == "--keep-home") {
+			keep_home = true;
 		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
@@ -58,7 +58,7 @@ int main(int argc_in, char *argv[]) {
 	}
 
 	// Override the home dir so the .duckdb dir is isolated per test process.
-	if (isolate_tests) {
+	if (!keep_home) {
 #ifdef DUCKDB_WINDOWS
 		if (_putenv_s("USERPROFILE", dir.c_str()) != 0) {
 			fprintf(stderr, "Failed to set USERPROFILE environment variable\n");

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -17,6 +17,7 @@ int main(int argc_in, char *argv[]) {
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
+	bool keep_home = false;
 
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
@@ -36,6 +37,8 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
+		} else if (argument == "--keep-home") {
+			keep_home = true;
 		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
@@ -55,17 +58,19 @@ int main(int argc_in, char *argv[]) {
 	}
 
 	// Override the home dir so the .duckdb dir is isolated per test process.
+	if (!keep_home) {
 #ifdef DUCKDB_WINDOWS
-	if (_putenv_s("USERPROFILE", dir.c_str()) != 0) {
-		fprintf(stderr, "Failed to set USERPROFILE environment variable\n");
-		return 1;
-	}
+		if (_putenv_s("USERPROFILE", dir.c_str()) != 0) {
+			fprintf(stderr, "Failed to set USERPROFILE environment variable\n");
+			return 1;
+		}
 #else
-	if (setenv("HOME", dir.c_str(), 1) != 0) {
-		fprintf(stderr, "Failed to set HOME environment variable\n");
-		return 1;
-	}
+		if (setenv("HOME", dir.c_str(), 1) != 0) {
+			fprintf(stderr, "Failed to set HOME environment variable\n");
+			return 1;
+		}
 #endif
+	}
 
 	if (test_config.GetSkipCompiledTests()) {
 		Catch::getMutableRegistryHub().clearTests();

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -17,7 +17,7 @@ int main(int argc_in, char *argv[]) {
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
-	bool keep_home = false;
+	bool isolate_tests = false;
 
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
@@ -37,8 +37,8 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
-		} else if (argument == "--keep-home") {
-			keep_home = true;
+		} else if (argument == "--isolate-tests") {
+			isolate_tests = true;
 		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
@@ -58,7 +58,7 @@ int main(int argc_in, char *argv[]) {
 	}
 
 	// Override the home dir so the .duckdb dir is isolated per test process.
-	if (!keep_home) {
+	if (isolate_tests) {
 #ifdef DUCKDB_WINDOWS
 		if (_putenv_s("USERPROFILE", dir.c_str()) != 0) {
 			fprintf(stderr, "Failed to set USERPROFILE environment variable\n");


### PR DESCRIPTION
One of the improvements added in #21211 is changing the `HOME` directory for the `unittest` process before tests are run. This improvement has an undesired side effect with extensions:

 - extension uses `require <extension_name>` in SQLlogic file
 - for known extensions this `require` is a no-op, so they are auto-installed into `duckdb_unittest_tempdir/<pid>/.duckdb/extensions/<version>/<platform>/<extension_name>.duckdb_extension'` and loaded from there
 - when running under debugger, the extension shared library is being loaded from a relative path with `HOME` rewritten - this confuses GDB that cannot find the symbols (despite them residing inside the file), like this:

```
Loaded 'duckdb_unittest_tempdir/93433/.duckdb/extensions/80554e9433/linux_amd64/mysql_scanner.duckdb_extension'. Cannot find or open the symbol file.
```

Note, with the error above I double-checked that the extension library installed under `duckdb_unittest_tempdir/<pid>/.duckdb/extensions/` is actually the correct version (with debuginfo included inside) taken from the specified `LOCAL_EXTENSION_REPO`.

The `HOME` is changed unconditionally, so it makes it not possible to debug unmodified SQLlogic test files.

This PR adds new switch `--keep-home` (off by default), that, when activated, skips the `HOME` switching logic.

This flag allows straightforward debugging setup:

 - add symlinks to required local-built extensions to `~/.duckdb/extensions/<version>/<platform>/`
 - use debugger config like this (VSCode example):

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "(gdb) Launch",
      "type": "cppdbg",
      "request": "launch",
      "program": "${workspaceFolder}/build/debug/test/unittest",
      "args": [
        "--keep-home",
        "${workspaceFolder}/test/sql/attach_many_nulls.test"
      ],
      "cwd": "${fileDirname}",
      "externalConsole": false,
      "MIMode": "gdb",
      "setupCommands": [
        {
          "description": "Enable pretty-printing for gdb",
          "text": "-enable-pretty-printing",
          "ignoreFailures": true
        }
      ]
    }
  ]
}
```
 - 1.5GB extension lib is loaded through symlink without copying it into temporary `HOME` on every `unittest` run

Ref: duckdblabs/duckdb-internal#7731