### PR TITLE
Evict dead ExternalFileCache opportunisticaly

### DIFF
--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -58,6 +58,10 @@ public:
 		string version_tag DUCKDB_GUARDED_BY(meta_lock);
 		bool can_seek DUCKDB_GUARDED_BY(meta_lock) = false;
 		bool on_disk_file DUCKDB_GUARDED_BY(meta_lock) = false;
+
+		//! Number of live CachingFileHandles referencing this CachedFile.
+		//! Used by ExternalFileCache to skip pruning of in-use entries.
+		atomic<idx_t> ref_count {0};
 	};
 
 public:
@@ -88,14 +92,21 @@ private:
 	void ReindexCachedFileCore(CachedFile &cached_file, idx_t file_size, idx_t old_block_size, idx_t new_block_size)
 	    DUCKDB_REQUIRES(cached_file.map_lock);
 
+	//! Erase entries that have no live CachingFileHandle and whose cached content
+	//! has already been released by the BufferManager.
+	void PruneStaleEntries() DUCKDB_REQUIRES(lock);
+
+	//! Return true if `file` has no live handle and no resident cached content.
+	static bool IsStale(const CachedFile &file);
+
 	//! The BufferManager used to cache files
 	BufferManager &buffer_manager;
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
+	//! Lock for accessing cached_files.
+	mutable annotated_mutex lock;
 	//! Mapping from file path to cached file with cached blocks
