### PR TITLE
Add CSV zstd compression level support and regression test

### DIFF
--- a/extension/parquet/include/zstd_file_system.hpp
+++ b/extension/parquet/include/zstd_file_system.hpp
@@ -22,6 +22,9 @@ namespace duckdb {
 
 class ZStdFileSystem : public CompressedFileSystem {
 public:
+	ZStdFileSystem();
+	explicit ZStdFileSystem(int64_t compression_level);
+
 	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
 	                                          const FileCompressionOptions &compression_options) override;
 
@@ -36,6 +39,9 @@ public:
 	static int64_t DefaultCompressionLevel();
 	static int64_t MinimumCompressionLevel();
 	static int64_t MaximumCompressionLevel();
+
+private:
+	int64_t compression_level;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/zstd_file_system.hpp
+++ b/extension/parquet/include/zstd_file_system.hpp
@@ -22,9 +22,6 @@ namespace duckdb {
 
 class ZStdFileSystem : public CompressedFileSystem {
 public:
-	ZStdFileSystem();
-	explicit ZStdFileSystem(int64_t compression_level);
-
 	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
 	                                          const FileCompressionOptions &compression_options) override;
 
@@ -32,16 +29,13 @@ public:
 		return "ZStdFileSystem";
 	}
 
-	unique_ptr<StreamWrapper> CreateStream() override;
+	unique_ptr<StreamWrapper> CreateStream(const FileCompressionOptions &compression_options) override;
 	idx_t InBufferSize() override;
 	idx_t OutBufferSize() override;
 
 	static int64_t DefaultCompressionLevel();
 	static int64_t MinimumCompressionLevel();
 	static int64_t MaximumCompressionLevel();
-
-private:
-	int64_t compression_level;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/zstd_file_system.hpp
+++ b/extension/parquet/include/zstd_file_system.hpp
@@ -22,7 +22,7 @@ namespace duckdb {
 
 class ZStdFileSystem : public CompressedFileSystem {
 public:
-	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                          const FileCompressionOptions &compression_options) override;
 
 	std::string GetName() const override {

--- a/extension/parquet/include/zstd_file_system.hpp
+++ b/extension/parquet/include/zstd_file_system.hpp
@@ -22,7 +22,8 @@ namespace duckdb {
 
 class ZStdFileSystem : public CompressedFileSystem {
 public:
-	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write) override;
+	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+	                                          const FileCompressionOptions &compression_options) override;
 
 	std::string GetName() const override {
 		return "ZStdFileSystem";

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -74,9 +74,8 @@ void ZstdStreamWrapper::Initialize(QueryContext context, CompressedFile &file, b
 	this->writing = write;
 	if (write) {
 		zstd_compress_ptr = duckdb_zstd::ZSTD_createCStream();
-		auto res =
-		    duckdb_zstd::ZSTD_CCtx_setParameter(zstd_compress_ptr, duckdb_zstd::ZSTD_c_compressionLevel,
-		                                        UnsafeNumericCast<int>(compression_level));
+		auto res = duckdb_zstd::ZSTD_CCtx_setParameter(zstd_compress_ptr, duckdb_zstd::ZSTD_c_compressionLevel,
+		                                               UnsafeNumericCast<int>(compression_level));
 		if (duckdb_zstd::ZSTD_isError(res)) {
 			throw IOException(duckdb_zstd::ZSTD_getErrorName(res));
 		}
@@ -205,7 +204,8 @@ struct ZStdFileSystemHolder {
 
 class ZStdFile : private ZStdFileSystemHolder, public CompressedFile {
 public:
-	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write, int64_t compression_level)
+	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write,
+	         int64_t compression_level)
 	    : ZStdFileSystemHolder(compression_level), CompressedFile(zstd_fs, std::move(child_handle_p), path) {
 		Initialize(context, write);
 	}
@@ -217,7 +217,8 @@ public:
 
 } // namespace
 
-unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
+                                                          bool write,
                                                           const FileCompressionOptions &compression_options) {
 	auto path = handle->path;
 	auto compression_level =

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -16,14 +16,24 @@
 
 namespace duckdb {
 
+ZStdFileSystem::ZStdFileSystem() : compression_level(DefaultCompressionLevel()) {
+}
+
+ZStdFileSystem::ZStdFileSystem(int64_t compression_level) : compression_level(compression_level) {
+}
+
 namespace {
 
 struct ZstdStreamWrapper : public StreamWrapper {
+	explicit ZstdStreamWrapper(int64_t compression_level) : compression_level(compression_level) {
+	}
+
 	~ZstdStreamWrapper() override;
 
 	CompressedFile *file = nullptr;
 	duckdb_zstd::ZSTD_DStream *zstd_stream_ptr = nullptr;
 	duckdb_zstd::ZSTD_CStream *zstd_compress_ptr = nullptr;
+	int64_t compression_level;
 	bool writing = false;
 
 public:
@@ -64,6 +74,12 @@ void ZstdStreamWrapper::Initialize(QueryContext context, CompressedFile &file, b
 	this->writing = write;
 	if (write) {
 		zstd_compress_ptr = duckdb_zstd::ZSTD_createCStream();
+		auto res =
+		    duckdb_zstd::ZSTD_CCtx_setParameter(zstd_compress_ptr, duckdb_zstd::ZSTD_c_compressionLevel,
+		                                        UnsafeNumericCast<int>(compression_level));
+		if (duckdb_zstd::ZSTD_isError(res)) {
+			throw IOException(duckdb_zstd::ZSTD_getErrorName(res));
+		}
 	} else {
 		zstd_stream_ptr = duckdb_zstd::ZSTD_createDStream();
 	}
@@ -181,13 +197,16 @@ void ZstdStreamWrapper::Close() {
 }
 
 struct ZStdFileSystemHolder {
+	explicit ZStdFileSystemHolder(int64_t compression_level) : zstd_fs(compression_level) {
+	}
+
 	ZStdFileSystem zstd_fs;
 };
 
 class ZStdFile : private ZStdFileSystemHolder, public CompressedFile {
 public:
-	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write)
-	    : CompressedFile(zstd_fs, std::move(child_handle_p), path) {
+	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write, int64_t compression_level)
+	    : ZStdFileSystemHolder(compression_level), CompressedFile(zstd_fs, std::move(child_handle_p), path) {
 		Initialize(context, write);
 	}
 
@@ -198,14 +217,16 @@ public:
 
 } // namespace
 
-unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, 
-														  bool write, const FileCompressionOptions &) {
+unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+                                                          const FileCompressionOptions &compression_options) {
 	auto path = handle->path;
-	return make_uniq<ZStdFile>(context, std::move(handle), path, write);
+	auto compression_level =
+	    compression_options.has_compression_level ? compression_options.compression_level : DefaultCompressionLevel();
+	return make_uniq<ZStdFile>(context, std::move(handle), path, write, compression_level);
 }
 
 unique_ptr<StreamWrapper> ZStdFileSystem::CreateStream() {
-	return make_uniq<ZstdStreamWrapper>();
+	return make_uniq<ZstdStreamWrapper>(compression_level);
 }
 
 idx_t ZStdFileSystem::InBufferSize() {

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -198,8 +198,8 @@ public:
 
 } // namespace
 
-unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                          bool write) {
+unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, 
+														  bool write, const FileCompressionOptions &) {
 	auto path = handle->path;
 	return make_uniq<ZStdFile>(context, std::move(handle), path, write);
 }

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -216,8 +216,7 @@ unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, 
 }
 
 unique_ptr<StreamWrapper> ZStdFileSystem::CreateStream(const FileCompressionOptions &compression_options) {
-	auto compression_level =
-	    compression_options.has_compression_level ? compression_options.compression_level : DefaultCompressionLevel();
+	auto compression_level = compression_options.compression_level.value_or(DefaultCompressionLevel());
 	return make_uniq<ZstdStreamWrapper>(compression_level);
 }
 

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -195,10 +195,10 @@ struct ZStdFileSystemHolder {
 
 class ZStdFile : private ZStdFileSystemHolder, public CompressedFile {
 public:
-	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write,
+	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path,
 	         FileCompressionOptions compression_options)
 	    : CompressedFile(zstd_fs, std::move(child_handle_p), path, compression_options) {
-		Initialize(context, write);
+		Initialize(context, compression_options.write);
 	}
 
 	FileCompressionType GetFileCompressionType() override {
@@ -209,10 +209,9 @@ public:
 } // namespace
 
 unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                          bool write,
                                                           const FileCompressionOptions &compression_options) {
 	auto path = handle->path;
-	return make_uniq<ZStdFile>(context, std::move(handle), path, write, compression_options);
+	return make_uniq<ZStdFile>(context, std::move(handle), path, compression_options);
 }
 
 unique_ptr<StreamWrapper> ZStdFileSystem::CreateStream(const FileCompressionOptions &compression_options) {

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -16,12 +16,6 @@
 
 namespace duckdb {
 
-ZStdFileSystem::ZStdFileSystem() : compression_level(DefaultCompressionLevel()) {
-}
-
-ZStdFileSystem::ZStdFileSystem(int64_t compression_level) : compression_level(compression_level) {
-}
-
 namespace {
 
 struct ZstdStreamWrapper : public StreamWrapper {
@@ -196,17 +190,14 @@ void ZstdStreamWrapper::Close() {
 }
 
 struct ZStdFileSystemHolder {
-	explicit ZStdFileSystemHolder(int64_t compression_level) : zstd_fs(compression_level) {
-	}
-
 	ZStdFileSystem zstd_fs;
 };
 
 class ZStdFile : private ZStdFileSystemHolder, public CompressedFile {
 public:
 	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write,
-	         int64_t compression_level)
-	    : ZStdFileSystemHolder(compression_level), CompressedFile(zstd_fs, std::move(child_handle_p), path) {
+	         FileCompressionOptions compression_options)
+	    : CompressedFile(zstd_fs, std::move(child_handle_p), path, compression_options) {
 		Initialize(context, write);
 	}
 
@@ -221,12 +212,12 @@ unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, 
                                                           bool write,
                                                           const FileCompressionOptions &compression_options) {
 	auto path = handle->path;
-	auto compression_level =
-	    compression_options.has_compression_level ? compression_options.compression_level : DefaultCompressionLevel();
-	return make_uniq<ZStdFile>(context, std::move(handle), path, write, compression_level);
+	return make_uniq<ZStdFile>(context, std::move(handle), path, write, compression_options);
 }
 
-unique_ptr<StreamWrapper> ZStdFileSystem::CreateStream() {
+unique_ptr<StreamWrapper> ZStdFileSystem::CreateStream(const FileCompressionOptions &compression_options) {
+	auto compression_level =
+	    compression_options.has_compression_level ? compression_options.compression_level : DefaultCompressionLevel();
 	return make_uniq<ZstdStreamWrapper>(compression_level);
 }
 

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -7,8 +7,10 @@ namespace duckdb {
 StreamWrapper::~StreamWrapper() {
 }
 
-CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path)
-    : FileHandle(fs, path, child_handle_p->GetFlags()), compressed_fs(fs), child_handle(std::move(child_handle_p)) {
+CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path,
+                               FileCompressionOptions compression_options)
+    : FileHandle(fs, path, child_handle_p->GetFlags()), compressed_fs(fs), child_handle(std::move(child_handle_p)),
+      compression_options(compression_options) {
 }
 
 CompressedFile::~CompressedFile() {
@@ -45,7 +47,7 @@ void CompressedFile::Initialize(QueryContext context, bool write) {
 
 	current_position = 0;
 
-	stream_wrapper = compressed_fs.CreateStream();
+	stream_wrapper = compressed_fs.CreateStream(compression_options);
 	stream_wrapper->Initialize(context, *this, write);
 }
 

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -62,13 +62,13 @@ CSVWriter::CSVWriter(WriteStream &stream, vector<string> name_list, bool shared)
 }
 
 CSVWriter::CSVWriter(CSVReaderOptions &options_p, FileSystem &fs, const string &file_path,
-                     FileCompressionType compression, bool shared)
+                     FileCompressionOptions compression_options, bool shared)
     : options(options_p),
       writer_options(options.dialect_options.state_machine_options.delimiter.GetValue(),
                      options.dialect_options.state_machine_options.quote.GetValue(), options.write_newline),
       file_writer(make_uniq<BufferedFileWriter>(fs, file_path,
                                                 FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
-                                                    FileLockType::WRITE_LOCK | compression)),
+                                                    FileLockType::WRITE_LOCK | compression_options)),
       write_stream(*file_writer), should_initialize(true), shared(shared) {
 	if (!shared) {
 		global_write_state = make_uniq<CSVWriterState>();

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -733,7 +733,7 @@ bool FileSystem::SupportsPositionalWrites(FileHandle &handle) {
 	return false;
 }
 
-unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
                                                       const FileCompressionOptions &) {
 	throw NotImplementedException("%s: OpenCompressedFile is not implemented!", GetName());
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -733,7 +733,8 @@ bool FileSystem::SupportsPositionalWrites(FileHandle &handle) {
 	return false;
 }
 
-unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write) {
+unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+                                                      const FileCompressionOptions &) {
 	throw NotImplementedException("%s: OpenCompressedFile is not implemented!", GetName());
 }
 

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -431,9 +431,9 @@ string GZipFileSystem::UncompressGZIPString(const char *data, idx_t size) {
 }
 
 unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                          bool write, const FileCompressionOptions &) {
+                                                          const FileCompressionOptions &compression_options) {
 	auto path = handle->path;
-	return make_uniq<GZipFile>(context, std::move(handle), path, write);
+	return make_uniq<GZipFile>(context, std::move(handle), path, compression_options.write);
 }
 
 unique_ptr<StreamWrapper> GZipFileSystem::CreateStream(const FileCompressionOptions &) {

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -431,7 +431,7 @@ string GZipFileSystem::UncompressGZIPString(const char *data, idx_t size) {
 }
 
 unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                          bool write) {
+														  bool write, const FileCompressionOptions &) {
 	auto path = handle->path;
 	return make_uniq<GZipFile>(context, std::move(handle), path, write);
 }

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -436,7 +436,7 @@ unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(QueryContext context, 
 	return make_uniq<GZipFile>(context, std::move(handle), path, write);
 }
 
-unique_ptr<StreamWrapper> GZipFileSystem::CreateStream() {
+unique_ptr<StreamWrapper> GZipFileSystem::CreateStream(const FileCompressionOptions &) {
 	return make_uniq<MiniZStreamWrapper>();
 }
 

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -431,7 +431,7 @@ string GZipFileSystem::UncompressGZIPString(const char *data, idx_t size) {
 }
 
 unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-														  bool write, const FileCompressionOptions &) {
+                                                          bool write, const FileCompressionOptions &) {
 	auto path = handle->path;
 	return make_uniq<GZipFile>(context, std::move(handle), path, write);
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -131,7 +131,8 @@ FileSystem &VirtualFileSystem::GetDefaultFileSystem() {
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                            optional_ptr<FileOpener> opener) {
-	auto compression = flags.Compression();
+	auto compression_options = flags.CompressionOptions();
+	auto compression = compression_options.type;
 	if (compression == FileCompressionType::AUTO_DETECT) {
 		// auto-detect compression settings based on file name
 		auto lower_path = StringUtil::Lower(file.path);
@@ -146,6 +147,7 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 		} else {
 			compression = FileCompressionType::UNCOMPRESSED;
 		}
+		compression_options.type = compression;
 	}
 
 	// open the base file handle in UNCOMPRESSED mode
@@ -186,7 +188,7 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			    "Attempting to open a compressed file, but the compression type is not supported");
 		}
 		auto &compressed_fs = *entry->second->file_system;
-		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
+		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting(), compression_options);
 	}
 	return file_handle;
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -188,7 +188,8 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			    "Attempting to open a compressed file, but the compression type is not supported");
 		}
 		auto &compressed_fs = *entry->second->file_system;
-		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting(), compression_options);
+		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting(),
+		                                               compression_options);
 	}
 	return file_handle;
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -187,9 +187,9 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			throw NotImplementedException(
 			    "Attempting to open a compressed file, but the compression type is not supported");
 		}
