### PR TITLE
fix(adbc): fill metadata of GetObjects

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -2450,26 +2450,92 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 						LIST({
 							column_name: column_name,
 							ordinal_position: ordinal_position,
-							remarks: '',
-							xdbc_data_type: NULL::SMALLINT,
-							xdbc_type_name: NULL::VARCHAR,
-							xdbc_column_size: NULL::INTEGER,
-							xdbc_decimal_digits: NULL::SMALLINT,
-							xdbc_num_prec_radix: NULL::SMALLINT,
-							xdbc_nullable: NULL::SMALLINT,
-							xdbc_column_def: NULL::VARCHAR,
-							xdbc_sql_data_type: NULL::SMALLINT,
-							xdbc_datetime_sub: NULL::SMALLINT,
-							xdbc_char_octet_length: NULL::INTEGER,
-							xdbc_is_nullable: NULL::VARCHAR,
-							xdbc_scope_catalog: NULL::VARCHAR,
+							remarks: comment,
+							xdbc_data_type: NULL::SMALLINT, -- Arrow type ID not derivable from SQL; SQL type codes are in xdbc_sql_data_type
+							xdbc_type_name: data_type,
+							xdbc_column_size: CASE
+								WHEN base_type = 'DATE' THEN 10::INTEGER
+								WHEN data_type IN ('TIME', 'TIME WITH TIME ZONE', 'TIME_NS') THEN 15::INTEGER
+								WHEN data_type LIKE 'TIMESTAMP%%' THEN 26::INTEGER
+								ELSE numeric_precision::INTEGER
+							END,
+							xdbc_decimal_digits: numeric_scale::SMALLINT,
+							xdbc_num_prec_radix: numeric_precision_radix::SMALLINT,
+							xdbc_nullable: CASE is_nullable
+								WHEN FALSE THEN 0::SMALLINT
+								WHEN TRUE THEN 1::SMALLINT
+								ELSE 2::SMALLINT
+							END,
+							xdbc_column_def: column_default,
+							xdbc_sql_data_type: CASE
+								WHEN data_type = 'TIMESTAMP WITH TIME ZONE' THEN 2014::SMALLINT
+								WHEN data_type LIKE 'TIMESTAMP%%' THEN 93::SMALLINT
+								WHEN data_type = 'TIME WITH TIME ZONE' THEN 2013::SMALLINT
+								WHEN data_type LIKE '%%]' THEN 2003::SMALLINT
+								WHEN type_codes[base_type] IS NOT NULL THEN type_codes[base_type]::SMALLINT
+								ELSE 1111::SMALLINT  -- Types.OTHER: aligned with DuckDB JDBC default for unmapped types
+							END,
+							xdbc_datetime_sub: CASE
+								WHEN base_type = 'DATE' THEN 1::SMALLINT
+								WHEN data_type LIKE 'TIMESTAMP%%' THEN 3::SMALLINT
+								WHEN data_type IN ('TIME', 'TIME WITH TIME ZONE', 'TIME_NS') THEN 2::SMALLINT
+								ELSE NULL::SMALLINT
+							END,
+							xdbc_char_octet_length: CASE
+								WHEN base_type IN ('VARCHAR', 'BLOB') THEN character_maximum_length::INTEGER
+								ELSE NULL::INTEGER
+							END,
+							xdbc_is_nullable: CASE is_nullable
+								WHEN FALSE THEN 'NO'
+								WHEN TRUE THEN 'YES'
+								ELSE ''
+							END,
+							xdbc_scope_catalog: NULL::VARCHAR,  -- REF types not supported in DuckDB
 							xdbc_scope_schema: NULL::VARCHAR,
 							xdbc_scope_table: NULL::VARCHAR,
-							xdbc_is_autoincrement: NULL::BOOLEAN,
-							xdbc_is_generatedcolumn: NULL::BOOLEAN,
+							xdbc_is_autoincrement: NULL::BOOLEAN,    -- not exposed via duckdb_columns()
+							xdbc_is_generatedcolumn: NULL::BOOLEAN,  -- not exposed via duckdb_columns()
 						}) table_columns
