### PR TITLE
Fix strict-prototypes warnings

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -297,6 +297,27 @@ def create_function_comment(function_obj):
     return result
 
 
+def create_parameter_list(function_obj):
+    params = function_obj.get('params', [])
+    if len(params) == 0:
+        return 'void'
+
+    result = ''
+    for param in params:
+        param_type = param['type']
+        param_name = param['name']
+        result += f'{param_type}'
+        if result[-1] != '*':
+            result += ' '
+        result += f'{param_name}, '
+    return result[:-2]  # Trailing comma
+
+
+def create_argument_list(function_obj):
+    params = function_obj.get('params', [])
+    return ', '.join(param['name'] for param in params)
+
+
 # Creates the function declaration for the regular C header file
 def create_function_declaration(function_obj):
     result = ''
@@ -308,17 +329,7 @@ def create_function_declaration(function_obj):
     if result[-1] != '*':
         result += ' '
     result += f'{function_name}('
-
-    if 'params' in function_obj:
-        if len(function_obj['params']) > 0:
-            for param in function_obj['params']:
-                param_type = param['type']
-                param_name = param['name']
-                result += f'{param_type}'
-                if result[-1] != '*':
-                    result += ' '
-                result += f'{param_name}, '
-            result = result[:-2]  # Trailing comma
+    result += create_parameter_list(function_obj)
     result += ');\n'
 
     return result
@@ -331,13 +342,7 @@ def create_struct_member(function_obj):
     function_name = function_obj['name']
     function_return_type = function_obj['return_type']
     result += f'    {function_return_type} (*{function_name})('
-    if 'params' in function_obj:
-        if len(function_obj['params']) > 0:
-            for param in function_obj['params']:
-                param_type = param['type']
-                param_name = param['name']
-                result += f'{param_type} {param_name},'
-            result = result[:-1]  # Trailing comma
+    result += create_parameter_list(function_obj)
     result += ');'
 
     return result
@@ -564,23 +569,10 @@ def create_struct_member_invoker(function_obj):
     if result[-1] != '*':
         result += ' '
     result += f'{function_name}('
-    invoked_params = ''
-
-    if 'params' in function_obj:
-        if len(function_obj['params']) > 0:
-            for param in function_obj['params']:
-                param_type = param['type']
-                param_name = param['name']
-                result += f'{param_type}'
-                if result[-1] != '*':
-                    result += ' '
-                result += f'{param_name}, '
-                invoked_params += f'{param_name}, '
-            result = result[:-2]  # Trailing comma
+    result += create_parameter_list(function_obj)
     result += ') {\n'
 
-    if invoked_params != '':
-        invoked_params = invoked_params[:-2]  # Trailing comma
+    invoked_params = create_argument_list(function_obj)
     result += f'\treturn duckdb_ext_api->{function_name}({invoked_params}); \n'
     result += '}'
     return result
