### PR TITLE
Support empty string casts to BIT

### DIFF
--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -130,8 +130,13 @@ string Bit::ToString(bitstring_t str) {
 }
 
 bool Bit::TryGetBitStringSize(string_t str, idx_t &str_len, string *error_message) {
-	auto data = const_data_ptr_cast(str.GetData());
 	auto len = str.GetSize();
+	if (len == 0) {
+		str_len = ComputeBitstringLen(1);
+		return true;
+	}
+
+	auto data = const_data_ptr_cast(str.GetData());
 	idx_t bit_count = 0;
 
 	if (data[0] == 'x') {
@@ -152,11 +157,15 @@ bool Bit::TryGetBitStringSize(string_t str, idx_t &str_len, string *error_messag
 
 bool Bit::ToBit(string_t str, bitstring_t &output_str, string *error_message) {
 	auto data = str.GetData();
+	auto len = str.GetSize();
+	if (len == 0) {
+		Bit::SetEmptyBitString(output_str, 1);
+		return true;
+	}
 	if (data[0] == 'x') {
 		return HexToBit(str, output_str, error_message);
 	}
 
-	auto len = str.GetSize();
 	auto output = output_str.GetDataWriteable();
 
 	char byte = 0;

--- a/test/sql/cast/test_bit_cast.test
+++ b/test/sql/cast/test_bit_cast.test
@@ -144,6 +144,23 @@ SELECT 7.4e-323::BIT;
 ----
 0000000000000000000000000000000000000000000000000000000000001111
 
+#              casting from string type
+# ---------------------------------------------------
+query I
+SELECT ''::BIT;
+----
+0
+
+query I
+SELECT bit_length(''::BIT);
+----
+1
+
+query I
+SELECT TRY_CAST('' AS BIT);
+----
+0
+
 #  bitstrings that are too large for casted-to type
 # ---------------------------------------------------
 statement error

--- a/test/sql/types/bit/test_bit.test
+++ b/test/sql/types/bit/test_bit.test
@@ -119,10 +119,10 @@ SELECT NULL::BIT
 ----
 NULL
 
-statement error
+query I
 SELECT ''::BIT
 ----
-<REGEX>:Conversion Error.*Cannot cast empty string to BIT.*
+0
 
 statement ok
 DELETE FROM bits
@@ -130,15 +130,14 @@ DELETE FROM bits
 statement ok
 INSERT INTO bits VALUES (NULL)
 
-statement error
+statement ok
 INSERT INTO bits VALUES ('')
-----
-<REGEX>:Conversion Error.*Cannot cast empty string to BIT.*
 
 query I
 SELECT * FROM bits
 ----
 NULL
+0
 
 # try cast
 query I


### PR DESCRIPTION
Closes #22863.

This treats an empty string cast to BIT as a one-bit zero, matching PostgreSQL behavior, while keeping empty BLOB casts and empty hex BIT strings rejected. The fix handles the empty input in the BIT conversion helpers so the output size and encoded bitstring stay consistent.
