### PR TITLE
PEG/3: Peeling statements stacked

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -462,7 +462,7 @@ static unique_ptr<SQLTokenizeFunctionData> GenerateTokens(ClientContext &context
 	MatchState state(tokenizer.tokens, suggestions, parse_allocator, max_token_index);
 
 	auto peg_matcher = PEGMatcher::Get(context);
-	peg_matcher->Root().Match(state);
+	peg_matcher->ProgramMatcher().Match(state);
 
 	return make_uniq<SQLTokenizeFunctionData>(tokenizer.tokens);
 }
@@ -551,7 +551,7 @@ static duckdb::unique_ptr<FunctionData> CheckPEGParserBind(ClientContext &contex
 	MatchState state(root_tokens, suggestions, parse_allocator, max_token_index);
 
 	auto peg_matcher = PEGMatcher::Get(context);
-	auto match_result = peg_matcher->Root().Match(state);
+	auto match_result = peg_matcher->ProgramMatcher().Match(state);
 	// `+ 1` accounts for the EOI sentinel — the autocomplete walk may report SUCCESS without
 	// consuming it.
 	if (match_result != MatchResultType::SUCCESS || state.token_index + 1 < root_tokens.size()) {

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -20,6 +20,7 @@
 namespace duckdb {
 
 struct ParserCache;
+struct MatcherToken;
 class GroupByNode;
 struct UnicodeSpace {
 	UnicodeSpace(idx_t pos, idx_t bytes) : pos(pos), bytes(bytes) {
@@ -46,6 +47,15 @@ public:
 	//! successful, the parsed statements will be stored in the statements
 	//! variable.
 	void ParseQuery(const string &query);
+
+	//! Parse a single TopLevelStatement from an already-tokenized stream starting at
+	//! `token_cursor`. On success advances `token_cursor` past the consumed tokens and returns
+	//! the SQLStatement. Returns nullptr at end-of-input or when the matched TLS was a
+	//! separator-only run (no statement). Throws ParserException on syntax error.
+	//!
+	//! Does NOT populate `stmt->query` — the caller owns the source string and can slice it
+	//! using `stmt->stmt_location` / `stmt->stmt_length` if needed.
+	DUCKDB_API unique_ptr<SQLStatement> ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor);
 
 	//! Tokenize a query, returning the raw tokens together with their locations
 	static vector<SimplifiedToken> Tokenize(const string &query);

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -13,9 +13,22 @@
 #include "duckdb/common/enums/statement_type.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/peg/token_type.hpp"
 
 namespace duckdb {
 struct DBConfig;
+
+//! A minimal token view handed to parser extensions: the token text together with its classified
+//! TokenType.
+struct SimpleToken {
+	SimpleToken(string text_p, TokenType type_p) : text(std::move(text_p)), type(type_p) {
+	}
+
+	//! The raw token text as it appears in the query
+	string text;
+	//! The classified type of the token
+	TokenType type;
+};
 
 //! The ParserExtensionInfo holds static information relevant to the parser extension
 //! It is made available in the parse_function, and will be kept alive as long as the database system is kept alive
@@ -74,9 +87,24 @@ struct ParserExtensionParseResult {
 	string error;
 	//! The error location (if unsuccessful)
 	optional_idx error_location;
+	//! How many leading tokens (from the start of the `tokens` view) the extension claimed:
+	//!    > 0 : SUCCESS — the extension accepted that many tokens; the peeler resumes parsing
+	//!          after them.
+	//!   == 0 : the extension ran fine but did not claim any tokens (it's not taking this input) —
+	//!          the peeler lets the next extension try.
+	//!    < 0 : the extension wants to surface an error — the peeler throws (using `error` /
+	//!          `error_location` if set).
+	//! A positive count must not exceed the number of tokens in the view, or the peeler throws.
+	int64_t consumed_tokens = 0;
 };
 
-typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, const string &query);
+//! Called when the PEG parser fails to parse a statement.
+//!
+//! `tokens` is the tokenized view of the source tail from the PEG failure point onward — one
+//! SimpleToken (text + TokenType) per token, in source order. The extension dispatches on this
+//! token stream and reports, via `ParserExtensionParseResult::consumed_tokens`, how many leading
+//! tokens it claimed (> 0 success, 0 = ran but claimed nothing, < 0 = throw).
+typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info, const vector<SimpleToken> &tokens);
 //===--------------------------------------------------------------------===//
 // Plan
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -116,8 +116,8 @@ struct MatcherSuggestion {
 
 struct MatchState {
 	MatchState(vector<MatcherToken> &tokens, vector<MatcherSuggestion> &suggestions, ParseResultAllocator &allocator,
-	           idx_t &max_token_index, bool preserve_identifier_case_p = true)
-	    : tokens(tokens), suggestions(suggestions), token_index(0), allocator(allocator),
+	           idx_t &max_token_index, bool preserve_identifier_case_p = true, idx_t starting_token_index = 0)
+	    : tokens(tokens), suggestions(suggestions), token_index(starting_token_index), allocator(allocator),
 	      max_token_index(max_token_index), preserve_identifier_case(preserve_identifier_case_p) {
 	}
 	MatchState(MatchState &state)
@@ -223,8 +223,11 @@ private:
 struct PEGMatcher {
 	MatcherAllocator allocator;
 
-	Matcher &Root() {
-		return *root;
+	Matcher &ProgramMatcher() {
+		return *program_matcher;
+	}
+	Matcher &TopLevelStatementMatcher() {
+		return *top_level_statement_matcher;
 	}
 
 	static shared_ptr<PEGMatcher> Get(ClientContext &context);
@@ -232,7 +235,8 @@ struct PEGMatcher {
 
 private:
 	friend struct ParserCache;
-	optional_ptr<Matcher> root;
+	optional_ptr<Matcher> program_matcher;
+	optional_ptr<Matcher> top_level_statement_matcher;
 };
 
 //! Per-database cache holder for the compiled PEG root matcher and transformer factory.

--- a/src/include/duckdb/parser/peg/token_type.hpp
+++ b/src/include/duckdb/parser/peg/token_type.hpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/peg/token_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+
+enum class TokenType {
+	INVALID,
+	KEYWORD,
+	STRING_LITERAL,
+	NUMBER_LITERAL,
+	OPERATOR,
+	IDENTIFIER,
+	COMMENT,
+	TERMINATOR,
+	CATALOG_NAME,
+	SCHEMA_NAME,
+	TABLE_NAME,
+	TYPE_NAME,
+	COLUMN_NAME,
+	SCALAR_FUNCTION,
+	TABLE_FUNCTION,
+	PRAGMA_FUNCTION,
+	SETTING_NAME,
+	//! Named TOKEN_ERROR (not ERROR) to avoid colliding with the Win32 `ERROR` macro.
+	TOKEN_ERROR,
+	//! Sentinel for real end of input — consumed by EndOfInputMatcher.
+	END_OF_INPUT,
+	//! Sentinel for cursor position in autocomplete mode — List/Repeat fire suggestion walk.
+	END_OF_INPUT_AUTOCOMPLETE
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -10,34 +10,10 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/peg/special_string_utils.hpp"
+#include "duckdb/parser/peg/token_type.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 
 namespace duckdb {
-
-enum class TokenType {
-	INVALID,
-	KEYWORD,
-	STRING_LITERAL,
-	NUMBER_LITERAL,
-	OPERATOR,
-	IDENTIFIER,
-	COMMENT,
-	TERMINATOR,
-	CATALOG_NAME,
-	SCHEMA_NAME,
-	TABLE_NAME,
-	TYPE_NAME,
-	COLUMN_NAME,
-	SCALAR_FUNCTION,
-	TABLE_FUNCTION,
-	PRAGMA_FUNCTION,
-	SETTING_NAME,
-	ERROR,
-	//! Sentinel for real end of input — consumed by EndOfInputMatcher.
-	END_OF_INPUT,
-	//! Sentinel for cursor position in autocomplete mode — List/Repeat fire suggestion walk.
-	END_OF_INPUT_AUTOCOMPLETE
-};
 
 inline string TokenTypeToString(TokenType type) {
 	switch (type) {
@@ -55,7 +31,7 @@ inline string TokenTypeToString(TokenType type) {
 		return "COMMENT";
 	case TokenType::TERMINATOR:
 		return "TERMINATOR";
-	case TokenType::ERROR:
+	case TokenType::TOKEN_ERROR:
 		return "ERROR";
 	case TokenType::CATALOG_NAME:
 		return "CATALOG_NAME";

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -226,9 +226,12 @@ class PEGTransformerFactory {
 public:
 	explicit PEGTransformerFactory();
 
-	//! Helper functions
-	vector<unique_ptr<SQLStatement>> Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-	                                           Matcher &root_matcher);
+	//! Match a single TopLevelStatement from `tokens` starting at `token_cursor` and transform it
+	//! into a SQLStatement. Returns nullptr if the matched TLS was separator-only (no statement).
+	//! Throws on syntax error. `token_cursor` is in/out: it's the token index where matching
+	//! starts, and on return holds the token index immediately past the last consumed token.
+	unique_ptr<SQLStatement> TransformTopLevelStatement(vector<MatcherToken> &tokens, ParserOptions &options,
+	                                                    Matcher &root_matcher, idx_t &token_cursor);
 	static ParseResult &ExtractResultFromParens(ParseResult &parse_result);
 	static vector<reference<ParseResult>> ExtractParseResultsFromList(ParseResult &parse_result);
 	static bool ExpressionIsEmptyStar(const ParsedExpression &expr);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -258,40 +258,62 @@ void Parser::ParseQuery(const string &query) {
 			last_strict_extension_error.Throw();
 		}
 	}
-	// PEG parser: tokenize then transform
-	auto &cache = GetCache();
-	auto peg_matcher = cache.GetMatcher();
-	auto peg_factory = cache.GetTransformerFactory();
-
+	// PEG parser: tokenize, then peel one TopLevelStatement at a time. On per-statement PEG
+	// failure, hand the rest of the query to parse_function extensions; the extension reports
+	// how many bytes it consumed and we advance the token cursor past them.
 	vector<MatcherToken> tokens;
 	ParserTokenizer tokenizer(query, tokens);
 	tokenizer.TokenizeInput();
-	if (!tokens.empty()) {
+	idx_t token_cursor = 0;
+	while (token_cursor < tokens.size()) {
 		try {
-			auto peg_statements = peg_factory->Transform(tokens, options, peg_matcher->Root());
-			for (auto &stmt : peg_statements) {
+			auto stmt = ParseTopLevelStatement(tokens, token_cursor);
+			if (stmt) {
 				statements.push_back(std::move(stmt));
 			}
 		} catch (ParserException &e) {
-			// fall back to parse_function extensions for unknown statement types
 			bool parsed = false;
 			if (options.extensions && options.extensions->HasParserExtensions()) {
+				idx_t failure_byte = token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
+				// SimpleToken view of the tail: text + classified type, in source order, so
+				// extensions can dispatch on the token stream without re-tokenizing. The extension
+				// reports how many of these tokens it consumed.
+				vector<SimpleToken> simple_tokens;
+				simple_tokens.reserve(tokens.size() - token_cursor);
+				for (idx_t i = token_cursor; i < tokens.size(); i++) {
+					simple_tokens.emplace_back(tokens[i].text, tokens[i].type);
+				}
 				for (auto &ext : options.extensions->ParserExtensions()) {
 					if (!ext.parse_function) {
 						continue;
 					}
-					auto result = ext.parse_function(ext.parser_info.get(), query);
-					if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
-						auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-						estmt->stmt_location = 0;
-						estmt->stmt_length = query.size();
-						statements.push_back(std::move(estmt));
-						parsed = true;
-						break;
-					}
-					if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
+					auto result = ext.parse_function(ext.parser_info.get(), simple_tokens);
+					if (result.consumed_tokens < 0) {
+						// The extension wants to surface an error.
 						throw ParserException::SyntaxError(query, result.error, result.error_location);
 					}
+					if (result.consumed_tokens == 0) {
+						// The extension ran but did not claim this input — let the next one try.
+						continue;
+					}
+					// consumed_tokens > 0: the extension accepted that many leading tokens.
+					auto consumed = NumericCast<idx_t>(result.consumed_tokens);
+					if (consumed > simple_tokens.size()) {
+						throw ParserException(
+						    "Extension returned consumed_tokens=%llu — only %llu tokens are available",
+						    (uint64_t)consumed, (uint64_t)simple_tokens.size());
+					}
+					// The claimed span runs from the failure point to the end of the last consumed
+					// token; advancing the cursor by consumed_tokens lands on a token boundary.
+					auto &last_token = tokens[token_cursor + consumed - 1];
+					const idx_t span_end_byte = last_token.offset + last_token.length;
+					auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
+					estmt->stmt_location = failure_byte;
+					estmt->stmt_length = span_end_byte - failure_byte;
+					statements.push_back(std::move(estmt));
+					token_cursor += consumed;
+					parsed = true;
+					break;
 				}
 			}
 			if (!parsed) {
@@ -315,6 +337,18 @@ void Parser::ParseQuery(const string &query) {
 			}
 		}
 	}
+}
+
+unique_ptr<SQLStatement> Parser::ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor) {
+	if (token_cursor >= tokens.size()) {
+		return nullptr;
+	}
+	auto &cache = GetCache();
+	auto peg_matcher = cache.GetMatcher();
+	auto peg_factory = cache.GetTransformerFactory();
+
+	return peg_factory->TransformTopLevelStatement(tokens, options, peg_matcher->TopLevelStatementMatcher(),
+	                                               token_cursor);
 }
 
 vector<SimplifiedToken> Parser::Tokenize(const string &query) {

--- a/src/parser/peg/autocomplete_core.cpp
+++ b/src/parser/peg/autocomplete_core.cpp
@@ -213,7 +213,7 @@ vector<AutoCompleteSuggestion> GenerateAutoCompleteSuggestions(AutoCompleteCatal
 		// no suggestions found during tokenizing
 		// run the root matcher
 		auto peg_matcher = provider.GetPEGMatcher();
-		peg_matcher->Root().Match(state);
+		peg_matcher->ProgramMatcher().Match(state);
 	}
 	if (state.suggestions.empty()) {
 		return {};

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -1053,6 +1053,9 @@ public:
 
 	//! Create a matcher from a PEG grammar
 	Matcher &CreateMatcher(const char *grammar, const char *root_rule);
+	//! Look up a matcher for a rule that was already built (as a sub-rule of a previous
+	//! CreateMatcher call). Throws if the rule has not been built.
+	Matcher &GetMatcher(const string &rule_name);
 
 private:
 	// Base primitives
@@ -1102,6 +1105,14 @@ Matcher &MatcherFactory::Optional(Matcher &matcher) const {
 
 Matcher &MatcherFactory::Repeat(Matcher &matcher) const {
 	return allocator.Allocate(make_uniq<RepeatMatcher>(matcher));
+}
+
+Matcher &MatcherFactory::GetMatcher(const string &rule_name) {
+	auto entry = matchers.find(rule_name);
+	if (entry == matchers.end()) {
+		throw InternalException("Matcher for rule '%s' has not been built", rule_name);
+	}
+	return entry->second.get();
 }
 
 Matcher &MatcherFactory::CreateMatcher(PEGParser &parser, string_t rule_name) {
@@ -1468,10 +1479,12 @@ shared_ptr<PEGMatcher> ParserCache::GetMatcher() {
 	buffer << t.rdbuf();
 	auto grammar_string = buffer.str();
 
-	new_matcher->root = factory.CreateMatcher(grammar_string.c_str(), "Program");
+	new_matcher->program_matcher = factory.CreateMatcher(grammar_string.c_str(), "Program");
 #else
-	new_matcher->root = factory.CreateMatcher(const_char_ptr_cast(INLINED_PEG_GRAMMAR), "Program");
+	new_matcher->program_matcher = factory.CreateMatcher(const_char_ptr_cast(INLINED_PEG_GRAMMAR), "Program");
 #endif
+	// TopLevelStatement is referenced by Program, so it has already been built and cached.
+	new_matcher->top_level_statement_matcher = factory.GetMatcher("TopLevelStatement");
 	std::unique_lock<std::mutex> lock(mutex);
 	if (!matcher) {
 		matcher = std::move(new_matcher);

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -53,22 +53,24 @@ static unique_ptr<SQLStatement> ExtractAndTransformStatement(PEGTransformer &tra
 	return stmt;
 }
 
-vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<MatcherToken> &tokens, ParserOptions &options,
-                                                                  Matcher &root_matcher) {
-	if (tokens.empty()) {
-		return {};
-	}
-	string token_stream;
-	for (auto &token : tokens) {
-		token_stream += token.text + " ";
+unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(vector<MatcherToken> &tokens,
+                                                                           ParserOptions &options,
+                                                                           Matcher &root_matcher, idx_t &token_cursor) {
+	if (token_cursor >= tokens.size()) {
+		return nullptr;
 	}
 	vector<MatcherSuggestion> suggestions;
 	ParseResultAllocator parse_result_allocator;
-	idx_t max_token_index = 0;
-	MatchState state(tokens, suggestions, parse_result_allocator, max_token_index, options.preserve_identifier_case);
-	auto &matcher = root_matcher;
-	auto match_result = matcher.MatchParseResult(state);
-	if (match_result == nullptr || state.token_index < state.tokens.size()) {
+	idx_t max_token_index = token_cursor;
+	MatchState state(tokens, suggestions, parse_result_allocator, max_token_index, options.preserve_identifier_case,
+	                 token_cursor);
+	auto match_result = root_matcher.MatchParseResult(state);
+	if (match_result == nullptr) {
+		// syntax error — surface as a parser exception in the same shape as Transform()
+		string token_stream;
+		for (auto &token : tokens) {
+			token_stream += token.text + " ";
+		}
 		idx_t error_token_idx = state.GetMaxTokenIndex();
 		if (error_token_idx >= tokens.size()) {
 			error_token_idx = tokens.size() - 1;
@@ -78,68 +80,39 @@ vector<unique_ptr<SQLStatement>> PEGTransformerFactory::Transform(vector<Matcher
 		                            tokens[error_token_idx].type == TokenType::END_OF_INPUT_AUTOCOMPLETE)) {
 			error_token_idx--;
 		}
-		idx_t stmt_start = error_token_idx;
-		while (stmt_start > 0 && tokens[stmt_start - 1].text != ";") {
-			stmt_start--;
-		}
-		idx_t stmt_end = error_token_idx;
-		while (stmt_end < tokens.size() && tokens[stmt_end].text != ";") {
-			stmt_end++;
-		}
-		if (stmt_start < stmt_end && (stmt_start > 0 || stmt_end < tokens.size())) {
-			vector<MatcherToken> statement_tokens;
-			statement_tokens.reserve(stmt_end - stmt_start);
-			for (idx_t i = stmt_start; i < stmt_end; i++) {
-				statement_tokens.push_back(tokens[i]);
-			}
-			Transform(statement_tokens, options, root_matcher);
-		}
-
 		auto &error_token = tokens[error_token_idx];
 		auto error_message = "syntax error at or near \"" + error_token.text + "\"";
 		throw ParserException::SyntaxError(token_stream, error_message, error_token.offset);
 	}
-	match_result->name = "Program";
 
-	// Program <- TopLevelStatement*
+	// Advance the caller's cursor past the consumed tokens.
+	token_cursor = state.token_index;
+
 	// TopLevelStatement <- Statement? (';'+ / EndOfInput)
 	//   child 0: Optional<Statement>
 	//   child 1: bracket-wrapper list around Choice<';'+ | EndOfInput>
-	auto &prog = match_result->Cast<ListParseResult>();
-	auto &program_opt = prog.Child<OptionalParseResult>(0);
+	auto &tls = match_result->Cast<ListParseResult>();
+	auto &stmt_opt = tls.Child<OptionalParseResult>(0);
+	if (!stmt_opt.HasResult()) {
+		// separator-only or EOI-only TopLevelStatement — no statement to yield
+		return nullptr;
+	}
+	auto &term_wrapper = tls.Child<ListParseResult>(1);
+	auto &term_inner = term_wrapper.Child<ChoiceParseResult>(0).GetResult();
+	optional_idx terminator_offset;
+	if (term_inner.type != ParseResultType::END_OF_INPUT) {
+		auto semi_children = term_inner.Cast<RepeatParseResult>().GetChildren();
+		if (!semi_children.empty()) {
+			terminator_offset = semi_children[0].get().offset;
+		}
+	}
 
 	ArenaAllocator transformer_allocator(Allocator::DefaultAllocator());
 	PEGTransformerState transformer_state(tokens);
 	PEGTransformer transformer(transformer_allocator, transformer_state, sql_transform_functions, parser.rules,
 	                           enum_mappings, options);
 
-	vector<unique_ptr<SQLStatement>> result;
-	if (!program_opt.HasResult()) {
-		return result;
-	}
-	auto &top_level_repeat = program_opt.GetResult().Cast<RepeatParseResult>();
-	for (auto &child : top_level_repeat.GetChildren()) {
-		auto &tls = child.get().Cast<ListParseResult>();
-		auto &stmt_opt = tls.Child<OptionalParseResult>(0);
-		if (!stmt_opt.HasResult()) {
-			// separator-only or EOI-only TopLevelStatement — no statement to yield
-			continue;
-		}
-		// Terminator span ends at the first separator `;` if the choice picked ';'+; the
-		// EndOfInput arm leaves the offset unset so ExtractAndTransformStatement defaults to
-		// end-of-token-stream.
-		auto &term_wrapper = tls.Child<ListParseResult>(1);
-		auto &term_inner = term_wrapper.Child<ChoiceParseResult>(0).GetResult();
-		optional_idx terminator_offset;
-		if (term_inner.type != ParseResultType::END_OF_INPUT) {
-			auto semi_children = term_inner.Cast<RepeatParseResult>().GetChildren();
-			if (!semi_children.empty()) {
-				terminator_offset = semi_children[0].get().offset;
-			}
-		}
-		result.push_back(ExtractAndTransformStatement(transformer, tokens, stmt_opt.GetResult(), terminator_offset));
-	}
-	return result;
+	return ExtractAndTransformStatement(transformer, tokens, stmt_opt.GetResult(), terminator_offset);
 }
 
 #define REGISTER_TRANSFORM(FUNCTION) Register(string(#FUNCTION).substr(9), &FUNCTION)

--- a/test/extension/consistent_semicolon_extension_parse.test
+++ b/test/extension/consistent_semicolon_extension_parse.test
@@ -27,4 +27,4 @@ Catalog Error: Type with name unrecognizedkeyword does not exist!
 statement error
 QUACK string_split('hello-world', ';');QUACK string_split('hello-world', ';')
 ----
-Parser Error: This is not a quack: string_split('hello-world', ';')
+<REGEX>:Parser Error: syntax error at or near.*

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -39,8 +39,9 @@ QUACK
 QUACK
 
 query I
-quACk QUaCk
+quACk QUaCk QUACK
 ----
+QUACK
 QUACK
 QUACK
 
@@ -53,7 +54,7 @@ QUAC
 statement error
 QUACK NOT QUACK
 ----
-<REGEX>:Parser Error: This is not a quack.*
+<REGEX>:Parser Error: syntax error at or near.*
 
 query I
 SELECT contains(loaded_extensions(), 'loadable_extension_demo')

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -362,39 +362,34 @@ public:
 		parser_override = QuackParser;
 	}
 
-	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, const string &query) {
-		auto lcase = StringUtil::Lower(query);
-		if (!StringUtil::Contains(lcase, "quack")) {
-			// quack not found!?
-			if (StringUtil::Contains(lcase, "quac")) {
-				// use our error
-				return ParserExtensionParseResult("Did you mean... QUACK!?");
-			}
-			// use original error
+	static ParserExtensionParseResult QuackParseFunction(ParserExtensionInfo *info, const vector<SimpleToken> &tokens) {
+		// Claim a maximal run of consecutive "quack" identifier tokens (case-insensitive) at the
+		// start of the view. PEG happily parses one or two identifiers (as `SELECT x AS y`), but
+		// three or more in a row without separators is the syntactic hole that invokes this
+		// parse_function; we then greedily consume every leading "quack".
+		idx_t quacks = 0;
+		while (quacks < tokens.size() && StringUtil::CIEquals(tokens[quacks].text, "quack")) {
+			quacks++;
+		}
+		if (quacks == 0) {
+			// Not our input — let the next extension or the original PEG error surface.
 			return ParserExtensionParseResult();
 		}
-
-		idx_t count = 0;
-		size_t pos = 0;
-		size_t last_end = 0;
-		while ((pos = lcase.find("quack", last_end)) != string::npos) {
-			string between = lcase.substr(last_end, pos - last_end);
-			StringUtil::Trim(between);
-			if (!between.empty() && !StringUtil::CIEquals(between, ";")) {
-				return ParserExtensionParseResult("This is not a quack: " + between);
-			}
-			count++;
-			last_end = pos + 5;
+		// To be a proper TopLevelStatement (`Statement? (';'+ / EndOfInput)`), the quack run must
+		// be followed by ';' or end-of-input. The tokenizer always appends an END_OF_INPUT
+		// sentinel, so tokens[quacks] is valid here. If a real token (e.g. SELECT) follows without
+		// a separator, decline so the original PEG syntax error surfaces.
+		const auto next_type = tokens[quacks].type;
+		if (next_type != TokenType::TERMINATOR && next_type != TokenType::END_OF_INPUT &&
+		    next_type != TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			return ParserExtensionParseResult();
 		}
-
-		string after = lcase.substr(last_end);
-		StringUtil::Trim(after);
-		if (!after.empty() && !StringUtil::CIEquals(after, ";")) {
-			return ParserExtensionParseResult("This is not a quack: " + after);
-		}
-
-		// QUACK
-		return ParserExtensionParseResult(make_uniq<QuackExtensionData>(count));
+		// The QUACK row count is the number of quack words.
+		auto result = ParserExtensionParseResult(make_uniq<QuackExtensionData>(quacks));
+		// Consume the terminator token too — whether it's ';' or the end-of-input sentinel — so the
+		// QUACK statement owns its terminator, just like a real TopLevelStatement.
+		result.consumed_tokens = NumericCast<int64_t>(quacks + 1);
+		return result;
 	}
 
 	static ParserExtensionPlanResult QuackPlanFunction(ParserExtensionInfo *info, ClientContext &context,

--- a/test/sql/extensions/quack_peeling.test
+++ b/test/sql/extensions/quack_peeling.test
@@ -1,0 +1,76 @@
+# name: test/sql/extensions/quack_peeling.test
+# description: Demonstrate per-segment parse_function — the QUACK extension claims its own
+# group: [extensions]
+
+#              statement (three consecutive "quack"s), PEG handles SQL statements
+#              interleaved with it.
+
+require skip_reload
+
+require allow_unsigned_extensions
+
+require notmingw
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+# A QUACK statement: three "quack"s in a row (PEG fails at three idents without separators)
+statement ok
+quack quack quack;
+
+# Case-insensitive
+statement ok
+QUACK quack QuAcK;
+
+# QUACK statement followed by SQL — extension claims the triplet, PEG handles the SELECT
+statement ok
+quack quack quack; SELECT 42;
+
+# SQL followed by a QUACK
+statement ok
+SELECT 1; quack quack quack;
+
+# Maximal munch — the extension greedily claims every consecutive "quack", so six in a row are a
+# single QUACK statement (six QUACK rows), not two triplets.
+query I
+quack quack quack quack quack quack;
+----
+QUACK
+QUACK
+QUACK
+QUACK
+QUACK
+QUACK
+
+# QUACK interleaved between two SELECTs
+statement ok
+SELECT 1; quack quack quack; SELECT 42;
+
+# Case-insensitive maximal run: four quacks terminated by ';' are one QUACK statement (four rows).
+query I
+quack quack QUACK quaCK;
+----
+QUACK
+QUACK
+QUACK
+QUACK
+
+# With a ';' separating it from the SELECT, it's two statements (the QUACK run is properly
+# terminated, then PEG handles SELECT 42).
+statement ok
+quack quack QUACK quaCK; SELECT 42;
+
+# Without a separator, "quack quack QUACK quaCK SELECT 42" is NOT a proper TopLevelStatement — the
+# quack run is followed by a real token (SELECT) rather than ';' or end-of-input, so the extension
+# declines and the original PEG syntax error (pointing at the start of the statement) surfaces.
+statement error
+quack quack QUACK quaCK SELECT 42;
+----
+syntax error at or near "quack"
+
+# A misspelled "quak" is not a "quack" — the extension declines (claims 0 tokens), so the original
+# PEG syntax error surfaces instead of being swallowed.
+statement error
+quak SELECT 32;
+----
+syntax error at or near "SELECT"

--- a/test/sql/peg_parser/peg_syntax_error.test
+++ b/test/sql/peg_parser/peg_syntax_error.test
@@ -3,19 +3,29 @@
 # group: [peg_parser]
 
 statement error
-SELECT (1 + (2 * 3);
+SELECT (1 + (2 * 3)
 ----
 Parser Error: syntax error at or near ")"
 
 statement error
+SELECT (1 + (2 * 3);
+----
+Parser Error: syntax error at or near ";"
+
+statement error
 SELECT 1 + 2 * ;
 ----
-Parser Error: syntax error at or near "*"
+Parser Error: syntax error at or near ";"
+
+statement error
+SELECT * FROM users JOIN orders
+----
+Parser Error: syntax error at or near "orders"
 
 statement error
 SELECT * FROM users JOIN orders;
 ----
-Parser Error: syntax error at or near "orders"
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT * FROM users WHERE id = 1 WHERE age > 20;
@@ -23,9 +33,14 @@ SELECT * FROM users WHERE id = 1 WHERE age > 20;
 Parser Error: syntax error at or near "WHERE"
 
 statement error
-SELECT (10).;
+SELECT (10).
 ----
 Parser Error: syntax error at or near "."
+
+statement error
+SELECT (10).;
+----
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT * FROM tbl WHERE id IN ();
@@ -43,7 +58,7 @@ SELECT users..id FROM users;
 Parser Error: syntax error at or near ".."
 
 statement error
-SELECT * FROM tbl WHERE x = (SELECT 1 FROM (SELECT 2);
+SELECT * FROM tbl WHERE x = (SELECT 1 FROM (SELECT 2)
 ----
 Parser Error: syntax error at or near ")"
 
@@ -55,7 +70,7 @@ Parser Error: syntax error at or near "FROM"
 statement error
 WITH cte AS (SELECT 1) SELECT * FROM cte WHERE (SELECT 1 FROM cte2;
 ----
-Parser Error: syntax error at or near "cte2"
+Parser Error: syntax error at or near ";"
 
 statement error
 SELECT id, SUM(amount) OVER (PARTITION BY ) FROM sales;
@@ -79,17 +94,17 @@ SELECT {'a': 1, 'b': };
 Parser Error: syntax error at or near "}"
 
 statement error
-SELECT CASE WHEN x > 10 THEN 'large' WHEN x < 5;
+SELECT CASE WHEN x > 10 THEN 'large' WHEN x < 5
 ----
 Parser Error: syntax error at or near "5"
 
 statement error
-SELECT '2023-01-01':: ;
+SELECT '2023-01-01'::
 ----
 Parser Error: syntax error at or near "::"
 
 statement error
-SELECT 1 INTERSECT;
+SELECT 1 INTERSECT
 ----
 Parser Error: syntax error at or near "INTERSECT"
 

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -28,7 +28,7 @@ static tokenType convertToken(TokenType token_type) {
 		return tokenType::TOKEN_KEYWORD;
 	case TokenType::COMMENT:
 		return tokenType::TOKEN_COMMENT;
-	case TokenType::ERROR:
+	case TokenType::TOKEN_ERROR:
 		return tokenType::TOKEN_ERROR;
 	case TokenType::END_OF_INPUT:
 	case TokenType::END_OF_INPUT_AUTOCOMPLETE:


### PR DESCRIPTION
Stacked on https://github.com/duckdb/duckdb/pull/23029 (that's stacked on https://github.com/duckdb/duckdb/pull/23027). Now also rebased on origin/main.

Idea is moving away from whole `Program` parsing, and into peeling one `TopLevelStatement` at a time.

This is relevant since it allows to interleave parsing and execution, for example:
```sql
LOAD <my_extension>; quack quack quack QUACK;
```
would parse correctly IF `<my_extension>` where to provide a parser_function that recognize `quack quack quack QUACK` as a valid statement.

In particular, working on `CONNECT`-statement, I found that it was restrictive to force all parsing to happen ahead of time, and we might want to allow interleaving of parse and execution (with side effects on parser itself).

Currently as per this PR, only infrastructure is added to introduce an StatementIterator of sort, but all code still does first tokenization (in full), then parsing (one at a time, until completion), then execution.
A next PR will interleave parsing and execution in certain code-paths.

A nice consequence of this, I think, is allowing parser extensions to be more proper first class citizens, where the logic changes from:
```
1. Does PEG recognise a query string? (possibly multiple statements)
2. If not 1, do any extension recognise a query string?
3. If not 2, errors.
```
to
```
while (true):
     1. Does PEG can peel out a statement from a query string? (possibly multiple statements)
     2. If not 1, do any extension recognise a statement from the start of the query string?
     3. if not 2, errors
     4. now, are there tokens left not consumed? if so, continue, else break
```

Say we have an extension that recognise:
```
quack;
quack QUACK;
quack quack QUACK QUack;
... basically, any amounts of quack (case insensitive)
```

```sql
SELECT 42; quack quack quack; SELECT 42;
```
Before this would not parse, given extension recognise only second part, and  PEG recognise the first and third, but no available parser is able to recognize the whole query.

Now, after the PR, statements are peeled once at a time:
```sql
SELECT 42;  ##--- default parser handled
           quack quack quack; ##--- extension handled
                              SELECT 42;  ##--- default parser handled
```
This basically means the PEG parser IS extensible at the `TopLevelStatement` level, that becomes sort of:
```
TopLevelStatement <- Statement? (';'+ / EndOfInput)
TopLevelStatement <- Statement? (';'+ / EndOfInput) / TopLevelExtensionStatement
```

that also means, if the extensions where to check for `(';'+ / EndOfInput)` as well, an extension can register a fully functional `Statement` equivalent.

This PR DOES rework the `parse_function`, so this will require extensions changes.

Alternative to https://github.com/duckdb/duckdb/pull/23000.