### PR TITLE
Add `decimal_division` scalar function

### DIFF
--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -136,6 +136,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_SCALAR_FUNCTION(CurrentQueryId),
 	DUCKDB_SCALAR_FUNCTION(CurrentTransactionId),
 	DUCKDB_SCALAR_FUNCTION(CurrvalFun),
+	DUCKDB_SCALAR_FUNCTION_SET(DecimalDivisionFun),
 	DUCKDB_WINDOW_FUNCTION(DenseRankFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(DivideFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(EndsWithFun),

--- a/src/function/scalar/operator/CMakeLists.txt
+++ b/src/function/scalar/operator/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(duckdb_func_ops_main OBJECT add.cpp arithmetic.cpp
-                  multiply.cpp subtract.cpp)
+add_library_unity(
+  duckdb_func_ops_main
+  OBJECT
+  add.cpp
+  arithmetic.cpp
+  decimal_division.cpp
+  multiply.cpp
+  subtract.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_ops_main>
     PARENT_SCOPE)

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -230,12 +230,10 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 	// during plan deserialization (bind is re-called with the stored argument types, and
 	// changing p changes the result-width formula).
 	// For cross-tier inputs, promote the narrower argument to the wider physical tier.
-	bound_function.GetArguments()[0] = (lhs_physical != wider)
-	                                       ? LogicalType::DECIMAL(input_max_width, s1)
-	                                       : arguments[0]->GetReturnType();
-	bound_function.GetArguments()[1] = (rhs_physical != wider)
-	                                       ? LogicalType::DECIMAL(input_max_width, s2)
-	                                       : arguments[1]->GetReturnType();
+	bound_function.GetArguments()[0] =
+	    (lhs_physical != wider) ? LogicalType::DECIMAL(input_max_width, s1) : arguments[0]->GetReturnType();
+	bound_function.GetArguments()[1] =
+	    (rhs_physical != wider) ? LogicalType::DECIMAL(input_max_width, s2) : arguments[1]->GetReturnType();
 
 	switch (wider) {
 	case PhysicalType::INT16:

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -1,0 +1,213 @@
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/hugeint.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
+#include "duckdb/common/types/decimal.hpp"
+#include "duckdb/function/scalar/operator_functions.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Bind data
+//===--------------------------------------------------------------------===//
+
+struct DecimalDivBindData : public FunctionData {
+	// Exponent for the scale factor applied to the numerator before dividing:
+	//   result_int = (a_int * 10^scale_exp) / b_int
+	// where scale_exp = s2 + result_scale - s1
+	uint8_t scale_exp;
+
+	explicit DecimalDivBindData(uint8_t scale_exp_p) : scale_exp(scale_exp_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<DecimalDivBindData>(scale_exp);
+	}
+
+	bool Equals(const FunctionData &other) const override {
+		return scale_exp == other.Cast<DecimalDivBindData>().scale_exp;
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Execute functions
+//
+// COMPUTE_TYPE controls intermediate arithmetic:
+//   int64_t   -- INT16 inputs only; scale_exp <= 13, max numerator ~10^17, fits in int64_t
+//   hugeint_t -- INT32/64/128 inputs; numerator can reach 10^37+
+//===--------------------------------------------------------------------===//
+
+template <class INPUT_TYPE, class RESULT_TYPE, class COMPUTE_TYPE>
+static void DecimalDivExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().BindInfo()->Cast<DecimalDivBindData>();
+
+	COMPUTE_TYPE scale_factor;
+	if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
+		scale_factor = NumericHelper::POWERS_OF_TEN[bind_data.scale_exp];
+	} else {
+		scale_factor = Hugeint::POWERS_OF_TEN[bind_data.scale_exp];
+	}
+
+	BinaryExecutor::Execute<INPUT_TYPE, INPUT_TYPE, RESULT_TYPE>(
+	    args.data[0], args.data[1], result, args.size(), [&](INPUT_TYPE a, INPUT_TYPE b) -> RESULT_TYPE {
+		    if (b == INPUT_TYPE(0)) {
+			    throw InvalidInputException("decimal_division: division by zero");
+		    }
+
+		    COMPUTE_TYPE numerator = COMPUTE_TYPE(a) * scale_factor;
+		    COMPUTE_TYPE divisor = COMPUTE_TYPE(b);
+
+		    bool negative;
+		    COMPUTE_TYPE abs_num, abs_div;
+		    if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
+			    negative = (numerator < 0) != (divisor < 0);
+			    abs_num = numerator < 0 ? -numerator : numerator;
+			    abs_div = divisor < 0 ? -divisor : divisor;
+		    } else {
+			    negative = (numerator.upper < 0) != (divisor.upper < 0);
+			    abs_num = numerator.upper < 0 ? -numerator : numerator;
+			    abs_div = divisor.upper < 0 ? -divisor : divisor;
+		    }
+
+		    COMPUTE_TYPE q;
+		    if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
+			    q = abs_num / abs_div;
+		    } else {
+			    if (abs_div.upper == 0) {
+				    uint64_t r64;
+				    q = Hugeint::DivModPositive(abs_num, abs_div.lower, r64);
+			    } else {
+				    hugeint_t r;
+				    q = Hugeint::DivMod(abs_num, abs_div, r);
+			    }
+		    }
+
+		    COMPUTE_TYPE final_val = negative ? -q : q;
+		    RESULT_TYPE out;
+		    if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
+			    if (!TryCast::Operation<int64_t, RESULT_TYPE>(final_val, out)) {
+				    throw OutOfRangeException("decimal_division: result out of range for result type");
+			    }
+		    } else {
+			    if (!Hugeint::TryCast(final_val, out)) {
+				    throw OutOfRangeException("decimal_division: result out of range for result type");
+			    }
+		    }
+		    return out;
+	    });
+}
+
+template <class INPUT_TYPE, class COMPUTE_TYPE>
+static scalar_function_t GetDecimalDivExecuteFunction(PhysicalType result_physical) {
+	switch (result_physical) {
+	case PhysicalType::INT16:
+		return DecimalDivExecute<INPUT_TYPE, int16_t, COMPUTE_TYPE>;
+	case PhysicalType::INT32:
+		return DecimalDivExecute<INPUT_TYPE, int32_t, COMPUTE_TYPE>;
+	case PhysicalType::INT64:
+		return DecimalDivExecute<INPUT_TYPE, int64_t, COMPUTE_TYPE>;
+	default:
+		return DecimalDivExecute<INPUT_TYPE, hugeint_t, COMPUTE_TYPE>;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Bind function
+//===--------------------------------------------------------------------===//
+
+// Result width and scale for e1 / e2 (SQL Server semantics):
+//   result_scale = max(6, s1 + p2 + 1)
+//   result_width = p1 - s1 + s2 + result_scale
+// Both are capped at Decimal::MAX_WIDTH_DECIMAL (38).
+static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
+	uint8_t p1, s1, p2, s2;
+	if (!arguments[0]->GetReturnType().GetDecimalProperties(p1, s1) ||
+	    !arguments[1]->GetReturnType().GetDecimalProperties(p2, s2)) {
+		throw InvalidInputException("decimal_division: both arguments must be DECIMAL");
+	}
+
+	uint8_t result_scale = MaxValue<uint8_t>(6, s1 + p2 + 1);
+	uint8_t result_width = p1 - s1 + s2 + result_scale;
+
+	if (result_scale > Decimal::MAX_WIDTH_DECIMAL) {
+		throw OutOfRangeException(
+		    "Needed scale %d to accurately represent the division result, but this is out of range of the "
+		    "DECIMAL type. Max scale is %d; could not perform an accurate division. Either add a cast to DOUBLE, "
+		    "or add an explicit cast to a decimal with a lower scale.",
+		    result_scale, Decimal::MAX_WIDTH_DECIMAL);
+	}
+	if (result_width > Decimal::MAX_WIDTH_DECIMAL) {
+		throw OutOfRangeException(
+		    "Needed width %d to accurately represent the division result, but this is out of range of the "
+		    "DECIMAL type. Max width is %d; could not perform an accurate division. Either add a cast to DOUBLE, "
+		    "or add an explicit cast to a decimal with a lower scale.",
+		    result_width, Decimal::MAX_WIDTH_DECIMAL);
+	}
+
+	PhysicalType result_physical;
+	if (result_width <= Decimal::MAX_WIDTH_INT16) {
+		result_physical = PhysicalType::INT16;
+	} else if (result_width <= Decimal::MAX_WIDTH_INT32) {
+		result_physical = PhysicalType::INT32;
+	} else if (result_width <= Decimal::MAX_WIDTH_INT64) {
+		result_physical = PhysicalType::INT64;
+	} else {
+		result_physical = PhysicalType::INT128;
+	}
+
+	bound_function.SetReturnType(LogicalType::DECIMAL(result_width, result_scale));
+
+	auto lhs_physical = arguments[0]->GetReturnType().InternalType();
+	auto rhs_physical = arguments[1]->GetReturnType().InternalType();
+	auto wider = MaxValue<PhysicalType>(lhs_physical, rhs_physical);
+
+	switch (wider) {
+	case PhysicalType::INT16:
+		// scale_exp <= 13, max numerator ~10^17 — int64_t intermediates are safe
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(4, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(4, s2);
+		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, int64_t>(result_physical));
+		break;
+	case PhysicalType::INT32:
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(9, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(9, s2);
+		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int32_t, hugeint_t>(result_physical));
+		break;
+	case PhysicalType::INT64:
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(18, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(18, s2);
+		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, hugeint_t>(result_physical));
+		break;
+	case PhysicalType::INT128:
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(38, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(38, s2);
+		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<hugeint_t, hugeint_t>(result_physical));
+		break;
+	default:
+		throw InternalException("decimal_division: unexpected physical type");
+	}
+
+	uint8_t scale_exp = s2 + result_scale - s1;
+	return make_uniq<DecimalDivBindData>(scale_exp);
+}
+
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+
+ScalarFunctionSet DecimalDivisionFun::GetFunctions() {
+	auto decimal_type = LogicalType(LogicalTypeId::DECIMAL);
+	ScalarFunctionSet set("decimal_division");
+	ScalarFunction func({decimal_type, decimal_type}, decimal_type, DecimalDivExecute<hugeint_t, hugeint_t, hugeint_t>,
+	                    DecimalDivisionBind);
+	func.SetFallible();
+	set.AddFunction(func);
+	return set;
+}
+
+} // namespace duckdb

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -15,12 +15,12 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 struct DecimalDivBindData : public FunctionData {
-	// Exponent for the scale factor applied to the numerator before dividing:
-	//   result_int = (a_int * 10^scale_exp) / b_int
-	// where scale_exp = s2 + result_scale - s1
-	uint8_t scale_exp;
+	// scale_exp = s2 + result_scale - s1
+	// >= 0: scale numerator up:   result_int = (a_int * 10^scale_exp) / b_int
+	// <  0: scale divisor up:     result_int =  a_int / (b_int * 10^|scale_exp|)
+	int32_t scale_exp;
 
-	explicit DecimalDivBindData(uint8_t scale_exp_p) : scale_exp(scale_exp_p) {
+	explicit DecimalDivBindData(int32_t scale_exp_p) : scale_exp(scale_exp_p) {
 	}
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -36,19 +36,23 @@ struct DecimalDivBindData : public FunctionData {
 // Execute functions
 //
 // COMPUTE_TYPE controls intermediate arithmetic:
-//   int64_t   -- INT16 inputs only; scale_exp <= 13, max numerator ~10^17, fits in int64_t
-//   hugeint_t -- INT32/64/128 inputs; numerator can reach 10^37+
+//   int64_t   -- when input_max_width + |scale_exp| < 19 (product fits in int64_t);
+//                always for INT16, conditionally for INT32 when |scale_exp| <= 9
+//   hugeint_t -- otherwise
 //===--------------------------------------------------------------------===//
 
 template <class INPUT_TYPE, class RESULT_TYPE, class COMPUTE_TYPE>
 static void DecimalDivExecute(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().BindInfo()->Cast<DecimalDivBindData>();
 
+	bool scale_divisor = bind_data.scale_exp < 0;
+	uint8_t abs_exp = UnsafeNumericCast<uint8_t>(scale_divisor ? -bind_data.scale_exp : bind_data.scale_exp);
+
 	COMPUTE_TYPE scale_factor;
 	if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
-		scale_factor = NumericHelper::POWERS_OF_TEN[bind_data.scale_exp];
+		scale_factor = NumericHelper::POWERS_OF_TEN[abs_exp];
 	} else {
-		scale_factor = Hugeint::POWERS_OF_TEN[bind_data.scale_exp];
+		scale_factor = Hugeint::POWERS_OF_TEN[abs_exp];
 	}
 
 	BinaryExecutor::Execute<INPUT_TYPE, INPUT_TYPE, RESULT_TYPE>(
@@ -57,8 +61,20 @@ static void DecimalDivExecute(DataChunk &args, ExpressionState &state, Vector &r
 			    throw InvalidInputException("decimal_division: division by zero");
 		    }
 
-		    COMPUTE_TYPE numerator = COMPUTE_TYPE(a) * scale_factor;
-		    COMPUTE_TYPE divisor = COMPUTE_TYPE(b);
+		    COMPUTE_TYPE numerator, divisor;
+		    if (scale_divisor) {
+			    numerator = COMPUTE_TYPE(a);
+			    if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {
+				    divisor = COMPUTE_TYPE(b) * scale_factor;
+			    } else {
+				    if (!Hugeint::TryMultiply(hugeint_t(b), scale_factor, divisor)) {
+					    throw OutOfRangeException("decimal_division: scaled divisor overflowed DECIMAL range");
+				    }
+			    }
+		    } else {
+			    numerator = COMPUTE_TYPE(a) * scale_factor;
+			    divisor = COMPUTE_TYPE(b);
+		    }
 
 		    bool negative;
 		    COMPUTE_TYPE abs_num, abs_div;
@@ -132,25 +148,31 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 		throw InvalidInputException("decimal_division: both arguments must be DECIMAL");
 	}
 
-	uint8_t min_scale = 6;
+	uint8_t result_scale;
 	if (arguments.size() == 3) {
 		if (!arguments[2]->IsFoldable()) {
-			throw NotImplementedException("decimal_division: min_scale argument must be a constant integer");
+			throw NotImplementedException("decimal_division: scale argument must be a constant integer");
 		}
-		Value min_scale_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[2]);
-		if (min_scale_val.IsNull()) {
-			throw InvalidInputException("decimal_division: min_scale argument must not be NULL");
+		Value scale_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[2]);
+		if (scale_val.IsNull()) {
+			throw InvalidInputException("decimal_division: scale argument must not be NULL");
 		}
-		int32_t min_scale_i = min_scale_val.GetValue<int32_t>();
-		if (min_scale_i < 0 || min_scale_i > Decimal::MAX_WIDTH_DECIMAL) {
-			throw InvalidInputException("decimal_division: min_scale must be between 0 and %d, got %d",
-			                            Decimal::MAX_WIDTH_DECIMAL, min_scale_i);
+		int32_t scale_i = scale_val.GetValue<int32_t>();
+		if (scale_i < 0 || scale_i > Decimal::MAX_WIDTH_DECIMAL) {
+			throw InvalidInputException("decimal_division: scale must be between 0 and %d, got %d",
+			                            Decimal::MAX_WIDTH_DECIMAL, scale_i);
 		}
-		min_scale = UnsafeNumericCast<uint8_t>(min_scale_i);
+		result_scale = UnsafeNumericCast<uint8_t>(scale_i);
+	} else {
+		result_scale = MaxValue<uint8_t>(6, s1 + p2 + 1);
 	}
-
-	uint8_t result_scale = MaxValue<uint8_t>(min_scale, s1 + p2 + 1);
-	uint8_t result_width = p1 - s1 + s2 + result_scale;
+	// result_width uses signed arithmetic to catch underflow before casting.
+	auto result_width_i = p1 - s1 + s2 + result_scale;
+	if (result_width_i < 1) {
+		throw InvalidInputException("decimal_division: scale %d produces a zero-width result for these input types",
+		                            result_scale);
+	}
+	uint8_t result_width = UnsafeNumericCast<uint8_t>(result_width_i);
 
 	if (result_scale > Decimal::MAX_WIDTH_DECIMAL) {
 		throw OutOfRangeException(
@@ -184,33 +206,43 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 	auto rhs_physical = arguments[1]->GetReturnType().InternalType();
 	auto wider = MaxValue<PhysicalType>(lhs_physical, rhs_physical);
 
+	int32_t scale_exp = s2 + result_scale - s1;
+	int32_t abs_scale_exp = scale_exp < 0 ? -scale_exp : scale_exp;
+
 	switch (wider) {
 	case PhysicalType::INT16:
-		// scale_exp <= 13, max numerator ~10^17 — int64_t intermediates are safe
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(4, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(4, s2);
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s2);
 		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, int64_t>(result_physical));
 		break;
 	case PhysicalType::INT32:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(9, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(9, s2);
-		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int32_t, hugeint_t>(result_physical));
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT32, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT32, s2);
+		// int64_t safe when MAX_WIDTH_INT32 + |scale_exp| < CACHED_POWERS_OF_TEN (19)
+		if (Decimal::MAX_WIDTH_INT32 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int32_t, int64_t>(result_physical));
+		} else {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int32_t, hugeint_t>(result_physical));
+		}
 		break;
 	case PhysicalType::INT64:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(18, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(18, s2);
-		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, hugeint_t>(result_physical));
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT64, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT64, s2);
+		if (Decimal::MAX_WIDTH_INT64 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, int64_t>(result_physical));
+		} else {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, hugeint_t>(result_physical));
+		}
 		break;
 	case PhysicalType::INT128:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(38, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(38, s2);
+		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, s1);
+		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, s2);
 		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<hugeint_t, hugeint_t>(result_physical));
 		break;
 	default:
 		throw InternalException("decimal_division: unexpected physical type");
 	}
 
