### PR TITLE
Implement file rotation for partitioned copy

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -140,6 +140,9 @@ struct GlobalFileState {
 	idx_t num_batches DUCKDB_GUARDED_BY(lock);
 };
 
+static bool PhysicalCopyRotateNow(const PhysicalCopyToFile &op, GlobalFileState &global_state)
+    DUCKDB_REQUIRES(global_state.lock);
+
 //===--------------------------------------------------------------------===//
 // Copy State Declarations
 //===--------------------------------------------------------------------===//
@@ -245,7 +248,7 @@ public:
 // Partitioned Copy Declarations
 //===--------------------------------------------------------------------===//
 enum class PartitionedCopyStage : uint8_t { SORT, MATERIALIZE, MASK, BATCH, PREPARE, FLUSH, DONE };
-enum class FileCreationReason : uint8_t { NORMAL, SORTED_RUN_BOUNDARY };
+enum class FileCreationReason : uint8_t { NORMAL, SORTED_RUN_BOUNDARY, ROTATION };
 
 struct PartitionedCopyTask {
 	PartitionedCopyStage stage = PartitionedCopyStage::DONE;
@@ -761,6 +764,12 @@ public:
 	    DUCKDB_EXCLUDES(active_writes_lock);
 	void EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &write_info, const vector<Value> &values)
 	    DUCKDB_EXCLUDES(active_writes_lock);
+	void EnsureFreshPartitionFileForRotation(PartitionWriteInfo &write_info, const vector<Value> &values)
+	    DUCKDB_EXCLUDES(active_writes_lock);
+	//! Swaps write_info.file_state after temporarily dropping copy_gstate.lock to initialize the replacement file.
+	//! Callers that can reach the swap path must serialize the full partition writer run for this write_info.
+	void EnsureFreshPartitionFile(PartitionWriteInfo &write_info, const vector<Value> &values,
+	                              FileCreationReason reason) DUCKDB_EXCLUDES(active_writes_lock);
 	void FinalizeActiveWrites() DUCKDB_EXCLUDES(active_writes_lock);
 	void FinalizeFileStates(vector<unique_ptr<GlobalFileState>> files_to_finalize) DUCKDB_EXCLUDES(active_writes_lock);
 	string GetOrCreateDirectory(string path, const vector<Value> &values) DUCKDB_REQUIRES(copy_gstate.lock);
@@ -1634,9 +1643,8 @@ bool PartitionedCopy::ShouldStopFlushing() const {
 }
 
 bool PartitionedCopy::RequiresSerializedPartitionWrites() const {
-	// A full partition writer run must remain serialized when the run boundary has file-state semantics.
-	// ORDER BY uses the boundary to start a fresh file per sorted run. Rotation is currently rejected with
-	// PARTITION_BY in the binder, but keeping it here makes the intended locking policy explicit for future support.
+	// A full partition writer run must remain serialized when the run boundary has file-state semantics:
+	// ORDER BY starts a fresh file per sorted run, and rotation can start a fresh file between batches.
 	return !op.order_columns.empty() || op.Rotate();
 }
 
@@ -2062,6 +2070,7 @@ void PartitionedCopy::FlushPreparedPartitionRun(const vector<Value> &values, Par
 		EnsureFreshPartitionFileForSortedRun(write_info, values);
 		for (auto &batch : batches) {
 			D_ASSERT(batch);
+			EnsureFreshPartitionFileForRotation(write_info, values);
 			FlushPreparedPartitionBatch(values, write_info, std::move(batch));
 		}
 	});
