### PR TITLE
Support multiple triggers per table event

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1385,6 +1385,11 @@ optional_ptr<CatalogEntry> DuckTableEntry::CreateTrigger(CatalogTransaction tran
 		if (old_entry) {
 			return nullptr;
 		}
+	} else if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		auto old_entry = triggers->GetEntry(transaction, entry_name);
+		if (old_entry) {
+			triggers->DropEntry(transaction, entry_name, false);
+		}
 	}
 	if (!triggers->CreateEntry(transaction, entry_name, std::move(trigger), dependencies)) {
 		throw CatalogException::EntryAlreadyExists(CatalogType::TRIGGER_ENTRY, entry_name);

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -376,6 +376,8 @@ vector<const_reference<TriggerCatalogEntry>> TableCatalogEntry::GetTriggersForEv
                                                                                     TriggerTiming timing,
                                                                                     TriggerEventType event_type) const {
 	vector<const_reference<TriggerCatalogEntry>> result;
+	// CatalogSet is backed by case_insensitive_tree_t (a map with case-insensitive comparator),
+	// so ScanTriggers yields entries in alphabetical order by name
 	ScanTriggers(transaction, [&](CatalogEntry &entry) {
 		auto &trigger = entry.Cast<TriggerCatalogEntry>();
 		if (trigger.timing == timing && trigger.event_type == event_type) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -681,12 +681,10 @@ BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<Pa
 		// Inject alias CTEs into the trigger body's own CTE map so each trigger' aliases won't be visible
 		// a local WITH shadows the alias
 		auto &body_map = trig_cte->query_node->cte_map.map;
-		if (!trigger.referencing_new_table.empty() &&
-		    body_map.find(trigger.referencing_new_table) == body_map.end()) {
+		if (!trigger.referencing_new_table.empty() && body_map.find(trigger.referencing_new_table) == body_map.end()) {
 			body_map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);
 		}
-		if (!trigger.referencing_old_table.empty() &&
-		    body_map.find(trigger.referencing_old_table) == body_map.end()) {
+		if (!trigger.referencing_old_table.empty() && body_map.find(trigger.referencing_old_table) == body_map.end()) {
 			body_map[trigger.referencing_old_table] = MakeTransitionTableAliasCTE(base_cte_name);
 		}
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -625,7 +625,7 @@ unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
 }
 
 static constexpr const char *TRIGGER_BASE_CTE_PREFIX = "__duckdb_trigger_base_";
-static constexpr const char *TRIGGER_BODY_CTE_PREFIX = "__duckdb_trigger_1_";
+static constexpr const char *TRIGGER_BODY_CTE_PREFIX = "__duckdb_trigger_body_";
 
 static unique_ptr<CommonTableExpressionInfo> MakeTransitionTableAliasCTE(const string &base_cte_name) {
 	auto alias_cte = make_uniq<CommonTableExpressionInfo>();
@@ -641,26 +641,18 @@ static unique_ptr<CommonTableExpressionInfo> MakeTransitionTableAliasCTE(const s
 
 BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
                                            const vector<const_reference<TriggerCatalogEntry>> &triggers) {
-	// multiple triggers per table are not yet supported
-	D_ASSERT(triggers.size() == 1);
+	D_ASSERT(!triggers.empty());
 
 	D_ASSERT(returning_list.empty());
 	returning_list.push_back(make_uniq<StarExpression>());
 
 	auto uuid_suffix = UUID::ToString(UUID::GenerateRandomUUID());
 	auto base_cte_name = TRIGGER_BASE_CTE_PREFIX + uuid_suffix;
-	auto body_cte_name = TRIGGER_BODY_CTE_PREFIX + uuid_suffix;
 
 	auto base_cte = make_uniq<CommonTableExpressionInfo>();
 	base_cte->query_node = node.Copy();
 	base_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
 	base_cte->is_trigger_generated = true;
-
-	auto &trigger = triggers[0].get();
-	auto trig_cte = make_uniq<CommonTableExpressionInfo>();
-	trig_cte->query_node = trigger.trigger_action->Copy();
-	trig_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
-	trig_cte->is_trigger_generated = true;
 
 	// count(*) over the base CTE gives CHANGED_ROWS ("N rows affected") to the client
 	auto outer = make_uniq<SelectNode>();
@@ -669,13 +661,27 @@ BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<Pa
 	from_ref->table_name = base_cte_name;
 	outer->from_table = std::move(from_ref);
 	outer->cte_map.map[base_cte_name] = std::move(base_cte);
-	if (!trigger.referencing_new_table.empty()) {
-		outer->cte_map.map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);
+
+	// Expand each trigger as a DML CTE.
+	// Alphabetical order by name (case-insensitive) - see GetTriggersForEvent.
+	for (idx_t i = 0; i < triggers.size(); i++) {
+		auto &trigger = triggers[i].get();
+		auto body_cte_name = string(TRIGGER_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
+
+		// Alias CTEs must precede the body CTE: cte_map is insertion-order-preserving.
+		if (!trigger.referencing_new_table.empty()) {
+			outer->cte_map.map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);
+		}
+		if (!trigger.referencing_old_table.empty()) {
+			outer->cte_map.map[trigger.referencing_old_table] = MakeTransitionTableAliasCTE(base_cte_name);
+		}
+
+		auto trig_cte = make_uniq<CommonTableExpressionInfo>();
+		trig_cte->query_node = trigger.trigger_action->Copy();
+		trig_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
+		trig_cte->is_trigger_generated = true;
+		outer->cte_map.map[body_cte_name] = std::move(trig_cte);
 	}
-	if (!trigger.referencing_old_table.empty()) {
-		outer->cte_map.map[trigger.referencing_old_table] = MakeTransitionTableAliasCTE(base_cte_name);
-	}
-	outer->cte_map.map[body_cte_name] = std::move(trig_cte);
 
 	auto bound = Bind(*outer);
 	auto &properties = GetStatementProperties();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -668,18 +668,23 @@ BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<Pa
 		auto &trigger = triggers[i].get();
 		auto body_cte_name = string(TRIGGER_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
 
-		// Alias CTEs must precede the body CTE: cte_map is insertion-order-preserving.
-		if (!trigger.referencing_new_table.empty()) {
-			outer->cte_map.map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);
-		}
-		if (!trigger.referencing_old_table.empty()) {
-			outer->cte_map.map[trigger.referencing_old_table] = MakeTransitionTableAliasCTE(base_cte_name);
-		}
-
 		auto trig_cte = make_uniq<CommonTableExpressionInfo>();
 		trig_cte->query_node = trigger.trigger_action->Copy();
 		trig_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
 		trig_cte->is_trigger_generated = true;
+
+		// Inject alias CTEs into the trigger body's own CTE map so each trigger' aliases won't be visible
+		// a local WITH shadows the alias
+		auto &body_map = trig_cte->query_node->cte_map.map;
+		if (!trigger.referencing_new_table.empty() &&
+		    body_map.find(trigger.referencing_new_table) == body_map.end()) {
+			body_map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);
+		}
+		if (!trigger.referencing_old_table.empty() &&
+		    body_map.find(trigger.referencing_old_table) == body_map.end()) {
+			body_map[trigger.referencing_old_table] = MakeTransitionTableAliasCTE(base_cte_name);
+		}
+
 		outer->cte_map.map[body_cte_name] = std::move(trig_cte);
 	}
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -621,7 +621,12 @@ unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
 		}
 	}
 	expanded_tables.insert(table);
-	return make_uniq<BoundStatement>(ExpandAfterTriggers(node, returning_list, triggers));
+	auto bound = ExpandAfterTriggers(node, returning_list, triggers);
+
+	// Erasing from the set, so we will track expanded tables only while we're on the same node in the recursive stack,
+	// meaning we're on the same "trigger" in the trigger chain.
+	expanded_tables.erase(table);
+	return make_uniq<BoundStatement>(std::move(bound));
 }
 
 static constexpr const char *TRIGGER_BASE_CTE_PREFIX = "__duckdb_trigger_base_";

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -543,14 +543,6 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 	    create_trigger_info.event_type == TriggerEventType::DELETE_EVENT) {
 		throw BinderException("REFERENCING NEW TABLE AS is not valid for AFTER DELETE triggers");
 	}