-	uint8_t scale_exp = s2 + result_scale - s1;
 	return make_uniq<DecimalDivBindData>(scale_exp);
 }
 

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/operator_functions.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -131,7 +132,24 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 		throw InvalidInputException("decimal_division: both arguments must be DECIMAL");
 	}
 
-	uint8_t result_scale = MaxValue<uint8_t>(6, s1 + p2 + 1);
+	uint8_t min_scale = 6;
+	if (arguments.size() == 3) {
+		if (!arguments[2]->IsFoldable()) {
+			throw NotImplementedException("decimal_division: min_scale argument must be a constant integer");
+		}
+		Value min_scale_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[2]);
+		if (min_scale_val.IsNull()) {
+			throw InvalidInputException("decimal_division: min_scale argument must not be NULL");
+		}
+		int32_t min_scale_i = min_scale_val.GetValue<int32_t>();
+		if (min_scale_i < 0 || min_scale_i > Decimal::MAX_WIDTH_DECIMAL) {
+			throw InvalidInputException("decimal_division: min_scale must be between 0 and %d, got %d",
+			                            Decimal::MAX_WIDTH_DECIMAL, min_scale_i);
+		}
+		min_scale = UnsafeNumericCast<uint8_t>(min_scale_i);
+	}
+
+	uint8_t result_scale = MaxValue<uint8_t>(min_scale, s1 + p2 + 1);
 	uint8_t result_width = p1 - s1 + s2 + result_scale;
 
 	if (result_scale > Decimal::MAX_WIDTH_DECIMAL) {
@@ -203,10 +221,17 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 ScalarFunctionSet DecimalDivisionFun::GetFunctions() {
 	auto decimal_type = LogicalType(LogicalTypeId::DECIMAL);
 	ScalarFunctionSet set("decimal_division");
-	ScalarFunction func({decimal_type, decimal_type}, decimal_type, DecimalDivExecute<hugeint_t, hugeint_t, hugeint_t>,
-	                    DecimalDivisionBind);
-	func.SetFallible();
-	set.AddFunction(func);
+
+	ScalarFunction two_arg({decimal_type, decimal_type}, decimal_type,
+	                       DecimalDivExecute<hugeint_t, hugeint_t, hugeint_t>, DecimalDivisionBind);
+	two_arg.SetFallible();
+	set.AddFunction(two_arg);
+
+	ScalarFunction three_arg({decimal_type, decimal_type, LogicalType::INTEGER}, decimal_type,
+	                         DecimalDivExecute<hugeint_t, hugeint_t, hugeint_t>, DecimalDivisionBind);
+	three_arg.SetFallible();
+	set.AddFunction(three_arg);
+
 	return set;
 }
 

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -36,8 +36,7 @@ struct DecimalDivBindData : public FunctionData {
 // Execute functions
 //
 // COMPUTE_TYPE controls intermediate arithmetic:
-//   int64_t   -- when input_max_width + |scale_exp| < 19 (product fits in int64_t);
-//                always for INT16, conditionally for INT32 when |scale_exp| <= 9
+//   int64_t   -- when input_max_width + |scale_exp| < CACHED_POWERS_OF_TEN (product fits in int64_t)
 //   hugeint_t -- otherwise
 //===--------------------------------------------------------------------===//
 
@@ -213,7 +212,11 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 	case PhysicalType::INT16:
 		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s1);
 		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s2);
