### PR TITLE
Retry cost runner

### DIFF
--- a/.github/patches/extensions/httpfs/relassert_thread_safety_lock_guard.patch
+++ b/.github/patches/extensions/httpfs/relassert_thread_safety_lock_guard.patch
@@ -1,0 +1,6 @@
+diff --git a/src/http_state.cpp b/src/http_state.cpp
+--- a/src/http_state.cpp
++++ b/src/http_state.cpp
+@@ -9 +9 @@ CachedFileHandle::CachedFileHandle(shared_ptr<CachedFile> &file_p) {
+-		lock = make_uniq<lock_guard<mutex>>(file_p->lock);
++		lock = unique_ptr<lock_guard<mutex>>(new lock_guard<mutex>(file_p->lock));

--- a/.github/patches/extensions/httpfs/relassert_werror_fixes.patch
+++ b/.github/patches/extensions/httpfs/relassert_werror_fixes.patch
@@ -1,0 +1,25 @@
+diff --git a/src/httpfs_connection_caching.cpp b/src/httpfs_connection_caching.cpp
+index 6db8f28..bb0ea67 100644
+--- a/src/httpfs_connection_caching.cpp
++++ b/src/httpfs_connection_caching.cpp
+@@ -149,7 +149,7 @@ unique_ptr<HTTPResponse> HTTPFSCurlUtil::CachingSendRequest(BaseRequest &request
+ 	if (!caller_owns_client) {
+ 		connection_cache.Store(std::move(client));
+ 	}
+-	return std::move(r);
++	return r;
+ }
+ 
+ unique_ptr<HTTPResponse> HTTPFSCurlUtil::SendRequest(BaseRequest &request, unique_ptr<HTTPClient> &client) {
+diff --git a/src/s3fs.cpp b/src/s3fs.cpp
+index b4f3f59..933302f 100644
+--- a/src/s3fs.cpp
++++ b/src/s3fs.cpp
+@@ -359,7 +359,6 @@ void S3FileHandle::Close() {
+ }
+ 
+ void S3FileHandle::FinalizeUpload() {
+-	auto &s3fs = (S3FileSystem &)file_system;
+ 	if (flags.OpenForWriting() && multi_part_upload) {
+ 		multi_part_upload->Finalize();
+ 	}

--- a/.github/patches/extensions/inet/0003-fix-deprecated-to-unified-format.patch
+++ b/.github/patches/extensions/inet/0003-fix-deprecated-to-unified-format.patch
@@ -1,0 +1,6 @@
+diff --git a/src/inet_functions.cpp b/src/inet_functions.cpp
+--- a/src/inet_functions.cpp
++++ b/src/inet_functions.cpp
+@@ -49 +49 @@ bool INetFunctions::CastVarcharToINET(Vector &source, Vector &result,
+-  source.ToUnifiedFormat(count, vdata);
++  source.ToUnifiedFormat(vdata);

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -294,7 +294,7 @@ jobs:
     - name: Build DuckDB
       uses: duckdb/duckdb-ci/build-duckdb@main
       env:
-        CORE_EXTENSIONS: "tpch;httpfs;parquet"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
       with:
         build-type: relassert
         build: python3 scripts/ci/retry.py -- make relassert

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -294,7 +294,7 @@ jobs:
     - name: Build DuckDB
       uses: duckdb/duckdb-ci/build-duckdb@main
       env:
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;test-utils;httpfs"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
       with:
         build-type: relassert
         build: python3 scripts/ci/retry.py -- make relassert

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -342,6 +342,9 @@ jobs:
     - name: Test
       run: make unittest_relassert
 
+    - name: Test Benchmark SQL
+      run: make test_benchmark_sql
+
  regression:
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'regression') }}
     uses: ./.github/workflows/Regression.yml

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -293,9 +293,12 @@ jobs:
 
     - name: Build DuckDB
       uses: duckdb/duckdb-ci/build-duckdb@main
+      env:
+        CORE_EXTENSIONS: "tpch;httpfs;parquet"
       with:
         build-type: relassert
         build: python3 scripts/ci/retry.py -- make relassert
+        vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
         test: make smoke T="--changed-tests=${{ runner.temp }}/changed_tests.txt"
         bundle: make relassert-artifact
         upload-name: linux-relassert-build

--- a/Makefile
+++ b/Makefile
@@ -715,7 +715,7 @@ benchmark:
 
 .PHONY: test_benchmark_sql
 test_benchmark_sql:
-	$(PYTHON) scripts/test_benchmark_sql_runner.py --shell build/relassert/duckdb
+	$(PYTHON) -u scripts/test_benchmark_sql_runner.py --shell build/relassert/duckdb
 
 
 tidy-check:

--- a/Makefile
+++ b/Makefile
@@ -713,6 +713,10 @@ benchmark:
 	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_WARN_UNUSED_FLAG} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${CMAKE_VARS} -DBUILD_BENCHMARKS=1 -DCMAKE_BUILD_TYPE=Release ../.. && \
 	$(NINJA_BUILD_WRAPPER) cmake --build . --config Release
 
