### PR TITLE
Colocation of index buffers in blocks

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -1042,7 +1042,8 @@ IndexStorageInfo ART::PrepareSerialize(const case_insensitive_map_t<Value> &opti
 	return info;
 }
 
-IndexStorageInfo ART::SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) {
+IndexStorageInfo ART::SerializeToDisk(const case_insensitive_map_t<Value> &options,
+                                      PartialBlockManager &partial_block_manager) {
 	lock_guard<mutex> guard(lock);
 
 	// If the storage format uses deprecated leaf storage,
@@ -1053,7 +1054,7 @@ IndexStorageInfo ART::SerializeToDisk(QueryContext context, const case_insensiti
 	auto allocator_count = v1_0_0_storage ? DEPRECATED_ALLOCATOR_COUNT : ALLOCATOR_COUNT;
 
 	// Store the data on disk as partial blocks and set the block ids.
-	WritePartialBlocks(context, v1_0_0_storage);
+	WritePartialBlocks(partial_block_manager, v1_0_0_storage);
 
 	for (idx_t i = 0; i < allocator_count; i++) {
 		info.allocator_infos.push_back((*allocators)[i]->GetInfo());
@@ -1082,15 +1083,11 @@ IndexStorageInfo ART::SerializeToWAL(const case_insensitive_map_t<Value> &option
 	return info;
 }
 
-void ART::WritePartialBlocks(QueryContext context, const bool v1_0_0_storage) {
-	auto &block_manager = table_io_manager.GetIndexBlockManager();
-	PartialBlockManager partial_block_manager(context, block_manager, PartialBlockType::FULL_CHECKPOINT);
-
+void ART::WritePartialBlocks(PartialBlockManager &partial_block_manager, const bool v1_0_0_storage) {
 	idx_t allocator_count = v1_0_0_storage ? DEPRECATED_ALLOCATOR_COUNT : ALLOCATOR_COUNT;
 	for (idx_t i = 0; i < allocator_count; i++) {
 		(*allocators)[i]->SerializeBuffers(partial_block_manager);
 	}
-	partial_block_manager.FlushPartialBlocks();
 }
 
 void ART::InitAllocators(const IndexStorageInfo &info) {

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -170,7 +170,8 @@ unique_ptr<BoundIndex> BoundIndex::CreateDeltaIndex(DeltaIndexType delta_index_t
 	throw InternalException("BoundIndex::CreateDeltaIndex is not supported for this index type");
 }
 
-IndexStorageInfo BoundIndex::SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) {
+IndexStorageInfo BoundIndex::SerializeToDisk(const case_insensitive_map_t<Value> &options,
+                                             PartialBlockManager &partial_block_manager) {
 	throw NotImplementedException("The implementation of this index disk serialization does not exist.");
 }
 

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -133,7 +133,8 @@ public:
 	void Vacuum(IndexLock &state) override;
 
 	//! Serializes ART memory to disk and returns the ART storage information.
-	IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) override;
+	IndexStorageInfo SerializeToDisk(const case_insensitive_map_t<Value> &options,
+	                                 PartialBlockManager &partial_block_manager) override;
 	//! Serializes ART memory to the WAL and returns the ART storage information.
 	IndexStorageInfo SerializeToWAL(const case_insensitive_map_t<Value> &options) override;
 
@@ -193,7 +194,7 @@ private:
 	void TransformToDeprecated();
 	IndexStorageInfo PrepareSerialize(const case_insensitive_map_t<Value> &options, const bool v1_0_0_storage);
 	void Deserialize(const BlockPointer &pointer);
-	void WritePartialBlocks(QueryContext context, const bool v1_0_0_storage);
+	void WritePartialBlocks(PartialBlockManager &partial_block_manager, const bool v1_0_0_storage);
 	void SetPrefixCount(const IndexStorageInfo &info);
 
 	string ToStringInternal(bool display_ascii);

--- a/src/include/duckdb/execution/index/bound_index.hpp
+++ b/src/include/duckdb/execution/index/bound_index.hpp
@@ -193,7 +193,8 @@ public:
 	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;
 
 	//! Serializes index memory to disk and returns the index storage information.
-	virtual IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options);
+	virtual IndexStorageInfo SerializeToDisk(const case_insensitive_map_t<Value> &options,
+	                                         PartialBlockManager &partial_block_manager);
 	//! Serializes index memory to the WAL and returns the index storage information.
 	virtual IndexStorageInfo SerializeToWAL(const case_insensitive_map_t<Value> &options);
 

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -148,6 +148,9 @@ public:
 	unique_ptr<TableDataWriter> GetTableDataWriter(TableCatalogEntry &table) override;
 
 	BlockManager &GetBlockManager();
+	PartialBlockManager &GetIndexPartialBlockManager() {
+		return index_partial_block_manager;
+	};
 	CheckpointOptions GetCheckpointOptions() const {
 		return options;
 	}
@@ -167,6 +170,8 @@ private:
 	//! Because this is single-file storage, we can share partial blocks across
 	//! an entire checkpoint.
 	PartialBlockManager partial_block_manager;
+	//! Share partial blocks between indexes across the entire checkpoint.
+	PartialBlockManager index_partial_block_manager;
 	//! Checkpoint type
 	CheckpointOptions options;
 	//! Block usage count for verification purposes

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -150,7 +150,7 @@ public:
 	BlockManager &GetBlockManager();
 	PartialBlockManager &GetIndexPartialBlockManager() {
 		return index_partial_block_manager;
-	};
+	}
 	CheckpointOptions GetCheckpointOptions() const {
 		return options;
 	}

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -107,7 +107,8 @@ public:
 	//! Get the combined column ids of the indexes.
 	unordered_set<column_t> GetRequiredColumns();
 	//! Serialize all indexes of the table.
-	IndexSerializationResult SerializeToDisk(QueryContext context, const IndexSerializationInfo &info);
+	IndexSerializationResult SerializeToDisk(const IndexSerializationInfo &info,
+	                                         PartialBlockManager &partial_block_manager);
 
 public:
 	//! Initialize an index_chunk from a table.

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -189,7 +189,8 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	}
 	serialization_info.checkpoint_id = GetCheckpointOptions().transaction_id;
 
-	auto index_storage_infos = info.GetIndexes().SerializeToDisk(context, serialization_info);
+	auto &partial_block_manager = checkpoint_manager.GetIndexPartialBlockManager();
+	auto index_storage_infos = info.GetIndexes().SerializeToDisk(serialization_info, partial_block_manager);
 
 	if (debug_verify_blocks) {
 		for (auto &entry : index_storage_infos.ordered_infos) {

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -88,7 +88,8 @@ void ReorderTableEntries(catalog_entry_vector_t &tables);
 SingleFileCheckpointWriter::SingleFileCheckpointWriter(QueryContext context, AttachedDatabase &db,
                                                        BlockManager &block_manager, CheckpointOptions options_p)
     : CheckpointWriter(db), context(context.GetClientContext()),
-      partial_block_manager(context, block_manager, PartialBlockType::FULL_CHECKPOINT), options(options_p) {
+      partial_block_manager(context, block_manager, PartialBlockType::FULL_CHECKPOINT),
+      index_partial_block_manager(context, block_manager, PartialBlockType::FULL_CHECKPOINT), options(options_p) {
 }
 
 BlockManager &SingleFileCheckpointWriter::GetBlockManager() {
@@ -273,6 +274,8 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 			list.WriteObject([&](Serializer &obj) { WriteEntry(entry.get(), obj); });
 		});
 		serializer.End();
+
+		index_partial_block_manager.FlushPartialBlocks();
 
 		metadata_writer->Flush();
 		table_metadata_writer->Flush();

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -311,7 +311,8 @@ unordered_set<column_t> TableIndexList::GetRequiredColumns() {
 	return column_ids;
 }
 
-IndexSerializationResult TableIndexList::SerializeToDisk(QueryContext context, const IndexSerializationInfo &info) {
+IndexSerializationResult TableIndexList::SerializeToDisk(const IndexSerializationInfo &info,
+                                                         PartialBlockManager &partial_block_manager) {
 	lock_guard<mutex> lock(index_entries_lock);
 
 	IndexSerializationResult result;
@@ -334,7 +335,7 @@ IndexSerializationResult TableIndexList::SerializeToDisk(QueryContext context, c
 		}
 		// Bound: move new storage info into bound_infos, then reference it
 		auto &bound_index = index.Cast<BoundIndex>();
-		auto storage_info = bound_index.SerializeToDisk(context, info.options);
+		auto storage_info = bound_index.SerializeToDisk(info.options, partial_block_manager);
 		D_ASSERT(storage_info.IsValid() && !storage_info.name.empty());
 		result.bound_infos.push_back(std::move(storage_info));
 		result.ordered_infos.push_back(result.bound_infos.back());


### PR DESCRIPTION
First part of https://github.com/duckdblabs/duckdb-internal/issues/8449. Previously colocation of index buffers was only supported for buffers of the same index. This PR adds colocation of index buffers for two additional cases:

- Buffers from different indexes that share the same table
- Buffers from different indexes and different tables

This is achieved by lifting the existing `PartialBlockManager` higher up in the checkpointing call stack, and this allocator is now part of `SingleFileCheckpointWriter` so it persists between serialization of tables.

## Results

To test/verify the impact of the changes I made a database file before and after the changes in this PR. This database file consists of 8 tables, each table having 16 `int32` columns plus `id`, filled with 4 rows. Then for each table we constructed 20 indexes.

### Before

| database_size | block_size | total_blocks | used_blocks | free_blocks |
| --- | --- | --- | --- | --- |
| 42.7 MiB      |     262144 |         171 |        171 |    0 |

### After

| database_size | block_size | total_blocks | used_blocks | free_blocks |
| --- | --- | --- | --- | --- |
| 3.2 MiB      |     262144 |         13 |        13 |    0 |