### PR TITLE
Fix RowGroup assertion

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1410,8 +1410,7 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 		}
 	}
 
-	if (!reused_columns.empty()) {
-		D_ASSERT(partial_reuse);
+	if (partial_reuse) {
 		// carry forward the extras for reused columns onto the new row group, so RowGroup::Checkpoint
 		// can look them up via this->per_column_metadata_blocks
 		auto extras = per_column_metadata_blocks.GetBlocksForColumns(reused_columns);


### PR DESCRIPTION
Fixes a condition in `RowGroup::Checkpoint` that would trigger an assertion in `RowGroup::WriteToDisk` (see here: https://github.com/duckdb/duckdb/blob/b4eeb55d58fdf26395efcb11ee830a48dec31955/src/storage/table/row_group.cpp#L1563) where it assumed that `has_per_column_metadata_blocks` was always true when `write_action == RowGroupWriteAction::PARTIALLY_REUSE_COLUMN_METADATA`.

With the previous condition that would only check `!reused_columns.empty()` (and which is adapted in the current PR here), it would be possible that no columns were reused, but the write_action would say `write_action == RowGroupWriteAction::PARTIALLY_REUSE_COLUMN_METADATA`. There would just be an empty list of per_column_metadata_blocks. With the change in this PR we align both places so that the assertion does no longer trip, i.e. setting `has_per_column_metadata_blocks = true` with an empty list of per_column_metadata_blocks.

Note that this was just an assertion failure, not a production-impairing bug in the code, as it still handled / treated an empty list of per_column_metadata_blocks correctly in `RowGroup::WriteToDisk`.