-		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, int64_t>(result_physical));
+		if (Decimal::MAX_WIDTH_INT16 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, int64_t>(result_physical));
+		} else {
+			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, hugeint_t>(result_physical));
+		}
 		break;
 	case PhysicalType::INT32:
 		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT32, s1);

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -46,7 +46,7 @@ static void DecimalDivExecute(DataChunk &args, ExpressionState &state, Vector &r
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().BindInfo()->Cast<DecimalDivBindData>();
 
 	bool scale_divisor = bind_data.scale_exp < 0;
-	uint8_t abs_exp = UnsafeNumericCast<uint8_t>(scale_divisor ? -bind_data.scale_exp : bind_data.scale_exp);
+	uint8_t abs_exp = UnsafeNumericCast<uint8_t>(AbsValue(bind_data.scale_exp));
 
 	COMPUTE_TYPE scale_factor;
 	if constexpr (std::is_same_v<COMPUTE_TYPE, int64_t>) {

--- a/src/function/scalar/operator/decimal_division.cpp
+++ b/src/function/scalar/operator/decimal_division.cpp
@@ -208,10 +208,37 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 	int32_t scale_exp = s2 + result_scale - s1;
 	int32_t abs_scale_exp = scale_exp < 0 ? -scale_exp : scale_exp;
 
+	uint8_t input_max_width;
 	switch (wider) {
 	case PhysicalType::INT16:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT16, s2);
+		input_max_width = Decimal::MAX_WIDTH_INT16;
+		break;
+	case PhysicalType::INT32:
+		input_max_width = Decimal::MAX_WIDTH_INT32;
+		break;
+	case PhysicalType::INT64:
+		input_max_width = Decimal::MAX_WIDTH_INT64;
+		break;
+	case PhysicalType::INT128:
+		input_max_width = Decimal::MAX_WIDTH_DECIMAL;
+		break;
+	default:
+		throw InternalException("decimal_division: unexpected physical type");
+	}
+
+	// For same-tier inputs, preserve the original argument type so bind is idempotent
+	// during plan deserialization (bind is re-called with the stored argument types, and
+	// changing p changes the result-width formula).
+	// For cross-tier inputs, promote the narrower argument to the wider physical tier.
+	bound_function.GetArguments()[0] = (lhs_physical != wider)
+	                                       ? LogicalType::DECIMAL(input_max_width, s1)
+	                                       : arguments[0]->GetReturnType();
+	bound_function.GetArguments()[1] = (rhs_physical != wider)
+	                                       ? LogicalType::DECIMAL(input_max_width, s2)
+	                                       : arguments[1]->GetReturnType();
+
+	switch (wider) {
+	case PhysicalType::INT16:
 		if (Decimal::MAX_WIDTH_INT16 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
 			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int16_t, int64_t>(result_physical));
 		} else {
@@ -219,9 +246,6 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 		}
 		break;
 	case PhysicalType::INT32:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT32, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT32, s2);
