### PR TITLE
Fix spurious foreign key violation when updating non-PK columns of a referenced table

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/constraints/bound_check_constraint.hpp"
+#include "duckdb/planner/constraints/bound_foreign_key_constraint.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
@@ -325,6 +326,42 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 
 	if (update.update_is_del_and_insert) {
+		// Before expanding update.columns to all columns, decide whether the delete-side FK
+		// check can be skipped for this UPDATE rewrite. It can iff every FK constraint that
+		// fires on delete has its PK columns disjoint from the user-specified updated columns
+		// and no FK is self-referential. See TableDeleteState::skip_unchanged_fk_delete_check.
+		physical_index_set_t user_updated_set;
+		for (auto &col : update.columns) {
+			user_updated_set.insert(col);
+		}
+		bool has_delete_fk = false;
+		bool can_skip = true;
+		for (auto &constraint : bound_constraints) {
+			if (constraint->type != ConstraintType::FOREIGN_KEY) {
+				continue;
+			}
+			auto &fk = constraint->Cast<BoundForeignKeyConstraint>();
+			if (!fk.info.IsDeleteConstraint()) {
+				continue;
+			}
+			if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				// Self-referential FKs need a per-row predicate; out of scope (see #16436).
+				can_skip = false;
+				break;
+			}
+			has_delete_fk = true;
+			for (auto &pk_idx : fk.info.pk_keys) {
+				if (user_updated_set.find(pk_idx) != user_updated_set.end()) {
+					can_skip = false;
+					break;
+				}
+			}
+			if (!can_skip) {
+				break;
+			}
+		}
+		update.skip_unchanged_fk_delete_check = can_skip && has_delete_fk;
+
 		// the update updates a column required by an index or requires returning the updated rows,
 		// push projections for all columns
 		physical_index_set_t all_columns;

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -282,6 +282,7 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 
 	if (GLOBAL) {
 		auto &delete_state = lstate.GetDeleteState(data_table, table, context.client);
+		delete_state.skip_unchanged_fk_delete_check = op.skip_unchanged_fk_delete_check;
 		data_table.Delete(delete_state, context.client, table, row_ids, update_chunk.size());
 	} else {
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -191,6 +191,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	}
 
 	auto &delete_state = l_state.GetDeleteState(table, tableref, context.client);
+	delete_state.skip_unchanged_fk_delete_check = skip_unchanged_fk_delete_check;
 	table.Delete(delete_state, context.client, tableref, del_row_ids, update_count);
 
 	// Arrange the columns in the standard table order.

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -134,6 +134,7 @@ PhysicalOperator &DuckCatalog::PlanInsert(ClientContext &context, PhysicalPlanGe
 	    std::move(op.on_conflict_info.on_conflict_condition), std::move(op.on_conflict_info.do_update_condition),
 	    std::move(op.on_conflict_info.on_conflict_filter), std::move(op.on_conflict_info.columns_to_fetch),
 	    op.on_conflict_info.update_is_del_and_insert);
+	insert.Cast<PhysicalInsert>().skip_unchanged_fk_delete_check = op.on_conflict_info.skip_unchanged_fk_delete_check;
 	insert.children.push_back(*plan);
 	return insert;
 }

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -39,6 +39,7 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		                                          std::move(bound_constraints), cardinality, op.return_chunk);
 		auto &cast_update = result->op->Cast<PhysicalUpdate>();
 		cast_update.update_is_del_and_insert = action.update_is_del_and_insert;
+		cast_update.skip_unchanged_fk_delete_check = action.skip_unchanged_fk_delete_check;
 		break;
 	}
 	case MergeActionType::MERGE_DELETE: {

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -14,6 +14,7 @@ PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGe
 	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
+	cast_update.skip_unchanged_fk_delete_check = op.skip_unchanged_fk_delete_check;
 	cast_update.children.push_back(plan);
 	return update;
 }

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -113,6 +113,8 @@ public:
 	unordered_set<column_t> conflict_target;
 	//! True, if the INSERT OR REPLACE requires delete + insert.
 	bool update_is_del_and_insert;
