### PR TITLE
Join filter mirroring

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -51,6 +51,8 @@ public:
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();
+	void GenerateEquivalentFilters(const Expression &filter,
+	                               const std::function<void(unique_ptr<Expression> filter)> &callback);
 	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids,
 	                                        vector<FilterPushdownResult> &pushdown_results);
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -111,6 +111,42 @@ FilterResult FilterCombiner::AddFilter(unique_ptr<Expression> expr) {
 	return result;
 }
 
+void FilterCombiner::GenerateEquivalentFilters(const Expression &filter,
+                                               const std::function<void(unique_ptr<Expression> filter)> &callback) {
+	if (filter.IsVolatile()) {
+		return;
+	}
+	// collect every column reference that belongs to an equivalence set
+	vector<reference<const BoundColumnRefExpression>> candidate_columns;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(filter, [&](const BoundColumnRefExpression &col) {
+		auto entry = equivalence_set_map.find(col);
+		if (entry == equivalence_set_map.end()) {
+			return;
+		}
+		for (auto &existing : candidate_columns) {
+			if (existing.get().Equals(col)) {
+				return;
+			}
+		}
+		candidate_columns.push_back(col);
+	});
+	// for each such column, generate an equivalent filter with the columns swapped
+	for (auto &col_ref : candidate_columns) {
+		auto &col = col_ref.get();
+		auto set_id = equivalence_set_map.find(col)->second;
+		for (auto &item : equivalence_map[set_id]) {
+			auto copy = filter.Copy();
+			ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+			    copy, [&](BoundColumnRefExpression &cref, unique_ptr<Expression> &child) {
+				    if (cref.Equals(col)) {
+					    child = item.get().Copy();
+				    }
+			    });
+			callback(std::move(copy));
+		}
+	}
+}
+
 void FilterCombiner::GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback) {
 	// first loop over the remaining filters
 	for (auto &filter : remaining_filters) {
@@ -149,6 +185,10 @@ void FilterCombiner::GenerateFilters(const std::function<void(unique_ptr<Express
 					auto constant = make_uniq<BoundConstantExpression>(info.constant);
 					auto comparison = BoundComparisonExpression::Create(info.comparison_type, entries[i].get().Copy(),
 					                                                    std::move(constant));
+					// column refs are already covered above
+					if (entries[i].get().GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+						GenerateEquivalentFilters(*comparison, callback);
+					}
 					callback(std::move(comparison));
 				}
 			}

--- a/test/sql/optimizer/plan/test_equivalent_filter_mirroring.test
+++ b/test/sql/optimizer/plan/test_equivalent_filter_mirroring.test
@@ -1,0 +1,53 @@
+# name: test/sql/optimizer/plan/test_equivalent_filter_mirroring.test
+# description: Test that filters are mirrored across equivalent columns in joins
+# group: [plan]
+
+statement ok
+CREATE TABLE tmp AS SELECT * FROM range(1000);
+
+query II
+EXPLAIN
+SELECT *
+FROM tmp AS t1
+NATURAL JOIN tmp AS t2
+WHERE t1.range * t1.range = 0
+----
+physical_plan	<REGEX>:.*range.*range.*
+
+statement ok
+CREATE TABLE t (f VARCHAR);
+
+statement ok
+INSERT INTO t (f) VALUES ('42'), ('43');
+
+# right(...) should be pushed to both scans
+query II
+explain SELECT *
+FROM t AS t1
+JOIN t AS t2 on t1.f = t2.f
+WHERE right(t1.f, 1) = '2'
+----
+physical_plan	<REGEX>:.*right.*right.*
+
+
+# same for a LEFT join. The filter must be pushed to the right side
+query II
+explain SELECT *
+FROM t AS t1
+LEFT JOIN t AS t2 on t1.f = t2.f
+WHERE right(t1.f, 1) = '2'
+----
+physical_plan	<REGEX>:.*right.*right.*
+
+
+# volatile expressions must NOT be propagated across the join
+statement ok
+CREATE TABLE tbl(x INTEGER);
+
+statement ok
+INSERT INTO tbl VALUES (1), (2), (3);
+
+query II
+EXPLAIN SELECT * FROM tbl n1 JOIN tbl n2 ON n1.x = n2.x WHERE n1.x + (random() * 0)::INTEGER = 1;
+----
+physical_plan	<!REGEX>:.*random.*random.*


### PR DESCRIPTION
`FilterCombiner` already propagates constant filters across an equi-join when the filter is on a plain column. This PR extends that to (non volatile) expressions on the joined column.

fixes: https://github.com/duckdb/duckdb/issues/9165
fixes: https://github.com/duckdblabs/duckdb-internal/issues/436