-		// int64_t safe when MAX_WIDTH_INT32 + |scale_exp| < CACHED_POWERS_OF_TEN (19)
 		if (Decimal::MAX_WIDTH_INT32 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
 			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int32_t, int64_t>(result_physical));
 		} else {
@@ -229,21 +253,15 @@ static unique_ptr<FunctionData> DecimalDivisionBind(BindScalarFunctionInput &inp
 		}
 		break;
 	case PhysicalType::INT64:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT64, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_INT64, s2);
 		if (Decimal::MAX_WIDTH_INT64 + abs_scale_exp < NumericHelper::CACHED_POWERS_OF_TEN) {
 			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, int64_t>(result_physical));
 		} else {
 			bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<int64_t, hugeint_t>(result_physical));
 		}
 		break;
-	case PhysicalType::INT128:
-		bound_function.GetArguments()[0] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, s1);
-		bound_function.GetArguments()[1] = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, s2);
+	default:
 		bound_function.SetFunctionCallback(GetDecimalDivExecuteFunction<hugeint_t, hugeint_t>(result_physical));
 		break;
-	default:
-		throw InternalException("decimal_division: unexpected physical type");
 	}
 
 	return make_uniq<DecimalDivBindData>(scale_exp);

--- a/src/function/scalar/operator/functions.json
+++ b/src/function/scalar/operator/functions.json
@@ -51,5 +51,13 @@
         "type": "scalar_function_set",
         "aliases": ["mod"],
         "struct": "OperatorModuloFun"
