### PR TITLE
MERGE INTO: only consider target table when binding `WHEN NOT MATCHED` and source table when binding `WHEN NOT MATCHED BY TARGET`

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -536,12 +536,10 @@ private:
 	void ExpandDefaultInValuesList(InsertStatement &stmt, TableCatalogEntry &table,
 	                               optional_ptr<ExpressionListRef> values_list,
 	                               const vector<LogicalIndex> &named_column_map);
-	unique_ptr<BoundMergeIntoAction> BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table,
-	                                                 LogicalGet &get, idx_t proj_index,
-	                                                 vector<unique_ptr<Expression>> &expressions,
-	                                                 unique_ptr<LogicalOperator> &root, MergeIntoAction &action,
-	                                                 const vector<BindingAlias> &source_aliases,
-	                                                 const vector<string> &source_names);
+	unique_ptr<BoundMergeIntoAction>
+	BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, LogicalGet &get, idx_t proj_index,
+	                vector<unique_ptr<Expression>> &expressions, MergeIntoAction &action,
+	                const vector<BindingAlias> &source_aliases, const vector<string> &source_names);
 
 	unique_ptr<MergeIntoStatement> GenerateMergeInto(InsertStatement &stmt, TableCatalogEntry &table);
 

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -31,12 +31,10 @@ vector<unique_ptr<ParsedExpression>> GenerateColumnReferences(Binder &binder, co
 	return result;
 }
 
-unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table,
-                                                         LogicalGet &get, idx_t proj_index,
-                                                         vector<unique_ptr<Expression>> &expressions,
-                                                         unique_ptr<LogicalOperator> &root, MergeIntoAction &action,
-                                                         const vector<BindingAlias> &source_aliases,
-                                                         const vector<string> &source_names) {
+unique_ptr<BoundMergeIntoAction>
+Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, LogicalGet &get, idx_t proj_index,
+                        vector<unique_ptr<Expression>> &expressions, MergeIntoAction &action,
+                        const vector<BindingAlias> &source_aliases, const vector<string> &source_names) {
 	auto result = make_uniq<BoundMergeIntoAction>();
 	result->action_type = action.action_type;
 	if (action.condition) {
@@ -44,7 +42,6 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
 			WhereBinder where_binder(*this, context);
 			auto cond = where_binder.Bind(action.condition);
-			PlanSubqueries(cond, root);
 			result->condition =
 			    make_uniq<BoundColumnRefExpression>(cond->return_type, ColumnBinding(proj_index, expressions.size()));
 			expressions.push_back(std::move(cond));
@@ -82,7 +79,9 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 				action.update_info->expressions = GenerateColumnReferences(*this, source_aliases, source_names);
 			}
 		}
-		BindUpdateSet(proj_index, root, *action.update_info, table, result->columns, result->expressions, expressions);
+		unique_ptr<LogicalOperator> fake_root;
+		BindUpdateSet(proj_index, fake_root, *action.update_info, table, result->columns, result->expressions,
+		              expressions);
 
 		// bind any additional columns that need to be bound for update constraints
 		// FIXME: this is pretty hacky
@@ -139,7 +138,6 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 			TryReplaceDefaultExpression(action.expressions[i], column);
 			auto insert_expr = insert_binder.Bind(action.expressions[i]);
 
-			PlanSubqueries(insert_expr, root);
 			insert_expressions.push_back(std::move(insert_expr));
 		}
 
@@ -255,6 +253,27 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 			source_names.push_back(column_names[c]);
 		}
 	}
+	// bind the WHEN NOT MATCHED BY SOURCE / TARGET merge actions
+	auto &get = bound_table.plan->Cast<LogicalGet>();
+	auto merge_into = make_uniq<LogicalMergeInto>(table);
+	merge_into->table_index = GenerateTableIndex();
+	auto proj_index = GenerateTableIndex();
+	vector<unique_ptr<Expression>> projection_expressions;
+
+	for (auto &entry : stmt.actions) {
+		if (entry.first == MergeActionCondition::WHEN_MATCHED) {
+			continue;
+		}
+		auto &action_binder =
+		    entry.first == MergeActionCondition::WHEN_NOT_MATCHED_BY_TARGET ? *source_binder : *target_binder;
+		vector<unique_ptr<BoundMergeIntoAction>> bound_actions;
+		for (auto &action : entry.second) {
+			CheckMergeAction(entry.first, action->action_type);
+			bound_actions.push_back(action_binder.BindMergeAction(
+			    *merge_into, table, get, proj_index, projection_expressions, *action, source_aliases, source_names));
+		}
+		merge_into->actions.emplace(entry.first, std::move(bound_actions));
+	}
 
 	// bind the join between the source and target
 	// our conditions determine the join type we need
@@ -274,7 +293,6 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 	} else {
 		join.type = JoinType::INNER;
 	}
