### PR TITLE
Reject NULL json key

### DIFF
--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -21,7 +21,7 @@ static const DefaultMacro JSON_MACROS[] = {
      "json_group_object",
      {"n", "v", nullptr},
      {{nullptr, nullptr}},
-     "CAST('{' || string_agg(to_json(n::VARCHAR) || ':' || CASE WHEN v IS NULL THEN 'null'::JSON ELSE to_json(v) END, "
+     "CAST('{' || string_agg(CASE WHEN n IS NULL THEN error('json_group_object key cannot be NULL') ELSE to_json(n::VARCHAR) END || ':' || CASE WHEN v IS NULL THEN 'null'::JSON ELSE to_json(v) END, "
      "',') || '}' AS JSON)"},
     {DEFAULT_SCHEMA,
      "json_group_structure",

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -21,7 +21,8 @@ static const DefaultMacro JSON_MACROS[] = {
      "json_group_object",
      {"n", "v", nullptr},
      {{nullptr, nullptr}},
-     "CAST('{' || string_agg(CASE WHEN n IS NULL THEN error('json_group_object key cannot be NULL') ELSE to_json(n::VARCHAR) END || ':' || CASE WHEN v IS NULL THEN 'null'::JSON ELSE to_json(v) END, "
+     "CAST('{' || string_agg(CASE WHEN n IS NULL THEN error('json_group_object key cannot be NULL') ELSE "
+     "to_json(n::VARCHAR) END || ':' || CASE WHEN v IS NULL THEN 'null'::JSON ELSE to_json(v) END, "
      "',') || '}' AS JSON)"},
     {DEFAULT_SCHEMA,
      "json_group_structure",

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -259,7 +259,7 @@ static void AddKeyValuePairs(yyjson_mut_doc *doc, yyjson_mut_val *objs[], Vector
 	for (idx_t i = 0; i < count; i++) {
 		auto key_idx = key_data.sel->get_index(i);
 		if (!key_data.validity.RowIsValid(key_idx)) {
-			continue;
+			throw InvalidInputException("json_object() key cannot be NULL");
 		}
 		auto key = CreateJSONValue<string_t, string_t>::Operation(doc, keys[key_idx]);
 		yyjson_mut_obj_add(objs[i], key, vals[i]);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -259,7 +259,7 @@ static void AddKeyValuePairs(yyjson_mut_doc *doc, yyjson_mut_val *objs[], Vector
 	for (idx_t i = 0; i < count; i++) {
 		auto key_idx = key_data.sel->get_index(i);
 		if (!key_data.validity.RowIsValid(key_idx)) {
-			throw InvalidInputException("json_object() key cannot be NULL");
+			throw InvalidInputException("JSON key cannot be NULL");
 		}
 		auto key = CreateJSONValue<string_t, string_t>::Operation(doc, keys[key_idx]);
 		yyjson_mut_obj_add(objs[i], key, vals[i]);

--- a/test/sql/json/issues/issue23114.test
+++ b/test/sql/json/issues/issue23114.test
@@ -1,0 +1,25 @@
+# name: test/sql/json/issues/issue23114.test
+# description: Test issue 23114 - json_object and json_group_object should error on NULL keys
+# group: [issues]
+
+require json
+
+statement error
+SELECT json_object(CAST(NULL AS VARCHAR), 'two');
+----
+json_object() key cannot be NULL
+
+query T
+SELECT json_object('key', NULL);
+----
+{"key":null}
+
+statement error
+SELECT json_group_object(k, v) FROM (VALUES ('ok', 'one'), (NULL, 'two')) t(k, v);
+----
+json_group_object key cannot be NULL
+
+query T
+SELECT json_group_object(k, v) FROM (VALUES ('ok', 'one'), ('two', NULL)) t(k, v);
+----
+{"ok":"one","two":null}

--- a/test/sql/json/issues/issue23114.test
+++ b/test/sql/json/issues/issue23114.test
@@ -7,7 +7,7 @@ require json
 statement error
 SELECT json_object(CAST(NULL AS VARCHAR), 'two');
 ----
-json_object() key cannot be NULL
+JSON key cannot be NULL
 
 query T
 SELECT json_object('key', NULL);

--- a/test/sql/json/scalar/test_json_create.test
+++ b/test/sql/json/scalar/test_json_create.test
@@ -141,13 +141,23 @@ select json_array(a, b, c, d, e) from test
 [-777,4.2,"goose",[4,2],null]
 
 query T
-select json_object(a::varchar, a, b::varchar, b, c, c, d::varchar, d, e::varchar, e) from test
+select json_object(a::varchar, a, b::varchar, b, c, c, 'd', d, 'e', e) from test
 ----
-{"0":0,"0.5":0.5,"short":"short","[0, 1, 2, 3, 4, 5, 6, 7, 9]":[0,1,2,3,4,5,6,7,9],"33":33}
-{"42":42,"1.0":1.0,"looooooooooooooong":"looooooooooooooong","[]":[],"42":42}
-{"-42":-42,"0.42":0.42,"2":"2","[1, 2, 3]":[1,2,3],"1111":1111}
-{"777":777,"19.96":19.96,"duck":"duck","1":1}
-{"-777":-777,"4.2":4.2,"goose":"goose","[4, 2]":[4,2]}
+{"0":0,"0.5":0.5,"short":"short","d":[0,1,2,3,4,5,6,7,9],"e":33}
+{"42":42,"1.0":1.0,"looooooooooooooong":"looooooooooooooong","d":[],"e":42}
+{"-42":-42,"0.42":0.42,"2":"2","d":[1,2,3],"e":1111}
+{"777":777,"19.96":19.96,"duck":"duck","d":null,"e":1}
+{"-777":-777,"4.2":4.2,"goose":"goose","d":[4,2],"e":null}
+
+statement error
+select json_object(d::varchar, d) from test where d is null
+----
+JSON key cannot be NULL
+
+statement error
+select json_object(e::varchar, e) from test where e is null
+----
+JSON key cannot be NULL
 
 query T
 select json_quote(map(list(a), list(b))) from test


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23114

In the current implementation, when NULL used as json object key, it's ignored directly without error.
I think a better approach is directly reject, same as postgres behavior: https://onecompiler.com/postgresql/44rnf6uxd