### PR TITLE
Aggregate States: Allow state layout types to be defined as template members in the actual state, instead of requiring a separate function

### DIFF
--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -41,6 +41,9 @@ struct KahanAvgState {
 		KahanAddInternal(other.value, this->value, this->err);
 		KahanAddInternal(other.err, this->value, this->err);
 	}
+
+	static constexpr const char *STATE_NAMES[] = {"count", "value", "err"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double>;
 };
 
 struct AverageDecimalBindData : public FunctionData {
@@ -222,13 +225,6 @@ LogicalType GetAvgStateType(const BoundAggregateFunction &function) {
 	return LogicalType::STRUCT(std::move(children));
 }
 
-LogicalType GetKahanAvgStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("count", LogicalType::UBIGINT);
-	children.emplace_back("value", LogicalType::DOUBLE);
-	children.emplace_back("err", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(children));
-}
 
 AggregateFunction GetAverageAggregate(PhysicalType type) {
 	switch (type) {
@@ -310,10 +306,8 @@ AggregateFunctionSet AvgFun::GetFunctions() {
 }
 
 AggregateFunction FAvgFun::GetFunction() {
-	auto function = AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE)
-	                    .SetStructStateExport(GetKahanAvgStateType);
-	return function;
+	return AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -15,6 +15,9 @@ struct AvgState {
 	uint64_t count;
 	T value;
 
+	static constexpr const char *STATE_NAMES[] = {"count", "value"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, T>;
+
 	void Combine(const AvgState<T> &other) {
 		this->count += other.count;
 		this->value += other.value;
@@ -24,6 +27,9 @@ struct AvgState {
 struct IntervalAvgState {
 	int64_t count;
 	interval_t value;
+
+	static constexpr const char *STATE_NAMES[] = {"count", "value"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, int64_t, interval_t>;
 
 	void Combine(const IntervalAvgState &other) {
 		this->count += other.count;
@@ -218,40 +224,27 @@ struct TimeTZAverageOperation : public BaseSumOperation<AverageSetOperation, Add
 	}
 };
 
-LogicalType GetAvgStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("count", LogicalType::UBIGINT);
-	children.emplace_back("value", function.GetArguments()[0]);
-	return LogicalType::STRUCT(std::move(children));
-}
-
-
 AggregateFunction GetAverageAggregate(PhysicalType type) {
 	switch (type) {
 	case PhysicalType::INT16: {
 		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
-		           LogicalType::SMALLINT, LogicalType::DOUBLE)
-		    .SetStructStateExport(GetAvgStateType);
+		    LogicalType::SMALLINT, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INT32: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
-		           LogicalType::INTEGER, LogicalType::DOUBLE)
-		    .SetStructStateExport(GetAvgStateType);
+		    LogicalType::INTEGER, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INT64: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
-		           LogicalType::BIGINT, LogicalType::DOUBLE)
-		    .SetStructStateExport(GetAvgStateType);
+		    LogicalType::BIGINT, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INT128: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
-		           LogicalType::HUGEINT, LogicalType::DOUBLE)
-		    .SetStructStateExport(GetAvgStateType);
+		    LogicalType::HUGEINT, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INTERVAL: {
 		return AggregateFunction::UnaryAggregate<IntervalAvgState, interval_t, interval_t, IntervalAverageOperation>(
-		           LogicalType::INTERVAL, LogicalType::INTERVAL)
-		    .SetStructStateExport(GetAvgStateType);
+		    LogicalType::INTERVAL, LogicalType::INTERVAL);
 	}
 	default:
 		throw InternalException("Unimplemented average aggregate");
@@ -285,29 +278,24 @@ AggregateFunctionSet AvgFun::GetFunctions() {
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INTERVAL));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE)
-	                    .SetStructStateExport(GetAvgStateType));
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, int64_t, DiscreteAverageOperation>(
-	                    LogicalType::TIMESTAMP, LogicalType::TIMESTAMP)
-	                    .SetStructStateExport(GetAvgStateType));
+	    LogicalType::TIMESTAMP, LogicalType::TIMESTAMP));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, int64_t, DiscreteAverageOperation>(
-	                    LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ)
-	                    .SetStructStateExport(GetAvgStateType));
+	    LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, int64_t, DiscreteAverageOperation>(
-	                    LogicalType::TIME, LogicalType::TIME)
-	                    .SetStructStateExport(GetAvgStateType));
+	    LogicalType::TIME, LogicalType::TIME));
 	avg.AddFunction(
 	    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, dtime_tz_t, dtime_tz_t, TimeTZAverageOperation>(
-	        LogicalType::TIME_TZ, LogicalType::TIME_TZ)
-	        .SetStructStateExport(GetAvgStateType));
+	        LogicalType::TIME_TZ, LogicalType::TIME_TZ));
 
 	return avg;
 }
 
 AggregateFunction FAvgFun::GetFunction() {
-	return AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(
-	    LogicalType::DOUBLE, LogicalType::DOUBLE);
+	return AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(LogicalType::DOUBLE,
+	                                                                                               LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -10,13 +10,14 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *AvgStateNames[] = {"count", "value"};
+
 template <class T>
 struct AvgState {
 	uint64_t count;
 	T value;
 
-	static constexpr const char *STATE_NAMES[] = {"count", "value"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, T>;
+	using STATE_TYPE = StructStateType<AvgStateNames, uint64_t, T>;
 
 	void Combine(const AvgState<T> &other) {
 		this->count += other.count;

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -10,14 +10,13 @@ namespace duckdb {
 
 namespace {
 
-static constexpr const char *AvgStateNames[] = {"count", "value"};
-
 template <class T>
 struct AvgState {
+	static constexpr const char *STATE_NAMES[] = {"count", "value"};
+	using STATE_TYPE = StructStateType<uint64_t, T>;
+
 	uint64_t count;
 	T value;
-
-	using STATE_TYPE = StructStateType<AvgStateNames, uint64_t, T>;
 
 	void Combine(const AvgState<T> &other) {
 		this->count += other.count;
@@ -26,11 +25,11 @@ struct AvgState {
 };
 
 struct IntervalAvgState {
+	static constexpr const char *STATE_NAMES[] = {"count", "value"};
+	using STATE_TYPE = StructStateType<int64_t, interval_t>;
+
 	int64_t count;
 	interval_t value;
-
-	static constexpr const char *STATE_NAMES[] = {"count", "value"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, int64_t, interval_t>;
 
 	void Combine(const IntervalAvgState &other) {
 		this->count += other.count;
@@ -39,6 +38,9 @@ struct IntervalAvgState {
 };
 
 struct KahanAvgState {
+	static constexpr const char *STATE_NAMES[] = {"count", "value", "err"};
+	using STATE_TYPE = StructStateType<uint64_t, double, double>;
+
 	uint64_t count;
 	double value;
 	double err;
@@ -48,9 +50,6 @@ struct KahanAvgState {
 		KahanAddInternal(other.value, this->value, this->err);
 		KahanAddInternal(other.err, this->value, this->err);
 	}
-
-	static constexpr const char *STATE_NAMES[] = {"count", "value", "err"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double>;
 };
 
 struct AverageDecimalBindData : public FunctionData {

--- a/extension/core_functions/aggregate/algebraic/corr.cpp
+++ b/extension/core_functions/aggregate/algebraic/corr.cpp
@@ -6,34 +6,8 @@
 
 namespace duckdb {
 
-LogicalType GetCorrStateType() {
-	child_list_t<LogicalType> covar_children;
-	covar_children.emplace_back("count", LogicalType::UBIGINT);
-	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
-	covar_children.emplace_back("meany", LogicalType::DOUBLE);
-	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
-
-	child_list_t<LogicalType> stddev_types;
-	stddev_types.emplace_back("count", LogicalType::UBIGINT);
-	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
-	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
-	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
-	state_children.emplace_back("dev_pop_x", stddev_type);
-	state_children.emplace_back("dev_pop_y", stddev_type);
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
-LogicalType GetCorrExportStateType(const BoundAggregateFunction &) {
-	return GetCorrStateType();
-}
-
 AggregateFunction CorrFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CorrState, double, double, double, CorrOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetCorrExportStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/covar.cpp
+++ b/extension/core_functions/aggregate/algebraic/covar.cpp
@@ -3,29 +3,14 @@
 
 namespace duckdb {
 
-namespace {
-
-LogicalType GetCovarStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("count", LogicalType::UBIGINT);
-	child_types.emplace_back("meanx", LogicalType::DOUBLE);
-	child_types.emplace_back("meany", LogicalType::DOUBLE);
-	child_types.emplace_back("co_moment", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
-} // namespace
-
 AggregateFunction CovarPopFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarPopOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetCovarStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 AggregateFunction CovarSampFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarSampOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetCovarStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/stddev.cpp
+++ b/extension/core_functions/aggregate/algebraic/stddev.cpp
@@ -4,46 +4,29 @@
 
 namespace duckdb {
 
-namespace {
-
-LogicalType GetStddevStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("count", LogicalType::UBIGINT);
-	child_types.emplace_back("mean", LogicalType::DOUBLE);
-	child_types.emplace_back("dsquared", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
-} // namespace
-
 AggregateFunction StdDevSampFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(LogicalType::DOUBLE,
-	                                                                                           LogicalType::DOUBLE)
-	    .SetStructStateExport(GetStddevStateType);
+	                                                                                           LogicalType::DOUBLE);
 }
 
 AggregateFunction StdDevPopFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevPopOperation>(LogicalType::DOUBLE,
-	                                                                                          LogicalType::DOUBLE)
-	    .SetStructStateExport(GetStddevStateType);
+	                                                                                          LogicalType::DOUBLE);
 }
 
 AggregateFunction VarPopFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(LogicalType::DOUBLE,
-	                                                                                       LogicalType::DOUBLE)
-	    .SetStructStateExport(GetStddevStateType);
+	                                                                                       LogicalType::DOUBLE);
 }
 
 AggregateFunction VarSampFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarSampOperation>(LogicalType::DOUBLE,
-	                                                                                        LogicalType::DOUBLE)
-	    .SetStructStateExport(GetStddevStateType);
+	                                                                                        LogicalType::DOUBLE);
 }
 
 AggregateFunction StandardErrorOfTheMeanFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, StandardErrorOfTheMeanOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetStddevStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -17,59 +17,34 @@ struct BitState {
 	using TYPE = T;
 	bool is_set;
 	T value;
+
+	static constexpr const char *STATE_NAMES[] = {"is_set", "value"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, bool, T>;
 };
-
-template <class T>
-LogicalType GetBitStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
-
-	LogicalType value_type = function.GetReturnType();
-	child_types.emplace_back("value", value_type);
-
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
-LogicalType GetBitStringStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
-	child_types.emplace_back("value", function.GetReturnType());
-	return LogicalType::STRUCT(std::move(child_types));
-}
 
 template <class OP>
 AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
 	switch (type.id()) {
 	case LogicalTypeId::TINYINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint8_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type);
 	case LogicalTypeId::SMALLINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint16_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type);
 	case LogicalTypeId::INTEGER:
-		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint32_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type);
 	case LogicalTypeId::BIGINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint64_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type);
 	case LogicalTypeId::HUGEINT:
-		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<hugeint_t>);
+		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
 	case LogicalTypeId::UTINYINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint8_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type);
 	case LogicalTypeId::USMALLINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint16_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type);
 	case LogicalTypeId::UINTEGER:
-		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint32_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type);
 	case LogicalTypeId::UBIGINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uint64_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type);
 	case LogicalTypeId::UHUGEINT:
-		return AggregateFunction::UnaryAggregate<BitState<uhugeint_t>, uhugeint_t, uhugeint_t, OP>(type, type)
-		    .SetStructStateExport(GetBitStateType<uhugeint_t>);
+		return AggregateFunction::UnaryAggregate<BitState<uhugeint_t>, uhugeint_t, uhugeint_t, OP>(type, type);
 	default:
 		throw InternalException("Unimplemented bitfield type for unary aggregate");
 	}
@@ -253,11 +228,9 @@ AggregateFunctionSet BitAndFun::GetFunctions() {
 		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
 	}
 
-	auto bit_string_fun =
+	bit_and.AddFunction(
 	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
-	        LogicalType::BIT, LogicalType::BIT);
-	bit_string_fun.SetStructStateExport(GetBitStringStateType);
-	bit_and.AddFunction(bit_string_fun);
+	        LogicalType::BIT, LogicalType::BIT));
 	return bit_and;
 }
 
