### PR TITLE
Fix external file cache disablement

### DIFF
--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -36,7 +36,7 @@ public:
 
 public:
 	DUCKDB_API CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system, const OpenFileInfo &path,
-	                             FileOpenFlags flags, optional_ptr<FileOpener> opener, CachedFile &cached_file);
+	                             FileOpenFlags flags, optional_ptr<FileOpener> opener);
 	DUCKDB_API ~CachingFileHandle();
 
 public:
@@ -78,8 +78,8 @@ private:
 	optional_ptr<FileOpener> opener;
 	//! Cache validation mode for this file
 	CacheValidationMode validate;
-	//! The associated CachedFile with cached blocks
-	CachedFile &cached_file;
+	//! Associated cached file.
+	shared_ptr<CachedFile> cached_file;
 
 	//! Used to ensure file handle and cached file metadata is only initialized once.
 	annotated_mutex file_handle_mutex;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -62,6 +62,8 @@ public:
 private:
 	//! Remove the 'force_full_download' option from the file handle if present, and return whether it was present
 	bool StripForceFullDownloadIfPresent();
+	//! Refresh the cached file if the global cache state has changed.
+	shared_ptr<CachedFile> EnsureCachedFileCurrent();
 
 private:
 	QueryContext context;

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -70,6 +70,8 @@ public:
 	bool IsEnabled() const;
 	void SetEnabled(bool enable);
 	vector<CachedFileInformation> GetCachedFileInformation() const;
+	//! Number of files tracked in the cache map, expose for testing purpose.
+	idx_t GetCachedFileCount() const;
 
 	//! Re-index to `current_block_size` if it differs from the cache block size.
 	//! Return the blocks cached for the given range.
@@ -77,8 +79,9 @@ public:
 	                                                       idx_t first_block, idx_t num_blocks);
 
 	BufferManager &GetBufferManager() const;
-	//! Gets the cached file, or creates it if is not yet present
-	CachedFile &GetOrCreateCachedFile(const string &path);
+	//! Gets the shared cached file for the given path, creating it if not yet present.
+	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
+	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
 
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
@@ -93,7 +96,7 @@ private:
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
 	//! Mapping from file path to cached file with cached blocks
-	unordered_map<string, unique_ptr<CachedFile>> cached_files;
+	unordered_map<string, shared_ptr<CachedFile>> cached_files;
 	//! Lock for accessing the cached files
 	mutable mutex lock;
 };

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -38,13 +38,14 @@ public:
 	//! Cached files
 	struct CachedFile {
 	public:
-		explicit CachedFile(string path_p);
+		CachedFile(string path_p, idx_t generation_p);
 
 	public:
 		//! Whether the CachedFile is still valid given the current modified/version tag
 		bool IsValid(bool validate, const string &current_version_tag, timestamp_t current_last_modified);
 
 		const string path;
+		const idx_t generation;
 
 		mutable annotated_mutex map_lock;
 		//! The block size used to index the current block map. Invalid if no blocks have been cached yet.
@@ -69,6 +70,7 @@ public:
 
 	bool IsEnabled() const;
 	void SetEnabled(bool enable);
+	idx_t GetGeneration() const;
 	vector<CachedFileInformation> GetCachedFileInformation() const;
 	//! Number of files tracked in the cache map, expose for testing purpose.
 	idx_t GetCachedFileCount() const;
@@ -95,6 +97,8 @@ private:
 	BufferManager &buffer_manager;
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
+	//! Generation counter, incremented whenever cache enablement changes.
+	atomic<idx_t> generation;
 	//! Mapping from file path to cached file with cached blocks
 	unordered_map<string, shared_ptr<CachedFile>> cached_files;
 	//! Lock for accessing the cached files

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -161,6 +161,26 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 	return true;
 }
 
+shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCurrent() {
+	bool needs_reopen = false;
+	{
+		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		if (cached_file && cached_file->generation == external_file_cache.GetGeneration()) {
+			return cached_file;
+		}
+		needs_reopen = file_handle != nullptr;
+		if (needs_reopen) {
+			file_handle.reset();
+		}
+		cached_file = external_file_cache.GetOrCreateCachedFile(path.path);
+	}
+
+	if (needs_reopen) {
+		GetFileHandle();
+	}
+	return cached_file;
+}
+
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
                                      optional_ptr<FileOpener> opener_p)
