### PR TITLE
Rename emscripten action in main

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -443,7 +443,7 @@ jobs:
       with:
         ref: ${{ needs.prepare.outputs.git_sha }}
 
-    - uses: mymindstorm/setup-emsdk@v16
+    - uses: emscripten-core/setup-emsdk@v16
       with:
         version: latest
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -556,7 +556,7 @@ jobs:
     needs: check-draft
     runs-on: ubuntu-22.04
     steps:
-    - uses: mymindstorm/setup-emsdk@v16
+    - uses: emscripten-core/setup-emsdk@v16
       with:
         version: 'latest'
 


### PR DESCRIPTION
The emscripten action has been [renamed](https://github.com/emscripten-core/setup-emsdk/issues/61).

Namespace runners have action caching so that could be the reason why we're not seeing similar errors in CI.

Related PR: https://github.com/duckdb/extension-ci-tools/pull/381.

Backports:
- https://github.com/duckdb/duckdb/pull/23043
- https://github.com/duckdb/duckdb/pull/23044