### PR TITLE
Fix Parquet thrift byte order on windows + relax geometry stats pruning

### DIFF
--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -113,10 +113,27 @@ public:
 		return GeometryExtent {EMPTY_MIN, EMPTY_MIN, EMPTY_MIN, EMPTY_MIN, EMPTY_MAX, EMPTY_MAX, EMPTY_MAX, EMPTY_MAX};
 	}
 
-	// Does this extent have any X/Y values set?
-	// In other words, is the range of the x/y axes not empty and not unknown?
+	// Does this extent have the X axis set?
+	// In other words, is the range of the x-axis not empty and not unknown?
+	bool HasX() const {
+		return std::isfinite(x_min) && std::isfinite(x_max);
+	}
+	// Does this extent have the Y axis set?
+	// In other words, is the range of the y-axis not empty and not unknown?
+	bool HasY() const {
+		return std::isfinite(y_min) && std::isfinite(y_max);
+	}
+	// Does this extent have both X and Y axes set?
+	// In other words, are the ranges of both the x and y axes not empty and not unknown?
+	// Used to gate serialization, where a non-finite axis cannot be represented.
 	bool HasXY() const {
-		return std::isfinite(x_min) && std::isfinite(y_min) && std::isfinite(x_max) && std::isfinite(y_max);
+		return HasX() && HasY();
+	}
+	// Can this extent be used for X/Y zonemap pruning?
+	// A single finite axis is enough: an unknown axis is treated as an infinite range,
+	// which intersects everything, so pruning simply degrades to the finite axis.
+	bool CanPruneXY() const {
+		return HasX() || HasY();
 	}
 	// Does this extent have any Z values set?
 	// In other words, is the range of the Z-axis not empty and not unknown?

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -231,8 +231,10 @@ static FilterPropagateResult CheckIntersectionFilter(const GeometryStatsData &da
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 
-	// This has been checked before and needs to be true for the checks below to be valid
-	D_ASSERT(data.extent.HasXY());
+	// This has been checked before and needs to be true for the checks below to be valid.
+	// Note: only one axis needs to be set; an unknown axis is an infinite range that
+	// intersects everything, so the IntersectsXY/ContainsXY math below stays valid.
+	D_ASSERT(data.extent.CanPruneXY());
 
 	const auto &geom = StringValue::Get(constant);
 	auto extent = GeometryExtent::Empty();
@@ -300,8 +302,10 @@ FilterPropagateResult GeometryStats::CheckZonemap(const BaseStatistics &stats, c
 
 	auto &data = GetDataUnsafe(stats);
 
-	if (!data.extent.HasXY()) {
-		// If the extent is empty or unknown, we cannot prune
+	if (!data.extent.CanPruneXY()) {
+		// If neither axis is set (the extent is empty or fully unknown), we cannot prune.
+		// A single known axis is enough: the unknown axis is an infinite range that
+		// intersects everything, so pruning degrades to the known axis.
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 

--- a/third_party/thrift/thrift/protocol/TProtocol.h
+++ b/third_party/thrift/thrift/protocol/TProtocol.h
@@ -89,6 +89,18 @@ static inline To bitwise_cast(From from) {
 #  define __THRIFT_BYTE_ORDER BYTE_ORDER
 #  define __THRIFT_LITTLE_ENDIAN LITTLE_ENDIAN
 #  define __THRIFT_BIG_ENDIAN BIG_ENDIAN
+# elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+   // GCC / Clang builtin (macOS, Linux, MinGW, ...). Reliable without relying on system headers happening to have
+   // defined BYTE_ORDER already.
+#  define __THRIFT_BYTE_ORDER __BYTE_ORDER__
+#  define __THRIFT_LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#  define __THRIFT_BIG_ENDIAN __ORDER_BIG_ENDIAN__
+# elif defined(_WIN32)
+   // All Windows targets (x86, x64, ARM, ARM64) are little-endian. MSVC does not define BYTE_ORDER, so without this
+   // we would fall through to the broken default below and byteswap every double on the wire.
+#  define __THRIFT_BYTE_ORDER 1234
+#  define __THRIFT_LITTLE_ENDIAN __THRIFT_BYTE_ORDER
+#  define __THRIFT_BIG_ENDIAN 0
 # else
 //#  include <boost/predef/other/endian.h>
 #  if BOOST_ENDIAN_BIG_BYTE
@@ -104,6 +116,13 @@ static inline To bitwise_cast(From from) {
 #  else
 #  endif
 # endif
+#endif
+
+// Guard against silently falling into the big-endian byteswap path.
+// if detection failed above, __THRIFT_BYTE_ORDER and __THRIFT_BIG_ENDIAN both expand to 0 and the comparison below
+// would be (0 == 0) -> true, byte-swapping every double.
+#if !defined(__THRIFT_BYTE_ORDER) || !defined(__THRIFT_LITTLE_ENDIAN) || !defined(__THRIFT_BIG_ENDIAN)
+# error "Could not detect endianness for Thrift; define __THRIFT_BYTE_ORDER explicitly."
 #endif
 
 #if __THRIFT_BYTE_ORDER == __THRIFT_BIG_ENDIAN


### PR DESCRIPTION
This PR fixes an issue where the byte-order check used in the parquet thrift coded was incorrect on windows, leading to `double` values being encoded wrong. I think this was caused by pulling out all the boost library stuff (which I presume originally included the windows check) when the thrift code was originally vendored.

Since the only place where we serialize `double`s in thrift is in the parquet `GeometryStatistics` field, as far as I can tell the consequences of this bug has been basically non-existent until we added support for native parquet geometry around the end of last year. And even then, it's not a problem if you read files on windows that were produced by windows as the byte order is at least consistent, even if it's wrong. I only managed to find this while using my Mac to investigate stats-pruning with a parquet file produced by a user on windows. 

It's difficult to write a test for this, but I have been verifying manually by building duckdb on a windows machine and comparing the stats output of files written both on windows and on osx with and without this patch. 

Additionally this PR also relaxes the geometry stats pruning check slightly to allow intersection checks even if the bounds of only one of the x/y axes are defined.