@@ -705,7 +697,7 @@ def create_extension_api_struct(
 
     if with_create_method:
         extension_struct_finished += COMMENT_HEADER("Struct Create Method")
-        extension_struct_finished += f"inline {DUCKDB_EXT_API_STRUCT_TYPENAME} {create_method_name}() {{\n"
+        extension_struct_finished += f"inline {DUCKDB_EXT_API_STRUCT_TYPENAME} {create_method_name}(void) {{\n"
         extension_struct_finished += f"    {DUCKDB_EXT_API_STRUCT_TYPENAME} result;\n"
 
         for api_version_entry in api_definition:

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -934,7 +934,7 @@ process. Must be destroyed with 'duckdb_destroy_instance_cache'.
 
 * @return The database instance cache.
 */
-DUCKDB_C_API duckdb_instance_cache duckdb_create_instance_cache();
+DUCKDB_C_API duckdb_instance_cache duckdb_create_instance_cache(void);
 
 /*!
 Creates a new database instance in the instance cache, or retrieves an existing database instance.
@@ -1071,7 +1071,7 @@ Returns the version of the linked DuckDB, with a version postfix for dev version
 
 Usually used for developing C extensions that must return this for a compatibility check.
 */
-DUCKDB_C_API const char *duckdb_library_version();
+DUCKDB_C_API const char *duckdb_library_version(void);
 
 /*!
 Get the list of (fully qualified) table names of the query.
@@ -1114,7 +1114,7 @@ This should not be called in a loop as it internally loops over all the options.
 
 * @return The amount of config options available.
 */
-DUCKDB_C_API size_t duckdb_config_count();
+DUCKDB_C_API size_t duckdb_config_count(void);
 
 /*!
 Obtains a human-readable name and description of a specific configuration option. This can be used to e.g.
@@ -1653,7 +1653,7 @@ This is the amount of tuples that will fit into a data chunk created by `duckdb_
 
 * @return The vector size.
 */
-DUCKDB_C_API idx_t duckdb_vector_size();
+DUCKDB_C_API idx_t duckdb_vector_size(void);
 
 /*!
 Whether or not the duckdb_string_t value is inlined.
@@ -3003,7 +3003,7 @@ Creates a value of type SQLNULL.
 
 * @return The duckdb_value representing SQLNULL. This must be destroyed with `duckdb_destroy_value`.
 */
-DUCKDB_C_API duckdb_value duckdb_create_null_value();
+DUCKDB_C_API duckdb_value duckdb_create_null_value(void);
 
 /*!
 Returns the number of elements in a LIST value.
@@ -3709,7 +3709,7 @@ The return value must be destroyed with `duckdb_destroy_scalar_function`.
 
 * @return The scalar function object.
 */
-DUCKDB_C_API duckdb_scalar_function duckdb_create_scalar_function();
+DUCKDB_C_API duckdb_scalar_function duckdb_create_scalar_function(void);
 
 /*!
 Destroys the given scalar function object.
@@ -4045,7 +4045,7 @@ The return value should be destroyed with `duckdb_destroy_aggregate_function`.
 
 * @return The aggregate function object.
 */
-DUCKDB_C_API duckdb_aggregate_function duckdb_create_aggregate_function();
+DUCKDB_C_API duckdb_aggregate_function duckdb_create_aggregate_function(void);
 
 /*!
 Destroys the given aggregate function object.
@@ -4206,7 +4206,7 @@ The return value should be destroyed with `duckdb_destroy_table_function`.
 
 * @return The table function object.
 */
-DUCKDB_C_API duckdb_table_function duckdb_create_table_function();
+DUCKDB_C_API duckdb_table_function duckdb_create_table_function(void);
 
 /*!
 Destroys the given table function object.
@@ -5420,7 +5420,7 @@ Creates a new cast function object.
 
 * @return The cast function object.
 */
-DUCKDB_C_API duckdb_cast_function duckdb_create_cast_function();
+DUCKDB_C_API duckdb_cast_function duckdb_create_cast_function(void);
 
 /*!
 Sets the source type of the cast function.
@@ -5608,7 +5608,7 @@ Creates a new file open options instance with blank settings.
 
 * @return The new file open options instance. Must be destroyed with `duckdb_destroy_file_open_options`.
 */
-DUCKDB_C_API duckdb_file_open_options duckdb_create_file_open_options();
+DUCKDB_C_API duckdb_file_open_options duckdb_create_file_open_options(void);
 
 /*!
 Sets a specific flag in the file open options.
@@ -5719,7 +5719,7 @@ Creates a configuration option instance.
 
 * @return The resulting configuration option instance. Must be destroyed with `duckdb_destroy_config_option`.
 */
-DUCKDB_C_API duckdb_config_option duckdb_create_config_option();
+DUCKDB_C_API duckdb_config_option duckdb_create_config_option(void);
 
 /*!
 Destroys the given configuration option instance.
@@ -5807,7 +5807,7 @@ The return value must be destroyed with `duckdb_destroy_copy_function`.
 
 * @return The copy function object.
 */
-DUCKDB_C_API duckdb_copy_function duckdb_create_copy_function();
+DUCKDB_C_API duckdb_copy_function duckdb_create_copy_function(void);
 
 /*!
 Sets the name of the copy function.
@@ -6234,7 +6234,7 @@ Creates a new log storage object.
 
 * @return A log storage object. Must be destroyed with `duckdb_destroy_log_storage`.
 */
-DUCKDB_C_API duckdb_log_storage duckdb_create_log_storage();
+DUCKDB_C_API duckdb_log_storage duckdb_create_log_storage(void);
 
 /*!
 Destroys a log storage object.

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -15,9 +15,9 @@ typedef struct {
 	void (*duckdb_interrupt)(duckdb_connection connection);
 	duckdb_query_progress_type (*duckdb_query_progress)(duckdb_connection connection);
 	void (*duckdb_disconnect)(duckdb_connection *connection);
-	const char *(*duckdb_library_version)();
+	const char *(*duckdb_library_version)(void);
 	duckdb_state (*duckdb_create_config)(duckdb_config *out_config);
-	size_t (*duckdb_config_count)();
+	size_t (*duckdb_config_count)(void);
 	duckdb_state (*duckdb_get_config_flag)(size_t index, const char **out_name, const char **out_description);
 	duckdb_state (*duckdb_set_config)(duckdb_config config, const char *name, const char *option);
 	void (*duckdb_destroy_config)(duckdb_config *config);
@@ -34,7 +34,7 @@ typedef struct {
 	duckdb_result_type (*duckdb_result_return_type)(duckdb_result result);
 	void *(*duckdb_malloc)(size_t size);
 	void (*duckdb_free)(void *ptr);
-	idx_t (*duckdb_vector_size)();
+	idx_t (*duckdb_vector_size)(void);
 	bool (*duckdb_string_is_inlined)(duckdb_string_t string);
 	uint32_t (*duckdb_string_t_length)(duckdb_string_t string);
 	const char *(*duckdb_string_t_data)(duckdb_string_t *string);
@@ -172,7 +172,7 @@ typedef struct {
 	duckdb_value (*duckdb_get_map_key)(duckdb_value value, idx_t index);
 	duckdb_value (*duckdb_get_map_value)(duckdb_value value, idx_t index);
 	bool (*duckdb_is_null_value)(duckdb_value value);
-	duckdb_value (*duckdb_create_null_value)();
+	duckdb_value (*duckdb_create_null_value)(void);
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
@@ -234,7 +234,7 @@ typedef struct {
 	void (*duckdb_validity_set_row_validity)(uint64_t *validity, idx_t row, bool valid);
 	void (*duckdb_validity_set_row_invalid)(uint64_t *validity, idx_t row);
 	void (*duckdb_validity_set_row_valid)(uint64_t *validity, idx_t row);
-	duckdb_scalar_function (*duckdb_create_scalar_function)();
+	duckdb_scalar_function (*duckdb_create_scalar_function)(void);
 	void (*duckdb_destroy_scalar_function)(duckdb_scalar_function *scalar_function);
 	void (*duckdb_scalar_function_set_name)(duckdb_scalar_function scalar_function, const char *name);
 	void (*duckdb_scalar_function_set_varargs)(duckdb_scalar_function scalar_function, duckdb_logical_type type);
@@ -253,7 +253,7 @@ typedef struct {
 	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
 	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
 	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
-	duckdb_aggregate_function (*duckdb_create_aggregate_function)();
+	duckdb_aggregate_function (*duckdb_create_aggregate_function)(void);
 	void (*duckdb_destroy_aggregate_function)(duckdb_aggregate_function *aggregate_function);
 	void (*duckdb_aggregate_function_set_name)(duckdb_aggregate_function aggregate_function, const char *name);
 	void (*duckdb_aggregate_function_add_parameter)(duckdb_aggregate_function aggregate_function,
@@ -280,7 +280,7 @@ typedef struct {
 	duckdb_state (*duckdb_add_aggregate_function_to_set)(duckdb_aggregate_function_set set,
 	                                                     duckdb_aggregate_function function);
 	duckdb_state (*duckdb_register_aggregate_function_set)(duckdb_connection con, duckdb_aggregate_function_set set);
-	duckdb_table_function (*duckdb_create_table_function)();
+	duckdb_table_function (*duckdb_create_table_function)(void);
 	void (*duckdb_destroy_table_function)(duckdb_table_function *table_function);
 	void (*duckdb_table_function_set_name)(duckdb_table_function table_function, const char *name);
 	void (*duckdb_table_function_add_parameter)(duckdb_table_function table_function, duckdb_logical_type type);
@@ -354,7 +354,7 @@ typedef struct {
 	void (*duckdb_destroy_task_state)(duckdb_task_state state);
 	bool (*duckdb_execution_is_finished)(duckdb_connection con);
 	duckdb_data_chunk (*duckdb_fetch_chunk)(duckdb_result result);
-	duckdb_cast_function (*duckdb_create_cast_function)();
+	duckdb_cast_function (*duckdb_create_cast_function)(void);
 	void (*duckdb_cast_function_set_source_type)(duckdb_cast_function cast_function, duckdb_logical_type source_type);
 	void (*duckdb_cast_function_set_target_type)(duckdb_cast_function cast_function, duckdb_logical_type target_type);
 	void (*duckdb_cast_function_set_implicit_cast_cost)(duckdb_cast_function cast_function, int64_t cost);
@@ -462,7 +462,7 @@ typedef struct {
 	duckdb_data_chunk (*duckdb_stream_fetch_chunk)(duckdb_result result);
 	// Exposing the instance cache
 
-	duckdb_instance_cache (*duckdb_create_instance_cache)();
+	duckdb_instance_cache (*duckdb_create_instance_cache)(void);
 	duckdb_state (*duckdb_get_or_create_from_cache)(duckdb_instance_cache instance_cache, const char *path,
 	                                                duckdb_database *out_database, duckdb_config config,
 	                                                char **out_error);
@@ -501,7 +501,7 @@ typedef struct {
 	void (*duckdb_destroy_catalog_entry)(duckdb_catalog_entry *entry);
 	// New configuration options functions
 
-	duckdb_config_option (*duckdb_create_config_option)();
+	duckdb_config_option (*duckdb_create_config_option)(void);
 	void (*duckdb_destroy_config_option)(duckdb_config_option *option);
 	void (*duckdb_config_option_set_name)(duckdb_config_option option, const char *name);
 	void (*duckdb_config_option_set_type)(duckdb_config_option option, duckdb_logical_type type);
@@ -514,7 +514,7 @@ typedef struct {
 	                                                        duckdb_config_option_scope *out_scope);
 	// API to define custom copy functions
 
-	duckdb_copy_function (*duckdb_create_copy_function)();
+	duckdb_copy_function (*duckdb_create_copy_function)(void);
 	void (*duckdb_copy_function_set_name)(duckdb_copy_function copy_function, const char *name);
 	void (*duckdb_copy_function_set_extra_info)(duckdb_copy_function copy_function, void *extra_info,
 	                                            duckdb_delete_callback_t destructor);
@@ -579,7 +579,7 @@ typedef struct {
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
 	duckdb_error_data (*duckdb_file_system_error_data)(duckdb_file_system file_system);
-	duckdb_file_open_options (*duckdb_create_file_open_options)();
+	duckdb_file_open_options (*duckdb_create_file_open_options)(void);
 	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
 	                                                  bool value);
 	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
@@ -597,7 +597,7 @@ typedef struct {
 	char *(*duckdb_geometry_type_get_crs)(duckdb_logical_type type);
 	// API to register a custom log storage.
 
-	duckdb_log_storage (*duckdb_create_log_storage)();
+	duckdb_log_storage (*duckdb_create_log_storage)(void);
 	void (*duckdb_destroy_log_storage)(duckdb_log_storage *log_storage);
 	void (*duckdb_log_storage_set_write_log_entry)(duckdb_log_storage log_storage,
 	                                               duckdb_logger_write_log_entry_t function);
@@ -684,7 +684,7 @@ typedef struct {
 //===--------------------------------------------------------------------===//
 // Struct Create Method
 //===--------------------------------------------------------------------===//
-inline duckdb_ext_api_v1 CreateAPIv1() {
+inline duckdb_ext_api_v1 CreateAPIv1(void) {
 	duckdb_ext_api_v1 result;
 	result.duckdb_open = duckdb_open;
 	result.duckdb_open_ext = duckdb_open_ext;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -78,9 +78,9 @@ typedef struct {
 	void (*duckdb_interrupt)(duckdb_connection connection);
 	duckdb_query_progress_type (*duckdb_query_progress)(duckdb_connection connection);
 	void (*duckdb_disconnect)(duckdb_connection *connection);
-	const char *(*duckdb_library_version)();
+	const char *(*duckdb_library_version)(void);
 	duckdb_state (*duckdb_create_config)(duckdb_config *out_config);
-	size_t (*duckdb_config_count)();
+	size_t (*duckdb_config_count)(void);
 	duckdb_state (*duckdb_get_config_flag)(size_t index, const char **out_name, const char **out_description);
 	duckdb_state (*duckdb_set_config)(duckdb_config config, const char *name, const char *option);
 	void (*duckdb_destroy_config)(duckdb_config *config);
@@ -97,7 +97,7 @@ typedef struct {
 	duckdb_result_type (*duckdb_result_return_type)(duckdb_result result);
 	void *(*duckdb_malloc)(size_t size);
 	void (*duckdb_free)(void *ptr);
-	idx_t (*duckdb_vector_size)();
+	idx_t (*duckdb_vector_size)(void);
 	bool (*duckdb_string_is_inlined)(duckdb_string_t string);
 	uint32_t (*duckdb_string_t_length)(duckdb_string_t string);
 	const char *(*duckdb_string_t_data)(duckdb_string_t *string);
@@ -235,7 +235,7 @@ typedef struct {
 	duckdb_value (*duckdb_get_map_key)(duckdb_value value, idx_t index);
 	duckdb_value (*duckdb_get_map_value)(duckdb_value value, idx_t index);
 	bool (*duckdb_is_null_value)(duckdb_value value);
-	duckdb_value (*duckdb_create_null_value)();
+	duckdb_value (*duckdb_create_null_value)(void);
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
@@ -297,7 +297,7 @@ typedef struct {
 	void (*duckdb_validity_set_row_validity)(uint64_t *validity, idx_t row, bool valid);
 	void (*duckdb_validity_set_row_invalid)(uint64_t *validity, idx_t row);
 	void (*duckdb_validity_set_row_valid)(uint64_t *validity, idx_t row);
-	duckdb_scalar_function (*duckdb_create_scalar_function)();
+	duckdb_scalar_function (*duckdb_create_scalar_function)(void);
 	void (*duckdb_destroy_scalar_function)(duckdb_scalar_function *scalar_function);
 	void (*duckdb_scalar_function_set_name)(duckdb_scalar_function scalar_function, const char *name);
 	void (*duckdb_scalar_function_set_varargs)(duckdb_scalar_function scalar_function, duckdb_logical_type type);
@@ -316,7 +316,7 @@ typedef struct {
 	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
 	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
 	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
-	duckdb_aggregate_function (*duckdb_create_aggregate_function)();
+	duckdb_aggregate_function (*duckdb_create_aggregate_function)(void);
 	void (*duckdb_destroy_aggregate_function)(duckdb_aggregate_function *aggregate_function);
 	void (*duckdb_aggregate_function_set_name)(duckdb_aggregate_function aggregate_function, const char *name);
 	void (*duckdb_aggregate_function_add_parameter)(duckdb_aggregate_function aggregate_function,
@@ -343,7 +343,7 @@ typedef struct {
 	duckdb_state (*duckdb_add_aggregate_function_to_set)(duckdb_aggregate_function_set set,
 	                                                     duckdb_aggregate_function function);
 	duckdb_state (*duckdb_register_aggregate_function_set)(duckdb_connection con, duckdb_aggregate_function_set set);
-	duckdb_table_function (*duckdb_create_table_function)();
+	duckdb_table_function (*duckdb_create_table_function)(void);
 	void (*duckdb_destroy_table_function)(duckdb_table_function *table_function);
 	void (*duckdb_table_function_set_name)(duckdb_table_function table_function, const char *name);
 	void (*duckdb_table_function_add_parameter)(duckdb_table_function table_function, duckdb_logical_type type);
@@ -417,7 +417,7 @@ typedef struct {
 	void (*duckdb_destroy_task_state)(duckdb_task_state state);
 	bool (*duckdb_execution_is_finished)(duckdb_connection con);
 	duckdb_data_chunk (*duckdb_fetch_chunk)(duckdb_result result);
-	duckdb_cast_function (*duckdb_create_cast_function)();
+	duckdb_cast_function (*duckdb_create_cast_function)(void);
 	void (*duckdb_cast_function_set_source_type)(duckdb_cast_function cast_function, duckdb_logical_type source_type);
 	void (*duckdb_cast_function_set_target_type)(duckdb_cast_function cast_function, duckdb_logical_type target_type);
 	void (*duckdb_cast_function_set_implicit_cast_cost)(duckdb_cast_function cast_function, int64_t cost);
@@ -529,7 +529,7 @@ typedef struct {
 
 // Exposing the instance cache
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	duckdb_instance_cache (*duckdb_create_instance_cache)();
+	duckdb_instance_cache (*duckdb_create_instance_cache)(void);
 	duckdb_state (*duckdb_get_or_create_from_cache)(duckdb_instance_cache instance_cache, const char *path,
 	                                                duckdb_database *out_database, duckdb_config config,
 	                                                char **out_error);
@@ -576,7 +576,7 @@ typedef struct {
 
 // New configuration options functions
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	duckdb_config_option (*duckdb_create_config_option)();
+	duckdb_config_option (*duckdb_create_config_option)(void);
 	void (*duckdb_destroy_config_option)(duckdb_config_option *option);
 	void (*duckdb_config_option_set_name)(duckdb_config_option option, const char *name);
 	void (*duckdb_config_option_set_type)(duckdb_config_option option, duckdb_logical_type type);
@@ -591,7 +591,7 @@ typedef struct {
 
 // API to define custom copy functions
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	duckdb_copy_function (*duckdb_create_copy_function)();
+	duckdb_copy_function (*duckdb_create_copy_function)(void);
 	void (*duckdb_copy_function_set_name)(duckdb_copy_function copy_function, const char *name);
 	void (*duckdb_copy_function_set_extra_info)(duckdb_copy_function copy_function, void *extra_info,
 	                                            duckdb_delete_callback_t destructor);
@@ -662,7 +662,7 @@ typedef struct {
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
 	duckdb_error_data (*duckdb_file_system_error_data)(duckdb_file_system file_system);
-	duckdb_file_open_options (*duckdb_create_file_open_options)();
+	duckdb_file_open_options (*duckdb_create_file_open_options)(void);
 	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
 	                                                  bool value);
 	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
@@ -684,7 +684,7 @@ typedef struct {
 
 // API to register a custom log storage.
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	duckdb_log_storage (*duckdb_create_log_storage)();
+	duckdb_log_storage (*duckdb_create_log_storage)(void);
 	void (*duckdb_destroy_log_storage)(duckdb_log_storage *log_storage);
 	void (*duckdb_log_storage_set_write_log_entry)(duckdb_log_storage log_storage,
 	                                               duckdb_logger_write_log_entry_t function);


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/8943

This PR generalizes the C-API generation script with `create_parameter_list` and `create_argument_list` as a companion so that empty parameter lists now declare functions with `void` if they have no parameters. 