### PR TITLE
Fix partial column metadata reuse bug

### DIFF
--- a/src/include/duckdb/storage/table/per_column_metadata_blocks.hpp
+++ b/src/include/duckdb/storage/table/per_column_metadata_blocks.hpp
@@ -34,6 +34,8 @@ public:
 	void AddColumn(idx_t col_idx, const vector<idx_t> &blocks);
 	//! Remove a column entry and all its block IDs (linear scan)
 	void RemoveColumn(idx_t col_idx);
+	//! Merge two PerColumnMetadataBlocks sorted by column index with disjoint column sets
+	static PerColumnMetadataBlocks Merge(const PerColumnMetadataBlocks &a, const PerColumnMetadataBlocks &b);
 
 	//! Iterate over all block IDs, passing (column_index, block_id) to the callback
 	template <typename Func>

--- a/src/storage/table/per_column_metadata_blocks.cpp
+++ b/src/storage/table/per_column_metadata_blocks.cpp
@@ -73,6 +73,33 @@ void PerColumnMetadataBlocks::AddColumn(idx_t col_idx, const vector<idx_t> &bloc
 	}
 }
 
+PerColumnMetadataBlocks PerColumnMetadataBlocks::Merge(const PerColumnMetadataBlocks &a,
+                                                       const PerColumnMetadataBlocks &b) {
+	PerColumnMetadataBlocks result;
+	result.data.reserve(a.data.size() + b.data.size());
+	idx_t ai = 0;
+	idx_t bi = 0;
+	// each marker is followed by its blocks until the next marker; data is sorted by column index
+	while (ai < a.data.size() && bi < b.data.size()) {
+		D_ASSERT(a.data[ai].is_column_index && b.data[bi].is_column_index);
+		D_ASSERT(a.data[ai].index != b.data[bi].index);
+		bool take_a = a.data[ai].index < b.data[bi].index;
+		const auto &src = take_a ? a.data : b.data;
+		idx_t &pos = take_a ? ai : bi;
+		result.data.push_back(src[pos++]); // marker
+		while (pos < src.size() && !src[pos].is_column_index) {
+			result.data.push_back(src[pos++]);
+		}
+	}
+	while (ai < a.data.size()) {
+		result.data.push_back(a.data[ai++]);
+	}
+	while (bi < b.data.size()) {
+		result.data.push_back(b.data[bi++]);
+	}
+	return result;
+}
+
 void PerColumnMetadataBlocks::RemoveColumn(idx_t col_idx) {
 	idx_t start = data.size();
 	idx_t end = data.size();

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1369,6 +1369,7 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 
 	RowGroupWriteInfo info(writer.GetPartialBlockManager(), compression_types, writer.GetCheckpointOptions());
 
+	vector<idx_t> reused_columns;
 	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
 		bool column_has_changes = true;
 		if (partial_reuse) {
@@ -1382,6 +1383,7 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 		if (!column_has_changes) {
 			// reuse this column's metadata
 			result.states.push_back(nullptr);
+			reused_columns.emplace_back(column_idx);
 			result_row_group->column_pointers[column_idx] = column_pointers[column_idx];
 			// carry forward existing column data and statistics
 			if (!ColumnIsLoaded(column_idx)) {
@@ -1406,6 +1408,17 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 			}
 			result_row_group->columns[column_idx] = CheckpointColumn(*this, column_idx, info, result);
 		}
+	}
+
+	if (!reused_columns.empty()) {
+		D_ASSERT(partial_reuse);
+		// carry forward the extras for reused columns onto the new row group, so RowGroup::Checkpoint
+		// can look them up via this->per_column_metadata_blocks
+		auto extras = per_column_metadata_blocks.GetBlocksForColumns(reused_columns);
+		for (idx_t i = 0; i < reused_columns.size(); i++) {
+			result_row_group->per_column_metadata_blocks.AddColumn(reused_columns[i], extras[i]);
+		}
+		result_row_group->has_per_column_metadata_blocks = true;
 	}
 
 	result.result_row_group = std::move(result_row_group);
@@ -1467,7 +1480,6 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 	}
 	// write path: write column metadata to disk (with optional per-column reuse)
 	D_ASSERT(write_data.states.size() == GetColumnCount());
