### PR TITLE
Merge Into: Avoid recursively binding in the ProjectionBinder

### DIFF
--- a/src/include/duckdb/planner/expression_binder/projection_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/projection_binder.hpp
@@ -32,6 +32,7 @@ private:
 	idx_t proj_index;
 	vector<unique_ptr<Expression>> &proj_expressions;
 	string clause;
+	bool in_child_projection = false;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -38,19 +38,10 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 	auto result = make_uniq<BoundMergeIntoAction>();
 	result->action_type = action.action_type;
 	if (action.condition) {
-		if (action.condition->HasSubquery()) {
-			// if we have a subquery we need to execute the condition outside of the MERGE INTO statement
-			WhereBinder where_binder(*this, context);
-			auto cond = where_binder.Bind(action.condition);
-			result->condition =
-			    make_uniq<BoundColumnRefExpression>(cond->return_type, ColumnBinding(proj_index, expressions.size()));
-			expressions.push_back(std::move(cond));
-		} else {
-			ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
-			proj_binder.target_type = LogicalType::BOOLEAN;
-			auto cond = proj_binder.Bind(action.condition);
-			result->condition = std::move(cond);
-		}
+		ProjectionBinder proj_binder(*this, context, proj_index, expressions, "WHERE clause");
+		proj_binder.target_type = LogicalType::BOOLEAN;
+		auto cond = proj_binder.Bind(action.condition);
+		result->condition = std::move(cond);
 	}
 	switch (action.action_type) {
 	case MergeActionType::MERGE_UPDATE: {

--- a/src/planner/expression_binder/projection_binder.cpp
+++ b/src/planner/expression_binder/projection_binder.cpp
@@ -10,7 +10,12 @@ ProjectionBinder::ProjectionBinder(Binder &binder, ClientContext &context, idx_t
 }
 
 BindResult ProjectionBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
+	if (in_child_projection) {
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+	in_child_projection = true;
 	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
+	in_child_projection = false;
 	if (result.HasError()) {
 		return result;
 	}
@@ -33,6 +38,7 @@ BindResult ProjectionBinder::BindExpression(unique_ptr<ParsedExpression> &expr_p
 	case ExpressionClass::WINDOW:
 		return BindUnsupportedExpression(expr, depth, clause + " cannot contain window functions!");
 	case ExpressionClass::COLUMN_REF:
+	case ExpressionClass::SUBQUERY:
 		return BindColumnRef(expr_ptr, depth, root_expression);
 	default:
 		return ExpressionBinder::BindExpression(expr_ptr, depth);

--- a/test/sql/merge/merge_into.test
+++ b/test/sql/merge/merge_into.test
@@ -78,6 +78,30 @@ FROM Stock ORDER BY item_id
 10	1000
 30	300
 
+# relation-alias row comparison in a matched condition with a derived source
+statement ok
+CREATE TABLE merge_distinct_target(tableticker VARCHAR NOT NULL, figi VARCHAR, cik VARCHAR, lastupdated DATE NOT NULL);
+
+statement ok
+INSERT INTO merge_distinct_target VALUES ('tablepermaticker', 'old_figi', 'old_cik', DATE '2026-04-30');
+
+query I
+MERGE INTO merge_distinct_target AS t
+USING (
+       SELECT 'tablepermaticker' AS tableticker, 'new_figi' AS figi, 'new_cik' AS cik, DATE '2026-05-01' AS lastupdated
+       ORDER BY tableticker
+) AS q
+ON t.tableticker = q.tableticker
+WHEN MATCHED AND t IS DISTINCT FROM q THEN UPDATE
+WHEN NOT MATCHED THEN INSERT
+----
+1
+
+query IIII
+FROM merge_distinct_target ORDER BY tableticker
+----
+tablepermaticker	new_figi	new_cik	2026-05-01
+
 # abort - row does not exist
 statement error
 MERGE INTO Stock USING Sale ON Stock.item_id = Sale.item_id


### PR DESCRIPTION
When binding conditions in the `MERGE INTO`, we extract column references and place them in a projection prior to the merge into, e.g.:

```sql
x + 10 > y
```

Becomes:

```sql
PROJECTION[x, y] -> CONDITION[#0 + 10 > #1]
```

This is done through the `ProjectionBinder`.

However, this goes wrong when binding table references. That happens because table references themselves expand to `struct_pack(col1, col2, col3, ...)`. We recursively call ourselves, which causes the following expansion to happen:

```sql
-- where t is the table with columns "x, y"
WHEN MATCHED THEN t IS DISTINCT FROM (1, 1)

PROJECTION[struct_pack(#1, #2), x, y] -> CONDITION[#0 IS DISTINCT FROM (1, 1)]
```

We end up pushing both the struct pack, and the child columns of the struct pack, causing the wrong bindings to be generated. This PR fixes this by tracking whether or not we are binding inside the child projection or not.