### PR TITLE
Retry db init/load command atomically in cost plan runner

### DIFF
--- a/scripts/plan_cost_runner.py
+++ b/scripts/plan_cost_runner.py
@@ -18,39 +18,52 @@ BANNER_SIZE = 52
 RETRIES = 2
 
 
-def run_with_retry(command, context, **kwargs):
-    attempts = RETRIES + 1
-    for attempt in range(1, attempts + 1):
-        completed = subprocess.run(command, shell=True, check=False, **kwargs)
-        if completed.returncode == 0:
-            return completed
-        if attempt < attempts:
-            print(
-                f"Retrying failure in {context} "
-                f"(attempt {attempt + 1}/{attempts}, return code {completed.returncode})"
-            )
-            continue
-        raise subprocess.CalledProcessError(
-            completed.returncode,
-            command,
-            output=completed.stdout,
-            stderr=completed.stderr,
-        )
+def run_command(command, **kwargs):
+    return subprocess.run(
+        command,
+        shell=True,
+        check=False,
+        **kwargs,
+    )
 
 
 def init_db(cli, dbname, benchmark_dir):
     print(f"INITIALIZING {dbname} ...")
-    run_with_retry(
-        f"{cli} {dbname} < {benchmark_dir}/init/schema.sql",
-        context=f"init schema ({dbname})",
-        stdout=subprocess.DEVNULL,
-    )
-    run_with_retry(
-        f"{cli} {dbname} < {benchmark_dir}/init/load.sql",
-        context=f"init load ({dbname})",
-        stdout=subprocess.DEVNULL,
-    )
-    print("INITIALIZATION DONE")
+    attempts = RETRIES + 1
+    if os.path.exists(dbname):
+        os.remove(dbname)
+
+    for attempt in range(1, attempts + 1):
+        schema_command = f"{cli} {dbname} < {benchmark_dir}/init/schema.sql"
+        completed = run_command(
+            schema_command,
+            stdout=subprocess.DEVNULL,
+        )
+        if completed.returncode == 0:
+            load_command = f"{cli} {dbname} < {benchmark_dir}/init/load.sql"
+            completed = run_command(
+                load_command,
+                stdout=subprocess.DEVNULL,
+            )
+            if completed.returncode == 0:
+                print("INITIALIZATION DONE")
+                return
+
+        if attempt < attempts:
+            if os.path.exists(dbname):
+                os.remove(dbname)
+            print(
+                f"Retrying failure in init db ({dbname}) "
+                f"(attempt {attempt + 1}/{attempts}, return code {completed.returncode})"
+            )
+            continue
+
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            completed.args,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
 
 
 class PlanCost:
@@ -156,11 +169,27 @@ def op_inspect(op) -> PlanCost:
 
 def query_plan_cost(cli, dbname, query):
     try:
-        run_with_retry(
-            f"{cli} --readonly {dbname} -c \"{ENABLE_PROFILING};{PROFILE_OUTPUT};{query}\"",
-            context=f"query profiling ({dbname})",
-            capture_output=True,
-        )
+        command = f"{cli} --readonly {dbname} -c \"{ENABLE_PROFILING};{PROFILE_OUTPUT};{query}\""
+        attempts = RETRIES + 1
+        for attempt in range(1, attempts + 1):
+            completed = run_command(
+                command,
+                capture_output=True,
+            )
+            if completed.returncode == 0:
+                break
+            if attempt < attempts:
+                print(
+                    f"Retrying failure in query profiling ({dbname}) "
+                    f"(attempt {attempt + 1}/{attempts}, return code {completed.returncode})"
+                )
+                continue
+            raise subprocess.CalledProcessError(
+                completed.returncode,
+                completed.args,
+                output=completed.stdout,
+                stderr=completed.stderr,
+            )
     except subprocess.CalledProcessError as e:
         print("-------------------------")
         print("--------Failure----------")


### PR DESCRIPTION
Retrying the init/load commands for the regression database can still fail:
```
$ python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
  python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: 
    GIT_REF: 968966ca4602ed0fb12da58d2439642e9a5e3d33
    BASE_BRANCH: main
    BASE_HASH: 
HTTP Error: HTTP GET error on 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_aka_title.parquet' (HTTP 0 Internal Server Error)
HTTP Error: HTTP GET error on 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/job_aka_title.parquet' (HTTP 0 Internal Server Error)
INITIALIZING old.duckdb ...
INITIALIZATION DONE
INITIALIZING new.duckdb ...
Retrying failure in init load (new.duckdb) (attempt 2/3, return code 1)
Retrying failure in init load (new.duckdb) (attempt 3/3, return code 1)
INITIALIZATION DONE

RUNNING BENCHMARK QUERIES
...
Retrying failure in query profiling (new.duckdb) (attempt 2/3, return code 1)
Retrying failure in query profiling (new.duckdb) (attempt 3/3, return code 1)
-------------------------
--------Failure----------
-------------------------
Out of Memory Error: failed to offload data block of size 256.0 KiB (70.1 GiB/70.1 GiB used).
This limit was set by the 'max_temp_directory_size' setting.
By default, this setting utilizes the available disk space on the drive where the 'temp_directory' is located.
You can adjust this setting, by using (for example) PRAGMA max_temp_directory_size='10GiB'

Possible solutions:
* Reducing the number of threads (SET threads=X)
* Disabling insertion-order preservation (SET preserve_insertion_order=false)
* Increasing the memory limit (SET memory_limit='...GB')

See also https://duckdb.org/docs/current/guides/performance/how_to_tune_workloads
```
because retrying the individual init/load commands can result in inserting more/different data.

So, we delete the database file before retrying the whole init and load command sequence.