### PR TITLE
Add setting to allows to get compile time STANDARD_VECTOR_SIZE from SQL

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1176,6 +1176,17 @@
         "custom_implementation": true
     },
     {
+        "name": "standard_vector_size",
+        "description": "The compiled-in STANDARD_VECTOR_SIZE (read-only)",
+        "type": "UBIGINT",
+        "scope": "global",
+        "custom_implementation": [
+            "get",
+            "set",
+            "reset"
+        ]
+    },
+    {
         "name": "storage_block_prefetch",
         "description": "In which scenarios to use storage block prefetching",
         "type": "ENUM<StorageBlockPrefetch>",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1726,6 +1726,16 @@ struct SecretDirectorySetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct StandardVectorSizeSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "standard_vector_size";
+	static constexpr const char *Description = "The compiled-in STANDARD_VECTOR_SIZE (read-only)";
+	static constexpr const char *InputType = "UBIGINT";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct StorageBlockPrefetchSetting {
 	using RETURN_TYPE = StorageBlockPrefetch;
 	static constexpr const char *Name = "storage_block_prefetch";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -212,6 +212,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(SchemaSetting),
     DUCKDB_LOCAL(SearchPathSetting),
     DUCKDB_GLOBAL(SecretDirectorySetting),
+    DUCKDB_GLOBAL(StandardVectorSizeSetting),
     DUCKDB_SETTING_CALLBACK(StorageBlockPrefetchSetting),
     DUCKDB_GLOBAL(StorageCompatibilityVersionSetting),
     DUCKDB_LOCAL(StreamingBufferSizeSetting),
@@ -235,9 +236,9 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 118),
                                                      DUCKDB_SETTING_ALIAS("null_order", 53),
                                                      DUCKDB_SETTING_ALIAS("profiling_output", 139),
-                                                     DUCKDB_SETTING_ALIAS("user", 155),
+                                                     DUCKDB_SETTING_ALIAS("user", 156),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 153),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 154),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1480,6 +1480,21 @@ Value StorageCompatibilityVersionSetting::GetSetting(const ClientContext &contex
 }
 
 //===----------------------------------------------------------------------===//
+// Standard Vector Size
+//===----------------------------------------------------------------------===//
+void StandardVectorSizeSetting::SetGlobal(DatabaseInstance *, DBConfig &, const Value &) {
+	throw InvalidInputException("standard_vector_size is a read-only setting determined at compile time");
+}
+
+void StandardVectorSizeSetting::ResetGlobal(DatabaseInstance *, DBConfig &) {
+	throw InvalidInputException("standard_vector_size is a read-only setting determined at compile time");
+}
+
+Value StandardVectorSizeSetting::GetSetting(const ClientContext &) {
+	return Value::UBIGINT(DuckDB::StandardVectorSize());
+}
+
+//===----------------------------------------------------------------------===//
 // Streaming Buffer Size
 //===----------------------------------------------------------------------===//
 void StreamingBufferSizeSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -215,6 +215,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "worker_threads",
 	    "tracked_metrics",
 	    "debug_verification_mode",
+	    "standard_vector_size",
 	    "warnings_as_errors",      // requires logging to be enabled
 	    "block_allocator_memory"}; // cant reduce
 	return excluded_options.count(name) == 1;


### PR DESCRIPTION
Minor, but handy to double check what's the compiled in `STANDARD_VECTOR_SIZE`

```sql
SELECT current_setting('standard_vector_size');
--- 2048
```