### PR TITLE
Minor fixes

### DIFF
--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -39,7 +39,7 @@ static LogicalType StructureToTypeObject(yyjson_val *obj, ClientContext &context
 	yyjson_val *key, *val;
 	yyjson_obj_foreach(obj, idx, max, key, val) {
 		val = yyjson_obj_iter_get_val(key);
-		auto key_str = unsafe_yyjson_get_str(key);
+		string key_str(unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key));
 		if (names.find(key_str) != names.end()) {
 			JSONCommon::ThrowValFormatError("Duplicate keys in object in JSON structure: %s", val);
 		}

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -335,7 +335,9 @@ static bool ConvertVariantToArray(FromVariantConversionData &conversion_data, Ve
 		}
 
 		FindValues(conversion_data.variant, row_index, new_sel, child_data_entry);
-		CastVariant(conversion_data, child, new_sel, total_offset, array_size, row_index);
+		if (!CastVariant(conversion_data, child, new_sel, total_offset, array_size, row_index)) {
+			return false;
+		}
 		total_offset += array_size;
 	}
 	return true;

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -371,7 +371,7 @@ string PivotRef::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += groups[i];
+			result += KeywordHelper::WriteOptionallyQuoted(groups[i]);
 		}
 	}
 	result += ")";

--- a/test/sql/json/scalar/test_json_transform.test
+++ b/test/sql/json/scalar/test_json_transform.test
@@ -548,7 +548,6 @@ select json_transform('{"test": ["a","b"]}', '{"test": "test_enum[2]"}')
 statement ok
 DROP TYPE test_enum;
 
-
 # object keys containing an embedded NUL byte must not be truncated
 query T
 select to_json(json_transform('{"a\u0000b":1}', '{"a\u0000b":"INTEGER"}'))

--- a/test/sql/json/scalar/test_json_transform.test
+++ b/test/sql/json/scalar/test_json_transform.test
@@ -547,3 +547,15 @@ select json_transform('{"test": ["a","b"]}', '{"test": "test_enum[2]"}')
 
 statement ok
 DROP TYPE test_enum;
+
+
+# object keys containing an embedded NUL byte must not be truncated
+query T
+select to_json(json_transform('{"a\u0000b":1}', '{"a\u0000b":"INTEGER"}'))
+----
+{"a\u0000b":1}
+
+query T
+select to_json(json_transform_strict('{"a\u0000b":1}', '{"a\u0000b":"INTEGER"}'))
+----
+{"a\u0000b":1}

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -130,11 +130,11 @@ statement ok
 INSERT INTO ms VALUES (1, 'JAN', 10);
 
 query I
-SELECT json_deserialize_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN ("JAN") GROUP BY "$id")'));
+SELECT json_deserialize_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN (''JAN'') GROUP BY "$id")'));
 ----
 SELECT * FROM ms PIVOT (sum(amount) FOR ("month") IN ('JAN') GROUP BY "$id")
 
 query II
-SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN ("JAN") GROUP BY "$id")'));
+SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN (''JAN'') GROUP BY "$id")'));
 ----
 1	10

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -122,3 +122,19 @@ query I
 SELECT json_deserialize_sql(json_serialize_sql('SELECT 1;SELECT 2'));
 ----
 SELECT 1; SELECT 2
+
+statement ok
+CREATE TABLE ms("$id" INT, month VARCHAR, amount INT);
+
+statement ok
+INSERT INTO ms VALUES (1, 'JAN', 10);
+
+query I
+SELECT json_deserialize_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN ("JAN") GROUP BY "$id")'));
+----
+SELECT * FROM ms PIVOT (sum(amount) FOR ("month") IN ('JAN') GROUP BY "$id")
+
+query II
+SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM ms PIVOT (SUM(amount) FOR month IN ("JAN") GROUP BY "$id")'));
+----
+1	10

--- a/test/sql/types/variant/try_cast_from_variant.test
+++ b/test/sql/types/variant/try_cast_from_variant.test
@@ -84,9 +84,6 @@ NULL
 
 require json
 
-# A failing element conversion must fail the whole conversion, consistently for
-# fixed-size arrays and lists (issue #23151)
-
 query I
 select try_cast(json('["1","x"]')::VARIANT as INTEGER[]);
 ----

--- a/test/sql/types/variant/try_cast_from_variant.test
+++ b/test/sql/types/variant/try_cast_from_variant.test
@@ -81,3 +81,23 @@ select try_cast(a as UNION(a integer, b decimal)) from cte;
 NULL
 NULL
 NULL
+
+require json
+
+# A failing element conversion must fail the whole conversion, consistently for
+# fixed-size arrays and lists (issue #23151)
+
+query I
+select try_cast(json('["1","x"]')::VARIANT as INTEGER[]);
+----
+NULL
+
+query I
+select try_cast(json('["1","x"]')::VARIANT as INTEGER[2]);
+----
+NULL
+
+statement error
+select cast(json('["1","x"]')::VARIANT as INTEGER[2]);
+----
+Conversion Error


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/23150 : `json_transform` truncating keys
Fixes: https://github.com/duckdb/duckdb/issues/23151 : Missing a check for failures when casting
Fixes: https://github.com/duckdb/duckdb/issues/23141 : All identifiers were rendered using `WriteOptionallyQuoted` except `GROUP BY`