### PR TITLE
Let AsyncExecutionTask always notify blocked pipeline when a task throws

### DIFF
--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -25,6 +25,8 @@ private:
 };
 
 class AsyncExecutionTask : public ExecutorTask {
+	enum class CompletionSignal { BATCH_FINISHED, BATCH_ERRORED };
+
 public:
 	AsyncExecutionTask(Executor &executor, unique_ptr<AsyncTask> &&async_task, InterruptState &interrupt_state,
 	                   shared_ptr<Counter> counter)
@@ -35,10 +37,10 @@ public:
 		try {
 			async_task->Execute();
 		} catch (...) {
-			SignalCompletion(true);
+			SignalCompletion(CompletionSignal::BATCH_ERRORED);
 			throw;
 		}
-		SignalCompletion(false);
+		SignalCompletion(CompletionSignal::BATCH_FINISHED);
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
@@ -47,9 +49,9 @@ public:
 	}
 
 private:
-	void SignalCompletion(bool force_callback) {
+	void SignalCompletion(CompletionSignal signal) {
 		auto finished = counter->IterateAndCheckCounter();
-		if (force_callback || finished) {
+		if (signal == CompletionSignal::BATCH_ERRORED || finished) {
 			interrupt_state.Callback();
 		}
 	}

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -32,10 +32,13 @@ public:
 	      counter(std::move(counter)) {
 	}
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
-		async_task->Execute();
-		if (counter->IterateAndCheckCounter()) {
-			interrupt_state.Callback();
+		try {
+			async_task->Execute();
+		} catch (...) {
+			SignalCompletion(true);
+			throw;
 		}
+		SignalCompletion(false);
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
@@ -44,6 +47,13 @@ public:
 	}
 
 private:
+	void SignalCompletion(bool force_callback) {
+		auto finished = counter->IterateAndCheckCounter();
+		if (force_callback || finished) {
+			interrupt_state.Callback();
+		}
+	}
+
 	unique_ptr<AsyncTask> async_task;
 	InterruptState interrupt_state;
 	shared_ptr<Counter> counter;

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -11,17 +11,24 @@
 
 namespace duckdb {
 
-struct Counter {
-	explicit Counter(idx_t size) : counter(size) {
+struct AsyncBatchCompletion {
+	explicit AsyncBatchCompletion(idx_t size) : counter(size), callback_sent(false) {
 	}
+
 	bool IterateAndCheckCounter() {
 		D_ASSERT(counter.load() > 0);
 		idx_t post_decreast = --counter;
 		return (post_decreast == 0);
 	}
 
+	bool MarkCallbackSent() {
+		bool expected = false;
+		return callback_sent.compare_exchange_strong(expected, true);
+	}
+
 private:
 	atomic<idx_t> counter;
+	atomic<bool> callback_sent;
 };
 
 class AsyncExecutionTask : public ExecutorTask {
@@ -29,9 +36,9 @@ class AsyncExecutionTask : public ExecutorTask {
 
 public:
 	AsyncExecutionTask(Executor &executor, unique_ptr<AsyncTask> &&async_task, InterruptState &interrupt_state,
-	                   shared_ptr<Counter> counter)
+	                   shared_ptr<AsyncBatchCompletion> completion)
 	    : ExecutorTask(executor, nullptr), async_task(std::move(async_task)), interrupt_state(interrupt_state),
-	      counter(std::move(counter)) {
+	      completion(std::move(completion)) {
 	}
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
 		try {
@@ -50,15 +57,21 @@ public:
 
 private:
 	void SignalCompletion(CompletionSignal signal) {
-		auto finished = counter->IterateAndCheckCounter();
-		if (signal == CompletionSignal::BATCH_ERRORED || finished) {
+		auto finished = completion->IterateAndCheckCounter();
+		if ((signal == CompletionSignal::BATCH_ERRORED || finished)) {
+			SendCallback();
+		}
+	}
+
+	void SendCallback() {
+		if (completion->MarkCallbackSent()) {
 			interrupt_state.Callback();
 		}
 	}
 
 	unique_ptr<AsyncTask> async_task;
 	InterruptState interrupt_state;
-	shared_ptr<Counter> counter;
+	shared_ptr<AsyncBatchCompletion> completion;
 };
 
 AsyncResult::AsyncResult(SourceResultType t) : AsyncResult(GetAsyncResultType(t)) {
@@ -104,10 +117,10 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 		throw InternalException("AsyncResult::ScheduleTasks called with no available tasks");
 	}
 
-	shared_ptr<Counter> counter = make_shared_ptr<Counter>(async_tasks.size());
+	shared_ptr<AsyncBatchCompletion> completion = make_shared_ptr<AsyncBatchCompletion>(async_tasks.size());
 
 	for (auto &async_task : async_tasks) {
-		auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state, counter);
+		auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state, completion);
 		TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task));
 	}
 }


### PR DESCRIPTION
In the NightlyTests workflow, the job `Forcing async Sinks/Sources` [fails](https://github.com/duckdb/duckdb/actions/runs/26699912877/job/78690840068#logs) with two test timeouts:

```
batch timed out after 600.0 seconds

=== stdout ===
[0/10] (0%): test/sql/copy/parquet/test_parquet_scan.test
[1/10] (10%): test/sql/copy/parquet/parquet_prefetch_projection.test
[2/10] (20%): test/sql/copy/parquet/parquet2.test
[3/10] (30%): test/sql/copy/parquet/parquet_6044.test
[4/10] (40%): test/sql/copy/parquet/recursive_parquet_union_by_name.test

...

batch timed out after 600.0 seconds

=== stdout ===
[0/10] (0%): test/sql/copy/partitioned/hive_partitioned_write.test
[1/10] (10%): test/sql/copy/partitioned/hive_filter_pushdown.test
[2/10] (20%): test/sql/copy/partitioned/hive_partition_case_insensitive_column.test
[3/10] (30%): test/sql/copy/partitioned/hive_partitioning_overwrite.test
[4/10] (40%): test/sql/copy/partitioned/partition_issue_6304.test
[5/10] (50%): test/sql/copy/partitioned/partitioned_order_by.test
[6/10] (60%): test/sql/copy/partitioned/hive_partition_recursive_cte.test
```

The hangs happen because `FORCE_ASYNC_SINK_SOURCE=1` makes parquet scans create fake async tasks for testing.

Some of those fake async tasks throw `ThrowAsyncTask`. Before this change, `AsyncExecutionTask` only called the interrupt callback after the async task finished successfully. If the task threw, the callback was skipped.

That left recursive CTE execution waiting forever here:

`ExecuteRecursivePipelineInline -> InterruptDoneSignalState::Await`

The fix makes `AsyncExecutionTask` always wake the waiting pipeline when an async task fails. On normal success, behavior stays the same: only the last async task in the batch wakes the waiter. On failure, we wake immediately so the query can see the executor error and stop instead of hanging.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9550.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9527.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9524.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9496.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9474.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9450.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9442.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9380.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9314.