### PR TITLE
Write column-level key/value metadata to Parquet

### DIFF
--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PARQUET_EXTENSION_FILES
     parquet_prefetch_cost_model.cpp
     parquet_reader.cpp
     parquet_field_id.cpp
+    parquet_column_kv.cpp
     parquet_statistics.cpp
     parquet_timestamp.cpp
     parquet_writer.cpp

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/common/uhugeint.hpp"
 #include "miniz.hpp"
 #include "parquet_field_id.hpp"
+#include "parquet_column_kv.hpp"
 #include "parquet_shredding.hpp"
 #include "parquet_timestamp.hpp"
 #include "parquet_types.h"
@@ -275,6 +276,7 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
                                                              const string &name, bool allow_geometry,
                                                              optional_ptr<const ChildFieldIDs> field_ids,
                                                              optional_ptr<const ShreddingType> shredding_types,
+                                                             optional_ptr<const ChildColumnKV> column_kv,
                                                              idx_t max_repeat, idx_t max_define, bool can_have_nulls) {
 	const bool parquet_write_timestamp_as_int96 = writer.WriteTimestampAsInt96();
 	path_in_schema.push_back(name);
@@ -296,6 +298,15 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 	}
 	if (shredding_types) {
 		shredding_type = shredding_types->GetChild(name);
+	}
+
+	optional_ptr<const ColumnKV> col_kv;
+	optional_ptr<const ChildColumnKV> child_column_kv;
+	if (column_kv) {
+		col_kv = column_kv->GetChild(name);
+		if (col_kv) {
+			child_column_kv = &col_kv->children;
+		}
 	}
 
 	if (type.id() == LogicalTypeId::VARIANT) {
@@ -346,8 +357,8 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 			}
 
 			child_writers.push_back(CreateWriterRecursive(context, writer, path_in_schema, child_type, child_name,
-			                                              allow_geometry, child_field_ids, child_shredding, max_repeat,
-			                                              max_define + 1, is_optional));
+			                                              allow_geometry, child_field_ids, child_shredding,
+			                                              child_column_kv, max_repeat, max_define + 1, is_optional));
 		}
 		return make_uniq<VariantColumnWriter>(writer, std::move(variant_column), path_in_schema,
 		                                      std::move(child_writers));
@@ -369,8 +380,8 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 			auto &child_type = entry.second;
 			auto &child_name = entry.first;
 			child_writers.push_back(CreateWriterRecursive(context, writer, path_in_schema, child_type, child_name,
-			                                              allow_geometry, child_field_ids, shredding_type, max_repeat,
-			                                              max_define + 1, true));
+			                                              allow_geometry, child_field_ids, shredding_type,
+			                                              child_column_kv, max_repeat, max_define + 1, true));
 		}
 		return make_uniq<StructColumnWriter>(writer, std::move(struct_column), std::move(path_in_schema),
 		                                     std::move(child_writers));
@@ -381,9 +392,9 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		auto &child_type = is_list ? ListType::GetChildType(type) : ArrayType::GetChildType(type);
 
 		path_in_schema.push_back("list");
-		auto child_writer =
-		    CreateWriterRecursive(context, writer, path_in_schema, child_type, "element", allow_geometry,
-		                          child_field_ids, shredding_type, max_repeat + 1, max_define + 2, true);
+		auto child_writer = CreateWriterRecursive(context, writer, path_in_schema, child_type, "element",
+		                                          allow_geometry, child_field_ids, shredding_type, child_column_kv,
+		                                          max_repeat + 1, max_define + 2, true);
 
 		auto list_column =
 		    ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type, allow_geometry);
@@ -423,9 +434,9 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 			bool is_key = i == 0;
 			auto &child_name = key_value[i].first;
 			auto &child_type = key_value[i].second;
-			auto child_writer =
-			    CreateWriterRecursive(context, writer, path_in_schema, child_type, child_name, allow_geometry,
-			                          child_field_ids, shredding_type, max_repeat + 1, max_define + 2, !is_key);
+			auto child_writer = CreateWriterRecursive(context, writer, path_in_schema, child_type, child_name,
+			                                          allow_geometry, child_field_ids, shredding_type, child_column_kv,
+			                                          max_repeat + 1, max_define + 2, !is_key);
 
 			child_writers.push_back(std::move(child_writer));
 		}
