### PR TITLE
PEG/1: Make EndOfInput explicit, by having Tokenizer add `END_OF_INPUT` or `END_OF_INPUT_AUTOCOMPLETE`

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -536,8 +536,8 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	const string &sql_ref = Parser::StripUnicodeSpaces(sql, clean_sql) ? clean_sql : sql;
 	ParserTokenizer tokenizer(sql_ref, root_tokens);
 
-	auto allow_complete = tokenizer.TokenizeInput();
-	if (!allow_complete) {
+	tokenizer.TokenizeInput();
+	if (!tokenizer.CanAutocomplete()) {
 		return nullptr;
 	}
 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -510,6 +510,9 @@ void SQLTokenizeFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 
 	while (data.offset < bind_data.tokens.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = bind_data.tokens[data.offset++];
+		if (entry.type == TokenType::END_OF_INPUT || entry.type == TokenType::END_NOW_AUTOCOMPLETE) {
+			continue;
+		}
 
 		offset_col.Append(Value::INTEGER(NumericCast<int32_t>(entry.offset)));
 		token_type.Append(Value(TokenTypeToString(entry.type)));
@@ -549,7 +552,9 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 
 	auto peg_matcher = PEGMatcher::Get(context);
 	auto match_result = peg_matcher->Root().Match(state);
-	if (match_result != MatchResultType::SUCCESS || state.token_index < root_tokens.size()) {
+	// `+ 1` accounts for the EOI sentinel — the autocomplete walk may report SUCCESS without
+	// consuming it.
+	if (match_result != MatchResultType::SUCCESS || state.token_index + 1 < root_tokens.size()) {
 		string token_list;
 		for (idx_t i = 0; i < root_tokens.size(); i++) {
 			if (!token_list.empty()) {

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -510,7 +510,7 @@ void SQLTokenizeFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 
 	while (data.offset < bind_data.tokens.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = bind_data.tokens[data.offset++];
-		if (entry.type == TokenType::END_OF_INPUT || entry.type == TokenType::END_NOW_AUTOCOMPLETE) {
+		if (entry.type == TokenType::END_OF_INPUT || entry.type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
 			continue;
 		}
 

--- a/scripts/parser/inline_grammar.py
+++ b/scripts/parser/inline_grammar.py
@@ -9,7 +9,7 @@ statements_dir = peg_dir / 'grammar' / 'statements'
 keywords_dir = peg_dir / 'grammar' / 'keywords'
 target_file = scripts_dir.parent / 'src' / 'include' / 'duckdb' / 'parser' / 'peg' / 'inlined_grammar.hpp'
 
-IMPLICIT_RULES = {'%whitespace'}
+IMPLICIT_RULES = {'%whitespace', 'EndOfInput'}
 
 # Maps filenames to string categories.
 # typefunc_keyword_map is the union of type name and func name keywords.
@@ -298,6 +298,9 @@ def check_undefined_rules(all_rules):
     for rule_name, rule in all_rules.items():
         for ref in rule.references():
             if ref in rule.parameters:
+                continue
+            if ref in IMPLICIT_RULES:
+                # Rule is provided at runtime via MatcherFactory::AddRuleOverride.
                 continue
             if ref not in all_rules:
                 print(f"Error: rule '{rule_name}' references undefined rule '{ref}'")

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3866,6 +3866,7 @@ const StringUtil::EnumStringLiteral *GetParseResultTypeValues() {
 		{ static_cast<uint32_t>(ParseResultType::EXTENSION), "EXTENSION" },
 		{ static_cast<uint32_t>(ParseResultType::NUMBER), "NUMBER" },
 		{ static_cast<uint32_t>(ParseResultType::STRING), "STRING" },
+		{ static_cast<uint32_t>(ParseResultType::END_OF_INPUT), "END_OF_INPUT" },
 		{ static_cast<uint32_t>(ParseResultType::INVALID), "INVALID" }
 	};
 	return values;
@@ -3873,12 +3874,12 @@ const StringUtil::EnumStringLiteral *GetParseResultTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<ParseResultType>(ParseResultType value) {
-	return StringUtil::EnumToString(GetParseResultTypeValues(), 13, "ParseResultType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetParseResultTypeValues(), 14, "ParseResultType", static_cast<uint32_t>(value));
 }
 
 template<>
 ParseResultType EnumUtil::FromString<ParseResultType>(const char *value) {
-	return static_cast<ParseResultType>(StringUtil::StringToEnum(GetParseResultTypeValues(), 13, "ParseResultType", value));
+	return static_cast<ParseResultType>(StringUtil::StringToEnum(GetParseResultTypeValues(), 14, "ParseResultType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetParserExtensionResultTypeValues() {

--- a/src/include/duckdb/parser/peg/inlined_grammar.gram
+++ b/src/include/duckdb/parser/peg/inlined_grammar.gram
@@ -1,4 +1,4 @@
-Program <- Statement? (';'+ Statement)* ';'*
+Program <- Statement? (';'+ Statement)* ';'* EndOfInput
 
 Statement <-
 	CreateStatement /

--- a/src/include/duckdb/parser/peg/inlined_grammar.hpp
+++ b/src/include/duckdb/parser/peg/inlined_grammar.hpp
@@ -4,7 +4,7 @@
 namespace duckdb {
 
 const char INLINED_PEG_GRAMMAR[] = {
-	"Program <- Statement? (';'+ Statement)* ';'*\n"
+	"Program <- Statement? (';'+ Statement)* ';'* EndOfInput\n"
 	"Statement <-\n"
 	"	CreateStatement /\n"
 	"	SelectStatement /\n"

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -147,7 +147,18 @@ struct MatchState {
 	void AddSuggestion(MatcherSuggestion suggestion);
 };
 
-enum class MatcherType { KEYWORD, LIST, OPTIONAL, CHOICE, REPEAT, VARIABLE, STRING_LITERAL, NUMBER_LITERAL, OPERATOR };
+enum class MatcherType {
+	KEYWORD,
+	LIST,
+	OPTIONAL,
+	CHOICE,
+	REPEAT,
+	VARIABLE,
+	STRING_LITERAL,
+	NUMBER_LITERAL,
+	OPERATOR,
+	END_OF_INPUT
+};
 
 class Matcher {
 public:

--- a/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
@@ -36,7 +36,7 @@ public:
 	//! True iff `TokenizeInput()` finished in a state where autocomplete could be offered (the
 	//! input wasn't truncated mid-comment / mid-dollar-quoted-string). Derived by inspecting the
 	//! trailing sentinel: the clean-exit paths append `GetTerminator()` (which becomes
-	//! `END_NOW_AUTOCOMPLETE` for autocomplete tokenizers); the dirty-exit paths always append
+	//! `END_OF_INPUT_AUTOCOMPLETE` for autocomplete tokenizers); the dirty-exit paths always append
 	//! `END_OF_INPUT`.
 	bool CanAutocomplete() const;
 
@@ -53,7 +53,7 @@ public:
 	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
 
 	//! Sentinel appended at the end of the token vector on a clean exit. Override to return
-	//! `END_NOW_AUTOCOMPLETE` in autocomplete tokenizers. Dirty exits (unterminated comment /
+	//! `END_OF_INPUT_AUTOCOMPLETE` in autocomplete tokenizers. Dirty exits (unterminated comment /
 	//! dollar-quote) always append `END_OF_INPUT` regardless of this hook.
 	virtual TokenType GetTerminator() const {
 		return TokenType::END_OF_INPUT;

--- a/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
@@ -37,6 +37,12 @@ public:
 	virtual void OnStatementEnd(idx_t pos);
 	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
 
+	//! Sentinel appended at the end of the token vector. Override to END_NOW_AUTOCOMPLETE in
+	//! autocomplete tokenizers.
+	virtual TokenType GetEndOfInputType() const {
+		return TokenType::END_OF_INPUT;
+	}
+
 	bool IsSpecialOperator(idx_t pos, idx_t &op_len) const;
 	static bool IsSingleByteOperator(char c);
 	static bool CharacterIsInitialNumber(char c);

--- a/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
+++ b/src/include/duckdb/parser/peg/tokenizer/base_tokenizer.hpp
@@ -31,15 +31,31 @@ public:
 	virtual ~BaseTokenizer() = default;
 
 public:
-	bool TokenizeInput();
+	void TokenizeInput();
 
+	//! True iff `TokenizeInput()` finished in a state where autocomplete could be offered (the
+	//! input wasn't truncated mid-comment / mid-dollar-quoted-string). Derived by inspecting the
+	//! trailing sentinel: the clean-exit paths append `GetTerminator()` (which becomes
+	//! `END_NOW_AUTOCOMPLETE` for autocomplete tokenizers); the dirty-exit paths always append
+	//! `END_OF_INPUT`.
+	bool CanAutocomplete() const;
+
+private:
+	//! Core tokenization loop. Returns true on a clean exit, false if the input ended inside an
+	//! unterminated comment / dollar-quoted string. Does NOT append the trailing sentinel —
+	//! `TokenizeInput()` is the one that appends `GetTerminator()` (clean) or `END_OF_INPUT`
+	//! (dirty) based on the return value.
+	bool TokenizeInputInternal();
+
+public:
 	virtual void PushToken(idx_t start, idx_t end, TokenType type, bool unterminated = false);
 	virtual void OnStatementEnd(idx_t pos);
 	virtual void OnLastToken(TokenizeState state, string last_word, idx_t last_pos);
 
-	//! Sentinel appended at the end of the token vector. Override to END_NOW_AUTOCOMPLETE in
-	//! autocomplete tokenizers.
-	virtual TokenType GetEndOfInputType() const {
+	//! Sentinel appended at the end of the token vector on a clean exit. Override to return
+	//! `END_NOW_AUTOCOMPLETE` in autocomplete tokenizers. Dirty exits (unterminated comment /
+	//! dollar-quote) always append `END_OF_INPUT` regardless of this hook.
+	virtual TokenType GetTerminator() const {
 		return TokenType::END_OF_INPUT;
 	}
 

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -32,7 +32,11 @@ enum class TokenType {
 	TABLE_FUNCTION,
 	PRAGMA_FUNCTION,
 	SETTING_NAME,
-	ERROR
+	ERROR,
+	//! Sentinel for real end of input — consumed by EndOfInputMatcher.
+	END_OF_INPUT,
+	//! Sentinel for cursor position in autocomplete mode — List/Repeat fire suggestion walk.
+	END_NOW_AUTOCOMPLETE
 };
 
 inline string TokenTypeToString(TokenType type) {
@@ -71,6 +75,10 @@ inline string TokenTypeToString(TokenType type) {
 		return "PRAGMA_FUNCTION";
 	case TokenType::SETTING_NAME:
 		return "SETTING_NAME";
+	case TokenType::END_OF_INPUT:
+		return "END_OF_INPUT";
+	case TokenType::END_NOW_AUTOCOMPLETE:
+		return "END_NOW_AUTOCOMPLETE";
 	default:
 		return "UNKNOWN";
 	}
@@ -91,6 +99,7 @@ enum class ParseResultType : uint8_t {
 	EXTENSION,
 	NUMBER,
 	STRING,
+	END_OF_INPUT,
 	INVALID
 };
 
@@ -120,6 +129,8 @@ inline const char *ParseResultToString(ParseResultType type) {
 		return "NUMBER";
 	case ParseResultType::STRING:
 		return "STRING";
+	case ParseResultType::END_OF_INPUT:
+		return "END_OF_INPUT";
 	case ParseResultType::INVALID:
 		return "INVALID";
 	}
@@ -178,6 +189,19 @@ struct IdentifierParseResult : ParseResult {
 	                      const std::string &indent, bool is_last) const override {
 		ParseResult::ToStringInternal(ss, visited, indent, is_last);
 		ss << ": " << identifier << "\n";
+	}
+};
+
+struct EndOfInputParseResult : ParseResult {
+	static constexpr ParseResultType TYPE = ParseResultType::END_OF_INPUT;
+
+	EndOfInputParseResult() : ParseResult(TYPE, optional_idx()) {
+	}
+
+	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
+	                      const std::string &indent, bool is_last) const override {
+		ParseResult::ToStringInternal(ss, visited, indent, is_last);
+		ss << "\n";
 	}
 };
 

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -36,7 +36,7 @@ enum class TokenType {
 	//! Sentinel for real end of input — consumed by EndOfInputMatcher.
 	END_OF_INPUT,
 	//! Sentinel for cursor position in autocomplete mode — List/Repeat fire suggestion walk.
-	END_NOW_AUTOCOMPLETE
+	END_OF_INPUT_AUTOCOMPLETE
 };
 
 inline string TokenTypeToString(TokenType type) {
@@ -77,8 +77,8 @@ inline string TokenTypeToString(TokenType type) {
 		return "SETTING_NAME";
 	case TokenType::END_OF_INPUT:
 		return "END_OF_INPUT";
-	case TokenType::END_NOW_AUTOCOMPLETE:
-		return "END_NOW_AUTOCOMPLETE";
+	case TokenType::END_OF_INPUT_AUTOCOMPLETE:
+		return "END_OF_INPUT_AUTOCOMPLETE";
 	default:
 		return "UNKNOWN";
 	}

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -168,6 +168,10 @@ public:
 		last_pos = 0;
 	}
 
+	TokenType GetEndOfInputType() const override {
+		return TokenType::END_NOW_AUTOCOMPLETE;
+	}
+
 	void OnLastToken(TokenizeState state, string last_word_p, idx_t last_pos_p) override {
 		if (TokenizeStateToType(state) == TokenType::STRING_LITERAL) {
 			suggestions.emplace_back(SuggestionState::SUGGEST_FILE_NAME);

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -169,7 +169,7 @@ public:
 	}
 
 	TokenType GetTerminator() const override {
-		return TokenType::END_NOW_AUTOCOMPLETE;
+		return TokenType::END_OF_INPUT_AUTOCOMPLETE;
 	}
 
 	void OnLastToken(TokenizeState state, string last_word_p, idx_t last_pos_p) override {

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -168,7 +168,7 @@ public:
 		last_pos = 0;
 	}
 
-	TokenType GetEndOfInputType() const override {
+	TokenType GetTerminator() const override {
 		return TokenType::END_NOW_AUTOCOMPLETE;
 	}
 
@@ -205,8 +205,8 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 	string clean_sql;
 	const string &sql_ref = Parser::StripUnicodeSpaces(sql, clean_sql) ? clean_sql : sql;
 	AutoCompleteTokenizer tokenizer(sql_ref, state);
-	auto allow_complete = tokenizer.TokenizeInput();
-	if (!allow_complete) {
+	tokenizer.TokenizeInput();
+	if (!tokenizer.CanAutocomplete()) {
 		return {};
 	}
 	if (state.suggestions.empty()) {

--- a/src/parser/peg/grammar/statements/common.gram
+++ b/src/parser/peg/grammar/statements/common.gram
@@ -1,4 +1,4 @@
-Program <- Statement? (';'+ Statement)* ';'*
+Program <- Statement? (';'+ Statement)* ';'* EndOfInput
 
 Statement <-
 	CreateStatement /

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -620,6 +620,9 @@ public:
 
 private:
 	bool MatchIdentifier(MatchState &state) const {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		// variable matchers match anything except for reserved keywords
 		auto &token_text = state.tokens[state.token_index].text;
 		const auto &keyword_helper = PEGKeywordHelper::Instance();
@@ -705,6 +708,9 @@ public:
 
 private:
 	bool MatchReservedIdentifier(MatchState &state) const {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		if (!IsIdentifier(token_text)) {
 			return false;
@@ -836,8 +842,11 @@ public:
 
 private:
 	static bool MatchNumberLiteral(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
-		if (!BaseTokenizer::CharacterIsInitialNumber(token_text[0])) {
+		if (token_text.empty() || !BaseTokenizer::CharacterIsInitialNumber(token_text[0])) {
 			return false;
 		}
 		// A lone '.' is a dot operator, not a number literal (e.g., '?.method()' should not consume '.')
@@ -937,6 +946,9 @@ public:
 
 private:
 	static bool MatchOperator(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		// Exclude the lambda arrow and JSON arrow — these have dedicated grammar roles
 		if (token_text == "->" || token_text == "->>") {
@@ -1004,6 +1016,9 @@ public:
 
 private:
 	static bool MatchArithmeticOperator(MatchState &state) {
+		if (state.token_index >= state.tokens.size()) {
+			return false;
+		}
 		auto &token_text = state.tokens[state.token_index].text;
 		for (auto &c : token_text) {
 			if (!IsArithmeticOperatorChar(c)) {

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -126,7 +126,7 @@ public:
 			auto &child_matcher = matchers[child_idx].get();
 			bool at_autocomplete_cursor =
 			    list_state.token_index < list_state.tokens.size() &&
-			    list_state.tokens[list_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			    list_state.tokens[list_state.token_index].type == TokenType::END_OF_INPUT_AUTOCOMPLETE;
 			if (at_autocomplete_cursor) {
 				if (suppress_suggestions) {
 					// this rule should not contribute autocomplete suggestions
@@ -361,7 +361,7 @@ public:
 
 			bool at_autocomplete_cursor =
 			    repeat_state.token_index < state.tokens.size() &&
-			    state.tokens[repeat_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			    state.tokens[repeat_state.token_index].type == TokenType::END_OF_INPUT_AUTOCOMPLETE;
 			if (at_autocomplete_cursor) {
 				element.AddSuggestion(state);
 				return MatchResultType::SUCCESS;
@@ -400,7 +400,7 @@ public:
 			state.token_index = repeat_state.token_index;
 
 			if (repeat_state.token_index < state.tokens.size() &&
-			    state.tokens[repeat_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE) {
+			    state.tokens[repeat_state.token_index].type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
 				break;
 			}
 

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -124,7 +124,10 @@ public:
 		auto saved_suggestion_size = suppress_suggestions ? list_state.suggestions.size() : 0;
 		for (idx_t child_idx = 0; child_idx < matchers.size(); child_idx++) {
 			auto &child_matcher = matchers[child_idx].get();
-			if (list_state.token_index >= list_state.tokens.size()) {
+			bool at_autocomplete_cursor =
+			    list_state.token_index < list_state.tokens.size() &&
+			    list_state.tokens[list_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			if (at_autocomplete_cursor) {
 				if (suppress_suggestions) {
 					// this rule should not contribute autocomplete suggestions
 					// discard any suggestions added by earlier children
@@ -133,7 +136,7 @@ public:
 					                             list_state.suggestions.end());
 					return MatchResultType::FAIL;
 				}
-				// we exhausted the tokens - push suggestions for the child matcher
+				// cursor is here - push suggestions for what could follow
 				for (; child_idx < matchers.size(); child_idx++) {
 					auto suggestion_type = matchers[child_idx].get().AddSuggestion(list_state);
 					if (suggestion_type == SuggestionType::MANDATORY) {
@@ -356,9 +359,10 @@ public:
 			// update the token index we propagate upwards
 			state.token_index = repeat_state.token_index;
 
-			// check if we have tokens left
-			if (repeat_state.token_index >= state.tokens.size()) {
-				// we exhausted the tokens - suggest the element
+			bool at_autocomplete_cursor =
+			    repeat_state.token_index < state.tokens.size() &&
+			    state.tokens[repeat_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE;
+			if (at_autocomplete_cursor) {
 				element.AddSuggestion(state);
 				return MatchResultType::SUCCESS;
 			}
@@ -395,8 +399,8 @@ public:
 			// Propagate the new state upwards.
 			state.token_index = repeat_state.token_index;
 
-			// Check if there are any tokens left.
-			if (repeat_state.token_index >= state.tokens.size()) {
+			if (repeat_state.token_index < state.tokens.size() &&
+			    state.tokens[repeat_state.token_index].type == TokenType::END_NOW_AUTOCOMPLETE) {
 				break;
 			}
 
@@ -423,6 +427,44 @@ public:
 
 private:
 	Matcher &element;
+};
+
+//! Consumes the END_OF_INPUT sentinel; wired into the grammar's EndOfInput rule.
+class EndOfInputMatcher : public Matcher {
+public:
+	static constexpr MatcherType TYPE = MatcherType::END_OF_INPUT;
+
+public:
+	EndOfInputMatcher() : Matcher(TYPE) {
+	}
+
+	MatchResultType Match(MatchState &state) const override {
+		if (state.token_index < state.tokens.size() &&
+		    state.tokens[state.token_index].type == TokenType::END_OF_INPUT) {
+			state.token_index++;
+			state.UpdateMaxTokenIndex();
+			return MatchResultType::SUCCESS;
+		}
+		return MatchResultType::FAIL;
+	}
+
+	optional_ptr<ParseResult> MatchParseResult(MatchState &state) const override {
+		if (state.token_index < state.tokens.size() &&
+		    state.tokens[state.token_index].type == TokenType::END_OF_INPUT) {
+			state.token_index++;
+			state.UpdateMaxTokenIndex();
+			return state.allocator.Allocate(make_uniq<EndOfInputParseResult>());
+		}
+		return nullptr;
+	}
+
+	SuggestionType AddSuggestionInternal(MatchState &state) const override {
+		return SuggestionType::MANDATORY;
+	}
+
+	string ToString() const override {
+		return "EndOfInput";
+	}
 };
 
 class IdentifierMatcher : public Matcher {
@@ -1375,6 +1417,9 @@ Matcher &MatcherFactory::CreateMatcher(const char *grammar, const char *root_rul
 	//===--------------------------------------------------------------------===//
 	// END GENERATED RULE OVERRIDES
 	//===--------------------------------------------------------------------===//
+
+	// EndOfInput has no grammar body; satisfied here (outside the regenerated block).
+	AddRuleOverride("EndOfInput", allocator.Allocate(make_uniq<EndOfInputMatcher>()));
 
 	// suppress suggestions for catch-all rules that would pollute statement-level autocomplete
 	SuppressSuggestions("ExpressionStatement");

--- a/src/parser/peg/sql_formatter.cpp
+++ b/src/parser/peg/sql_formatter.cpp
@@ -91,7 +91,7 @@ string SQLFormatter::Format(const string &sql) {
 	tokenizer.TokenizeInput();
 	if (!tokenizer.tokens.empty()) {
 		auto back_type = tokenizer.tokens.back().type;
-		if (back_type == TokenType::END_OF_INPUT || back_type == TokenType::END_NOW_AUTOCOMPLETE) {
+		if (back_type == TokenType::END_OF_INPUT || back_type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
 			tokenizer.tokens.pop_back();
 		}
 	}

--- a/src/parser/peg/sql_formatter.cpp
+++ b/src/parser/peg/sql_formatter.cpp
@@ -89,6 +89,12 @@ SQLFormatter::SQLFormatter(const FormatterConfig &config) : config(config) {
 string SQLFormatter::Format(const string &sql) {
 	HighlightTokenizer tokenizer(sql);
 	tokenizer.TokenizeInput();
+	if (!tokenizer.tokens.empty()) {
+		auto back_type = tokenizer.tokens.back().type;
+		if (back_type == TokenType::END_OF_INPUT || back_type == TokenType::END_NOW_AUTOCOMPLETE) {
+			tokenizer.tokens.pop_back();
+		}
+	}
 	const auto &tokens = tokenizer.tokens;
 
 	if (tokens.empty()) {

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -507,21 +507,30 @@ bool BaseTokenizer::TokenizeInput() {
 		}
 	}
 
-	// finished processing - check the final state
+	// `append_end_of_input` always emits END_OF_INPUT (suggestions wouldn't make sense from
+	// inside an unterminated comment or string).
+	auto append_sentinel = [&]() {
+		tokens.emplace_back("", sql.size(), GetEndOfInputType());
+	};
+	auto append_end_of_input = [&]() {
+		tokens.emplace_back("", sql.size(), TokenType::END_OF_INPUT);
+	};
 	switch (state) {
 	case TokenizeState::SINGLE_LINE_COMMENT:
 	case TokenizeState::MULTI_LINE_COMMENT:
 		PushToken(last_pos, sql.size(), TokenType::COMMENT);
-		// no suggestions in comments or dollar-quoted strings
+		append_end_of_input();
 		return false;
 	case TokenizeState::DOLLAR_QUOTED_STRING:
 		PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
+		append_end_of_input();
 		return false;
 	default:
 		break;
 	}
 	string last_word = sql.substr(last_pos, sql.size() - last_pos);
 	OnLastToken(state, std::move(last_word), last_pos);
+	append_sentinel();
 	return true;
 }
 

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -221,7 +221,19 @@ bool BaseTokenizer::IsUnterminatedState(TokenizeState state) {
 	}
 }
 
-bool BaseTokenizer::TokenizeInput() {
+bool BaseTokenizer::CanAutocomplete() const {
+	return !tokens.empty() && tokens.back().type == TokenType::END_NOW_AUTOCOMPLETE;
+}
+
+void BaseTokenizer::TokenizeInput() {
+	if (TokenizeInputInternal()) {
+		tokens.emplace_back("", sql.size(), GetTerminator());
+	} else {
+		tokens.emplace_back("", sql.size(), TokenType::END_OF_INPUT);
+	}
+}
+
+bool BaseTokenizer::TokenizeInputInternal() {
 	auto state = TokenizeState::STANDARD;
 	idx_t last_pos = 0;
 	string dollar_quote_marker;
@@ -507,30 +519,19 @@ bool BaseTokenizer::TokenizeInput() {
 		}
 	}
 
-	// `append_end_of_input` always emits END_OF_INPUT (suggestions wouldn't make sense from
-	// inside an unterminated comment or string).
-	auto append_sentinel = [&]() {
-		tokens.emplace_back("", sql.size(), GetEndOfInputType());
-	};
-	auto append_end_of_input = [&]() {
-		tokens.emplace_back("", sql.size(), TokenType::END_OF_INPUT);
-	};
 	switch (state) {
 	case TokenizeState::SINGLE_LINE_COMMENT:
 	case TokenizeState::MULTI_LINE_COMMENT:
 		PushToken(last_pos, sql.size(), TokenType::COMMENT);
-		append_end_of_input();
 		return false;
 	case TokenizeState::DOLLAR_QUOTED_STRING:
 		PushToken(last_pos, sql.size(), TokenType::STRING_LITERAL, true);
-		append_end_of_input();
 		return false;
 	default:
 		break;
 	}
 	string last_word = sql.substr(last_pos, sql.size() - last_pos);
 	OnLastToken(state, std::move(last_word), last_pos);
-	append_sentinel();
 	return true;
 }
 

--- a/src/parser/peg/tokenizer/base_tokenizer.cpp
+++ b/src/parser/peg/tokenizer/base_tokenizer.cpp
@@ -222,7 +222,7 @@ bool BaseTokenizer::IsUnterminatedState(TokenizeState state) {
 }
 
 bool BaseTokenizer::CanAutocomplete() const {
-	return !tokens.empty() && tokens.back().type == TokenType::END_NOW_AUTOCOMPLETE;
+	return !tokens.empty() && tokens.back().type == TokenType::END_OF_INPUT_AUTOCOMPLETE;
 }
 
 void BaseTokenizer::TokenizeInput() {

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -73,6 +73,11 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 		if (error_token_idx >= tokens.size()) {
 			error_token_idx = tokens.size() - 1;
 		}
+		// Walk back past the EOI sentinel so the error message names a real token.
+		while (error_token_idx > 0 && (tokens[error_token_idx].type == TokenType::END_OF_INPUT ||
+		                               tokens[error_token_idx].type == TokenType::END_NOW_AUTOCOMPLETE)) {
+			error_token_idx--;
+		}
 		idx_t stmt_start = error_token_idx;
 		while (stmt_start > 0 && tokens[stmt_start - 1].text != ";") {
 			stmt_start--;
@@ -96,10 +101,11 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 	}
 	match_result->name = "Program";
 
-	// Program <- Statement? (';'+ Statement)* ';'*
+	// Program <- Statement? (';'+ Statement)* ';'* EndOfInput
 	// Program[0] = optional first Statement
 	// Program[1] = optional repeat of groups: (';'+ Statement)
 	// Program[2] = optional repeat of trailing ';'
+	// Program[3] = EndOfInput (sentinel, not walked here)
 	auto &prog = match_result->Cast<ListParseResult>();
 
 	ArenaAllocator transformer_allocator(Allocator::DefaultAllocator());

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -75,7 +75,7 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 		}
 		// Walk back past the EOI sentinel so the error message names a real token.
 		if (error_token_idx > 0 && (tokens[error_token_idx].type == TokenType::END_OF_INPUT ||
-		                               tokens[error_token_idx].type == TokenType::END_NOW_AUTOCOMPLETE)) {
+		                            tokens[error_token_idx].type == TokenType::END_OF_INPUT_AUTOCOMPLETE)) {
 			error_token_idx--;
 		}
 		idx_t stmt_start = error_token_idx;

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -74,7 +74,7 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 			error_token_idx = tokens.size() - 1;
 		}
 		// Walk back past the EOI sentinel so the error message names a real token.
-		while (error_token_idx > 0 && (tokens[error_token_idx].type == TokenType::END_OF_INPUT ||
+		if (error_token_idx > 0 && (tokens[error_token_idx].type == TokenType::END_OF_INPUT ||
 		                               tokens[error_token_idx].type == TokenType::END_NOW_AUTOCOMPLETE)) {
 			error_token_idx--;
 		}

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -30,6 +30,9 @@ static tokenType convertToken(TokenType token_type) {
 		return tokenType::TOKEN_COMMENT;
 	case TokenType::ERROR:
 		return tokenType::TOKEN_ERROR;
+	case TokenType::END_OF_INPUT:
+	case TokenType::END_NOW_AUTOCOMPLETE:
+		return tokenType::TOKEN_OPERATOR;
 	default:
 		throw duckdb::InternalException("Unrecognized token type");
 	}

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -31,7 +31,7 @@ static tokenType convertToken(TokenType token_type) {
 	case TokenType::ERROR:
 		return tokenType::TOKEN_ERROR;
 	case TokenType::END_OF_INPUT:
-	case TokenType::END_NOW_AUTOCOMPLETE:
+	case TokenType::END_OF_INPUT_AUTOCOMPLETE:
 		return tokenType::TOKEN_OPERATOR;
 	default:
 		throw duckdb::InternalException("Unrecognized token type");


### PR DESCRIPTION
Two new TokenType values are appended as a sentinel at the end of every tokenized vector:
* `END_OF_INPUT`, input genuinely ended; consumed by the new EndOfInput PEG rule via EndOfInputMatcher.
* `END_OF_INPUT_AUTOCOMPLETE`, cursor is here; ListMatcher and RepeatMatcher key off this token instead of running off the end of the vector.

BaseTokenizer::TokenizeInput appends the sentinel from the virtual GetEndOfInputType() on clean exit (autocomplete tokenizer overrides to `END_OF_INPUT_AUTOCOMPLETE`), and unconditionally `END_OF_INPUT` on the comment / dollar-quoted-string error exits.

Program now terminates with `EndOfInput`. EndOfInputMatcher is wired in via AddRuleOverride outside the generated block; IMPLICIT_RULES in the grammar generator skips the undefined-reference check for it. The transformer's error reporter walks back past the trailing sentinel so syntax errors name a real token. SQLTokenizeFunction, SQLFormatter and the linenoise highlighter ignore the sentinel; the autocomplete extension's check accepts state.token_index landing one short of tokens.size().


This adds some code, but do make explicit the terminator.
This would allow (in a follow up), to rewrite from:
```
Program <- Statement? (';'+ Statement)* ';'* EndOfInput
```
to
```
Program <- TopLevelStatement*
```