### PR TITLE
[INSERT] Resolve nested defaults at a more granular level

### DIFF
--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -151,19 +151,7 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 					children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(original_type, "")));
 
 					//! defaults
-					child_list_t<Value> default_children;
-					auto &struct_default_children = StructValue::GetChildren(bound_default.value);
-					auto &struct_default_type_children = StructType::GetChildTypes(bound_default.value.type());
-					for (idx_t i = 0; i < struct_default_children.size(); i++) {
-						auto &child_default = struct_default_children[i];
-						auto &child_name = struct_default_type_children[i].first;
-						if (child_default.type().id() == LogicalTypeId::STRUCT) {
-							default_children.emplace_back(child_name, CreateStructDefault(child_default));
-						} else {
-							default_children.emplace_back(child_name, child_default);
-						}
-					}
-					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(default_children))));
+					children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(bound_default.value)));
 					select_list.push_back(RemapStructFun::GetFunction().Bind(context, std::move(children)));
 				} else {
 					select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -98,25 +98,53 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 				auto &bound_default = op.bound_defaults[storage_idx]->Cast<BoundConstantExpression>();
 				if (!bound_default.value.IsNull()) {
 					//! input
-					children.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+					children.push_back(BoundCastExpression::AddDefaultCastToType(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index), original_type));
 					//! target_type
 					children.push_back(make_uniq<BoundConstantExpression>(Value(col.Type())));
+
 					//! mapping
+					//! FIXME: this needs to be recursive
 					child_list_t<Value> mapping_children;
-					for (auto &[child_name, _] : struct_children) {
-						mapping_children.emplace_back(child_name, Value(child_name));
+					for (auto &[child_name, child_type] : struct_children) {
+						Value child_value;
+						if (child_type.id() == LogicalTypeId::STRUCT) {
+							auto &child_struct_types = StructType::GetChildTypes(child_type);
+							child_list_t<Value> nested_child_values;
+							for (auto &[child_struct_name, _] : child_struct_types) {
+								nested_child_values.emplace_back(child_struct_name, Value(child_struct_name));
+							}
+							child_value = Value::STRUCT({{"", Value(child_name)}, {"", Value::STRUCT(nested_child_values)}});
+						} else {
+							child_value = Value(child_name);
+						}
+						mapping_children.emplace_back(child_name, child_value);
 					}
 					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(mapping_children))));
+
 					//! defaults
 					child_list_t<Value> default_children;
 					auto &struct_default_children = StructValue::GetChildren(bound_default.value);
 					auto &struct_default_type_children = StructType::GetChildTypes(bound_default.value.type());
 					for (idx_t i = 0; i < struct_default_children.size(); i++) {
 						auto &child_default = struct_default_children[i];
-						if (child_default.IsNull()) {
-							continue;
+						auto &child_name = struct_default_type_children[i].first;
+						auto &child_type = struct_default_type_children[i].second;
+						if (child_default.type().id() == LogicalTypeId::STRUCT) {
+							child_list_t<Value> nested_default_children;
+							auto &nested_struct_children = StructValue::GetChildren(child_default);
+							auto &nested_struct_type_children = StructType::GetChildTypes(child_default.type());
+							for (idx_t j = 0; j < nested_struct_children.size(); j++) {
+								auto &nested_child_name = nested_struct_type_children[j].first;
+								auto &nested_child_default = nested_struct_children[j];
+								if (nested_child_name == "d") {
+									continue;
+								}
+								nested_default_children.emplace_back(nested_child_name, nested_child_default);
+							}
+							default_children.emplace_back(child_name, Value::STRUCT(nested_default_children));
+						} else {
+							default_children.emplace_back(child_name, child_default);
 						}
-						default_children.emplace_back(struct_default_type_children[i].first, child_default);
 					}
 					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(default_children))));
 					select_list.push_back(RemapStructFun::GetFunction().Bind(context, std::move(children)));

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -75,6 +75,15 @@ bool PhysicalPlanGenerator::UseBatchIndex(PhysicalOperator &plan) {
 	return UseBatchIndex(context, plan);
 }
 
