### PR TITLE
Make HTTP 502 responses retryable

### DIFF
--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -117,6 +117,7 @@ bool HTTPResponse::ShouldRetry() const {
 	case HTTPStatusCode::ImATeapot_418:
 	case HTTPStatusCode::TooManyRequests_429:
 	case HTTPStatusCode::InternalServerError_500:
+	case HTTPStatusCode::BadGateway_502:
 	case HTTPStatusCode::ServiceUnavailable_503:
 	case HTTPStatusCode::GatewayTimeout_504:
 		return true;


### PR DESCRIPTION
Fixes #22673

DuckDB already retries 500 and 504 responses. Retrying 502 is consistent with that behavior, since it is another transient server-side/gateway failure. Practically a lot of object storage services return 502 intermittently and this makes HTTP accesses resilient.