### PR TITLE
Fix concurrent extension signing on main

### DIFF
--- a/.github/patches/extensions/ducklake/0021-disable-musl-concurrent-table-creation-test.patch
+++ b/.github/patches/extensions/ducklake/0021-disable-musl-concurrent-table-creation-test.patch
@@ -1,0 +1,14 @@
+diff --git a/test/sql/concurrent/concurrent_table_creation.test_slow b/test/sql/concurrent/concurrent_table_creation.test_slow
+--- a/test/sql/concurrent/concurrent_table_creation.test_slow
++++ b/test/sql/concurrent/concurrent_table_creation.test_slow
+@@ -4,8 +4,10 @@
+ 
+ require notwindows
+ 
+ require ducklake
++
++require notmusl
+ 
+ require parquet
+ 
+ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -247,6 +247,31 @@ jobs:
 
           ls /tmp/repository_generation/*/*/*.duckdb_extension*
 
+      - name: Validate extension signing
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          AWS_ENDPOINT_URL: https://example.com
+          AWS_ACCESS_KEY_ID: duckdb-signing-validation
+          AWS_SECRET_ACCESS_KEY: duckdb-signing-validation
+          DUCKDB_EXTENSION_SIGNING_OUTPUT_DIR: /tmp/repository_signed_validation
+        run: |
+          set -euo pipefail
+
+          private_key_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-signing-validation.XXXXXX.pem")
+          public_key_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-signing-validation.XXXXXX.pub")
+          trap 'rm -f "$private_key_file" "$public_key_file"' EXIT
+
+          openssl genrsa -out "$private_key_file" 2048
+          openssl rsa -in "$private_key_file" -pubout -out "$public_key_file"
+          DUCKDB_EXTENSION_SIGNING_PK="$(cat "$private_key_file")"
+          export DUCKDB_EXTENSION_SIGNING_PK
+
+          rm -rf /tmp/repository_signed_validation
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://rclone.org/install.sh | sudo bash
+          make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/repository_generation
+          ./scripts/verify-extension-signing.sh /tmp/repository_signed_validation "$public_key_file"
+
       - name: Deploy extensions
         shell: bash
         env:

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass
 from io import StringIO
 from pathlib import Path
 
-DEFAULT_BATCH_SIZE = 30
+DEFAULT_BATCH_SIZE = 10
 DEFAULT_BATCH_TIMEOUT_SECONDS = 600
 HIGH_WORKER_BATCH_TIMEOUT_SECONDS = 300
 HIGH_WORKER_BATCH_TIMEOUT_THRESHOLD = 10

--- a/scripts/compute-extension-hash.sh
+++ b/scripts/compute-extension-hash.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
-rm -f hash_concats
-touch hash_concats
+set -euo pipefail
 
-split -b 1M $1
+input_file="$1"
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/duckdb-extension-hash.XXXXXX")
 