+namespace {
+
+//! Used to determine if the field of a struct is mapped or not
+struct StructFieldMapping {
+	case_insensitive_map_t<StructFieldMapping> child_mapping;
+};
+
+} // namespace
+
 static Value CreateStructMapping(const LogicalType &struct_type, const string &name) {
 	child_list_t<Value> field_mapping;
 
@@ -96,7 +105,7 @@ static Value CreateStructMapping(const LogicalType &struct_type, const string &n
 	return Value::STRUCT({{"", Value(name)}, {"", struct_value}});
 }
 
-static Value CreateStructDefault(const Value &value) {
+static Value CreateStructDefault(const Value &value, const case_insensitive_map_t<StructFieldMapping> &mapping = {}) {
 	child_list_t<Value> field_defaults;
 	auto &field_values = StructValue::GetChildren(value);
 	auto &struct_children = StructType::GetChildTypes(value.type());
@@ -105,17 +114,33 @@ static Value CreateStructDefault(const Value &value) {
 		auto &field_type = struct_children[j].second;
 		auto &field_value = field_values[j];
 
-		if (field_name == "d") {
-			continue;
-		}
+		auto it = mapping.find(field_name);
+		const bool is_mapped = it != mapping.end();
 
 		Value field_default;
 		if (field_type.id() == LogicalTypeId::STRUCT) {
-			field_default = CreateStructDefault(field_value);
+			if (is_mapped) {
+				field_default = CreateStructDefault(field_value, it->second.child_mapping);
+			} else {
+				field_default = CreateStructDefault(field_value);
+			}
+
+			if (field_default.IsNull()) {
+				//! All fields were skipped, no need to include this value
+				continue;
+			}
 		} else {
+			if (is_mapped) {
+				continue;
+			}
 			field_default = field_value;
 		}
+
 		field_defaults.emplace_back(field_name, field_default);
+	}
+	if (field_defaults.empty()) {
+		//! Skipped all fields, signal that the value should be omitted
+		return Value();
 	}
 	return Value::STRUCT(field_defaults);
 }
@@ -151,7 +176,9 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 					children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(original_type, "")));
 
 					//! defaults
-					children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(bound_default.value)));
+					case_insensitive_map_t<StructFieldMapping> mapping;
+					mapping["b"].child_mapping["d"];
+					children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(bound_default.value, mapping)));
 					select_list.push_back(RemapStructFun::GetFunction().Bind(context, std::move(children)));
 				} else {
 					select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/settings.hpp"
 
+#include "duckdb/function/scalar/struct_functions.hpp"
+
 namespace duckdb {
 
 OrderPreservationType PhysicalPlanGenerator::OrderPreservationRecursive(PhysicalOperator &op) {
@@ -87,8 +89,44 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 			// push default value
 			select_list.push_back(std::move(op.bound_defaults[storage_idx]));
 		} else {
-			// push reference
-			select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+			//! Column is present
+			if (col.Type().id() == LogicalTypeId::STRUCT) {
+				auto &original_type = child.children[0].get().types[mapped_index];
+				//! Column is of type STRUCT, create a COALESCE of the default with the input
+				vector<unique_ptr<Expression>> children;
+				auto &struct_children = StructType::GetChildTypes(original_type);
+				auto &bound_default = op.bound_defaults[storage_idx]->Cast<BoundConstantExpression>();
+				if (!bound_default.value.IsNull()) {
+					//! input
+					children.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+					//! target_type
+					children.push_back(make_uniq<BoundConstantExpression>(Value(col.Type())));
+					//! mapping
+					child_list_t<Value> mapping_children;
+					for (auto &[child_name, _] : struct_children) {
+						mapping_children.emplace_back(child_name, Value(child_name));
+					}
+					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(mapping_children))));
+					//! defaults
+					child_list_t<Value> default_children;
+					auto &struct_default_children = StructValue::GetChildren(bound_default.value);
+					auto &struct_default_type_children = StructType::GetChildTypes(bound_default.value.type());
+					for (idx_t i = 0; i < struct_default_children.size(); i++) {
+						auto &child_default = struct_default_children[i];
+						if (child_default.IsNull()) {
+							continue;
+						}
+						default_children.emplace_back(struct_default_type_children[i].first, child_default);
+					}
+					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(default_children))));
+					select_list.push_back(RemapStructFun::GetFunction().Bind(context, std::move(children)));
+				} else {
+					select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+				}
+			} else {
+				// push reference
+				select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+			}
 		}
 		types.push_back(col.Type());
 	}

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -84,14 +84,15 @@ struct StructFieldMapping {
 
 } // namespace
 
-static Value CreateStructMapping(const LogicalType &struct_type, const string &name) {
+static Value CreateStructMapping(const LogicalType &struct_type, const string &name, case_insensitive_map_t<StructFieldMapping> &out_mapping) {
 	child_list_t<Value> field_mapping;
 
 	auto &struct_children = StructType::GetChildTypes(struct_type);
 	for (auto &[field_name, field_type] : struct_children) {
+		auto &child_mapping = out_mapping[field_name];
 		Value mapping;
 		if (field_type.id() == LogicalTypeId::STRUCT) {
-			mapping = CreateStructMapping(field_type, field_name);
+			mapping = CreateStructMapping(field_type, field_name, child_mapping.child_mapping);
 		} else {
 			mapping = Value(field_name);
 		}
@@ -173,11 +174,10 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 					children.push_back(make_uniq<BoundConstantExpression>(Value(col.Type())));
 
 					//! mapping
-					children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(original_type, "")));
+					case_insensitive_map_t<StructFieldMapping> mapping;
+					children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(original_type, "", mapping)));
 
 					//! defaults
