### PR TITLE
Improve test output and highlight functions in stack trace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 UNITTEST_BINARY ?= test/unittest$(EXE_SUFFIX)
 SMOKE_UNITTEST ?= build/relassert/$(UNITTEST_BINARY)
 SMOKE_RUNNER ?= build/relassert/test/run
-UNITTEST_SLOW_FLAGS ?= --batch-size=5 --track-runtime=100
+UNITTEST_SLOW_FLAGS ?= --track-runtime=100
 UNITTEST_HUGE_FLAGS ?= --workers=50% $(UNITTEST_SLOW_FLAGS)
 
 # Allow setting extra unit test parameters using `make smoke T=...`.

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass
 from io import StringIO
 from pathlib import Path
 
-DEFAULT_BATCH_SIZE = 10
+DEFAULT_BATCH_SIZE = 30
 DEFAULT_BATCH_TIMEOUT_SECONDS = 600
 HIGH_WORKER_BATCH_TIMEOUT_SECONDS = 300
 HIGH_WORKER_BATCH_TIMEOUT_THRESHOLD = 10

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -32,6 +32,7 @@ STABILIZE_FAST_TOTAL_RUNS_LARGE = 3
 STABILIZE_CHANGED_TEST_THRESHOLD = 500
 STOP_REQUESTED = threading.Event()
 ANSI_RED = "\033[31m"
+ANSI_TEAL = "\033[36m"
 ANSI_DARK_GRAY = "\033[90m"
 ANSI_RESET = "\033[0m"
 FAILURE_MARKER = "================================================================"
@@ -397,6 +398,60 @@ def format_dark_gray(text: str):
     return f"{ANSI_DARK_GRAY}{text}{ANSI_RESET}"
 
 
+def highlight_stack_frame_line(line: str):
+    match = re.match(r"^(\d+)(\s+)(.+)$", line)
+    if not match:
+        return line
+
+    frame_idx, spacing, remainder = match.groups()
+    delimiters = [pos for pos in (remainder.find("("), remainder.find("<")) if pos != -1]
+    if delimiters:
+        split_idx = min(delimiters)
+        function_name = remainder[:split_idx]
+        suffix = remainder[split_idx:]
+    else:
+        function_name = remainder
+        suffix = ""
+
+    return f"{format_dark_gray(frame_idx)}{spacing}{ANSI_TEAL}{function_name}{ANSI_RESET}{suffix}"
+
+
+def should_filter_stack_frame_line(line: str):
+    match = re.match(r"^\d+\s+(.+)$", line)
+    if not match:
+        return False
+    remainder = match.group(1)
+    for marker in (
+        "invokeActiveTestCase",
+        "Catch::RunContext",
+        "Catch::Session::run",
+        "Catch::Session::runInternal",
+        "main(",
+    ):
+        if marker in remainder:
+            return True
+    return False
+
+
+def highlight_stack_trace_lines(lines: list[str]):
+    highlighted = []
+    in_stack_trace = False
+    for line in lines:
+        if line == "Stack Trace:":
+            in_stack_trace = True
+            highlighted.append(line)
+            continue
+        if in_stack_trace and re.match(r"^\d+\s+", line):
+            if should_filter_stack_frame_line(line):
+                continue
+            highlighted.append(highlight_stack_frame_line(line))
+            continue
+        if in_stack_trace:
+            in_stack_trace = False
+        highlighted.append(line)
+    return highlighted
+
+
 def render_test_snippet(test_name: str | None, line_number: int | None):
     if not test_name or line_number is None or line_number <= 0:
         return []
@@ -691,10 +746,11 @@ def parse_stdout_failure_info(stdout_lines: list[str]):
 
 def extract_query_failure_diagnostics(stderr_lines: list[str]):
     for idx, line in enumerate(stderr_lines):
-        if not line.startswith("Query failed with message:"):
+        stripped = line.strip()
+        if not stripped.startswith("Query failed with message:") and not stripped.startswith("INTERNAL Error:"):
             continue
 
-        block = [line.strip()]
+        block = [stripped]
         seen_stack_trace = False
         for next_line in stderr_lines[idx + 1 :]:
             stripped = next_line.strip()
@@ -901,8 +957,8 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
 
     detail_lines = []
     snippet_lines = []
-    if stderr_info.failing_summary_block:
-        detail_lines.extend(stderr_info.failing_summary_block)
+    if stderr_info.query_failure_lines:
+        detail_lines.extend(stderr_info.query_failure_lines)
 
     preferred_assertion = stdout_info.preferred_assertion
     if preferred_assertion is not None:
