### PR TITLE
Step 1: Remove duplicate-eliminated joins and replace them with materialized CTEs

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -476,6 +476,13 @@
         "default_value": "ALL_ERRORS_INVALIDATE_TRANSACTION"
     },
     {
+        "name": "delim_join_as_cte",
+        "description": "Rewrite delim joins to materialized CTEs during dependent join flattening",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "deprecated_using_key_syntax",
         "description": "Configures the use of the deprecated union syntax for USING KEY CTEs.",
         "type": "ENUM<DeprecatedUsingKeySyntax>",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -759,6 +759,17 @@ struct DefaultTransactionInvalidationPolicySetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct DelimJoinAsCteSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "delim_join_as_cte";
+	static constexpr const char *Description =
+	    "Rewrite delim joins to materialized CTEs during dependent join flattening";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct DeprecatedUsingKeySyntaxSetting {
 	using RETURN_TYPE = DeprecatedUsingKeySyntax;
 	static constexpr const char *Name = "deprecated_using_key_syntax";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -28,44 +28,41 @@ bool DBConfigOptions::debug_print_bindings = false;
 DebugVerificationMode DBConfigOptions::global_verification_mode = DebugVerificationMode::NONE;
 
 #define DUCKDB_SETTING(_PARAM)                                                                                         \
-	{_PARAM::Name,      _PARAM::Description,                                                                           \
-	 _PARAM::InputType, nullptr,                                                                                       \
-	 nullptr,           nullptr,                                                                                       \
-	 nullptr,           nullptr,                                                                                       \
-	 _PARAM::Scope,     _PARAM::DefaultValue,                                                                          \
-	 nullptr,           _PARAM::SettingIndex}
+	{                                                                                                                  \
+		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, nullptr, nullptr, nullptr, nullptr,             \
+		    _PARAM::Scope, _PARAM::DefaultValue, nullptr, _PARAM::SettingIndex                                         \
+	}
 #define DUCKDB_SETTING_CALLBACK(_PARAM)                                                                                \
-	{_PARAM::Name,      _PARAM::Description,                                                                           \
-	 _PARAM::InputType, nullptr,                                                                                       \
-	 nullptr,           nullptr,                                                                                       \
-	 nullptr,           nullptr,                                                                                       \
-	 _PARAM::Scope,     _PARAM::DefaultValue,                                                                          \
-	 _PARAM::OnSet,     _PARAM::SettingIndex}
+	{                                                                                                                  \
+		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, nullptr, nullptr, nullptr, nullptr,             \
+		    _PARAM::Scope, _PARAM::DefaultValue, _PARAM::OnSet, _PARAM::SettingIndex                                   \
+	}
 #define DUCKDB_GLOBAL(_PARAM)                                                                                          \
-	{_PARAM::Name, _PARAM::Description, _PARAM::InputType,           _PARAM::SetGlobal, nullptr, _PARAM::ResetGlobal,  \
-	 nullptr,      _PARAM::GetSetting,  SettingScopeTarget::INVALID, nullptr,           nullptr, optional_idx()}
+	{                                                                                                                  \
+		_PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, nullptr, _PARAM::ResetGlobal,         \
+		    nullptr, _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr, nullptr, optional_idx()                 \
+	}
 #define DUCKDB_LOCAL(_PARAM)                                                                                           \
-	{_PARAM::Name,       _PARAM::Description, _PARAM::InputType,           nullptr, _PARAM::SetLocal, nullptr,         \
-	 _PARAM::ResetLocal, _PARAM::GetSetting,  SettingScopeTarget::INVALID, nullptr, nullptr,          optional_idx()}
+	{                                                                                                                  \
+		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, _PARAM::SetLocal, nullptr, _PARAM::ResetLocal,  \
+		    _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr, nullptr, optional_idx()                          \
+	}
 #define DUCKDB_GLOBAL_LOCAL(_PARAM)                                                                                    \
-	{_PARAM::Name,                                                                                                     \
-	 _PARAM::Description,                                                                                              \
-	 _PARAM::InputType,                                                                                                \
-	 _PARAM::SetGlobal,                                                                                                \
-	 _PARAM::SetLocal,                                                                                                 \
-	 _PARAM::ResetGlobal,                                                                                              \
-	 _PARAM::ResetLocal,                                                                                               \
-	 _PARAM::GetSetting,                                                                                               \
-	 SettingScopeTarget::INVALID,                                                                                      \
-	 nullptr,                                                                                                          \
-	 nullptr,                                                                                                          \
-	 optional_idx()}
+	{                                                                                                                  \
+		_PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, _PARAM::SetLocal,                     \
+		    _PARAM::ResetGlobal, _PARAM::ResetLocal, _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr,         \
+		    nullptr, optional_idx()                                                                                    \
+	}
 #define FINAL_SETTING                                                                                                  \
-	{nullptr, nullptr, nullptr,       nullptr, nullptr, nullptr, nullptr, nullptr, SettingScopeTarget::INVALID,        \
-	 nullptr, nullptr, optional_idx()}
+	{                                                                                                                  \
+		nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, SettingScopeTarget::INVALID, nullptr,  \
+		    nullptr, optional_idx()                                                                                    \
+	}
 
-#define DUCKDB_SETTING_ALIAS(_ALIAS, _SETTING_INDEX) {_ALIAS, _SETTING_INDEX}
-#define FINAL_ALIAS                                  {nullptr, 0}
+#define DUCKDB_SETTING_ALIAS(_ALIAS, _SETTING_INDEX)                                                                   \
+	{ _ALIAS, _SETTING_INDEX }
+#define FINAL_ALIAS                                                                                                    \
+	{ nullptr, 0 }
 
 static const ConfigurationOption internal_options[] = {
 
@@ -240,14 +237,14 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 119),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 53),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 140),
-                                                     DUCKDB_SETTING_ALIAS("user", 156),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 154),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 28),
+                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 28),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 122),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 55),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 143),
+                                                     DUCKDB_SETTING_ALIAS("user", 160),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 27),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 158),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -28,41 +28,44 @@ bool DBConfigOptions::debug_print_bindings = false;
 DebugVerificationMode DBConfigOptions::global_verification_mode = DebugVerificationMode::NONE;
 
 #define DUCKDB_SETTING(_PARAM)                                                                                         \
-	{                                                                                                                  \
-		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, nullptr, nullptr, nullptr, nullptr,             \
-		    _PARAM::Scope, _PARAM::DefaultValue, nullptr, _PARAM::SettingIndex                                         \
-	}
+	{_PARAM::Name,      _PARAM::Description,                                                                           \
+	 _PARAM::InputType, nullptr,                                                                                       \
+	 nullptr,           nullptr,                                                                                       \
+	 nullptr,           nullptr,                                                                                       \
+	 _PARAM::Scope,     _PARAM::DefaultValue,                                                                          \
+	 nullptr,           _PARAM::SettingIndex}
 #define DUCKDB_SETTING_CALLBACK(_PARAM)                                                                                \
-	{                                                                                                                  \
-		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, nullptr, nullptr, nullptr, nullptr,             \
-		    _PARAM::Scope, _PARAM::DefaultValue, _PARAM::OnSet, _PARAM::SettingIndex                                   \
-	}
+	{_PARAM::Name,      _PARAM::Description,                                                                           \
+	 _PARAM::InputType, nullptr,                                                                                       \
+	 nullptr,           nullptr,                                                                                       \
+	 nullptr,           nullptr,                                                                                       \
+	 _PARAM::Scope,     _PARAM::DefaultValue,                                                                          \
+	 _PARAM::OnSet,     _PARAM::SettingIndex}
 #define DUCKDB_GLOBAL(_PARAM)                                                                                          \
