### PR TITLE
Parquet Reader with Async I/O

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -197,7 +197,7 @@ public:
 	int64_t current_group;
 	idx_t offset_in_group;
 	idx_t group_offset;
-	unique_ptr<CachingFileHandle> file_handle;
+	shared_ptr<CachingFileHandle> file_handle;
 	vector<unique_ptr<ColumnReader>> column_readers;
 	duckdb_base_std::unique_ptr<duckdb_apache::thrift::protocol::TProtocol> thrift_file_proto;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -394,6 +394,12 @@ private:
 	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
 	SourceResultType Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	//! Run the filters
+	idx_t EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, vector<bool> &need_to_read,
+	                      idx_t scan_count, uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch);
+	//! Read the remaining (non-filter) columns into result.
+	void DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, const vector<bool> &need_to_read,
+	                            idx_t filter_count, uint8_t *define_ptr, uint8_t *repeat_ptr);
 	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
 	                                      idx_t schema_index, idx_t column_index,
 	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -394,12 +394,12 @@ private:
 	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
 	SourceResultType Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
-	//! Run the filters
-	idx_t EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, vector<bool> &need_to_read,
-	                      idx_t scan_count, uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch);
+	//! Run the filters into state.sel; returns the surviving row count. Advances every filter column.
+	idx_t EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count, uint8_t *define_ptr,
+	                      uint8_t *repeat_ptr, bool log_prefetch);
 	//! Read the remaining (non-filter) columns into result.
-	void DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, const vector<bool> &need_to_read,
-	                            idx_t filter_count, uint8_t *define_ptr, uint8_t *repeat_ptr);
+	void DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, idx_t filter_count,
+	                            uint8_t *define_ptr, uint8_t *repeat_ptr);
 	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
 	                                      idx_t schema_index, idx_t column_index,
 	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -209,6 +209,8 @@ public:
 
 	bool prefetch_mode = false;
 	bool current_group_prefetched = false;
+	//! Number of filter head counts, used for prefetching
+	idx_t filter_head_count = 0;
 
 	ParquetPrefetchMetrics prefetch_metrics;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -211,6 +211,12 @@ public:
 	bool current_group_prefetched = false;
 	//! Number of filter head counts, used for prefetching
 	idx_t filter_head_count = 0;
+	//! true once the filters ran
+	bool filter_done = false;
+	//! Surviving row count
+	idx_t filter_count = 0;
+	//! Filter columns kept across the payload BLOCKED
+	DataChunk filter_stash;
 
 	ParquetPrefetchMetrics prefetch_metrics;
 
@@ -393,10 +399,16 @@ private:
 	//! Switch to the next row group and schedule its I/O (prepare column buffers, prefetch the bytes).
 	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
-	SourceResultType Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	AsyncResult Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	//! Process filters
+	AsyncResult ProcessFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count, uint8_t *define_ptr,
+	                           uint8_t *repeat_ptr, bool log_prefetch);
 	//! Run the filters into state.sel; returns the surviving row count. Advances every filter column.
 	idx_t EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count, uint8_t *define_ptr,
 	                      uint8_t *repeat_ptr, bool log_prefetch);
+	//! Async-fetch the surviving payload columns (stashing the filter columns); empty if no fetch is needed.
+	vector<unique_ptr<AsyncTask>> ScheduleRemainingColumns(ParquetReaderScanState &state, DataChunk &result,
+	                                                       idx_t scan_count);
 	//! Read the remaining (non-filter) columns into result.
 	void DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, idx_t filter_count,
 	                            uint8_t *define_ptr, uint8_t *repeat_ptr);

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <list>
 #include "thrift/protocol/TCompactProtocol.h"
 #include "thrift/transport/TBufferTransports.h"
 
@@ -90,8 +89,8 @@ struct ReadAheadBuffer {
 	    : merge_set(ReadHeadComparator(accepted_column_gap)), file_handle(file_handle_p) {
 	}
 
-	// The list of read heads
-	std::list<ReadHead> read_heads;
+	// The list of read heads.
+	vector<shared_ptr<ReadHead>> read_heads;
 	// Set for merging consecutive ranges
 	std::set<ReadHead *, ReadHeadComparator> merge_set;
 
@@ -120,9 +119,9 @@ struct ReadAheadBuffer {
 			}
 		}
 
-		read_heads.emplace_front(ReadHead(pos, len));
+		read_heads.insert(read_heads.begin(), make_shared_ptr<ReadHead>(pos, len));
 		total_size += len;
