### PR TITLE
Fix skewness() test failure and stabilize main CI

### DIFF
--- a/.github/patches/extensions/ducklake/0020-disable-musl-timeout-tests.patch
+++ b/.github/patches/extensions/ducklake/0020-disable-musl-timeout-tests.patch
@@ -1,0 +1,45 @@
+diff --git a/test/sql/alter/many_schema_versions_low_memory.test_slow b/test/sql/alter/many_schema_versions_low_memory.test_slow
+index e4ab7fd2..859d8614 100644
+--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
++++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
+@@ -2,8 +2,10 @@
+ # description: test that many DDL operations work under a low memory limit with schema cache eviction
+ # group: [alter]
+ 
+ require ducklake
++
++require notmusl
+ 
+ require parquet
+ 
+ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+diff --git a/test/sql/deletion_inlining/test_multiple_files_flush.test_slow b/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
+index 147b9cf6..76bca20f 100644
+--- a/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
++++ b/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
+@@ -2,8 +2,10 @@
+ # description: test ducklake flushing deletion on inserted inline, but the flush produces multiple files
+ # group: [deletion_inlining]
+ 
+ require ducklake
++
++require notmusl
+ 
+ require parquet
+ 
+ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+diff --git a/test/sql/insert/insert_wide_table_low_memory.test_slow b/test/sql/insert/insert_wide_table_low_memory.test_slow
+index 8f742392..735278e6 100644
+--- a/test/sql/insert/insert_wide_table_low_memory.test_slow
++++ b/test/sql/insert/insert_wide_table_low_memory.test_slow
+@@ -2,8 +2,10 @@
+ # description: test that many small inserts into a wide table work under low memory limit
+ # group: [insert]
+ 
+ require ducklake
++
++require notmusl
+ 
+ require parquet
+ 
+ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db

--- a/.github/patches/extensions/vss/0004-disable-musl-timeout-test.patch
+++ b/.github/patches/extensions/vss/0004-disable-musl-timeout-test.patch
@@ -1,0 +1,12 @@
+diff --git a/test/sql/slow/hnsw_reclaim_storage.test_slow b/test/sql/slow/hnsw_reclaim_storage.test_slow
+index 6ec3e8d7..551dc206 100644
+--- a/test/sql/slow/hnsw_reclaim_storage.test_slow
++++ b/test/sql/slow/hnsw_reclaim_storage.test_slow
+@@ -2,6 +2,8 @@
+ # group: [slow]
+ 
+ require vss
++
++require notmusl
+ 
+ load {TEST_DIR}/hnsw_reclaim_space.db

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1196,50 +1196,6 @@ jobs:
         if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
         run: make unittest_reldebug
 
- valgrind:
-    name: Valgrind
-    if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'valgrind') }}
-    runs-on: ubuntu-24.04
-    needs:
-      - prepare
-      - linux-relassert
-    env:
-      CC: clang-20
-      CXX: clang++-20
-      DISABLE_SANITIZER: 1
-      BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: 'icu;json;parquet;tpch'
-      GEN: ninja
-
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        ref: ${{ needs.prepare.outputs.git_sha }}
-
-    - name: Install
-      timeout-minutes: 10
-      shell: bash
-      run: |
-        python3 scripts/ci/retry.py -- make toolsci
-        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq valgrind clang
-
-    - uses: ./.github/actions/ccache-action
-      with:
-        save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
-
-    - name: Build
-      shell: bash
-      run: python3 scripts/ci/retry.py -- make relassert
-
-    - name: Output version info
-      shell: bash
-      run: ./build/relassert/duckdb -c "PRAGMA version;"
-
-    - name: Test
-      if: ${{ !fromJson(needs.prepare.outputs.skip_tests) }}
-      shell: bash
-      run: python3 scripts/ci/run_tests.py --workers 1 --batch-size 1 --test-command "valgrind {binary} {flags} -f {test_list}" ./build/relassert/test/unittest test/sql/tpch/tpch_sf001.test_slow
-
  threadsan:
     name: Thread Sanitizer
     if: ${{ contains(fromJson(needs.prepare.outputs.enabled_jobs), 'threadsan') }}
@@ -1366,7 +1322,6 @@ jobs:
       - static-libs-windows-mingw
       - no-string-inline
       - vector-sizes
