### PR TITLE
Fix out-of-bounds write in decode ignore mode

### DIFF
--- a/extension/core_functions/scalar/blob/encode.cpp
+++ b/extension/core_functions/scalar/blob/encode.cpp
@@ -78,7 +78,6 @@ void BinaryDecodeFunction(DataChunk &args, ExpressionState &state, Vector &resul
 			    auto target = StringVector::EmptyString(result, new_str.size());
 			    auto output = target.GetDataWriteable();
 			    memcpy(output, new_str.data(), new_str.size());
-			    output[new_str.size()] = '\0';
 			    target.Finalize();
 			    return target;
 		    }

--- a/test/fuzzer/pedro/utf8_invalid_unicode.test
+++ b/test/fuzzer/pedro/utf8_invalid_unicode.test
@@ -31,6 +31,12 @@ SELECT decode('\xA0\x50\x51\xA0\xA0'::BLOB, 'ignore')::VARCHAR;
 ----
 PQ
 
+# ignore mode where exactly 12 bytes remain (string_t inline boundary)
+query I
+SELECT decode('\xA0ABCDEFGHIJKL'::BLOB, 'ignore')::VARCHAR;
+----
+ABCDEFGHIJKL
+
 
 query I
 SELECT upper(decode('\xF0\x9F\x98\x84'::BLOB)::VARCHAR);


### PR DESCRIPTION
decode(blob, 'ignore') sizes the cleaned output with EmptyString(new_str.size()) and then writes a terminating '\0' at output[new_str.size()], one byte past the allocation. string_t values are length-prefixed and never NUL-terminated, so a result of exactly 12 bytes overruns the inlined string_t. The write was introduced in 62f9c995b; removing it restores the original behavior.