### PR TITLE
Fix geometry stats checkpointing when no changes are detected

### DIFF
--- a/src/include/duckdb/storage/table/geo_column_data.hpp
+++ b/src/include/duckdb/storage/table/geo_column_data.hpp
@@ -74,7 +74,7 @@ public:
 private:
 	static void Specialize(Vector &source, Vector &target, idx_t count, GeometryStorageType storage_type);
 	static void Reassemble(Vector &source, Vector &target, idx_t count, GeometryStorageType storage_type, idx_t offset);
-	static void InterpretStats(BaseStatistics &source, BaseStatistics &target, GeometryType geom_type,
+	static void InterpretStats(const BaseStatistics &source, BaseStatistics &target, GeometryType geom_type,
 	                           VertexType vert_type);
 };
 

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -345,6 +345,17 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 		checkpoint_state->inner_column = base_column;
 		checkpoint_state->inner_column_state =
 		    checkpoint_state->inner_column->Checkpoint(row_group, info, old_column_stats);
+
+		if (base_column->GetType().id() == LogicalTypeId::GEOMETRY) {
+			// Get the stats from the base column.
+			checkpoint_state->global_stats = checkpoint_state->inner_column_state->GetStatistics();
+		} else {
+			// Otherwise interpret stats from shredded column
+			const auto [gtype, vtype] = Geometry::GetSpecializedType(checkpoint_state->storage_type);
+			auto new_stats = checkpoint_state->inner_column_state->GetStatistics();
+			InterpretStats(*new_stats, *checkpoint_state->global_stats, gtype, vtype);
+		}
+
 		return std::move(checkpoint_state);
 	}
 
@@ -592,7 +603,7 @@ void GeoColumnData::Reassemble(Vector &source, Vector &target, idx_t count, Geom
 	Geometry::FromVectorizedFormat(source, target, count, type, result_offset);
 }
 