@@ -168,7 +188,8 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
       external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
-      cached_file(external_file_cache.GetOrCreateCachedFile(path_p.path)), position(0) {
+      cached_file(nullptr), position(0) {
+	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
 	if (!external_file_cache.IsEnabled() || Validate()) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
@@ -235,13 +256,15 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return FileBufferHandleGroup(std::move(mem_handles));
 	}
 
-	const idx_t block_size = external_file_cache.GetCacheBlockSize(cached_file->path);
+	auto current_cached_file = EnsureCachedFileCurrent();
+	const idx_t block_size = external_file_cache.GetCacheBlockSize(current_cached_file->path);
 	const idx_t first_block = location / block_size;
 	const idx_t last_block = (location + nr_bytes - 1) / block_size;
 	const idx_t num_blocks = last_block - first_block + 1;
 
 	// Atomically reindex (if needed) and acquire the block range.
-	auto blocks = external_file_cache.ReindexAndAcquireBlocks(*cached_file, block_size, first_block, num_blocks);
+	auto blocks =
+	    external_file_cache.ReindexAndAcquireBlocks(*current_cached_file, block_size, first_block, num_blocks);
 
 	// Schedule block fetch tasks for all blocks.
 	vector<BufferHandle> pins(num_blocks);
@@ -277,9 +300,9 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	// After all tasks complete, check if the cache was invalidated by another thread.
 	if (Validate()) {
-		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
-		if (!ExternalFileCache::IsValid(true, cached_file->version_tag, cached_file->last_modified, version_tag,
-		                                last_modified)) {
+		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
+		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
+		                                version_tag, last_modified)) {
 			for (auto &block : blocks) {
 				block->Reinit();
 			}
@@ -312,21 +335,23 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 }
 
 string CachingFileHandle::GetPath() const {
-	return cached_file->path;
+	return path.path;
 }
 
 idx_t CachingFileHandle::GetFileSize() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		return cached_file->file_size;
+		auto current_cached_file = EnsureCachedFileCurrent();
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		return current_cached_file->file_size;
 	}
 	return GetFileHandle().GetFileSize();
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		return cached_file->last_modified;
+		auto current_cached_file = EnsureCachedFileCurrent();
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		return current_cached_file->last_modified;
 	}
 	GetFileHandle();
 	return last_modified;
@@ -334,8 +359,9 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 
 string CachingFileHandle::GetVersionTag() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		return cached_file->version_tag;
+		auto current_cached_file = EnsureCachedFileCurrent();
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		return current_cached_file->version_tag;
 	}
 	GetFileHandle();
 	return version_tag;
@@ -346,7 +372,7 @@ bool CachingFileHandle::Validate() const {
 	case CacheValidationMode::VALIDATE_ALL:
 		return true;
 	case CacheValidationMode::VALIDATE_REMOTE:
-		return FileSystem::IsRemoteFile(cached_file->path);
+		return FileSystem::IsRemoteFile(path.path);
 	case CacheValidationMode::NO_VALIDATION:
 		return false;
 	default:
@@ -356,20 +382,22 @@ bool CachingFileHandle::Validate() const {
 
 bool CachingFileHandle::CanSeek() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		return cached_file->can_seek;
+		auto current_cached_file = EnsureCachedFileCurrent();
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		return current_cached_file->can_seek;
 	}
 	return GetFileHandle().CanSeek();
 }
 
 bool CachingFileHandle::IsRemoteFile() const {
-	return FileSystem::IsRemoteFile(cached_file->path);
+	return FileSystem::IsRemoteFile(path.path);
 }
 
 bool CachingFileHandle::OnDiskFile() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		return cached_file->on_disk_file;
+		auto current_cached_file = EnsureCachedFileCurrent();
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		return current_cached_file->on_disk_file;
 	}
 	return GetFileHandle().OnDiskFile();
 }

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -126,14 +126,12 @@ CachingFileSystem CachingFileSystem::Get(ClientContext &context) {
 
 unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
                                                           optional_ptr<FileOpener> opener) {
-	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener,
-	                                    external_file_cache.GetOrCreateCachedFile(path.path));
+	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener);
 }
 
 unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, const OpenFileInfo &path,
                                                           FileOpenFlags flags, optional_ptr<FileOpener> opener) {
-	return make_uniq<CachingFileHandle>(context, *this, path, flags, opener,
-	                                    external_file_cache.GetOrCreateCachedFile(path.path));
+	return make_uniq<CachingFileHandle>(context, *this, path, flags, opener);
 }
 
 //===----------------------------------------------------------------------===//