+.PHONY: test_benchmark_sql
+test_benchmark_sql:
+	$(PYTHON) scripts/test_benchmark_sql_runner.py --shell build/relassert/duckdb
+
 
 tidy-check:
 	mkdir -p ./build/tidy && \

--- a/scripts/plan_cost_runner.py
+++ b/scripts/plan_cost_runner.py
@@ -15,14 +15,42 @@ ENABLE_PROFILING = "PRAGMA enable_profiling=json"
 PROFILE_OUTPUT = f"PRAGMA profile_output='{PROFILE_FILENAME}'"
 
 BANNER_SIZE = 52
+RETRIES = 2
+RETRIABLE_EXIT_CODES = {134, -6}
+
+
+def run_with_retry(command, context, **kwargs):
+    attempts = RETRIES + 1
+    for attempt in range(1, attempts + 1):
+        completed = subprocess.run(command, shell=True, check=False, **kwargs)
+        if completed.returncode == 0:
+            return completed
+        if completed.returncode in RETRIABLE_EXIT_CODES and attempt < attempts:
+            print(
+                f"Retrying crash-like failure in {context} "
+                f"(attempt {attempt + 1}/{attempts}, return code {completed.returncode})"
+            )
+            continue
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            command,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
 
 
 def init_db(cli, dbname, benchmark_dir):
     print(f"INITIALIZING {dbname} ...")
