### PR TITLE
feat(swift): add ARRAY type support and array binding

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/DatabaseType.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/DatabaseType.swift
@@ -102,8 +102,10 @@ public extension DatabaseType {
   static let timestampNS = DatabaseType(rawValue: DUCKDB_TYPE_TIMESTAMP_NS.rawValue)
   /// Enum type castable to suitable `Decodable` conforming types
   static let `enum` = DatabaseType(rawValue: DUCKDB_TYPE_ENUM.rawValue)
-  /// Array type castable to suitable `Decodable` conforming types
+  /// List type castable to suitable `Decodable` conforming types
   static let list = DatabaseType(rawValue: DUCKDB_TYPE_LIST.rawValue)
+  /// Array type castable to suitable `Decodable` conforming types
+  static let array = DatabaseType(rawValue: DUCKDB_TYPE_ARRAY.rawValue)
   /// Struct type castable to suitable `Decodable` conforming types
   static let `struct` = DatabaseType(rawValue: DUCKDB_TYPE_STRUCT.rawValue)
   /// Dictionary type castable to suitable `Decodable` conforming types
@@ -151,6 +153,7 @@ extension DatabaseType: CustomStringConvertible {
     case .timestampNS: return "\(Self.self).timestampNS"
     case .`enum`: return "\(Self.self).enum"
     case .list: return "\(Self.self).list"
+    case .array: return "\(Self.self).array"
     case .`struct`: return "\(Self.self).struct"
     case .map: return "\(Self.self).map"
     case .union: return "\(Self.self).union"

--- a/tools/swift/duckdb-swift/Sources/DuckDB/DuckDBArrayElement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/DuckDBArrayElement.swift
@@ -1,0 +1,106 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2024 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
+@_implementationOnly import Cduckdb
+#endif
+
+/// A type that can be used as the element type of a DuckDB ARRAY column.
+///
+/// Conforming types can be bound to prepared statement parameters as fixed-size
+/// arrays via ``PreparedStatement/bind(_:at:)-swift.type.method``.
+protocol DuckDBArrayElement {
+  /// The DuckDB logical type ID for this element type.
+  static var duckdbType: duckdb_type { get }
+  /// Creates a `duckdb_value` representing this value.
+  func createDuckDBValue() -> duckdb_value?
+}
+
+// MARK: - Numeric Conformances
+
+extension Float: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_FLOAT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_float(self) }
+}
+
+extension Double: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_DOUBLE }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_double(self) }
+}
+
+extension Int8: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_TINYINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_int8(self) }
+}
+
+extension Int16: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_SMALLINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_int16(self) }
+}
+
+extension Int32: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_INTEGER }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_int32(self) }
+}
+
+extension Int64: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_BIGINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_int64(self) }
+}
+
+extension UInt8: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_UTINYINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_uint8(self) }
+}
+
+extension UInt16: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_USMALLINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_uint16(self) }
+}
+
+extension UInt32: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_UINTEGER }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_uint32(self) }
+}
+
+extension UInt64: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_UBIGINT }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_uint64(self) }
+}
+
+// MARK: - Bool
+
+extension Bool: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_BOOLEAN }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_bool(self) }
+}
+
+// MARK: - String
+
+extension String: DuckDBArrayElement {
+  static var duckdbType: duckdb_type { DUCKDB_TYPE_VARCHAR }
+  func createDuckDBValue() -> duckdb_value? { duckdb_create_varchar(self) }
+}

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
@@ -126,6 +126,20 @@ extension duckdb_uhugeint {
   }
   
   var asUIntHuge: UIntHuge { .init(high: upper, low: lower) }