-		auto &read_head = read_heads.front();
+		auto &read_head = *read_heads.front();
 
 		if (merge_buffers) {
 			merge_set.insert(&read_head);
@@ -139,8 +138,8 @@ struct ReadAheadBuffer {
 	// Returns the relevant read head
 	ReadHead *GetReadHead(idx_t pos) {
 		for (auto &read_head : read_heads) {
-			if (pos >= read_head.location && pos < read_head.GetEnd()) {
-				return &read_head;
+			if (pos >= read_head->location && pos < read_head->GetEnd()) {
+				return read_head.get();
 			}
 		}
 		return nullptr;
@@ -149,7 +148,7 @@ struct ReadAheadBuffer {
 	// Prefetch all read heads
 	void Prefetch() {
 		for (auto &read_head : read_heads) {
-			read_head.Fetch(file_handle);
+			read_head->Fetch(file_handle);
 		}
 	}
 };
@@ -243,7 +242,7 @@ public:
 		return ra_buffer.GetReadHead(pos);
 	}
 
-	std::list<ReadHead> &GetReadHeads() {
+	vector<shared_ptr<ReadHead>> &GetReadHeads() {
 		return ra_buffer.read_heads;
 	}
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1904,7 +1904,8 @@ void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataCh
 }
 
 // When doing ParquetPrefetchStrategy::PREFETCH_FILTERS, we gotta block mid processing to get the other columns.
-// on the re-entry the chunk is reset in the multifilescan which borkes our datachunk, hence we need to copy for ownership.
+// on the re-entry the chunk is reset in the multifilescan which borkes our datachunk, hence we need to copy for
+// ownership.
 // FIXME: maybe we can change this to be able to move? or not have the multifile reset? bigger refactor though.
 static void CopyFilterColumns(const vector<ParquetScanFilter> &scan_filters, DataChunk &src, DataChunk &dst,
                               idx_t count) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1738,6 +1738,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		           {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
 	}
 
+	vector<unique_ptr<AsyncTask>> io_tasks;
 	if (state.prefetch_mode && state.offset_in_group != (idx_t)group.num_rows) {
 		uint64_t total_row_group_span = GetGroupSpan(state);
 
@@ -1774,16 +1775,16 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 			}
 		}
 		if (strategy != ParquetPrefetchStrategy::PREFETCH_FILTERS) {
-			// If it's not filers, we fetch the whole shebang
-			for (auto &io_task : CollectIOTasks(trans)) {
-				io_task->Execute();
-			}
+			io_tasks = CollectIOTasks(trans);
 		}
 		if (log_prefetch) {
 			state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();
 		}
 	}
 	result.Reset();
+	if (!io_tasks.empty()) {
+		return AsyncResult(std::move(io_tasks));
+	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1564,34 +1564,29 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 // An I/O task that fetches the bytes of a ReadHead.
 class ParquetIOAsyncTask : public AsyncTask {
 public:
-	ParquetIOAsyncTask(ReadHead &read_head, shared_ptr<CachingFileHandle> file_handle,
-	                   std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport)
-	    : read_head(read_head), file_handle(std::move(file_handle)), transport(std::move(transport)) {
+	ParquetIOAsyncTask(shared_ptr<ReadHead> read_head, shared_ptr<CachingFileHandle> file_handle)
+	    : read_head(std::move(read_head)), file_handle(std::move(file_handle)) {
 	}
 
 	void Execute() override {
-		read_head.Fetch(*file_handle);
+		read_head->Fetch(*file_handle);
 	}
 
 private:
-	ReadHead &read_head;
+	shared_ptr<ReadHead> read_head;
 	shared_ptr<CachingFileHandle> file_handle;
-	std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport;
 };
 
 // Async I/O tasks for the read heads in the index range [from, to), skipping any that are already fetched.
 static vector<unique_ptr<AsyncTask>>
-CollectIOTasks(std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport,
-               const shared_ptr<CachingFileHandle> &file_handle, idx_t from, idx_t to) {
-	auto &trans = reinterpret_cast<ThriftFileTransport &>(*transport);
+CollectIOTasks(ThriftFileTransport &trans, const shared_ptr<CachingFileHandle> &file_handle, idx_t from, idx_t to) {
 	auto &read_heads = trans.GetReadHeads();
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	idx_t i = 0;
-	for (auto &read_head : read_heads) {
-		if (i >= from && i < to && !read_head.data_isset) {
-			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle, transport));
+	for (idx_t i = from; i < to; i++) {
+		auto &read_head = read_heads[i];
+		if (!read_head->data_isset) {
+			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle));
 		}
-		i++;
 	}
 	return io_tasks;
 }
@@ -1791,13 +1786,13 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		switch (strategy) {
 		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
 			// schedule only the filter columns' I/O, they are last in our list
-			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
-			                          read_head_count - state.filter_head_count, read_head_count);
+			io_tasks =
+			    CollectIOTasks(trans, state.file_handle, read_head_count - state.filter_head_count, read_head_count);
 			break;
 		case ParquetPrefetchStrategy::WHOLE_GROUP:
 		case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
 			// schedule the I/O for all columns up front
-			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, read_head_count);
+			io_tasks = CollectIOTasks(trans, state.file_handle, 0, read_head_count);
 			break;
 		default:
 			throw InternalException("Unexpected parquet prefetch strategy when scheduling I/O");
@@ -1923,7 +1918,7 @@ vector<unique_ptr<AsyncTask>> ParquetReader::ScheduleRemainingColumns(ParquetRea
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	auto payload_head_count = trans.GetReadHeads().size() - state.filter_head_count;
 	// payload columns are the leading read heads
-	auto io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
+	auto io_tasks = CollectIOTasks(trans, state.file_handle, 0, payload_head_count);
 	if (io_tasks.empty()) {
 		// no payload to do
 		return {};

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1578,21 +1578,19 @@ private:
 	std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport;
 };
 
+// Async I/O tasks for the read heads in the index range [from, to), skipping any that are already fetched.
 static vector<unique_ptr<AsyncTask>>
 CollectIOTasks(std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport,
-               const shared_ptr<CachingFileHandle> &file_handle, idx_t tail_count = 0) {
+               const shared_ptr<CachingFileHandle> &file_handle, idx_t from, idx_t to) {
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*transport);
 	auto &read_heads = trans.GetReadHeads();
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	if (tail_count == 0) {
-		for (auto &read_head : read_heads) {
+	idx_t i = 0;
+	for (auto &read_head : read_heads) {
+		if (i >= from && i < to && !read_head.data_isset) {
 			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle, transport));
 		}
-	} else {
-		auto it = read_heads.rbegin();
-		for (idx_t n = 0; n < tail_count && it != read_heads.rend(); ++n, ++it) {
-			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(*it, file_handle, transport));
-		}
+		i++;
 	}
 	return io_tasks;
 }
@@ -1790,16 +1788,17 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 				strategy = ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 			}
 		}
+		auto read_head_count = trans.GetReadHeads().size();
 		switch (strategy) {
 		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
-			// schedule only the filter columns' I/O (the trailing filter read heads).
-			io_tasks =
-			    CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, state.filter_head_count);
+			// schedule only the filter columns' I/O, they are last so we do from read_head_count - state.filter_head_count
+			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
+			                          read_head_count - state.filter_head_count, read_head_count);
 			break;
 		case ParquetPrefetchStrategy::WHOLE_GROUP:
 		case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
 			// schedule the I/O for all columns up front
-			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle);
+			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, read_head_count);
 			break;
 		default:
 			throw InternalException("Unexpected parquet prefetch strategy when scheduling I/O");
@@ -1876,6 +1875,17 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result,
                                            const vector<bool> &need_to_read, idx_t filter_count, uint8_t *define_ptr,
                                            uint8_t *repeat_ptr) {
+	// On the lazy PREFETCH_FILTERS path the surviving payload columns are not yet fetched
+	if (filter_count > 0 && state.filter_head_count > 0) {
+		auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
+		auto payload_head_count = trans.GetReadHeads().size() - state.filter_head_count;
+		// payload columns are registered early, so we do from 0 to head
+		auto io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
+		for (auto &task : io_tasks) {
+			task->Execute();
+		}
+	}
+
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		MultiFileLocalIndex col_idx(i);
 		if (!need_to_read[col_idx]) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1793,8 +1793,8 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		switch (strategy) {
 		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
 			// schedule only the filter columns' I/O (the trailing filter read heads).
-			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
-			                          state.filter_head_count);
+			io_tasks =
+			    CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, state.filter_head_count);
 			break;
 		case ParquetPrefetchStrategy::WHOLE_GROUP:
 		case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