@@ -165,12 +163,12 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
-                                     optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
+                                     optional_ptr<FileOpener> opener_p)
     : context(context), caching_file_system(caching_file_system_p),
       external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
-      cached_file(cached_file_p), position(0) {
+      cached_file(external_file_cache.GetOrCreateCachedFile(path_p.path)), position(0) {
 	if (!external_file_cache.IsEnabled() || Validate()) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
@@ -179,8 +177,8 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 	// If we don't have any cached blocks, we must also open the file.
 	bool needs_open = false;
 	{
-		annotated_lock_guard<annotated_mutex> guard(cached_file.map_lock);
-		needs_open = cached_file.blocks.empty();
+		annotated_lock_guard<annotated_mutex> guard(cached_file->map_lock);
+		needs_open = cached_file->blocks.empty();
 	}
 	if (needs_open) {
 		GetFileHandle();
@@ -205,20 +203,20 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 
 	{
-		annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-		const bool first_access = (cached_file.file_size == 0);
+		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
+		const bool first_access = (cached_file->file_size == 0);
 		if (first_access || Validate()) {
-			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified, version_tag,
-			                                last_modified)) {
-				annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
-				cached_file.blocks.clear();
-				cached_file.cached_block_size.SetInvalid();
+			if (!ExternalFileCache::IsValid(Validate(), cached_file->version_tag, cached_file->last_modified,
+			                                version_tag, last_modified)) {
+				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
+				cached_file->blocks.clear();
+				cached_file->cached_block_size.SetInvalid();
 			}
-			cached_file.file_size = file_handle->GetFileSize();
-			cached_file.last_modified = last_modified;
-			cached_file.version_tag = version_tag;
-			cached_file.can_seek = file_handle->CanSeek();
-			cached_file.on_disk_file = file_handle->OnDiskFile();
+			cached_file->file_size = file_handle->GetFileSize();
+			cached_file->last_modified = last_modified;
+			cached_file->version_tag = version_tag;
+			cached_file->can_seek = file_handle->CanSeek();
+			cached_file->on_disk_file = file_handle->OnDiskFile();
 		}
 	}
 	return *file_handle;
@@ -237,13 +235,13 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return FileBufferHandleGroup(std::move(mem_handles));
 	}
 
-	const idx_t block_size = external_file_cache.GetCacheBlockSize(cached_file.path);
+	const idx_t block_size = external_file_cache.GetCacheBlockSize(cached_file->path);
 	const idx_t first_block = location / block_size;
 	const idx_t last_block = (location + nr_bytes - 1) / block_size;
 	const idx_t num_blocks = last_block - first_block + 1;
 
 	// Atomically reindex (if needed) and acquire the block range.
-	auto blocks = external_file_cache.ReindexAndAcquireBlocks(cached_file, block_size, first_block, num_blocks);
+	auto blocks = external_file_cache.ReindexAndAcquireBlocks(*cached_file, block_size, first_block, num_blocks);
 
 	// Schedule block fetch tasks for all blocks.
 	vector<BufferHandle> pins(num_blocks);
@@ -279,8 +277,8 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	// After all tasks complete, check if the cache was invalidated by another thread.
 	if (Validate()) {
-		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-		if (!ExternalFileCache::IsValid(true, cached_file.version_tag, cached_file.last_modified, version_tag,
+		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
+		if (!ExternalFileCache::IsValid(true, cached_file->version_tag, cached_file->last_modified, version_tag,
 		                                last_modified)) {
 			for (auto &block : blocks) {
 				block->Reinit();
@@ -314,21 +312,21 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 }
 
 string CachingFileHandle::GetPath() const {
-	return cached_file.path;
+	return cached_file->path;
 }
 
 idx_t CachingFileHandle::GetFileSize() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
-		return cached_file.file_size;
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		return cached_file->file_size;
 	}
 	return GetFileHandle().GetFileSize();
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
-		return cached_file.last_modified;
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		return cached_file->last_modified;
 	}
 	GetFileHandle();
 	return last_modified;
@@ -336,8 +334,8 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 
 string CachingFileHandle::GetVersionTag() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
-		return cached_file.version_tag;
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		return cached_file->version_tag;
 	}
 	GetFileHandle();
 	return version_tag;
@@ -348,7 +346,7 @@ bool CachingFileHandle::Validate() const {
 	case CacheValidationMode::VALIDATE_ALL:
 		return true;
 	case CacheValidationMode::VALIDATE_REMOTE:
-		return FileSystem::IsRemoteFile(cached_file.path);
+		return FileSystem::IsRemoteFile(cached_file->path);
 	case CacheValidationMode::NO_VALIDATION:
 		return false;
 	default:
@@ -358,20 +356,20 @@ bool CachingFileHandle::Validate() const {
 
 bool CachingFileHandle::CanSeek() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
-		return cached_file.can_seek;
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		return cached_file->can_seek;
 	}
 	return GetFileHandle().CanSeek();
 }
 
 bool CachingFileHandle::IsRemoteFile() const {
-	return FileSystem::IsRemoteFile(cached_file.path);
+	return FileSystem::IsRemoteFile(cached_file->path);
 }
 
 bool CachingFileHandle::OnDiskFile() {
 	if (!Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
-		return cached_file.on_disk_file;
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		return cached_file->on_disk_file;
 	}
 	return GetFileHandle().OnDiskFile();
 }

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -146,7 +146,8 @@ vector<shared_ptr<CacheBlock>> ExternalFileCache::ReindexAndAcquireBlocks(Cached
 	return blocks;
 }
 
-ExternalFileCache::CachedFile::CachedFile(string path_p) : path(std::move(path_p)) {
+ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
+    : path(std::move(path_p)), generation(generation_p) {
 }
 
 bool ExternalFileCache::CachedFile::IsValid(bool validate, const string &current_version_tag,
@@ -192,7 +193,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)
-    : buffer_manager(BufferManager::GetBufferManager(db)), enable(enable_p) {
+    : buffer_manager(BufferManager::GetBufferManager(db)), enable(enable_p), generation(0) {
 }
 
 bool ExternalFileCache::IsEnabled() const {
@@ -201,10 +202,18 @@ bool ExternalFileCache::IsEnabled() const {
 
 void ExternalFileCache::SetEnabled(bool enable_p) {
 	lock_guard<mutex> guard(lock);
+	if (enable == enable_p) {
+		return;
+	}
 	enable = enable_p;
+	generation++;
 	if (!enable) {
 		cached_files.clear();
 	}
+}
+
+idx_t ExternalFileCache::GetGeneration() const {
+	return generation;
 }
 
 vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() const {
@@ -250,11 +259,11 @@ BufferManager &ExternalFileCache::GetBufferManager() const {
 shared_ptr<ExternalFileCache::CachedFile> ExternalFileCache::GetOrCreateCachedFile(const string &path) {
 	lock_guard<mutex> guard(lock);
 	if (!enable) {
-		return make_shared_ptr<CachedFile>(path);
+		return make_shared_ptr<CachedFile>(path, generation);
 	}
 	auto &entry = cached_files[path];
 	if (!entry) {
-		entry = make_shared_ptr<CachedFile>(path);
+		entry = make_shared_ptr<CachedFile>(path, generation);
 	}
 	return entry;
 }

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -230,6 +230,11 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 	return result;
 }
 
+idx_t ExternalFileCache::GetCachedFileCount() const {
+	const lock_guard<mutex> files_guard(lock);
+	return cached_files.size();
+}
+
 ExternalFileCache &ExternalFileCache::Get(DatabaseInstance &db) {
 	return db.GetExternalFileCache();
 }
@@ -242,13 +247,16 @@ BufferManager &ExternalFileCache::GetBufferManager() const {
 	return buffer_manager;
 }
 
-ExternalFileCache::CachedFile &ExternalFileCache::GetOrCreateCachedFile(const string &path) {
+shared_ptr<ExternalFileCache::CachedFile> ExternalFileCache::GetOrCreateCachedFile(const string &path) {
 	lock_guard<mutex> guard(lock);
+	if (!enable) {
+		return make_shared_ptr<CachedFile>(path);
+	}
 	auto &entry = cached_files[path];
 	if (!entry) {
-		entry = make_uniq<CachedFile>(path);
+		entry = make_shared_ptr<CachedFile>(path);
 	}
-	return *entry;
+	return entry;
 }
 
 } // namespace duckdb

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -39,6 +39,13 @@ string ReadFull(CachingFileHandle &handle, idx_t size, idx_t offset = 0) {
 	return result;
 }
 
+void WriteTestContent(const string &path, const string &content) {
+	auto local_fs = FileSystem::CreateLocal();
+	auto handle = local_fs->OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	handle->Write(QueryContext(), const_cast<char *>(content.data()), content.size(), 0);
+	handle->Sync();
+}
+
 idx_t CountCachedBlocks(ExternalFileCache &cache) {
 	return cache.GetCachedFileInformation().size();
 }
@@ -267,6 +274,31 @@ TEST_CASE("Disabled external file cache does not insert into cached_files", "[ex
 		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
 		REQUIRE(ReadFull(*handle, FILE_SIZE) == content);
 	}
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	const string content_a(64, 'A');
+	const string content_b(128, 'B');
+	EFCTestFileGuard test_file("test_efc_reenabled_live_handle_metadata.bin", content_a);
+
+	auto tracking_fs = make_uniq<EFCTrackingFileSystem>();
+	CachingFileSystem cfs(*tracking_fs, db_instance);
+
+	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(handle->GetFileSize() == content_a.size());
+	REQUIRE(cache.GetCachedFileCount() == 1);
+
+	cache.SetEnabled(false);
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	WriteTestContent(test_file.GetPath(), content_b);
+
+	cache.SetEnabled(true);
+	REQUIRE(handle->GetFileSize() == content_b.size());
 	REQUIRE(cache.GetCachedFileCount() == 1);
 }
 

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -234,6 +234,42 @@ TEST_CASE("Lazy reindex: only touched file is reindexed", "[external_file_cache]
 	REQUIRE(blocks_b == 8); // untouched: still 8 x 4KiB
 }
 
+TEST_CASE("Disabled external file cache does not insert into cached_files", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	const idx_t FILE_SIZE = 16384;
+	const auto content = MakeTestContent(FILE_SIZE);
+	EFCTestFileGuard test_file("test_efc_disabled.bin", content);
+
+	auto tracking_fs = make_uniq<EFCTrackingFileSystem>();
+	CachingFileSystem cfs(*tracking_fs, db_instance);
+
+	// Disable the cache.
+	cache.SetEnabled(false);
+	REQUIRE_FALSE(cache.IsEnabled());
+	REQUIRE(cache.GetCachedFileCount() == 0);
+
+	// Open and fully read the file with caching disabled.
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, FILE_SIZE) == content);
+	}
+
+	// With caching disabled, no entry should exist in the cache file map.
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	REQUIRE(CountCachedBlocks(cache) == 0);
+
+	// When cache enabled, opening and reading the file does populate the map.
+	cache.SetEnabled(true);
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, FILE_SIZE) == content);
+	}
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
 TEST_CASE("Concurrent SET and Read do not corrupt data or cache state", "[external_file_cache]") {
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;


### PR DESCRIPTION
Hi team, I found even when external file cache is disabled, we still populate the filepath in the `cached_files` map [here](https://github.com/duckdb/duckdb/blob/bbd990d55458620be783f90da2b3d92ace15c834/src/storage/external_file_cache/external_file_cache.cpp#L245-L252), which definitely doesn't match user expectation.

In this PR, no entries will be inserted into the map when cache disabled. To keep change set little, I decided to store `shared_ptr<CachedFile>` in the map, instead of a unique pointer so it could be returned to caching filesystem as well.

Another reason I think it a proper fix: I'm reworking https://github.com/duckdb/duckdb/pull/22857, a big challenge is to reason about the `CachedFile` ownership when external file cache disabled, thus clearing the whole map. Shared pointer makes implementation 10x easy without hurting clarity on `CachedFile` ownership.

v1.5 backport plan: since I rewrote the external file cache in latest main, it's quite different from what it is in v1.5, so if needed, I will backport two fix PRs together to v1.5, after they've been merged into main.