-      - valgrind
       - threadsan
       - linux-configs
     steps:

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -274,6 +274,48 @@ jobs:
       run: |
           python3 scripts/ci/run_tests.py --test-config test/configs/release_assertions.json --batch-timeout 600 build/relassert/test/unittest "*"
 
+  valgrind:
+    name: Valgrind
+    runs-on: ubuntu-24.04
+    needs: linux-memory-leaks
+    env:
+      CC: clang-20
+      CXX: clang++-20
+      DISABLE_SANITIZER: 1
+      BUILD_JEMALLOC: 1
+      CORE_EXTENSIONS: 'icu;json;parquet;tpch'
+      GEN: ninja
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Install
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        python3 scripts/ci/retry.py -- make toolsci
+        python3 scripts/ci/retry.py -- sudo apt-get install -y -qq valgrind clang
+
+    - uses: ./.github/actions/ccache-action
+
+    - uses: ./.github/actions/cleanup_runner
+
+    - uses: ./.github/actions/swap_space
+
+    - name: Build
+      shell: bash
+      run: python3 scripts/ci/retry.py -- make relassert
+
+    - name: Output version info
+      shell: bash
+      run: ./build/relassert/duckdb -c "PRAGMA version;"
+
+    - name: Test
+      shell: bash
+      run: python3 scripts/ci/run_tests.py --retry 0 --workers 1 --batch-size 1 --batch-timeout 1200 --test-command "valgrind {binary} {flags} -f {test_list}" ./build/relassert/test/unittest test/sql/tpch/tpch_sf001.test_slow
+
   sqllogic:
      name: Sqllogic tests
      runs-on: ubuntu-latest # Secondary task of this CI job is to test building duckdb on latest ubuntu

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -54,8 +54,9 @@ jobs:
 
     env:
       TREAT_WARNINGS_AS_ERRORS: 1
-      CMAKE_CXX_FLAGS: '-DDEBUG'
+      FORCE_DEBUG: 1
       FORCE_ASSERT: 1
+      GEN: ninja
 
     steps:
     - uses: actions/checkout@v6
@@ -70,14 +71,12 @@ jobs:
     - uses: ./.github/actions/ccache-action
 
     - name: Install ninja
-      shell: bash
       run: python3 scripts/ci/retry.py -- brew install ninja
 
     - uses: ./.github/actions/cleanup_runner
 
     - name: Build
-      shell: bash
-      run: python3 scripts/ci/retry.py -- bash -lc 'GEN=ninja make release'
+      run: python3 scripts/ci/retry.py -- make
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
@@ -88,14 +87,12 @@ jobs:
 
     - name: Test
       if: ${{ !inputs.skip_tests }}
-      shell: bash
       run: make unittest_release
 
   xcode-release:
     # Builds binaries for osx_arm64 and osx_amd64
     name: OSX Release
     runs-on: macos-latest
-    needs: xcode-debug
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -123,11 +120,9 @@ jobs:
           python3 scripts/ci/retry.py -- python -m pip install pytest
 
       - name: Build
-        shell: bash
         run: python3 scripts/ci/retry.py -- make
 
       - name: CLI check
-        shell: bash
         run: |
           ./build/release/duckdb -c "PRAGMA platform; PRAGMA version;"
           if [ "${{ github.ref_name }}" == "main" ]; then

