### PR TITLE
Fix correlated joinside regression

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -333,6 +333,8 @@ public:
 	void SetCanContainNulls(bool can_contain_nulls);
 	bool CanContainNulls() const;
 	void SetAlwaysRequireRebind();
+	void SetInsideSubquery();
+	bool IsInsideSubquery() const;
 
 	StatementProperties &GetStatementProperties();
 	static void ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_ptr<ParsedExpression> &replacement);
@@ -363,6 +365,8 @@ private:
 	bool is_outside_flattened = true;
 	//! LEGACY: Whether or not the binder can contain NULLs as the root of expressions
 	bool legacy_can_contain_nulls = false;
+	//! Whether this binder is inside a subquery boundary
+	bool inside_subquery = false;
 	//! The set of bound views
 	reference_set_t<ViewCatalogEntry> bound_views;
 	//! Used to retrieve CatalogEntry's

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -82,6 +82,14 @@ public:
 		return false;
 	}
 
+	virtual bool IsLateralBinder() const {
+		return false;
+	}
+
+	Binder &GetBinder() const {
+		return binder;
+	}
+
 	// Returns true if the ColumnRef could be an alias reference (unqualified or qualified with table name "alias")
 	static bool IsPotentialAlias(const ColumnRefExpression &colref);
 

--- a/src/include/duckdb/planner/expression_binder/lateral_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/lateral_binder.hpp
@@ -24,6 +24,10 @@ public:
 		return !correlated_columns.empty();
 	}
 
