### PR TITLE
 Require parallel access for shared handle in external file cache

### DIFF
--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -200,7 +200,11 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 		return *file_handle;
 	}
 
-	file_handle = caching_file_system.file_system.OpenFile(path, flags, opener);
+	// The caching file handle can service parallel block fetch tasks against a single shared FileHandle.
+	// Request parallel access on the underlying filesystem handle to avoid races in implementations that
+	// require explicit opt-in for concurrent pread-style access (e.g., HTTPFS).
+	auto internal_flags = flags | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
+	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
 	last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
 	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 


### PR DESCRIPTION
`HTTPFileHandle` is intended to support multi-threaded reads only when `RequireParallelAccess()` is enabled.

Without the flag, httpfs' `AddStatistics` is called from `HTTPFileSystem::TryRangeRequest(...)` after a successful HTTP range GET, to record (`offset`, `length`, `duration`). `HTTPFileHandle` data is not thread-safe and concurrent access results in data races and [use-after-free](https://github.com/duckdb/duckdb/actions/runs/26612217022/job/78420999231#step:10:41) errors. For example, it fails in:

```
duckdb::FetchBlockTask::ExecuteTask() in external file cache path
duckdb::HTTPFileSystem::Read(...) at httpfs.cpp:630
duckdb::HTTPFileSystem::ReadInternal(...) at httpfs.cpp:552
duckdb::HTTPFileSystem::TryRangeRequest(...) at httpfs.cpp:504
duckdb::HTTPFileHandle::AddStatistics(...) at httpfs.cpp:465
```

because `FetchBlockTask` which schedules parallel block fetches and can concurrently invoke HTTP reads on the same underlying handle.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9497.

note: I tried to replicate error locally with this SQL test, but it did not reproduce on my machine:
```sql
# name: test/sql/storage/external_file_cache/parallel_split_blocks.test_slow
# description: Update external file cache with parallel block fetch
# group: [external_file_cache]

require parquet

require httpfs

statement ok
SET threads=8;

statement ok
SET enable_external_file_cache=true;

# Force many blocks for a remote file to maximize parallel FetchBlockTask activity.
statement ok
SET external_file_cache_remote_block_size=2048;

# Warmup: populate external file cache for the remote parquet file.
statement ok
FROM read_blob('https://blobs.duckdb.org/data/shakespeare.parquet');

# Verify we cached multiple blocks for this file, i.e., we exercised block-splitting.
query I
SELECT count(*) > 1 FROM duckdb_external_file_cache()
WHERE path = 'https://blobs.duckdb.org/data/shakespeare.parquet';
----
true

# Stress repeated full reads through the external file cache path.
loop i 0 40

statement ok
FROM read_blob('https://blobs.duckdb.org/data/shakespeare.parquet');

endloop
```