-	auto &get = bound_table.plan->Cast<LogicalGet>();
 	join.left = make_uniq<BoundRefWrapper>(std::move(source_binding), std::move(source_binder));
 	join.right = make_uniq<BoundRefWrapper>(std::move(bound_table), std::move(target_binder));
 	if (stmt.join_condition) {
@@ -297,8 +315,6 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 	bool inverted = join.type == JoinType::RIGHT;
 	auto &source = join_ref.get().children[inverted ? 1 : 0];
 
-	auto merge_into = make_uniq<LogicalMergeInto>(table);
-	merge_into->table_index = GenerateTableIndex();
 	if (!stmt.returning_list.empty()) {
 		merge_into->return_chunk = true;
 	}
@@ -310,18 +326,23 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 
 	merge_into->bound_constraints = BindConstraints(table);
 
-	// bind the merge actions
-	auto proj_index = GenerateTableIndex();
-	vector<unique_ptr<Expression>> projection_expressions;
-
+	// bind WHEN_MATCHED merge actions (can contain references to both source and target)
 	for (auto &entry : stmt.actions) {
+		if (entry.first != MergeActionCondition::WHEN_MATCHED) {
+			continue;
+		}
 		vector<unique_ptr<BoundMergeIntoAction>> bound_actions;
 		for (auto &action : entry.second) {
 			CheckMergeAction(entry.first, action->action_type);
-			bound_actions.push_back(BindMergeAction(*merge_into, table, get, proj_index, projection_expressions, root,
+			bound_actions.push_back(BindMergeAction(*merge_into, table, get, proj_index, projection_expressions,
 			                                        *action, source_aliases, source_names));
 		}
 		merge_into->actions.emplace(entry.first, std::move(bound_actions));
+	}
+
+	// plan merge action subqueries
+	for (auto &expr : projection_expressions) {
+		PlanSubqueries(expr, root);
 	}
 
 	if (has_not_matched_by_source) {

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -58,7 +58,9 @@ void Binder::BindUpdateSet(idx_t proj_index, unique_ptr<LogicalOperator> &root, 
 			UpdateBinder binder(*expr_binder_ptr, context);
 			binder.target_type = column.Type();
 			auto bound_expr = binder.Bind(expr);
-			PlanSubqueries(bound_expr, root);
+			if (root) {
+				PlanSubqueries(bound_expr, root);
+			}
 
 			update_expressions.push_back(make_uniq<BoundColumnRefExpression>(
 			    bound_expr->return_type, ColumnBinding(proj_index, projection_expressions.size())));

--- a/test/sql/merge/merge_into_bind_matching_columns.test
+++ b/test/sql/merge/merge_into_bind_matching_columns.test
@@ -1,0 +1,63 @@
+# name: test/sql/merge/merge_into_bind_matching_columns.test
+# description: Test MERGE INTO
+# group: [merge]
+
+statement ok
+CREATE TABLE dest (id INTEGER, val INTEGER);
+
+statement ok
+CREATE TABLE src  (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO dest VALUES (1, 10);
+
+statement ok
+INSERT INTO src  VALUES (1, 100), (2, 200);
+
+# WHEN NOT MATCHED (BY TARGET)
+statement ok
+MERGE INTO dest AS DBT_INTERNAL_DEST
+USING src AS DBT_INTERNAL_SOURCE
+    ON DBT_INTERNAL_SOURCE.id = DBT_INTERNAL_DEST.id
+WHEN MATCHED THEN UPDATE SET
+    "id"  = DBT_INTERNAL_SOURCE."id",
+    "val" = DBT_INTERNAL_SOURCE."val"
+WHEN NOT MATCHED THEN INSERT
+    ("id", "val")
+VALUES
+    ("id", "val");
+
+query II
+SELECT * FROM dest
+----
+1	100
+2	200
+
+# WHEN NOT MATCHED BY SOURCE
+statement ok
+DELETE FROM dest;
+
+statement ok
+DELETE FROM src;
+
+statement ok
+INSERT INTO dest VALUES (1, 10), (2, 20);
+
+statement ok
+INSERT INTO src  VALUES (1, 100);
+
+statement ok
+MERGE INTO dest AS DBT_INTERNAL_DEST
+USING src AS DBT_INTERNAL_SOURCE
+    ON DBT_INTERNAL_SOURCE.id = DBT_INTERNAL_DEST.id
+WHEN MATCHED THEN UPDATE SET
+    "id"  = DBT_INTERNAL_SOURCE."id",
+    "val" = DBT_INTERNAL_SOURCE."val"
+WHEN NOT MATCHED BY SOURCE THEN
+	UPDATE SET val=val+1;
+
+query II
+SELECT * FROM dest
+----
+1	100
+2	21

--- a/test/sql/upsert/postgres/planner_preprocessing.test
+++ b/test/sql/upsert/postgres/planner_preprocessing.test
@@ -141,12 +141,11 @@ insert into excluded AS target values(1, '2') on conflict (key) do update set da
 statement ok
 insert into excluded AS target values(1, '2') on conflict (key) do update set data = target.data RETURNING *;
 
-## -- We don't support excluded in RETURNING, also, this is ambiguous??? -- ##
-# make sure excluded isn't a problem in returning clause
+## -- We don't support excluded in RETURNING
 statement error
 insert into excluded values(1, '2') on conflict (key) do update set data = 3 RETURNING excluded.*;
 ----
-Ambiguous reference to table "excluded"
+not supported in the RETURNING
 
 # clean up
 statement ok

--- a/test/sql/upsert/upsert_aliased.test
+++ b/test/sql/upsert/upsert_aliased.test
@@ -85,6 +85,6 @@ select * from tbl order by all
 # When we alias to 'excluded' we create an ambiguity error
 
 statement error
-insert into tbl as excluded values (8,3) on conflict (j) do update set i = 5;
+insert into tbl as excluded values (8,3) on conflict (j) do update set i = excluded.i;
 ----
 Ambiguous reference to table "excluded"


### PR DESCRIPTION
Currently we always bind using the joint binder, which has access to both the `source` and `target` tables. This can then cause conflicts when these have the same conflicts. In e.g. Postgres expressions don't conflict when the merge action is `WHEN NOT MATCHED (BY SOURCE/TARGET)` and instead can only be bound to the table that has a match available.