@@ -442,6 +453,9 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 	    ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type, allow_geometry);
 	if (field_id && field_id->set) {
 		schema.field_id = field_id->field_id;
+	}
+	if (col_kv && !col_kv->metadata.empty()) {
+		schema.kv_metadata = col_kv->metadata;
 	}
 
 	switch (type.id()) {

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -39,6 +39,8 @@ class ParquetWriter;
 class ColumnWriterPageState;
 class PrimitiveColumnWriterState;
 struct ChildFieldIDs;
+struct ChildColumnKV;
+struct ColumnKV;
 struct ShreddingType;
 class ResizeableBuffer;
 class ParquetBloomFilter;
@@ -176,13 +178,11 @@ public:
 	virtual idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;
 
 	//! Create the column writer for a specific type recursively
-	static unique_ptr<ColumnWriter> CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,
-	                                                      vector<string> path_in_schema, const LogicalType &type,
-	                                                      const string &name, bool allow_geometry,
-	                                                      optional_ptr<const ChildFieldIDs> field_ids,
-	                                                      optional_ptr<const ShreddingType> shredding_types,
-	                                                      idx_t max_repeat = 0, idx_t max_define = 1,
-	                                                      bool can_have_nulls = true);
+	static unique_ptr<ColumnWriter> CreateWriterRecursive(
+	    ClientContext &context, ParquetWriter &writer, vector<string> path_in_schema, const LogicalType &type,
+	    const string &name, bool allow_geometry, optional_ptr<const ChildFieldIDs> field_ids,
+	    optional_ptr<const ShreddingType> shredding_types, optional_ptr<const ChildColumnKV> column_kv,
+	    idx_t max_repeat = 0, idx_t max_define = 1, bool can_have_nulls = true);
 
 	virtual unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) = 0;
 

--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -199,5 +199,40 @@
       }
     ],
     "pointer_type": "none"
+  },
+  {
+    "class": "ColumnKV",
+    "includes": [
+      "parquet_column_kv.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "metadata",
+        "type": "vector<pair<string, string>>"
+      },
+      {
+        "id": 101,
+        "name": "children",
+        "type": "ChildColumnKV"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
+    "class": "ChildColumnKV",
+    "includes": [
+      "parquet_column_kv.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "children",
+        "type": "case_insensitive_map_t<ColumnKV>",
+        "serialize_property": "children.operator*()",
+        "deserialize_property": "children.operator*()"
+      }
+    ],
+    "pointer_type": "none"
   }
 ]

