### PR TITLE
Pass INPUT_TYPE and STATE_TYPE to fix windows compilation

### DIFF
--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -560,10 +560,11 @@ public:
 	}
 
 	// true if OP defines ClusteredOp (early-exit optimization for first/last/any_value).
-	template <class OP, class = void>
+	template <class OP, class INPUT_TYPE, class STATE_TYPE, class = void>
 	struct HasClusteredOperation : std::false_type {};
-	template <class OP>
-	struct HasClusteredOperation<OP, void_t_helper<decltype(&OP::template ClusteredOp<int32_t, int32_t, OP>)>>
+	template <class OP, class INPUT_TYPE, class STATE_TYPE>
+	struct HasClusteredOperation<OP, INPUT_TYPE, STATE_TYPE,
+	                             void_t_helper<decltype(&OP::template ClusteredOp<INPUT_TYPE, STATE_TYPE, OP>)>>
 	    : std::true_type {};
 
 	template <class STATE_TYPE, class INPUT_TYPE, class OP>
@@ -584,7 +585,7 @@ public:
 	template <class STATE_TYPE, class INPUT_TYPE, class OP>
 	static void ExecuteUnaryNoClusteredOpt(Vector &input, AggregateInputData &aggr_input_data,
 	                                       const ClusteredAggr &clustered, idx_t count) {
-		static_assert(HasClusteredOperation<OP>::value, "Expected custom clustered operation");
+		static_assert(HasClusteredOperation<OP, INPUT_TYPE, STATE_TYPE>::value, "Expected custom clustered operation");
 		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			ExecuteUnaryClustConstantCustomState<STATE_TYPE, INPUT_TYPE, OP>(input, aggr_input_data, clustered);
 			return;
@@ -627,7 +628,7 @@ public:
 				return;
 			}
 		}
-		if constexpr (HasClusteredOperation<OP>::value) {
+		if constexpr (HasClusteredOperation<OP, INPUT_TYPE, STATE_TYPE>::value) {
 			ExecuteUnaryNoClusteredOpt<STATE_TYPE, INPUT_TYPE, OP>(input, aggr_input_data, clustered, count);
 		} else {
 			D_ASSERT(false);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -508,7 +508,7 @@ public:
 	template <class STATE, class INPUT_TYPE, class OP>
 	static aggregate_cluster_update_t UnaryClusterUpdateCallback() {
 		if constexpr (AggregateExecutor::HasClusteredLocalState<OP, STATE>::value ||
-		              AggregateExecutor::HasClusteredOperation<OP>::value) {
+		              AggregateExecutor::HasClusteredOperation<OP, INPUT_TYPE, STATE>::value) {
 			return AggregateFunction::UnaryClusterUpdate<STATE, INPUT_TYPE, OP>;
 		} else {
 			return nullptr;


### PR DESCRIPTION
In CI, Windows 64-bit amd64 MinGW [fails](https://github.com/duckdb/duckdb/actions/runs/26396998900/job/77708828366#step:28:1032):
```c++
// FAILED: [code=1] src/function/aggregate/distributive/CMakeFiles/duckdb_aggr_distr.dir/ub_duckdb_aggr_distr.cpp.obj
```

because

`HasClusteredOperation<OP, void_t_helper<decltype(&OP::template ClusteredOp<int32_t, int32_t, OP>)>>` checks whether `OP` has a `ClusteredOp` specialization for exactly `(INPUT_TYPE=int32_t, STATE_TYPE=int32_t)`.

For ops like `FirstFunctionString`, `ClusteredOp` is a template that is only valid when:

- `STATE_TYPE `looks like `FirstState<string_t>` (has `is_set`, `is_null`, `value`)
- `INPUT_TYPE` is compatible with string handling (`string_t`)

So probing with `(int32_t, int32_t)` forces an invalid specialization on MinGW:

- `state.is_set` on `int32_t` is invalid
- `SetValue(..., vals[idx], ...)` with `vals[idx]` as `int32_t` is invalid for string-only `SetValue`.

Thus, pass `INPUT_TYPE` and `STATE_TYPE` to fix the windows MinGW compilation error.