### PR TITLE
Parse short timestamp times with UTC suffixes

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -30,12 +30,7 @@ static bool CanStartTimestampSuffix(char c) {
 	return c == 'Z' || c == '+' || c == '-' || StringUtil::CharacterIsSpace(c);
 }
 
-static bool TryConvertTimestampTimePrefix(const char *str, idx_t len, idx_t &time_pos, dtime_t &time,
-                                          optional_ptr<int32_t> nanos) {
-	if (Time::TryConvertInterval(str, len, time_pos, time, false, nanos)) {
-		return true;
-	}
-
+static idx_t TimestampTimeLength(const char *str, idx_t len) {
 	idx_t suffix_pos = 0;
 	while (suffix_pos < len && StringUtil::CharacterIsSpace(str[suffix_pos])) {
 		suffix_pos++;
@@ -43,16 +38,7 @@ static bool TryConvertTimestampTimePrefix(const char *str, idx_t len, idx_t &tim
 	while (suffix_pos < len && !CanStartTimestampSuffix(str[suffix_pos])) {
 		suffix_pos++;
 	}
-	if (suffix_pos == 0 || suffix_pos == len) {
-		return false;
-	}
-
-	// HH:MM is valid when it is followed by a timestamp suffix that is parsed below.
-	time_pos = 0;
-	if (!Time::TryConvertInterval(str, suffix_pos, time_pos, time, false, nanos)) {
-		return false;
-	}
-	return time_pos == suffix_pos;
+	return suffix_pos;
 }
 
 // timestamp/datetime uses 64 bits, high 32 bits for date and low 32 bits for time
@@ -92,10 +78,10 @@ TimestampCastResult Timestamp::TryConvertTimestampTZ(const char *str, idx_t len,
 		pos++;
 	}
 	idx_t time_pos = 0;
-	// TryConvertTime may recursively call us, so TryConvertTimestampTimePrefix
-	// uses TryConvertInterval. Note that we can't pass strict== true here
-	// because we want to process any suffix.
-	if (!TryConvertTimestampTimePrefix(str + pos, len - pos, time_pos, time, nanos)) {
+	// TryConvertTime may recursively call us, so we use TryConvertInterval.
+	// Note that we can't pass strict== true here because we want to process any suffix.
+	auto time_len = TimestampTimeLength(str + pos, len - pos);
+	if (!Time::TryConvertInterval(str + pos, time_len, time_pos, time, false, nanos) || time_pos != time_len) {
 		return TimestampCastResult::ERROR_INCORRECT_FORMAT;
 	}
 	//	We parsed an interval, so make sure it is in range.

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -92,9 +92,9 @@ TimestampCastResult Timestamp::TryConvertTimestampTZ(const char *str, idx_t len,
 		pos++;
 	}
 	idx_t time_pos = 0;
-	// TryConvertTime may recursively call us, so we opt for a stricter
-	// operation. Note that we can't pass strict== true here because we
-	// want to process any suffix.
+	// TryConvertTime may recursively call us, so TryConvertTimestampTimePrefix
+	// uses TryConvertInterval. Note that we can't pass strict== true here
+	// because we want to process any suffix.
 	if (!TryConvertTimestampTimePrefix(str + pos, len - pos, time_pos, time, nanos)) {
 		return TimestampCastResult::ERROR_INCORRECT_FORMAT;
 	}

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -215,7 +215,7 @@ TimestampCastResult Timestamp::TryConvertTimestamp(const char *str, idx_t len, t
 
 string Timestamp::FormatError(const string &str) {
 	return StringUtil::Format("invalid timestamp field format: \"%s\", "
-	                          "expected format is (YYYY-MM-DD HH:MM:SS[.US][±HH[:MM[:SS]]| ZONE])",
+	                          "expected format is (YYYY-MM-DD HH:MM[:SS[.US]][±HH[:MM[:SS]]| ZONE])",
 	                          str);
 }
 

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -26,6 +26,35 @@ static inline T TemporalRound(T value, T scale) {
 	return UnsafeNumericCast<T>((value + negative) / scale - negative);
 }
 
+static bool CanStartTimestampSuffix(char c) {
+	return c == 'Z' || c == '+' || c == '-' || StringUtil::CharacterIsSpace(c);
+}
+
+static bool TryConvertTimestampTimePrefix(const char *str, idx_t len, idx_t &time_pos, dtime_t &time,
+                                          optional_ptr<int32_t> nanos) {
+	if (Time::TryConvertInterval(str, len, time_pos, time, false, nanos)) {
+		return true;
+	}
+
+	idx_t suffix_pos = 0;
+	while (suffix_pos < len && StringUtil::CharacterIsSpace(str[suffix_pos])) {
+		suffix_pos++;
+	}
+	while (suffix_pos < len && !CanStartTimestampSuffix(str[suffix_pos])) {
+		suffix_pos++;
+	}
+	if (suffix_pos == 0 || suffix_pos == len) {
+		return false;
+	}
+
+	// HH:MM is valid when it is followed by a timestamp suffix that is parsed below.
+	time_pos = 0;
+	if (!Time::TryConvertInterval(str, suffix_pos, time_pos, time, false, nanos)) {
+		return false;
+	}
+	return time_pos == suffix_pos;
+}
+
 // timestamp/datetime uses 64 bits, high 32 bits for date and low 32 bits for time
 // string format is YYYY-MM-DDThh:mm:ssZ
 // T may be a space
@@ -66,7 +95,7 @@ TimestampCastResult Timestamp::TryConvertTimestampTZ(const char *str, idx_t len,
 	// TryConvertTime may recursively call us, so we opt for a stricter
 	// operation. Note that we can't pass strict== true here because we
 	// want to process any suffix.
-	if (!Time::TryConvertInterval(str + pos, len - pos, time_pos, time, false, nanos)) {
+	if (!TryConvertTimestampTimePrefix(str + pos, len - pos, time_pos, time, nanos)) {
 		return TimestampCastResult::ERROR_INCORRECT_FORMAT;
 	}
 	//	We parsed an interval, so make sure it is in range.

--- a/test/sql/types/timestamp/test_timestamp.test
+++ b/test/sql/types/timestamp/test_timestamp.test
@@ -23,6 +23,11 @@ SELECT timestamp '2017-07-23T13:10:11', timestamp '2017-07-23T13:10:11Z';
 2017-07-23 13:10:11
 2017-07-23 13:10:11
 
+query T
+SELECT timestamp '1970-01-01 00:00Z';
+----
+1970-01-01 00:00:00
+
 # spaces everywhere
 query T
 SELECT timestamp '    2017-07-23     13:10:11    ';


### PR DESCRIPTION
Fixes #22920.

`Timestamp::TryConvertTimestampTZ` parses the date first, then parses the remaining time portion before handling timestamp suffixes such as `Z`, UTC offsets, and timezone names. The time parser accepts short `HH:MM` input only when the parsed time reaches the end of the provided string, so `TIMESTAMP '1970-01-01 00:00Z'` failed before the timestamp suffix handling could consume the `Z`.

This keeps the fix in the timestamp parser: it first tries the existing full time parse, and only falls back to parsing a time prefix when the following characters can start a timestamp suffix that is handled by the existing code below. This avoids changing the broader `TIME`/`INTERVAL` parsing behavior.
