### PR TITLE
Add support for includes and variables in sqllogic test files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,22 @@ Slow tests should use `.test_slow` extension instead of `.test`.
 
 ```bash
 make format-fix        # Format all code (clang-format + black)
+make generate-files    # Generate files + format all code
 ```
 
 Ensure you run formatting before committing.
+
+## Extensive Testing / Making CI Work
+
+Below is a set of tests that should be run in order to make sure a changeset passes extensive tests in CI. If the user is asking you to fix CI make sure that the below commands succeed.
+
+```bash
+make allunit
+FORCE_DEBUG=1 FORCE_ASSERT=1 make reldebug && build/reldebug/test/unittest
+make test_configs
+make test_vector
+```
+
 
 ## Architecture
 

--- a/test/sql/aggregate/aggregates/arg_min_max_n_tpch.test
+++ b/test/sql/aggregate/aggregates/arg_min_max_n_tpch.test
@@ -2,10 +2,9 @@
 # description: Test max/min N overloads with TPCH data
 # group: [aggregates]
 
-require tpch
+set variable sf 0.001
 
-statement ok
-CALL dbgen(sf=0.001);
+include test/sql/tpch/tpch_setup.test_template
 
 query I
 select min(l_orderkey, 3) from lineitem;

--- a/test/sql/aggregate/quantile_fun.test
+++ b/test/sql/aggregate/quantile_fun.test
@@ -2,14 +2,13 @@
 # description: Test pg_sequence function
 # group: [aggregate]
 
-require tpch
+set variable sf 0.001
+
+include test/sql/tpch/tpch_setup.test_template
 
 # scalar quantiles
 statement ok
 create table quantiles as select range r, random() FROM range(100) union all values (NULL, 0.1), (NULL, 0.5), (NULL, 0.9) order by 2;
-
-statement ok
-CALL dbgen(sf=0.001);
 
 statement ok
 SET debug_force_external=true;

--- a/test/sql/copy/csv/test_glob_reorder_lineitem.test
+++ b/test/sql/copy/csv/test_glob_reorder_lineitem.test
@@ -2,10 +2,9 @@
 # description: Test the generation of lineitem csv files in different orders
 # group: [csv]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-call dbgen(sf=0.1);
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 copy (select l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment from lineitem limit 10000 offset 0)

--- a/test/sql/cte/recursive_cte_correlated_complex.test
+++ b/test/sql/cte/recursive_cte_correlated_complex.test
@@ -2,10 +2,9 @@
 # description: Must not report "More than one row returned by a subquery used as an expression"
 # group: [cte]
 
-require tpch
+set variable sf 0.001
 
-statement ok
-call dbgen(sf=0.001);
+include test/sql/tpch/tpch_setup.test_template
 
 query II
 SELECT s.s_name, COUNT(*) AS numwait

--- a/test/sql/function/autocomplete/tpch.test
+++ b/test/sql/function/autocomplete/tpch.test
@@ -4,11 +4,9 @@
 
 require autocomplete
 
-require tpch
+set variable sf 0
 
-# column names
-statement ok
-CALL dbgen(sf=0);
+include test/sql/tpch/tpch_setup.test_template
 
 query II
 SELECT suggestion, suggestion_start FROM sql_auto_complete('SELECT l_ord') LIMIT 1;

--- a/test/sql/index/art/scan/test_hash_join_in_filter_index_scan.test
+++ b/test/sql/index/art/scan/test_hash_join_in_filter_index_scan.test
@@ -2,10 +2,9 @@
 # description: Test using an index scan for IN filter pushdown via hash joins.
 # group: [scan]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-CALL dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 CREATE TABLE random_orders AS (

--- a/test/sql/join/hash_join/hash_join_constant_probe.test
+++ b/test/sql/join/hash_join/hash_join_constant_probe.test
@@ -2,9 +2,6 @@
 # description: Test constant-vector hash-join probing (TryProbeConstant)
 # group: [hash_join]
 