+
+  /// The flipped-sign uhugeint representation DuckDB uses for UUID storage,
+  /// derived from a `UUID`'s big-endian bytes. Inverse of `duckdb_hugeint.asUUID`.
+  init(uuid: UUID) {
+    let b = uuid.uuid
+    var value: UIntHuge = 0
+    for byte in [
+      b.0, b.1, b.2, b.3, b.4, b.5, b.6, b.7,
+      b.8, b.9, b.10, b.11, b.12, b.13, b.14, b.15,
+    ] {
+      value = (value << 8) | UIntHuge(byte)
+    }
+    self = duckdb_uhugeint(lower: value.low, upper: value.high)
+  }
 }
 
 // MARK: - Time

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
@@ -302,11 +302,17 @@ extension Vector.Element {
   }
   
   var childVector: Vector? {
-    guard let child = duckdb_list_vector_get_child(vector.cvector) else { return nil }
-    let count = duckdb_list_vector_get_size(vector.cvector)
-    let info = vector.unsafelyUnwrapElement(as: duckdb_list_entry_t.self, at: vector.offset + index)
-    precondition(info.offset + info.length <= count)
-    return Vector(child, count: Int(info.length), offset: Int(info.offset))
+    if dataType == .array {
+      guard let child = duckdb_array_vector_get_child(vector.cvector) else { return nil }
+      let arraySize = Int(duckdb_array_type_array_size(vector.logicalType.ptr.pointee))
+      return Vector(child, count: arraySize, offset: arraySize * Int(index))
+    } else {
+      guard let child = duckdb_list_vector_get_child(vector.cvector) else { return nil }
+      let count = duckdb_list_vector_get_size(vector.cvector)
+      let info = vector.unsafelyUnwrapElement(as: duckdb_list_entry_t.self, at: vector.offset + index)
+      precondition(info.offset + info.length <= count)
+      return Vector(child, count: Int(info.length), offset: Int(info.offset))
+    }
   }
   
   var mapContents: MapContent? {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
@@ -92,7 +92,7 @@ fileprivate struct VectorElementDataDecoder: Decoder {
   
   func unkeyedContainer() throws -> UnkeyedDecodingContainer {
     switch element.dataType {
-    case .list:
+    case .list, .array:
       return try UnkeyedValueContainer.createListContainer(decoder: self, element: element)
     default:
       let columnType = element.dataType
@@ -540,15 +540,15 @@ fileprivate extension VectorElementDataDecoder.UnkeyedValueContainer {
       )
       throw DecodingError.valueNotFound(Self.self, context)
     }
-    guard dataType == .list else {
+    guard dataType == .list || dataType == .array else {
       let context = DecodingError.Context(
         codingPath: codingPath,
-        debugDescription: "Expected list column type, found \(dataType) column type instead."
+        debugDescription: "Expected list or array column type, found \(dataType) column type instead."
       )
       throw DecodingError.typeMismatch(Self.self, context)
     }
     guard let childVector = element.childVector else {
-      fatalError("Internal consistency error. Expected list content in vector.")
+      fatalError("Internal consistency error. Expected list/array content in vector.")
     }
     return Self(decoder: decoder, codingPath: codingPath, vector: childVector)
   }

--- a/tools/swift/duckdb-swift/Sources/DuckDB/LogicalType.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/LogicalType.swift
@@ -31,7 +31,7 @@ import Foundation
 
 public final class LogicalType {
   
-  private let ptr = UnsafeMutablePointer<duckdb_logical_type?>.allocate(capacity: 1)
+  let ptr = UnsafeMutablePointer<duckdb_logical_type?>.allocate(capacity: 1)
   
   init(_ body: () -> duckdb_logical_type?) {
     self.ptr.pointee = body()
@@ -146,6 +146,12 @@ public extension LogicalType {
   var listChildType: LogicalType? {
     guard dataType == .list else { return nil }
     return LogicalType { duckdb_list_type_child_type(ptr.pointee) }
+  }
+
+  /// Child type of an array type. For all other types, returns `nil`
+  var arrayChildType: LogicalType? {
+    guard dataType == .array else { return nil }
+    return LogicalType { duckdb_array_type_child_type(ptr.pointee) }
   }
 }
 

--- a/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
@@ -463,6 +463,41 @@ public extension PreparedStatement {
   func bind(_ value: [String]?, at index: Int) throws {
     try _bindArray(value, at: index)
   }
+
+  /// Binds a `TINYINT[]` array value at the specified parameter index.
+  func bind(_ value: [Int8]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `SMALLINT[]` array value at the specified parameter index.
+  func bind(_ value: [Int16]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `BIGINT[]` array value at the specified parameter index.
+  func bind(_ value: [Int64]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `UTINYINT[]` array value at the specified parameter index.
+  func bind(_ value: [UInt8]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `USMALLINT[]` array value at the specified parameter index.
+  func bind(_ value: [UInt16]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `UINTEGER[]` array value at the specified parameter index.
+  func bind(_ value: [UInt32]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `UBIGINT[]` array value at the specified parameter index.
+  func bind(_ value: [UInt64]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
 }
 
 private extension PreparedStatement {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
@@ -498,6 +498,23 @@ public extension PreparedStatement {
   func bind(_ value: [UInt64]?, at index: Int) throws {
     try _bindArray(value, at: index)
   }
+
+  /// Binds a UUID value at the specified parameter index
+  ///
+  /// Sets the value that will be used for the next call to ``execute()``.
+  ///
+  /// - Important: Prepared statement parameters use one-based indexing
+  /// - Parameter value: the value to bind (or `nil` to bind NULL)
+  /// - Parameter index: the one-based parameter index
+  /// - Throws: ``DatabaseError/preparedStatementFailedToBindParameter(reason:)``
+  ///   if there is a type-mismatch between the value being bound and the
+  ///   underlying column type
+  func bind(_ value: UUID?, at index: Int) throws {
+    guard let value = try unwrapValueOrBindNull(value, at: index) else { return }
+    var uuidValue: duckdb_value? = duckdb_create_uuid(duckdb_uhugeint(uuid: value))
+    defer { duckdb_destroy_value(&uuidValue) }
+    try withThrowingCommand { duckdb_bind_value(ptr.pointee, .init(index), uuidValue) }
+  }
 }
 
 private extension PreparedStatement {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
@@ -434,31 +434,34 @@ public extension PreparedStatement {
     }
   }
 
-  /// Binds a fixed-size `FLOAT[]` array value at the specified parameter index.
-  ///
-  /// The bound value is a DuckDB ARRAY value whose element count equals the
-  /// number of elements in `value`, so it casts cleanly to a fixed-size
-  /// `FLOAT[N]` column.
+  /// Binds a `FLOAT[]` array value at the specified parameter index.
   ///
   /// - Important: Prepared statement parameters use one-based indexing
   /// - Parameter value: the array of floats to bind (or `nil` to bind NULL)
   /// - Parameter index: the one-based parameter index
   /// - Throws: ``DatabaseError/preparedStatementFailedToBindParameter(reason:)``
   func bind(_ value: [Float]?, at index: Int) throws {
-    guard let value = try unwrapValueOrBindNull(value, at: index) else { return }
-    let elemType = duckdb_create_logical_type(DUCKDB_TYPE_FLOAT)
-    var elemTypePtr: duckdb_logical_type? = elemType
-    defer { duckdb_destroy_logical_type(&elemTypePtr) }
+    try _bindArray(value, at: index)
+  }
 
-    var children: [duckdb_value?] = value.map { duckdb_create_float($0) }
-    defer { for i in children.indices { duckdb_destroy_value(&children[i]) } }
+  /// Binds an `INTEGER[]` array value at the specified parameter index.
+  func bind(_ value: [Int32]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
 
-    var arrayValue: duckdb_value? = children.withUnsafeMutableBufferPointer { buf in
-      duckdb_create_array_value(elemType, buf.baseAddress, .init(value.count))
-    }
-    defer { duckdb_destroy_value(&arrayValue) }
+  /// Binds a `DOUBLE[]` array value at the specified parameter index.
+  func bind(_ value: [Double]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
 
-    try withThrowingCommand { duckdb_bind_value(ptr.pointee, .init(index), arrayValue) }
+  /// Binds a `BOOLEAN[]` array value at the specified parameter index.
+  func bind(_ value: [Bool]?, at index: Int) throws {
+    try _bindArray(value, at: index)
+  }
+
+  /// Binds a `VARCHAR[]` array value at the specified parameter index.
+  func bind(_ value: [String]?, at index: Int) throws {
+    try _bindArray(value, at: index)
   }
 }
 
@@ -485,5 +488,26 @@ private extension PreparedStatement {
   
   func preparedStatementError() -> String? {
     duckdb_prepare_error(ptr.pointee).map(String.init(cString:))
+  }
+}
+
+extension PreparedStatement {
+
+  /// Internal generic implementation for binding an array value.
+  func _bindArray<T: DuckDBArrayElement>(_ value: [T]?, at index: Int) throws {
+    guard let value = try unwrapValueOrBindNull(value, at: index) else { return }
+    let elemType = duckdb_create_logical_type(T.duckdbType)
+    var elemTypePtr: duckdb_logical_type? = elemType
+    defer { duckdb_destroy_logical_type(&elemTypePtr) }
+
+    var children: [duckdb_value?] = value.map { $0.createDuckDBValue() }
+    defer { for i in children.indices { duckdb_destroy_value(&children[i]) } }
+
+    var arrayValue: duckdb_value? = children.withUnsafeMutableBufferPointer { buf in
+      duckdb_create_array_value(elemType, buf.baseAddress, .init(value.count))
+    }
+    defer { duckdb_destroy_value(&arrayValue) }
+
+    try withThrowingCommand { duckdb_bind_value(ptr.pointee, .init(index), arrayValue) }
   }
 }

--- a/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
@@ -433,6 +433,33 @@ public extension PreparedStatement {
       }
     }
   }
+
+  /// Binds a fixed-size `FLOAT[]` array value at the specified parameter index.
+  ///
+  /// The bound value is a DuckDB ARRAY value whose element count equals the
+  /// number of elements in `value`, so it casts cleanly to a fixed-size
+  /// `FLOAT[N]` column.
+  ///
+  /// - Important: Prepared statement parameters use one-based indexing
+  /// - Parameter value: the array of floats to bind (or `nil` to bind NULL)
+  /// - Parameter index: the one-based parameter index
+  /// - Throws: ``DatabaseError/preparedStatementFailedToBindParameter(reason:)``
+  func bind(_ value: [Float]?, at index: Int) throws {
+    guard let value = try unwrapValueOrBindNull(value, at: index) else { return }
+    let elemType = duckdb_create_logical_type(DUCKDB_TYPE_FLOAT)
+    var elemTypePtr: duckdb_logical_type? = elemType
+    defer { duckdb_destroy_logical_type(&elemTypePtr) }
+
+    var children: [duckdb_value?] = value.map { duckdb_create_float($0) }
+    defer { for i in children.indices { duckdb_destroy_value(&children[i]) } }
+
+    var arrayValue: duckdb_value? = children.withUnsafeMutableBufferPointer { buf in
+      duckdb_create_array_value(elemType, buf.baseAddress, .init(value.count))
+    }
+    defer { duckdb_destroy_value(&arrayValue) }
+
+    try withThrowingCommand { duckdb_bind_value(ptr.pointee, .init(index), arrayValue) }
+  }
 }
 
 private extension PreparedStatement {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/LogicalTypeTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/LogicalTypeTests.swift
@@ -389,6 +389,18 @@ final class LogicalTypeTests: XCTestCase {
       }
     )
   }
+
+  func test_array() throws {
+    try logicalTypeTest(
+      dataType: "FLOAT[4]",
+      cast: { $0.cast(to: [Float?].self) },
+      validate: {
+        XCTAssertEqual($0.dataType, .array)
+        XCTAssertEqual($0.underlyingDataType, .array)
+        XCTAssertEqual($0.arrayChildType?.dataType, .float)
+      }
+    )
+  }
 }
 
 private extension LogicalTypeTests {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/LogicalTypeTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/LogicalTypeTests.swift
@@ -393,7 +393,7 @@ final class LogicalTypeTests: XCTestCase {
   func test_array() throws {
     try logicalTypeTest(
       dataType: "FLOAT[4]",
-      cast: { $0.cast(to: [Float?].self) },
+      cast: { $0.cast(to: [Float].self) },
       validate: {
         XCTAssertEqual($0.dataType, .array)
         XCTAssertEqual($0.underlyingDataType, .array)

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
@@ -280,6 +280,58 @@ final class PreparedStatementTests: XCTestCase {
       cast: { $0.cast(to: [Float].self) }
     )
   }
+
+  func test_int_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "INTEGER[3]",
+      expected: [
+        [Int32(1), 2, 3],
+        [Int32(-1), 0, 1],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Int32].self) }
+    )
+  }
+
+  func test_double_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "DOUBLE[2]",
+      expected: [
+        [Double(1.5), 2.5],
+        [Double(-1.5), 0.0],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Double].self) }
+    )
+  }
+
+  func test_bool_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "BOOLEAN[2]",
+      expected: [
+        [true, false],
+        [false, true],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Bool].self) }
+    )
+  }
+
+  func test_varchar_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "VARCHAR[2]",
+      expected: [
+        ["hello", "world"],
+        ["", "🦆"],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [String].self) }
+    )
+  }
 }
 
 private extension PreparedStatementTests {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
@@ -267,6 +267,19 @@ final class PreparedStatementTests: XCTestCase {
       cast: { $0.cast(to: Decimal.self) }
     )
   }
