### PR TITLE
Re-enable all explicitly disabled tests on musl

### DIFF
--- a/test/fuzzer/duckfuzz/array_group_by_sample.test
+++ b/test/fuzzer/duckfuzz/array_group_by_sample.test
@@ -2,8 +2,6 @@
 # description: Test allocating enough dummy list_entry_t's during tuple format serialization.
 # group: [duckfuzz]
 
-require notmusl
-
 statement ok
 CREATE TABLE array_tbl(c50 INTEGER[2][]);
 

--- a/test/sql/aggregate/group/test_group_by_nested.test
+++ b/test/sql/aggregate/group/test_group_by_nested.test
@@ -2,8 +2,6 @@
 # description: GROUP BY nested types (STRUCTs, LISTs)
 # group: [group]
 
-require notmusl
-
 statement ok
 SET default_null_order='nulls_first';
 

--- a/test/sql/order/issue_11936.test
+++ b/test/sql/order/issue_11936.test
@@ -2,8 +2,6 @@
 # description: Test order nested list
 # group: [order]
 
-require notmusl
-
 statement ok
 CREATE TABLE test(col1 INT, col2 INT2[][][][][][]);
 

--- a/test/sql/types/list/nested_list_extract.test
+++ b/test/sql/types/list/nested_list_extract.test
@@ -2,8 +2,6 @@
 # description: Test nested list extract
 # group: [list]
 
-require notmusl
-
 # nesting level=2
 statement ok
 CREATE TABLE a(id INTEGER, b INTEGER[][]);


### PR DESCRIPTION
There are no more tests left with `require notmusl`.

Tests were disabled in https://github.com/duckdb/duckdb/pull/15607.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/3827.