### PR TITLE
Add constant and dictionary optimization to select path in execute function

### DIFF
--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -295,6 +295,7 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 		} else {
 			ExecuteConstantSelectFunction(expr, arguments, *state, result);
 		}
+		arguments.SetChildCardinality(count);
 		return SelectBooleanResult(result, sel, count, true_sel, false_sel);
 	}
 	auto &execute_function_state = state->Cast<ExecuteFunctionState>();

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -214,6 +214,24 @@ static void ExecuteSelectFunction(const BoundFunctionExpression &expr, DataChunk
 	}
 }
 
+static idx_t SelectBooleanResult(Vector &result, const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                 SelectionVector *false_sel) {
+	return UnaryExecutor::Select<bool>(
+	    result, sel, count, [](bool value) { return value; }, true_sel, false_sel);
+}
+
+static void ExecuteConstantSelectFunction(const BoundFunctionExpression &expr, DataChunk &args, ExpressionState &state,
+                                          Vector &result) {
+	D_ASSERT(args.size() == 1);
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::Validity(result).SetAllValid(1);
+
+	SelectionVector true_sel(1);
+	SelectionVector false_sel(1);
+	auto true_count = expr.function.GetSelectCallback()(args, state, nullptr, &true_sel, &false_sel);
+	*ConstantVector::GetData<bool>(result) = true_count == 1;
+}
+
 void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, ExpressionState *state,
                                  const SelectionVector *sel, idx_t count, Vector &result) {
 	state->intermediate_chunk.Reset();
@@ -284,15 +302,53 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 	if (!expr.function.HasSelectCallback()) {
 		return DefaultSelect(expr, state, sel, count, true_sel, false_sel);
 	}
-	// FIXME: push constant handling in here similar to Execute
 	state->intermediate_chunk.Reset();
 	auto &arguments = state->intermediate_chunk;
+	bool all_constant = true;
+	if (expr.function.GetStability() == FunctionStability::VOLATILE) {
+		all_constant = false;
+	}
+	auto default_null_handling = expr.function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING;
 	for (idx_t i = 0; i < expr.children.size(); i++) {
 		D_ASSERT(state->types[i] == expr.children[i]->GetReturnType());
 		Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
+		if (arguments.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			all_constant = false;
+		} else if (default_null_handling && ConstantVector::IsNull(arguments.data[i])) {
+			Vector result(LogicalType::BOOLEAN);
+			ConstantVector::SetNull(result, count_t(1));
+			return SelectBooleanResult(result, sel, count, true_sel, false_sel);
+		}
 	}
-	arguments.SetCardinality(count);
+	if (all_constant) {
+		arguments.SetChildCardinality(1ULL);
+	} else {
+		arguments.SetCardinality(count);
+	}
 	arguments.Verify(context);
+	if (all_constant) {
+		Vector result(LogicalType::BOOLEAN);
+		if (expr.function.HasFunctionCallback()) {
+			expr.function.GetFunctionCallback()(arguments, *state, result);
+			if (result.GetVectorType() != VectorType::FLAT_VECTOR &&
+			    result.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+				result.Flatten();
+			}
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		} else {
+			ExecuteConstantSelectFunction(expr, arguments, *state, result);
+		}
+		return SelectBooleanResult(result, sel, count, true_sel, false_sel);
+	}
+	auto &execute_function_state = state->Cast<ExecuteFunctionState>();
+	if (expr.function.HasFunctionCallback()) {
+		Vector result(LogicalType::BOOLEAN);
+		auto dictionary_executed =
+		    execute_function_state.TryExecuteDictionaryExpression(expr, arguments, *state, result);
+		if (dictionary_executed) {
+			return SelectBooleanResult(result, sel, count, true_sel, false_sel);
+		}
+	}
 	return expr.function.GetSelectCallback()(arguments, *state, sel, true_sel, false_sel);
 }
 

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -172,48 +172,6 @@ static void VerifyNullHandling(const BoundFunctionExpression &expr, DataChunk &a
 #endif
 }
 