+		compression_options.write = flags.OpenForWriting();
 		auto &compressed_fs = *entry->second->file_system;
-		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting(),
-		                                               compression_options);
+		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), compression_options);
 	}
 	return file_handle;
 }

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
-#include "zstd.h"
+#include "zstd_file_system.hpp"
 
 namespace duckdb {
 
@@ -410,8 +410,8 @@ void CSVReaderOptions::SetWriteOption(const string &loption, const Value &value)
 		suffix = ParseString(value, loption);
 	} else if (loption == "compression_level") {
 		auto val = ParseInteger(value, loption);
-		auto min_level = static_cast<int64_t>(duckdb_zstd::ZSTD_minCLevel());
-		auto max_level = static_cast<int64_t>(duckdb_zstd::ZSTD_maxCLevel());
+		auto min_level = ZStdFileSystem::MinimumCompressionLevel();
+		auto max_level = ZStdFileSystem::MaximumCompressionLevel();
 		if (val < min_level || val > max_level) {
 			throw BinderException("Compression level must be between %lld and %lld", min_level, max_level);
 		}

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "zstd.h"
 
 namespace duckdb {
 
@@ -407,6 +408,15 @@ void CSVReaderOptions::SetWriteOption(const string &loption, const Value &value)
 		prefix = ParseString(value, loption);
 	} else if (loption == "suffix") {
 		suffix = ParseString(value, loption);
+	} else if (loption == "compression_level") {
+		auto val = ParseInteger(value, loption);
+		auto min_level = static_cast<int64_t>(duckdb_zstd::ZSTD_minCLevel());
+		auto max_level = static_cast<int64_t>(duckdb_zstd::ZSTD_maxCLevel());
+		if (val < min_level || val > max_level) {
+			throw BinderException("Compression level must be between %lld and %lld", min_level, max_level);
+		}
+		compression_level = val;
+		compression_level_set = true;
 	} else {
 		throw BinderException("Unrecognized option CSV writer \"%s\"", loption);
 	}

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
-#include "zstd_file_system.hpp"
+#include "zstd.h"
 
 namespace duckdb {
 
@@ -410,8 +410,8 @@ void CSVReaderOptions::SetWriteOption(const string &loption, const Value &value)
 		suffix = ParseString(value, loption);
 	} else if (loption == "compression_level") {
 		auto val = ParseInteger(value, loption);
-		auto min_level = ZStdFileSystem::MinimumCompressionLevel();
-		auto max_level = ZStdFileSystem::MaximumCompressionLevel();
+		auto min_level = static_cast<int64_t>(duckdb_zstd::ZSTD_minCLevel());
+		auto max_level = static_cast<int64_t>(duckdb_zstd::ZSTD_maxCLevel());
 		if (val < min_level || val > max_level) {
 			throw BinderException("Compression level must be between %lld and %lld", min_level, max_level);
 		}

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -182,6 +182,9 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyFunctio
 		auto &set = option.second;
 		bind_data->options.SetWriteOption(loption, ConvertVectorToValue(set));
 	}
+	if (bind_data->options.compression_level_set && bind_data->options.compression != FileCompressionType::ZSTD) {
+		throw BinderException("Compression level is only supported for the ZSTD compression codec");
+	}
 	// verify the parsed options
 	if (bind_data->options.force_quote.empty()) {
 		// no FORCE_QUOTE specified: initialize to false
@@ -251,6 +254,7 @@ static void CSVListCopyOptions(ClientContext &context, CopyOptionsInput &input) 
 	copy_options["nullstr"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
 	copy_options["null"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
 	copy_options["compression"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["compression_level"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::WRITE_ONLY);
 	copy_options["strict_mode"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_WRITE);
 }
 
@@ -274,8 +278,8 @@ public:
 
 struct GlobalWriteCSVData : public GlobalFunctionData {
 	GlobalWriteCSVData(CSVReaderOptions &options, FileSystem &fs, const string &file_path,
-	                   FileCompressionType compression)
-	    : writer(options, fs, file_path, compression) {
+	                   FileCompressionOptions compression_options)
+	    : writer(options, fs, file_path, compression_options) {
 	}
 
 	idx_t FileSize() {
@@ -325,8 +329,12 @@ static unique_ptr<GlobalFunctionData> WriteCSVInitializeGlobal(ClientContext &co
                                                                const string &file_path) {
 	auto &csv_data = bind_data.Cast<WriteCSVData>();
 	auto &options = csv_data.options;
+	FileCompressionOptions compression_options(options.compression);
+	if (options.compression_level_set) {
+		compression_options = FileCompressionOptions(options.compression, options.compression_level);
+	}
 	auto global_data =
-	    make_uniq<GlobalWriteCSVData>(options, FileSystem::GetFileSystem(context), file_path, options.compression);
+	    make_uniq<GlobalWriteCSVData>(options, FileSystem::GetFileSystem(context), file_path, compression_options);
 
 	global_data->writer.Initialize();
 

--- a/src/include/duckdb/common/compressed_file_system.hpp
+++ b/src/include/duckdb/common/compressed_file_system.hpp
@@ -51,20 +51,22 @@ public:
 	DUCKDB_API bool OnDiskFile(FileHandle &handle) override;
 	DUCKDB_API bool CanSeek() override;
 
-	DUCKDB_API virtual unique_ptr<StreamWrapper> CreateStream() = 0;
+	DUCKDB_API virtual unique_ptr<StreamWrapper> CreateStream(const FileCompressionOptions &compression_options) = 0;
 	DUCKDB_API virtual idx_t InBufferSize() = 0;
 	DUCKDB_API virtual idx_t OutBufferSize() = 0;
 };
 
 class CompressedFile : public FileHandle {
 public:
-	DUCKDB_API CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path);
+	DUCKDB_API CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path,
+	                          FileCompressionOptions compression_options = FileCompressionOptions());
 	DUCKDB_API ~CompressedFile() override;
 
 	DUCKDB_API idx_t GetProgress() override;
 
 	CompressedFileSystem &compressed_fs;
 	unique_ptr<FileHandle> child_handle;
+	FileCompressionOptions compression_options;
 	//! Whether the file is opened for reading or for writing
 	bool write = false;
 	StreamData stream_data;

--- a/src/include/duckdb/common/csv_writer.hpp
+++ b/src/include/duckdb/common/csv_writer.hpp
@@ -63,8 +63,7 @@ public:
 
 	//! Create a CSVWriter that writes to a file
 	CSVWriter(CSVReaderOptions &options, FileSystem &fs, const string &file_path,
-	          FileCompressionOptions compression_options,
-	          bool shared = true);
+	          FileCompressionOptions compression_options, bool shared = true);
 
 	//! Writes header and prefix if necessary
 	void Initialize(bool force = false);

--- a/src/include/duckdb/common/csv_writer.hpp
+++ b/src/include/duckdb/common/csv_writer.hpp
@@ -62,7 +62,8 @@ public:
 	CSVWriter(WriteStream &stream, vector<string> name_list, bool shared = true);
 
 	//! Create a CSVWriter that writes to a file
-	CSVWriter(CSVReaderOptions &options, FileSystem &fs, const string &file_path, FileCompressionType compression,
+	CSVWriter(CSVReaderOptions &options, FileSystem &fs, const string &file_path,
+	          FileCompressionOptions compression_options,
 	          bool shared = true);
 
 	//! Writes header and prefix if necessary

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -16,6 +16,20 @@ namespace duckdb {
 
 enum class FileLockType : uint8_t { NO_LOCK = 0, READ_LOCK = 1, WRITE_LOCK = 2 };
 
+struct FileCompressionOptions {
+	constexpr FileCompressionOptions() = default;
+	constexpr FileCompressionOptions(FileCompressionType type) // NOLINT: allow implicit conversion
+	    : type(type) {
+	}
+	constexpr FileCompressionOptions(FileCompressionType type, int64_t compression_level)
+	    : type(type), compression_level(compression_level), has_compression_level(true) {
+	}
+
+	FileCompressionType type = FileCompressionType::UNCOMPRESSED;
+	int64_t compression_level = 0;
+	bool has_compression_level = false;
+};
+
 class FileOpenFlags {
 public:
 	static constexpr idx_t FILE_FLAGS_READ = idx_t(1 << 0);
@@ -40,18 +54,21 @@ public:
 	constexpr FileOpenFlags(FileLockType lock) : lock(lock) { // NOLINT: allow implicit conversion
 	}
 	constexpr FileOpenFlags(FileCompressionType compression) // NOLINT: allow implicit conversion
-	    : compression(compression) {
+	    : compression_options(compression) {
 	}
-	constexpr FileOpenFlags(idx_t flags, FileLockType lock, FileCompressionType compression)
-	    : flags(flags), lock(lock), compression(compression) {
+	constexpr FileOpenFlags(FileCompressionOptions compression_options) // NOLINT: allow implicit conversion
+	    : compression_options(compression_options) {
+	}
+	constexpr FileOpenFlags(idx_t flags, FileLockType lock, FileCompressionOptions compression_options)
+	    : flags(flags), lock(lock), compression_options(compression_options) {
 	}
 
 	static constexpr FileLockType MergeLock(FileLockType a, FileLockType b) {
 		return a == FileLockType::NO_LOCK ? b : a;
 	}
 
-	static constexpr FileCompressionType MergeCompression(FileCompressionType a, FileCompressionType b) {
-		return a == FileCompressionType::UNCOMPRESSED ? b : a;
+	static constexpr FileCompressionOptions MergeCompression(FileCompressionOptions a, FileCompressionOptions b) {
+		return a.type == FileCompressionType::UNCOMPRESSED ? b : a;
 	}
 
 	static constexpr CachingMode MergeCachingMode(CachingMode a, CachingMode b) {
@@ -59,12 +76,12 @@ public:
 	}
 
 	inline constexpr FileOpenFlags operator|(FileOpenFlags b) const {
-		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression, b.compression));
+		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression_options, b.compression_options));
 	}
 	inline FileOpenFlags &operator|=(FileOpenFlags b) {
 		flags |= b.flags;
 		lock = MergeLock(lock, b.lock);
-		compression = MergeCompression(compression, b.compression);
+		compression_options = MergeCompression(compression_options, b.compression_options);
 		caching_mode = MergeCachingMode(caching_mode, b.caching_mode);
 		return *this;
 	}
@@ -74,11 +91,22 @@ public:
 	}
 
 	FileCompressionType Compression() {
-		return compression;
+		return compression_options.type;
+	}
+
+	FileCompressionOptions CompressionOptions() {
+		return compression_options;
 	}
 
 	void SetCompression(FileCompressionType new_compression) {
-		compression = new_compression;
+		compression_options.type = new_compression;
+		if (new_compression == FileCompressionType::UNCOMPRESSED) {
+			compression_options.has_compression_level = false;
+		}
+	}
+
+	void SetCompressionOptions(FileCompressionOptions new_compression_options) {
+		compression_options = new_compression_options;
 	}
 
 	CachingMode GetCachingMode() {
@@ -140,7 +168,7 @@ private:
 	idx_t flags = 0;
 	FileLockType lock = FileLockType::NO_LOCK;
 	CachingMode caching_mode = CachingMode::NO_CACHING;
-	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
+	FileCompressionOptions compression_options;
 };
 
 class FileFlags {

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/storage/caching_mode.hpp"
 
 namespace duckdb {
@@ -22,12 +23,11 @@ struct FileCompressionOptions {
 	    : type(type) {
 	}
 	constexpr FileCompressionOptions(FileCompressionType type, int64_t compression_level)
-	    : type(type), compression_level(compression_level), has_compression_level(true) {
+	    : type(type), compression_level(compression_level) {
 	}
 
 	FileCompressionType type = FileCompressionType::UNCOMPRESSED;
-	int64_t compression_level = 0;
-	bool has_compression_level = false;
+	optional<int64_t> compression_level;
 };
 
 class FileOpenFlags {
@@ -102,7 +102,7 @@ public:
 	void SetCompression(FileCompressionType new_compression) {
 		compression_options.type = new_compression;
 		if (new_compression == FileCompressionType::UNCOMPRESSED) {
-			compression_options.has_compression_level = false;
+			compression_options.compression_level = nullopt;
 		}
 	}
 

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -76,7 +76,8 @@ public:
 	}
 
 	inline constexpr FileOpenFlags operator|(FileOpenFlags b) const {
-		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression_options, b.compression_options));
+		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock),
+		                     MergeCompression(compression_options, b.compression_options));
 	}
 	inline FileOpenFlags &operator|=(FileOpenFlags b) {
 		flags |= b.flags;

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -28,6 +28,7 @@ struct FileCompressionOptions {
 
 	FileCompressionType type = FileCompressionType::UNCOMPRESSED;
 	optional<int64_t> compression_level;
+	bool write = false;
 };
 
 class FileOpenFlags {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -320,7 +320,8 @@ public:
 	DUCKDB_API virtual bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                                             bool write, const FileCompressionOptions &compression_options);
+	                                                             bool write,
+	                                                             const FileCompressionOptions &compression_options);
 
 	//! Create a LocalFileSystem.
 	DUCKDB_API static unique_ptr<FileSystem> CreateLocal();

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -320,7 +320,6 @@ public:
 	DUCKDB_API virtual bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                                             bool write,
 	                                                             const FileCompressionOptions &compression_options);
 
 	//! Create a LocalFileSystem.

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -320,7 +320,7 @@ public:
 	DUCKDB_API virtual bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                                             bool write);
+	                                                             bool write, const FileCompressionOptions &compression_options);
 
 	//! Create a LocalFileSystem.
 	DUCKDB_API static unique_ptr<FileSystem> CreateLocal();

--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -17,7 +17,7 @@ class GZipFileSystem : public CompressedFileSystem {
 	static constexpr const idx_t BUFFER_SIZE = 1u << 15;
 
 public:
-	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                          const FileCompressionOptions &compression_options) override;
 
 	std::string GetName() const override {

--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -32,7 +32,7 @@ public:
 	static string UncompressGZIPString(const string &in);
 	static string UncompressGZIPString(const char *length, idx_t size);
 
-	unique_ptr<StreamWrapper> CreateStream() override;
+	unique_ptr<StreamWrapper> CreateStream(const FileCompressionOptions &compression_options) override;
 	idx_t InBufferSize() override;
 	idx_t OutBufferSize() override;
 };

--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -17,7 +17,8 @@ class GZipFileSystem : public CompressedFileSystem {
 	static constexpr const idx_t BUFFER_SIZE = 1u << 15;
 
 public:
-	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write) override;
+	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write,
+	                                          const FileCompressionOptions &compression_options) override;
 
 	std::string GetName() const override {
 		return "GZipFileSystem";

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -63,6 +63,9 @@ struct CSVReaderOptions {
 	//! Whether file is compressed or not, and if so which compression type
 	//! AUTO_DETECT (default; infer from file extension)
 	FileCompressionType compression = FileCompressionType::AUTO_DETECT;
+	//! The compression level to use for writing compressed files, if specified
+	int64_t compression_level = 0;
+	bool compression_level_set = false;
 	//! Option to convert quoted values to NULL values
 	bool allow_quoted_nulls = true;
 	char comment = '\0';

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -114,7 +114,6 @@ public:
 	DUCKDB_API bool OnDiskFile(FileHandle &handle) override;
 
 	DUCKDB_API unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                                     bool write,
 	                                                     const FileCompressionOptions &compression_options) override;
 
 	DUCKDB_API void SetDisabledFileSystems(const vector<string> &names) override;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -113,8 +113,8 @@ public:
 	DUCKDB_API bool CanSeek() override;
 	DUCKDB_API bool OnDiskFile(FileHandle &handle) override;
 
-	DUCKDB_API unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                                     bool write) override;
+		DUCKDB_API unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
+		                                                     bool write, const FileCompressionOptions &compression_options) override;
 
 	DUCKDB_API void SetDisabledFileSystems(const vector<string> &names) override;
 	DUCKDB_API bool SubSystemIsDisabled(const string &name) override;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -113,8 +113,9 @@ public:
 	DUCKDB_API bool CanSeek() override;
 	DUCKDB_API bool OnDiskFile(FileHandle &handle) override;
 