+	bool IsLateralBinder() const override {
+		return true;
+	}
+
 	static void ReduceExpressionDepth(LogicalOperator &op, const CorrelatedColumns &info);
 
 protected:

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -63,6 +63,7 @@ Binder::Binder(ClientContext &context, shared_ptr<Binder> parent_p, BinderType b
 	IncreaseDepth();
 	if (parent) {
 		entry_retriever.Inherit(parent->entry_retriever);
+		inside_subquery = parent->inside_subquery;
 
 		// We have to inherit macro and lambda parameter bindings and from the parent binder, if there is a parent.
 		macro_binding = parent->macro_binding;
@@ -238,6 +239,14 @@ optional_ptr<BoundParameterMap> Binder::GetParameters() {
 
 void Binder::SetParameters(BoundParameterMap &parameters) {
 	global_binder_state->parameters = parameters;
+}
+
+void Binder::SetInsideSubquery() {
+	inside_subquery = true;
+}
+
+bool Binder::IsInsideSubquery() const {
+	return inside_subquery;
 }
 
 void Binder::BeginSubqueryBind(Binder &parent, ExpressionBinder &binder) {

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -96,6 +96,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 		// first bind the actual subquery in a new binder
 		auto subquery_binder = Binder::CreateBinder(context, binder);
 		subquery_binder->SetCanContainNulls(true);
+		subquery_binder->SetInsideSubquery();
 
 		subquery_binder->BeginSubqueryBind(binder, *this);
 		auto bound_node = subquery_binder->BindNode(*expr.Subquery()->node);

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -367,7 +367,8 @@ BoundStatement Binder::Bind(JoinRef &ref) {
 	if (ref.condition) {
 		WhereBinder binder(*this, context);
 		result->condition = binder.Bind(ref.condition);
-		if (result->type != JoinType::INNER && HasLateralCorrelatedColumns(*result->condition, *this)) {
+		if (result->type != JoinType::INNER && result->type != JoinType::LEFT &&
+		    HasLateralCorrelatedColumns(*result->condition, *this)) {
 			throw NotImplementedException("Non-inner join on correlated columns not supported");
 		}
 	}

--- a/src/planner/binder/tableref/bind_joinref.cpp
+++ b/src/planner/binder/tableref/bind_joinref.cpp
@@ -10,7 +10,9 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_binder/lateral_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {
@@ -97,6 +99,33 @@ static void SetPrimaryBinding(UsingColumnSet &set, JoinType join_type, const Bin
 	default:
 		break;
 	}
+}
+
+static bool HasLateralCorrelatedColumns(const Expression &root_expr, Binder &binder) {
+	if (binder.IsInsideSubquery()) {
+		return false;
+	}
+	unordered_set<TableIndex> lateral_bindings;
+	for (auto &active_binder_ref : binder.GetActiveBinders()) {
+		auto &active_binder = active_binder_ref.get();
+		if (!active_binder.IsLateralBinder()) {
+			continue;
+		}
+		for (auto &binding : active_binder.GetBinder().bind_context.GetBindingsList()) {
+			lateral_bindings.insert(binding->GetIndex());
+		}
+	}
+	if (lateral_bindings.empty()) {
+		return false;
+	}
+	bool has_lateral_correlated_columns = false;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+	    root_expr, [&](const BoundColumnRefExpression &colref) {
+		    if (colref.Depth() > 0 && lateral_bindings.find(colref.Binding().table_index) != lateral_bindings.end()) {
+			    has_lateral_correlated_columns = true;
+		    }
+	    });
+	return has_lateral_correlated_columns;
 }
 
 BindingAlias Binder::RetrieveUsingBinding(Binder &current_binder, optional_ptr<UsingColumnSet> current_set,
@@ -338,6 +367,9 @@ BoundStatement Binder::Bind(JoinRef &ref) {
 	if (ref.condition) {
 		WhereBinder binder(*this, context);
 		result->condition = binder.Bind(ref.condition);
+		if (result->type != JoinType::INNER && HasLateralCorrelatedColumns(*result->condition, *this)) {
+			throw NotImplementedException("Non-inner join on correlated columns not supported");
+		}
 	}
 
 	if (result->type == JoinType::SEMI || result->type == JoinType::ANTI || result->type == JoinType::MARK) {

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -6,6 +6,7 @@ namespace duckdb {
 BoundStatement Binder::Bind(SubqueryRef &ref) {
 	auto binder = Binder::CreateBinder(context, this);
 	binder->SetCanContainNulls(true);
+	binder->SetInsideSubquery();
 	auto subquery = binder->BindNode(*ref.subquery->node);
 	binder->alias = ref.alias.empty() ? "unnamed_subquery" : ref.alias;
 	auto bind_index = subquery.plan->GetRootIndex();

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -415,7 +415,6 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
 		filter->AddChild(std::move(root));
 		return std::move(filter);
 	}
-
 	// now create the join operator from the join condition
 	auto result = LogicalComparisonJoin::CreateJoin(context, ref.type, ref.ref_type, std::move(left), std::move(right),
 	                                                std::move(ref.condition));

--- a/src/planner/joinside.cpp
+++ b/src/planner/joinside.cpp
@@ -83,7 +83,7 @@ JoinSide JoinSide::GetJoinSide(const Expression &expression, const unordered_set
 	if (expression.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = expression.Cast<BoundColumnRefExpression>();
 		if (colref.Depth() > 0) {
-			throw NotImplementedException("Non-inner join on correlated columns not supported");
+			return JoinSide::NONE;
 		}
 		return GetJoinSide(colref.Binding().table_index, left_bindings, right_bindings);
 	}

--- a/test/sql/join/left_outer/test_left_outer.test
+++ b/test/sql/join/left_outer/test_left_outer.test
@@ -178,3 +178,12 @@ select * from (values(1), (2)) t1(i) left join (values (2), (3)) t2(i) on t1.i=t
 ----
 1	NULL
 2	2
+
+query IIII
+SELECT pl.id, g.k, t.player_id, mo.player_id
+FROM (SELECT 1 AS id) pl
+CROSS JOIN (SELECT 1 AS k) g
+LEFT JOIN (SELECT 1 AS player_id) t ON pl.id = t.player_id
+LEFT JOIN (SELECT 1 AS player_id) mo ON pl.id = mo.player_id;
+----
+1	1	1	1

--- a/test/sql/subquery/scalar/test_complex_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_complex_correlated_subquery.test
@@ -97,9 +97,13 @@ SELECT * FROM integers s1 LEFT OUTER JOIN integers s2 ON s1.i=s2.i AND (SELECT C
 ----
 
 # left outer join in correlated expression
-statement error
+query II
 SELECT i, (SELECT SUM(s1.i) FROM integers s1 LEFT OUTER JOIN integers s2 ON s1.i=s2.i OR s1.i=i1.i-1) AS j FROM integers i1 ORDER BY i;
 ----
+NULL	6
+1	6
+2	9
+3	12
 
 # REQUIRE(CHECK_COLUMN(result, 0, {Value(), 1, 2, 3}));
 # REQUIRE(CHECK_COLUMN(result, 1, {Value(), 6, 9, 12}));

--- a/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
@@ -128,6 +128,20 @@ SELECT (SELECT count(*) FROM range(1, 3) t(i) LEFT JOIN range(1, 2) u(j) ON t.i 
 ----
 2
 
+# correlated LEFT JOIN condition inside a LATERAL subquery
+query I
+WITH outer_t(x) AS (SELECT 1)
+SELECT q.cnt
+FROM outer_t
+CROSS JOIN LATERAL (
+	SELECT count(*) AS cnt
+	FROM (SELECT 1 AS r) e
+	CROSS JOIN (SELECT 1 AS v) d
+	LEFT JOIN (SELECT 1 AS r, 1 AS v) e2 ON e2.r = outer_t.x AND e2.v = d.v
+) q;
+----
+1
+
 query I
 SELECT CASE WHEN NOT col1 NOT IN (SELECT (SELECT MAX(col7)) UNION (SELECT MIN(ColID) FROM tbl_ProductSales LEFT JOIN another_T t2 ON t2.col5 = t1.col1)) THEN 1 ELSE 2 END FROM another_T t1 GROUP BY col1 ORDER BY 1;
 ----

--- a/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
@@ -121,13 +121,21 @@ SELECT (SELECT MIN(ColID) FROM tbl_ProductSales INNER JOIN another_T t2 ON t1.co
 1
 1
 
-# LEFT JOIN between correlated columns not supported for now
-statement error
+# LEFT JOIN conditions can reference correlated columns
+query I
+WITH outer_t(x) AS (SELECT 1)
+SELECT (SELECT count(*) FROM range(1, 3) t(i) LEFT JOIN range(1, 2) u(j) ON t.i = outer_t.x) FROM outer_t;
+----
+2
+
+query I
 SELECT CASE WHEN NOT col1 NOT IN (SELECT (SELECT MAX(col7)) UNION (SELECT MIN(ColID) FROM tbl_ProductSales LEFT JOIN another_T t2 ON t2.col5 = t1.col1)) THEN 1 ELSE 2 END FROM another_T t1 GROUP BY col1 ORDER BY 1;
 ----
-<REGEX>:.*Not implemented Error.*Non-inner join on correlated columns not supported.*
+1
+2
+2
+2
 
-# REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 2, 2}));
 # correlated columns in window functions not supported yet
 statement error
 SELECT EXISTS (SELECT RANK() OVER (PARTITION BY SUM(DISTINCT col5))) FROM another_T t1;


### PR DESCRIPTION
Some changes in the binder introduced a regression where some queries would fail with `Non-inner join on correlated columns not supported`, while in reality, we could execute those queries safely. This PR fixes that.