### PR TITLE
[v1.5] Backport external file cache fix

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -894,11 +894,11 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 			metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 			                        encryption_util, footer_size);
 		} else {
-			metadata = ObjectCache::GetObjectCache(context_p).Get<ParquetFileMetadataCache>(file.path);
+			metadata = ObjectCache::GetObjectCache(context_p).GetWithTypePrefix<ParquetFileMetadataCache>(file.path);
 			if (!metadata || !metadata->IsValid(*file_handle)) {
 				metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 				                        encryption_util, footer_size);
-				ObjectCache::GetObjectCache(context_p).Put(file.path, metadata);
+				ObjectCache::GetObjectCache(context_p).PutWithTypePrefix<ParquetFileMetadataCache>(file.path, metadata);
 			}
 		}
 	} else {
@@ -915,7 +915,7 @@ bool ParquetReader::MetadataCacheEnabled(ClientContext &context) {
 
 shared_ptr<ParquetFileMetadataCache> ParquetReader::GetMetadataCacheEntry(ClientContext &context,
                                                                           const OpenFileInfo &file) {
-	return ObjectCache::GetObjectCache(context).Get<ParquetFileMetadataCache>(file.path);
+	return ObjectCache::GetObjectCache(context).GetWithTypePrefix<ParquetFileMetadataCache>(file.path);
 }
 
 ParquetUnionData::~ParquetUnionData() {

--- a/src/execution/operator/persistent/csv_rejects_table.cpp
+++ b/src/execution/operator/persistent/csv_rejects_table.cpp
@@ -34,8 +34,8 @@ shared_ptr<CSVRejectsTable> CSVRejectsTable::GetOrCreate(ClientContext &context,
 		throw BinderException("The names of the rejects scan and rejects error tables can't be the same. Use different "
 		                      "names for these tables.");
 	}
-	auto key =
-	    "CSV_REJECTS_TABLE_CACHE_ENTRY_" + StringUtil::Upper(rejects_scan) + "_" + StringUtil::Upper(rejects_error);
+	auto key = StringUtil::Format("CSV_REJECTS_TABLE_CACHE_ENTRY_%s_%s", StringUtil::Upper(rejects_scan),
+	                              StringUtil::Upper(rejects_error));
 	auto &cache = ObjectCache::GetObjectCache(context);
 	auto &catalog = Catalog::GetCatalog(context, TEMP_CATALOG);
 	auto rejects_scan_exist = catalog.GetEntry<TableCatalogEntry>(context, DEFAULT_SCHEMA, rejects_scan,

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -36,7 +36,7 @@ public:
 
 public:
 	DUCKDB_API CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system, const OpenFileInfo &path,
-	                             FileOpenFlags flags, optional_ptr<FileOpener> opener, CachedFile &cached_file);
+	                             FileOpenFlags flags, optional_ptr<FileOpener> opener);
 	DUCKDB_API ~CachingFileHandle();
 
 public:
@@ -60,6 +60,8 @@ public:
 	DUCKDB_API void Seek(idx_t location);
 
 private:
+	//! Refresh the cached file if the global cache state has changed.
+	shared_ptr<CachedFile> EnsureCachedFileCurrent();
 	//! Get the version tag of the file (for checking cache invalidation)
 	const string &GetVersionTag(const unique_ptr<StorageLockKey> &guard);
 	//! Tries to read from the cache, filling "overlapping_ranges" with ranges that overlap with the request.
@@ -94,8 +96,8 @@ private:
 	optional_ptr<FileOpener> opener;
 	//! Cache validation mode for this file
 	CacheValidationMode validate;
-	//! The associated CachedFile with cached ranges
-	CachedFile &cached_file;
+	//! Associated cached file.
+	shared_ptr<CachedFile> cached_file;
 
 	//! The underlying FileHandle (optional)
 	unique_ptr<FileHandle> file_handle;

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/common/types/timestamp.hpp"
@@ -99,7 +100,7 @@ public:
 	void SetEnabled(bool enable);
 	idx_t GetGeneration() const;
 	vector<CachedFileInformation> GetCachedFileInformation() const;
-	//! Number of files tracked in the cache map, exposed for testing.
+	//! Number of files tracked in the ObjectCache, exposed for testing.
 	idx_t GetCachedFileCount() const;
 
 	BufferManager &GetBufferManager() const;
@@ -111,15 +112,25 @@ public:
 	                               const string &current_version_tag, timestamp_t current_last_modified);
 
 private:
+	class ExternalFileCacheObjectCacheEntry;
+
+	//! Registers a cached file path in the tracked set.
+	void InsertCachedFileKey(const string &path);
+	//! Removes a cached file path from the tracked set.
+	void EraseCachedFileKey(const string &path);
+	//! Delete the ObjectCache entries for the given cached file paths.
+	void DeleteObjectCacheEntries(const vector<string> &paths);
+
 	//! The BufferManager used to cache files
 	BufferManager &buffer_manager;
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
 	//! Generation counter, incremented whenever cache enablement changes.
 	atomic<idx_t> generation;
-	//! Mapping from file path to cached file with cached ranges
-	unordered_map<string, shared_ptr<CachedFile>> cached_files;
-	//! Lock for accessing the cached files
+	//! Paths of the cached files tracked in the ObjectCache.
+	//! Entries should only be inserted at `GetOrCreateCachedFile` and deleted at object cache entry deletion.
+	unordered_set<string> cached_file_keys;
+	//! Lock for accessing cached_file_keys.
 	mutable mutex lock;
 };
 

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -56,7 +56,7 @@ public:
 	//! Cached files
 	struct CachedFile {
 	public:
-		explicit CachedFile(string path_p);
+		CachedFile(string path_p, idx_t generation_p);
 
 	public:
 		//! Verifies that none of the ranges fully overlap (must hold the lock)
@@ -75,6 +75,7 @@ public:
 
 	public:
 		const string path;
+		const idx_t generation;
 		StorageLock lock;
 
 	private:
@@ -96,11 +97,15 @@ public:
 
 	bool IsEnabled() const;
 	void SetEnabled(bool enable);
+	idx_t GetGeneration() const;
 	vector<CachedFileInformation> GetCachedFileInformation() const;
+	//! Number of files tracked in the cache map, exposed for testing.
+	idx_t GetCachedFileCount() const;
 
 	BufferManager &GetBufferManager() const;
-	//! Gets the cached file, or creates it if is not yet present
-	CachedFile &GetOrCreateCachedFile(const string &path);
+	//! Gets the shared cached file for the given path, creating it if not yet present.
+	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
+	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
 
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
@@ -110,8 +115,10 @@ private:
 	BufferManager &buffer_manager;
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
+	//! Generation counter, incremented whenever cache enablement changes.
+	atomic<idx_t> generation;
 	//! Mapping from file path to cached file with cached ranges
-	unordered_map<string, unique_ptr<CachedFile>> cached_files;
+	unordered_map<string, shared_ptr<CachedFile>> cached_files;
 	//! Lock for accessing the cached files
 	mutable mutex lock;
 };

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -85,7 +85,7 @@ public:
 	}
 
 	template <class T, class... ARGS>