--- a/extension/core_functions/aggregate/distributive/skew.cpp
+++ b/extension/core_functions/aggregate/distributive/skew.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include <limits>
 
 namespace duckdb {
 
@@ -58,7 +59,15 @@ struct SkewnessOperation {
 		}
 		double n = state.n;
 		double temp = 1 / n;
-		double variance = temp * (state.sum_sqr - state.sum * state.sum * temp);
+		double raw_m2 = state.sum_sqr - state.sum * state.sum * temp;
+		// Only treat finite second-moment noise as zero; overflow should still surface as out-of-range.
+		if (Value::DoubleIsFinite(raw_m2) && Value::DoubleIsFinite(state.sum_sqr) &&
+		    // Scale the tolerance by the accumulated squared magnitude instead of using a fixed epsilon.
+		    std::abs(raw_m2) <= std::numeric_limits<double>::epsilon() * std::max(1.0, std::abs(state.sum_sqr))) {
+			finalize_data.ReturnNull();
+			return;
+		}
+		double variance = temp * raw_m2;
 		if (variance <= 0) {
 			finalize_data.ReturnNull();
 			return;

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -35,7 +35,6 @@ PULL_REQUEST_JOBS = COMMON_JOBS + PULL_REQUEST_ONLY_JOBS
 
 NIGHTLY_ONLY_JOBS = [
     "main_julia",
-    "valgrind",
     "static-libs-osx",
     "static-libs-windows-mingw",
 ]

--- a/scripts/ci/test_job_stages.py
+++ b/scripts/ci/test_job_stages.py
@@ -135,7 +135,6 @@ class JobStagesTest(unittest.TestCase):
     def test_main_includes_main_only_jobs(self):
         selection = self._compute_job_selection("push", "main", "duckdb/duckdb")
         self.assertIn("main_julia", selection.enabled_jobs)
-        self.assertIn("valgrind", selection.enabled_jobs)
         self.assertTrue(selection.save_cache)
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
@@ -155,7 +154,6 @@ class JobStagesTest(unittest.TestCase):
     def test_regular_branch_excludes_main_only_jobs(self):
         selection = self._compute_job_selection("pull_request", "feature/my-branch", "duckdb/duckdb")
         self.assertNotIn("main_julia", selection.enabled_jobs)
-        self.assertNotIn("valgrind", selection.enabled_jobs)
         self.assertFalse(selection.save_cache)
 
     def test_fork_saves_cache(self):

--- a/scripts/github_cache_usage.py
+++ b/scripts/github_cache_usage.py
@@ -33,12 +33,12 @@ MAIN = {
     "linux-relassert",
     "linux-configs",
     "vector-sizes",
-    "valgrind",
     "threadsan",
     "no-string-inline",
 }
 
 NIGHTLYTESTS = {
+    "valgrind",
     "release-assert",
     "release-assert-clang",
     "release-assert-osx-storage",

--- a/test/configs/hash_zero.json
+++ b/test/configs/hash_zero.json
@@ -29,7 +29,9 @@
         "test/sql/settings/max_execution_time.test",
         "test/sql/settings/operator_memory_limit.test",
         "test/sql/table_function/duckdb_eviction_queues.test",
-        "test/sql/pragma/profiling/test_custom_profiling_total_memory_allocated.test"
+        "test/sql/pragma/profiling/test_custom_profiling_total_memory_allocated.test",
+        "test/sql/optimizer/table_filters.test",
+        "test/optimizer/partial_aggregate_pushdown.test"
       ]
     },
     {

--- a/test/sql/function/list/aggregates/skewness.test
+++ b/test/sql/function/list/aggregates/skewness.test
@@ -22,6 +22,16 @@ select list_skewness (i) from skew
 NULL
 
 query I
+select list_skewness([5, 5, 5])
+----
+NULL
+
+query I
+select list_skewness([1.5, 1.5, 1.5])
+----
+NULL
+
+query I
 select list_skewness ([1,2])
 ----
 NULL


### PR DESCRIPTION
### Fix `skewness()` test failure for machine epsilon difference on macOS

CI [failed](https://github.com/duckdb/duckdb/actions/runs/26858244603/job/79205969064#step:10:253) for `OSX debug` on main.

I reproduced the problem locally:
```
$ build/release/test/unittest test/sql/aggregate/skewness_zero_variance.test
Filters: test/sql/aggregate/skewness_zero_variance.test
[0/1] (0%): test/sql/aggregate/skewness_zero_variance.test                                                                                                      
1. test/sql/aggregate/skewness_zero_variance.test:6
================================================================================
Wrong result in query! (test/sql/aggregate/skewness_zero_variance.test:6)!
================================================================================
SELECT skewness(x) FROM (VALUES (5), (5), (5)) t(x);
================================================================================
Mismatch on row 1, column skewness(x)(index 1)
1137965073.46744 <> NULL
================================================================================
Expected result:
================================================================================
NULL

================================================================================
Actual result:
================================================================================
1137965073.46744
```

The problem is that `skewness` computes variance from raw moments, and for constant inputs on macOS builds that variance can round to a tiny positive number instead of exact zero. That bypasses the old `variance <= 0` check, so the final division runs on what is mathematically a zero-variance case and returns a large number instead of `NULL`.

Recently merged, related PR: https://github.com/duckdb/duckdb/pull/21871. @rustyconover FYI.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9558.

### Small CI changes

Move the `valgrind` job to `NightlyRuns.yml` so we can keep `Main.yml` stable and fast.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9137. (By increasing the test timeout.)

Add two patches to ignore very slow tests that timeout on `linux_arm64_musl`. See comments.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9559.