@@ -910,20 +966,20 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
         reproduce_batch = [test_name] if test_name else list(batch)
         line_number = preferred_assertion.line_number or line_number
         snippet_lines = preferred_assertion.snippet_lines
-        if not detail_lines and stderr_info.query_failure_lines:
-            detail_lines.extend(stderr_info.query_failure_lines)
         if preferred_assertion.detail_lines:
             if detail_lines:
                 detail_lines.append("")
             detail_lines.extend(preferred_assertion.detail_lines)
+    if not snippet_lines and test_name is not None and line_number is not None:
+        snippet_lines = render_test_snippet(test_name, line_number)
     if not detail_lines:
         if stdout_info.fallback_failure_block:
             stdout_failure_test_name, stdout_failure_block = stdout_info.fallback_failure_block
             test_name = stdout_failure_test_name or stdout_info.last_started_test or test_name
             reproduce_batch = [test_name] if test_name else list(batch)
             detail_lines.extend(stdout_failure_block)
-    if not detail_lines and stderr_info.query_failure_lines:
-        detail_lines.extend(stderr_info.query_failure_lines)
+    if not detail_lines and stderr_info.failing_summary_block:
+        detail_lines.extend(stderr_info.failing_summary_block)
     if not detail_lines:
         detail_lines.extend(extract_interesting_failure_block(stderr_lines))
     if not detail_lines:
@@ -991,7 +1047,7 @@ def render_failure_lines(failure: FailureInfo):
     if failure.snippet_lines:
         lines.extend(["", *failure.snippet_lines])
     if failure.detail_lines:
-        lines.extend(["", *failure.detail_lines])
+        lines.extend(["", *highlight_stack_trace_lines(failure.detail_lines)])
     return lines
 
 

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -1140,6 +1140,9 @@ def run_batch(config: TestRunnerConfig, batch):
     message = None
     allow_retry = True
     peak_rss_bytes = 0
+    child_env = os.environ.copy()
+    # Omit printing "FAILURES SUMMARY" block at the end of each unittest process.
+    child_env["SUMMARIZE_FAILURES"] = "0"
 
     # On Windows the child process cannot reopen a NamedTemporaryFile while it
     # is still open here, so keep it after close and unlink it ourselves.
@@ -1158,6 +1161,7 @@ def run_batch(config: TestRunnerConfig, batch):
             errors="backslashreplace",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=child_env,
         )
         deadline = time.monotonic() + config.batch_timeout_seconds
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -33,6 +33,43 @@ def strip_ansi_lines(lines: list[str]) -> list[str]:
 
 
 class RunTestsScriptTest(unittest.TestCase):
