### PR TITLE
C++23: fix forward declaration 

### DIFF
--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -134,8 +134,7 @@ public:
 
 struct ParquetWriteGlobalState : public GlobalFunctionData {
 public:
-	ParquetWriteGlobalState() {
-	}
+	ParquetWriteGlobalState();
 
 public:
 	unique_ptr<ParquetWriter> writer;

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -24,8 +24,8 @@ struct ArrayAnalyzeData;
 
 struct VariantAnalyzeData {
 public:
-	VariantAnalyzeData() {
-	}
+	VariantAnalyzeData();
+	~VariantAnalyzeData();
 
 public:
 	//! Map for every value what type it is
@@ -36,8 +36,8 @@ public:
 	idx_t total_count = 0;
 
 	//! Map for every decimal value what physical type it has
-	unique_ptr<ObjectAnalyzeData> object_data = nullptr;
-	unique_ptr<ArrayAnalyzeData> array_data = nullptr;
+	unique_ptr<ObjectAnalyzeData> object_data;
+	unique_ptr<ArrayAnalyzeData> array_data;
 };
 
 struct ObjectAnalyzeData {

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1337,4 +1337,6 @@ void ParquetWriter::SetWrittenStatistics(CopyFunctionFileStatistics &written_sta
 	//! NOTE: the actual accumulators for the writers are created after FinalizeSchema() is called
 }
 
+ParquetWriteGlobalState::ParquetWriteGlobalState() = default;
+
 } // namespace duckdb

--- a/extension/parquet/writer/CMakeLists.txt
+++ b/extension/parquet/writer/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library_unity(
   enum_column_writer.cpp
   list_column_writer.cpp
   primitive_column_writer.cpp
-  struct_column_writer.cpp)
+  struct_column_writer.cpp
+  variant_column_writer.cpp)
 
 add_subdirectory(variant)
 

--- a/extension/parquet/writer/variant_column_writer.cpp
+++ b/extension/parquet/writer/variant_column_writer.cpp
@@ -1,0 +1,8 @@
+#include "writer/variant_column_writer.hpp"
+
+namespace duckdb {
+
+VariantAnalyzeData::VariantAnalyzeData() = default;
+VariantAnalyzeData::~VariantAnalyzeData() = default;
+
+} // namespace duckdb

--- a/src/include/duckdb/main/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiling_utils.hpp
@@ -26,9 +26,9 @@ struct MetricsTimer;
 // Top level query metrics
 struct QueryMetrics {
 public:
-	QueryMetrics() : bytes_read(0), bytes_written(0), total_memory_allocated(0) {
-		Reset();
-	}
+	QueryMetrics();
+	~QueryMetrics();
+
 	idx_t system_peak_buffer_memory;
 	idx_t system_peak_temp_dir_size;
 	double blocked_thread_time;

--- a/src/main/profiling_utils.cpp
+++ b/src/main/profiling_utils.cpp
@@ -19,4 +19,10 @@ void QueryMetrics::FinalizeMetrics(GatheredMetrics &info) {
 	info.SetMetric<MetricSystemTotalMemoryAllocated>(GetTotalMemoryAllocated());
 }
 
+QueryMetrics::QueryMetrics() : bytes_read(0), bytes_written(0), total_memory_allocated(0) {
+	Reset();
+}
+
+QueryMetrics::~QueryMetrics() = default;
+
 } // namespace duckdb


### PR DESCRIPTION
C++23: dtor for unique_ptr is constexpr: https://cppreference.com/cpp/memory/unique_ptr/~unique_ptr.

I suggest adding so simple fix.