--- a/extension/parquet/include/parquet_column_kv.hpp
+++ b/extension/parquet/include/parquet_column_kv.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+struct ColumnKV;
+class Deserializer;
+class Serializer;
+
+struct ChildColumnKV {
+	ChildColumnKV();
+	ChildColumnKV Copy() const;
+	//! Look up a child carrier by (case-insensitive) column name; null if absent
+	optional_ptr<const ColumnKV> GetChild(const string &name) const;
+	unique_ptr<case_insensitive_map_t<ColumnKV>> children;
+
+	void Serialize(Serializer &serializer) const;
+	static ChildColumnKV Deserialize(Deserializer &source);
+};
+
+struct ColumnKV {
+	ColumnKV();
+	ColumnKV Copy() const;
+	//! Leaf key/value metadata (empty for nesting nodes)
+	vector<pair<string, string>> metadata;
+	ChildColumnKV children;
+
+	void Serialize(Serializer &serializer) const;
+	static ColumnKV Deserialize(Deserializer &source);
+
+public:
+	static void GetColumnKV(const Value &kv_value, ChildColumnKV &kv,
+	                        const case_insensitive_map_t<LogicalType> &name_to_type_map);
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -13,6 +13,7 @@
 #include "duckdb.hpp"
 #include "parquet_types.h"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
@@ -96,6 +97,8 @@ public:
 	ParquetExtraTypeInfo type_info = ParquetExtraTypeInfo::NONE;
 	vector<ParquetColumnSchema> children;
 	optional_idx field_id;
+	//! Column-level key/value metadata, emitted onto the leaf ColumnMetaData per row group
+	vector<pair<string, string>> kv_metadata;
 	//! Whether a column is nullable or not
 	duckdb_parquet::FieldRepetitionType::type repetition_type = duckdb_parquet::FieldRepetitionType::OPTIONAL;
 	//! Whether the column can be recognized as a GEOMETRY type

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -28,6 +28,7 @@
 #include "parquet_statistics.hpp"
 #include "column_writer.hpp"
 #include "parquet_field_id.hpp"
+#include "parquet_column_kv.hpp"
 #include "parquet_shredding.hpp"
 #include "parquet_types.h"
 #include "parquet_geometry.hpp"
@@ -156,6 +157,8 @@ struct ParquetWriterOptions {
 	duckdb_parquet::CompressionCodec::type codec;
 	//! The field-ids to assign to the column(s) and their fields
 	ChildFieldIDs field_ids;
+	//! The column-level key/value metadata to attach to the leaf column chunks
+	ChildColumnKV column_kv;
 	//! The mapping of name->type to shred VARIANT on, set explicitly by the user
 	ShreddingType shredding_types;
 	//! The encryption config for the file we're writing

--- a/extension/parquet/parquet_column_kv.cpp
+++ b/extension/parquet/parquet_column_kv.cpp
@@ -1,0 +1,165 @@
+#include "parquet_column_kv.hpp"
+
+#include "duckdb/common/exception/binder_exception.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+ChildColumnKV::ChildColumnKV() : children(make_uniq<case_insensitive_map_t<ColumnKV>>()) {
+}
+
+ChildColumnKV ChildColumnKV::Copy() const {
+	ChildColumnKV result;
+	for (const auto &child : *children) {
+		result.children->emplace(child.first, child.second.Copy());
+	}
+	return result;
+}
+
+optional_ptr<const ColumnKV> ChildColumnKV::GetChild(const string &name) const {
+	auto it = children->find(name);
+	if (it == children->end()) {
+		return nullptr;
+	}
+	return it->second;
+}
+
+ColumnKV::ColumnKV() {
+}
+
+ColumnKV ColumnKV::Copy() const {
+	ColumnKV result;
+	result.metadata = metadata;
+	result.children = children.Copy();
+	return result;
+}
+
+static case_insensitive_map_t<LogicalType> GetChildNameToTypeMap(const LogicalType &type) {
+	case_insensitive_map_t<LogicalType> name_to_type_map;
+	switch (type.id()) {
+	case LogicalTypeId::LIST:
+		name_to_type_map.emplace("element", ListType::GetChildType(type));
+		break;
+	case LogicalTypeId::ARRAY:
+		name_to_type_map.emplace("element", ArrayType::GetChildType(type));
+		break;
+	case LogicalTypeId::MAP:
+		name_to_type_map.emplace("key", MapType::KeyType(type));
+		name_to_type_map.emplace("value", MapType::ValueType(type));
+		break;
+	case LogicalTypeId::STRUCT:
+		for (auto &child_type : StructType::GetChildTypes(type)) {
+			name_to_type_map.emplace(child_type);
+		}
+		break;
+	default: // LCOV_EXCL_START
+		throw InternalException("Unexpected type in GetChildNameToTypeMap");
+	} // LCOV_EXCL_STOP
+	return name_to_type_map;
+}
+
+//! Nested types that COLUMN_KV_METADATA can recurse into (and that GetChildNameToTypeMap handles). This is
+//! intentionally narrower than LogicalType::IsNested(): VARIANT/UNION/AGGREGATE_STATE are nested but expose no
+//! stable user-facing child surface to attach key/value metadata to, so they are rejected rather than recursed.
+static bool IsRecursableNestedType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::ARRAY:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::STRUCT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static string ColumnKVValueToString(const Value &value, const string &col_name) {
+	if (value.IsNull()) {
+		throw BinderException("COLUMN_KV_METADATA: NULL key/value not allowed for column \"%s\"", col_name);
+	}
+	const auto type_id = value.type().id();
+	if (type_id != LogicalTypeId::VARCHAR && type_id != LogicalTypeId::BLOB) {
+		throw BinderException("COLUMN_KV_METADATA: key/value for column \"%s\" must be VARCHAR or BLOB, found \"%s\"",
+		                      col_name, value.type().ToString());
+	}
+	// VARCHAR and BLOB are both string-backed; StringValue::Get preserves raw bytes (including embedded NULs).
+	return StringValue::Get(value);
+}
+
+void ColumnKV::GetColumnKV(const Value &kv_value, ChildColumnKV &kv,
+                           const case_insensitive_map_t<LogicalType> &name_to_type_map) {
+	const auto &struct_type = kv_value.type();
+	if (struct_type.id() != LogicalTypeId::STRUCT) {
+		throw BinderException("COLUMN_KV_METADATA must be a STRUCT of column names, e.g., {col1: MAP {'k': 'v'}, col2: "
+		                      "{nested_col: MAP {'k': 'v'}}}");
+	}
+	if (kv_value.IsNull()) {
+		throw BinderException("COLUMN_KV_METADATA must not be NULL");
+	}
+	const auto &struct_children = StructValue::GetChildren(kv_value);
+	D_ASSERT(StructType::GetChildTypes(struct_type).size() == struct_children.size());
+	for (idx_t i = 0; i < struct_children.size(); i++) {
+		const auto &col_name = StructType::GetChildName(struct_type, i);
+
+		auto it = name_to_type_map.find(col_name);
+		if (it == name_to_type_map.end()) {
+			string names;
+			for (const auto &name : name_to_type_map) {
+				if (!names.empty()) {
+					names += ", ";
+				}
+				names += name.first;
+			}
+			throw BinderException("Column name \"%s\" specified in COLUMN_KV_METADATA not found. Consider using "
+			                      "WRITE_PARTITION_COLUMNS if this column is a partition column. Available column "
+			                      "names: [%s]",
+			                      col_name, names);
+		}
+		const auto &col_type = it->second;
+
+		const auto &child_value = struct_children[i];
+		const auto &child_type = child_value.type();
+		if (child_value.IsNull()) {
+			throw BinderException("COLUMN_KV_METADATA: specification for column \"%s\" must not be NULL", col_name);
+		}
+
+		ColumnKV column_kv;
+		if (child_type.id() == LogicalTypeId::MAP) {
+			// Leaf KV: the column must be a primitive (non-nested) type. VARIANT/UNION/AGGREGATE_STATE are nested
+			// (PhysicalType::STRUCT) and have no leaf column chunk to carry KV, so they are rejected here rather
+			// than silently dropped at write time.
+			if (col_type.IsNested()) {
+				throw BinderException("COLUMN_KV_METADATA: column \"%s\" with type \"%s\" is a nested type; specify "
+				                      "key/value metadata on its leaf columns",
+				                      col_name, LogicalTypeIdToString(col_type.id()));
+			}
+			const auto &entries = MapValue::GetChildren(child_value);
+			for (const auto &entry : entries) {
+				const auto &entry_children = StructValue::GetChildren(entry);
+				D_ASSERT(entry_children.size() == 2);
+				auto key = ColumnKVValueToString(entry_children[0], col_name);
+				auto value = ColumnKVValueToString(entry_children[1], col_name);
+				column_kv.metadata.emplace_back(std::move(key), std::move(value));
+			}
+		} else if (child_type.id() == LogicalTypeId::STRUCT) {
+			// Nesting: the column must be a nested type we can recurse into (LIST/ARRAY/MAP/STRUCT).
+			if (!IsRecursableNestedType(col_type)) {
+				throw BinderException("COLUMN_KV_METADATA: column \"%s\" with type \"%s\" does not support nested "
+				                      "key/value metadata",
+				                      col_name, LogicalTypeIdToString(col_type.id()));
+			}
+			GetColumnKV(child_value, column_kv.children, GetChildNameToTypeMap(col_type));
+		} else {
+			throw BinderException("COLUMN_KV_METADATA: \"%s\" must be a STRUCT (nesting) or MAP (leaf)", col_name);
+		}
+
+		// Case-insensitive duplicate column names are already rejected by the STRUCT literal binder.
+		kv.children->emplace(col_name, std::move(column_kv));
+	}
+}
+
+} // namespace duckdb

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -69,6 +69,7 @@
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "parquet_field_id.hpp"
+#include "parquet_column_kv.hpp"
 #include "parquet_types.h"
 
 namespace duckdb {
@@ -104,6 +105,7 @@ struct ParquetWriteBindData : public TableFunctionData {
 	optional_idx row_groups_per_file;
 
 	ChildFieldIDs field_ids;
+	ChildColumnKV column_kv;
 	ShreddingType shredding_types;
 	//! The compression level, higher value is more
 	int64_t compression_level = ZStdFileSystem::DefaultCompressionLevel();
@@ -135,6 +137,7 @@ static void ParquetListCopyOptions(ClientContext &context, CopyOptionsInput &inp
 	copy_options["codec"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
 	copy_options["field_ids"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
 	copy_options["kv_metadata"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
+	copy_options["column_kv_metadata"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
 	copy_options["encryption_config"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
 	copy_options["dictionary_size_limit"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::WRITE_ONLY);
 	copy_options["string_dictionary_page_size_limit"] = CopyOption(LogicalType::UBIGINT, CopyOptionMode::WRITE_ONLY);
@@ -274,6 +277,12 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 					bind_data->kv_metadata.emplace_back(key, value.ToString());
 				}
 			}
+		} else if (loption == "column_kv_metadata") {
+			case_insensitive_map_t<LogicalType> name_to_type_map;
+			for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
+				name_to_type_map.emplace(names[col_idx], sql_types[col_idx]);
+			}
+			ColumnKV::GetColumnKV(option.second[0], bind_data->column_kv, name_to_type_map);
 		} else if (loption == "encryption_config") {
 			bind_data->encryption_config = ParquetEncryptionConfig::Create(context, option.second[0]);
 		} else if (loption == "dictionary_compression_ratio_threshold" || loption == "debug_use_openssl" ||
@@ -380,6 +389,7 @@ static unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext
 	options.sql_types = parquet_bind.sql_types;
 	options.column_names = parquet_bind.column_names;
 	options.codec = parquet_bind.codec, options.field_ids = parquet_bind.field_ids.Copy();
+	options.column_kv = parquet_bind.column_kv.Copy();
 	options.shredding_types = parquet_bind.shredding_types.Copy();
 	options.encryption_config = parquet_bind.encryption_config;
 	options.dictionary_size_limit = parquet_bind.dictionary_size_limit,
@@ -704,6 +714,7 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                    default_value.write_timestamp_as_int96);
 	serializer.WritePropertyWithDefault<vector<bool>>(120, "not_null_columns", bind_data.not_null_columns,
 	                                                  default_value.not_null_columns);
+	serializer.WriteProperty<ChildColumnKV>(121, "column_kv", bind_data.column_kv);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -744,6 +755,7 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	    119, "write_timestamp_as_int96", default_value.write_timestamp_as_int96);
 	data->not_null_columns =
 	    deserializer.ReadPropertyWithExplicitDefault<vector<bool>>(120, "not_null_columns", vector<bool>());
+	data->column_kv = deserializer.ReadPropertyWithExplicitDefault<ChildColumnKV>(121, "column_kv", ChildColumnKV());
 
 	return std::move(data);
 }

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -490,7 +490,7 @@ void ParquetWriter::InitializeColumnWriters() {
 		const bool can_have_nulls = options.not_null_columns.empty() || !options.not_null_columns[i];
 		column_writers.push_back(ColumnWriter::CreateWriterRecursive(
 		    context, *this, path_in_schema, types[i], unique_names[i], allow_geometry, &options.field_ids,
-		    &options.shredding_types, 0, 1, can_have_nulls));
+		    &options.shredding_types, &options.column_kv, 0, 1, can_have_nulls));
 	}
 }
 

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -9,8 +9,19 @@
 #include "parquet_crypto.hpp"
 #include "parquet_field_id.hpp"
 #include "parquet_shredding.hpp"