-					FROM information_schema.columns
-					WHERE column_name LIKE %s
+					FROM (
+						SELECT
+							database_name AS table_catalog,
+							schema_name AS table_schema,
+							table_name,
+							column_name,
+							column_index AS ordinal_position,
+							comment,
+							column_default,
+							is_nullable,
+							numeric_scale,
+							numeric_precision,
+							numeric_precision_radix,
+							character_maximum_length,
+							data_type,
+							STRING_SPLIT(data_type, '(')[1] AS base_type, -- normalize typemods for type-code lookup
+							-- JDBC java.sql.Types-compatible codes, matching DuckDB JDBC where possible.
+							MAP {
+								'BOOLEAN': 16,
+								'TINYINT': -6,
+								'UTINYINT': 5,
+								'SMALLINT': 5,
+								'USMALLINT': 4,
+								'INTEGER': 4,
+								'UINTEGER': -5,
+								'BIGINT': -5,
+								'FLOAT': 6,
+								'DOUBLE': 8,
+								'DATE': 91,
+								'TIME': 92,
+								'TIME_NS': 92,
+								'VARCHAR': 12,
+								'BLOB': 2004,
+								'DECIMAL': 3,
+								'BIT': -7,
+								'STRUCT': 2002,
+							} AS type_codes
+						FROM duckdb_columns()
+						WHERE column_name LIKE %s
+					) cols
 					GROUP BY table_catalog, table_schema, table_name
 				),
 				constraints AS (

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -2310,18 +2310,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2338,18 +2338,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2478,18 +2478,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2527,18 +2527,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2556,6 +2556,117 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 			    (StringUtil::Replace(res->GetValue(0, 0).ToString(), " ", "").find(expected_clean) != string::npos));
 			db.Query("Drop table result;");
 		}
