### PR TITLE
Fix JSON create functions for VARIANT input

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -94,6 +94,8 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 	case LogicalTypeId::BIGNUM:
 	case LogicalTypeId::DECIMAL:
 		return type;
+	case LogicalTypeId::VARIANT:
+		return LogicalType::JSON();
 	case LogicalTypeId::LIST:
 		return LogicalType::LIST(GetJSONType(const_struct_names, ListType::GetChildType(type)));
 	case LogicalTypeId::ARRAY:
@@ -130,6 +132,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_function,
                                                      vector<unique_ptr<Expression>> &arguments, bool object) {
 	StructNames const_struct_names;
+	bound_function.GetArguments().clear();
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		auto &type = arguments[i]->GetReturnType();
 		if (arguments[i]->HasParameter()) {

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -132,7 +132,9 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_function,
                                                      vector<unique_ptr<Expression>> &arguments, bool object) {
 	StructNames const_struct_names;
-	bound_function.GetArguments().clear();
+	auto &bound_arguments = bound_function.GetArguments();
+	bound_arguments.clear();
+	bound_arguments.reserve(arguments.size());
 	for (idx_t i = 0; i < arguments.size(); i++) {
 		auto &type = arguments[i]->GetReturnType();
 		if (arguments[i]->HasParameter()) {
@@ -142,10 +144,10 @@ static unique_ptr<FunctionData> JSONCreateBindParams(BoundScalarFunction &bound_
 				throw BinderException("json_object() keys must be VARCHAR, add an explicit cast to argument \"%s\"",
 				                      arguments[i]->GetName());
 			}
-			bound_function.GetArguments().push_back(LogicalType::VARCHAR);
+			bound_arguments.push_back(LogicalType::VARCHAR);
 		} else {
 			// Value, cast to types that we can put in JSON
-			bound_function.GetArguments().push_back(GetJSONType(const_struct_names, type));
+			bound_arguments.push_back(GetJSONType(const_struct_names, type));
 		}
 	}
 	return make_uniq<JSONCreateFunctionData>(std::move(const_struct_names));

--- a/test/sql/json/scalar/test_json_create.test
+++ b/test/sql/json/scalar/test_json_create.test
@@ -21,6 +21,22 @@ select to_json({n: 42})
 ----
 {"n":42}
 
+# issue #22828
+query T
+select to_json(42::VARIANT)
+----
+42
+
+query T
+select json_array(42::VARIANT)
+----
+[42]
+
+query T
+select json_object('x', 42::VARIANT)
+----
+{"x":42}
+
 statement error
 select to_json({n: 42}, {extra: 'argument'})
 ----


### PR DESCRIPTION
Fixes #22828.

This updates JSON create binding so it clears the expanded ANY varargs before replacing them with concrete JSON-compatible argument types. VARIANT inputs are bound as JSON and therefore use the existing VARIANT-to-JSON cast instead of reaching the JSON create executor as an unsupported physical type.

Tests:
- `make allunit`