### PR TITLE
Validate width/scale in duckdb_create_decimal_type and duckdb_create_decimal

### DIFF
--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -45,7 +45,7 @@ LogicalType BindDecimalType(BindLogicalTypeInput &input) {
 		if (scale_value.DefaultTryCastAs(LogicalTypeId::UTINYINT)) {
 			scale = scale_value.GetValueUnsafe<uint8_t>();
 		} else {
-			throw BinderException("DECIMAL type scale must be between 0 and %d", Decimal::MAX_WIDTH_DECIMAL - 1);
+			throw BinderException("DECIMAL type scale must be between 0 and %d", Decimal::MAX_WIDTH_DECIMAL);
 		}
 	}
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2516,8 +2516,11 @@ DUCKDB_C_API duckdb_value duckdb_create_bignum(duckdb_bignum input);
 /*!
 Creates a DECIMAL value from a duckdb_decimal
 
+The width must be between 1 and 38, and the scale must not exceed the width.
+
 * @param input The duckdb_decimal value
-* @return The value. This must be destroyed with `duckdb_destroy_value`.
+* @return The value, or `nullptr` if the width or scale are out of range. This must be destroyed with
+`duckdb_destroy_value`.
 */
 DUCKDB_C_API duckdb_value duckdb_create_decimal(duckdb_decimal input);
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -3138,9 +3138,9 @@ DUCKDB_C_API duckdb_logical_type duckdb_create_enum_type(const char **member_nam
 Creates a DECIMAL type with the specified width and scale.
 The resulting type should be destroyed with `duckdb_destroy_logical_type`.
 
-* @param width The width of the decimal type
-* @param scale The scale of the decimal type
-* @return The logical type.
+* @param width The width of the decimal type. Must be between 1 and 38.
+* @param scale The scale of the decimal type. Must not exceed the width.
+* @return The logical type, or `nullptr` if the width or scale are out of range.
 */
 DUCKDB_C_API duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale);
 

--- a/src/include/duckdb/common/types/decimal.hpp
+++ b/src/include/duckdb/common/types/decimal.hpp
@@ -45,6 +45,10 @@ public:
 	static constexpr uint8_t MAX_WIDTH_DECIMAL = MAX_WIDTH_INT128;
 
 public:
+	//! Whether width/scale form a valid DECIMAL type: width in [1, MAX_WIDTH_DECIMAL] and scale not exceeding width.
+	static bool IsValidWidthScale(uint8_t width, uint8_t scale) {
+		return width >= 1 && width <= MAX_WIDTH_DECIMAL && scale <= width;
+	}
 	static string ToString(int16_t value, uint8_t width, uint8_t scale);
 	static string ToString(int32_t value, uint8_t width, uint8_t scale);
 	static string ToString(int64_t value, uint8_t width, uint8_t scale);

