### PR TITLE
Change scope of max execution time

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -334,6 +334,9 @@ SequenceException::SequenceException(const string &msg) : Exception(ExceptionTyp
 InterruptException::InterruptException() : Exception(ExceptionType::INTERRUPT, INTERRUPT_MESSAGE) {
 }
 
+InterruptException::InterruptException(const string &message) : Exception(ExceptionType::INTERRUPT, message) {
+}
+
 FatalException::FatalException(ExceptionType type, const string &msg) : Exception(type, msg) {
 	// FIXME: Make any log context available to add error logging.
 }

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -940,7 +940,7 @@
         "name": "max_execution_time",
         "description": "The maximum execution time per query in milliseconds (0 = no limit)",
         "type": "BIGINT",
-        "scope": "local",
+        "default_scope": "local",
         "default_value": "0"
     },
     {

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -303,6 +303,7 @@ class InterruptException : public Exception {
 public:
 	static constexpr const char *INTERRUPT_MESSAGE = "Interrupted!";
 	DUCKDB_API InterruptException();
+	DUCKDB_API explicit InterruptException(const string &message);
 };
 
 class FatalException : public Exception {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1385,7 +1385,7 @@ struct MaxExecutionTimeSetting {
 	static constexpr const char *Description = "The maximum execution time per query in milliseconds (0 = no limit)";
 	static constexpr const char *InputType = "BIGINT";
 	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_ONLY;
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1276,7 +1276,7 @@ void ClientContext::InterruptCheck() const {
 	if (query_deadline.IsValid() && ++timeout_check_counter % TIMEOUT_CHECK_INTERVAL == 0) {
 		auto now = NumericCast<idx_t>(duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
 		if (now >= query_deadline.GetIndex()) {
-			throw InterruptException();
+			throw InterruptException("Query exceeded maximum execution time");
 		}
 	}
 }

--- a/test/sql/settings/max_execution_time.test
+++ b/test/sql/settings/max_execution_time.test
@@ -48,7 +48,7 @@ SET max_execution_time=50
 statement error
 SELECT COUNT(*) FROM range(100000000) t1, range(1000) t2
 ----
-Interrupt
+Query exceeded maximum execution time
 
 # increase timeout so RESET can succeed  
 statement ok
@@ -86,7 +86,7 @@ WITH RECURSIVE cte AS (
 )
 SELECT COUNT(*) FROM cte
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 SET max_execution_time=5000
@@ -98,7 +98,7 @@ SET max_execution_time=50
 statement error
 SELECT i % 10000000 as g, COUNT(*) FROM range(100000000) t(i) GROUP BY 1
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 SET max_execution_time=5000
@@ -110,7 +110,7 @@ SET max_execution_time=50
 statement error
 SELECT * FROM range(50000000) ORDER BY random()
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 SET max_execution_time=5000
@@ -122,7 +122,7 @@ SET max_execution_time=50
 statement error
 SELECT i, SUM(i) OVER (PARTITION BY i % 1000000 ORDER BY i) FROM range(10000000) t(i)
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 SET max_execution_time=5000
@@ -144,7 +144,7 @@ SELECT
 FROM range(100000000) t(i) 
 GROUP BY 1
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 SET max_execution_time=5000
@@ -156,7 +156,7 @@ SET max_execution_time=50
 statement error
 SELECT DISTINCT i FROM range(50000000) t(i)
 ----
-Interrupt
+Query exceeded maximum execution time
 
 statement ok
 RESET max_execution_time
@@ -164,4 +164,39 @@ RESET max_execution_time
 # Verify everything works without timeout
 statement ok
 SELECT COUNT(*) FROM range(1000)
+
+statement ok
+SET GLOBAL max_execution_time=5000
+
+query I
+SELECT current_setting('max_execution_time')
+----
+5000
+
+# local override takes precedence over global
+statement ok
+SET max_execution_time=9000
+
+query I
+SELECT current_setting('max_execution_time')
+----
+9000
+
+# reset local, global value should be visible again
+statement ok
+RESET max_execution_time
+
+query I
+SELECT current_setting('max_execution_time')
+----
+5000
+
+# reset global back to default
+statement ok
+SET GLOBAL max_execution_time=0
+
+query I
+SELECT current_setting('max_execution_time')
+----
+0
 


### PR DESCRIPTION
This PR changes the scope of `max_execution_time` and throws an appropriate exception when this set time is exceeded. This is useful e.g. if you want to limit the execution time of _all_ queries on a quack server.

Intended for https://github.com/duckdblabs/duckdb-internal/issues/9424