-	unordered_map<string, unique_ptr<CachedFile>> cached_files;
-	//! Lock for accessing the cached files
-	mutable mutex lock;
+	unordered_map<string, unique_ptr<CachedFile>> cached_files DUCKDB_GUARDED_BY(lock);
 };
 
 } // namespace duckdb

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -171,6 +171,9 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
       cached_file(cached_file_p), position(0) {
+	// ref_count is incremented by ExternalFileCache::GetOrCreateCachedFile while
+	// the cache lock is held, to prevent a concurrent prune from evicting this
+	// entry between its lookup and our construction. We decrement in the dtor.
 	if (!external_file_cache.IsEnabled() || Validate()) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
@@ -192,6 +195,7 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 }
 
 CachingFileHandle::~CachingFileHandle() {
+	--cached_file.ref_count;
 }
 
 FileHandle &CachingFileHandle::GetFileHandle() {

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -200,15 +200,49 @@ bool ExternalFileCache::IsEnabled() const {
 }
 
 void ExternalFileCache::SetEnabled(bool enable_p) {
-	lock_guard<mutex> guard(lock);
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	enable = enable_p;
 	if (!enable) {
 		cached_files.clear();
 	}
 }
 
+bool ExternalFileCache::IsStale(const CachedFile &file) {
+	if (file.ref_count.load() != 0) {
+		return false;
+	}
+	// The BufferManager owns CacheBlock buffers and is not aware of the file cache.
+	// An entry becomes stale when all its blocks have been evicted from the buffer
+	// pool: the skeleton CachedFile remains but holds no resident content.
+	annotated_lock_guard<annotated_mutex> map_guard(file.map_lock);
+	if (file.blocks.empty()) {
+		return true;
+	}
+	for (const auto &block_entry : file.blocks) {
+		const auto &block = *block_entry.second;
+		annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+		if (block.state != CacheBlockState::LOADED || !block.block_handle) {
+			continue;
+		}
+		if (!block.block_handle->GetMemory().IsUnloaded()) {
+			return false; // still holds resident content
+		}
+	}
+	return true;
+}
+
+void ExternalFileCache::PruneStaleEntries() {
+	for (auto it = cached_files.begin(); it != cached_files.end();) {
+		if (IsStale(*it->second)) {
+			it = cached_files.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
 vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() const {
-	unique_lock<mutex> files_guard(lock);
+	annotated_unique_lock<annotated_mutex> files_guard(lock);
 	vector<CachedFileInformation> result;
 	for (const auto &file : cached_files) {
 		annotated_lock_guard<annotated_mutex> map_guard(file.second->map_lock);
@@ -243,12 +277,20 @@ BufferManager &ExternalFileCache::GetBufferManager() const {
 }
 
 ExternalFileCache::CachedFile &ExternalFileCache::GetOrCreateCachedFile(const string &path) {
-	lock_guard<mutex> guard(lock);
-	auto &entry = cached_files[path];
-	if (!entry) {
-		entry = make_uniq<CachedFile>(path);
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	auto existing = cached_files.find(path);
+	if (existing != cached_files.end()) {
+		// Pin the entry before returning so a concurrent prune cannot evict it
+		// between this call and CachingFileHandle's constructor.
+		++existing->second->ref_count;
+		return *existing->second;
 	}
-	return *entry;
+	// Opportunistic cleanup: drop entries whose content has been released by the
+	// BufferManager and that have no live handle. Amortizes O(N) over inserts.
+	PruneStaleEntries();
+	auto inserted = cached_files.emplace(path, make_uniq<CachedFile>(path)).first;
+	++inserted->second->ref_count;
+	return *inserted->second;
 }
 
 } // namespace duckdb

--- a/test/sql/storage/external_file_cache/external_file_cache_prune_stale.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_prune_stale.test
@@ -1,0 +1,101 @@
+# name: test/sql/storage/external_file_cache/external_file_cache_prune_stale.test
+# description: Stale CachedFile entries (no live handle, no resident content) are pruned on cache miss
+# group: [external_file_cache]
+
+require parquet
+
+statement ok
+set enable_external_file_cache=true;
+
+statement ok
+set prefetch_all_parquet_files=true;
+
+# Two parquet files large enough that scanning produces many cache blocks.
+statement ok
+copy (
+    select range % 1500000 a,
+    range % 200000 b,
+    range % 10000 c,
+    range % 7 d,
+    from range(6_000_000)
+) to '{TEST_DIR}/efc_prune_a.parquet' (row_group_size 6_000_000);
+
+statement ok
+copy (
+    select range % 1500000 a,
+    range % 200000 b,
+    range % 10000 c,
+    range % 7 d,
+    from range(6_000_000)
+) to '{TEST_DIR}/efc_prune_b.parquet' (row_group_size 6_000_000);
+
+statement ok
+create view va as from '{TEST_DIR}/efc_prune_a.parquet';
+
+# Populate A's cache with many blocks across columns.
+statement ok
+select a from va;
+
+statement ok
+select b from va;
+
+statement ok
+select c from va;
+
+# A has resident content.
+query I
+select bool_or(loaded)
+  from duckdb_external_file_cache()
+  where path like '%efc_prune_a.parquet';
+----
+true
+
+# --- Hot content survives prune ------------------------------------------
+
+# Opening B is a cache miss and triggers PruneStaleEntries. A's content is
+# still resident in the BufferManager so the entry must survive.
+statement ok
+select count(*) from '{TEST_DIR}/efc_prune_b.parquet';
+
+query I
+select bool_or(loaded)
+  from duckdb_external_file_cache()
+  where path like '%efc_prune_a.parquet';
+----
+true
+
+# --- Stale skeleton is pruned --------------------------------------------
+
+# Force the BufferManager to release all cached blocks by squeezing memory
+# below the cache footprint. The SET may fail with OOM after the eviction
+# sweep runs, which is fine: by then the buffer pool has already been swept.
+statement maybe
+set memory_limit='128KiB';
+----
+
+statement ok
+set memory_limit='500mb';
+
+# Confirm A is now a skeleton: still listed but no resident blocks.
+query II
+select count(*) > 0, bool_or(loaded)
+  from duckdb_external_file_cache()
+  where path like '%efc_prune_a.parquet';
+----
+true	false
+
+# Open a fresh third path that the cache has never seen. The miss triggers
+# PruneStaleEntries; A has ref_count=0 and all blocks unloaded, so it must
+# be evicted from cached_files.
+statement ok
+copy (select range i from range(100)) to '{TEST_DIR}/efc_prune_c.parquet';
+
+statement ok
+select count(*) from '{TEST_DIR}/efc_prune_c.parquet';
+
+query I
+select count(*)
+  from duckdb_external_file_cache()
+  where path like '%efc_prune_a.parquet';
+----
+0


### PR DESCRIPTION
## Summary

Fix #22730.

Fixes unbounded growth of `ExternalFileCache::cached_files`. The map only ever shrinks on `SET enable_external_file_cache = false`, so long-running processes that open many distinct paths accumulate `CachedFile` skeletons indefinitely, even after the `BufferManager` has evicted all their cached content.


## Change

Opportunistically prune stale entries in `GetOrCreateCachedFile` on the miss path. An entry is stale when:
1. `ref_count == 0` (no live `CachingFileHandle`), **and**
2. All its `CacheBlock`s report `block_handle->GetMemory().IsUnloaded()` (BufferManager already released the buffers).
The cost is amortized over inserts. 

## Alternatives I've considered

I looked at a few other places to put the eviction and settled on this one:

- **Prune in `~CachingFileHandle()`** — kills cross-query cache reuse: the moment the last handle closes, the entry is gone, so the next open of the same path re-reads from source. Defeats the cache.
- **BufferManager → EFC callback on block eviction** — semantically the right place, but `BufferManager` is intentionally agnostic of `ExternalFileCache` and adding a notification hook is a pretty big cross-cutting change, not sure if worth it.
- **Bounded LRU + new `external_file_cache_max_entries` setting** — the new knob's semantic is quite awkward, does not feel right. 
- **Background sweeper / scheduled task** — new lifecycle infrastructure, it might be the right option but bigger change, happy to switch to this one if people feel it's worth it.

The chosen approach has the smallest blast radius: ~60 lines across 3 files, no public API change. 

## Notes

- `ref_count` is incremented inside `GetOrCreateCachedFile` (under the cache lock) rather than in the `CachingFileHandle` constructor, to close a TOCTOU window where a concurrent prune could evict the entry between lookup and pin. Decrement remains in the destructor.
- Soft guarantee: entries with live handles are never pruned, even if their content is unloaded. This is correct — the handle reader may re-populate blocks at any moment.