### PR TITLE
remove assert in DataTable::RemoveFromIndexes

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1493,8 +1493,6 @@ void DataTable::RevertIndexAppend(TableAppendState &state, DataChunk &chunk, Vec
 
 void DataTable::RemoveFromIndexes(const QueryContext &context, Vector &row_identifiers, idx_t count,
                                   IndexRemovalType removal_type, optional_idx active_checkpoint) {
-	D_ASSERT(IsMainTable() || removal_type == IndexRemovalType::REVERT_MAIN_INDEX ||
-	         removal_type == IndexRemovalType::REVERT_MAIN_INDEX_ONLY);
 	row_groups->RemoveFromIndexes(context, info->indexes, row_identifiers, count, removal_type, active_checkpoint);
 }
 

--- a/test/sql/transactions/test_index_delete_cleanup_non_main_storage.test
+++ b/test/sql/transactions/test_index_delete_cleanup_non_main_storage.test
@@ -1,0 +1,194 @@
+# name: test/sql/transactions/test_index_delete_cleanup_non_main_storage.test
+# description: Index delete cleanup can target non-main table storage versions
+# group: [transactions]
+
+load {TEST_DIR}/test_index_delete_cleanup_non_main_storage.db
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+SET index_scan_percentage=1.0
+
+statement ok
+SET index_scan_max_count=1
+
+statement ok con3
+SET index_scan_percentage=1.0
+
+statement ok con3
+SET index_scan_max_count=1
+
+# Cleanup after DROP/recreate.
+statement ok
+CREATE TABLE t_drop (id INTEGER PRIMARY KEY, val INTEGER)
+
+statement ok
+INSERT INTO t_drop SELECT i, i * 10 FROM range(1000) tbl(i)
+
+statement ok con3
+BEGIN TRANSACTION
+
+query I con3
+SELECT COUNT(*) FROM t_drop
+----
+1000
+
+statement ok con2
+DELETE FROM t_drop WHERE id < 500
+
+statement ok con1
+DROP TABLE t_drop
+
+statement ok con1
+CREATE TABLE t_drop (id INTEGER PRIMARY KEY, val INTEGER)
+
+query II con3
+EXPLAIN ANALYZE SELECT val FROM t_drop WHERE id = 42
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I con3
+SELECT val FROM t_drop WHERE id = 42
+----
+420
+
+statement ok con3
+COMMIT
+
+query I
+SELECT COUNT(*) FROM t_drop
+----
+0
+
+# Cleanup after CREATE OR REPLACE.
+statement ok
+CREATE TABLE t_replace (id INTEGER PRIMARY KEY, val INTEGER)
+
+statement ok
+INSERT INTO t_replace SELECT i, i * 10 FROM range(1000) tbl(i)
+
+statement ok con3
+BEGIN TRANSACTION
+
+query I con3
+SELECT COUNT(*) FROM t_replace
+----
+1000
+
+statement ok con2
+DELETE FROM t_replace WHERE id < 500
+
+statement ok con1
+CREATE OR REPLACE TABLE t_replace (id INTEGER PRIMARY KEY, val INTEGER)
+
+query II con3
+EXPLAIN ANALYZE SELECT val FROM t_replace WHERE id = 42
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I con3
+SELECT val FROM t_replace WHERE id = 42
+----
+420
+
+statement ok con3
+COMMIT
+
+query I
+SELECT COUNT(*) FROM t_replace
+----
+0
+
+# Cleanup after ALTER.
+statement ok
+CREATE TABLE t_alter (id INTEGER PRIMARY KEY, val INTEGER)
+
+statement ok
+INSERT INTO t_alter SELECT i, i * 10 FROM range(1000) tbl(i)
+
+statement ok con3
+BEGIN TRANSACTION
+
+query I con3
+SELECT COUNT(*) FROM t_alter
+----
+1000
+
+statement ok con2
+DELETE FROM t_alter WHERE id < 500
+
+statement ok con1
+ALTER TABLE t_alter ADD COLUMN extra INTEGER DEFAULT 0
+
+query II con3
+EXPLAIN ANALYZE SELECT val FROM t_alter WHERE id = 42
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I con3
+SELECT val FROM t_alter WHERE id = 42
+----
+420
+
+statement ok con3
+COMMIT
+
+query IIIII
+SELECT COUNT(*), MIN(id), MAX(id), MIN(extra), MAX(extra) FROM t_alter
+----
+500	500	999	0	0
+
+query II
+EXPLAIN ANALYZE SELECT val FROM t_alter WHERE id = 700
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I
+SELECT val FROM t_alter WHERE id = 700
+----
+7000
+
+query I
+SELECT COUNT(*) FROM t_alter WHERE id = 42
+----
+0
+
+# Same-transaction DELETE then ALTER.
+statement ok
+CREATE TABLE t_same_tx (id INTEGER PRIMARY KEY, val INTEGER)
+
+statement ok
+INSERT INTO t_same_tx SELECT i, i * 10 FROM range(1000) tbl(i)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM t_same_tx WHERE id < 500
+
+statement ok
+ALTER TABLE t_same_tx ADD COLUMN extra INTEGER DEFAULT 0
+
+statement ok
+COMMIT
+
+query IIIII
+SELECT COUNT(*), MIN(id), MAX(id), MIN(extra), MAX(extra) FROM t_same_tx
+----
+500	500	999	0	0
+
+query II
+EXPLAIN ANALYZE SELECT val FROM t_same_tx WHERE id = 700
+----
+analyzed_plan	<REGEX>:.*Index Scan.*
+
+query I
+SELECT val FROM t_same_tx WHERE id = 700
+----
+7000
+
+query I
+SELECT COUNT(*) FROM t_same_tx WHERE id = 42
+----
+0


### PR DESCRIPTION
https://github.com/duckdblabs/duckdb-internal/issues/7507

Also a follow up to https://github.com/duckdb/duckdb/pull/22198. I'm targeting this PR to main since the related tests can still fail on 1.5, since they depend on the deferred index/block marking PR that was targeted to main. 

I don't think there are more issues in the related code path, the issue here is a spurious debug assert failure. I tried to make the assert more restrictive in the previous PR, but there are some more cases we can reach here, so I think it's better to just get rid of it for now. 

I also added some tests that exercise where the assert was previously failing, which doesn't hurt to add as transaction/index test coverage. 