@@ -1813,6 +1813,87 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		return AsyncResult(std::move(io_tasks), TaskSchedulerType::ASYNC);
 	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
+}
+
+idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, vector<bool> &need_to_read,
+                                     idx_t scan_count, uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch) {
+	idx_t filter_count = result.size();
+	D_ASSERT(filter_count == scan_count);
+
+	state.sel.Initialize(nullptr);
+	D_ASSERT(!filters || state.scan_filters.size() == filters->FilterCount());
+
+	bool is_first_filter = true;
+	if (deletion_filter) {
+		auto row_start = UnsafeNumericCast<row_t>(state.offset_in_group + state.group_offset);
+		filter_count = deletion_filter->Filter(row_start, scan_count, state.sel);
+		//! FIXME: does this need to be set?
+		//! As part of 'DirectFilter' we also initialize reads of the child readers
+		is_first_filter = false;
+	}
+	if (!filters) {
+		return filter_count;
+	}
+
+	// first load the columns that are used in filters
+	auto &adaptive_filter = state.adaptive_filter_cache.GetAdaptiveFilter();
+	auto filter_state = adaptive_filter.BeginFilter();
+	const auto &permutation = adaptive_filter.GetPermutation();
+	for (idx_t i = 0; i < state.scan_filters.size(); i++) {
+		if (filter_count == 0) {
+			// if no rows are left we can stop checking filters
+			break;
+		}
+		auto &scan_filter = state.scan_filters[permutation[i]];
+		MultiFileLocalIndex local_idx(scan_filter.filter_idx);
+
+		auto &result_vector = result.data[local_idx.GetIndex()];
+		auto &child_reader = state.GetColumnReader(local_idx);
+		ColumnReaderInput reader_input(scan_count, define_ptr, repeat_ptr);
+		child_reader.Filter(reader_input, result_vector, scan_filter.filter, *scan_filter.filter_state, state.sel,
+		                    filter_count, is_first_filter);
+		if (log_prefetch) {
+			auto &filters_used = state.prefetch_metrics.logger.filters_used;
+			if (filters_used.size() != state.scan_filters.size()) {
+				filters_used.assign(state.scan_filters.size(), false);
+			}
+			filters_used[permutation[i]] = true;
+		}
+		need_to_read[local_idx.GetIndex()] = false;
+		is_first_filter = false;
+		if (filter_count == 0) {
+			state.filter_eliminated_all_rows[permutation[i]] = true;
+		}
+	}
+	adaptive_filter.EndFilter(filter_state);
+	state.prefetch_metrics.filter_ran = true;
+	if (filter_count > 0) {
+		state.prefetch_metrics.had_match = true;
+	}
+	return filter_count;
+}
+
+void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result,
+                                           const vector<bool> &need_to_read, idx_t filter_count, uint8_t *define_ptr,
+                                           uint8_t *repeat_ptr) {
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		MultiFileLocalIndex col_idx(i);
+		if (!need_to_read[col_idx]) {
+			continue;
+		}
+		if (filter_count == 0) {
+			state.GetColumnReader(col_idx).Skip(result.size());
+			continue;
+		}
+		auto &result_vector = result.data[i];
+		auto &child_reader = state.GetColumnReader(col_idx);
+		if (metadata->crypto_metadata->encryption_algorithm.__isset.AES_GCM_V1) {
+			child_reader.InitializeCryptoMetadata(metadata->crypto_metadata->encryption_algorithm,
+			                                      GetGroup(state).ordinal);
+		}
+		ColumnReaderInput reader_input(result.size(), define_ptr, repeat_ptr);
+		child_reader.Select(reader_input, result_vector, state.sel, filter_count);
+	}
 }
 
 SourceResultType ParquetReader::Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch) {
@@ -1834,79 +1915,11 @@ SourceResultType ParquetReader::Process(ParquetReaderScanState &state, DataChunk
 	auto repeat_ptr = (uint8_t *)state.repeat_buf.ptr;
 
 	if (filters || deletion_filter) {
-		idx_t filter_count = result.size();
-		D_ASSERT(filter_count == scan_count);
 		vector<bool> need_to_read(column_ids.size(), true);
-
-		state.sel.Initialize(nullptr);
-		D_ASSERT(!filters || state.scan_filters.size() == filters->FilterCount());
-
-		bool is_first_filter = true;
-		if (deletion_filter) {
-			auto row_start = UnsafeNumericCast<row_t>(state.offset_in_group + state.group_offset);
-			filter_count = deletion_filter->Filter(row_start, scan_count, state.sel);
-			//! FIXME: does this need to be set?
-			//! As part of 'DirectFilter' we also initialize reads of the child readers
-			is_first_filter = false;
-		}
-
-		if (filters) {
-			// first load the columns that are used in filters
-			auto &adaptive_filter = state.adaptive_filter_cache.GetAdaptiveFilter();
-			auto filter_state = adaptive_filter.BeginFilter();
-			const auto &permutation = adaptive_filter.GetPermutation();
-			for (idx_t i = 0; i < state.scan_filters.size(); i++) {
-				if (filter_count == 0) {
-					// if no rows are left we can stop checking filters
-					break;
-				}
-				auto &scan_filter = state.scan_filters[permutation[i]];
-				MultiFileLocalIndex local_idx(scan_filter.filter_idx);
-
-				auto &result_vector = result.data[local_idx.GetIndex()];
-				auto &child_reader = state.GetColumnReader(local_idx);
-				ColumnReaderInput reader_input(scan_count, define_ptr, repeat_ptr);
-				child_reader.Filter(reader_input, result_vector, scan_filter.filter, *scan_filter.filter_state,
-				                    state.sel, filter_count, is_first_filter);
-				if (log_prefetch) {
-					auto &filters_used = state.prefetch_metrics.logger.filters_used;
-					if (filters_used.size() != state.scan_filters.size()) {
-						filters_used.assign(state.scan_filters.size(), false);
-					}
-					filters_used[permutation[i]] = true;
-				}
-				need_to_read[local_idx.GetIndex()] = false;
-				is_first_filter = false;
-				if (filter_count == 0) {
-					state.filter_eliminated_all_rows[permutation[i]] = true;
-				}
-			}
-			adaptive_filter.EndFilter(filter_state);
-			state.prefetch_metrics.filter_ran = true;
-			if (filter_count > 0) {
-				state.prefetch_metrics.had_match = true;
-			}
-		}
-
+		idx_t filter_count =
+		    EvaluateFilters(state, result, need_to_read, scan_count, define_ptr, repeat_ptr, log_prefetch);
 		// we still may have to read some cols
-		for (idx_t i = 0; i < column_ids.size(); i++) {
-			MultiFileLocalIndex col_idx(i);
-			if (!need_to_read[col_idx]) {
-				continue;
-			}
-			if (filter_count == 0) {
-				state.GetColumnReader(col_idx).Skip(result.size());
-				continue;
-			}
-			auto &result_vector = result.data[i];
-			auto &child_reader = state.GetColumnReader(col_idx);
-			if (metadata->crypto_metadata->encryption_algorithm.__isset.AES_GCM_V1) {
-				child_reader.InitializeCryptoMetadata(metadata->crypto_metadata->encryption_algorithm,
-				                                      GetGroup(state).ordinal);
-			}
-			ColumnReaderInput reader_input(result.size(), define_ptr, repeat_ptr);
-			child_reader.Select(reader_input, result_vector, state.sel, filter_count);
-		}
+		DecodeRemainingColumns(state, result, need_to_read, filter_count, define_ptr, repeat_ptr);
 		if (scan_count != filter_count) {
 			result.Slice(state.sel, filter_count);
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1787,7 +1787,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	}
 	result.Reset();
 	if (!io_tasks.empty()) {
-		return AsyncResult(std::move(io_tasks));
+		return AsyncResult(std::move(io_tasks), TaskSchedulerType::ASYNC);
 	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1656,9 +1656,7 @@ ParquetPrefetchStrategy ParquetReader::ColumnWisePrefetch(ParquetReaderScanState
 			}
 			already_registered[local_idx.GetIndex()] = true;
 		}
-		// Done with the filter columns, time to merge the non-filter columns. At this point the read-head list holds
-		// exactly the (coalesced) filter-column read heads; record how many so the lazy path can async-fetch only
-		// those.
+		// Done with the filter columns, time to merge the non-filter columns.
 		trans.FinalizeRegistration();
 		state.filter_head_count = trans.GetReadHeads().size();
 		if (log_prefetch) {
@@ -1792,8 +1790,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		auto read_head_count = trans.GetReadHeads().size();
 		switch (strategy) {
 		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
-			// schedule only the filter columns' I/O, they are last so we do from read_head_count -
-			// state.filter_head_count
+			// schedule only the filter columns' I/O, they are last in our list
 			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
 			                          read_head_count - state.filter_head_count, read_head_count);
 			break;
@@ -1873,7 +1870,7 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 	return filter_count;
 }
 
-// Whether column position `i` is used by a filter (already decoded by EvaluateFilters).
+// Whether column position `i` is used by a filter.
 static bool IsFilterColumn(const vector<ParquetScanFilter> &scan_filters, idx_t column_index) {
 	for (auto &scan_filter : scan_filters) {
 		if (MultiFileLocalIndex(scan_filter.filter_idx).GetIndex() == column_index) {
@@ -1906,7 +1903,9 @@ void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataCh
 	}
 }
 
-// FIXME: We now do this copy due to the Process reenter, maybe there is a better way
+// When doing ParquetPrefetchStrategy::PREFETCH_FILTERS, we gotta block mid processing to get the other columns.
+// on the re-entry the chunk is reset in the multifilescan which borkes our datachunk, hence we need to copy for ownership.
+// FIXME: maybe we can change this to be able to move? or not have the multifile reset? bigger refactor though.
 static void CopyFilterColumns(const vector<ParquetScanFilter> &scan_filters, DataChunk &src, DataChunk &dst,
                               idx_t count) {
 	for (auto &scan_filter : scan_filters) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1791,7 +1791,8 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		auto read_head_count = trans.GetReadHeads().size();
 		switch (strategy) {
 		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
-			// schedule only the filter columns' I/O, they are last so we do from read_head_count - state.filter_head_count
+			// schedule only the filter columns' I/O, they are last so we do from read_head_count -
+			// state.filter_head_count
 			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
 			                          read_head_count - state.filter_head_count, read_head_count);
 			break;
@@ -1814,8 +1815,8 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, vector<bool> &need_to_read,
-                                     idx_t scan_count, uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch) {
+idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count,
+                                     uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch) {
 	idx_t filter_count = result.size();
 	D_ASSERT(filter_count == scan_count);
 
@@ -1839,15 +1840,15 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 	auto filter_state = adaptive_filter.BeginFilter();
 	const auto &permutation = adaptive_filter.GetPermutation();
 	for (idx_t i = 0; i < state.scan_filters.size(); i++) {
-		if (filter_count == 0) {
-			// if no rows are left we can stop checking filters
-			break;
-		}
 		auto &scan_filter = state.scan_filters[permutation[i]];
 		MultiFileLocalIndex local_idx(scan_filter.filter_idx);
+		auto &child_reader = state.GetColumnReader(local_idx);
+		if (filter_count == 0) {
+			child_reader.Skip(scan_count);
+			continue;
+		}
 
 		auto &result_vector = result.data[local_idx.GetIndex()];
-		auto &child_reader = state.GetColumnReader(local_idx);
 		ColumnReaderInput reader_input(scan_count, define_ptr, repeat_ptr);
 		child_reader.Filter(reader_input, result_vector, scan_filter.filter, *scan_filter.filter_state, state.sel,
 		                    filter_count, is_first_filter);
@@ -1858,7 +1859,6 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 			}
 			filters_used[permutation[i]] = true;
 		}
-		need_to_read[local_idx.GetIndex()] = false;
 		is_first_filter = false;
 		if (filter_count == 0) {
 			state.filter_eliminated_all_rows[permutation[i]] = true;
@@ -1872,15 +1872,25 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 	return filter_count;
 }
 
-void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result,
-                                           const vector<bool> &need_to_read, idx_t filter_count, uint8_t *define_ptr,
-                                           uint8_t *repeat_ptr) {
+// Whether column position `i` is used by a filter (already decoded by EvaluateFilters).
+static bool IsFilterColumn(const vector<ParquetScanFilter> &scan_filters, idx_t column_index) {
+	for (auto &scan_filter : scan_filters) {
+		if (MultiFileLocalIndex(scan_filter.filter_idx).GetIndex() == column_index) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, idx_t filter_count,
+                                           uint8_t *define_ptr, uint8_t *repeat_ptr) {
 	// On the lazy PREFETCH_FILTERS path the surviving payload columns are not yet fetched
 	if (filter_count > 0 && state.filter_head_count > 0) {
 		auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 		auto payload_head_count = trans.GetReadHeads().size() - state.filter_head_count;
 		// payload columns are registered early, so we do from 0 to head
-		auto io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
+		auto io_tasks =
+		    CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
 		for (auto &task : io_tasks) {
 			task->Execute();
 		}
@@ -1888,7 +1898,8 @@ void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataCh
 
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		MultiFileLocalIndex col_idx(i);
-		if (!need_to_read[col_idx]) {
+		if (IsFilterColumn(state.scan_filters, i)) {
+			// already decoded (or skipped) by EvaluateFilters
 			continue;
 		}
 		if (filter_count == 0) {
@@ -1925,11 +1936,9 @@ SourceResultType ParquetReader::Process(ParquetReaderScanState &state, DataChunk
 	auto repeat_ptr = (uint8_t *)state.repeat_buf.ptr;
 
 	if (filters || deletion_filter) {
-		vector<bool> need_to_read(column_ids.size(), true);
-		idx_t filter_count =
-		    EvaluateFilters(state, result, need_to_read, scan_count, define_ptr, repeat_ptr, log_prefetch);
+		idx_t filter_count = EvaluateFilters(state, result, scan_count, define_ptr, repeat_ptr, log_prefetch);
 		// we still may have to read some cols
-		DecodeRemainingColumns(state, result, need_to_read, filter_count, define_ptr, repeat_ptr);
+		DecodeRemainingColumns(state, result, filter_count, define_ptr, repeat_ptr);
 		if (scan_count != filter_count) {
 			result.Slice(state.sel, filter_count);
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1563,24 +1563,28 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 // An I/O task that fetches the bytes of a ReadHead.
 class ParquetIOAsyncTask : public AsyncTask {
 public:
-	ParquetIOAsyncTask(ReadHead &read_head, CachingFileHandle &file_handle)
-	    : read_head(read_head), file_handle(file_handle) {
+	ParquetIOAsyncTask(ReadHead &read_head, shared_ptr<CachingFileHandle> file_handle,
+	                   std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport)
+	    : read_head(read_head), file_handle(std::move(file_handle)), transport(std::move(transport)) {
 	}
 
 	void Execute() override {
-		read_head.Fetch(file_handle);
+		read_head.Fetch(*file_handle);
 	}
 
 private:
 	ReadHead &read_head;
-	CachingFileHandle &file_handle;
+	shared_ptr<CachingFileHandle> file_handle;
+	std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport;
 };
 
-static vector<unique_ptr<AsyncTask>> CollectIOTasks(ThriftFileTransport &trans) {
+static vector<unique_ptr<AsyncTask>>
+CollectIOTasks(std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport,
+               const shared_ptr<CachingFileHandle> &file_handle) {
+	auto &trans = reinterpret_cast<ThriftFileTransport &>(*transport);
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	auto &file_handle = trans.GetCachingFileHandle();
 	for (auto &read_head : trans.GetReadHeads()) {
-		io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle));
+		io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle, transport));
 	}
 	return io_tasks;
 }
@@ -1775,7 +1779,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 			}
 		}
 		if (strategy != ParquetPrefetchStrategy::PREFETCH_FILTERS) {
-			io_tasks = CollectIOTasks(trans);
+			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle);
 		}
 		if (log_prefetch) {
 			state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1580,11 +1580,19 @@ private:
 
 static vector<unique_ptr<AsyncTask>>
 CollectIOTasks(std::shared_ptr<duckdb_apache::thrift::transport::TTransport> transport,
-               const shared_ptr<CachingFileHandle> &file_handle) {
+               const shared_ptr<CachingFileHandle> &file_handle, idx_t tail_count = 0) {
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*transport);
+	auto &read_heads = trans.GetReadHeads();
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	for (auto &read_head : trans.GetReadHeads()) {
-		io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle, transport));
+	if (tail_count == 0) {
+		for (auto &read_head : read_heads) {
+			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(read_head, file_handle, transport));
+		}
+	} else {
+		auto it = read_heads.rbegin();
+		for (idx_t n = 0; n < tail_count && it != read_heads.rend(); ++n, ++it) {
+			io_tasks.push_back(make_uniq<ParquetIOAsyncTask>(*it, file_handle, transport));
+		}
 	}
 	return io_tasks;
 }
@@ -1649,8 +1657,11 @@ ParquetPrefetchStrategy ParquetReader::ColumnWisePrefetch(ParquetReaderScanState
 			}
 			already_registered[local_idx.GetIndex()] = true;
 		}
-		// Done with the filter columns, time to merge the non-filter columns
+		// Done with the filter columns, time to merge the non-filter columns. At this point the read-head list holds
+		// exactly the (coalesced) filter-column read heads; record how many so the lazy path can async-fetch only
+		// those.
 		trans.FinalizeRegistration();
+		state.filter_head_count = trans.GetReadHeads().size();
 		if (log_prefetch) {
 			state.prefetch_metrics.logger.GeneratePrefetchGroup(trans, pending_registrations, group.columns);
 		}
@@ -1704,6 +1715,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	trans.ClearPrefetch();
 	state.current_group_prefetched = false;
+	state.filter_head_count = 0;
 
 	if (state.prefetch_mode && !state.file_handle->OnDiskFile()) {
 		NetworkThroughputEstimate estimate;
@@ -1778,8 +1790,19 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 				strategy = ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 			}
 		}
-		if (strategy != ParquetPrefetchStrategy::PREFETCH_FILTERS) {
+		switch (strategy) {
+		case ParquetPrefetchStrategy::PREFETCH_FILTERS:
+			// schedule only the filter columns' I/O (the trailing filter read heads).
+			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle,
+			                          state.filter_head_count);
+			break;
+		case ParquetPrefetchStrategy::WHOLE_GROUP:
+		case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
+			// schedule the I/O for all columns up front
 			io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle);
+			break;
+		default:
+			throw InternalException("Unexpected parquet prefetch strategy when scheduling I/O");
 		}
 		if (log_prefetch) {
 			state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1432,6 +1432,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 		auto flags = FileFlags::FILE_FLAGS_READ;
 		if (ShouldAndCanPrefetch(context, *file_handle)) {
 			state.prefetch_mode = true;
+			flags |= FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 			if (file_handle->IsRemoteFile()) {
 				flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
 			}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "duckdb/planner/table_filter_state.hpp"
@@ -1884,18 +1885,6 @@ static bool IsFilterColumn(const vector<ParquetScanFilter> &scan_filters, idx_t 
 
 void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataChunk &result, idx_t filter_count,
                                            uint8_t *define_ptr, uint8_t *repeat_ptr) {
-	// On the lazy PREFETCH_FILTERS path the surviving payload columns are not yet fetched
-	if (filter_count > 0 && state.filter_head_count > 0) {
-		auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
-		auto payload_head_count = trans.GetReadHeads().size() - state.filter_head_count;
-		// payload columns are registered early, so we do from 0 to head
-		auto io_tasks =
-		    CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
-		for (auto &task : io_tasks) {
-			task->Execute();
-		}
-	}
-
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		MultiFileLocalIndex col_idx(i);
 		if (IsFilterColumn(state.scan_filters, i)) {
@@ -1917,7 +1906,61 @@ void ParquetReader::DecodeRemainingColumns(ParquetReaderScanState &state, DataCh
 	}
 }
 
-SourceResultType ParquetReader::Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch) {
+// FIXME: We now do this copy due to the Process reenter, maybe there is a better way
+static void CopyFilterColumns(const vector<ParquetScanFilter> &scan_filters, DataChunk &src, DataChunk &dst,
+                              idx_t count) {
+	for (auto &scan_filter : scan_filters) {
+		auto idx = MultiFileLocalIndex(scan_filter.filter_idx).GetIndex();
+		VectorOperations::Copy(src.data[idx], dst.data[idx], count, 0, 0);
+	}
+}
+
+vector<unique_ptr<AsyncTask>> ParquetReader::ScheduleRemainingColumns(ParquetReaderScanState &state, DataChunk &result,
+                                                                      idx_t scan_count) {
+	if (state.filter_count == 0 || state.filter_head_count == 0) {
+		return {};
+	}
+	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
+	auto payload_head_count = trans.GetReadHeads().size() - state.filter_head_count;
+	// payload columns are the leading read heads
+	auto io_tasks = CollectIOTasks(state.thrift_file_proto->getTransport(), state.file_handle, 0, payload_head_count);
+	if (io_tasks.empty()) {
+		// no payload to do
+		return {};
+	}
+	// stash the decoded filter columns and empty the chunk for the BLOCKED return
+	if (state.filter_stash.data.empty()) {
+		state.filter_stash.Initialize(allocator, result.GetTypes());
+	}
+	state.filter_stash.Reset();
+	CopyFilterColumns(state.scan_filters, result, state.filter_stash, scan_count);
+	result.Reset();
+	state.filter_done = true;
+	return io_tasks;
+}
+
+AsyncResult ParquetReader::ProcessFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count,
+                                          uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch) {
+	if (state.filter_done) {
+		// the filters already ran, we restore the stashed columns
+		state.filter_done = false;
+		CopyFilterColumns(state.scan_filters, state.filter_stash, result, scan_count);
+	} else {
+		// we need to evaluate the filters, then async-fetch the payload and resume into the decode
+		state.filter_count = EvaluateFilters(state, result, scan_count, define_ptr, repeat_ptr, log_prefetch);
+		auto io_tasks = ScheduleRemainingColumns(state, result, scan_count);
+		if (!io_tasks.empty()) {
+			return AsyncResult(std::move(io_tasks), TaskSchedulerType::ASYNC);
+		}
+	}
+	DecodeRemainingColumns(state, result, state.filter_count, define_ptr, repeat_ptr);
+	if (scan_count != state.filter_count) {
+		result.Slice(state.sel, state.filter_count);
+	}
+	return SourceResultType::HAVE_MORE_OUTPUT;
+}
+
+AsyncResult ParquetReader::Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch) {
 	auto scan_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, GetGroup(state).num_rows - state.offset_in_group);
 	result.SetChildCardinality(scan_count);
 
@@ -1936,11 +1979,10 @@ SourceResultType ParquetReader::Process(ParquetReaderScanState &state, DataChunk
 	auto repeat_ptr = (uint8_t *)state.repeat_buf.ptr;
 
 	if (filters || deletion_filter) {
-		idx_t filter_count = EvaluateFilters(state, result, scan_count, define_ptr, repeat_ptr, log_prefetch);
-		// we still may have to read some cols
-		DecodeRemainingColumns(state, result, filter_count, define_ptr, repeat_ptr);
-		if (scan_count != filter_count) {
-			result.Slice(state.sel, filter_count);
+		auto res = ProcessFilters(state, result, scan_count, define_ptr, repeat_ptr, log_prefetch);
+		if (res.GetResultType() == AsyncResultType::BLOCKED) {
+			// we must wait  on the payload I/O
+			return res;
 		}
 	} else {
 		for (idx_t i = 0; i < column_ids.size(); i++) {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -187,12 +187,15 @@ SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, D
 		switch (output_async_result) {
 		case AsyncResultType::BLOCKED: {
 			D_ASSERT(data.async_result.HasTasks());
-			annotated_lock_guard<annotated_mutex> guard(g_state.lock);
-			if (g_state.CanBlock()) {
-				data.async_result.ScheduleTasks(input.interrupt_state, context.pipeline->executor);
-				return SourceResultType::BLOCKED;
+			{
+				annotated_lock_guard<annotated_mutex> guard(g_state.lock);
+				if (g_state.CanBlock()) {
+					data.async_result.ScheduleTasks(input.interrupt_state, context.pipeline->executor);
+					return SourceResultType::BLOCKED;
+				}
 			}
-			return SourceResultType::FINISHED;
+			data.async_result.ExecuteTasksSynchronously();
+			return SourceResultType::HAVE_MORE_OUTPUT;
 		}
 		case AsyncResultType::IMPLICIT:
 			if (chunk.size() > 0) {

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -184,4 +184,16 @@ public:
 	                                  const vector<string> &minimal_filters, uint64_t accepted_column_gap);
 };
 
+class AsyncTaskScheduleLogType : public LogType {
+public:
+	static constexpr const char *NAME = "AsyncTaskSchedule";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	AsyncTaskScheduleLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(const string &pool, idx_t task_count);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -21,8 +21,8 @@ class TaskExecutor;
 class Executor;
 
 enum class AsyncResultsExecutionMode : uint8_t {
-	SYNCHRONOUS,  // BLOCKED should not bubble up, and they should be executed synchronously
-	TASK_EXECUTOR // BLOCKED is allowed
+	SYNCHRONOUS,  //! BLOCKED should not bubble up, and they should be executed synchronously
+	TASK_EXECUTOR //! BLOCKED is allowed
 };
 
 class AsyncTask {
@@ -43,21 +43,21 @@ public:
 	AsyncResult &operator=(SourceResultType t);
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
-	// Schedule held async_tasks into the Executor, eventually unblocking InterruptState
-	// needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
-	// into INVALID
+	//! Schedule held async_tasks into the Executor, eventually unblocking InterruptState
+	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! into INVALID
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
-	// Execute tasks synchronously at callsite
-	// needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
-	// into HAVE_MORE_OUTPUT
+	//! Execute tasks synchronously at callsite
+	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! into HAVE_MORE_OUTPUT
 	void ExecuteTasksSynchronously();
 
 	static AsyncResultType GetAsyncResultType(SourceResultType s);
 
-	// Check whether there are tasks associated
+	//! Check whether there are tasks associated
 	bool HasTasks() const;
 	AsyncResultType GetResultType() const;
-	// Extract associated tasks, moving them away, will empty async_tasks and transform to INVALID
+	//! Extract associated tasks, moving them away, will empty async_tasks and transform to INVALID
 	vector<unique_ptr<AsyncTask>> &&ExtractAsyncTasks();
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
+#include "duckdb/common/enums/task_scheduler_type.hpp"
 
 namespace duckdb {
 
@@ -37,7 +38,8 @@ public:
 	AsyncResult() = default;
 	AsyncResult(AsyncResult &&) = default;
 	AsyncResult(SourceResultType t); // NOLINT
-	explicit AsyncResult(vector<unique_ptr<AsyncTask>> &&task);
+	explicit AsyncResult(vector<unique_ptr<AsyncTask>> &&task,
+	                     TaskSchedulerType pool_type = TaskSchedulerType::REGULAR);
 	AsyncResult &operator=(SourceResultType t);
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
@@ -68,5 +70,7 @@ public:
 private:
 	AsyncResultType result_type {AsyncResultType::INVALID};
 	vector<unique_ptr<AsyncTask>> async_tasks {};
+	//! The thread pool that the async_tasks are scheduled onto when BLOCKED
+	TaskSchedulerType pool_type {TaskSchedulerType::REGULAR};
 };
 } // namespace duckdb

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -274,6 +274,7 @@ void LogManager::RegisterDefaultLogTypes() {
 	RegisterLogType(make_uniq<MetricsLogType>());
 	RegisterLogType(make_uniq<AdaptiveFilterLogType>());
 	RegisterLogType(make_uniq<ParquetPrefetchLogType>());
+	RegisterLogType(make_uniq<AsyncTaskScheduleLogType>());
 }
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -21,6 +21,7 @@ constexpr LogLevel MetricsLogType::LEVEL;
 constexpr LogLevel CheckpointLogType::LEVEL;
 constexpr LogLevel AdaptiveFilterLogType::LEVEL;
 constexpr LogLevel ParquetPrefetchLogType::LEVEL;
+constexpr LogLevel AsyncTaskScheduleLogType::LEVEL;
 
 //===--------------------------------------------------------------------===//
 // QueryLogType
@@ -331,6 +332,28 @@ string ParquetPrefetchLogType::ConstructLogMessage(const string &file_path, idx_
 	    {"prefetch_groups", Value::LIST(LogicalType::LIST(LogicalType::VARCHAR), std::move(outer))},
 	    {"minimal_filters", Value::LIST(LogicalType::VARCHAR, std::move(minimal))},
 	    {"accepted_column_gap", Value::UBIGINT(accepted_column_gap)},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
+//===--------------------------------------------------------------------===//
+// AsyncTaskScheduleLogType
+//===--------------------------------------------------------------------===//
+AsyncTaskScheduleLogType::AsyncTaskScheduleLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType AsyncTaskScheduleLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"pool", LogicalType::VARCHAR},
+	    {"task_count", LogicalType::BIGINT},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string AsyncTaskScheduleLogType::ConstructLogMessage(const string &pool, idx_t task_count) {
+	child_list_t<Value> child_list = {
+	    {"pool", Value(pool)},
+	    {"task_count", Value::BIGINT(static_cast<int64_t>(task_count))},
 	};
 	return Value::STRUCT(std::move(child_list)).ToString();
 }

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -629,7 +629,8 @@ idx_t DBConfig::GetSystemMaxAsyncThreads(FileSystem &fs) {
 #ifdef DUCKDB_NO_THREADS
 	return 0;
 #else
-	return GetSystemMaxThreads(fs);
+	// via benchmark, it seems that ~2x system threads is the I/O-concurrency sweet spot for remote (S3) scans
+	return 2 * GetSystemMaxThreads(fs);
 #endif
 }
 

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/execution/physical_table_scan_enum.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logger.hpp"
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 #include "duckdb/parallel/sleep_async_task.hpp"
@@ -83,8 +85,8 @@ AsyncResult::AsyncResult(AsyncResultType t) : result_type(t) {
 	}
 }
 
-AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)
-    : result_type(AsyncResultType::BLOCKED), async_tasks(std::move(tasks)) {
+AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks, TaskSchedulerType pool_type_p)
+    : result_type(AsyncResultType::BLOCKED), async_tasks(std::move(tasks)), pool_type(pool_type_p) {
 	if (async_tasks.empty()) {
 		throw InternalException("AsyncResult constructed from empty vector of tasks");
 	}
@@ -105,6 +107,7 @@ AsyncResult &AsyncResult::operator=(duckdb::AsyncResultType t) {
 AsyncResult &AsyncResult::operator=(AsyncResult &&other) noexcept {
 	result_type = other.result_type;
 	async_tasks = std::move(other.async_tasks);
+	pool_type = other.pool_type;
 	return *this;
 }
 
@@ -117,11 +120,13 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 		throw InternalException("AsyncResult::ScheduleTasks called with no available tasks");
 	}
 
+	DUCKDB_LOG(executor.context, AsyncTaskScheduleLogType, EnumUtil::ToString(pool_type), async_tasks.size());
+
 	shared_ptr<AsyncBatchCompletion> completion = make_shared_ptr<AsyncBatchCompletion>(async_tasks.size());
 
 	for (auto &async_task : async_tasks) {
 		auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state, completion);
-		TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task));
+		TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task), pool_type);
 	}
 }
 

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -41,7 +41,8 @@
         "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
         "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
         "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
-        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test"
+        "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test",
+        "test/sql/parallelism/async_task_schedule_pool.test"
       ]
     },
     {

--- a/test/sql/copy/parquet/parquet_parallel_limit_glob.test_slow
+++ b/test/sql/copy/parquet/parquet_parallel_limit_glob.test_slow
@@ -73,3 +73,22 @@ query I
 4978324
 4978325
 4978326
+
+statement ok
+SET threads=32
+
+statement ok
+SET prefetch_all_parquet_files=true
+
+loop iter 0 50
+
+query I
+SELECT * FROM integers WHERE i>1978321 OR i=334 LIMIT 5
+----
+334
+1978322
+1978323
+1978324
+1978325
+
+endloop

--- a/test/sql/copy/parquet/parquet_prefetch_error_cancel.test_slow
+++ b/test/sql/copy/parquet/parquet_prefetch_error_cancel.test_slow
@@ -1,0 +1,23 @@
+# name: test/sql/copy/parquet/parquet_prefetch_error_cancel.test_slow
+# description: A runtime error mid-scan must not use-after-free in-flight async prefetch reads
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT i FROM range(0, 2000000) t(i)) TO '{TEST_DIR}/uaf.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 10000)
+
+statement ok
+SET threads=32
+
+statement ok
+SET prefetch_all_parquet_files=true
+
+loop iter 0 50
+
+statement error
+SELECT min(CAST(CASE WHEN i = 1000000 THEN 999 ELSE 1 END AS TINYINT)) FROM '{TEST_DIR}/uaf.parquet'
+----
+Conversion Error
+
+endloop

