### PR TITLE
Remove several unnecessary calls to `SetChildCardinality`

### DIFF
--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -201,7 +201,6 @@ struct ICUTableRange {
 			}
 			if (state.empty_range) {
 				// empty range
-				output.SetChildCardinality(0);
 				state.current_input_row++;
 				state.initialized_row = false;
 				return OperatorResultType::HAVE_MORE_OUTPUT;

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -477,7 +477,6 @@ void MultiFileReader::FinalizeChunk(ClientContext &context, const MultiFileBindD
 			                          first_message, original_error, extended_error);
 		}
 	}
-	output_chunk.SetChildCardinality(input_chunk.size());
 }
 
 void MultiFileReader::GetPartitionData(ClientContext &context, const MultiFileReaderBindData &bind_data,

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -474,7 +474,6 @@ void ART::GenerateKeyVectors(ArenaAllocator &allocator, DataChunk &input, const 
 	row_id_chunk.Initialize(Allocator::DefaultAllocator(), vector<LogicalType> {LogicalType::ROW_TYPE},
 	                        key_input->size());
 	row_id_chunk.data[0].Reference(row_ids);
-	row_id_chunk.SetChildCardinality(key_input->size());
 	GenerateKeys<>(allocator, row_id_chunk, row_id_keys);
 }
 

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -249,7 +249,6 @@ void BoundIndex::ApplyBufferedReplays(const vector<LogicalType> &table_types, Bu
 				table_chunk.data[col_id].Reference(state.current_chunk.data[col_idx]);
 				table_chunk.data[col_id].Slice(sel, rows_to_process);
 			}
-			table_chunk.SetChildCardinality(rows_to_process);
 			Vector row_ids(state.current_chunk.data.back(), sel, rows_to_process);
 
 			if (replay_range.type == BufferedIndexReplay::INSERT_ENTRY) {

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1462,8 +1462,6 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 						idx_t probe_col_idx = ht.lhs_output_in_probe[i];
 						result.data[i].Slice(probe_data.data[probe_col_idx], chain_match_sel_vector, result_count);
 					}
-					result.SetChildCardinality(result_count);
-
 					// on the RHS, we need to fetch the data from the hash table
 					ht.GatherRHS(pointers, chain_match_sel_vector, result_count, result, ht.lhs_output_in_probe.size());
 
@@ -1485,8 +1483,6 @@ void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &probe_data, DataCh
 			idx_t probe_col_idx = ht.lhs_output_in_probe[i];
 			result.data[i].Slice(probe_data.data[probe_col_idx], lhs_sel_vector, base_count);
 		}
-		result.SetChildCardinality(base_count);
-
 		// 2) gather RHS vectors
 		ht.GatherRHS(rhs_pointers, *FlatVector::IncrementalSelectionVector(), base_count, result,
 		             ht.lhs_output_in_probe.size());
@@ -1535,7 +1531,6 @@ void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, DataChunk &probe_data, D
 			idx_t probe_col_idx = ht.lhs_output_in_probe[i];
 			result.data[i].Slice(probe_data.data[probe_col_idx], sel, result_count);
 		}
-		result.SetChildCardinality(result_count);
 	} else {
 		D_ASSERT(result.size() == 0);
 	}
@@ -1772,8 +1767,6 @@ void ScanStructure::NextLeftJoin(DataChunk &keys, DataChunk &probe_data, DataChu
 				idx_t probe_col_idx = ht.lhs_output_in_probe[i];
 				result.data[i].Slice(probe_data.data[probe_col_idx], sel, remaining_count);
 			}
