### PR TITLE
Make casts extensible for CASE expression

### DIFF
--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -709,7 +709,7 @@ void UnionByName::CombineUnionTypes(const vector<string> &col_names, const vecto
 		if (union_find != union_names_map.end()) {
 			// given same name , union_col's type must compatible with col's type
 			auto &current_type = union_col_types[union_find->second];
-			auto compatible_type = LogicalType::ForceMaxLogicalType(current_type, sql_types[col]);
+			auto compatible_type = LogicalType::DefaultForceMaxLogicalType(current_type, sql_types[col]);
 			union_col_types[union_find->second] = compatible_type;
 		} else {
 			union_names_map[col_names[col]] = union_col_names.size();

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1183,8 +1183,8 @@ struct TryGetTypeOperation {
 struct ForceGetTypeOperation {
 	static bool Operation(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
 	                      LogicalType &result) {
-		(void)context;
-		result = LogicalType::ForceMaxLogicalType(left, right);
+		result = context ? LogicalType::ForceMaxLogicalType(*context, left, right)
+		                 : LogicalType::DefaultForceMaxLogicalType(left, right);
 		return true;
 	}
 };
@@ -1192,14 +1192,19 @@ struct ForceGetTypeOperation {
 bool LogicalType::TryGetMaxLogicalType(ClientContext &context, const LogicalType &left, const LogicalType &right,
                                        LogicalType &result) {
 	if (Settings::Get<OldImplicitCastingSetting>(context)) {
-		result = LogicalType::ForceMaxLogicalType(left, right);
+		result = LogicalType::ForceMaxLogicalType(context, left, right);
 		return true;
 	}
+	return TryGetMaxLogicalTypeUnchecked(context, left, right, result);
+}
+
+bool LogicalType::TryGetMaxLogicalTypeUnchecked(ClientContext &context, const LogicalType &left,
+                                                const LogicalType &right, LogicalType &result) {
 	return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(&context, left, right, result);
 }
 
-bool LogicalType::TryGetMaxLogicalTypeUnchecked(const LogicalType &left, const LogicalType &right,
-                                                LogicalType &result) {
+bool LogicalType::DefaultTryGetMaxLogicalTypeUnchecked(const LogicalType &left, const LogicalType &right,
+                                                       LogicalType &result) {
 	return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(nullptr, left, right, result);
 }
 
@@ -1305,9 +1310,10 @@ static idx_t GetLogicalTypeScore(const LogicalType &type) {
 	return 1000;
 }
 
-LogicalType LogicalType::ForceMaxLogicalType(const LogicalType &left, const LogicalType &right) {
+static LogicalType ForceMaxLogicalTypeInternal(optional_ptr<ClientContext> context, const LogicalType &left,
+                                               const LogicalType &right) {
 	LogicalType result;
-	if (TryGetMaxLogicalTypeInternal<ForceGetTypeOperation>(nullptr, left, right, result)) {
+	if (TryGetMaxLogicalTypeInternal<ForceGetTypeOperation>(context, left, right, result)) {
 		return result;
 	}
 	// we prefer the type with the highest score
@@ -1318,6 +1324,15 @@ LogicalType LogicalType::ForceMaxLogicalType(const LogicalType &left, const Logi
 	} else {
 		return left;
 	}
+}
+
+LogicalType LogicalType::ForceMaxLogicalType(ClientContext &context, const LogicalType &left,
+                                             const LogicalType &right) {
+	return ForceMaxLogicalTypeInternal(&context, left, right);
+}
+
+LogicalType LogicalType::DefaultForceMaxLogicalType(const LogicalType &left, const LogicalType &right) {
+	return ForceMaxLogicalTypeInternal(nullptr, left, right);
 }
 
 LogicalType LogicalType::MaxLogicalType(ClientContext &context, const LogicalType &left, const LogicalType &right) {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/function/cast_rules.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/common/types/type_manager.hpp"
@@ -892,7 +893,8 @@ LogicalType LogicalType::NormalizeType(const LogicalType &type) {
 }
 
 template <class OP>
-static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+static bool CombineUnequalTypes(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
+                                LogicalType &result) {
 	D_ASSERT(right.id() != left.id());
 	if (right.id() == LogicalTypeId::VARIANT) {
 		result = right;
@@ -918,9 +920,9 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 
 	// for enums, match the varchar rules
 	if (left.id() == LogicalTypeId::ENUM) {
-		return OP::Operation(LogicalType::VARCHAR, right, result);
+		return OP::Operation(context, LogicalType::VARCHAR, right, result);
 	} else if (right.id() == LogicalTypeId::ENUM) {
-		return OP::Operation(left, LogicalType::VARCHAR, result);
+		return OP::Operation(context, left, LogicalType::VARCHAR, result);
 	}
 
 	// for everything but enums - string literals also take the other type
@@ -932,9 +934,14 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 		return true;
 	}
 
-	// for other types - use implicit cast rules to check if we can combine the types
-	auto left_to_right_cost = CastRules::ImplicitCast(left, right);
-	auto right_to_left_cost = CastRules::ImplicitCast(right, left);
+	// for other types - use implicit cast rules to check if we can combine the types.
+	// When a ClientContext is available, route through CastFunctionSet so that extensions
+	// that registered casts via RegisterCastFunction(..., implicit_cost) participate.
+	// Without a context (e.g. TryGetMaxLogicalTypeUnchecked) fall back to the raw rules.
+	auto left_to_right_cost =
+	    context ? CastFunctionSet::ImplicitCastCost(*context, left, right) : CastRules::ImplicitCast(left, right);
+	auto right_to_left_cost =
+	    context ? CastFunctionSet::ImplicitCastCost(*context, right, left) : CastRules::ImplicitCast(right, left);
 	if (left_to_right_cost >= 0 && (left_to_right_cost < right_to_left_cost || right_to_left_cost < 0)) {
 		// we can implicitly cast left to right, return right
 		//! Depending on the type, we might need to grow the `width` of the DECIMAL type
@@ -967,10 +974,10 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 	}
 	// for integer literals - rerun the operation with the underlying type
 	if (left.id() == LogicalTypeId::INTEGER_LITERAL) {
-		return OP::Operation(IntegerLiteral::GetType(left), right, result);
+		return OP::Operation(context, IntegerLiteral::GetType(left), right, result);
 	}
 	if (right.id() == LogicalTypeId::INTEGER_LITERAL) {
-		return OP::Operation(left, IntegerLiteral::GetType(right), result);
+		return OP::Operation(context, left, IntegerLiteral::GetType(right), result);
 	}
 	// for unsigned/signed comparisons we have a few fallbacks
 	if (left.IsNumeric() && right.IsNumeric()) {
@@ -989,7 +996,8 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 }
 
 template <class OP>
-static bool CombineStructTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+static bool CombineStructTypes(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
+                               LogicalType &result) {
 	auto &left_children = StructType::GetChildTypes(left);
 	auto &right_children = StructType::GetChildTypes(right);
 
@@ -1006,7 +1014,7 @@ static bool CombineStructTypes(const LogicalType &left, const LogicalType &right
 
 		for (idx_t i = 0; i < left_children.size(); i++) {
 			LogicalType child_type;
-			if (!OP::Operation(left_children[i].second, right_children[i].second, child_type)) {
+			if (!OP::Operation(context, left_children[i].second, right_children[i].second, child_type)) {
 				return false;
 			}
 			auto &child_name = left_unnamed ? right_children[i].first : left_children[i].first;
@@ -1037,7 +1045,7 @@ static bool CombineStructTypes(const LogicalType &left, const LogicalType &right
 		// We need to recurse to ensure the children have a maximum logical type.
 		LogicalType child_type;
 		auto &right_child = right_children[right_child_it->second];
-		if (!OP::Operation(left_child.second, right_child.second, child_type)) {
+		if (!OP::Operation(context, left_child.second, right_child.second, child_type)) {
 			return false;
 		}
 		child_types.emplace_back(left_child.first, std::move(child_type));
@@ -1055,7 +1063,8 @@ static bool CombineStructTypes(const LogicalType &left, const LogicalType &right
 }
 
 template <class OP>
-static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+static bool CombineEqualTypes(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
+                              LogicalType &result) {
 	// Since both left and right are equal we get the left type as our type_id for checks
 	auto type_id = left.id();
 	switch (type_id) {
@@ -1065,7 +1074,7 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 		return true;
 	case LogicalTypeId::INTEGER_LITERAL:
 		// for two integer literals we unify the underlying types
-		return OP::Operation(IntegerLiteral::GetType(left), IntegerLiteral::GetType(right), result);
+		return OP::Operation(context, IntegerLiteral::GetType(left), IntegerLiteral::GetType(right), result);
 	case LogicalTypeId::ENUM:
 		// If both types are different ENUMs we do a string comparison.
 		result = left == right ? left : LogicalType::VARCHAR;
@@ -1100,7 +1109,7 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 	case LogicalTypeId::LIST: {
 		// list: perform max recursively on child type
 		LogicalType new_child;
-		if (!OP::Operation(ListType::GetChildType(left), ListType::GetChildType(right), new_child)) {
+		if (!OP::Operation(context, ListType::GetChildType(left), ListType::GetChildType(right), new_child)) {
 			return false;
 		}
 		result = LogicalType::LIST(new_child);
@@ -1108,7 +1117,7 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 	}
 	case LogicalTypeId::ARRAY: {
 		LogicalType new_child;
-		if (!OP::Operation(ArrayType::GetChildType(left), ArrayType::GetChildType(right), new_child)) {
+		if (!OP::Operation(context, ArrayType::GetChildType(left), ArrayType::GetChildType(right), new_child)) {
 			return false;
 		}
 		auto new_size = MaxValue(ArrayType::GetSize(left), ArrayType::GetSize(right));
@@ -1118,14 +1127,14 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 	case LogicalTypeId::MAP: {
 		// map: perform max recursively on child type
 		LogicalType new_child;
-		if (!OP::Operation(ListType::GetChildType(left), ListType::GetChildType(right), new_child)) {
+		if (!OP::Operation(context, ListType::GetChildType(left), ListType::GetChildType(right), new_child)) {
 			return false;
 		}
 		result = LogicalType::MAP(new_child);
 		return true;
 	}
 	case LogicalTypeId::STRUCT: {
-		return CombineStructTypes<OP>(left, right, result);
+		return CombineStructTypes<OP>(context, left, right, result);
 	}
 	case LogicalTypeId::UNION: {
 		auto left_member_count = UnionType::GetMemberCount(left);
@@ -1146,7 +1155,8 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 }
 
 template <class OP>
-static bool TryGetMaxLogicalTypeInternal(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+static bool TryGetMaxLogicalTypeInternal(optional_ptr<ClientContext> context, const LogicalType &left,
+                                         const LogicalType &right, LogicalType &result) {
 	// we always prefer aliased types
 	if (!left.GetAlias().empty()) {
 		result = left;
@@ -1157,20 +1167,23 @@ static bool TryGetMaxLogicalTypeInternal(const LogicalType &left, const LogicalT
 		return true;
 	}
 	if (left.id() != right.id()) {
-		return CombineUnequalTypes<OP>(left, right, result);
+		return CombineUnequalTypes<OP>(context, left, right, result);
 	} else {
-		return CombineEqualTypes<OP>(left, right, result);
+		return CombineEqualTypes<OP>(context, left, right, result);
 	}
 }
 
 struct TryGetTypeOperation {
-	static bool Operation(const LogicalType &left, const LogicalType &right, LogicalType &result) {
-		return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(left, right, result);
+	static bool Operation(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
+	                      LogicalType &result) {
+		return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(context, left, right, result);
 	}
 };
 
 struct ForceGetTypeOperation {
-	static bool Operation(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+	static bool Operation(optional_ptr<ClientContext> context, const LogicalType &left, const LogicalType &right,
+	                      LogicalType &result) {
+		(void)context;
 		result = LogicalType::ForceMaxLogicalType(left, right);
 		return true;
 	}
@@ -1182,12 +1195,12 @@ bool LogicalType::TryGetMaxLogicalType(ClientContext &context, const LogicalType
 		result = LogicalType::ForceMaxLogicalType(left, right);
 		return true;
 	}
-	return TryGetMaxLogicalTypeUnchecked(left, right, result);
+	return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(&context, left, right, result);
 }
 
 bool LogicalType::TryGetMaxLogicalTypeUnchecked(const LogicalType &left, const LogicalType &right,
                                                 LogicalType &result) {
-	return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(left, right, result);
+	return TryGetMaxLogicalTypeInternal<TryGetTypeOperation>(nullptr, left, right, result);
 }
 
 static idx_t GetLogicalTypeScore(const LogicalType &type) {
@@ -1294,7 +1307,7 @@ static idx_t GetLogicalTypeScore(const LogicalType &type) {
 
 LogicalType LogicalType::ForceMaxLogicalType(const LogicalType &left, const LogicalType &right) {
 	LogicalType result;
-	if (TryGetMaxLogicalTypeInternal<ForceGetTypeOperation>(left, right, result)) {
+	if (TryGetMaxLogicalTypeInternal<ForceGetTypeOperation>(nullptr, left, right, result)) {
 		return result;
 	}
 	// we prefer the type with the highest score

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -935,9 +935,8 @@ static bool CombineUnequalTypes(optional_ptr<ClientContext> context, const Logic
 	}
 
 	// for other types - use implicit cast rules to check if we can combine the types.
-	// When a ClientContext is available, route through CastFunctionSet so that extensions
-	// that registered casts via RegisterCastFunction(..., implicit_cost) participate.
-	// Without a context (e.g. TryGetMaxLogicalTypeUnchecked) fall back to the raw rules.
+	// With a context: go through CastFunctionSet so that any registered casts are honored.
+	// Without a context: consult the built-in CastRules table directly.
 	auto left_to_right_cost =
 	    context ? CastFunctionSet::ImplicitCastCost(*context, left, right) : CastRules::ImplicitCast(left, right);
 	auto right_to_left_cost =

--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -80,7 +80,7 @@ static bool TemplatedBooleanOperation(const Value &left, const Value &right) {
 		Value left_copy = left;
 		Value right_copy = right;
 
-		auto comparison_type = LogicalType::ForceMaxLogicalType(left_type, right_type);
+		auto comparison_type = LogicalType::DefaultForceMaxLogicalType(left_type, right_type);
 		if (!left_copy.DefaultTryCastAs(comparison_type) || !right_copy.DefaultTryCastAs(comparison_type)) {
 			return false;
 		}

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -571,7 +571,7 @@ static void VariantComparator(const Vector &left, const Vector &right, int8_t *r
 		auto right_val = VariantUtils::ConvertVariantToValue(right_variant, rhs_sel.get_index(i), 0);
 
 		LogicalType max_logical_type;
-		if (!LogicalType::TryGetMaxLogicalTypeUnchecked(left_val.type(), right_val.type(), max_logical_type)) {
+		if (!LogicalType::DefaultTryGetMaxLogicalTypeUnchecked(left_val.type(), right_val.type(), max_logical_type)) {
 			throw InvalidInputException(
 			    "Can't compare values of type %s (%s) and type %s (%s) - an explicit cast is required",
 			    left_val.type().ToString(), left_val.ToString(), right_val.type().ToString(), right_val.ToString());

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -364,9 +364,13 @@ struct LogicalType {
 	//! Returns the maximum logical type when combining the two types - or throws an exception if combining is not possible
 	DUCKDB_API static LogicalType MaxLogicalType(ClientContext &context, const LogicalType &left, const LogicalType &right);
 	DUCKDB_API static bool TryGetMaxLogicalType(ClientContext &context, const LogicalType &left, const LogicalType &right, LogicalType &result);
-	DUCKDB_API static bool TryGetMaxLogicalTypeUnchecked(const LogicalType &left, const LogicalType &right, LogicalType &result);
+	DUCKDB_API static bool TryGetMaxLogicalTypeUnchecked(ClientContext &context, const LogicalType &left, const LogicalType &right, LogicalType &result);
+	//! Variant of TryGetMaxLogicalTypeUnchecked for call-sites that have no ClientContext available; uses only the built-in CastRules (no extension-registered casts).
+	DUCKDB_API static bool DefaultTryGetMaxLogicalTypeUnchecked(const LogicalType &left, const LogicalType &right, LogicalType &result);
 	//! Forcibly returns a maximum logical type - similar to MaxLogicalType but never throws. As a fallback either left or right are returned.
-	DUCKDB_API static LogicalType ForceMaxLogicalType(const LogicalType &left, const LogicalType &right);
+	DUCKDB_API static LogicalType ForceMaxLogicalType(ClientContext &context, const LogicalType &left, const LogicalType &right);
+	//! Variant of ForceMaxLogicalType for call-sites that have no ClientContext available; uses only the built-in CastRules (no extension-registered casts).
+	DUCKDB_API static LogicalType DefaultForceMaxLogicalType(const LogicalType &left, const LogicalType &right);
 	//! Normalize a type - removing literals
 	DUCKDB_API static LogicalType NormalizeType(const LogicalType &type);
 

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -832,7 +832,7 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			// figure out child type
 			LogicalType child_type(LogicalTypeId::SQLNULL);
 			for (auto &child_value : values) {
-				child_type = LogicalType::ForceMaxLogicalType(child_type, child_value.type());
+				child_type = LogicalType::DefaultForceMaxLogicalType(child_type, child_value.type());
 			}
 
 			// finally create the list

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -172,7 +172,7 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 			// figure out child type
 			LogicalType child_type(LogicalTypeId::SQLNULL);
 			for (auto &child_value : values) {
-				child_type = LogicalType::ForceMaxLogicalType(child_type, child_value.type());
+				child_type = LogicalType::DefaultForceMaxLogicalType(child_type, child_value.type());
 			}
 
 			// finally create the list

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -78,7 +78,7 @@ bool BoundComparisonExpression::TryBindComparison(ClientContext &context, const 
 		break;
 	}
 	if (is_equality) {
-		res = LogicalType::ForceMaxLogicalType(left_type, right_type);
+		res = LogicalType::ForceMaxLogicalType(context, left_type, right_type);
 	} else {
 		if (!LogicalType::TryGetMaxLogicalType(context, left_type, right_type, res)) {
 			return false;

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -162,7 +162,7 @@ void Binder::BuildUnionByNameInfo(BoundSetOperationNode &result) {
 				if (result_type.id() == LogicalTypeId::INVALID) {
 					result_type = child_col_type;
 				} else {
-					result_type = LogicalType::ForceMaxLogicalType(result_type, child_col_type);
+					result_type = LogicalType::ForceMaxLogicalType(context, result_type, child_col_type);
 				}
 				if (i != col_idx_in_child) {
 					// the column exists - but the children are out-of-order, so we need to re-order anyway
@@ -278,7 +278,7 @@ BoundStatement Binder::BindNode(SetOperationNode &statement) {
 			auto result_type = result.bound_children[0].types[i];
 			for (idx_t child_idx = 1; child_idx < result.bound_children.size(); ++child_idx) {
 				auto &child_types = result.bound_children[child_idx].types;
-				result_type = LogicalType::ForceMaxLogicalType(result_type, child_types[i]);
+				result_type = LogicalType::ForceMaxLogicalType(context, result_type, child_types[i]);
 			}
 			if (!can_contain_nulls) {
 				if (ExpressionBinder::ContainsNullType(result_type)) {

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -241,7 +241,7 @@ unique_ptr<Expression> BoundCastExpression::Copy() const {
 bool BoundCastExpression::CanThrow() const {
 	const auto child_type = child->GetReturnType();
 	if (return_type.id() != child_type.id() &&
-	    LogicalType::ForceMaxLogicalType(return_type, child_type) == child_type.id()) {
+	    LogicalType::DefaultForceMaxLogicalType(return_type, child_type) == child_type.id()) {
 		return true;
 	}
 	// Casting VARCHAR to JSON involves parsing and validation that can throw on malformed input


### PR DESCRIPTION
This is an attempt to improve extensibility of casts for the CASE expression.
# The problem
When trying to implement the spark compatibility extension, I ran into the following issue:

This works in spark
```sql
CREATE TEMPORARY VIEW t AS SELECT 1;
SELECT IF(true, cast(1 as tinyint), cast(2 as string)) FROM t;
```
But in duckdb:
```sql
memory D CREATE TEMPORARY VIEW t AS SELECT 1
memory D SELECT IF(true, cast(1 as tinyint), cast(2 as string)) FROM t;
```
```
Binder Error:
Cannot mix values of type VARCHAR and TINYINT in CASE expression - an explicit cast is required    
```

Inside extensions we can register new implicit cast rules just fine. Example:

```c++
void myfunction(ExtensionLoader &loader) {

loader.RegisterCastFunction(LogicalType::VARCHAR, LogicalType::DOUBLE, BindSparkCastWrapper, 150)
```

But that doesn't get picked up in our query, because `CombineUnequalTypes` calls `CastRules::ImplicitCast()`, which is just a hardcoded set of rules, not pluggable by extensions.

# The fix
This PR lets `CombineUnequalTypes` call `CastFunctionSet::ImplicitCastCost(*context, right, left)` instead, which does look at the casts registered by extensions.