+	//! See TableDeleteState::skip_unchanged_fk_delete_check.
+	bool skip_unchanged_fk_delete_check = false;
 
 	// Column ids from the original table to fetch
 	vector<StorageIndex> columns_to_fetch;

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -34,6 +34,8 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;
+	//! See TableDeleteState::skip_unchanged_fk_delete_check.
+	bool skip_unchanged_fk_delete_check = false;
 	//! If the returning statement is present, return the whole chunk
 	bool return_chunk;
 	//! Set to true, if we are updating an index column.

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -43,6 +43,8 @@ struct BoundOnConflictInfo {
 	vector<column_t> source_columns;
 	//! True, if the INSERT OR REPLACE requires delete + insert.
 	bool update_is_del_and_insert;
+	//! See TableDeleteState::skip_unchanged_fk_delete_check.
+	bool skip_unchanged_fk_delete_check = false;
 };
 
 //! LogicalInsert represents an insertion of data into a base table

--- a/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -32,6 +32,8 @@ public:
 	physical_index_vector_t<idx_t> column_index_map;
 	//! Whether or not an UPDATE is a DELETE + INSERT
 	bool update_is_del_and_insert = false;
+	//! See TableDeleteState::skip_unchanged_fk_delete_check.
+	bool skip_unchanged_fk_delete_check = false;
 
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<BoundMergeIntoAction> Deserialize(Deserializer &deserializer);

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -34,6 +34,8 @@ public:
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;
+	//! See TableDeleteState::skip_unchanged_fk_delete_check.
+	bool skip_unchanged_fk_delete_check = false;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -758,6 +758,13 @@
         "type": "bool",
         "default": "false",
         "property": "on_conflict_info.update_is_del_and_insert"
+      },
+      {
+        "id": 219,
+        "name": "skip_unchanged_fk_delete_check",
+        "type": "bool",
+        "default": "false",
+        "property": "on_conflict_info.skip_unchanged_fk_delete_check"
       }
     ],
     "constructor": [
@@ -842,6 +849,12 @@
         "id": 206,
         "name": "update_is_del_and_insert",
         "type": "bool"
+      },
+      {
+        "id": 207,
+        "name": "skip_unchanged_fk_delete_check",
+        "type": "bool",
+        "default": "false"
       }
     ],
     "constructor": [
@@ -930,6 +943,12 @@
         "id": 205,
         "name": "update_is_del_and_insert",
         "type": "bool"
+      },
+      {
+        "id": 206,
+        "name": "skip_unchanged_fk_delete_check",
+        "type": "bool",
+        "default": "false"
       }
     ]
   },

--- a/src/include/duckdb/storage/table/delete_state.hpp
+++ b/src/include/duckdb/storage/table/delete_state.hpp
@@ -19,6 +19,11 @@ struct TableDeleteState {
 	DataChunk verify_chunk;
 	vector<StorageIndex> col_ids;
 	shared_ptr<CheckpointLock> checkpoint_lock;
+	//! True if this delete is the DELETE half of an UPDATE rewrite (UPDATE/INSERT OR REPLACE/
+	//! ON CONFLICT DO UPDATE) where the updated columns don't intersect any FK's PK columns and
+	//! the FK is not self-referential. In that case the matching INSERT half re-adds the same
+	//! PK in the same statement, so the delete-side FK check is spurious and can be skipped.
+	bool skip_unchanged_fk_delete_check = false;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -155,6 +155,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		result->columns = std::move(update.columns);
 		result->expressions = std::move(update.expressions);
 		result->update_is_del_and_insert = update.update_is_del_and_insert;
+		result->skip_unchanged_fk_delete_check = update.skip_unchanged_fk_delete_check;
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1531,6 +1531,14 @@ void DataTable::VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage,
 		case ConstraintType::FOREIGN_KEY: {
 			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
 			if (bound_foreign_key.info.IsDeleteConstraint()) {
+				// Skip the spurious delete-side FK check when this delete is the DELETE-half of
+				// an UPDATE rewrite whose updated columns are disjoint from the FK's PK columns
+				// and the FK is not self-referential. The matching INSERT in the same statement
+				// re-adds the identical PK so the reference is never actually going to dangle.
+				if (state.skip_unchanged_fk_delete_check &&
+				    bound_foreign_key.info.type != ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+					break;
+				}
 				VerifyDeleteForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
 			}
 			break;

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -211,6 +211,7 @@ void BoundMergeIntoAction::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
 	serializer.WriteProperty<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", column_index_map);
 	serializer.WritePropertyWithDefault<bool>(205, "update_is_del_and_insert", update_is_del_and_insert);
+	serializer.WritePropertyWithDefault<bool>(206, "skip_unchanged_fk_delete_check", skip_unchanged_fk_delete_check, false);
 }
 
 unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer &deserializer) {
@@ -221,6 +222,7 @@ unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer 
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadProperty<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", result->column_index_map);
 	deserializer.ReadPropertyWithDefault<bool>(205, "update_is_del_and_insert", result->update_is_del_and_insert);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(206, "skip_unchanged_fk_delete_check", result->skip_unchanged_fk_delete_check, false);
 	return result;
 }
 