-	{                                                                                                                  \
-		_PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, nullptr, _PARAM::ResetGlobal,         \
-		    nullptr, _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr, nullptr, optional_idx()                 \
-	}
+	{_PARAM::Name, _PARAM::Description, _PARAM::InputType,           _PARAM::SetGlobal, nullptr, _PARAM::ResetGlobal,  \
+	 nullptr,      _PARAM::GetSetting,  SettingScopeTarget::INVALID, nullptr,           nullptr, optional_idx()}
 #define DUCKDB_LOCAL(_PARAM)                                                                                           \
-	{                                                                                                                  \
-		_PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, _PARAM::SetLocal, nullptr, _PARAM::ResetLocal,  \
-		    _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr, nullptr, optional_idx()                          \
-	}
+	{_PARAM::Name,       _PARAM::Description, _PARAM::InputType,           nullptr, _PARAM::SetLocal, nullptr,         \
+	 _PARAM::ResetLocal, _PARAM::GetSetting,  SettingScopeTarget::INVALID, nullptr, nullptr,          optional_idx()}
 #define DUCKDB_GLOBAL_LOCAL(_PARAM)                                                                                    \
-	{                                                                                                                  \
-		_PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, _PARAM::SetLocal,                     \
-		    _PARAM::ResetGlobal, _PARAM::ResetLocal, _PARAM::GetSetting, SettingScopeTarget::INVALID, nullptr,         \
-		    nullptr, optional_idx()                                                                                    \
-	}
+	{_PARAM::Name,                                                                                                     \
+	 _PARAM::Description,                                                                                              \
+	 _PARAM::InputType,                                                                                                \
+	 _PARAM::SetGlobal,                                                                                                \
+	 _PARAM::SetLocal,                                                                                                 \
+	 _PARAM::ResetGlobal,                                                                                              \
+	 _PARAM::ResetLocal,                                                                                               \
+	 _PARAM::GetSetting,                                                                                               \
+	 SettingScopeTarget::INVALID,                                                                                      \
+	 nullptr,                                                                                                          \
+	 nullptr,                                                                                                          \
+	 optional_idx()}
 #define FINAL_SETTING                                                                                                  \
-	{                                                                                                                  \
-		nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, SettingScopeTarget::INVALID, nullptr,  \
-		    nullptr, optional_idx()                                                                                    \
-	}
+	{nullptr, nullptr, nullptr,       nullptr, nullptr, nullptr, nullptr, nullptr, SettingScopeTarget::INVALID,        \
+	 nullptr, nullptr, optional_idx()}
 
-#define DUCKDB_SETTING_ALIAS(_ALIAS, _SETTING_INDEX)                                                                   \
-	{ _ALIAS, _SETTING_INDEX }
-#define FINAL_ALIAS                                                                                                    \
-	{ nullptr, 0 }
+#define DUCKDB_SETTING_ALIAS(_ALIAS, _SETTING_INDEX) {_ALIAS, _SETTING_INDEX}
+#define FINAL_ALIAS                                  {nullptr, 0}
 
 static const ConfigurationOption internal_options[] = {
 
@@ -125,6 +128,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DefaultOrderSetting),
     DUCKDB_GLOBAL(DefaultSecretStorageSetting),
     DUCKDB_SETTING_CALLBACK(DefaultTransactionInvalidationPolicySetting),
+    DUCKDB_SETTING(DelimJoinAsCteSetting),
     DUCKDB_SETTING_CALLBACK(DeprecatedUsingKeySyntaxSetting),
     DUCKDB_SETTING_CALLBACK(DisableDatabaseInvalidationSetting),
     DUCKDB_SETTING(DisableTimestamptzCastsSetting),
@@ -236,14 +240,14 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 28),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 28),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 121),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 55),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 142),
-                                                     DUCKDB_SETTING_ALIAS("user", 159),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 27),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 157),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 27),
+                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 27),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 119),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 53),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 140),
+                                                     DUCKDB_SETTING_ALIAS("user", 156),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 26),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 154),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -230,12 +230,27 @@ static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &c
                                           const vector<ReplacementBinding> &replacements);
 static void RewriteDelimJoinsToCTEs(Binder &binder, unique_ptr<LogicalOperator> &plan);
 
+static void VerifyNoDelim(LogicalOperator &op) {
+	// Verify that there are no delim joins or delim scans in the plan, as these should have been rewritten to CTEs at
+	// this point.
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		throw InternalException("Found DELIM_JOIN after flattening dependent joins");
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		throw InternalException("Found DELIM_GET after flattening dependent joins");
+	}
+	for (auto &child : op.children) {
+		VerifyNoDelim(*child);
+	}
+}
+
 unique_ptr<LogicalOperator> FlattenDependentJoins::DecorrelateIndependent(Binder &binder,
                                                                           unique_ptr<LogicalOperator> plan) {
 	CorrelatedColumns correlated;
 	FlattenDependentJoins flatten(binder, correlated);
 	flatten.DecorrelateSubtree(plan, true, {});
 	RewriteDelimJoinsToCTEs(binder, plan);
+	VerifyNoDelim(*plan);
 	return plan;
 }
 

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -224,6 +224,11 @@ void FlattenDependentJoins::CreateDelimJoinConditions(LogicalComparisonJoin &del
 	}
 }
 