-statement ok
-PRAGMA enable_verification
-
 # build side - small dimension table
 statement ok
 CREATE TABLE dim (k VARCHAR PRIMARY KEY, name VARCHAR)

--- a/test/sql/join/hash_join/hash_join_dictionary_probe.test
+++ b/test/sql/join/hash_join/hash_join_dictionary_probe.test
@@ -2,9 +2,6 @@
 # description: Test dictionary-aware hash-join probing on storage dict-encoded VARCHAR keys
 # group: [hash_join]
 
-statement ok
-PRAGMA enable_verification
-
 # persistent + dictionary compression so probe-side VARCHAR keys arrive as DICTIONARY_VECTOR with a non-empty id
 load {TEST_DIR}/dictionary_probe.db
 

--- a/test/sql/join/hash_join/hash_join_residual_predicates.test
+++ b/test/sql/join/hash_join/hash_join_residual_predicates.test
@@ -2,10 +2,9 @@
 # description: Test hash join with residual predicates (non-pushdown conditions in ON clause)
 # group: [hash_join]
 
-require tpch
+set variable sf 0
 
-statement ok
-CALL dbgen(sf=0);
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 set disabled_optimizers to 'build_side_probe_side';

--- a/test/sql/limit/streaming_limit_pipeline_flush.test
+++ b/test/sql/limit/streaming_limit_pipeline_flush.test
@@ -2,13 +2,9 @@
 # description: Test that pipeline correctly flushes operators after STREAMING_LIMIT finishes
 # group: [limit]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-LOAD tpch;
-
-statement ok
-CALL dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 # The optimizer pushes down filters which reduces cardinality estimates, causing it to
 # place STREAMING_LIMIT on the right side. We disable it to keep it on the left side, to trigger the pipeline flush bug

--- a/test/sql/optimizer/test_rowid_pushdown_plan.test
+++ b/test/sql/optimizer/test_rowid_pushdown_plan.test
@@ -1,10 +1,9 @@
 # name: test/sql/optimizer/test_rowid_pushdown_plan.test
 # group: [optimizer]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-CALL dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 query IIIIIIIIIIIIIIII rowsort top5_result
 SELECT * FROM lineitem ORDER BY l_orderkey DESC LIMIT 5;

