### PR TITLE
Parquet Prefetch - CostModel for defining column gaps

### DIFF
--- a/.github/patches/extensions/httpfs/combined.patch
+++ b/.github/patches/extensions/httpfs/combined.patch
@@ -1,8 +1,92 @@
+diff --git a/src/httpfs.cpp b/src/httpfs.cpp
+index 1a9c466..348feb0 100644
+--- a/src/httpfs.cpp
++++ b/src/httpfs.cpp
+@@ -365,6 +365,18 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+ 	auto response = http_util.Request(get_request, http_client);
+ 
+ 	hfh.StoreClient(std::move(http_client));
++
++	// Feed the prefetch cost model a network measurement for this ranged GET
++	if (response && (response->Success() || response->status == HTTPStatusCode::PartialContent_206 ||
++	                 response->status == HTTPStatusCode::Accepted_202)) {
++		double total_seconds = 0;
++		if (get_request.request_end.value > get_request.request_start.value) {
++			total_seconds =
++			    static_cast<double>(get_request.request_end.value - get_request.request_start.value) / 1e6;
++		}
++		const idx_t bytes = get_request.bytes_received != 0 ? get_request.bytes_received : buffer_out_len;
++		hfh.RecordNetworkSample(total_seconds, bytes, get_request.have_ttfb, get_request.ttfb_seconds);
++	}
+ 	return response;
+ }
+ 
+@@ -462,9 +474,43 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file
+ }
+ 
+ void HTTPFileHandle::AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) {
++	lock_guard<mutex> guard(throughput_lock);
+ 	range_request_statistics.push_back({read_offset, read_length, read_duration});
+ }
+ 
++void HTTPFileHandle::RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb,
++                                         double ttfb_seconds) {
++	if (!(total_seconds > 0)) {
++		return;
++	}
++	lock_guard<mutex> guard(throughput_lock);
++	const idx_t n = tp_sample_count + 1;
++	const double alpha = MaxValue<double>(0.2, 1.0 / static_cast<double>(n));
++
++	if (sample_has_ttfb && ttfb_seconds > 0) {
++		tp_latency_seconds =
++		    tp_latency_seconds <= 0 ? ttfb_seconds : alpha * ttfb_seconds + (1.0 - alpha) * tp_latency_seconds;
++	}
++
++	const double transfer_seconds = sample_has_ttfb ? (total_seconds - ttfb_seconds) : total_seconds;
++	if (bytes >= MIN_BANDWIDTH_SAMPLE_BYTES && transfer_seconds > 0) {
++		const double bandwidth = static_cast<double>(bytes) / transfer_seconds;
++		tp_bandwidth_bps = tp_bandwidth_bps <= 0 ? bandwidth : alpha * bandwidth + (1.0 - alpha) * tp_bandwidth_bps;
++	}
++	tp_sample_count = n;
++}
++
++bool HTTPFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
++	lock_guard<mutex> guard(throughput_lock);
++	if (tp_sample_count == 0 || tp_latency_seconds <= 0 || tp_bandwidth_bps <= 0) {
++		return false;
++	}
++	result.latency_seconds = tp_latency_seconds;
++	result.bandwidth_bytes_per_s = tp_bandwidth_bps;
++	result.sample_count = tp_sample_count;
++	return true;
++}
++
+ void HTTPFileHandle::AdaptReadBufferSize(idx_t next_read_offset) {
+ 	D_ASSERT(!SkipBuffer());
+ 	if (range_request_statistics.empty()) {
 diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
-index efdc87d..c893468 100644
+index efdc87d..992ba63 100644
 --- a/src/httpfs_curl_client.cpp
 +++ b/src/httpfs_curl_client.cpp
-@@ -409,6 +409,34 @@ public:
+@@ -254,6 +254,16 @@ public:
+ 		curl_easy_getinfo(*curl, CURLINFO_RESPONSE_CODE, &request_info->response_code);
+ 
+ 		const idx_t bytes_received = request_info->body.size();
++
++		//  libcurl reports latency via CURLINFO_STARTTRANSFER_TIME
++		info.bytes_received = bytes_received;
++		double starttransfer_seconds = 0;
++		if (curl_easy_getinfo(*curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_seconds) == CURLE_OK &&
++		    starttransfer_seconds > 0) {
++			info.have_ttfb = true;
++			info.ttfb_seconds = starttransfer_seconds;
++		}
++
+ 		if (!request_info->header_collection.empty() &&
+ 		    request_info->header_collection.back().HasHeader("content-length")) {
+ 			const idx_t content_length_received =
+@@ -409,6 +419,34 @@ public:
  		return TransformResponseCurl(res);
  	}
  
@@ -38,10 +122,44 @@ index efdc87d..c893468 100644
  		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
  		ResetRequestInfo();
 diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
-index f4e01f7..21becf7 100644
+index f4e01f7..d3f9e39 100644
 --- a/src/httpfs_httplib_client.cpp
 +++ b/src/httpfs_httplib_client.cpp
-@@ -94,6 +94,11 @@ public:
+@@ -54,18 +54,32 @@ public:
+ 		if (!info.response_handler && !info.content_handler) {
+ 			return TransformResult(client->Get(info.path, headers));
+ 		} else {
+-			return TransformResult(client->Get(
++			// The httplib client streams per chunk, so the first chunk gives us TTFB, used by the prefetch cost model as the latency estimate.
++			const auto request_start = Timestamp::GetCurrentTimestamp();
++			idx_t total_bytes = 0;
++			bool first_chunk = true;
++			auto result = TransformResult(client->Get(
+ 			    info.path.c_str(), headers,
+ 			    [&](const duckdb_httplib_openssl::Response &response) {
+ 				    auto http_response = TransformResponse(response);
+ 				    return info.response_handler(*http_response);
+ 			    },
+ 			    [&](const char *data, size_t data_length) {
++				    if (first_chunk) {
++					    first_chunk = false;
++					    info.have_ttfb = true;
++			            // We calculate the time to first byte as the time from when the request was issues to the chunk arrived.
++					    info.ttfb_seconds =
++					        static_cast<double>(Timestamp::GetCurrentTimestamp().value - request_start.value) / 1e6;
++				    }
++				    total_bytes += data_length;
+ 				    if (state) {
+ 					    state->total_bytes_received += data_length;
+ 				    }
+ 				    return info.content_handler(const_data_ptr_cast(data), data_length);
+ 			    }));
++			info.bytes_received = total_bytes;
++			return result;
+ 		}
+ 	}
+ 	unique_ptr<HTTPResponse> Put(PutRequestInfo &info) override {
+@@ -94,6 +108,11 @@ public:
  		return TransformResult(client->Delete(info.path, headers));
  	}
  
@@ -53,6 +171,47 @@ index f4e01f7..21becf7 100644
  	unique_ptr<HTTPResponse> Post(PostRequestInfo &info) override {
  		if (state) {
  			state->post_count++;
+diff --git a/src/include/httpfs.hpp b/src/include/httpfs.hpp
+index 7d0f9b7..084405e 100644
+--- a/src/include/httpfs.hpp
++++ b/src/include/httpfs.hpp
+@@ -115,6 +115,11 @@ public:
+ 	void AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration);
+ 	void AdaptReadBufferSize(idx_t next_read_offset);
+ 
++	// Record a completed range request into the network throughput estimate (latency + bandwidth)
++	void RecordNetworkSample(double total_seconds, idx_t bytes, bool sample_has_ttfb, double ttfb_seconds);
++	// Expose the measured network throughput estimate to the (parquet) prefetch cost model.
++	bool TryGetNetworkThroughput(NetworkThroughputEstimate &result);
++
+ 	void AddHeaders(HTTPHeaders &map);
+ 
+ 	// Get a Client to run requests over
+@@ -138,6 +143,14 @@ private:
+ 	};
+ 	vector<RangeRequestStatistics> range_request_statistics;
+ 
++	// throughput_lock guards the throughput estimate (fed by RecordNetworkSample) and range_request_statistics against concurrent prefetch reads.
++	mutex throughput_lock;
++	double tp_latency_seconds = 0;
++	double tp_bandwidth_bps = 0;
++	idx_t tp_sample_count = 0;
++	// Minimum payload size for a request to contribute a bandwidth sample
++	constexpr static idx_t MIN_BANDWIDTH_SAMPLE_BYTES = 1 << 16; // 64 KiB
++
+ public:
+ 	void Close() override {
+ 	}
+@@ -210,6 +223,9 @@ public:
+ 	bool OnDiskFile(FileHandle &handle) override {
+ 		return false;
+ 	}
++	bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result) override {
++		return handle.Cast<HTTPFileHandle>().TryGetNetworkThroughput(result);
++	}
+ 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener) override {
+ 		return false;
+ 	}
 diff --git a/src/include/s3_multi_part_upload.hpp b/src/include/s3_multi_part_upload.hpp
 index c1020e7..2425342 100644
 --- a/src/include/s3_multi_part_upload.hpp

--- a/.github/patches/extensions/httpfs/combined.patch
+++ b/.github/patches/extensions/httpfs/combined.patch
@@ -1,8 +1,8 @@
 diff --git a/src/httpfs.cpp b/src/httpfs.cpp
-index 1a9c466..348feb0 100644
+index 1a9c466..973a3a5 100644
 --- a/src/httpfs.cpp
 +++ b/src/httpfs.cpp
-@@ -365,6 +365,18 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+@@ -365,6 +365,19 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
  	auto response = http_util.Request(get_request, http_client);
  
  	hfh.StoreClient(std::move(http_client));
@@ -16,12 +16,13 @@ index 1a9c466..348feb0 100644
 +			    static_cast<double>(get_request.request_end.value - get_request.request_start.value) / 1e6;
 +		}
 +		const idx_t bytes = get_request.bytes_received != 0 ? get_request.bytes_received : buffer_out_len;