+    def test_highlight_stack_trace_lines_colors_frame_index_and_function_name(self):
+        lines = run_tests.highlight_stack_trace_lines(
+            [
+                "INTERNAL Error: something bad happened",
+                "Stack Trace:",
+                "0        duckdb::Exception::Exception(duckdb::ExceptionType) + 288",
+                "1        duckdb::TaskScheduler::ExecuteForever(std::__1::atomic<bool>*, duckdb::TaskSchedulerType) + 868",
+                "2        Catch::RunContext::invokeActiveTestCase() + 144",
+                "3        main(int, char**) + 32",
+            ]
+        )
+
+        self.assertEqual(
+            lines[2],
+            (
+                f"{run_tests.ANSI_DARK_GRAY}0{run_tests.ANSI_RESET}        "
+                f"{run_tests.ANSI_TEAL}duckdb::Exception::Exception{run_tests.ANSI_RESET}"
+                "(duckdb::ExceptionType) + 288"
+            ),
+        )
+        self.assertEqual(
+            lines[3],
+            (
+                f"{run_tests.ANSI_DARK_GRAY}1{run_tests.ANSI_RESET}        "
+                f"{run_tests.ANSI_TEAL}duckdb::TaskScheduler::ExecuteForever{run_tests.ANSI_RESET}"
+                "(std::__1::atomic<bool>*, duckdb::TaskSchedulerType) + 868"
+            ),
+        )
+        self.assertEqual(
+            strip_ansi_lines(lines[2:]),
+            [
+                "0        duckdb::Exception::Exception(duckdb::ExceptionType) + 288",
+                "1        duckdb::TaskScheduler::ExecuteForever(std::__1::atomic<bool>*, duckdb::TaskSchedulerType) + 868",
+            ],
+        )
+        self.assertEqual(len(lines), 4)
+
     def test_wrapper_builds_sibling_unittest_argv(self):
         argv = test_runner_wrapper.build_run_tests_argv(["[slow]", "test/sql/a.test"], "build/release/test/run")
         self.assertEqual(
@@ -1391,6 +1428,74 @@ For more information, see https://duckdb.org/docs/current/dev/internal_errors
                 "FAILED: REQUIRE( NO_FAIL((con1.Query( \"SELECT first_name FROM PARQUET_SCAN('data/parquet-testing/userdata1.parquet') GROUP BY first_name\"))) )",
                 "  with expansion:",
                 "false",
+            ],
+        )
+
+    def test_generic_failure_extracts_sqllogictest_assertion_details(self):
+        batch = ["test/sql/copy/partitioned/partitioned_order_by_flush_race.test"]
+        stdout = """
+Filters: test/sql/copy/partitioned/partitioned_order_by_flush_race.test
+[0/1] (0%): test/sql/copy/partitioned/partitioned_order_by_flush_race.test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+unittest is a Catch v2.13.7 host application.
+Run with -? for options
+
+-------------------------------------------------------------------------------
+test/sql/copy/partitioned/partitioned_order_by_flush_race.test
+-------------------------------------------------------------------------------
+/Users/sander/dev/duckdb/duckdb/test/sqlite/test_sqllogictest.cpp:41
+...............................................................................
+
+test/sql/copy/partitioned/partitioned_order_by_flush_race.test:27: FAILED:
+explicitly with message:
+  0
+
+[1/1] (100%): test/sql/copy/partitioned/partitioned_order_by_flush_race.test took 1.086s
+===============================================================================
+test cases: 1 | 1 failed
+assertions: 8 | 7 passed | 1 failed
+"""
+        stderr = """
+1. test/sql/copy/partitioned/partitioned_order_by_flush_race.test:27
+================================================================================
+
+::error::Query unexpectedly failed! (test/sql/copy/partitioned/partitioned_order_by_flush_race.test:27)!
+================================================================================
+COPY (SELECT p, v FROM large_ordered_source ORDER BY v DESC, p DESC)
+TO 'duckdb_unittest_tempdir/11276/large_ordered_partitioned_1'
+(FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (p, v), ROW_GROUP_SIZE 2048);
+================================================================================
+INTERNAL Error: Assertion triggered in file "/Users/sander/dev/duckdb/duckdb/src/execution/operator/persistent/physical_copy_to_file.cpp" on line 1335: batch_state.mode == PartitionedCopyBatchMode::PREPARING
+
+Stack Trace:
+
+0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 288
+1        duckdb::InternalException::InternalException<char const*&, int&, char const*&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*&, int&, char const*&) + 396
+2        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 480
+3        duckdb::PartitionedCopyHashGroup::Prepare(duckdb::ExecutionContext&, duckdb::InterruptState&, duckdb::PartitionedCopyTask const&) + 660
+
+This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
+For more information, see https://duckdb.org/docs/current/dev/internal_errors
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, stderr, batch)
+        self.assertEqual(reproduce_batch, batch)
+        self.assertEqual(
+            strip_ansi_lines(lines)[1:],
+            [
+                "error: FAIL test/sql/copy/partitioned/partitioned_order_by_flush_race.test",
+                "",
+                "  > 27  statement ok",
+                "    28  COPY (SELECT p, v FROM large_ordered_source ORDER BY v DESC, p DESC)",
+                "    29  TO '{TEST_DIR}/large_ordered_partitioned_{i}'",
+                "    30  (FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (p, v), ROW_GROUP_SIZE 2048);",
+                "",
+                ""
+                "INTERNAL Error: Assertion triggered in file \"/Users/sander/dev/duckdb/duckdb/src/execution/operator/persistent/physical_copy_to_file.cpp\" on line 1335: batch_state.mode == PartitionedCopyBatchMode::PREPARING",
+                "Stack Trace:",
+                "0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 288",
+                "1        duckdb::InternalException::InternalException<char const*&, int&, char const*&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*&, int&, char const*&) + 396",
+                "2        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 480",
+                "3        duckdb::PartitionedCopyHashGroup::Prepare(duckdb::ExecutionContext&, duckdb::InterruptState&, duckdb::PartitionedCopyTask const&) + 660",
             ],
         )
 


### PR DESCRIPTION
### Misc

- Increase batch size from 10 to 30 to speed up test runs.
  - Fewer test processes needed, so reducing startup overhead.
- Omit redundant `FAILURES SUMMARY` block shown in a failed test output.

### Highlight function names and trim runner frames

Remove Catch2 function frames from the stack trace (less noise).
Highlight function names with teal so they are easier to spot/scan.

<img width="1000" height="677" alt="Screenshot 2026-06-05 at 09 24 59" src="https://github.com/user-attachments/assets/72a77bca-d16b-4c7f-9e38-1c9127603202" />
