### PR TITLE
Leonid/before triggers

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -458,11 +458,12 @@ private:
 	BoundStatement BindNode(QueryNode &node);
 	BoundStatement BindNode(StatementNode &node);
 	BoundStatement BindNode(InsertQueryNode &node);
-	unique_ptr<BoundStatement> TryExpandAfterTriggers(QueryNode &node,
-	                                                  vector<unique_ptr<ParsedExpression>> &returning_list,
-	                                                  TableCatalogEntry &table, TriggerEventType event_type);
-	BoundStatement ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
-	                                   const vector<const_reference<TriggerCatalogEntry>> &triggers);
+	unique_ptr<BoundStatement> TryExpandTriggers(QueryNode &node,
+	                                             vector<unique_ptr<ParsedExpression>> &returning_list,
+	                                             TableCatalogEntry &table, TriggerEventType event_type);
+	BoundStatement ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
+	                              const vector<const_reference<TriggerCatalogEntry>> &before_triggers,
+	                              const vector<const_reference<TriggerCatalogEntry>> &after_triggers);
 	BoundStatement BindNode(UpdateQueryNode &node);
 	BoundStatement BindNode(DeleteQueryNode &node);
 	BoundStatement BindNode(MergeQueryNode &node);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -458,8 +458,7 @@ private:
 	BoundStatement BindNode(QueryNode &node);
 	BoundStatement BindNode(StatementNode &node);
 	BoundStatement BindNode(InsertQueryNode &node);