@@ -566,6 +568,7 @@ void LogicalInsert::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<column_t>>(216, "source_columns", on_conflict_info.source_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(217, "expressions", expressions);
 	serializer.WritePropertyWithDefault<bool>(218, "update_is_del_and_insert", on_conflict_info.update_is_del_and_insert, false);
+	serializer.WritePropertyWithDefault<bool>(219, "skip_unchanged_fk_delete_check", on_conflict_info.skip_unchanged_fk_delete_check, false);
 }
 
 unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserializer) {
@@ -589,6 +592,7 @@ unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<vector<column_t>>(216, "source_columns", result->on_conflict_info.source_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(217, "expressions", result->expressions);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(218, "update_is_del_and_insert", result->on_conflict_info.update_is_del_and_insert, false);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(219, "skip_unchanged_fk_delete_check", result->on_conflict_info.skip_unchanged_fk_delete_check, false);
 	return std::move(result);
 }
 
@@ -824,6 +828,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "columns", columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", bound_defaults);
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
+	serializer.WritePropertyWithDefault<bool>(207, "skip_unchanged_fk_delete_check", skip_unchanged_fk_delete_check, false);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -835,6 +840,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "skip_unchanged_fk_delete_check", result->skip_unchanged_fk_delete_check, false);
 	return std::move(result);
 }
 

--- a/test/sql/constraints/foreignkey/fk_update_nonpk_columns.test
+++ b/test/sql/constraints/foreignkey/fk_update_nonpk_columns.test
@@ -1,0 +1,107 @@
+# name: test/sql/constraints/foreignkey/fk_update_nonpk_columns.test
+# description: Test that updating non-PK columns of an FK-referenced table does not raise a spurious FK violation (issue #16409)
+# group: [foreignkey]
+
+# NOTE for the implementing agent:
+# Before the fix, every "statement ok" UPDATE / INSERT-OR-REPLACE / ON CONFLICT block
+# below FAILS with: "Violates foreign key constraint because key ... is still referenced".
+# After the fix they must all pass. The "statement error" blocks at the end must STILL error.
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test (id INTEGER PRIMARY KEY, arr VARCHAR[]);
+
+statement ok
+INSERT INTO test VALUES (1, ['asdf', '2e3f']);
+
+statement ok
+CREATE TABLE test_fk (test_id INTEGER REFERENCES test (id), val VARCHAR);
+
+statement ok
+INSERT INTO test_fk VALUES (1, 'blkaj');
+
+# --- Variant 1: plain UPDATE of a LIST column, PK unchanged ---
+statement ok
+UPDATE test SET arr = [] WHERE id = 1;
+
+query II
+SELECT id, arr FROM test;
+----
+1	[]
+
+# --- Variant 2: UPDATE to a non-empty list, PK unchanged ---
+statement ok
+UPDATE test SET arr = ['x'] WHERE id = 1;
+
+query II
+SELECT id, arr FROM test;
+----
+1	[x]
+
+# --- Variant 3: INSERT OR REPLACE (same PK) ---
+statement ok
+INSERT OR REPLACE INTO test VALUES (1, ['replaced']);
+
+query II
+SELECT id, arr FROM test;
+----
+1	[replaced]
+
+# --- Variant 4: INSERT ... ON CONFLICT DO UPDATE (same PK) ---
+statement ok
+INSERT INTO test VALUES (1, ['conflict']) ON CONFLICT (id) DO UPDATE SET arr = EXCLUDED.arr;
+
+query II
+SELECT id, arr FROM test;
+----
+1	[conflict]
+
+# child reference must still be intact after all those updates
+query IT
+SELECT test_id, val FROM test_fk;
+----
+1	blkaj
+
+# --- Regression: a genuine FK violation must STILL be rejected ---
+
+# deleting the referenced parent row must fail
+statement error
+DELETE FROM test WHERE id = 1;
+----
+<REGEX>:.*Constraint Error.*foreign key.*
+
+# updating the PK column to a value the child does not reference must fail
+statement error
+UPDATE test SET id = 99 WHERE id = 1;
+----
+<REGEX>:.*Constraint Error.*foreign key.*
+
+# inserting a child row referencing a non-existent parent must fail
+statement error
+INSERT INTO test_fk VALUES (12345, 'orphan');
+----
+<REGEX>:.*Constraint Error.*foreign key.*
+
+# --- Related types: STRUCT and MAP columns (issues #16354, #11288, #11915, #15830) ---
+
+statement ok
+CREATE TABLE p2 (id INTEGER PRIMARY KEY, s STRUCT(a INTEGER, b VARCHAR));
+
+statement ok
+INSERT INTO p2 VALUES (1, {'a': 1, 'b': 'x'});
+
+statement ok
+CREATE TABLE c2 (pid INTEGER REFERENCES p2 (id));
+
+statement ok
+INSERT INTO c2 VALUES (1);
+
+statement ok
+UPDATE p2 SET s = {'a': 2, 'b': 'y'} WHERE id = 1;
+
+query I
+SELECT pid FROM c2;
+----
+1

