### PR TITLE
PEG/4: StatementIterator interface and use to interleave parsing and execution

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/main/pending_query_result.hpp"
+#include "duckdb/main/statement_iterator.hpp"
 #include "duckdb/main/prepared_statement.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/table_description.hpp"
@@ -210,6 +211,20 @@ public:
 
 	//! Parse statements from a query
 	DUCKDB_API vector<unique_ptr<SQLStatement>> ParseStatements(const string &query);
+
+	//! Parse a query that must contain exactly one statement and return it raw — no
+	//! StatementPreprocessor pass (no PRAGMA reparse, no MULTI_STATEMENT unpacking). Throws if
+	//! the query yields zero or more than one statement. Use this when you need the AST and
+	//! plan to run preprocessing yourself (or skip it entirely, e.g. for static analysis).
+	DUCKDB_API unique_ptr<SQLStatement> ParseStatementRaw(const string &query);
+	//! Same as above, but for callers that already hold the context lock.
+	unique_ptr<SQLStatement> ParseStatementRaw(ClientContextLock &lock, const string &query);
+
+	//! Extract a query's statements as a StatementIterator (iterator-style API). The caller drives
+	//! Peek(context) + GetStatement() to walk through statements one at a time. Replaces the
+	//! flat-vector form (`ParseStatements` / `ExtractStatements`) over time. `preprocess` (default
+	//! true) yields ready-to-execute statements; callers that preprocess themselves pass false.
+	DUCKDB_API StatementIterator ExtractStatements(const string &query, bool preprocess = true);
 
 	//! Extract the logical plan of a query
 	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query);

--- a/src/include/duckdb/main/statement_iterator.hpp
+++ b/src/include/duckdb/main/statement_iterator.hpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/statement_iterator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+class ClientContext;
+class Parser;
+class SQLStatement;
+struct MatcherToken;
+
+//! Iterator over the SQL statements contained in a multi-statement query.
+//!
+//! Usage:
+//!   auto it = context.ExtractStatements(sql);
+//!   while (it.Peek(context)) {
+//!       auto stmt = it.GetStatement();
+//!       // dispatch stmt
+//!   }
+//!
+//! Peek does the work — it advances the byte cursor through `sql` and parses one
+//! TopLevelStatement per call via `Parser::ParseStatement`. The iterator buffers at most one
+//! statement at a time; GetStatement yields it and clears the buffer for the next Peek.
+//!
+//! Separator-only stretches (e.g. ";;;") are transparently skipped inside Peek — the caller
+//! always sees either a real statement or a clean exhaustion.
+class StatementIterator {
+public:
+	//! When `preprocess` is true, each peeled statement is run through the StatementPreprocessor
+	//! (PRAGMA reparse, MULTI_STATEMENT unpack, transaction wrapping) so the caller gets
+	//! ready-to-execute statements. Internal callers that drive their own preprocessor leave it
+	//! false (the default); ClientContext::ExtractStatements passes true for eager-API parity.
+	DUCKDB_API explicit StatementIterator(string sql, bool preprocess = false);
+	DUCKDB_API ~StatementIterator();
+
+	StatementIterator(const StatementIterator &) = delete;
+	StatementIterator &operator=(const StatementIterator &) = delete;
+	DUCKDB_API StatementIterator(StatementIterator &&) noexcept;
+	DUCKDB_API StatementIterator &operator=(StatementIterator &&) noexcept;
+
+	//! Returns true if a statement is currently available (after parsing as needed). Returns
+	//! false when the iterator is exhausted. Non-const: parses on demand and buffers the result.
+	DUCKDB_API bool Peek(ClientContext &context);
+
+	//! Returns the next buffered statement and clears the buffer. Returns nullptr if no
+	//! statement is buffered — the caller should call Peek(context) first.
+	DUCKDB_API unique_ptr<SQLStatement> GetStatement();
+
+private:
+	string sql;
+	//! Parser instance kept alive across Peek calls so its PEG matcher / transformer caches
+	//! stay warm. Constructed lazily on the first Peek.
+	unique_ptr<Parser> parser;
+	//! Tokenized view of `sql`. Populated once on the first Peek and walked thereafter via
+	//! `token_cursor`, avoiding O(N²) re-tokenization across N statements.
+	unique_ptr<vector<MatcherToken>> tokens;
+	//! Index into `tokens` at which the next match starts.
+	idx_t token_cursor = 0;
+	//! Single-statement buffer holding the result of the most recent Peek. Cleared by
+	//! GetStatement.
+	unique_ptr<SQLStatement> current_statement;
+	//! Once Peek determines there are no more statements (cursor past end of tokens), we stay
+	//! exhausted; subsequent Peek calls return false without re-invoking the parser.
+	bool exhausted = false;
+	//! Statements produced by a successful `parser_override` extension; if non-empty the
+	//! iterator yields these in order instead of running the PEG parser at all. Populated on
+	//! the first Peek when an extension claims the query.
+	unique_ptr<vector<unique_ptr<SQLStatement>>> overridden_statements;
+	//! Cursor into `overridden_statements`.
+	idx_t override_cursor = 0;
+	//! True once we've consulted parser_override extensions for this query.
+	bool override_resolved = false;
+	//! Set from the constructor `preprocess` argument. When true, Peek runs each peeled statement
+	//! through the StatementPreprocessor before yielding it.
+	bool preprocess_on_peek = false;
+	//! Buffer for statements produced by preprocessing one peeled statement. Drained
+	//! one-at-a-time across subsequent Peek calls before parsing the next raw statement.
+	vector<unique_ptr<SQLStatement>> preprocess_buffer;
+	idx_t preprocess_buffer_cursor = 0;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -57,6 +57,14 @@ public:
 	//! using `stmt->stmt_location` / `stmt->stmt_length` if needed.
 	DUCKDB_API unique_ptr<SQLStatement> ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor);
 
