### PR TITLE
Fix json_keys with wildcard paths

### DIFF
--- a/extension/json/include/json_executors.hpp
+++ b/extension/json/include/json_executors.hpp
@@ -80,7 +80,7 @@ public:
 					for (idx_t i = 0; i < vals.size(); i++) {
 						auto &val = vals[i];
 						D_ASSERT(val != nullptr); // Wildcard extract shouldn't give back nullptrs
-						child_vals[current_size + i] = fun(val, alc, result, child_validity, current_size + i);
+						child_vals[current_size + i] = fun(val, alc, child_entry, child_validity, current_size + i);
 					}
 
 					ListVector::SetListSize(result, new_size);

--- a/test/sql/json/scalar/test_json_keys.test
+++ b/test/sql/json/scalar/test_json_keys.test
@@ -32,6 +32,12 @@ select json_keys('{"duck": {"key1": 42}, "goose": {"key1": 42, "key2": 43}}', ['
 ----
 [[key1], [key1, key2]]
 
+query TT
+select typeof(json_keys('{"duck": {"key1": 42}, "goose": {"key1": 42, "key2": 43}}', '$.*')),
+       json_keys('{"duck": {"key1": 42}, "goose": {"key1": 42, "key2": 43}}', '$.*')
+----
+VARCHAR[][]	[[key1], [key1, key2]]
+
 statement ok
 create table t1 as
 select range, case when range % 2 = 0 then '{"duck": 42}' else '{"duck": 42, "goose": 43}' end j


### PR DESCRIPTION
Fixes #22749

## Summary
- pass the wildcard result child vector to JSON read callbacks
- add a regression test for `json_keys(..., $.*)` returning nested key lists


- ## Tests
- `make allunit`