@@ -266,11 +239,9 @@ AggregateFunctionSet BitOrFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
 	}
-	auto bit_string_fun =
+	bit_or.AddFunction(
 	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
-	        LogicalType::BIT, LogicalType::BIT);
-	bit_string_fun.SetStructStateExport(GetBitStringStateType);
-	bit_or.AddFunction(bit_string_fun);
+	        LogicalType::BIT, LogicalType::BIT));
 	return bit_or;
 }
 
@@ -279,11 +250,9 @@ AggregateFunctionSet BitXorFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
 	}
-	auto bit_string_fun =
+	bit_xor.AddFunction(
 	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
-	        LogicalType::BIT, LogicalType::BIT);
-	bit_string_fun.SetStructStateExport(GetBitStringStateType);
-	bit_xor.AddFunction(bit_string_fun);
+	        LogicalType::BIT, LogicalType::BIT));
 	return bit_xor;
 }
 

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -12,14 +12,15 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *BitStateNames[] = {"is_set", "value"};
+
 template <class T>
 struct BitState {
 	using TYPE = T;
 	bool is_set;
 	T value;
 
-	static constexpr const char *STATE_NAMES[] = {"is_set", "value"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, T>;
+	using STATE_TYPE = StructStateType<BitStateNames, bool, T>;
 };
 
 template <class OP>

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -12,15 +12,14 @@ namespace duckdb {
 
 namespace {
 
-static constexpr const char *BitStateNames[] = {"is_set", "value"};
-
 template <class T>
 struct BitState {
+	static constexpr const char *STATE_NAMES[] = {"is_set", "value"};
+	using STATE_TYPE = StructStateType<bool, T>;
+
 	using TYPE = T;
 	bool is_set;
 	T value;
-
-	using STATE_TYPE = StructStateType<BitStateNames, bool, T>;
 };
 
 template <class OP>

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -13,17 +13,13 @@ namespace {
 struct BoolState {
 	bool empty;
 	bool val;
+
+	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, bool, bool>;
 };
 
 using BoolAndFunFunction = EmptyValAggregate<LogicalAnd, ConstantInit<true>>;
 using BoolOrFunFunction = EmptyValAggregate<LogicalOr, ConstantInit<false>>;
-
-LogicalType GetBoolAndStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("empty", LogicalType::BOOLEAN);
-	child_types.emplace_back("val", LogicalType::BOOLEAN);
-	return LogicalType::STRUCT(std::move(child_types));
-}
 
 } // namespace
 
@@ -32,7 +28,7 @@ AggregateFunction BoolOrFun::GetFunction() {
 	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
-	return fun.SetStructStateExport(GetBoolAndStateType);
+	return fun;
 }
 
 AggregateFunction BoolAndFun::GetFunction() {
@@ -40,7 +36,7 @@ AggregateFunction BoolAndFun::GetFunction() {
 	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
-	return fun.SetStructStateExport(GetBoolAndStateType);
+	return fun;
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 namespace {
 
 struct BoolState {
+	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
+	using STATE_TYPE = StructStateType<bool, bool>;
+
 	bool empty;
 	bool val;
-
-	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, bool>;
 };
 
 using BoolAndFunFunction = EmptyValAggregate<LogicalAnd, ConstantInit<true>>;

--- a/extension/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/extension/core_functions/aggregate/distributive/kurtosis.cpp
@@ -14,6 +14,9 @@ struct KurtosisState {
 	double sum_sqr;
 	double sum_cub;
 	double sum_four;
+
+	static constexpr const char *STATE_NAMES[] = {"n", "sum", "sum_sqr", "sum_cub", "sum_four"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, idx_t, double, double, double, double>;
 };
 
 struct KurtosisFlagBiasCorrection {};
@@ -94,16 +97,6 @@ struct KurtosisOperation {
 	}
 };
 
-LogicalType GetKurtosisStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("n", LogicalType::UBIGINT);
-	children.emplace_back("sum", LogicalType::DOUBLE);
-	children.emplace_back("sum_sqr", LogicalType::DOUBLE);
-	children.emplace_back("sum_cub", LogicalType::DOUBLE);
-	children.emplace_back("sum_four", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(children));
-}
-
 } // namespace
 
 AggregateFunction KurtosisFun::GetFunction() {
@@ -111,7 +104,6 @@ AggregateFunction KurtosisFun::GetFunction() {
 	    AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation<KurtosisFlagBiasCorrection>>(
 	        LogicalType::DOUBLE, LogicalType::DOUBLE);
 	result.SetFallible();
-	result.SetStructStateExport(GetKurtosisStateType);
 	return result;
 }
 
@@ -120,7 +112,6 @@ AggregateFunction KurtosisPopFun::GetFunction() {
 	                                                KurtosisOperation<KurtosisFlagNoBiasCorrection>>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE);
 	result.SetFallible();
-	result.SetStructStateExport(GetKurtosisStateType);
 	return result;
 }
 

--- a/extension/core_functions/aggregate/distributive/kurtosis.cpp
+++ b/extension/core_functions/aggregate/distributive/kurtosis.cpp
@@ -9,14 +9,14 @@ namespace duckdb {
 namespace {
 
 struct KurtosisState {
+	static constexpr const char *STATE_NAMES[] = {"n", "sum", "sum_sqr", "sum_cub", "sum_four"};
+	using STATE_TYPE = StructStateType<idx_t, double, double, double, double>;
+
 	idx_t n;
 	double sum;
 	double sum_sqr;
 	double sum_cub;
 	double sum_four;
-
-	static constexpr const char *STATE_NAMES[] = {"n", "sum", "sum_sqr", "sum_cub", "sum_four"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, idx_t, double, double, double, double>;
 };
 
 struct KurtosisFlagBiasCorrection {};

--- a/extension/core_functions/aggregate/distributive/product.cpp
+++ b/extension/core_functions/aggregate/distributive/product.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 namespace {
 
 struct ProductState {
+	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
+	using STATE_TYPE = StructStateType<bool, double>;
+
 	bool empty;
 	double val;
-
-	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, double>;
 };
 
 struct ProductReduce {

--- a/extension/core_functions/aggregate/distributive/product.cpp
+++ b/extension/core_functions/aggregate/distributive/product.cpp
@@ -13,6 +13,9 @@ namespace {
 struct ProductState {
 	bool empty;
 	double val;
+
+	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, bool, double>;
 };
 
 struct ProductReduce {
@@ -33,19 +36,11 @@ struct ProductFunction : public EmptyValAggregate<ProductReduce, ConstantInit<1>
 	}
 };
 
-LogicalType GetProductStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("empty", LogicalType::BOOLEAN);
-	children.emplace_back("val", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(children));
-}
-
 } // namespace
 
 AggregateFunction ProductFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<ProductState, double, double, ProductFunction>(
-	           LogicalType(LogicalTypeId::DOUBLE), LogicalType::DOUBLE)
-	    .SetStructStateExport(GetProductStateType);
+	    LogicalType(LogicalTypeId::DOUBLE), LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/distributive/skew.cpp
+++ b/extension/core_functions/aggregate/distributive/skew.cpp
@@ -11,7 +11,7 @@ namespace {
 
 struct SkewState {
 	static constexpr const char *STATE_NAMES[] = {"n", "sum", "sum_sqr", "sum_cub"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, idx_t, double, double, double>;
+	using STATE_TYPE = StructStateType<idx_t, double, double, double>;
 
 	idx_t n;
 	double sum;

--- a/extension/core_functions/aggregate/distributive/skew.cpp
+++ b/extension/core_functions/aggregate/distributive/skew.cpp
@@ -10,6 +10,9 @@ namespace duckdb {
 namespace {
 
 struct SkewState {
+	static constexpr const char *STATE_NAMES[] = {"n", "sum", "sum_sqr", "sum_cub"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, idx_t, double, double, double>;
+
 	idx_t n;
 	double sum;
 	double sum_sqr;
@@ -81,22 +84,11 @@ struct SkewnessOperation {
 	}
 };
 
-LogicalType GetSkewnessStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("n", LogicalType::UBIGINT);
-	children.emplace_back("sum", LogicalType::DOUBLE);
-	children.emplace_back("sum_sqr", LogicalType::DOUBLE);
-	children.emplace_back("sum_cub", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(children));
-}
-
 } // namespace
 
 AggregateFunction SkewnessFun::GetFunction() {
-	auto result = AggregateFunction::UnaryAggregate<SkewState, double, double, SkewnessOperation>(LogicalType::DOUBLE,
-	                                                                                              LogicalType::DOUBLE);
-	result.SetStructStateExport(GetSkewnessStateType);
-	return result;
+	return AggregateFunction::UnaryAggregate<SkewState, double, double, SkewnessOperation>(LogicalType::DOUBLE,
+	                                                                                       LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -183,37 +183,6 @@ struct KahanSumOperation : public BaseSumOperation<SumSetOperation, KahanAdd> {
 using HugeintSumOperation =
     ClusteredSumOperation<BaseSumOperation<SumSetOperation, HugeintAdd>, ClusteredAddOp<HugeintAdd>>;
 
-template <class T>
-static LogicalType GetValueLogicalType();
-
-template <>
-LogicalType GetValueLogicalType<int64_t>() {
-	return LogicalType::BIGINT;
-}
-template <>
-LogicalType GetValueLogicalType<hugeint_t>() {
-	return LogicalType::HUGEINT;
-}
-template <>
-LogicalType GetValueLogicalType<double>() {
-	return LogicalType::DOUBLE;
-}
-
-template <class T>
-LogicalType GetSumStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("isset", LogicalType::BOOLEAN);
-
-	LogicalType value_type = GetValueLogicalType<T>();
-	// Use the return type when its physical representation matches the state type
-	if (function.GetReturnType().InternalType() == value_type.InternalType()) {
-		value_type = function.GetReturnType();
-	}
-	child_types.emplace_back("value", value_type);
-
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
 unique_ptr<FunctionData> SumNoOverflowBind(BindAggregateFunctionInput &input) {
 	throw BinderException("sum_no_overflow is for internal use only!");
 }
@@ -238,7 +207,7 @@ AggregateFunction GetSumAggregateNoOverflow(PhysicalType type) {
 		function.SetBindCallback(SumNoOverflowBind);
 		function.SetSerializeCallback(SumNoOverflowSerialize);
 		function.SetDeserializeCallback(SumNoOverflowDeserialize);
-		return function.SetStructStateExport(GetSumStateType<int64_t>);
+		return function;
 	}
 	case PhysicalType::INT64: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, int64_t, hugeint_t, IntegerSumOperation>(
@@ -248,7 +217,7 @@ AggregateFunction GetSumAggregateNoOverflow(PhysicalType type) {
 		function.SetBindCallback(SumNoOverflowBind);
 		function.SetSerializeCallback(SumNoOverflowSerialize);
 		function.SetDeserializeCallback(SumNoOverflowDeserialize);
-		return function.SetStructStateExport(GetSumStateType<int64_t>);
+		return function;
 	}
 	default:
 		throw BinderException("Unsupported internal type for sum_no_overflow");
@@ -305,13 +274,13 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, bool, hugeint_t, IntegerSumOperation>(
 		    LogicalType::BOOLEAN, LogicalType::HUGEINT);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-		return function.SetStructStateExport(GetSumStateType<int64_t>);
+		return function;
 	}
 	case PhysicalType::INT16: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
 		    LogicalType::SMALLINT, LogicalType::HUGEINT);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-		return function.SetStructStateExport(GetSumStateType<int64_t>);
+		return function;
 	}
 
 	case PhysicalType::INT32: {
@@ -320,7 +289,7 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 		        LogicalType::INTEGER, LogicalType::HUGEINT);
 		function.SetStatisticsCallback(SumPropagateStats);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-		return function.SetStructStateExport(GetSumStateType<hugeint_t>);
+		return function;
 	}
 	case PhysicalType::INT64: {
 		auto function =
@@ -328,14 +297,14 @@ AggregateFunction GetSumAggregate(PhysicalType type) {
 		        LogicalType::BIGINT, LogicalType::HUGEINT);
 		function.SetStatisticsCallback(SumPropagateStats);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-		return function.SetStructStateExport(GetSumStateType<hugeint_t>);
+		return function;
 	}
 	case PhysicalType::INT128: {
 		auto function =
 		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
 		        LogicalType::HUGEINT, LogicalType::HUGEINT);
 		function.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
-		return function.SetStructStateExport(GetSumStateType<hugeint_t>);
+		return function;
 	}
 	default:
 		throw InternalException("Unimplemented sum aggregate");
@@ -418,8 +387,7 @@ AggregateFunctionSet SumFun::GetFunctions() {
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
 	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE)
-	                    .SetStructStateExport(GetSumStateType<double>));
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 	sum.AddFunction(AggregateFunction::UnaryAggregate<BignumState, bignum_t, bignum_t, BignumOperation>(
 	    LogicalType::BIGNUM, LogicalType::BIGNUM));
 	return sum;

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -437,18 +437,9 @@ AggregateFunctionSet SumNoOverflowFun::GetFunctions() {
 	return sum_no_overflow;
 }
 
-LogicalType GetKahanSumStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("isset", LogicalType::BOOLEAN);
-	children.emplace_back("value", LogicalType::DOUBLE);
-	children.emplace_back("err", LogicalType::DOUBLE);
-	return LogicalType::STRUCT(std::move(children));
-}
-
 AggregateFunction KahanSumFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<KahanSumState, double, double, KahanSumOperation>(LogicalType::DOUBLE,
-	                                                                                           LogicalType::DOUBLE)
-	    .SetStructStateExport(GetKahanSumStateType);
+	                                                                                           LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_avg.cpp
+++ b/extension/core_functions/aggregate/regression/regr_avg.cpp
@@ -11,6 +11,9 @@ namespace {
 struct RegrState {
 	double sum;
 	uint64_t count;
+
+	static constexpr const char *STATE_NAMES[] = {"sum", "count"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, double, uint64_t>;
 };
 
 struct RegrAvgFunction {
@@ -48,25 +51,16 @@ struct RegrAvgYFunction : RegrAvgFunction {
 	}
 };
 
-LogicalType GetRegrAvgStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("sum", LogicalType::DOUBLE);
-	child_types.emplace_back("count", LogicalType::UBIGINT);
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
 } // namespace
 
 AggregateFunction RegrAvgxFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgXFunction>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrAvgStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 AggregateFunction RegrAvgyFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgYFunction>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrAvgStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_avg.cpp
+++ b/extension/core_functions/aggregate/regression/regr_avg.cpp
@@ -9,11 +9,11 @@ namespace duckdb {
 namespace {
 
 struct RegrState {
+	static constexpr const char *STATE_NAMES[] = {"sum", "count"};
+	using STATE_TYPE = StructStateType<double, uint64_t>;
+
 	double sum;
 	uint64_t count;
-
-	static constexpr const char *STATE_NAMES[] = {"sum", "count"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, double, uint64_t>;
 };
 
 struct RegrAvgFunction {

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -8,13 +8,13 @@ namespace duckdb {
 
 namespace {
 struct RegrInterceptState {
+	static constexpr const char *STATE_NAMES[] = {"count", "sum_x", "sum_y", "slope"};
+	using STATE_TYPE = StructStateType<uint64_t, double, double, RegrSlopeState>;
+
 	uint64_t count;
 	double sum_x;
 	double sum_y;
 	RegrSlopeState slope;
-
-	static constexpr const char *STATE_NAMES[] = {"count", "sum_x", "sum_y", "slope"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double, RegrSlopeState>;
 };
 
 struct RegrInterceptOperation {

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -12,6 +12,9 @@ struct RegrInterceptState {
 	double sum_x;
 	double sum_y;
 	RegrSlopeState slope;
+
+	static constexpr const char *STATE_NAMES[] = {"count", "sum_x", "sum_y", "slope"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double, RegrSlopeState>;
 };
 
 struct RegrInterceptOperation {
@@ -52,37 +55,11 @@ struct RegrInterceptOperation {
 	}
 };
 
-LogicalType GetRegrInterceptStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> covpop_children;
-	covpop_children.emplace_back("count", LogicalType::UBIGINT);
-	covpop_children.emplace_back("meanx", LogicalType::DOUBLE);
-	covpop_children.emplace_back("meany", LogicalType::DOUBLE);
-	covpop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	auto covpop_type = LogicalType::STRUCT(std::move(covpop_children));
-
-	child_list_t<LogicalType> varpop_children;
-	varpop_children.emplace_back("count", LogicalType::UBIGINT);
-	varpop_children.emplace_back("mean", LogicalType::DOUBLE);
-	varpop_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	auto varpop_type = LogicalType::STRUCT(std::move(varpop_children));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("count", LogicalType::UBIGINT);
-	state_children.emplace_back("sum_x", LogicalType::DOUBLE);
-	state_children.emplace_back("sum_y", LogicalType::DOUBLE);
-	child_list_t<LogicalType> slope_children;
-	slope_children.emplace_back("cov_pop", std::move(covpop_type));
-	slope_children.emplace_back("var_pop", std::move(varpop_type));
-	state_children.emplace_back("slope", LogicalType::STRUCT(std::move(slope_children)));
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
 } // namespace
 
 AggregateFunction RegrInterceptFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrInterceptState, double, double, double, RegrInterceptOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrInterceptStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -13,12 +13,12 @@ namespace duckdb {
 
 namespace {
 struct RegrR2State {
+	static constexpr const char *STATE_NAMES[] = {"corr", "var_pop_x", "var_pop_y"};
+	using STATE_TYPE = StructStateType<CorrState, StddevState, StddevState>;
+
 	CorrState corr;
 	StddevState var_pop_x;
 	StddevState var_pop_y;
-
-	static constexpr const char *STATE_NAMES[] = {"corr", "var_pop_x", "var_pop_y"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, CorrState, StddevState, StddevState>;
 };
 
 struct RegrR2Operation {

--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -16,6 +16,9 @@ struct RegrR2State {
 	CorrState corr;
 	StddevState var_pop_x;
 	StddevState var_pop_y;
+
+	static constexpr const char *STATE_NAMES[] = {"corr", "var_pop_x", "var_pop_y"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, CorrState, StddevState, StddevState>;
 };
 
 struct RegrR2Operation {
@@ -54,39 +57,11 @@ struct RegrR2Operation {
 	}
 };
 
-LogicalType GetRegrR2StateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> covar_children;
-	covar_children.emplace_back("count", LogicalType::UBIGINT);
-	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
-	covar_children.emplace_back("meany", LogicalType::DOUBLE);
-	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
-
-	child_list_t<LogicalType> stddev_types;
-	stddev_types.emplace_back("count", LogicalType::UBIGINT);
-	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
-	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
-	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
-
-	child_list_t<LogicalType> corr_children;
-	corr_children.emplace_back("cov_pop", std::move(cov_pop_type));
-	corr_children.emplace_back("dev_pop_x", stddev_type);
-	corr_children.emplace_back("dev_pop_y", stddev_type);
-	auto corr_state = LogicalType::STRUCT(std::move(corr_children));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("corr", corr_state);
-	state_children.emplace_back("var_pop_x", stddev_type);
-	state_children.emplace_back("var_pop_y", stddev_type);
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
 } // namespace
 
 AggregateFunction RegrR2Fun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrR2State, double, double, double, RegrR2Operation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrR2StateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_slope.cpp
+++ b/extension/core_functions/aggregate/regression/regr_slope.cpp
@@ -12,34 +12,9 @@
 
 namespace duckdb {
 
-namespace {
-
-LogicalType GetRegrSlopeStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> covar_children;
-	covar_children.emplace_back("count", LogicalType::UBIGINT);
-	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
-	covar_children.emplace_back("meany", LogicalType::DOUBLE);
-	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
-
-	child_list_t<LogicalType> stddev_types;
-	stddev_types.emplace_back("count", LogicalType::UBIGINT);
-	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
-	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
-	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
-	state_children.emplace_back("var_pop", std::move(stddev_type));
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
-} // namespace
-
 AggregateFunction RegrSlopeFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrSlopeState, double, double, double, RegrSlopeOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrSlopeStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 
 namespace {
 struct RegrSState {
+	static constexpr const char *STATE_NAMES[] = {"count", "var_pop"};
+	using STATE_TYPE = StructStateType<uint64_t, StddevState>;
+
 	uint64_t count;
 	StddevState var_pop;
-
-	static constexpr const char *STATE_NAMES[] = {"count", "var_pop"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, StddevState>;
 };
 
 struct RegrBaseOperation {

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -13,6 +13,9 @@ namespace {
 struct RegrSState {
 	uint64_t count;
 	StddevState var_pop;
+
+	static constexpr const char *STATE_NAMES[] = {"count", "var_pop"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, StddevState>;
 };
 
 struct RegrBaseOperation {
@@ -54,31 +57,16 @@ struct RegrSYYOperation : RegrBaseOperation {
 	}
 };
 
-LogicalType GetRegrSStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> stddev_types;
-	stddev_types.emplace_back("count", LogicalType::UBIGINT);
-	stddev_types.emplace_back("mean", LogicalType::DOUBLE);
-	stddev_types.emplace_back("dsquared", LogicalType::DOUBLE);
-	auto stddev_type = LogicalType::STRUCT(std::move(stddev_types));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("count", LogicalType::UBIGINT);
-	state_children.emplace_back("var_pop", stddev_type);
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
 } // namespace
 
 AggregateFunction RegrSXXFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSXXOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrSStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 AggregateFunction RegrSYYFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSYYOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrSStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 namespace {
 
 struct RegrSXyState {
+	static constexpr const char *STATE_NAMES[] = {"count", "cov_pop"};
+	using STATE_TYPE = StructStateType<uint64_t, CovarState>;
+
 	uint64_t count;
 	CovarState cov_pop;
-
-	static constexpr const char *STATE_NAMES[] = {"count", "cov_pop"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, CovarState>;
 };
 
 struct RegrSXYOperation {

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -13,6 +13,9 @@ namespace {
 struct RegrSXyState {
 	uint64_t count;
 	CovarState cov_pop;
+
+	static constexpr const char *STATE_NAMES[] = {"count", "cov_pop"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, CovarState>;
 };
 
 struct RegrSXYOperation {
@@ -41,27 +44,11 @@ struct RegrSXYOperation {
 	}
 };
 
-LogicalType GetRegrSXYStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> covar_children;
-	covar_children.emplace_back("count", LogicalType::UBIGINT);
-	covar_children.emplace_back("meanx", LogicalType::DOUBLE);
-	covar_children.emplace_back("meany", LogicalType::DOUBLE);
-	covar_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	auto cov_pop_type = LogicalType::STRUCT(std::move(covar_children));
-
-	child_list_t<LogicalType> state_children;
-	state_children.emplace_back("count", LogicalType::UBIGINT);
-	state_children.emplace_back("cov_pop", std::move(cov_pop_type));
-
-	return LogicalType::STRUCT(std::move(state_children));
-}
-
 } // namespace
 
 AggregateFunction RegrSXYFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<RegrSXyState, double, double, double, RegrSXYOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetRegrSXYStateType);
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
 }
 
 } // namespace duckdb

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
@@ -18,6 +18,9 @@ struct CorrState {
 	CovarState cov_pop;
 	StddevState dev_pop_x;
 	StddevState dev_pop_y;
+
+	static constexpr const char *STATE_NAMES[] = {"cov_pop", "dev_pop_x", "dev_pop_y"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, CovarState, StddevState, StddevState>;
 };
 
 // Returns the correlation coefficient for non-null pairs in a group.

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/corr.hpp
@@ -15,12 +15,12 @@
 namespace duckdb {
 
 struct CorrState {
+	static constexpr const char *STATE_NAMES[] = {"cov_pop", "dev_pop_x", "dev_pop_y"};
+	using STATE_TYPE = StructStateType<CovarState, StddevState, StddevState>;
+
 	CovarState cov_pop;
 	StddevState dev_pop_x;
 	StddevState dev_pop_y;
-
-	static constexpr const char *STATE_NAMES[] = {"cov_pop", "dev_pop_x", "dev_pop_y"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, CovarState, StddevState, StddevState>;
 };
 
 // Returns the correlation coefficient for non-null pairs in a group.

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
@@ -18,6 +18,9 @@ struct CovarState {
 	double meanx;
 	double meany;
 	double co_moment;
+
+	static constexpr const char *STATE_NAMES[] = {"count", "meanx", "meany", "co_moment"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double, double>;
 };
 
 struct CovarOperation {

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/covar.hpp
@@ -14,13 +14,13 @@
 namespace duckdb {
 
 struct CovarState {
+	static constexpr const char *STATE_NAMES[] = {"count", "meanx", "meany", "co_moment"};
+	using STATE_TYPE = StructStateType<uint64_t, double, double, double>;
+
 	uint64_t count;
 	double meanx;
 	double meany;
 	double co_moment;
-
-	static constexpr const char *STATE_NAMES[] = {"count", "meanx", "meany", "co_moment"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double, double>;
 };
 
 struct CovarOperation {

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -15,12 +15,12 @@
 namespace duckdb {
 
 struct StddevState {
+	static constexpr const char *STATE_NAMES[] = {"count", "mean", "dsquared"};
+	using STATE_TYPE = StructStateType<uint64_t, double, double>;
+
 	uint64_t count;  //  n
 	double mean;     //  M1
 	double dsquared; //  M2
-
-	static constexpr const char *STATE_NAMES[] = {"count", "mean", "dsquared"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double>;
 };
 
 // Streaming approximate standard deviation using Welford's

--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -18,6 +18,9 @@ struct StddevState {
 	uint64_t count;  //  n
 	double mean;     //  M1
 	double dsquared; //  M2
+
+	static constexpr const char *STATE_NAMES[] = {"count", "mean", "dsquared"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double, double>;
 };
 
 // Streaming approximate standard deviation using Welford's

--- a/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
@@ -13,11 +13,11 @@
 namespace duckdb {
 
 struct RegrSlopeState {
+	static constexpr const char *STATE_NAMES[] = {"cov_pop", "var_pop"};
+	using STATE_TYPE = StructStateType<CovarState, StddevState>;
+
 	CovarState cov_pop;
 	StddevState var_pop;
-
-	static constexpr const char *STATE_NAMES[] = {"cov_pop", "var_pop"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, CovarState, StddevState>;
 };
 
 struct RegrSlopeOperation {

--- a/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/regression/regr_slope.hpp
@@ -15,6 +15,9 @@ namespace duckdb {
 struct RegrSlopeState {
 	CovarState cov_pop;
 	StddevState var_pop;
+
+	static constexpr const char *STATE_NAMES[] = {"cov_pop", "var_pop"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, CovarState, StddevState>;
 };
 
 struct RegrSlopeOperation {

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -29,6 +29,9 @@ struct SumState {
 	bool isset;
 	T value;
 
+	static constexpr const char *STATE_NAMES[] = {"isset", "value"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, bool, T>;
+
 	void Combine(const SumState<T> &other) {
 		this->isset = other.isset || this->isset;
 		this->value += other.value;

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -24,14 +24,13 @@ static inline void KahanAddInternal(double input, double &summed, double &err) {
 	summed = newval;
 }
 
-inline constexpr const char *SumStateNames[] = {"isset", "value"};
-
 template <class T>
 struct SumState {
+	static constexpr const char *STATE_NAMES[] = {"isset", "value"};
+	using STATE_TYPE = StructStateType<bool, T>;
+
 	bool isset;
 	T value;
-
-	using STATE_TYPE = StructStateType<SumStateNames, bool, T>;
 
 	void Combine(const SumState<T> &other) {
 		this->isset = other.isset || this->isset;
@@ -40,6 +39,9 @@ struct SumState {
 };
 
 struct KahanSumState {
+	static constexpr const char *STATE_NAMES[] = {"isset", "value", "err"};
+	using STATE_TYPE = StructStateType<bool, double, double>;
+
 	bool isset;
 	double value;
 	double err;
@@ -49,9 +51,6 @@ struct KahanSumState {
 		KahanAddInternal(other.value, this->value, this->err);
 		KahanAddInternal(other.err, this->value, this->err);
 	}
-
-	static constexpr const char *STATE_NAMES[] = {"isset", "value", "err"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, double, double>;
 };
 
 struct RegularAdd {

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/function/aggregate_state.hpp"
+#include "duckdb/function/aggregate_state_layout.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 
 namespace duckdb {
@@ -44,6 +45,9 @@ struct KahanSumState {
 		KahanAddInternal(other.value, this->value, this->err);
 		KahanAddInternal(other.err, this->value, this->err);
 	}
+
+	static constexpr const char *STATE_NAMES[] = {"isset", "value", "err"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, bool, double, double>;
 };
 
 struct RegularAdd {

--- a/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/sum_helpers.hpp
@@ -24,13 +24,14 @@ static inline void KahanAddInternal(double input, double &summed, double &err) {
 	summed = newval;
 }
 
+inline constexpr const char *SumStateNames[] = {"isset", "value"};
+
 template <class T>
 struct SumState {
 	bool isset;
 	T value;
 
-	static constexpr const char *STATE_NAMES[] = {"isset", "value"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, T>;
+	using STATE_TYPE = StructStateType<SumStateNames, bool, T>;
 
 	void Combine(const SumState<T> &other) {
 		this->isset = other.isset || this->isset;

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -15,6 +15,9 @@ struct FirstState {
 	T value;
 	bool is_set;
 	bool is_null;
+
+	static constexpr const char *STATE_NAMES[] = {"value", "is_set", "is_null"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool, bool>;
 };
 
 struct FirstFunctionBase {
@@ -293,15 +296,6 @@ struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	}
 };
 
-LogicalType GetFirstStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> child_types;
-	LogicalType value_type = function.GetArguments()[0];
-	child_types.emplace_back("value", value_type);
-	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
-	child_types.emplace_back("is_null", LogicalType::BOOLEAN);
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
 template <class T, bool LAST, bool SKIP_NULLS>
 void FirstFunctionClusterUpdate(Vector inputs[], AggregateInputData &aggregate_input_data, idx_t input_count,
                                 const ClusteredAggr &clustered, idx_t count) {
@@ -328,7 +322,7 @@ AggregateFunction GetFirstAggregateTemplated(const LogicalType &type) {
 	                      AggregateFunction::StateCombine<FirstState<T>, FirstFunction<LAST, SKIP_NULLS>>,
 	                      AggregateFunction::StateFinalize<FirstState<T>, T, FirstFunction<LAST, SKIP_NULLS>>,
 	                      FunctionNullHandling::DEFAULT_NULL_HANDLING, FirstFunctionClusterUpdate<T, LAST, SKIP_NULLS>);
-	result.SetStructStateExport(GetFirstStateType);
+	AggregateFunction::WireStructStateType<FirstState<T>>(result);
 	return result;
 }
 
@@ -388,15 +382,11 @@ AggregateFunction GetFirstFunction(const LogicalType &type) {
 		return GetFirstAggregateTemplated<interval_t, LAST, SKIP_NULLS>(type);
 	case PhysicalType::VARCHAR:
 		if (LAST) {
-			auto fun = AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
-			                                                       FirstFunctionString<LAST, SKIP_NULLS>>(type, type);
-			fun.SetStructStateExport(GetFirstStateType);
-			return fun;
+			return AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
+			                                                   FirstFunctionString<LAST, SKIP_NULLS>>(type, type);
 		} else {
-			auto fun = AggregateFunction::UnaryAggregate<FirstState<string_t>, string_t, string_t,
-			                                             FirstFunctionString<LAST, SKIP_NULLS>>(type, type);
-			fun.SetStructStateExport(GetFirstStateType);
-			return fun;
+			return AggregateFunction::UnaryAggregate<FirstState<string_t>, string_t, string_t,
+			                                         FirstFunctionString<LAST, SKIP_NULLS>>(type, type);
 		}
 	default: {
 		using OP = FirstVectorFunction<LAST, SKIP_NULLS>;
@@ -406,7 +396,7 @@ AggregateFunction GetFirstFunction(const LogicalType &type) {
 		    OP::Update, AggregateFunction::StateCombine<STATE, OP>, AggregateFunction::StateVoidFinalize<STATE, OP>,
 		    FunctionNullHandling::DEFAULT_NULL_HANDLING, AggregateFunction::NoClusterUpdate(), OP::Bind,
 		    LAST ? AggregateFunction::StateDestroy<STATE, OP> : nullptr, nullptr, nullptr);
-		fun.SetStructStateExport(GetFirstStateType);
+		AggregateFunction::WireStructStateType<STATE>(fun);
 		return fun;
 	}
 	}

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -9,6 +9,8 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *FirstStateNames[] = {"value", "is_set", "is_null"};
+
 template <class T>
 struct FirstState {
 	using VALUE_TYPE = T;
@@ -16,8 +18,7 @@ struct FirstState {
 	bool is_set;
 	bool is_null;
 
-	static constexpr const char *STATE_NAMES[] = {"value", "is_set", "is_null"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool, bool>;
+	using STATE_TYPE = StructStateType<FirstStateNames, T, bool, bool>;
 };
 
 struct FirstFunctionBase {

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -9,16 +9,15 @@ namespace duckdb {
 
 namespace {
 
-static constexpr const char *FirstStateNames[] = {"value", "is_set", "is_null"};
-
 template <class T>
 struct FirstState {
+	static constexpr const char *STATE_NAMES[] = {"value", "is_set", "is_null"};
+	using STATE_TYPE = StructStateType<T, bool, bool>;
+
 	using VALUE_TYPE = T;
 	T value;
 	bool is_set;
 	bool is_null;
-
-	using STATE_TYPE = StructStateType<FirstStateNames, T, bool, bool>;
 };
 
 struct FirstFunctionBase {

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -20,13 +20,14 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *MinMaxStateNames[] = {"value", "isset"};
+
 template <class T>
 struct MinMaxState {
 	T value;
 	bool isset;
 
-	static constexpr const char *STATE_NAMES[] = {"value", "isset"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool>;
+	using STATE_TYPE = StructStateType<MinMaxStateNames, T, bool>;
 };
 
 template <class OP>

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -20,14 +20,13 @@ namespace duckdb {
 
 namespace {
 
-static constexpr const char *MinMaxStateNames[] = {"value", "isset"};
-
 template <class T>
 struct MinMaxState {
+	static constexpr const char *STATE_NAMES[] = {"value", "isset"};
+	using STATE_TYPE = StructStateType<T, bool>;
+
 	T value;
 	bool isset;
-
-	using STATE_TYPE = StructStateType<MinMaxStateNames, T, bool>;
 };
 
 template <class OP>

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -24,6 +24,9 @@ template <class T>
 struct MinMaxState {
 	T value;
 	bool isset;
+
+	static constexpr const char *STATE_NAMES[] = {"value", "isset"};
+	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool>;
 };
 
 template <class OP>
@@ -361,7 +364,9 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	auto state_export_type = function.GetStateTypeCallback();
 	auto minmax_func = GetMinMaxOperator<OP, OP_STRING, OP_VECTOR>(input_type);
 
-	minmax_func.SetStructStateExport(state_export_type);
+	if (state_export_type) {
+		minmax_func.SetStructStateExport(state_export_type);
+	}
 	minmax_func.SetName(std::move(name));
 	minmax_func.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	minmax_func.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
@@ -541,14 +546,14 @@ LogicalType GetExportStateType(const BoundAggregateFunction &function) {
 //---------------------------------------------------s
 AggregateFunctionSet MinFun::GetFunctions() {
 	AggregateFunctionSet min("min");
-	min.AddFunction(MinFunction::GetFunction().SetStructStateExport(GetExportStateType));
+	min.AddFunction(MinFunction::GetFunction());
 	min.AddFunction(GetMinMaxNFunction<LessThan>().SetStructStateExport(GetExportStateType));
 	return min;
 }
 
 AggregateFunctionSet MaxFun::GetFunctions() {
 	AggregateFunctionSet max("max");
-	max.AddFunction(MaxFunction::GetFunction().SetStructStateExport(GetExportStateType));
+	max.AddFunction(MaxFunction::GetFunction());
 	max.AddFunction(GetMinMaxNFunction<GreaterThan>().SetStructStateExport(GetExportStateType));
 	return max;
 }

--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -135,4 +135,64 @@ bool IsIntegerType() {
 	return TypeIsIntegral(GetTypeId<T>());
 }
 
+//! Returns the LogicalType corresponding to a C++ primitive type
+template <class T>
+LogicalType PrimitiveToLogicalType() {
+	using TYPE = typename std::remove_cv<T>::type;
+	if (std::is_same<TYPE, bool>()) {
+		return LogicalType::BOOLEAN;
+	} else if (std::is_same<TYPE, int8_t>()) {
+		return LogicalType::TINYINT;
+	} else if (std::is_same<TYPE, int16_t>()) {
+		return LogicalType::SMALLINT;
+	} else if (std::is_same<TYPE, int32_t>()) {
+		return LogicalType::INTEGER;
+	} else if (std::is_same<TYPE, int64_t>()) {
+		return LogicalType::BIGINT;
+	} else if (std::is_same<TYPE, uint8_t>()) {
+		return LogicalType::UTINYINT;
+	} else if (std::is_same<TYPE, uint16_t>()) {
+		return LogicalType::USMALLINT;
+	} else if (std::is_same<TYPE, uint32_t>()) {
+		return LogicalType::UINTEGER;
+	} else if (std::is_same<TYPE, uint64_t>() || std::is_same<TYPE, idx_t>()) {
+		return LogicalType::UBIGINT;
+	} else if (std::is_same<TYPE, hugeint_t>()) {
+		return LogicalType::HUGEINT;
+	} else if (std::is_same<TYPE, uhugeint_t>()) {
+		return LogicalType::UHUGEINT;
+	} else if (std::is_same<TYPE, float>()) {
+		return LogicalType::FLOAT;
+	} else if (std::is_same<TYPE, double>()) {
+		return LogicalType::DOUBLE;
+	} else if (std::is_same<TYPE, date_t>()) {
+		return LogicalType::DATE;
+	} else if (std::is_same<TYPE, dtime_t>()) {
+		return LogicalType::TIME;
+	} else if (std::is_same<TYPE, dtime_tz_t>()) {
+		return LogicalType::TIME_TZ;
+	} else if (std::is_same<TYPE, dtime_ns_t>()) {
+		return LogicalType::TIME_NS;
+	} else if (std::is_same<TYPE, timestamp_t>()) {
+		return LogicalType::TIMESTAMP;
+	} else if (std::is_same<TYPE, timestamp_sec_t>()) {
+		return LogicalType::TIMESTAMP_S;
+	} else if (std::is_same<TYPE, timestamp_ms_t>()) {
+		return LogicalType::TIMESTAMP_MS;
+	} else if (std::is_same<TYPE, timestamp_ns_t>()) {
+		return LogicalType::TIMESTAMP_NS;
+	} else if (std::is_same<TYPE, timestamp_tz_t>()) {
+		return LogicalType::TIMESTAMP_TZ;
+	} else if (std::is_same<TYPE, timestamp_tz_ns_t>()) {
+		return LogicalType::TIMESTAMP_TZ_NS;
+	} else if (std::is_same<TYPE, interval_t>()) {
+		return LogicalType::INTERVAL;
+	} else if (std::is_same<TYPE, const char *>() || std::is_same<TYPE, char *>() || std::is_same<TYPE, string_t>() ||
+	           std::is_same<TYPE, bignum_t>()) {
+		return LogicalType::VARCHAR;
+	} else {
+		throw InternalException("Unsupported type in PrimitiveToLogicalType");
+	}
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -573,7 +573,7 @@ public:
 	static void WireStructStateType(AggregateFunction &result) {
 		if constexpr (HasStructStateType<STATE>::value) {
 			result.SetStructStateExport(
-			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(); });
+			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(STATE::STATE_NAMES); });
 		}
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/array.hpp"
 #include "duckdb/common/vector_operations/aggregate_executor.hpp"
 #include "duckdb/function/aggregate_state.hpp"
+#include "duckdb/function/aggregate_state_layout.hpp"
 #include "duckdb/planner/bound_result_modifier.hpp"
 #include "duckdb/planner/expression.hpp"
 
@@ -499,6 +500,13 @@ public:
 		return *this;
 	}
 
+	template <class STATE_TYPE>
+	AggregateFunction &SetStructStateExport() {
+		return SetStructStateExport([](const BoundAggregateFunction &) {
+			return STATE_TYPE::GetLogicalType();
+		});
+	}
+
 	AggregateFunction &SetClusterCallback(aggregate_cluster_update_t cluster_update) {
 		callbacks.cluster_update = cluster_update;
 		return *this;
@@ -517,11 +525,13 @@ public:
 
 	template <class STATE, class RESULT_TYPE, class OP>
 	static AggregateFunction NullaryAggregate(LogicalType return_type) {
-		return AggregateFunction(
+		AggregateFunction result(
 		    string(), {}, return_type, AggregateFunction::StateSize<STATE>,
 		    AggregateFunction::StateInitialize<STATE, OP>, AggregateFunction::NullaryScatterUpdate<STATE, OP>,
 		    AggregateFunction::StateCombine<STATE, OP>, AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>,
 		    FunctionNullHandling::DEFAULT_NULL_HANDLING, AggregateFunction::NullaryClusterUpdate<STATE, OP>);
+		WireStructStateType<STATE>(result);
+		return result;
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP,
@@ -529,12 +539,14 @@ public:
 	static AggregateFunction
 	UnaryAggregate(const LogicalType &input_type, LogicalType return_type,
 	               FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING) {
-		return AggregateFunction(string(), {input_type}, return_type, AggregateFunction::StateSize<STATE>,
+		AggregateFunction result(string(), {input_type}, return_type, AggregateFunction::StateSize<STATE>,
 		                         AggregateFunction::StateInitialize<STATE, OP, destructor_type>,
 		                         AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>,
 		                         AggregateFunction::StateCombine<STATE, OP>,
 		                         AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, null_handling,
 		                         UnaryClusterUpdateCallback<STATE, INPUT_TYPE, OP>());
+		WireStructStateType<STATE>(result);
+		return result;
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP,
@@ -549,14 +561,25 @@ public:
 	          AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
 	static AggregateFunction BinaryAggregate(const LogicalType &a_type, const LogicalType &b_type,
 	                                         LogicalType return_type) {
-		return AggregateFunction({a_type, b_type}, return_type, AggregateFunction::StateSize<STATE>,
+		AggregateFunction result({a_type, b_type}, return_type, AggregateFunction::StateSize<STATE>,
 		                         AggregateFunction::StateInitialize<STATE, OP, destructor_type>,
 		                         AggregateFunction::BinaryScatterUpdate<STATE, A_TYPE, B_TYPE, OP>,
 		                         AggregateFunction::StateCombine<STATE, OP>,
 		                         AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>, nullptr);
+		WireStructStateType<STATE>(result);
+		return result;
 	}
 
 public:
+	template <class STATE>
+	static void WireStructStateType(AggregateFunction &result) {
+		if constexpr (HasStructStateType<STATE>::value) {
+			result.SetStructStateExport([](const BoundAggregateFunction &) {
+				return STATE::STATE_TYPE::GetLogicalType();
+			});
+		}
+	}
+
 	template <class STATE>
 	static idx_t StateSize(const BoundAggregateFunction &) {
 		return sizeof(STATE);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -502,9 +502,7 @@ public:
 
 	template <class STATE_TYPE>
 	AggregateFunction &SetStructStateExport() {
-		return SetStructStateExport([](const BoundAggregateFunction &) {
-			return STATE_TYPE::GetLogicalType();
-		});
+		return SetStructStateExport([](const BoundAggregateFunction &) { return STATE_TYPE::GetLogicalType(); });
 	}
 
 	AggregateFunction &SetClusterCallback(aggregate_cluster_update_t cluster_update) {
@@ -574,9 +572,8 @@ public:
 	template <class STATE>
 	static void WireStructStateType(AggregateFunction &result) {
 		if constexpr (HasStructStateType<STATE>::value) {
-			result.SetStructStateExport([](const BoundAggregateFunction &) {
-				return STATE::STATE_TYPE::GetLogicalType();
-			});
+			result.SetStructStateExport(
+			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(); });
 		}
 	}
 

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// duckdb/function/aggregate_state_layout.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/type_util.hpp"
+
+namespace duckdb {
+
+//! Describes a struct-typed aggregate state layout using a compile-time field name array and a type parameter pack.
+//! Intended for use as a nested type inside an aggregate STATE struct:
+//!   static constexpr const char *STATE_NAMES[] = {"field_a", "field_b"};
+//!   using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double>;
+//! UnaryAggregate/BinaryAggregate/NullaryAggregate detect STATE_TYPE and wire up SetStructStateExport automatically.
+template <const char *const *Names, typename... Ts>
+struct StructStateType {
+	static LogicalType GetLogicalType() {
+		child_list_t<LogicalType> children;
+		idx_t i = 0;
+		(children.emplace_back(Names[i++], PrimitiveToLogicalType<Ts>()), ...);
+		return LogicalType::STRUCT(std::move(children));
+	}
+};
+
+//! Detection trait: true when STATE defines a nested STATE_TYPE (i.e. StructStateType<...>)
+template <class STATE, class = void>
+struct HasStructStateType : std::false_type {};
+
+template <class STATE>
+struct HasStructStateType<STATE, std::void_t<typename STATE::STATE_TYPE>> : std::true_type {};
+
+} // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -11,26 +11,38 @@
 
 namespace duckdb {
 
-//! Describes a struct-typed aggregate state layout using a compile-time field name array and a type parameter pack.
-//! Intended for use as a nested type inside an aggregate STATE struct:
-//!   static constexpr const char *STATE_NAMES[] = {"field_a", "field_b"};
-//!   using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double>;
-//! UnaryAggregate/BinaryAggregate/NullaryAggregate detect STATE_TYPE and wire up SetStructStateExport automatically.
-template <const char *const *Names, typename... Ts>
-struct StructStateType {
-	static LogicalType GetLogicalType() {
-		child_list_t<LogicalType> children;
-		idx_t i = 0;
-		(children.emplace_back(Names[i++], PrimitiveToLogicalType<Ts>()), ...);
-		return LogicalType::STRUCT(std::move(children));
-	}
-};
-
 //! Detection trait: true when STATE defines a nested STATE_TYPE (i.e. StructStateType<...>)
 template <class STATE, class = void>
 struct HasStructStateType : std::false_type {};
 
 template <class STATE>
 struct HasStructStateType<STATE, std::void_t<typename STATE::STATE_TYPE>> : std::true_type {};
+
+//! Maps a single C++ field type to a LogicalType.
+//! If T itself defines STATE_TYPE, returns its nested struct type; otherwise calls PrimitiveToLogicalType<T>().
+template <class T>
+LogicalType FieldToLogicalType() {
+	if constexpr (HasStructStateType<T>::value) {
+		return T::STATE_TYPE::GetLogicalType();
+	} else {
+		return PrimitiveToLogicalType<T>();
+	}
+}
+
+//! Describes a struct-typed aggregate state layout using a compile-time field name array and a type parameter pack.
+//! Intended for use as a nested type inside an aggregate STATE struct:
+//!   static constexpr const char *STATE_NAMES[] = {"field_a", "field_b"};
+//!   using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double>;
+//! UnaryAggregate/BinaryAggregate/NullaryAggregate detect STATE_TYPE and wire up SetStructStateExport automatically.
+//! Fields that themselves have STATE_TYPE are recursively expanded into nested struct types.
+template <const char *const *Names, typename... Ts>
+struct StructStateType {
+	static LogicalType GetLogicalType() {
+		child_list_t<LogicalType> children;
+		idx_t i = 0;
+		(children.emplace_back(Names[i++], FieldToLogicalType<Ts>()), ...);
+		return LogicalType::STRUCT(std::move(children));
+	}
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -23,24 +23,24 @@ struct HasStructStateType<STATE, std::void_t<typename STATE::STATE_TYPE>> : std:
 template <class T>
 LogicalType FieldToLogicalType() {
 	if constexpr (HasStructStateType<T>::value) {
-		return T::STATE_TYPE::GetLogicalType();
+		return T::STATE_TYPE::GetLogicalType(T::STATE_NAMES);
 	} else {
 		return PrimitiveToLogicalType<T>();
 	}
 }
 
-//! Describes a struct-typed aggregate state layout using a compile-time field name array and a type parameter pack.
-//! Intended for use as a nested type inside an aggregate STATE struct:
+//! Describes a struct-typed aggregate state layout. Intended for use as a nested type inside an aggregate STATE struct:
 //!   static constexpr const char *STATE_NAMES[] = {"field_a", "field_b"};
-//!   using STATE_TYPE = StructStateType<STATE_NAMES, uint64_t, double>;
+//!   using STATE_TYPE = StructStateType<uint64_t, double>;
 //! UnaryAggregate/BinaryAggregate/NullaryAggregate detect STATE_TYPE and wire up SetStructStateExport automatically.
 //! Fields that themselves have STATE_TYPE are recursively expanded into nested struct types.
-template <const char *const *Names, typename... Ts>
+//! Names are passed at call time (STATE::STATE_NAMES) rather than as template arguments.
+template <typename... Ts>
 struct StructStateType {
-	static LogicalType GetLogicalType() {
+	static LogicalType GetLogicalType(const char *const *names) {
 		child_list_t<LogicalType> children;
 		idx_t i = 0;
-		(children.emplace_back(Names[i++], FieldToLogicalType<Ts>()), ...);
+		(children.emplace_back(names[i++], FieldToLogicalType<Ts>()), ...);
 		return LogicalType::STRUCT(std::move(children));
 	}
 };


### PR DESCRIPTION
Currently state layout types need to be defined in a separate function:


```cpp
LogicalType GetCovarStateType(const BoundAggregateFunction &) {
	child_list_t<LogicalType> child_types;
	child_types.emplace_back("count", LogicalType::UBIGINT);
	child_types.emplace_back("meanx", LogicalType::DOUBLE);
	child_types.emplace_back("meany", LogicalType::DOUBLE);
	child_types.emplace_back("co_moment", LogicalType::DOUBLE);
	return LogicalType::STRUCT(std::move(child_types));
}
```

This function then needs to be registered:

```cpp
function.SetStructStateExport(GetCovarStateType);
```

This is not very pretty and requires a lot of extra code. It's also very easy to forget - and easy to forget to update.

In an ideal world we would just be able to do reflection on the state struct to figure out the layout - but unfortunately this is not (yet) possible in C++. Instead we move towards defining this as part of the state struct itself:

```cpp
struct CovarState {
	static constexpr const char *STATE_NAMES[] = {"count", "meanx", "meany", "co_moment"};
	using STATE_TYPE = StructStateType<uint64_t, double, double, double>;

	uint64_t count;
	double meanx;
	double meany;
	double co_moment;
};
```

This is then automatically used during function registration to register the state layout. 

This approach also allows us to directly use templates from the state in the state layout, e.g.:

```cpp
template <class T>
struct SumState {
	static constexpr const char *STATE_NAMES[] = {"isset", "value"};
	using STATE_TYPE = StructStateType<bool, T>;

	bool isset;
	T value;
};
```


