### PR TITLE
Fix #17011: don't duplicate-eliminate correlated subqueries with volatile functions

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -250,7 +250,39 @@ static bool PerformDelimOnType(const LogicalType &type) {
 	return true;
 }
 
-static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns) {
+//! duckdb#17011: a subquery body that contains a VOLATILE expression (e.g. random(),
+//! gen_random_uuid()) must be re-evaluated for every outer row, even when the correlated key
+//! repeats. Duplicate-eliminating the correlated keys would collapse repeated keys into a single
+//! evaluation, observably differing from PostgreSQL and the SQL semantics for correlated
+//! subqueries containing nondeterministic functions. Mirrors the IsVolatile() gate already used
+//! by src/optimizer/cse_optimizer.cpp and other optimizer consumers in DuckDB.
+//!
+//! CONSISTENT_WITHIN_QUERY functions (e.g. current_timestamp, now()) are intentionally NOT
+//! flagged: they return the same value throughout a query, so deduplication is still sound.
+//! Expression::IsVolatile() correctly returns false for them.
+static bool SubqueryPlanHasVolatileExpression(LogicalOperator &op) {
+	bool has_volatile = false;
+	LogicalOperatorVisitor::EnumerateExpressions(op, [&](unique_ptr<Expression> *expr_ptr) {
+		if (has_volatile) {
+			return;
+		}
+		if ((*expr_ptr)->IsVolatile()) {
+			has_volatile = true;
+		}
+	});
+	if (has_volatile) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (SubqueryPlanHasVolatileExpression(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns,
+                                        LogicalOperator &subquery_plan) {
 	if (!Settings::Get<EnableOptimizerSetting>(binder.context)) {
 		// if optimizations are disabled we always do a delim join
 		return true;
@@ -261,6 +293,10 @@ static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &corre
 			perform_delim = false;
 			break;
 		}
+	}
+	if (perform_delim && SubqueryPlanHasVolatileExpression(subquery_plan)) {
+		// duckdb#17011: see SubqueryPlanHasVolatileExpression above.
+		perform_delim = false;
 	}
 	if (perform_delim) {
 		return true;
@@ -280,7 +316,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 	auto &correlated_columns = expr.binder->correlated_columns;
 	// FIXME: there should be a way of disabling decorrelation for ANY queries as well, but not for now...
 	bool perform_delim =
-	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns);
+	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns, *plan);
 	D_ASSERT(expr.IsCorrelated());
 	// correlated subquery
 	// for a more in-depth explanation of this code, read the paper "Unnesting Arbitrary Subqueries"
@@ -468,7 +504,7 @@ unique_ptr<LogicalOperator> Binder::PlanLateralJoin(unique_ptr<LogicalOperator> 
 		}
 	}
 
-	auto perform_delim = PerformDuplicateElimination(*this, correlated);
+	auto perform_delim = PerformDuplicateElimination(*this, correlated, *right);
 	auto delim_join = CreateDuplicateEliminatedJoin(correlated, join_type, std::move(left), perform_delim);
 
 	// Store all information required to perform UNNESTING later.

--- a/test/sql/subquery/scalar/test_correlated_side_effects.test
+++ b/test/sql/subquery/scalar/test_correlated_side_effects.test
@@ -1,10 +1,11 @@
 # name: test/sql/subquery/scalar/test_correlated_side_effects.test
-# description: Test correlated subqueries with side effects
+# description: Test correlated subqueries with side effects (duckdb#17011)
 # group: [scalar]
 
-# FIXME: we should not perform duplicate elimination for subqueries that have side-effects
-
-mode skip instable
+# Correlated subqueries whose body contains a VOLATILE expression must be re-evaluated for every
+# outer row, even when the correlated key repeats. Duplicate-eliminating the correlated keys would
+# observably differ from PostgreSQL and SQL semantics. See PlanCorrelatedSubquery() and the
+# SubqueryPlanHasVolatileExpression() gate in src/planner/binder/query_node/plan_subquery.cpp.
 
 query I
 SELECT COUNT(DISTINCT
@@ -13,3 +14,22 @@ SELECT COUNT(DISTINCT
 FROM (SELECT 1 FROM generate_series(1, 100, 1)) AS t(r)
 ----
 100
+
+# duckdb#17011 original reporter's repro: two outer rows with r=1 must produce two distinct
+# random() values (PostgreSQL behavior). Under the bug, dedupe collapsed both rows into one
+# subquery evaluation and the two outputs were identical.
+query I
+SELECT COUNT(DISTINCT s) FROM (
+  SELECT (SELECT random() + r) AS s FROM (VALUES (1), (1)) _(r)
+)
+----
+2
+
+# Sanity oracle: CONSISTENT_WITHIN_QUERY functions (e.g. current_timestamp) must STILL dedupe —
+# they return the same value throughout a query, so deduplication is sound. If the predicate is
+# accidentally widened to "any non-default stability", this test fails (would return 3).
+query I
+SELECT COUNT(DISTINCT (SELECT current_timestamp::VARCHAR || '_' || r::VARCHAR))
+FROM (VALUES (1), (1), (1)) _(r)
+----
+1


### PR DESCRIPTION
## Description

Fixes #17011. A correlated subquery containing a `VOLATILE` function (e.g.
`random()`, `gen_random_uuid()`) was duplicate-eliminated across repeated
correlation keys, so the function was evaluated once and the value reused for
every duplicate outer row — differing from PostgreSQL.

- Gate `PerformDuplicateElimination` on volatility: if the subquery plan
  contains a volatile expression, take the existing `delim_index`
  (per-outer-row) path. The predicate is `IsVolatile()` only, so
  `CONSISTENT_WITHIN_QUERY` functions (`current_timestamp`, `now()`) still
  deduplicate. Mirrors the `IsVolatile()` gate already used in
  `cse_optimizer.cpp` and other optimizer consumers.
- Removes `mode skip instable` from
  `test/sql/subquery/scalar/test_correlated_side_effects.test` (the FIXME this
  addresses) and adds the original repro + a `CONSISTENT_WITHIN_QUERY` sanity check.

## Reproduce

```sql
SELECT r, (SELECT random() + r) FROM (VALUES (1), (1)) _(r);
```

Before: both rows return the same value. After: each row is independent (matches PostgreSQL).