-					case_insensitive_map_t<StructFieldMapping> mapping;
-					mapping["b"].child_mapping["d"];
 					children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(bound_default.value, mapping)));
 					select_list.push_back(RemapStructFun::GetFunction().Bind(context, std::move(children)));
 				} else {

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -75,6 +75,51 @@ bool PhysicalPlanGenerator::UseBatchIndex(PhysicalOperator &plan) {
 	return UseBatchIndex(context, plan);
 }
 
+static Value CreateStructMapping(const LogicalType &struct_type, const string &name) {
+	child_list_t<Value> field_mapping;
+
+	auto &struct_children = StructType::GetChildTypes(struct_type);
+	for (auto &[field_name, field_type] : struct_children) {
+		Value mapping;
+		if (field_type.id() == LogicalTypeId::STRUCT) {
+			mapping = CreateStructMapping(field_type, field_name);
+		} else {
+			mapping = Value(field_name);
+		}
+		field_mapping.emplace_back(field_name, mapping);
+	}
+	auto struct_value = Value::STRUCT(field_mapping);
+	if (name.empty()) {
+		//! Root column
+		return struct_value;
+	}
+	return Value::STRUCT({{"", Value(name)}, {"", struct_value}});
+}
+
+static Value CreateStructDefault(const Value &value) {
+	child_list_t<Value> field_defaults;
+	auto &field_values = StructValue::GetChildren(value);
+	auto &struct_children = StructType::GetChildTypes(value.type());
+	for (idx_t j = 0; j < field_values.size(); j++) {
+		auto &field_name = struct_children[j].first;
+		auto &field_type = struct_children[j].second;
+		auto &field_value = field_values[j];
+
+		if (field_name == "d") {
+			continue;
+		}
+
+		Value field_default;
+		if (field_type.id() == LogicalTypeId::STRUCT) {
+			field_default = CreateStructDefault(field_value);
+		} else {
+			field_default = field_value;
+		}
+		field_defaults.emplace_back(field_name, field_default);
+	}
+	return Value::STRUCT(field_defaults);
+}
+
 PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert &op, PhysicalOperator &child) {
 	if (op.column_index_map.empty()) {
 		throw InternalException("No defaults to push");
@@ -103,23 +148,7 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 					children.push_back(make_uniq<BoundConstantExpression>(Value(col.Type())));
 
 					//! mapping
-					//! FIXME: this needs to be recursive
-					child_list_t<Value> mapping_children;
-					for (auto &[child_name, child_type] : struct_children) {
-						Value child_value;
-						if (child_type.id() == LogicalTypeId::STRUCT) {
-							auto &child_struct_types = StructType::GetChildTypes(child_type);
-							child_list_t<Value> nested_child_values;
-							for (auto &[child_struct_name, _] : child_struct_types) {
-								nested_child_values.emplace_back(child_struct_name, Value(child_struct_name));
-							}
-							child_value = Value::STRUCT({{"", Value(child_name)}, {"", Value::STRUCT(nested_child_values)}});
-						} else {
-							child_value = Value(child_name);
-						}
-						mapping_children.emplace_back(child_name, child_value);
-					}
-					children.push_back(make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(mapping_children))));
+					children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(original_type, "")));
 
 					//! defaults
 					child_list_t<Value> default_children;
@@ -128,20 +157,8 @@ PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert
 					for (idx_t i = 0; i < struct_default_children.size(); i++) {
 						auto &child_default = struct_default_children[i];
 						auto &child_name = struct_default_type_children[i].first;
-						auto &child_type = struct_default_type_children[i].second;
 						if (child_default.type().id() == LogicalTypeId::STRUCT) {
-							child_list_t<Value> nested_default_children;
-							auto &nested_struct_children = StructValue::GetChildren(child_default);
-							auto &nested_struct_type_children = StructType::GetChildTypes(child_default.type());
-							for (idx_t j = 0; j < nested_struct_children.size(); j++) {
-								auto &nested_child_name = nested_struct_type_children[j].first;
-								auto &nested_child_default = nested_struct_children[j];
-								if (nested_child_name == "d") {
-									continue;
-								}
-								nested_default_children.emplace_back(nested_child_name, nested_child_default);
-							}
-							default_children.emplace_back(child_name, Value::STRUCT(nested_default_children));
+							default_children.emplace_back(child_name, CreateStructDefault(child_default));
 						} else {
 							default_children.emplace_back(child_name, child_default);
 						}


### PR DESCRIPTION
This PR changes the `DEFAULT` resolution for columns of type `STRUCT`

type: `STRUCT(a VARCHAR, b BOOLEAN)`
default: `{'a': NULL, 'b': true}`
in: `{'a': 'test'}`

### Current behavior

result: `{'a': 'test', 'b': NULL}`

### New behavior

result: `{'a': 'test', 'b': true}`

### Details

At every level of the struct, we evaluate whether a value for a field was provided.
It's always used if provided, but now it's substituted by the DEFAULT if present, before falling back to NULL if it's not.