### PR TITLE
Avoid join filter pushdown below limits

### DIFF
--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -95,9 +95,12 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 	auto &probe_child = op;
 	switch (probe_child.type) {
 	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		// LIMIT/TOP_N determines which rows are part of the probe side before the join.
+		// Pushing a join filter below it can change which rows survive the limit/offset.
+		break;
 	case LogicalOperatorType::LOGICAL_FILTER:
 	case LogicalOperatorType::LOGICAL_ORDER_BY:
-	case LogicalOperatorType::LOGICAL_TOP_N:
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:

--- a/test/sql/join/inner/test_inner_join_filter_pushdown.test
+++ b/test/sql/join/inner/test_inner_join_filter_pushdown.test
@@ -52,3 +52,31 @@ INNER JOIN right_table r ON l.id = r.id AND l.amount + r.budget > 1100;
 ----
 2	1	75	2	2	2000
 3	2	60	3	1	1500
+
+# join filter pushdown must not push below LIMIT/OFFSET
+statement ok
+CREATE TABLE ordered_probe(flag BOOLEAN, ord INTEGER);
+
+statement ok
+INSERT INTO ordered_probe VALUES (true, 1), (true, 2), (false, 3);
+
+statement ok
+CREATE TABLE boolean_keys(flag_key BOOLEAN);
+
+statement ok
+INSERT INTO boolean_keys VALUES (false);
+
+query II
+WITH c AS (
+	SELECT flag FROM ordered_probe ORDER BY ord OFFSET 2
+)
+SELECT * FROM c INNER JOIN boolean_keys ON flag = flag_key;
+----
+false	false
+
+query II
+WITH c AS (
+	SELECT flag FROM ordered_probe ORDER BY ord LIMIT 1
+)
+SELECT * FROM c INNER JOIN boolean_keys ON flag = flag_key;
+----


### PR DESCRIPTION
Fixes #22924.

This prevents join filter pushdown from crossing `LIMIT`/`TOP_N` operators. These operators decide which rows are present on the probe side before the join, so pushing a runtime join filter below them can change `LIMIT`/`OFFSET` results and produce wrong answers.

The regression test covers both `ORDER BY ... OFFSET` and `ORDER BY ... LIMIT` shapes.
