### PR TITLE
support `partition_by` for JSON writes

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/operator_expression.hpp"
@@ -48,17 +49,21 @@ static string GetSingleJSONCopyString(const string &loption, const vector<Value>
 
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	static const unordered_set<string> SUPPORTED_BASE_OPTIONS {
-	    "compression", "encoding", "use_tmp_file", "overwrite_or_ignore", "overwrite", "append", "filename_pattern",
-	    "file_extension", "per_thread_output", "file_size_bytes",
-	    // "partition_by", unsupported
-	    "return_files", "preserve_order", "return_stats", "write_partition_columns", "write_empty_file",
-	    "hive_file_pattern"};
+	    "compression",      "encoding",         "use_tmp_file",   "overwrite_or_ignore", "overwrite",
+	    "append",           "filename_pattern", "file_extension", "per_thread_output",   "file_size_bytes",
+	    "partition_by",     "return_files",     "preserve_order", "return_stats",        "write_partition_columns",
+	    "write_empty_file", "hive_file_pattern"};
 
 	auto &copy_info = *stmt.info;
 
 	// Parse the options, creating options for the CSV writer while doing so
 	string date_format;
 	string timestamp_format;
+	// Partition columns are kept as separate columns (instead of being packed into the JSON object), so that the
+	// COPY writer can partition on them. By default they are excluded from the written JSON, matching the behavior
+	// of the other formats. WRITE_PARTITION_COLUMNS keeps them inside the JSON object instead.
+	vector<string> partition_columns;
+	bool write_partition_columns = false;
 	// We insert the JSON file extension here so it works properly with PER_THREAD_OUTPUT/FILE_SIZE_BYTES etc.
 	case_insensitive_map_t<vector<Value>> csv_copy_options {{"file_extension", {"json"}}};
 	for (const auto &kv : copy_info.options) {
@@ -82,6 +87,24 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 		} else if (loption == "file_extension") {
 			// Since we set the file extension to "json" above, we need to override it
 			csv_copy_options["file_extension"] = {GetSingleJSONCopyString(loption, kv.second)};
+		} else if (loption == "partition_by") {
+			// Remember the partition columns so we can keep them as separate columns below
+			for (const auto &val : kv.second) {
+				if (val.IsNull()) {
+					ThrowJSONCopyNullException(loption);
+				}
+				partition_columns.push_back(val.ToString());
+			}
+			// Pass the option through to the CSV writer
+			csv_copy_options.insert(kv);
+		} else if (loption == "write_partition_columns") {
+			if (!kv.second.empty() && kv.second.back().IsNull()) {
+				ThrowJSONCopyNullException(loption);
+			}
+			// Handled below by keeping the partition columns inside the JSON object. We do not forward this to the
+			// CSV writer, as that would write the (separate) partition columns as their own JSON lines.
+			write_partition_columns =
+			    kv.second.empty() || BooleanValue::Get(kv.second.back().DefaultCastAs(LogicalTypeId::BOOLEAN));
 		} else if (SUPPORTED_BASE_OPTIONS.find(loption) != SUPPORTED_BASE_OPTIONS.end()) {
 			if (!kv.second.empty() && kv.second.back().IsNull()) {
 				ThrowJSONCopyNullException(loption);
@@ -141,6 +164,12 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 
 	auto columns_star = make_uniq<StarExpression>();
 	columns_star->IsColumnsMutable() = true;
+	if (!write_partition_columns) {
+		// Exclude the partition columns from the JSON object - they are kept as separate columns below
+		for (const auto &partition_column : partition_columns) {
+			columns_star->ExcludeListMutable().insert(QualifiedColumnName(partition_column));
+		}
+	}
 	auto unpack = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_UNPACK);
 	unpack->GetChildrenMutable().push_back(std::move(columns_star));
 
@@ -151,6 +180,13 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	vector<unique_ptr<ParsedExpression>> to_json_args;
 	to_json_args.push_back(std::move(struct_pack));
 	select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
+
+	// Keep the partition columns as separate columns so the COPY writer can partition on them. The writer routes rows
+	// into the right files based on these columns but does not write them to disk (WRITE_PARTITION_COLUMNS is handled
+	// above by keeping the columns inside the JSON object instead).
+	for (const auto &partition_column : partition_columns) {
+		select_node.select_list.push_back(make_uniq<ColumnRefExpression>(partition_column));
+	}
 
 	// Now we can just use the CSV writer
 	copy_info.format = "csv";

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/common/bind_helpers.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
@@ -47,6 +48,36 @@ static string GetSingleJSONCopyString(const string &loption, const vector<Value>
 	return StringValue::Get(value);
 }
 
+static bool GetJSONCopyBoolean(Binder &binder, const string &loption, const vector<Value> &values) {
+	if (values.size() > 1) {
+		throw InvalidInputException("Copy option \"%s\" did not expect a list as argument", loption);
+	}
+	if (values.empty()) {
+		return true;
+	}
+	if (values.back().IsNull()) {
+		ThrowJSONCopyNullException(loption);
+	}
+	return values.back().CastAs(binder.context, LogicalType::BOOLEAN).GetValue<bool>();
+}
+
+static unique_ptr<SubqueryRef> PushJSONFormatProjection(unique_ptr<SubqueryRef> source_ref, const string &function_name,
+                                                        const string &format) {
+	auto format_node = make_uniq<SelectNode>();
+	format_node->from_table = std::move(source_ref);
+
+	auto columns_star = make_uniq<StarExpression>();
+	columns_star->IsColumnsMutable() = true;
+	vector<unique_ptr<ParsedExpression>> args;
+	args.push_back(std::move(columns_star));
+	args.push_back(make_uniq<ConstantExpression>(Value(format)));
+	format_node->select_list.push_back(make_uniq<FunctionExpression>(function_name, std::move(args)));
+
+	auto format_stmt = make_uniq<SelectStatement>();
+	format_stmt->node = std::move(format_node);
+	return make_uniq<SubqueryRef>(std::move(format_stmt));
+}
+
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	static const unordered_set<string> SUPPORTED_BASE_OPTIONS {
 	    "compression",      "encoding",         "use_tmp_file",   "overwrite_or_ignore", "overwrite",
@@ -64,6 +95,7 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	// of the other formats. WRITE_PARTITION_COLUMNS keeps them inside the JSON object instead.
 	vector<string> partition_columns;
 	bool write_partition_columns = false;
+	vector<string> original_column_names;
 	// We insert the JSON file extension here so it works properly with PER_THREAD_OUTPUT/FILE_SIZE_BYTES etc.
 	case_insensitive_map_t<vector<Value>> csv_copy_options {{"file_extension", {"json"}}};
 	for (const auto &kv : copy_info.options) {
@@ -88,23 +120,31 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			// Since we set the file extension to "json" above, we need to override it
 			csv_copy_options["file_extension"] = {GetSingleJSONCopyString(loption, kv.second)};
 		} else if (loption == "partition_by") {
-			// Remember the partition columns so we can keep them as separate columns below
 			for (const auto &val : kv.second) {
 				if (val.IsNull()) {
 					ThrowJSONCopyNullException(loption);
 				}
-				partition_columns.push_back(val.ToString());
 			}
-			// Pass the option through to the CSV writer
-			csv_copy_options.insert(kv);
+			if (original_column_names.empty()) {
+				auto node_copy = copy_info.select_statement->Copy();
+				auto child_binder = Binder::CreateBinder(binder.context, &binder);
+				auto bound = child_binder->Bind(*node_copy);
+				original_column_names = std::move(bound.names);
+			}
+			auto converted = ConvertVectorToValue(vector<Value>(kv.second));
+			auto partition_indices = ParseColumnsOrdered(converted, original_column_names, loption);
+			for (auto &partition_index : partition_indices) {
+				partition_columns.push_back(original_column_names[partition_index]);
+			}
+			vector<Value> csv_partition_columns;
+			for (const auto &partition_column : partition_columns) {
+				csv_partition_columns.push_back(partition_column);
+			}
+			csv_copy_options["partition_by"] = std::move(csv_partition_columns);
 		} else if (loption == "write_partition_columns") {
-			if (!kv.second.empty() && kv.second.back().IsNull()) {
-				ThrowJSONCopyNullException(loption);
-			}
 			// Handled below by keeping the partition columns inside the JSON object. We do not forward this to the
 			// CSV writer, as that would write the (separate) partition columns as their own JSON lines.
-			write_partition_columns =
-			    kv.second.empty() || BooleanValue::Get(kv.second.back().DefaultCastAs(LogicalTypeId::BOOLEAN));
+			write_partition_columns = GetJSONCopyBoolean(binder, loption, kv.second);
 		} else if (SUPPORTED_BASE_OPTIONS.find(loption) != SUPPORTED_BASE_OPTIONS.end()) {
 			if (!kv.second.empty() && kv.second.back().IsNull()) {
 				ThrowJSONCopyNullException(loption);
@@ -115,6 +155,11 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 			throw BinderException("Unknown option for COPY ... TO ... (FORMAT JSON): \"%s\".", loption);
 		}
 	}
+	if (!write_partition_columns && !partition_columns.empty() &&
+	    partition_columns.size() == original_column_names.size()) {
+		throw NotImplementedException("No column to write as all columns are specified as partition columns. "
+		                              "WRITE_PARTITION_COLUMNS option can be used to write partition columns.");
+	}
 
 	// Run the following query to convert everything into a single JSON column, then invoke the CSV writer
 	// SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source>
@@ -122,39 +167,13 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	auto inner_select_stmt = make_uniq<SelectStatement>();
 	inner_select_stmt->node = std::move(copy_info.select_statement);
 
-	unique_ptr<SubqueryRef> source_ref;
-	if (!date_format.empty() || !timestamp_format.empty()) {
-		// if we have date_format or timestamp_format defined, we use the json_copy macros to apply them
-		// e.g. SELECT json_copy_strftime_if_date(COLUMNS(*), date_format) FROM <source>
-		auto strftime_node = make_uniq<SelectNode>();
-		strftime_node->from_table = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
-
-		unique_ptr<ParsedExpression> expr;
-		auto columns_star = make_uniq<StarExpression>();
-		columns_star->IsColumnsMutable() = true;
-		expr = std::move(columns_star);
-		if (!date_format.empty()) {
-			// apply date format
-			vector<unique_ptr<ParsedExpression>> args;
-			args.push_back(std::move(expr));
-			args.push_back(make_uniq<ConstantExpression>(Value(date_format)));
-			auto strftime_date = make_uniq<FunctionExpression>("json_copy_strftime_if_date", std::move(args));
-			expr = std::move(strftime_date);
-		}
-		if (!timestamp_format.empty()) {
-			// apply timestamp format
-			vector<unique_ptr<ParsedExpression>> args;
-			args.push_back(std::move(expr));
-			args.push_back(make_uniq<ConstantExpression>(Value(timestamp_format)));
-			auto strftime_ts = make_uniq<FunctionExpression>("json_copy_strftime_if_timestamp", std::move(args));
-			expr = std::move(strftime_ts);
-		}
-		strftime_node->select_list.push_back(std::move(expr));
-		auto strftime_stmt = make_uniq<SelectStatement>();
-		strftime_stmt->node = std::move(strftime_node);
-		source_ref = make_uniq<SubqueryRef>(std::move(strftime_stmt));
-	} else {
-		source_ref = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
+	auto source_ref = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
+	if (!date_format.empty()) {
+		source_ref = PushJSONFormatProjection(std::move(source_ref), "json_copy_strftime_if_date", date_format);
+	}
+	if (!timestamp_format.empty()) {
+		source_ref =
+		    PushJSONFormatProjection(std::move(source_ref), "json_copy_strftime_if_timestamp", timestamp_format);
 	}
 
 	// Build outer: SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source_ref>

--- a/test/sql/json/copy_json_partition_by.test
+++ b/test/sql/json/copy_json_partition_by.test
@@ -1,0 +1,54 @@
+# name: test/sql/json/copy_json_partition_by.test
+# description: Test PARTITION_BY with COPY ... TO ... (FORMAT JSON) (issue #14927)
+# group: [json]
+
+require json
+
+# Basic partitioned write: the partition column drives the directory layout and (by default) is NOT written into
+# the JSON files themselves. One row per partition keeps the file contents deterministic.
+statement ok
+COPY (SELECT i AS part, 'v' || i AS val FROM range(2) t(i))
+TO '{TEST_DIR}/json_partition_basic' (FORMAT JSON, PARTITION_BY (part));
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_basic/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_basic/part=0/data_0.json	{"val":"v0"}
+{TEST_DIR}/json_partition_basic/part=1/data_0.json	{"val":"v1"}
+
+# WRITE_PARTITION_COLUMNS keeps the partition column inside the JSON object
+statement ok
+COPY (SELECT i AS part, 'v' || i AS val FROM range(2) t(i))
+TO '{TEST_DIR}/json_partition_written' (FORMAT JSON, PARTITION_BY (part), WRITE_PARTITION_COLUMNS true);
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_written/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_written/part=0/data_0.json	{"part":0,"val":"v0"}
+{TEST_DIR}/json_partition_written/part=1/data_0.json	{"part":1,"val":"v1"}
+
+# Multiple partition columns
+statement ok
+COPY (SELECT i AS a, i + 10 AS b, 'v' || i AS val FROM range(2) t(i))
+TO '{TEST_DIR}/json_partition_multi' (FORMAT JSON, PARTITION_BY (a, b));
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_multi/*/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_multi/a=0/b=10/data_0.json	{"val":"v0"}
+{TEST_DIR}/json_partition_multi/a=1/b=11/data_0.json	{"val":"v1"}
+
+# PARTITION_BY combined with date formatting still applies the format inside the JSON object
+statement ok
+COPY (SELECT DATE '2024-01-01' AS d, i AS val FROM range(2) t(i))
+TO '{TEST_DIR}/json_partition_dateformat' (FORMAT JSON, PARTITION_BY (val), dateformat '%Y/%m/%d');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_dateformat/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_dateformat/val=0/data_0.json	{"d":"2024/01/01"}
+{TEST_DIR}/json_partition_dateformat/val=1/data_0.json	{"d":"2024/01/01"}

--- a/test/sql/json/copy_json_partition_by.test
+++ b/test/sql/json/copy_json_partition_by.test
@@ -52,3 +52,43 @@ FROM read_text('{TEST_DIR}/json_partition_dateformat/*/*.json') ORDER BY filenam
 ----
 {TEST_DIR}/json_partition_dateformat/val=0/data_0.json	{"d":"2024/01/01"}
 {TEST_DIR}/json_partition_dateformat/val=1/data_0.json	{"d":"2024/01/01"}
+
+# PARTITION_BY all columns matches generic COPY and requires WRITE_PARTITION_COLUMNS
+statement error
+COPY (SELECT 1 AS a, 2 AS b)
+TO '{TEST_DIR}/json_partition_all' (FORMAT JSON, PARTITION_BY (a, b));
+----
+Not implemented Error: No column to write as all columns are specified as partition columns. WRITE_PARTITION_COLUMNS option can be used to write partition columns.
+
+statement error
+COPY (SELECT 1 AS a, 2 AS b)
+TO '{TEST_DIR}/json_partition_star' (FORMAT JSON, PARTITION_BY '*');
+----
+Not implemented Error: No column to write as all columns are specified as partition columns. WRITE_PARTITION_COLUMNS option can be used to write partition columns.
+
+statement ok
+COPY (SELECT 1 AS a, 2 AS b)
+TO '{TEST_DIR}/json_partition_star_written' (FORMAT JSON, PARTITION_BY '*', WRITE_PARTITION_COLUMNS);
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_star_written/*/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_star_written/a=1/b=2/data_0.json	{"a":1,"b":2}
+
+# Date formatting is projected before partitioning, so it also applies to hive partition values
+statement ok
+COPY (SELECT DATE '2024-01-02' AS d, 42 AS v)
+TO '{TEST_DIR}/json_partition_date_dir' (FORMAT JSON, PARTITION_BY (d), dateformat '%Y/%m/%d');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEST_DIR}/json_partition_date_dir/*/*.json') ORDER BY filename;
+----
+{TEST_DIR}/json_partition_date_dir/d=2024%2F01%2F02/data_0.json	{"v":42}
+
+statement error
+COPY (SELECT 1 AS a, 2 AS b)
+TO '{TEST_DIR}/json_partition_bad_wpc' (FORMAT JSON, PARTITION_BY (a), WRITE_PARTITION_COLUMNS (true, false));
+----
+Invalid Input Error: Copy option "write_partition_columns" did not expect a list as argument


### PR DESCRIPTION
Already supported by JSON reads via translation to a CSV read with special settings. This extends that approach to JSON writes.

Resolves #14927

An archive of the LLM thread through which this was implemented (with me reviewing/monitoring) is uploaded here:
https://gist.github.com/vergenzt/4ed340d1f38d087499728530b8e3f20d