-FILES="x*"
-for f in $FILES
-do
-	# sha256 a segment
-	openssl dgst -binary -sha256 $f >> hash_concats
-	rm $f
+cleanup() {
+	rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+hash_concats="$work_dir/hash_concats"
+hash_composite="$work_dir/hash_composite"
+split_prefix="$work_dir/chunk_"
+
+touch "$hash_concats"
+split -b 1M "$input_file" "$split_prefix"
+
+for f in "${split_prefix}"*; do
+	# SHA256 each segment independently, then hash the concatenation of those digests.
+	openssl dgst -binary -sha256 "$f" >> "$hash_concats"
 done
 
-# sha256 the concatenation
-openssl dgst -binary -sha256 hash_concats > hash_composite
-
-cat hash_composite
+openssl dgst -binary -sha256 "$hash_concats" > "$hash_composite"
+cat "$hash_composite"

--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -14,12 +14,12 @@
 # <copy_to_versioned>   : Set this as a versioned version that will not be overwritten
 # <path_to_ext>         : (optional) Search this path for the extension
 
-set -e
+set -euo pipefail
 
-if [ -z "$8" ]; then
-    BASE_EXT_DIR="/tmp/extension"
+if [ -z "${8:-}" ]; then
+	BASE_EXT_DIR="/tmp/extension"
 else
-    BASE_EXT_DIR="$8"
+	BASE_EXT_DIR="$8"
 fi
 
 if [[ $4 == wasm* ]]; then
@@ -32,40 +32,48 @@ script_dir="$(dirname "$(readlink -f "$0")")"
 private_key_file=""
 
 cleanup() {
-  if [ -n "$private_key_file" ]; then
-    rm -f "$private_key_file"
-  fi
+	if [ -n "$private_key_file" ]; then
+		rm -f "$private_key_file"
+	fi
 }
 
 trap cleanup EXIT
 
 # calculate SHA256 hash of extension binary
-cat $ext > $ext.append
+cat "$ext" > "$ext.append"
 
-( command -v truncate >/dev/null 2>&1 && truncate -s -256 $ext.append ) || ( command -v gtruncate >/dev/null 2>&1 && gtruncate -s -256 $ext.append ) || exit 1
+( command -v truncate >/dev/null 2>&1 && truncate -s -256 "$ext.append" ) || \
+	( command -v gtruncate >/dev/null 2>&1 && gtruncate -s -256 "$ext.append" ) || exit 1
 
 # (Optionally) Sign binary
-if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
-  private_key_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-signing.XXXXXX.pem")
-  echo "$DUCKDB_EXTENSION_SIGNING_PK" > "$private_key_file"
-  $script_dir/compute-extension-hash.sh $ext.append > $ext.hash
-  openssl pkeyutl -sign -in $ext.hash -inkey "$private_key_file" -pkeyopt digest:sha256 -out $ext.sign
+if [ -n "${DUCKDB_EXTENSION_SIGNING_PK:-}" ]; then
+	private_key_file=$(mktemp "${TMPDIR:-/tmp}/duckdb-extension-signing.XXXXXX.pem")
+	printf '%s\n' "$DUCKDB_EXTENSION_SIGNING_PK" > "$private_key_file"
+	"$script_dir/compute-extension-hash.sh" "$ext.append" > "$ext.hash"
+	openssl pkeyutl -sign -in "$ext.hash" -inkey "$private_key_file" -pkeyopt digest:sha256 -out "$ext.sign"
 else
-  # Default to 256 zeros
-  dd if=/dev/zero of=$ext.sign bs=256 count=1 status=none
+	# Default to 256 zeros
+	dd if=/dev/zero of="$ext.sign" bs=256 count=1 status=none
 fi
 
 # append signature to extension binary
-cat $ext.sign >> $ext.append
-rm $ext.sign
+cat "$ext.sign" >> "$ext.append"
+rm "$ext.sign"
+rm -f "$ext.hash"
+
+if [ -n "${DUCKDB_EXTENSION_SIGNING_OUTPUT_DIR:-}" ]; then
+	signed_output_file="$DUCKDB_EXTENSION_SIGNING_OUTPUT_DIR/$3/$4/$(basename "$ext")"
+	mkdir -p "$(dirname "$signed_output_file")"
+	cp "$ext.append" "$signed_output_file"
+fi
 
 # compress extension binary
 if [[ $4 == wasm_* ]]; then
-  brotli < $ext.append > "$ext.compressed"
+	brotli < "$ext.append" > "$ext.compressed"
 else
-  gzip < $ext.append > "$ext.compressed"
+	gzip < "$ext.append" > "$ext.compressed"
 fi
-rm $ext.append
+rm "$ext.append"
 
 set -e
 
@@ -86,19 +94,19 @@ fi
 
 # Set dry run unless guard var is set
 DRY_RUN_PARAM="--dry-run"
-if [ "$DUCKDB_DEPLOY_SCRIPT_MODE" == "for_real" ]; then
+if [ "${DUCKDB_DEPLOY_SCRIPT_MODE:-}" == "for_real" ]; then
   DRY_RUN_PARAM=""
 fi
 
 # Abort if credentials are not set
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-    echo "Missing AWS credentials: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required"
-    rm "$ext.compressed"
-    if [ "$DRY_RUN_PARAM" == "" ]; then
-      exit 1
-    else
-      exit 0
-    fi
+	echo "Missing AWS credentials: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required"
+	rm "$ext.compressed"
+	if [ "$DRY_RUN_PARAM" == "" ]; then
+		exit 1
+	else
+		exit 0
+	fi
 fi
 
 dest_extension="gz"
@@ -139,8 +147,8 @@ upload_extension() {
 if [[ $7 = 'true' ]]; then
   if [ -z "$3" ]; then
     echo "extension-upload-single.sh called with upload_versioned=true but no extension version was passed"
-    rm "$ext.compressed"
-    exit 1
+	rm "$ext.compressed"
+	exit 1
   fi
 
   upload_extension "$5/$1/$2/$3/$4/$1.duckdb_extension.$dest_extension"

--- a/scripts/verify-extension-signing.sh
+++ b/scripts/verify-extension-signing.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "Usage: $0 <signed_extensions_dir> <public_key_file>"
+	exit 1
+fi
+
+signed_extensions_dir="$1"
+public_key_file="$2"
+script_dir="$(dirname "$(readlink -f "$0")")"
+signature_size=256
+
+get_file_size() {
+	if stat -c%s "$1" >/dev/null 2>&1; then
+		stat -c%s "$1"
+	else
+		stat -f%z "$1"
+	fi
+}
+
+if [ ! -d "$signed_extensions_dir" ]; then
+	echo "Signed extensions directory '$signed_extensions_dir' does not exist"
+	exit 1
+fi
+
+if [ ! -f "$public_key_file" ]; then
+	echo "Public key file '$public_key_file' does not exist"
+	exit 1
+fi
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/duckdb-extension-verify.XXXXXX")
+
+cleanup() {
+	rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+verified_count=0
+
+while IFS= read -r -d '' signed_extension; do
+	relative_path="${signed_extension#"$signed_extensions_dir"/}"
+	unsigned_extension="$work_dir/${relative_path}.unsigned"
+	signature_file="$work_dir/${relative_path}.signature"
+	hash_file="$work_dir/${relative_path}.hash"
+
+	mkdir -p "$(dirname "$unsigned_extension")"
+	file_size=$(get_file_size "$signed_extension")
+	if [ "$file_size" -lt "$signature_size" ]; then
+		echo "Signed extension '$signed_extension' is smaller than the signature footer"
+		exit 1
+	fi
+
+	unsigned_size=$((file_size - signature_size))
+	dd if="$signed_extension" of="$unsigned_extension" bs=1 count="$unsigned_size" status=none
+	dd if="$signed_extension" of="$signature_file" bs=1 skip="$unsigned_size" count="$signature_size" status=none
+
+	"$script_dir/compute-extension-hash.sh" "$unsigned_extension" > "$hash_file"
+	openssl pkeyutl -verify -pubin -inkey "$public_key_file" -sigfile "$signature_file" -in "$hash_file" \
+		-pkeyopt digest:sha256 >/dev/null
+
+	echo "Verified signature: $relative_path"
+	verified_count=$((verified_count + 1))
+done < <(find "$signed_extensions_dir" -type f \( -name '*.duckdb_extension' -o -name '*.duckdb_extension.wasm' \) -print0 | sort -z)
+
+if [ "$verified_count" -eq 0 ]; then
+	echo "No signed extensions found under '$signed_extensions_dir'"
+	exit 1
+fi
+
+echo "Verified $verified_count signed extensions"


### PR DESCRIPTION
Disable a [failing](https://github.com/duckdb/duckdb/actions/runs/26989589908/job/79648178268#step:30:44) ducklake test on duckdb main's musl CI builds.
```
Error: Query unexpectedly failed! (/duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/concurrent/concurrent_table_creation.test_slow:28)!
================================================================================
INSERT INTO ducklake.tbl_1_0 VALUES (1 * 1000 + 0);
================================================================================
TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
Exceeded the maximum retry count of 10 set by the ducklake_max_retry_count setting.
. Consider increasing the value with: e.g., "SET ducklake_max_retry_count = 100;"
Failed to flush changes into DuckLake: Duplicate key "snapshot_id: 40" violates primary key constraint.
```

Allow concurrent extension signing/upload and verify in PR's CI runs. The errors like:
```
Processing extension: autocomplete (architecture: linux_amd64, version: 53cd06eeb6, path: /tmp/repository_generation/53cd06eeb6/linux_amd64/autocomplete.duckdb_extension)
xac: No such file or directory
40274695037F0000:error:80000002:system library:file_ctrl:No such file or directory:../crypto/bio/bss_file.c:297:calling fopen(xac, r)
40274695037F0000:error:10080002:BIO routines:file_ctrl:system lib:../crypto/bio/bss_file.c:300:
rm: cannot remove 'xac': No such file or directory
+ rclone copyto --no-traverse --ignore-times --ignore-checksum --s3-no-check-bucket --s3-no-head --s3-provider Cloudflare --s3-endpoint *** /tmp/repository_generation/53cd06eeb6/linux_amd64/autocomplete.duckdb_extension.compressed :s3,env_auth=true:duckdb-core-extensions/53cd06eeb6/linux_amd64/autocomplete.duckdb_extension.gz
2026/06/04 14:20:34 NOTICE: Config file "/home/runner/.config/rclone/rclone.conf" not found - using defaults
+ rm /tmp/repository_generation/53cd06eeb6/linux_amd64/autocomplete.duckdb_extension.compressed
+ cleanup
+ '[' -n /tmp/duckdb-extension-signing.Pzyu8E.pem ']'
+ rm -f /tmp/duckdb-extension-signing.Pzyu8E.pem
```
were caused by concurrently modifying the directory that stored the binary segments and thus affected their hashes.

Changed signing to use an isolated directory and added `set -euo pipefail` to detect any signing command errors.

Also verify the extension signing logic in PRs to detect these issues in a PR instead of only at the end of a CI run on the main branch.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9575.