-static void ExecuteSelectFunction(const BoundFunctionExpression &expr, DataChunk &args, ExpressionState &state,
-                                  Vector &result) {
-	if (expr.GetReturnType() != LogicalType::BOOLEAN) {
-		throw InvalidInputException("Function %s only has a select callback but returns %s", expr.function.GetName(),
-		                            expr.GetReturnType().ToString());
-	}
-	if (expr.function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
-		throw InvalidInputException("Function %s only has a select callback with SPECIAL_HANDLING but projected "
-		                            "execution requires a scalar callback to produce NULL results",
-		                            expr.function.GetName());
-	}
-
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto count = args.size();
-	auto result_data = FlatVector::GetDataMutable<bool>(result);
-	for (idx_t i = 0; i < count; i++) {
-		result_data[i] = false;
-	}
-
-	auto &result_validity = FlatVector::ValidityMutable(result);
-	result_validity.SetAllValid(count);
-	D_ASSERT(expr.function.GetNullHandling() == FunctionNullHandling::DEFAULT_NULL_HANDLING);
-	for (const auto &arg : args.data) {
-		auto entries = arg.Validity();
-		if (!entries.CanHaveNull()) {
-			continue;
-		}
-		for (idx_t i = 0; i < count; i++) {
-			if (!entries.IsValid(i)) {
-				result_validity.SetInvalid(i);
-			}
-		}
-	}
-
-	SelectionVector true_sel(count);
-	auto true_count =
-	    expr.function.GetSelectCallback()(args, state, FlatVector::IncrementalSelectionVector(), &true_sel, nullptr);
-	for (idx_t i = 0; i < true_count; i++) {
-		result_data[true_sel.get_index(i)] = true;
-	}
-}
-
 static idx_t SelectBooleanResult(Vector &result, const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
                                  SelectionVector *false_sel) {
 	return UnaryExecutor::Select<bool>(
@@ -270,11 +228,10 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	if (!dictionary_executed) {
 		if (expr.function.HasFunctionCallback()) {
 			expr.function.GetFunctionCallback()(arguments, *state, result);
-		} else if (expr.function.HasSelectCallback()) {
-			ExecuteSelectFunction(expr, arguments, *state, result);
+		} else if (all_constant && expr.function.HasSelectCallback()) {
+			ExecuteConstantSelectFunction(expr, arguments, *state, result);
 		} else {
-			throw InternalException("Scalar function %s has neither an execution nor a select callback",
-			                        expr.function.GetName());
+			throw InternalException("Scalar function %s has no execution callback", expr.function.GetName());
 		}
 	}
 	if (all_constant) {

--- a/test/sql/filter/test_expression_executor_select.test
+++ b/test/sql/filter/test_expression_executor_select.test
@@ -1,0 +1,96 @@
+# name: test/sql/filter/test_expression_executor_select.test
+# description: Exercise ExpressionExecutor::Select with constant parameters and dictionary-compressed scans
+# group: [filter]
+
+statement ok
+PRAGMA disable_optimizer
+
+statement ok
+PREPARE const_eq AS
+SELECT count(*) FROM range(6) tbl(i) WHERE ?::INTEGER = ?::INTEGER;
+
+query I
+EXECUTE const_eq(1, 1)
+----
+6
+
+query I
+EXECUTE const_eq(1, 2)
+----
+0
+
+statement ok
+PREPARE const_is_not_distinct AS
+SELECT count(*) FROM range(6) tbl(i) WHERE ?::INTEGER IS NOT DISTINCT FROM ?::INTEGER;
+
+query I
+EXECUTE const_is_not_distinct(NULL, NULL)
+----
+6
+
+query I
+EXECUTE const_is_not_distinct(1, NULL)
+----
+0
+
+statement ok
+CREATE TABLE dict_select(
+	id INTEGER,
+	s VARCHAR USING COMPRESSION Dictionary
+);
+
+statement ok
+INSERT INTO dict_select VALUES
+	(1, 'duck'),
+	(2, 'goose'),
+	(3, NULL),
+	(4, 'duck'),
+	(5, 'swan'),
+	(6, 'duck');
+
+statement ok
+PREPARE dict_eq AS
+SELECT id FROM dict_select WHERE s = ?::VARCHAR ORDER BY id;
+
+query I
+EXECUTE dict_eq('duck')
+----
+1
+4
+6
+
+query I
+EXECUTE dict_eq('goose')
+----
+2
+
+statement ok
+PREPARE dict_is_not_distinct AS
+SELECT id FROM dict_select WHERE s IS NOT DISTINCT FROM ?::VARCHAR ORDER BY id;
+
+query I
+EXECUTE dict_is_not_distinct(NULL)
+----
+3
+
+query I
+EXECUTE dict_is_not_distinct('duck')
+----
+1
+4
+6
+
+statement ok
+PREPARE dict_between AS
+SELECT id FROM dict_select WHERE s BETWEEN ?::VARCHAR AND ?::VARCHAR ORDER BY id;
+
+query I
+EXECUTE dict_between('duck', 'goose')
+----
+1
+2
+4
+6
+
+statement ok
+PRAGMA enable_optimizer

--- a/test/sql/filter/test_expression_executor_select.test
+++ b/test/sql/filter/test_expression_executor_select.test
@@ -1,5 +1,5 @@
 # name: test/sql/filter/test_expression_executor_select.test
-# description: Exercise ExpressionExecutor::Select with constant parameters and dictionary-compressed scans
+# description: Exercise ExpressionExecutor::Select with constant parameters and dictionary vectors
 # group: [filter]
 
 statement ok
@@ -36,8 +36,11 @@ EXECUTE const_is_not_distinct(1, NULL)
 statement ok
 CREATE TABLE dict_select(
 	id INTEGER,
-	s VARCHAR USING COMPRESSION Dictionary
+	s VARCHAR
 );
+
+statement ok
+PRAGMA debug_verify_vector='dictionary_expression'
 
 statement ok
 INSERT INTO dict_select VALUES
@@ -91,6 +94,9 @@ EXECUTE dict_between('duck', 'goose')
 2
 4
 6
+
+statement ok
+PRAGMA debug_verify_vector='none'
 
 statement ok
 PRAGMA enable_optimizer


### PR DESCRIPTION
This PR adds the constant and dictionary optimizations we already use for regular function execution to the `Select` path, too. Also, it removes the `ExecuteSelectFunction` again.