### PR TITLE
Add `CATALOG_MODE` and `CONNECT_MODE` attach options

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1192,7 +1192,7 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 	auto &db_manager = DatabaseManager::Get(context);
 	auto databases = db_manager.GetDatabases(context);
 	for (auto &database : databases) {
-		if (database->GetVisibility() == AttachVisibility::HIDDEN) {
+		if (database->IsHidden()) {
 			continue;
 		}
 		auto &catalog = database->GetCatalog();

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -93,6 +93,11 @@ optional_ptr<Catalog> Catalog::GetCatalogEntry(CatalogEntryRetriever &retriever,
 	if (!entry) {
 		return nullptr;
 	}
+	if (entry->GetCatalogMode() == CatalogMode::NONE) {
+		// CATALOG_MODE NONE: catalog provides no tables and is unreachable from binding.
+		// Treat as if the catalog doesn't exist for lookup purposes (reads + writes both fail).
+		return nullptr;
+	}
 	return &entry->GetCatalog();
 }
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1376,6 +1376,25 @@ ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value)
 	return static_cast<ConflictManagerMode>(StringUtil::StringToEnum(GetConflictManagerModeValues(), 2, "ConflictManagerMode", value));
 }
 
+const StringUtil::EnumStringLiteral *GetConnectModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ConnectMode::NONE), "NONE" },
+		{ static_cast<uint32_t>(ConnectMode::AUTO), "AUTO" },
+		{ static_cast<uint32_t>(ConnectMode::ENABLE), "ENABLE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ConnectMode>(ConnectMode value) {
+	return StringUtil::EnumToString(GetConnectModeValues(), 3, "ConnectMode", static_cast<uint32_t>(value));
+}
+
+template<>
+ConnectMode EnumUtil::FromString<ConnectMode>(const char *value) {
+	return static_cast<ConnectMode>(StringUtil::StringToEnum(GetConnectModeValues(), 3, "ConnectMode", value));
+}
+
 const StringUtil::EnumStringLiteral *GetConstraintTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(ConstraintType::INVALID), "INVALID" },

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1052,6 +1052,26 @@ CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *va
 	return static_cast<CatalogLookupBehavior>(StringUtil::StringToEnum(GetCatalogLookupBehaviorValues(), 3, "CatalogLookupBehavior", value));
 }
 
