### PR TITLE
Fix hang in PartitionedCopyState with regression test

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -360,6 +360,7 @@ public:
 
 public:
 	bool ShouldInitiateFlush(const idx_t &local_append_count);
+	bool IsCombineComplete() const DUCKDB_REQUIRES(lock);
 	void CreateTaskList() DUCKDB_REQUIRES(lock);
 	bool HasCompleted() const;
 	optional<PartitionedCopyTask> TryAssignTask();
@@ -843,6 +844,10 @@ bool PartitionedCopyState::ShouldInitiateFlush(const idx_t &local_append_count) 
 	return total_count / unique_count >= Settings::Get<PartitionedWriteFlushThresholdSetting>(partitioned_copy.context);
 }
 
+bool PartitionedCopyState::IsCombineComplete() const {
+	return combined == locals;
+}
+
 void PartitionedCopyState::CreateTaskList() {
 	global_source_state =
 	    partitioned_copy.sort_strategy->GetGlobalSourceState(partitioned_copy.context, *global_sink_state);
@@ -913,7 +918,6 @@ optional<PartitionedCopyTask> PartitionedCopyState::TryAssignTask() {
 	while (next_group < partition_blocks.size()) {
 		const auto group_idx = partition_blocks[next_group++].second;
 		active_groups.emplace_back(group_idx);
-
 		auto &hash_group = hash_groups[group_idx];
 		annotated_lock_guard<annotated_mutex> guard(hash_group->lock);
 		hash_group->TryPrepareNextStage();
@@ -1225,9 +1229,18 @@ void PartitionedCopy::Flush(ExecutionContext &execution_context, InterruptState 
 
 	{
 		annotated_lock_guard<annotated_mutex> guard(flushing_state_copy->lock);
+		D_ASSERT(flushing_state_copy->combined <= flushing_state_copy->locals);
 		if (!flushing_state_copy->global_source_state) {
-			return; // Finalization not yet complete, nothing to do
+			if (!flushing_state_copy->IsCombineComplete()) {
+				return; // Combine not complete yet
+			}
+			D_ASSERT(flushing_state_copy->IsCombineComplete());
+			FinalizeState(*flushing_state_copy, interrupt_state);
+			if (!flushing_state_copy->global_source_state) {
+				return; // Finalization not yet complete, nothing to do
+			}
 		}
+		D_ASSERT(flushing_state_copy->global_source_state);
 	}
 
 	if (ShouldStopFlushing()) {

--- a/test/sql/copy/partitioned/partitioned_order_by_flush_race.test
+++ b/test/sql/copy/partitioned/partitioned_order_by_flush_race.test
@@ -1,0 +1,38 @@
+# name: test/sql/copy/partitioned/partitioned_order_by_flush_race.test
+# description: Regression test for intermittent hang in partitioned COPY ORDER_BY intermediate flushing
+# group: [partitioned]
+
+require parquet
+
+statement ok
+SET debug_force_external=true;
+
+statement ok
+PRAGMA threads=6;
+
+statement ok
+SET partitioned_write_flush_threshold=2048;
+
+# Intentionally high parallelism + many iterations: this amplifies the
+# intermediate-flush scheduling race window that previously caused hangs.
+loop i 0 20
+
+statement ok
+CREATE OR REPLACE TABLE large_ordered_source AS
+SELECT
+	(i % 16)::INTEGER AS p,
+	((i * 17) % 65536)::INTEGER AS v
+FROM range(524288) tbl(i);
+
+statement ok
+COPY (SELECT p, v FROM large_ordered_source ORDER BY v DESC, p DESC)
+TO '{TEST_DIR}/large_ordered_partitioned_{i}'
+(FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (p, v), ROW_GROUP_SIZE 2048);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/large_ordered_partitioned_{i}/**/*.parquet', hive_partitioning = true);
+----
+524288
+
+endloop


### PR DESCRIPTION
### Test timeouts on main

Multiple timeouts happened for the [same](https://github.com/duckdb/duckdb/actions/runs/26582773380/job/78321912631#step:8:321) [test](https://github.com/duckdb/duckdb/actions/runs/26582773380/job/78321912631#step:8:321) [in](https://github.com/duckdb/duckdb/actions/runs/26580988638/job/78318138359#step:8:263) different CI runs when running tests with `--test-config test/configs/force_external.json`:
```shell
  batch timed out after 600 seconds
  
  === stdout ===
  
  [0/10] (0%): test/sql/copy/partitioned/hive_partitioned_write.test
  [1/10] (10%): test/sql/copy/partitioned/hive_partition_case_insensitive_column.test
  [2/10] (20%): test/sql/copy/partitioned/hive_partition_append.test
  [3/10] (30%): test/sql/copy/partitioned/partitioned_window.test
  [4/10] (40%): test/sql/copy/partitioned/hive_partition_join_pushdown.test
  [5/10] (50%): test/sql/copy/partitioned/partition_issue_6304.test
  [6/10] (60%): test/sql/copy/partitioned/partitioned_order_by.test  # <-- hangs
```

I noticed the timeout because the CI job `linux-release-configs` on branch `main` started to take much longer in namespace's job analytics:

<img width="932" height="401" alt="Screenshot 2026-05-28 at 21 36 21" src="https://github.com/user-attachments/assets/53a0766f-30c3-4bec-a308-483a21b83cda" />


### Stacktrace when hanging

I reproduced the hang locally (it happened a few times per ~10 test runs) for a release build on my laptop:
```shell
GEN=ninja DUCKDB_EXTENSIONS='icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs' \
DISABLE_SANITIZER=1 BUILD_BENCHMARK=1 BUILD_JEMALLOC=1 \
make clean release VCPKG_TOOLCHAIN_PATH="$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake";
```

I asked Codex to create a reproducing test `test/sql/copy/partitioned/partitioned_order_by_flush_race.test` that hanged without any code changes.

Next, I asked Codex to use `sample` on macOS on the hung `unittest` process. It showed threads spending most time here:

- `PartitionedCopyFinalizeTask::ExecuteTask`
- `PartitionedCopy::Flush`
- heavy `pthread_mutex_lock` / `__psynch_mutexwait`

### Timeout cause

The timeout was caused by a race during **partitioned COPY flush/finalize**.

In some runs, `Flush()` was called while `flushing_state->global_source_state` was still null.
At that moment, the code just returned early with “nothing to do”.

The problem: if combine had already finished (`combined == locals`), that state actually *was* ready to be finalized, but we skipped finalization and kept looping. Under `force_external`, this could repeat and eventually hit the timeout (`600s`!).


### Fix

In `PartitionedCopy::Flush`, when `global_source_state` is null:

1. If combine is **not** done yet, return as before.
2. If combine **is** done (`combined == locals`), call `FinalizeState(...)` immediately.
3. Then continue normal flush work.

So instead of waiting for some other path to finalize, `Flush()` now finalizes lazily as soon as it has enough information, preventing the stuck loop.