### PR TITLE
Issue #23059: Dead WindowExpression Code

### DIFF
--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -414,12 +414,6 @@ private:
 private:
 	WindowExpression();
 
-	WindowExpression(ExpressionType type, vector<unique_ptr<ParsedExpression>> children,
-	                 unique_ptr<ParsedExpression> offset_expr, unique_ptr<ParsedExpression> default_expr);
-
-	WindowExpression(ExpressionType type, vector<FunctionArgument> children, unique_ptr<ParsedExpression> offset_expr,
-	                 unique_ptr<ParsedExpression> default_expr);
-
 	//	Backwards-compatible serialization interface
 	//	Remove LEAD/LAG offset/default
 	vector<unique_ptr<ParsedExpression>> SerializedChildren(Serializer &serializer) const;

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -7,32 +7,6 @@ namespace duckdb {
 WindowExpression::WindowExpression() : ParsedExpression(ExpressionType::INVALID, ExpressionClass::WINDOW) {
 }
 
-WindowExpression::WindowExpression(ExpressionType type, vector<FunctionArgument> arguments_p,
-                                   unique_ptr<ParsedExpression> offset_expr, unique_ptr<ParsedExpression> default_expr)
-    : ParsedExpression(type, ExpressionClass::WINDOW), arguments(std::move(arguments_p)) {
-	if (offset_expr) {
-		arguments.emplace_back("offset", std::move(offset_expr));
-	}
-	if (default_expr) {
-		arguments.emplace_back("default", std::move(default_expr));
-	}
-}
-
-WindowExpression::WindowExpression(ExpressionType type, vector<unique_ptr<ParsedExpression>> children_p,
-                                   unique_ptr<ParsedExpression> offset_expr, unique_ptr<ParsedExpression> default_expr)
-    : ParsedExpression(type, ExpressionClass::WINDOW) {
-	for (auto &child : children_p) {
-		// Unnamed arguments
-		arguments.emplace_back(std::move(child));
-	}
-	if (offset_expr) {
-		arguments.emplace_back("offset", std::move(offset_expr));
-	}
-	if (default_expr) {
-		arguments.emplace_back("default", std::move(default_expr));
-	}
-}
-
 vector<unique_ptr<ParsedExpression>> WindowExpression::SerializedChildren(Serializer &serializer) const {
 	vector<unique_ptr<ParsedExpression>> result;
 	idx_t nargs = arguments.size();


### PR DESCRIPTION
* Remove dead code formerly used for deserialising LEAD/LAG