+const StringUtil::EnumStringLiteral *GetCatalogModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(CatalogMode::NONE), "NONE" },
+		{ static_cast<uint32_t>(CatalogMode::AUTO), "AUTO" },
+		{ static_cast<uint32_t>(CatalogMode::HIDDEN), "HIDDEN" },
+		{ static_cast<uint32_t>(CatalogMode::ENABLE), "ENABLE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<CatalogMode>(CatalogMode value) {
+	return StringUtil::EnumToString(GetCatalogModeValues(), 4, "CatalogMode", static_cast<uint32_t>(value));
+}
+
+template<>
+CatalogMode EnumUtil::FromString<CatalogMode>(const char *value) {
+	return static_cast<CatalogMode>(StringUtil::StringToEnum(GetCatalogModeValues(), 4, "CatalogMode", value));
+}
+
 const StringUtil::EnumStringLiteral *GetCatalogTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(CatalogType::INVALID), "INVALID" },

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -252,6 +252,7 @@ AttachedDatabase &DuckDBReader::GetAttachedDatabase() {
 		info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 		unordered_map<string, Value> attach_kv;
 		AttachOptions attach_options(attach_kv, AccessMode::READ_ONLY);
+		attach_options.catalog_mode = CatalogMode::HIDDEN;
 		attach_options.visibility = AttachVisibility::HIDDEN;
 
 		auto attached = db_manager.AttachDatabase(context, info, attach_options);

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -253,7 +253,6 @@ AttachedDatabase &DuckDBReader::GetAttachedDatabase() {
 		unordered_map<string, Value> attach_kv;
 		AttachOptions attach_options(attach_kv, AccessMode::READ_ONLY);
 		attach_options.catalog_mode = CatalogMode::HIDDEN;
-		attach_options.visibility = AttachVisibility::HIDDEN;
 
 		auto attached = db_manager.AttachDatabase(context, info, attach_options);
 		db_wrapper = make_shared_ptr<AttachedDatabaseWrapper>(context, std::move(attached));

--- a/src/function/table/system/duckdb_databases.cpp
+++ b/src/function/table/system/duckdb_databases.cpp
@@ -96,7 +96,7 @@ void DuckDBDatabasesFunction(ClientContext &context, TableFunctionInput &data_p,
 		auto &entry = data.entries[data.offset++];
 		auto &attached = *entry;
 		auto &catalog = attached.GetCatalog();
-		if (attached.GetVisibility() == AttachVisibility::HIDDEN) {
+		if (attached.IsHidden()) {
 			continue;
 		}
 

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -146,6 +146,8 @@ enum class CompressionValidity : uint8_t;
 
 enum class ConflictManagerMode : uint8_t;
 
+enum class ConnectMode : uint8_t;
+
 enum class ConstraintType : uint8_t;
 
 enum class CoordinateReferenceSystemType : uint8_t;
@@ -727,6 +729,9 @@ const char* EnumUtil::ToChars<CompressionValidity>(CompressionValidity value);
 
 template<>
 const char* EnumUtil::ToChars<ConflictManagerMode>(ConflictManagerMode value);
+
+template<>
+const char* EnumUtil::ToChars<ConnectMode>(ConnectMode value);
 
 template<>
 const char* EnumUtil::ToChars<ConstraintType>(ConstraintType value);
@@ -1514,6 +1519,9 @@ CompressionValidity EnumUtil::FromString<CompressionValidity>(const char *value)
 
 template<>
 ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value);
+
+template<>
+ConnectMode EnumUtil::FromString<ConnectMode>(const char *value);
 
 template<>
 ConstraintType EnumUtil::FromString<ConstraintType>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -116,6 +116,8 @@ enum class CachingMode : uint8_t;
 
 enum class CatalogLookupBehavior : uint8_t;
 
+enum class CatalogMode : uint8_t;
+
 enum class CatalogType : uint8_t;
 
 enum class CheckpointAbort : uint8_t;
@@ -680,6 +682,9 @@ const char* EnumUtil::ToChars<CachingMode>(CachingMode value);
 
 template<>
 const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value);
+
+template<>
+const char* EnumUtil::ToChars<CatalogMode>(CatalogMode value);
 
 template<>
 const char* EnumUtil::ToChars<CatalogType>(CatalogType value);
@@ -1464,6 +1469,9 @@ CachingMode EnumUtil::FromString<CachingMode>(const char *value);
 
 template<>
 CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *value);
+
+template<>
+CatalogMode EnumUtil::FromString<CatalogMode>(const char *value);
 
 template<>
 CatalogType EnumUtil::FromString<CatalogType>(const char *value);

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -163,6 +163,11 @@ public:
 	CatalogMode GetCatalogMode() const {
 		return catalog_mode;
 	}
+	//! True when the database does not appear in catalog enumeration (HIDDEN, or NONE which has
+	//! no tables to expose anyway).
+	bool IsHidden() const {
+		return catalog_mode == CatalogMode::HIDDEN || catalog_mode == CatalogMode::NONE;
+	}
 	ConnectMode GetConnectMode() const {
 		return connect_mode;
 	}

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -29,8 +29,6 @@ enum class AttachedDatabaseType {
 	TEMP_DATABASE,
 };
 
-enum class AttachVisibility { SHOWN, HIDDEN };
-
 //! Controls whether the attached database provides any tables, and whether it surfaces in
 //! catalog enumeration (`SHOW DATABASES`, schema enumeration, etc).
 //!  - NONE:   no tables, not surfaced. Pure routing target (used by `CONNECT '<uri>'`).
@@ -90,8 +88,6 @@ struct AttachOptions {
 	QualifiedName default_table;
 	//! Whether this is the main database.
 	bool is_main_database = false;
-	//! The visibility of the attached database
-	AttachVisibility visibility = AttachVisibility::SHOWN;
 	//! Whether the attached database provides tables, and whether it surfaces in catalog
 	//! enumeration. Defaults to AUTO (backend's choice; today equivalent to ENABLE for all
 	//! current backends).
@@ -154,9 +150,6 @@ public:
 	RecoveryMode GetRecoveryMode() const {
 		return recovery_mode;
 	}
-	AttachVisibility GetVisibility() const {
-		return visibility;
-	}
 	//! vacuum_rebuild_indexes threshold for this attached database.
 	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
 	idx_t GetVacuumRebuildIndexThreshold() const;
@@ -191,7 +184,6 @@ private:
 	optional_ptr<Catalog> parent_catalog;
 	optional_ptr<StorageExtension> storage_extension;
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;
-	AttachVisibility visibility = AttachVisibility::SHOWN;
 	CatalogMode catalog_mode = CatalogMode::AUTO;
 	ConnectMode connect_mode = ConnectMode::AUTO;
 	bool is_initial_database = false;

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -31,6 +31,14 @@ enum class AttachedDatabaseType {
 
 enum class AttachVisibility { SHOWN, HIDDEN };
 
+//! Controls whether the attached database provides any tables, and whether it surfaces in
+//! catalog enumeration (`SHOW DATABASES`, schema enumeration, etc).
+//!  - NONE:   no tables, not surfaced. Pure routing target (used by `CONNECT '<uri>'`).
+//!  - AUTO:   backend's default. For all current backends this is equivalent to ENABLE.
+//!  - HIDDEN: provides tables (asserted, same as ENABLE) but not surfaced in enumeration.
+//!  - ENABLE: provides tables (asserted); surfaced normally. Errors if backend can't.
+enum class CatalogMode : uint8_t { NONE, AUTO, HIDDEN, ENABLE };
+
 //! DEFAULT is the standard ACID crash recovery mode.
 //! NO_WAL_WRITES disables the WAL for the attached database, i.e., disabling the D in ACID.
 //! Use this mode with caution, as it disables recovery from crashes for the file.
@@ -77,6 +85,10 @@ struct AttachOptions {
 	bool is_main_database = false;
 	//! The visibility of the attached database
 	AttachVisibility visibility = AttachVisibility::SHOWN;
+	//! Whether the attached database provides tables, and whether it surfaces in catalog
+	//! enumeration. Defaults to AUTO (backend's choice; today equivalent to ENABLE for all
+	//! current backends).
+	CatalogMode catalog_mode = CatalogMode::AUTO;
 	//! The stored database path (in the path manager)
 	unique_ptr<StoredDatabasePath> stored_database_path;
 	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
@@ -138,6 +150,9 @@ public:
 	//! vacuum_rebuild_indexes threshold for this attached database.
 	//! Falls back to the global VacuumRebuildIndexesSetting if not overridden.
 	idx_t GetVacuumRebuildIndexThreshold() const;
+	CatalogMode GetCatalogMode() const {
+		return catalog_mode;
+	}
 	const unordered_map<string, Value> &GetAttachOptions() const {
 		return attach_options;
 	}
@@ -159,6 +174,7 @@ private:
 	optional_ptr<StorageExtension> storage_extension;
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;
 	AttachVisibility visibility = AttachVisibility::SHOWN;
+	CatalogMode catalog_mode = CatalogMode::AUTO;
 	bool is_initial_database = false;
 	bool is_closed = false;
 	shared_ptr<mutex> close_lock;

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -39,6 +39,13 @@ enum class AttachVisibility { SHOWN, HIDDEN };
 //!  - ENABLE: provides tables (asserted); surfaced normally. Errors if backend can't.
 enum class CatalogMode : uint8_t { NONE, AUTO, HIDDEN, ENABLE };
 
+//! Controls whether the attached database accepts `CONNECT`.
+//!  - NONE:   explicitly disabled — `CONNECT` to this catalog errors, even if backend supports it.
+//!  - AUTO:   backend's default — checked via `Supports(RemoteCapability::CONNECT)`.
+//!  - ENABLE: explicitly required — `CONNECT` is allowed; if backend doesn't support it, the
+//!            ATTACH itself errors so the user finds out at attach time rather than at first use.
+enum class ConnectMode : uint8_t { NONE, AUTO, ENABLE };
+
 //! DEFAULT is the standard ACID crash recovery mode.
 //! NO_WAL_WRITES disables the WAL for the attached database, i.e., disabling the D in ACID.
 //! Use this mode with caution, as it disables recovery from crashes for the file.
@@ -89,6 +96,9 @@ struct AttachOptions {
 	//! enumeration. Defaults to AUTO (backend's choice; today equivalent to ENABLE for all
 	//! current backends).
 	CatalogMode catalog_mode = CatalogMode::AUTO;
+	//! Whether `CONNECT` to this attached database is allowed. Defaults to AUTO (the
+	//! backend's `Supports(RemoteCapability::CONNECT)` declaration decides).
+	ConnectMode connect_mode = ConnectMode::AUTO;
 	//! The stored database path (in the path manager)
 	unique_ptr<StoredDatabasePath> stored_database_path;
 	//! Per-database override of vacuum_rebuild_indexes. If not set, the global setting value is used.
@@ -153,6 +163,9 @@ public:
 	CatalogMode GetCatalogMode() const {
 		return catalog_mode;
 	}
+	ConnectMode GetConnectMode() const {
+		return connect_mode;
+	}
 	const unordered_map<string, Value> &GetAttachOptions() const {
 		return attach_options;
 	}
@@ -175,6 +188,7 @@ private:
 	RecoveryMode recovery_mode = RecoveryMode::DEFAULT;
 	AttachVisibility visibility = AttachVisibility::SHOWN;
 	CatalogMode catalog_mode = CatalogMode::AUTO;
+	ConnectMode connect_mode = ConnectMode::AUTO;
 	bool is_initial_database = false;
 	bool is_closed = false;
 	shared_ptr<mutex> close_lock;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -86,8 +86,20 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 		}
 
 		if (entry.first == "hidden") {
+			// Legacy bool shorthand; CATALOG_MODE HIDDEN is the new form. Keep both so existing
+			// ATTACH ... (HIDDEN) keeps working — it just sets catalog_mode under the hood.
 			auto is_hidden = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
 			if (is_hidden) {
+				visibility = AttachVisibility::HIDDEN;
+				catalog_mode = CatalogMode::HIDDEN;
+			}
+			continue;
+		}
+
+		if (entry.first == "catalog_mode") {
+			auto mode_str = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
+			catalog_mode = EnumUtil::FromString<CatalogMode>(mode_str);
+			if (catalog_mode == CatalogMode::HIDDEN || catalog_mode == CatalogMode::NONE) {
 				visibility = AttachVisibility::HIDDEN;
 			}
 			continue;
@@ -140,6 +152,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	catalog_mode = options.catalog_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
@@ -162,6 +175,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	}
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
+	catalog_mode = options.catalog_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -104,7 +104,11 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 			}
 			continue;
 		}
-
+		if (entry.first == "connect_mode") {
+			auto mode_str = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
+			connect_mode = EnumUtil::FromString<ConnectMode>(mode_str);
+			continue;
+		}
 		if (entry.first == "vacuum_rebuild_indexes") {
 			const auto threshold = UBigIntValue::Get(entry.second.DefaultCastAs(LogicalType::UBIGINT));
 			try {
@@ -153,6 +157,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
 	catalog_mode = options.catalog_mode;
+	connect_mode = options.connect_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
@@ -162,6 +167,13 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
 	attach_options = options.options;
 	internal = true;
+	// DuckCatalog doesn't support CONNECT; resolve AUTO to NONE here, error on ENABLE.
+	if (connect_mode == ConnectMode::AUTO) {
+		connect_mode = catalog->Supports(RemoteCapability::CONNECT) ? ConnectMode::ENABLE : ConnectMode::NONE;
+	} else if (connect_mode == ConnectMode::ENABLE && !catalog->Supports(RemoteCapability::CONNECT)) {
+		throw InvalidInputException("ATTACH ... (CONNECT_MODE ENABLE): database \"%s\" does not support CONNECT",
+		                            name);
+	}
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension_p,
@@ -176,6 +188,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	recovery_mode = options.recovery_mode;
 	visibility = options.visibility;
 	catalog_mode = options.catalog_mode;
+	connect_mode = options.connect_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
@@ -183,6 +196,14 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 	stored_database_path = std::move(options.stored_database_path);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
+	}
+	// Resolve CONNECT_MODE against the backend's capability so downstream checks read a single
+	// boolean off connect_mode rather than re-querying Supports(CONNECT). AUTO becomes ENABLE when
+	// the backend supports CONNECT, NONE otherwise.
+	if (connect_mode == ConnectMode::AUTO) {
+		connect_mode = catalog->Supports(RemoteCapability::CONNECT) ? ConnectMode::ENABLE : ConnectMode::NONE;
+	} else if (connect_mode == ConnectMode::ENABLE && !catalog->Supports(RemoteCapability::CONNECT)) {
+		throw InvalidInputException("ATTACH ... (CONNECT_MODE ENABLE): database \"%s\" does not support CONNECT", name);
 	}
 	if (catalog->IsDuckCatalog()) {
 		// The attached database uses the DuckCatalog.

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -356,7 +356,7 @@ void AttachedDatabase::OnDetach(ClientContext &context) {
 	if (catalog) {
 		catalog->OnDetach(context);
 	}
-	if (stored_database_path && visibility != AttachVisibility::HIDDEN) {
+	if (stored_database_path && !IsHidden()) {
 		stored_database_path->OnDetach();
 	}
 }

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -180,8 +180,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	if (connect_mode == ConnectMode::AUTO) {
 		connect_mode = catalog->Supports(RemoteCapability::CONNECT) ? ConnectMode::ENABLE : ConnectMode::NONE;
 	} else if (connect_mode == ConnectMode::ENABLE && !catalog->Supports(RemoteCapability::CONNECT)) {
-		throw InvalidInputException("ATTACH ... (CONNECT_MODE ENABLE): database \"%s\" does not support CONNECT",
-		                            name);
+		throw InvalidInputException("ATTACH ... (CONNECT_MODE ENABLE): database \"%s\" does not support CONNECT", name);
 	}
 }
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -42,6 +42,9 @@ AttachOptions::AttachOptions(const DBConfigOptions &options)
 
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)
     : access_mode(default_access_mode) {
+	// Local capture of the legacy `(HIDDEN)` option; reconciled with catalog_mode below so each
+	// individual setter stays single-purpose.
+	CatalogMode catalog_mode_hidden = CatalogMode::AUTO;
 	for (auto &entry : attach_options) {
 		if (entry.first == "readonly" || entry.first == "read_only") {
 			// Extract the read access mode.
@@ -86,12 +89,9 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 		}
 
 		if (entry.first == "hidden") {
-			// Legacy bool shorthand; CATALOG_MODE HIDDEN is the new form. Keep both so existing
-			// ATTACH ... (HIDDEN) keeps working — it just sets catalog_mode under the hood.
 			auto is_hidden = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
 			if (is_hidden) {
-				visibility = AttachVisibility::HIDDEN;
-				catalog_mode = CatalogMode::HIDDEN;
+				catalog_mode_hidden = CatalogMode::HIDDEN;
 			}
 			continue;
 		}
@@ -99,9 +99,6 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 		if (entry.first == "catalog_mode") {
 			auto mode_str = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
 			catalog_mode = EnumUtil::FromString<CatalogMode>(mode_str);
-			if (catalog_mode == CatalogMode::HIDDEN || catalog_mode == CatalogMode::NONE) {
-				visibility = AttachVisibility::HIDDEN;
-			}
 			continue;
 		}
 		if (entry.first == "connect_mode") {
@@ -121,6 +118,19 @@ AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options,
 			continue;
 		}
 		options.emplace(entry.first, entry.second);
+	}
+
+	// Reconciliation: fold the legacy `(HIDDEN)` signal into catalog_mode. Conflict semantics:
+	//  - (HIDDEN) + CATALOG_MODE ENABLE       -> error (user asked to both hide and assert tables-shown)
+	//  - (HIDDEN) + CATALOG_MODE AUTO         -> promote catalog_mode to HIDDEN
+	//  - (HIDDEN) + CATALOG_MODE HIDDEN/NONE  -> consistent, no-op
+	if (catalog_mode_hidden == CatalogMode::HIDDEN) {
+		if (catalog_mode == CatalogMode::ENABLE) {
+			throw BinderException("ATTACH: HIDDEN option cannot be combined with CATALOG_MODE ENABLE");
+		}
+		if (catalog_mode == CatalogMode::AUTO) {
+			catalog_mode = CatalogMode::HIDDEN;
+		}
 	}
 }
 
@@ -155,7 +165,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 		type = AttachedDatabaseType::READ_WRITE_DATABASE;
 	}
 	recovery_mode = options.recovery_mode;
-	visibility = options.visibility;
 	catalog_mode = options.catalog_mode;
 	connect_mode = options.connect_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;
@@ -186,7 +195,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		type = AttachedDatabaseType::READ_WRITE_DATABASE;
 	}
 	recovery_mode = options.recovery_mode;
-	visibility = options.visibility;
 	catalog_mode = options.catalog_mode;
 	connect_mode = options.connect_mode;
 	vacuum_rebuild_threshold = options.vacuum_rebuild_indexes_threshold;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -223,10 +223,9 @@ unique_ptr<ClientContextLock> ClientContext::LockContext() {
 
 void ClientContext::ConnectToCatalog(const shared_ptr<AttachedDatabase> &target) {
 	D_ASSERT(target);
-	// Pre-flight: Supports(RemoteCapability::CONNECT) is the capability declaration; catalogs that
-	// return true MUST implement RemoteExecute(string). Validation runs before mutation so a throw
-	// leaves the client unbound.
-	if (!target->GetCatalog().Supports(RemoteCapability::CONNECT)) {
+	// connect_mode is resolved at attach time (AUTO -> ENABLE/NONE based on backend's Supports()),
+	// so a single boolean check covers both the per-attachment policy and the backend capability.
+	if (target->GetConnectMode() != ConnectMode::ENABLE) {
 		throw InvalidInputException("Database \"%s\" does not support CONNECT", target->GetName());
 	}
 	connected_to_database = target;

--- a/test/sql/catalog/attach_catalog_mode.test
+++ b/test/sql/catalog/attach_catalog_mode.test
@@ -4,6 +4,8 @@
 
 # Baseline: regular ATTACH — table is reachable, db is listed.
 
+require vector_size 2048
+
 statement ok
 ATTACH 'data/storage/wal_test_092.db' AS t (READ_ONLY);
 

--- a/test/sql/catalog/attach_catalog_mode.test
+++ b/test/sql/catalog/attach_catalog_mode.test
@@ -1,0 +1,126 @@
+# name: test/sql/catalog/attach_catalog_mode.test
+# description: CATALOG_MODE option on ATTACH. NONE makes tables unreachable; HIDDEN hides
+#              the database from enumeration but keeps tables queryable.
+# group: [catalog]
+
+# Baseline: regular ATTACH — table is reachable, db is listed.
+
+statement ok
+ATTACH 'data/storage/wal_test_092.db' AS t (READ_ONLY);
+
+query I
+SELECT i FROM t.main.integers ORDER BY i LIMIT 3;
+----
+0
+1
+2
+
+query I
+SELECT count(*) FROM duckdb_databases() WHERE database_name = 't';
+----
+1
+
+statement ok
+DETACH t;
+
+# CATALOG_MODE NONE — table not reachable, db not listed.
+
+statement ok
+ATTACH 'data/storage/wal_test_092.db' AS t (READ_ONLY, CATALOG_MODE NONE);
+
+# Reads against the catalog must fail.
+statement error
+SELECT i FROM t.main.integers;
+----
+<REGEX>:.*
+
+# Not surfaced in enumeration either.
+query I
+SELECT count(*) FROM duckdb_databases() WHERE database_name = 't';
+----
+0
+
+statement ok
+DETACH t;
+
+# Writes are also gated by CATALOG_MODE NONE — use a fresh writable temp db so this section
+# isn't conflated with READ_ONLY blocking the writes for other reasons.
+
+statement ok
+ATTACH '{TEST_DIR}/catalog_mode_writable.db' AS w;
+
+statement ok
+CREATE TABLE w.main.t (i INT);
+
+statement ok
+INSERT INTO w.main.t VALUES (1), (2);
+
+statement ok
+DETACH w;
+
+statement ok
+ATTACH '{TEST_DIR}/catalog_mode_writable.db' AS w (CATALOG_MODE NONE);
+
+statement error
+SELECT * FROM w.main.t;
+----
+<REGEX>:.*
+
+statement error
+CREATE TABLE w.main.new_table (x INT);
+----
+<REGEX>:.*
+
+statement error
+INSERT INTO w.main.t VALUES (3);
+----
+<REGEX>:.*
+
+statement error
+DROP TABLE w.main.t;
+----
+<REGEX>:.*
+
+statement ok
+DETACH w;
+
+# CATALOG_MODE HIDDEN — table reachable, db not listed (parity with the legacy HIDDEN flag).
+
+statement ok
+ATTACH 'data/storage/wal_test_092.db' AS t (READ_ONLY, CATALOG_MODE HIDDEN);
+
+query I
+SELECT i FROM t.main.integers ORDER BY i LIMIT 3;
+----
+0
+1
+2
+
+query I
+SELECT count(*) FROM duckdb_databases() WHERE database_name = 't';
+----
+0
+
+statement ok
+DETACH t;
+
+# CATALOG_MODE ENABLE — explicit version of default. Behaves identically to no option for
+# DuckDB-backed catalogs (which all provide tables).
+
+statement ok
+ATTACH 'data/storage/wal_test_092.db' AS t (READ_ONLY, CATALOG_MODE ENABLE);
+
+query I
+SELECT i FROM t.main.integers ORDER BY i LIMIT 3;
+----
+0
+1
+2
+
+query I
+SELECT count(*) FROM duckdb_databases() WHERE database_name = 't';
+----
+1
+
+statement ok
+DETACH t;

--- a/test/sql/catalog/attach_catalog_mode.test
+++ b/test/sql/catalog/attach_catalog_mode.test
@@ -1,6 +1,5 @@
 # name: test/sql/catalog/attach_catalog_mode.test
-# description: CATALOG_MODE option on ATTACH. NONE makes tables unreachable; HIDDEN hides
-#              the database from enumeration but keeps tables queryable.
+# description: CATALOG_MODE option on ATTACH. NONE makes tables unreachable; HIDDEN hides the database from enumeration but keeps tables queryable.
 # group: [catalog]
 
 # Baseline: regular ATTACH — table is reachable, db is listed.

--- a/test/sql/catalog/attach_connect_mode.test
+++ b/test/sql/catalog/attach_connect_mode.test
@@ -1,7 +1,8 @@
 # name: test/sql/catalog/attach_connect_mode.test
 # description: CONNECT_MODE option on ATTACH. NONE disables; ENABLE asserts at attach time;
-#              AUTO defers to backend's Supports(CONNECT) declaration.
 # group: [catalog]
+
+#              AUTO defers to backend's Supports(CONNECT) declaration.
 
 # DuckDB-backed catalogs don't support CONNECT, so:
 #   AUTO   -> CONNECT errors at CONNECT time

--- a/test/sql/catalog/attach_connect_mode.test
+++ b/test/sql/catalog/attach_connect_mode.test
@@ -1,0 +1,39 @@
+# name: test/sql/catalog/attach_connect_mode.test
+# description: CONNECT_MODE option on ATTACH. NONE disables; ENABLE asserts at attach time;
+#              AUTO defers to backend's Supports(CONNECT) declaration.
+# group: [catalog]
+
+# DuckDB-backed catalogs don't support CONNECT, so:
+#   AUTO   -> CONNECT errors at CONNECT time
+#   NONE   -> CONNECT errors at CONNECT time (same outcome, different reason)
+#   ENABLE -> ATTACH itself errors (early visibility)
+
+# AUTO is the default — no option needed.
+statement ok
+ATTACH ':memory:' AS m_auto;
+
+statement error
+CONNECT m_auto;
+----
+<REGEX>:Invalid Input Error:.*does not support CONNECT.*
+
+statement ok
+DETACH m_auto;
+
+# NONE: explicit opt-out. Same outcome as AUTO for DuckDB, but the intent is captured.
+statement ok
+ATTACH ':memory:' AS m_none (CONNECT_MODE NONE);
+
+statement error
+CONNECT m_none;
+----
+<REGEX>:Invalid Input Error:.*does not support CONNECT.*
+
+statement ok
+DETACH m_none;
+
+# ENABLE on a non-CONNECT backend fails at ATTACH time, not at CONNECT time.
+statement error
+ATTACH ':memory:' AS m_enable (CONNECT_MODE ENABLE);
+----
+<REGEX>:Invalid Input Error:.*CONNECT_MODE ENABLE.*does not support CONNECT.*


### PR DESCRIPTION
Allow to explicitly opt-in (or opt-out) to make an Attached Database queriable OR connetable.

This could make sense both for assert a given backend has capacities OR for restrict a given AttachedDatabase capabilities.
This is a building block for `CONNECT '<connection_string>';`, since in that case we would like to set the underlying attach to: `CONNECT_MODE ENABLED, CATALOG_MODE NONE`.

Defaults for both is `AUTO`, that means, defer to the capabilities of a given Catalog. But you can decide to say do:
```sql
ATTACH 'file1.db' (CATALOG_MODE NONE);
ATTACH 'file2.db' (CATALOG_MODE HIDDEN);
ATTACH 'file3.db' (CATALOG_MODE AUTO);
ATTACH 'file4.db' (CATALOG_MODE ENABLE);
```
Now, file1 tables / views are not visible, file2's are visible but not auto-discovered (same as `HIDDEN`), file3 and file4 are regular.

Now:
```sql
FROM duckdb_databases();
```
gives:
```
┌───────────────┬──────────────┬──────────────────────────────────┬─────────┬───┬─────────┬──────────┬───────────┬─────────┬──────────────────────┐
│ database_name │ database_oid │               path               │ comment │ … │  type   │ readonly │ encrypted │ cipher  │       options        │
│    varchar    │    int64     │             varchar              │ varchar │ … │ varchar │ boolean  │  boolean  │ varchar │ map(varchar, varcha… │
├───────────────┼──────────────┼──────────────────────────────────┼─────────┼───┼─────────┼──────────┼───────────┼─────────┼──────────────────────┤
│ file4         │        22184 │ /Users/carlo/duckdb-stable/file… │ NULL    │ … │ duckdb  │ false    │ false     │ NULL    │ {}                   │
│ file3         │        22180 │ /Users/carlo/duckdb-stable/file… │ NULL    │ … │ duckdb  │ false    │ false     │ NULL    │ {}                   │
│ memory        │        20680 │ NULL                             │ NULL    │ … │ duckdb  │ false    │ false     │ NULL    │ {}                   │
│ system        │            0 │ NULL                             │ NULL    │ … │ duckdb  │ false    │ false     │ NULL    │ {}                   │
│ temp          │        22162 │ NULL                             │ NULL    │ … │ duckdb  │ false    │ false     │ NULL    │ {}                   │
└───────────────┴──────────────┴──────────────────────────────────┴─────────┴───┴─────────┴──────────┴───────────┴─────────┴──────────────────────┘
```
with file2 still reachable but `HIDDEN`, and file1 not reachable. Example:
```
memory D FROM file1.T;
Binder Error:
Catalog "file1" does not exist!
memory D FROM file2.T;
Catalog Error:
Table with name T does not exist!

LINE 1: FROM file2.T;
             ^
memory D FROM file3.T;
Catalog Error:
Table with name T does not exist!

LINE 1: FROM file3.T;
             ^
```
Where `file1` is not a catalog, `file2` is an hidden catalog, and `file3` and `file4` regular catalog.

Similarly for `CONNECT_MODE`:
```
memory D ATTACH 'quack:localhost' as a (TOKEN '1234');
memory D CONNECT a;
a memory D DISCONNECT;
memory D DETACH a;
memory D
memory D ATTACH 'quack:localhost' as b (TOKEN '1234', CONNECT_MODE NONE);
memory D CONNECT b;
Invalid Input Error:
Database "b" does not support CONNECT
memory D DETACH b;
```
here the first can be `CONNECT`-ed regularly, but `CONNECT_MODE NONE` make CONNECT not viable. Note, quack will not (at this moment) enforce this on `quack_query_by_name`, so arbitrary queries can still be sent to be backend, but I think a `quack` change that would make sense is reducing surface depending on `connect_mode`.