-    subprocess.run(
-        f"{cli} {dbname} < {benchmark_dir}/init/schema.sql", shell=True, check=True, stdout=subprocess.DEVNULL
+    run_with_retry(
+        f"{cli} {dbname} < {benchmark_dir}/init/schema.sql",
+        context=f"init schema ({dbname})",
+        stdout=subprocess.DEVNULL,
     )
-    subprocess.run(f"{cli} {dbname} < {benchmark_dir}/init/load.sql", shell=True, check=True, stdout=subprocess.DEVNULL)
+    run_with_retry(
+        f"{cli} {dbname} < {benchmark_dir}/init/load.sql",
+        context=f"init load ({dbname})",
+        stdout=subprocess.DEVNULL,
+    )
     print("INITIALIZATION DONE")
 
 
@@ -129,10 +157,9 @@ def op_inspect(op) -> PlanCost:
 
 def query_plan_cost(cli, dbname, query):
     try:
-        subprocess.run(
+        run_with_retry(
             f"{cli} --readonly {dbname} -c \"{ENABLE_PROFILING};{PROFILE_OUTPUT};{query}\"",
-            shell=True,
-            check=True,
+            context=f"query profiling ({dbname})",
             capture_output=True,
         )
     except subprocess.CalledProcessError as e:

--- a/scripts/test_benchmark_sql_runner.py
+++ b/scripts/test_benchmark_sql_runner.py
@@ -1,0 +1,80 @@
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import glob
+import os
+import subprocess
+import sys
+
+
+DEFAULT_BENCHMARK_DIRS = [
+    "benchmark/imdb_plan_cost",
+    "benchmark/tpch_plan_cost",
+]
+
+
+def run_sql_file(cli: str, db_path: str, sql_path: str, benchmark_dir: str) -> None:
+    print(f"[{benchmark_dir}] RUNNING {sql_path}")
+    with open(sql_path, "rb") as sql_file:
+        subprocess.run([cli, db_path], stdin=sql_file, check=True, stdout=subprocess.DEVNULL)
+
+
+def run_benchmark_dir(cli: str, benchmark_dir: str) -> None:
+    benchmark_name = os.path.basename(os.path.normpath(benchmark_dir))
+    db_path = f"{benchmark_name}.duckdb"
+
+    try:
+        run_sql_file(cli, db_path, os.path.join(benchmark_dir, "init", "schema.sql"), benchmark_dir)
+        run_sql_file(cli, db_path, os.path.join(benchmark_dir, "init", "load.sql"), benchmark_dir)
+
+        query_files = sorted(glob.glob(os.path.join(benchmark_dir, "queries", "*.sql")))
+        for query_file in query_files:
+            run_sql_file(cli, db_path, query_file, benchmark_dir)
+    finally:
+        if os.path.exists(db_path):
+            os.remove(db_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run benchmark SQL files with DuckDB CLI to detect crashes.")
+    parser.add_argument("--shell", type=str, required=True, help="Path to DuckDB CLI")
+    parser.add_argument(
+        "--benchmark-dir",
+        action="append",
+        default=[],
+        help="Benchmark directory containing init/ and queries/ (can be passed multiple times)",
+    )
+    args = parser.parse_args()
+
+    benchmark_dirs = args.benchmark_dir if args.benchmark_dir else DEFAULT_BENCHMARK_DIRS
+    workers = min(len(benchmark_dirs), os.cpu_count() or 1)
+    print(f"RUNNING {len(benchmark_dirs)} BENCHMARKS WITH {workers} THREADS")
+
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {}
+            for benchmark_dir in benchmark_dirs:
+                print(f"START BENCHMARK {benchmark_dir}")
+                futures[executor.submit(run_benchmark_dir, args.shell, benchmark_dir)] = benchmark_dir
+
+            for future in as_completed(futures):
+                benchmark_dir = futures[future]
+                try:
+                    future.result()
+                    print(f"[{benchmark_dir}] DONE")
+                except subprocess.CalledProcessError as exc:
+                    print(
+                        f"[{benchmark_dir}] FAILED: command '{exc.cmd}' returned exit code {exc.returncode}",
+                        file=sys.stderr,
+                    )
+                    for pending_future in futures:
+                        if pending_future is not future:
+                            pending_future.cancel()
+                    return exc.returncode
+    except subprocess.CalledProcessError as exc:
+        print(f"FAILED: command '{exc.cmd}' returned exit code {exc.returncode}", file=sys.stderr)
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_benchmark_sql_runner.py
+++ b/scripts/test_benchmark_sql_runner.py
@@ -20,7 +20,10 @@ def run_sql_file(cli: str, db_path: str, sql_path: str, benchmark_dir: str) -> N
 
 def run_benchmark_dir(cli: str, benchmark_dir: str) -> None:
     benchmark_name = os.path.basename(os.path.normpath(benchmark_dir))
-    db_path = f"{benchmark_name}.duckdb"
+    build_dir = "build"
+    os.makedirs(build_dir, exist_ok=True)
+    db_path = os.path.join(build_dir, f"{benchmark_name}.duckdb")
+    wal_path = f"{db_path}.wal"
 
     try:
         run_sql_file(cli, db_path, os.path.join(benchmark_dir, "init", "schema.sql"), benchmark_dir)
@@ -32,6 +35,8 @@ def run_benchmark_dir(cli: str, benchmark_dir: str) -> None:
     finally:
         if os.path.exists(db_path):
             os.remove(db_path)
+        if os.path.exists(wal_path):
+            os.remove(wal_path)
 
 
 def main() -> int:


### PR DESCRIPTION
I noticed that the plan cost regression test runner can fail with:
```
$ Run python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
double free or corruption (out)
Aborted (core dumped)
INITIALIZING old.duckdb ...
Traceback (most recent call last):
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 236, in <module>
    main()
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 192, in main
    init_db(old, OLD_DB_NAME, benchmark_dir)
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 25, in init_db
    subprocess.run(f"{cli} {dbname} < {benchmark_dir}/init/load.sql", shell=True, check=True, stdout=subprocess.DEVNULL)
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'build/base/release/duckdb old.duckdb < benchmark/imdb_plan_cost/init/load.sql' returned non-zero exit status 134.
Error: Process completed with exit code 1.
```

This PR:
- retries crashed init/load/query commands in plan cost runner, so we stabilize CI jobs.
- adds `make test_benchmark_sql` to run plan cost SQL under ASAN, so we detect the actual crashes.