-			result.SetChildCardinality(remaining_count);
-
 			// now set the right side to NULL
 			for (idx_t i = ht.lhs_output_in_probe.size(); i < result.ColumnCount(); i++) {
 				Vector &vec = result.data[i];
@@ -1940,8 +1933,6 @@ void JoinHashTable::ScanFullOuter(JoinHTScanState &state, Vector &addresses, Dat
 	if (found_entries == 0) {
 		return;
 	}
-	result.SetChildCardinality(found_entries);
-
 	idx_t left_column_count = result.ColumnCount() - output_columns.size();
 	if (join_type == JoinType::RIGHT_SEMI || join_type == JoinType::RIGHT_ANTI) {
 		left_column_count = 0;

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -450,7 +450,6 @@ SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, DataChunk 
 		}
 	}
 
-	aggregate_input_chunk.SetChildCardinality(chunk.size());
 	aggregate_input_chunk.Verify(context.client.db);
 
 	// For every grouping set there is one radix_table
@@ -795,7 +794,6 @@ TaskExecutionResult HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping
 				auto &bound_ref_expr = group->Cast<BoundReferenceExpression>();
 				group_chunk.data[bound_ref_expr.Index()].Reference(output_chunk.data[group_idx]);
 			}
-			group_chunk.SetChildCardinality(output_chunk.size());
 
 			for (idx_t child_idx = 0; child_idx < grouped_aggregate_data.groups.size() - group_by_size; child_idx++) {
 				aggregate_input_chunk.data[payload_idx + child_idx].Reference(

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -450,6 +450,7 @@ SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, DataChunk 
 		}
 	}
 
+	aggregate_input_chunk.SetChildCardinality(chunk.size());
 	aggregate_input_chunk.Verify(context.client.db);
 
 	// For every grouping set there is one radix_table

--- a/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_perfecthash_aggregate.cpp
@@ -147,8 +147,6 @@ SinkResultType PhysicalPerfectHashAggregate::Sink(ExecutionContext &context, Dat
 		}
 	}
 
-	aggregate_input_chunk.SetChildCardinality(chunk.size());
-
 	group_chunk.Verify(context.client.db);
 	aggregate_input_chunk.Verify(context.client.db);
 	D_ASSERT(aggregate_input_chunk.ColumnCount() == 0 || group_chunk.size() == aggregate_input_chunk.size());

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -419,7 +419,6 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
 		//	then just delay more rows, return nothing
 		//	and ask for more data.
 		delayed.Append(input);