--- a/test/sql/parallelism/async_task_schedule_pool.test
+++ b/test/sql/parallelism/async_task_schedule_pool.test
@@ -1,5 +1,5 @@
 # name: test/sql/parallelism/async_task_schedule_pool.test
-# description: The AsyncTaskSchedule log records which thread pool async I/O tasks are routed to; parquet prefetch currently routes to the REGULAR pool
+# description: The AsyncTaskSchedule log records which thread pool async I/O tasks are routed to; parquet prefetch routes its eager I/O onto the dedicated ASYNC pool
 # group: [parallelism]
 
 require parquet
@@ -19,11 +19,11 @@ CALL enable_logging('AsyncTaskSchedule')
 statement ok
 SELECT sum(i) FROM '{TEST_DIR}/async_pool.parquet'
 
-# the parquet prefetch eagerly scheduled I/O tasks, today they are routed to the REGULAR pool
+# the parquet prefetch eagerly scheduled I/O tasks, and routes them onto the dedicated ASYNC pool
 query I
 SELECT DISTINCT pool FROM duckdb_logs_parsed('AsyncTaskSchedule')
 ----
-REGULAR
+ASYNC
 
 # at least one batch of I/O tasks was scheduled
 query I

--- a/test/sql/parallelism/async_task_schedule_pool.test
+++ b/test/sql/parallelism/async_task_schedule_pool.test
@@ -1,0 +1,35 @@
+# name: test/sql/parallelism/async_task_schedule_pool.test
+# description: The AsyncTaskSchedule log records which thread pool async I/O tasks are routed to; parquet prefetch currently routes to the REGULAR pool
+# group: [parallelism]
+
+require parquet
+
+statement ok
+SET threads=1
+
+statement ok
+SET prefetch_all_parquet_files=true
+
+statement ok
+COPY (SELECT range AS i FROM range(100000)) TO '{TEST_DIR}/async_pool.parquet' (ROW_GROUP_SIZE 10000)
+
+statement ok
+CALL enable_logging('AsyncTaskSchedule')
+
+statement ok
+SELECT sum(i) FROM '{TEST_DIR}/async_pool.parquet'
+
+# the parquet prefetch eagerly scheduled I/O tasks, today they are routed to the REGULAR pool
+query I
+SELECT DISTINCT pool FROM duckdb_logs_parsed('AsyncTaskSchedule')
+----
+REGULAR
+
+# at least one batch of I/O tasks was scheduled
+query I
+SELECT sum(task_count) > 0 FROM duckdb_logs_parsed('AsyncTaskSchedule')
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs()