+#include "parquet_column_kv.hpp"
 
 namespace duckdb {
+
+void ChildColumnKV::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<case_insensitive_map_t<ColumnKV>>(100, "children", children.operator*());
+}
+
+ChildColumnKV ChildColumnKV::Deserialize(Deserializer &deserializer) {
+	ChildColumnKV result;
+	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<ColumnKV>>(100, "children", result.children.operator*());
+	return result;
+}
 
 void ChildFieldIDs::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", ids.operator*());
@@ -29,6 +40,18 @@ void ChildShreddingTypes::Serialize(Serializer &serializer) const {
 ChildShreddingTypes ChildShreddingTypes::Deserialize(Deserializer &deserializer) {
 	ChildShreddingTypes result;
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<ShreddingType>>(100, "types", result.types.operator*());
+	return result;
+}
+
+void ColumnKV::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<vector<pair<string, string>>>(100, "metadata", metadata);
+	serializer.WriteProperty<ChildColumnKV>(101, "children", children);
+}
+
+ColumnKV ColumnKV::Deserialize(Deserializer &deserializer) {
+	ColumnKV result;
+	deserializer.ReadPropertyWithDefault<vector<pair<string, string>>>(100, "metadata", result.metadata);
+	deserializer.ReadProperty<ChildColumnKV>(101, "children", result.children);
 	return result;
 }
 

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -396,6 +396,18 @@ void PrimitiveColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 
 	// record the start position of the pages for this column
 	column_chunk.meta_data.data_page_offset = 0;
