### PR TITLE
BinaryExecutor: unrolled path, also there perform blind store on selection vector

### DIFF
--- a/src/include/duckdb/common/vector_operations/binary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/binary_executor.hpp
@@ -589,15 +589,16 @@ public:
 			auto result_idx = result_sel.get_index(i);
 			auto lindex = lsel->get_index(i);
 			auto rindex = rsel->get_index(i);
-			if ((NO_NULL || (lvalidity.RowIsValid(lindex) && rvalidity.RowIsValid(rindex))) &&
-			    OP::Operation(ldata[lindex], rdata[rindex])) {
-				if (HAS_TRUE_SEL) {
-					true_sel->set_index(true_count++, result_idx);
-				}
-			} else {
-				if (HAS_FALSE_SEL) {
-					false_sel->set_index(false_count++, result_idx);
-				}
+			const bool comparison_result =
+			    (NO_NULL || (lvalidity.RowIsValid(lindex) && rvalidity.RowIsValid(rindex))) &&
+			    OP::Operation(ldata[lindex], rdata[rindex]);
+			if (HAS_TRUE_SEL) {
+				true_sel->set_index(true_count, result_idx);
+				true_count += comparison_result;
+			}
+			if (HAS_FALSE_SEL) {
+				false_sel->set_index(false_count, result_idx);
+				false_count += !comparison_result;
 			}
 		}
 		if (HAS_TRUE_SEL) {


### PR DESCRIPTION
Idea, already applied in other paths, is that location is always valid to write to, and will be (if it is to be used) rewritten.

Minor local optimization to align the code to what already done elsewhere in the same file.