### PR TITLE
Add file_row_group_number virtual column to the Parquet reader

### DIFF
--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -31,7 +31,7 @@ using duckdb_parquet::SchemaElement;
 using duckdb_parquet::FileMetaData;
 struct ParquetOptions;
 
-enum class ParquetColumnSchemaType { COLUMN, FILE_ROW_NUMBER, EXPRESSION, VARIANT, GEOMETRY };
+enum class ParquetColumnSchemaType { COLUMN, FILE_ROW_NUMBER, EXPRESSION, VARIANT, GEOMETRY, FILE_ROW_GROUP_NUMBER };
 
 enum class ParquetExtraTypeInfo {
 	NONE,
@@ -72,6 +72,7 @@ public:
 	                                            vector<ParquetColumnSchema> &&children,
 	                                            ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	static ParquetColumnSchema FileRowNumber();
+	static ParquetColumnSchema FileRowGroupNumber();
 
 public:
 	unique_ptr<BaseStatistics> Stats(const FileMetaData &file_meta_data, const ParquetOptions &parquet_options,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -222,6 +222,11 @@ public:
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
 
+	//! (optional) counters (owned by the scan's global state) for row groups whose data was read / skipped,
+	//! incremented as row groups are processed and surfaced as profiling metrics
+	optional_ptr<atomic<idx_t>> row_groups_read;
+	optional_ptr<atomic<idx_t>> row_groups_skipped;
+
 	//! Prefetch cost model
 	PrefetchCostModelState cost_model_state;
 };
@@ -287,6 +292,10 @@ struct ParquetUnionData : public BaseUnionData {
 };
 
 class ParquetReader : public BaseFileReader {
+public:
+	//! Virtual column identifier for the "file_row_group_number" column (the file-relative row group index of each row)
+	static constexpr column_t COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER = UINT64_C(9223372036854775820);
+
 public:
 	ParquetReader(ClientContext &context, OpenFileInfo file, ParquetOptions parquet_options,
 	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -222,10 +222,11 @@ public:
 	//! (optional) pointer to the PhysicalOperator for logging
 	optional_ptr<const PhysicalOperator> op;
 
-	//! (optional) counters (owned by the scan's global state) for row groups whose data was read / skipped,
-	//! incremented as row groups are processed and surfaced as profiling metrics
-	optional_ptr<atomic<idx_t>> row_groups_read;
-	optional_ptr<atomic<idx_t>> row_groups_skipped;
+	//! Per-thread counters for row groups whose data was read / skipped, incremented as row groups are processed.
+	//! Read in ParquetScanGetMetrics and surfaced as the standard row_groups_scanned / total_row_groups_to_scan
+	//! profiling metrics (the profiler sums them across threads).
+	idx_t row_groups_read = 0;
+	idx_t row_groups_skipped = 0;
 
 	//! Prefetch cost model
 	PrefetchCostModelState cost_model_state;

--- a/extension/parquet/include/reader/row_number_column_reader.hpp
+++ b/extension/parquet/include/reader/row_number_column_reader.hpp
@@ -71,4 +71,36 @@ private:
 	idx_t row_group_offset;
 };
 
+//! Reads the file-relative row group number as a virtual column that's not actually stored in the file
+class RowGroupColumnReader : public ColumnReader {
+public:
+	static constexpr const PhysicalType TYPE = PhysicalType::INT64;
+
+public:
+	RowGroupColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
+
+public:
+	idx_t Read(ColumnReaderInput &input, Vector &result) override;
+
+	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
+
+	void Skip(idx_t num_values) override {
+	}
+	idx_t GroupRowsAvailable() override {
+		return NumericLimits<idx_t>::Maximum();
+	};
+	uint64_t TotalCompressedSize() override {
+		return 0;
+	}
+	idx_t FileOffset() const override {
+		return 0;
+	}
+	void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge) override {
+	}
+
+private:
+	//! The index of the row group currently being read
+	idx_t row_group_idx = 0;
+};
+
 } // namespace duckdb

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -103,7 +103,8 @@ ParquetColumnSchema ParquetColumnSchema::FileRowGroupNumber() {
 	res.schema_index = 0;
 	res.column_index = 0;
 	res.schema_type = ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER;
-	res.type = LogicalType::BIGINT, res.repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL;
+	res.type = LogicalType::UBIGINT;
+	res.repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL;
 	return res;
 }
 