+
+	auto &kv_metadata = column_schema.kv_metadata;
+	if (!kv_metadata.empty()) {
+		for (auto &entry : kv_metadata) {
+			duckdb_parquet::KeyValue kv_pair;
+			kv_pair.__set_key(entry.first);
+			kv_pair.__set_value(entry.second);
+			column_chunk.meta_data.key_value_metadata.push_back(std::move(kv_pair));
+		}
+		column_chunk.meta_data.__isset.key_value_metadata = true;
+	}
+
 	SetParquetStatistics(state, column_chunk);
 
 	// write the individual pages to disk

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -226,10 +226,10 @@ void VariantColumnWriter::AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState 
 	child_writers.pop_back();
 	//! Recreate the column writer for 'value' because this is now "optional"
 	child_writers.push_back(ColumnWriter::CreateWriterRecursive(context, writer, schema_path, LogicalType::BLOB,
-	                                                            "value", false, nullptr, nullptr, schema.max_repeat,
-	                                                            schema.max_define + 1, true));
+	                                                            "value", false, nullptr, nullptr, nullptr,
+	                                                            schema.max_repeat, schema.max_define + 1, true));
 	child_writers.push_back(ColumnWriter::CreateWriterRecursive(context, writer, schema_path, typed_value,
-	                                                            "typed_value", false, nullptr, nullptr,
+	                                                            "typed_value", false, nullptr, nullptr, nullptr,
 	                                                            schema.max_repeat, schema.max_define + 1, true));
 }
 