+    },
+    {
+        "name": "decimal_division",
+        "parameters": "x,y",
+        "description": "Divides two DECIMAL values using exact integer arithmetic, returning a DECIMAL result with scale determined by SQL Server semantics (result_scale = max(6, s1 + p2 + 1)).",
+        "example": "decimal_division(10.00::DECIMAL(10,2), 3.00::DECIMAL(10,2))",
+        "type": "scalar_function_set",
+        "struct": "DecimalDivisionFun"
     }
 ]

--- a/src/function/scalar/operator/functions.json
+++ b/src/function/scalar/operator/functions.json
@@ -54,7 +54,7 @@
     },
     {
         "name": "decimal_division",
-        "parameters": "x,y",
+        "parameters": "x,y[,scale]",
         "description": "Divides two DECIMAL values using exact integer arithmetic, returning a DECIMAL result with scale determined by SQL Server semantics (result_scale = max(6, s1 + p2 + 1)).",
         "example": "decimal_division(10.00::DECIMAL(10,2), 3.00::DECIMAL(10,2))",
         "type": "scalar_function_set",

--- a/src/include/duckdb/function/scalar/operator_functions.hpp
+++ b/src/include/duckdb/function/scalar/operator_functions.hpp
@@ -105,4 +105,14 @@ struct ModFun {
 	static constexpr const char *Name = "mod";
 };
 
+struct DecimalDivisionFun {
+	static constexpr const char *Name = "decimal_division";
+	static constexpr const char *Parameters = "x,y";
+	static constexpr const char *Description = "Divides two DECIMAL values using exact integer arithmetic, returning a DECIMAL result with scale determined by SQL Server semantics (result_scale = max(6, s1 + p2 + 1)).";
+	static constexpr const char *Example = "decimal_division(10.00::DECIMAL(10,2), 3.00::DECIMAL(10,2))";
+	static constexpr const char *Categories = "";
+
+	static ScalarFunctionSet GetFunctions();
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar/operator_functions.hpp
+++ b/src/include/duckdb/function/scalar/operator_functions.hpp
@@ -107,7 +107,7 @@ struct ModFun {
 
 struct DecimalDivisionFun {
 	static constexpr const char *Name = "decimal_division";
-	static constexpr const char *Parameters = "x,y";
+	static constexpr const char *Parameters = "x,y[,scale]";
 	static constexpr const char *Description = "Divides two DECIMAL values using exact integer arithmetic, returning a DECIMAL result with scale determined by SQL Server semantics (result_scale = max(6, s1 + p2 + 1)).";
 	static constexpr const char *Example = "decimal_division(10.00::DECIMAL(10,2), 3.00::DECIMAL(10,2))";
 	static constexpr const char *Categories = "";

--- a/test/sql/types/decimal/decimal_division.test
+++ b/test/sql/types/decimal/decimal_division.test
@@ -1,0 +1,91 @@
+# name: test/sql/types/decimal/decimal_division.test
+# description: Test decimal_division scalar function
+# group: [decimal]
+
+# Basic division
+query I
+SELECT decimal_division(10.00, 4.00);
+----
+2.500000
+
+# Unqualified DECIMAL literals resolve to DECIMAL(18,3); result_width=40 overflows -> error
+# result_scale = max(6, 3+18+1) = 22, result_width = 18-3+3+22 = 40 > 38
+statement error
+SELECT decimal_division(DECIMAL '1.00', DECIMAL '3.000');
+----
+<REGEX>:.*could not perform an accurate division.*
+
+# Explicit small-precision inputs: p1=5 s1=2, p2=5 s2=3
+# result_scale = max(6, 2+5+1) = 8, result_width = 5-2+3+8 = 14 -> DECIMAL(14,8)
+query I
+SELECT decimal_division(1.00::DECIMAL(5,2), 3.000::DECIMAL(5,3));
+----
+0.33333333
+
+# Negative dividend
+query I
+SELECT decimal_division(-7.00, 2.00);
+----
+-3.500000
+
+# Division by a value less than 1
+query I
+SELECT decimal_division(1.00, 0.25);
+----
+4.000000
+
+# Division by zero raises an error
+statement error
+SELECT decimal_division(1.00, 0.00);
+----
+decimal_division: division by zero
+
+# INT16 inputs (p<=4) -> DECIMAL(10, 7), INT64 result physical type
+# p1=4 s1=2 p2=4 s2=1: result_scale=max(6,2+4+1)=7, result_width=4-2+1+7=10
+query I
+SELECT typeof(decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1)));
+----
+DECIMAL(10,7)
+
+query I
+SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1));
+----
+3.5257142
+
+# INT32 inputs (p<=9) -> DECIMAL(18, 10), INT64 result physical type
+# p1=9 s1=3 p2=6 s2=2: result_scale=max(6,3+6+1)=10, result_width=9-3+2+10=18
+query I
+SELECT typeof(decimal_division(1000.000::DECIMAL(9,3), 4.00::DECIMAL(6,2)));
+----
+DECIMAL(18,10)
+
+query I
+SELECT decimal_division(1000.000::DECIMAL(9,3), 4.00::DECIMAL(6,2));
+----
+250.0000000000
+
+# INT64 inputs (p<=18) -> DECIMAL(31, 18), INT128 result physical type
+# p1=15 s1=5 p2=12 s2=3: result_scale=max(6,5+12+1)=18, result_width=15-5+3+18=31
+query I
+SELECT typeof(decimal_division(100000.00000::DECIMAL(15,5), 8.000::DECIMAL(12,3)));
+----
+DECIMAL(31,18)
+
+query I
+SELECT decimal_division(100000.00000::DECIMAL(15,5), 8.000::DECIMAL(12,3));
+----
+12500.000000000000000000
+
+# INT128 inputs where result_width overflows (54 > 38) -> error
+# p1=28 s1=8 p2=20 s2=5: result_scale=max(6,8+20+1)=29, result_width=28-8+5+29=54
+statement error
+SELECT decimal_division(10000000000.00000000::DECIMAL(28,8), 4.00000::DECIMAL(20,5));
+----
+<REGEX>:.*could not perform an accurate division.*
+
+# result_scale overflows (40 > 38) -> error
+# p1=38 s1=2 p2=37 s2=2: result_scale=max(6,2+37+1)=40
+statement error
+SELECT decimal_division(3::decimal(38,2), 16384::decimal(37,2));
+----
+<REGEX>:.*could not perform an accurate division.*