```
$ cmake -DCMAKE_CXX_STANDARD=20 ..
-- git hash 932e831ce7, version v1.6.0-dev6886, extension folder 932e831ce7
-- Build workers: compile= link_release=4 link_non_release=2
-- Extensions will be deployed to: /home/focus/dev/repo/duckdb/build/repository
-- Load extension 'core_functions' from '/home/focus/dev/repo/duckdb/extensions' @ 932e831ce7
-- Load extension 'parquet' from '/home/focus/dev/repo/duckdb/extensions' @ 932e831ce7
-- Extensions linked into DuckDB: [core_functions, parquet]
-- Configuring done (0.8s)
-- Generating done (0.3s)
-- Build files have been written to: /home/focus/dev/repo/duckdb/build
$ make -j 16
[ 99%] Built target parquet_loadable_extension
[ 99%] repository
[ 99%] Built target plan_serializer
[ 99%] Built target duckdb_local_extension_repo
[ 99%] Built target duckdb
[ 99%] Building CXX object test/CMakeFiles/unittest.dir/unittest.cpp.o
[100%] Linking CXX executable unittest
[100%] Built target unittest

$ cmake -DCMAKE_CXX_STANDARD=23 ..
-- git hash 932e831ce7, version v1.6.0-dev6886, extension folder 932e831ce7
-- Build workers: compile= link_release=4 link_non_release=2
-- Extensions will be deployed to: /home/focus/dev/repo/duckdb/build/repository
-- Load extension 'core_functions' from '/home/focus/dev/repo/duckdb/extensions' @ 932e831ce7
-- Load extension 'parquet' from '/home/focus/dev/repo/duckdb/extensions' @ 932e831ce7
-- Extensions linked into DuckDB: [core_functions, parquet]
-- Configuring done (1.0s)
-- Generating done (0.3s)
-- Build files have been written to: /home/focus/dev/repo/duckdb/build

$ make -j 16
...
[ 23%] Linking CXX static library libduckdb_zstd.a
[ 23%] Built target duckdb_zstd
[ 23%] Building CXX object src/planner/expression_binder/CMakeFiles/duckdb_expression_binders.dir/ub_duckdb_expression_binders.cpp.o
In file included from /home/focus/dev/repo/duckdb/build/src/optimizer/pullup/ub_duckdb_optimizer_pullup.cpp:2:
In file included from /home/focus/dev/repo/duckdb/src/optimizer/pullup/pullup_filter.cpp:1:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/optimizer/filter_pullup.hpp:12:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/planner/logical_operator.hpp:11:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/catalog/catalog.hpp:11:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/catalog/catalog_entry.hpp:11:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/common/common.hpp:11:
In file included from /home/focus/dev/repo/duckdb/src/include/duckdb/common/constants.hpp:11:
In file included from /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/memory:78:
/usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/unique_ptr.h:91:16: error: invalid application of 'sizeof' to an incomplete type 'duckdb::MetricsTimer'
   91 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/unique_ptr.h:399:4: note: in instantiation of member function 'std::default_delete<duckdb::MetricsTimer>::operator()' requested here
  399 |           get_deleter()(std::move(__ptr));
      |           ^
/home/focus/dev/repo/duckdb/src/include/duckdb/common/unique_ptr.hpp:14:7: note: in instantiation of member function 'std::unique_ptr<duckdb::MetricsTimer>::~unique_ptr' requested here
   14 | class unique_ptr : public duckdb_base_std::unique_ptr<DATA_TYPE, DELETER> { // NOLINT: naming
      |       ^
/home/focus/dev/repo/duckdb/src/include/duckdb/main/profiling_utils.hpp:29:2: note: in implicit default constructor for 'duckdb::unique_ptr<duckdb::MetricsTimer>' first required here
   29 |         QueryMetrics() : bytes_read(0), bytes_written(0), total_memory_allocated(0) {
      |         ^
/home/focus/dev/repo/duckdb/src/include/duckdb/main/profiling_utils.hpp:24:8: note: forward declaration of 'duckdb::MetricsTimer'
   24 | struct MetricsTimer;
      |        ^
1 error generated.
...
/home/focus/dev/repo/duckdb/src/include/duckdb/main/profiling_utils.hpp:24:8: note: forward declaration of 'duckdb::MetricsTimer'
   24 | struct MetricsTimer;
      |        ^
1 error generated.
```