-	vector<idx_t> reused_columns;
 
 	// merge stats
 	{
@@ -1475,7 +1487,6 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
 			bool is_reused = !write_data.states[column_idx];
 			if (is_reused) {
-				reused_columns.emplace_back(column_idx);
 				if (!ColumnIsLoaded(column_idx) &&
 				    collection.get().GetTypes()[column_idx].id() != LogicalTypeId::VARIANT) {
 					writer.SetHasUnloadedColumn(column_idx);
@@ -1492,28 +1503,17 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 
 	// collect blocks that need to be preserved for reused columns
 	vector<MetaBlockPointer> reused_column_blocks;
-
-	vector<vector<idx_t>> extra_blocks_for_columns;
-	if (!reused_columns.empty()) {
-		extra_blocks_for_columns = per_column_metadata_blocks.GetBlocksForColumns(reused_columns);
-	}
-	idx_t reused_column_idx = 0;
+	// per-column extras for newly written columns, collected separately and merged with the
+	// partial map of reused-column extras (carried over onto this row group by WriteToDisk).
+	PerColumnMetadataBlocks written_column_blocks;
 
 	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
 		bool is_reused = !write_data.states[column_idx];
 		if (is_reused) {
-			// reuse existing column pointer and per-column blocks
+			// reuse existing column pointer (extras are already carried on this->per_column_metadata_blocks)
 			auto col_ptr = column_pointers[column_idx];
 			row_group_pointer.data_pointers.push_back(col_ptr);
-			auto &col_blocks = extra_blocks_for_columns[reused_column_idx];
-			row_group_pointer.per_column_metadata_blocks.AddColumn(column_idx, col_blocks);
-
-			// collect all blocks for this reused column for ClearModifiedBlocks
 			reused_column_blocks.push_back(col_ptr);
-			for (auto &block_id : col_blocks) {
-				reused_column_blocks.emplace_back(block_id, 0);
-			}
-			++reused_column_idx;
 			continue;
 		}
 		// write new metadata for this column
@@ -1553,16 +1553,35 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 				col_extra_blocks.push_back(written_ptr.block_pointer);
 			}
 		}
-		row_group_pointer.per_column_metadata_blocks.AddColumn(column_idx, col_extra_blocks);
+		written_column_blocks.AddColumn(column_idx, col_extra_blocks);
 	}
 
 	if (GetCollection().SupportsPerColumnWrites()) {
-		row_group_pointer.has_per_column_metadata_blocks = true; // blocks already populated above
+		row_group_pointer.has_per_column_metadata_blocks = true;
+		if (write_data.write_action == RowGroupWriteAction::PARTIALLY_REUSE_COLUMN_METADATA) {
+			// merge reused-column extras (on this) with newly-written-column extras
+			D_ASSERT(has_per_column_metadata_blocks);
+			row_group_pointer.per_column_metadata_blocks =
+			    PerColumnMetadataBlocks::Merge(per_column_metadata_blocks, written_column_blocks);
+
+			// reused column blocks must be preserved by ClearModifiedBlocks
+			per_column_metadata_blocks.ForEachBlock(
+			    [&](idx_t, idx_t block_id) { reused_column_blocks.emplace_back(block_id, 0); });
+		} else {
+			row_group_pointer.per_column_metadata_blocks = written_column_blocks;
+		}
+		row_group_pointer.has_metadata_blocks = false;
+		row_group_pointer.extra_metadata_blocks.clear();
 	} else {
-		row_group_pointer.has_metadata_blocks = true;
-		row_group_pointer.per_column_metadata_blocks.ForEachBlock(
-		    [&](idx_t, idx_t block_id) { row_group_pointer.extra_metadata_blocks.push_back(block_id); });
+		// Per-column reuse is not supported, so instead flatten the newly-written per-column extras into
+		// extra_metadata_blocks to still allow reusing the full row-group metadata on future checkpoints.
+		D_ASSERT(write_data.write_action != RowGroupWriteAction::PARTIALLY_REUSE_COLUMN_METADATA);
+		row_group_pointer.has_per_column_metadata_blocks = false;
 		row_group_pointer.per_column_metadata_blocks = {};
+		row_group_pointer.has_metadata_blocks = true;
+		row_group_pointer.extra_metadata_blocks.clear();
+		written_column_blocks.ForEachBlock(
+		    [&](idx_t, idx_t block_id) { row_group_pointer.extra_metadata_blocks.push_back(block_id); });
 	}
 
 	if (metadata_manager) {

--- a/test/sql/storage/metadata/partial_column_metadata_reuse_small_block.test
+++ b/test/sql/storage/metadata/partial_column_metadata_reuse_small_block.test
@@ -1,0 +1,44 @@
+# name: test/sql/storage/metadata/partial_column_metadata_reuse_small_block.test
+# description: Regression test for PARTIALLY_REUSE_COLUMN_METADATA losing per-column extras for reused columns
+# group: [metadata]
+
+# small block size shrinks the metadata block size (block_size / 64), so per-row-group
+# column metadata easily spills past one metadata block and reused columns end up with extras
+statement ok
+ATTACH '__TEST_DIR__/partial_reuse_carries_column_extras.db' (BLOCK_SIZE 16384, STORAGE_VERSION 'latest')
+
+statement ok
+USE partial_reuse_carries_column_extras
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+statement ok
+SET force_column_metadata_reuse=true
+
+statement ok
+SET debug_verify_blocks=true
+
+statement ok
+CREATE TABLE wide_tbl AS SELECT
+    i AS c0, i AS c1, i AS c2, i AS c3, i AS c4,
+    i AS c5, i AS c6, i AS c7, i AS c8, i AS c9,
+    i AS c10, i AS c11, i AS c12, i AS c13, i AS c14, i AS c15
+FROM range(500000) t(i)
+
+# Initial checkpoint persists all column metadata, spilling into extra metadata blocks
+statement ok
+CHECKPOINT
+
+# Partial update: only c6 and c7 change, all others remain reused
+statement ok
+UPDATE wide_tbl SET c6 = c6 + 1, c7 = c7 + 1 WHERE c0 < 100
+
+# Without the fix this checkpoint fails because reused-column extras are dropped
+statement ok
+CHECKPOINT
+
+query II
+SELECT COUNT(*), SUM(c0) FROM wide_tbl
+----
+500000	124999750000


### PR DESCRIPTION
Fixes an (unreleased) bug from https://github.com/duckdb/duckdb/pull/22333 where the column metadata would not be carried correctly forward between `RowGroup::WriteToDisk` and `RowGroup::Checkpoint` when forcing column metadata reuse was enabled (disabled by default in 1.5).

Found this while fuzzing the existing test suite with a combination of force_column_metadata_reuse / debug_verify_blocks / "force_restart": "true" and  "block_size": "16384" and added a test to specifically catch this.