### PR TITLE
fix(adbc): support `StatementExecuteSchema` of ADBC 1.1.0

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -92,7 +92,7 @@ AdbcStatusCode duckdb_adbc_init(int version, void *driver, struct AdbcError *err
 		adbc_driver->ConnectionSetOptionDouble = duckdb_adbc::ConnectionSetOptionDouble;
 
 		adbc_driver->StatementCancel = duckdb_adbc::StatementCancel;
-		adbc_driver->StatementExecuteSchema = nullptr;
+		adbc_driver->StatementExecuteSchema = duckdb_adbc::StatementExecuteSchema;
 		adbc_driver->StatementGetOption = duckdb_adbc::StatementGetOption;
 		adbc_driver->StatementGetOptionBytes = duckdb_adbc::StatementGetOptionBytes;
 		adbc_driver->StatementGetOptionDouble = duckdb_adbc::StatementGetOptionDouble;
@@ -1490,6 +1490,62 @@ AdbcStatusCode StatementCancel(struct AdbcStatement *statement, struct AdbcError
 		return ADBC_STATUS_INVALID_ARGUMENT;
 	}
 	duckdb_interrupt(wrapper->connection);
+	return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode StatementExecuteSchema(struct AdbcStatement *statement, struct ArrowSchema *schema,
+                                      struct AdbcError *error) {
+	if (!statement) {
+		SetError(error, "Missing statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!statement->private_data) {
+		SetError(error, "Invalid statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!schema) {
+		SetError(error, "Missing schema object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto wrapper = static_cast<DuckDBAdbcStatementWrapper *>(statement->private_data);
+	if (!wrapper->statement) {
+		SetError(error, "Must call StatementSetSqlQuery before StatementExecuteSchema");
+		return ADBC_STATUS_INVALID_STATE;
+	}
+
+	if (wrapper->conn_wrapper) {
+		wrapper->conn_wrapper->MaterializeStreams();
+	}
+
+	auto count = duckdb_prepared_statement_column_count(wrapper->statement);
+	std::vector<duckdb_logical_type> types(count);
+	std::vector<std::string> owned_names;
+	owned_names.reserve(count);
+	duckdb::vector<const char *> names(count);
+
+	for (idx_t i = 0; i < count; i++) {
+		types[i] = duckdb_prepared_statement_column_logical_type(wrapper->statement, i);
+		auto column_name = duckdb_prepared_statement_column_name(wrapper->statement, i);
+		owned_names.emplace_back(column_name ? column_name : "");
+		names[i] = owned_names.back().c_str();
+		duckdb_free(const_cast<char *>(column_name));
+	}
+
+	duckdb_arrow_options arrow_options;
+	duckdb_connection_get_arrow_options(wrapper->connection, &arrow_options);
+
+	auto res = duckdb_to_arrow_schema(arrow_options, types.data(), names.data(), count, schema);
+
+	for (auto &type : types) {
+		duckdb_destroy_logical_type(&type);
+	}
+	duckdb_destroy_arrow_options(&arrow_options);
+
+	if (res) {
+		SetError(error, duckdb_error_data_message(res));
+		duckdb_destroy_error_data(&res);
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
 	return ADBC_STATUS_OK;
 }
 

--- a/src/include/duckdb/common/adbc/adbc.hpp
+++ b/src/include/duckdb/common/adbc/adbc.hpp
@@ -214,6 +214,9 @@ AdbcStatusCode StatementBind(struct AdbcStatement *statement, struct ArrowArray 
 AdbcStatusCode StatementBindStream(struct AdbcStatement *statement, struct ArrowArrayStream *stream,
                                    struct AdbcError *error);
 
+AdbcStatusCode StatementExecuteSchema(struct AdbcStatement *statement, struct ArrowSchema *schema,
+                                      struct AdbcError *error);
+
 AdbcStatusCode StatementGetParameterSchema(struct AdbcStatement *statement, struct ArrowSchema *schema,
                                            struct AdbcError *error);
 

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -4587,4 +4587,50 @@ TEST_CASE("ADBC - regression test for #21772", "[adbc]") {
 	}
 }
 
+TEST_CASE("ADBC - StatementExecuteSchema", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+
+	ADBCTestDatabase db;
+	AdbcStatement stmt;
+
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt, &db.adbc_error)));
+
+	SECTION("basic SELECT") {
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt, "SELECT 42 AS answer, 'hello' AS greeting", &db.adbc_error)));
+
+		ArrowSchema schema;
+		schema.release = nullptr;
+		REQUIRE(SUCCESS(AdbcStatementExecuteSchema(&stmt, &schema, &db.adbc_error)));
+
+		REQUIRE(schema.n_children == 2);
+		REQUIRE(string(schema.children[0]->name) == "answer");
+		REQUIRE(string(schema.children[1]->name) == "greeting");
+		schema.release(&schema);
+	}
+
+	SECTION("no query set") {
+		ArrowSchema schema;
+		schema.release = nullptr;
+		REQUIRE(!SUCCESS(AdbcStatementExecuteSchema(&stmt, &schema, &db.adbc_error)));
+		REQUIRE(string(db.adbc_error.message).find("StatementSetSqlQuery") != string::npos);
+		if (db.adbc_error.release) {
+			db.adbc_error.release(&db.adbc_error);
+		}
+		InitializeADBCError(&db.adbc_error);
+	}
+
+	SECTION("missing schema pointer") {
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt, "SELECT 1", &db.adbc_error)));
+		REQUIRE(!SUCCESS(AdbcStatementExecuteSchema(&stmt, nullptr, &db.adbc_error)));
+		if (db.adbc_error.release) {
+			db.adbc_error.release(&db.adbc_error);
+		}
+		InitializeADBCError(&db.adbc_error);
+	}
+
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt, &db.adbc_error)));
+}
+
 } // namespace duckdb


### PR DESCRIPTION
This implements `StatementExecuteSchema` added in the ADBC ​​1.1.0 spec.

cc @lidavidm