### PR TITLE
Test runner: prevent double-registration of tests

### DIFF
--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb.hpp"
+#include "duckdb/common/path.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -162,6 +163,29 @@ static string ParseGroupFromPath(string file) {
 
 namespace duckdb {
 
+// This function is used to check that tests for this extension are already registered
+// when "test" relative path is registered. The check is strict (full path, not prefix)
+// as it is better to double-register a test (it will run twice) than to accidentally skip it.
+static bool ExtensionIsCurrentDir(FileSystem &fs, const string &extension_test_path) {
+	// <abs_path>/test/sql is used by default in register_external_extension and in
+	// duckdb_extension_load in CMake scripts
+	string current_test_path = "test/sql";
+	if (extension_test_path.rfind(current_test_path) == std::string::npos) {
+		return false;
+	}
+	string working_dir = fs.GetWorkingDirectory();
+	string current_test_path_absolute = fs.JoinPath(working_dir, current_test_path);
+	string current_test_path_normalized = Path::Normalize(current_test_path_absolute);
+	string extension_test_path_absolute;
+	if (fs.IsPathAbsolute(extension_test_path)) {
+		extension_test_path_absolute = extension_test_path;
+	} else {
+		extension_test_path_absolute = fs.JoinPath(working_dir, extension_test_path);
+	}
+	string extension_test_path_normalized = Path::Normalize(extension_test_path_absolute);
+	return current_test_path_normalized == extension_test_path_normalized;
+}
+
 void RegisterSqllogictests() {
 	vector<string> excludes = {
 	    // tested separately
@@ -221,6 +245,9 @@ void RegisterSqllogictests() {
 	});
 
 	for (const auto &extension_test_path : ExtensionHelper::LoadedExtensionTestPaths()) {
+		if (ExtensionIsCurrentDir(*fs, extension_test_path)) {
+			continue;
+		}
 		listFiles(*fs, extension_test_path, [&](const string &path) {
 			if (endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage")) {
 				auto fun = testRunner<true>;


### PR DESCRIPTION
There is a problem with `unittest` SQLlogic runner that, when tests are run from the extension repo directory, extension tests from under `test/sql` can be registered twice. First they are registered from under the relative `test` directory and the second time from [ExtensionHelper::LoadedExtensionTestPaths()](https://github.com/duckdb/duckdb/blob/a93109abaed85521e4199770f6ff205aa6995a87/extension/generated_extension_loader.cpp.in#L25) that is generated at configure-time and contains `TEST_DIR` argument passed to `duckdb_extension_load` CMake function.

There is no tests deduplication on registration:

 - if `TEST_DIR` is specified as `test` or `test/sql` then the runner fails with:

```
error: TEST_CASE( "test/sql/storage/attach_simple.test" ) already defined.
    First seen at /home/alex/projects/duckdb-sqlite/duckdb/test/sqlite/test_sqllogictest.cpp:41
    Redefined at /home/alex/projects/duckdb-sqlite/duckdb/test/sqlite/test_sqllogictest.cpp:41
```

 - if `TEST_DIR` is not specified, the absolute path `/path/to/extension/repo/test/sql` is used for it; that results into the test to be registered twice - once on relative path and once on absolute path.

The problem is not severe, when the test runner is invoked with a pattern argument like this (used in most cases):

```
./build/release/unittest 'test/*'
```

Then only relative path-registered tests are run.

But the problem stil remains with `.test_slow`. Such tests are registed with `[.]` group label. The double registration problem makes it impossible (at least I didn't find the way without additional `require-env`) to run all tests once excluding `.test_slow` (that is desired for ASan/TSan test runs):

 - `./build/release/unittest` - runs tests (excluding `.test_slow`) twice
 - `./build/release/unittest 'test/*'` - runs test once, but does not exclude `.test_slow`
 - `./build/release/unittest '~[.]'` (Catch2 group negation) - runs tests (excluding `.test_slow`) twice

This PR attempts to detect that relative `test/sql` path and `ExtensionHelper::LoadedExtensionTestPaths()` path are resolved to the same path and skip the second registration.