### PR TITLE
CLI: Make .schema indent by default and add syntax highlighting, and add `--no-indent/--no-format` to revert to the old single-line formatting

### DIFF
--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -79,6 +79,9 @@ public:
 		return true;
 	}
 
+	// Print a complete SQL statement, applying syntax highlighting when the output stream supports it
+	void PrintSQL(const string &sql);
+
 	void RenderAlignedValue(const string &str, idx_t width, TextAlignment alignment = TextAlignment::CENTER);
 	void RenderAlignedValue(const char *str, idx_t str_len, idx_t width,
 	                        TextAlignment alignment = TextAlignment::CENTER);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -64,7 +64,6 @@ enum class RenderMode : uint32_t {
 	EXPLAIN,   /* Like RenderMode::Column, but do not truncate data */
 	DESCRIBE,  /* Special DESCRIBE Renderer */
 	ASCII,     /* Use ASCII unit and record separators (0x1F/0x1E) */
-	PRETTY,    /* Pretty-print schemas */
 	EQP,       /* Converts EXPLAIN QUERY PLAN output into a graph */
 	JSON,      /* Output JSON */
 	MARKDOWN,  /* Markdown formatting */
@@ -440,6 +439,8 @@ public:
 	static string ModeToString(RenderMode mode);
 	MetadataResult FormatSQL(string &sql);
 	void HighlightSQL(string &sql);
+	// Print a complete SQL statement directly to the output, applying syntax highlighting when appropriate
+	void PrintSQL(const string &sql);
 	string ReadFileContents(FILE *f);
 	string ReadFileContents(const string &filename);
 };

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -688,8 +688,6 @@ string ShellState::ModeToString(RenderMode mode) {
 		return "describe";
 	case RenderMode::ASCII:
 		return "ascii";
-	case RenderMode::PRETTY:
-		return "prettyprint";
 	case RenderMode::EQP:
 		return "eqp";
 	case RenderMode::JSON:
@@ -881,7 +879,7 @@ void ShellState::RunTableDumpQuery(const string &zSelect) {
 	}
 	for (auto &row : *result) {
 		auto zStr = row.GetValue<string>(0);
-		Print(zStr);
+		PrintSQL(zStr);
 		auto z = zStr.c_str();
 		if (!z) {
 			z = "";
@@ -1104,7 +1102,7 @@ void ShellState::RunSchemaDumpQuery(const string &zQuery) {
 		auto zSql = row.GetValue<string>(2);
 
 		// print sql
-		Print(GetSchemaLine(zSql, ";\n"));
+		PrintSQL(GetSchemaLine(zSql, ";\n"));
 		if (zType == "table") {
 			// dump table contents
 			string sSelect;
@@ -2056,26 +2054,39 @@ bool ShellState::ReadFromFile(const string &file) {
 bool ShellState::DisplaySchemas(const vector<string> &args) {
 	const char *zName = nullptr;
 	bool bDebug = 0;
+	// statements are pretty-printed using the SQL formatter by default
+	bool bFormat = true;
 	SuccessState rc = SuccessState::SUCCESS;
 
-	RenderMode mode = RenderMode::SEMI;
 	for (idx_t ii = 1; ii < args.size(); ii++) {
-		if (optionMatch(args[ii], "indent")) {
-			mode = RenderMode::PRETTY;
+		// --indent (and its alias --format) pretty-prints the statements using the SQL formatter (the default)
+		if (optionMatch(args[ii], "indent") || optionMatch(args[ii], "format")) {
+			bFormat = true;
+			// --no-indent (and its alias --no-format) prints the statements as they are stored
+		} else if (optionMatch(args[ii], "no-indent") || optionMatch(args[ii], "no-format")) {
+			bFormat = false;
 		} else if (optionMatch(args[ii], "debug")) {
 			bDebug = true;
+		} else if (!args[ii].empty() && args[ii][0] == '-') {
+			PrintF(PrintOutput::STDERR,
+			       "Error: unknown option \"%s\"\nUsage: .schema ?--indent|--no-indent? ?LIKE-PATTERN?\n",
+			       args[ii].c_str());
+			return false;
 		} else if (zName == 0) {
 			zName = args[ii].c_str();
 		} else {
-			PrintF(PrintOutput::STDERR, "Usage: .schema ?--indent? ?LIKE-PATTERN?\n");
+			PrintF(PrintOutput::STDERR, "Usage: .schema ?--indent|--no-indent? ?LIKE-PATTERN?\n");
 			return false;
 		}
 	}
-	auto renderer = GetRenderer(mode);
+	auto renderer = GetRenderer(RenderMode::SEMI);
 	renderer->show_header = false;
 
 	string sSelect;
-	sSelect += "SELECT sql FROM sqlite_master WHERE ";
+	// by default the stored SQL is pretty-printed through the duckdb_format_sql function
+	// (unless --no-indent/--no-format was passed)
+	sSelect +=
+	    bFormat ? "SELECT duckdb_format_sql(sql) FROM sqlite_master WHERE " : "SELECT sql FROM sqlite_master WHERE ";
 	if (zName) {
 		auto zQarg = StringUtil::Format("%s", SQLString(zName));
 		int bGlob = strchr(zName, '*') != 0 || strchr(zName, '?') != 0 || strchr(zName, '[') != 0;
@@ -2928,6 +2939,13 @@ void ShellState::HighlightSQL(string &sql) {
 	auto highlighted =
 	    duckdb::Highlighting::HighlightText(const_cast<char *>(sql.c_str()), sql.size(), 0, sql.size(), tokens);
 	sql = std::move(highlighted);
+}
+
+void ShellState::PrintSQL(const string &sql) {
+	string highlighted = sql;
+	// HighlightSQL is a no-op when highlighting is disabled or output is not a console
+	HighlightSQL(highlighted);
+	Print(highlighted);
 }
 
 string ShellState::ReadFileContents(FILE *f) {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -133,7 +133,7 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 		}
 	}
 
-	state.PrintF("BEGIN TRANSACTION;\n");
+	state.PrintSQL("BEGIN TRANSACTION;\n");
 	state.showHeader = 0;
 	state.nErr = 0;
 	if (zLike.empty()) {
@@ -151,7 +151,7 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 	for (auto &row : *result) {
 		auto schema = row.GetValue<string>(0);
 		auto create_schema = StringUtil::Format("CREATE SCHEMA IF NOT EXISTS %s;", SQLIdentifier(schema));
-		state.PrintF("%s;\n", create_schema.c_str());
+		state.PrintSQL(create_schema + ";\n");
 	}
 
 	zSql = StringUtil::Format("SELECT name, type, sql FROM sqlite_schema "
@@ -165,7 +165,7 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 	                          "  AND type IN ('index','trigger','view')",
 	                          zLike);
 	state.RunTableDumpQuery(zSql);
-	state.PrintF(state.nErr ? "ROLLBACK; -- due to errors\n" : "COMMIT;\n");
+	state.PrintSQL(state.nErr ? "ROLLBACK; -- due to errors\n" : "COMMIT;\n");
 	state.showHeader = savedShowHeader;
 	state.shellFlgs = savedShellFlags;
 	return MetadataResult::SUCCESS;
@@ -971,7 +971,9 @@ static const MetadataCommand metadata_commands[] = {
     {"safe_mode", 0, ShellState::EnableSafeMode, "", "Enable safe-mode", 0, ""},
     {"separator", 0, ShellState::SetSeparator, "COL ?ROW?", "Change the column and row separators", 0, ""},
     {"schema", 0, DisplaySchemas, "?PATTERN?", "Show the CREATE statements matching PATTERN", 0,
-     "Options:\n\t--indent\tTry to pretty-print the schema"},
+     "By default the schema is pretty-printed using the SQL formatter.\nOptions:\n\t--no-indent\tPrint the schema as "
+     "it is stored, without formatting\n\t--no-format\tAlias for --no-indent\n\t--indent\tForce pretty-printing (the "
+     "default)\n\t--format\tAlias for --indent"},
     {"shell", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0, ""},
     {"show", 1, ShowConfiguration, "", "Show the current values for various settings", 0, ""},
 #ifdef HAVE_LINENOISE

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -50,6 +50,44 @@ void PrintStream::PrintDashes(idx_t N) {
 	Print(string(N, '-'));
 }
 
+void PrintStream::PrintSQL(const string &sql) {
+	if (!SupportsHighlight()) {
+		// the output stream does not support highlighting (e.g. width measuring / redirected output)
+		Print(sql);
+		return;
+	}
+	string highlighted = sql;
+	// HighlightSQL is a no-op when highlighting is disabled or output is not a console
+	state.HighlightSQL(highlighted);
+	Print(highlighted);
+}
+
+// A PrintStream that captures all output into a string instead of writing it out.
+// Used to build a complete SQL statement so it can be highlighted as a whole before printing.
+struct StringPrintStream : public PrintStream {
+	explicit StringPrintStream(ShellState &state) : PrintStream(state) {
+	}
+
+	void Print(const string &str) override {
+		result += str;
+	}
+	void Print(duckdb::string_t str) override {
+		result.append(str.GetData(), str.GetSize());
+	}
+	void Print(const char *str) override {
+		result += str;
+	}
+	void SetBinaryMode() override {
+	}
+	void SetTextMode() override {
+	}
+	bool SupportsHighlight() override {
+		return false;
+	}
+
+	string result;
+};
+
 void PrintStream::OutputQuotedIdentifier(const string &str) {
 	Print(StringUtil::Format("%s", SQLIdentifier(str)));
 }
@@ -1358,31 +1396,34 @@ public:
 		auto &col_names = result.column_names;
 		auto &is_null = row.is_null;
 
-		out.Print("INSERT INTO ");
-		out.Print(state.zDestTable);
+		// build the full INSERT statement into a buffer so it can be highlighted as a whole
+		StringPrintStream buffer(state);
+		buffer.Print("INSERT INTO ");
+		buffer.Print(state.zDestTable);
 		if (show_header) {
-			out.Print("(");
+			buffer.Print("(");
 			for (idx_t i = 0; i < col_names.size(); i++) {
 				if (i > 0) {
-					out.Print(",");
+					buffer.Print(",");
 				}
-				out.OutputQuotedIdentifier(col_names[i]);
+				buffer.OutputQuotedIdentifier(col_names[i]);
 			}
-			out.Print(")");
+			buffer.Print(")");
 		}
 		for (idx_t i = 0; i < data.size(); i++) {
-			out.Print(i > 0 ? "," : " VALUES(");
+			buffer.Print(i > 0 ? "," : " VALUES(");
 			if (is_null[i]) {
-				out.Print("NULL");
+				buffer.Print("NULL");
 			} else if (types[i].IsNumeric()) {
-				out.Print(data[i]);
+				buffer.Print(data[i]);
 			} else if (state.ShellHasFlag(ShellFlags::SHFLG_Newlines)) {
-				out.OutputQuotedString(data[i].GetString());
+				buffer.OutputQuotedString(data[i].GetString());
 			} else {
-				out.Print(EscapeNewlines(data[i].GetString()));
+				buffer.Print(EscapeNewlines(data[i].GetString()));
 			}
 		}
-		out.Print(");\n");
+		buffer.Print(");\n");
+		out.PrintSQL(buffer.result);
 	}
 
 	string EscapeNewlines(const string &str) {
@@ -1448,116 +1489,7 @@ public:
 
 	void RenderRow(PrintStream &out, ResultMetadata &result, RowData &row) override {
 		/* .schema and .fullschema output */
-		out.Print(state.GetSchemaLine(row.data[0].GetString(), "\n"));
-	}
-};
-
-class ModePrettyRenderer : public RowRenderer {
-public:
-	explicit ModePrettyRenderer(ShellState &state) : RowRenderer(state) {
-	}
-
-	static bool IsSpace(char c) {
-		return duckdb::StringUtil::CharacterIsSpace(c);
-	}
-
-	void RenderRow(PrintStream &out, ResultMetadata &result, RowData &row) override {
-		auto &data = row.data;
-		/* .schema and .fullschema with --indent */
-		if (data.size() != 1) {
-			throw std::runtime_error("row must have exactly one value for pretty rendering");
-		}
-		int j;
-		int nParen = 0;
-		char cEnd = 0;
-		char c;
-		int nLine = 0;
-		if (duckdb::StringUtil::StartsWith(data[0].GetString(), "CREATE VIEW") ||
-		    duckdb::StringUtil::StartsWith(data[0].GetString(), "CREATE TRIG")) {
-			out.Print(data[0]);
-			out.Print(";\n");
-			return;
-		}
-		auto zStr = unique_ptr<char[]>(new char[data[0].GetSize() + 1]);
-		memcpy(zStr.get(), data[0].GetData(), data[0].GetSize());
-		zStr[data[0].GetSize()] = '\0';
-		auto z = zStr.get();
-		j = 0;
-		idx_t i;
-		for (i = 0; IsSpace(z[i]); i++) {
-		}
-		for (; (c = z[i]) != 0; i++) {
-			if (IsSpace(c)) {
-				if (z[j - 1] == '\r') {
-					z[j - 1] = '\n';
-				}
-				if (IsSpace(z[j - 1]) || z[j - 1] == '(') {
-					continue;
-				}
-			} else if ((c == '(' || c == ')') && j > 0 && IsSpace(z[j - 1])) {
-				j--;
-			}
-			z[j++] = c;
-		}
-		while (j > 0 && IsSpace(z[j - 1])) {
-			j--;
-		}
-		z[j] = 0;
-		if (state.StringLength(z) >= 79) {
-			for (i = j = 0; (c = z[i]) != 0; i++) { /* Copy from z[i] back to z[j] */
-				if (c == cEnd) {
-					cEnd = 0;
-				} else if (c == '"' || c == '\'' || c == '`') {
-					cEnd = c;
-				} else if (c == '[') {
-					cEnd = ']';
-				} else if (c == '-' && z[i + 1] == '-') {
-					cEnd = '\n';
-				} else if (c == '(') {
-					nParen++;
-				} else if (c == ')') {
-					nParen--;
-					if (nLine > 0 && nParen == 0 && j > 0) {
-						out.Print(state.GetSchemaLineN(z, j, "\n"));
-						j = 0;
-					}
-				}
-				z[j++] = c;
-				if (nParen == 1 && cEnd == 0 && (c == '(' || c == '\n' || (c == ',' && !wsToEol(z + i + 1)))) {
-					if (c == '\n')
-						j--;
-					out.Print(state.GetSchemaLineN(z, j, "\n  "));
-					j = 0;
-					nLine++;
-					while (IsSpace(z[i + 1])) {
-						i++;
-					}
-				}
-			}
-			z[j] = 0;
-		}
-		out.Print(state.GetSchemaLine(z, ";\n"));
-	}
-
-	/*
-	** Return true if string z[] has nothing but whitespace and comments to the
-	** end of the first line.
-	*/
-	static bool wsToEol(const char *z) {
-		int i;
-		for (i = 0; z[i]; i++) {
-			if (z[i] == '\n') {
-				return true;
-			}
-			if (IsSpace(z[i])) {
-				continue;
-			}
-			if (z[i] == '-' && z[i + 1] == '-') {
-				return true;
-			}
-			return false;
-		}
-		return true;
+		out.PrintSQL(state.GetSchemaLine(row.data[0].GetString(), "\n"));
 	}
 };
 
@@ -1831,8 +1763,6 @@ unique_ptr<ShellRenderer> ShellState::GetRenderer(RenderMode mode) {
 		return make_uniq<ModeInsertRenderer>(*this);
 	case RenderMode::SEMI:
 		return make_uniq<ModeSemiRenderer>(*this);
-	case RenderMode::PRETTY:
-		return make_uniq<ModePrettyRenderer>(*this);
 	case RenderMode::COLUMN:
 		return make_uniq<ModeColumnRenderer>(*this);
 	case RenderMode::TABLE:

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -441,6 +441,7 @@ def test_volatile_commands(shell, cmd):
     ""
 ])
 def test_schema(shell, pattern):
+    # .schema pretty-prints the statements using the SQL formatter by default
     test = (
         ShellTest(shell)
         .statement("create table test (a int, b varchar);")
@@ -448,7 +449,7 @@ def test_schema(shell, pattern):
         .statement(f".schema {pattern}")
     )
     result = test.run()
-    result.check_stdout("CREATE TABLE test(a INTEGER, b VARCHAR);")
+    result.check_stdout("CREATE TABLE test(\n    a INTEGER,\n    b VARCHAR\n);")
 
 def test_schema_indent(shell):
     test = (
@@ -458,6 +459,27 @@ def test_schema_indent(shell):
     )
     result = test.run()
     result.check_stdout("CREATE TABLE test(\n")
+
+@pytest.mark.parametrize("option", ["--no-indent", "--no-format"])
+def test_schema_no_indent(shell, option):
+    # --no-indent / --no-format prints the statements as they are stored (single line)
+    test = (
+        ShellTest(shell)
+        .statement("create table test (a int, b varchar);")
+        .statement(f".schema {option}")
+    )
+    result = test.run()
+    result.check_stdout("CREATE TABLE test(a INTEGER, b VARCHAR);")
+
+def test_schema_unknown_option(shell):
+    test = (
+        ShellTest(shell)
+        .statement("create table test (a int, b varchar);")
+        .statement(".schema -x")
+    )
+    result = test.run()
+    assert result.status_code == 1
+    result.check_stderr('unknown option "-x"')
 
 def test_tables(shell):
     test = (
@@ -567,7 +589,7 @@ def test_schema_pattern(shell):
         .statement(".schema %p")
     )
     result = test.run()
-    result.check_stdout("CREATE TABLE duckdb_p(a INTEGER, b VARCHAR, c BIT);")
+    result.check_stdout("CREATE TABLE duckdb_p(\n    a INTEGER,\n    b VARCHAR,\n    c BIT\n);")
 
 @pytest.mark.skipif(os.name == 'nt', reason="Windows treats newlines in a problematic manner")
 def test_schema_pattern_extended(shell):
@@ -579,8 +601,8 @@ def test_schema_pattern_extended(shell):
     )
     result = test.run()
     expected = [
-        "CREATE TABLE duckdb_p(a INTEGER, b VARCHAR, c BIT);",
-        "CREATE TABLE p_duck(d INTEGER, f DATE);"
+        "CREATE TABLE duckdb_p(\n    a INTEGER,\n    b VARCHAR,\n    c BIT\n);",
+        "CREATE TABLE p_duck(\n    d INTEGER,\n    f DATE\n);"
     ]
     result.check_stdout(expected)
 


### PR DESCRIPTION
`.schema` gives back a list of the schemas of the current database:

<img width="2196" height="204" alt="Screenshot 2026-06-04 at 15 20 45" src="https://github.com/user-attachments/assets/6aab2f74-db04-4497-bed5-f1ca16aca362" />

Currently we're lacking syntax highlighting. Formatting is available through `.schema --indent` but it uses SQLite's formatter (not ours):

<img width="556" height="431" alt="Screenshot 2026-06-04 at 15 21 36" src="https://github.com/user-attachments/assets/43c61449-3cf2-4b52-af39-a0ac907e6af5" />


This PR makes a few changes to `.schema`:

* `.schema` now indents by default, using DuckDB's formatter. The SQLite formatting code (`RenderMode::PRETTY_PRINT`) is removed.
* `.schema` and `.dump` now use syntax highlighting when printing the emitted SQL
* `.schema --no-format` is added as an option which reverts to not formatting the SQL.

Here's what `.schema` now looks like:

<img width="561" height="603" alt="Screenshot 2026-06-04 at 15 34 36" src="https://github.com/user-attachments/assets/449fe1b0-b780-4d83-9eb9-e7d6c3a048d5" />
