### PR TITLE
use StringUtil::CharacterToLower in strptime parser

### DIFF
--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -810,7 +810,7 @@ int32_t StrpTimeFormat::TryParseCollection(const char *data, idx_t &pos, idx_t s
 		// compare the characters
 		idx_t i;
 		for (i = 0; i < entry_size; i++) {
-			if (std::tolower(entry_data[i]) != std::tolower(data[pos + i])) {
+			if (StringUtil::CharacterToLower(entry_data[i]) != StringUtil::CharacterToLower(data[pos + i])) {
 				break;
 			}
 		}
@@ -1243,8 +1243,8 @@ bool StrpTimeFormat::Parse(const char *data, size_t size, ParseResult &result, b
 					error_position = pos;
 					return false;
 				}
-				char pa_char = char(std::tolower(data[pos]));
-				char m_char = char(std::tolower(data[pos + 1]));
+				char pa_char = StringUtil::CharacterToLower(data[pos]);
+				char m_char = StringUtil::CharacterToLower(data[pos + 1]);
 				if (m_char != 'm') {
 					error_message = "Expected AM/PM";
 					error_position = pos;

--- a/test/sql/function/timestamp/test_strptime_nonascii.test
+++ b/test/sql/function/timestamp/test_strptime_nonascii.test
@@ -1,0 +1,27 @@
+# name: test/sql/function/timestamp/test_strptime_nonascii.test
+# description: strptime with non-ascii bytes in the input string
+# group: [timestamp]
+
+# non-ascii bytes reaching the %B month-name lookup must not match and must not be UB
+query I
+SELECT try_strptime('21 Jüne, 2018', '%d %B, %Y')
+----
+NULL
+
+# non-ascii byte reaching the %A day-name lookup
+query I
+SELECT try_strptime('Mänday', '%A')
+----
+NULL
+
+# non-ascii byte reaching the %p AM/PM lookup
+query I
+SELECT try_strptime('10 äm', '%I %p')
+----
+NULL
+
+# a valid ascii month name still parses after the fix
+query I
+SELECT try_strptime('21 June, 2018', '%d %B, %Y')
+----
+2018-06-21 00:00:00


### PR DESCRIPTION
the strptime parser passes a raw signed char to std::tolower when matching month/day names in TryParseCollection (%B/%A/%a/%b) and the AM/PM branch (%p). data is the untrusted first argument to strptime/try_strptime, so any non-ascii byte (e.g. ä) reaches tolower as a negative value, which is undefined behavior per STR37-C and locale-dependent. switch to StringUtil::CharacterToLower, the ascii range check already used across src/common/types.