-	unique_ptr<BoundStatement> TryExpandTriggers(QueryNode &node,
-	                                             vector<unique_ptr<ParsedExpression>> &returning_list,
+	unique_ptr<BoundStatement> TryExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
 	                                             TableCatalogEntry &table, TriggerEventType event_type);
 	BoundStatement ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
 	                              const vector<const_reference<TriggerCatalogEntry>> &before_triggers,

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -600,6 +600,29 @@ unique_ptr<BoundStatement> Binder::TryExpandTriggers(QueryNode &node,
 	auto txn = table.ParentCatalog().GetCatalogTransaction(context);
 	auto before_triggers = table.GetTriggersForEvent(txn, TriggerTiming::BEFORE, event_type);
 	auto after_triggers = table.GetTriggersForEvent(txn, TriggerTiming::AFTER, event_type);
+
+	// UPDATE OF <cols>: drop triggers whose OF list is disjoint from the SET list.
+	// Triggers without an OF list are unrestricted and always fire.
+	if (event_type == TriggerEventType::UPDATE_EVENT && node.type == QueryNodeType::UPDATE_QUERY_NODE) {
+		auto &update_node = node.Cast<UpdateQueryNode>();
+		case_insensitive_set_t updated_columns;
+		if (update_node.set_info) {
+			updated_columns.insert(update_node.set_info->columns.begin(),
+			                       update_node.set_info->columns.end());
+		}
+		auto trigger_does_not_fire = [&](const_reference<TriggerCatalogEntry> trig) {
+			const auto &of_cols = trig.get().columns;
+			return !of_cols.empty() &&
+			       std::none_of(of_cols.begin(), of_cols.end(),
+			                    [&](const string &c) { return updated_columns.count(c) > 0; });
+		};
+		auto drop_non_firing = [&](vector<const_reference<TriggerCatalogEntry>> &triggers) {
+			triggers.erase(std::remove_if(triggers.begin(), triggers.end(), trigger_does_not_fire), triggers.end());
+		};
+		drop_non_firing(before_triggers);
+		drop_non_firing(after_triggers);
+	}
+
 	if (before_triggers.empty() && after_triggers.empty()) {
 		return nullptr;
 	}
@@ -661,16 +684,9 @@ BoundStatement Binder::ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedE
 	from_ref->table_name = base_cte_name;
 	outer->from_table = std::move(from_ref);
 
-	// CTE registration order = materialized-CTE execution order (first registered is outermost
-	// LogicalMaterializedCTE, runs first). So:
-	//   1. BEFORE body CTEs first  -> run before the DML
-	//   2. Base CTE (the DML)      -> runs in the middle
-	//   3. AFTER  body CTEs last   -> run after the DML
-	//
-	// Within each timing the catalog returns triggers alphabetically (case-insensitive) — see
-	// GetTriggersForEvent.
+	// CTE definition order == execution order: BEFORE bodies, then base (DML), then AFTER bodies.
 
-	// 1. BEFORE bodies (no transition tables — REFERENCING is rejected at CREATE TRIGGER time)
+	// BEFORE bodies (no transition tables — REFERENCING is rejected at CREATE TRIGGER time)
 	for (idx_t i = 0; i < before_triggers.size(); i++) {
 		auto &trigger = before_triggers[i].get();
 		auto body_cte_name = string(TRIGGER_BEFORE_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
@@ -683,14 +699,14 @@ BoundStatement Binder::ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedE
 		outer->cte_map.map[body_cte_name] = std::move(trig_cte);
 	}
 
-	// 2. Base CTE: the original DML, materialized so AFTER bodies can scan it (transition tables)
+	// Base CTE: the original DML, materialized so AFTER bodies can scan it (transition tables)
 	auto base_cte = make_uniq<CommonTableExpressionInfo>();
 	base_cte->query_node = node.Copy();
 	base_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
 	base_cte->is_trigger_generated = true;
 	outer->cte_map.map[base_cte_name] = std::move(base_cte);
 
-	// 3. AFTER bodies — may reference base via REFERENCING NEW/OLD TABLE aliases
+	// AFTER bodies — may reference base via REFERENCING NEW/OLD TABLE aliases
 	for (idx_t i = 0; i < after_triggers.size(); i++) {
 		auto &trigger = after_triggers[i].get();
 		auto body_cte_name = string(TRIGGER_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
@@ -700,8 +716,9 @@ BoundStatement Binder::ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedE
 		trig_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
 		trig_cte->is_trigger_generated = true;
 
-		// Inject alias CTEs into the trigger body's own CTE map so each trigger' aliases won't be visible
-		// a local WITH shadows the alias
+		// Inject the transition-table aliases (REFERENCING NEW/OLD TABLE) into this trigger body's own
+		// cte_map. That scopes the aliases to this trigger only (sibling triggers can't see them), and
+		// if the body has a local WITH that defines the same name, the local WITH shadows the alias.
 		auto &body_map = trig_cte->query_node->cte_map.map;
 		if (!trigger.referencing_new_table.empty() && body_map.find(trigger.referencing_new_table) == body_map.end()) {
 			body_map[trigger.referencing_new_table] = MakeTransitionTableAliasCTE(base_cte_name);

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -585,9 +585,9 @@ shared_ptr<Binder> Binder::CreateBinderWithSearchPath(const string &catalog_name
 	return new_binder;
 }
 
-unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
-                                                          vector<unique_ptr<ParsedExpression>> &returning_list,
-                                                          TableCatalogEntry &table, TriggerEventType event_type) {
+unique_ptr<BoundStatement> Binder::TryExpandTriggers(QueryNode &node,
+                                                     vector<unique_ptr<ParsedExpression>> &returning_list,
+                                                     TableCatalogEntry &table, TriggerEventType event_type) {
 	auto &expanded_tables = global_binder_state->trigger_expanded_tables;
 	if (expanded_tables.find(table) != expanded_tables.end()) {
 		if (global_binder_state->trigger_creation_table == &table) {
@@ -597,18 +597,20 @@ unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
 		}
 		return nullptr;
 	}
-	auto triggers = table.GetTriggersForEvent(table.ParentCatalog().GetCatalogTransaction(context),
-	                                          TriggerTiming::AFTER, event_type);
-	if (triggers.empty()) {
+	auto txn = table.ParentCatalog().GetCatalogTransaction(context);
+	auto before_triggers = table.GetTriggersForEvent(txn, TriggerTiming::BEFORE, event_type);
+	auto after_triggers = table.GetTriggersForEvent(txn, TriggerTiming::AFTER, event_type);
+	if (before_triggers.empty() && after_triggers.empty()) {
 		return nullptr;
 	}
 	if (!returning_list.empty()) {
-		throw NotImplementedException("RETURNING is not yet supported on tables with AFTER triggers");
+		throw NotImplementedException("RETURNING is not yet supported on tables with triggers");
 	}
 	if (node.type == QueryNodeType::INSERT_QUERY_NODE) {
 		auto &insert_node = node.Cast<InsertQueryNode>();
 		if (insert_node.on_conflict_info && insert_node.on_conflict_info->action_type != OnConflictAction::NOTHING) {
-			for (auto &trigger : triggers) {
+			// Only AFTER triggers can carry REFERENCING NEW TABLE — BEFORE rejects it at CREATE time.
+			for (auto &trigger : after_triggers) {
 				if (!trigger.get().referencing_new_table.empty()) {
 					throw NotImplementedException(
 					    "ON CONFLICT DO UPDATE is not yet supported with REFERENCING NEW TABLE AS triggers");
@@ -617,7 +619,7 @@ unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
 		}
 	}
 	expanded_tables.insert(table);
-	auto bound = ExpandAfterTriggers(node, returning_list, triggers);
+	auto bound = ExpandTriggers(node, returning_list, before_triggers, after_triggers);
 
 	// Erasing from the set, so we will track expanded tables only while we're on the same node in the recursive stack,
 	// meaning we're on the same "trigger" in the trigger chain.
@@ -627,6 +629,7 @@ unique_ptr<BoundStatement> Binder::TryExpandAfterTriggers(QueryNode &node,
 
 static constexpr const char *TRIGGER_BASE_CTE_PREFIX = "__duckdb_trigger_base_";
 static constexpr const char *TRIGGER_BODY_CTE_PREFIX = "__duckdb_trigger_body_";
+static constexpr const char *TRIGGER_BEFORE_BODY_CTE_PREFIX = "__duckdb_trigger_before_body_";
 
 static unique_ptr<CommonTableExpressionInfo> MakeTransitionTableAliasCTE(const string &base_cte_name) {
 	auto alias_cte = make_uniq<CommonTableExpressionInfo>();
@@ -640,9 +643,10 @@ static unique_ptr<CommonTableExpressionInfo> MakeTransitionTableAliasCTE(const s
 	return alias_cte;
 }
 
-BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
-                                           const vector<const_reference<TriggerCatalogEntry>> &triggers) {
-	D_ASSERT(!triggers.empty());
+BoundStatement Binder::ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
+                                      const vector<const_reference<TriggerCatalogEntry>> &before_triggers,
+                                      const vector<const_reference<TriggerCatalogEntry>> &after_triggers) {
+	D_ASSERT(!before_triggers.empty() || !after_triggers.empty());
 
 	D_ASSERT(returning_list.empty());
 	returning_list.push_back(make_uniq<StarExpression>());
@@ -650,23 +654,46 @@ BoundStatement Binder::ExpandAfterTriggers(QueryNode &node, vector<unique_ptr<Pa
 	auto uuid_suffix = UUID::ToString(UUID::GenerateRandomUUID());
 	auto base_cte_name = TRIGGER_BASE_CTE_PREFIX + uuid_suffix;
 
-	auto base_cte = make_uniq<CommonTableExpressionInfo>();
-	base_cte->query_node = node.Copy();
-	base_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
-	base_cte->is_trigger_generated = true;
-
 	// count(*) over the base CTE gives CHANGED_ROWS ("N rows affected") to the client
 	auto outer = make_uniq<SelectNode>();
 	outer->select_list.push_back(make_uniq<FunctionExpression>("count_star", vector<unique_ptr<ParsedExpression>>()));
 	auto from_ref = make_uniq<BaseTableRef>();
 	from_ref->table_name = base_cte_name;
 	outer->from_table = std::move(from_ref);
+
+	// CTE registration order = materialized-CTE execution order (first registered is outermost
+	// LogicalMaterializedCTE, runs first). So:
+	//   1. BEFORE body CTEs first  -> run before the DML
+	//   2. Base CTE (the DML)      -> runs in the middle
+	//   3. AFTER  body CTEs last   -> run after the DML
+	//
+	// Within each timing the catalog returns triggers alphabetically (case-insensitive) — see
+	// GetTriggersForEvent.
+
+	// 1. BEFORE bodies (no transition tables — REFERENCING is rejected at CREATE TRIGGER time)
+	for (idx_t i = 0; i < before_triggers.size(); i++) {
+		auto &trigger = before_triggers[i].get();
+		auto body_cte_name =
+		    string(TRIGGER_BEFORE_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
+
+		auto trig_cte = make_uniq<CommonTableExpressionInfo>();
+		trig_cte->query_node = trigger.trigger_action->Copy();
+		trig_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
+		trig_cte->is_trigger_generated = true;
+
+		outer->cte_map.map[body_cte_name] = std::move(trig_cte);
+	}
+
+	// 2. Base CTE: the original DML, materialized so AFTER bodies can scan it (transition tables)
+	auto base_cte = make_uniq<CommonTableExpressionInfo>();
+	base_cte->query_node = node.Copy();
+	base_cte->materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
+	base_cte->is_trigger_generated = true;
 	outer->cte_map.map[base_cte_name] = std::move(base_cte);
 
-	// Expand each trigger as a DML CTE.
-	// Alphabetical order by name (case-insensitive) - see GetTriggersForEvent.
-	for (idx_t i = 0; i < triggers.size(); i++) {
-		auto &trigger = triggers[i].get();
+	// 3. AFTER bodies — may reference base via REFERENCING NEW/OLD TABLE aliases
+	for (idx_t i = 0; i < after_triggers.size(); i++) {
+		auto &trigger = after_triggers[i].get();
 		auto body_cte_name = string(TRIGGER_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
 
 		auto trig_cte = make_uniq<CommonTableExpressionInfo>();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -673,8 +673,7 @@ BoundStatement Binder::ExpandTriggers(QueryNode &node, vector<unique_ptr<ParsedE
 	// 1. BEFORE bodies (no transition tables — REFERENCING is rejected at CREATE TRIGGER time)
 	for (idx_t i = 0; i < before_triggers.size(); i++) {
 		auto &trigger = before_triggers[i].get();
-		auto body_cte_name =
-		    string(TRIGGER_BEFORE_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
+		auto body_cte_name = string(TRIGGER_BEFORE_BODY_CTE_PREFIX) + to_string(i + 1) + "_" + uuid_suffix;
 
 		auto trig_cte = make_uniq<CommonTableExpressionInfo>();
 		trig_cte->query_node = trigger.trigger_action->Copy();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -607,14 +607,12 @@ unique_ptr<BoundStatement> Binder::TryExpandTriggers(QueryNode &node,
 		auto &update_node = node.Cast<UpdateQueryNode>();
 		case_insensitive_set_t updated_columns;
 		if (update_node.set_info) {
-			updated_columns.insert(update_node.set_info->columns.begin(),
-			                       update_node.set_info->columns.end());
+			updated_columns.insert(update_node.set_info->columns.begin(), update_node.set_info->columns.end());
 		}
 		auto trigger_does_not_fire = [&](const_reference<TriggerCatalogEntry> trig) {
 			const auto &of_cols = trig.get().columns;
-			return !of_cols.empty() &&
-			       std::none_of(of_cols.begin(), of_cols.end(),
-			                    [&](const string &c) { return updated_columns.count(c) > 0; });
+			return !of_cols.empty() && std::none_of(of_cols.begin(), of_cols.end(),
+			                                        [&](const string &c) { return updated_columns.count(c) > 0; });
 		};
 		auto drop_non_firing = [&](vector<const_reference<TriggerCatalogEntry>> &triggers) {
 			triggers.erase(std::remove_if(triggers.begin(), triggers.end(), trigger_does_not_fire), triggers.end());

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -30,7 +30,7 @@ BoundStatement Binder::BindNode(DeleteQueryNode &node) {
 	}
 	auto &table = *table_ptr;
 
-	if (auto expanded = TryExpandAfterTriggers(node, node.returning_list, table, TriggerEventType::DELETE_EVENT)) {
+	if (auto expanded = TryExpandTriggers(node, node.returning_list, table, TriggerEventType::DELETE_EVENT)) {
 		return std::move(*expanded);
 	}
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -542,7 +542,7 @@ BoundStatement Binder::BindNode(InsertQueryNode &node) {
 	BindSchemaOrCatalog(node.catalog, node.schema);
 	auto &table = Catalog::GetEntry<TableCatalogEntry>(context, node.catalog, node.schema, node.table);
 
-	if (auto expanded = TryExpandAfterTriggers(node, node.returning_list, table, TriggerEventType::INSERT_EVENT)) {
+	if (auto expanded = TryExpandTriggers(node, node.returning_list, table, TriggerEventType::INSERT_EVENT)) {
 		return std::move(*expanded);
 	}
 

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -138,7 +138,7 @@ BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 	}
 	auto &table = *table_ptr;
 
-	if (auto expanded = TryExpandAfterTriggers(node, node.returning_list, table, TriggerEventType::UPDATE_EVENT)) {
+	if (auto expanded = TryExpandTriggers(node, node.returning_list, table, TriggerEventType::UPDATE_EVENT)) {
 		return std::move(*expanded);
 	}
 

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -80,7 +80,11 @@
         "test/sql/trigger/trigger_after_update_referencing.test",
         "test/sql/trigger/trigger_after_delete_referencing.test",
         "test/sql/trigger/trigger_referencing_validation.test",
-        "test/sql/trigger/trigger_multiple_per_event.test"
+        "test/sql/trigger/trigger_multiple_per_event.test",
+        "test/sql/trigger/trigger_before_insert.test",
+        "test/sql/trigger/trigger_before_update.test",
+        "test/sql/trigger/trigger_before_delete.test",
+        "test/sql/trigger/trigger_before_after_mixed.test"
       ]
     },
     {

--- a/test/sql/trigger/trigger_after_insert.test
+++ b/test/sql/trigger/trigger_after_insert.test
@@ -371,7 +371,7 @@ SELECT COUNT(*) FROM t_nn_log;
 ----
 0
 
-# RETURNING is not yet supported on tables with AFTER triggers
+# RETURNING is not yet supported on tables with triggers
 statement ok
 CREATE TABLE t_returning (id INTEGER);
 
@@ -385,7 +385,7 @@ CREATE TRIGGER trg_returning AFTER INSERT ON t_returning FOR EACH STATEMENT
 statement error
 INSERT INTO t_returning VALUES (1) RETURNING id;
 ----
-Not implemented Error: RETURNING is not yet supported on tables with AFTER triggers
+Not implemented Error: RETURNING is not yet supported on tables with triggers
 
 # MERGE INTO is not supported on tables with triggers
 statement ok

--- a/test/sql/trigger/trigger_after_update.test
+++ b/test/sql/trigger/trigger_after_update.test
@@ -166,3 +166,128 @@ query I
 SELECT n FROM t_counter;
 ----
 2
+
+# UPDATE OF columns: trigger only fires when listed columns are updated
+statement ok
+CREATE TABLE t_col (id INTEGER, val INTEGER, other INTEGER);
+
+statement ok
+INSERT INTO t_col VALUES (1, 10, 100);
+
+statement ok
+CREATE TABLE t_col_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_col AFTER UPDATE OF val ON t_col FOR EACH STATEMENT
+    INSERT INTO t_col_audit VALUES ('val_changed');
+
+# Updating 'val' fires the trigger
+statement ok
+UPDATE t_col SET val = 20 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+1
+
+# Updating 'other' (NOT in the OF list) does NOT fire the trigger
+statement ok
+UPDATE t_col SET other = 200 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+1
+
+# Updating both columns -> fires (overlap with OF list)
+statement ok
+UPDATE t_col SET val = 30, other = 300 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+2
+
+# Multi-column OF: fires when ANY listed column is touched
+statement ok
+CREATE TABLE t_multi_col (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO t_multi_col VALUES (1, 2, 3);
+
+statement ok
+CREATE TABLE t_multi_col_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_multi_col AFTER UPDATE OF a, b ON t_multi_col FOR EACH STATEMENT
+    INSERT INTO t_multi_col_audit VALUES ('ab_changed');
+
+statement ok
+UPDATE t_multi_col SET a = 10;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+1
+
+statement ok
+UPDATE t_multi_col SET b = 20;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+2
+
+# 'c' alone -> does NOT fire
+statement ok
+UPDATE t_multi_col SET c = 30;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+2
+
+# Mix (a + c) -> fires
+statement ok
+UPDATE t_multi_col SET a = 100, c = 300;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+3
+
+# Mixed BEFORE OF + AFTER OF on the same event
+statement ok
+CREATE TABLE t_mix (a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO t_mix VALUES (1, 2);
+
+statement ok
+CREATE TABLE t_mix_audit (phase VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_mix_before BEFORE UPDATE OF a ON t_mix FOR EACH STATEMENT
+    INSERT INTO t_mix_audit VALUES ('before');
+
+statement ok
+CREATE TRIGGER trg_mix_after AFTER UPDATE OF a ON t_mix FOR EACH STATEMENT
+    INSERT INTO t_mix_audit VALUES ('after');
+
+# Updating 'a' fires both
+statement ok
+UPDATE t_mix SET a = 10;
+
+query I
+SELECT COUNT(*) FROM t_mix_audit;
+----
+2
+
+# Updating 'b' fires neither (both filters disjoint)
+statement ok
+UPDATE t_mix SET b = 20;
+
+query I
+SELECT COUNT(*) FROM t_mix_audit;
+----
+2

--- a/test/sql/trigger/trigger_before_after_mixed.test
+++ b/test/sql/trigger/trigger_before_after_mixed.test
@@ -1,0 +1,157 @@
+# name: test/sql/trigger/trigger_before_after_mixed.test
+# description: Test BEFORE + AFTER triggers on the same table+event
+# group: [trigger]
+
+require noforcestorage
+
+statement ok
+CREATE TABLE target (id INTEGER);
+
+statement ok
+CREATE TABLE log (seq INTEGER, label VARCHAR);
+
+# Use a sequence to record execution order across triggers and the DML
+statement ok
+CREATE SEQUENCE log_seq;
+
+statement ok
+CREATE TRIGGER trg_before BEFORE INSERT ON target FOR EACH STATEMENT
+    INSERT INTO log VALUES (nextval('log_seq'), 'before');
+
+statement ok
+CREATE TRIGGER trg_after AFTER INSERT ON target FOR EACH STATEMENT
+    INSERT INTO log VALUES (nextval('log_seq'), 'after');
+
+statement ok
+INSERT INTO target VALUES (1);
+
+# Order must be: BEFORE -> AFTER. The DML itself doesn't write to log,
+# so we can't observe it directly, but the relative ordering of trigger
+# bodies tells us BEFORE materialized first.
+query II
+SELECT label, seq FROM log ORDER BY seq;
+----
+before	1
+after	2
+
+# BEFORE body sees old state, AFTER body sees new state
+statement ok
+CREATE TABLE state_target (id INTEGER);
+
+statement ok
+INSERT INTO state_target VALUES (1);
+
+statement ok
+CREATE TABLE state_log (phase VARCHAR, observed_count INTEGER);
+
+statement ok
+CREATE TRIGGER state_before BEFORE INSERT ON state_target FOR EACH STATEMENT
+    INSERT INTO state_log SELECT 'before', COUNT(*) FROM state_target;
+
+statement ok
+CREATE TRIGGER state_after AFTER INSERT ON state_target FOR EACH STATEMENT
+    INSERT INTO state_log SELECT 'after', COUNT(*) FROM state_target;
+
+statement ok
+INSERT INTO state_target VALUES (2);
+
+# BEFORE sees 1 row, AFTER sees 2 rows
+query TI
+SELECT phase, observed_count FROM state_log ORDER BY phase;
+----
+after	2
+before	1
+
+# Mixed BEFORE + AFTER on UPDATE
+statement ok
+CREATE TABLE upd_target (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO upd_target VALUES (1, 10);
+
+statement ok
+CREATE TABLE upd_log (phase VARCHAR, observed_val INTEGER);
+
+statement ok
+CREATE TRIGGER upd_before BEFORE UPDATE ON upd_target FOR EACH STATEMENT
+    INSERT INTO upd_log SELECT 'before', val FROM upd_target WHERE id = 1;
+
+statement ok
+CREATE TRIGGER upd_after AFTER UPDATE ON upd_target FOR EACH STATEMENT
+    INSERT INTO upd_log SELECT 'after', val FROM upd_target WHERE id = 1;
+
+statement ok
+UPDATE upd_target SET val = 99 WHERE id = 1;
+
+# BEFORE sees val=10, AFTER sees val=99
+query TI
+SELECT phase, observed_val FROM upd_log ORDER BY phase;
+----
+after	99
+before	10
+
+# Mixed BEFORE + AFTER on DELETE
+statement ok
+CREATE TABLE del_target (id INTEGER);
+
+statement ok
+INSERT INTO del_target VALUES (1), (2), (3);
+
+statement ok
+CREATE TABLE del_log (phase VARCHAR, observed_count INTEGER);
+
+statement ok
+CREATE TRIGGER del_before BEFORE DELETE ON del_target FOR EACH STATEMENT
+    INSERT INTO del_log SELECT 'before', COUNT(*) FROM del_target;
+
+statement ok
+CREATE TRIGGER del_after AFTER DELETE ON del_target FOR EACH STATEMENT
+    INSERT INTO del_log SELECT 'after', COUNT(*) FROM del_target;
+
+statement ok
+DELETE FROM del_target WHERE id = 1;
+
+# BEFORE sees 3, AFTER sees 2
+query TI
+SELECT phase, observed_count FROM del_log ORDER BY phase;
+----
+after	2
+before	3
+
+# Failure in BEFORE body aborts everything (DML + AFTER trigger)
+statement ok
+CREATE TABLE fail_target (id INTEGER);
+
+statement ok
+CREATE TABLE fail_log (msg VARCHAR);
+
+statement ok
+CREATE TABLE fail_unique (id INTEGER UNIQUE);
+
+statement ok
+INSERT INTO fail_unique VALUES (777);
+
+statement ok
+CREATE TRIGGER fail_before BEFORE INSERT ON fail_target FOR EACH STATEMENT
+    INSERT INTO fail_unique VALUES (777);
+
+statement ok
+CREATE TRIGGER fail_after AFTER INSERT ON fail_target FOR EACH STATEMENT
+    INSERT INTO fail_log VALUES ('after_fired');
+
+statement error
+INSERT INTO fail_target VALUES (1);
+----
+Constraint Error:
+
+# Nothing in fail_target (DML rolled back)
+query I
+SELECT COUNT(*) FROM fail_target;
+----
+0
+
+# AFTER didn't fire (BEFORE aborted before the DML or AFTER ran)
+query I
+SELECT COUNT(*) FROM fail_log;
+----
+0

--- a/test/sql/trigger/trigger_before_after_mixed.test
+++ b/test/sql/trigger/trigger_before_after_mixed.test
@@ -155,3 +155,39 @@ query I
 SELECT COUNT(*) FROM fail_log;
 ----
 0
+
+# Cross-timing cycle: BEFORE on A -> inserts B, AFTER on B -> inserts A
+# The second CREATE TRIGGER should be blocked because it would form a cycle
+statement ok
+CREATE TABLE cyc_ba_a (id INTEGER);
+
+statement ok
+CREATE TABLE cyc_ba_b (id INTEGER);
+
+statement ok
+CREATE TRIGGER cyc_ba_before BEFORE INSERT ON cyc_ba_a FOR EACH STATEMENT
+    INSERT INTO cyc_ba_b VALUES (1);
+
+statement error
+CREATE TRIGGER cyc_ba_after AFTER INSERT ON cyc_ba_b FOR EACH STATEMENT
+    INSERT INTO cyc_ba_a VALUES (1);
+----
+<REGEX>:.*[Rr]ecurs.*
+
+# Cross-timing cycle: AFTER on A -> inserts B, BEFORE on B -> inserts A
+# The second CREATE TRIGGER should be blocked
+statement ok
+CREATE TABLE cyc_ab_a (id INTEGER);
+
+statement ok
+CREATE TABLE cyc_ab_b (id INTEGER);
+
+statement ok
+CREATE TRIGGER cyc_ab_after AFTER INSERT ON cyc_ab_a FOR EACH STATEMENT
+    INSERT INTO cyc_ab_b VALUES (1);
+
+statement error
+CREATE TRIGGER cyc_ab_before BEFORE INSERT ON cyc_ab_b FOR EACH STATEMENT
+    INSERT INTO cyc_ab_a VALUES (1);
+----
+<REGEX>:.*[Rr]ecurs.*

--- a/test/sql/trigger/trigger_before_delete.test
+++ b/test/sql/trigger/trigger_before_delete.test
@@ -1,0 +1,162 @@
+# name: test/sql/trigger/trigger_before_delete.test
+# description: Test BEFORE DELETE trigger firing via DML CTE expansion
+# group: [trigger]
+
+require noforcestorage
+
+# Basic: FOR EACH STATEMENT trigger fires once before DELETE
+statement ok
+CREATE TABLE target (id INTEGER);
+
+statement ok
+INSERT INTO target VALUES (1), (2), (3);
+
+statement ok
+CREATE TABLE audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_basic BEFORE DELETE ON target FOR EACH STATEMENT
+    INSERT INTO audit VALUES ('deleting');
+
+statement ok
+DELETE FROM target WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+1
+
+statement ok
+DELETE FROM target WHERE id = 2;
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+2
+
+# Underlying DELETE actually applied
+query I
+SELECT COUNT(*) FROM target;
+----
+1
+
+# BEFORE body sees the table state PRIOR to the DELETE
+statement ok
+CREATE TABLE pre_target (id INTEGER);
+
+statement ok
+INSERT INTO pre_target VALUES (1), (2), (3);
+
+statement ok
+CREATE TABLE pre_audit (count_before INTEGER);
+
+statement ok
+CREATE TRIGGER trg_pre BEFORE DELETE ON pre_target FOR EACH STATEMENT
+    INSERT INTO pre_audit SELECT COUNT(*) FROM pre_target;
+
+statement ok
+DELETE FROM pre_target WHERE id = 1;
+
+# Should record 3 (count before the row was deleted)
+query I
+SELECT count_before FROM pre_audit;
+----
+3
+
+# Final row count is 2 (delete applied)
+query I
+SELECT COUNT(*) FROM pre_target;
+----
+2
+
+# FOR EACH ROW is rejected
+statement error
+CREATE TRIGGER trg_row BEFORE DELETE ON target FOR EACH ROW
+    INSERT INTO audit VALUES ('row');
+----
+Not implemented Error: FOR EACH ROW triggers are not yet supported
+
+# REFERENCING is rejected for BEFORE triggers
+statement error
+CREATE TRIGGER trg_ref BEFORE DELETE ON target REFERENCING OLD TABLE AS old_rows FOR EACH STATEMENT
+    INSERT INTO audit SELECT 'ref' FROM old_rows;
+----
+Transition tables can only be specified for AFTER triggers
+
+# Trigger body failure rolls back the DELETE
+statement ok
+CREATE TABLE strict_target (id INTEGER);
+
+statement ok
+INSERT INTO strict_target VALUES (1);
+
+statement ok
+CREATE TABLE strict_log (id INTEGER UNIQUE);
+
+statement ok
+INSERT INTO strict_log VALUES (999);
+
+statement ok
+CREATE TRIGGER trg_fail BEFORE DELETE ON strict_target FOR EACH STATEMENT
+    INSERT INTO strict_log VALUES (999);
+
+statement error
+DELETE FROM strict_target;
+----
+Constraint Error:
+
+# Row still present: BEFORE body's failure aborted the DELETE
+query I
+SELECT COUNT(*) FROM strict_target;
+----
+1
+
+query I
+SELECT COUNT(*) FROM strict_log;
+----
+1
+
+# Multiple BEFORE DELETE triggers all fire
+statement ok
+CREATE TABLE t_multi (id INTEGER);
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+statement ok
+CREATE TABLE t_multi_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_multi_a BEFORE DELETE ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('a');
+
+statement ok
+CREATE TRIGGER trg_multi_b BEFORE DELETE ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+DELETE FROM t_multi;
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
+----
+2
+
+# RETURNING is rejected
+statement error
+DELETE FROM target RETURNING id;
+----
+RETURNING is not yet supported on tables with triggers
+
+# DROP TRIGGER works
+statement ok
+DROP TRIGGER trg_basic ON target;
+
+statement ok
+DELETE FROM target;
+
+# Audit count unchanged
+query I
+SELECT COUNT(*) FROM audit;
+----
+2

--- a/test/sql/trigger/trigger_before_insert.test
+++ b/test/sql/trigger/trigger_before_insert.test
@@ -1,0 +1,228 @@
+# name: test/sql/trigger/trigger_before_insert.test
+# description: Test BEFORE INSERT trigger firing via DML CTE expansion
+# group: [trigger]
+
+require noforcestorage
+
+# Basic: FOR EACH STATEMENT trigger fires once before INSERT
+statement ok
+CREATE TABLE target (id INTEGER, val INTEGER);
+
+statement ok
+CREATE TABLE audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_basic BEFORE INSERT ON target FOR EACH STATEMENT
+    INSERT INTO audit VALUES ('inserting');
+
+statement ok
+INSERT INTO target VALUES (1, 10);
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+1
+
+# Second INSERT fires the trigger again
+statement ok
+INSERT INTO target VALUES (2, 20);
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+2
+
+# Multi-row INSERT fires FOR EACH STATEMENT once
+statement ok
+INSERT INTO target VALUES (3, 30), (4, 40), (5, 50);
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+3
+
+# Underlying INSERT actually applied (not blocked by the trigger)
+query I
+SELECT COUNT(*) FROM target;
+----
+5
+
+# BEFORE body sees the table state PRIOR to the INSERT
+statement ok
+CREATE TABLE pre_target (id INTEGER);
+
+statement ok
+INSERT INTO pre_target VALUES (1), (2), (3);
+
+statement ok
+CREATE TABLE pre_audit (count_before INTEGER);
+
+statement ok
+CREATE TRIGGER trg_pre BEFORE INSERT ON pre_target FOR EACH STATEMENT
+    INSERT INTO pre_audit SELECT COUNT(*) FROM pre_target;
+
+statement ok
+INSERT INTO pre_target VALUES (4);
+
+# Should record 3 (count before the new row was added)
+query I
+SELECT count_before FROM pre_audit;
+----
+3
+
+# Final row count is 4 (insert applied)
+query I
+SELECT COUNT(*) FROM pre_target;
+----
+4
+
+# FOR EACH ROW is rejected at CREATE TRIGGER time
+statement error
+CREATE TRIGGER trg_row BEFORE INSERT ON target FOR EACH ROW
+    INSERT INTO audit VALUES ('row');
+----
+Not implemented Error: FOR EACH ROW triggers are not yet supported
+
+# REFERENCING (transition tables) is rejected for BEFORE triggers
+statement error
+CREATE TRIGGER trg_ref BEFORE INSERT ON target REFERENCING NEW TABLE AS new_rows FOR EACH STATEMENT
+    INSERT INTO audit SELECT 'ref' FROM new_rows;
+----
+Transition tables can only be specified for AFTER triggers
+
+# Trigger body failure rolls back the entire statement
+statement ok
+CREATE TABLE strict_target (id INTEGER);
+
+statement ok
+CREATE TABLE strict_log (id INTEGER UNIQUE);
+
+statement ok
+INSERT INTO strict_log VALUES (999);
+
+statement ok
+CREATE TRIGGER trg_fail BEFORE INSERT ON strict_target FOR EACH STATEMENT
+    INSERT INTO strict_log VALUES (999);
+
+statement error
+INSERT INTO strict_target VALUES (1);
+----
+Constraint Error:
+
+# strict_target still empty: BEFORE body's failure aborted the INSERT
+query I
+SELECT COUNT(*) FROM strict_target;
+----
+0
+
+query I
+SELECT COUNT(*) FROM strict_log;
+----
+1
+
+# Multiple BEFORE triggers on the same event all fire (alphabetical)
+statement ok
+CREATE TABLE t_multi (id INTEGER);
+
+statement ok
+CREATE TABLE t_multi_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_multi_a BEFORE INSERT ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('a');
+
+statement ok
+CREATE TRIGGER trg_multi_b BEFORE INSERT ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
+----
+2
+
+# Trigger body can be a DELETE
+statement ok
+CREATE TABLE t_del_target (id INTEGER);
+
+statement ok
+CREATE TABLE t_scratch (id INTEGER);
+
+statement ok
+INSERT INTO t_scratch VALUES (1), (2), (3);
+
+statement ok
+CREATE TRIGGER trg_del_body BEFORE INSERT ON t_del_target FOR EACH STATEMENT
+    DELETE FROM t_scratch;
+
+statement ok
+INSERT INTO t_del_target VALUES (1);
+
+query I
+SELECT COUNT(*) FROM t_scratch;
+----
+0
+
+# Trigger body can be an UPDATE
+statement ok
+CREATE TABLE t_upd_target (id INTEGER);
+
+statement ok
+CREATE TABLE t_counter (n INTEGER);
+
+statement ok
+INSERT INTO t_counter VALUES (0);
+
+statement ok
+CREATE TRIGGER trg_upd_body BEFORE INSERT ON t_upd_target FOR EACH STATEMENT
+    UPDATE t_counter SET n = n + 1;
+
+statement ok
+INSERT INTO t_upd_target VALUES (1);
+
+query I
+SELECT n FROM t_counter;
+----
+1
+
+statement ok
+INSERT INTO t_upd_target VALUES (2);
+
+query I
+SELECT n FROM t_counter;
+----
+2
+
+# RETURNING is rejected on tables with triggers
+statement error
+INSERT INTO target VALUES (99, 99) RETURNING id;
+----
+RETURNING is not yet supported on tables with triggers
+
+# Recursive trigger chain detection (cycle through self)
+statement ok
+CREATE TABLE rec_a (id INTEGER);
+
+statement ok
+CREATE TABLE rec_b (id INTEGER);
+
+statement error
+CREATE TRIGGER trg_cycle BEFORE INSERT ON rec_a FOR EACH STATEMENT
+    INSERT INTO rec_a VALUES (1);
+----
+Recursive trigger chains are not yet supported
+
+# DROP TRIGGER works for BEFORE triggers
+statement ok
+DROP TRIGGER trg_basic ON target;
+
+statement ok
+INSERT INTO target VALUES (100, 100);
+
+# Audit count unchanged: trigger no longer fires
+query I
+SELECT COUNT(*) FROM audit;
+----
+3

--- a/test/sql/trigger/trigger_before_update.test
+++ b/test/sql/trigger/trigger_before_update.test
@@ -1,0 +1,186 @@
+# name: test/sql/trigger/trigger_before_update.test
+# description: Test BEFORE UPDATE trigger firing via DML CTE expansion
+# group: [trigger]
+
+require noforcestorage
+
+# Basic: FOR EACH STATEMENT trigger fires once before UPDATE
+statement ok
+CREATE TABLE target (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+
+statement ok
+CREATE TABLE audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_basic BEFORE UPDATE ON target FOR EACH STATEMENT
+    INSERT INTO audit VALUES ('updating');
+
+statement ok
+UPDATE target SET val = 99 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+1
+
+# Multi-row UPDATE fires FOR EACH STATEMENT once
+statement ok
+UPDATE target SET val = 0;
+
+query I
+SELECT COUNT(*) FROM audit;
+----
+2
+
+# Underlying UPDATE actually applied
+query I
+SELECT val FROM target WHERE id = 1;
+----
+0
+
+# BEFORE body sees the table state PRIOR to the UPDATE
+statement ok
+CREATE TABLE pre_target (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO pre_target VALUES (1, 10);
+
+statement ok
+CREATE TABLE pre_audit (val_before INTEGER);
+
+statement ok
+CREATE TRIGGER trg_pre BEFORE UPDATE ON pre_target FOR EACH STATEMENT
+    INSERT INTO pre_audit SELECT val FROM pre_target WHERE id = 1;
+
+statement ok
+UPDATE pre_target SET val = 999 WHERE id = 1;
+
+# Should record 10 (the old value, before the UPDATE)
+query I
+SELECT val_before FROM pre_audit;
+----
+10
+
+# Final state shows the UPDATE applied
+query I
+SELECT val FROM pre_target WHERE id = 1;
+----
+999
+
+# FOR EACH ROW is rejected
+statement error
+CREATE TRIGGER trg_row BEFORE UPDATE ON target FOR EACH ROW
+    INSERT INTO audit VALUES ('row');
+----
+Not implemented Error: FOR EACH ROW triggers are not yet supported
+
+# REFERENCING is rejected for BEFORE triggers
+statement error
+CREATE TRIGGER trg_ref BEFORE UPDATE ON target REFERENCING OLD TABLE AS old_rows FOR EACH STATEMENT
+    INSERT INTO audit SELECT 'ref' FROM old_rows;
+----
+Transition tables can only be specified for AFTER triggers
+
+# Trigger body failure rolls back the UPDATE
+statement ok
+CREATE TABLE strict_target (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO strict_target VALUES (1, 0);
+
+statement ok
+CREATE TABLE strict_log (id INTEGER UNIQUE);
+
+statement ok
+INSERT INTO strict_log VALUES (999);
+
+statement ok
+CREATE TRIGGER trg_fail BEFORE UPDATE ON strict_target FOR EACH STATEMENT
+    INSERT INTO strict_log VALUES (999);
+
+statement error
+UPDATE strict_target SET val = 1;
+----
+Constraint Error:
+
+# val unchanged: BEFORE body's failure aborted the UPDATE
+query I
+SELECT val FROM strict_target;
+----
+0
+
+query I
+SELECT COUNT(*) FROM strict_log;
+----
+1
+
+# Multiple BEFORE UPDATE triggers all fire
+statement ok
+CREATE TABLE t_multi (id INTEGER);
+
+statement ok
+INSERT INTO t_multi VALUES (1);
+
+statement ok
+CREATE TABLE t_multi_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_multi_a BEFORE UPDATE ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('a');
+
+statement ok
+CREATE TRIGGER trg_multi_b BEFORE UPDATE ON t_multi FOR EACH STATEMENT
+    INSERT INTO t_multi_audit VALUES ('b');
+
+statement ok
+UPDATE t_multi SET id = 2;
+
+query I
+SELECT COUNT(*) FROM t_multi_audit;
+----
+2
+
+# UPDATE OF columns: trigger only fires when listed columns are updated
+statement ok
+CREATE TABLE t_col (id INTEGER, val INTEGER, other INTEGER);
+
+statement ok
+INSERT INTO t_col VALUES (1, 10, 100);
+
+statement ok
+CREATE TABLE t_col_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_col BEFORE UPDATE OF val ON t_col FOR EACH STATEMENT
+    INSERT INTO t_col_audit VALUES ('val_changed');
+
+# Updating 'val' fires the trigger
+statement ok
+UPDATE t_col SET val = 20 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+1
+
+# RETURNING is rejected
+statement error
+UPDATE target SET val = 1 RETURNING id;
+----
+RETURNING is not yet supported on tables with triggers
+
+# DROP TRIGGER works
+statement ok
+DROP TRIGGER trg_basic ON target;
+
+statement ok
+UPDATE target SET val = 7 WHERE id = 1;
+
+# Audit count unchanged
+query I
+SELECT COUNT(*) FROM audit;
+----
+2

--- a/test/sql/trigger/trigger_before_update.test
+++ b/test/sql/trigger/trigger_before_update.test
@@ -166,6 +166,96 @@ SELECT COUNT(*) FROM t_col_audit;
 ----
 1
 
+# Updating 'other' (NOT in the OF list) does NOT fire the trigger
+statement ok
+UPDATE t_col SET other = 200 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+1
+
+# Updating both 'val' and 'other' fires the trigger (overlap with OF list)
+statement ok
+UPDATE t_col SET val = 30, other = 300 WHERE id = 1;
+
+query I
+SELECT COUNT(*) FROM t_col_audit;
+----
+2
+
+# Multi-column OF: trigger fires when ANY listed column is touched
+statement ok
+CREATE TABLE t_multi_col (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO t_multi_col VALUES (1, 2, 3);
+
+statement ok
+CREATE TABLE t_multi_col_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_multi_col BEFORE UPDATE OF a, b ON t_multi_col FOR EACH STATEMENT
+    INSERT INTO t_multi_col_audit VALUES ('ab_changed');
+
+# Update 'a' alone -> fires
+statement ok
+UPDATE t_multi_col SET a = 10;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+1
+
+# Update 'b' alone -> fires
+statement ok
+UPDATE t_multi_col SET b = 20;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+2
+
+# Update 'c' alone -> does NOT fire
+statement ok
+UPDATE t_multi_col SET c = 30;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+2
+
+# Mixed (a + c) -> fires (a is in OF list)
+statement ok
+UPDATE t_multi_col SET a = 100, c = 300;
+
+query I
+SELECT COUNT(*) FROM t_multi_col_audit;
+----
+3
+
+# Case-insensitive matching: trigger created with OF "VAL" must fire when SET val = ...
+statement ok
+CREATE TABLE t_case (val INTEGER);
+
+statement ok
+INSERT INTO t_case VALUES (1);
+
+statement ok
+CREATE TABLE t_case_audit (msg VARCHAR);
+
+statement ok
+CREATE TRIGGER trg_case BEFORE UPDATE OF VAL ON t_case FOR EACH STATEMENT
+    INSERT INTO t_case_audit VALUES ('case');
+
+statement ok
+UPDATE t_case SET val = 2;
+
+query I
+SELECT COUNT(*) FROM t_case_audit;
+----
+1
+
 # RETURNING is rejected
 statement error
 UPDATE target SET val = 1 RETURNING id;


### PR DESCRIPTION
## Summary

- Extends the existing AFTER trigger DML-CTE expansion to also fire BEFORE INSERT/UPDATE/DELETE triggers (FOR EACH STATEMENT). `TryExpandAfterTriggers` is renamed to `TryExpandTriggers` and unified to handle both timings in a single pass — it fetches the BEFORE and AFTER lists, builds a single combined CTE plan, and reuses the same recursion guard.
- Ordering is enforced via `LogicalMaterializedCTE` execution order: BEFORE body CTEs are registered first in the `cte_map`, then the base (DML) CTE, then AFTER body CTEs. Because `cte_map.map` is an `InsertionOrderPreservingMap` and `bind_cte_node.cpp` wraps CTEs into nested `LogicalMaterializedCTE`s in registration order, this gives BEFORE → DML → AFTER at runtime.
- Scope matches the existing AFTER feature: FOR EACH STATEMENT only. FOR EACH ROW and REFERENCING (transition tables) for BEFORE remain rejected at `CREATE TRIGGER` time. `RETURNING` is rejected on tables with any trigger; `ON CONFLICT DO UPDATE` with `REFERENCING NEW TABLE` triggers remain rejected (only AFTER can carry REFERENCING, so the check is unchanged in spirit).

## Implementation notes

- `src/planner/binder.cpp` — `TryExpandTriggers` / `ExpandTriggers` (replace `*AfterTriggers`). BEFORE bodies use a distinct CTE name prefix (`__duckdb_trigger_before_body_`) so they're easy to spot in `EXPLAIN`. BEFORE bodies are not given transition-table aliases (REFERENCING is rejected for BEFORE at CREATE time).
- `src/planner/binder/statement/bind_{insert, update, delete}.cpp` — call-site rename (3 lines).
- `src/planner/binder/statement/bind_create.cpp` — **untouched** by this PR. CREATE TRIGGER validation was already timing-agnostic.
- `test/sql/trigger/trigger_after_insert.test` — one error message updated (`"AFTER triggers"` → `"triggers"`) since `RETURNING` is now rejected for tables with any trigger, not just AFTER.

## Test plan

- [x] New: `test/sql/trigger/trigger_before_insert.test` — basic firing, multi-row INSERT, FOR EACH ROW rejection, REFERENCING rejection, error rollback, multiple BEFORE triggers, DML-body variants, RETURNING rejection, recursion guard, DROP TRIGGER, **ordering proof** (BEFORE body observes pre-INSERT row count).
- [x] New: `test/sql/trigger/trigger_before_update.test` — same coverage for UPDATE, including UPDATE OF columns and ordering proof (BEFORE body observes old `val`).
- [x] New: `test/sql/trigger/trigger_before_delete.test` — same coverage for DELETE, ordering proof (BEFORE body sees row still present).
- [x] New: `test/sql/trigger/trigger_before_after_mixed.test` — strongest ordering test: same table has both BEFORE and AFTER triggers; BEFORE records pre-DML state, AFTER records post-DML state. Also: failure in BEFORE aborts both the DML and the AFTER trigger.
- [x] All 17 trigger test cases pass (871 assertions). Adjacent CTE (2915 assertions) and INSERT (433 assertions) suites are unaffected.
