### PR TITLE
Make url a value, not a const ref

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -134,7 +134,7 @@ struct BaseRequest {
 	BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params);
 
 	RequestType type;
-	const string &url;
+	string url;
 	string path;
 	string proto_host_port;
 	HTTPHeaders headers;


### PR DESCRIPTION
BaseRequest has a const ref string as member making it very easy to create lifecycle issues