### PR TITLE
Fix VARIANT cast reading wrong rows under a filter

### DIFF
--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -257,6 +257,8 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 
 	auto &result = result_data.variant;
 	for (idx_t source_index = 0; source_index < count; source_index++) {
+		//! Map the loop index through the incoming selection to the actual source row.
+		const auto scan_index = source_data.GetMappedIndex(source_index);
 		auto result_index = selvec ? selvec->get_index(source_index) : source_index;
 
 		auto &keys_list_entry = result.keys_data[result_index];
@@ -269,7 +271,7 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 
 		uint32_t keys_count = 0;
 		uint32_t blob_size = 0;
-		if (!source.RowIsValid(source_index)) {
+		if (!source.RowIsValid(scan_index)) {
 			if (!IGNORE_NULLS) {
 				HandleVariantNull<WRITE_DATA>(result_data, result_index, values_offset_data, blob_offset,
 				                              values_index_selvec, source_index, is_root);
@@ -287,23 +289,23 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 
 		//! First write all children
 		//! NOTE: this has to happen first because we use 'values_offset', which is increased when we write the values
-		auto source_children_list_entry = source.GetChildrenListEntry(source_index);
+		auto source_children_list_entry = source.GetChildrenListEntry(scan_index);
 		for (idx_t source_children_index = 0; source_children_index < source_children_list_entry.length;
 		     source_children_index++) {
 			//! values_index
 			if (WRITE_DATA) {
 				auto &values_offset = values_offset_data[result_index];
-				auto source_value_index = source.GetValuesIndex(source_index, source_children_index);
+				auto source_value_index = source.GetValuesIndex(scan_index, source_children_index);
 				result.values_index_data[children_list_entry.offset + children_offset + source_children_index] =
 				    values_offset + source_value_index;
 			}
 
 			//! keys_index
-			if (source.KeysIndexIsValid(source_index, source_children_index)) {
+			if (source.KeysIndexIsValid(scan_index, source_children_index)) {
 				if (WRITE_DATA) {
 					//! Look up the existing key from 'source'
-					auto source_key_index = source.GetKeysIndex(source_index, source_children_index);
-					auto &source_key_value = source.GetKey(source_index, source_key_index);
+					auto source_key_index = source.GetKeysIndex(scan_index, source_children_index);
+					auto &source_key_value = source.GetKey(scan_index, source_key_index);
 
 					//! Now write this key to the dictionary of the result
 					auto dict_index = result_data.GetOrCreateIndex(source_key_value);
@@ -320,26 +322,25 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 			}
 		}
 
-		auto source_values_list_entry = source.GetValuesListEntry(source_index);
+		auto source_values_list_entry = source.GetValuesListEntry(scan_index);
 
 		if (WRITE_DATA) {
 			WriteState write_state(keys_offset, children_offset, blob_offset, blob_data, blob_size);
 			for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
 			     source_value_index++) {
-				auto source_type_id = source.GetTypeId(source_index, source_value_index);
+				auto source_type_id = source.GetTypeId(scan_index, source_value_index);
 				WriteVariantMetadata<WRITE_DATA>(result_data, result_index, values_offset_data, blob_offset + blob_size,
 				                                 nullptr, 0, source_type_id);
 
-				VariantVisitor<VariantToVariantDataWriter>::Visit(source, source_index, source_value_index,
-				                                                  write_state);
+				VariantVisitor<VariantToVariantDataWriter>::Visit(source, scan_index, source_value_index, write_state);
 			}
 		} else {
 			AnalyzeState analyze_state(children_offset);
 			for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
 			     source_value_index++) {
 				values_offset_data[result_index]++;
-				blob_size += VariantVisitor<VariantToVariantSizeAnalyzer>::Visit(source, source_index,
-				                                                                 source_value_index, analyze_state);
+				blob_size += VariantVisitor<VariantToVariantSizeAnalyzer>::Visit(source, scan_index, source_value_index,
+				                                                                 analyze_state);
 			}
 		}
 

--- a/test/sql/types/variant/variant_map_to_variant_filter.test
+++ b/test/sql/types/variant/variant_map_to_variant_filter.test
@@ -2,6 +2,9 @@
 # description: MAP(VARCHAR, VARIANT) -> VARIANT must read the selected rows under a filter
 # group: [variant]
 
+# Forced storage uses the default storage version, but VARIANT requires v1.5.0, so skip.
+require no_force_storage
+
 statement ok
 CREATE TABLE t AS SELECT i, MAP{'k': i::VARIANT} AS m FROM range(2) t(i);
 

--- a/test/sql/types/variant/variant_map_to_variant_filter.test
+++ b/test/sql/types/variant/variant_map_to_variant_filter.test
@@ -1,0 +1,23 @@
+# name: test/sql/types/variant/variant_map_to_variant_filter.test
+# description: MAP(VARCHAR, VARIANT) -> VARIANT must read the selected rows under a filter
+# group: [variant]
+
+statement ok
+CREATE TABLE t AS SELECT i, MAP{'k': i::VARIANT} AS m FROM range(2) t(i);
+
+# filtering row 1 must yield value 1, not row 0's value
+query I
+SELECT m::VARIANT FROM t WHERE i = 1;
+----
+[{'key': k, 'value': 1}]
+
+# multi-row selection, incl. a row past the 2048 vector boundary
+statement ok
+CREATE TABLE big AS SELECT i, MAP{'k': i::VARIANT} AS m FROM range(3000) t(i);
+
+query II
+SELECT i, m::VARIANT FROM big WHERE i IN (1, 2, 2050) ORDER BY i;
+----
+1	[{'key': k, 'value': 1}]
+2	[{'key': k, 'value': 2}]
+2050	[{'key': k, 'value': 2050}]


### PR DESCRIPTION
`ConvertVariantToVariant` indexed the source by the raw loop counter, ignoring the incoming selection vector, so nested `VARIANT` values were read from the wrong rows under a filter. Map the index through `GetMappedIndex` like the other converters.

Before:

```
❯ duckdb
-- Loading resources from /Users/mathias/.duckdbrc
DuckDB v1.5.3 (Variegata)
Enter ".help" for usage hints.
🟡◗ CREATE TABLE t AS SELECT i, MAP{'k': i::VARIANT} AS m FROM range(2) t(i);
🟡◗ SELECT m::VARIANT FROM t WHERE i = 1;
┌──────────────────────────┐
│   CAST(m AS "VARIANT")   │
│         variant          │
├──────────────────────────┤
│ [{'key': k, 'value': 0}] │
└──────────────────────────┘
🟡◗ SELECT m::VARCHAR FROM t WHERE i = 1;
┌────────────────────┐
│ CAST(m AS VARCHAR) │
│      varchar       │
├────────────────────┤
│ {k=1}              │
└────────────────────┘
```

(`'value': 0` is wrong)

After:

```
❯ ./build/release/duckdb
-- Loading resources from /Users/mathias/.duckdbrc
DuckDB v1.5.4-dev84 (Development Version, 4e6c9e90a7)
Enter ".help" for usage hints.
🟡◗ CREATE TABLE t AS SELECT i, MAP{'k': i::VARIANT} AS m FROM range(2) t(i);
🟡◗ SELECT m::VARIANT FROM t WHERE i = 1;
┌──────────────────────────┐
│   CAST(m AS "VARIANT")   │
│         variant          │
├──────────────────────────┤
│ [{'key': k, 'value': 1}] │
└──────────────────────────┘
🟡◗ SELECT m::VARCHAR FROM t WHERE i = 1;
┌────────────────────┐
│ CAST(m AS VARCHAR) │
│      varchar       │
├────────────────────┤
│ {k=1}              │
└────────────────────┘
```

Reported on [Discord](https://discord.com/channels/909674491309850675/1125676736311480340/1511698549354664020)