### PR TITLE
Fix #22971: re-evaluate volatile functions in correlated ANY/IN subqueries

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -282,20 +282,28 @@ static bool SubqueryPlanHasVolatileExpression(LogicalOperator &op) {
 }
 
 static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns,
-                                        LogicalOperator &subquery_plan) {
+                                        LogicalOperator &subquery_plan, bool is_any = false) {
 	if (!Settings::Get<EnableOptimizerSetting>(binder.context)) {
 		// if optimizations are disabled we always do a delim join
 		return true;
 	}
-	bool perform_delim = true;
+	bool delim_supported_for_types = true;
 	for (auto &col : correlated_columns) {
 		if (!PerformDelimOnType(col.type)) {
-			perform_delim = false;
+			delim_supported_for_types = false;
 			break;
 		}
 	}
-	if (perform_delim && SubqueryPlanHasVolatileExpression(subquery_plan)) {
-		// duckdb#17011: see SubqueryPlanHasVolatileExpression above.
+	bool perform_delim = true;
+	if (!delim_supported_for_types && !is_any) {
+		// SCALAR/EXISTS fall back to the delim_index (non-dedup) path for types that cannot be
+		// duplicate-eliminated. ANY cannot use that path for such types (e.g. LIST), so it keeps
+		// duplicate-elimination in that case (see the existing FIXME on ANY decorrelation).
+		perform_delim = false;
+	} else if (delim_supported_for_types && SubqueryPlanHasVolatileExpression(subquery_plan)) {
+		// duckdb#17011 (+ ANY sibling): a correlated subquery containing a VOLATILE expression must
+		// be re-evaluated per outer row. Only disable dedup when the delim_index path is usable for
+		// these correlated types; for ANY with an unsupported type, dedup is kept.
 		perform_delim = false;
 	}
 	if (perform_delim) {
@@ -314,9 +322,12 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
                                                      unique_ptr<LogicalOperator> &root,
                                                      unique_ptr<LogicalOperator> plan) {
 	auto &correlated_columns = expr.binder->correlated_columns;
-	// FIXME: there should be a way of disabling decorrelation for ANY queries as well, but not for now...
+	// ANY/IN, like SCALAR/EXISTS, must not duplicate-eliminate a correlated subquery that contains a
+	// VOLATILE expression (it would evaluate the volatile once and reuse it across duplicate outer
+	// rows -- observably wrong vs PostgreSQL, same class as duckdb#17011). The is_any flag preserves
+	// the existing ANY behavior for correlated types the delim_index path does not support (e.g. LIST).
 	bool perform_delim =
-	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns, *plan);
+	    PerformDuplicateElimination(binder, correlated_columns, *plan, expr.subquery_type == SubqueryType::ANY);
 	D_ASSERT(expr.IsCorrelated());
 	// correlated subquery
 	// for a more in-depth explanation of this code, read the paper "Unnesting Arbitrary Subqueries"

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -250,7 +250,39 @@ static bool PerformDelimOnType(const LogicalType &type) {
 	return true;
 }
 
-static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns) {
+//! duckdb#17011: a subquery body that contains a VOLATILE expression (e.g. random(),
+//! gen_random_uuid()) must be re-evaluated for every outer row, even when the correlated key
+//! repeats. Duplicate-eliminating the correlated keys would collapse repeated keys into a single
+//! evaluation, observably differing from PostgreSQL and the SQL semantics for correlated
+//! subqueries containing nondeterministic functions. Mirrors the IsVolatile() gate already used
+//! by src/optimizer/cse_optimizer.cpp and other optimizer consumers in DuckDB.
+//!
+//! CONSISTENT_WITHIN_QUERY functions (e.g. current_timestamp, now()) are intentionally NOT
+//! flagged: they return the same value throughout a query, so deduplication is still sound.
+//! Expression::IsVolatile() correctly returns false for them.
+static bool SubqueryPlanHasVolatileExpression(LogicalOperator &op) {
+	bool has_volatile = false;
+	LogicalOperatorVisitor::EnumerateExpressions(op, [&](unique_ptr<Expression> *expr_ptr) {
+		if (has_volatile) {
+			return;
+		}
+		if ((*expr_ptr)->IsVolatile()) {
+			has_volatile = true;
+		}
+	});
+	if (has_volatile) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (SubqueryPlanHasVolatileExpression(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns,
+                                        LogicalOperator &subquery_plan) {
 	if (!Settings::Get<EnableOptimizerSetting>(binder.context)) {
 		// if optimizations are disabled we always do a delim join
 		return true;
@@ -261,6 +293,10 @@ static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &corre
 			perform_delim = false;
 			break;
 		}
+	}
+	if (perform_delim && SubqueryPlanHasVolatileExpression(subquery_plan)) {
+		// duckdb#17011: see SubqueryPlanHasVolatileExpression above.
+		perform_delim = false;
 	}
 	if (perform_delim) {
 		return true;
@@ -280,7 +316,7 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 	auto &correlated_columns = expr.binder->correlated_columns;
 	// FIXME: there should be a way of disabling decorrelation for ANY queries as well, but not for now...
 	bool perform_delim =
-	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns);
+	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns, *plan);
 	D_ASSERT(expr.IsCorrelated());
 	// correlated subquery
 	// for a more in-depth explanation of this code, read the paper "Unnesting Arbitrary Subqueries"
@@ -468,7 +504,7 @@ unique_ptr<LogicalOperator> Binder::PlanLateralJoin(unique_ptr<LogicalOperator> 
 		}
 	}
 
-	auto perform_delim = PerformDuplicateElimination(*this, correlated);
+	auto perform_delim = PerformDuplicateElimination(*this, correlated, *right);
 	auto delim_join = CreateDuplicateEliminatedJoin(correlated, join_type, std::move(left), perform_delim);
 
 	// Store all information required to perform UNNESTING later.

--- a/test/sql/subquery/scalar/test_correlated_any_volatile.test
+++ b/test/sql/subquery/scalar/test_correlated_any_volatile.test
@@ -1,0 +1,33 @@
+# name: test/sql/subquery/scalar/test_correlated_any_volatile.test
+# description: Correlated ANY/IN subqueries with volatile functions must re-evaluate per outer row (duckdb#17011 sibling)
+# group: [scalar]
+
+statement ok
+CREATE SEQUENCE seq;
+
+# A correlated IN/ANY subquery containing a VOLATILE expression (here nextval) must be evaluated
+# once per outer row, not duplicate-eliminated across repeated correlation keys.
+# 5 duplicate outer rows -> 5 nextval() calls (was 1 before the fix, due to ANY caching).
+statement ok
+SELECT r, r IN (SELECT nextval('seq') + r) FROM (VALUES (1), (1), (1), (1), (1)) _(r);
+
+query I
+SELECT currval('seq');
+----
+5
+
+# Regression guard: LIST-typed correlated ANY keeps working. Its decorrelation cannot use the
+# delim_index (non-dedup) path, so duplicate-elimination is preserved for non-volatile and
+# delim-unsupported-type cases (this is the case that rejected the naive one-line fix).
+statement ok
+CREATE TABLE lst(l INTEGER[])
+
+statement ok
+INSERT INTO lst VALUES (ARRAY[1]), (ARRAY[2]), (NULL)
+
+query I
+SELECT l IN (SELECT i1.l FROM lst i1 WHERE i1.l = lst.l) FROM lst ORDER BY l NULLS LAST
+----
+true
+true
+false

--- a/test/sql/subquery/scalar/test_correlated_side_effects.test
+++ b/test/sql/subquery/scalar/test_correlated_side_effects.test
@@ -1,10 +1,11 @@
 # name: test/sql/subquery/scalar/test_correlated_side_effects.test
-# description: Test correlated subqueries with side effects
+# description: Test correlated subqueries with side effects (duckdb#17011)
 # group: [scalar]
 
-# FIXME: we should not perform duplicate elimination for subqueries that have side-effects
-
-mode skip instable
+# Correlated subqueries whose body contains a VOLATILE expression must be re-evaluated for every
+# outer row, even when the correlated key repeats. Duplicate-eliminating the correlated keys would
+# observably differ from PostgreSQL and SQL semantics. See PlanCorrelatedSubquery() and the
+# SubqueryPlanHasVolatileExpression() gate in src/planner/binder/query_node/plan_subquery.cpp.
 
 query I
 SELECT COUNT(DISTINCT
@@ -13,3 +14,22 @@ SELECT COUNT(DISTINCT
 FROM (SELECT 1 FROM generate_series(1, 100, 1)) AS t(r)
 ----
 100
+
+# duckdb#17011 original reporter's repro: two outer rows with r=1 must produce two distinct
+# random() values (PostgreSQL behavior). Under the bug, dedupe collapsed both rows into one
+# subquery evaluation and the two outputs were identical.
+query I
+SELECT COUNT(DISTINCT s) FROM (
+  SELECT (SELECT random() + r) AS s FROM (VALUES (1), (1)) _(r)
+)
+----
+2
+
+# Sanity oracle: CONSISTENT_WITHIN_QUERY functions (e.g. current_timestamp) must STILL dedupe —
+# they return the same value throughout a query, so deduplication is sound. If the predicate is
+# accidentally widened to "any non-default stability", this test fails (would return 3).
+query I
+SELECT COUNT(DISTINCT (SELECT current_timestamp::VARCHAR || '_' || r::VARCHAR))
+FROM (VALUES (1), (1), (1)) _(r)
+----
+1


### PR DESCRIPTION
## Description

Fixes #22971 — sibling of #17011 in the `ANY`/`IN` decorrelation path.

> **Stacked on #22970** (the #17011 fix), which this builds on. The diff therefore
> includes that PR's commit; the net change here is the second commit. Once #22970
> merges this rebases down to just that.

The `ANY`/`IN` path forced `perform_delim = true` — there's a `// FIXME: there
should be a way of disabling decorrelation for ANY queries as well, but not for
now...` at the call site — so a correlated `IN`/`ANY` subquery containing a
`VOLATILE` function was duplicate-eliminated and evaluated once across duplicate
outer rows.

- Route `ANY` through `PerformDuplicateElimination` with an `is_any` flag: disable
  duplicate-elimination when the subquery is volatile, but keep it for correlated
  types the `delim_index` path can't handle (e.g. `LIST`) — so non-volatile `ANY`
  and list-correlated `ANY` are unchanged.
- Adds `test/sql/subquery/scalar/test_correlated_any_volatile.test` (deterministic
  sequence repro + a `LIST`-`ANY` regression guard).

## Reproduce

```sql
CREATE SEQUENCE seq;
SELECT r, r IN (SELECT nextval('seq') + r) FROM (VALUES (1),(1),(1),(1),(1)) _(r);
SELECT currval('seq');
```

Before: `currval` is `1` (the volatile was cached). After: `5` — one evaluation per
outer row (matches PostgreSQL).