-		output.SetChildCardinality(0);
 		return OperatorResultType::NEED_MORE_INPUT;
 	} else if (input.size() < delayed.size()) {
 		// If we can't consume all of the delayed values,

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -1169,7 +1169,6 @@ void WindowLocalSourceState::GetData(ExecutionContext &context, DataChunk &resul
 		OperatorSinkInput sink {*gestates[expr_idx], *local_states[expr_idx], interrupt};
 		executor.Evaluate(context, position, eval_chunk, result, sink, input_chunk.size());
 	}
-	output_chunk.SetChildCardinality(input_chunk.size());
 	output_chunk.Verify(context.client.db);
 
 	idx_t out_idx = 0;

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1668,7 +1668,7 @@ void IEJoinLocalSourceState::ResolveMarkJoin(ExecutionContext &context, DataChun
 
 	//	Merge lsel and unmatched LHS rids into (the unused) rsel, tracking the matches
 	bool found_match[STANDARD_VECTOR_SIZE];
-	const idx_t result_count = FindSimpleMatches(context, found_match);
+	FindSimpleMatches(context, found_match);
 
 	//	Read the lhs rows
 	left_table.Repin(*left_iterator);

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -614,7 +614,6 @@ idx_t IEJoinUnion::AppendKey(ExecutionContext &context, InterruptState &interrup
 
 		// Mark the rid column
 		payload.data[0].Sequence(rid, increment, scan_count);
-		payload.SetChildCardinality(scan_count);
 		keys.Fuse(payload);
 		rid += increment * UnsafeNumericCast<int64_t>(scan_count);
 
@@ -1430,8 +1429,6 @@ void IEJoinLocalSourceState::SplitPayloads(DataChunk &chunk) {
 			rpayload.data[col_idx - left_cols].Reference(chunk.data[col_idx - left_cols]);
 		}
 	}
-	lpayload.SetChildCardinality(chunk.size());
-	rpayload.SetChildCardinality(chunk.size());
 }
 
 const SelectionVector *IEJoinLocalSourceState::ApplyArbitraryPredicate(DataChunk &chunk) {
@@ -1550,7 +1547,6 @@ void IEJoinLocalSourceState::ResolveSimpleJoin(ExecutionContext &context) {
 			left_table.Repin(*left_iterator);
 			op.SliceSortedPayload(lpayload, left_table, *left_iterator, left_chunk_state, left_block_index, lsel,
 			                      *left_scan_state);
-			lpayload.SetChildCardinality(result_count);
 		}
 
 		//	Handle chunk boundaries: If we found a match for the last value
@@ -1649,7 +1645,6 @@ void IEJoinLocalSourceState::ResolveAntiJoin(ExecutionContext &context, DataChun
 		left_table.Repin(*left_iterator);
 		op.SliceSortedPayload(lpayload, left_table, *left_iterator, left_chunk_state, left_block_index, rsel,
 		                      *left_scan_state);
-		lpayload.SetChildCardinality(result_count);
 
 		result.Reference(lpayload);
 		result.Verify(context.client.db);
@@ -1679,7 +1674,6 @@ void IEJoinLocalSourceState::ResolveMarkJoin(ExecutionContext &context, DataChun
 	left_table.Repin(*left_iterator);
 	op.SliceSortedPayload(lpayload, left_table, *left_iterator, left_chunk_state, left_block_index, rsel,
 	                      *left_scan_state);
-	lpayload.SetChildCardinality(result_count);
 
 	//	Compute the residual keys
 	//	We know here that the two sort columns are not NULL, so the tail columns are all we need
@@ -2040,7 +2034,6 @@ void IEJoinLocalSourceState::ExecuteLeftTask(ExecutionContext &context, DataChun
 	}
 
 	op.ProjectResult(chunk, result);
-	result.SetChildCardinality(count);
 	result.Verify(context.client.db);
 }
 
@@ -2073,7 +2066,6 @@ void IEJoinLocalSourceState::ExecuteRightTask(ExecutionContext &context, DataChu
 	}
 
 	op.ProjectResult(chunk, result);
-	result.SetChildCardinality(count);
 	result.Verify(context.client.db);
 }
 

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -70,6 +70,7 @@ void PhysicalRangeJoin::LocalSortedTable::Sink(ExecutionContext &context, DataCh
 	for (column_t col_idx = 0; col_idx < input.ColumnCount(); ++col_idx) {
 		sort_chunk.data[col_idx + 1].Reference(input.data[col_idx]);
 	}
+	sort_chunk.SetChildCardinality(input.size());
 	// Sink the data into the local sort state
 	InterruptState interrupt;
 	OperatorSinkInput sink {*global_table.global_sink, *local_sink, interrupt};

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -70,8 +70,6 @@ void PhysicalRangeJoin::LocalSortedTable::Sink(ExecutionContext &context, DataCh
 	for (column_t col_idx = 0; col_idx < input.ColumnCount(); ++col_idx) {
 		sort_chunk.data[col_idx + 1].Reference(input.data[col_idx]);
 	}
-	sort_chunk.SetChildCardinality(input.size());
-
 	// Sink the data into the local sort state
 	InterruptState interrupt;
 	OperatorSinkInput sink {*global_table.global_sink, *local_sink, interrupt};

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -151,7 +151,6 @@ static void CombineExistingAndInsertTuples(DataChunk &result, DataChunk &scan_ch
 		// We have not scanned the initial table, so we can just duplicate the initial chunk
 		result.Initialize(client, input_chunk.GetTypes());
 		result.Reference(input_chunk);
-		result.CheckCardinality(input_chunk.size());
 		return;
 	}
 	vector<LogicalType> combined_types;
@@ -212,7 +211,6 @@ static void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, DuckT
 		if (count != chunk.size()) {
 			// Filter any conflicts not meeting the condition.
 			chunk.Slice(sel, count);
-			chunk.CheckCardinality(count);
 			row_ids.Slice(sel, count);
 			row_ids.Flatten();
 		}
@@ -252,7 +250,6 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 
 	// Arrange the columns in the standard table order.
 	DataChunk &append_chunk = lstate.append_chunk;
-	append_chunk.SetChildCardinality(update_chunk.size());
 	for (idx_t i = 0; i < append_chunk.ColumnCount(); i++) {
 		append_chunk.data[i].Reference(chunk.data[i]);
 	}
@@ -483,7 +480,6 @@ static idx_t HandleInsertConflicts(DuckTableEntry &table, ExecutionContext &cont
 	conflict_chunk.InitializeEmpty(tuples.GetTypes());
 	conflict_chunk.Reference(tuples);
 	conflict_chunk.Slice(conflict_manager.GetInvertedSel(), conflict_count);
-	conflict_chunk.CheckCardinality(conflict_count);
 
 	// Contains the conflict chunk and the scanned chunk (wide).
 	DataChunk combined_chunk;
@@ -507,7 +503,6 @@ static idx_t HandleInsertConflicts(DuckTableEntry &table, ExecutionContext &cont
 	auto &inverted_sel = conflict_manager.GetInvertedSel();
 	auto new_size = SelectionVector::Inverted(inverted_sel, sel_vec, conflict_count, tuples.size());
 	tuples.Slice(sel_vec, new_size);
-	tuples.CheckCardinality(new_size);
 
 	return affected_tuples;
 }
@@ -596,11 +591,9 @@ idx_t PhysicalInsert::OnConflictHandling(DuckTableEntry &table, ExecutionContext
 
 			lstate.update_chunk.Reference(insert_chunk);
 			lstate.update_chunk.Slice(last_occurrences, last_occurrences_count);
-			lstate.update_chunk.CheckCardinality(last_occurrences_count);
 		}
 
 		insert_chunk.Slice(sel, sel_count);
-		insert_chunk.CheckCardinality(sel_count);
 	}
 
 	// Check whether any conflicts arise, and if they all meet the conflict_target + condition

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -114,7 +114,6 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	DataChunk &update_chunk = l_state.update_chunk;
 	update_chunk.Reset();
-	update_chunk.SetChildCardinality(chunk.size());
 
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		// Default expression, set to the default value of the column.
@@ -179,7 +178,6 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	auto &delete_chunk = index_update ? l_state.delete_chunk : l_state.mock_chunk;
 	delete_chunk.Reset();
-	delete_chunk.SetChildCardinality(update_count);
 
 	if (index_update) {
 		auto &transaction = DuckTransaction::Get(context.client, table.db);

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -112,7 +112,6 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 			ConstantVector::Reference(state.input_chunk.data[col_idx], count_t(1), input.data[col_idx], state.row_index,
 			                          input.size());
 		}
-		state.input_chunk.SetChildCardinality(1);
 		state.row_index++;
 		state.new_row = false;
 		state.current_ordinality_idx = 1;

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -59,7 +59,6 @@ public:
 			for (idx_t c = 0; c < op.parameters.size(); c++) {
 				input_chunk.data[c].Reference(op.parameters[c], count_t(1));
 			}
-			input_chunk.SetChildCardinality(1);
 		}
 	}
 

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -229,7 +229,6 @@ static void ScatterChunk(DataChunk &output_chunk, DataChunk &input_chunk, const 
 	for (auto &group_idx : idx_set) {
 		output_chunk.data[group_idx].Reference(input_chunk.data[chunk_index++]);
 	}
-	output_chunk.SetChildCardinality(input_chunk.size());
 }
 
 SinkResultType PhysicalRecursiveCTE::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -502,8 +502,6 @@ OperatorFinalizeResultType CachingPhysicalOperator::FinalExecute(ExecutionContex
 	if (state.cached_chunk) {
 		chunk.Move(*state.cached_chunk);
 		state.cached_chunk.reset();
-	} else {
-		chunk.SetChildCardinality(0);
 	}
 	return OperatorFinalizeResultType::FINISHED;
 }

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -46,8 +46,6 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
 	for (idx_t i = 0; i < keys.size(); i++) {
 		chunk.data[0].Append(Value(keys[i]));
 		chunk.data[1].Append(Value(values[i]));
-		// the appends grow the child vectors - record the new cardinality on the chunk itself
-		chunk.CheckCardinality(chunk.data[0].size());
 		if (chunk.size() == STANDARD_VECTOR_SIZE) {
 			collection->Append(chunk);
 			chunk.Reset();

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -199,7 +199,6 @@ struct SortedAggregateState {
 		idx_t total_count = 0;
 		for (column_t i = 0; i < linked.size(); ++i) {
 			funcs[i].BuildListVector(linked[i], chunk.data[i], total_count);
-			chunk.SetChildCardinality(linked[i].total_capacity);
 			FlatVector::SetSize(chunk.data[i], count_t(linked[i].total_capacity));
 		}
 	}
@@ -376,7 +375,6 @@ struct SortedAggregateState {
 		for (column_t col_idx = 0; col_idx < input_chunk->ColumnCount(); ++col_idx) {
 			prefixed.data[col_idx + 1].Reference(input_chunk->data[col_idx]);
 		}
-		prefixed.SetChildCardinality(input_chunk->size());
 		// data[0] was referenced as a constant with count=1 - resize to match
 		FlatVector::SetSize(prefixed.data[0], count_t(input_chunk->size()));
 	}
@@ -446,7 +444,6 @@ struct SortedAggregateFunction {
 			D_ASSERT(buffered_cols[b] < input_count);
 			buffered.data[b].Reference(inputs[buffered_cols[b]]);
 		}
-		buffered.SetChildCardinality(count);
 	}
 
 	static void ScatterUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
@@ -625,7 +622,6 @@ struct SortedAggregateFunction {
 					for (column_t col_idx = 0; col_idx < scanned.ColumnCount(); ++col_idx) {
 						sliced.data[col_idx].Slice(scanned.data[col_idx], consumed, consumed + input_count);
 					}
-					sliced.CheckCardinality(input_count);
 
 					if (cluster_update) {
 						ClusteredAggr clustered;

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -346,7 +346,6 @@ static OperatorResultType RangeDateTimeFunction(ExecutionContext &context, Table
 		}
 		if (state.empty_range) {
 			// empty range
-			output.SetChildCardinality(0);
 			state.current_input_row++;
 			state.initialized_row = false;
 			return OperatorResultType::HAVE_MORE_OUTPUT;

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -43,6 +43,7 @@ static void RepeatFunction(ClientContext &context, TableFunctionInput &data_p, D
 
 	idx_t remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
 	output.data[0].Reference(bind_data.value, count_t(remaining));
+	output.SetChildCardinality(remaining);
 	state.current_count += remaining;
 }
 

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -43,7 +43,6 @@ static void RepeatFunction(ClientContext &context, TableFunctionInput &data_p, D
 
 	idx_t remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
 	output.data[0].Reference(bind_data.value, count_t(remaining));
-	output.SetChildCardinality(remaining);
 	state.current_count += remaining;
 }
 

--- a/src/function/table/repeat_row.cpp
+++ b/src/function/table/repeat_row.cpp
@@ -47,7 +47,6 @@ static void RepeatRowFunction(ClientContext &context, TableFunctionInput &data_p
 	for (idx_t val_idx = 0; val_idx < bind_data.values.size(); val_idx++) {
 		output.data[val_idx].Reference(bind_data.values[val_idx], count_t(remaining));
 	}
-	output.SetChildCardinality(remaining);
 	state.current_count += remaining;
 }
 

--- a/src/function/table/repeat_row.cpp
+++ b/src/function/table/repeat_row.cpp
@@ -47,6 +47,7 @@ static void RepeatRowFunction(ClientContext &context, TableFunctionInput &data_p
 	for (idx_t val_idx = 0; val_idx < bind_data.values.size(); val_idx++) {
 		output.data[val_idx].Reference(bind_data.values[val_idx], count_t(remaining));
 	}
+	output.SetChildCardinality(remaining);
 	state.current_count += remaining;
 }
 

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -141,7 +141,6 @@ void CSVLogStorage::ExecuteCast(LoggingTargetTable table, DataChunk &chunk) {
 	for (idx_t i = 0; i < chunk.data.size(); i++) {
 		VectorOperations::DefaultCast(chunk.data[i], cast_buffer.data[i], count, false);
 	}
-	cast_buffer.SetChildCardinality(count);
 }
 
 void CSVLogStorage::ResetAllBuffers() {

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -96,7 +96,6 @@ void CAPIAggregateUpdate(Vector inputs[], AggregateInputData &aggr_input_data, i
 		inputs[c].Flatten();
 		chunk.data.emplace_back(Vector::Ref(inputs[c]));
 	}
-	chunk.SetChildCardinality(count);
 
 	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();
 	auto state_data = FlatVector::GetDataMutableUnsafe<duckdb_aggregate_state>(state);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -412,7 +412,6 @@ void DataTable::RebuildIndexes() {
 			for (idx_t i = 0; i < col_ids.size(); i++) {
 				table_chunk.data[col_ids[i]].Reference(scan_chunk.data[i]);
 			}
-			table_chunk.SetChildCardinality(scan_chunk.size());
 			Vector &row_ids = scan_chunk.data[col_ids.size()];
 
 			auto error = bound_index.Append(table_chunk, row_ids);
@@ -695,7 +694,6 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 	}
 
 	auto count = chunk.size();
-	dst_chunk.SetChildCardinality(count);
 	if (count <= 0) {
 		return;
 	}
@@ -1632,7 +1630,6 @@ static void CreateMockChunk(vector<LogicalType> &types, const vector<PhysicalInd
 	for (column_t i = 0; i < column_ids.size(); i++) {
 		mock_chunk.data[column_ids[i].index].Reference(chunk.data[i]);
 	}
-	mock_chunk.SetChildCardinality(chunk.size());
 }
 
 static bool CreateMockChunk(TableCatalogEntry &table, const vector<PhysicalIndex> &column_ids,
@@ -1754,7 +1751,6 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTabl
 	if (n_local_update > 0) {
 		updates_slice.Slice(updates, sel_local_update, n_local_update);
 		updates_slice.Flatten();
-		updates_slice.SetChildCardinality(n_local_update);
 		row_ids_slice.Slice(row_ids, sel_local_update, n_local_update);
 		row_ids_slice.Flatten();
 
@@ -1766,7 +1762,6 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTabl
 		auto &transaction = DuckTransaction::Get(context, db);
 		updates_slice.Slice(updates, sel_global_update, n_global_update);
 		updates_slice.Flatten();
-		updates_slice.SetChildCardinality(n_global_update);
 		row_ids_slice.Slice(row_ids, sel_global_update, n_global_update);
 		row_ids_slice.Flatten();
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -197,7 +197,6 @@ ErrorData LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, RowGr
 			auto col_id = mapped_column_ids[i].GetPrimaryIndex();
 			table_chunk.data[col_id].Reference(index_chunk.data[i]);
 		}
-		table_chunk.SetChildCardinality(index_chunk.size());
 
 		// Pass both the table and the index chunk.
 		// We need the table chunk for the bound indexes,

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -424,7 +424,6 @@ static idx_t ExecuteExpressionFilterSelection(SelectionVector &sel, Vector &vect
 			idx_t chunk_end = offset + chunk_count;
 			DataChunk chunk;
 			chunk.data.emplace_back(vector, offset, chunk_end);
-			chunk.SetChildCardinality(chunk_count);
 
 			// construct the relevant selection vector for the current chunk (offset ... offset + chunk_count)
 			idx_t current_count = 0;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -137,7 +137,6 @@ static void ScanChild(ColumnScanState &state, Vector &result, const std::functio
 		input.Reset();
 		auto scan_count = callback(input.data[0]);
 		FlatVector::SetSize(input.data[0], scan_count);
-		input.SetChildCardinality(scan_count);
 		executor.Execute(input, target);
 		result.Reference(target.data[0]);
 	} else {

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -289,7 +289,6 @@ idx_t VariantColumnData::ScanWithCallback(
 			input.Reset();
 			target.Reset();
 			input.data[0].Reference(extract_intermediate);
-			input.SetChildCardinality(scan_count);
 			executor.Execute(input, target);
 			result.Reference(target.data[0]);
 		} else {


### PR DESCRIPTION
Now that chunks no longer need a cardinality we usually don't need to set it - this PR removes a bunch of calls that are now unnecessary