### PR TITLE
[Bug] Fix string-heap copy for updates mixing NULL and non-NULL values

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1299,11 +1299,9 @@ void UpdateSegment::Update(TransactionData transaction, DuckTableEntry &table_en
 		// for strings - we need to push all strings we are going to place here into the string heap of the segment
 		update_p.Flatten(count);
 		auto update_data = FlatVector::GetDataMutable<string_t>(update_p);
-		auto &validity = FlatVector::ValidityMutable(update_p);
 		for (idx_t i = 0; i < count; i++) {
-			if (validity.RowIsValid(i)) {
-				update_data[i] = GetStringHeap().AddBlob(update_data[i]);
-			}
+			auto idx = sel.get_index(i);
+			update_data[idx] = GetStringHeap().AddBlob(update_data[idx]);
 		}
 		update_p.ToUnifiedFormat(count, update_format);
 	}

--- a/test/sql/update/string_update_null_heap.test
+++ b/test/sql/update/string_update_null_heap.test
@@ -1,0 +1,18 @@
+# name: test/sql/update/string_update_null_heap.test
+# description: VARCHAR update where a leading row turns NULL and a trailing row gets a heap string
+# group: [update]
+
+statement ok
+CREATE TABLE test (id INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO test VALUES (1, 'a'), (2, 'b');
+
+statement ok
+UPDATE test SET s=CASE WHEN id=1 THEN NULL ELSE 'cccccccccccccccccccc' END;
+
+query IT
+SELECT * FROM test ORDER BY id;
+----
+1	NULL
+2	cccccccccccccccccccc


### PR DESCRIPTION
Found while trying to get DuckLake up to date with DuckDB main.