-	if (create_trigger_info.on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT) {
-		table.ScanTriggers(table.ParentCatalog().GetCatalogTransaction(context), [&](CatalogEntry &entry) {
-			auto &t = entry.Cast<TriggerCatalogEntry>();
-			if (t.timing == create_trigger_info.timing && t.event_type == create_trigger_info.event_type) {
-				throw NotImplementedException("Multiple triggers per table event are not yet supported");
-			}
-		});
-	}
 
 	// Validate the trigger body using an isolated binder (own GlobalBinderState).
 	// Set up trigger_expanded_tables to match runtime behavior.

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -79,7 +79,8 @@
         "test/sql/trigger/trigger_after_update.test",
         "test/sql/trigger/trigger_after_update_referencing.test",
         "test/sql/trigger/trigger_after_delete_referencing.test",
-        "test/sql/trigger/trigger_referencing_validation.test"
+        "test/sql/trigger/trigger_referencing_validation.test",
+        "test/sql/trigger/trigger_multiple_per_event.test"
       ]
     },
     {

--- a/test/sql/trigger/trigger_after_delete.test
+++ b/test/sql/trigger/trigger_after_delete.test
@@ -83,7 +83,7 @@ SELECT COUNT(*) FROM strict_log;
 ----
 1
 
-# Multiple triggers on the same event are not yet supported
+# Multiple triggers on the same event are supported
 statement ok
 CREATE TABLE t_multi (id INTEGER);
 
@@ -94,11 +94,20 @@ statement ok
 CREATE TRIGGER trg_multi_a AFTER DELETE ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('a');
 
-statement error
+statement ok
 CREATE TRIGGER trg_multi_b AFTER DELETE ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+statement ok
+DELETE FROM t_multi;
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
 ----
-Not implemented Error: Multiple triggers per table event are not yet supported
+2
 
 # Trigger body can be an UPDATE statement
 statement ok

--- a/test/sql/trigger/trigger_after_insert.test
+++ b/test/sql/trigger/trigger_after_insert.test
@@ -83,7 +83,7 @@ SELECT COUNT(*) FROM strict_log;
 ----
 1
 
-# Multiple triggers on the same event are not yet supported
+# Multiple triggers on the same event are supported
 statement ok
 CREATE TABLE t_multi (id INTEGER);
 
@@ -94,11 +94,17 @@ statement ok
 CREATE TRIGGER trg_multi_a AFTER INSERT ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('a');
 
-statement error
+statement ok
 CREATE TRIGGER trg_multi_b AFTER INSERT ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
 ----
-Not implemented Error: Multiple triggers per table event are not yet supported
+2
 
 # INSERT into nonexistent table is caught at CREATE TRIGGER time
 statement ok

--- a/test/sql/trigger/trigger_after_update.test
+++ b/test/sql/trigger/trigger_after_update.test
@@ -83,7 +83,7 @@ SELECT COUNT(*) FROM strict_log;
 ----
 1
 
-# Multiple triggers on the same event are not yet supported
+# Multiple triggers on the same event are supported
 statement ok
 CREATE TABLE t_multi (id INTEGER);
 
@@ -94,11 +94,20 @@ statement ok
 CREATE TRIGGER trg_multi_a AFTER UPDATE ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('a');
 
-statement error
+statement ok
 CREATE TRIGGER trg_multi_b AFTER UPDATE ON t_multi FOR EACH STATEMENT
     INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+statement ok
+UPDATE t_multi SET id = 2;
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
 ----
-Not implemented Error: Multiple triggers per table event are not yet supported
+2
 
 # Trigger body can be a DELETE statement
 statement ok

--- a/test/sql/trigger/trigger_multiple_per_event.test
+++ b/test/sql/trigger/trigger_multiple_per_event.test
@@ -1,0 +1,421 @@
+# name: test/sql/trigger/trigger_multiple_per_event.test
+# description: Test multiple triggers per table event
+# group: [trigger]
+
+require noforcestorage
+
+# Two triggers on same INSERT event - both fire
+statement ok
+CREATE TABLE t1 (id INTEGER);
+
+statement ok
+CREATE TABLE audit1 (msg VARCHAR);
+
+statement ok
+CREATE TABLE audit2 (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg1 AFTER INSERT ON t1 FOR EACH STATEMENT
+    INSERT INTO audit1 VALUES ('trg1 fired');
+
+statement ok
+CREATE TRIGGER trg2 AFTER INSERT ON t1 FOR EACH STATEMENT
+    INSERT INTO audit2 VALUES ('trg2 fired');
+
+statement ok
+INSERT INTO t1 VALUES (1);
+
+query I
+SELECT COUNT(*) FROM audit1;
+----
+1
+
+query I
+SELECT COUNT(*) FROM audit2;
+----
+1
+
+# Alphabetical order wins over creation order - b_trg created first, a_trg fires first
+statement ok
+CREATE TABLE t2 (id INTEGER);
+
+statement ok
+CREATE SEQUENCE order_seq START 1;
+
+statement ok
+CREATE TABLE order_audit (seq_val INTEGER, name VARCHAR);
+
+statement ok
+CREATE TRIGGER b_trg AFTER INSERT ON t2 FOR EACH STATEMENT
+    INSERT INTO order_audit VALUES (nextval('order_seq'), 'b_trg');
+
+statement ok
+CREATE TRIGGER a_trg AFTER INSERT ON t2 FOR EACH STATEMENT
+    INSERT INTO order_audit VALUES (nextval('order_seq'), 'a_trg');
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+query II
+SELECT seq_val, name FROM order_audit ORDER BY seq_val;
+----
+1	a_trg
+2	b_trg
+
+# Alphabetical order holds when creation order matches it too - a_trg created first, a_trg fires first,
+# making sure it's not LIFO for some reason
+statement ok
+CREATE TABLE t2b (id INTEGER);
+
+statement ok
+CREATE SEQUENCE order_seq2 START 1;
+
+statement ok
+CREATE TABLE order_audit2 (seq_val INTEGER, name VARCHAR);
+
+statement ok
+CREATE TRIGGER a_trg2 AFTER INSERT ON t2b FOR EACH STATEMENT
+    INSERT INTO order_audit2 VALUES (nextval('order_seq2'), 'a_trg2');
+
+statement ok
+CREATE TRIGGER b_trg2 AFTER INSERT ON t2b FOR EACH STATEMENT
+    INSERT INTO order_audit2 VALUES (nextval('order_seq2'), 'b_trg2');
+
+statement ok
+INSERT INTO t2b VALUES (1);
+
+query II
+SELECT seq_val, name FROM order_audit2 ORDER BY seq_val;
+----
+1	a_trg2
+2	b_trg2
+
+# Three triggers on same event - all fire
+statement ok
+CREATE TABLE t3 (id INTEGER);
+
+statement ok
+CREATE TABLE count3 (n INTEGER);
+
+statement ok
+INSERT INTO count3 VALUES (0);
+
+statement ok
+CREATE TRIGGER trg3_a AFTER INSERT ON t3 FOR EACH STATEMENT
+    UPDATE count3 SET n = n + 1;
+
+statement ok
+CREATE TRIGGER trg3_b AFTER INSERT ON t3 FOR EACH STATEMENT
+    UPDATE count3 SET n = n + 1;
+
+statement ok
+CREATE TRIGGER trg3_c AFTER INSERT ON t3 FOR EACH STATEMENT
+    UPDATE count3 SET n = n + 1;
+
+statement ok
+INSERT INTO t3 VALUES (1);
+
+query I
+SELECT n FROM count3;
+----
+3
+
+# Mixed events - two on INSERT, one on DELETE: only INSERT pair fires on INSERT
+statement ok
+CREATE TABLE t4 (id INTEGER);
+
+statement ok
+CREATE TABLE mixed_audit (event VARCHAR);
+
+statement ok
+CREATE TRIGGER t4_ins1 AFTER INSERT ON t4 FOR EACH STATEMENT
+    INSERT INTO mixed_audit VALUES ('insert1');
+
+statement ok
+CREATE TRIGGER t4_ins2 AFTER INSERT ON t4 FOR EACH STATEMENT
+    INSERT INTO mixed_audit VALUES ('insert2');
+
+statement ok
+CREATE TRIGGER t4_del AFTER DELETE ON t4 FOR EACH STATEMENT
+    INSERT INTO mixed_audit VALUES ('delete');
+
+statement ok
+INSERT INTO t4 VALUES (1), (2);
+
+query I
+SELECT COUNT(*) FROM mixed_audit WHERE event LIKE 'insert%';
+----
+2
+
+query I
+SELECT COUNT(*) FROM mixed_audit WHERE event = 'delete';
+----
+0
+
+statement ok
+DELETE FROM t4;
+
+query I
+SELECT COUNT(*) FROM mixed_audit WHERE event = 'delete';
+----
+1
+
+# REFERENCING aliases with multiple triggers - each trigger uses its own alias
+statement ok
+CREATE TABLE t5 (id INTEGER);
+
+statement ok
+CREATE TABLE ref_audit (val INTEGER);
+
+statement ok
+CREATE TRIGGER t5_ref1 AFTER INSERT ON t5
+    REFERENCING NEW TABLE AS new_rows1
+    FOR EACH STATEMENT
+    INSERT INTO ref_audit SELECT id FROM new_rows1;
+
+statement ok
+CREATE TRIGGER t5_ref2 AFTER INSERT ON t5
+    REFERENCING NEW TABLE AS new_rows2
+    FOR EACH STATEMENT
+    INSERT INTO ref_audit SELECT id * 10 FROM new_rows2;
+
+statement ok
+INSERT INTO t5 VALUES (1), (2);
+
+query I
+SELECT COUNT(*) FROM ref_audit;
+----
+4
+
+query I
+SELECT SUM(val) FROM ref_audit;
+----
+33
+
+# Same REFERENCING alias name across two triggers - both resolve to the same base CTE
+statement ok
+CREATE TABLE t6 (id INTEGER);
+
+statement ok
+CREATE TABLE same_alias_audit (val INTEGER);
+
+statement ok
+CREATE TRIGGER t6_a AFTER INSERT ON t6
+    REFERENCING NEW TABLE AS inserted
+    FOR EACH STATEMENT
+    INSERT INTO same_alias_audit SELECT id FROM inserted;
+
+statement ok
+CREATE TRIGGER t6_b AFTER INSERT ON t6
+    REFERENCING NEW TABLE AS inserted
+    FOR EACH STATEMENT
+    INSERT INTO same_alias_audit SELECT id * 100 FROM inserted;
+
+statement ok
+INSERT INTO t6 VALUES (3);
+
+query I
+SELECT COUNT(*) FROM same_alias_audit;
+----
+2
+
+query I
+SELECT SUM(val) FROM same_alias_audit;
+----
+303
+
+# REFERENCING alias from one trigger is not visible to a sibling trigger that did not declare it
+statement ok
+CREATE TABLE t6b (id INTEGER);
+
+statement ok
+CREATE TABLE t6b_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t6b_with_ref AFTER INSERT ON t6b
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT
+    INSERT INTO t6b_audit VALUES ('fired');
+
+statement error
+CREATE TRIGGER t6b_no_ref AFTER INSERT ON t6b FOR EACH STATEMENT
+    INSERT INTO t6b_audit SELECT id FROM new_rows;
+----
+<REGEX>:.*[Cc]atalog.*
+
+# Chained triggers - t7 has 2 triggers, one inserts into t7b which has its own trigger
+statement ok
+CREATE TABLE t7 (id INTEGER);
+
+statement ok
+CREATE TABLE t7b (id INTEGER);
+
+statement ok
+CREATE TABLE chain_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t7b_trg AFTER INSERT ON t7b FOR EACH STATEMENT
+    INSERT INTO chain_audit VALUES ('t7b fired');
+
+statement ok
+CREATE TRIGGER t7_direct AFTER INSERT ON t7 FOR EACH STATEMENT
+    INSERT INTO chain_audit VALUES ('t7 direct');
+
+statement ok
+CREATE TRIGGER t7_chain AFTER INSERT ON t7 FOR EACH STATEMENT
+    INSERT INTO t7b VALUES (99);
+
+statement ok
+INSERT INTO t7 VALUES (1);
+
+# t7_direct and t7b_trg (via t7_chain -> t7b) both write to chain_audit
+query I
+SELECT COUNT(*) FROM chain_audit;
+----
+2
+
+# t7b got a row from t7_chain, confirming the chain fired
+query I
+SELECT COUNT(*) FROM t7b;
+----
+1
+
+# Triggers on distinct unrelated tables both fire independently
+statement ok
+CREATE TABLE ta (id INTEGER);
+
+statement ok
+CREATE TABLE tb (id INTEGER);
+
+statement ok
+CREATE TABLE ta_audit (msg VARCHAR);
+
+statement ok
+CREATE TABLE tb_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER ta_trg AFTER INSERT ON ta FOR EACH STATEMENT
+    INSERT INTO ta_audit VALUES ('ta fired');
+
+statement ok
+CREATE TRIGGER tb_trg AFTER INSERT ON tb FOR EACH STATEMENT
+    INSERT INTO tb_audit VALUES ('tb fired');
+
+statement ok
+INSERT INTO ta VALUES (1);
+
+statement ok
+INSERT INTO tb VALUES (2);
+
+query I
+SELECT COUNT(*) FROM ta_audit;
+----
+1
+
+query I
+SELECT COUNT(*) FROM tb_audit;
+----
+1
+
+# Recursive trigger still blocked
+statement ok
+CREATE TABLE t8 (id INTEGER);
+
+statement error
+CREATE TRIGGER t8_recursive AFTER INSERT ON t8 FOR EACH STATEMENT
+    INSERT INTO t8 VALUES (1);
+----
+<REGEX>:.*[Rr]ecurs.*
+
+# Cycle through a multi-trigger chain is blocked: A has two triggers (one chains to B),
+# creating a trigger on B that inserts back into A is blocked
+statement ok
+CREATE TABLE t_cycle_a (id INTEGER);
+
+statement ok
+CREATE TABLE t_cycle_b (id INTEGER);
+
+statement ok
+CREATE TABLE t_cycle_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t_cycle_a_harmless AFTER INSERT ON t_cycle_a FOR EACH STATEMENT
+    INSERT INTO t_cycle_audit VALUES ('harmless');
+
+statement ok
+CREATE TRIGGER t_cycle_a_to_b AFTER INSERT ON t_cycle_a FOR EACH STATEMENT
+    INSERT INTO t_cycle_b VALUES (1);
+
+statement error
+CREATE TRIGGER t_cycle_b_to_a AFTER INSERT ON t_cycle_b FOR EACH STATEMENT
+    INSERT INTO t_cycle_a VALUES (1);
+----
+<REGEX>:.*[Rr]ecurs.*
+
+# DROP one trigger - other still fires
+statement ok
+CREATE TABLE t9 (id INTEGER);
+
+statement ok
+CREATE TABLE drop_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t9_keep AFTER INSERT ON t9 FOR EACH STATEMENT
+    INSERT INTO drop_audit VALUES ('keep');
+
+statement ok
+CREATE TRIGGER t9_drop AFTER INSERT ON t9 FOR EACH STATEMENT
+    INSERT INTO drop_audit VALUES ('drop');
+
+statement ok
+DROP TRIGGER t9_drop ON t9;
+
+statement ok
+INSERT INTO t9 VALUES (1);
+
+query I
+SELECT COUNT(*) FROM drop_audit WHERE msg = 'keep';
+----
+1
+
+query I
+SELECT COUNT(*) FROM drop_audit WHERE msg = 'drop';
+----
+0
+
+# OR REPLACE on one trigger - other is unaffected
+statement ok
+CREATE TABLE t10 (id INTEGER);
+
+statement ok
+CREATE TABLE replace_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t10_a AFTER INSERT ON t10 FOR EACH STATEMENT
+    INSERT INTO replace_audit VALUES ('original_a');
+
+statement ok
+CREATE TRIGGER t10_b AFTER INSERT ON t10 FOR EACH STATEMENT
+    INSERT INTO replace_audit VALUES ('b');
+
+statement ok
+CREATE OR REPLACE TRIGGER t10_a AFTER INSERT ON t10 FOR EACH STATEMENT
+    INSERT INTO replace_audit VALUES ('replaced_a');
+
+statement ok
+INSERT INTO t10 VALUES (1);
+
+query I
+SELECT COUNT(*) FROM replace_audit WHERE msg = 'original_a';
+----
+0
+
+query I
+SELECT COUNT(*) FROM replace_audit WHERE msg = 'replaced_a';
+----
+1
+
+query I
+SELECT COUNT(*) FROM replace_audit WHERE msg = 'b';
+----
+1

--- a/test/sql/trigger/trigger_multiple_per_event.test
+++ b/test/sql/trigger/trigger_multiple_per_event.test
@@ -243,6 +243,41 @@ CREATE TRIGGER t6b_no_ref AFTER INSERT ON t6b FOR EACH STATEMENT
 ----
 <REGEX>:.*[Cc]atalog.*
 
+# Two parent triggers both chain to the same child - child's trigger fires twice (once per parent chain)
+statement ok
+CREATE TABLE t_chain2_parent (id INTEGER);
+
+statement ok
+CREATE TABLE t_chain2_child (id INTEGER);
+
+statement ok
+CREATE TABLE t_chain2_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER t_chain2_child_trg AFTER INSERT ON t_chain2_child FOR EACH STATEMENT
+    INSERT INTO t_chain2_audit VALUES ('child fired');
+
+statement ok
+CREATE TRIGGER t_chain2_parent_a AFTER INSERT ON t_chain2_parent FOR EACH STATEMENT
+    INSERT INTO t_chain2_child VALUES (1);
+
+statement ok
+CREATE TRIGGER t_chain2_parent_b AFTER INSERT ON t_chain2_parent FOR EACH STATEMENT
+    INSERT INTO t_chain2_child VALUES (2);
+
+statement ok
+INSERT INTO t_chain2_parent VALUES (99);
+
+query I
+SELECT COUNT(*) FROM t_chain2_child;
+----
+2
+
+query I
+SELECT COUNT(*) FROM t_chain2_audit;
+----
+2
+
 # Chained triggers - t7 has 2 triggers, one inserts into t7b which has its own trigger
 statement ok
 CREATE TABLE t7 (id INTEGER);
@@ -349,6 +384,31 @@ CREATE TRIGGER t_cycle_a_to_b AFTER INSERT ON t_cycle_a FOR EACH STATEMENT
 statement error
 CREATE TRIGGER t_cycle_b_to_a AFTER INSERT ON t_cycle_b FOR EACH STATEMENT
     INSERT INTO t_cycle_a VALUES (1);
+----
+<REGEX>:.*[Rr]ecurs.*
+
+# Cycle detectable only through one of two triggers on A: T1 (A->B) is harmless,
+# T2 (A->C) creates the path that makes C->A a cycle - blocked because of T2
+statement ok
+CREATE TABLE t_cycle2_a (id INTEGER);
+
+statement ok
+CREATE TABLE t_cycle2_b (id INTEGER);
+
+statement ok
+CREATE TABLE t_cycle2_c (id INTEGER);
+
+statement ok
+CREATE TRIGGER t_cycle2_a_to_b AFTER INSERT ON t_cycle2_a FOR EACH STATEMENT
+    INSERT INTO t_cycle2_b VALUES (1);
+
+statement ok
+CREATE TRIGGER t_cycle2_a_to_c AFTER INSERT ON t_cycle2_a FOR EACH STATEMENT
+    INSERT INTO t_cycle2_c VALUES (1);
+
+statement error
+CREATE TRIGGER t_cycle2_c_to_a AFTER INSERT ON t_cycle2_c FOR EACH STATEMENT
+    INSERT INTO t_cycle2_a VALUES (1);
 ----
 <REGEX>:.*[Rr]ecurs.*
 

--- a/test/sql/trigger/trigger_multiple_per_event.test
+++ b/test/sql/trigger/trigger_multiple_per_event.test
@@ -243,6 +243,42 @@ CREATE TRIGGER t6b_no_ref AFTER INSERT ON t6b FOR EACH STATEMENT
 ----
 <REGEX>:.*[Cc]atalog.*
 
+# REFERENCING alias does not shadow a real table with the same name in a sibling trigger
+statement ok
+CREATE TABLE alias_parent (id INTEGER);
+
+statement ok
+CREATE TABLE shadow_alias (id INTEGER);
+
+statement ok
+CREATE TABLE alias_audit (id INTEGER);
+
+statement ok
+INSERT INTO shadow_alias VALUES (1000);
+
+statement ok
+CREATE TRIGGER a_alias AFTER INSERT ON alias_parent
+    REFERENCING NEW TABLE AS shadow_alias
+    FOR EACH STATEMENT
+    INSERT INTO alias_audit SELECT id FROM shadow_alias;
+
+statement ok
+CREATE TRIGGER b_plain AFTER INSERT ON alias_parent FOR EACH STATEMENT
+    INSERT INTO alias_audit SELECT id FROM shadow_alias;
+
+statement ok
+INSERT INTO alias_parent VALUES (7);
+
+query I
+SELECT COUNT(*) FROM alias_audit WHERE id = 7;
+----
+1
+
+query I
+SELECT COUNT(*) FROM alias_audit WHERE id = 1000;
+----
+1
+
 # Two parent triggers both chain to the same child - child's trigger fires twice (once per parent chain)
 statement ok
 CREATE TABLE t_chain2_parent (id INTEGER);


### PR DESCRIPTION
## Summary

Multiple triggers on the same table and event are now supported. When a DML statement fires, all matching triggers execute in alphabetical order by name.

**Note:** PostgreSQL uses byte (ASCII) ordering for trigger names, where uppercase sorts before lowercase.
We use the `CatalogEntryMap` which its comparator is not case-sensitive: https://github.com/duckdb/duckdb/blob/06efe8d484311db189cca15426445664b77d6201/src/catalog/catalog_set.cpp#L48-L50