-	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
 		const lock_guard<mutex> lock(lock_mutex);
 
 		// Check non-evictable entries first
@@ -159,7 +159,7 @@ public:
 	}
 
 	template <class T, class... ARGS>
-	shared_ptr<T> GetOrCreateWithTypePrefix(const string &key, ARGS &&...args) {
+	shared_ptr<T> GetOrCreateWithTypePrefix(const string &key, ARGS &&... args) {
 		return GetOrCreate<T>(MakeCacheKey<T>(key), std::forward<ARGS>(args)...);
 	}
 

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/lru_cache.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
@@ -84,7 +85,7 @@ public:
 	}
 
 	template <class T, class... ARGS>
-	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
 		const lock_guard<mutex> lock(lock_mutex);
 
 		// Check non-evictable entries first
@@ -149,6 +150,30 @@ public:
 		lru_cache.Delete(key);
 	}
 
+	//! Type-prefixed variants of the methods above. These namespace the caller-provided key with the entry's
+	//! ObjectType so that callers can pass a natural key (e.g. a file path) without having to build a unique
+	//! cache key themselves.
+	template <class T>
+	shared_ptr<T> GetWithTypePrefix(const string &key) {
+		return Get<T>(MakeCacheKey<T>(key));
+	}
+
+	template <class T, class... ARGS>
+	shared_ptr<T> GetOrCreateWithTypePrefix(const string &key, ARGS &&...args) {
+		return GetOrCreate<T>(MakeCacheKey<T>(key), std::forward<ARGS>(args)...);
+	}
+
+	template <class T>
+	void PutWithTypePrefix(const string &key,
+	                       shared_ptr<ObjectCacheEntry> value) { // NOLINT(performance-unnecessary-value-param)
+		Put(MakeCacheKey<T>(key), std::move(value));
+	}
+
+	template <class T>
+	void DeleteWithTypePrefix(const string &key) {
+		Delete(MakeCacheKey<T>(key));
+	}
+
 	DUCKDB_API static ObjectCache &GetObjectCache(ClientContext &context);
 
 	idx_t GetMaxMemory() const {
@@ -171,6 +196,14 @@ public:
 	idx_t EvictToReduceMemory(idx_t target_bytes) {
 		const lock_guard<mutex> lock(lock_mutex);
 		return lru_cache.EvictToReduceAtLeast(target_bytes);
+	}
+
+private:
+	//! Build the internal cache key for a typed entry by namespacing the caller-provided key with the entry's
+	//! ObjectType.
+	template <class T>
+	static string MakeCacheKey(const string &key) {
+		return StringUtil::Format("%s-%s", T::ObjectType(), key);
 	}
 
 private:

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -61,32 +61,46 @@ CachingFileSystem CachingFileSystem::Get(ClientContext &context) {
 
 unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
                                                           optional_ptr<FileOpener> opener) {
-	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener,
-	                                    external_file_cache.GetOrCreateCachedFile(path.path));
+	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener);
 }
 
 unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, const OpenFileInfo &path,
                                                           FileOpenFlags flags, optional_ptr<FileOpener> opener) {
-	return make_uniq<CachingFileHandle>(context, *this, path, flags, opener,
-	                                    external_file_cache.GetOrCreateCachedFile(path.path));
+	return make_uniq<CachingFileHandle>(context, *this, path, flags, opener);
+}
+
+shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCurrent() {
+	if (cached_file && cached_file->generation == external_file_cache.GetGeneration()) {
+		return cached_file;
+	}
+	const bool needs_reopen = file_handle != nullptr;
+	if (needs_reopen) {
+		file_handle.reset();
+	}
+	cached_file = external_file_cache.GetOrCreateCachedFile(path.path);
+	if (needs_reopen) {
+		GetFileHandle();
+	}
+	return cached_file;
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
-                                     optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
+                                     optional_ptr<FileOpener> opener_p)
     : context(context), caching_file_system(caching_file_system_p),
       external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
