### PR TITLE
Fix race condition in partitioned copy

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -1094,7 +1094,6 @@ optional<PartitionedCopyTask> PartitionedCopyHashGroup::TryNextPrepareTask() {
 			break;
 		}
 		if (prepare_batch_idx == batch_state.collections.size()) {
-			batch_state.MarkPrepared();
 			++prepare_partition_idx;
 			prepare_batch_idx = 0;
 			continue;


### PR DESCRIPTION
We marked a partition batch state as `PREPARED` too soon, namely after all prepare tasks had been assigned, but not yet completed. Just removing this line and letting it be marked as prepared once all prepare tasks are complete fixes the race condition. This was showing up spuriously in CI.