### PR TITLE
Fix ORDER BY true/false bypassing non-integer literal validation

### DIFF
--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -1538,12 +1538,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformConstantLiteral(PEG
                                                                              ParseResult &parse_result) {
 	auto &list_pr = parse_result.Cast<ListParseResult>();
 	auto val = transformer.Transform<Value>(list_pr.Child<ChoiceParseResult>(0).GetResult());
-	if (val.IsNull()) {
-		return make_uniq<ConstantExpression>(val);
-	} else {
-		auto varchar_val = make_uniq<ConstantExpression>(val.GetValue<string>().substr(0, 1));
-		return make_uniq<CastExpression>(LogicalType::BOOLEAN, std::move(varchar_val));
-	}
+	return make_uniq<ConstantExpression>(val);
 }
 
 Value PEGTransformerFactory::TransformFalseLiteral(PEGTransformer &transformer, ParseResult &parse_result) {

--- a/test/sql/binder/order_by_view.test
+++ b/test/sql/binder/order_by_view.test
@@ -29,12 +29,14 @@ CreatedAt >= '2023-12-01' AND
 CreatedAt < '2023-12-13' 
 GROUP BY HasCustomAddress ;
 
-statement ok
-SELECT HasCustomAddress, count(*) AS total_records 
-FROM model 
-WHERE  1 = 1 AND 
+statement error
+SELECT HasCustomAddress, count(*) AS total_records
+FROM model
+WHERE  1 = 1 AND
 CreatedAt >= '2023-12-01' AND
-CreatedAt < '2023-12-13' 
+CreatedAt < '2023-12-13'
 GROUP BY HasCustomAddress
-ORDER BY true, total_records DESC NULLS LAST 
+ORDER BY true, total_records DESC NULLS LAST
 LIMIT 250 OFFSET 0;
+----
+ORDER BY non-integer literal has no effect

--- a/test/sql/order/test_order_by_non_ordinal_literal.test
+++ b/test/sql/order/test_order_by_non_ordinal_literal.test
@@ -1,0 +1,125 @@
+# name: test/sql/order/test_order_by_non_ordinal_literal.test
+# description: Non-ordinal literal validation (ORDER BY, DISTINCT ON, UNION)
+# group: [order]
+
+statement ok
+CREATE TABLE t (a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO t VALUES (11, 22), (12, 21), (13, 22);
+
+# integer ordinals still work (ORDER BY 1 is a column index, not a literal rejection)
+query II
+SELECT a, b FROM t ORDER BY 1, 2
+----
+11	22
+12	21
+13	22
+
+# ---------------------------------------------------------------------------
+# Query ORDER BY: non-ordinal literals are rejected by default
+# ---------------------------------------------------------------------------
+
+statement error
+SELECT a FROM t ORDER BY NULL, a
+----
+ORDER BY non-integer literal has no effect
+
+statement error
+SELECT a FROM t ORDER BY true, a
+----
+ORDER BY non-integer literal has no effect
+
+statement error
+SELECT a FROM t ORDER BY false, a
+----
+ORDER BY non-integer literal has no effect
+
+# ---------------------------------------------------------------------------
+# User-written casts: not treated as non-ordinal literals (pre-existing behavior)
+# Bare 'hello' / true are rejected; CAST(...) forms are still bound as sort keys.
+# ---------------------------------------------------------------------------
+
+statement ok
+SELECT a FROM t ORDER BY CAST('a' AS VARCHAR), a
+
+statement ok
+SELECT a FROM t ORDER BY CAST('t' AS BOOLEAN), a
+
+statement ok
+SELECT a FROM t ORDER BY CAST('yes' AS BOOLEAN), a
+
+# ---------------------------------------------------------------------------
+# UNION ORDER BY: same validation via OrderBinder
+# ---------------------------------------------------------------------------
+
+statement error
+SELECT a FROM t UNION SELECT b FROM t ORDER BY true
+----
+ORDER BY non-integer literal has no effect
+
+statement error
+SELECT a FROM t UNION SELECT b FROM t ORDER BY false
+----
+ORDER BY non-integer literal has no effect
+
+statement error
+SELECT a AS k FROM t UNION SELECT a AS k FROM t ORDER BY true, k
+----
+ORDER BY non-integer literal has no effect
+
+# ---------------------------------------------------------------------------
+# DISTINCT ON: distinct targets use OrderBinder with DISTINCT ON error prefix
+# ---------------------------------------------------------------------------
+
+statement error
+SELECT DISTINCT ON (true) a, b FROM t ORDER BY a, b
+----
+DISTINCT ON non-integer literal has no effect
+
+statement error
+SELECT DISTINCT ON (false) a, b FROM t ORDER BY a, b
+----
+DISTINCT ON non-integer literal has no effect
+
+# ORDER BY clause in a DISTINCT ON query is validated separately
+statement error
+SELECT DISTINCT ON (a) a, b FROM t ORDER BY true, a
+----
+ORDER BY non-integer literal has no effect
+
+# ---------------------------------------------------------------------------
+# With order_by_non_integer_literal=true: literals are allowed and skipped
+# ---------------------------------------------------------------------------
+
+statement ok
+SET order_by_non_integer_literal=true
+
+query I
+SELECT a FROM t ORDER BY true, a
+----
+11
+12
+13
+
+query I
+SELECT a FROM t ORDER BY false, a
+----
+11
+12
+13
+
+query I
+SELECT a AS k FROM t UNION SELECT a AS k FROM t ORDER BY true, k
+----
+11
+12
+13
+
+query II
+SELECT DISTINCT ON (a) a, b FROM t ORDER BY true, a, b
+----
+11	22
+12	21
+13	22
+

--- a/test/sql/pivot/pivot_star.test
+++ b/test/sql/pivot/pivot_star.test
@@ -31,4 +31,4 @@ CREATE VIEW expr_view AS SELECT * FROM t UNPIVOT (val FOR col IN (1+2+id));
 statement error
 CREATE VIEW v AS PIVOT t ON id IN (CASE WHEN true THEN 'a' END) USING (SUM(feb))
 ----
-Cannot serialize non-constant expression 'CASE  WHEN (CAST('t' AS BOOLEAN)) THEN ('a') ELSE NULL END' in pivot list when targeting database storage version
+Cannot serialize non-constant expression 'CASE  WHEN (true) THEN ('a') ELSE NULL END' in pivot list when targeting database storage version


### PR DESCRIPTION
Fixes [#23076](https://github.com/duckdb/duckdb/issues/23076)

`ORDER BY true` and `ORDER BY false` were silently accepted and bound as real sort keys. Other non-integer literals (`'a'`, `NULL`, `3.14`) already followed the expected path, they either raised an error (default behavior) or were ignored when `order_by_non_integer_literal=true`.

### Root cause

`TransformConstantLiteral` emitted `TRUE`/`FALSE` as `CastExpression(BOOLEAN, ConstantExpression('t'|'f'))` instead of plain `ConstantExpression` nodes.

`OrderBinder::TryGetProjectionReference()` and `bind_aggregate_expression.cpp` both only recognize plain constant expressions (`ExpressionClass::CONSTANT` / `ExpressionType::VALUE_CONSTANT`). Because boolean literals were wrapped in `CastExpression`, they bypassed both checks and fell through to the general binding path, where `CreateExtraReference()` appended them to the SELECT list as real sort keys.

### Solution

Fixed the root cause in the parser.

`TransformConstantLiteral` now produces a plain `ConstantExpression(val)` for booleans also.

No binder changes are needed, the existing non-integral constant checks in `TryGetProjectionReference()` and `bind_aggregate_expression.cpp` already handle `ConstantExpression(Value(true/false))` correctly.

### Tests

```bash
build/reldebug/test/unittest test/sql/order/test_order_by_non_ordinal_literal.test
build/reldebug/test/unittest test/sql/order/test_order_by_exceptions.test
build/reldebug/test/unittest test/sql/binder/order_by_view.test
build/reldebug/test/unittest test/sql/pivot/pivot_star.test