--- a/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
@@ -211,10 +211,10 @@
             "comment": {
                 "description": "Creates a DECIMAL type with the specified width and scale.\nThe resulting type should be destroyed with `duckdb_destroy_logical_type`.\n\n",
                 "param_comments": {
-                    "width": "The width of the decimal type",
-                    "scale": "The scale of the decimal type"
+                    "width": "The width of the decimal type. Must be between 1 and 38.",
+                    "scale": "The scale of the decimal type. Must not exceed the width."
                 },
-                "return_value": "The logical type."
+                "return_value": "The logical type, or `nullptr` if the width or scale are out of range."
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -272,11 +272,11 @@
                 }
             ],
             "comment": {
-                "description": "Creates a DECIMAL value from a duckdb_decimal\n\n",
+                "description": "Creates a DECIMAL value from a duckdb_decimal\n\nThe width must be between 1 and 38, and the scale must not exceed the width.\n\n",
                 "param_comments": {
                     "input": "The duckdb_decimal value"
                 },
-                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+                "return_value": "The value, or `nullptr` if the width or scale are out of range. This must be destroyed with `duckdb_destroy_value`."
             }
         },
         {

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/bignum.hpp"
+#include "duckdb/common/types/decimal.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 
 using duckdb::LogicalTypeId;
@@ -139,6 +140,9 @@ duckdb_bignum duckdb_get_bignum(duckdb_value val) {
 	return {data, size, is_negative};
 }
 duckdb_value duckdb_create_decimal(duckdb_decimal input) {
+	if (input.width < 1 || input.width > duckdb::Decimal::MAX_WIDTH_DECIMAL || input.scale > input.width) {
+		return nullptr;
+	}
 	duckdb::hugeint_t hugeint(input.value.upper, input.value.lower);
 	int64_t int64;
 	if (duckdb::Hugeint::TryCast<int64_t>(hugeint, int64)) {

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -140,7 +140,7 @@ duckdb_bignum duckdb_get_bignum(duckdb_value val) {
 	return {data, size, is_negative};
 }
 duckdb_value duckdb_create_decimal(duckdb_decimal input) {
-	if (input.width < 1 || input.width > duckdb::Decimal::MAX_WIDTH_DECIMAL || input.scale > input.width) {
+	if (!duckdb::Decimal::IsValidWidthScale(input.width, input.scale)) {
 		return nullptr;
 	}
 	duckdb::hugeint_t hugeint(input.value.upper, input.value.lower);

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/types/geometry_crs.hpp"
+#include "duckdb/common/types/decimal.hpp"
 
 namespace duckdb {
 
@@ -155,7 +156,15 @@ duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_
 }
 
 duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale) {
-	return reinterpret_cast<duckdb_logical_type>(new duckdb::LogicalType(duckdb::LogicalType::DECIMAL(width, scale)));
+	if (width < 1 || width > duckdb::Decimal::MAX_WIDTH_DECIMAL || scale > width) {
+		return nullptr;
+	}
+	try {
+		return reinterpret_cast<duckdb_logical_type>(
+		    new duckdb::LogicalType(duckdb::LogicalType::DECIMAL(width, scale)));
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 duckdb_type duckdb_get_type_id(duckdb_logical_type type) {

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -156,7 +156,7 @@ duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_
 }
 
 duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale) {
-	if (width < 1 || width > duckdb::Decimal::MAX_WIDTH_DECIMAL || scale > width) {
+	if (!duckdb::Decimal::IsValidWidthScale(width, scale)) {
 		return nullptr;
 	}
 	try {

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -50,6 +50,28 @@ TEST_CASE("Test decimal types C API", "[capi]") {
 	REQUIRE(duckdb_decimal_internal_type(nullptr) == DUCKDB_TYPE_INVALID);
 }
 
+TEST_CASE("Test duckdb_create_decimal_type width/scale validation", "[capi]") {
+	// valid width/scale combinations succeed and round-trip
+	duckdb::vector<std::pair<uint8_t, uint8_t>> valid = {{1, 0}, {4, 1}, {9, 2}, {18, 3}, {38, 4}, {38, 38}};
+	for (auto &entry : valid) {
+		auto type = duckdb_create_decimal_type(entry.first, entry.second);
+		REQUIRE(type != nullptr);
+		REQUIRE(duckdb_get_type_id(type) == DUCKDB_TYPE_DECIMAL);
+		REQUIRE(duckdb_decimal_width(type) == entry.first);
+		REQUIRE(duckdb_decimal_scale(type) == entry.second);
+		duckdb_destroy_logical_type(&type);
+	}
+
+	// invalid width/scale combinations return nullptr instead of throwing or returning a malformed type
+	duckdb::vector<std::pair<uint8_t, uint8_t>> invalid = {{0, 0},  // width below the minimum
+	                                                       {39, 0}, // width above the maximum (MAX_WIDTH_DECIMAL == 38)
+	                                                       {4, 5},  // scale greater than width
+	                                                       {255, 255}};
+	for (auto &entry : invalid) {
+		REQUIRE(duckdb_create_decimal_type(entry.first, entry.second) == nullptr);
+	}
+}
+
 TEST_CASE("Test enum types C API", "[capi]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -344,6 +344,18 @@ TEST_CASE("Test DECIMAL value", "[capi]") {
 		REQUIRE(output.value.upper == input.value.upper);
 		duckdb_destroy_value(&value);
 	}
+	{
+		// invalid width/scale combinations return nullptr instead of throwing or returning a malformed value
+		duckdb::vector<std::pair<uint8_t, uint8_t>> invalid = {
+		    {0, 0},  // width below the minimum
+		    {39, 0}, // width above the maximum (MAX_WIDTH_DECIMAL == 38)
+		    {4, 5},  // scale greater than width
+		    {255, 255}};
+		for (auto &entry : invalid) {
+			duckdb_decimal input {entry.first, entry.second, {0, 0}};
+			REQUIRE(duckdb_create_decimal(input) == nullptr);
+		}
+	}
 }
 
 TEST_CASE("Test BIT value", "[capi]") {


### PR DESCRIPTION
This adds missing validation to the C API to reject invalid decimals as the CLI does.

Also fixes a misleading error message in the binder.