+	}
+	// 4-2. Test ADBC_OBJECT_DEPTH_COLUMNS: xdbc_* metadata for diverse column types
+	// Covers: remarks (comment), column default, DECIMAL precision/scale, DATE/TIME/TIMESTAMP
+	// datetime subtypes and column sizes, TIME_NS and TIME WITH TIME ZONE sql type codes,
+	// VARCHAR/BLOB char_octet_length, and array sql type code.
+	{
+		ADBCTestDatabase db("type_meta_test");
+		db.Query(R"(
+			CREATE TABLE type_test (
+				c_bool BOOLEAN,
+				c_bigint BIGINT,
+				c_decimal DECIMAL(10,3),
+				c_varchar VARCHAR,
+				c_blob BLOB,
+				c_date DATE,
+				c_time TIME,
+				c_time_tz TIMETZ,
+				c_time_ns TIME_NS,
+				c_ts TIMESTAMP,
+				c_ts_tz TIMESTAMPTZ,
+				c_arr INTEGER[],
+				c_with_default INTEGER DEFAULT 42
+			)
+		)");
+		db.Query("COMMENT ON COLUMN type_test.c_bool IS 'my comment'");
+
+		AdbcError adbc_error = {};
+		InitializeADBCError(&adbc_error);
+		ArrowArrayStream arrow_stream;
+		REQUIRE(SUCCESS(AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, "type_meta_test",
+		                                         nullptr, "type_test", nullptr, nullptr, &arrow_stream, &adbc_error)));
+		db.CreateTable("result", arrow_stream);
+
+		// Flatten the nested GetObjects result to one row per column
+		auto res = db.Query(R"(
+			SELECT col.column_name, col.remarks, col.xdbc_type_name, col.xdbc_column_size,
+			       col.xdbc_decimal_digits, col.xdbc_num_prec_radix, col.xdbc_sql_data_type,
+			       col.xdbc_datetime_sub, col.xdbc_char_octet_length, col.xdbc_column_def
+			FROM (
+				SELECT UNNEST(
+					list_filter(
+						list_filter(catalog_db_schemas, lambda s: s.db_schema_name = 'main')[1].db_schema_tables,
+						lambda t: t.table_name = 'type_test'
+					)[1].table_columns
+				) AS col
+				FROM result
+				WHERE catalog_name = 'type_meta_test'
+			) sub
+			ORDER BY col.ordinal_position
+		)");
+
+		// col indices: 0=column_name, 1=remarks, 2=xdbc_type_name, 3=xdbc_column_size,
+		//              4=xdbc_decimal_digits, 5=xdbc_num_prec_radix, 6=xdbc_sql_data_type,
+		//              7=xdbc_datetime_sub, 8=xdbc_char_octet_length, 9=xdbc_column_def
+		// row indices: 0=c_bool,1=c_bigint,2=c_decimal,3=c_varchar,4=c_blob,
+		//              5=c_date,6=c_time,7=c_time_tz,8=c_time_ns,9=c_ts,10=c_ts_tz,11=c_arr,12=c_with_default
+		REQUIRE((res->RowCount() == 13));
+
+		// remarks: only c_bool has a comment
+		REQUIRE((res->GetValue(1, 0).ToString() == "my comment"));
+		REQUIRE((res->GetValue(1, 1).IsNull()));
+
+		// xdbc_column_def: only c_with_default has a default value
+		REQUIRE((res->GetValue(9, 12).ToString() == "42"));
+		REQUIRE((res->GetValue(9, 0).IsNull()));
+
+		// xdbc_sql_data_type covers every branch in the CASE expression
+		REQUIRE((res->GetValue(6, 0).ToString() == "16"));    // BOOLEAN → 16
+		REQUIRE((res->GetValue(6, 1).ToString() == "-5"));    // BIGINT → -5
+		REQUIRE((res->GetValue(6, 2).ToString() == "3"));     // DECIMAL → 3
+		REQUIRE((res->GetValue(6, 3).ToString() == "12"));    // VARCHAR → 12
+		REQUIRE((res->GetValue(6, 4).ToString() == "2004"));  // BLOB → 2004
+		REQUIRE((res->GetValue(6, 5).ToString() == "91"));    // DATE → 91
+		REQUIRE((res->GetValue(6, 6).ToString() == "92"));    // TIME → 92
+		REQUIRE((res->GetValue(6, 7).ToString() == "2013"));  // TIME WITH TIME ZONE → 2013
+		REQUIRE((res->GetValue(6, 8).ToString() == "92"));    // TIME_NS → 92
+		REQUIRE((res->GetValue(6, 9).ToString() == "93"));    // TIMESTAMP → 93
+		REQUIRE((res->GetValue(6, 10).ToString() == "2014")); // TIMESTAMP WITH TIME ZONE → 2014
+		REQUIRE((res->GetValue(6, 11).ToString() == "2003")); // INTEGER[] → 2003
+		REQUIRE((res->GetValue(6, 12).ToString() == "4"));    // INTEGER → 4
+
+		// xdbc_column_size: DATE=10, TIME variants=15, TIMESTAMP variants=26
+		REQUIRE((res->GetValue(3, 0).IsNull()));            // BOOLEAN: no numeric precision
+		REQUIRE((res->GetValue(3, 1).ToString() == "64"));  // BIGINT: 64
+		REQUIRE((res->GetValue(3, 2).ToString() == "10"));  // DECIMAL(10,3): precision
+		REQUIRE((res->GetValue(3, 5).ToString() == "10"));  // DATE: hardcoded 10
+		REQUIRE((res->GetValue(3, 6).ToString() == "15"));  // TIME: hardcoded 15
+		REQUIRE((res->GetValue(3, 7).ToString() == "15"));  // TIME WITH TIME ZONE: 15
+		REQUIRE((res->GetValue(3, 8).ToString() == "15"));  // TIME_NS: 15
+		REQUIRE((res->GetValue(3, 9).ToString() == "26"));  // TIMESTAMP: hardcoded 26
+		REQUIRE((res->GetValue(3, 10).ToString() == "26")); // TIMESTAMP WITH TIME ZONE: 26
+
+		// xdbc_datetime_sub: DATE=1, TIME variants=2, TIMESTAMP variants=3
+		REQUIRE((res->GetValue(7, 5).ToString() == "1"));  // DATE → 1
+		REQUIRE((res->GetValue(7, 6).ToString() == "2"));  // TIME → 2
+		REQUIRE((res->GetValue(7, 7).ToString() == "2"));  // TIME WITH TIME ZONE → 2
+		REQUIRE((res->GetValue(7, 8).ToString() == "2"));  // TIME_NS → 2
+		REQUIRE((res->GetValue(7, 9).ToString() == "3"));  // TIMESTAMP → 3
+		REQUIRE((res->GetValue(7, 10).ToString() == "3")); // TIMESTAMP WITH TIME ZONE → 3
+		REQUIRE((res->GetValue(7, 11).IsNull()));          // INTEGER[]: NULL
+
+		// DECIMAL: scale and radix
+		REQUIRE((res->GetValue(4, 2).ToString() == "3"));  // xdbc_decimal_digits = scale = 3
+		REQUIRE((res->GetValue(5, 2).ToString() == "10")); // xdbc_num_prec_radix = 10
+
+		// xdbc_char_octet_length: NULL for unbounded VARCHAR/BLOB
+		REQUIRE((res->GetValue(8, 3).IsNull())); // VARCHAR (unbounded)
+		REQUIRE((res->GetValue(8, 4).IsNull())); // BLOB (unbounded)
+		REQUIRE((res->GetValue(8, 0).IsNull())); // BOOLEAN: not a char type
+
+		db.Query("Drop table result;");
 	}
 	// 5. Test ADBC_OBJECT_DEPTH_ALL
 	{
@@ -2611,18 +2722,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': a,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 0,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': NO,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2632,18 +2743,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': b,
                                 'ordinal_position': 2,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 0,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': NO,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2667,18 +2778,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': a,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2688,18 +2799,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': b,
                                 'ordinal_position': 2,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2844,18 +2955,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': a,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 0,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': NO,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2865,18 +2976,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': b,
                                 'ordinal_position': 2,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 0,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': NO,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2920,18 +3031,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': a,
                                 'ordinal_position': 1,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,
@@ -2941,18 +3052,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': b,
                                 'ordinal_position': 2,
-                                'remarks': '',
+                                'remarks': NULL,
                                 'xdbc_data_type': NULL,
-                                'xdbc_type_name': NULL,
-                                'xdbc_column_size': NULL,
-                                'xdbc_decimal_digits': NULL,
-                                'xdbc_num_prec_radix': NULL,
-                                'xdbc_nullable': NULL,
+                                'xdbc_type_name': INTEGER,
+                                'xdbc_column_size': 32,
+                                'xdbc_decimal_digits': 0,
+                                'xdbc_num_prec_radix': 2,
+                                'xdbc_nullable': 1,
                                 'xdbc_column_def': NULL,
-                                'xdbc_sql_data_type': NULL,
+                                'xdbc_sql_data_type': 4,
                                 'xdbc_datetime_sub': NULL,
                                 'xdbc_char_octet_length': NULL,
-                                'xdbc_is_nullable': NULL,
+                                'xdbc_is_nullable': YES,
                                 'xdbc_scope_catalog': NULL,
                                 'xdbc_scope_schema': NULL,
                                 'xdbc_scope_table': NULL,


### PR DESCRIPTION
Currently, much of the metadata is empty.
It can be added by referring to the JDBC driver.

cc @lidavidm @kentkwu