--- a/test/sql/types/decimal/decimal_division.test
+++ b/test/sql/types/decimal/decimal_division.test
@@ -89,3 +89,39 @@ statement error
 SELECT decimal_division(3::decimal(38,2), 16384::decimal(37,2));
 ----
 <REGEX>:.*could not perform an accurate division.*
+
+# Optional min_scale argument
+# min_scale=2: result_scale=max(2,2+4+1)=7, same result as default for this input
+query I
+SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 2);
+----
+3.5257142
+
+# min_scale=0: result_scale=max(0,2+4+1)=7, still driven by s1+p2+1
+query I
+SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 0);
+----
+3.5257142
+
+# min_scale=10: overrides s1+p2+1=7, result_scale=10
+# result_width=4-2+1+10=13
+query I
+SELECT typeof(decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 10));
+----
+DECIMAL(13,10)
+
+query I
+SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 10);
+----
+3.5257142857
+
+# min_scale out of range
+statement error
+SELECT decimal_division(1.0::DECIMAL(4,1), 3.0::DECIMAL(4,1), -1);
+----
+<REGEX>:.*min_scale must be between.*
+
+statement error
+SELECT decimal_division(1.0::DECIMAL(4,1), 3.0::DECIMAL(4,1), 39);
+----
+<REGEX>:.*min_scale must be between.*