+
+  func test_float_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "FLOAT[3]",
+      expected: [
+        [Float(1.0), 2.0, 3.0],
+        [Float(-1.0), 0.0, 1.0],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Float].self) }
+    )
+  }
 }
 
 private extension PreparedStatementTests {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
@@ -411,6 +411,18 @@ final class PreparedStatementTests: XCTestCase {
     )
   }
 
+  func test_uuid_round_trip() throws {
+    let u1 = UUID(uuidString: "00112233-4455-6677-8899-AABBCCDDEEFF")!
+    let u2 = UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")!
+    let u3 = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+    try roundTripTest(
+      dataType: "UUID",
+      expected: [u1, u2, u3, UUID(), nil],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: UUID.self) }
+    )
+  }
+
   func test_ubigint_array_round_trip() throws {
     try roundTripTest(
       dataType: "UBIGINT[3]",

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/PreparedStatementTests.swift
@@ -332,6 +332,97 @@ final class PreparedStatementTests: XCTestCase {
       cast: { $0.cast(to: [String].self) }
     )
   }
+
+  func test_tinyint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "TINYINT[3]",
+      expected: [
+        [Int8.min, 0, Int8.max],
+        [Int8(-1), 0, 1],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Int8].self) }
+    )
+  }
+
+  func test_smallint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "SMALLINT[3]",
+      expected: [
+        [Int16.min, 0, Int16.max],
+        [Int16(-1), 0, 1],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Int16].self) }
+    )
+  }
+
+  func test_bigint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "BIGINT[3]",
+      expected: [
+        [Int64.min, 0, Int64.max],
+        [Int64(-1), 0, 1],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [Int64].self) }
+    )
+  }
+
+  func test_utinyint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "UTINYINT[3]",
+      expected: [
+        [UInt8.min, 42, UInt8.max],
+        [UInt8(0), 1, 2],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [UInt8].self) }
+    )
+  }
+
+  func test_usmallint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "USMALLINT[3]",
+      expected: [
+        [UInt16.min, 42, UInt16.max],
+        [UInt16(0), 1, 2],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [UInt16].self) }
+    )
+  }
+
+  func test_uinteger_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "UINTEGER[3]",
+      expected: [
+        [UInt32.min, 42, UInt32.max],
+        [UInt32(0), 1, 2],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [UInt32].self) }
+    )
+  }
+
+  func test_ubigint_array_round_trip() throws {
+    try roundTripTest(
+      dataType: "UBIGINT[3]",
+      expected: [
+        [UInt64.min, 42, UInt64.max],
+        [UInt64(0), 1, 2],
+        nil,
+      ],
+      bind: { statement, item in try statement.bind(item, at: 1) },
+      cast: { $0.cast(to: [UInt64].self) }
+    )
+  }
 }
 
 private extension PreparedStatementTests {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
@@ -419,6 +419,19 @@ final class TypeConversionTests: XCTestCase {
     try extractTest(
       testColumnName: "map", expected: expected) { $0.cast(to: [String: String].self) }
   }
+
+  func test_extract_from_float_array() throws {
+    let connection = try Database(store: .inMemory).connect()
+    try connection.execute(
+      "CREATE TABLE t1(arr FLOAT[3]);")
+    try connection.execute(
+      "INSERT INTO t1 VALUES (ARRAY[1.0, 2.0, 3.0]), (ARRAY[-1.0, 0.0, 1.0]), (NULL);")
+    let result = try connection.query("SELECT arr FROM t1;")
+    let column = result[0].cast(to: [Float?].self)
+    XCTAssertEqual(column[0], [1.0, 2.0, 3.0])
+    XCTAssertEqual(column[1], [-1.0, 0.0, 1.0])
+    XCTAssertEqual(column[2], nil as [Float?]?)
+  }
 }
 
 private extension TypeConversionTests {

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/TypeConversionTests.swift
@@ -427,10 +427,10 @@ final class TypeConversionTests: XCTestCase {
     try connection.execute(
       "INSERT INTO t1 VALUES (ARRAY[1.0, 2.0, 3.0]), (ARRAY[-1.0, 0.0, 1.0]), (NULL);")
     let result = try connection.query("SELECT arr FROM t1;")
-    let column = result[0].cast(to: [Float?].self)
+    let column = result[0].cast(to: [Float].self)
     XCTAssertEqual(column[0], [1.0, 2.0, 3.0])
     XCTAssertEqual(column[1], [-1.0, 0.0, 1.0])
-    XCTAssertEqual(column[2], nil as [Float?]?)
+    XCTAssertEqual(column[2], nil as [Float]?)
   }
 }
 


### PR DESCRIPTION
Add support for DuckDB fixed-size ARRAY type in the Swift bindings:

- **Type system**: `DatabaseType.array` + `LogicalType.arrayChildType`
- **Decoding**: handle `DUCKDB_TYPE_ARRAY` in vector element decoder and child vector access
- **Binding**: bind `[T]?` arrays to prepared statements for 12 common types (`Bool`, `Int8`–`Int64`, `UInt8`–`UInt64`, `Float`, `Double`, `String`)

The primary use case is inserting embedding vectors.