### PR TITLE
Improve test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ EXE_SUFFIX := .exe
 endif
 UNITTEST_BINARY ?= test/unittest$(EXE_SUFFIX)
 SMOKE_UNITTEST ?= build/relassert/$(UNITTEST_BINARY)
-UNITTEST_SLOW_FLAGS ?= --batch-size=5 --batch-timeout=300 --track-runtime=100
+UNITTEST_SLOW_FLAGS ?= --batch-size=5 --track-runtime=100
 UNITTEST_HUGE_FLAGS ?= --workers=50% $(UNITTEST_SLOW_FLAGS)
 
 # Allow setting extra unit test parameters using `make smoke T=...`.

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -360,10 +360,24 @@ SKIPPED_TESTS_PATTERN = re.compile(
 SKIP_REASON_PATTERN = re.compile(r"(.+):\s+(\d+)$")
 MODE_SKIP_REASON_PATTERN = re.compile(r"^mode skip(?:\s+(.*\S))?\s*$")
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+TEST_RUNTIME_PATTERN = re.compile(r"^\[\d+/\d+\] \(\d+%\): (.+) took ([0-9]+(?:\.[0-9]+)?)s\s*$")
 
 
 def strip_ansi(text: str):
     return ANSI_ESCAPE_PATTERN.sub("", text)
+
+
+def parse_test_runtimes(output: str):
+    runtimes = []
+    for line in strip_ansi(output).splitlines():
+        match = TEST_RUNTIME_PATTERN.match(line.strip())
+        if match:
+            runtimes.append((match.group(1), float(match.group(2))))
+    return runtimes
+
+
+def extract_test_runtimes(stdout: str, stderr: str):
+    return parse_test_runtimes(stdout) + parse_test_runtimes(stderr)
 
 
 def parse_skipped_tests_count(output: str):
@@ -549,8 +563,14 @@ def handle_failed_batch(ctx: RunContext, batch_info, result):
 
 
 def report_batch_metrics(ctx: RunContext, batch_info, result, elapsed: float):
-    if ctx.config.runtime_threshold_seconds is not None and elapsed >= ctx.config.runtime_threshold_seconds:
-        ctx.progress.print_message(f"warn: {batch_info['batch'][0]} took {elapsed:.2f}s")
+    if ctx.config.runtime_threshold_seconds is not None:
+        test_runtimes = extract_test_runtimes(result["stdout"], result["stderr"])
+        if test_runtimes:
+            for test_name, test_elapsed in test_runtimes:
+                if test_elapsed >= ctx.config.runtime_threshold_seconds:
+                    ctx.progress.print_message(f"warn: {test_name} took {test_elapsed:.2f}s")
+        elif elapsed >= ctx.config.runtime_threshold_seconds:
+            ctx.progress.print_message(f"warn: {batch_info['batch'][0]} took {elapsed:.2f}s")
     if (
         ctx.config.rss_memory_threshold_mib is not None
         and format_mib(result["peak_rss_bytes"]) >= ctx.config.rss_memory_threshold_mib
@@ -825,11 +845,7 @@ def main_impl(argv: list[str] | None = None):
     unittest_bin = args.unittest_bin
     if os.name == "nt":
         unittest_bin = unittest_bin.replace("/", "\\")
-    if args.track_runtime is not None:
-        print("enabling runtime tracking forces batch_size=1")
-        batch_size = 1
-    else:
-        batch_size = args.batch_size
+    batch_size = args.batch_size
     failed_configs = []
     if len(config_invocations) > 1:
         print(f"running {len(config_invocations)} configs")

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 DEFAULT_BATCH_SIZE = 10
 DEFAULT_BATCH_TIMEOUT_SECONDS = 600
+HIGH_WORKER_BATCH_TIMEOUT_SECONDS = 300
+HIGH_WORKER_BATCH_TIMEOUT_THRESHOLD = 10
 DEFAULT_RSS_MEMORY_THRESHOLD_MIB = 1024
 DEFAULT_RUNTIME_THRESHOLD_SECONDS = 10
 DEFAULT_RSS_POLL_INTERVAL_SECONDS = 0.05
@@ -257,6 +259,14 @@ def resolve_workers(workers: str):
         percentage = int(workers[:-1])
         return max(1, int(cpu_count * (percentage / 100.0)))
     return max(1, int(workers))
+
+
+def resolve_batch_timeout(batch_timeout: float | None, workers: int):
+    if batch_timeout is not None:
+        return batch_timeout
+    if workers >= HIGH_WORKER_BATCH_TIMEOUT_THRESHOLD:
+        return HIGH_WORKER_BATCH_TIMEOUT_SECONDS
+    return DEFAULT_BATCH_TIMEOUT_SECONDS
 
 
 def generate_test_list(
@@ -600,7 +610,7 @@ def parse_args(argv: list[str] | None = None):
     parser.add_argument("--retry", type=int, default=0)
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
-    parser.add_argument("--batch-timeout", type=float, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
+    parser.add_argument("--batch-timeout", type=float)
     parser.add_argument(
         "--fail-require-skip",
         action="store_true",
@@ -811,6 +821,7 @@ def main_impl(argv: list[str] | None = None):
         print("CI detected, enabling retry=2 per batch")
     max_retries = max(0, args.max_retries)
     workers = resolve_workers(args.workers)
+    args.batch_timeout = resolve_batch_timeout(args.batch_timeout, workers)
     unittest_bin = args.unittest_bin
     if os.name == "nt":
         unittest_bin = unittest_bin.replace("/", "\\")

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -325,12 +325,10 @@ def format_batch_failure(
     stderr: str,
     message: str | None = None,
 ):
-    rerun_cmd = (
-        "printf '%s\\n' "
-        + " ".join(shlex.quote(test) for test in batch)
-        + " > /tmp/duckdb_test_batch.txt && "
-        + build_test_command(config, "/tmp/duckdb_test_batch.txt")
-    )
+    rerun_parts = [shlex.quote(config.unittest_bin)]
+    rerun_parts.extend(shlex.split(config.test_flags))
+    rerun_parts.append(",".join(batch))
+    rerun_cmd = shlex.join(rerun_parts)
     parts = [f"### failed test batch {batch_idx} ###", ""]
     if message is not None:
         parts.extend([message, ""])

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -354,7 +354,9 @@ def normalize_output(output):
     return output or ""
 
 
-SKIPPED_TESTS_PATTERN = re.compile(r"All tests passed \((\d+) skipped tests,")
+SKIPPED_TESTS_PATTERN = re.compile(
+    r"(?:All tests passed \(|All tests were skipped \(total skipped )(\d+)(?: skipped tests,|\))"
+)
 SKIP_REASON_PATTERN = re.compile(r"(.+):\s+(\d+)$")
 MODE_SKIP_REASON_PATTERN = re.compile(r"^mode skip(?:\s+(.*\S))?\s*$")
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -315,7 +315,11 @@ require windows: 2
             #!/bin/sh
             # run_tests.py calls: <helper> --list-tests <pattern>
             if [ "$1" != "--list-tests" ]; then
-              exit 2
+              printf '\\n[0/2] (0%%): test/sql/slow.test\\n'
+              printf '[1/2] (50%%): test/sql/slow.test took 0.001s\\n'
+              printf '[2/2] (100%%): test/sql/fast.test took 0.002s\\n'
+              printf 'All tests passed (100 assertions in 2 test cases)\\n'
+              exit 0
             fi
             cat "$2"
             exit 2
@@ -334,7 +338,7 @@ require windows: 2
                     "--track-runtime",
                     "0",
                     "--test-command",
-                    "echo fake-run {test_list}",
+                    "{binary} {test_list}",
                     str(list_helper_path),
                     str(listed_tests_path),
                 ]
@@ -345,7 +349,9 @@ require windows: 2
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("generated test list using:", proc.stdout)
+        self.assertIn("batch_size=2", proc.stdout)
         self.assertNotIn("found 2 tests", proc.stdout)
+        self.assertNotIn("forces batch_size=1", proc.stdout)
         self.assertIn("warn: test/sql/slow.test took", proc.stdout)
         self.assertIn("warn: test/sql/fast.test took", proc.stdout)
         self.assertIn("ran tests: ", proc.stdout)

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -13477,10 +13477,16 @@ namespace Catch {
             return reporter;
         }
 
-        void renderTestProgress(int current_test, int total_tests, std::string next_test) {
+        void renderTestProgress(int current_test, int total_tests, std::string next_test, double elapsed_seconds = -1) {
             double progress = (double) current_test / (double) total_tests;
             std::string prefix = "[" + std::to_string(current_test) + "/" + std::to_string(total_tests) + "] (" + std::to_string(int(progress * 100)) + "%): ";
-            std::string result = prefix + next_test;
+            std::string test_label = next_test;
+            if (elapsed_seconds >= 0) {
+                char elapsed_buffer[64];
+                snprintf(elapsed_buffer, sizeof(elapsed_buffer), " took %.3fs", elapsed_seconds);
+                test_label += elapsed_buffer;
+            }
+            std::string result = prefix + test_label;
 
             if (IsTerminal()) {
                 // For terminals, we want to overwrite the previous line to not flood the window with successful tests.
@@ -13495,9 +13501,9 @@ namespace Catch {
                     result += std::string(render_width - result.size(), ' ');
                 } else if (result.size() > static_cast<size_t>(render_width)) {
                     int available_for_test = render_width - prefix.size() - 3; // 3 for "..."
-                    if (available_for_test > 0 && next_test.size() > static_cast<size_t>(available_for_test)) {
+                    if (available_for_test > 0 && test_label.size() > static_cast<size_t>(available_for_test)) {
                         // Replace the start of the test name with "..." to indicate truncation
-                        result = prefix + "..." + next_test.substr(next_test.size() - available_for_test);
+                        result = prefix + "..." + test_label.substr(test_label.size() - available_for_test);
                     } else {
                         // If prefix is too long for terminal width, fall back to simple truncation
                         result = result.substr(0, render_width - 3) + "...";
@@ -13560,6 +13566,7 @@ namespace Catch {
 
                 int total_tests_run = m_tests.size();
                 int current_test = 0;
+                bool rendered_initial_progress = false;
 
                 int start_offset = 0;
                 int end_offset = total_tests_run;
@@ -13580,14 +13587,20 @@ namespace Catch {
                             current_test++;
                             continue;
                         }
-                        if (!m_config->printFailingTests()) {
+                        if (!m_config->printFailingTests() && !rendered_initial_progress) {
                             renderTestProgress(current_test, total_tests_run, testCase->name);
+                            rendered_initial_progress = true;
                         }
+                        Timer timer;
+                        timer.start();
                         totals += m_context.runTest(*testCase);
+                        double elapsed_seconds = timer.getElapsedSeconds();
                         current_test++;
-                        if (current_test == total_tests_run && !m_config->printFailingTests()) {
-                            renderTestProgress(current_test, total_tests_run, testCase->name);
-                            std::cout << std::endl;
+                        if (!m_config->printFailingTests()) {
+                            renderTestProgress(current_test, total_tests_run, testCase->name, elapsed_seconds);
+                            if (current_test == total_tests_run) {
+                                std::cout << std::endl;
+                            }
                         }
                     } else {
                         m_context.reporter().skipTest(*testCase);


### PR DESCRIPTION
- Use test timeout on slow runners (having a few test workers)
  - use `300s` for fast runners (10+ workers).
  - otherwise, use `600s`.
- Make test reproduce command easier to read/paste.
- Parse `All tests were skipped` message correctly (was ignored previously and counted as - Extract test time from a test batch.
  - Removes the implicitly forced `--batch-size=1` when `--track-runtime` is used.