--- a/test/sql/copy/parquet/writer/parquet_write_column_kv_metadata.test
+++ b/test/sql/copy/parquet/writer/parquet_write_column_kv_metadata.test
@@ -1,0 +1,278 @@
+# name: test/sql/copy/parquet/writer/parquet_write_column_kv_metadata.test
+# description: Parquet writer COLUMN_KV_METADATA tests
+# group: [writer]
+
+require parquet
+
+# flat column, VARCHAR KV
+statement ok
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_flat.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k1': 'v1', 'k2': 'v2'}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_flat.parquet')
+  WHERE path_in_schema = 'col'
+)
+ORDER BY key
+----
+k1	v1
+k2	v2
+
+# flat column, BLOB value, round-trips to BLOB on read
+statement ok
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_blob.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': '\x01\x02'::BLOB}})
+
+query II
+SELECT key::VARCHAR, hex(value::BLOB)
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_blob.parquet')
+  WHERE path_in_schema = 'col'
+)
+----
+k	0102
+
+# nested STRUCT column, KV on a leaf field
+statement ok
+COPY (SELECT {'zip': 90210, 'city': 'x'} AS addr) TO '{TEST_DIR}/ckv_struct.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {addr: {zip: MAP {'pii': 'true'}}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_struct.parquet')
+  WHERE path_in_schema = 'addr, zip'
+)
+----
+pii	true
+
+# sibling leaf addr.city must not receive any KV
+query I
+SELECT cardinality(key_value_metadata)
+FROM parquet_metadata('{TEST_DIR}/ckv_struct.parquet')
+WHERE path_in_schema = 'addr, city'
+----
+0
+
+# LIST column, KV on the element leaf
+statement ok
+COPY (SELECT [1, 2, 3] AS arr) TO '{TEST_DIR}/ckv_list.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {arr: {element: MAP {'src': 'x'}}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_list.parquet')
+  WHERE path_in_schema = 'arr, list, element'
+)
+----
+src	x
+
+# ARRAY column, KV on the element leaf (shares the LIST write path)
+statement ok
+COPY (SELECT [1, 2, 3]::INTEGER[3] AS arr) TO '{TEST_DIR}/ckv_array.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {arr: {element: MAP {'src': 'y'}}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_array.parquet')
+  WHERE path_in_schema = 'arr, list, element'
+)
+----
+src	y
+
+# MAP column, KV on both key and value leaves
+statement ok
+COPY (SELECT MAP {'a': 1, 'b': 2} AS m) TO '{TEST_DIR}/ckv_map.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {m: {key: MAP {'k': 'v'}, value: MAP {'k2': 'v2'}}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_map.parquet')
+  WHERE path_in_schema = 'm, key_value, key'
+)
+----
+k	v
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_map.parquet')
+  WHERE path_in_schema = 'm, key_value, value'
+)
+----
+k2	v2
+
+# multiple row groups: KV replicated per chunk, one parquet_metadata row per chunk
+statement ok
+COPY (SELECT range AS col FROM range(10000)) TO '{TEST_DIR}/ckv_rg.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': 'v'}}, ROW_GROUP_SIZE 2048)
+
+query II
+SELECT DISTINCT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_rg.parquet')
+  WHERE path_in_schema = 'col'
+)
+----
+k	v
+
+query I
+SELECT count(*)
+FROM parquet_metadata('{TEST_DIR}/ckv_rg.parquet')
+WHERE path_in_schema = 'col' AND cardinality(key_value_metadata) > 0
+----
+5
+
+# case-insensitive column name matching
+statement ok
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_ci.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {"COL": MAP {'K': 'v'}})
+
+query II
+SELECT key::VARCHAR, value::VARCHAR
+FROM (
+  SELECT UNNEST(map_keys(key_value_metadata)) AS key,
+         UNNEST(map_values(key_value_metadata)) AS value
+  FROM parquet_metadata('{TEST_DIR}/ckv_ci.parquet')
+  WHERE path_in_schema = 'col'
+)
+----
+K	v
+
+# empty MAP: no KV emitted
+statement ok
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_empty.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {}})
+
+query I
+SELECT cardinality(key_value_metadata)
+FROM parquet_metadata('{TEST_DIR}/ckv_empty.parquet')
+WHERE path_in_schema = 'col'
+----
+0
+
+# error: MAP supplied on a nested column
+statement error
+COPY (SELECT [1, 2, 3] AS arr) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {arr: MAP {'k': 'v'}})
+----
+<REGEX>:Binder Error:.*is a nested type.*
+
+# error: STRUCT supplied on a primitive column
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: {nested: MAP {'k': 'v'}}})
+----
+<REGEX>:Binder Error:.*does not support nested.*
+
+# error: unknown column name
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {nope: MAP {'k': 'v'}})
+----
+<REGEX>:Binder Error:.*not found.*
+
+# error: non-STRUCT top-level value
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA 'not a struct')
+----
+<REGEX>:Binder Error:.*must be a STRUCT.*
+
+# error: NULL value inside a leaf MAP
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': NULL}})
+----
+<REGEX>:Binder Error:.*NULL key/value not allowed.*
+
+# error: leaf MAP on a VARIANT column
+statement error
+COPY (SELECT 'foo'::VARIANT AS v) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {v: MAP {'k':'val'}})
+----
+<REGEX>:Binder Error:.*is a nested type.*
+
+# error: leaf MAP on a UNION column
+statement error
+COPY (SELECT union_value(num := 1) AS u) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {u: MAP {'k':'val'}})
+----
+<REGEX>:Binder Error:.*is a nested type.*
+
+# error: nesting spec on a VARIANT column
+statement error
+COPY (SELECT 'foo'::VARIANT AS v) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {v: {value: MAP {'k':'val'}}})
+----
+<REGEX>:Binder Error:.*does not support nested.*
+
+# error: non-VARCHAR/BLOB MAP value (integer)
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': 42}})
+----
+<REGEX>:Binder Error:.*must be VARCHAR or BLOB.*
+
+# error: non-VARCHAR/BLOB MAP value (nested STRUCT)
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': {a: 1}}})
+----
+<REGEX>:Binder Error:.*must be VARCHAR or BLOB.*
+
+# error: non-VARCHAR/BLOB MAP key (integer)
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {42: 'v'}})
+----
+<REGEX>:Binder Error:.*must be VARCHAR or BLOB.*
+
+# error: NULL-typed leaf MAP spec
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: NULL::MAP(VARCHAR, VARCHAR)})
+----
+<REGEX>:Binder Error:.*specification for column.*must not be NULL.*
+
+# error: NULL-typed nesting STRUCT spec on a struct column
+statement error
+COPY (SELECT {'zip': 90210, 'city': 'x'} AS addr) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {addr: NULL::STRUCT(zip MAP(VARCHAR, VARCHAR))})
+----
+<REGEX>:Binder Error:.*specification for column.*must not be NULL.*
+
+# error: NULL top-level spec (rejected by the generic COPY-option binder)
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA NULL::STRUCT(col MAP(VARCHAR, VARCHAR)))
+----
+<REGEX>:Binder Error:.*NULL is not supported.*
+
+# error: case-insensitive duplicate column names (rejected by the STRUCT literal binder)
+statement error
+COPY (SELECT range AS col FROM range(10)) TO '{TEST_DIR}/ckv_err.parquet'
+    (FORMAT parquet, COLUMN_KV_METADATA {col: MAP {'k': 'v'}, COL: MAP {'k2': 'v2'}})
+----
+<REGEX>:[\s\S]*Duplicate[\s\S]*


