### PR TITLE
`COMMENT ON` aliased view column

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -74,19 +74,27 @@ unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, Al
 		auto &comment_on_column_info = info.Cast<SetColumnCommentInfo>();
 		auto copied_view = Copy(context);
 
+		string &resolved_column_name = comment_on_column_info.column_name;
 		auto view_columns = GetColumnInfo();
 		if (view_columns) {
 			// if the view is bound - verify the name we are commenting on exists
 			auto &names = view_columns->names;
-			auto entry = std::find(names.begin(), names.end(), comment_on_column_info.column_name);
+			auto entry = std::find(names.begin(), names.end(), resolved_column_name);
 			if (entry == names.end()) {
-				throw BinderException("View \"%s\" does not have a column with name \"%s\"", name,
-				                      comment_on_column_info.column_name);
+				// the column name might be a view alias - check those as well
+				auto alias_entry = std::find(aliases.begin(), aliases.end(), resolved_column_name);
+				if (alias_entry == aliases.end()) {
+					throw BinderException("View \"%s\" does not have a column with name \"%s\"", name,
+					                      resolved_column_name);
+				}
+				auto alias_index = NumericCast<idx_t>(std::distance(aliases.begin(), alias_entry));
+				D_ASSERT(alias_index < names.size());
+				resolved_column_name = names[alias_index];
 			}
 		}
 		// apply the comment to the view
 		auto &copied_view_entry = copied_view->Cast<ViewCatalogEntry>();
-		copied_view_entry.column_comments[comment_on_column_info.column_name] = comment_on_column_info.comment_value;
+		copied_view_entry.column_comments[resolved_column_name] = comment_on_column_info.comment_value;
 		return copied_view;
 	}
 

--- a/test/sql/catalog/comment_on_column.test
+++ b/test/sql/catalog/comment_on_column.test
@@ -95,3 +95,31 @@ query TTI
 SELECT table_name, database_name, temporary FROM duckdb_tables() WHERE table_name='temp_comment_test'
 ----
 temp_comment_test	temp	true
+
+# test that COMMENT ON COLUMN works with view column aliases
+statement ok
+CREATE VIEW aliased_view(c1, c2) AS SELECT 1, 2;
+
+statement ok
+COMMENT ON COLUMN aliased_view.c1 IS 'comment on aliased column'
+
+query II
+SELECT column_name, comment FROM duckdb_columns() WHERE table_name='aliased_view' AND column_name='c1';
+----
+c1	comment on aliased column
+
+# also works with multiple aliases
+statement ok
+COMMENT ON COLUMN aliased_view.c2 IS 'second aliased column comment'
+
+query II
+SELECT column_name, comment FROM duckdb_columns() WHERE table_name='aliased_view' ORDER BY column_index;
+----
+c1	comment on aliased column
+c2	second aliased column comment
+
+# error on non-existent column with aliases
+statement error
+COMMENT ON COLUMN aliased_view.nonexistent IS 'bad'
+----
+View "aliased_view" does not have a column with name "nonexistent"


### PR DESCRIPTION
Previously this would fail:
```sql
memory D CREATE TEMPORARY VIEW v(c1) AS SELECT 1;
memory D COMMENT ON column v.c1 is 'hello'; 
Binder Error:
View "v" does not have a column with name "c1"                                                                                                                                     
memory D from v;
┌───────┐
│  c1   │                                                                                                                                                                          
│ int32 │                                                                                                                                                                          
├───────┤                                                                                                                                                                          
│     1 │                                                                                                                                                                          
└───────┘
```
Now this is fixed