-static const BaseStatistics *GetVertexStats(BaseStatistics &stats, GeometryType geom_type) {
+static const BaseStatistics *GetVertexStats(const BaseStatistics &stats, GeometryType geom_type) {
 	switch (geom_type) {
 	case GeometryType::POINT: {
 		return StructStats::GetChildStats(stats);
@@ -627,7 +638,7 @@ static const BaseStatistics *GetVertexStats(BaseStatistics &stats, GeometryType 
 	}
 }
 
-void GeoColumnData::InterpretStats(BaseStatistics &source, BaseStatistics &target, GeometryType geom_type,
+void GeoColumnData::InterpretStats(const BaseStatistics &source, BaseStatistics &target, GeometryType geom_type,
                                    VertexType vert_type) {
 	// Copy base stats
 	target.CopyBase(source);

--- a/src/storage/table/geo_column_data.cpp
+++ b/src/storage/table/geo_column_data.cpp
@@ -351,7 +351,10 @@ unique_ptr<ColumnCheckpointState> GeoColumnData::Checkpoint(const RowGroup &row_
 			checkpoint_state->global_stats = checkpoint_state->inner_column_state->GetStatistics();
 		} else {
 			// Otherwise interpret stats from shredded column
-			const auto [gtype, vtype] = Geometry::GetSpecializedType(checkpoint_state->storage_type);
+			const auto types = Geometry::GetSpecializedType(checkpoint_state->storage_type);
+			const auto gtype = types.first;
+			const auto vtype = types.second;
+
 			auto new_stats = checkpoint_state->inner_column_state->GetStatistics();
 			InterpretStats(*new_stats, *checkpoint_state->global_stats, gtype, vtype);
 		}

--- a/test/sql/types/geo/geometry_stats_prune.test
+++ b/test/sql/types/geo/geometry_stats_prune.test
@@ -1,0 +1,53 @@
+# name: test/sql/types/geo/geometry_stats_prune.test
+# group: [geo]
+
+# Originall reported in issue duckdb-spatial/#817
+
+require noforcestorage
+
+#statement ok
+#set geometry_minimum_shredding_size=0;
+
+statement ok
+ATTACH '__TEST_DIR__/repro_geo_rowgroup.db' AS geoms (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v1.5.0');
+
+statement ok
+USE geoms;
+
+statement ok
+CREATE TABLE geoms AS
+SELECT
+printf('POLYGON((%f %f, %f %f, %f %f, %f %f, %f %f))',
+	x, 			y,
+	x, 			y + 0.005,
+	x + 0.005, 	y + 0.005,
+	x + 0.005, 	y,
+	x, 			y
+)::GEOMETRY AS geom
+FROM (
+    SELECT
+        ((i % 10)::DOUBLE * 0.01) AS x,
+        (floor(i / 10)::DOUBLE * 0.01) AS y
+    FROM range(2048) AS t(i)
+);
+
+# Correct before detach: count = 16.
+query II rowsort results
+SELECT count(*) AS count FROM geoms WHERE geom && 'POLYGON ((0.02 0.02, 0.02 0.05, 0.05 0.05, 0.05 0.02, 0.02 0.02))'::GEOMETRY;
+----
+
+statement ok
+USE memory;
+
+statement ok
+DETACH geoms;
+
+statement ok
+ATTACH '__TEST_DIR__/repro_geo_rowgroup.db' AS geoms (STORAGE_VERSION 'v1.5.0');
+
+statement ok
+USE geoms;
+
+query II rowsort results
+SELECT count(*) AS count FROM geoms WHERE geom && 'POLYGON ((0.02 0.02, 0.02 0.05, 0.05 0.05, 0.05 0.02, 0.02 0.02))'::GEOMETRY;
+----

--- a/test/sql/types/geo/geometry_stats_prune_shredded.test
+++ b/test/sql/types/geo/geometry_stats_prune_shredded.test
@@ -1,0 +1,55 @@
+# name: test/sql/types/geo/geometry_stats_prune_shredded.test
+# group: [geo]
+
+# Originall reported in issue duckdb-spatial/#817
+# This is the same as geometry_stats_prune.test, except that it sets geometry_minimum_shredding_size to 0,
+# which means that the geometry row groups are always shredded.
+
+require noforcestorage
+
+statement ok
+set geometry_minimum_shredding_size=0;
+
+statement ok
+ATTACH '__TEST_DIR__/repro_geo_rowgroup.db' AS geoms (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v1.5.0');
+
+statement ok
+USE geoms;
+
+statement ok
+CREATE TABLE geoms AS
+SELECT
+printf('POLYGON((%f %f, %f %f, %f %f, %f %f, %f %f))',
+	x, 			y,
+	x, 			y + 0.005,
+	x + 0.005, 	y + 0.005,
+	x + 0.005, 	y,
+	x, 			y
+)::GEOMETRY AS geom
+FROM (
+    SELECT
+        ((i % 10)::DOUBLE * 0.01) AS x,
+        (floor(i / 10)::DOUBLE * 0.01) AS y
+    FROM range(2048) AS t(i)
+);
+
+# Correct before detach: count = 16.
+query II rowsort results
+SELECT count(*) AS count FROM geoms WHERE geom && 'POLYGON ((0.02 0.02, 0.02 0.05, 0.05 0.05, 0.05 0.02, 0.02 0.02))'::GEOMETRY;
+----
+
+statement ok
+USE memory;
+
+statement ok
+DETACH geoms;
+
+statement ok
+ATTACH '__TEST_DIR__/repro_geo_rowgroup.db' AS geoms (STORAGE_VERSION 'v1.5.0');
+
+statement ok
+USE geoms;
+
+query II rowsort results
+SELECT count(*) AS count FROM geoms WHERE geom && 'POLYGON ((0.02 0.02, 0.02 0.05, 0.05 0.05, 0.05 0.02, 0.02 0.02))'::GEOMETRY;
+----


### PR DESCRIPTION
Even if no changes have been made to the geometry column data row group, we need to "lift up" the stats from the inner column on checkpoint, or they will be empty on deserialization until the next time the stats gets merged.

Issue originally reported in https://github.com/duckdb/duckdb-spatial/issues/817