### PR TITLE
Fix #21931: avoid trying to bind an expression that doesn't exist in `UNPIVOT`

### DIFF
--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -700,14 +700,16 @@ struct UnpivotEntry {
 void Binder::ExtractUnpivotEntries(Binder &child_binder, PivotColumnEntry &entry,
                                    vector<UnpivotEntry> &unpivot_entries) {
 	// Try to bind the entry expression as values
-	try {
-		auto expr_copy = entry.expr->Copy();
-		BindPivotInList(expr_copy, entry.values, child_binder);
-		// successfully bound as values - clear the expression
-		entry.expr = nullptr;
-	} catch (...) {
-		// ignore binder exceptions here - we fall back to expression mode
-		entry.values.clear();
+	if (entry.expr) {
+		try {
+			auto expr_copy = entry.expr->Copy();
+			BindPivotInList(expr_copy, entry.values, child_binder);
+			// successfully bound as values - clear the expression
+			entry.expr = nullptr;
+		} catch (...) {
+			// ignore binder exceptions here - we fall back to expression mode
+			entry.values.clear();
+		}
 	}
 
 	if (!entry.expr) {

--- a/test/sql/pivot/unpivot_view.test
+++ b/test/sql/pivot/unpivot_view.test
@@ -1,0 +1,26 @@
+# name: test/sql/pivot/unpivot_view.test
+# description: Test unpivot in a view
+# group: [pivot]
+
+load {TEST_DIR}/unpivot_view.db
+
+statement ok
+CREATE TABLE t (
+    id INTEGER,
+    a INTEGER,
+    b INTEGER
+);
+
+statement ok
+INSERT INTO t VALUES (1, 10, 20);
+
+statement ok
+CREATE VIEW v AS
+SELECT *
+FROM t
+UNPIVOT (val FOR key IN (a, b));
+
+restart
+
+statement ok
+FROM v;


### PR DESCRIPTION
Fixes #21931