### PR TITLE
change sqllogictest branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -792,7 +792,7 @@ format-configs:
 
 
 third_party/sqllogictest:
-	git clone --depth=1 --branch hawkfish-statistical-rounding https://github.com/duckdb/sqllogictest.git third_party/sqllogictest
+	git clone --depth=1 --branch ccfelius/sqlite_overflow https://github.com/duckdb/sqllogictest.git third_party/sqllogictest
 
 sqlite: release | third_party/sqllogictest
 	git --git-dir third_party/sqllogictest/.git pull

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -35,7 +35,8 @@
         "test/parquet/variant/variant_stats_propagation.test",
         "test/sql/types/geo/geometry_compatability.test",
         "test/sql/copy/parquet/parquet_glob_cache.test",
-        "test/optimizer/joins/fkpk_composite_key_ce.test"
+        "test/optimizer/joins/fkpk_composite_key_ce.test",
+        "test/sql/cast/signed_cast_repro.test"
       ]
     },
     {

--- a/test/sql/cast/signed_cast_repro.test
+++ b/test/sql/cast/signed_cast_repro.test
@@ -1,0 +1,21 @@
+# name: test/sql/cast/signed_cast_repro.test
+# description: String to Integer casts with Decimals
+# group: [cast]
+
+statement ok
+CREATE TABLE tab2(col0 INTEGER, col1 INTEGER, col2 INTEGER)
+
+statement ok
+INSERT INTO tab2 VALUES(64,77,40)
+
+statement ok
+INSERT INTO tab2 VALUES(75,67,58)
+
+statement ok
+INSERT INTO tab2 VALUES(46,51,23)
+
+# the overflow error is optimized away
+query I
+SELECT 43 - MAX( ALL - 87 + col1 ) FROM tab2 WHERE col1 * col1 * - CAST( - col2 AS SIGNED ) * + - col0 * + - 77 * - col0 IS NOT NULL AND NOT + col0 BETWEEN 35 * - col2 AND NULL
+----
+NULL


### PR DESCRIPTION
In V1.5 the WHERE clause evaluates a chain of INT multiplications that overflow, which are on their turn causing an Out of Range Error.

Currently the multiplication is never executed since all input columns are non-null. So the test should pass since the error is optimized away.

Fixes https://github.com/orgs/duckdblabs/projects/43/views/3?filterQuery=-status%3ANew%2CBacklog%2C%22Ready+to+Pick+Up%22%2CDone+assignee%3A%40me&pane=issue&itemId=182928659&issue=duckdblabs%7Cduckdb-internal%7C9115