### PR TITLE
Fix Parquet TIMETZ metadata

### DIFF
--- a/extension/parquet/include/writer/parquet_write_operators.hpp
+++ b/extension/parquet/include/writer/parquet_write_operators.hpp
@@ -319,6 +319,22 @@ struct ParquetTimeTZOperator : public BaseParquetOperator {
 	static TGT Operation(SRC input) {
 		return input.time().micros;
 	}
+
+	template <class SRC, class TGT>
+	static unique_ptr<ColumnWriterStatistics> InitializeStats() {
+		return make_uniq<NumericStatisticsState<TGT, TGT, BaseParquetOperator>>();
+	}
+
+	template <class SRC, class TGT>
+	static void HandleStats(ColumnWriterStatistics *stats, TGT target_value) {
+		auto &numeric_stats = stats->Cast<NumericStatisticsState<TGT, TGT, BaseParquetOperator>>();
+		if (LessThan::Operation(target_value, numeric_stats.min)) {
+			numeric_stats.min = target_value;
+		}
+		if (GreaterThan::Operation(target_value, numeric_stats.max)) {
+			numeric_stats.max = target_value;
+		}
+	}
 };
 
 struct ParquetHugeintOperator : public BaseParquetOperator {

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -287,14 +287,23 @@ void PrimitiveColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, id
 
 void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &state,
                                                  duckdb_parquet::ColumnChunk &column_chunk) {
+	auto add_encoding = [&](duckdb_parquet::Encoding::type encoding) {
+		for (const auto &existing_encoding : column_chunk.meta_data.encodings) {
+			if (existing_encoding == encoding) {
+				return;
+			}
+		}
+		column_chunk.meta_data.encodings.push_back(encoding);
+	};
+
 	for (const auto &write_info : state.write_info) {
 		// only care about data page encodings, data_page_header.encoding is meaningless for dict
 		switch (write_info.page_header.type) {
 		case PageType::DATA_PAGE:
-			column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header.encoding);
+			add_encoding(write_info.page_header.data_page_header.encoding);
 			break;
 		case PageType::DATA_PAGE_V2:
-			column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header_v2.encoding);
+			add_encoding(write_info.page_header.data_page_header_v2.encoding);
 			break;
 		default:
 			break;

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -289,11 +289,16 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
                                                  duckdb_parquet::ColumnChunk &column_chunk) {
 	for (const auto &write_info : state.write_info) {
 		// only care about data page encodings, data_page_header.encoding is meaningless for dict
-		if (write_info.page_header.type != PageType::DATA_PAGE &&
-		    write_info.page_header.type != PageType::DATA_PAGE_V2) {
-			continue;
+		switch (write_info.page_header.type) {
+		case PageType::DATA_PAGE:
+			column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header.encoding);
+			break;
+		case PageType::DATA_PAGE_V2:
+			column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header_v2.encoding);
+			break;
+		default:
+			break;
 		}
-		column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header.encoding);
 	}
 
 	if (!state.stats_state) {

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -287,6 +287,15 @@ void PrimitiveColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, id
 
 void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &state,
                                                  duckdb_parquet::ColumnChunk &column_chunk) {
+	for (const auto &write_info : state.write_info) {
+		// only care about data page encodings, data_page_header.encoding is meaningless for dict
+		if (write_info.page_header.type != PageType::DATA_PAGE &&
+		    write_info.page_header.type != PageType::DATA_PAGE_V2) {
+			continue;
+		}
+		column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header.encoding);
+	}
+
 	if (!state.stats_state) {
 		return;
 	}
@@ -350,15 +359,6 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 			writer.GetGeoParquetData().AddGeoParquetStats(writer.GetContext(), column_schema.name, column_schema.type,
 			                                              *state.stats_state->GetGeoStats(), gpq_version);
 		}
-	}
-
-	for (const auto &write_info : state.write_info) {
-		// only care about data page encodings, data_page_header.encoding is meaningless for dict
-		if (write_info.page_header.type != PageType::DATA_PAGE &&
-		    write_info.page_header.type != PageType::DATA_PAGE_V2) {
-			continue;
-		}
-		column_chunk.meta_data.encodings.push_back(write_info.page_header.data_page_header.encoding);
 	}
 }
 

--- a/test/sql/copy/parquet/writer/parquet_timetz_metadata.test
+++ b/test/sql/copy/parquet/writer/parquet_timetz_metadata.test
@@ -13,12 +13,12 @@ COPY (
 	FROM range(1000) tbl(i)
 ) TO '{TEST_DIR}/timetz_metadata.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
 
-query TIIIII
-SELECT path_in_schema, encodings <> '', stats_min IS NOT NULL, stats_max IS NOT NULL,
-       stats_min_value IS NOT NULL, stats_max_value IS NOT NULL
+query TITTTT
+SELECT path_in_schema, encodings <> '', stats_min::VARCHAR, stats_max::VARCHAR,
+       stats_min_value::VARCHAR, stats_max_value::VARCHAR
 FROM parquet_metadata('{TEST_DIR}/timetz_metadata.parquet')
 ORDER BY column_id
 ----
-event_time_tz	true	true	true	true	true
-event_time	true	true	true	true	true
-ts_tz	true	true	true	true	true
+event_time_tz	true	08:30:00+00	08:34:00+00	08:30:00+00	08:34:00+00
+event_time	true	08:30:00	08:34:00	08:30:00	08:34:00
+ts_tz	true	2026-01-02 08:30:00+00	2026-01-02 08:34:00+00	2026-01-02 08:30:00+00	2026-01-02 08:34:00+00

--- a/test/sql/copy/parquet/writer/parquet_timetz_metadata.test
+++ b/test/sql/copy/parquet/writer/parquet_timetz_metadata.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/parquet/writer/parquet_timetz_metadata.test
+# description: TIME WITH TIME ZONE Parquet metadata
+# group: [writer]
+
+require parquet
+
+statement ok
+COPY (
+	SELECT
+		CAST(TIMETZ '08:30:00+00' + (i % 5) * INTERVAL 1 MINUTE AS TIME WITH TIME ZONE) AS event_time_tz,
+		CAST(TIME '08:30:00' + (i % 5) * INTERVAL 1 MINUTE AS TIME) AS event_time,
+		CAST(TIMESTAMP '2026-01-02 08:30:00+00' + (i % 5) * INTERVAL 1 MINUTE AS TIMESTAMP WITH TIME ZONE) AS ts_tz
+	FROM range(1000) tbl(i)
+) TO '{TEST_DIR}/timetz_metadata.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+
+query TIIIII
+SELECT path_in_schema, encodings <> '', stats_min IS NOT NULL, stats_max IS NOT NULL,
+       stats_min_value IS NOT NULL, stats_max_value IS NOT NULL
+FROM parquet_metadata('{TEST_DIR}/timetz_metadata.parquet')
+ORDER BY column_id
+----
+event_time_tz	true	true	true	true	true
+event_time	true	true	true	true	true
+ts_tz	true	true	true	true	true


### PR DESCRIPTION
Fixes #22883.

This fixes two Parquet writer metadata paths for `TIME WITH TIME ZONE` columns:

- record data page encodings independently of whether a writer has statistics state
- initialize `TIME_TZ` statistics from the written `TIME_MICROS` `INT64` value

The second part matches the existing Parquet physical representation and the reader-side `TIME_TZ` stats decoding path.