--- a/test/sql/parallelism/async_task_schedule_pool.test
+++ b/test/sql/parallelism/async_task_schedule_pool.test
@@ -4,6 +4,11 @@
 
 require parquet
 
+# this test exercises the async I/O path, so override any forced-synchronous
+# table scan execution strategy (e.g. from test_table_scan's --on-init)
+statement ok
+SET debug_physical_table_scan_execution_strategy=DEFAULT
+
 statement ok
 SET threads=1
 


### PR DESCRIPTION
This PR continues the work on implementing async I/O for the parquet reader.

The first thing we did was a further refactor to also split the filter-processing path (i.e. the `ParquetPrefetchStrategy::PREFETCH_FILTERS` strategy) into a schedule and a process step. This is necessary because this prefetch strategy initially only prefetches the filter columns, checks if any rows survive, and only then prefetches the remaining columns. As a result, scheduling also happens in the process step, not just the initial schedule. This is unlike `WHOLE_GROUP` and `COLUMN_WISE_EAGER`, which schedule all of their I/O up front.

Second, we wired these functions to return AsyncResult tasks scheduled on the `TaskSchedulerType::ASYNC` pool, so the scan returns `BLOCKED` and its I/O runs on the dedicated async thread pool instead of blocking the worker thread.

## Benchmark
To benchmark this we created a dataset of 16 files, about 8.2 GB total, with 17 columns (16 random doubles plus one filter column), 64M rows across 640 row groups. We stored it on S3 and read it from a c6in.4xlarge instance in the same region. Across the workloads we measured, async I/O gives roughly a 1.5x to 1.7x speedup over main. All numbers are the mean of 5 timed runs after 1 warmup

| Workload | main | async (16T) | async (32T) | Improvement (32T vs main) |
|---|---|---|---|---|
| All columns (whole_group) | 10.19 s | 8.15 s | 6.08 s | 1.68× |
| Column-wise eager (12 of 17 cols) | 9.34 s | 6.12 s | 6.34 s | 1.47× |
| Filtered (`WHERE g=500`) | 8.92 s | 6.83 s | 5.62 s | 1.59× |

One thing we learnt from this benchmark is that defaulting our async threads to 2x the system threads seems sensible, so this PR also changes the default accordingly.

## Next steps
  1. We should have our parquet reads from local disk also default to the prefetch strategy, so they will do async too. We probably have to revisit the network cost model to make sure it is sensible for local speeds.
  2. On httpfs, each thread has a single file handle, and if we want to do parallel reads to httpfs we might need more connections. This could be the next performance booster here.