--- a/test/sql/peg_parser/parser/support_unreserved_keywords.test
+++ b/test/sql/peg_parser/parser/support_unreserved_keywords.test
@@ -10,8 +10,6 @@ CALL check_peg_parser($TEST_PEG_PARSER$CREATE OR REPLACE TABLE 'everflow_daily' 
 statement ok
 CALL check_peg_parser($TEST_PEG_PARSER$CREATE TABLE tmp.t1(id int);$TEST_PEG_PARSER$);
 
-require tpch
-
 statement ok
 CREATE SCHEMA abcdefgh;
 
@@ -20,9 +18,9 @@ SELECT suggestion, suggestion_start FROM sql_auto_complete('CREATE TABLE abcd') 
 ----
 abcdefgh.	13
 
+set variable sf 0
 
-statement ok
-CALL dbgen(sf=0);
+include test/sql/tpch/tpch_setup.test_template
 
 query II
 SELECT suggestion, suggestion_start FROM sql_auto_complete('INSERT INTO lin') LIMIT 1;

--- a/test/sql/subquery/scalar/correlated_missing_columns.test
+++ b/test/sql/subquery/scalar/correlated_missing_columns.test
@@ -2,10 +2,9 @@
 # description: Test correlated missing columns
 # group: [scalar]
 
-require tpch
+set variable sf 0
 
-statement ok
-CALL dbgen(sf=0);
+include test/sql/tpch/tpch_setup.test_template
 
 # verify that we can grab missing columns from either the correlated subquery or the outer (uncorrelated) subquery
 statement error

--- a/test/sql/tpch/q01_propagate.test_slow
+++ b/test/sql/tpch/q01_propagate.test_slow
@@ -2,10 +2,9 @@
 # description: Test statistics propagation in Q01
 # group: [tpch]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-CALL dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 query II
 select s.min, s.max from (SELECT stats(1 - l_discount) s FROM lineitem LIMIT 1);

--- a/test/sql/tpch/q01_union.test_slow
+++ b/test/sql/tpch/q01_union.test_slow
@@ -2,16 +2,15 @@
 # description: Test TPC-H SF0.01 Q1 with unions
 # group: [tpch]
 
-require tpch
+set variable sf 0.01
+
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 PRAGMA threads=4
 
 statement ok
 PRAGMA verify_parallelism
-
-statement ok
-CALL dbgen(sf=0.01);
 
 query IIIII
 SELECT

--- a/test/sql/tpch/tpch_setup.test_template
+++ b/test/sql/tpch/tpch_setup.test_template
@@ -1,0 +1,4 @@
+require tpch
+
+statement ok
+CALL dbgen(sf={sf});

--- a/test/sql/tpch/tpch_sf0.test
+++ b/test/sql/tpch/tpch_sf0.test
@@ -2,10 +2,9 @@
 # description: Test TPC-H SF0
 # group: [tpch]
 
-require tpch
+set variable sf 0
 
-statement ok
-CALL dbgen(sf=0);
+include test/sql/tpch/tpch_setup.test_template
 
 loop i 1 23
 

--- a/test/sql/tpch/tpch_sf001.test_slow
+++ b/test/sql/tpch/tpch_sf001.test_slow
@@ -2,16 +2,15 @@
 # description: Test TPC-H SF0.01
 # group: [tpch]
 
-require tpch
+set variable sf 0.01
+
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 SET debug_force_external=true;
 
 statement ok
 SET debug_verify_serializer=true;
-
-statement ok
-CALL dbgen(sf=0.01);
 
 loop i 1 9
 

--- a/test/sql/tpch/tpch_sf01.test_slow
+++ b/test/sql/tpch/tpch_sf01.test_slow
@@ -2,10 +2,9 @@
 # description: Test TPC-H SF0.1
 # group: [tpch]
 
-require tpch
+set variable sf 0.1
 
-statement ok
-CALL dbgen(sf=0.1);
+include test/sql/tpch/tpch_setup.test_template
 
 loop i 1 9
 

--- a/test/sql/tpch/tpch_sf1.test_slow
+++ b/test/sql/tpch/tpch_sf1.test_slow
@@ -2,13 +2,12 @@
 # description: Test TPC-H SF1
 # group: [tpch]
 
-require tpch
+set variable sf 1
+
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 SET debug_force_external=true;
-
-statement ok
-CALL dbgen(sf=1);
 
 loop i 1 9
 

--- a/test/sql/tpch/tpch_topn.test_slow
+++ b/test/sql/tpch/tpch_topn.test_slow
@@ -2,10 +2,9 @@
 # description: Test top-n queries on TPC-H
 # group: [tpch]
 
-require tpch
+set variable sf 1
 
-statement ok
-CALL dbgen(sf=1);
+include test/sql/tpch/tpch_setup.test_template
 
 query IIIIIIII
 SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority FROM orders ORDER BY o_orderkey LIMIT 5;

--- a/test/sql/types/variant/tpch_test.test
+++ b/test/sql/types/variant/tpch_test.test
@@ -1,12 +1,11 @@
 # name: test/sql/types/variant/tpch_test.test
 # group: [variant]
 
-require tpch
-
 require json
 
-statement ok
-call dbgen(sf=0.001)
+set variable sf 0.001
+
+include test/sql/tpch/tpch_setup.test_template
 
 statement ok
 attach '{TEST_DIR}/tpch_sf0001_variant.db' as foo (STORAGE_VERSION 'v1.5.0');

--- a/test/sql/types/variant/tpch_test_through_json.test
+++ b/test/sql/types/variant/tpch_test_through_json.test
@@ -3,10 +3,9 @@
 
 require json
 
-require tpch
+set variable sf 0.01
 
-statement ok
-call dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 query I nosort res
 select lineitem::json from lineitem limit 2;

--- a/test/sql/window/test_constant_orderby.test
+++ b/test/sql/window/test_constant_orderby.test
@@ -2,10 +2,9 @@
 # description: Constant window aggregation functionality.
 # group: [window]
 
-require tpch
+set variable sf 0.01
 
-statement ok
-call dbgen(sf=0.01);
+include test/sql/tpch/tpch_setup.test_template
 
 query IIII
 SELECT 

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -20,11 +20,23 @@ bool SQLLogicParser::OpenFile(const string &path) {
 	return !infile.bad();
 }
 
+void SQLLogicParser::IncludeFile(const string &file_name) {
+	auto include_parser = make_uniq<SQLLogicParser>();
+	auto success = include_parser->OpenFile(file_name);
+	if (!success) {
+		Fail("Failed to open include file %s", file_name);
+	}
+	current_include = std::move(include_parser);
+}
+
 bool SQLLogicParser::EmptyOrComment(const string &line) {
 	return line.empty() || StringUtil::StartsWith(line, "#");
 }
 
 bool SQLLogicParser::NextLineEmptyOrComment() {
+	if (current_include) {
+		return current_include->NextLineEmptyOrComment();
+	}
 	if (current_line + 1 >= lines.size()) {
 		return true;
 	} else {
@@ -33,6 +45,14 @@ bool SQLLogicParser::NextLineEmptyOrComment() {
 }
 
 bool SQLLogicParser::NextStatement() {
+	if (current_include) {
+		auto result = current_include->NextStatement();
+		if (result) {
+			return true;
+		}
+		// finished processing this include - continue processing the main file
+		current_include.reset();
+	}
 	if (seen_statement) {
 		// skip the current statement
 		// but only if we have already seen a statement in the file
@@ -50,10 +70,17 @@ bool SQLLogicParser::NextStatement() {
 }
 
 void SQLLogicParser::NextLine() {
+	if (current_include) {
+		current_include->NextLine();
+		return;
+	}
 	current_line++;
 }
 
 string SQLLogicParser::ExtractStatement() {
+	if (current_include) {
+		return current_include->ExtractStatement();
+	}
 	string statement;
 
 	bool first_line = true;
@@ -74,6 +101,9 @@ string SQLLogicParser::ExtractStatement() {
 }
 
 vector<string> SQLLogicParser::ExtractExpectedResult() {
+	if (current_include) {
+		return current_include->ExtractExpectedResult();
+	}
 	vector<string> result;
 	// skip the result line (----) if we are still reading that
 	if (current_line < lines.size() && lines[current_line] == "----") {
@@ -88,6 +118,9 @@ vector<string> SQLLogicParser::ExtractExpectedResult() {
 }
 
 string SQLLogicParser::ExtractExpectedError(ExpectedResult expected_result, bool original_sqlite_test) {
+	if (current_include) {
+		return current_include->ExtractExpectedError(expected_result, original_sqlite_test);
+	}
 	bool expect_error_message =
 	    expected_result == ExpectedResult::RESULT_ERROR || expected_result == ExpectedResult::RESULT_UNKNOWN;
 
@@ -120,6 +153,9 @@ void SQLLogicParser::FailRecursive(const string &msg, vector<ExceptionFormatValu
 }
 
 SQLLogicToken SQLLogicParser::Tokenize() {
+	if (current_include) {
+		return current_include->Tokenize();
+	}
 	SQLLogicToken result;
 	if (current_line >= lines.size()) {
 		result.type = SQLLogicTokenType::SQLLOGIC_INVALID;
@@ -175,6 +211,7 @@ bool SQLLogicParser::IsSingleLineStatement(SQLLogicToken &token) {
 	case SQLLogicTokenType::SQLLOGIC_UNZIP:
 	case SQLLogicTokenType::SQLLOGIC_TAGS:
 	case SQLLogicTokenType::SQLLOGIC_CONTINUE:
+	case SQLLogicTokenType::SQLLOGIC_INCLUDE:
 		return true;
 
 	case SQLLogicTokenType::SQLLOGIC_SKIP_IF:
@@ -219,6 +256,7 @@ bool SQLLogicParser::IsTestCommand(SQLLogicTokenType &type) {
 	case SQLLogicTokenType::SQLLOGIC_CONTINUE:
 	case SQLLogicTokenType::SQLLOGIC_TEST_ENV:
 	case SQLLogicTokenType::SQLLOGIC_UNZIP:
+	case SQLLogicTokenType::SQLLOGIC_INCLUDE:
 		return false;
 
 	default:
@@ -275,6 +313,8 @@ SQLLogicTokenType SQLLogicParser::CommandToToken(const string &token) {
 		return SQLLogicTokenType::SQLLOGIC_TAGS;
 	} else if (token == "continue") {
 		return SQLLogicTokenType::SQLLOGIC_CONTINUE;
+	} else if (token == "include") {
+		return SQLLogicTokenType::SQLLOGIC_INCLUDE;
 	}
 	Fail("Unrecognized parameter %s", token);
 	return SQLLogicTokenType::SQLLOGIC_INVALID;

--- a/test/sqlite/sqllogic_parser.hpp
+++ b/test/sqlite/sqllogic_parser.hpp
@@ -41,6 +41,7 @@ enum class SQLLogicTokenType {
 	SQLLOGIC_UNZIP,
 	SQLLOGIC_TAGS,
 	SQLLOGIC_CONTINUE,
+	SQLLOGIC_INCLUDE
 };
 
 class SQLLogicToken {
@@ -60,6 +61,8 @@ public:
 	bool print_input = false;
 	//! Whether or not we have seen a statement
 	bool seen_statement = false;
+	//! Include files
+	unique_ptr<SQLLogicParser> current_include;
 
 public:
 	static bool EmptyOrComment(const string &line);
@@ -71,6 +74,8 @@ public:
 
 	//! Opens the file, returns whether or not reading was successful
 	bool OpenFile(const string &path);
+
+	void IncludeFile(const string &file_name);
 
 	//! Moves the current line to the beginning of the next statement
 	//! Returns false if there is no next statement (i.e. we reached the end of the file)

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -966,6 +966,13 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 					parser.Fail("Failed to set seed: %s", res->GetError());
 				}
 				skip_reload = true;
+			} else if (token.parameters[0] == "variable") {
+				if (token.parameters.size() != 3) {
+					parser.Fail("set variable requires two parameters (name value)");
+				}
+				auto &var_name = token.parameters[1];
+				auto &var_value = token.parameters[2];
+				environment_variables[var_name] = var_value;
 			} else {
 				parser.Fail("unrecognized set parameter: %s", token.parameters[0]);
 			}
@@ -1200,6 +1207,11 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			auto command = make_uniq<ContinueCommand>(*this);
 			command->conditions = std::move(conditions);
 			ExecuteCommand(std::move(command));
+		} else if (token.type == SQLLogicTokenType::SQLLOGIC_INCLUDE) {
+			if (token.parameters.size() != 1) {
+				parser.Fail("Expected include <path>");
+			}
+			parser.IncludeFile(token.parameters[0]);
 		}
 	}
 	if (InLoop()) {


### PR DESCRIPTION
This is useful for cleaning up tests / avoiding a lot of duplicate set-up code, especially in extensions.

Syntax:

#### set variable
```sql
set variable my_var my_value

query I
select '{my_var}'
----
my_value
```

#### include
```sql
include test/sql/tpch/tpch_setup.test_template
```


