### PR TITLE
Fix *COLUMNS() false rejection when operators appear in lambda bodies

### DIFF
--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -75,21 +75,34 @@ static void ReplaceInOperator(unique_ptr<ParsedExpression> &expr, expression_lis
                               optional_ptr<duckdb_re2::RE2> regex) {
 	auto &operator_expr = expr->Cast<OperatorExpression>();
 
-	vector<ExpressionType> allowed_types({
-	    ExpressionType::OPERATOR_COALESCE,
-	    ExpressionType::COMPARE_IN,
-	    ExpressionType::COMPARE_NOT_IN,
-	});
-	bool allowed = false;
-	for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
-		auto &type = allowed_types[i];
-		if (operator_expr.GetExpressionType() == type) {
-			allowed = true;
+	// Only enforce the operator allowlist when a direct child IS *COLUMNS() — i.e., when the
+	// expansion would change this operator's arity. Operators that appear elsewhere in the tree
+	// (e.g. inside a lambda body) must not be rejected just because they are operators.
+	bool has_unpacked_child = false;
+	for (auto &child : operator_expr.GetChildren()) {
+		if (StarExpression::IsColumnsUnpacked(*child)) {
+			has_unpacked_child = true;
+			break;
 		}
 	}
-	if (!allowed) {
-		throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
-		                      EnumUtil::ToString(operator_expr.GetExpressionType()));
+
+	if (has_unpacked_child) {
+		vector<ExpressionType> allowed_types({
+		    ExpressionType::OPERATOR_COALESCE,
+		    ExpressionType::COMPARE_IN,
+		    ExpressionType::COMPARE_NOT_IN,
+		});
+		bool allowed = false;
+		for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
+			auto &type = allowed_types[i];
+			if (operator_expr.GetExpressionType() == type) {
+				allowed = true;
+			}
+		}
+		if (!allowed) {
+			throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
+			                      EnumUtil::ToString(operator_expr.GetExpressionType()));
+		}
 	}
 
 	// Replace children

--- a/test/sql/parser/test_columns_unpacked_operators.test
+++ b/test/sql/parser/test_columns_unpacked_operators.test
@@ -1,0 +1,49 @@
+# name: test/sql/parser/test_columns_unpacked_operators.test
+# description: Test *COLUMNS() used alongside operators that appear in lambda bodies (issue #17617)
+# group: [parser]
+
+statement ok
+CREATE TABLE test (a VARCHAR, b VARCHAR);
+
+statement ok
+INSERT INTO test VALUES ('hello', 'world'), ('empty', NULL);
+
+# IS NOT NULL inside a lambda body — *COLUMNS() is only in the list argument, not inside IS NOT NULL
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL) FROM test;
+----
+[hello, world]
+[empty]
+
+# IS NULL inside a lambda body
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: x IS NULL) FROM test;
+----
+[]
+[NULL]
+
+# NOT inside a lambda body — lambda x: NOT (x = 'hello')
+# NULL = 'hello' is NULL, NOT NULL is NULL (falsy), so NULL is filtered out
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: NOT (x = 'hello')) FROM test;
+----
+[world]
+[empty]
+
+# Combined: IS NOT NULL AND a string predicate (the original issue #17617 reproduction)
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: lower(x) != 'empty' AND x IS NOT NULL) FROM test;
+----
+[hello, world]
+[]
+
+# Operators directly wrapping *COLUMNS() are still disallowed (arity is undefined)
+statement error
+SELECT *COLUMNS(*) IS NOT NULL FROM test;
+----
+*COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
+
+statement error
+SELECT *COLUMNS(*) IS NULL FROM test;
+----
+*COLUMNS() can not be used together with the 'OPERATOR_IS_NULL' operator


### PR DESCRIPTION
## Problem

`*COLUMNS()` could not be used in a `list_filter` (or any function) whose lambda body contained operators like `IS NOT NULL`, `IS NULL`, or `NOT`, even though those operators had nothing to do with the `*COLUMNS()` expression.

**Reproduction:**
```sql
CREATE TABLE test (a VARCHAR, b VARCHAR);
INSERT INTO test VALUES ('hello', 'world'), ('empty', NULL);

-- Fails with: *COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
SELECT list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL) FROM test;
```

The original issue report (#17617):
```sql
list_filter([*columns(getvariable('my_patt'))], lambda x: lower(x) != 'empty' and x is not null)
```

## Root Cause

`ReplaceUnpackedStarExpression` walks the entire expression tree and calls `ReplaceInOperator` on **every** operator it encounters — including operators deep inside lambda bodies that contain no `*COLUMNS()` child at all. The allowlist check in `ReplaceInOperator` fired unconditionally, throwing a `BinderException` for any operator type not in the allowlist (`OPERATOR_COALESCE`, `COMPARE_IN`, `COMPARE_NOT_IN`).

## Fix

Guard the allowlist check in `ReplaceInOperator` so it only fires when at least one **direct child** of the operator is an unpacked `*COLUMNS()` expression. If no child is `*COLUMNS()`, the operator is just passing through and the check is irrelevant.

```cpp
bool has_unpacked_child = false;
for (auto &child : operator_expr.GetChildren()) {
    if (StarExpression::IsColumnsUnpacked(*child)) {
        has_unpacked_child = true;
        break;
    }
}
if (has_unpacked_child) {
    // ... allowlist check ...
}
```

Operators that **directly wrap** `*COLUMNS()` (e.g. `SELECT *COLUMNS(*) IS NOT NULL FROM t`) are still correctly rejected, since their arity would be undefined after expansion.

## Tests

Added `test/sql/parser/test_columns_unpacked_operators.test` covering:
- `list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL)`
- `list_filter([*COLUMNS(*)], lambda x: x IS NULL)`
- `list_filter([*COLUMNS(*)], lambda x: NOT (x = 'hello'))`
- The original issue's exact pattern (`lower(x) != 'empty' AND x IS NOT NULL`)
- Regression: operators directly wrapping `*COLUMNS()` still error

Fixes #17617

🤖 Generated with [Claude Code](https://claude.com/claude-code)