### PR TITLE
Use atomic for CatalogEntry->parent to fix data race

### DIFF
--- a/src/catalog/catalog_entry.cpp
+++ b/src/catalog/catalog_entry.cpp
@@ -54,13 +54,13 @@ string CatalogEntry::ToSQL() const {
 void CatalogEntry::SetChild(unique_ptr<CatalogEntry> child_p) {
 	child = std::move(child_p);
 	if (child) {
-		child->parent = this;
+		child->parent.store(this);
 	}
 }
 
 unique_ptr<CatalogEntry> CatalogEntry::TakeChild() {
 	if (child) {
-		child->parent = nullptr;
+		child->parent.store(nullptr);
 	}
 	return std::move(child);
 }
@@ -69,7 +69,7 @@ bool CatalogEntry::HasChild() const {
 	return child != nullptr;
 }
 bool CatalogEntry::HasParent() const {
-	return parent != nullptr;
+	return parent.load() != nullptr;
 }
 
 CatalogEntry &CatalogEntry::Child() {
@@ -77,7 +77,11 @@ CatalogEntry &CatalogEntry::Child() {
 }
 
 CatalogEntry &CatalogEntry::Parent() {
-	return *parent;
+	return *parent.load();
+}
+
+const CatalogEntry &CatalogEntry::Parent() const {
+	return *parent.load();
 }
 
 Catalog &CatalogEntry::ParentCatalog() {

--- a/src/include/duckdb/catalog/catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry.hpp
@@ -65,7 +65,7 @@ private:
 	//! Child entry
 	unique_ptr<CatalogEntry> child;
 	//! Parent entry (the node that dependents_map this node)
-	optional_ptr<CatalogEntry> parent;
+	atomic<CatalogEntry *> parent;
 
 public:
 	virtual unique_ptr<CatalogEntry> AlterEntry(ClientContext &context, AlterInfo &info);


### PR DESCRIPTION
In CI, threadsan [detects](https://github.com/duckdb/duckdb/actions/runs/26503003444/job/78049352201#step:7:67) a data race:
```
[0/1] (0%): test/sql/parallelism/interquery/concurrent_update_drop.test_slow
[1/1] (100%): test/sql/parallelism/interquery/concurrent_update_drop.test_slow
===============================================================================
All tests passed (4 assertions in 1 test case)

=== stderr ===
==================
WARNING: ThreadSanitizer: data race (pid=110823)
  Read of size 8 at 0x725800010008 by thread T16 (mutexes: write M0, write M1):
    #0 duckdb::optional_ptr<duckdb::CatalogEntry, true>::operator!=(duckdb::optional_ptr<duckdb::CatalogEntry, true> const&) const /home/runner/work/duckdb/duckdb/src/include/duckdb/common/optional_ptr.hpp:77:10 (libduckdb.so+0x32696d9) (BuildId: 7e7a22542d67257f570da68c2b0494db0c67469d)
    #1 duckdb::CatalogEntry::HasParent() const /home/runner/work/duckdb/duckdb/src/catalog/catalog_entry.cpp:72:16 (libduckdb.so+0x32696d9)

...

  Previous write of size 8 at 0x725800010008 by thread T4 (mutexes: write M2, write M3):
    #0 duckdb::CatalogEntry::SetChild(duckdb::unique_ptr<duckdb::CatalogEntry, std::default_delete<duckdb::CatalogEntry>, true>) /home/runner/work/duckdb/duckdb/src/catalog/catalog_entry.cpp:57:17 (libduckdb.so+0x3281b9f) (BuildId: 7e7a22542d67257f570da68c2b0494db0c67469d)
    #1 duckdb::CatalogEntryMap::UpdateEntry(duckdb::unique_ptr<duckdb::CatalogEntry, std::default_delete<duckdb::CatalogEntry>, true>) /home/runner/work/duckdb/duckdb/src/catalog/catalog_set.cpp:45:17 (libduckdb.so+0x3281b9f)
    #2 duckdb::CatalogSet::DropEntryInternal(duckdb::CatalogTransaction, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) /home/runner/work/duckdb/duckdb/src/catalog/catalog_set.cpp:433:6 (libduckdb.so+0x3284ae2) (BuildId: 7e7a22542d67257f570da68c2b0494db0c67469d)

...

SUMMARY: ThreadSanitizer: data race /home/runner/work/duckdb/duckdb/src/include/duckdb/common/optional_ptr.hpp:77:10 in duckdb::optional_ptr<duckdb::CatalogEntry, true>::operator!=(duckdb::optional_ptr<duckdb::CatalogEntry, true> const&) const
==================
ThreadSanitizer: reported 1 warnings
```

I asked Codex for the cause and how we can fix the data race:

### What races

- Raced field: `CatalogEntry::parent` (a non-atomic pointer-like field).
- Read side (Thread T16):
    - `CommitState::CommitEntry` calls `info->table->HasParent()` (and then `Parent().timestamp`) during commit of tuple undo records.
    - Stack points to:
        - `src/transaction/commit_state.cpp:328` (also similar checks at :301, :315)
        - `src/catalog/catalog_entry.cpp:72` (`HasParent`)
- Write side (Thread T4):
    - Catalog chain rewiring during drop/alter does `child->parent = this` in `SetChild`.
    - Stack points to:
        - `src/catalog/catalog_entry.cpp:57` (`SetChild`)
        - `src/catalog/catalog_set.cpp:45` (`CatalogEntryMap::UpdateEntry`)
        - `src/catalog/catalog_set.cpp:433+` (drop path)

### Why it happens

- The writer updates parent while holding catalog/catalog-set locks.
- The reader in commit-time tuple checks reads parent without those same locks.
- Since parent is not atomic and not consistently protected by one mutex, TSAN sees a true data race: concurrent unsynchronized read/write of the same memory.