### PR DESCRIPTION
DuckDB can already write file-level Parquet key/value metadata and read column-level metadata back, but it has no way to *write* column-level metadata. This adds a `COLUMN_KV_METADATA` `COPY` option that attaches key/value pairs to individual columns. The pairs land on each leaf column chunk's `ColumnMetaData.key_value_metadata` (Thrift field 8), so they round-trip through the existing `parquet_metadata()` function with no reader changes.

## Usage

A `STRUCT` keyed by column name carries the metadata. A `MAP` value is the leaf payload. A `STRUCT` value nests into a complex column. Values may be `VARCHAR` or `BLOB`.

```sql
-- Flat column
COPY tbl TO 'f.parquet' (FORMAT parquet, COLUMN_KV_METADATA {
    id: MAP {'pii': 'false', 'source': 'crm'}
});

-- Complex columns: STRUCT nests by name, MAP is the leaf payload
COPY tbl TO 'f.parquet' (FORMAT parquet, COLUMN_KV_METADATA {
    addr:  {zip: MAP {'pii': 'true'}},                    -- struct field
    tags:  {element: MAP {'source': 'ingest'}},           -- list/array element
    attrs: {key:   MAP {'encoding': 'utf8'},              -- map key
            value: MAP {'encoding': 'utf8'}}              -- map value
});
```

