### PR TITLE
Add file_row_group_number virtual column to the Parquet reader

### DIFF
--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -31,7 +31,7 @@ using duckdb_parquet::SchemaElement;
 using duckdb_parquet::FileMetaData;
 struct ParquetOptions;
 
-enum class ParquetColumnSchemaType { COLUMN, FILE_ROW_NUMBER, EXPRESSION, VARIANT, GEOMETRY };
+enum class ParquetColumnSchemaType { COLUMN, FILE_ROW_NUMBER, EXPRESSION, VARIANT, GEOMETRY, FILE_ROW_GROUP_NUMBER };
 
 enum class ParquetExtraTypeInfo {
 	NONE,
@@ -72,6 +72,7 @@ public:
 	                                            vector<ParquetColumnSchema> &&children,
 	                                            ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	static ParquetColumnSchema FileRowNumber();
+	static ParquetColumnSchema FileRowGroupNumber();
 
 public:
 	unique_ptr<BaseStatistics> Stats(const FileMetaData &file_meta_data, const ParquetOptions &parquet_options,

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -82,6 +82,7 @@ struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context, const MultiFileBindData &bind_data,
 	                                          idx_t file_count) override;
 	void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result) override;
+	void GetMetrics(optional_ptr<GlobalTableFunctionState> global_state, OperatorMetrics &metrics) override;
 	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;
 };

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -222,6 +222,11 @@ public:
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
 
+	//! (optional) counters (owned by the scan's global state) for row groups whose data was read / skipped,
+	//! incremented as row groups are processed and surfaced as profiling metrics
+	optional_ptr<atomic<idx_t>> row_groups_read;
+	optional_ptr<atomic<idx_t>> row_groups_skipped;
+
 	//! Prefetch cost model
 	PrefetchCostModelState cost_model_state;
 };

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -288,6 +288,10 @@ struct ParquetUnionData : public BaseUnionData {
 
 class ParquetReader : public BaseFileReader {
 public:
+	//! Virtual column identifier for the "file_row_group_number" column (the file-relative row group index of each row)
+	static constexpr column_t COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER = UINT64_C(9223372036854775820);
+
+public:
 	ParquetReader(ClientContext &context, OpenFileInfo file, ParquetOptions parquet_options,
 	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);
 	~ParquetReader() override;

--- a/extension/parquet/include/reader/row_number_column_reader.hpp
+++ b/extension/parquet/include/reader/row_number_column_reader.hpp
@@ -71,4 +71,36 @@ private:
 	idx_t row_group_offset;
 };
 
+//! Reads the file-relative row group number as a virtual column that's not actually stored in the file
+class RowGroupColumnReader : public ColumnReader {
+public:
+	static constexpr const PhysicalType TYPE = PhysicalType::INT64;
+
+public:
+	RowGroupColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
+
+public:
+	idx_t Read(ColumnReaderInput &input, Vector &result) override;
+
+	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
+
+	void Skip(idx_t num_values) override {
+	}
+	idx_t GroupRowsAvailable() override {
+		return NumericLimits<idx_t>::Maximum();
+	};
+	uint64_t TotalCompressedSize() override {
+		return 0;
+	}
+	idx_t FileOffset() const override {
+		return 0;
+	}
+	void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge) override {
+	}
+
+private:
+	//! The index of the row group currently being read
+	idx_t row_group_idx = 0;
+};
+
 } // namespace duckdb

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -95,11 +95,31 @@ ParquetColumnSchema ParquetColumnSchema::FileRowNumber() {
 	return res;
 }
 
