### PR TITLE
use StringUtil::CharacterIsDigit in Bignum::VarcharFormatting

### DIFF
--- a/src/common/types/bignum.cpp
+++ b/src/common/types/bignum.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/types/bignum.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include <cmath>
 
@@ -136,7 +137,7 @@ bool Bignum::VarcharFormatting(const string_t &value, idx_t &start_pos, idx_t &e
 	}
 	idx_t cur_pos = start_pos;
 	// Verify all is numeric
-	while (cur_pos < end_pos && std::isdigit(int_value_char[cur_pos])) {
+	while (cur_pos < end_pos && StringUtil::CharacterIsDigit(int_value_char[cur_pos])) {
 		cur_pos++;
 	}
 	if (cur_pos < end_pos) {
@@ -149,7 +150,7 @@ bool Bignum::VarcharFormatting(const string_t &value, idx_t &start_pos, idx_t &e
 		}
 
 		while (cur_pos < end_pos) {
-			if (std::isdigit(int_value_char[cur_pos])) {
+			if (StringUtil::CharacterIsDigit(int_value_char[cur_pos])) {
 				cur_pos++;
 			} else {
 				// By now we can only have numbers, otherwise this is invalid.

--- a/test/sql/types/bignum/test_bignum_varchar_invalid.test
+++ b/test/sql/types/bignum/test_bignum_varchar_invalid.test
@@ -1,0 +1,24 @@
+# name: test/sql/types/bignum/test_bignum_varchar_invalid.test
+# description: Test VARCHAR -> BIGNUM cast of strings with non-ascii bytes
+# group: [bignum]
+
+# high-bit bytes (signed char < 0) must be rejected as non-numeric, not fed to a ctype function
+statement error
+SELECT 'ä'::BIGNUM
+----
+<REGEX>:.*Conversion Error.*
+
+statement error
+SELECT '12ä34'::BIGNUM
+----
+<REGEX>:.*Conversion Error.*
+
+statement error
+SELECT '€'::BIGNUM
+----
+<REGEX>:.*Conversion Error.*
+
+query I
+SELECT '12345'::BIGNUM
+----
+12345


### PR DESCRIPTION
VarcharFormatting feeds int_value_char[cur_pos] straight into std::isdigit while parsing a VARCHAR being cast to BIGNUM. char is signed here, so a non-ascii byte (e.g. casting 'ä' or '€') is passed as a negative value, which is undefined for the ctype functions. The rest of src/common/types already uses StringUtil::CharacterIsDigit for exactly this reason; switching to it keeps the parse ascii-only and drops the signed-char hazard.