--- a/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
+++ b/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
@@ -44,9 +44,14 @@ statement ok
 ATTACH '{TEST_DIR}/test_fk_eager.db' AS fk_db;
 
 # Now, we try to update the PK table.
-# The over-eager constraint checking fix is not yet supported for FKs, thus, we throw a constraint violation.
-statement error
+# Updating only a non-PK column (here, payload) must NOT raise a spurious FK violation —
+# the matching INSERT half of the DELETE+INSERT rewrite re-adds the same PK. See issue #16409.
+statement ok
 UPDATE fk_db.tbl_pk SET payload = {'v': 'new hello', 'i': [7]} WHERE i = 1;
+
+query IT
+SELECT i, payload FROM fk_db.tbl_pk ORDER BY i;
 ----
-<REGEX>:Constraint Error.*Violates foreign key constraint because.*
+1	{'v': new hello, 'i': [7]}
+2	{'v': world, 'i': [43]}
 


### PR DESCRIPTION
Fixes #16409.

Updating a LIST/ARRAY/STRUCT/MAP column on a table referenced by a foreign key can raise a foreign-key violation even when the referenced key is unchanged. The update is rewritten as DELETE + INSERT, and the transient delete incorrectly checks whether the unchanged key is still referenced.

This change skips the delete-side check only when all referenced key columns are disjoint from the actual update assignments and none of the foreign keys is self-referential. Insert-side checks and checks for real deletes or referenced-key changes remain in place. The same handling applies to UPDATE, MERGE, INSERT OR REPLACE, and ON CONFLICT DO UPDATE.

The assignment set is captured before CHECK constraints and RETURNING add unchanged columns to the projection. Self-referential foreign keys (#16436) remain outside this change.

Updated against current main, preserving its UPDATE/MERGE behavior and assigning the LogicalUpdate flag serialization ID 210 to avoid the new upstream fields.

Validation:
- Built the merged branch and test extension fixtures locally.
- Expanded regression test: 45 assertions passed, including RETURNING, CHECK constraints, explicit MERGE, and rejection of genuine key changes.
- Constraint/UPDATE tests: 99 test cases passed.
- MERGE/upsert tests: 74 test cases passed.
- Foreign-key tests passed with logical-plan serialization verification and with persistent storage (28 test cases per configuration).
- Changed-file formatting and whitespace checks passed.

- Full local unit suite: 6,933 passed, 451 skipped by test directives or unavailable extension/platform requirements (535 seconds).

[Fork CI](https://github.com/berges99/duckdb/actions/runs/35353131950) is running; its preparation and formatting gate passed.