+ParquetColumnSchema ParquetColumnSchema::FileRowGroupNumber() {
+	ParquetColumnSchema res;
+	res.name = "file_row_group_number";
+	res.max_define = 0;
+	res.max_repeat = 0;
+	res.schema_index = 0;
+	res.column_index = 0;
+	res.schema_type = ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER;
+	res.type = LogicalType::BIGINT, res.repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL;
+	return res;
+}
+
 unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_meta_data,
                                                       const ParquetOptions &parquet_options, idx_t row_group_idx_p,
                                                       const vector<ColumnChunk> &columns) const {
 	if (schema_type == ParquetColumnSchemaType::EXPRESSION) {
 		return nullptr;
+	}
+	if (schema_type == ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER) {
+		// the row group number is constant within a row group - set min and max to the row group index
+		auto stats = NumericStats::CreateUnknown(type);
+		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
+		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
+		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+		return stats.ToUnique();
 	}
 	if (schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
 		auto &row_groups = file_meta_data.row_groups;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -94,6 +94,10 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
+	//! Number of row groups that had their data read / skipped (via row-group pruning), aggregated across all
+	//! files and threads. Surfaced as profiling metrics in EXPLAIN ANALYZE.
+	atomic<idx_t> row_groups_read {0};
+	atomic<idx_t> row_groups_skipped {0};
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -801,7 +805,18 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
+	local_state.scan_state.row_groups_read = &gstate.row_groups_read;
+	local_state.scan_state.row_groups_skipped = &gstate.row_groups_skipped;
 	return Scan(context, local_state.scan_state, chunk);
+}
+
+void ParquetMultiFileInfo::GetMetrics(optional_ptr<GlobalTableFunctionState> global_state, OperatorMetrics &metrics) {
+	if (!global_state) {
+		return;
+	}
+	auto &gstate = global_state->Cast<ParquetReadGlobalState>();
+	metrics.AddExtraInfo("Row Groups Read", to_string(gstate.row_groups_read.load()));
+	metrics.AddExtraInfo("Row Groups Skipped", to_string(gstate.row_groups_skipped.load()));
 }
 
 unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::Copy() {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "parquet_column_schema.hpp"
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_types.h"
@@ -327,6 +328,33 @@ static vector<column_t> ParquetGetRowIdColumns(ClientContext &context, optional_
 	return result;
 }
 
+static unique_ptr<BaseStatistics> ParquetScanStatistics(ClientContext &context,
+                                                        TableFunctionGetStatisticsInput &input) {
+	auto &column_index = input.column_index;
+	if (column_index.IsVirtualColumn() &&
+	    column_index.GetPrimaryIndex() == ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER) {
+		// the file_row_group_number ranges from 0 to (number of row groups in the file - 1)
+		// providing this range allows the optimizer to prune a filter on a non-existing row group to an empty scan
+		auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
+		// we can only bound the range safely when scanning a single file - with multiple files the row group
+		// count can differ per file (and only the first file's metadata is read at bind time)
+		if (bind_data.file_list->GetExpandResult() == FileExpandResult::MULTIPLE_FILES) {
+			return nullptr;
+		}
+		auto &parquet_bind = bind_data.bind_data->Cast<ParquetReadBindData>();
+		if (parquet_bind.initial_file_row_groups == 0) {
+			return nullptr;
+		}
+		auto stats = NumericStats::CreateUnknown(LogicalType::BIGINT);
+		NumericStats::SetMin(stats, Value::BIGINT(0));
+		NumericStats::SetMax(stats,
+		                     Value::BIGINT(UnsafeNumericCast<int64_t>(parquet_bind.initial_file_row_groups - 1)));
+		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+		return stats.ToUnique();
+	}
+	return MultiFileFunction<ParquetMultiFileInfo>::MultiFileScanStatsExtended(context, input);
+}
+
 ParquetMetadataCacheEntry::ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata_p,
                                                      ParquetCacheValidity validity_p, bool has_deletes_p)
     : metadata(std::move(metadata_p)), validity(validity_p), has_deletes(has_deletes_p) {
@@ -422,7 +450,7 @@ TableFunctionSet ParquetScanFunction::GetFunctionSet() {
 	table_function.named_parameters["parquet_version"] = LogicalType::VARCHAR;
 	table_function.named_parameters["can_have_nan"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["prefetch_strategy"] = LogicalType::VARCHAR;
-	table_function.statistics_extended = MultiFileFunction<ParquetMultiFileInfo>::MultiFileScanStatsExtended;
+	table_function.statistics_extended = ParquetScanStatistics;
 	table_function.supports_pushdown_extract = ParquetScanSupportPushdownExtract;
 	table_function.serialize = ParquetScanSerialize;
 	table_function.deserialize = ParquetScanDeserialize;
@@ -681,6 +709,8 @@ double ParquetReader::GetProgressInFile(ClientContext &context) {
 void ParquetMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData &, virtual_column_map_t &result) {
 	result.insert(make_pair(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER,
 	                        TableColumn("file_row_number", LogicalType::BIGINT)));
+	result.insert(make_pair(ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER,
+	                        TableColumn("file_row_group_number", LogicalType::BIGINT)));
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, GlobalTableFunctionState &,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -581,6 +581,8 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 	switch (schema.schema_type) {
 	case ParquetColumnSchemaType::FILE_ROW_NUMBER:
 		return make_uniq<RowNumberColumnReader>(*this, schema);
+	case ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER:
+		return make_uniq<RowGroupColumnReader>(*this, schema);
 	case ParquetColumnSchemaType::GEOMETRY: {
 		return GeometryColumnReader::Create(*this, schema, context);
 	}
@@ -907,6 +909,10 @@ static ParquetColumnSchema FileRowNumberSchema() {
 	return ParquetColumnSchema::FileRowNumber();
 }
 
+static ParquetColumnSchema FileRowGroupNumberSchema() {
+	return ParquetColumnSchema::FileRowGroupNumber();
+}
+
 unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema(ClientContext &context) {
 	auto file_meta_data = GetFileMetadata();
 	idx_t next_schema_idx = 0;
@@ -990,6 +996,8 @@ void ParquetReader::InitializeSchema(ClientContext &context) {
 void ParquetReader::AddVirtualColumn(column_t virtual_column_id) {
 	if (virtual_column_id == MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER) {
 		root_schema->children.push_back(FileRowNumberSchema());
+	} else if (virtual_column_id == ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER) {
+		root_schema->children.push_back(FileRowGroupNumberSchema());
 	} else {
 		throw InternalException("Unsupported virtual column id %d for parquet reader", virtual_column_id);
 	}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1707,9 +1707,17 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		}
 
 		auto &group = GetGroup(state);
+		const bool row_group_skipped = state.offset_in_group == (idx_t)group.num_rows;
+		if (row_group_skipped) {
+			if (state.row_groups_skipped) {
+				++(*state.row_groups_skipped);
+			}
+		} else if (state.row_groups_read) {
+			++(*state.row_groups_read);
+		}
 		if (state.op) {
 			DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader",
-			           state.offset_in_group == (idx_t)group.num_rows ? "SkipRowGroup" : "ReadRowGroup",
+			           row_group_skipped ? "SkipRowGroup" : "ReadRowGroup",
 			           {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
 		}
 

--- a/extension/parquet/reader/row_number_column_reader.cpp
+++ b/extension/parquet/reader/row_number_column_reader.cpp
@@ -64,4 +64,28 @@ idx_t RowNumberColumnReader::Read(ColumnReaderInput &input, Vector &result) {
 	return num_values;
 }
 
+//===--------------------------------------------------------------------===//
+// Row Group Column Reader
+//===--------------------------------------------------------------------===//
+RowGroupColumnReader::RowGroupColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
+    : ColumnReader(reader, schema) {
+}
+
+void RowGroupColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,
+                                          TProtocol &protocol_p) {
+	row_group_idx = row_group_idx_p;
+}
+
+idx_t RowGroupColumnReader::Read(ColumnReaderInput &input, Vector &result) {
+	auto &num_values = input.num_values;
+
+	// the row group number is constant for all rows within a row group
+	auto value = UnsafeNumericCast<int64_t>(row_group_idx);
+	auto data_ptr = FlatVector::Writer<int64_t>(result, num_values);
+	for (idx_t i = 0; i < num_values; i++) {
+		data_ptr.WriteValue(value);
+	}
+	return num_values;
+}
+
 } // namespace duckdb

--- a/src/common/multi_file/multi_file_function.cpp
+++ b/src/common/multi_file/multi_file_function.cpp
@@ -37,6 +37,10 @@ void MultiFileReaderInterface::GetVirtualColumns(ClientContext &context, MultiFi
                                                  virtual_column_map_t &result) {
 }
 
+void MultiFileReaderInterface::GetMetrics(optional_ptr<GlobalTableFunctionState> global_state,
+                                          OperatorMetrics &metrics) {
+}
+
 void MultiFileReaderInterface::FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
                                              LocalTableFunctionState &local_state) {
 }

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -62,6 +62,9 @@ struct MultiFileReaderInterface {
 		return GetCardinality(bind_data, file_count);
 	}
 	virtual void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
+	//! (Optional) add format-specific profiling metrics for this scan, shown in EXPLAIN ANALYZE. The global_state is
+	//! the format-specific GlobalTableFunctionState returned by InitializeGlobalState.
+	virtual void GetMetrics(optional_ptr<GlobalTableFunctionState> global_state, OperatorMetrics &metrics);
 	virtual unique_ptr<MultiFileReaderInterface> Copy();
 	virtual FileGlobInput GetGlobInput();
 };
@@ -908,6 +911,9 @@ public:
 			auto list_of_types = StringUtil::Join(file_path_names, ", ");
 			input.operator_metrics.AddExtraInfo("Filename(s)", list_of_types);
 		}
+
+		auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
+		bind_data.interface->GetMetrics(gstate.global_state.get(), input.operator_metrics);
 	}
 
 	static void PushdownType(ClientContext &context, optional_ptr<FunctionData> bind_data_p,

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -81,7 +81,8 @@
         "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
         "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
         "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
-        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test"
+        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test",
+        "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },
     {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -41,7 +41,8 @@
         "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
         "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
         "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
-        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test"
+        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test",
+        "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },
     {

--- a/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+++ b/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
@@ -103,64 +103,34 @@ select i, j, file_row_group_number from '{TEST_DIR}/rg.parquet' where i in (0, 2
 
 #-------------------------------------------------------------------------------
 # verify that filtering by file_row_group_number short-circuits reads:
-# only the matching row group is actually read from storage, the rest are skipped
+# only the matching row group's data is read, the rest are skipped via row-group
+# pruning. The parquet scan reports the counts as "Row Groups Read" / "Row Groups
+# Skipped" profiling metrics, visible in EXPLAIN ANALYZE.
+# (single threaded so the reported per-operator counts are deterministic)
 #-------------------------------------------------------------------------------
 
 statement ok
 set threads=1;
 
-statement ok
-CALL enable_logging('PhysicalOperator');
-
-statement ok
-select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
-
-statement ok
-CALL disable_logging();
-
-# exactly one row group is read (row group 2) ...
-query I
-select count(*) from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup';
+# filtering on a single row group reads only that one (1) and skips the other 4
+query II
+EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
 ----
-1
+analyzed_plan	<REGEX>:.*Row Groups Read: 1.*Row Groups Skipped: 4.*
 
-# ... and it is the correct one
-query I
-select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup';
+# reading multiple non-contiguous row groups (IN (1, 3)) reads ONLY those two row
+# groups and skips the other three
+query II
+EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
 ----
-2
+analyzed_plan	<REGEX>:.*Row Groups Read: 2.*Row Groups Skipped: 3.*
 
-# the other 4 row groups are skipped without being read
-query I
-select count(*) from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'SkipRowGroup';
+# without a row-group filter, all row groups are read and none are skipped
+# (sum forces reading the column data - count(*) would be answered from metadata)
+query II
+EXPLAIN ANALYZE select sum(j) from '{TEST_DIR}/rg.parquet';
 ----
-4
-
-# reading multiple non-contiguous row groups (IN (1, 3)) reads ONLY those row groups
-# and does not touch the data of any other row group
-statement ok
-CALL truncate_duckdb_logs();
-
-statement ok
-CALL enable_logging('PhysicalOperator');
-
-statement ok
-select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
-
-statement ok
-CALL disable_logging();
-
-# exactly row groups 1 and 3 are read ...
-query I
-select string_agg(row_group_id, ',' order by row_group_id) from (select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup');
-----
-1,3
-
-# ... and row groups 0, 2 and 4 are skipped without being read
-query I
-select string_agg(row_group_id, ',' order by row_group_id) from (select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'SkipRowGroup');
-----
-0,2,4
+analyzed_plan	<REGEX>:.*Row Groups Read: 5.*Row Groups Skipped: 0.*
 
 #-------------------------------------------------------------------------------
 # the row group number is file-relative: each file restarts the numbering at 0

--- a/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+++ b/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
@@ -1,0 +1,196 @@
+# name: test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+# description: Test file_row_group_number virtual column
+# group: [parquet]
+
+require parquet
+
+# write a parquet file with 5 row groups (2048 rows each, except the last)
+statement ok
+copy (select i, i * 2 as j from range(10000) t(i)) to '{TEST_DIR}/rg.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+# sanity check: 5 row groups
+query I
+select count(distinct row_group_id) from parquet_metadata('{TEST_DIR}/rg.parquet');
+----
+5
+
+# the file_row_group_number is the file-relative row group index, starting at 0
+query IIII
+select file_row_group_number, count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' group by file_row_group_number order by file_row_group_number;
+----
+0	2048	0	2047
+1	2048	2048	4095
+2	2048	4096	6143
+3	2048	6144	8191
+4	1808	8192	9999
+
+# row group number is virtual - no values are NULL
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number is null;
+----
+0
+
+# filtering by a specific row group returns only the rows in that row group
+query III
+select count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+----
+2048	4096	6143
+
+# filtering with a range works too
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number >= 1 and file_row_group_number <= 3;
+----
+6144
+
+# reading multiple non-contiguous row groups via IN
+query III
+select count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+----
+4096	2048	8191
+
+# the result only contains data from row groups 1 and 3
+query I
+select distinct file_row_group_number from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3) order by file_row_group_number;
+----
+1
+3
+
+# no data from any other row group leaks in (row group 2 covers i in [4096, 6143])
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3) and i between 4096 and 6143;
+----
+0
+
+# a row group that does not exist returns no rows
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 100;
+----
+0
+
+# filtering on a non-existing row group is pruned to a dummy scan at plan time
+# (the column statistics bound the row group number to [0, num_row_groups - 1])
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query II nosort empty_result
+explain select i from '{TEST_DIR}/rg.parquet' where file_row_group_number = 100;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query II nosort empty_result
+explain select i from '{TEST_DIR}/rg.parquet' where file_row_group_number >= 5;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+query II nosort empty_result
+explain select i from '{TEST_DIR}/rg.parquet' where file_row_group_number < 0;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# an existing row group is NOT pruned - it still scans the parquet file
+query II nosort parquet_scan
+explain select i from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+----
+logical_opt	<REGEX>:.*PARQUET_SCAN.*
+
+# combined projection with regular columns
+query III
+select i, j, file_row_group_number from '{TEST_DIR}/rg.parquet' where i in (0, 2048, 9999) order by i;
+----
+0	0	0
+2048	4096	1
+9999	19998	4
+
+#-------------------------------------------------------------------------------
+# verify that filtering by file_row_group_number short-circuits reads:
+# only the matching row group is actually read from storage, the rest are skipped
+#-------------------------------------------------------------------------------
+
+statement ok
+set threads=1;
+
+statement ok
+CALL enable_logging('PhysicalOperator');
+
+statement ok
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+
+statement ok
+CALL disable_logging();
+
+# exactly one row group is read (row group 2) ...
+query I
+select count(*) from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup';
+----
+1
+
+# ... and it is the correct one
+query I
+select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup';
+----
+2
+
+# the other 4 row groups are skipped without being read
+query I
+select count(*) from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'SkipRowGroup';
+----
+4
+
+# reading multiple non-contiguous row groups (IN (1, 3)) reads ONLY those row groups
+# and does not touch the data of any other row group
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+CALL enable_logging('PhysicalOperator');
+
+statement ok
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+
+statement ok
+CALL disable_logging();
+
+# exactly row groups 1 and 3 are read ...
+query I
+select string_agg(row_group_id, ',' order by row_group_id) from (select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'ReadRowGroup');
+----
+1,3
+
+# ... and row groups 0, 2 and 4 are skipped without being read
+query I
+select string_agg(row_group_id, ',' order by row_group_id) from (select distinct info.row_group_id from duckdb_logs_parsed('PhysicalOperator') where class = 'ParquetReader' and event = 'SkipRowGroup');
+----
+0,2,4
+
+#-------------------------------------------------------------------------------
+# the row group number is file-relative: each file restarts the numbering at 0
+#-------------------------------------------------------------------------------
+
+statement ok
+copy (select i from range(5000) t(i)) to '{TEST_DIR}/rg_a.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+statement ok
+copy (select i from range(3000) t(i)) to '{TEST_DIR}/rg_b.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+query II
+select file_row_group_number, count(*) from read_parquet(['{TEST_DIR}/rg_a.parquet', '{TEST_DIR}/rg_b.parquet']) group by file_row_group_number order by file_row_group_number;
+----
+0	4096
+1	3000
+2	904
+
+# multi-file safety: rg_a has 3 row groups, rg_b has 2. Row group 2 exists only in rg_a.
+# the optimizer must NOT prune this to an empty scan (per-file row group counts differ), and the
+# filter must still return the correct rows
+query I
+select count(*) from read_parquet(['{TEST_DIR}/rg_a.parquet', '{TEST_DIR}/rg_b.parquet']) where file_row_group_number = 2;
+----
+904
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query II nosort parquet_scan_multi
+explain select i from read_parquet(['{TEST_DIR}/rg_a.parquet', '{TEST_DIR}/rg_b.parquet']) where file_row_group_number = 2;
+----
+logical_opt	<REGEX>:.*PARQUET_SCAN.*


### PR DESCRIPTION
This adds a virtual column `file_row_group_number` to the parquet reader that allows (somewhat) efficient reading of individual row groups from parquet files, e.g.
```SQL
FROM 'my_file.parquet' WHERE file_row_group_number=42;
```
or 
```SQL
FROM 'my_file.parquet' WHERE file_row_group_number IN (42, 43);
```