### PR TITLE
use StringUtil char helpers in geometry WKT parsers

### DIFF
--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types/geometry.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "fast_float/fast_float.h"
 #include "fmt/format.h"
@@ -245,7 +246,7 @@ public:
 
 	bool TryMatch(const char *str) {
 		auto ptr = pos;
-		while (*str && pos < end && tolower(*pos) == tolower(*str)) {
+		while (*str && pos < end && StringUtil::CharacterToLower(*pos) == StringUtil::CharacterToLower(*str)) {
 			pos++;
 			str++;
 		}
@@ -258,7 +259,7 @@ public:
 	}
 
 	bool TryMatch(char c) {
-		if (pos < end && tolower(*pos) == tolower(c)) {
+		if (pos < end && StringUtil::CharacterToLower(*pos) == StringUtil::CharacterToLower(c)) {
 			pos++;
 			SkipWhitespace(); // remove trailing whitespace
 			return true;      // matched
@@ -326,7 +327,7 @@ public:
 	}
 
 	void SkipWhitespace() {
-		while (pos < end && isspace(*pos)) {
+		while (pos < end && StringUtil::CharacterIsSpace(*pos)) {
 			pos++;
 		}
 	}

--- a/src/common/types/geometry_crs.cpp
+++ b/src/common/types/geometry_crs.cpp
@@ -156,10 +156,10 @@ private:
 	bool TryMatchText(string &result) {
 		const auto start = pos;
 		// First character must be alphabetic or underscore
-		if (pos < end && (isalpha(*pos) || *pos == '_')) {
+		if (pos < end && (StringUtil::CharacterIsAlpha(*pos) || *pos == '_')) {
 			pos++;
 			// Subsequent characters can also include digits
-			while (pos < end && (isalnum(*pos) || *pos == '_')) {
+			while (pos < end && (StringUtil::CharacterIsAlphaNumeric(*pos) || *pos == '_')) {
 				pos++;
 			}
 		}
@@ -286,7 +286,7 @@ private:
 	}
 
 	void SkipWhitespace() {
-		while (pos < end && isspace(*pos)) {
+		while (pos < end && StringUtil::CharacterIsSpace(*pos)) {
 			pos++;
 		}
 	}

--- a/test/sql/types/geo/geometry_nonascii_cast.test
+++ b/test/sql/types/geo/geometry_nonascii_cast.test
@@ -1,0 +1,26 @@
+# name: test/sql/types/geo/geometry_nonascii_cast.test
+# description: WKT with non-ascii bytes must not pass a negative char to ctype helpers
+# group: [geo]
+
+# The high-bit bytes of 'ä' (0xC3 0xA4) used to reach tolower/isspace/isalpha
+# as negative chars while parsing the WKT string, which is undefined behavior.
+
+statement error
+select 'pä int(0 1)'::GEOMETRY
+----
+Invalid Input Error
+
+statement error
+select 'ä POINT(0 1)'::GEOMETRY
+----
+Invalid Input Error
+
+# valid geometry still parses
+query I
+select 'POINT(0 1)'::GEOMETRY::VARCHAR
+----
+POINT (0 1)
+
+# non-ascii bytes in a CRS definition string must not crash the WKT2 parser
+statement ok
+select ST_SetCRS('POINT(0 1)'::GEOMETRY, 'GEäDCRS')


### PR DESCRIPTION
The WKT parsers in geometry.cpp and geometry_crs.cpp pass a raw signed char to tolower/isspace/isalpha/isalnum, so casting a non-ascii VARCHAR to GEOMETRY (or passing one through ST_SetCRS) feeds a negative value to the ctype functions (UB, CERT STR37-C). Swapped them for the StringUtil::Character* helpers, which are pure ascii checks already used elsewhere in geometry_crs.cpp.