@@ -2095,6 +2104,7 @@ void PartitionedCopy::FlushDelayedPartitionRun(const vector<Value> &values, Part
 			if (batch->Count() == 0) {
 				return;
 			}
+			EnsureFreshPartitionFileForRotation(write_info, values);
 			auto prepared_batch = PreparePartitionBatch(
 			    values, write_info,
 			    PartitionedCopyCollection(PartitionedCopyCollectionSchema::WRITE_SCHEMA, std::move(batch)));
@@ -2199,7 +2209,7 @@ PartitionFileStateReservation PartitionedCopy::ReservePartitionFileStateLocked(c
 	}
 
 	if (op.hive_file_pattern) {
-		if (reason == FileCreationReason::SORTED_RUN_BOUNDARY) {
+		if (reason == FileCreationReason::SORTED_RUN_BOUNDARY || reason == FileCreationReason::ROTATION) {
 			++previous_partitions[values];
 		}
 		auto prev_offset = previous_partitions.find(values);
@@ -2242,6 +2252,20 @@ void PartitionedCopy::EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &w
 	if (op.order_columns.empty()) {
 		return;
 	}
+	EnsureFreshPartitionFile(write_info, values, FileCreationReason::SORTED_RUN_BOUNDARY);
+}
+
+void PartitionedCopy::EnsureFreshPartitionFileForRotation(PartitionWriteInfo &write_info, const vector<Value> &values) {
+	if (!op.Rotate()) {
+		return;
+	}
+	EnsureFreshPartitionFile(write_info, values, FileCreationReason::ROTATION);
+}
+
+void PartitionedCopy::EnsureFreshPartitionFile(PartitionWriteInfo &write_info, const vector<Value> &values,
+                                               FileCreationReason reason) {
+	D_ASSERT(reason == FileCreationReason::SORTED_RUN_BOUNDARY || reason == FileCreationReason::ROTATION);
+	D_ASSERT(RequiresSerializedPartitionWrites());
 
 	optional_ptr<GlobalFileState> old_file_state_ptr;
 	{
@@ -2251,12 +2275,15 @@ void PartitionedCopy::EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &w
 		}
 		old_file_state_ptr = write_info.file_state.get();
 		annotated_lock_guard<annotated_mutex> file_guard(old_file_state_ptr->lock);
-		if (old_file_state_ptr->num_batches == 0) {
+		if (reason == FileCreationReason::SORTED_RUN_BOUNDARY && old_file_state_ptr->num_batches == 0) {
+			return;
+		}
+		if (reason == FileCreationReason::ROTATION && !PhysicalCopyRotateNow(op, *old_file_state_ptr)) {
 			return;
 		}
 	}
 
-	auto new_file_state = CreatePartitionFileState(values, FileCreationReason::SORTED_RUN_BOUNDARY);
+	auto new_file_state = CreatePartitionFileState(values, reason);
 
 	unique_ptr<GlobalFileState> old_file_state;
 	{
@@ -2264,7 +2291,11 @@ void PartitionedCopy::EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &w
 		D_ASSERT(write_info.file_state);
 		D_ASSERT(RefersToSameObject(*old_file_state_ptr.get(), *write_info.file_state));
 		annotated_lock_guard<annotated_mutex> file_guard(write_info.file_state->lock);
-		D_ASSERT(write_info.file_state->num_batches > 0);
+		if (reason == FileCreationReason::SORTED_RUN_BOUNDARY) {
+			D_ASSERT(write_info.file_state->num_batches > 0);
+		} else {
+			D_ASSERT(PhysicalCopyRotateNow(op, *write_info.file_state));
+		}
 
 		old_file_state = std::move(write_info.file_state);
 		write_info.file_state = std::move(new_file_state);
@@ -2581,7 +2612,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 		}
 
 		auto state = make_uniq<CopyToFileGlobalState>(*this, context);
-		if (!per_thread_output && Rotate() && write_empty_file) {
+		if (!partition_output && !per_thread_output && Rotate() && write_empty_file) {
 			annotated_lock_guard<annotated_mutex> guard(state->lock);
 			state->global_state = state->CreateFileStateLocked();
 		}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -762,14 +762,6 @@ public:
 	    DUCKDB_REQUIRES(active_writes_lock);
 	unique_ptr<GlobalFileState> CreatePartitionFileStateFromReservation(const vector<Value> &values, idx_t offset)
 	    DUCKDB_EXCLUDES(active_writes_lock);
-	void EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &write_info, const vector<Value> &values)
-	    DUCKDB_EXCLUDES(active_writes_lock);
-	void EnsureFreshPartitionFileForRotation(PartitionWriteInfo &write_info, const vector<Value> &values)
-	    DUCKDB_EXCLUDES(active_writes_lock);
-	//! Swaps write_info.file_state after temporarily dropping copy_gstate.lock to initialize the replacement file.
-	//! Callers that can reach the swap path must serialize the full partition writer run for this write_info.
-	void EnsureFreshPartitionFile(PartitionWriteInfo &write_info, const vector<Value> &values,
-	                              FileCreationReason reason) DUCKDB_EXCLUDES(active_writes_lock);
 	void FinalizeActiveWrites() DUCKDB_EXCLUDES(active_writes_lock);
 	void FinalizeFileStates(vector<unique_ptr<GlobalFileState>> files_to_finalize) DUCKDB_EXCLUDES(active_writes_lock);
 	string GetOrCreateDirectory(string path, const vector<Value> &values) DUCKDB_REQUIRES(copy_gstate.lock);
@@ -779,6 +771,14 @@ private:
 	void CreateNextState();
 	bool ShouldStopFlushing() const;
 	bool RequiresSerializedPartitionWrites() const;
+	void EnsureFreshPartitionFileForSortedRun(PartitionWriteInfo &write_info, const vector<Value> &values)
+	    DUCKDB_EXCLUDES(active_writes_lock);
+	void EnsureFreshPartitionFileForRotation(PartitionWriteInfo &write_info, const vector<Value> &values)
+	    DUCKDB_EXCLUDES(active_writes_lock);
+	//! Swaps write_info.file_state after temporarily dropping copy_gstate.lock to initialize the replacement file.
+	//! Callers that can reach the swap path must serialize the full partition writer run for this write_info.
+	void EnsureFreshPartitionFile(PartitionWriteInfo &write_info, const vector<Value> &values,
+	                              FileCreationReason reason) DUCKDB_EXCLUDES(active_writes_lock);
 	template <class FUNC>
 	void WithSerializedPartitionWriteRun(PartitionWriteInfo &write_info, FUNC &&func) {
 		annotated_unique_lock<annotated_mutex> run_guard(write_info.lock, std::defer_lock);

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -104,10 +104,9 @@ static idx_t ParseBytesArg(const string &name, Value &arg) {
 }
 
 struct CopyToBindOptions {
-	bool use_tmp_file = true;
-	CopyOverwriteMode overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
-	FilenamePattern filename_pattern;
-	bool user_set_use_tmp_file = false;
+	optional<bool> use_tmp_file;
+	optional<CopyOverwriteMode> overwrite_mode;
+	optional<FilenamePattern> filename_pattern;
 	bool per_thread_output = false;
 	optional_idx batch_size;
 	optional_idx batch_size_bytes;
@@ -115,13 +114,44 @@ struct CopyToBindOptions {
 	optional_idx batches_per_file;
 	vector<idx_t> partition_cols;
 	vector<BoundOrderByNode> order_columns;
-	bool seen_overwrite_mode = false;
-	bool seen_filepattern = false;
 	bool write_partition_columns = false;
 	bool write_empty_file = true;
 	bool hive_file_pattern = true;
 	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
-	CopyFunctionReturnType return_type = CopyFunctionReturnType::CHANGED_ROWS;
+	optional<CopyFunctionReturnType> return_type;
+
+	bool UserSetUseTmpFile() const {
+		return use_tmp_file.has_value();
+	}
+
+	bool UseTmpFile() const {
+		return use_tmp_file.value_or(true);
+	}
+
+	CopyOverwriteMode OverwriteMode() const {
+		return overwrite_mode.value_or(CopyOverwriteMode::COPY_ERROR_ON_CONFLICT);
+	}
+
+	FilenamePattern GetFilenamePattern() const {
+		return filename_pattern.value_or(FilenamePattern());
+	}
+
+	CopyFunctionReturnType ReturnType() const {
+		return return_type.value_or(CopyFunctionReturnType::CHANGED_ROWS);
+	}
+
+	void SetFilenamePattern(const string &pattern) {
+		FilenamePattern result;
+		result.SetFilenamePattern(pattern);
+		filename_pattern = std::move(result);
+	}
+
+	void SetReturnType(CopyFunctionReturnType return_type_p) {
+		if (return_type.has_value() && *return_type != return_type_p) {
+			throw BinderException("Can only set one of RETURN_FILES or RETURN_STATS for COPY");
+		}
+		return_type = return_type_p;
+	}
 
 	bool Rotate() const {
 		return file_size_bytes.IsValid() || batches_per_file.IsValid();
@@ -134,16 +164,16 @@ struct CopyToBindOptions {
 
 static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, const CopyFunction &function,
                                              const string &format) {
-	if (options.overwrite_mode == CopyOverwriteMode::COPY_APPEND && !options.filename_pattern.HasUUID()) {
+	if (options.OverwriteMode() == CopyOverwriteMode::COPY_APPEND && !options.GetFilenamePattern().HasUUID()) {
 		throw BinderException("APPEND mode requires a {uuid} label in filename_pattern");
 	}
-	if (options.user_set_use_tmp_file && options.per_thread_output) {
+	if (options.UserSetUseTmpFile() && options.per_thread_output) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
 	}
-	if (options.user_set_use_tmp_file && options.Rotate()) {
+	if (options.UserSetUseTmpFile() && options.Rotate()) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and FILE_SIZE_BYTES/BATCHES_PER_FILE for COPY");
 	}
-	if (options.user_set_use_tmp_file && options.Partitioned()) {
+	if (options.UserSetUseTmpFile() && options.Partitioned()) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PARTITION_BY for COPY");
 	}
 	if (options.per_thread_output && options.Partitioned()) {
@@ -161,7 +191,7 @@ static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, c
 			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PARTITION_BY");
 		}
 	}
-	if (options.return_type == CopyFunctionReturnType::WRITTEN_FILE_STATISTICS &&
+	if (options.ReturnType() == CopyFunctionReturnType::WRITTEN_FILE_STATISTICS &&
 	    !function.copy_to_get_written_statistics) {
 		throw NotImplementedException("RETURN_STATS is not supported for the \"%s\" copy format", format);
 	}
@@ -205,12 +235,10 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 		auto loption = StringUtil::Lower(option.first);
 		if (loption == "use_tmp_file") {
 			options.use_tmp_file = GetBooleanArg(context, option.second);
-			options.user_set_use_tmp_file = true;
 		} else if (loption == "overwrite_or_ignore" || loption == "overwrite" || loption == "append") {
-			if (options.seen_overwrite_mode) {
+			if (options.overwrite_mode.has_value()) {
 				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE, OVERWRITE or APPEND");
 			}
-			options.seen_overwrite_mode = true;
 
 			auto boolean = GetBooleanArg(context, option.second);
 			if (boolean) {
@@ -219,19 +247,19 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 				} else if (loption == "overwrite") {
 					options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
 				} else if (loption == "append") {
-					if (!options.seen_filepattern) {
-						options.filename_pattern.SetFilenamePattern("{uuid}");
+					if (!options.filename_pattern.has_value()) {
+						options.SetFilenamePattern("{uuid}");
 					}
 					options.overwrite_mode = CopyOverwriteMode::COPY_APPEND;
 				}
+			} else {
+				options.overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
 			}
 		} else if (loption == "filename_pattern") {
 			if (option.second.empty()) {
 				throw IOException("FILENAME_PATTERN cannot be empty");
 			}
-			options.filename_pattern.SetFilenamePattern(
-			    option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
-			options.seen_filepattern = true;
+			options.SetFilenamePattern(option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
 		} else if (loption == "file_extension") {
 			if (option.second.empty()) {
 				throw IOException("FILE_EXTENSION cannot be empty");
@@ -269,7 +297,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 			options.order_columns = ParseOrderByColumns(*this, option.second, select_node, loption);
 		} else if (loption == "return_files") {
 			if (GetBooleanArg(context, option.second)) {
-				options.return_type = CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
+				options.SetReturnType(CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST);
 			}
 		} else if (loption == "preserve_order") {
 			if (GetBooleanArg(context, option.second)) {
@@ -279,7 +307,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 			}
 		} else if (loption == "return_stats") {
 			if (GetBooleanArg(context, option.second)) {
-				options.return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
+				options.SetReturnType(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
 			}
 		} else if (loption == "write_partition_columns") {
 			options.write_partition_columns = GetBooleanArg(context, option.second);
@@ -301,7 +329,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 		auto &fs = FileSystem::GetFileSystem(context);
 		bool is_file_and_exists = fs.FileExists(stmt.info->file_path);
 		bool is_stdout = stmt.info->file_path == "/dev/stdout";
-		if (!options.user_set_use_tmp_file) {
+		if (!options.UserSetUseTmpFile()) {
 			options.use_tmp_file =
 			    is_file_and_exists && !options.per_thread_output && !options.Partitioned() && !is_stdout;
 		}
@@ -346,20 +374,18 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 
 	ValidateCopyToOutputColumns(options, select_node.names.size());
 
-	auto names_to_write =
-	    LogicalCopyToFile::GetNamesWithoutPartitions(unique_column_names, options.partition_cols,
-	                                                 options.write_partition_columns);
-	auto types_to_write =
-	    LogicalCopyToFile::GetTypesWithoutPartitions(select_node.types, options.partition_cols,
-	                                                 options.write_partition_columns);
+	auto names_to_write = LogicalCopyToFile::GetNamesWithoutPartitions(unique_column_names, options.partition_cols,
+	                                                                   options.write_partition_columns);
+	auto types_to_write = LogicalCopyToFile::GetTypesWithoutPartitions(select_node.types, options.partition_cols,
+	                                                                   options.write_partition_columns);
 	auto function_data = function.copy_to_bind(context, bind_input, names_to_write, types_to_write);
 
 	// now create the copy information
 	auto copy = make_uniq<LogicalCopyToFile>(function, std::move(function_data), std::move(stmt.info));
 	copy->file_path = file_path;
-	copy->use_tmp_file = options.use_tmp_file;
-	copy->overwrite_mode = options.overwrite_mode;
-	copy->filename_pattern = options.filename_pattern;
+	copy->use_tmp_file = options.UseTmpFile();
+	copy->overwrite_mode = options.OverwriteMode();
+	copy->filename_pattern = options.GetFilenamePattern();
 	copy->file_extension = bind_input.file_extension;
 	copy->per_thread_output = options.per_thread_output;
 	copy->batch_size = options.batch_size;
@@ -371,7 +397,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	copy->write_partition_columns = options.write_partition_columns;
 	copy->partition_columns = std::move(options.partition_cols);
 	copy->write_empty_file = options.write_empty_file;
-	copy->return_type = options.return_type;
+	copy->return_type = options.ReturnType();
 	copy->preserve_order = options.preserve_order;
 	copy->hive_file_pattern = options.hive_file_pattern;
 	copy->order_columns = std::move(options.order_columns);

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -103,23 +103,7 @@ static idx_t ParseBytesArg(const string &name, Value &arg) {
 	return arg.GetValue<idx_t>();
 }
 
-BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &function, CopyToType copy_to_type) {
-	if (function.plan) {
-		// plan rewrite COPY TO
-		return function.plan(*this, stmt);
-	}
-
-	auto &copy_info = *stmt.info;
-	// bind the select statement
-	// preserve SQLNULL types from table functions (e.g. JSON reader null columns)
-	// so file writers that support it can emit the correct null type (e.g. parquet UNKNOWN/NullType)
-	auto node_copy = copy_info.select_statement->Copy();
-	auto select_node = Bind(*node_copy);
-
-	if (!function.copy_to_bind) {
-		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);
-	}
-
+struct CopyToBindOptions {
 	bool use_tmp_file = true;
 	CopyOverwriteMode overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
 	FilenamePattern filename_pattern;
@@ -139,6 +123,78 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
 	CopyFunctionReturnType return_type = CopyFunctionReturnType::CHANGED_ROWS;
 
+	bool Rotate() const {
+		return file_size_bytes.IsValid() || batches_per_file.IsValid();
+	}
+
+	bool Partitioned() const {
+		return !partition_cols.empty();
+	}
+};
+
+static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, const CopyFunction &function,
+                                             const string &format) {
+	if (options.overwrite_mode == CopyOverwriteMode::COPY_APPEND && !options.filename_pattern.HasUUID()) {
+		throw BinderException("APPEND mode requires a {uuid} label in filename_pattern");
+	}
+	if (options.user_set_use_tmp_file && options.per_thread_output) {
+		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
+	}
+	if (options.user_set_use_tmp_file && options.Rotate()) {
+		throw NotImplementedException("Can't combine USE_TMP_FILE and FILE_SIZE_BYTES/BATCHES_PER_FILE for COPY");
+	}
+	if (options.user_set_use_tmp_file && options.Partitioned()) {
+		throw NotImplementedException("Can't combine USE_TMP_FILE and PARTITION_BY for COPY");
+	}
+	if (options.per_thread_output && options.Partitioned()) {
+		throw NotImplementedException("Can't combine PER_THREAD_OUTPUT and PARTITION_BY for COPY");
+	}
+	if (options.Rotate() && (!function.prepare_batch || !function.flush_batch)) {
+		throw NotImplementedException("Can't use file rotation (e.g., ROW_GROUPS_PER_FILE) with FORMAT %s",
+		                              function.name);
+	}
+	if (!options.write_empty_file) {
+		if (options.per_thread_output) {
+			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PER_THREAD_OUTPUT");
+		}
+		if (options.Partitioned()) {
+			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PARTITION_BY");
+		}
+	}
+	if (options.return_type == CopyFunctionReturnType::WRITTEN_FILE_STATISTICS &&
+	    !function.copy_to_get_written_statistics) {
+		throw NotImplementedException("RETURN_STATS is not supported for the \"%s\" copy format", format);
+	}
+	if (!options.order_columns.empty() && !options.Partitioned()) {
+		throw NotImplementedException("ORDER_BY is not supported without PARTITION_BY");
+	}
+}
+
+static void ValidateCopyToOutputColumns(const CopyToBindOptions &options, idx_t column_count) {
+	if (!options.write_partition_columns && options.partition_cols.size() == column_count) {
+		throw NotImplementedException("No column to write as all columns are specified as partition columns. "
+		                              "WRITE_PARTITION_COLUMNS option can be used to write partition columns.");
+	}
+}
+
+BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &function, CopyToType copy_to_type) {
+	if (function.plan) {
+		// plan rewrite COPY TO
+		return function.plan(*this, stmt);
+	}
+
+	auto &copy_info = *stmt.info;
+	// bind the select statement
+	// preserve SQLNULL types from table functions (e.g. JSON reader null columns)
+	// so file writers that support it can emit the correct null type (e.g. parquet UNKNOWN/NullType)
+	auto node_copy = copy_info.select_statement->Copy();
+	auto select_node = Bind(*node_copy);
+
+	if (!function.copy_to_bind) {
+		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);
+	}
+
+	CopyToBindOptions options;
 	CopyFunctionBindInput bind_input(*stmt.info, function.function_info);
 
 	bind_input.file_extension = function.extension;
@@ -148,51 +204,51 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	for (auto &option : original_options) {
 		auto loption = StringUtil::Lower(option.first);
 		if (loption == "use_tmp_file") {
-			use_tmp_file = GetBooleanArg(context, option.second);
-			user_set_use_tmp_file = true;
+			options.use_tmp_file = GetBooleanArg(context, option.second);
+			options.user_set_use_tmp_file = true;
 		} else if (loption == "overwrite_or_ignore" || loption == "overwrite" || loption == "append") {
-			if (seen_overwrite_mode) {
+			if (options.seen_overwrite_mode) {
 				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE, OVERWRITE or APPEND");
 			}
-			seen_overwrite_mode = true;
+			options.seen_overwrite_mode = true;
 
 			auto boolean = GetBooleanArg(context, option.second);
 			if (boolean) {
 				if (loption == "overwrite_or_ignore") {
-					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
+					options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 				} else if (loption == "overwrite") {
-					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
+					options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
 				} else if (loption == "append") {
-					if (!seen_filepattern) {
-						filename_pattern.SetFilenamePattern("{uuid}");
+					if (!options.seen_filepattern) {
+						options.filename_pattern.SetFilenamePattern("{uuid}");
 					}
-					overwrite_mode = CopyOverwriteMode::COPY_APPEND;
+					options.overwrite_mode = CopyOverwriteMode::COPY_APPEND;
 				}
 			}
 		} else if (loption == "filename_pattern") {
 			if (option.second.empty()) {
 				throw IOException("FILENAME_PATTERN cannot be empty");
 			}
-			filename_pattern.SetFilenamePattern(
+			options.filename_pattern.SetFilenamePattern(
 			    option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
-			seen_filepattern = true;
+			options.seen_filepattern = true;
 		} else if (loption == "file_extension") {
 			if (option.second.empty()) {
 				throw IOException("FILE_EXTENSION cannot be empty");
 			}
 			bind_input.file_extension = option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>();
 		} else if (loption == "per_thread_output") {
-			per_thread_output = GetBooleanArg(context, option.second);
+			options.per_thread_output = GetBooleanArg(context, option.second);
 		} else if (loption == "batch_size" || loption == "row_group_size") {
 			if (option.second.empty()) {
 				throw BinderException("BATCH_SIZE/ROW_GROUP_SIZE cannot be empty");
 			}
-			batch_size = option.second[0].GetValue<uint64_t>();
+			options.batch_size = option.second[0].GetValue<uint64_t>();
 		} else if (loption == "batch_size_bytes" || loption == "row_group_size_bytes") {
 			if (option.second.empty()) {
 				throw BinderException("BATCH_SIZE_BYTES/ROW_GROUP_SIZE_BYTES cannot be empty");
 			}
-			batch_size_bytes = ParseBytesArg(loption, option.second[0]);
+			options.batch_size_bytes = ParseBytesArg(loption, option.second[0]);
 		} else if (loption == "file_size_bytes") {
 			if (option.second.empty()) {
 				throw BinderException("FILE_SIZE_BYTES cannot be empty");
@@ -200,74 +256,54 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 			if (!function.file_size_bytes) {
 				throw BinderException("FILE_SIZE_BYTES not implemented for %s", function.name);
 			}
-			file_size_bytes = ParseBytesArg(loption, option.second[0]);
+			options.file_size_bytes = ParseBytesArg(loption, option.second[0]);
 		} else if (loption == "batches_per_file" || loption == "row_groups_per_file") {
 			if (option.second.empty()) {
 				throw BinderException("BATCHES_PER_FILE/ROW_GROUPS_PER_FILE cannot be empty");
 			}
-			batches_per_file = option.second[0].GetValue<uint64_t>();
+			options.batches_per_file = option.second[0].GetValue<uint64_t>();
 		} else if (loption == "partition_by") {
 			auto converted = ConvertVectorToValue(std::move(option.second));
-			partition_cols = ParseColumnsOrdered(converted, select_node.names, loption);
+			options.partition_cols = ParseColumnsOrdered(converted, select_node.names, loption);
 		} else if (loption == "order_by") {
-			order_columns = ParseOrderByColumns(*this, option.second, select_node, loption);
+			options.order_columns = ParseOrderByColumns(*this, option.second, select_node, loption);
 		} else if (loption == "return_files") {
 			if (GetBooleanArg(context, option.second)) {
-				return_type = CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
+				options.return_type = CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
 			}
 		} else if (loption == "preserve_order") {
 			if (GetBooleanArg(context, option.second)) {
-				preserve_order = PreserveOrderType::PRESERVE_ORDER;
+				options.preserve_order = PreserveOrderType::PRESERVE_ORDER;
 			} else {
-				preserve_order = PreserveOrderType::DONT_PRESERVE_ORDER;
+				options.preserve_order = PreserveOrderType::DONT_PRESERVE_ORDER;
 			}
 		} else if (loption == "return_stats") {
 			if (GetBooleanArg(context, option.second)) {
-				return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
+				options.return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
 			}
 		} else if (loption == "write_partition_columns") {
-			write_partition_columns = GetBooleanArg(context, option.second);
+			options.write_partition_columns = GetBooleanArg(context, option.second);
 		} else if (loption == "write_empty_file") {
-			write_empty_file = GetBooleanArg(context, option.second);
+			options.write_empty_file = GetBooleanArg(context, option.second);
 		} else if (loption == "hive_file_pattern") {
-			hive_file_pattern = GetBooleanArg(context, option.second);
+			options.hive_file_pattern = GetBooleanArg(context, option.second);
 		} else {
 			stmt.info->options[option.first] = option.second;
 		}
 	}
-	if (overwrite_mode == CopyOverwriteMode::COPY_APPEND && !filename_pattern.HasUUID()) {
-		throw BinderException("APPEND mode requires a {uuid} label in filename_pattern");
-	}
-	if (user_set_use_tmp_file && per_thread_output) {
-		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
-	}
-	if (user_set_use_tmp_file && (file_size_bytes.IsValid() || batches_per_file.IsValid())) {
-		throw NotImplementedException("Can't combine USE_TMP_FILE and FILE_SIZE_BYTES/BATCHES_PER_FILE for COPY");
-	}
-	if (user_set_use_tmp_file && !partition_cols.empty()) {
-		throw NotImplementedException("Can't combine USE_TMP_FILE and PARTITION_BY for COPY");
-	}
-	if (per_thread_output && !partition_cols.empty()) {
-		throw NotImplementedException("Can't combine PER_THREAD_OUTPUT and PARTITION_BY for COPY");
-	}
-	if ((file_size_bytes.IsValid() || batches_per_file.IsValid()) && !partition_cols.empty()) {
-		throw NotImplementedException("Can't combine FILE_SIZE_BYTES and PARTITION_BY for COPY");
-	}
-	if (!write_partition_columns) {
-		if (partition_cols.size() == select_node.names.size()) {
-			throw NotImplementedException("No column to write as all columns are specified as partition columns. "
-			                              "WRITE_PARTITION_COLUMNS option can be used to write partition columns.");
-		}
-	}
+
+	ValidateCopyToOptionCombinations(options, function, stmt.info->format);
+
 	bool is_remote_file = FileSystem::IsRemoteFile(stmt.info->file_path);
 	if (is_remote_file) {
-		use_tmp_file = false;
+		options.use_tmp_file = false;
 	} else {
 		auto &fs = FileSystem::GetFileSystem(context);
 		bool is_file_and_exists = fs.FileExists(stmt.info->file_path);
 		bool is_stdout = stmt.info->file_path == "/dev/stdout";
-		if (!user_set_use_tmp_file) {
-			use_tmp_file = is_file_and_exists && !per_thread_output && partition_cols.empty() && !is_stdout;
+		if (!options.user_set_use_tmp_file) {
+			options.use_tmp_file =
+			    is_file_and_exists && !options.per_thread_output && !options.Partitioned() && !is_stdout;
 		}
 	}
 
@@ -308,64 +344,37 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	QueryResult::DeduplicateColumns(unique_column_names);
 	auto file_path = stmt.info->file_path;
 
+	ValidateCopyToOutputColumns(options, select_node.names.size());
+
 	auto names_to_write =
-	    LogicalCopyToFile::GetNamesWithoutPartitions(unique_column_names, partition_cols, write_partition_columns);
+	    LogicalCopyToFile::GetNamesWithoutPartitions(unique_column_names, options.partition_cols,
+	                                                 options.write_partition_columns);
 	auto types_to_write =
-	    LogicalCopyToFile::GetTypesWithoutPartitions(select_node.types, partition_cols, write_partition_columns);
+	    LogicalCopyToFile::GetTypesWithoutPartitions(select_node.types, options.partition_cols,
+	                                                 options.write_partition_columns);
 	auto function_data = function.copy_to_bind(context, bind_input, names_to_write, types_to_write);
-
-	const auto rotate = file_size_bytes.IsValid() || batches_per_file.IsValid();
-	if (rotate) {
-		if (user_set_use_tmp_file) {
-			throw NotImplementedException(
-			    "Can't combine USE_TMP_FILE and file rotation (e.g., ROW_GROUPS_PER_FILE) for COPY");
-		}
-		if (!partition_cols.empty()) {
-			throw NotImplementedException(
-			    "Can't combine file rotation (e.g., ROW_GROUPS_PER_FILE) and PARTITION_BY for COPY");
-		}
-		if (!function.prepare_batch || !function.flush_batch) {
-			throw NotImplementedException(
-			    "Can't use file rotation (e.g., ROW_GROUPS_PER_FILE) and PARTITION_BY with FORMAT %s", function.name);
-		}
-	}
-	if (!write_empty_file) {
-		if (per_thread_output) {
-			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PER_THREAD_OUTPUT");
-		}
-		if (!partition_cols.empty()) {
-			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PARTITION_BY");
-		}
-	}
-	if (return_type == CopyFunctionReturnType::WRITTEN_FILE_STATISTICS && !function.copy_to_get_written_statistics) {
-		throw NotImplementedException("RETURN_STATS is not supported for the \"%s\" copy format", stmt.info->format);
-	}
-
-	if (!order_columns.empty() && partition_cols.empty()) {
-		throw NotImplementedException("ORDER_BY is not supported without PARTITION_BY");
-	}
 
 	// now create the copy information
 	auto copy = make_uniq<LogicalCopyToFile>(function, std::move(function_data), std::move(stmt.info));
 	copy->file_path = file_path;
-	copy->use_tmp_file = use_tmp_file;
-	copy->overwrite_mode = overwrite_mode;
-	copy->filename_pattern = filename_pattern;
+	copy->use_tmp_file = options.use_tmp_file;
+	copy->overwrite_mode = options.overwrite_mode;
+	copy->filename_pattern = options.filename_pattern;
 	copy->file_extension = bind_input.file_extension;
-	copy->per_thread_output = per_thread_output;
-	copy->batch_size = batch_size;
-	copy->batch_size_bytes = batch_size_bytes;
-	copy->batches_per_file = batches_per_file;
-	copy->file_size_bytes = file_size_bytes;
-	copy->rotate = rotate;
-	copy->partition_output = !partition_cols.empty();
-	copy->write_partition_columns = write_partition_columns;
-	copy->partition_columns = std::move(partition_cols);
-	copy->write_empty_file = write_empty_file;
-	copy->return_type = return_type;
-	copy->preserve_order = preserve_order;
-	copy->hive_file_pattern = hive_file_pattern;
-	copy->order_columns = std::move(order_columns);
+	copy->per_thread_output = options.per_thread_output;
+	copy->batch_size = options.batch_size;
+	copy->batch_size_bytes = options.batch_size_bytes;
+	copy->batches_per_file = options.batches_per_file;
+	copy->file_size_bytes = options.file_size_bytes;
+	copy->rotate = options.Rotate();
+	copy->partition_output = options.Partitioned();
+	copy->write_partition_columns = options.write_partition_columns;
+	copy->partition_columns = std::move(options.partition_cols);
+	copy->write_empty_file = options.write_empty_file;
+	copy->return_type = options.return_type;
+	copy->preserve_order = options.preserve_order;
+	copy->hive_file_pattern = options.hive_file_pattern;
+	copy->order_columns = std::move(options.order_columns);
 
 	copy->names = unique_column_names;
 	copy->expected_types = select_node.types;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -103,29 +103,45 @@ static idx_t ParseBytesArg(const string &name, Value &arg) {
 	return arg.GetValue<idx_t>();
 }
 
-struct CopyToBindOptions {
+struct CopyToParsedOptions {
 	optional<bool> use_tmp_file;
 	optional<CopyOverwriteMode> overwrite_mode;
 	optional<FilenamePattern> filename_pattern;
-	bool per_thread_output = false;
+	optional<bool> per_thread_output;
 	optional_idx batch_size;
 	optional_idx batch_size_bytes;
 	optional_idx file_size_bytes;
 	optional_idx batches_per_file;
 	vector<idx_t> partition_cols;
 	vector<BoundOrderByNode> order_columns;
-	bool write_partition_columns = false;
-	bool write_empty_file = true;
-	bool hive_file_pattern = true;
-	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
+	optional<bool> write_partition_columns;
+	optional<bool> write_empty_file;
+	optional<bool> hive_file_pattern;
+	optional<PreserveOrderType> preserve_order;
 	optional<CopyFunctionReturnType> return_type;
 
 	bool UserSetUseTmpFile() const {
 		return use_tmp_file.has_value();
 	}
 
-	bool UseTmpFile() const {
-		return use_tmp_file.value_or(true);
+	bool PerThreadOutput() const {
+		return per_thread_output.value_or(false);
+	}
+
+	bool WritePartitionColumns() const {
+		return write_partition_columns.value_or(false);
+	}
+
+	bool WriteEmptyFile() const {
+		return write_empty_file.value_or(true);
+	}
+
+	bool HiveFilePattern() const {
+		return hive_file_pattern.value_or(true);
+	}
+
+	PreserveOrderType PreserveOrder() const {
+		return preserve_order.value_or(PreserveOrderType::AUTOMATIC);
 	}
 
 	CopyOverwriteMode OverwriteMode() const {
@@ -162,12 +178,73 @@ struct CopyToBindOptions {
 	}
 };
 
-static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, const CopyFunction &function,
+struct CopyToResolvedOptions {
+	bool use_tmp_file = true;
+	CopyOverwriteMode overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
+	FilenamePattern filename_pattern;
+	bool per_thread_output = false;
+	optional_idx batch_size;
+	optional_idx batch_size_bytes;
+	optional_idx file_size_bytes;
+	optional_idx batches_per_file;
+	vector<idx_t> partition_cols;
+	vector<BoundOrderByNode> order_columns;
+	bool write_partition_columns = false;
+	bool write_empty_file = true;
+	bool hive_file_pattern = true;
+	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
+	CopyFunctionReturnType return_type = CopyFunctionReturnType::CHANGED_ROWS;
+
+	bool Rotate() const {
+		return file_size_bytes.IsValid() || batches_per_file.IsValid();
+	}
+
+	bool Partitioned() const {
+		return !partition_cols.empty();
+	}
+};
+
+static bool ResolveUseTmpFile(ClientContext &context, const string &file_path, const CopyToParsedOptions &options) {
+	if (FileSystem::IsRemoteFile(file_path)) {
+		return false;
+	}
+	if (options.use_tmp_file.has_value()) {
+		return *options.use_tmp_file;
+	}
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	bool is_file_and_exists = fs.FileExists(file_path);
+	bool is_stdout = file_path == "/dev/stdout";
+	return is_file_and_exists && !options.PerThreadOutput() && !options.Partitioned() && !is_stdout;
+}
+
+static CopyToResolvedOptions ResolveCopyToOptions(ClientContext &context, const string &file_path,
+                                                  CopyToParsedOptions options) {
+	CopyToResolvedOptions result;
+	result.use_tmp_file = ResolveUseTmpFile(context, file_path, options);
+	result.overwrite_mode = options.OverwriteMode();
+	result.filename_pattern = options.GetFilenamePattern();
+	result.per_thread_output = options.PerThreadOutput();
+	result.batch_size = options.batch_size;
+	result.batch_size_bytes = options.batch_size_bytes;
+	result.file_size_bytes = options.file_size_bytes;
+	result.batches_per_file = options.batches_per_file;
+	result.partition_cols = std::move(options.partition_cols);
+	result.order_columns = std::move(options.order_columns);
+	result.write_partition_columns = options.WritePartitionColumns();
+	result.write_empty_file = options.WriteEmptyFile();
+	result.hive_file_pattern = options.HiveFilePattern();
+	result.preserve_order = options.PreserveOrder();
+	result.return_type = options.ReturnType();
+	return result;
+}
+
+static void ValidateCopyToOptionCombinations(const CopyToParsedOptions &options, const CopyFunction &function,
                                              const string &format) {
 	if (options.OverwriteMode() == CopyOverwriteMode::COPY_APPEND && !options.GetFilenamePattern().HasUUID()) {
 		throw BinderException("APPEND mode requires a {uuid} label in filename_pattern");
 	}
-	if (options.UserSetUseTmpFile() && options.per_thread_output) {
+	if (options.UserSetUseTmpFile() && options.PerThreadOutput()) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");
 	}
 	if (options.UserSetUseTmpFile() && options.Rotate()) {
@@ -176,15 +253,15 @@ static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, c
 	if (options.UserSetUseTmpFile() && options.Partitioned()) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PARTITION_BY for COPY");
 	}
-	if (options.per_thread_output && options.Partitioned()) {
+	if (options.PerThreadOutput() && options.Partitioned()) {
 		throw NotImplementedException("Can't combine PER_THREAD_OUTPUT and PARTITION_BY for COPY");
 	}
 	if (options.Rotate() && (!function.prepare_batch || !function.flush_batch)) {
 		throw NotImplementedException("Can't use file rotation (e.g., ROW_GROUPS_PER_FILE) with FORMAT %s",
 		                              function.name);
 	}
-	if (!options.write_empty_file) {
-		if (options.per_thread_output) {
+	if (!options.WriteEmptyFile()) {
+		if (options.PerThreadOutput()) {
 			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PER_THREAD_OUTPUT");
 		}
 		if (options.Partitioned()) {
@@ -200,7 +277,7 @@ static void ValidateCopyToOptionCombinations(const CopyToBindOptions &options, c
 	}
 }
 
-static void ValidateCopyToOutputColumns(const CopyToBindOptions &options, idx_t column_count) {
+static void ValidateCopyToOutputColumns(const CopyToResolvedOptions &options, idx_t column_count) {
 	if (!options.write_partition_columns && options.partition_cols.size() == column_count) {
 		throw NotImplementedException("No column to write as all columns are specified as partition columns. "
 		                              "WRITE_PARTITION_COLUMNS option can be used to write partition columns.");
@@ -224,7 +301,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);
 	}
 
-	CopyToBindOptions options;
+	CopyToParsedOptions parsed_options;
 	CopyFunctionBindInput bind_input(*stmt.info, function.function_info);
 
 	bind_input.file_extension = function.extension;
@@ -234,49 +311,50 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	for (auto &option : original_options) {
 		auto loption = StringUtil::Lower(option.first);
 		if (loption == "use_tmp_file") {
-			options.use_tmp_file = GetBooleanArg(context, option.second);
+			parsed_options.use_tmp_file = GetBooleanArg(context, option.second);
 		} else if (loption == "overwrite_or_ignore" || loption == "overwrite" || loption == "append") {
-			if (options.overwrite_mode.has_value()) {
+			if (parsed_options.overwrite_mode.has_value()) {
 				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE, OVERWRITE or APPEND");
 			}
 
 			auto boolean = GetBooleanArg(context, option.second);
 			if (boolean) {
 				if (loption == "overwrite_or_ignore") {
-					options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
+					parsed_options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 				} else if (loption == "overwrite") {
-					options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
+					parsed_options.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
 				} else if (loption == "append") {
-					if (!options.filename_pattern.has_value()) {
-						options.SetFilenamePattern("{uuid}");
+					if (!parsed_options.filename_pattern.has_value()) {
+						parsed_options.SetFilenamePattern("{uuid}");
 					}
-					options.overwrite_mode = CopyOverwriteMode::COPY_APPEND;
+					parsed_options.overwrite_mode = CopyOverwriteMode::COPY_APPEND;
 				}
 			} else {
-				options.overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
+				parsed_options.overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
 			}
 		} else if (loption == "filename_pattern") {
 			if (option.second.empty()) {
 				throw IOException("FILENAME_PATTERN cannot be empty");
 			}
-			options.SetFilenamePattern(option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
+			parsed_options.SetFilenamePattern(
+			    option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
 		} else if (loption == "file_extension") {
 			if (option.second.empty()) {
 				throw IOException("FILE_EXTENSION cannot be empty");
 			}
 			bind_input.file_extension = option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>();
 		} else if (loption == "per_thread_output") {
-			options.per_thread_output = GetBooleanArg(context, option.second);
+			parsed_options.per_thread_output = GetBooleanArg(context, option.second);
 		} else if (loption == "batch_size" || loption == "row_group_size") {
 			if (option.second.empty()) {
 				throw BinderException("BATCH_SIZE/ROW_GROUP_SIZE cannot be empty");
 			}
-			options.batch_size = option.second[0].GetValue<uint64_t>();
+			parsed_options.batch_size = option.second[0].GetValue<uint64_t>();
 		} else if (loption == "batch_size_bytes" || loption == "row_group_size_bytes") {
 			if (option.second.empty()) {
 				throw BinderException("BATCH_SIZE_BYTES/ROW_GROUP_SIZE_BYTES cannot be empty");
 			}
-			options.batch_size_bytes = ParseBytesArg(loption, option.second[0]);
+			parsed_options.batch_size_bytes = ParseBytesArg(loption, option.second[0]);
 		} else if (loption == "file_size_bytes") {
 			if (option.second.empty()) {
 				throw BinderException("FILE_SIZE_BYTES cannot be empty");
@@ -284,56 +362,44 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 			if (!function.file_size_bytes) {
 				throw BinderException("FILE_SIZE_BYTES not implemented for %s", function.name);
 			}
-			options.file_size_bytes = ParseBytesArg(loption, option.second[0]);
+			parsed_options.file_size_bytes = ParseBytesArg(loption, option.second[0]);
 		} else if (loption == "batches_per_file" || loption == "row_groups_per_file") {
 			if (option.second.empty()) {
 				throw BinderException("BATCHES_PER_FILE/ROW_GROUPS_PER_FILE cannot be empty");
 			}
-			options.batches_per_file = option.second[0].GetValue<uint64_t>();
+			parsed_options.batches_per_file = option.second[0].GetValue<uint64_t>();
 		} else if (loption == "partition_by") {
 			auto converted = ConvertVectorToValue(std::move(option.second));
-			options.partition_cols = ParseColumnsOrdered(converted, select_node.names, loption);
+			parsed_options.partition_cols = ParseColumnsOrdered(converted, select_node.names, loption);
 		} else if (loption == "order_by") {
-			options.order_columns = ParseOrderByColumns(*this, option.second, select_node, loption);
+			parsed_options.order_columns = ParseOrderByColumns(*this, option.second, select_node, loption);
 		} else if (loption == "return_files") {
 			if (GetBooleanArg(context, option.second)) {
-				options.SetReturnType(CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST);
+				parsed_options.SetReturnType(CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST);
 			}
 		} else if (loption == "preserve_order") {
 			if (GetBooleanArg(context, option.second)) {
-				options.preserve_order = PreserveOrderType::PRESERVE_ORDER;
+				parsed_options.preserve_order = PreserveOrderType::PRESERVE_ORDER;
 			} else {
-				options.preserve_order = PreserveOrderType::DONT_PRESERVE_ORDER;
+				parsed_options.preserve_order = PreserveOrderType::DONT_PRESERVE_ORDER;
 			}
 		} else if (loption == "return_stats") {
 			if (GetBooleanArg(context, option.second)) {
-				options.SetReturnType(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
+				parsed_options.SetReturnType(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
 			}
 		} else if (loption == "write_partition_columns") {
-			options.write_partition_columns = GetBooleanArg(context, option.second);
+			parsed_options.write_partition_columns = GetBooleanArg(context, option.second);
 		} else if (loption == "write_empty_file") {
-			options.write_empty_file = GetBooleanArg(context, option.second);
+			parsed_options.write_empty_file = GetBooleanArg(context, option.second);
 		} else if (loption == "hive_file_pattern") {
-			options.hive_file_pattern = GetBooleanArg(context, option.second);
+			parsed_options.hive_file_pattern = GetBooleanArg(context, option.second);
 		} else {
 			stmt.info->options[option.first] = option.second;
 		}
 	}
 
-	ValidateCopyToOptionCombinations(options, function, stmt.info->format);
-
-	bool is_remote_file = FileSystem::IsRemoteFile(stmt.info->file_path);
-	if (is_remote_file) {
-		options.use_tmp_file = false;
-	} else {
-		auto &fs = FileSystem::GetFileSystem(context);
-		bool is_file_and_exists = fs.FileExists(stmt.info->file_path);
-		bool is_stdout = stmt.info->file_path == "/dev/stdout";
-		if (!options.UserSetUseTmpFile()) {
-			options.use_tmp_file =
-			    is_file_and_exists && !options.per_thread_output && !options.Partitioned() && !is_stdout;
-		}
-	}
+	ValidateCopyToOptionCombinations(parsed_options, function, stmt.info->format);
+	auto resolved_options = ResolveCopyToOptions(context, stmt.info->file_path, std::move(parsed_options));
 
 	// Allow the copy function to intercept the select list and types and push a new projection on top of the plan
 	if (function.copy_to_select) {
@@ -372,35 +438,35 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 	QueryResult::DeduplicateColumns(unique_column_names);
 	auto file_path = stmt.info->file_path;
 
-	ValidateCopyToOutputColumns(options, select_node.names.size());
+	ValidateCopyToOutputColumns(resolved_options, select_node.names.size());
 
-	auto names_to_write = LogicalCopyToFile::GetNamesWithoutPartitions(unique_column_names, options.partition_cols,
-	                                                                   options.write_partition_columns);
-	auto types_to_write = LogicalCopyToFile::GetTypesWithoutPartitions(select_node.types, options.partition_cols,
-	                                                                   options.write_partition_columns);
+	auto names_to_write = LogicalCopyToFile::GetNamesWithoutPartitions(
+	    unique_column_names, resolved_options.partition_cols, resolved_options.write_partition_columns);
+	auto types_to_write = LogicalCopyToFile::GetTypesWithoutPartitions(
+	    select_node.types, resolved_options.partition_cols, resolved_options.write_partition_columns);
 	auto function_data = function.copy_to_bind(context, bind_input, names_to_write, types_to_write);
 
 	// now create the copy information
 	auto copy = make_uniq<LogicalCopyToFile>(function, std::move(function_data), std::move(stmt.info));
 	copy->file_path = file_path;
-	copy->use_tmp_file = options.UseTmpFile();
-	copy->overwrite_mode = options.OverwriteMode();
-	copy->filename_pattern = options.GetFilenamePattern();
+	copy->use_tmp_file = resolved_options.use_tmp_file;
+	copy->overwrite_mode = resolved_options.overwrite_mode;
+	copy->filename_pattern = resolved_options.filename_pattern;
 	copy->file_extension = bind_input.file_extension;
-	copy->per_thread_output = options.per_thread_output;
-	copy->batch_size = options.batch_size;
-	copy->batch_size_bytes = options.batch_size_bytes;
-	copy->batches_per_file = options.batches_per_file;
-	copy->file_size_bytes = options.file_size_bytes;
-	copy->rotate = options.Rotate();
-	copy->partition_output = options.Partitioned();
-	copy->write_partition_columns = options.write_partition_columns;
-	copy->partition_columns = std::move(options.partition_cols);
-	copy->write_empty_file = options.write_empty_file;
-	copy->return_type = options.ReturnType();
-	copy->preserve_order = options.preserve_order;
-	copy->hive_file_pattern = options.hive_file_pattern;
-	copy->order_columns = std::move(options.order_columns);
+	copy->per_thread_output = resolved_options.per_thread_output;
+	copy->batch_size = resolved_options.batch_size;
+	copy->batch_size_bytes = resolved_options.batch_size_bytes;
+	copy->batches_per_file = resolved_options.batches_per_file;
+	copy->file_size_bytes = resolved_options.file_size_bytes;
+	copy->rotate = resolved_options.Rotate();
+	copy->partition_output = resolved_options.Partitioned();
+	copy->write_partition_columns = resolved_options.write_partition_columns;
+	copy->partition_columns = std::move(resolved_options.partition_cols);
+	copy->write_empty_file = resolved_options.write_empty_file;
+	copy->return_type = resolved_options.return_type;
+	copy->preserve_order = resolved_options.preserve_order;
+	copy->hive_file_pattern = resolved_options.hive_file_pattern;
+	copy->order_columns = std::move(resolved_options.order_columns);
 
 	copy->names = unique_column_names;
 	copy->expected_types = select_node.types;

--- a/test/sql/copy/file_size_bytes.test
+++ b/test/sql/copy/file_size_bytes.test
@@ -157,3 +157,30 @@ statement error
 COPY (FROM bigdata) TO '{TEST_DIR}/file_size_bytes_csv7' (FORMAT CSV, FILE_SIZE_BYTES '190kb', USE_TMP_FILE TRUE);
 ----
 Not implemented Error
+
+# file rotation also works with partitioned CSV output
+statement ok
+COPY (SELECT col_a % 4 AS p, col_a, col_b FROM bigdata)
+TO '{TEST_DIR}/file_size_bytes_csv_partitioned'
+(FORMAT CSV, FILE_SIZE_BYTES '50kb', PARTITION_BY (p));
+
+query I
+SELECT count(*)
+FROM read_csv_auto('{TEST_DIR}/file_size_bytes_csv_partitioned/**/*.csv', hive_partitioning = true);
+----
+100000
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) file_count
+	FROM read_csv_auto(
+		'{TEST_DIR}/file_size_bytes_csv_partitioned/**/*.csv',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT count(*) = 4 AND min(file_count) > 1
+FROM files;
+----
+true

--- a/test/sql/copy/file_size_bytes.test
+++ b/test/sql/copy/file_size_bytes.test
@@ -157,8 +157,3 @@ statement error
 COPY (FROM bigdata) TO '{TEST_DIR}/file_size_bytes_csv7' (FORMAT CSV, FILE_SIZE_BYTES '190kb', USE_TMP_FILE TRUE);
 ----
 Not implemented Error
-
-statement error
-COPY (FROM bigdata) TO '{TEST_DIR}/file_size_bytes_csv7' (FORMAT CSV, FILE_SIZE_BYTES '190kb', PARTITION_BY col_a);
-----
-Not implemented Error

--- a/test/sql/copy/partitioned/partitioned_file_rotation.test
+++ b/test/sql/copy/partitioned/partitioned_file_rotation.test
@@ -1,0 +1,154 @@
+# name: test/sql/copy/partitioned/partitioned_file_rotation.test
+# description: Test file rotation for partitioned COPY
+# group: [partitioned]
+
+require parquet
+
+statement ok
+PRAGMA threads=4;
+
+statement ok
+CREATE TABLE partitioned_rotation_source AS
+SELECT
+	(i % 4)::INTEGER AS p,
+	((i * 17) % 32768)::INTEGER AS v,
+	hash(i)::DOUBLE AS payload
+FROM range(32768) tbl(i);
+
+# FILE_SIZE_BYTES rotates files independently within each partition
+statement ok
+COPY partitioned_rotation_source
+TO '{TEST_DIR}/partitioned_rotation_size'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 1024, FILE_SIZE_BYTES '1kb');
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/partitioned_rotation_size/**/*.parquet', hive_partitioning = true);
+----
+32768
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_rotation_size/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT min(file_count) > 1
+FROM files;
+----
+true
+
+query I
+SELECT count(*) = count(DISTINCT file)
+FROM glob('{TEST_DIR}/partitioned_rotation_size/**/*.parquet');
+----
+true
+
+# ROW_GROUPS_PER_FILE uses the same rotation path
+statement ok
+COPY partitioned_rotation_source
+TO '{TEST_DIR}/partitioned_rotation_row_groups'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 1024, ROW_GROUPS_PER_FILE 1);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/partitioned_rotation_row_groups/**/*.parquet', hive_partitioning = true);
+----
+32768
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_rotation_row_groups/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT min(file_count) > 1
+FROM files;
+----
+true
+
+# ORDER_BY and rotation can both request fresh partition files
+statement ok
+COPY (SELECT p, v, payload FROM partitioned_rotation_source ORDER BY v DESC, p DESC)
+TO '{TEST_DIR}/partitioned_rotation_ordered'
+(FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (v), ROW_GROUP_SIZE 1024, ROW_GROUPS_PER_FILE 1);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/partitioned_rotation_ordered/**/*.parquet', hive_partitioning = true);
+----
+32768
+
+query I
+WITH files AS (
+	SELECT p, count(DISTINCT filename) file_count
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_rotation_ordered/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY p
+)
+SELECT min(file_count) > 1
+FROM files;
+----
+true
+
+query I
+WITH per_file AS (
+	SELECT
+		filename,
+		v,
+		lag(v) OVER (PARTITION BY filename ORDER BY file_row_number) AS prev_v
+	FROM read_parquet(
+		'{TEST_DIR}/partitioned_rotation_ordered/**/*.parquet',
+		filename = true,
+		file_row_number = true,
+		hive_partitioning = true
+	)
+)
+SELECT count(*)
+FROM per_file
+WHERE prev_v IS NOT NULL AND prev_v > v;
+----
+0
+
+# RETURN_FILES and RETURN_STATS include all rotated partition files
+statement ok
+SET threads=1;
+
+statement ok
+CREATE TABLE partitioned_rotation_metadata_source AS
+SELECT
+	(i % 2)::INTEGER AS p,
+	i::INTEGER AS v
+FROM range(16384) tbl(i);
+
+query II
+COPY partitioned_rotation_metadata_source
+TO '{TEST_DIR}/partitioned_rotation_return_files'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 1024, ROW_GROUPS_PER_FILE 1, RETURN_FILES);
+----
+16384	<REGEX>:.*partitioned_rotation_return_files.*p=0.*data_0[.]parquet.*partitioned_rotation_return_files.*p=0.*data_1[.]parquet.*partitioned_rotation_return_files.*p=0.*data_2[.]parquet.*partitioned_rotation_return_files.*p=0.*data_3[.]parquet.*partitioned_rotation_return_files.*p=1.*data_0[.]parquet.*partitioned_rotation_return_files.*p=1.*data_1[.]parquet.*partitioned_rotation_return_files.*p=1.*data_2[.]parquet.*partitioned_rotation_return_files.*p=1.*data_3[.]parquet.*
+
+query IIIIII rowsort
+COPY partitioned_rotation_metadata_source
+TO '{TEST_DIR}/partitioned_rotation_return_stats'
+(FORMAT PARQUET, PARTITION_BY (p), ROW_GROUP_SIZE 1024, ROW_GROUPS_PER_FILE 1, RETURN_STATS);
+----
+<REGEX>:.*partitioned_rotation_return_stats.*p=0.*data_0[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=0}
+<REGEX>:.*partitioned_rotation_return_stats.*p=0.*data_1[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=0}
+<REGEX>:.*partitioned_rotation_return_stats.*p=0.*data_2[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=0}
+<REGEX>:.*partitioned_rotation_return_stats.*p=0.*data_3[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=0}
+<REGEX>:.*partitioned_rotation_return_stats.*p=1.*data_0[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=1}
+<REGEX>:.*partitioned_rotation_return_stats.*p=1.*data_1[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=1}
+<REGEX>:.*partitioned_rotation_return_stats.*p=1.*data_2[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=1}
+<REGEX>:.*partitioned_rotation_return_stats.*p=1.*data_3[.]parquet	2048	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:.*	{p=1}

--- a/test/sql/copy/partitioned/partitioned_file_rotation.test
+++ b/test/sql/copy/partitioned/partitioned_file_rotation.test
@@ -4,6 +4,8 @@
 
 require parquet
 
+require vector_size 2048
+
 statement ok
 PRAGMA threads=4;
 

--- a/test/sql/copy/return_files.test
+++ b/test/sql/copy/return_files.test
@@ -23,6 +23,11 @@ COPY integers TO '{TEST_DIR}/test_batch_copy_to_file.parquet' (RETURN_FILES TRUE
 ----
 200000	<REGEX>:.*test_batch_copy_to_file.parquet.*
 
+statement error
+COPY integers TO '{TEST_DIR}/test_return_files_stats_conflict.parquet' (RETURN_FILES, RETURN_STATS);
+----
+Binder Error
+
 statement ok
 SET threads=2;
 

--- a/test/sql/copy/row_groups_per_file.test
+++ b/test/sql/copy/row_groups_per_file.test
@@ -154,7 +154,32 @@ COPY bigdata TO '{TEST_DIR}/row_groups_per_file_error' (FORMAT PARQUET, ROW_GROU
 ----
 Not implemented Error
 
-statement error
-COPY bigdata TO '{TEST_DIR}/row_groups_per_file_error' (FORMAT PARQUET, ROW_GROUPS_PER_FILE 1, PARTITION_BY col_a);
+statement ok
+CREATE TABLE partitioned_bigdata AS
+SELECT col_a % 4 AS part, col_a, col_b FROM bigdata;
+
+statement ok
+COPY partitioned_bigdata
+TO '{TEST_DIR}/row_groups_per_file_partitioned'
+(FORMAT PARQUET, ROW_GROUP_SIZE 1000, ROW_GROUPS_PER_FILE 1, PARTITION_BY part);
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/row_groups_per_file_partitioned/**/*.parquet', hive_partitioning = true);
 ----
-Not implemented Error
+10000
+
+query I
+WITH files AS (
+	SELECT part, count(DISTINCT filename) file_count
+	FROM read_parquet(
+		'{TEST_DIR}/row_groups_per_file_partitioned/**/*.parquet',
+		filename = true,
+		hive_partitioning = true
+	)
+	GROUP BY part
+)
+SELECT min(file_count) > 1
+FROM files;
+----
+true


### PR DESCRIPTION
This PR enables `FILE_SIZE_BYTES` and `ROW_GROUPS_PER_FILE` for `COPY` with `PARTITION_BY`. *Almost* all the functionality was there, but it was just guarded by the binder. While doing this I've also improved how we check copy option compatibility and setting defaults in `bind_copy.cpp` because the implementation got stuff bolted on over time and it started to bug me how it looked.