-      cached_file(cached_file_p), position(0) {
+      cached_file(nullptr), position(0) {
+	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
 	if (!external_file_cache.IsEnabled() || Validate()) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
 		return;
 	}
 	// If we don't have any cached file ranges, we must also open the file.
-	auto guard = cached_file.lock.GetSharedLock();
-	if (cached_file.Ranges(guard).empty()) {
+	auto guard = cached_file->lock.GetSharedLock();
+	if (cached_file->Ranges(guard).empty()) {
 		guard.reset();
 		GetFileHandle();
 	}
@@ -101,15 +115,15 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 		last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
 		version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 
-		auto guard = cached_file.lock.GetExclusiveLock();
-		if (!cached_file.IsValid(guard, Validate(), version_tag, last_modified)) {
-			cached_file.Ranges(guard).clear(); // Invalidate entire cache
+		auto guard = cached_file->lock.GetExclusiveLock();
+		if (!cached_file->IsValid(guard, Validate(), version_tag, last_modified)) {
+			cached_file->Ranges(guard).clear(); // Invalidate entire cache
 		}
-		cached_file.FileSize(guard) = file_handle->GetFileSize();
-		cached_file.LastModified(guard) = last_modified;
-		cached_file.VersionTag(guard) = version_tag;
-		cached_file.CanSeek(guard) = file_handle->CanSeek();
-		cached_file.OnDiskFile(guard) = file_handle->OnDiskFile();
+		cached_file->FileSize(guard) = file_handle->GetFileSize();
+		cached_file->LastModified(guard) = last_modified;
+		cached_file->VersionTag(guard) = version_tag;
+		cached_file->CanSeek(guard) = file_handle->CanSeek();
+		cached_file->OnDiskFile(guard) = file_handle->OnDiskFile();
 	}
 	return *file_handle;
 }
@@ -122,6 +136,7 @@ BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, c
 		GetFileHandle().Read(context, buffer, nr_bytes, location);
 		return result;
 	}
+	EnsureCachedFileCurrent();
 
 	// Try to read from the cache, filling overlapping_ranges in the process
 	vector<shared_ptr<CachedFileRange>> overlapping_ranges;