Read it back with `parquet_metadata()`, addressing leaves by `path_in_schema`:

```sql
SELECT path_in_schema, key_value_metadata
FROM parquet_metadata('f.parquet')
WHERE cardinality(key_value_metadata) > 0;
-- addr, zip                  {pii=true}
-- tags, list, element        {source=ingest}
-- attrs, key_value, key      {encoding=utf8}
-- attrs, key_value, value    {encoding=utf8}
```

Column names match case-insensitively. The metadata is written onto every row group, so a leaf carries the same pairs in each of its column chunks.

## Design

I modeled the feature on the existing `field_ids` machinery, which already solves the same problem: a column-name-keyed, recursively nested `COPY` option threaded from bind through serialization. The leaf payload is a `vector<pair<string, string>>` instead of a single id, and it attaches to `ColumnMetaData` (per chunk, leaves only) rather than onto the column's `SchemaElement`.

## Validation

The bind step rejects specs that can't be honored, rather than writing surprising output:

- A leaf `MAP` on a complex column, or a nesting `STRUCT` on a primitive column.
- Values that aren't `VARCHAR` or `BLOB` (e.g. an integer or a nested value), which would otherwise be coerced to an internal debug string.
- `NULL` specifications, and `NULL` keys or values inside a leaf `MAP`.
- `VARIANT`, `UNION`, and `AGGREGATE_STATE` columns. They are nested (`PhysicalType::STRUCT`) but expose no addressable leaf, so the nested-type guards above reject them rather than silently dropping the metadata.

## Testing

I included tests for the supported leaf shapes (flat `VARCHAR`/`BLOB`, struct fields, list and array elements, map key/value), replication across row groups, case-insensitive matching, and the empty-`MAP` case. 