@@ -116,8 +117,8 @@ unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_m
 	if (schema_type == ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER) {
 		// the row group number is constant within a row group - set min and max to the row group index
 		auto stats = NumericStats::CreateUnknown(type);
-		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
-		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
+		NumericStats::SetMin(stats, Value::UBIGINT(UnsafeNumericCast<uint64_t>(row_group_idx_p)));
+		NumericStats::SetMax(stats, Value::UBIGINT(UnsafeNumericCast<uint64_t>(row_group_idx_p)));
 		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
 		return stats.ToUnique();
 	}

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -95,11 +95,31 @@ ParquetColumnSchema ParquetColumnSchema::FileRowNumber() {
 	return res;
 }
 
+ParquetColumnSchema ParquetColumnSchema::FileRowGroupNumber() {
+	ParquetColumnSchema res;
+	res.name = "file_row_group_number";
+	res.max_define = 0;
+	res.max_repeat = 0;
+	res.schema_index = 0;
+	res.column_index = 0;
+	res.schema_type = ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER;
+	res.type = LogicalType::BIGINT, res.repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL;
+	return res;
+}
+
 unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_meta_data,
                                                       const ParquetOptions &parquet_options, idx_t row_group_idx_p,
                                                       const vector<ColumnChunk> &columns) const {
 	if (schema_type == ParquetColumnSchemaType::EXPRESSION) {
 		return nullptr;
+	}
+	if (schema_type == ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER) {
+		// the row group number is constant within a row group - set min and max to the row group index
+		auto stats = NumericStats::CreateUnknown(type);
+		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
+		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_idx_p)));
+		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+		return stats.ToUnique();
 	}
 	if (schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
 		auto &row_groups = file_meta_data.row_groups;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -93,6 +93,10 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
+	//! Number of row groups that had their data read / skipped (via row-group pruning), aggregated across all
+	//! files and threads. Surfaced as profiling metrics in EXPLAIN ANALYZE.
+	atomic<idx_t> row_groups_read {0};
+	atomic<idx_t> row_groups_skipped {0};
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -328,6 +332,22 @@ static vector<column_t> ParquetGetRowIdColumns(ClientContext &context, optional_
 	return result;
 }
 
+static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
+	// emit the shared multi-file metrics (files read, filenames, rows scanned)
+	MultiFileFunction<ParquetMultiFileInfo>::MultiFileGetMetrics(input);
+	// add the parquet-specific row group read/skip counts (aggregated across files and threads)
+	if (!input.global_state) {
+		return;
+	}
+	auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
+	if (!gstate.global_state) {
+		return;
+	}
+	auto &parquet_gstate = gstate.global_state->Cast<ParquetReadGlobalState>();
+	input.operator_metrics.AddExtraInfo("Row Groups Read", to_string(parquet_gstate.row_groups_read.load()));
+	input.operator_metrics.AddExtraInfo("Row Groups Skipped", to_string(parquet_gstate.row_groups_skipped.load()));
+}
+
 ParquetMetadataCacheEntry::ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata_p,
                                                      ParquetCacheValidity validity_p, bool has_deletes_p)
     : metadata(std::move(metadata_p)), validity(validity_p), has_deletes(has_deletes_p) {
@@ -424,6 +444,7 @@ TableFunctionSet ParquetScanFunction::GetFunctionSet() {
 	table_function.named_parameters["can_have_nan"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["prefetch_strategy"] = LogicalType::VARCHAR;
 	table_function.statistics_extended = MultiFileFunction<ParquetMultiFileInfo>::MultiFileScanStatsExtended;
+	table_function.get_metrics = ParquetScanGetMetrics;
 	table_function.supports_pushdown_extract = ParquetScanSupportPushdownExtract;
 	table_function.serialize = ParquetScanSerialize;
 	table_function.deserialize = ParquetScanDeserialize;
@@ -682,6 +703,8 @@ double ParquetReader::GetProgressInFile(ClientContext &context) {
 void ParquetMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData &, virtual_column_map_t &result) {
 	result.insert(make_pair(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER,
 	                        TableColumn("file_row_number", LogicalType::BIGINT)));
+	result.insert(make_pair(ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER,
+	                        TableColumn("file_row_group_number", LogicalType::BIGINT)));
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, GlobalTableFunctionState &,
@@ -772,6 +795,8 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
+	local_state.scan_state.row_groups_read = &gstate.row_groups_read;
+	local_state.scan_state.row_groups_skipped = &gstate.row_groups_skipped;
 	return Scan(context, local_state.scan_state, chunk);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -93,10 +93,6 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
-	//! Number of row groups that had their data read / skipped (via row-group pruning), aggregated across all
-	//! files and threads. Surfaced as profiling metrics in EXPLAIN ANALYZE.
-	atomic<idx_t> row_groups_read {0};
-	atomic<idx_t> row_groups_skipped {0};
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
@@ -335,17 +331,18 @@ static vector<column_t> ParquetGetRowIdColumns(ClientContext &context, optional_
 static void ParquetScanGetMetrics(TableFunctionGetMetricsInput &input) {
 	// emit the shared multi-file metrics (files read, filenames, rows scanned)
 	MultiFileFunction<ParquetMultiFileInfo>::MultiFileGetMetrics(input);
-	// add the parquet-specific row group read/skip counts (aggregated across files and threads)
-	if (!input.global_state) {
+	// report row groups read vs. considered as the standard per-thread row-group metrics: the profiler sums
+	// row_groups_scanned / total_row_groups_to_scan across threads, and "skipped" = total - scanned
+	if (!input.local_state) {
 		return;
 	}
-	auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
-	if (!gstate.global_state) {
+	auto &local = input.local_state->Cast<MultiFileLocalState>();
+	if (!local.local_state) {
 		return;
 	}
-	auto &parquet_gstate = gstate.global_state->Cast<ParquetReadGlobalState>();
-	input.operator_metrics.AddExtraInfo("Row Groups Read", to_string(parquet_gstate.row_groups_read.load()));
-	input.operator_metrics.AddExtraInfo("Row Groups Skipped", to_string(parquet_gstate.row_groups_skipped.load()));
+	auto &scan_state = local.local_state->Cast<ParquetReadLocalState>().scan_state;
+	input.operator_metrics.row_groups_scanned = scan_state.row_groups_read;
+	input.operator_metrics.total_row_groups_to_scan = scan_state.row_groups_read + scan_state.row_groups_skipped;
 }
 
 ParquetMetadataCacheEntry::ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata_p,
@@ -704,7 +701,7 @@ void ParquetMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData 
 	result.insert(make_pair(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER,
 	                        TableColumn("file_row_number", LogicalType::BIGINT)));
 	result.insert(make_pair(ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER,
-	                        TableColumn("file_row_group_number", LogicalType::BIGINT)));
+	                        TableColumn("file_row_group_number", LogicalType::UBIGINT)));
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, GlobalTableFunctionState &,
@@ -795,8 +792,6 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
-	local_state.scan_state.row_groups_read = &gstate.row_groups_read;
-	local_state.scan_state.row_groups_skipped = &gstate.row_groups_skipped;
 	return Scan(context, local_state.scan_state, chunk);
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -581,6 +581,8 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 	switch (schema.schema_type) {
 	case ParquetColumnSchemaType::FILE_ROW_NUMBER:
 		return make_uniq<RowNumberColumnReader>(*this, schema);
+	case ParquetColumnSchemaType::FILE_ROW_GROUP_NUMBER:
+		return make_uniq<RowGroupColumnReader>(*this, schema);
 	case ParquetColumnSchemaType::GEOMETRY: {
 		return GeometryColumnReader::Create(*this, schema, context);
 	}
@@ -907,6 +909,10 @@ static ParquetColumnSchema FileRowNumberSchema() {
 	return ParquetColumnSchema::FileRowNumber();
 }
 
+static ParquetColumnSchema FileRowGroupNumberSchema() {
+	return ParquetColumnSchema::FileRowGroupNumber();
+}
+
 unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema(ClientContext &context) {
 	auto file_meta_data = GetFileMetadata();
 	idx_t next_schema_idx = 0;
@@ -990,6 +996,8 @@ void ParquetReader::InitializeSchema(ClientContext &context) {
 void ParquetReader::AddVirtualColumn(column_t virtual_column_id) {
 	if (virtual_column_id == MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER) {
 		root_schema->children.push_back(FileRowNumberSchema());
+	} else if (virtual_column_id == ParquetReader::COLUMN_IDENTIFIER_FILE_ROW_GROUP_NUMBER) {
+		root_schema->children.push_back(FileRowGroupNumberSchema());
 	} else {
 		throw InternalException("Unsupported virtual column id %d for parquet reader", virtual_column_id);
 	}
@@ -1733,9 +1741,17 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	}
 
 	auto &group = GetGroup(state);
+	const bool row_group_skipped = state.offset_in_group == (idx_t)group.num_rows;
+	if (row_group_skipped) {
+		if (state.row_groups_skipped) {
+			++(*state.row_groups_skipped);
+		}
+	} else if (state.row_groups_read) {
+		++(*state.row_groups_read);
+	}
 	if (state.op) {
 		DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader",
-		           state.offset_in_group == (idx_t)group.num_rows ? "SkipRowGroup" : "ReadRowGroup",
+		           row_group_skipped ? "SkipRowGroup" : "ReadRowGroup",
 		           {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
 	}
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1743,11 +1743,9 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	auto &group = GetGroup(state);
 	const bool row_group_skipped = state.offset_in_group == (idx_t)group.num_rows;
 	if (row_group_skipped) {
-		if (state.row_groups_skipped) {
-			++(*state.row_groups_skipped);
-		}
-	} else if (state.row_groups_read) {
-		++(*state.row_groups_read);
+		++state.row_groups_skipped;
+	} else {
+		++state.row_groups_read;
 	}
 	if (state.op) {
 		DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader",

--- a/extension/parquet/reader/row_number_column_reader.cpp
+++ b/extension/parquet/reader/row_number_column_reader.cpp
@@ -79,12 +79,9 @@ void RowGroupColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<Co
 idx_t RowGroupColumnReader::Read(ColumnReaderInput &input, Vector &result) {
 	auto &num_values = input.num_values;
 
-	// the row group number is constant for all rows within a row group
-	auto value = UnsafeNumericCast<int64_t>(row_group_idx);
-	auto data_ptr = FlatVector::Writer<int64_t>(result, num_values);
-	for (idx_t i = 0; i < num_values; i++) {
-		data_ptr.WriteValue(value);
-	}
+	// the row group number is constant for all rows within a row group - emit a constant vector
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<uint64_t>(result)[0] = UnsafeNumericCast<uint64_t>(row_group_idx);
 	return num_values;
 }
 

--- a/extension/parquet/reader/row_number_column_reader.cpp
+++ b/extension/parquet/reader/row_number_column_reader.cpp
@@ -64,4 +64,28 @@ idx_t RowNumberColumnReader::Read(ColumnReaderInput &input, Vector &result) {
 	return num_values;
 }
 
+//===--------------------------------------------------------------------===//
+// Row Group Column Reader
+//===--------------------------------------------------------------------===//
+RowGroupColumnReader::RowGroupColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
+    : ColumnReader(reader, schema) {
+}
+
+void RowGroupColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,
+                                          TProtocol &protocol_p) {
+	row_group_idx = row_group_idx_p;
+}
+
+idx_t RowGroupColumnReader::Read(ColumnReaderInput &input, Vector &result) {
+	auto &num_values = input.num_values;
+
+	// the row group number is constant for all rows within a row group
+	auto value = UnsafeNumericCast<int64_t>(row_group_idx);
+	auto data_ptr = FlatVector::Writer<int64_t>(result, num_values);
+	for (idx_t i = 0; i < num_values; i++) {
+		data_ptr.WriteValue(value);
+	}
+	return num_values;
+}
+
 } // namespace duckdb

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -7,7 +7,8 @@
       "reason": "Zone map pruning requires filter pushdown from optimizer.",
       "paths": [
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test",
-        "test/optimizer/statistics/statistics_filter_pruning.test"
+        "test/optimizer/statistics/statistics_filter_pruning.test",
+        "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },
     {

--- a/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+++ b/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
@@ -4,6 +4,8 @@
 
 require parquet
 
+require json
+
 # write a parquet file with 5 row groups (2048 rows each, except the last)
 statement ok
 copy (select i, i * 2 as j from range(10000) t(i)) to '{TEST_DIR}/rg.parquet' (format parquet, ROW_GROUP_SIZE 2048);
@@ -78,33 +80,94 @@ select i, j, file_row_group_number from '{TEST_DIR}/rg.parquet' where i in (0, 2
 #-------------------------------------------------------------------------------
 # verify that filtering by file_row_group_number short-circuits reads:
 # only the matching row group's data is read, the rest are skipped via row-group
-# pruning. The parquet scan reports the counts as "Row Groups Read" / "Row Groups
-# Skipped" profiling metrics, visible in EXPLAIN ANALYZE.
+# pruning. The parquet scan reports this via the standard row-group profiling
+# metrics: row_groups_scanned = row groups read, total_row_groups_to_scan = all row
+# groups considered (so row groups skipped = total_row_groups_to_scan - row_groups_scanned).
 # (single threaded so the reported per-operator counts are deterministic)
 #-------------------------------------------------------------------------------
 
 statement ok
 set threads=1;
 
-# filtering on a single row group reads only that one (1) and skips the other 4
+# filtering on a single row group reads only that one (1) and considers all 5 (skips 4)
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.row_groups_scanned', 'operator.total_row_groups_to_scan', 'operator.type'];
+
+statement ok
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+
+statement ok
+PRAGMA disable_profiling;
+
+# view over the scanned / total row group counts of the parquet scan operator, read from
+# the last profiled query's output. Profiling must be disabled before querying this, so the
+# view query itself does not overwrite the output it is reading.
+statement ok
+CREATE VIEW parquet_scan_row_groups AS
+WITH RECURSIVE ops(op) AS (
+    SELECT unnest(operator)::JSON AS op FROM '{TEST_DIR}/profiling_output.json'
+    UNION ALL
+    SELECT unnest((op->'children')::JSON[]) FROM ops WHERE json_array_length(op->'children') > 0
+)
+SELECT (op->>'row_groups_scanned')::BIGINT AS scanned,
+       (op->>'total_row_groups_to_scan')::BIGINT AS total
+FROM ops
+WHERE op->>'type' = 'TABLE_SCAN';
+
 query II
-EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+SELECT scanned, total - scanned AS skipped FROM parquet_scan_row_groups;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Read: 1.*Row Groups Skipped: 4.*
+1	4
 
 # reading multiple non-contiguous row groups (IN (1, 3)) reads ONLY those two row
 # groups and skips the other three
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.row_groups_scanned', 'operator.total_row_groups_to_scan', 'operator.type'];
+
+statement ok
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+
+statement ok
+PRAGMA disable_profiling;
+
 query II
-EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+SELECT scanned, total - scanned AS skipped FROM parquet_scan_row_groups;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Read: 2.*Row Groups Skipped: 3.*
+2	3
 
 # without a row-group filter, all row groups are read and none are skipped
 # (sum forces reading the column data - count(*) would be answered from metadata)
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/profiling_output.json';
+
+statement ok
+SET tracked_metrics = ['operator.row_groups_scanned', 'operator.total_row_groups_to_scan', 'operator.type'];
+
+statement ok
+select sum(j) from '{TEST_DIR}/rg.parquet';
+
+statement ok
+PRAGMA disable_profiling;
+
 query II
-EXPLAIN ANALYZE select sum(j) from '{TEST_DIR}/rg.parquet';
+SELECT scanned, total - scanned AS skipped FROM parquet_scan_row_groups;
 ----
-analyzed_plan	<REGEX>:.*Row Groups Read: 5.*Row Groups Skipped: 0.*
+5	0
 
 #-------------------------------------------------------------------------------
 # the row group number is file-relative: each file restarts the numbering at 0

--- a/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+++ b/test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
@@ -1,0 +1,131 @@
+# name: test/sql/copy/parquet/parquet_virtual_file_row_group_number.test
+# description: Test file_row_group_number virtual column
+# group: [parquet]
+
+require parquet
+
+# write a parquet file with 5 row groups (2048 rows each, except the last)
+statement ok
+copy (select i, i * 2 as j from range(10000) t(i)) to '{TEST_DIR}/rg.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+# sanity check: 5 row groups
+query I
+select count(distinct row_group_id) from parquet_metadata('{TEST_DIR}/rg.parquet');
+----
+5
+
+# the file_row_group_number is the file-relative row group index, starting at 0
+query IIII
+select file_row_group_number, count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' group by file_row_group_number order by file_row_group_number;
+----
+0	2048	0	2047
+1	2048	2048	4095
+2	2048	4096	6143
+3	2048	6144	8191
+4	1808	8192	9999
+
+# row group number is virtual - no values are NULL
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number is null;
+----
+0
+
+# filtering by a specific row group returns only the rows in that row group
+query III
+select count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+----
+2048	4096	6143
+
+# filtering with a range works too
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number >= 1 and file_row_group_number <= 3;
+----
+6144
+
+# reading multiple non-contiguous row groups via IN
+query III
+select count(*), min(i), max(i) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+----
+4096	2048	8191
+
+# the result only contains data from row groups 1 and 3
+query I
+select distinct file_row_group_number from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3) order by file_row_group_number;
+----
+1
+3
+
+# no data from any other row group leaks in (row group 2 covers i in [4096, 6143])
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3) and i between 4096 and 6143;
+----
+0
+
+# a row group that does not exist returns no rows
+query I
+select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 100;
+----
+0
+
+# combined projection with regular columns
+query III
+select i, j, file_row_group_number from '{TEST_DIR}/rg.parquet' where i in (0, 2048, 9999) order by i;
+----
+0	0	0
+2048	4096	1
+9999	19998	4
+
+#-------------------------------------------------------------------------------
+# verify that filtering by file_row_group_number short-circuits reads:
+# only the matching row group's data is read, the rest are skipped via row-group
+# pruning. The parquet scan reports the counts as "Row Groups Read" / "Row Groups
+# Skipped" profiling metrics, visible in EXPLAIN ANALYZE.
+# (single threaded so the reported per-operator counts are deterministic)
+#-------------------------------------------------------------------------------
+
+statement ok
+set threads=1;
+
+# filtering on a single row group reads only that one (1) and skips the other 4
+query II
+EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number = 2;
+----
+analyzed_plan	<REGEX>:.*Row Groups Read: 1.*Row Groups Skipped: 4.*
+
+# reading multiple non-contiguous row groups (IN (1, 3)) reads ONLY those two row
+# groups and skips the other three
+query II
+EXPLAIN ANALYZE select count(*) from '{TEST_DIR}/rg.parquet' where file_row_group_number in (1, 3);
+----
+analyzed_plan	<REGEX>:.*Row Groups Read: 2.*Row Groups Skipped: 3.*
+
+# without a row-group filter, all row groups are read and none are skipped
+# (sum forces reading the column data - count(*) would be answered from metadata)
+query II
+EXPLAIN ANALYZE select sum(j) from '{TEST_DIR}/rg.parquet';
+----
+analyzed_plan	<REGEX>:.*Row Groups Read: 5.*Row Groups Skipped: 0.*
+
+#-------------------------------------------------------------------------------
+# the row group number is file-relative: each file restarts the numbering at 0
+#-------------------------------------------------------------------------------
+
+statement ok
+copy (select i from range(5000) t(i)) to '{TEST_DIR}/rg_a.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+statement ok
+copy (select i from range(3000) t(i)) to '{TEST_DIR}/rg_b.parquet' (format parquet, ROW_GROUP_SIZE 2048);
+
+query II
+select file_row_group_number, count(*) from read_parquet(['{TEST_DIR}/rg_a.parquet', '{TEST_DIR}/rg_b.parquet']) group by file_row_group_number order by file_row_group_number;
+----
+0	4096
+1	3000
+2	904
+
+# multi-file safety: rg_a has 3 row groups, rg_b has 2. Row group 2 exists only in rg_a,
+# so a filter on row group 2 must still return the rows from rg_a (and nothing from rg_b)
+query I
+select count(*) from read_parquet(['{TEST_DIR}/rg_a.parquet', '{TEST_DIR}/rg_b.parquet']) where file_row_group_number = 2;
+----
+904


### PR DESCRIPTION
This adds a virtual column `file_row_group_number` to the parquet reader that allows (somewhat) efficient reading of individual row groups from parquet files, e.g.
```SQL
FROM 'my_file.parquet' WHERE file_row_group_number=42;
```
or 
```SQL
FROM 'my_file.parquet' WHERE file_row_group_number IN (42, 43);
```