### PR TITLE
Reapply: Enable jemalloc heap profiling with the libgcc unwinder

### DIFF
--- a/third_party/jemalloc/README.md
+++ b/third_party/jemalloc/README.md
@@ -189,6 +189,28 @@ malloc_write(const char *s) {
 }
 ```
 
+In the `JEMALLOC_PROF_LIBGCC` block in `prof_sys.c`, wrap the `#include <unwind.h>`
+so `_GNU_SOURCE` is defined just for that include (and restored afterwards). The
+musl extension build images install `libunwind-dev`, whose `/usr/include/unwind.h`
+shadows gcc's own header and only declares `_Unwind_Backtrace` under `_GNU_SOURCE`;
+without this, gcc 14 fails with an implicit-declaration error in C99-and-later
+modes. The `#undef _Unwind_Backtrace` and final `#define _Unwind_Backtrace`
+lines already exist upstream; the DuckDB-specific edit is the `_GNU_SOURCE`
+guard around `#include <unwind.h>`.
+```c++
+#undef _Unwind_Backtrace
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#define JE_DUCKDB_TMP_GNU_SOURCE
+#endif
+#include <unwind.h>
+#ifdef JE_DUCKDB_TMP_GNU_SOURCE
+#undef _GNU_SOURCE
+#undef JE_DUCKDB_TMP_GNU_SOURCE
+#endif
+#define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
+```
+
 Almost no symbols are leaked due to `private_namespace.h`.
 The `exported_symbols_check.py` script still found a few, so these lines need to be added to `private_namespace.h`:
 ```c++

--- a/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/third_party/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -211,12 +211,10 @@
 /* #undef JEMALLOC_PROF_LIBUNWIND */
 
 /* Use libgcc for profile backtracing if defined. */
-#ifdef __GLIBC__
 #define JEMALLOC_PROF_LIBGCC
-#endif
 
 /* Use gcc intrinsics for profile backtracing if defined. */
-#define JEMALLOC_PROF_GCC
+/* #undef JEMALLOC_PROF_GCC */
 
 /* JEMALLOC_PAGEID enabled page id */
 /* #undef JEMALLOC_PAGEID */

--- a/third_party/jemalloc/src/prof_sys.c
+++ b/third_party/jemalloc/src/prof_sys.c
@@ -18,7 +18,26 @@
  * already hooked _Unwind_Backtrace.  We'll temporarily disable hooking.
  */
 #undef _Unwind_Backtrace
+/*
+ * libunwind's <unwind.h> (pulled in by libunwind-dev on the musl extension
+ * build images) shadows gcc's own <unwind.h> on the include path and only
+ * declares _Unwind_Backtrace under _GNU_SOURCE.  Without it the declaration is
+ * missing, and gcc 14 treats implicit function declarations as errors in
+ * C99-and-later modes.
+ *
+ * Define _GNU_SOURCE just for this include and restore the prior state right
+ * after, so the change stays confined to <unwind.h> and does not alter the
+ * feature-test posture seen by the rest of this translation unit.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#define JE_DUCKDB_TMP_GNU_SOURCE
+#endif
 #include <unwind.h>
+#ifdef JE_DUCKDB_TMP_GNU_SOURCE
+#undef _GNU_SOURCE
+#undef JE_DUCKDB_TMP_GNU_SOURCE
+#endif
 #define _Unwind_Backtrace JEMALLOC_TEST_HOOK(_Unwind_Backtrace, test_hooks_libc_hook)
 #endif
 


### PR DESCRIPTION
Brings back https://github.com/duckdb/duckdb/pull/22630. This time by also fixing jemalloc builds on musl.

Before:

```
❯ git cat-file -p "$(git rev-parse HEAD^:third_party/jemalloc/src/prof_sys.c)" | docker run --rm -i --platform linux/arm64 -v "$PWD:/src:ro" -w /src alpine:3.22 sh -lc '
  set -eu
  apk add --no-cache build-base libunwind-dev >/dev/null
  gcc --version | head -1
  gcc -std=gnu99 -Werror=implicit-function-declaration \
    -DJEMALLOC_NO_PRIVATE_NAMESPACE \
    -Ithird_party/jemalloc/include \
    -Ithird_party/jemalloc/include/jemalloc/internal \
    -Ithird_party/jemalloc/include/jemalloc \
    -x c -c -o /tmp/prof_sys.before.o -
'
gcc (Alpine 14.2.0) 14.2.0
In file included from third_party/jemalloc/include/jemalloc/internal/jemalloc_preamble.h:54,
                 from <stdin>:1:
<stdin>: In function 'prof_backtrace_impl':
<stdin>:22:46: error: implicit declaration of function '_Unwind_Backtrace' [-Wimplicit-function-declaration]
<stdin>:22:27: note: in expansion of macro 'JEMALLOC_TEST_HOOK'
<stdin>:99:2: note: in expansion of macro '_Unwind_Backtrace'
```

After:

```
❯ docker run --rm --platform linux/arm64 -v "$PWD:/src:ro" -w /src alpine:3.22 sh -lc '
  set -eu
  apk add --no-cache build-base libunwind-dev >/dev/null
  gcc --version | head -1
  gcc -std=gnu99 -Werror=implicit-function-declaration \
    -DJEMALLOC_NO_PRIVATE_NAMESPACE \
    -Ithird_party/jemalloc/include \
    -Ithird_party/jemalloc/include/jemalloc/internal \
    -Ithird_party/jemalloc/include/jemalloc \
    -c third_party/jemalloc/src/prof_sys.c \
    -o /tmp/prof_sys.after.o
  echo prof_sys_after=pass
'
gcc (Alpine 14.2.0) 14.2.0
prof_sys_after=pass
```

Closes https://github.com/duckdblabs/duckdb-internal/issues/9354