+static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &op, LogicalOperator &child,
+                                                              const vector<ColumnBinding> &old_child_bindings);
+static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &correlated_aliases,
+                                          const vector<ReplacementBinding> &replacements);
+
 unique_ptr<LogicalOperator> FlattenDependentJoins::DecorrelateIndependent(Binder &binder,
                                                                           unique_ptr<LogicalOperator> plan) {
 	CorrelatedColumns correlated;
@@ -281,6 +286,8 @@ vector<ColumnBinding> FlattenDependentJoins::DecorrelateSubtree(unique_ptr<Logic
 	for (auto &child : plan->children) {
 		auto old_child_bindings = child->GetColumnBindings();
 		state = DecorrelateSubtree(child, propagate_null_values, std::move(state));
+		auto replacements = RewriteChangedChildBindings(*plan, *child, old_child_bindings);
+		RegisterChangedBindingAliases(correlated_aliases, replacements);
 		RewriteCorrelatedExpressions::Rewrite(*plan, GetCurrentBindings(state), correlated_aliases);
 	}
 	return state;
@@ -308,6 +315,7 @@ static unique_ptr<LogicalWindow> CreateRowNumberWindow(Binder &binder, unique_pt
 vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDependentJoin &op,
                                                                       bool propagate_null_values,
                                                                       vector<ColumnBinding> state) {
+	auto old_left_bindings = op.children[0]->GetColumnBindings();
 	// If we have a parent, we unnest the left side of the DEPENDENT JOIN in the parent's context.
 	if (parent) {
 		// only push the dependent join to the left side, if there is correlation.
@@ -318,9 +326,14 @@ vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDep
 			op.children[0] = DecorrelateIndependent(binder, std::move(op.children[0]));
 		}
 
-		RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(state), correlated_aliases);
 	} else {
 		state = DecorrelateSubtree(op.children[0], true, std::move(state));
+	}
+
+	auto replacements = RewriteChangedChildBindings(op, *op.children[0], old_left_bindings);
+	RegisterChangedBindingAliases(correlated_aliases, replacements);
+	if (parent) {
+		RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(state), correlated_aliases);
 	}
 
 	if (!op.perform_delim) {
@@ -335,7 +348,10 @@ vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDep
 vector<ColumnBinding> FlattenDependentJoins::PushDownChild(unique_ptr<LogicalOperator> &plan,
                                                            bool propagate_null_values, vector<ColumnBinding> state,
                                                            bool rewrite_parent, idx_t child_idx) {
+	auto old_child_bindings = plan->children[child_idx]->GetColumnBindings();
 	state = PushDownCorrelatedNode(plan->children[child_idx], propagate_null_values, std::move(state));
+	auto replacements = RewriteChangedChildBindings(*plan, *plan->children[child_idx], old_child_bindings);
+	RegisterChangedBindingAliases(correlated_aliases, replacements);
 	if (rewrite_parent) {
 		RewriteCorrelatedExpressions::Rewrite(*plan, GetCurrentBindings(state), correlated_aliases);
 	}
@@ -434,6 +450,12 @@ static vector<string> GenerateCTEColumnNames(idx_t column_count, const string &p
 }
 
 static void RewriteDelimScanReferences(unique_ptr<LogicalOperator> &op, TableIndex delim_scan_index) {
+	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		if (!op->children.empty()) {
+			RewriteDelimScanReferences(op->children[0], delim_scan_index);
+		}
+		return;
+	}
 	for (auto &child : op->children) {
 		RewriteDelimScanReferences(child, delim_scan_index);
 	}
@@ -446,11 +468,100 @@ static void RewriteDelimScanReferences(unique_ptr<LogicalOperator> &op, TableInd
 	}
 }
 
+static vector<ReplacementBinding> CreateBindingReplacements(const vector<ColumnBinding> &old_bindings,
+                                                            const vector<ColumnBinding> &new_bindings) {
+	vector<ReplacementBinding> result;
+	auto count = MinValue(old_bindings.size(), new_bindings.size());
+	for (idx_t i = 0; i < count; i++) {
+		if (old_bindings[i] != new_bindings[i] &&
+		    std::find(new_bindings.begin(), new_bindings.end(), old_bindings[i]) == new_bindings.end()) {
+			result.emplace_back(old_bindings[i], new_bindings[i]);
+		}
+	}
+	return result;
+}
+
+static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &op, LogicalOperator &child,
+                                                              const vector<ColumnBinding> &old_child_bindings) {
+	auto new_child_bindings = child.GetColumnBindings();
+	auto replacements = CreateBindingReplacements(old_child_bindings, new_child_bindings);
+	if (replacements.empty()) {
+		return replacements;
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
+		auto &dependent_join = op.Cast<LogicalDependentJoin>();
+		for (auto &col : dependent_join.correlated_columns) {
+			for (const auto &replacement : replacements) {
+				if (col.binding == replacement.old_binding) {
+					col.binding = replacement.new_binding;
+					break;
+				}
+			}
+		}
+	}
+	ColumnBindingReplacer replacer;
+	replacer.replacement_bindings = replacements;
+	if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN && op.children[0].get() == &child) {
+		replacer.stop_operator = child;
+		replacer.VisitOperator(op);
+	} else {
+		LogicalOperatorVisitor::EnumerateExpressions(op,
+		                                             [&](unique_ptr<Expression> *expr) { replacer.VisitExpression(expr); });
+	}
+	return replacements;
+}
+
+static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &correlated_aliases,
+                                          const vector<ReplacementBinding> &replacements) {
+	for (const auto &replacement : replacements) {
+		auto entry = correlated_aliases.find(replacement.old_binding);
+		if (entry == correlated_aliases.end()) {
+			continue;
+		}
+		auto result = correlated_aliases.emplace(replacement.new_binding, entry->second);
+		D_ASSERT(result.second || result.first->second == entry->second);
+	}
+}
+
+static vector<ColumnBinding> RewriteStateBindings(vector<ColumnBinding> state,
+                                                  const vector<ReplacementBinding> &replacements) {
+	for (auto &binding : state) {
+		for (const auto &replacement : replacements) {
+			if (binding == replacement.old_binding) {
+				binding = replacement.new_binding;
+				break;
+			}
+		}
+	}
+	return state;
+}
+
+static optional_idx FindBindingIndex(const vector<ColumnBinding> &bindings, const ColumnBinding &binding) {
+	auto entry = std::find(bindings.begin(), bindings.end(), binding);
+	if (entry == bindings.end()) {
+		return optional_idx();
+	}
+	return NumericCast<idx_t>(entry - bindings.begin());
+}
+
 vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<LogicalOperator> &plan,
                                                                    vector<ColumnBinding> outer_state,
                                                                    const vector<ColumnBinding> &right_state) {
 	auto &op = plan->Cast<LogicalDependentJoin>();
 	RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(outer_state), correlated_aliases);
+
+	auto left_bindings = plan->children[0]->GetColumnBindings();
+	idx_t correlated_idx = 0;
+	for (auto &col : op.correlated_columns) {
+		if (correlated_idx >= outer_state.size()) {
+			break;
+		}
+		if (!FindBindingIndex(left_bindings, col.binding).IsValid() &&
+		    FindBindingIndex(left_bindings, outer_state[correlated_idx]).IsValid()) {
+			col.binding = outer_state[correlated_idx];
+		}
+		correlated_idx++;
+	}
 
 	op.duplicate_eliminated_columns.clear();
 	op.mark_types.clear();
@@ -493,31 +604,104 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 		// Build the same comparison join that a DELIM_JOIN would execute, then make the
 		// delim inputs explicit through materialized CTEs.
 		plan->type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
-		auto dedup_column_count = plan->children[0]->GetColumnBindings().size();
+		if (op.right_projection_map.empty() && !right_state.empty()) {
+			auto right_bindings = plan->children[1]->GetColumnBindings();
+			vector<ProjectionIndex> right_projection_map;
+			right_projection_map.reserve(right_bindings.size());
+			for (idx_t i = 0; i < right_bindings.size(); i++) {
+				if (!FindBindingIndex(right_state, right_bindings[i]).IsValid()) {
+					right_projection_map.emplace_back(i);
+				}
+			}
+			if (right_projection_map.size() < right_bindings.size()) {
+				op.right_projection_map = std::move(right_projection_map);
+			}
+		}
+
+		left_bindings = plan->children[0]->GetColumnBindings();
+		plan->children[0]->ResolveOperatorTypes();
+		auto left_types = plan->children[0]->types;
+		vector<idx_t> dedup_column_indices;
+		vector<LogicalType> dedup_types;
+		vector<string> dedup_names;
+		vector<unique_ptr<Expression>> extra_left_expressions;
+		bool added_hidden_left_columns = false;
+		dedup_column_indices.reserve(op.duplicate_eliminated_columns.size());
+		dedup_types.reserve(op.duplicate_eliminated_columns.size());
+		dedup_names.reserve(op.duplicate_eliminated_columns.size());
+		for (auto &expr : op.duplicate_eliminated_columns) {
+			if (expr->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+				throw InternalException("Flatten dependent joins - expected duplicate eliminated column reference");
+			}
+			auto &colref_expr = expr->Cast<BoundColumnRefExpression>();
+			auto binding_index = FindBindingIndex(left_bindings, colref_expr.Binding());
+			if (binding_index.IsValid()) {
+				dedup_column_indices.push_back(binding_index.GetIndex());
+			} else {
+				dedup_column_indices.push_back(left_bindings.size() + extra_left_expressions.size());
+				extra_left_expressions.push_back(expr->Copy());
+			}
+			dedup_types.push_back(expr->GetReturnType());
+			dedup_names.push_back(expr->GetName());
+		}
+
+		if (!extra_left_expressions.empty()) {
+			added_hidden_left_columns = true;
+			vector<unique_ptr<Expression>> expressions;
+			expressions.reserve(left_bindings.size() + extra_left_expressions.size());
+			for (idx_t i = 0; i < left_bindings.size(); i++) {
+				expressions.push_back(make_uniq<BoundColumnRefExpression>(left_types[i], left_bindings[i]));
+			}
+			for (auto &expr : extra_left_expressions) {
+				expressions.push_back(std::move(expr));
+			}
+			auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+			projection->children.push_back(std::move(plan->children[0]));
+			plan->children[0] = std::move(projection);
+			plan->children[0]->ResolveOperatorTypes();
+			left_types = plan->children[0]->types;
+		}
+
+		auto left_column_count = plan->children[0]->GetColumnBindings().size();
 		auto cte_index = binder.GenerateTableIndex();
 		auto cte_name = "__duckdb_delim_" + to_string(cte_index.index);
 		auto cte =