-+		hfh.RecordNetworkSample(total_seconds, bytes, get_request.have_ttfb, get_request.ttfb_seconds);
++		hfh.RecordNetworkSample(total_seconds, bytes, get_request.have_time_to_fst_byte,
++		                        get_request.time_to_fst_byte_sec);
 +	}
  	return response;
  }
  
-@@ -462,9 +474,43 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file
+@@ -462,9 +475,42 @@ unique_ptr<FileHandle> HTTPFileSystem::OpenFileExtended(const OpenFileInfo &file
  }
  
  void HTTPFileHandle::AddStatistics(idx_t read_offset, idx_t read_length, idx_t read_duration) {
@@ -58,7 +59,6 @@ index 1a9c466..348feb0 100644
 +	}
 +	result.latency_seconds = tp_latency_seconds;
 +	result.bandwidth_bytes_per_s = tp_bandwidth_bps;
-+	result.sample_count = tp_sample_count;
 +	return true;
 +}
 +
@@ -66,7 +66,7 @@ index 1a9c466..348feb0 100644
  	D_ASSERT(!SkipBuffer());
  	if (range_request_statistics.empty()) {
 diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
-index efdc87d..992ba63 100644
+index efdc87d..3852958 100644
 --- a/src/httpfs_curl_client.cpp
 +++ b/src/httpfs_curl_client.cpp
 @@ -254,6 +254,16 @@ public:
@@ -79,8 +79,8 @@ index efdc87d..992ba63 100644
 +		double starttransfer_seconds = 0;
 +		if (curl_easy_getinfo(*curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_seconds) == CURLE_OK &&
 +		    starttransfer_seconds > 0) {
-+			info.have_ttfb = true;
-+			info.ttfb_seconds = starttransfer_seconds;
++			info.have_time_to_fst_byte = true;
++			info.time_to_fst_byte_sec = starttransfer_seconds;
 +		}
 +
  		if (!request_info->header_collection.empty() &&
@@ -122,7 +122,7 @@ index efdc87d..992ba63 100644
  		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
  		ResetRequestInfo();
 diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
-index f4e01f7..d3f9e39 100644
+index f4e01f7..9e197d1 100644
 --- a/src/httpfs_httplib_client.cpp
 +++ b/src/httpfs_httplib_client.cpp
 @@ -54,18 +54,32 @@ public:
@@ -143,9 +143,9 @@ index f4e01f7..d3f9e39 100644
  			    [&](const char *data, size_t data_length) {
 +				    if (first_chunk) {
 +					    first_chunk = false;
-+					    info.have_ttfb = true;
++					    info.have_time_to_fst_byte = true;
 +			            // We calculate the time to first byte as the time from when the request was issues to the chunk arrived.
-+					    info.ttfb_seconds =
++					    info.time_to_fst_byte_sec =
 +					        static_cast<double>(Timestamp::GetCurrentTimestamp().value - request_start.value) / 1e6;
 +				    }
 +				    total_bytes += data_length;

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PARQUET_EXTENSION_FILES
     parquet_float16.cpp
     parquet_multi_file_info.cpp
     parquet_metadata.cpp
+    parquet_prefetch_cost_model.cpp
     parquet_reader.cpp
     parquet_field_id.cpp
     parquet_statistics.cpp

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include "duckdb/common/helper.hpp"
 #include "duckdb/common/types.hpp"
+
+#include <atomic>
 
 namespace duckdb {
 
@@ -21,32 +22,40 @@ struct PrefetchCostModel {
 	double bandwidth_bytes_per_s;
 
 	//! Floor for the coalescing gap
-	static constexpr uint64_t GAP_MIN = 1ULL << 12; // 4 KiB
+	static constexpr uint64_t GAP_MIN = 1ULL << 12; //! 4 KiB
 	//! Ceiling for the coalescing gap
-	static constexpr uint64_t GAP_MAX = 32ULL << 20; // 32 MiB
+	static constexpr uint64_t GAP_MAX = 32ULL << 20; //! 32 MiB
 
-	static PrefetchCostModel LocalProfile() {
-		return {1e-5, 2e9}; // 10 us, 2 GB/s -> ~20 KB
-	}
-	static PrefetchCostModel RemoteProfile() {
-		return {5e-2, 64e6}; // 50 ms, 64 MB/s -> ~3.2 MB
-	}
+	//! Per-medium seeds used before any read has been measured
+	static PrefetchCostModel LocalProfile();  //! ~20 KiB gap
+	static PrefetchCostModel RemoteProfile(); //! ~3.2 MiB gap
 
 	//! The coalescing gap implied by this model, clamped to [GAP_MIN, GAP_MAX]
-	uint64_t CoalesceGap() const {
-		const double bdp = latency_seconds * bandwidth_bytes_per_s;
-		if (!(bdp > 0)) { // also catches NaN
-			return GAP_MIN;
-		}
-		if (bdp >= static_cast<double>(GAP_MAX)) {
-			return GAP_MAX;
-		}
-		return MaxValue<uint64_t>(GAP_MIN, static_cast<uint64_t>(bdp));
+	uint64_t GetColumnGapSize() const;
+};
+
+//! Measured Network Stats
+class NetworkPrefetchStats {
+public:
+	explicit NetworkPrefetchStats(PrefetchCostModel seed)
+	    : latency_seconds(seed.latency_seconds), bandwidth_bytes_per_s(seed.bandwidth_bytes_per_s) {
 	}
 
-	static uint64_t CoalesceGap(bool on_disk) {
-		return (on_disk ? LocalProfile() : RemoteProfile()).CoalesceGap();
+	//! Record number of bytes and time (s) that take to get it
+	void RecordRead(idx_t bytes, double seconds);
+
+	//! Snapshot of the current estimate
+	PrefetchCostModel GetModel() const;
+
+private:
+	static constexpr double ALPHA = 0.25;
+	//! Running average that weights new samples at 0.25
+	static double WeightedAVG(double prev, double sample) {
+		return ALPHA * sample + (1.0 - ALPHA) * prev;
 	}
+
+	std::atomic<double> latency_seconds;
+	std::atomic<double> bandwidth_bytes_per_s;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/common/types.hpp"
-#include "duckdb/common/mutex.hpp"
 
 namespace duckdb {
 
@@ -38,13 +37,12 @@ public:
 	//! Refine the model from a measured network throughput estimate.
 	void RefineFromEstimate(const NetworkThroughputEstimate &estimate);
 
-bool TryGetColumnGapSize(uint64_t &result) const;
+	bool TryGetColumnGapSize(uint64_t &result) const;
 
 private:
 	//! Weight applied to an estimate
 	static constexpr double ALPHA = 0.5;
 
-	mutable mutex lock;
 	//! Measured cost model
 	PrefetchCostModel model = {0, 0};
 	//! Whether we have switched from the seed to measured values

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -9,10 +9,11 @@
 #pragma once
 
 #include "duckdb/common/types.hpp"
-
-#include <atomic>
+#include "duckdb/common/mutex.hpp"
 
 namespace duckdb {
+
+struct NetworkThroughputEstimate;
 
 //! Cost model that decides how large a gap between two needed byte ranges may be
 struct PrefetchCostModel {
@@ -34,28 +35,27 @@ struct PrefetchCostModel {
 	uint64_t GetColumnGapSize() const;
 };
 
-//! Measured Network Stats
-class NetworkPrefetchStats {
+class PrefetchCostModelState {
 public:
-	explicit NetworkPrefetchStats(PrefetchCostModel seed)
-	    : latency_seconds(seed.latency_seconds), bandwidth_bytes_per_s(seed.bandwidth_bytes_per_s) {
+	explicit PrefetchCostModelState(PrefetchCostModel seed) : model(seed) {
 	}
 
-	//! Record number of bytes and time (s) that take to get it
-	void RecordRead(idx_t bytes, double seconds);
+	//! Refine the model from a measured network throughput estimate.
+	void RefineFromEstimate(const NetworkThroughputEstimate &estimate);
 
-	//! Snapshot of the current estimate
+	//! Snapshot of the current model
 	PrefetchCostModel GetModel() const;
 
 private:
-	static constexpr double ALPHA = 0.25;
-	//! Running average that weights new samples at 0.25
-	static double WeightedAVG(double prev, double sample) {
-		return ALPHA * sample + (1.0 - ALPHA) * prev;
-	}
+	//! Number of minimal measured network samples
+	static constexpr idx_t MIN_SAMPLES = 4;
+	//! Weight applied to an estimate
+	static constexpr double ALPHA = 0.5;
 
-	std::atomic<double> latency_seconds;
-	std::atomic<double> bandwidth_bytes_per_s;
+	mutable mutex lock;
+	PrefetchCostModel model;
+	//! Whether we have switched from the seed to measured values
+	bool measured_adopted = false;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -41,8 +41,6 @@ public:
 bool TryGetColumnGapSize(uint64_t &result) const;
 
 private:
-	//! Number of minimal measured network samples
-	static constexpr idx_t MIN_SAMPLES = 4;
 	//! Weight applied to an estimate
 	static constexpr double ALPHA = 0.5;
 

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// parquet_prefetch_cost_model.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+//! Cost model that decides how large a gap between two needed byte ranges may be
+struct PrefetchCostModel {
+	//! round-trip latency + request setup
+	double latency_seconds;
+	//! single-stream throughput, in bytes per second
+	double bandwidth_bytes_per_s;
+
+	//! Floor for the coalescing gap
+	static constexpr uint64_t GAP_MIN = 1ULL << 12; // 4 KiB
+	//! Ceiling for the coalescing gap
+	static constexpr uint64_t GAP_MAX = 32ULL << 20; // 32 MiB
+
+	static PrefetchCostModel LocalProfile() {
+		return {1e-5, 2e9}; // 10 us, 2 GB/s -> ~20 KB
+	}
+	static PrefetchCostModel RemoteProfile() {
+		return {5e-2, 64e6}; // 50 ms, 64 MB/s -> ~3.2 MB
+	}
+
+	//! The coalescing gap implied by this model, clamped to [GAP_MIN, GAP_MAX]
+	uint64_t CoalesceGap() const {
+		const double bdp = latency_seconds * bandwidth_bytes_per_s;
+		if (!(bdp > 0)) { // also catches NaN
+			return GAP_MIN;
+		}
+		if (bdp >= static_cast<double>(GAP_MAX)) {
+			return GAP_MAX;
+		}
+		return MaxValue<uint64_t>(GAP_MIN, static_cast<uint64_t>(bdp));
+	}
+
+	static uint64_t CoalesceGap(bool on_disk) {
+		return (on_disk ? LocalProfile() : RemoteProfile()).CoalesceGap();
+	}
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/parquet_prefetch_cost_model.hpp
+++ b/extension/parquet/include/parquet_prefetch_cost_model.hpp
@@ -27,24 +27,18 @@ struct PrefetchCostModel {
 	//! Ceiling for the coalescing gap
 	static constexpr uint64_t GAP_MAX = 32ULL << 20; //! 32 MiB
 
-	//! Per-medium seeds used before any read has been measured
-	static PrefetchCostModel LocalProfile();  //! ~20 KiB gap
-	static PrefetchCostModel RemoteProfile(); //! ~3.2 MiB gap
-
 	//! The coalescing gap implied by this model, clamped to [GAP_MIN, GAP_MAX]
 	uint64_t GetColumnGapSize() const;
 };
 
 class PrefetchCostModelState {
 public:
-	explicit PrefetchCostModelState(PrefetchCostModel seed) : model(seed) {
-	}
+	PrefetchCostModelState() = default;
 
 	//! Refine the model from a measured network throughput estimate.
 	void RefineFromEstimate(const NetworkThroughputEstimate &estimate);
 
-	//! Snapshot of the current model
-	PrefetchCostModel GetModel() const;
+bool TryGetColumnGapSize(uint64_t &result) const;
 
 private:
 	//! Number of minimal measured network samples
@@ -53,7 +47,8 @@ private:
 	static constexpr double ALPHA = 0.5;
 
 	mutable mutex lock;
-	PrefetchCostModel model;
+	//! Measured cost model
+	PrefetchCostModel model = {0, 0};
 	//! Whether we have switched from the seed to measured values
 	bool measured_adopted = false;
 };

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -221,6 +221,9 @@ public:
 
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
+
+	//! Prefetch cost model for this scan
+	optional_ptr<PrefetchCostModelState> cost_model_state;
 };
 
 struct ParquetColumnDefinition {
@@ -394,7 +397,6 @@ private:
 
 private:
 	unique_ptr<CachingFileHandle> file_handle;
-	unique_ptr<PrefetchCostModelState> cost_model_state;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -148,11 +148,14 @@ struct ParquetLoggerPrefetchMetrics {
 	vector<bool> filters_used;
 	//! Prefetch strategy chosen for the current row group
 	ParquetPrefetchStrategy strategy = ParquetPrefetchStrategy::NONE;
+	//! Accepted column gap (bytes)
+	uint64_t accepted_column_gap = 0;
 
 	void Reset() {
 		prefetch_groups.clear();
 		std::fill(filters_used.begin(), filters_used.end(), false);
 		strategy = ParquetPrefetchStrategy::NONE;
+		accepted_column_gap = 0;
 	}
 
 	//! Build a prefetch group

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -394,7 +394,7 @@ private:
 
 private:
 	unique_ptr<CachingFileHandle> file_handle;
-	unique_ptr<NetworkPrefetchStats> network_stats;
+	unique_ptr<PrefetchCostModelState> cost_model_state;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -222,8 +222,8 @@ public:
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
 
-	//! Prefetch cost model for this scan
-	optional_ptr<PrefetchCostModelState> cost_model_state;
+	//! Prefetch cost model
+	PrefetchCostModelState cost_model_state;
 };
 
 struct ParquetColumnDefinition {

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -29,6 +29,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "column_reader.hpp"
+#include "parquet_prefetch_cost_model.hpp"
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_rle_bp_decoder.hpp"
 #include "parquet_types.h"
@@ -390,6 +391,7 @@ private:
 
 private:
 	unique_ptr<CachingFileHandle> file_handle;
+	unique_ptr<NetworkPrefetchStats> network_stats;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -50,16 +50,22 @@ struct ReadHead {
 	}
 };
 
-// Comparator for ReadHeads that are either overlapping, adjacent, or within ALLOW_GAP bytes from each other
 struct ReadHeadComparator {
-	static constexpr uint64_t ALLOW_GAP = 1 << 14; // 16 KiB
+	static constexpr uint64_t DEFAULT_ACCEPTED_COLUMN_GAP = 1 << 14; // 16 KiB
+
+	ReadHeadComparator() = default;
+	explicit ReadHeadComparator(uint64_t accepted_column_gap_p) : accepted_column_gap(accepted_column_gap_p) {
+	}
+
+	uint64_t accepted_column_gap = DEFAULT_ACCEPTED_COLUMN_GAP;
+
 	bool operator()(const ReadHead *a, const ReadHead *b) const {
 		auto a_start = a->location;
 		auto a_end = a->location + a->size;
 		auto b_start = b->location;
 
-		if (a_end <= NumericLimits<idx_t>::Maximum() - ALLOW_GAP) {
-			a_end += ALLOW_GAP;
+		if (a_end <= NumericLimits<idx_t>::Maximum() - accepted_column_gap) {
+			a_end += accepted_column_gap;
 		}
 
 		return a_start < b_start && a_end < b_start;
@@ -70,7 +76,9 @@ struct ReadHeadComparator {
 // 1: register all ranges that will be read, merging ranges that are consecutive
 // 2: prefetch all registered ranges
 struct ReadAheadBuffer {
-	explicit ReadAheadBuffer(CachingFileHandle &file_handle_p) : file_handle(file_handle_p) {
+	explicit ReadAheadBuffer(CachingFileHandle &file_handle_p,
+	                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
+	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p) {
 	}
 
 	// The list of read heads
@@ -141,9 +149,10 @@ class ThriftFileTransport : public duckdb_apache::thrift::transport::TVirtualTra
 public:
 	static constexpr uint64_t PREFETCH_FALLBACK_BUFFERSIZE = 1000000;
 
-	ThriftFileTransport(CachingFileHandle &file_handle_p, bool prefetch_mode_p)
+	ThriftFileTransport(CachingFileHandle &file_handle_p, bool prefetch_mode_p,
+	                    uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
 	    : file_handle(file_handle_p), location(0), size(file_handle.GetFileSize()),
-	      ra_buffer(ReadAheadBuffer(file_handle)), prefetch_mode(prefetch_mode_p) {
+	      ra_buffer(ReadAheadBuffer(file_handle, accepted_column_gap)), prefetch_mode(prefetch_mode_p) {
 	}
 
 	uint32_t read(uint8_t *buf, uint32_t len) {

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -17,6 +17,8 @@
 #include "duckdb/storage/external_file_cache/file_buffer_handle_group.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/profiler.hpp"
+#include "parquet_prefetch_cost_model.hpp"
 
 namespace duckdb {
 
@@ -77,8 +79,10 @@ struct ReadHeadComparator {
 // 2: prefetch all registered ranges
 struct ReadAheadBuffer {
 	explicit ReadAheadBuffer(CachingFileHandle &file_handle_p,
-	                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
-	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p) {
+	                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
+	                         optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr)
+	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p),
+	      prefetch_stats(prefetch_stats) {
 	}
 
 	// The list of read heads
@@ -88,7 +92,15 @@ struct ReadAheadBuffer {
 
 	CachingFileHandle &file_handle;
 
+	// Network latency/bandwidth, fed by completed prefetch reads
+	optional_ptr<NetworkPrefetchStats> prefetch_stats;
+
 	idx_t total_size = 0;
+
+	void SetAcceptedColumnGap(uint64_t accepted_column_gap) {
+		D_ASSERT(merge_set.empty());
+		merge_set = std::set<ReadHead *, ReadHeadComparator>(ReadHeadComparator(accepted_column_gap));
+	}
 
 	// Add a read head to the prefetching list
 	void AddReadHead(idx_t pos, uint64_t len, bool merge_buffers = true) {
@@ -138,7 +150,13 @@ struct ReadAheadBuffer {
 			if (read_head.GetEnd() > file_handle.GetFileSize()) {
 				throw std::runtime_error("Prefetch registered requested for bytes outside file");
 			}
+			Profiler profiler;
+			profiler.Start();
 			read_head.handle_group = file_handle.Read(read_head.size, read_head.location);
+			profiler.End();
+			if (prefetch_stats) {
+				prefetch_stats->RecordRead(read_head.size, profiler.Elapsed());
+			}
 			read_head.Materialize();
 			read_head.data_isset = true;
 		}
@@ -150,9 +168,14 @@ public:
 	static constexpr uint64_t PREFETCH_FALLBACK_BUFFERSIZE = 1000000;
 
 	ThriftFileTransport(CachingFileHandle &file_handle_p, bool prefetch_mode_p,
-	                    uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
+	                    uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
+	                    optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr)
 	    : file_handle(file_handle_p), location(0), size(file_handle.GetFileSize()),
-	      ra_buffer(ReadAheadBuffer(file_handle, accepted_column_gap)), prefetch_mode(prefetch_mode_p) {
+	      ra_buffer(ReadAheadBuffer(file_handle, accepted_column_gap, prefetch_stats)), prefetch_mode(prefetch_mode_p) {
+	}
+
+	void SetAcceptedColumnGap(uint64_t accepted_column_gap) {
+		ra_buffer.SetAcceptedColumnGap(accepted_column_gap);
 	}
 
 	uint32_t read(uint8_t *buf, uint32_t len) {

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -178,6 +178,11 @@ public:
 		ra_buffer.SetAcceptedColumnGap(accepted_column_gap);
 	}
 
+	// The accepted column gap currently used to coalesce adjacent ranges.
+	uint64_t GetAcceptedColumnGap() const {
+		return ra_buffer.merge_set.key_comp().accepted_column_gap;
+	}
+
 	uint32_t read(uint8_t *buf, uint32_t len) {
 		auto prefetch_buffer = ra_buffer.GetReadHead(location);
 		if (prefetch_buffer != nullptr && location - prefetch_buffer->location + len <= prefetch_buffer->size) {

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -17,8 +17,6 @@
 #include "duckdb/storage/external_file_cache/file_buffer_handle_group.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/allocator.hpp"
-#include "duckdb/common/profiler.hpp"
-#include "parquet_prefetch_cost_model.hpp"
 
 namespace duckdb {
 
@@ -79,10 +77,8 @@ struct ReadHeadComparator {
 // 2: prefetch all registered ranges
 struct ReadAheadBuffer {
 	explicit ReadAheadBuffer(CachingFileHandle &file_handle_p,
-	                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
-	                         optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr)
-	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p),
-	      prefetch_stats(prefetch_stats) {
+	                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
+	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p) {
 	}
 
 	// The list of read heads
@@ -91,9 +87,6 @@ struct ReadAheadBuffer {
 	std::set<ReadHead *, ReadHeadComparator> merge_set;
 
 	CachingFileHandle &file_handle;
-
-	// Network latency/bandwidth, fed by completed prefetch reads
-	optional_ptr<NetworkPrefetchStats> prefetch_stats;
 
 	idx_t total_size = 0;
 
@@ -150,13 +143,7 @@ struct ReadAheadBuffer {
 			if (read_head.GetEnd() > file_handle.GetFileSize()) {
 				throw std::runtime_error("Prefetch registered requested for bytes outside file");
 			}
-			Profiler profiler;
-			profiler.Start();
 			read_head.handle_group = file_handle.Read(read_head.size, read_head.location);
-			profiler.End();
-			if (prefetch_stats) {
-				prefetch_stats->RecordRead(read_head.size, profiler.Elapsed());
-			}
 			read_head.Materialize();
 			read_head.data_isset = true;
 		}
@@ -168,10 +155,9 @@ public:
 	static constexpr uint64_t PREFETCH_FALLBACK_BUFFERSIZE = 1000000;
 
 	ThriftFileTransport(CachingFileHandle &file_handle_p, bool prefetch_mode_p,
-	                    uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
-	                    optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr)
+	                    uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP)
 	    : file_handle(file_handle_p), location(0), size(file_handle.GetFileSize()),
-	      ra_buffer(ReadAheadBuffer(file_handle, accepted_column_gap, prefetch_stats)), prefetch_mode(prefetch_mode_p) {
+	      ra_buffer(ReadAheadBuffer(file_handle, accepted_column_gap)), prefetch_mode(prefetch_mode_p) {
 	}
 
 	void SetAcceptedColumnGap(uint64_t accepted_column_gap) {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -752,22 +752,27 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 	return true;
 }
 
-static PrefetchCostModelState &GetScanCostModel(ParquetReadGlobalState &gstate, bool on_disk_file) {
+
+static void AttachScanCostModel(ParquetReadGlobalState &gstate, ParquetReaderScanState &scan_state, bool on_disk_file) {
+	if (on_disk_file) {
+		scan_state.cost_model_state = nullptr;
+		return;
+	}
+	if (scan_state.cost_model_state) {
+		return;
+	}
 	lock_guard<mutex> guard(gstate.cost_model_lock);
 	if (!gstate.cost_model_state) {
-		gstate.cost_model_state = make_uniq<PrefetchCostModelState>(
-		    on_disk_file ? PrefetchCostModel::LocalProfile() : PrefetchCostModel::RemoteProfile());
+		gstate.cost_model_state = make_uniq<PrefetchCostModelState>();
 	}
-	return *gstate.cost_model_state;
+	scan_state.cost_model_state = gstate.cost_model_state.get();
 }
 
 void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                 LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
-	if (!lstate.scan_state.cost_model_state) {
-		lstate.scan_state.cost_model_state = &GetScanCostModel(gstate, file_handle->OnDiskFile());
-	}
+	AttachScanCostModel(gstate, lstate.scan_state, file_handle->OnDiskFile());
 	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
 }
 
@@ -789,9 +794,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
-	if (!local_state.scan_state.cost_model_state) {
-		local_state.scan_state.cost_model_state = &GetScanCostModel(gstate, file_handle->OnDiskFile());
-	}
+	AttachScanCostModel(gstate, local_state.scan_state, file_handle->OnDiskFile());
 	return Scan(context, local_state.scan_state, chunk);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -93,11 +93,6 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
-	//! Prefetch cost model shared across all files and threads of this scan: network throughput measured
-	//! on one file carries over to the next, instead of re-warming from the per-medium seed for every file
-	//! in a glob. Lazily created (seeded from the first scanned file's medium); guarded by cost_model_lock.
-	mutex cost_model_lock;
-	unique_ptr<PrefetchCostModelState> cost_model_state;
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -752,27 +747,9 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 	return true;
 }
 
-
-static void AttachScanCostModel(ParquetReadGlobalState &gstate, ParquetReaderScanState &scan_state, bool on_disk_file) {
-	if (on_disk_file) {
-		scan_state.cost_model_state = nullptr;
-		return;
-	}
-	if (scan_state.cost_model_state) {
-		return;
-	}
-	lock_guard<mutex> guard(gstate.cost_model_lock);
-	if (!gstate.cost_model_state) {
-		gstate.cost_model_state = make_uniq<PrefetchCostModelState>();
-	}
-	scan_state.cost_model_state = gstate.cost_model_state.get();
-}
-
 void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                 LocalTableFunctionState &lstate_p) {
-	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
-	AttachScanCostModel(gstate, lstate.scan_state, file_handle->OnDiskFile());
 	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
 }
 
@@ -794,7 +771,6 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
-	AttachScanCostModel(gstate, local_state.scan_state, file_handle->OnDiskFile());
 	return Scan(context, local_state.scan_state, chunk);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -93,6 +93,11 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
+	//! Prefetch cost model shared across all files and threads of this scan: network throughput measured
+	//! on one file carries over to the next, instead of re-warming from the per-medium seed for every file
+	//! in a glob. Lazily created (seeded from the first scanned file's medium); guarded by cost_model_lock.
+	mutex cost_model_lock;
+	unique_ptr<PrefetchCostModelState> cost_model_state;
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -747,9 +752,22 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 	return true;
 }
 
+static PrefetchCostModelState &GetScanCostModel(ParquetReadGlobalState &gstate, bool on_disk_file) {
+	lock_guard<mutex> guard(gstate.cost_model_lock);
+	if (!gstate.cost_model_state) {
+		gstate.cost_model_state = make_uniq<PrefetchCostModelState>(
+		    on_disk_file ? PrefetchCostModel::LocalProfile() : PrefetchCostModel::RemoteProfile());
+	}
+	return *gstate.cost_model_state;
+}
+
 void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                 LocalTableFunctionState &lstate_p) {
+	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
+	if (!lstate.scan_state.cost_model_state) {
+		lstate.scan_state.cost_model_state = &GetScanCostModel(gstate, file_handle->OnDiskFile());
+	}
 	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
 }
 
@@ -771,6 +789,9 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
+	if (!local_state.scan_state.cost_model_state) {
+		local_state.scan_state.cost_model_state = &GetScanCostModel(gstate, file_handle->OnDiskFile());
+	}
 	return Scan(context, local_state.scan_state, chunk);
 }
 

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -10,14 +10,6 @@ constexpr uint64_t PrefetchCostModel::GAP_MAX;
 constexpr idx_t PrefetchCostModelState::MIN_SAMPLES;
 constexpr double PrefetchCostModelState::ALPHA;
 
-PrefetchCostModel PrefetchCostModel::LocalProfile() {
-	return {1e-5, 2e9}; // 10 us, 2 GB/s -> ~20 KB
-}
-
-PrefetchCostModel PrefetchCostModel::RemoteProfile() {
-	return {5e-2, 64e6}; // 50 ms, 64 MB/s -> ~3.2 MB
-}
-
 uint64_t PrefetchCostModel::GetColumnGapSize() const {
 	const double column_gap_size = latency_seconds * bandwidth_bytes_per_s;
 	if (!(column_gap_size > 0)) { // also catches NaN
@@ -53,9 +45,13 @@ void PrefetchCostModelState::RefineFromEstimate(const NetworkThroughputEstimate 
 	}
 }
 
-PrefetchCostModel PrefetchCostModelState::GetModel() const {
+bool PrefetchCostModelState::TryGetColumnGapSize(uint64_t &result) const {
 	lock_guard<mutex> guard(lock);
-	return model;
+	if (!measured_adopted) {
+		return false;
+	}
+	result = model.GetColumnGapSize();
+	return true;
 }
 
 } // namespace duckdb

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -28,20 +28,17 @@ void PrefetchCostModelState::RefineFromEstimate(const NetworkThroughputEstimate 
 		return;
 	}
 
-	lock_guard<mutex> guard(lock);
 	if (!measured_adopted) {
 		model.latency_seconds = latency;
 		model.bandwidth_bytes_per_s = bandwidth;
 		measured_adopted = true;
 	} else {
-
 		model.latency_seconds = ALPHA * latency + (1.0 - ALPHA) * model.latency_seconds;
 		model.bandwidth_bytes_per_s = ALPHA * bandwidth + (1.0 - ALPHA) * model.bandwidth_bytes_per_s;
 	}
 }
 
 bool PrefetchCostModelState::TryGetColumnGapSize(uint64_t &result) const {
-	lock_guard<mutex> guard(lock);
 	if (!measured_adopted) {
 		return false;
 	}

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 
 constexpr uint64_t PrefetchCostModel::GAP_MIN;
 constexpr uint64_t PrefetchCostModel::GAP_MAX;
-constexpr idx_t PrefetchCostModelState::MIN_SAMPLES;
 constexpr double PrefetchCostModelState::ALPHA;
 
 uint64_t PrefetchCostModel::GetColumnGapSize() const {
@@ -22,10 +21,6 @@ uint64_t PrefetchCostModel::GetColumnGapSize() const {
 }
 
 void PrefetchCostModelState::RefineFromEstimate(const NetworkThroughputEstimate &estimate) {
-	// Keep the per-medium seed until the underlying handle has measured enough requests.
-	if (estimate.sample_count < MIN_SAMPLES) {
-		return;
-	}
 	const double latency = estimate.latency_seconds;
 	const double bandwidth = estimate.bandwidth_bytes_per_s;
 	// Ignore degenerate estimates (also catches NaN).

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -1,0 +1,57 @@
+#include "parquet_prefetch_cost_model.hpp"
+
+#include "duckdb/common/helper.hpp"
+
+namespace duckdb {
+
+constexpr uint64_t PrefetchCostModel::GAP_MIN;
+constexpr uint64_t PrefetchCostModel::GAP_MAX;
+constexpr double NetworkPrefetchStats::ALPHA;
+
+PrefetchCostModel PrefetchCostModel::LocalProfile() {
+	return {1e-5, 2e9}; // 10 us, 2 GB/s -> ~20 KB
+}
+
+PrefetchCostModel PrefetchCostModel::RemoteProfile() {
+	return {5e-2, 64e6}; // 50 ms, 64 MB/s -> ~3.2 MB
+}
+
+uint64_t PrefetchCostModel::GetColumnGapSize() const {
+	const double column_gap_size = latency_seconds * bandwidth_bytes_per_s;
+	if (!(column_gap_size > 0)) { // also catches NaN
+		return GAP_MIN;
+	}
+	if (column_gap_size >= static_cast<double>(GAP_MAX)) {
+		return GAP_MAX;
+	}
+	return MaxValue<uint64_t>(GAP_MIN, static_cast<uint64_t>(column_gap_size));
+}
+
+void NetworkPrefetchStats::RecordRead(idx_t bytes, double seconds) {
+	if (seconds <= 0 || bytes == 0) {
+		return;
+	}
+	const double latency = latency_seconds.load();
+	const double bandwidth = bandwidth_bytes_per_s.load();
+	const double expected_transfer_time = static_cast<double>(bytes) / bandwidth;
+	// lets figure out if this read is dominated by either latency or bandwidth
+	if (expected_transfer_time < latency) {
+		// Latency-dominated sample
+		const double observed_latency = seconds - expected_transfer_time;
+		if (observed_latency > 0) {
+			latency_seconds.store(WeightedAVG(latency, observed_latency));
+		}
+	} else {
+		// Bandwidth-dominated sample
+		const double transfer_time = seconds - latency;
+		if (transfer_time > 0) {
+			bandwidth_bytes_per_s.store(WeightedAVG(bandwidth, static_cast<double>(bytes) / transfer_time));
+		}
+	}
+}
+
+PrefetchCostModel NetworkPrefetchStats::GetModel() const {
+	return {latency_seconds.load(), bandwidth_bytes_per_s.load()};
+}
+
+} // namespace duckdb

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -1,12 +1,14 @@
 #include "parquet_prefetch_cost_model.hpp"
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/file_system.hpp"
 
 namespace duckdb {
 
 constexpr uint64_t PrefetchCostModel::GAP_MIN;
 constexpr uint64_t PrefetchCostModel::GAP_MAX;
-constexpr double NetworkPrefetchStats::ALPHA;
+constexpr idx_t PrefetchCostModelState::MIN_SAMPLES;
+constexpr double PrefetchCostModelState::ALPHA;
 
 PrefetchCostModel PrefetchCostModel::LocalProfile() {
 	return {1e-5, 2e9}; // 10 us, 2 GB/s -> ~20 KB
@@ -27,39 +29,33 @@ uint64_t PrefetchCostModel::GetColumnGapSize() const {
 	return MaxValue<uint64_t>(GAP_MIN, static_cast<uint64_t>(column_gap_size));
 }
 
-void NetworkPrefetchStats::RecordRead(idx_t bytes, double seconds) {
-
-	static constexpr double MIN_SAMPLE_SECONDS = 1e-6;
-	if (bytes == 0 || seconds < MIN_SAMPLE_SECONDS) {
+void PrefetchCostModelState::RefineFromEstimate(const NetworkThroughputEstimate &estimate) {
+	// Keep the per-medium seed until the underlying handle has measured enough requests.
+	if (estimate.sample_count < MIN_SAMPLES) {
 		return;
 	}
-	const double latency = latency_seconds.load();
-	const double bandwidth = bandwidth_bytes_per_s.load();
-	const double expected_transfer_time = static_cast<double>(bytes) / bandwidth;
-	// lets figure out if this read is dominated by either latency or bandwidth
-	if (expected_transfer_time < latency) {
-		// Latency-dominated sample: the fixed per-request cost should be most of the time.
-		const double observed_latency = seconds - expected_transfer_time;
-		if (observed_latency > 0) {
-			latency_seconds.store(WeightedAVG(latency, observed_latency));
-		} else {
-			// bandwidth was underestimated, so raise it.
-			bandwidth_bytes_per_s.store(WeightedAVG(bandwidth, static_cast<double>(bytes) / seconds));
-		}
+	const double latency = estimate.latency_seconds;
+	const double bandwidth = estimate.bandwidth_bytes_per_s;
+	// Ignore degenerate estimates (also catches NaN).
+	if (!(latency > 0) || !(bandwidth > 0)) {
+		return;
+	}
+
+	lock_guard<mutex> guard(lock);
+	if (!measured_adopted) {
+		model.latency_seconds = latency;
+		model.bandwidth_bytes_per_s = bandwidth;
+		measured_adopted = true;
 	} else {
-		// Bandwidth-dominated sample: streaming the bytes should be most of the time.
-		const double transfer_time = seconds - latency;
-		if (transfer_time > 0) {
-			bandwidth_bytes_per_s.store(WeightedAVG(bandwidth, static_cast<double>(bytes) / transfer_time));
-		} else {
-			// latency was overestimated, so lower it.
-			latency_seconds.store(WeightedAVG(latency, seconds));
-		}
+
+		model.latency_seconds = ALPHA * latency + (1.0 - ALPHA) * model.latency_seconds;
+		model.bandwidth_bytes_per_s = ALPHA * bandwidth + (1.0 - ALPHA) * model.bandwidth_bytes_per_s;
 	}
 }
 
-PrefetchCostModel NetworkPrefetchStats::GetModel() const {
-	return {latency_seconds.load(), bandwidth_bytes_per_s.load()};
+PrefetchCostModel PrefetchCostModelState::GetModel() const {
+	lock_guard<mutex> guard(lock);
+	return model;
 }
 
 } // namespace duckdb

--- a/extension/parquet/parquet_prefetch_cost_model.cpp
+++ b/extension/parquet/parquet_prefetch_cost_model.cpp
@@ -28,7 +28,9 @@ uint64_t PrefetchCostModel::GetColumnGapSize() const {
 }
 
 void NetworkPrefetchStats::RecordRead(idx_t bytes, double seconds) {
-	if (seconds <= 0 || bytes == 0) {
+
+	static constexpr double MIN_SAMPLE_SECONDS = 1e-6;
+	if (bytes == 0 || seconds < MIN_SAMPLE_SECONDS) {
 		return;
 	}
 	const double latency = latency_seconds.load();
@@ -36,16 +38,22 @@ void NetworkPrefetchStats::RecordRead(idx_t bytes, double seconds) {
 	const double expected_transfer_time = static_cast<double>(bytes) / bandwidth;
 	// lets figure out if this read is dominated by either latency or bandwidth
 	if (expected_transfer_time < latency) {
-		// Latency-dominated sample
+		// Latency-dominated sample: the fixed per-request cost should be most of the time.
 		const double observed_latency = seconds - expected_transfer_time;
 		if (observed_latency > 0) {
 			latency_seconds.store(WeightedAVG(latency, observed_latency));
+		} else {
+			// bandwidth was underestimated, so raise it.
+			bandwidth_bytes_per_s.store(WeightedAVG(bandwidth, static_cast<double>(bytes) / seconds));
 		}
 	} else {
-		// Bandwidth-dominated sample
+		// Bandwidth-dominated sample: streaming the bytes should be most of the time.
 		const double transfer_time = seconds - latency;
 		if (transfer_time > 0) {
 			bandwidth_bytes_per_s.store(WeightedAVG(bandwidth, static_cast<double>(bytes) / transfer_time));
+		} else {
+			// latency was overestimated, so lower it.
+			latency_seconds.store(WeightedAVG(latency, seconds));
 		}
 	}
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -184,7 +184,8 @@ static void LogRowGroupPrefetch(ClientContext &context, const string &file_path,
 	}
 	DUCKDB_LOG(context, ParquetPrefetchLogType, file_path, row_group_id, fully_filtered,
 	           ParquetPrefetchStrategyToString(state.prefetch_metrics.logger.strategy),
-	           state.prefetch_metrics.logger.prefetch_groups, minimal_filters);
+	           state.prefetch_metrics.logger.prefetch_groups, minimal_filters,
+	           state.prefetch_metrics.logger.accepted_column_gap);
 }
 
 using duckdb_parquet::ColumnChunk;
@@ -1730,6 +1731,9 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 				} else {
 					ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 				}
+			}
+			if (log_prefetch) {
+				state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();
 			}
 		}
 		result.Reset();

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1035,11 +1035,6 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
 		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
 	}
-	// Seed the prefetch cost model from a per-medium profile. Remote files refine this from real
-	// network measurements during the scan (HTTPFileSystem::TryGetNetworkThroughput); local files keep the seed.
-	cost_model_state = make_uniq<PrefetchCostModelState>(
-	    file_handle->OnDiskFile() ? PrefetchCostModel::LocalProfile() : PrefetchCostModel::RemoteProfile());
-
 	// read the extended file open info (if any)
 	optional_idx footer_size;
 	if (file.extended_info) {
@@ -1458,12 +1453,12 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	}
 
 	uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
-	if (state.prefetch_mode) {
+	if (state.prefetch_mode && state.cost_model_state) {
 		NetworkThroughputEstimate estimate;
 		if (state.file_handle->TryGetNetworkThroughput(estimate)) {
-			cost_model_state->RefineFromEstimate(estimate);
+			state.cost_model_state->RefineFromEstimate(estimate);
 		}
-		accepted_column_gap = cost_model_state->GetModel().GetColumnGapSize();
+		accepted_column_gap = state.cost_model_state->GetModel().GetColumnGapSize();
 	}
 	state.thrift_file_proto =
 	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
@@ -1673,12 +1668,12 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		trans.ClearPrefetch();
 		state.current_group_prefetched = false;
 
-		if (state.prefetch_mode) {
+		if (state.prefetch_mode && state.cost_model_state) {
 			NetworkThroughputEstimate estimate;
 			if (state.file_handle->TryGetNetworkThroughput(estimate)) {
-				cost_model_state->RefineFromEstimate(estimate);
+				state.cost_model_state->RefineFromEstimate(estimate);
 			}
-			trans.SetAcceptedColumnGap(cost_model_state->GetModel().GetColumnGapSize());
+			trans.SetAcceptedColumnGap(state.cost_model_state->GetModel().GetColumnGapSize());
 		}
 
 		if (log_prefetch && state.prefetch_metrics.filter_ran && state.current_group > 0) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -200,10 +200,8 @@ using duckdb_parquet::Type;
 
 static unique_ptr<duckdb_apache::thrift::protocol::TProtocol>
 CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, bool prefetch_mode,
-                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
-                         optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr) {
-	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode, accepted_column_gap,
-	                                                                   prefetch_stats);
+                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP) {
+	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode, accepted_column_gap);
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
@@ -1037,8 +1035,10 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
 		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
 	}
-	network_stats = make_uniq<NetworkPrefetchStats>(file_handle->OnDiskFile() ? PrefetchCostModel::LocalProfile()
-	                                                                          : PrefetchCostModel::RemoteProfile());
+	// Seed the prefetch cost model from a per-medium profile. Remote files refine this from real
+	// network measurements during the scan (HTTPFileSystem::TryGetNetworkThroughput); local files keep the seed.
+	cost_model_state = make_uniq<PrefetchCostModelState>(
+	    file_handle->OnDiskFile() ? PrefetchCostModel::LocalProfile() : PrefetchCostModel::RemoteProfile());
 
 	// read the extended file open info (if any)
 	optional_idx footer_size;
@@ -1457,10 +1457,16 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		state.filter_eliminated_all_rows.assign(state.scan_filters.size(), false);
 	}
 
-	auto accepted_column_gap = state.prefetch_mode ? network_stats->GetModel().GetColumnGapSize()
-	                                               : ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
-	state.thrift_file_proto = CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode,
-	                                                   accepted_column_gap, network_stats.get());
+	uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
+	if (state.prefetch_mode) {
+		NetworkThroughputEstimate estimate;
+		if (state.file_handle->TryGetNetworkThroughput(estimate)) {
+			cost_model_state->RefineFromEstimate(estimate);
+		}
+		accepted_column_gap = cost_model_state->GetModel().GetColumnGapSize();
+	}
+	state.thrift_file_proto =
+	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
 
 	state.column_readers.resize(column_indexes.size());
 	for (idx_t i = 0; i < column_indexes.size(); i++) {
@@ -1668,7 +1674,11 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		state.current_group_prefetched = false;
 
 		if (state.prefetch_mode) {
-			trans.SetAcceptedColumnGap(network_stats->GetModel().GetColumnGapSize());
+			NetworkThroughputEstimate estimate;
+			if (state.file_handle->TryGetNetworkThroughput(estimate)) {
+				cost_model_state->RefineFromEstimate(estimate);
+			}
+			trans.SetAcceptedColumnGap(cost_model_state->GetModel().GetColumnGapSize());
 		}
 
 		if (log_prefetch && state.prefetch_metrics.filter_ran && state.current_group > 0) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1453,12 +1453,12 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	}
 
 	uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
-	if (state.prefetch_mode && state.cost_model_state) {
+	if (state.prefetch_mode && !state.file_handle->OnDiskFile()) {
 		NetworkThroughputEstimate estimate;
 		if (state.file_handle->TryGetNetworkThroughput(estimate)) {
-			state.cost_model_state->RefineFromEstimate(estimate);
+			state.cost_model_state.RefineFromEstimate(estimate);
 		}
-		state.cost_model_state->TryGetColumnGapSize(accepted_column_gap);
+		state.cost_model_state.TryGetColumnGapSize(accepted_column_gap);
 	}
 	state.thrift_file_proto =
 	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
@@ -1668,13 +1668,13 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		trans.ClearPrefetch();
 		state.current_group_prefetched = false;
 
-		if (state.prefetch_mode && state.cost_model_state) {
+		if (state.prefetch_mode && !state.file_handle->OnDiskFile()) {
 			NetworkThroughputEstimate estimate;
 			if (state.file_handle->TryGetNetworkThroughput(estimate)) {
-				state.cost_model_state->RefineFromEstimate(estimate);
+				state.cost_model_state.RefineFromEstimate(estimate);
 			}
 			uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
-			state.cost_model_state->TryGetColumnGapSize(accepted_column_gap);
+			state.cost_model_state.TryGetColumnGapSize(accepted_column_gap);
 			trans.SetAcceptedColumnGap(accepted_column_gap);
 		}
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -19,6 +19,7 @@
 #include "reader/variant_column_reader.hpp"
 #include "reader/struct_column_reader.hpp"
 #include "thrift_tools.hpp"
+#include "parquet_prefetch_cost_model.hpp"
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -197,8 +198,9 @@ using duckdb_parquet::Statistics;
 using duckdb_parquet::Type;
 
 static unique_ptr<duckdb_apache::thrift::protocol::TProtocol>
-CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, bool prefetch_mode) {
-	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode);
+CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, bool prefetch_mode,
+                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP) {
+	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode, accepted_column_gap);
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
@@ -1450,7 +1452,10 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		state.filter_eliminated_all_rows.assign(state.scan_filters.size(), false);
 	}
 
-	state.thrift_file_proto = CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode);
+	auto accepted_column_gap = state.prefetch_mode ? PrefetchCostModel::CoalesceGap(state.file_handle->OnDiskFile())
+	                                               : ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
+	state.thrift_file_proto =
+	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
 
 	state.column_readers.resize(column_indexes.size());
 	for (idx_t i = 0; i < column_indexes.size(); i++) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -199,8 +199,10 @@ using duckdb_parquet::Type;
 
 static unique_ptr<duckdb_apache::thrift::protocol::TProtocol>
 CreateThriftFileProtocol(QueryContext context, CachingFileHandle &file_handle, bool prefetch_mode,
-                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP) {
-	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode, accepted_column_gap);
+                         uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP,
+                         optional_ptr<NetworkPrefetchStats> prefetch_stats = nullptr) {
+	auto transport = duckdb_base_std::make_shared<ThriftFileTransport>(file_handle, prefetch_mode, accepted_column_gap,
+	                                                                   prefetch_stats);
 	return make_uniq<duckdb_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
@@ -1034,6 +1036,8 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
 		    "metadata is located at the end of the file. Write the stream to disk first and read from there instead.");
 	}
+	network_stats = make_uniq<NetworkPrefetchStats>(file_handle->OnDiskFile() ? PrefetchCostModel::LocalProfile()
+	                                                                          : PrefetchCostModel::RemoteProfile());
 
 	// read the extended file open info (if any)
 	optional_idx footer_size;
@@ -1452,10 +1456,10 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		state.filter_eliminated_all_rows.assign(state.scan_filters.size(), false);
 	}
 
-	auto accepted_column_gap = state.prefetch_mode ? PrefetchCostModel::CoalesceGap(state.file_handle->OnDiskFile())
+	auto accepted_column_gap = state.prefetch_mode ? network_stats->GetModel().GetColumnGapSize()
 	                                               : ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
-	state.thrift_file_proto =
-	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
+	state.thrift_file_proto = CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode,
+	                                                   accepted_column_gap, network_stats.get());
 
 	state.column_readers.resize(column_indexes.size());
 	for (idx_t i = 0; i < column_indexes.size(); i++) {
@@ -1661,6 +1665,10 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 		trans.ClearPrefetch();
 		state.current_group_prefetched = false;
+
+		if (state.prefetch_mode) {
+			trans.SetAcceptedColumnGap(network_stats->GetModel().GetColumnGapSize());
+		}
 
 		if (log_prefetch && state.prefetch_metrics.filter_ran && state.current_group > 0) {
 			LogRowGroupPrefetch(context, file.path, state.group_idx_list[state.current_group - 1], state);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1458,7 +1458,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		if (state.file_handle->TryGetNetworkThroughput(estimate)) {
 			state.cost_model_state->RefineFromEstimate(estimate);
 		}
-		accepted_column_gap = state.cost_model_state->GetModel().GetColumnGapSize();
+		state.cost_model_state->TryGetColumnGapSize(accepted_column_gap);
 	}
 	state.thrift_file_proto =
 	    CreateThriftFileProtocol(context, *state.file_handle, state.prefetch_mode, accepted_column_gap);
@@ -1673,7 +1673,9 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 			if (state.file_handle->TryGetNetworkThroughput(estimate)) {
 				state.cost_model_state->RefineFromEstimate(estimate);
 			}
-			trans.SetAcceptedColumnGap(state.cost_model_state->GetModel().GetColumnGapSize());
+			uint64_t accepted_column_gap = ReadHeadComparator::DEFAULT_ACCEPTED_COLUMN_GAP;
+			state.cost_model_state->TryGetColumnGapSize(accepted_column_gap);
+			trans.SetAcceptedColumnGap(accepted_column_gap);
 		}
 
 		if (log_prefetch && state.prefetch_metrics.filter_ran && state.current_group > 0) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -742,6 +742,10 @@ bool FileSystem::OnDiskFile(FileHandle &handle) {
 }
 // LCOV_EXCL_STOP
 
+bool FileSystem::TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result) {
+	return false;
+}
+
 FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags flags)
     : file_system(file_system), path(std::move(path_p)), flags(flags) {
 }
@@ -851,6 +855,10 @@ string FileHandle::ReadLine(QueryContext context) {
 
 bool FileHandle::OnDiskFile() {
 	return file_system.OnDiskFile(*this);
+}
+
+bool FileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
+	return file_system.TryGetNetworkThroughput(*this, result);
 }
 
 idx_t FileHandle::GetFileSize() {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -77,8 +77,6 @@ struct NetworkThroughputEstimate {
 	double latency_seconds = 0;
 	//! Single-stream throughput, in bytes per second
 	double bandwidth_bytes_per_s = 0;
-	//! Number of network samples behind this estimate
-	idx_t sample_count = 0;
 };
 
 struct FileHandle {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -71,6 +71,16 @@ struct FileMetadata {
 	unordered_map<string, Value> extended_file_info;
 };
 
+//! Measured network throughput for a (remote) file handle. Used to size prefetch coalescing gaps.
+struct NetworkThroughputEstimate {
+	//! Round-trip latency + request setup, in seconds
+	double latency_seconds = 0;
+	//! Single-stream throughput, in bytes per second
+	double bandwidth_bytes_per_s = 0;
+	//! Number of network samples behind this estimate
+	idx_t sample_count = 0;
+};
+
 struct FileHandle {
 public:
 	DUCKDB_API FileHandle(FileSystem &file_system, string path, FileOpenFlags flags);
@@ -102,6 +112,8 @@ public:
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsPipe();
 	DUCKDB_API bool OnDiskFile();
+	//! Try to obtain a network throughput estimate (Local files return false).
+	DUCKDB_API bool TryGetNetworkThroughput(NetworkThroughputEstimate &result);
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API FileType GetType();
 	DUCKDB_API FileMetadata Stats();
@@ -295,6 +307,9 @@ public:
 	//! Whether or not the FS handles plain files on disk. This is relevant for certain optimizations, as random reads
 	//! in a file on-disk are much cheaper than e.g. random reads in a file over the network
 	DUCKDB_API virtual bool OnDiskFile(FileHandle &handle);
+	//! Try to obtain a measured network throughput estimate. Default: not supported (returns false).
+	//! Used for file systems
+	DUCKDB_API virtual bool TryGetNetworkThroughput(FileHandle &handle, NetworkThroughputEstimate &result);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                                             bool write);

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -149,10 +149,15 @@ struct BaseRequest {
 	//! Whether or not to return failed requests (instead of throwing)
 	bool try_request = false;
 
-	// Requests will optionally contain their timings
+	//! Requests will optionally contain their timings
 	bool have_request_timing = false;
 	timestamp_t request_start;
 	timestamp_t request_end;
+
+	//! Optional per-request network measurements, populated by clients that measure them.
+	bool have_time_to_fst_byte = false;
+	double time_to_fst_byte_sec = 0;
+	idx_t bytes_received = 0;
 
 	template <class TARGET>
 	TARGET &Cast() {

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -181,7 +181,7 @@ public:
 
 	static string ConstructLogMessage(const string &file_path, idx_t row_group_id, bool fully_filtered,
 	                                  const char *strategy, const vector<vector<string>> &prefetch_groups,
-	                                  const vector<string> &minimal_filters);
+	                                  const vector<string> &minimal_filters, uint64_t accepted_column_gap);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -27,6 +27,7 @@ class DatabaseInstance;
 class FileOpenFlags;
 class FileSystem;
 struct FileHandle;
+struct NetworkThroughputEstimate;
 class QueryContext;
 class CachingFileSystem;
 
@@ -56,6 +57,7 @@ public:
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsRemoteFile() const;
 	DUCKDB_API bool OnDiskFile();
+	DUCKDB_API bool TryGetNetworkThroughput(NetworkThroughputEstimate &result);
 	DUCKDB_API idx_t SeekPosition();
 	DUCKDB_API void Seek(idx_t location);
 

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -299,13 +299,14 @@ LogicalType ParquetPrefetchLogType::GetLogType() {
 	    {"strategy", LogicalType::VARCHAR},
 	    {"prefetch_groups", LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR))},
 	    {"minimal_filters", LogicalType::LIST(LogicalType::VARCHAR)},
+	    {"accepted_column_gap", LogicalType::UBIGINT},
 	};
 	return LogicalType::STRUCT(child_list);
 }
 
 string ParquetPrefetchLogType::ConstructLogMessage(const string &file_path, idx_t row_group_id, bool fully_filtered,
                                                    const char *strategy, const vector<vector<string>> &prefetch_groups,
-                                                   const vector<string> &minimal_filters) {
+                                                   const vector<string> &minimal_filters, uint64_t accepted_column_gap) {
 	vector<Value> outer;
 	outer.reserve(prefetch_groups.size());
 	for (auto &group : prefetch_groups) {
@@ -328,6 +329,7 @@ string ParquetPrefetchLogType::ConstructLogMessage(const string &file_path, idx_
 	    {"strategy", strategy ? Value(strategy) : Value(LogicalType::VARCHAR)},
 	    {"prefetch_groups", Value::LIST(LogicalType::LIST(LogicalType::VARCHAR), std::move(outer))},
 	    {"minimal_filters", Value::LIST(LogicalType::VARCHAR, std::move(minimal))},
+	    {"accepted_column_gap", Value::UBIGINT(accepted_column_gap)},
 	};
 	return Value::STRUCT(std::move(child_list)).ToString();
 }

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -306,7 +306,8 @@ LogicalType ParquetPrefetchLogType::GetLogType() {
 
 string ParquetPrefetchLogType::ConstructLogMessage(const string &file_path, idx_t row_group_id, bool fully_filtered,
                                                    const char *strategy, const vector<vector<string>> &prefetch_groups,
-                                                   const vector<string> &minimal_filters, uint64_t accepted_column_gap) {
+                                                   const vector<string> &minimal_filters,
+                                                   uint64_t accepted_column_gap) {
 	vector<Value> outer;
 	outer.reserve(prefetch_groups.size());
 	for (auto &group : prefetch_groups) {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -265,20 +265,14 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 		}
 
 		try {
-			if (request.have_request_timing) {
-				request.request_start = Timestamp::GetCurrentTimestamp();
-			}
+			request.request_start = Timestamp::GetCurrentTimestamp();
 			response = client->Request(request);
 		} catch (...) {
-			if (request.have_request_timing) {
-				request.request_end = Timestamp::GetCurrentTimestamp();
-			}
+			request.request_end = Timestamp::GetCurrentTimestamp();
 			LogRequest(request, nullptr);
 			throw;
 		}
-		if (request.have_request_timing) {
-			request.request_end = Timestamp::GetCurrentTimestamp();
-		}
+		request.request_end = Timestamp::GetCurrentTimestamp();
 		LogRequest(request, response ? response.get() : nullptr);
 		return response;
 	});

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -376,6 +376,10 @@ bool CachingFileHandle::OnDiskFile() {
 	return GetFileHandle().OnDiskFile();
 }
 
+bool CachingFileHandle::TryGetNetworkThroughput(NetworkThroughputEstimate &result) {
+	return GetFileHandle().TryGetNetworkThroughput(result);
+}
+
 idx_t CachingFileHandle::SeekPosition() {
 	return position;
 }

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -76,7 +76,9 @@
         "test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test",
         "test/sql/copy/parquet/parquet_prefetch_projection.test",
         "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
-        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test"
+        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
+        "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
+        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test"
       ]
     },
     {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -39,7 +39,9 @@
         "test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test",
         "test/sql/copy/parquet/parquet_prefetch_projection.test",
         "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
-        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test"
+        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
+        "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
+        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test"
       ]
     },
     {

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/parquet/parquet_prefetch_cost_model.test
-# description: Check Parquet Prefetching gap uses the local cost-model seed (network refinement is remote-only)
+# description: Check Parquet Prefetching gap stays at the default for local files (cost model is remote-only)
 # group: [parquet]
 
 require parquet
@@ -33,13 +33,13 @@ SELECT sum(b + j) FROM read_parquet('{TEST_DIR}/cost_model_gap.parquet') WHERE a
 ----
 52350266
 
-# Starts of with the seed
+# Local files have no network to measure, so they use the default gap (DEFAULT_ACCEPTED_COLUMN_GAP = 16 KiB)
 query I
 SELECT accepted_column_gap
 FROM duckdb_logs_parsed('ParquetPrefetch')
 WHERE file_path LIKE '%cost_model_gap.parquet' AND row_group_id = 0
 ----
-20000
+16384
 
 # values are between the limits
 query I
@@ -49,10 +49,10 @@ WHERE file_path LIKE '%cost_model_gap.parquet' AND (accepted_column_gap < 4096 O
 ----
 0
 
-# Local files are not network-measured, so every row group keeps the local seed gap (1e-5 s * 2e9 B/s = 20000)
+# The cost model is remote-only: local (on-disk) files keep the default gap (DEFAULT_ACCEPTED_COLUMN_GAP = 16 KiB)
 query I
 SELECT DISTINCT accepted_column_gap
 FROM duckdb_logs_parsed('ParquetPrefetch')
 WHERE file_path LIKE '%cost_model_gap.parquet'
 ----
-20000
+16384

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/parquet/parquet_prefetch_cost_model.test
-# description: Check Parquet Prefetching gap values change with cost model
+# description: Check Parquet Prefetching gap uses the local cost-model seed (network refinement is remote-only)
 # group: [parquet]
 
 require parquet
@@ -49,9 +49,10 @@ WHERE file_path LIKE '%cost_model_gap.parquet' AND (accepted_column_gap < 4096 O
 ----
 0
 
+# Local files are not network-measured, so every row group keeps the local seed gap (1e-5 s * 2e9 B/s = 20000)
 query I
-SELECT count(DISTINCT accepted_column_gap) > 1
+SELECT DISTINCT accepted_column_gap
 FROM duckdb_logs_parsed('ParquetPrefetch')
 WHERE file_path LIKE '%cost_model_gap.parquet'
 ----
-true
+20000

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model.test
@@ -1,0 +1,57 @@
+# name: test/sql/copy/parquet/parquet_prefetch_cost_model.test
+# description: Check Parquet Prefetching gap values change with cost model
+# group: [parquet]
+
+require parquet
+
+statement ok
+SET threads=1
+
+statement ok
+SET prefetch_all_parquet_files=true
+
+statement ok
+COPY (
+    SELECT CASE WHEN i % 7 = 0 THEN NULL ELSE i END AS a,
+        i + 1 AS b,
+        CASE WHEN i % 11 = 0 THEN NULL ELSE i + 2 END AS c,
+        hash(i)::VARCHAR AS d,
+        hash(i + 1)::VARCHAR AS e,
+        hash(i + 2)::VARCHAR AS f,
+        hash(i + 3)::VARCHAR AS g,
+        hash(i + 4)::VARCHAR AS h,
+        hash(i + 5)::VARCHAR AS ii,
+        i + 9 AS j
+    FROM RANGE(8192) t(i)
+) TO '{TEST_DIR}/cost_model_gap.parquet' (ROW_GROUP_SIZE 2048, WRITE_BLOOM_FILTER FALSE)
+
+statement ok
+CALL enable_logging('ParquetPrefetch')
+
+query I
+SELECT sum(b + j) FROM read_parquet('{TEST_DIR}/cost_model_gap.parquet') WHERE a >= 0 AND c >= 0
+----
+52350266
+
+# Starts of with the seed
+query I
+SELECT accepted_column_gap
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%cost_model_gap.parquet' AND row_group_id = 0
+----
+20000
+
+# values are between the limits
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%cost_model_gap.parquet' AND (accepted_column_gap < 4096 OR accepted_column_gap > 33554432)
+----
+0
+
+query I
+SELECT count(DISTINCT accepted_column_gap) > 1
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%cost_model_gap.parquet'
+----
+true

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
@@ -21,13 +21,13 @@ SELECT count(*)
 FROM read_parquet('http://blobs.duckdb.org/data/train-services-window-self-join-benchmark.parquet') t(c0, c1)
 WHERE c1 > 500000
 
-# The first row group is sized from the remote seed, before enough network samples have been measured
+# The first row group is sized from the default, before enough network samples have been measured
 query I
 SELECT accepted_column_gap
 FROM duckdb_logs_parsed('ParquetPrefetch')
 WHERE file_path LIKE '%train-services%' AND row_group_id = 0
 ----
-3200000
+16384
 
 query I
 SELECT count(*)
@@ -36,7 +36,7 @@ WHERE file_path LIKE '%train-services%' AND (accepted_column_gap < 4096 OR accep
 ----
 0
 
-# Once enough network samples accumulate, the gap moves off the seed: the cost model adapted to real measurements
+# Once enough network samples accumulate, the gap moves off the default: the cost model adapted to real measurements
 query I
 SELECT count(DISTINCT accepted_column_gap) > 1
 FROM duckdb_logs_parsed('ParquetPrefetch')

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
-# description: Check Parquet Prefetching gap values change with cost model (over remote files)
+# description: Check Parquet Prefetching gap adapts to measured network latency/bandwidth (over remote files)
 # group: [parquet]
 
 require parquet
@@ -11,6 +11,9 @@ statement ok
 SET threads=1
 
 statement ok
+SET enable_external_file_cache=false
+
+statement ok
 CALL enable_logging('ParquetPrefetch')
 
 statement ok
@@ -18,6 +21,7 @@ SELECT count(*)
 FROM read_parquet('http://blobs.duckdb.org/data/train-services-window-self-join-benchmark.parquet') t(c0, c1)
 WHERE c1 > 500000
 
+# The first row group is sized from the remote seed, before enough network samples have been measured
 query I
 SELECT accepted_column_gap
 FROM duckdb_logs_parsed('ParquetPrefetch')
@@ -32,6 +36,7 @@ WHERE file_path LIKE '%train-services%' AND (accepted_column_gap < 4096 OR accep
 ----
 0
 
+# Once enough network samples accumulate, the gap moves off the seed: the cost model adapted to real measurements
 query I
 SELECT count(DISTINCT accepted_column_gap) > 1
 FROM duckdb_logs_parsed('ParquetPrefetch')

--- a/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
+++ b/test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
@@ -1,0 +1,40 @@
+# name: test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test
+# description: Check Parquet Prefetching gap values change with cost model (over remote files)
+# group: [parquet]
+
+require parquet
+
+require httpfs
+
+
+statement ok
+SET threads=1
+
+statement ok
+CALL enable_logging('ParquetPrefetch')
+
+statement ok
+SELECT count(*)
+FROM read_parquet('http://blobs.duckdb.org/data/train-services-window-self-join-benchmark.parquet') t(c0, c1)
+WHERE c1 > 500000
+
+query I
+SELECT accepted_column_gap
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%train-services%' AND row_group_id = 0
+----
+3200000
+
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%train-services%' AND (accepted_column_gap < 4096 OR accepted_column_gap > 33554432)
+----
+0
+
+query I
+SELECT count(DISTINCT accepted_column_gap) > 1
+FROM duckdb_logs_parsed('ParquetPrefetch')
+WHERE file_path LIKE '%train-services%'
+----
+true


### PR DESCRIPTION
This PR introduces a cost model to adaptively calculate the accepted column gap size for requests.

Prior to this PR, the gap was hardcoded to be 16Kib. 

For example, say we have a table in a remote parquet file with columns `C1|C2|C3`, but only `C1` and `C3` where being queried, we could have either a request with all columns, or two requests, one for `C1` and another for `C3`, this decision was made by checking if `C2` was `<= 16kib`.

The hardcoded value was problematic for remote files, as the decision of the gap size is highly dependent on the latency (i.e., costs of doing a request) and bandwidth (speed at which you can transfer bytes), hence we now calculate the gap by multiplying latency and bandwidth.

The latency and bandwidth are captured directly in the httpfs extension, with time to first byte representing latency and transfer speed representing bandwidth. The on-disk behavior is unchanged, and the first network read still falls into the `16kb` default.

The network capture system is lock-free, as each thread keeps its own estimates, and it also passes to the next files, avoiding file warm-up.

## Benchmark
To benchmark this, ive created several parquet files with many row groups where we have needed columns (k) and gap columns (f),
with the schema looking like: `k0|f0|k1|f1|k2|f2|k3|f3|k4|f4|k5|f5|k6|f6|k7`, the gap columns are ~ 64Kb. The files sit in S3, and I'm querying it from my laptop.

The query looks like: 
```sql
SELECT sum(k0)+sum(k1)+sum(k2)+sum(k3)+sum(k4)+sum(k5)+sum(k6)+sum(k7)
  FROM read_parquet('s3://.../prefetch_bench_wide/part_*.parquet');
```

In this benchmark, the baseline will always do 8 requests, while our algorithm will quickly adapt to do one request by also bringing the filler columns, as the bandwidth is fast and the latency is high. With 8 requests, this query runs in 28 seconds, while with our new algorithm, it runs in 5 seconds, hence, it brings a 5-6x better performance in this scenario.