-		DUCKDB_API unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-		                                                     bool write, const FileCompressionOptions &compression_options) override;
+	DUCKDB_API unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
+	                                                     bool write,
+	                                                     const FileCompressionOptions &compression_options) override;
 
 	DUCKDB_API void SetDisabledFileSystems(const vector<string> &names) override;
 	DUCKDB_API bool SubSystemIsDisabled(const string &name) override;

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -369,7 +369,8 @@ bool CachingFileSystemWrapper::OnDiskFile(FileHandle &handle) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 unique_ptr<FileHandle> CachingFileSystemWrapper::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                                    bool write, const FileCompressionOptions &compression_options) {
+                                                                    bool write,
+                                                                    const FileCompressionOptions &compression_options) {
 	return underlying_file_system.OpenCompressedFile(context, std::move(handle), write, compression_options);
 }
 

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -369,9 +369,8 @@ bool CachingFileSystemWrapper::OnDiskFile(FileHandle &handle) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 unique_ptr<FileHandle> CachingFileSystemWrapper::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                                    bool write,
                                                                     const FileCompressionOptions &compression_options) {
-	return underlying_file_system.OpenCompressedFile(context, std::move(handle), write, compression_options);
+	return underlying_file_system.OpenCompressedFile(context, std::move(handle), compression_options);
 }
 
 void CachingFileSystemWrapper::SetDisabledFileSystems(const vector<string> &names) {

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -369,8 +369,8 @@ bool CachingFileSystemWrapper::OnDiskFile(FileHandle &handle) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 unique_ptr<FileHandle> CachingFileSystemWrapper::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-                                                                    bool write) {
-	return underlying_file_system.OpenCompressedFile(context, std::move(handle), write);
+                                                                    bool write, const FileCompressionOptions &compression_options) {
+	return underlying_file_system.OpenCompressedFile(context, std::move(handle), write, compression_options);
 }
 
 void CachingFileSystemWrapper::SetDisabledFileSystems(const vector<string> &names) {

--- a/test/sql/copy/csv/csv_write_compression_level.test
+++ b/test/sql/copy/csv/csv_write_compression_level.test
@@ -1,0 +1,73 @@
+# name: test/sql/copy/csv/csv_write_compression_level.test
+# description: Test zstd compression levels for CSV COPY TO
+# group: [csv]
+
+require parquet
+
+require no_extension_autoloading "FIXME: Autoloading on zstd compression (parquet) not yet there"
+
+# Binder accepts COMPRESSION_LEVEL for CSV zstd writes and creates the file
+statement ok
+COPY (SELECT 1)
+TO '{TEST_DIR}/result.csv.zst'
+WITH (
+    COMPRESSION zstd,
+    COMPRESSION_LEVEL 19
+);
+
+query I
+SELECT size > 0 FROM read_blob('{TEST_DIR}/result.csv.zst');
+----
+true
+
+# COMPRESSION_LEVEL only applies to zstd
+statement error
+COPY (SELECT 1)
+TO '{TEST_DIR}/bad.csv.gz'
+WITH (
+    COMPRESSION gzip,
+    COMPRESSION_LEVEL 19
+);
+----
+Compression level is only supported for the ZSTD compression codec
+
+# Validate zstd compression level bounds
+statement error
+COPY (SELECT 1)
+TO '{TEST_DIR}/bad.csv.zst'
+WITH (
+    COMPRESSION zstd,
+    COMPRESSION_LEVEL 999999
+);
+----
+Compression level must be between
+
+# The selected level reaches ZSTD_CCtx_setParameter
+statement ok
+COPY (
+    SELECT repeat('aaaaaaaaaaaaaaaaaaaaaaaa', 1000) AS s
+    FROM range(200)
+)
+TO '{TEST_DIR}/level1.csv.zst'
+WITH (
+    COMPRESSION zstd,
+    COMPRESSION_LEVEL 1
+);
+
+statement ok
+COPY (
+    SELECT repeat('aaaaaaaaaaaaaaaaaaaaaaaa', 1000) AS s
+    FROM range(200)
+)
+TO '{TEST_DIR}/level19.csv.zst'
+WITH (
+    COMPRESSION zstd,
+    COMPRESSION_LEVEL 19
+);
+
+query I
+SELECT level19.size < level1.size
+FROM read_blob('{TEST_DIR}/level1.csv.zst') level1,
+     read_blob('{TEST_DIR}/level19.csv.zst') level19;
+----
+true


### PR DESCRIPTION
Fixes #22820 

This PR adds support for `COMPRESSION_LEVEL` when writing CSV files with `COMPRESSION zstd`, e.g.:
```sql
COPY (SELECT 1)
TO 'result.csv.zst'
WITH (
    COMPRESSION zstd,
    COMPRESSION_LEVEL 19
);
```

Previously, CSV COPY rejected this option during binding with:
`Unrecognized option "compression_level" for csv`


## Changes
- Add a `FileCompressionOptions` carrier so file open flags can pass both the compression type and optional compression level through the virtual file system layer.
- Thread compression options through `VirtualFileSystem::OpenFileExtended`, compressed file-system wrappers, and `BufferedFileWriter`.
- Teach the zstd file-system wrapper to apply the requested compression level via `ZSTD_CCtx_setParameter(..., ZSTD_c_compressionLevel, ...)`.
- Register and parse CSV `COMPRESSION_LEVEL` as a write-only COPY option.
- Validate CSV compression levels using zstd min/max bounds.
- Reject `COMPRESSION_LEVEL` for non-zstd CSV compression modes.
- Pass the parsed CSV compression level from `CSVReaderOptions` into `CSVWriter` and file open flags.
- Add a regression test covering:
  - zstd CSV export with `COMPRESSION_LEVEL`
  - rejection for gzip + compression level
  - rejection for out-of-range zstd levels
  - actual size differences between zstd level 1 and 19 output

## Testing
```bash
build/debug/test/unittest
test/sql/copy/csv/csv_write_compression_level.test
```