### PR TITLE
Fix SetVectorType for VectorStructBuffer

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -2,36 +2,23 @@
 #include "duckdb/common/vector/constant_vector.hpp"
 #include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/fsst_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
-#include "duckdb/common/vector/map_vector.hpp"
 #include "duckdb/common/vector/sequence_vector.hpp"
 #include "duckdb/common/vector/shredded_vector.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
-#include "duckdb/common/vector/union_vector.hpp"
-#include "duckdb/common/vector/variant_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
-
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/fsst.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
-#include "duckdb/common/type_visitor.hpp"
-#include "duckdb/common/types/bit.hpp"
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/types/sel_cache.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/types/value_map.hpp"
-#include "duckdb/common/types/bignum.hpp"
-#include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/common/types/vector_cache.hpp"
-#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
-#include "duckdb/storage/buffer/buffer_handle.hpp"
-#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -845,6 +832,18 @@ void Vector::SetVectorType(VectorType new_vector_type) {
 		// FIXME: should we allow vectors without a buffer?
 		BufferMutable().SetVectorType(new_vector_type);
 	}
+}
+
+void Vector::FlattenAndSetConstant() {
+	if (GetVectorType() != VectorType::FLAT_VECTOR && GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		Flatten();
+	}
+	// Struct buffers propagate vector type changes to their children. A flat or constant struct vector can still
+	// contain non-flat descendants, e.g. after slicing a list of structs, so normalize only those descendants first.
+	if (GetType().InternalType() == PhysicalType::STRUCT) {
+		BufferMutable().Cast<VectorStructBuffer>().PrepareChildrenForSetConstant();
+	}
+	SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void Vector::Verify(idx_t) const {

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/vector/constant_vector.hpp"
 #include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
@@ -42,6 +43,17 @@ void VectorStructBuffer::SetVectorType(VectorType new_vector_type) {
 	vector_type = new_vector_type;
 	for (auto &child : children) {
 		child.SetVectorType(new_vector_type);
+	}
+}
+
+void VectorStructBuffer::PrepareChildrenForSetConstant() {
+	for (auto &child : children) {
+		if (child.GetVectorType() != VectorType::FLAT_VECTOR && child.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			child.Flatten();
+		}
+		if (child.GetType().InternalType() == PhysicalType::STRUCT) {
+			child.BufferMutable().Cast<VectorStructBuffer>().PrepareChildrenForSetConstant();
+		}
 	}
 }
 

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -1,7 +1,5 @@
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 
 namespace duckdb {
@@ -60,11 +58,7 @@ void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionStat
 		// restore the size of the input vector
 		FlatVector::SetSize(child, count);
 		// ensure the result type is constant
-		if (result.GetVectorType() != VectorType::FLAT_VECTOR &&
-		    result.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.Flatten();
-		}
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.FlattenAndSetConstant();
 	}
 	FlatVector::SetSize(result, count_t(count));
 }

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -1,8 +1,6 @@
-#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -241,11 +239,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 		}
 		arguments.SetChildCardinality(count);
 		// ensure the result type is constant
-		if (result.GetVectorType() != VectorType::FLAT_VECTOR &&
-		    result.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.Flatten();
-		}
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.FlattenAndSetConstant();
 	}
 	FlatVector::SetSize(result, count_t(count));
 
@@ -287,11 +281,7 @@ idx_t ExpressionExecutor::Select(const BoundFunctionExpression &expr, Expression
 		Vector result(LogicalType::BOOLEAN);
 		if (expr.function.HasFunctionCallback()) {
 			expr.function.GetFunctionCallback()(arguments, *state, result);
-			if (result.GetVectorType() != VectorType::FLAT_VECTOR &&
-			    result.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-				result.Flatten();
-			}
-			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			result.FlattenAndSetConstant();
 		} else {
 			ExecuteConstantSelectFunction(expr, arguments, *state, result);
 		}

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -204,6 +204,7 @@ public:
 
 	// Setters
 	DUCKDB_API void SetVectorType(VectorType vector_type);
+	DUCKDB_API void FlattenAndSetConstant();
 
 	// Transform vector to an equivalent dictionary vector
 	static void DebugTransformToDictionary(Vector &vector);

--- a/src/include/duckdb/common/vector/struct_vector.hpp
+++ b/src/include/duckdb/common/vector/struct_vector.hpp
@@ -42,6 +42,7 @@ public:
 		return children;
 	}
 	void SetVectorType(VectorType vector_type) override;
+	void PrepareChildrenForSetConstant();
 
 public:
 	idx_t GetDataSize(const LogicalType &type, idx_t count) const override;

--- a/test/sql/types/nested/list/test_list_extract.test
+++ b/test/sql/types/nested/list/test_list_extract.test
@@ -68,6 +68,36 @@ SELECT LIST_EXTRACT(LIST_VALUE(42, 43, 44, 45), -5)
 ----
 NULL
 
+query TI
+SELECT ([{ t:'abc', len:5 }][1]).t, ([{ t:'abc', len:5 }][1]).len
+----
+abc	5
+
+statement error
+SELECT [{ t:'abc', len:5 }][1]=1
+----
+<REGEX>:.*Conversion Error: Unimplemented type for cast \(INTEGER -> STRUCT\(t VARCHAR, len INTEGER\)\).*
+
+query I
+SELECT ([{ parent: { t:'abc', len:5 } }][1]).parent.len
+----
+5
+
+statement error
+SELECT [{ parent: { t:'abc', len:5 } }][1]=1
+----
+<REGEX>:.*Conversion Error:.*INTEGER -> STRUCT.*
+
+query T
+SELECT ([{ parent: { child: { t:'abc' } }, n: 42 }][1]).parent.child.t
+----
+abc
+
+statement error
+SELECT [{ parent: { child: { t:'abc' } }, n: 42 }][1]=1
+----
+<REGEX>:.*Conversion Error:.*INTEGER -> STRUCT.*
+
 query I
 SELECT LIST_EXTRACT(LIST_VALUE(42), 2)
 ----
@@ -227,4 +257,3 @@ query I
 SELECT list_extract(a, 0) FROM list_array_table;
 ----
 NULL
-


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/9258

`VectorStructBuffer` is initialized as a `FLAT_VECTOR` but its child vectors may be dictionary vectors or others. However, there are some places where we want to set a vector type to `CONSTANT_VECTOR` and assume it is allowed because the current vector type is flat. That is not necessarily true for nested data types, specifically `STRUCT`, where this results in an error if any of the children is not flat and not constant.