### PR TITLE
Retry all errors in plan cost runner

### DIFF
--- a/scripts/plan_cost_runner.py
+++ b/scripts/plan_cost_runner.py
@@ -16,7 +16,6 @@ PROFILE_OUTPUT = f"PRAGMA profile_output='{PROFILE_FILENAME}'"
 
 BANNER_SIZE = 52
 RETRIES = 2
-RETRIABLE_EXIT_CODES = {134, -6}
 
 
 def run_with_retry(command, context, **kwargs):
@@ -25,9 +24,9 @@ def run_with_retry(command, context, **kwargs):
         completed = subprocess.run(command, shell=True, check=False, **kwargs)
         if completed.returncode == 0:
             return completed
-        if completed.returncode in RETRIABLE_EXIT_CODES and attempt < attempts:
+        if attempt < attempts:
             print(
-                f"Retrying crash-like failure in {context} "
+                f"Retrying failure in {context} "
                 f"(attempt {attempt + 1}/{attempts}, return code {completed.returncode})"
             )
             continue


### PR DESCRIPTION
Some [errors](https://github.com/duckdb/duckdb/actions/runs/26739931605/job/78802572452?pr=22976#step:8:21) were missed, so we'll retry the failing command a few times regardless of the returned exit code:
```
Run python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
  python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: 
    GIT_REF: 50ff378428c98b4b8dad931dec35b01428a6a2bf
    BASE_BRANCH: main
    BASE_HASH: 
Segmentation fault (core dumped)
INITIALIZING old.duckdb ...
Traceback (most recent call last):
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 263, in <module>
    main()
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 219, in main
    init_db(old, OLD_DB_NAME, benchmark_dir)
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 49, in init_db
    run_with_retry(
  File "/home/runner/work/duckdb/duckdb/scripts/plan_cost_runner.py", line 34, in run_with_retry
    raise subprocess.CalledProcessError(
subprocess.CalledProcessError: Command 'build/base/release/duckdb old.duckdb < benchmark/imdb_plan_cost/init/load.sql' returned non-zero exit status 139.
Error: Process completed with exit code 1.
```