--- a/test/sql/types/decimal/decimal_division.test
+++ b/test/sql/types/decimal/decimal_division.test
@@ -127,6 +127,18 @@ SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 10);
 ----
 3.5257142857
 
+# INT16 inputs with large explicit scale: scale_exp exceeds int64_t safe range (4+|exp|>=19),
+# must fall back to hugeint_t compute path — previously caused out-of-bounds POWERS_OF_TEN access
+query I
+SELECT decimal_division(1.00::DECIMAL(3,2), 3.00::DECIMAL(3,2), 17);
+----
+0.33333333333333333
+
+query I
+SELECT decimal_division(1.00::DECIMAL(3,2), 3.00::DECIMAL(3,2), 35);
+----
+0.33333333333333333333333333333333333
+
 statement error
 SELECT decimal_division(1.0::DECIMAL(4,1), 3.0::DECIMAL(4,1), -1);
 ----

--- a/test/sql/types/decimal/decimal_division.test
+++ b/test/sql/types/decimal/decimal_division.test
@@ -90,21 +90,33 @@ SELECT decimal_division(3::decimal(38,2), 16384::decimal(37,2));
 ----
 <REGEX>:.*could not perform an accurate division.*
 
-# Optional min_scale argument
-# min_scale=2: result_scale=max(2,2+4+1)=7, same result as default for this input
+query I
+SELECT typeof(decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 2));
+----
+DECIMAL(5,2)
+
 query I
 SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 2);
 ----
