### PR TITLE
Fix OSX release error: 'fmt/format.h' file not found

### DIFF
--- a/examples/embedded-c++/CMakeLists.txt
+++ b/examples/embedded-c++/CMakeLists.txt
@@ -4,6 +4,7 @@ project(example-c++)
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(../../src/include)
+include_directories(../../third_party/fmt/include)
 link_directories(../../build/release/src)
 
 add_executable(example main.cpp)


### PR DESCRIPTION
CI job `OSX Release` [fails](https://github.com/duckdb/duckdb/actions/runs/26670381090/job/78615844925) with:
```
-- Build files have been written to: /Users/runner/work/duckdb/duckdb/examples/embedded-c++/build
[ 50%] Building CXX object CMakeFiles/example.dir/main.cpp.o
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/main.cpp:1:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb.hpp:11:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/main/connection.hpp:18:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/main/relation.hpp:19:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/main/client_context.hpp:23:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/main/client_context_state.hpp:19:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/main/database_manager.hpp:17:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/common/checked_integer.hpp:13:
In file included from /Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/common/operator/add.hpp:14:
/Users/runner/work/duckdb/duckdb/examples/embedded-c++/../../src/include/duckdb/common/types/cast_helpers.hpp:20:10: fatal error: 'fmt/format.h' file not found
   20 | #include "fmt/format.h"
      |          ^~~~~~~~~~~~~~
1 error generated.
make[3]: *** [CMakeFiles/example.dir/main.cpp.o] Error 1
make[2]: *** [CMakeFiles/example.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [main] Error 2
```

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9507.