### PR TITLE
Fix RevertAppend with empty trailing column segments

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -645,10 +645,9 @@ void ColumnData::RevertAppend(row_t new_count_p) {
 			return;
 		}
 	}
-	auto &last_segment = last_segment_node->GetNode();
-	if (new_count >= last_segment_node->GetRowStart() + last_segment.count) {
+	if (new_count >= last_segment_node->GetRowEnd()) {
 		// the start row is equal to the final portion of the column data: nothing was ever appended here
-		D_ASSERT(new_count == last_segment_node->GetRowStart() + last_segment.count);
+		D_ASSERT(new_count == last_segment_node->GetRowEnd());
 		return;
 	}
 	// find the segment index that the current row belongs to

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -631,6 +631,20 @@ void ColumnData::RevertAppend(row_t new_count_p) {
 	if (!last_segment_node) {
 		return;
 	}
+	while (last_segment_node->GetCount() == 0 && new_count <= last_segment_node->GetRowStart()) {
+		// Appends can create the next transient segment before any rows are written to it. If the append is
+		// reverted after that point, drop the empty tail before looking up the row to truncate at.
+		auto last_segment_index = last_segment_node->GetIndex();
+		data.EraseSegments(l, last_segment_index);
+		if (last_segment_index > 0) {
+			auto previous_segment = data.GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(last_segment_index - 1));
+			previous_segment->SetNext(nullptr);
+		}
+		last_segment_node = data.GetLastSegment(l);
+		if (!last_segment_node) {
+			return;
+		}
+	}
 	auto &last_segment = last_segment_node->GetNode();
 	if (new_count >= last_segment_node->GetRowStart() + last_segment.count) {
 		// the start row is equal to the final portion of the column data: nothing was ever appended here

--- a/test/sql/storage/test_storage.cpp
+++ b/test/sql/storage/test_storage.cpp
@@ -124,4 +124,5 @@ TEST_CASE("RevertAppend removes trailing empty column segments", "[storage]") {
 		REQUIRE(last_segment->GetRowEnd() == revert_count);
 		REQUIRE(column.count == revert_count);
 	}
+	REQUIRE_NOTHROW(con.Rollback());
 }

--- a/test/sql/storage/test_storage.cpp
+++ b/test/sql/storage/test_storage.cpp
@@ -1,7 +1,14 @@
 #include "catch.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/common/file_system.hpp"
-#include "test_helpers.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/appender.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/column_segment.hpp"
+#include "duckdb/storage/table/row_group.hpp"
+#include "test_helpers.hpp"
 
 using namespace duckdb;
 
@@ -72,4 +79,49 @@ TEST_CASE("Test interleaving of insertions/updates/deletes on multiple tables", 
 		REQUIRE(CHECK_COLUMN(result, 1, {405513}));
 	}
 	DeleteDatabase(storage_database);
+}
+
+TEST_CASE("RevertAppend removes trailing empty column segments", "[storage]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t SELECT * FROM range(100)"));
+	REQUIRE_NOTHROW(con.BeginTransaction());
+
+	auto &table_entry =
+	    Catalog::GetEntry<TableCatalogEntry>(*con.context, INVALID_CATALOG, DEFAULT_SCHEMA, "t").Cast<DuckTableEntry>();
+	auto row_group = table_entry.GetStorage().GetRowGroupCollection()->GetRowGroup(0);
+	REQUIRE(row_group);
+
+	auto &column = row_group->GetRawColumnData(0);
+	auto &segment_tree = column.GetSegmentTree();
+	idx_t revert_count;
+	idx_t segment_count;
+	{
+		auto lock = segment_tree.Lock();
+		auto last_segment = segment_tree.GetLastSegment(lock);
+		REQUIRE(last_segment);
+		revert_count = last_segment->GetRowEnd();
+		segment_count = segment_tree.GetSegmentCount(lock);
+
+		auto &db_instance = DatabaseInstance::GetDatabase(*con.context);
+		auto &config = DBConfig::GetConfig(db_instance);
+		auto function =
+		    config.GetCompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, column.type.InternalType());
+		auto empty_segment = ColumnSegment::CreateTransientSegment(
+		    db_instance, function, column.type, column.GetBlockManager().GetBlockSize(), column.GetBlockManager());
+		segment_tree.AppendSegment(lock, shared_ptr<ColumnSegment>(std::move(empty_segment)),
+		                           revert_count + STANDARD_VECTOR_SIZE);
+	}
+
+	REQUIRE_NOTHROW(column.ColumnData::RevertAppend(UnsafeNumericCast<row_t>(revert_count)));
+
+	{
+		auto lock = segment_tree.Lock();
+		REQUIRE(segment_tree.GetSegmentCount(lock) == segment_count);
+		auto last_segment = segment_tree.GetLastSegment(lock);
+		REQUIRE(last_segment);
+		REQUIRE(last_segment->GetRowEnd() == revert_count);
+		REQUIRE(column.count == revert_count);
+	}
 }


### PR DESCRIPTION
Fixes #22861.

This fixes a rollback path in `ColumnData::RevertAppend` where an append can leave a zero-count trailing transient segment behind before any rows are written to it. If rollback then asks to revert to a count before that empty segment's start, `GetSegmentIndex` looks for a row in the gap and can throw an internal segment-tree error.

The fix drops zero-count trailing column segments before looking up the segment that contains the revert point. This keeps the fix in the column append/revert path instead of changing `SegmentTree::TryGetSegmentIndex` into a defensive guard for invalid states.

A C++ regression test is included because the SQL-level trigger depends on OOM timing during commit rollback and was not stable enough for a deterministic sqllogictest. The test constructs the minimal storage state directly: a valid column segment followed by an empty trailing segment, then calls `ColumnData::RevertAppend` back to the valid end.