-		    make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, dedup_column_count, std::move(plan->children[0]),
+		    make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, left_column_count, std::move(plan->children[0]),
 		                                      nullptr, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
 
 		cte->children[0]->ResolveOperatorTypes();
-		auto types = cte->children[0]->types;
+		left_types = cte->children[0]->types;
 
 		auto cte_ref_index = binder.GenerateTableIndex();
-		auto cte_ref = make_uniq<LogicalCTERef>(cte_ref_index, cte_index, types,
-		                                        GenerateCTEColumnNames(dedup_column_count, "__duckdb_delim_col_"));
+		auto cte_ref = make_uniq<LogicalCTERef>(cte_ref_index, cte_index, left_types,
+		                                        GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
 		plan->children[0] = std::move(cte_ref);
+		if (added_hidden_left_columns && op.left_projection_map.empty()) {
+			op.left_projection_map.reserve(left_bindings.size());
+			for (idx_t i = 0; i < left_bindings.size(); i++) {
+				op.left_projection_map.emplace_back(i);
+			}
+		}
 
 		// the bindings are now materialized in the CTE, and the join reads from a CTE_REF
 
 		ColumnBindingReplacer replacer;
-		vector<ReplacementBinding> binding_replacements;
-		auto old_bindings = cte->children[0]->GetColumnBindings();
 		auto new_bindings = plan->children[0]->GetColumnBindings();
-		for (idx_t i = 0; i < old_bindings.size() && i < new_bindings.size(); i++) {
-			binding_replacements.push_back({old_bindings[i], new_bindings[i]});
+		vector<ColumnBinding> new_visible_bindings(
+		    new_bindings.begin(),
+		    new_bindings.begin() + NumericCast<vector<ColumnBinding>::difference_type>(left_bindings.size()));
+		auto binding_replacements = CreateBindingReplacements(left_bindings, new_visible_bindings);
+		for (idx_t i = 0; i < op.duplicate_eliminated_columns.size(); i++) {
+			auto &expr = op.duplicate_eliminated_columns[i];
+			auto &colref_expr = expr->Cast<BoundColumnRefExpression>();
+			auto new_binding = new_bindings[dedup_column_indices[i]];
+			if (colref_expr.Binding() != new_binding) {
+				binding_replacements.emplace_back(colref_expr.Binding(), new_binding);
+			}
 		}
-		replacer.replacement_bindings = std::move(binding_replacements);
+		outer_state = RewriteStateBindings(std::move(outer_state), binding_replacements);
+		RegisterChangedBindingAliases(correlated_aliases, binding_replacements);
+		replacer.replacement_bindings = binding_replacements;
 		replacer.VisitOperator(*plan);
 
 		auto dedup_group_index = binder.GenerateTableIndex();
@@ -526,16 +710,17 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 
 		auto dedup1 = make_uniq<LogicalAggregate>(dedup_group_index, dedup_aggregate_index, std::move(dedup_aggrs));
 		auto dedup_child_index = binder.GenerateTableIndex();
-		for (idx_t i = 0; i < dedup_column_count; i++) {
-			auto colref =
-			    make_uniq<BoundColumnRefExpression>("", types[i], ColumnBinding(dedup_child_index, ProjectionIndex(i)));
+		auto dedup_child = make_uniq<LogicalCTERef>(dedup_child_index, cte_index, left_types,
+		                                            GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
+		auto dedup_child_bindings = dedup_child->GetColumnBindings();
+		for (idx_t i = 0; i < dedup_column_indices.size(); i++) {
+			auto colref = make_uniq<BoundColumnRefExpression>(dedup_names[i], dedup_types[i],
+			                                                  dedup_child_bindings[dedup_column_indices[i]]);
 			auto new_group_index = ColumnBinding::PushExpression(dedup1->groups, std::move(colref));
 			for (auto &set : dedup1->grouping_sets) {
 				set.insert(new_group_index);
 			}
 		}
-		auto dedup_child = make_uniq<LogicalCTERef>(dedup_child_index, cte_index, types,
-		                                            GenerateCTEColumnNames(dedup_column_count, "__duckdb_delim_col_"));
 		dedup1->children.push_back(std::move(dedup_child));
 
 		auto dedup_cte_index = binder.GenerateTableIndex();
@@ -544,8 +729,8 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 		op.duplicate_eliminated_columns.clear();
 
 		auto dedup_cte =
-		    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_column_count, std::move(dedup1),
-		                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+		    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_types.size(), std::move(dedup1),
+		                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
 
 		cte->children[1] = std::move(dedup_cte);
 
@@ -560,7 +745,10 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownSingleCorrelatedChild(uniqu
                                                                            bool correlated_left) {
 	idx_t correlated_idx = correlated_left ? 0 : 1;
 	idx_t independent_idx = correlated_left ? 1 : 0;
+	auto old_correlated_bindings = plan->children[correlated_idx]->GetColumnBindings();
 	state = PushDownCorrelatedNode(plan->children[correlated_idx], propagate_null_values, std::move(state));
+	auto replacements = RewriteChangedChildBindings(*plan, *plan->children[correlated_idx], old_correlated_bindings);
+	RegisterChangedBindingAliases(correlated_aliases, replacements);
 	plan->children[independent_idx] = DecorrelateIndependent(binder, std::move(plan->children[independent_idx]));
 	return state;
 }

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -227,8 +227,6 @@ void FlattenDependentJoins::CreateDelimJoinConditions(LogicalComparisonJoin &del
 
 static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &op, LogicalOperator &child,
                                                               const vector<ColumnBinding> &old_child_bindings);
-static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &correlated_aliases,
-                                          const vector<ReplacementBinding> &replacements);
 static void RewriteDelimJoinsToCTEs(Binder &binder, unique_ptr<LogicalOperator> &plan);
 
 static void VerifyNoDelim(LogicalOperator &op) {
@@ -306,8 +304,6 @@ vector<ColumnBinding> FlattenDependentJoins::DecorrelateSubtree(unique_ptr<Logic
 	for (auto &child : plan->children) {
 		auto old_child_bindings = child->GetColumnBindings();
 		state = DecorrelateSubtree(child, propagate_null_values, std::move(state));
-		auto replacements = RewriteChangedChildBindings(*plan, *child, old_child_bindings);
-		RegisterChangedBindingAliases(correlated_aliases, replacements);
 		RewriteCorrelatedExpressions::Rewrite(*plan, GetCurrentBindings(state), correlated_aliases);
 	}
 	return state;
@@ -335,7 +331,6 @@ static unique_ptr<LogicalWindow> CreateRowNumberWindow(Binder &binder, unique_pt
 vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDependentJoin &op,
                                                                       bool propagate_null_values,
                                                                       vector<ColumnBinding> state) {
-	auto old_left_bindings = op.children[0]->GetColumnBindings();
 	// If we have a parent, we unnest the left side of the DEPENDENT JOIN in the parent's context.
 	if (parent) {
 		// only push the dependent join to the left side, if there is correlation.
@@ -346,14 +341,9 @@ vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDep
 			op.children[0] = DecorrelateIndependent(binder, std::move(op.children[0]));
 		}
 
+		RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(state), correlated_aliases);
 	} else {
 		state = DecorrelateSubtree(op.children[0], true, std::move(state));
-	}
-
-	auto replacements = RewriteChangedChildBindings(op, *op.children[0], old_left_bindings);
-	RegisterChangedBindingAliases(correlated_aliases, replacements);
-	if (parent) {
-		RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(state), correlated_aliases);
 	}
 
 	if (!op.perform_delim) {
@@ -368,10 +358,7 @@ vector<ColumnBinding> FlattenDependentJoins::PrepareDependentJoinLeft(LogicalDep
 vector<ColumnBinding> FlattenDependentJoins::PushDownChild(unique_ptr<LogicalOperator> &plan,
                                                            bool propagate_null_values, vector<ColumnBinding> state,
                                                            bool rewrite_parent, idx_t child_idx) {
-	auto old_child_bindings = plan->children[child_idx]->GetColumnBindings();
 	state = PushDownCorrelatedNode(plan->children[child_idx], propagate_null_values, std::move(state));
-	auto replacements = RewriteChangedChildBindings(*plan, *plan->children[child_idx], old_child_bindings);
-	RegisterChangedBindingAliases(correlated_aliases, replacements);
 	if (rewrite_parent) {
 		RewriteCorrelatedExpressions::Rewrite(*plan, GetCurrentBindings(state), correlated_aliases);
 	}
@@ -531,18 +518,6 @@ static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &o
 	return replacements;
 }
 
-static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &correlated_aliases,
-                                          const vector<ReplacementBinding> &replacements) {
-	for (const auto &replacement : replacements) {
-		auto entry = correlated_aliases.find(replacement.old_binding);
-		if (entry == correlated_aliases.end()) {
-			continue;
-		}
-		auto result = correlated_aliases.emplace(replacement.new_binding, entry->second);
-		D_ASSERT(result.second || result.first->second == entry->second);
-	}
-}
-
 static optional_idx FindBindingIndex(const vector<ColumnBinding> &bindings, const ColumnBinding &binding) {
 	auto entry = std::find(bindings.begin(), bindings.end(), binding);
 	if (entry == bindings.end()) {
@@ -690,19 +665,6 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 	auto &op = plan->Cast<LogicalDependentJoin>();
 	RewriteCorrelatedExpressions::Rewrite(op, GetCurrentBindings(outer_state), correlated_aliases);
 
-	auto left_bindings = plan->children[0]->GetColumnBindings();
-	idx_t correlated_idx = 0;
-	for (auto &col : op.correlated_columns) {
-		if (correlated_idx >= outer_state.size()) {
-			break;
-		}
-		if (!FindBindingIndex(left_bindings, col.binding).IsValid() &&
-		    FindBindingIndex(left_bindings, outer_state[correlated_idx]).IsValid()) {
-			col.binding = outer_state[correlated_idx];
-		}
-		correlated_idx++;
-	}
-
 	op.duplicate_eliminated_columns.clear();
 	op.mark_types.clear();
 	for (idx_t i = 0; i < op.correlated_columns.size(); i++) {
@@ -738,7 +700,6 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 	if (op.subquery_type == SubqueryType::ANY) {
 		AddAnyJoinConditions(op, plan_columns);
 	}
-
 	return outer_state;
 }
 
@@ -748,10 +709,7 @@ vector<ColumnBinding> FlattenDependentJoins::PushDownSingleCorrelatedChild(uniqu
                                                                            bool correlated_left) {
 	idx_t correlated_idx = correlated_left ? 0 : 1;
 	idx_t independent_idx = correlated_left ? 1 : 0;
-	auto old_correlated_bindings = plan->children[correlated_idx]->GetColumnBindings();
 	state = PushDownCorrelatedNode(plan->children[correlated_idx], propagate_null_values, std::move(state));
-	auto replacements = RewriteChangedChildBindings(*plan, *plan->children[correlated_idx], old_correlated_bindings);
-	RegisterChangedBindingAliases(correlated_aliases, replacements);
 	plan->children[independent_idx] = DecorrelateIndependent(binder, std::move(plan->children[independent_idx]));
 	return state;
 }

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -228,12 +228,14 @@ static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &o
                                                               const vector<ColumnBinding> &old_child_bindings);
 static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &correlated_aliases,
                                           const vector<ReplacementBinding> &replacements);
+static void RewriteDelimJoinsToCTEs(Binder &binder, unique_ptr<LogicalOperator> &plan);
 
 unique_ptr<LogicalOperator> FlattenDependentJoins::DecorrelateIndependent(Binder &binder,
                                                                           unique_ptr<LogicalOperator> plan) {
 	CorrelatedColumns correlated;
 	FlattenDependentJoins flatten(binder, correlated);
 	flatten.DecorrelateSubtree(plan, true, {});
+	RewriteDelimJoinsToCTEs(binder, plan);
 	return plan;
 }
 
@@ -505,8 +507,8 @@ static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &o
 		replacer.stop_operator = child;
 		replacer.VisitOperator(op);
 	} else {
-		LogicalOperatorVisitor::EnumerateExpressions(op,
-		                                             [&](unique_ptr<Expression> *expr) { replacer.VisitExpression(expr); });
+		LogicalOperatorVisitor::EnumerateExpressions(
+		    op, [&](unique_ptr<Expression> *expr) { replacer.VisitExpression(expr); });
 	}
 	return replacements;
 }
@@ -523,25 +525,135 @@ static void RegisterChangedBindingAliases(column_binding_map_t<ColumnBinding> &c
 	}
 }
 
-static vector<ColumnBinding> RewriteStateBindings(vector<ColumnBinding> state,
-                                                  const vector<ReplacementBinding> &replacements) {
-	for (auto &binding : state) {
-		for (const auto &replacement : replacements) {
-			if (binding == replacement.old_binding) {
-				binding = replacement.new_binding;
-				break;
-			}
-		}
-	}
-	return state;
-}
-
 static optional_idx FindBindingIndex(const vector<ColumnBinding> &bindings, const ColumnBinding &binding) {
 	auto entry = std::find(bindings.begin(), bindings.end(), binding);
 	if (entry == bindings.end()) {
 		return optional_idx();
 	}
 	return NumericCast<idx_t>(entry - bindings.begin());
+}
+
+static void MaterializeDelimJoinAsCTE(Binder &binder, unique_ptr<LogicalOperator> &plan) {
+	auto &join = plan->Cast<LogicalComparisonJoin>();
+	if (join.delim_flipped) {
+		throw InternalException("Flatten dependent joins - flipped delim join CTE rewrite not supported");
+	}
+
+	plan->type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
+	if (join.join_type == JoinType::MARK) {
+		// Match the LOGICAL_DELIM_JOIN filter-pushdown semantics: the mark column can still be required above
+		// this join, so pushing NOT(mark) into the join must not drop it by rewriting to ANTI.
+		join.convert_mark_to_semi = false;
+	}
+
+	plan->children[0]->ResolveOperatorTypes();
+	auto left_bindings = plan->children[0]->GetColumnBindings();
+	auto left_types = plan->children[0]->types;
+	auto visible_left_column_count = left_bindings.size();
+
+	vector<idx_t> dedup_column_indices;
+	vector<LogicalType> dedup_types;
+	vector<string> dedup_names;
+	vector<unique_ptr<Expression>> extra_left_expressions;
+	dedup_column_indices.reserve(join.duplicate_eliminated_columns.size());
+	dedup_types.reserve(join.duplicate_eliminated_columns.size());
+	dedup_names.reserve(join.duplicate_eliminated_columns.size());
+	for (auto &expr : join.duplicate_eliminated_columns) {
+		optional_idx binding_index;
+		if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			auto &colref_expr = expr->Cast<BoundColumnRefExpression>();
+			binding_index = FindBindingIndex(left_bindings, colref_expr.Binding());
+		}
+		if (binding_index.IsValid()) {
+			dedup_column_indices.push_back(binding_index.GetIndex());
+		} else {
+			dedup_column_indices.push_back(left_bindings.size() + extra_left_expressions.size());
+			extra_left_expressions.push_back(expr->Copy());
+		}
+		dedup_types.push_back(expr->GetReturnType());
+		dedup_names.push_back(expr->GetName());
+	}
+
+	if (!extra_left_expressions.empty()) {
+		vector<unique_ptr<Expression>> expressions;
+		expressions.reserve(left_bindings.size() + extra_left_expressions.size());
+		for (idx_t i = 0; i < left_bindings.size(); i++) {
+			expressions.push_back(make_uniq<BoundColumnRefExpression>(left_types[i], left_bindings[i]));
+		}
+		for (auto &expr : extra_left_expressions) {
+			expressions.push_back(std::move(expr));
+		}
+		auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+		projection->children.push_back(std::move(plan->children[0]));
+		plan->children[0] = std::move(projection);
+		plan->children[0]->ResolveOperatorTypes();
+		left_bindings = plan->children[0]->GetColumnBindings();
+		left_types = plan->children[0]->types;
+		if (join.left_projection_map.empty()) {
+			join.left_projection_map.reserve(visible_left_column_count);
+			for (idx_t i = 0; i < visible_left_column_count; i++) {
+				join.left_projection_map.emplace_back(i);
+			}
+		}
+	}
+
+	auto left_column_count = left_bindings.size();
+	auto cte_index = binder.GenerateTableIndex();
+	auto cte_name = "__duckdb_delim_" + to_string(cte_index.index);
+	auto cte_source = std::move(plan->children[0]);
+
+	auto left_cte_ref_index = binder.GenerateTableIndex();
+	auto left_cte_ref = make_uniq<LogicalCTERef>(left_cte_ref_index, cte_index, left_types,
+	                                             GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
+	auto new_left_bindings = left_cte_ref->GetColumnBindings();
+	auto binding_replacements = CreateBindingReplacements(left_bindings, new_left_bindings);
+
+	plan->children[0] = std::move(left_cte_ref);
+	ColumnBindingReplacer replacer;
+	replacer.replacement_bindings = binding_replacements;
+	replacer.stop_operator = plan->children[1];
+	replacer.VisitOperator(*plan);
+
+	auto dedup_cte_index = binder.GenerateTableIndex();
+	RewriteDelimScanReferences(plan->children[1], dedup_cte_index);
+	join.duplicate_eliminated_columns.clear();
+
+	auto dedup_group_index = binder.GenerateTableIndex();
+	auto dedup_aggregate_index = binder.GenerateTableIndex();
+	vector<unique_ptr<Expression>> dedup_aggrs;
+	auto dedup = make_uniq<LogicalAggregate>(dedup_group_index, dedup_aggregate_index, std::move(dedup_aggrs));
+	auto dedup_child_index = binder.GenerateTableIndex();
+	auto dedup_child = make_uniq<LogicalCTERef>(dedup_child_index, cte_index, left_types,
+	                                            GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
+	auto dedup_child_bindings = dedup_child->GetColumnBindings();
+	for (idx_t i = 0; i < dedup_column_indices.size(); i++) {
+		auto colref = make_uniq<BoundColumnRefExpression>(dedup_names[i], dedup_types[i],
+		                                                  dedup_child_bindings[dedup_column_indices[i]]);
+		auto new_group_index = ColumnBinding::PushExpression(dedup->groups, std::move(colref));
+		for (auto &set : dedup->grouping_sets) {
+			set.insert(new_group_index);
+		}
+	}
+	dedup->children.push_back(std::move(dedup_child));
+
+	auto dedup_cte_name = "__duckdb_delim_dedup_" + to_string(dedup_cte_index.index);
+	auto dedup_cte =
+	    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_types.size(), std::move(dedup),
+	                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	auto cte = make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, left_column_count, std::move(cte_source),
+	                                             std::move(dedup_cte), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	plan = std::move(cte);
+}
+
+static void RewriteDelimJoinsToCTEs(Binder &binder, unique_ptr<LogicalOperator> &plan) {
+	for (auto &child : plan->children) {
+		auto old_child_bindings = child->GetColumnBindings();
+		RewriteDelimJoinsToCTEs(binder, child);
+		RewriteChangedChildBindings(*plan, *child, old_child_bindings);
+	}
+	if (plan->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		MaterializeDelimJoinAsCTE(binder, plan);
+	}
 }
 
 vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<LogicalOperator> &plan,
@@ -599,143 +711,6 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 		AddAnyJoinConditions(op, plan_columns);
 	}
 
-	if (true) {
-		// We are done using the operator as a DEPENDENT JOIN, it is now fully decorrelated.
-		// Build the same comparison join that a DELIM_JOIN would execute, then make the
-		// delim inputs explicit through materialized CTEs.
-		plan->type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
-		if (op.right_projection_map.empty() && !right_state.empty()) {
-			auto right_bindings = plan->children[1]->GetColumnBindings();
-			vector<ProjectionIndex> right_projection_map;
-			right_projection_map.reserve(right_bindings.size());
-			for (idx_t i = 0; i < right_bindings.size(); i++) {
-				if (!FindBindingIndex(right_state, right_bindings[i]).IsValid()) {
-					right_projection_map.emplace_back(i);
-				}
-			}
-			if (right_projection_map.size() < right_bindings.size()) {
-				op.right_projection_map = std::move(right_projection_map);
-			}
-		}
-
-		left_bindings = plan->children[0]->GetColumnBindings();
-		plan->children[0]->ResolveOperatorTypes();
-		auto left_types = plan->children[0]->types;
-		vector<idx_t> dedup_column_indices;
-		vector<LogicalType> dedup_types;
-		vector<string> dedup_names;
-		vector<unique_ptr<Expression>> extra_left_expressions;
-		bool added_hidden_left_columns = false;
-		dedup_column_indices.reserve(op.duplicate_eliminated_columns.size());
-		dedup_types.reserve(op.duplicate_eliminated_columns.size());
-		dedup_names.reserve(op.duplicate_eliminated_columns.size());
-		for (auto &expr : op.duplicate_eliminated_columns) {
-			if (expr->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
-				throw InternalException("Flatten dependent joins - expected duplicate eliminated column reference");
-			}
-			auto &colref_expr = expr->Cast<BoundColumnRefExpression>();
-			auto binding_index = FindBindingIndex(left_bindings, colref_expr.Binding());
-			if (binding_index.IsValid()) {
-				dedup_column_indices.push_back(binding_index.GetIndex());
-			} else {
-				dedup_column_indices.push_back(left_bindings.size() + extra_left_expressions.size());
-				extra_left_expressions.push_back(expr->Copy());
-			}
-			dedup_types.push_back(expr->GetReturnType());
-			dedup_names.push_back(expr->GetName());
-		}
-
-		if (!extra_left_expressions.empty()) {
-			added_hidden_left_columns = true;
-			vector<unique_ptr<Expression>> expressions;
-			expressions.reserve(left_bindings.size() + extra_left_expressions.size());
-			for (idx_t i = 0; i < left_bindings.size(); i++) {
-				expressions.push_back(make_uniq<BoundColumnRefExpression>(left_types[i], left_bindings[i]));
-			}
-			for (auto &expr : extra_left_expressions) {
-				expressions.push_back(std::move(expr));
-			}
-			auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
-			projection->children.push_back(std::move(plan->children[0]));
-			plan->children[0] = std::move(projection);
-			plan->children[0]->ResolveOperatorTypes();
-			left_types = plan->children[0]->types;
-		}
-
-		auto left_column_count = plan->children[0]->GetColumnBindings().size();
-		auto cte_index = binder.GenerateTableIndex();
-		auto cte_name = "__duckdb_delim_" + to_string(cte_index.index);
-		auto cte =
-		    make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, left_column_count, std::move(plan->children[0]),
-		                                      nullptr, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
-
-		cte->children[0]->ResolveOperatorTypes();
-		left_types = cte->children[0]->types;
-
-		auto cte_ref_index = binder.GenerateTableIndex();
-		auto cte_ref = make_uniq<LogicalCTERef>(cte_ref_index, cte_index, left_types,
-		                                        GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
-		plan->children[0] = std::move(cte_ref);
-		if (added_hidden_left_columns && op.left_projection_map.empty()) {
-			op.left_projection_map.reserve(left_bindings.size());
-			for (idx_t i = 0; i < left_bindings.size(); i++) {
-				op.left_projection_map.emplace_back(i);
-			}
-		}
-
-		// the bindings are now materialized in the CTE, and the join reads from a CTE_REF
-
-		ColumnBindingReplacer replacer;
-		auto new_bindings = plan->children[0]->GetColumnBindings();
-		vector<ColumnBinding> new_visible_bindings(
-		    new_bindings.begin(),
-		    new_bindings.begin() + NumericCast<vector<ColumnBinding>::difference_type>(left_bindings.size()));
-		auto binding_replacements = CreateBindingReplacements(left_bindings, new_visible_bindings);
-		for (idx_t i = 0; i < op.duplicate_eliminated_columns.size(); i++) {
-			auto &expr = op.duplicate_eliminated_columns[i];
-			auto &colref_expr = expr->Cast<BoundColumnRefExpression>();
-			auto new_binding = new_bindings[dedup_column_indices[i]];
-			if (colref_expr.Binding() != new_binding) {
-				binding_replacements.emplace_back(colref_expr.Binding(), new_binding);
-			}
-		}
-		outer_state = RewriteStateBindings(std::move(outer_state), binding_replacements);
-		RegisterChangedBindingAliases(correlated_aliases, binding_replacements);
-		replacer.replacement_bindings = binding_replacements;
-		replacer.VisitOperator(*plan);
-
-		auto dedup_group_index = binder.GenerateTableIndex();
-		auto dedup_aggregate_index = binder.GenerateTableIndex();
-		vector<unique_ptr<Expression>> dedup_aggrs;
-
-		auto dedup1 = make_uniq<LogicalAggregate>(dedup_group_index, dedup_aggregate_index, std::move(dedup_aggrs));
-		auto dedup_child_index = binder.GenerateTableIndex();
-		auto dedup_child = make_uniq<LogicalCTERef>(dedup_child_index, cte_index, left_types,
-		                                            GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
-		auto dedup_child_bindings = dedup_child->GetColumnBindings();
-		for (idx_t i = 0; i < dedup_column_indices.size(); i++) {
-			auto colref = make_uniq<BoundColumnRefExpression>(dedup_names[i], dedup_types[i],
-			                                                  dedup_child_bindings[dedup_column_indices[i]]);
-			auto new_group_index = ColumnBinding::PushExpression(dedup1->groups, std::move(colref));
-			for (auto &set : dedup1->grouping_sets) {
-				set.insert(new_group_index);
-			}
-		}
-		dedup1->children.push_back(std::move(dedup_child));
-
-		auto dedup_cte_index = binder.GenerateTableIndex();
-		auto dedup_cte_name = "__duckdb_delim_dedup_" + to_string(dedup_cte_index.index);
-		RewriteDelimScanReferences(plan->children[1], dedup_cte_index);
-		op.duplicate_eliminated_columns.clear();
-
-		auto dedup_cte =
-		    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_types.size(), std::move(dedup1),
-		                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
-
-		cte->children[1] = std::move(dedup_cte);
-
-		plan = std::move(cte);
-	}
 	return outer_state;
 }
 

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -598,15 +598,25 @@ static void MaterializeDelimJoinAsCTE(Binder &binder, unique_ptr<LogicalOperator
 	}
 
 	auto left_column_count = left_bindings.size();
+	auto cte_source_bindings = left_bindings;
+	vector<unique_ptr<Expression>> cte_source_expressions;
+	cte_source_expressions.reserve(left_column_count);
+	for (idx_t i = 0; i < left_column_count; i++) {
+		cte_source_expressions.push_back(make_uniq<BoundColumnRefExpression>(left_types[i], left_bindings[i]));
+	}
+	auto cte_source = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(cte_source_expressions));
+	cte_source->children.push_back(std::move(plan->children[0]));
+	cte_source->ResolveOperatorTypes();
+	left_types = cte_source->types;
+
 	auto cte_index = binder.GenerateTableIndex();
 	auto cte_name = "__duckdb_delim_" + to_string(cte_index.index);
-	auto cte_source = std::move(plan->children[0]);
 
 	auto left_cte_ref_index = binder.GenerateTableIndex();
 	auto left_cte_ref = make_uniq<LogicalCTERef>(left_cte_ref_index, cte_index, left_types,
 	                                             GenerateCTEColumnNames(left_column_count, "__duckdb_delim_col_"));
 	auto new_left_bindings = left_cte_ref->GetColumnBindings();
-	auto binding_replacements = CreateBindingReplacements(left_bindings, new_left_bindings);
+	auto binding_replacements = CreateBindingReplacements(cte_source_bindings, new_left_bindings);
 
 	plan->children[0] = std::move(left_cte_ref);
 	ColumnBindingReplacer replacer;

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/subquery/rewrite_correlated_expressions.hpp"
 #include "duckdb/planner/operator/logical_dependent_join.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
 
 namespace duckdb {
 
@@ -423,6 +424,28 @@ vector<ColumnBinding> FlattenDependentJoins::CreateDelimCrossProduct(unique_ptr<
 	return state;
 }
 
+static vector<string> GenerateCTEColumnNames(idx_t column_count, const string &prefix) {
+	vector<string> result;
+	result.reserve(column_count);
+	for (idx_t i = 0; i < column_count; i++) {
+		result.push_back(prefix + to_string(i));
+	}
+	return result;
+}
+
+static void RewriteDelimScanReferences(unique_ptr<LogicalOperator> &op, TableIndex delim_scan_index) {
+	for (auto &child : op->children) {
+		RewriteDelimScanReferences(child, delim_scan_index);
+	}
+	if (op->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		auto &delim_get = op->Cast<LogicalDelimGet>();
+		auto delim_scan_names = GenerateCTEColumnNames(delim_get.chunk_types.size(), "__duckdb_delim_scan_");
+		auto cte_scan =
+		    make_uniq<LogicalCTERef>(delim_get.table_index, delim_scan_index, delim_get.chunk_types, delim_scan_names);
+		op = std::move(cte_scan);
+	}
+}
+
 vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<LogicalOperator> &plan,
                                                                    vector<ColumnBinding> outer_state,
                                                                    const vector<ColumnBinding> &right_state) {
@@ -463,6 +486,70 @@ vector<ColumnBinding> FlattenDependentJoins::FinalizeDependentJoin(unique_ptr<Lo
 
 	if (op.subquery_type == SubqueryType::ANY) {
 		AddAnyJoinConditions(op, plan_columns);
+	}
+
+	if (true) {
+		// We are done using the operator as a DEPENDENT JOIN, it is now fully decorrelated.
+		// Build the same comparison join that a DELIM_JOIN would execute, then make the
+		// delim inputs explicit through materialized CTEs.
+		plan->type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
+		auto dedup_column_count = plan->children[0]->GetColumnBindings().size();
+		auto cte_index = binder.GenerateTableIndex();
+		auto cte_name = "__duckdb_delim_" + to_string(cte_index.index);
+		auto cte =
+		    make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, dedup_column_count, std::move(plan->children[0]),
+		                                      nullptr, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
+
+		cte->children[0]->ResolveOperatorTypes();
+		auto types = cte->children[0]->types;
+
+		auto cte_ref_index = binder.GenerateTableIndex();
+		auto cte_ref = make_uniq<LogicalCTERef>(cte_ref_index, cte_index, types,
+		                                        GenerateCTEColumnNames(dedup_column_count, "__duckdb_delim_col_"));
+		plan->children[0] = std::move(cte_ref);
+
+		// the bindings are now materialized in the CTE, and the join reads from a CTE_REF
+
+		ColumnBindingReplacer replacer;
+		vector<ReplacementBinding> binding_replacements;
+		auto old_bindings = cte->children[0]->GetColumnBindings();
+		auto new_bindings = plan->children[0]->GetColumnBindings();
+		for (idx_t i = 0; i < old_bindings.size() && i < new_bindings.size(); i++) {
+			binding_replacements.push_back({old_bindings[i], new_bindings[i]});
+		}
+		replacer.replacement_bindings = std::move(binding_replacements);
+		replacer.VisitOperator(*plan);
+
+		auto dedup_group_index = binder.GenerateTableIndex();
+		auto dedup_aggregate_index = binder.GenerateTableIndex();
+		vector<unique_ptr<Expression>> dedup_aggrs;
+
+		auto dedup1 = make_uniq<LogicalAggregate>(dedup_group_index, dedup_aggregate_index, std::move(dedup_aggrs));
+		auto dedup_child_index = binder.GenerateTableIndex();
+		for (idx_t i = 0; i < dedup_column_count; i++) {
+			auto colref =
+			    make_uniq<BoundColumnRefExpression>("", types[i], ColumnBinding(dedup_child_index, ProjectionIndex(i)));
+			auto new_group_index = ColumnBinding::PushExpression(dedup1->groups, std::move(colref));
+			for (auto &set : dedup1->grouping_sets) {
+				set.insert(new_group_index);
+			}
+		}
+		auto dedup_child = make_uniq<LogicalCTERef>(dedup_child_index, cte_index, types,
+		                                            GenerateCTEColumnNames(dedup_column_count, "__duckdb_delim_col_"));
+		dedup1->children.push_back(std::move(dedup_child));
+
+		auto dedup_cte_index = binder.GenerateTableIndex();
+		auto dedup_cte_name = "__duckdb_delim_dedup_" + to_string(dedup_cte_index.index);
+		RewriteDelimScanReferences(plan->children[1], dedup_cte_index);
+		op.duplicate_eliminated_columns.clear();
+
+		auto dedup_cte =
+		    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_column_count, std::move(dedup1),
+		                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+
+		cte->children[1] = std::move(dedup_cte);
+
+		plan = std::move(cte);
 	}
 	return outer_state;
 }

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -639,9 +639,9 @@ static void MaterializeDelimJoinAsCTE(Binder &binder, unique_ptr<LogicalOperator
 	auto dedup_cte_name = "__duckdb_delim_dedup_" + to_string(dedup_cte_index.index);
 	auto dedup_cte =
 	    make_uniq<LogicalMaterializedCTE>(dedup_cte_name, dedup_cte_index, dedup_types.size(), std::move(dedup),
-	                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	                                      std::move(plan), CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
 	auto cte = make_uniq<LogicalMaterializedCTE>(cte_name, cte_index, left_column_count, std::move(cte_source),
-	                                             std::move(dedup_cte), CTEMaterialize::CTE_MATERIALIZE_ALWAYS);
+	                                             std::move(dedup_cte), CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
 	plan = std::move(cte);
 }
 

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/window/rows_functions.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -249,8 +250,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::DecorrelateIndependent(Binder
 	CorrelatedColumns correlated;
 	FlattenDependentJoins flatten(binder, correlated);
 	flatten.DecorrelateSubtree(plan, true, {});
-	RewriteDelimJoinsToCTEs(binder, plan);
-	VerifyNoDelim(*plan);
+	if (Settings::Get<DelimJoinAsCteSetting>(binder.context)) {
+		RewriteDelimJoinsToCTEs(binder, plan);
+		VerifyNoDelim(*plan);
+	}
 	return plan;
 }
 

--- a/test/configs/delim_join_as_cte.json
+++ b/test/configs/delim_join_as_cte.json
@@ -1,5 +1,14 @@
 {
   "description": "Run with SET delim_join_as_cte=true.",
   "on_init": "SET delim_join_as_cte=true;",
-  "skip_compiled": "true"
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "Unexpected plan shape change due to the new CTE-based implementation of delim joins.",
+      "paths": [
+        "test/optimizer/deliminator.test",
+        "test/issues/general/test_4950.test"
+      ]
+    }
+  ]
 }

--- a/test/configs/delim_join_as_cte.json
+++ b/test/configs/delim_join_as_cte.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run with SET delim_join_as_cte=true.",
+  "on_init": "SET delim_join_as_cte=true;",
+  "skip_compiled": "true"
+}


### PR DESCRIPTION
This is the first step of removing duplicate-eliminated joins (`DELIM_JOIN`) from the system by replacing them with materialized CTEs. `DELIM_JOIN`s are used in the system when we are dealing with correlation. The `DELIM_JOIN` operator computes two magic sets based on the correlation variables, once with duplicates and once without duplicates. Then, these sets are used to express the semantics of the correlated subquery. Details about this can be found in the papers "Unnesting Arbitrary Queries" and "Improving Unnesting of Complex Queries" by Thomas Neumann et. al.

However, there is nothing inherently special about `DELIM_JOIN`s, and we can express the same semantics using materialized CTEs. This is what this PR does. It replaces `DELIM_JOIN`s with materialized CTEs that compute the same magic sets. For now, this rewriting is behind a feature flag `delim_join_as_cte`, and I can not recommend enabling it, because of missing optimizations. I will address these in follow-up PRs. The main goal of this PR is to show that we can express the semantics of `DELIM_JOIN`s using materialized CTEs, and to lay the groundwork.