+	//! Run the `parse_function` extensions over the tail of `query` starting at `token_cursor`,
+	//! the way `ParseQuery` does in its catch handler. Returns the produced `ExtensionStatement`
+	//! and advances `token_cursor` past the bytes the extension claimed. Returns nullptr if no
+	//! extension claims the segment. Used by both `ParseQuery` and the lazy `StatementIterator`
+	//! so the two paths handle PEG failures identically.
+	DUCKDB_API unique_ptr<SQLStatement> TryParseExtensionStatement(vector<MatcherToken> &tokens, idx_t &token_cursor,
+	                                                               const string &query);
+
 	//! Tokenize a query, returning the raw tokens together with their locations
 	static vector<SimplifiedToken> Tokenize(const string &query);
 
@@ -89,6 +97,10 @@ public:
 	                                              ParserOptions options = ParserOptions());
 
 	static bool StripUnicodeSpaces(const string &query_str, string &new_query);
+
+	//! Throw a ParserException if `query` contains invalid UTF-8. Called up front by ParseQuery
+	//! and by StatementIterator so the tokenizer never has to read past bad bytes.
+	static void ValidateUTF8Query(const string &query);
 
 	void ThrowParserOverrideError(ParserOverrideResult &result);
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library_unity(
   config.cpp
   connection.cpp
   database.cpp
+  statement_iterator.cpp
   database_file_path_manager.cpp
   database_path_and_type.cpp
   database_manager.cpp

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -783,21 +783,58 @@ vector<unique_ptr<SQLStatement>> ClientContext::ParseStatements(const string &qu
 	auto lock = LockContext();
 	return ParseStatementsInternal(*lock, query);
 }
+
+StatementIterator ClientContext::ExtractStatements(const string &query, bool preprocess) {
+	// With preprocess=true (the default) the iterator yields ready-to-execute statements: PRAGMA
+	// reparse, MULTI_STATEMENT unpack and transaction wrapping per peel — matches the eager API
+	// users expect. Callers that drive their own preprocessor (e.g. the shell, at execute time)
+	// pass false to avoid double work.
+	return StatementIterator(query, preprocess);
+}
+
+unique_ptr<SQLStatement> ClientContext::ParseStatementRaw(const string &query) {
+	auto lock = LockContext();
+	return ParseStatementRaw(*lock, query);
+}
+
+unique_ptr<SQLStatement> ClientContext::ParseStatementRaw(ClientContextLock &lock, const string &query) {
+	InitialCleanup(lock);
+	try {
+		StatementIterator iterator(query);
+		if (!iterator.Peek(*this)) {
+			throw InvalidInputException("Expected a single statement, got none");
+		}
+		auto stmt = iterator.GetStatement();
+		if (iterator.Peek(*this)) {
+			throw InvalidInputException("Expected a single statement, got more than one");
+		}
+		return stmt;
+	} catch (std::exception &ex) {
+		auto error = ErrorData(ex);
+		ProcessError(error, query);
+		error.Throw();
+	}
+}
+
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
 	try {
-		Parser parser(GetParserOptions());
-		auto &profiler = QueryProfiler::Get(*this);
-		profiler.StartQuery(query);
-		auto parser_timer = profiler.StartTimer<MetricParserTotalTime>();
-		parser.ParseQuery(query);
+		QueryProfiler::Get(*this).StartQuery(query);
 
+		// Drain the lazy iterator into a vector for callers that want the eager shape.
+		StatementIterator iterator(query);
+		vector<unique_ptr<SQLStatement>> result;
 		StatementPreprocessor preprocessor(*this);
-
-		const CurrentTransactionState transaction_context_state =
-		    transaction.HasActiveTransaction() ? IN_ACTIVE_TRANSACTION : NOT_IN_ACTIVE_TRANSACTION;
-		preprocessor.Preprocess(lock, parser.statements, transaction_context_state);
-
-		return std::move(parser.statements);
+		while (iterator.Peek(*this)) {
+			vector<unique_ptr<SQLStatement>> expanded;
+			expanded.push_back(iterator.GetStatement());
+			const CurrentTransactionState transaction_context_state =
+			    transaction.HasActiveTransaction() ? IN_ACTIVE_TRANSACTION : NOT_IN_ACTIVE_TRANSACTION;
+			preprocessor.Preprocess(lock, expanded, transaction_context_state);
+			for (auto &stmt : expanded) {
+				result.push_back(std::move(stmt));
+			}
+		}
+		return result;
 	} catch (std::exception &ex) {
 		auto error = ErrorData(ex);
 		ProcessError(error, query);
@@ -1102,13 +1139,37 @@ unique_ptr<QueryResult> ClientContext::Query(unique_ptr<SQLStatement> statement,
 
 unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameters query_parameters) {
 	auto lock = LockContext();
-	vector<unique_ptr<SQLStatement>> statements;
+	// The lazy path bypasses ParseStatements → InitialCleanup, so clear leftover query state
+	// (interrupt flag, etc.) ourselves.
+	InitialCleanup(*lock);
+	auto &profiler = QueryProfiler::Get(*this);
+	profiler.StartQuery(query);
+	// Constructor runs UTF-8 validation / Unicode-space strip and can throw — route through
+	// ErrorResult so the source location attaches the same way Peek failures do.
+	optional_ptr<StatementIterator> iterator_ptr;
+	unique_ptr<StatementIterator> iterator_storage;
 	try {
-		statements = ParseStatements(*lock, query);
+		iterator_storage = make_uniq<StatementIterator>(query);
+		iterator_ptr = *iterator_storage;
 	} catch (const std::exception &ex) {
 		return ErrorResult<MaterializedQueryResult>(ErrorData(ex), query);
 	}
-	if (statements.empty()) {
+	auto &iterator = *iterator_ptr;
+
+	auto peek_or_error = [&](bool &has_now) -> unique_ptr<QueryResult> {
+		try {
+			has_now = iterator.Peek(*this);
+			return nullptr;
+		} catch (const std::exception &ex) {
+			return ErrorResult<MaterializedQueryResult>(ErrorData(ex), query);
+		}
+	};
+
+	bool has_current = false;
+	if (auto error = peek_or_error(has_current)) {
+		return error;
+	}
+	if (!has_current) {
 		// no statements, return empty successful result
 		StatementProperties properties;
 		vector<string> names;
@@ -1120,47 +1181,72 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 	unique_ptr<QueryResult> result;
 	optional_ptr<QueryResult> last_result;
 	bool last_had_result = false;
-	for (idx_t i = 0; i < statements.size(); i++) {
-		auto &statement = statements[i];
-		bool is_last_statement = i + 1 == statements.size();
-		PendingQueryParameters parameters;
-		parameters.query_parameters = query_parameters;
-		if (!is_last_statement) {
-			parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	StatementPreprocessor preprocessor(*this);
+	while (has_current) {
+		auto statement = iterator.GetStatement();
+		// PRAGMA reparse / MULTI_STATEMENT unpacking expand into `expanded` one peel at a time.
+		vector<unique_ptr<SQLStatement>> expanded;
+		expanded.push_back(std::move(statement));
+		const CurrentTransactionState transaction_context_state =
+		    transaction.HasActiveTransaction() ? IN_ACTIVE_TRANSACTION : NOT_IN_ACTIVE_TRANSACTION;
+		try {
+			preprocessor.Preprocess(*lock, expanded, transaction_context_state);
+		} catch (const std::exception &ex) {
+			return ErrorResult<MaterializedQueryResult>(ErrorData(ex), query);
 		}
-		auto pending_query = PendingQueryInternal(*lock, std::move(statement), parameters);
-		auto has_result = pending_query->properties.return_type == StatementReturnType::QUERY_RESULT;
-		unique_ptr<QueryResult> current_result;
-		if (pending_query->HasError()) {
-			current_result = ErrorResult<MaterializedQueryResult>(pending_query->GetErrorObject());
-		} else {
-			current_result = ExecutePendingQueryInternal(*lock, *pending_query);
-		}
-		if (current_result->HasError()) {
-			if (transaction.HasActiveTransaction() && transaction.GetAutoRollback()) {
-				transaction.Rollback(current_result->GetErrorObject());
+
+		// Peek ahead; if the next statement fails to parse, defer the error until after we run
+		// what we've already peeled.
+		bool has_next = false;
+		unique_ptr<QueryResult> deferred_parse_error = peek_or_error(has_next);
+
+		for (idx_t i = 0; i < expanded.size(); i++) {
+			bool is_last_in_expansion = i + 1 == expanded.size();
+			bool is_last_overall = is_last_in_expansion && !has_next && !deferred_parse_error;
+			PendingQueryParameters parameters;
+			parameters.query_parameters = query_parameters;
+			if (!is_last_overall) {
+				parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 			}
-			// Reset the interrupted flag, this was set by the task that found the error
-			// Next statements should not be bothered by that interruption
-			interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
-			return current_result;
-		}
-		// now append the result to the list of results
-		if (!last_result || !last_had_result) {
-			// first result of the query
-			result = std::move(current_result);
-			last_result = result.get();
-			last_had_result = has_result;
-		} else {
-			// later results; attach to the result chain
-			// but only if there is a result
-			if (!has_result) {
-				continue;
+			auto pending_query = PendingQueryInternal(*lock, std::move(expanded[i]), parameters);
+			auto has_result = pending_query->properties.return_type == StatementReturnType::QUERY_RESULT;
+			unique_ptr<QueryResult> current_result;
+			if (pending_query->HasError()) {
+				current_result = ErrorResult<MaterializedQueryResult>(pending_query->GetErrorObject());
+			} else {
+				current_result = ExecutePendingQueryInternal(*lock, *pending_query);
 			}
-			last_result->next = std::move(current_result);
-			last_result = last_result->next.get();
+			if (current_result->HasError()) {
+				if (transaction.HasActiveTransaction() && transaction.GetAutoRollback()) {
+					transaction.Rollback(current_result->GetErrorObject());
+				}
+				// Reset the interrupted flag, this was set by the task that found the error
+				// Next statements should not be bothered by that interruption
+				interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
+				return current_result;
+			}
+			// now append the result to the list of results
+			if (!last_result || !last_had_result) {
+				// first result of the query
+				result = std::move(current_result);
+				last_result = result.get();
+				last_had_result = has_result;
+			} else {
+				// later results; attach to the result chain
+				// but only if there is a result
+				if (!has_result) {
+					continue;
+				}
+				last_result->next = std::move(current_result);
+				last_result = last_result->next.get();
+			}
+			D_ASSERT(last_result);
 		}
-		D_ASSERT(last_result);
+
+		if (deferred_parse_error) {
+			return deferred_parse_error;
+		}
+		has_current = has_next;
 	}
 	return result;
 }
@@ -1423,6 +1509,9 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 unordered_set<string> ClientContext::GetTableNames(const string &query, const bool qualified) {
 	auto lock = LockContext();
 
+	// Preprocess before binding so PRAGMA reparse / macro expansion happens up front — GetTableNames
+	// extracts names from the *underlying* query (e.g. `PRAGMA tpch(1)` -> the TPC-H SELECT, whose
+	// tables are what the caller wants). A raw, un-preprocessed PRAGMA would never surface them.
 	auto statements = ParseStatementsInternal(*lock, query);
 	if (statements.size() != 1) {
 		throw InvalidInputException("Expected a single statement");

--- a/src/main/statement_iterator.cpp
+++ b/src/main/statement_iterator.cpp
@@ -1,0 +1,180 @@
+#include "duckdb/main/statement_iterator.hpp"
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/query_profiler.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/parser/peg/matcher.hpp"
+#include "duckdb/parser/peg/tokenizer/parser_tokenizer.hpp"
+#include "duckdb/parser/peg/transformer/parse_result.hpp"
+#include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+
+namespace duckdb {
+
+StatementIterator::StatementIterator(string sql_p, bool preprocess)
+    : sql(std::move(sql_p)), preprocess_on_peek(preprocess) {
+	// Mirror Parser::ParseQuery's up-front normalization: reject invalid UTF-8 (otherwise the
+	// tokenizer can recurse on bad bytes — see ossfuzz clusterfuzz-test-24) and strip non-ASCII
+	// Unicode spaces.
+	Parser::ValidateUTF8Query(sql);
+	string normalized;
+	if (Parser::StripUnicodeSpaces(sql, normalized)) {
+		sql = std::move(normalized);
+	}
+}
+
+StatementIterator::~StatementIterator() = default;
+
+StatementIterator::StatementIterator(StatementIterator &&) noexcept = default;
+StatementIterator &StatementIterator::operator=(StatementIterator &&) noexcept = default;
+
+bool StatementIterator::Peek(ClientContext &context) {
+	// Already buffered from a prior Peek — just report it.
+	if (current_statement) {
+		return true;
+	}
+	// Drain any preprocessed leftovers first.
+	if (preprocess_buffer_cursor < preprocess_buffer.size()) {
+		current_statement = std::move(preprocess_buffer[preprocess_buffer_cursor++]);
+		return true;
+	}
+	if (exhausted) {
+		return false;
+	}
+	// Charge the time spent tokenizing/parsing on this Peek to MetricParserTotalTime so callers
+	// (Query, ParseStatementsInternal, ParseStatementRaw, …) get parse metrics without each
+	// having to remember to wrap us in a timer.
+	auto parser_timer = QueryProfiler::Get(context).StartTimer<MetricParserTotalTime>();
+	auto options = context.GetParserOptions();
+	// On the very first Peek, give `parser_override` extensions a chance to claim the whole
+	// query. If one does, we yield its statements one at a time and skip the PEG path entirely.
+	if (!override_resolved) {
+		override_resolved = true;
+		if (options.extensions) {
+			bool has_strict_extension_error = false;
+			ErrorData last_strict_extension_error;
+			for (auto &ext : options.extensions->ParserExtensions()) {
+				if (!ext.parser_override) {
+					continue;
+				}
+				if (options.parser_override_setting == AllowParserOverride::DEFAULT_OVERRIDE) {
+					continue;
+				}
+				auto result = ext.parser_override(ext.parser_info.get(), sql, options);
+				if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
+					overridden_statements = make_uniq<vector<unique_ptr<SQLStatement>>>(std::move(result.statements));
+					break;
+				}
+				if (options.parser_override_setting == AllowParserOverride::STRICT_OVERRIDE) {
+					if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
+						has_strict_extension_error = true;
+						last_strict_extension_error = std::move(result.error);
+					} else {
+						has_strict_extension_error = false;
+					}
+					continue;
+				}
+			}
+			if (!overridden_statements && options.parser_override_setting == AllowParserOverride::STRICT_OVERRIDE &&
+			    has_strict_extension_error) {
+				last_strict_extension_error.Throw();
+			}
+		}
+	}
+	if (overridden_statements) {
+		if (override_cursor >= overridden_statements->size()) {
+			exhausted = true;
+			return false;
+		}
+		current_statement = std::move((*overridden_statements)[override_cursor++]);
+		return true;
+	}
+	if (!parser) {
+		parser = make_uniq<Parser>(options);
+	}
+	if (!tokens) {
+		// Tokenize the full input once. Subsequent Peek calls walk through `tokens` via
+		// `token_cursor`; we never re-tokenize.
+		tokens = make_uniq<vector<MatcherToken>>();
+		ParserTokenizer tokenizer(sql, *tokens);
+		tokenizer.TokenizeInput();
+	}
+	// Walk the token cursor through the cached `tokens`, calling Parser::ParseTopLevelStatement
+	// repeatedly. A nullptr return with cursor advanced means a separator-only TopLevelStatement
+	// (e.g. between statements or trailing ';'s); we loop past it. A nullptr return with cursor
+	// at end means the input is exhausted.
+	auto at_end_of_real_tokens = [&]() {
+		return token_cursor >= tokens->size() || (*tokens)[token_cursor].type == TokenType::END_OF_INPUT;
+	};
+	while (true) {
+		if (at_end_of_real_tokens()) {
+			exhausted = true;
+			return false;
+		}
+		unique_ptr<SQLStatement> stmt;
+		try {
+			stmt = parser->ParseTopLevelStatement(*tokens, token_cursor);
+		} catch (ParserException &) {
+			// Mirror Parser::ParseQuery's parse_function-extension fallback so extensions like
+			// `quack` can claim a segment that PEG couldn't parse.
+			stmt = parser->TryParseExtensionStatement(*tokens, token_cursor, sql);
+			if (!stmt) {
+				throw;
+			}
+		}
+		if (stmt) {
+			// ParseTopLevelStatement doesn't populate stmt->query (it operates on tokens, not the
+			// source string). Mirror Parser::ParseQuery's per-statement post-processing: span from
+			// the statement's start to the next statement's start (or end of input) so the trailing
+			// `;` and inter-statement whitespace end up inside stmt->query — downstream consumers
+			// (logging, error reporting, EXPLAIN) rely on that shape.
+			idx_t stmt_loc = stmt->stmt_location;
+			idx_t end_loc = sql.size();
+			if (token_cursor < tokens->size() && (*tokens)[token_cursor].type != TokenType::END_OF_INPUT) {
+				end_loc = (*tokens)[token_cursor].offset;
+			}
+			stmt->query = sql.substr(stmt_loc, end_loc - stmt_loc);
+			stmt->stmt_location = 0;
+			stmt->stmt_length = stmt->query.size();
+			if (stmt->type == StatementType::CREATE_STATEMENT) {
+				auto &create = stmt->Cast<CreateStatement>();
+				create.info->sql = stmt->query;
+			}
+			if (preprocess_on_peek) {
+				// Drive PRAGMA reparse / MULTI_STATEMENT unpacking / transaction wrapping. One
+				// peeled statement can expand into multiple; we park the tail in preprocess_buffer
+				// and yield them across subsequent Peek calls.
+				preprocess_buffer.clear();
+				preprocess_buffer_cursor = 0;
+				preprocess_buffer.push_back(std::move(stmt));
+				context.PreprocessStatements(preprocess_buffer);
+				if (preprocess_buffer.empty()) {
+					// Preprocessor swallowed the statement; loop and parse the next.
+					continue;
+				}
+				current_statement = std::move(preprocess_buffer[0]);
+				preprocess_buffer_cursor = 1;
+				return true;
+			}
+			current_statement = std::move(stmt);
+			return true;
+		}
+		if (at_end_of_real_tokens()) {
+			exhausted = true;
+			return false;
+		}
+		// separator-only TLS in the middle of the input — loop and try the next.
+	}
+}
+
+unique_ptr<SQLStatement> StatementIterator::GetStatement() {
+	if (!current_statement) {
+		return nullptr;
+	}
+	return std::move(current_statement);
+}
+
+} // namespace duckdb

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -58,7 +58,7 @@ static bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {
 	return IsValidDollarQuotedStringTagFirstChar(c) || (c >= '0' && c <= '9');
 }
 
-static void ValidateUTF8Query(const string &query) {
+void Parser::ValidateUTF8Query(const string &query) {
 	UnicodeInvalidReason reason = UnicodeInvalidReason::INVALID_UNICODE;
 	size_t invalid_pos = 0;
 	auto unicode_type = Utf8Proc::Analyze(query.c_str(), query.size(), &reason, &invalid_pos);
@@ -221,7 +221,7 @@ void Parser::ThrowParserOverrideError(ParserOverrideResult &result) {
 }
 
 void Parser::ParseQuery(const string &query) {
-	ValidateUTF8Query(query);
+	Parser::ValidateUTF8Query(query);
 	{
 		string new_query;
 		if (StripUnicodeSpaces(query, new_query)) {
@@ -272,53 +272,11 @@ void Parser::ParseQuery(const string &query) {
 				statements.push_back(std::move(stmt));
 			}
 		} catch (ParserException &e) {
-			bool parsed = false;
-			if (options.extensions && options.extensions->HasParserExtensions()) {
-				idx_t failure_byte = token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
-				// SimpleToken view of the tail: text + classified type, in source order, so
-				// extensions can dispatch on the token stream without re-tokenizing. The extension
-				// reports how many of these tokens it consumed.
-				vector<SimpleToken> simple_tokens;
-				simple_tokens.reserve(tokens.size() - token_cursor);
-				for (idx_t i = token_cursor; i < tokens.size(); i++) {
-					simple_tokens.emplace_back(tokens[i].text, tokens[i].type);
-				}
-				for (auto &ext : options.extensions->ParserExtensions()) {
-					if (!ext.parse_function) {
-						continue;
-					}
-					auto result = ext.parse_function(ext.parser_info.get(), simple_tokens);
-					if (result.consumed_tokens < 0) {
-						// The extension wants to surface an error.
-						throw ParserException::SyntaxError(query, result.error, result.error_location);
-					}
-					if (result.consumed_tokens == 0) {
-						// The extension ran but did not claim this input — let the next one try.
-						continue;
-					}
-					// consumed_tokens > 0: the extension accepted that many leading tokens.
-					auto consumed = NumericCast<idx_t>(result.consumed_tokens);
-					if (consumed > simple_tokens.size()) {
-						throw ParserException(
-						    "Extension returned consumed_tokens=%llu — only %llu tokens are available",
-						    (uint64_t)consumed, (uint64_t)simple_tokens.size());
-					}
-					// The claimed span runs from the failure point to the end of the last consumed
-					// token; advancing the cursor by consumed_tokens lands on a token boundary.
-					auto &last_token = tokens[token_cursor + consumed - 1];
-					const idx_t span_end_byte = last_token.offset + last_token.length;
-					auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
-					estmt->stmt_location = failure_byte;
-					estmt->stmt_length = span_end_byte - failure_byte;
-					statements.push_back(std::move(estmt));
-					token_cursor += consumed;
-					parsed = true;
-					break;
-				}
-			}
-			if (!parsed) {
+			auto ext_stmt = TryParseExtensionStatement(tokens, token_cursor, query);
+			if (!ext_stmt) {
 				throw;
 			}
+			statements.push_back(std::move(ext_stmt));
 		}
 	}
 
@@ -337,6 +295,52 @@ void Parser::ParseQuery(const string &query) {
 			}
 		}
 	}
+}
+
+unique_ptr<SQLStatement> Parser::TryParseExtensionStatement(vector<MatcherToken> &tokens, idx_t &token_cursor,
+                                                            const string &query) {
+	if (!options.extensions || !options.extensions->HasParserExtensions()) {
+		return nullptr;
+	}
+	idx_t failure_byte = token_cursor < tokens.size() ? tokens[token_cursor].offset : query.size();
+	// SimpleToken view of the tail: text + classified type, in source order, so extensions can
+	// dispatch on the token stream without re-tokenizing. The extension reports how many of these
+	// tokens it consumed.
+	vector<SimpleToken> simple_tokens;
+	simple_tokens.reserve(tokens.size() - token_cursor);
+	for (idx_t i = token_cursor; i < tokens.size(); i++) {
+		simple_tokens.emplace_back(tokens[i].text, tokens[i].type);
+	}
+	for (auto &ext : options.extensions->ParserExtensions()) {
+		if (!ext.parse_function) {
+			continue;
+		}
+		auto result = ext.parse_function(ext.parser_info.get(), simple_tokens);
+		if (result.consumed_tokens < 0) {
+			// The extension wants to surface an error.
+			throw ParserException::SyntaxError(query, result.error, result.error_location);
+		}
+		if (result.consumed_tokens == 0) {
+			// The extension ran but did not claim this input — let the next one try.
+			continue;
+		}
+		// consumed_tokens > 0: the extension accepted that many leading tokens.
+		auto consumed = NumericCast<idx_t>(result.consumed_tokens);
+		if (consumed > simple_tokens.size()) {
+			throw ParserException("Extension returned consumed_tokens=%llu — only %llu tokens are available",
+			                      (uint64_t)consumed, (uint64_t)simple_tokens.size());
+		}
+		// The claimed span runs from the failure point to the end of the last consumed token;
+		// advancing the cursor by consumed_tokens lands on a token boundary.
+		auto &last_token = tokens[token_cursor + consumed - 1];
+		const idx_t span_end_byte = last_token.offset + last_token.length;
+		auto estmt = make_uniq<ExtensionStatement>(ext, std::move(result.parse_data));
+		estmt->stmt_location = failure_byte;
+		estmt->stmt_length = span_end_byte - failure_byte;
+		token_cursor += consumed;
+		return std::move(estmt);
+	}
+	return nullptr;
 }
 
 unique_ptr<SQLStatement> Parser::ParseTopLevelStatement(vector<MatcherToken> &tokens, idx_t &token_cursor) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_API_OBJECTS
     test_query_profiler.cpp
     test_dbdir.cpp
     test_pending_with_parameters.cpp
+    test_statement_iterator.cpp
     test_progress_bar.cpp
     test_uuid.cpp
     test_insertion_order_preserving_map.cpp

--- a/test/api/test_statement_iterator.cpp
+++ b/test/api/test_statement_iterator.cpp
@@ -1,0 +1,314 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/main/statement_iterator.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+
+using namespace duckdb;
+
+// Drains an iterator into a flat vector of statements for compact assertions.
+static vector<unique_ptr<SQLStatement>> DrainIterator(StatementIterator &it, ClientContext &context) {
+	vector<unique_ptr<SQLStatement>> result;
+	while (it.Peek(context)) {
+		auto stmt = it.GetStatement();
+		REQUIRE(stmt);
+		result.push_back(std::move(stmt));
+	}
+	return result;
+}
+
+// Drives the StatementIterator API end to end. The iterator is constructed via
+// ClientContext::ExtractStatements(sql) and walked with Peek(context) + GetStatement(); these
+// tests assert the basic state machine before we layer chunk-level / Layer-1 awareness on top.
+
+TEST_CASE("StatementIterator: single statement", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1;");
+	REQUIRE(it.Peek(ctx));
+	auto stmt = it.GetStatement();
+	REQUIRE(stmt);
+	REQUIRE(stmt->type == StatementType::SELECT_STATEMENT);
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: empty input yields nothing", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("");
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: whitespace-only input yields nothing", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("   \n\t  ");
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: multiple statements yielded in order", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2; SELECT 3;");
+	int seen = 0;
+	while (it.Peek(ctx)) {
+		auto stmt = it.GetStatement();
+		REQUIRE(stmt);
+		REQUIRE(stmt->type == StatementType::SELECT_STATEMENT);
+		seen++;
+	}
+	REQUIRE(seen == 3);
+}
+
+TEST_CASE("StatementIterator: Peek is idempotent until consumed", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	// Multiple Peeks before GetStatement should keep returning true and not advance.
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.Peek(ctx));
+	auto first = it.GetStatement();
+	REQUIRE(first);
+	REQUIRE(it.Peek(ctx));
+	auto second = it.GetStatement();
+	REQUIRE(second);
+	REQUIRE_FALSE(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: GetStatement without prior Peek", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1;");
+	// First GetStatement without Peek returns nullptr — Peek is the trigger that fills the
+	// buffer. The user is expected to call Peek(ctx) before GetStatement().
+	auto stmt = it.GetStatement();
+	REQUIRE_FALSE(stmt);
+	// After a Peek, the statement becomes available.
+	REQUIRE(it.Peek(ctx));
+	stmt = it.GetStatement();
+	REQUIRE(stmt);
+}
+
+TEST_CASE("StatementIterator: mixed statement types", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("CREATE TABLE t (a INT); INSERT INTO t VALUES (1); SELECT * FROM t;");
+	REQUIRE(it.Peek(ctx));
+	auto s0 = it.GetStatement();
+	REQUIRE(s0);
+	REQUIRE(s0->type == StatementType::CREATE_STATEMENT);
+
+	REQUIRE(it.Peek(ctx));
+	auto s1 = it.GetStatement();
+	REQUIRE(s1);
+	REQUIRE(s1->type == StatementType::INSERT_STATEMENT);
+
+	REQUIRE(it.Peek(ctx));
+	auto s2 = it.GetStatement();
+	REQUIRE(s2);
+	REQUIRE(s2->type == StatementType::SELECT_STATEMENT);
+
+	REQUIRE_FALSE(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: parser errors surface through Peek", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT FROM;");
+	REQUIRE_THROWS(it.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: movable", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	REQUIRE(it.Peek(ctx));
+	auto s0 = it.GetStatement();
+	REQUIRE(s0);
+
+	// Move-construct a new iterator from `it`. The remaining statements should be reachable
+	// through the moved-to iterator.
+	StatementIterator moved(std::move(it));
+	REQUIRE(moved.Peek(ctx));
+	auto s1 = moved.GetStatement();
+	REQUIRE(s1);
+	REQUIRE_FALSE(moved.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: move-assignment", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.GetStatement());
+
+	// Move-assign over a separately constructed iterator. The target's own state is dropped and
+	// the remaining statements from `it` become reachable through it.
+	auto target = ctx.ExtractStatements("SELECT 99;");
+	target = std::move(it);
+	REQUIRE(target.Peek(ctx));
+	auto s1 = target.GetStatement();
+	REQUIRE(s1);
+	REQUIRE(s1->type == StatementType::SELECT_STATEMENT);
+	REQUIRE_FALSE(target.Peek(ctx));
+}
+
+TEST_CASE("StatementIterator: no trailing separator", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	// A final statement without a trailing ';' is still yielded.
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2");
+	auto stmts = DrainIterator(it, ctx);
+	REQUIRE(stmts.size() == 2);
+	REQUIRE(stmts[0]->type == StatementType::SELECT_STATEMENT);
+	REQUIRE(stmts[1]->type == StatementType::SELECT_STATEMENT);
+}
+
+TEST_CASE("StatementIterator: separator-only input yields nothing", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	// A run of nothing but separators is equivalent to empty input — no statements, clean
+	// exhaustion (no throw).
+	auto it = ctx.ExtractStatements(";;;;;;;;;;;");
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}
+
+TEST_CASE("StatementIterator: heavy separators around statements are skipped", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	// Leading, interior and trailing separator runs collapse — exactly the two real statements
+	// come through, in order.
+	auto it = ctx.ExtractStatements(";;;;;;;;;; SELECT 42;;;;;; SELECT 1000;;;;;;;");
+	auto stmts = DrainIterator(it, ctx);
+	REQUIRE(stmts.size() == 2);
+	REQUIRE(stmts[0]->type == StatementType::SELECT_STATEMENT);
+	REQUIRE(stmts[1]->type == StatementType::SELECT_STATEMENT);
+	REQUIRE(StringUtil::Contains(stmts[0]->query, "42"));
+	REQUIRE(StringUtil::Contains(stmts[1]->query, "1000"));
+}
+
+TEST_CASE("StatementIterator: leading separators before a single statement", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements(";;; SELECT 7;");
+	auto stmts = DrainIterator(it, ctx);
+	REQUIRE(stmts.size() == 1);
+	REQUIRE(stmts[0]->type == StatementType::SELECT_STATEMENT);
+	REQUIRE(StringUtil::Contains(stmts[0]->query, "7"));
+}
+
+TEST_CASE("StatementIterator: statement query text is populated and normalized", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1; SELECT 2;");
+	REQUIRE(it.Peek(ctx));
+	auto s0 = it.GetStatement();
+	REQUIRE(s0);
+	// Peek slices stmt->query out of the source and normalizes location/length to span exactly
+	// that slice (location reset to 0, length == query size).
+	REQUIRE_FALSE(s0->query.empty());
+	REQUIRE(StringUtil::Contains(s0->query, "SELECT 1"));
+	REQUIRE_FALSE(StringUtil::Contains(s0->query, "SELECT 2"));
+	REQUIRE(s0->stmt_location == 0);
+	REQUIRE(s0->stmt_length == s0->query.size());
+
+	// The sliced query text round-trips through the parser as a standalone single statement.
+	Parser reparser(ctx.GetParserOptions());
+	reparser.ParseQuery(s0->query);
+	REQUIRE(reparser.statements.size() == 1);
+	REQUIRE(reparser.statements[0]->type == StatementType::SELECT_STATEMENT);
+}
+
+TEST_CASE("StatementIterator: CREATE propagates query into CreateInfo", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("CREATE TABLE t (a INT);");
+	REQUIRE(it.Peek(ctx));
+	auto stmt = it.GetStatement();
+	REQUIRE(stmt);
+	REQUIRE(stmt->type == StatementType::CREATE_STATEMENT);
+	// Peek mirrors Parser::ParseQuery's post-processing: the normalized query is copied into the
+	// CreateInfo so downstream consumers (e.g. catalog `sql` column) see it.
+	auto &create = stmt->Cast<CreateStatement>();
+	REQUIRE(create.info->sql == stmt->query);
+	REQUIRE(StringUtil::Contains(create.info->sql, "CREATE TABLE"));
+}
+
+TEST_CASE("StatementIterator: semicolon inside string literal is not a separator", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	// The ';' lives inside a single-quoted string, so it must not split the statement.
+	auto it = ctx.ExtractStatements("SELECT 'a;b;c' AS x;");
+	auto stmts = DrainIterator(it, ctx);
+	REQUIRE(stmts.size() == 1);
+	REQUIRE(stmts[0]->type == StatementType::SELECT_STATEMENT);
+}
+
+TEST_CASE("StatementIterator: comments between statements are skipped", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("/* block */ SELECT 1; -- line comment\nSELECT 2;");
+	auto stmts = DrainIterator(it, ctx);
+	REQUIRE(stmts.size() == 2);
+	REQUIRE(stmts[0]->type == StatementType::SELECT_STATEMENT);
+	REQUIRE(stmts[1]->type == StatementType::SELECT_STATEMENT);
+}
+
+TEST_CASE("StatementIterator: exhaustion is sticky across repeated Peek", "[api][statement_iterator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &ctx = *con.context;
+
+	auto it = ctx.ExtractStatements("SELECT 1;");
+	REQUIRE(it.Peek(ctx));
+	REQUIRE(it.GetStatement());
+	// Once drained, every subsequent Peek stays false — no re-parsing, no resurrection.
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.Peek(ctx));
+	REQUIRE_FALSE(it.GetStatement());
+}

--- a/test/sql/settings/errors_as_json.test
+++ b/test/sql/settings/errors_as_json.test
@@ -18,7 +18,7 @@ COLUMN_NOT_FOUND
 statement error
 SECT cbl FROM (VALUES (42)) t(col)
 ----
-<REGEX>:.*Parser Error.*syntax error at or near.*
+SYNTAX_ERROR
 
 statement error
 select corr('hello'::VARCHAR, 'world'::VARCHAR)

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -990,8 +990,9 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 SuccessState ShellState::ExecuteSQL(const string &zSql) {
 	auto &con = *conn;
 	try {
-		auto statements = con.ExtractStatements(zSql);
-		for (auto &statement : statements) {
+		auto iterator = con.context->ExtractStatements(zSql);
+		while (iterator.Peek(*con.context)) {
+			auto statement = iterator.GetStatement();
 			idx_t start_pos = statement->stmt_location;
 			idx_t len = statement->stmt_length;
 			while (len > 0 && IsSpace(zSql[start_pos])) {
@@ -1022,6 +1023,7 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 		} /* end while */
 	} catch (std::exception &ex) {
 		duckdb::ErrorData error(ex);
+		error.AddErrorLocation(zSql);
 		PrintDatabaseError(error.Message());
 		return SuccessState::FAILURE;
 	}


### PR DESCRIPTION
Stacked on top of https://github.com/duckdb/duckdb/pull/23032, only last commit is relevant.

This allows a given `query` string to be unpacked into multiple statements, extracted and executed one at a time, that means that for example the state of the parser might change.

Example:
```
carlo@MacBook-Pro-2 duckdb-stable % ./build/release/duckdb -unsigned
DuckDB v1.6.0-dev8256 (Development Version, 4523194c2f)
Enter ".help" for usage hints.
memory D QUACK quack quack;
Parser Error:
syntax error at or near "quack"

LINE 1: QUACK quack quack;
              ^
memory D LOAD './build/release/test/extension/loadable_extension_demo.duckdb_extension'; QUACK quack quack;
┌─────────┐
│  quack  │
│ varchar │
├─────────┤
│ QUACK   │
│ QUACK   │
│ QUACK   │
└─────────┘
memory D 
memory D 
```

Where `LOAD loadable_extension_demo.duckdb_extension` changes to the parser are directly visible in the same statement.