-3.5257142
+3.52
 
-# min_scale=0: result_scale=max(0,2+4+1)=7, still driven by s1+p2+1
+# scale=0: scale_exp = s2 + 0 - s1 = 1 - 2 = -1, divisor scaled up -> integer result
+query I
+SELECT typeof(decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 0));
+----
+DECIMAL(3,0)
+
 query I
 SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 0);
 ----
-3.5257142
+3
 
-# min_scale=10: overrides s1+p2+1=7, result_scale=10
-# result_width=4-2+1+10=13
+# scale=1: scale_exp = 0
+query I
+SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 1);
+----
+3.5
+
 query I
 SELECT typeof(decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 10));
 ----
@@ -115,13 +127,12 @@ SELECT decimal_division(12.34::DECIMAL(4,2), 3.5::DECIMAL(4,1), 10);
 ----
 3.5257142857
 
-# min_scale out of range
 statement error
 SELECT decimal_division(1.0::DECIMAL(4,1), 3.0::DECIMAL(4,1), -1);
 ----
-<REGEX>:.*min_scale must be between.*
+<REGEX>:.*scale must be between.*
 
 statement error
 SELECT decimal_division(1.0::DECIMAL(4,1), 3.0::DECIMAL(4,1), 39);
 ----
-<REGEX>:.*min_scale must be between.*
+<REGEX>:.*scale must be between.*


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/8441
Previous PR here: https://github.com/duckdb/duckdb/pull/22955

Second attempt at adding `decimal_division`, but now as an explicit scalar function, rather than overriding `/`:
`decimal_division(x, y)` 
`decimal_division(x, y, scale)`

If the `scale` is provided by the user this is the exact `scale` used for the output. 
If the `scale` is not given by the user explicitly we still use the SQL server formulas:
```
  result_scale = max(6, s1 + p2 + 1)
  result_width = p1 - s1 + s2 + result_scale
```

We now throw an `OutOfRangeException` if `scale` or `width` is greater than 38, rather than capping the precision.

We operate on `int64_t` whenever it is safe from overflow and fallback to `hugeint_t` when needed. 

I'll work on `decimal_avg` in a follow-up PR. 