### PR TITLE
Mark json_deserialize_sql as fallible

### DIFF
--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -246,8 +246,10 @@ static void JsonDeserializeFunction(DataChunk &args, ExpressionState &state, Vec
 
 ScalarFunctionSet JSONFunctions::GetDeserializeSqlFunction() {
 	ScalarFunctionSet set("json_deserialize_sql");
-	set.AddFunction(ScalarFunction({LogicalType::JSON()}, LogicalType::VARCHAR, JsonDeserializeFunction, nullptr,
-	                               nullptr, JSONFunctionLocalState::Init));
+	auto function = ScalarFunction({LogicalType::JSON()}, LogicalType::VARCHAR, JsonDeserializeFunction, nullptr,
+	                               nullptr, JSONFunctionLocalState::Init);
+	function.SetFallible();
+	set.AddFunction(std::move(function));
 	return set;
 }
 

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -126,6 +126,23 @@ SELECT * FROM json_execute_serialized_sql('{ "statements": [ {"expression_class"
 ----
 Parser Error: Error parsing json: no select node found in json
 
+# json_deserialize_sql can throw and should not be pushed down before the JSON shape guard
+statement ok
+CREATE TEMP TABLE json_deserialize_filter_pushdown(j JSON);
+
+statement ok
+INSERT INTO json_deserialize_filter_pushdown VALUES
+	('{"error":false,"statements":[]}'::JSON),
+	(json_serialize_sql('SELECT 1'));
+
+query I
+SELECT count(*)
+FROM json_deserialize_filter_pushdown
+WHERE json_exists(j, '$.statements[0]')
+  AND json_deserialize_sql(j) IS NOT NULL;
+----
+1
+
 # Test execute json serialized sql with multiple select nodes
 query I
 SELECT json_deserialize_sql(json_serialize_sql('SELECT 1;SELECT 2'));


### PR DESCRIPTION
Fixes #22761.

`json_deserialize_sql` can throw parser errors while deserializing invalid serialized SQL JSON, but the scalar function was registered with the default non-fallible error mode. That allowed filter pushdown to move `json_deserialize_sql(j) IS NOT NULL` below a guarding `json_exists` predicate and evaluate it for rows that should have been filtered first.

This marks `json_deserialize_sql` as fallible so existing `CanThrow()` checks keep the expression above the scan when needed.
