### PR TITLE
Step2: Push DELIM filters into CTE rewrite

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -821,13 +821,15 @@ void JoinHashTable::PrepareBuildBloomFilter(idx_t estimated_row_count) {
 	}
 }
 
-void JoinHashTable::PrepareBloomFilterForPushdown() {
-	should_build_bloom_filter = true;
-	const auto build_count = Count();
-	if (build_count == 0) {
+void JoinHashTable::PrepareBloomFilterForFinalize() {
+	if (!should_build_bloom_filter) {
 		return;
 	}
 
+	// Finalize scans every build tuple and inserts its hash into the bloom filter.
+	// Resize here if the planner estimate was too low, then let finalize populate it.
+	const auto build_count = Count();
+	const auto actual_init_count = MaxValue<idx_t>(build_count, 1);
 	static constexpr double REBUILD_UNDERESTIMATE_THRESHOLD = 2.0;
 	const auto estimated_too_low = bloom_filter_init_count == 0 ||
 	                               static_cast<double>(build_count) >
@@ -837,43 +839,8 @@ void JoinHashTable::PrepareBloomFilterForPushdown() {
 	}
 
 	bloom_filter.Reset();
-	bloom_filter_init_count = build_count;
+	bloom_filter_init_count = actual_init_count;
 	bloom_filter.Initialize(context, bloom_filter_init_count);
-	RebuildBloomFilter();
-}
-
-void JoinHashTable::RebuildBloomFilter() {
-	D_ASSERT(bloom_filter.IsInitialized());
-	D_ASSERT(equality_types.size() == 1);
-	if (data_collection->ChunkCount() == 0) {
-		return;
-	}
-
-	Vector addresses(LogicalType::POINTER);
-	vector<LogicalType> key_types {layout_ptr->GetTypes()[0]};
-	DataChunk keys;
-	keys.Initialize(BufferAllocator::Get(context), key_types);
-	Vector hashes(LogicalType::HASH);
-	const auto &sel = *FlatVector::IncrementalSelectionVector();
-	auto addresses_data = FlatVector::GetDataMutable<data_ptr_t>(addresses);
-
-	JoinHTScanState scan_state(*data_collection, 0, data_collection->ChunkCount(),
-	                           TupleDataPinProperties::KEEP_EVERYTHING_PINNED);
-	auto &iterator = scan_state.iterator;
-	do {
-		const auto row_locations = iterator.GetRowLocations();
-		const auto chunk_count = iterator.GetCurrentChunkCount();
-		for (idx_t chunk_offset = 0; chunk_offset < chunk_count; chunk_offset += STANDARD_VECTOR_SIZE) {
-			const auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, chunk_count - chunk_offset);
-			for (idx_t i = 0; i < count; i++) {
-				addresses_data[i] = row_locations[chunk_offset + i];
-			}
-			data_collection->Gather(addresses, sel, count, 0, keys.data[0], sel, nullptr);
-			keys.SetChildCardinality(count);
-			Hash(keys, sel, count, hashes);
-			bloom_filter.InsertHashes(hashes);
-		}
-	} while (iterator.Next());
 }
 
 void JoinHashTable::InitializePointerTable(idx_t entry_idx_from, idx_t entry_idx_to) {

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -786,7 +786,8 @@ void JoinHashTable::AllocatePointerTable() {
 	}
 
 	if (should_build_bloom_filter && !bloom_filter.IsInitialized()) {
-		bloom_filter.Initialize(context, Count());
+		bloom_filter_init_count = MaxValue<idx_t>(Count(), 1);
+		bloom_filter.Initialize(context, bloom_filter_init_count);
 	}
 
 	if (hash_map.get()) {
@@ -815,8 +816,64 @@ void JoinHashTable::AllocatePointerTable() {
 void JoinHashTable::PrepareBuildBloomFilter(idx_t estimated_row_count) {
 	should_build_bloom_filter = true;
 	if (!bloom_filter.IsInitialized()) {
-		bloom_filter.Initialize(context, MaxValue<idx_t>(estimated_row_count, idx_t(1)));
+		bloom_filter_init_count = MaxValue<idx_t>(estimated_row_count, idx_t(1));
+		bloom_filter.Initialize(context, bloom_filter_init_count);
 	}
+}
+
+void JoinHashTable::PrepareBloomFilterForPushdown() {
+	should_build_bloom_filter = true;
+	const auto build_count = Count();
+	if (build_count == 0) {
+		return;
+	}
+
+	static constexpr double REBUILD_UNDERESTIMATE_THRESHOLD = 2.0;
+	const auto estimated_too_low = bloom_filter_init_count == 0 ||
+	                               static_cast<double>(build_count) >
+	                                   static_cast<double>(bloom_filter_init_count) * REBUILD_UNDERESTIMATE_THRESHOLD;
+	if (bloom_filter.IsInitialized() && !estimated_too_low) {
+		return;
+	}
+
+	bloom_filter.Reset();
+	bloom_filter_init_count = build_count;
+	bloom_filter.Initialize(context, bloom_filter_init_count);
+	RebuildBloomFilter();
+}
+
+void JoinHashTable::RebuildBloomFilter() {
+	D_ASSERT(bloom_filter.IsInitialized());
+	D_ASSERT(equality_types.size() == 1);
+	if (data_collection->ChunkCount() == 0) {
+		return;
+	}
+
+	Vector addresses(LogicalType::POINTER);
+	vector<LogicalType> key_types {layout_ptr->GetTypes()[0]};
+	DataChunk keys;
+	keys.Initialize(BufferAllocator::Get(context), key_types);
+	Vector hashes(LogicalType::HASH);
+	const auto &sel = *FlatVector::IncrementalSelectionVector();
+	auto addresses_data = FlatVector::GetDataMutable<data_ptr_t>(addresses);
+
+	JoinHTScanState scan_state(*data_collection, 0, data_collection->ChunkCount(),
+	                           TupleDataPinProperties::KEEP_EVERYTHING_PINNED);
+	auto &iterator = scan_state.iterator;
+	do {
+		const auto row_locations = iterator.GetRowLocations();
+		const auto chunk_count = iterator.GetCurrentChunkCount();
+		for (idx_t chunk_offset = 0; chunk_offset < chunk_count; chunk_offset += STANDARD_VECTOR_SIZE) {
+			const auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, chunk_count - chunk_offset);
+			for (idx_t i = 0; i < count; i++) {
+				addresses_data[i] = row_locations[chunk_offset + i];
+			}
+			data_collection->Gather(addresses, sel, count, 0, keys.data[0], sel, nullptr);
+			keys.SetChildCardinality(count);
+			Hash(keys, sel, count, hashes);
+			bloom_filter.InsertHashes(hashes);
+		}
+	} while (iterator.Next());
 }
 
 void JoinHashTable::InitializePointerTable(idx_t entry_idx_from, idx_t entry_idx_to) {
@@ -2156,6 +2213,7 @@ void JoinHashTable::ResetForNewIterationSinglePartition() {
 	load_factor = DEFAULT_LOAD_FACTOR;
 	should_build_bloom_filter = false;
 	bloom_filter.Reset();
+	bloom_filter_init_count = 0;
 	prefix_range_filter.reset();
 	should_build_prefix_range_filter = false;
 	ResetCorrelatedMarkJoinInfo(*this);

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1228,6 +1228,7 @@ void JoinFilterPushdownInfo::PushBloomFilter(ClientContext &context, const Physi
 	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
 	auto filter_input_type = GetRuntimeFilterInputType(info.columns[filter_idx], key_type);
 	ht.SetBuildBloomFilter(true);
+	ht.PrepareBloomFilterForPushdown();
 	float selectivity_threshold;
 	idx_t n_vectors_to_check;
 	GetThresholdAndVectorsToCheck(SelectivityOptionalFilterType::BF, selectivity_threshold, n_vectors_to_check);

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1228,7 +1228,6 @@ void JoinFilterPushdownInfo::PushBloomFilter(ClientContext &context, const Physi
 	const auto key_type = ht.conditions[0].GetLHS().GetReturnType();
 	auto filter_input_type = GetRuntimeFilterInputType(info.columns[filter_idx], key_type);
 	ht.SetBuildBloomFilter(true);
-	ht.PrepareBloomFilterForPushdown();
 	float selectivity_threshold;
 	idx_t n_vectors_to_check;
 	GetThresholdAndVectorsToCheck(SelectivityOptionalFilterType::BF, selectivity_threshold, n_vectors_to_check);
@@ -1561,6 +1560,9 @@ SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 
 	if (filter_min_max) {
 		filter_pushdown->FinalizeFilters(context, *this, std::move(filter_min_max), &ht, sink.perfect_join_executor);
+		if (!use_perfect_hash) {
+			ht.PrepareBloomFilterForFinalize();
+		}
 	}
 
 	// In case of a large build side or duplicates, use regular hash join

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -142,4 +142,17 @@ InsertionOrderPreservingMap<string> PhysicalCTE::ParamsToString() const {
 	return result;
 }
 
+ProgressData PhysicalCTE::GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
+                                          const ProgressData source_progress) const {
+	auto &state = gstate.Cast<CTEGlobalState>();
+	if (!state.working_table_ref) {
+		return ProgressData {0, 1, true};
+	}
+	auto &working_table = *state.working_table_ref;
+	ProgressData progress;
+	progress.done = working_table.Count();
+	progress.total = working_table.Count() + source_progress.total;
+	return progress;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -145,13 +145,15 @@ InsertionOrderPreservingMap<string> PhysicalCTE::ParamsToString() const {
 ProgressData PhysicalCTE::GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
                                           const ProgressData source_progress) const {
 	auto &state = gstate.Cast<CTEGlobalState>();
+	lock_guard<mutex> guard(state.lhs_lock);
 	if (!state.working_table_ref) {
 		return ProgressData {0, 1, true};
 	}
 	auto &working_table = *state.working_table_ref;
+	auto count = double(working_table.Count());
 	ProgressData progress;
-	progress.done = double(working_table.Count());
-	progress.total = double(working_table.Count()) + source_progress.total;
+	progress.done = count;
+	progress.total = count + source_progress.total;
 	return progress;
 }
 

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -150,8 +150,8 @@ ProgressData PhysicalCTE::GetSinkProgress(ClientContext &context, GlobalSinkStat
 	}
 	auto &working_table = *state.working_table_ref;
 	ProgressData progress;
-	progress.done = working_table.Count();
-	progress.total = working_table.Count() + source_progress.total;
+	progress.done = double(working_table.Count());
+	progress.total = double(working_table.Count()) + source_progress.total;
 	return progress;
 }
 

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -401,6 +401,7 @@ private:
 	void InitializeScanStructure(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
 	                             optional_ptr<const SelectionVector> &current_sel);
 	void Hash(DataChunk &keys, const SelectionVector &sel, idx_t count, Vector &hashes);
+	void RebuildBloomFilter();
 
 	//! Dictionary-aware variant of Probe. Returns false if the LHS keys are not dictionary-eligible.
 	bool TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
@@ -450,6 +451,7 @@ private:
 	//! Whether or not to use a bloom filter will be determined by the operator
 	BloomFilter bloom_filter;
 	bool should_build_bloom_filter = false;
+	idx_t bloom_filter_init_count = 0;
 
 	unique_ptr<PrefixRangeFilter> prefix_range_filter;
 	bool should_build_prefix_range_filter = false;
@@ -535,6 +537,7 @@ public:
 		this->should_build_bloom_filter = should_build;
 	}
 	void PrepareBuildBloomFilter(idx_t estimated_row_count);
+	void PrepareBloomFilterForPushdown();
 
 	BloomFilter &GetBloomFilter() {
 		return bloom_filter;

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -401,7 +401,6 @@ private:
 	void InitializeScanStructure(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
 	                             optional_ptr<const SelectionVector> &current_sel);
 	void Hash(DataChunk &keys, const SelectionVector &sel, idx_t count, Vector &hashes);
-	void RebuildBloomFilter();
 
 	//! Dictionary-aware variant of Probe. Returns false if the LHS keys are not dictionary-eligible.
 	bool TryProbeDictionary(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state,
@@ -537,7 +536,7 @@ public:
 		this->should_build_bloom_filter = should_build;
 	}
 	void PrepareBuildBloomFilter(idx_t estimated_row_count);
-	void PrepareBloomFilterForPushdown();
+	void PrepareBloomFilterForFinalize();
 
 	BloomFilter &GetBloomFilter() {
 		return bloom_filter;

--- a/src/include/duckdb/execution/operator/set/physical_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_cte.hpp
@@ -55,6 +55,9 @@ public:
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 
+	ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
+	                             const ProgressData source_progress) const override;
+
 public:
 	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;
 

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -227,6 +227,7 @@ void FlattenDependentJoins::CreateDelimJoinConditions(LogicalComparisonJoin &del
 
 static vector<ReplacementBinding> RewriteChangedChildBindings(LogicalOperator &op, LogicalOperator &child,
                                                               const vector<ColumnBinding> &old_child_bindings);
+static bool PushEligibleFiltersIntoDelimJoinInputs(unique_ptr<LogicalOperator> &plan);
 static void RewriteDelimJoinsToCTEs(Binder &binder, unique_ptr<LogicalOperator> &plan);
 
 static void VerifyNoDelim(LogicalOperator &op) {
@@ -249,6 +250,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::DecorrelateIndependent(Binder
 	FlattenDependentJoins flatten(binder, correlated);
 	flatten.DecorrelateSubtree(plan, true, {});
 	if (Settings::Get<DelimJoinAsCteSetting>(binder.context)) {
+		bool filters_pushed;
+		do {
+			filters_pushed = PushEligibleFiltersIntoDelimJoinInputs(plan);
+		} while (filters_pushed);
 		RewriteDelimJoinsToCTEs(binder, plan);
 		VerifyNoDelim(*plan);
 	}
@@ -524,6 +529,97 @@ static optional_idx FindBindingIndex(const vector<ColumnBinding> &bindings, cons
 		return optional_idx();
 	}
 	return NumericCast<idx_t>(entry - bindings.begin());
+}
+
+static void AddFilterToOperator(unique_ptr<LogicalOperator> &child, unique_ptr<Expression> filter) {
+	if (child->type == LogicalOperatorType::LOGICAL_FILTER && !child->HasProjectionMap()) {
+		child->Cast<LogicalFilter>().expressions.push_back(std::move(filter));
+		return;
+	}
+
+	auto new_filter = make_uniq<LogicalFilter>();
+	new_filter->expressions.push_back(std::move(filter));
+	new_filter->children.push_back(std::move(child));
+	child = std::move(new_filter);
+}
+
+static bool GetExpressionColumnBindings(Expression &expr, column_binding_set_t &bindings) {
+	bool depth_zero = true;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		if (colref.Depth() == 0) {
+			bindings.insert(colref.Binding());
+		} else {
+			depth_zero = false;
+		}
+	});
+	return depth_zero;
+}
+
+static bool ChildContainsBindings(LogicalOperator &child, const column_binding_set_t &bindings) {
+	column_binding_set_t child_bindings;
+	for (auto &binding : child.GetColumnBindings()) {
+		child_bindings.insert(binding);
+	}
+	for (auto &binding : bindings) {
+		if (child_bindings.find(binding) == child_bindings.end()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool FilterReferencesDelimInput(LogicalComparisonJoin &delim_join, Expression &filter) {
+	D_ASSERT(delim_join.type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	column_binding_set_t filter_bindings;
+	if (!GetExpressionColumnBindings(filter, filter_bindings)) {
+		return false;
+	}
+	if (filter_bindings.empty()) {
+		return false;
+	}
+	return ChildContainsBindings(*delim_join.children[0], filter_bindings);
+}
+
+static bool PushEligibleFilterExpressionsIntoDelimJoinInputs(unique_ptr<LogicalOperator> &plan) {
+	auto &filter = plan->Cast<LogicalFilter>();
+	if (filter.HasProjectionMap()) {
+		return false;
+	}
+	if (filter.children[0]->type != LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		return false;
+	}
+
+	bool changed = false;
+	auto &delim_join = filter.children[0]->Cast<LogicalComparisonJoin>();
+	vector<unique_ptr<Expression>> remaining_expressions;
+	auto expressions = std::move(filter.expressions);
+	LogicalFilter::SplitPredicates(expressions);
+	for (auto &expr : expressions) {
+		if (FilterReferencesDelimInput(delim_join, *expr)) {
+			AddFilterToOperator(delim_join.children[0], std::move(expr));
+			changed = true;
+			continue;
+		}
+		remaining_expressions.push_back(std::move(expr));
+	}
+
+	if (remaining_expressions.empty()) {
+		plan = std::move(filter.children[0]);
+	} else {
+		filter.expressions = std::move(remaining_expressions);
+	}
+	return changed;
+}
+
+static bool PushEligibleFiltersIntoDelimJoinInputs(unique_ptr<LogicalOperator> &plan) {
+	bool changed = false;
+	for (auto &child : plan->children) {
+		changed = PushEligibleFiltersIntoDelimJoinInputs(child) || changed;
+	}
+	if (plan->type == LogicalOperatorType::LOGICAL_FILTER) {
+		changed = PushEligibleFilterExpressionsIntoDelimJoinInputs(plan) || changed;
+	}
+	return changed;
 }
 
 static void MaterializeDelimJoinAsCTE(Binder &binder, unique_ptr<LogicalOperator> &plan) {


### PR DESCRIPTION
Follow up of https://github.com/duckdb/duckdb/pull/23098.

This PR actually pushes DELIM filters to the right location, so that all rewritten `DELIM_SCAN`s (that are now `CTE_REF`s) read the already filtered data.

This PR also makes join bloom filters robust against underestimated build cardinality, by:
- Tracking the row count used when JoinHashTable::PrepareBuildBloomFilter initializes the bloom filter.
- Before publishing the bloom filter in hash-join finalize, compare actual ht.Count() with that initialization count.
- If actual count is more than 2x the initialization count, reset/reinitialize the bloom filter for ht.Count() and rebuild it from the finalized hash-table key data.

Finally, I have implemented `GetSinkProgress` for CTEs, so that the progress bar works for them.