### PR TITLE
Rename emscripten action in v1.5

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -569,7 +569,7 @@ jobs:
     needs: check-draft
     runs-on: ubuntu-22.04
     steps:
-    - uses: mymindstorm/setup-emsdk@v12
+    - uses: emscripten-core/setup-emsdk@v12
       with:
         version: 'latest'
 


### PR DESCRIPTION
The emscripten action has been [renamed](https://github.com/emscripten-core/setup-emsdk/issues/61).

Namespace runners have action caching so that could be the reason why we're not seeing similar errors in CI.

Related PR: https://github.com/duckdb/extension-ci-tools/pull/381.

See also:
- https://github.com/duckdb/duckdb/pull/23043
- https://github.com/duckdb/duckdb/pull/23045