### PR TITLE
Normalize version number in CMake version config

### DIFF
--- a/DuckDBConfigVersion.cmake.in
+++ b/DuckDBConfigVersion.cmake.in
@@ -1,5 +1,11 @@
 set(PACKAGE_VERSION "@DUCKDB_VERSION@")
 
+# The format of DUCKDB_VERSION is either:
+#   - v1.2.3
+#   - v1.2.3-devxxxx
+# CMake won't recognize these formats. Leave "1.2.3" only.
+string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)" "\\1" PACKAGE_VERSION "${PACKAGE_VERSION}")
+
 if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
     set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()


### PR DESCRIPTION
In `DuckDBConfigVersion.cmake`, the value of `DUCKDB_VERSION` is interpreted as a CMake-compatible version number and compared against the user-specified version number. However, a typical `DUCKDB_VERSION` value is of the form `v1.2.3` or `v1.2.3-devxxxx`, neither of which can be recognized by CMake. This leads to a broken version check when trying to import DuckDB through CMake's `find_package` command.

This patch "normalizes" the value of `DUCKDB_VERSION` in `DuckDBConfigVersion.cmake` by removing the leading "v" and any trailing non-numerical suffix after the patch number, before performing the version check.