@@ -204,57 +219,62 @@ BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, idx_t &nr_bytes) {
 }
 
 string CachingFileHandle::GetPath() const {
-	return cached_file.path;
+	return path.path;
 }
 
 idx_t CachingFileHandle::GetFileSize() {
-	if (file_handle || Validate()) {
-		return GetFileHandle().GetFileSize();
+	if (!Validate()) {
+		auto current_cached_file = EnsureCachedFileCurrent();
+		auto guard = current_cached_file->lock.GetSharedLock();
+		return current_cached_file->FileSize(guard);
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.FileSize(guard);
+	return GetFileHandle().GetFileSize();
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
-	if (file_handle || Validate()) {
-		GetFileHandle();
-		return last_modified;
+	if (!Validate()) {
+		auto current_cached_file = EnsureCachedFileCurrent();
+		auto guard = current_cached_file->lock.GetSharedLock();
+		return current_cached_file->LastModified(guard);
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.LastModified(guard);
+	GetFileHandle();
+	return last_modified;
 }
 
 string CachingFileHandle::GetVersionTag() {
-	if (file_handle || Validate()) {
-		GetFileHandle();
-		return version_tag;
+	if (!Validate()) {
+		auto current_cached_file = EnsureCachedFileCurrent();
+		auto guard = current_cached_file->lock.GetSharedLock();
+		return current_cached_file->VersionTag(guard);
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.VersionTag(guard);
+	GetFileHandle();
+	return version_tag;
 }
 
 bool CachingFileHandle::Validate() const {
-	return ShouldValidate(path, context.GetClientContext(), caching_file_system.db, cached_file.path);
+	return ShouldValidate(path, context.GetClientContext(), caching_file_system.db, path.path);
 }
 
 bool CachingFileHandle::CanSeek() {
-	if (file_handle || Validate()) {
-		return GetFileHandle().CanSeek();
+	if (!Validate()) {
+		auto current_cached_file = EnsureCachedFileCurrent();
+		auto guard = current_cached_file->lock.GetSharedLock();
+		return current_cached_file->CanSeek(guard);
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.CanSeek(guard);
+	return GetFileHandle().CanSeek();
 }
 
 bool CachingFileHandle::IsRemoteFile() const {
-	return FileSystem::IsRemoteFile(cached_file.path);
+	return FileSystem::IsRemoteFile(path.path);
 }
 
 bool CachingFileHandle::OnDiskFile() {
-	if (file_handle || Validate()) {
-		return GetFileHandle().OnDiskFile();
+	if (!Validate()) {
+		auto current_cached_file = EnsureCachedFileCurrent();
+		auto guard = current_cached_file->lock.GetSharedLock();
+		return current_cached_file->OnDiskFile(guard);
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.OnDiskFile(guard);
+	return GetFileHandle().OnDiskFile();
 }
 
 const string &CachingFileHandle::GetVersionTag(const unique_ptr<StorageLockKey> &guard) {
@@ -262,7 +282,7 @@ const string &CachingFileHandle::GetVersionTag(const unique_ptr<StorageLockKey> 
 		GetFileHandle();
 		return version_tag;
 	}
-	return cached_file.VersionTag(guard);
+	return cached_file->VersionTag(guard);
 }
 
 idx_t CachingFileHandle::SeekPosition() {
@@ -282,8 +302,8 @@ BufferHandle CachingFileHandle::TryReadFromCache(data_ptr_t &buffer, idx_t nr_by
 	BufferHandle result;
 
 	// Get read lock for cached ranges
-	auto guard = cached_file.lock.GetSharedLock();
-	auto &ranges = cached_file.Ranges(guard);
+	auto guard = cached_file->lock.GetSharedLock();
+	auto &ranges = cached_file->Ranges(guard);
 
 	// First, try to see if we've read from the exact same location before
 	auto it = ranges.find(location);
@@ -354,8 +374,8 @@ BufferHandle CachingFileHandle::TryReadFromFileRange(const unique_ptr<StorageLoc
 BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t &buffer, idx_t nr_bytes,
                                                    idx_t location, shared_ptr<CachedFileRange> &new_file_range) {
 	// Grab the lock again (write lock this time) to insert the newly created buffer into the ranges
-	auto guard = cached_file.lock.GetExclusiveLock();
-	auto &ranges = cached_file.Ranges(guard);
+	auto guard = cached_file->lock.GetExclusiveLock();
+	auto &ranges = cached_file->Ranges(guard);
 
 	// Start at lower_bound (first range with location not less than location of newly created range)
 	const auto this_end = location + nr_bytes;
@@ -399,7 +419,7 @@ BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t
 	// Finally, insert newly created buffer into the map
 	new_file_range->AddCheckSum();
 	ranges[location] = std::move(new_file_range);
-	cached_file.Verify(guard);
+	cached_file->Verify(guard);
 
 	return std::move(pin);
 }

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -5,8 +5,41 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/buffer/block_handle.hpp"
+#include "duckdb/storage/object_cache.hpp"
 
 namespace duckdb {
+
+class ExternalFileCache::ExternalFileCacheObjectCacheEntry : public ObjectCacheEntry {
+public:
+	ExternalFileCacheObjectCacheEntry(ExternalFileCache &cache_p, string path_p, idx_t generation_p)
+	    : cache(cache_p), cached_file(make_shared_ptr<CachedFile>(std::move(path_p), generation_p)) {
+		cache.InsertCachedFileKey(cached_file->path);
+	}
+
+	~ExternalFileCacheObjectCacheEntry() override {
+		cache.EraseCachedFileKey(cached_file->path);
+	}
+
+	static string ObjectType() {
+		return "external_file_cache";
+	}
+
+	string GetObjectType() override {
+		return ObjectType();
+	}
+
+	optional_idx GetEstimatedCacheMemory() const override {
+		return cached_file->path.size() * 2;
+	}
+
+	shared_ptr<CachedFile> GetCachedFile() const {
+		return cached_file;
+	}
+
+private:
+	ExternalFileCache &cache;
+	shared_ptr<CachedFile> cached_file;
+};
 
 ExternalFileCache::CachedFileRange::CachedFileRange(shared_ptr<BlockHandle> block_handle_p, idx_t nr_bytes_p,
                                                     idx_t location_p, string version_tag_p)
@@ -140,15 +173,22 @@ bool ExternalFileCache::IsEnabled() const {
 }
 
 void ExternalFileCache::SetEnabled(bool enable_p) {
-	lock_guard<mutex> guard(lock);
-	if (enable == enable_p) {
-		return;
+	vector<string> keys_to_delete;
+	{
+		const lock_guard<mutex> guard(lock);
+		if (enable == enable_p) {
+			return;
+		}
+		enable = enable_p;
+		generation++;
+		if (!enable) {
+			keys_to_delete.reserve(cached_file_keys.size());
+			for (auto &key : cached_file_keys) {
+				keys_to_delete.emplace_back(key);
+			}
+		}
 	}
-	enable = enable_p;
-	generation++;
-	if (!enable) {
-		cached_files.clear();
-	}
+	DeleteObjectCacheEntries(keys_to_delete);
 }
 
 idx_t ExternalFileCache::GetGeneration() const {
@@ -156,14 +196,28 @@ idx_t ExternalFileCache::GetGeneration() const {
 }
 
 vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() const {
-	unique_lock<mutex> files_guard(lock);
+	vector<string> keys;
+	{
+		const lock_guard<mutex> files_guard(lock);
+		keys.reserve(cached_file_keys.size());
+		for (auto &key : cached_file_keys) {
+			keys.emplace_back(key);
+		}
+	}
+
+	auto &object_cache = buffer_manager.GetDatabase().GetObjectCache();
 	vector<CachedFileInformation> result;
-	for (const auto &file : cached_files) {
-		auto ranges_guard = file.second->lock.GetSharedLock();
-		for (const auto &range_entry : file.second->Ranges(ranges_guard)) {
+	for (const auto &key : keys) {
+		auto entry = object_cache.GetWithTypePrefix<ExternalFileCacheObjectCacheEntry>(key);
+		if (!entry) {
+			continue;
+		}
+		auto file = entry->GetCachedFile();
+		auto ranges_guard = file->lock.GetSharedLock();
+		for (const auto &range_entry : file->Ranges(ranges_guard)) {
 			const auto &range = *range_entry.second;
 			result.push_back(
-			    {file.first, range.nr_bytes, range.location, !range.block_handle->GetMemory().IsUnloaded()});
+			    {file->path, range.nr_bytes, range.location, !range.block_handle->GetMemory().IsUnloaded()});
 		}
 	}
 	return result;
@@ -171,7 +225,7 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 
 idx_t ExternalFileCache::GetCachedFileCount() const {
 	const lock_guard<mutex> files_guard(lock);
-	return cached_files.size();
+	return cached_file_keys.size();
 }
 
 ExternalFileCache &ExternalFileCache::Get(DatabaseInstance &db) {
@@ -186,16 +240,48 @@ BufferManager &ExternalFileCache::GetBufferManager() const {
 	return buffer_manager;
 }
 
+void ExternalFileCache::DeleteObjectCacheEntries(const vector<string> &paths) {
+	auto &object_cache = buffer_manager.GetDatabase().GetObjectCache();
+	for (auto &path : paths) {
+		object_cache.DeleteWithTypePrefix<ExternalFileCacheObjectCacheEntry>(path);
+	}
+}
+
 shared_ptr<ExternalFileCache::CachedFile> ExternalFileCache::GetOrCreateCachedFile(const string &path) {
-	lock_guard<mutex> guard(lock);
-	if (!enable) {
-		return make_shared_ptr<CachedFile>(path, generation);
+	auto &object_cache = buffer_manager.GetDatabase().GetObjectCache();
+	while (true) {
+		const auto current_generation = generation.load();
+		if (!enable) {
+			return make_shared_ptr<CachedFile>(path, current_generation);
+		}
+
+		auto entry = object_cache.GetOrCreateWithTypePrefix<ExternalFileCacheObjectCacheEntry>(path, *this, path,
+		                                                                                       current_generation);
+		auto cached_file = entry->GetCachedFile();
+
+		if (!enable) {
+			object_cache.DeleteWithTypePrefix<ExternalFileCacheObjectCacheEntry>(path);
+			return make_shared_ptr<CachedFile>(path, current_generation);
+		}
+		if (cached_file->generation != current_generation) {
+			object_cache.DeleteWithTypePrefix<ExternalFileCacheObjectCacheEntry>(path);
+			continue;
+		}
+		return cached_file;
 	}
-	auto &entry = cached_files[path];
-	if (!entry) {
-		entry = make_shared_ptr<CachedFile>(path, generation);
-	}
-	return entry;
+}
+
+void ExternalFileCache::InsertCachedFileKey(const string &path) {
+	const lock_guard<mutex> guard(lock);
+	auto inserted = cached_file_keys.insert(path);
+	ALWAYS_ASSERT(inserted.second);
+}
+
+void ExternalFileCache::EraseCachedFileKey(const string &path) {
+	const lock_guard<mutex> guard(lock);
+	auto entry = cached_file_keys.find(path);
+	ALWAYS_ASSERT(entry != cached_file_keys.end());
+	cached_file_keys.erase(entry);
 }
 
 } // namespace duckdb

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -57,8 +57,9 @@ void ExternalFileCache::CachedFileRange::VerifyCheckSum() {
 #endif
 }
 
-ExternalFileCache::CachedFile::CachedFile(string path_p)
-    : path(std::move(path_p)), file_size(0), last_modified(0), can_seek(false), on_disk_file(false) {
+ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
+    : path(std::move(path_p)), generation(generation_p), file_size(0), last_modified(0), can_seek(false),
+      on_disk_file(false) {
 }
 
 void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &guard) const {
@@ -131,7 +132,7 @@ ExternalFileCache::CachedFile::Ranges(const unique_ptr<StorageLockKey> &guard) {
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)
-    : buffer_manager(BufferManager::GetBufferManager(db)), enable(enable_p) {
+    : buffer_manager(BufferManager::GetBufferManager(db)), enable(enable_p), generation(0) {
 }
 
 bool ExternalFileCache::IsEnabled() const {
@@ -140,10 +141,18 @@ bool ExternalFileCache::IsEnabled() const {
 
 void ExternalFileCache::SetEnabled(bool enable_p) {
 	lock_guard<mutex> guard(lock);
+	if (enable == enable_p) {
+		return;
+	}
 	enable = enable_p;
+	generation++;
 	if (!enable) {
 		cached_files.clear();
 	}
+}
+
+idx_t ExternalFileCache::GetGeneration() const {
+	return generation;
 }
 
 vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() const {
@@ -160,6 +169,11 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 	return result;
 }
 
+idx_t ExternalFileCache::GetCachedFileCount() const {
+	const lock_guard<mutex> files_guard(lock);
+	return cached_files.size();
+}
+
 ExternalFileCache &ExternalFileCache::Get(DatabaseInstance &db) {
 	return db.GetExternalFileCache();
 }
@@ -172,13 +186,16 @@ BufferManager &ExternalFileCache::GetBufferManager() const {
 	return buffer_manager;
 }
 
-ExternalFileCache::CachedFile &ExternalFileCache::GetOrCreateCachedFile(const string &path) {
+shared_ptr<ExternalFileCache::CachedFile> ExternalFileCache::GetOrCreateCachedFile(const string &path) {
 	lock_guard<mutex> guard(lock);
+	if (!enable) {
+		return make_shared_ptr<CachedFile>(path, generation);
+	}
 	auto &entry = cached_files[path];
 	if (!entry) {
-		entry = make_uniq<CachedFile>(path);
+		entry = make_shared_ptr<CachedFile>(path, generation);
 	}
-	return *entry;
+	return entry;
 }
 
 } // namespace duckdb

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   test_checksum.cpp
   test_file_system.cpp
   test_caching_file_system_wrapper.cpp
+  test_external_file_cache.cpp
   test_hyperlog.cpp
   test_lru_cache.cpp
   test_numeric_cast.cpp

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -1,0 +1,108 @@
+#include "catch.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/storage/caching_file_system.hpp"
+#include "test_helpers.hpp"
+
+namespace duckdb {
+
+namespace {
+
+class ExternalCacheTestFileGuard {
+public:
+	ExternalCacheTestFileGuard(const string &filename, const string &content) : file_path(TestCreatePath(filename)) {
+		WriteContent(content);
+	}
+
+	~ExternalCacheTestFileGuard() {
+		auto local_fs = FileSystem::CreateLocal();
+		local_fs->TryRemoveFile(file_path);
+	}
+
+	const string &GetPath() const {
+		return file_path;
+	}
+
+	void WriteContent(const string &content) const {
+		auto local_fs = FileSystem::CreateLocal();
+		auto handle = local_fs->OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+		handle->Write(QueryContext(), const_cast<char *>(content.data()), content.size(), 0);
+		handle->Sync();
+	}
+
+private:
+	string file_path;
+};
+
+OpenFileInfo MakeTestOpenFileInfo(const string &path) {
+	OpenFileInfo info(path);
+	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+	return info;
+}
+
+string ReadFull(CachingFileHandle &handle, idx_t size, idx_t offset = 0) {
+	data_ptr_t data;
+	auto pin = handle.Read(data, size, offset);
+	return string(reinterpret_cast<const char *>(data), size);
+}
+
+} // namespace
+
+TEST_CASE("Disabled external file cache does not insert into cached_files", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	const string content(16384, 'A');
+	ExternalCacheTestFileGuard test_file("test_efc_disabled.bin", content);
+
+	auto local_fs = FileSystem::CreateLocal();
+	CachingFileSystem cfs(*local_fs, db_instance);
+
+	cache.SetEnabled(false);
+	REQUIRE_FALSE(cache.IsEnabled());
+	REQUIRE(cache.GetCachedFileCount() == 0);
+
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, content.size()) == content);
+	}
+
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	REQUIRE(cache.GetCachedFileInformation().empty());
+
+	cache.SetEnabled(true);
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, content.size()) == content);
+	}
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	const string content_a(64, 'A');
+	const string content_b(128, 'B');
+	ExternalCacheTestFileGuard test_file("test_efc_reenabled_live_handle_metadata.bin", content_a);
+
+	auto local_fs = FileSystem::CreateLocal();
+	CachingFileSystem cfs(*local_fs, db_instance);
+
+	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(handle->GetFileSize() == content_a.size());
+	REQUIRE(cache.GetCachedFileCount() == 1);
+
+	cache.SetEnabled(false);
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	test_file.WriteContent(content_b);
+
+	cache.SetEnabled(true);
+	REQUIRE(handle->GetFileSize() == content_b.size());
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+} // namespace duckdb

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
+#include "duckdb/storage/object_cache.hpp"
 #include "test_helpers.hpp"
 
 namespace duckdb {
@@ -47,12 +48,19 @@ string ReadFull(CachingFileHandle &handle, idx_t size, idx_t offset = 0) {
 	return string(reinterpret_cast<const char *>(data), size);
 }
 
+void EvictObjectCache(ObjectCache &object_cache) {
+	const auto memory = object_cache.GetCurrentMemory();
+	REQUIRE(memory > 0);
+	REQUIRE(object_cache.EvictToReduceMemory(memory) > 0);
+}
+
 } // namespace
 
-TEST_CASE("Disabled external file cache does not insert into cached_files", "[external_file_cache]") {
+TEST_CASE("Disabled external file cache does not insert into ObjectCache", "[external_file_cache]") {
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;
 	auto &cache = db_instance.GetExternalFileCache();
+	auto &object_cache = db_instance.GetObjectCache();
 
 	const string content(16384, 'A');
 	ExternalCacheTestFileGuard test_file("test_efc_disabled.bin", content);
@@ -63,6 +71,7 @@ TEST_CASE("Disabled external file cache does not insert into cached_files", "[ex
 	cache.SetEnabled(false);
 	REQUIRE_FALSE(cache.IsEnabled());
 	REQUIRE(cache.GetCachedFileCount() == 0);
+	REQUIRE(object_cache.GetCurrentMemory() == 0);
 
 	{
 		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
@@ -71,6 +80,7 @@ TEST_CASE("Disabled external file cache does not insert into cached_files", "[ex
 
 	REQUIRE(cache.GetCachedFileCount() == 0);
 	REQUIRE(cache.GetCachedFileInformation().empty());
+	REQUIRE(object_cache.GetCurrentMemory() == 0);
 
 	cache.SetEnabled(true);
 	{
@@ -78,6 +88,7 @@ TEST_CASE("Disabled external file cache does not insert into cached_files", "[ex
 		REQUIRE(ReadFull(*handle, content.size()) == content);
 	}
 	REQUIRE(cache.GetCachedFileCount() == 1);
+	REQUIRE(object_cache.GetCurrentMemory() > 0);
 }
 
 TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[external_file_cache]") {
@@ -103,6 +114,67 @@ TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[ext
 	cache.SetEnabled(true);
 	REQUIRE(handle->GetFileSize() == content_b.size());
 	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Disabling external file cache clears ObjectCache sentinels", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+	auto &object_cache = db_instance.GetObjectCache();
+
+	const string content(16384, 'A');
+	ExternalCacheTestFileGuard test_file("test_efc_object_cache_disable.bin", content);
+
+	auto local_fs = FileSystem::CreateLocal();
+	CachingFileSystem cfs(*local_fs, db_instance);
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, content.size()) == content);
+	}
+
+	REQUIRE(cache.GetCachedFileCount() == 1);
+	REQUIRE(object_cache.GetCurrentMemory() > 0);
+
+	cache.SetEnabled(false);
+	REQUIRE(cache.GetCachedFileInformation().empty());
+	REQUIRE(cache.GetCachedFileCount() == 0);
+	REQUIRE(object_cache.GetCurrentMemory() == 0);
+
+	cache.SetEnabled(true);
+	auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(ReadFull(*handle, content.size()) == content);
+	REQUIRE(cache.GetCachedFileCount() == 1);
+}
+
+TEST_CASE("Failed CachingFileHandle construction leaves evictable cached file entries", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+	auto &object_cache = db_instance.GetObjectCache();
+
+	auto local_fs = FileSystem::CreateLocal();
+	CachingFileSystem cfs(*local_fs, db_instance);
+
+	const auto missing_a = TestCreatePath("test_efc_missing_a.bin");
+	const auto missing_b = TestCreatePath("test_efc_missing_b.bin");
+	local_fs->TryRemoveFile(missing_a);
+	local_fs->TryRemoveFile(missing_b);
+
+	REQUIRE_THROWS(cfs.OpenFile(MakeTestOpenFileInfo(missing_a), FileFlags::FILE_FLAGS_READ));
+	REQUIRE_THROWS(cfs.OpenFile(MakeTestOpenFileInfo(missing_b), FileFlags::FILE_FLAGS_READ));
+
+	REQUIRE(cache.GetCachedFileCount() == 2);
+
+	const string content(16384, 'A');
+	ExternalCacheTestFileGuard test_file("test_efc_missing_a.bin", content);
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, content.size()) == content);
+	}
+	REQUIRE(cache.GetCachedFileCount() == 2);
+
+	EvictObjectCache(object_cache);
+	REQUIRE(cache.GetCachedFileCount() == 0);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR backports the following issue fixes with external file cache from https://github.com/duckdb/duckdb/pull/22961 and https://github.com/duckdb/duckdb/pull/23052 to v1.5 branch
- When external file cache disabled, cached files still track new key-value pairs
- Disable external file cache, existing file handle clearly directly which potentially leads to invalid memory access
- cached file entries are managed by buffer pool manager, which will be evicted under memory pressure