### PR TITLE
Isolate .tmp/ to avoid concurrent test temp-spill data corruption

### DIFF
--- a/test/sql/json/test_json_copy_tpch.test_slow
+++ b/test/sql/json/test_json_copy_tpch.test_slow
@@ -10,6 +10,9 @@ statement ok
 set threads=4
 
 statement ok
+PRAGMA temp_directory='{TEST_DIR}/json_copy_tpch.tmp'
+
+statement ok
 start transaction
 
 statement ok

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -677,6 +677,16 @@ void add_env_tag(vector<string> &tags, const string &name, const string *value =
 	}
 }
 
+void SQLLogicTestRunner::ConfigureDefaultInMemoryTemporaryDirectory(const string &script) {
+	if (!dbpath.empty() || !config->options.use_temporary_directory || config->options.temporary_directory != ".tmp") {
+		return;
+	}
+	auto normalized_script = StringUtil::Replace(script, "\\", "/");
+	auto temp_directory_name = StringUtil::Replace(normalized_script, "/", "_");
+	auto temp_directory = TestJoinPath(TestJoinPath(TestDirectoryPath(), "sqllogic_temp"), temp_directory_name);
+	config->SetOptionByName("temp_directory", temp_directory);
+}
+
 void SQLLogicTestRunner::ExecuteFile(string script) {
 	auto &test_config = TestConfiguration::Get();
 	if (test_config.ShouldSkipTest(script)) {
@@ -709,6 +719,10 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 	for (auto ignore : test_config.ErrorMessagesToBeSkipped()) {
 		ignore_error_messages.insert(ignore);
 	}
+
+	// In-memory sqllogictests otherwise share ".tmp" across unittest processes.
+	// Give each script its own spill directory under the per-process TEST_DIR.
+	ConfigureDefaultInMemoryTemporaryDirectory(script);
 
 	// initialize the database with the default dbpath
 	LoadDatabase(dbpath, true);

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -112,6 +112,7 @@ public:
 
 private:
 	RequireResult CheckRequire(SQLLogicParser &parser, const vector<string> &params);
+	void ConfigureDefaultInMemoryTemporaryDirectory(const string &script);
 	static void AddSkipReason(const string &reason);
 
 private:


### PR DESCRIPTION
I see random [failures](https://github.com/duckdb/duckdb/actions/runs/26892372539/job/79328374405#step:7:16) in CI related to temp spill files:
```
retrying failed test test/sql/json/test_json_copy_tpch.test_slow (attempt 1/2, retry 1/4)
..
error: FAIL test/sql/json/test_json_copy_tpch.test_slow

1. test/sql/json/test_json_copy_tpch.test_slow:53
================================================================================

Error: Query unexpectedly failed! (test/sql/json/test_json_copy_tpch.test_slow:53)!
================================================================================
COPY lineitem TO 'duckdb_unittest_tempdir/189284/lineitem.json.gz';
================================================================================
IO Error: Could not read enough bytes from file ".tmp/duckdb_temp_storage_DEFAULT-0.tmp": attempted to read 262144 bytes from location 4980736

====================================================
================  FAILURES SUMMARY  ================
====================================================


1. test/sql/json/test_json_copy_tpch.test_slow:53
================================================================================
Query unexpectedly failed! (test/sql/json/test_json_copy_tpch.test_slow:53)!
================================================================================
COPY lineitem TO 'duckdb_unittest_tempdir/189284/lineitem.json.gz';
================================================================================
IO Error: Could not read enough bytes from file ".tmp/duckdb_temp_storage_DEFAULT-0.tmp": attempted to read 262144 bytes from location 4980736

recovered: passed on retry 1/2

reproduce:
build/release/test/unittest test/sql/json/test_json_copy_tpch.test_slow
```

In CI, different test processes can spill to the same `duckdb_temp_storage_*` files. That corrupts temp data, which showed up here as short reads from `.tmp/duckdb_temp_storage_DEFAULT-0.tmp` and sometimes as bad query results earlier in the test.

I think we can fix this by not sharing that spill location. So, change the shared default `.tmp` to a per-script temp directory under that process’s test temp root. 

We still allow tests to override this `temp_directory` (and that breaks test isolation, unfortunately).