### PR TITLE
Internal #9053: Unbound DECIMAL Literals

### DIFF
--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2454,7 +2454,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformTypeLiteral(PEGTran
 		throw ParserException("Cannot convert to type %s, requires exactly one type modifier",
 		                      EnumUtil::ToString(type.id()));
 	}
-	if (type == LogicalTypeId::UNBOUND) {
+	if (type == LogicalTypeId::UNBOUND || type.InternalType() == PhysicalType::INVALID) {
 		type = LogicalType::UNBOUND(make_uniq<TypeExpression>(colid, vector<unique_ptr<ParsedExpression>>()));
 	}
 	auto string_literal = list_pr.Child<StringLiteralParseResult>(1).result;

--- a/test/sql/types/decimal/test_decimal_from_string.test
+++ b/test/sql/types/decimal/test_decimal_from_string.test
@@ -53,3 +53,8 @@ statement error
 select cast('9.99' as decimal(1,0));
 ----
 Conversion Error: Could not convert string
+
+statement error
+select map { 1: decimal 'b' };
+----
+Conversion Error: Could not convert string


### PR DESCRIPTION
* Mark DECIMAL literals in the PEG parser as unbound if they are incomplete.