### PR TITLE
Aggregates: Make `StateInitialize` zero-initialize by default if no Initialize method is provided

### DIFF
--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -15,10 +15,6 @@ struct AvgState {
 	uint64_t count;
 	T value;
 
-	void Initialize() {
-		this->count = 0;
-	}
-
 	void Combine(const AvgState<T> &other) {
 		this->count += other.count;
 		this->value += other.value;
@@ -28,11 +24,6 @@ struct AvgState {
 struct IntervalAvgState {
 	int64_t count;
 	interval_t value;
-
-	void Initialize() {
-		this->count = 0;
-		this->value = interval_t();
-	}
 
 	void Combine(const IntervalAvgState &other) {
 		this->count += other.count;
@@ -44,11 +35,6 @@ struct KahanAvgState {
 	uint64_t count;
 	double value;
 	double err;
-
-	void Initialize() {
-		this->count = 0;
-		this->err = 0.0;
-	}
 
 	void Combine(const KahanAvgState &other) {
 		this->count += other.count;
@@ -75,10 +61,6 @@ public:
 };
 
 struct AverageSetOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.Initialize();
-	}
 	template <class STATE>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target.Combine(source);
@@ -172,12 +154,6 @@ struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, Kaha
 };
 
 struct IntervalAverageOperation : public BaseSumOperation<AverageSetOperation, IntervalAdd> {
-	// Override BaseSumOperation::Initialize because
-	// IntervalAvgState does not have an assignment constructor from 0
-	static void Initialize(IntervalAvgState &state) {
-		AverageSetOperation::Initialize<IntervalAvgState>(state);
-	}
-
 	template <class RESULT_TYPE, class STATE>
 	static void Finalize(STATE &state, RESULT_TYPE &target, AggregateFinalizeData &finalize_data) {
 		if (state.count == 0) {

--- a/extension/core_functions/aggregate/distributive/approx_count.cpp
+++ b/extension/core_functions/aggregate/distributive/approx_count.cpp
@@ -14,11 +14,6 @@ struct ApproxDistinctCountState {
 };
 
 struct ApproxCountDistinctFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		new (&state) STATE();
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target.hll.Merge(source.hll);

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -85,11 +85,6 @@ struct ArgMinMaxState : public ArgMinMaxStateBase {
 template <class COMPARATOR>
 struct ArgMinMaxBase {
 	template <class STATE>
-	static void Initialize(STATE &state) {
-		new (&state) STATE;
-	}
-
-	template <class STATE>
 	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
 		state.~STATE();
 	}

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -76,12 +76,6 @@ AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
 }
 
 struct BitwiseOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		//  If there are no matching rows, returns a null value.
-		state.is_set = false;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
 		if (!state.is_set) {

--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -67,11 +67,6 @@ struct BitstringAggBindData : public FunctionData {
 struct BitStringAggOperation {
 	static constexpr const idx_t MAX_BIT_RANGE = 1000000000; // for now capped at 1 billion bits
 
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.is_set = false;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		auto &bind_agg_data = unary_input.input.bind_data->template Cast<BitstringAggBindData>();

--- a/extension/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/extension/core_functions/aggregate/distributive/kurtosis.cpp
@@ -22,12 +22,6 @@ struct KurtosisFlagNoBiasCorrection {};
 
 template <class KURTOSIS_FLAG>
 struct KurtosisOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.n = 0;
-		state.sum = state.sum_sqr = state.sum_cub = state.sum_four = 0.0;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {

--- a/extension/core_functions/aggregate/distributive/skew.cpp
+++ b/extension/core_functions/aggregate/distributive/skew.cpp
@@ -17,12 +17,6 @@ struct SkewState {
 };
 
 struct SkewnessOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.n = 0;
-		state.sum = state.sum_sqr = state.sum_cub = 0;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {

--- a/extension/core_functions/aggregate/distributive/string_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/string_agg.cpp
@@ -34,11 +34,6 @@ struct StringAggBindData : public FunctionData {
 };
 
 struct StringAggFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		memset(&state, 0, sizeof(STATE));
-	}
-
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
 		if (!state.is_set) {

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -13,10 +13,6 @@ namespace {
 
 struct SumSetOperation {
 	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.Initialize();
-	}
-	template <class STATE>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target.Combine(source);
 	}
@@ -364,11 +360,6 @@ struct BignumState {
 };
 
 struct BignumOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.is_set = false;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -192,11 +192,6 @@ struct ApproxTopKState {
 };
 
 struct ApproxTopKOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.state = nullptr;
-	}
-
 	template <class TYPE, class STATE>
 	static void Operation(STATE &aggr_state, const TYPE &input, AggregateInputData &aggr_input,
 	                      const Vector &top_k_vector, idx_t offset, idx_t count) {

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -103,12 +103,6 @@ struct ApproximateQuantileBindData : public FunctionData {
 struct ApproxQuantileOperation {
 	using SAVE_TYPE = duckdb_tdigest::Value;
 
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.pos = 0;
-		state.h = nullptr;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {

--- a/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -92,14 +92,6 @@ struct ReservoirQuantileBindData : public FunctionData {
 };
 
 struct ReservoirQuantileOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.v = nullptr;
-		state.len = 0;
-		state.pos = 0;
-		state.r_samp = nullptr;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -21,11 +21,6 @@ struct HistogramBinState {
 	unsafe_vector<T> *bin_boundaries;
 	unsafe_vector<idx_t> *counts;
 
-	void Initialize() {
-		bin_boundaries = nullptr;
-		counts = nullptr;
-	}
-
 	void Destroy() {
 		if (bin_boundaries) {
 			delete bin_boundaries;
@@ -80,11 +75,6 @@ struct HistogramBinState {
 };
 
 struct HistogramBinFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.Initialize();
-	}
-
 	template <class STATE>
 	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
 		state.Destroy();

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -14,11 +14,6 @@ namespace {
 template <class MAP_TYPE>
 struct HistogramFunction {
 	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.hist = nullptr;
-	}
-
-	template <class STATE>
 	static void Destroy(STATE &state, AggregateInputData &) {
 		if (state.hist) {
 			delete state.hist;

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -36,12 +36,6 @@ struct ListAggState {
 };
 
 struct ListFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.linked_list.total_capacity = 0;
-		state.linked_list.first_segment = nullptr;
-		state.linked_list.last_segment = nullptr;
-	}
 	static bool IgnoreNull() {
 		return false;
 	}

--- a/extension/core_functions/aggregate/regression/regr_avg.cpp
+++ b/extension/core_functions/aggregate/regression/regr_avg.cpp
@@ -14,12 +14,6 @@ struct RegrState {
 };
 
 struct RegrAvgFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.sum = 0;
-		state.count = 0;
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target.sum += source.sum;

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -15,14 +15,6 @@ struct RegrInterceptState {
 };
 
 struct RegrInterceptOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.count = 0;
-		state.sum_x = 0;
-		state.sum_y = 0;
-		RegrSlopeOperation::Initialize<RegrSlopeState>(state.slope);
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		state.count++;

--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -19,13 +19,6 @@ struct RegrR2State {
 };
 
 struct RegrR2Operation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		CorrOperation::Initialize<CorrState>(state.corr);
-		STDDevBaseOperation::Initialize<StddevState>(state.var_pop_x);
-		STDDevBaseOperation::Initialize<StddevState>(state.var_pop_y);
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(state.corr, y, x, idata);

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -16,12 +16,6 @@ struct RegrSState {
 };
 
 struct RegrBaseOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		RegrCountFunction::Initialize<uint64_t>(state.count);
-		STDDevBaseOperation::Initialize<StddevState>(state.var_pop);
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		RegrCountFunction::Combine<uint64_t, OP>(source.count, target.count, aggr_input_data);

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -16,12 +16,6 @@ struct RegrSXyState {
 };
 
 struct RegrSXYOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		RegrCountFunction::Initialize<uint64_t>(state.count);
-		CovarOperation::Initialize<CovarState>(state.cov_pop);
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		RegrCountFunction::Operation<A_TYPE, B_TYPE, uint64_t, OP>(state.count, y, x, idata);

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
@@ -23,13 +23,6 @@ struct CorrState {
 // Returns the correlation coefficient for non-null pairs in a group.
 // CORR(y, x) = COVAR_POP(y, x) / (STDDEV_POP(x) * STDDEV_POP(y))
 struct CorrOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		CovarOperation::Initialize<CovarState>(state.cov_pop);
-		STDDevBaseOperation::Initialize<StddevState>(state.dev_pop_x);
-		STDDevBaseOperation::Initialize<StddevState>(state.dev_pop_y);
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, y, x, idata);

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
@@ -21,14 +21,6 @@ struct CovarState {
 };
 
 struct CovarOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.count = 0;
-		state.meanx = 0;
-		state.meany = 0;
-		state.co_moment = 0;
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		// update running mean and d^2

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -23,13 +23,6 @@ struct StddevState {
 // Streaming approximate standard deviation using Welford's
 // method, DOI: 10.2307/1266577
 struct STDDevBaseOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.count = 0;
-		state.mean = 0;
-		state.dsquared = 0;
-	}
-
 	template <class INPUT_TYPE, class STATE>
 	static void Execute(STATE &state, const INPUT_TYPE &input) {
 		// update running mean and d^2

--- a/extension/core_functions/include/core_functions/aggregate/regression/regr_count.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression/regr_count.hpp
@@ -16,11 +16,6 @@
 namespace duckdb {
 
 struct RegrCountFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state = 0;
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target += source;

--- a/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
@@ -18,12 +18,6 @@ struct RegrSlopeState {
 };
 
 struct RegrSlopeOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		CovarOperation::Initialize<CovarState>(state.cov_pop);
-		STDDevBaseOperation::Initialize<StddevState>(state.var_pop);
-	}
-
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, y, x, idata);

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -28,11 +28,6 @@ struct SumState {
 	bool isset;
 	T value;
 
-	void Initialize() {
-		this->isset = false;
-		this->value = 0;
-	}
-
 	void Combine(const SumState<T> &other) {
 		this->isset = other.isset || this->isset;
 		this->value += other.value;
@@ -43,11 +38,6 @@ struct KahanSumState {
 	bool isset;
 	double value;
 	double err;
-
-	void Initialize() {
-		this->isset = false;
-		this->err = 0.0;
-	}
 
 	void Combine(const KahanSumState &other) {
 		this->isset = other.isset || this->isset;
@@ -161,12 +151,6 @@ struct AddToHugeint {
 
 template <class STATEOP, class ADDOP>
 struct BaseSumOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.value = 0;
-		STATEOP::template Initialize<STATE>(state);
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		STATEOP::template Combine<STATE>(source, target, aggr_input_data);

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -8,11 +8,6 @@ namespace duckdb {
 
 namespace {
 struct BaseCountFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state = 0;
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
 		target += source;

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -18,13 +18,6 @@ struct FirstState {
 };
 
 struct FirstFunctionBase {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		memset(&state.value, 0, sizeof(typename STATE::VALUE_TYPE));
-		state.is_set = false;
-		state.is_null = false;
-	}
-
 	static bool IgnoreNull() {
 		return false;
 	}

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -63,11 +63,6 @@ static AggregateFunction GetUnaryAggregate(const LogicalType &type) {
 }
 
 struct MinMaxBase {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.isset = false;
-	}
-
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {
@@ -229,11 +224,6 @@ struct VectorMinMaxBase {
 
 	static bool IgnoreNull() {
 		return true;
-	}
-
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.isset = false;
 	}
 
 	template <class STATE>

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -424,11 +424,6 @@ struct MinMaxFixedValueOrNull {
 // MinMaxN Operation (common for both ArgMinMaxN and MinMaxN)
 //------------------------------------------------------------------------------
 struct MinMaxNOperation {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		new (&state) STATE();
-	}
-
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input) {
 		if (!source.is_initialized) {

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -562,6 +562,16 @@ public:
 		return sizeof(STATE);
 	}
 
+	template <class...>
+	using initialize_void_t = void;
+
+	//! Detects whether "OP" provides an "Initialize(STATE &)" method
+	template <class STATE, class OP, class = void>
+	struct OperationHasInitialize : std::false_type {};
+	template <class STATE, class OP>
+	struct OperationHasInitialize<STATE, OP, initialize_void_t<decltype(OP::Initialize(std::declval<STATE &>()))>>
+	    : std::true_type {};
+
 	template <class STATE, class OP, AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
 	static void StateInitialize(const BoundAggregateFunction &, data_ptr_t state) {
 		// FIXME: we should remove the "destructor_type" option in the future
@@ -570,7 +580,12 @@ public:
 		                  destructor_type == AggregateDestructorType::LEGACY,
 		              "Aggregate state must be trivially move constructible");
 #endif
-		OP::Initialize(*reinterpret_cast<STATE *>(state));
+		if constexpr (OperationHasInitialize<STATE, OP>::value) {
+			OP::Initialize(*reinterpret_cast<STATE *>(state));
+		} else {
+			// if the operation does not define an Initialize method - initialize the state by zero-initializing it
+			memset(state, 0, sizeof(STATE));
+		}
 	}
 
 	template <class STATE, class OP>


### PR DESCRIPTION
There's no reason to provide manual zero-initialization code (which is the initialization behavior for almost all aggregate states). Instead just default to zero-initialization - if aggregates need something else they can provide the `Initialize` method.