### PR TITLE
Add threadsan config and update test loop counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,13 +579,13 @@ endif
 
 unittest_threadsan: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
 unittest_threadsan: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/$(UNITTEST_BINARY) "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" $(T)
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage --force-reload" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json build/reldebug/$(UNITTEST_BINARY) "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json --test-flags="--force-storage --force-reload" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
 
 .PHONY: unittest_threadsan_extra
 unittest_threadsan_extra: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
 unittest_threadsan_extra: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json --test-flags="--force-storage" build/reldebug/$(UNITTEST_BINARY) "[interquery]" $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/test/configs/threadsan.json
+++ b/test/configs/threadsan.json
@@ -1,0 +1,11 @@
+{
+  "description": "ThreadSanitizer-specific test config for CI runtime.",
+  "skip_tests": [
+    {
+      "reason": "Runtime-heavy under ThreadSanitizer.",
+      "paths": [
+        "test/sql/parallelism/intraquery/depth_first_evaluation.test_slow"
+      ]
+    }
+  ]
+}

--- a/test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow
@@ -7,7 +7,7 @@ CREATE TABLE t1 (id INTEGER, s TEXT);
 
 concurrentloop threadid 0 2
 
-loop i 0 1000
+loop i 0 500
 
 onlyif threadid=0
 statement ok
@@ -28,7 +28,7 @@ COMMIT
 
 endloop
 
-loop i 0 10000
+loop i 0 5000
 
 onlyif threadid=1
 statement ok

--- a/test/sql/parallelism/interquery/concurrent_checkpoint_deletes_mix_index.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_checkpoint_deletes_mix_index.test_slow
@@ -14,7 +14,7 @@ SET index_scan_max_count=999999999
 statement ok
 SET index_scan_percentage=1
 
-foreach sleep_time 0 25 50 75 100
+foreach sleep_time 0 50 100
 
 statement ok
 SET debug_checkpoint_sleep_ms={sleep_time}

--- a/test/sql/parallelism/interquery/concurrent_checkpoint_index_single_inserter.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_checkpoint_index_single_inserter.test_slow
@@ -16,7 +16,7 @@ SET index_scan_percentage=1
 
 foreach storage_version latest v0.10.3
 
-foreach sleep_time 0 25 50 75 100
+foreach sleep_time 0 50 100
 
 statement ok
 SET debug_checkpoint_sleep_ms={sleep_time}

--- a/test/sql/parallelism/interquery/concurrent_update_single_updater.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_update_single_updater.test_slow
@@ -12,7 +12,7 @@ INSERT INTO accounts SELECT i AS id, 10 AS money FROM range(10) t(i)
 
 concurrentforeach thread reader updater
 
-loop x 0 2000
+loop x 0 1000
 
 # the total balance should remain constant regardless of updates
 onlyif thread=reader
@@ -23,7 +23,7 @@ SELECT SUM(money) FROM accounts
 
 endloop
 
-loop x 0 1000
+loop x 0 500
 
 # generate a random transfer (random from / to / amount)
 onlyif thread=updater

--- a/test/sql/parallelism/interquery/tpch_concurrent_checkpoints.test_slow
+++ b/test/sql/parallelism/interquery/tpch_concurrent_checkpoints.test_slow
@@ -29,7 +29,7 @@ CHECKPOINT
 
 endloop
 
-loop i 0 50
+loop i 0 25
 
 skipif threadid=0
 statement ok
@@ -41,5 +41,4 @@ WHERE l_orderkey IN (SELECT l_orderkey FROM lineitem WHERE l_shipdate >= DATE '1
 endloop
 
 endloop
-
 

--- a/test/sql/parallelism/interquery/tpch_concurrent_operations.test_slow
+++ b/test/sql/parallelism/interquery/tpch_concurrent_operations.test_slow
@@ -31,7 +31,7 @@ DELETE FROM lineitem WHERE l_comment = 'this is an extra row'
 
 endloop
 
-loop i 0 30
+loop i 0 15
 
 skipif threadid=0
 statement ok
@@ -60,4 +60,3 @@ PRAGMA tpch({i})
 <FILE>:extension/tpch/dbgen/answers/sf1/q{i}.csv
 
 endloop
-


### PR DESCRIPTION
Discussed with @lnkuiper how we can reduce the test time under threadsan for certain very slow tests.

Before, we saw in CI:
```$ python3 scripts/ci/run_tests.py --workers=50% --batch-size=5 --batch-timeout=300 --track-runtime=100 build/reldebug/test/unittest "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" 
# test/sql/parallelism/intraquery/depth_first_evaluation.test_slow took 166.48s
# test/sql/parallelism/interquery/tpch_concurrent_operations.test_slow took 183.22s
# test/sql/parallelism/interquery/concurrent_checkpoint_deletes_mix_index.test_slow took 172.69s
# test/sql/parallelism/interquery/tpch_concurrent_checkpoints.test_slow took 136.51s
# test/sql/parallelism/interquery/concurrent_update_single_updater.test_slow took 140.36s
# test/sql/parallelism/interquery/concurrent_checkpoint_index_single_inserter.test_slow took 139.62s
# test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow took 108.65s
all tests passed in 326s
```

And we want to aim for a 60-90s test runtime under threadsan.