### PR TITLE
Allow aggregate states to be scalars, and clean-up aggregate state (de)serialization code

### DIFF
--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -1,25 +1,52 @@
 #include "core_functions/aggregate/distributive_functions.hpp"
-#include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/aggregate_operators.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
-#include "duckdb/function/aggregate/distributive_function_utils.hpp"
-#include "duckdb/function/function_set.hpp"
 
 namespace duckdb {
 
 namespace {
 
-struct BoolState {
-	bool empty;
-	bool val;
+using BoolState = optional<bool>;
 
-	static constexpr const char *STATE_NAMES[] = {"empty", "val"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, bool, bool>;
+template <class REDUCE_OP, bool INIT_VALUE>
+struct BoolAggregate {
+	// No Initialize: StateInitialize falls back to memset(state, 0) = nullopt
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+		state = REDUCE_OP::template Operation<bool>(state.value_or(INIT_VALUE), bool(input));
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+		if (count > 0) {
+			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+		if (!source.has_value()) {
+			return;
+		}
+		target = REDUCE_OP::template Operation<bool>(target.value_or(INIT_VALUE), *source);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+		if (!state.has_value()) {
+			finalize_data.ReturnNull();
+			return;
+		}
+		target = *state;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
 };
 
-using BoolAndFunFunction = EmptyValAggregate<LogicalAnd, ConstantInit<true>>;
-using BoolOrFunFunction = EmptyValAggregate<LogicalOr, ConstantInit<false>>;
+using BoolAndFunFunction = BoolAggregate<LogicalAnd, true>;
+using BoolOrFunFunction = BoolAggregate<LogicalOr, false>;
 
 } // namespace
 

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -17,7 +17,8 @@ struct BoolAggregate {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		if (count > 0) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}

--- a/extension/core_functions/aggregate/regression/regr_count.cpp
+++ b/extension/core_functions/aggregate/regression/regr_count.cpp
@@ -1,28 +1,17 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "core_functions/aggregate/regression_functions.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "core_functions/aggregate/regression/regr_count.hpp"
 #include "duckdb/function/function_set.hpp"
 
 namespace duckdb {
-
-namespace {
-
-LogicalType GetRegrCountStateType(const BoundAggregateFunction &) {
-	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("count", LogicalType::UBIGINT);
-	return LogicalType::STRUCT(std::move(child_types));
-}
-
-} // namespace
 
 AggregateFunction RegrCountFun::GetFunction() {
 	auto regr_count = AggregateFunction::BinaryAggregate<uint64_t, double, double, uint32_t, RegrCountFunction>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::UINTEGER);
 	regr_count.name = "regr_count";
 	regr_count.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	return regr_count.SetStructStateExport(GetRegrCountStateType);
+	return regr_count;
 }
 
 } // namespace duckdb

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -256,8 +256,8 @@ struct CountFunction : public BaseCountFunction {
 	}
 };
 
-LogicalType GetCountStateType(const BoundAggregateFunction &function) {
-	return LogicalType::BIGINT;
+AggregateStateLayout GetCountStateType(const BoundAggregateFunction &function) {
+	return AggregateStateLayout(LogicalType::BIGINT, AlignValue(function.GetStateSizeCallback()(function)));
 }
 
 unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -257,9 +257,7 @@ struct CountFunction : public BaseCountFunction {
 };
 
 LogicalType GetCountStateType(const BoundAggregateFunction &function) {
-	child_list_t<LogicalType> children;
-	children.emplace_back("count", LogicalType::BIGINT);
-	return LogicalType::STRUCT(std::move(children));
+	return LogicalType::BIGINT;
 }
 
 unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
@@ -294,7 +292,6 @@ AggregateFunction CountStarFun::GetFunction() {
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetWindowBatchCallback(CountStarFunction::Window<int64_t>);
-	fun.SetStructStateExport(GetCountStateType);
 	return fun;
 }
 

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -9,6 +9,8 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *FirstStateNames[] = {"value", "is_set", "is_null"};
+
 template <class T>
 struct FirstState {
 	using VALUE_TYPE = T;
@@ -16,8 +18,7 @@ struct FirstState {
 	bool is_set;
 	bool is_null;
 
-	static constexpr const char *STATE_NAMES[] = {"value", "is_set", "is_null"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool, bool>;
+	using STATE_TYPE = StructStateType<FirstStateNames, T, bool, bool>;
 };
 
 struct FirstFunctionBase {

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -20,13 +20,14 @@ namespace duckdb {
 
 namespace {
 
+static constexpr const char *MinMaxStateNames[] = {"value", "isset"};
+
 template <class T>
 struct MinMaxState {
 	T value;
 	bool isset;
 
-	static constexpr const char *STATE_NAMES[] = {"value", "isset"};
-	using STATE_TYPE = StructStateType<STATE_NAMES, T, bool>;
+	using STATE_TYPE = StructStateType<MinMaxStateNames, T, bool>;
 };
 
 template <class OP>
@@ -533,11 +534,12 @@ AggregateFunction GetMinMaxNFunction() {
 	                         MinMaxNBind<COMPARATOR>, nullptr);
 }
 
-LogicalType GetExportStateType(const BoundAggregateFunction &function) {
-	auto struct_children_types = child_list_t<LogicalType> {};
+AggregateStateLayout GetExportStateType(const BoundAggregateFunction &function) {
+	child_list_t<LogicalType> struct_children_types;
 	struct_children_types.emplace_back("value", function.GetReturnType());
 	struct_children_types.emplace_back("isset", LogicalType::BOOLEAN);
-	return LogicalType::STRUCT(std::move(struct_children_types));
+	return AggregateStateLayout(LogicalType::STRUCT(std::move(struct_children_types)),
+	                            AlignValue(function.GetStateSizeCallback()(function)));
 }
 
 } // namespace

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -140,10 +140,10 @@ struct StoreOp {
 // Serialize optional<T> state buffers into a result vector, setting NULL for disengaged optionals.
 struct StorePrimitiveOptionalOp {
 	template <class T>
-	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses, idx_t base_offset) {
 		auto dst = FlatVector::Writer<T>(result, count);
 		for (idx_t i = 0; i < count; i++) {
-			const auto opt = Load<optional<T>>(addresses[i]);
+			const auto opt = Load<optional<T>>(addresses[i] + base_offset);
 			if (opt.has_value()) {
 				dst.WriteValue(*opt);
 			} else {
@@ -170,47 +170,16 @@ struct LoadPrimitiveOptionalOp {
 	}
 };
 
-void DeserializeStructFields(const LogicalType &type, const AggregateStateField &field, idx_t root_stride,
-                             const Vector &struct_vec, idx_t count, data_ptr_t dest_buffer) {
-	const auto &child_types = StructType::GetChildTypes(type);
-	const auto &struct_entries = StructVector::GetEntries(struct_vec);
-	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
-		const auto &child = field.children[field_idx];
-		const auto &child_type = child_types[field_idx].second;
-		auto physical = child_type.InternalType();
-		const auto &child_vec = struct_entries[field_idx];
-
-		if (!child.children.empty()) {
-			DeserializeStructFields(child_type, child, root_stride, child_vec, count, dest_buffer + child.field_offset);
-		} else {
-			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, count, dest_buffer, child.field_offset);
-		}
-	}
-}
-
-void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
-                           const data_ptr_t *addresses_ptrs, idx_t base_offset = 0) {
-	const auto &child_types = StructType::GetChildTypes(type);
-	auto &struct_entries = StructVector::GetEntries(result);
-	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
-		const auto &child = field.children[field_idx];
-		const auto &child_type = child_types[field_idx].second;
-		auto physical = child_type.InternalType();
-		auto &child_vec = struct_entries[field_idx];
-
-		if (!child.children.empty()) {
-			SerializeStructFields(child_type, child, child_vec, count, addresses_ptrs,
-			                      base_offset + child.field_offset);
-		} else {
-			TemplateDispatch<StoreOp>(physical, child_vec, count, addresses_ptrs, base_offset + child.field_offset);
-		}
-	}
-}
-
 void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec, idx_t count,
                       data_ptr_t dest_buffer) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, count, dest_buffer);
+		const auto &child_types = StructType::GetChildTypes(layout.type);
+		const auto &struct_entries = StructVector::GetEntries(input_vec);
+		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+			const auto &child = layout.field.children[field_idx];
+			AggregateStateLayout child_layout(child_types[field_idx].second, layout.total_state_size, child.is_optional);
+			DeserializeState(child_layout, struct_entries[field_idx], count, dest_buffer + child.field_offset);
+		}
 	} else if (layout.field.is_optional) {
 		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, count, dest_buffer,
 		                                          layout.total_state_size);
@@ -219,13 +188,21 @@ void DeserializeState(const AggregateStateLayout &layout, const Vector &input_ve
 	}
 }
 
-void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses) {
+void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses,
+                    idx_t base_offset = 0) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		SerializeStructFields(layout.type, layout.field, result, count, addresses);
+		const auto &child_types = StructType::GetChildTypes(layout.type);
+		auto &struct_entries = StructVector::GetEntries(result);
+		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+			const auto &child = layout.field.children[field_idx];
+			AggregateStateLayout child_layout(child_types[field_idx].second, 0, child.is_optional);
+			SerializeState(child_layout, struct_entries[field_idx], count, addresses,
+			               base_offset + child.field_offset);
+		}
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses);
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses, base_offset);
 	} else {
-		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, count, addresses, 0);
+		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, count, addresses, base_offset);
 	}
 }
 

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -4,7 +4,6 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_common.hpp"
@@ -113,32 +112,32 @@ static AggregateStateLayout GetLayout(const BoundAggregateFunction &aggr) {
 }
 
 // Load rows from input_vec into the packed binary state buffer.
-// Checks validity via input_data and skips null rows.
-// Used for struct fields (input_data=outer state format, field_offset=child offset)
-// and primitive states (root_stride=aligned_state_size, field_offset=0).
+// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
+// Skips null rows.
 struct LoadOp {
 	template <class T>
-	static void Operation(idx_t root_stride, const Vector &input_vec, const UnifiedVectorFormat &input_data,
-	                      idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
+	static void Operation(idx_t root_stride, const Vector &input_vec, const SelectionVector &sel, idx_t count,
+	                      data_ptr_t base_ptr, idx_t field_offset) {
 		auto values = input_vec.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
-			auto src_idx = input_data.sel->get_index(i);
-			if (!input_data.validity.RowIsValid(src_idx)) {
-				continue;
+			idx_t row = sel.get_index(i);
+			const auto entry = values[row];
+			if (entry.IsValid()) {
+				Store(entry.GetValue(), base_ptr + i * root_stride + field_offset);
 			}
-			Store(values.GetValueUnsafe(i), base_ptr + i * root_stride + field_offset);
 		}
 	}
 };
 
 // Store rows from the packed binary state buffer into a result vector.
-// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
+// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct StoreOp {
 	template <class T>
-	static void Operation(Vector &result, idx_t count, const data_ptr_t *sources, idx_t field_offset) {
-		auto result_data = FlatVector::Writer<T>(result, count);
+	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, const data_ptr_t *sources,
+	                      idx_t field_offset) {
+		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
-			result_data.WriteValue(Load<T>(sources[i] + field_offset));
+			dst[sel.get_index(i)] = Load<T>(sources[i] + field_offset);
 		}
 	}
 };
@@ -157,61 +156,36 @@ struct CopyOp {
 	}
 };
 
-// Load selected rows from input_vec into sequential packed binary state buffer slots.
-// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
-struct LoadForSelectedRowsOp {
-	template <class T>
-	static void Operation(idx_t total_state_size, const Vector &input_vec, const SelectionVector &sel, idx_t count,
-	                      data_ptr_t base_ptr, idx_t field_offset) {
-		auto values = input_vec.Values<T>();
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			Store(values.GetValueUnsafe(row), base_ptr + i * total_state_size + field_offset);
-		}
-	}
-};
-
-// Store sequential packed binary state buffer slots into selected rows of a result vector.
-// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
-struct StoreForSelectedRowsOp {
-	template <class T>
-	static void Operation(idx_t total_state_size, Vector &result, const SelectionVector &sel, idx_t count,
-	                      data_ptr_t base_ptr, idx_t field_offset) {
-		auto dst = FlatVector::ScatterWriter<T>(result);
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			dst[row] = Load<T>(base_ptr + i * total_state_size + field_offset);
-		}
-	}
-};
-
-// Serialize optional<T> state buffers into a flat result vector, setting NULL for disengaged optionals
+// Serialize optional<T> state buffers into a result vector, setting NULL for disengaged optionals.
+// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct StorePrimitiveOptionalOp {
 	template <class T>
-	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
-		auto dst = FlatVector::Writer<T>(result, count);
+	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, const data_ptr_t *addresses) {
+		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
 			const auto opt = Load<optional<T>>(addresses[i]);
 			if (opt.has_value()) {
-				dst.WriteValue(*opt);
+				dst[sel.get_index(i)] = *opt;
 			} else {
-				dst.WriteNull();
+				dst.SetInvalid(sel.get_index(i));
 			}
 		}
 	}
 };
 
-// Deserialize a nullable flat input vector into optional<T> state buffer slots
+// Deserialize a nullable input vector into optional<T> state buffer slots.
+// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct LoadPrimitiveOptionalOp {
 	template <class T>
-	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t base_ptr,
+	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
 	                      idx_t aligned_state_size) {
 		auto values = input.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
-			auto src_idx = input_data.sel->get_index(i);
+			idx_t row = sel.get_index(i);
+			const auto entry = values[row];
 			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
-			if (input_data.validity.RowIsValid(src_idx)) {
-				opt = values.GetValueUnsafe(i);
+			if (entry.IsValid()) {
+				opt = entry.GetValue();
 			} else {
 				opt = nullopt;
 			}
@@ -222,52 +196,14 @@ struct LoadPrimitiveOptionalOp {
 // Copy a nullable primitive value from selected rows of input to the same rows of result
 struct CopyPrimitiveOptionalOp {
 	template <class T>
-	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count,
-	                      const UnifiedVectorFormat &input_data) {
+	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
 		auto input_values = input.Values<T>();
 		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
-			idx_t src_idx = input_data.sel->get_index(row);
-			if (input_data.validity.RowIsValid(src_idx)) {
-				dst[row] = input_values.GetValueUnsafe(row);
-			} else {
-				dst.SetInvalid(row);
-			}
-		}
-	}
-};
-
-// Deserialize selected rows of a nullable flat input vector into sequential optional<T> state buffer slots
-struct LoadPrimitiveOptionalForSelectedRowsOp {
-	template <class T>
-	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count,
-	                      const UnifiedVectorFormat &input_data, data_ptr_t base_ptr, idx_t aligned_state_size) {
-		auto values = input.Values<T>();
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			idx_t src_idx = input_data.sel->get_index(row);
-			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
-			if (input_data.validity.RowIsValid(src_idx)) {
-				opt = values.GetValueUnsafe(row);
-			} else {
-				opt = nullopt;
-			}
-		}
-	}
-};
-
-// Serialize sequential optional<T> state buffer slots into selected rows of a flat result vector
-struct StorePrimitiveOptionalForSelectedRowsOp {
-	template <class T>
-	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
-	                      idx_t aligned_state_size) {
-		auto dst = FlatVector::ScatterWriter<T>(result);
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			const auto opt = Load<optional<T>>(base_ptr + i * aligned_state_size);
-			if (opt.has_value()) {
-				dst[row] = *opt;
+			const auto entry = input_values[row];
+			if (entry.IsValid()) {
+				dst[row] = entry.GetValue();
 			} else {
 				dst.SetInvalid(row);
 			}
@@ -277,9 +213,9 @@ struct StorePrimitiveOptionalForSelectedRowsOp {
 
 // Deserialize struct fields from a flattened struct vector into a state buffer.
 // root_stride is the aligned size of the top-level state, used to stride between rows in the buffer.
-// Child field offsets are pre-computed in AggregateStateField.field_offset (relative to dest_buffer).
+// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
 void DeserializeStructFields(const LogicalType &type, const AggregateStateField &field, idx_t root_stride,
-                             const Vector &struct_vec, const UnifiedVectorFormat &state_data, idx_t count,
+                             const Vector &struct_vec, const SelectionVector &sel, idx_t count,
                              data_ptr_t dest_buffer) {
 	const auto &child_types = StructType::GetChildTypes(type);
 	const auto &struct_entries = StructVector::GetEntries(struct_vec);
@@ -290,19 +226,18 @@ void DeserializeStructFields(const LogicalType &type, const AggregateStateField 
 		const auto &child_vec = struct_entries[field_idx];
 
 		if (!child.children.empty()) {
-			DeserializeStructFields(child_type, child, root_stride, child_vec, state_data, count,
+			DeserializeStructFields(child_type, child, root_stride, child_vec, sel, count,
 			                        dest_buffer + child.field_offset);
 		} else {
-			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, state_data, count, dest_buffer,
-			                        child.field_offset);
+			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, sel, count, dest_buffer, child.field_offset);
 		}
 	}
 }
 
 // Serialize packed binary states into a struct result vector.
-// Child field offsets are pre-computed in AggregateStateField.field_offset (relative to addresses_ptrs[row]).
-void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
-                           const data_ptr_t *addresses_ptrs) {
+// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
+void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result,
+                           const SelectionVector &sel, idx_t count, const data_ptr_t *addresses_ptrs) {
 	const auto &child_types = StructType::GetChildTypes(type);
 	auto &struct_entries = StructVector::GetEntries(result);
 	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
@@ -319,39 +254,41 @@ void SerializeStructFields(const LogicalType &type, const AggregateStateField &f
 				child_writer.WriteValue(addresses_ptrs[row] + child.field_offset);
 			}
 			auto child_ptrs = FlatVector::GetData<data_ptr_t>(child_addresses);
-			SerializeStructFields(child_type, child, child_vec, count, child_ptrs);
+			SerializeStructFields(child_type, child, child_vec, sel, count, child_ptrs);
 		} else {
-			TemplateDispatch<StoreOp>(physical, child_vec, count, addresses_ptrs, child.field_offset);
+			TemplateDispatch<StoreOp>(physical, child_vec, sel, count, addresses_ptrs, child.field_offset);
 		}
 	}
 }
 
-void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec,
-                      const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t dest_buffer) {
+// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
+void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec, const SelectionVector &sel,
+                      idx_t count, data_ptr_t dest_buffer) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, input_data, count,
-		                        dest_buffer);
+		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, sel, count, dest_buffer);
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, input_data, count, dest_buffer,
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, sel, count, dest_buffer,
 		                                          layout.total_state_size);
 	} else {
-		TemplateDispatch<LoadOp>(layout.type.InternalType(), layout.total_state_size, input_vec, input_data, count,
-		                         dest_buffer, 0);
+		TemplateDispatch<LoadOp>(layout.type.InternalType(), layout.total_state_size, input_vec, sel, count, dest_buffer,
+		                         0);
 	}
 }
 
-void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses) {
+// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
+void SerializeState(const AggregateStateLayout &layout, Vector &result, const SelectionVector &sel, idx_t count,
+                    const data_ptr_t *addresses) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		SerializeStructFields(layout.type, layout.field, result, count, addresses);
+		SerializeStructFields(layout.type, layout.field, result, sel, count, addresses);
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses);
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, sel, count, addresses);
 	} else {
-		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, count, addresses, 0);
+		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, sel, count, addresses, 0);
 	}
 }
 
 void CopyState(const AggregateStateLayout &layout, const Vector &input, Vector &result, const SelectionVector &sel,
-               idx_t count, const UnifiedVectorFormat &input_data) {
+               idx_t count) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
 		const auto &child_types = StructType::GetChildTypes(layout.type);
 		const auto &input_entries = StructVector::GetEntries(input);
@@ -361,49 +298,9 @@ void CopyState(const AggregateStateLayout &layout, const Vector &input, Vector &
 			TemplateDispatch<CopyOp>(physical, input_entries[field_idx], result_entries[field_idx], sel, count);
 		}
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input, result, sel, count, input_data);
+		TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input, result, sel, count);
 	} else {
 		TemplateDispatch<CopyOp>(layout.type.InternalType(), input, result, sel, count);
-	}
-}
-
-void DeserializeStateForSelected(const AggregateStateLayout &layout, const Vector &input, const SelectionVector &sel,
-                                 idx_t count, const UnifiedVectorFormat &input_data, data_ptr_t dest_buffer) {
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		const auto &child_types = StructType::GetChildTypes(layout.type);
-		const auto &input_entries = StructVector::GetEntries(input);
-		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
-			const auto &child = layout.field.children[field_idx];
-			auto physical = child_types[field_idx].second.InternalType();
-			TemplateDispatch<LoadForSelectedRowsOp>(physical, layout.total_state_size, input_entries[field_idx], sel,
-			                                        count, dest_buffer, child.field_offset);
-		}
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(layout.type.InternalType(), input, sel, count,
-		                                                         input_data, dest_buffer, layout.total_state_size);
-	} else {
-		TemplateDispatch<LoadForSelectedRowsOp>(layout.type.InternalType(), layout.total_state_size, input, sel, count,
-		                                        dest_buffer, 0);
-	}
-}
-
-void SerializeStateForSelected(const AggregateStateLayout &layout, Vector &result, const SelectionVector &sel,
-                               idx_t count, data_ptr_t base_ptr) {
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		const auto &child_types = StructType::GetChildTypes(layout.type);
-		auto &result_entries = StructVector::GetEntries(result);
-		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
-			const auto &child = layout.field.children[field_idx];
-			auto physical = child_types[field_idx].second.InternalType();
-			TemplateDispatch<StoreForSelectedRowsOp>(physical, layout.total_state_size, result_entries[field_idx], sel,
-			                                         count, base_ptr, child.field_offset);
-		}
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalForSelectedRowsOp>(layout.type.InternalType(), result, sel, count,
-		                                                          base_ptr, layout.total_state_size);
-	} else {
-		TemplateDispatch<StoreForSelectedRowsOp>(layout.type.InternalType(), layout.total_state_size, result, sel,
-		                                         count, base_ptr, 0);
 	}
 }
 
@@ -463,21 +360,19 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 
 	input.data[0].Flatten();
 
-	UnifiedVectorFormat state_data;
-	input.data[0].ToUnifiedFormat(state_data);
-
 	for (idx_t i = 0; i < input.size(); i++) {
 		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.total_state_size);
 	}
 
-	DeserializeState(layout, input.data[0], state_data, input.size(), local_state.state_buffer.get());
+	DeserializeState(layout, input.data[0], *FlatVector::IncrementalSelectionVector(), input.size(),
+	                 local_state.state_buffer.get());
 
 	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
 	bind_data.aggr.GetStateFinalizeCallback()(local_state.addresses, aggr_input_data, result, input.size(), 0);
 
+	auto &validity = FlatVector::Validity(input.data[0]);
 	for (idx_t i = 0; i < input.size(); i++) {
-		auto state_idx = state_data.sel->get_index(i);
-		if (!state_data.validity.RowIsValid(state_idx)) {
+		if (!validity.RowIsValid(i)) {
 			FlatVector::SetNull(result, i, true);
 		}
 	}
@@ -504,9 +399,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	input.data[1].Flatten();
 	result.Flatten();
 
-	UnifiedVectorFormat state0_data, state1_data;
-	input.data[0].ToUnifiedFormat(state0_data);
-	input.data[1].ToUnifiedFormat(state1_data);
+	auto &validity0 = FlatVector::Validity(input.data[0]);
+	auto &validity1 = FlatVector::Validity(input.data[1]);
 
 	// Partition rows by NULL using SelectionVector
 	SelectionVector both_null_sel(STANDARD_VECTOR_SIZE);
@@ -519,8 +413,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	idx_t both_null_count = 0, copy_from_0_count = 0, copy_from_1_count = 0, both_valid_count = 0;
 
 	for (idx_t i = 0; i < input.size(); i++) {
-		const bool is_null0 = !state0_data.validity.RowIsValid(state0_data.sel->get_index(i));
-		const bool is_null1 = !state1_data.validity.RowIsValid(state1_data.sel->get_index(i));
+		const bool is_null0 = !validity0.RowIsValid(i);
+		const bool is_null1 = !validity1.RowIsValid(i);
 
 		if (is_null0 && is_null1) {
 			both_null_sel.set_index(both_null_count++, i);
@@ -542,10 +436,10 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 
 	// Handle one-null rows - copy non-null input directly to result
 	if (copy_from_0_count > 0) {
-		CopyState(layout, input.data[0], result, copy_from_0_sel, copy_from_0_count, state0_data);
+		CopyState(layout, input.data[0], result, copy_from_0_sel, copy_from_0_count);
 	}
 	if (copy_from_1_count > 0) {
-		CopyState(layout, input.data[1], result, copy_from_1_sel, copy_from_1_count, state1_data);
+		CopyState(layout, input.data[1], result, copy_from_1_sel, copy_from_1_count);
 	}
 
 	// Handle both-valid rows - batched load, combine, store
@@ -559,10 +453,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.total_state_size);
 		}
 
-		DeserializeStateForSelected(layout, input.data[0], both_valid_sel, both_valid_count, state0_data,
-		                            local_state.state_buffer0.get());
-		DeserializeStateForSelected(layout, input.data[1], both_valid_sel, both_valid_count, state1_data,
-		                            local_state.state_buffer1.get());
+		DeserializeState(layout, input.data[0], both_valid_sel, both_valid_count, local_state.state_buffer0.get());
+		DeserializeState(layout, input.data[1], both_valid_sel, both_valid_count, local_state.state_buffer1.get());
 
 		// Single batched combine call
 		AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator,
@@ -570,7 +462,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 		bind_data.aggr.GetStateCombineCallback()(local_state.addresses0, local_state.addresses1, aggr_input_data,
 		                                         both_valid_count);
 
-		SerializeStateForSelected(layout, result, both_valid_sel, both_valid_count, local_state.state_buffer1.get());
+		SerializeState(layout, result, both_valid_sel, both_valid_count,
+		               FlatVector::GetData<data_ptr_t>(local_state.addresses1));
 	}
 }
 
@@ -682,7 +575,7 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 	auto layout = GetLayout(aggr_input_data.function);
 
 	result.Flatten();
-	SerializeState(layout, result, count, addresses_ptrs);
+	SerializeState(layout, result, *FlatVector::IncrementalSelectionVector(), count, addresses_ptrs);
 }
 
 unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
@@ -717,9 +610,6 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 
 	inputs[0].Flatten();
 
-	UnifiedVectorFormat input_data;
-	inputs[0].ToUnifiedFormat(input_data);
-
 	auto aligned_size = layout.total_state_size;
 	unsafe_unique_array<data_t> temp_state_buf = make_unsafe_uniq_array<data_t>(count * aligned_size);
 
@@ -739,7 +629,7 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 		target_data.WriteValue(state_ptrs[sdata.sel->get_index(i)]);
 	}
 
-	DeserializeState(layout, inputs[0], input_data, count, temp_state_buf.get());
+	DeserializeState(layout, inputs[0], *FlatVector::IncrementalSelectionVector(), count, temp_state_buf.get());
 
 	ArenaAllocator allocator(Allocator::DefaultAllocator());
 	AggregateInputData combine_input(bind_data.aggr, bind_data.bind_data.get(), allocator,
@@ -765,7 +655,7 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	auto layout = GetLayout(underlying_aggr);
 
 	result.Flatten();
-	SerializeState(layout, result, count, addresses_ptrs);
+	SerializeState(layout, result, *FlatVector::IncrementalSelectionVector(), count, addresses_ptrs);
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -114,10 +115,15 @@ struct AggregateStateLayout {
 		is_struct = type.InternalType() == PhysicalType::STRUCT;
 		if (is_struct) {
 			child_types = &StructType::GetChildTypes(owned_type);
+		} else {
+			// optional<T> states are larger than the physical primitive T due to the has_value byte + alignment.
+			// Detect this by comparing the actual state_size against what a bare T would occupy.
+			is_optional = state_size > GetTypeIdSize(type.InternalType());
 		}
 	}
 
-	bool is_struct;
+	bool is_struct = false;
+	bool is_optional = false;
 	idx_t state_size;
 	idx_t aligned_state_size;
 	LogicalType owned_type;
@@ -278,6 +284,96 @@ struct StorePrimitiveForSelectedRowsOp {
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
 			dst[row] = *reinterpret_cast<const T *>(base_ptr + i * aligned_state_size);
+		}
+	}
+};
+
+// Serialize optional<T> state buffers into a flat result vector, setting NULL for disengaged optionals
+struct StorePrimitiveOptionalOp {
+	template <class T>
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
+		auto dst = FlatVector::GetDataMutable<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			const auto &opt = *reinterpret_cast<const optional<T> *>(addresses[i]);
+			if (opt.has_value()) {
+				dst[i] = *opt;
+			} else {
+				FlatVector::SetNull(result, i, true);
+			}
+		}
+	}
+};
+
+// Deserialize a nullable flat input vector into optional<T> state buffer slots
+struct LoadPrimitiveOptionalOp {
+	template <class T>
+	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count,
+	                      data_ptr_t base_ptr, idx_t aligned_state_size) {
+		auto src = FlatVector::GetData<T>(input);
+		for (idx_t i = 0; i < count; i++) {
+			auto src_idx = input_data.sel->get_index(i);
+			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
+			if (input_data.validity.RowIsValid(src_idx)) {
+				opt = src[src_idx];
+			} else {
+				opt = nullopt;
+			}
+		}
+	}
+};
+
+// Copy a nullable primitive value from selected rows of input to the same rows of result
+struct CopyPrimitiveOptionalOp {
+	template <class T>
+	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count,
+	                      const UnifiedVectorFormat &input_data) {
+		auto src = FlatVector::GetData<T>(input);
+		auto dst = FlatVector::GetDataMutable<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			idx_t src_idx = input_data.sel->get_index(row);
+			if (input_data.validity.RowIsValid(src_idx)) {
+				dst[row] = src[src_idx];
+			} else {
+				FlatVector::SetNull(result, row, true);
+			}
+		}
+	}
+};
+
+// Deserialize selected rows of a nullable flat input vector into sequential optional<T> state buffer slots
+struct LoadPrimitiveOptionalForSelectedRowsOp {
+	template <class T>
+	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count,
+	                      const UnifiedVectorFormat &input_data, data_ptr_t base_ptr, idx_t aligned_state_size) {
+		auto src = FlatVector::GetData<T>(input);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			idx_t src_idx = input_data.sel->get_index(row);
+			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
+			if (input_data.validity.RowIsValid(src_idx)) {
+				opt = src[src_idx];
+			} else {
+				opt = nullopt;
+			}
+		}
+	}
+};
+
+// Serialize sequential optional<T> state buffer slots into selected rows of a flat result vector
+struct StorePrimitiveOptionalForSelectedRowsOp {
+	template <class T>
+	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
+	                      idx_t aligned_state_size) {
+		auto dst = FlatVector::GetDataMutable<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			const auto &opt = *reinterpret_cast<const optional<T> *>(base_ptr + i * aligned_state_size);
+			if (opt.has_value()) {
+				dst[row] = *opt;
+			} else {
+				FlatVector::SetNull(result, row, true);
+			}
 		}
 	}
 };
@@ -475,6 +571,10 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	if (layout.is_struct) {
 		DeserializeStructFields(layout, layout.aligned_state_size, input.data[0], state_data, input.size(),
 		                        local_state.state_buffer.get());
+	} else if (layout.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[0], state_data,
+		                                           input.size(), local_state.state_buffer.get(),
+		                                           layout.aligned_state_size);
 	} else {
 		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], state_data, input.size(),
 		                                  local_state.state_buffer.get(), layout.aligned_state_size);
@@ -571,6 +671,9 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				                                       copy_from_0_count, state0_data);
 				offset_in_state += field_size;
 			}
+		} else if (layout.is_optional) {
+			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[0], result,
+			                                           copy_from_0_sel, copy_from_0_count, state0_data);
 		} else {
 			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], result, copy_from_0_sel,
 			                                  copy_from_0_count, state0_data);
@@ -590,6 +693,9 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				                                       copy_from_1_count, state1_data);
 				offset_in_state += field_size;
 			}
+		} else if (layout.is_optional) {
+			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[1], result,
+			                                           copy_from_1_sel, copy_from_1_count, state1_data);
 		} else {
 			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[1], result, copy_from_1_sel,
 			                                  copy_from_1_count, state1_data);
@@ -625,6 +731,13 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				                                             local_state.state_buffer1.get(), offset_in_state);
 				offset_in_state += field_size;
 			}
+		} else if (layout.is_optional) {
+			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
+			    layout.owned_type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
+			    local_state.state_buffer0.get(), layout.aligned_state_size);
+			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
+			    layout.owned_type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
+			    local_state.state_buffer1.get(), layout.aligned_state_size);
 		} else {
 			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(
 			    layout.owned_type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
@@ -655,6 +768,10 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				                                              offset_in_state);
 				offset_in_state += field_size;
 			}
+		} else if (layout.is_optional) {
+			TemplateDispatch<StorePrimitiveOptionalForSelectedRowsOp>(
+			    layout.owned_type.InternalType(), result, both_valid_sel, both_valid_count,
+			    local_state.state_buffer1.get(), layout.aligned_state_size);
 		} else {
 			TemplateDispatch<StorePrimitiveForSelectedRowsOp>(layout.owned_type.InternalType(), result, both_valid_sel,
 			                                                  both_valid_count, local_state.state_buffer1.get(),
@@ -775,6 +892,8 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 	result.Flatten();
 	if (layout.is_struct) {
 		SerializeStructFields(layout, result, count, addresses_ptrs);
+	} else if (layout.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
 	} else {
 		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
 	}
@@ -837,6 +956,9 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 
 	if (layout.is_struct) {
 		DeserializeStructFields(layout, layout.aligned_state_size, inputs[0], input_data, count, temp_state_buf.get());
+	} else if (layout.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.owned_type.InternalType(), inputs[0], input_data, count,
+		                                           temp_state_buf.get(), layout.aligned_state_size);
 	} else {
 		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), inputs[0], input_data, count,
 		                                  temp_state_buf.get(), layout.aligned_state_size);
@@ -869,6 +991,8 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	result.Flatten();
 	if (layout.is_struct) {
 		SerializeStructFields(layout, result, count, addresses_ptrs);
+	} else if (layout.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
 	} else {
 		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
 	}

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -1,6 +1,4 @@
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/map_vector.hpp"
-#include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/extension_type_info.hpp"
@@ -119,26 +117,6 @@ struct AggregateStateLayout {
 		}
 	}
 
-	// Reconstruct a packed binary state from the vector representation
-	// Works only on a legacy state format where the entire state is stored as a blob
-	void Load(Vector &vec, const UnifiedVectorFormat &state_data, idx_t row, data_ptr_t dest) {
-		D_ASSERT(!is_struct);
-		auto idx = state_data.sel->get_index(row);
-		auto &blob = UnifiedVectorFormat::GetData<string_t>(state_data)[idx];
-		if (blob.GetSize() != state_size) {
-			throw IOException("Aggregate state size mismatch, expect %llu, got %llu", state_size, blob.GetSize());
-		}
-		memcpy(dest, blob.GetData(), state_size);
-	}
-
-	// Serializes a packed binary state back into a `Vector` format
-	// Works only on a legacy state format where the entire state is stored as a blob
-	void Store(Vector &result, idx_t row, data_ptr_t src) const {
-		D_ASSERT(!is_struct);
-		auto result_ptr = FlatVector::GetDataMutable<string_t>(result);
-		result_ptr[row] = StringVector::AddStringOrBlob(result, const_char_ptr_cast(src), state_size);
-	}
-
 	bool is_struct;
 	idx_t state_size;
 	idx_t aligned_state_size;
@@ -231,6 +209,75 @@ struct StoreFieldForSelectedRowsOp {
 			idx_t row = sel.get_index(i);
 			auto src = base_ptr + i * layout.aligned_state_size + field_offset;
 			child_data[row] = *reinterpret_cast<T *>(src);
+		}
+	}
+};
+
+// Serialize a primitive state buffer (one T per row) into a flat result vector
+struct StorePrimitiveOp {
+	template <class T>
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
+		auto result_data = FlatVector::Writer<T>(result, count);
+		for (idx_t i = 0; i < count; i++) {
+			result_data.WriteValue(*reinterpret_cast<const T *>(addresses[i]));
+		}
+	}
+};
+
+// Deserialize a primitive value from a flat input vector into sequential state buffer slots
+struct LoadPrimitiveOp {
+	template <class T>
+	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t base_ptr,
+	                      idx_t aligned_state_size) {
+		auto src = FlatVector::GetData<T>(input);
+		for (idx_t i = 0; i < count; i++) {
+			auto src_idx = input_data.sel->get_index(i);
+			if (!input_data.validity.RowIsValid(src_idx)) {
+				continue;
+			}
+			*reinterpret_cast<T *>(base_ptr + i * aligned_state_size) = src[src_idx];
+		}
+	}
+};
+
+// Copy a primitive value from selected rows of input to the same rows of result
+struct CopyPrimitiveOp {
+	template <class T>
+	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count,
+	                      const UnifiedVectorFormat &input_data) {
+		auto src = FlatVector::GetData<T>(input);
+		auto dst = FlatVector::GetDataMutable<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			idx_t src_idx = input_data.sel->get_index(row);
+			dst[row] = src[src_idx];
+		}
+	}
+};
+
+// Deserialize selected rows of a flat input vector into sequential state buffer slots
+struct LoadPrimitiveForSelectedRowsOp {
+	template <class T>
+	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count,
+	                      const UnifiedVectorFormat &input_data, data_ptr_t base_ptr, idx_t aligned_state_size) {
+		auto src = FlatVector::GetData<T>(input);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			idx_t src_idx = input_data.sel->get_index(row);
+			*reinterpret_cast<T *>(base_ptr + i * aligned_state_size) = src[src_idx];
+		}
+	}
+};
+
+// Serialize sequential state buffer slots into selected rows of a flat result vector
+struct StorePrimitiveForSelectedRowsOp {
+	template <class T>
+	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
+	                      idx_t aligned_state_size) {
+		auto dst = FlatVector::GetDataMutable<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			dst[row] = *reinterpret_cast<const T *>(base_ptr + i * aligned_state_size);
 		}
 	}
 };
@@ -421,27 +468,16 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	UnifiedVectorFormat state_data;
 	input.data[0].ToUnifiedFormat(state_data);
 
-	if (layout.is_struct) {
-		for (idx_t i = 0; i < input.size(); i++) {
-			state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.aligned_state_size);
-		}
+	for (idx_t i = 0; i < input.size(); i++) {
+		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.aligned_state_size);
+	}
 
+	if (layout.is_struct) {
 		DeserializeStructFields(layout, layout.aligned_state_size, input.data[0], state_data, input.size(),
 		                        local_state.state_buffer.get());
 	} else {
-		for (idx_t i = 0; i < input.size(); i++) {
-			auto target_ptr = local_state.state_buffer.get() + layout.aligned_state_size * i;
-			auto state_idx = state_data.sel->get_index(i);
-
-			if (state_data.validity.RowIsValid(state_idx)) {
-				layout.Load(input.data[0], state_data, i, target_ptr);
-			} else {
-				// create a dummy state because finalize does not understand NULLs in its input
-				// we put the NULL back in explicitly below
-				bind_data.aggr.GetStateInitCallback()(bind_data.aggr, data_ptr_cast(target_ptr));
-			}
-			state_vec_writer.WriteValue(data_ptr_cast(target_ptr));
-		}
+		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], state_data, input.size(),
+		                                  local_state.state_buffer.get(), layout.aligned_state_size);
 	}
 
 	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
@@ -480,11 +516,9 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 		                  input.data[0].GetType().ToString(), input.data[1].GetType().ToString());
 	}
 
-	if (layout.is_struct) {
-		input.data[0].Flatten();
-		input.data[1].Flatten();
-		result.Flatten();
-	}
+	input.data[0].Flatten();
+	input.data[1].Flatten();
+	result.Flatten();
 
 	UnifiedVectorFormat state0_data, state1_data;
 	input.data[0].ToUnifiedFormat(state0_data);
@@ -538,11 +572,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				offset_in_state += field_size;
 			}
 		} else {
-			for (idx_t i = 0; i < copy_from_0_count; i++) {
-				idx_t row = copy_from_0_sel.get_index(i);
-				layout.Load(input.data[0], state0_data, row, local_state.state_buffer0.get());
-				layout.Store(result, row, local_state.state_buffer0.get());
-			}
+			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], result, copy_from_0_sel,
+			                                  copy_from_0_count, state0_data);
 		}
 	}
 	// copy_from_1: input0 is null, copy input1
@@ -560,11 +591,8 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				offset_in_state += field_size;
 			}
 		} else {
-			for (idx_t i = 0; i < copy_from_1_count; i++) {
-				idx_t row = copy_from_1_sel.get_index(i);
-				layout.Load(input.data[1], state1_data, row, local_state.state_buffer1.get());
-				layout.Store(result, row, local_state.state_buffer1.get());
-			}
+			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[1], result, copy_from_1_sel,
+			                                  copy_from_1_count, state1_data);
 		}
 	}
 
@@ -578,9 +606,6 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 			state0_writer.WriteValue(local_state.state_buffer0.get() + i * layout.aligned_state_size);
 			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.aligned_state_size);
 		}
-
-		auto state0_ptrs = FlatVector::GetData<data_ptr_t>(local_state.addresses0);
-		auto state1_ptrs = FlatVector::GetData<data_ptr_t>(local_state.addresses1);
 
 		if (layout.is_struct) {
 			// Use tight loops to load both inputs
@@ -601,12 +626,12 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				offset_in_state += field_size;
 			}
 		} else {
-			// Handle blob case - load both inputs for all both_valid rows
-			for (idx_t i = 0; i < both_valid_count; i++) {
-				idx_t row = both_valid_sel.get_index(i);
-				layout.Load(input.data[0], state0_data, row, state0_ptrs[i]);
-				layout.Load(input.data[1], state1_data, row, state1_ptrs[i]);
-			}
+			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(
+			    layout.owned_type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
+			    local_state.state_buffer0.get(), layout.aligned_state_size);
+			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(
+			    layout.owned_type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
+			    local_state.state_buffer1.get(), layout.aligned_state_size);
 		}
 
 		// Single batched combine call
@@ -631,11 +656,9 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 				offset_in_state += field_size;
 			}
 		} else {
-			// Handle blob case - store results using the legacy not tight-loop strategy
-			for (idx_t i = 0; i < both_valid_count; i++) {
-				idx_t row = both_valid_sel.get_index(i);
-				layout.Store(result, row, state1_ptrs[i]);
-			}
+			TemplateDispatch<StorePrimitiveForSelectedRowsOp>(layout.owned_type.InternalType(), result, both_valid_sel,
+			                                                  both_valid_count, local_state.state_buffer1.get(),
+			                                                  layout.aligned_state_size);
 		}
 	}
 }
@@ -747,11 +770,14 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 
 	auto state_size = aggr_input_data.function.GetStateSizeCallback()(aggr_input_data.function);
 
-	// Note: The underlying state type should always be a struct (we have a D_ASSERT for that in `GetStateType`
 	AggregateStateLayout layout(result.GetType(), state_size);
 
 	result.Flatten();
-	SerializeStructFields(layout, result, count, addresses_ptrs);
+	if (layout.is_struct) {
+		SerializeStructFields(layout, result, count, addresses_ptrs);
+	} else {
+		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+	}
 }
 
 unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
@@ -809,7 +835,12 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 		target_data.WriteValue(state_ptrs[sdata.sel->get_index(i)]);
 	}
 
-	DeserializeStructFields(layout, layout.aligned_state_size, inputs[0], input_data, count, temp_state_buf.get());
+	if (layout.is_struct) {
+		DeserializeStructFields(layout, layout.aligned_state_size, inputs[0], input_data, count, temp_state_buf.get());
+	} else {
+		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), inputs[0], input_data, count,
+		                                  temp_state_buf.get(), layout.aligned_state_size);
+	}
 
 	ArenaAllocator allocator(Allocator::DefaultAllocator());
 	AggregateInputData combine_input(bind_data.aggr, bind_data.bind_data.get(), allocator,
@@ -836,7 +867,11 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	AggregateStateLayout layout(underlying_aggr.GetStateType(), state_size);
 
 	result.Flatten();
-	SerializeStructFields(layout, result, count, addresses_ptrs);
+	if (layout.is_struct) {
+		SerializeStructFields(layout, result, count, addresses_ptrs);
+	} else {
+		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+	}
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -112,159 +112,75 @@ static AggregateStateLayout GetLayout(const BoundAggregateFunction &aggr) {
 	return aggr.GetStateTypeCallback()(aggr);
 }
 
-/*
- * Load a specific field from the struct aggregate state into the packed binary representation
- * By iterating over rows in the inner loop for a specific type T, the compiler is given a tight loop with a
- * predictable memory access pattern. Since the field in a struct is a contiguous array of type `T`, the compiler
- * can easily vectorize the read operations using SIMD instructions
- */
-struct LoadFieldOp {
+// Load rows from input_vec into the packed binary state buffer.
+// Checks validity via input_data and skips null rows.
+// Used for struct fields (input_data=outer state format, field_offset=child offset)
+// and primitive states (root_stride=aligned_state_size, field_offset=0).
+struct LoadOp {
 	template <class T>
-	static void Operation(idx_t root_stride, const Vector &struct_vec, idx_t field_idx,
-	                      const UnifiedVectorFormat &state_data, idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
-		const auto &child = StructVector::GetEntries(struct_vec)[field_idx];
-		auto child_data = FlatVector::GetData<T>(child);
-
-		for (idx_t row = 0; row < count; row++) {
-			auto row_idx = state_data.sel->get_index(row);
-			if (!state_data.validity.RowIsValid(row_idx)) {
-				continue;
-			}
-
-			auto dest = base_ptr + row * root_stride + field_offset;
-			*reinterpret_cast<T *>(dest) = child_data[row];
-		}
-	}
-};
-
-struct StoreFieldOp {
-	template <class T>
-	static void Operation(Vector &struct_vec, idx_t field_idx, idx_t count, const data_ptr_t *sources,
-	                      idx_t field_offset) {
-		auto &child = StructVector::GetEntries(struct_vec)[field_idx];
-		auto child_data = FlatVector::Writer<T>(child, count);
-
-		for (idx_t row = 0; row < count; row++) {
-			auto src = sources[row] + field_offset;
-			child_data.WriteValue(*reinterpret_cast<T *>(src));
-		}
-	}
-};
-
-struct CopyFromInputFieldOp {
-	template <class T>
-	static void Operation(const Vector &input_vec, Vector &result_vec, idx_t field_idx, const SelectionVector &sel,
-	                      idx_t count, const UnifiedVectorFormat &input_data) {
-		const auto &input_child = StructVector::GetEntries(input_vec)[field_idx];
-		auto input_child_data = FlatVector::GetData<T>(input_child);
-
-		auto &result_child = StructVector::GetEntries(result_vec)[field_idx];
-		auto result_child_data = FlatVector::GetDataMutable<T>(result_child);
-
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			auto src_idx = input_data.sel->get_index(row);
-			result_child_data[row] = input_child_data[src_idx];
-		}
-	}
-};
-
-struct LoadFieldForSelectedRowsOp {
-	template <class T>
-	static void Operation(idx_t total_state_size, const Vector &struct_vec, idx_t field_idx, const SelectionVector &sel,
-	                      idx_t count, const UnifiedVectorFormat &state_data, data_ptr_t base_ptr, idx_t field_offset) {
-		const auto &child = StructVector::GetEntries(struct_vec)[field_idx];
-		auto child_data = FlatVector::GetData<T>(child);
-
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			auto src_idx = state_data.sel->get_index(row);
-			auto dest = base_ptr + i * total_state_size + field_offset;
-			*reinterpret_cast<T *>(dest) = child_data[src_idx];
-		}
-	}
-};
-
-struct StoreFieldForSelectedRowsOp {
-	template <class T>
-	static void Operation(idx_t total_state_size, Vector &result, idx_t field_idx, const SelectionVector &sel,
+	static void Operation(idx_t root_stride, const Vector &input_vec, const UnifiedVectorFormat &input_data,
 	                      idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
-		auto &child = StructVector::GetEntries(result)[field_idx];
-		auto child_data = FlatVector::ScatterWriter<T>(child);
-
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			auto src = base_ptr + i * total_state_size + field_offset;
-			child_data[row] = *reinterpret_cast<T *>(src);
-		}
-	}
-};
-
-// Serialize a primitive state buffer (one T per row) into a flat result vector
-struct StorePrimitiveOp {
-	template <class T>
-	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
-		auto result_data = FlatVector::Writer<T>(result, count);
-		for (idx_t i = 0; i < count; i++) {
-			result_data.WriteValue(*reinterpret_cast<const T *>(addresses[i]));
-		}
-	}
-};
-
-// Deserialize a primitive value from a flat input vector into sequential state buffer slots
-struct LoadPrimitiveOp {
-	template <class T>
-	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t base_ptr,
-	                      idx_t aligned_state_size) {
-		auto src = FlatVector::GetData<T>(input);
+		auto values = input_vec.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
 			auto src_idx = input_data.sel->get_index(i);
 			if (!input_data.validity.RowIsValid(src_idx)) {
 				continue;
 			}
-			*reinterpret_cast<T *>(base_ptr + i * aligned_state_size) = src[src_idx];
+			Store(values.GetValueUnsafe(i), base_ptr + i * root_stride + field_offset);
 		}
 	}
 };
 
-// Copy a primitive value from selected rows of input to the same rows of result
-struct CopyPrimitiveOp {
+// Store rows from the packed binary state buffer into a result vector.
+// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
+struct StoreOp {
 	template <class T>
-	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count,
-	                      const UnifiedVectorFormat &input_data) {
-		auto src = FlatVector::GetData<T>(input);
-		auto dst = FlatVector::GetDataMutable<T>(result);
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *sources, idx_t field_offset) {
+		auto result_data = FlatVector::Writer<T>(result, count);
 		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			idx_t src_idx = input_data.sel->get_index(row);
-			dst[row] = src[src_idx];
+			result_data.WriteValue(Load<T>(sources[i] + field_offset));
 		}
 	}
 };
 
-// Deserialize selected rows of a flat input vector into sequential state buffer slots
-struct LoadPrimitiveForSelectedRowsOp {
+// Copy selected rows from input to result.
+// Used for struct fields (extract child before calling) and primitive states.
+struct CopyOp {
 	template <class T>
-	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count,
-	                      const UnifiedVectorFormat &input_data, data_ptr_t base_ptr, idx_t aligned_state_size) {
-		auto src = FlatVector::GetData<T>(input);
+	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
+		auto input_values = input.Values<T>();
+		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
-			idx_t src_idx = input_data.sel->get_index(row);
-			*reinterpret_cast<T *>(base_ptr + i * aligned_state_size) = src[src_idx];
+			dst[row] = input_values.GetValueUnsafe(row);
 		}
 	}
 };
 
-// Serialize sequential state buffer slots into selected rows of a flat result vector
-struct StorePrimitiveForSelectedRowsOp {
+// Load selected rows from input_vec into sequential packed binary state buffer slots.
+// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
+struct LoadForSelectedRowsOp {
 	template <class T>
-	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
-	                      idx_t aligned_state_size) {
-		auto dst = FlatVector::GetDataMutable<T>(result);
+	static void Operation(idx_t total_state_size, const Vector &input_vec, const SelectionVector &sel, idx_t count,
+	                      data_ptr_t base_ptr, idx_t field_offset) {
+		auto values = input_vec.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
-			dst[row] = *reinterpret_cast<const T *>(base_ptr + i * aligned_state_size);
+			Store(values.GetValueUnsafe(row), base_ptr + i * total_state_size + field_offset);
+		}
+	}
+};
+
+// Store sequential packed binary state buffer slots into selected rows of a result vector.
+// Used for struct fields (field_offset=child offset) and primitive states (field_offset=0).
+struct StoreForSelectedRowsOp {
+	template <class T>
+	static void Operation(idx_t total_state_size, Vector &result, const SelectionVector &sel, idx_t count,
+	                      data_ptr_t base_ptr, idx_t field_offset) {
+		auto dst = FlatVector::ScatterWriter<T>(result);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t row = sel.get_index(i);
+			dst[row] = Load<T>(base_ptr + i * total_state_size + field_offset);
 		}
 	}
 };
@@ -273,13 +189,13 @@ struct StorePrimitiveForSelectedRowsOp {
 struct StorePrimitiveOptionalOp {
 	template <class T>
 	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
-		auto dst = FlatVector::GetDataMutable<T>(result);
+		auto dst = FlatVector::Writer<T>(result, count);
 		for (idx_t i = 0; i < count; i++) {
-			const auto &opt = *reinterpret_cast<const optional<T> *>(addresses[i]);
+			const auto opt = Load<optional<T>>(addresses[i]);
 			if (opt.has_value()) {
-				dst[i] = *opt;
+				dst.WriteValue(*opt);
 			} else {
-				FlatVector::SetNull(result, i, true);
+				dst.WriteNull();
 			}
 		}
 	}
@@ -290,12 +206,12 @@ struct LoadPrimitiveOptionalOp {
 	template <class T>
 	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t base_ptr,
 	                      idx_t aligned_state_size) {
-		auto src = FlatVector::GetData<T>(input);
+		auto values = input.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
 			auto src_idx = input_data.sel->get_index(i);
 			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
 			if (input_data.validity.RowIsValid(src_idx)) {
-				opt = src[src_idx];
+				opt = values.GetValueUnsafe(i);
 			} else {
 				opt = nullopt;
 			}
@@ -308,15 +224,15 @@ struct CopyPrimitiveOptionalOp {
 	template <class T>
 	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count,
 	                      const UnifiedVectorFormat &input_data) {
-		auto src = FlatVector::GetData<T>(input);
-		auto dst = FlatVector::GetDataMutable<T>(result);
+		auto input_values = input.Values<T>();
+		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
 			idx_t src_idx = input_data.sel->get_index(row);
 			if (input_data.validity.RowIsValid(src_idx)) {
-				dst[row] = src[src_idx];
+				dst[row] = input_values.GetValueUnsafe(row);
 			} else {
-				FlatVector::SetNull(result, row, true);
+				dst.SetInvalid(row);
 			}
 		}
 	}
@@ -327,13 +243,13 @@ struct LoadPrimitiveOptionalForSelectedRowsOp {
 	template <class T>
 	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count,
 	                      const UnifiedVectorFormat &input_data, data_ptr_t base_ptr, idx_t aligned_state_size) {
-		auto src = FlatVector::GetData<T>(input);
+		auto values = input.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
 			idx_t src_idx = input_data.sel->get_index(row);
 			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
 			if (input_data.validity.RowIsValid(src_idx)) {
-				opt = src[src_idx];
+				opt = values.GetValueUnsafe(row);
 			} else {
 				opt = nullopt;
 			}
@@ -346,53 +262,54 @@ struct StorePrimitiveOptionalForSelectedRowsOp {
 	template <class T>
 	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
 	                      idx_t aligned_state_size) {
-		auto dst = FlatVector::GetDataMutable<T>(result);
+		auto dst = FlatVector::ScatterWriter<T>(result);
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
-			const auto &opt = *reinterpret_cast<const optional<T> *>(base_ptr + i * aligned_state_size);
+			const auto opt = Load<optional<T>>(base_ptr + i * aligned_state_size);
 			if (opt.has_value()) {
 				dst[row] = *opt;
 			} else {
-				FlatVector::SetNull(result, row, true);
+				dst.SetInvalid(row);
 			}
 		}
 	}
 };
 
 // Deserialize struct fields from a flattened struct vector into a state buffer.
-// Uses LoadFieldOp for tight SIMD-friendly loops.
 // root_stride is the aligned size of the top-level state, used to stride between rows in the buffer.
 // Child field offsets are pre-computed in AggregateStateField.field_offset (relative to dest_buffer).
 void DeserializeStructFields(const LogicalType &type, const AggregateStateField &field, idx_t root_stride,
                              const Vector &struct_vec, const UnifiedVectorFormat &state_data, idx_t count,
                              data_ptr_t dest_buffer) {
 	const auto &child_types = StructType::GetChildTypes(type);
+	const auto &struct_entries = StructVector::GetEntries(struct_vec);
 	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
 		const auto &child = field.children[field_idx];
 		const auto &child_type = child_types[field_idx].second;
 		auto physical = child_type.InternalType();
+		const auto &child_vec = struct_entries[field_idx];
 
 		if (!child.children.empty()) {
-			const auto &struct_entries = StructVector::GetEntries(struct_vec);
-			DeserializeStructFields(child_type, child, root_stride, struct_entries[field_idx], state_data, count,
+			DeserializeStructFields(child_type, child, root_stride, child_vec, state_data, count,
 			                        dest_buffer + child.field_offset);
 		} else {
-			TemplateDispatch<LoadFieldOp>(physical, root_stride, struct_vec, field_idx, state_data, count, dest_buffer,
-			                              child.field_offset);
+			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, state_data, count, dest_buffer,
+			                        child.field_offset);
 		}
 	}
 }
 
 // Serialize packed binary states into a struct result vector.
-// Uses StoreFieldOp for tight SIMD-friendly loops.
 // Child field offsets are pre-computed in AggregateStateField.field_offset (relative to addresses_ptrs[row]).
 void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
                            const data_ptr_t *addresses_ptrs) {
 	const auto &child_types = StructType::GetChildTypes(type);
+	auto &struct_entries = StructVector::GetEntries(result);
 	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
 		const auto &child = field.children[field_idx];
 		const auto &child_type = child_types[field_idx].second;
 		auto physical = child_type.InternalType();
+		auto &child_vec = struct_entries[field_idx];
 
 		if (!child.children.empty()) {
 			// Adjust addresses to point to the start of this nested struct field for each row
@@ -402,68 +319,93 @@ void SerializeStructFields(const LogicalType &type, const AggregateStateField &f
 				child_writer.WriteValue(addresses_ptrs[row] + child.field_offset);
 			}
 			auto child_ptrs = FlatVector::GetData<data_ptr_t>(child_addresses);
-			auto &struct_entries = StructVector::GetEntries(result);
-			SerializeStructFields(child_type, child, struct_entries[field_idx], count, child_ptrs);
+			SerializeStructFields(child_type, child, child_vec, count, child_ptrs);
 		} else {
-			TemplateDispatch<StoreFieldOp>(physical, result, field_idx, count, addresses_ptrs, child.field_offset);
+			TemplateDispatch<StoreOp>(physical, child_vec, count, addresses_ptrs, child.field_offset);
 		}
 	}
 }
 
-#ifdef DEBUG
-// Internal verification: export all states to struct, import back, finalize, and compare to main path result
-// using vector operations. Catches serialization/deserialization bugs for struct-based aggregate state.
-void VerifyStructStateRoundtrip(const AggregateStateLayout &layout, const Vector &state_vec, idx_t count,
-                                const UnifiedVectorFormat &state_data, const data_ptr_t *state_vec_ptr,
-                                const Vector &result, const ExportAggregateBindData &bind_data,
-                                AggregateInputData &aggr_input_data) {
-	// Build selection of valid state rows
-	SelectionVector valid_sel(count);
-	idx_t valid_count = 0;
-	for (idx_t i = 0; i < count; i++) {
-		if (state_data.validity.RowIsValid(state_data.sel->get_index(i))) {
-			valid_sel.set_index(valid_count++, i);
-		}
+void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec,
+                      const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t dest_buffer) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, input_data, count,
+		                        dest_buffer);
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, input_data, count, dest_buffer,
+		                                          layout.total_state_size);
+	} else {
+		TemplateDispatch<LoadOp>(layout.type.InternalType(), layout.total_state_size, input_vec, input_data, count,
+		                         dest_buffer, 0);
 	}
-	if (valid_count == 0) {
-		return;
-	}
-
-	// SerializeStructFields: all valid states -> struct vector
-	Vector struct_vec(state_vec.GetType(), valid_count);
-	unsafe_unique_array<data_ptr_t> addresses_ptrs(make_unsafe_uniq_array<data_ptr_t>(valid_count));
-	for (idx_t i = 0; i < valid_count; i++) {
-		addresses_ptrs[i] = state_vec_ptr[valid_sel.get_index(i)];
-	}
-	SerializeStructFields(layout.type, layout.field, struct_vec, valid_count, addresses_ptrs.get());
-
-	// DeserializeStructFields: struct vector -> packed buffer
-	unsafe_unique_array<data_t> temp_state_buf(make_unsafe_uniq_array<data_t>(valid_count * layout.total_state_size));
-	UnifiedVectorFormat struct_format;
-	struct_vec.ToUnifiedFormat(struct_format);
-	DeserializeStructFields(layout.type, layout.field, layout.total_state_size, struct_vec, struct_format, valid_count,
-	                        temp_state_buf.get());
-
-	// AggregateStateFinalize: packed buffer -> result values
-	Vector addresses_vec(LogicalType::POINTER);
-	auto addresses_finalize = FlatVector::Writer<data_ptr_t>(addresses_vec, valid_count);
-	for (idx_t i = 0; i < valid_count; i++) {
-		addresses_finalize.WriteValue(temp_state_buf.get() + i * layout.total_state_size);
-	}
-	Vector result_roundtrip(result.GetType(), valid_count);
-	bind_data.aggr.GetStateFinalizeCallback()(addresses_vec, aggr_input_data, result_roundtrip, valid_count, 0);
-
-	Vector result_slice(result.GetType(), valid_count);
-	result_slice.Slice(result, valid_sel, valid_count);
-	SelectionVector true_sel(valid_count);
-	SelectionVector false_sel(valid_count);
-	idx_t match_count =
-	    VectorOperations::NotDistinctFrom(result_slice, result_roundtrip, nullptr, valid_count, &true_sel, &false_sel);
-	D_ASSERT(match_count == valid_count &&
-	         "Struct state roundtrip failed: finalize(serialize->deserialize(state)) != finalize(state). "
-	         "Check SerializeStructFields/DeserializeStructFields for this aggregate.");
 }
-#endif
+
+void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		SerializeStructFields(layout.type, layout.field, result, count, addresses);
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses);
+	} else {
+		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, count, addresses, 0);
+	}
+}
+
+void CopyState(const AggregateStateLayout &layout, const Vector &input, Vector &result, const SelectionVector &sel,
+               idx_t count, const UnifiedVectorFormat &input_data) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		const auto &child_types = StructType::GetChildTypes(layout.type);
+		const auto &input_entries = StructVector::GetEntries(input);
+		auto &result_entries = StructVector::GetEntries(result);
+		for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
+			auto physical = child_types[field_idx].second.InternalType();
+			TemplateDispatch<CopyOp>(physical, input_entries[field_idx], result_entries[field_idx], sel, count);
+		}
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input, result, sel, count, input_data);
+	} else {
+		TemplateDispatch<CopyOp>(layout.type.InternalType(), input, result, sel, count);
+	}
+}
+
+void DeserializeStateForSelected(const AggregateStateLayout &layout, const Vector &input, const SelectionVector &sel,
+                                 idx_t count, const UnifiedVectorFormat &input_data, data_ptr_t dest_buffer) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		const auto &child_types = StructType::GetChildTypes(layout.type);
+		const auto &input_entries = StructVector::GetEntries(input);
+		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+			const auto &child = layout.field.children[field_idx];
+			auto physical = child_types[field_idx].second.InternalType();
+			TemplateDispatch<LoadForSelectedRowsOp>(physical, layout.total_state_size, input_entries[field_idx], sel,
+			                                        count, dest_buffer, child.field_offset);
+		}
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(layout.type.InternalType(), input, sel, count,
+		                                                         input_data, dest_buffer, layout.total_state_size);
+	} else {
+		TemplateDispatch<LoadForSelectedRowsOp>(layout.type.InternalType(), layout.total_state_size, input, sel, count,
+		                                        dest_buffer, 0);
+	}
+}
+
+void SerializeStateForSelected(const AggregateStateLayout &layout, Vector &result, const SelectionVector &sel,
+                               idx_t count, data_ptr_t base_ptr) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		const auto &child_types = StructType::GetChildTypes(layout.type);
+		auto &result_entries = StructVector::GetEntries(result);
+		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+			const auto &child = layout.field.children[field_idx];
+			auto physical = child_types[field_idx].second.InternalType();
+			TemplateDispatch<StoreForSelectedRowsOp>(physical, layout.total_state_size, result_entries[field_idx], sel,
+			                                         count, base_ptr, child.field_offset);
+		}
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalForSelectedRowsOp>(layout.type.InternalType(), result, sel, count,
+		                                                          base_ptr, layout.total_state_size);
+	} else {
+		TemplateDispatch<StoreForSelectedRowsOp>(layout.type.InternalType(), layout.total_state_size, result, sel,
+		                                         count, base_ptr, 0);
+	}
+}
 
 struct CombineState : public FunctionLocalState {
 	idx_t state_size;
@@ -528,16 +470,7 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.total_state_size);
 	}
 
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input.data[0], state_data,
-		                        input.size(), local_state.state_buffer.get());
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input.data[0], state_data, input.size(),
-		                                          local_state.state_buffer.get(), layout.total_state_size);
-	} else {
-		TemplateDispatch<LoadPrimitiveOp>(layout.type.InternalType(), input.data[0], state_data, input.size(),
-		                                  local_state.state_buffer.get(), layout.total_state_size);
-	}
+	DeserializeState(layout, input.data[0], state_data, input.size(), local_state.state_buffer.get());
 
 	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
 	bind_data.aggr.GetStateFinalizeCallback()(local_state.addresses, aggr_input_data, result, input.size(), 0);
@@ -548,14 +481,6 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 			FlatVector::SetNull(result, i, true);
 		}
 	}
-
-#ifdef DEBUG
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		auto state_vec_ptr = FlatVector::GetData<data_ptr_t>(local_state.addresses);
-		VerifyStructStateRoundtrip(layout, input.data[0], input.size(), state_data, state_vec_ptr, result, bind_data,
-		                           aggr_input_data);
-	}
-#endif
 }
 
 void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &result) {
@@ -616,39 +541,11 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	}
 
 	// Handle one-null rows - copy non-null input directly to result
-	// copy_from_0: input1 is null, copy input0
 	if (copy_from_0_count > 0) {
-		if (layout.type.id() == LogicalTypeId::STRUCT) {
-			const auto &child_types = StructType::GetChildTypes(layout.type);
-			for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
-				auto physical = child_types[field_idx].second.InternalType();
-				TemplateDispatch<CopyFromInputFieldOp>(physical, input.data[0], result, field_idx, copy_from_0_sel,
-				                                       copy_from_0_count, state0_data);
-			}
-		} else if (layout.field.is_optional) {
-			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input.data[0], result,
-			                                          copy_from_0_sel, copy_from_0_count, state0_data);
-		} else {
-			TemplateDispatch<CopyPrimitiveOp>(layout.type.InternalType(), input.data[0], result, copy_from_0_sel,
-			                                  copy_from_0_count, state0_data);
-		}
+		CopyState(layout, input.data[0], result, copy_from_0_sel, copy_from_0_count, state0_data);
 	}
-	// copy_from_1: input0 is null, copy input1
 	if (copy_from_1_count > 0) {
-		if (layout.type.id() == LogicalTypeId::STRUCT) {
-			const auto &child_types = StructType::GetChildTypes(layout.type);
-			for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
-				auto physical = child_types[field_idx].second.InternalType();
-				TemplateDispatch<CopyFromInputFieldOp>(physical, input.data[1], result, field_idx, copy_from_1_sel,
-				                                       copy_from_1_count, state1_data);
-			}
-		} else if (layout.field.is_optional) {
-			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input.data[1], result,
-			                                          copy_from_1_sel, copy_from_1_count, state1_data);
-		} else {
-			TemplateDispatch<CopyPrimitiveOp>(layout.type.InternalType(), input.data[1], result, copy_from_1_sel,
-			                                  copy_from_1_count, state1_data);
-		}
+		CopyState(layout, input.data[1], result, copy_from_1_sel, copy_from_1_count, state1_data);
 	}
 
 	// Handle both-valid rows - batched load, combine, store
@@ -662,35 +559,10 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.total_state_size);
 		}
 
-		if (layout.type.id() == LogicalTypeId::STRUCT) {
-			// Use tight loops to load both inputs
-			const auto &child_types = StructType::GetChildTypes(layout.type);
-			for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
-				const auto &child = layout.field.children[field_idx];
-				auto physical = child_types[field_idx].second.InternalType();
-
-				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout.total_state_size, input.data[0],
-				                                             field_idx, both_valid_sel, both_valid_count, state0_data,
-				                                             local_state.state_buffer0.get(), child.field_offset);
-				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout.total_state_size, input.data[1],
-				                                             field_idx, both_valid_sel, both_valid_count, state1_data,
-				                                             local_state.state_buffer1.get(), child.field_offset);
-			}
-		} else if (layout.field.is_optional) {
-			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
-			    layout.type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
-			    local_state.state_buffer0.get(), layout.total_state_size);
-			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
-			    layout.type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
-			    local_state.state_buffer1.get(), layout.total_state_size);
-		} else {
-			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(layout.type.InternalType(), input.data[0], both_valid_sel,
-			                                                 both_valid_count, state0_data,
-			                                                 local_state.state_buffer0.get(), layout.total_state_size);
-			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(layout.type.InternalType(), input.data[1], both_valid_sel,
-			                                                 both_valid_count, state1_data,
-			                                                 local_state.state_buffer1.get(), layout.total_state_size);
-		}
+		DeserializeStateForSelected(layout, input.data[0], both_valid_sel, both_valid_count, state0_data,
+		                            local_state.state_buffer0.get());
+		DeserializeStateForSelected(layout, input.data[1], both_valid_sel, both_valid_count, state1_data,
+		                            local_state.state_buffer1.get());
 
 		// Single batched combine call
 		AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator,
@@ -698,26 +570,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 		bind_data.aggr.GetStateCombineCallback()(local_state.addresses0, local_state.addresses1, aggr_input_data,
 		                                         both_valid_count);
 
-		// Store results
-		if (layout.type.id() == LogicalTypeId::STRUCT) {
-			const auto &child_types = StructType::GetChildTypes(layout.type);
-			for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
-				const auto &child = layout.field.children[field_idx];
-				auto physical = child_types[field_idx].second.InternalType();
-
-				TemplateDispatch<StoreFieldForSelectedRowsOp>(physical, layout.total_state_size, result, field_idx,
-				                                              both_valid_sel, both_valid_count,
-				                                              local_state.state_buffer1.get(), child.field_offset);
-			}
-		} else if (layout.field.is_optional) {
-			TemplateDispatch<StorePrimitiveOptionalForSelectedRowsOp>(
-			    layout.type.InternalType(), result, both_valid_sel, both_valid_count, local_state.state_buffer1.get(),
-			    layout.total_state_size);
-		} else {
-			TemplateDispatch<StorePrimitiveForSelectedRowsOp>(layout.type.InternalType(), result, both_valid_sel,
-			                                                  both_valid_count, local_state.state_buffer1.get(),
-			                                                  layout.total_state_size);
-		}
+		SerializeStateForSelected(layout, result, both_valid_sel, both_valid_count, local_state.state_buffer1.get());
 	}
 }
 
@@ -829,13 +682,7 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 	auto layout = GetLayout(aggr_input_data.function);
 
 	result.Flatten();
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		SerializeStructFields(layout.type, layout.field, result, count, addresses_ptrs);
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses_ptrs);
-	} else {
-		TemplateDispatch<StorePrimitiveOp>(layout.type.InternalType(), result, count, addresses_ptrs);
-	}
+	SerializeState(layout, result, count, addresses_ptrs);
 }
 
 unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
@@ -892,16 +739,7 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 		target_data.WriteValue(state_ptrs[sdata.sel->get_index(i)]);
 	}
 
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, inputs[0], input_data, count,
-		                        temp_state_buf.get());
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), inputs[0], input_data, count,
-		                                          temp_state_buf.get(), layout.total_state_size);
-	} else {
-		TemplateDispatch<LoadPrimitiveOp>(layout.type.InternalType(), inputs[0], input_data, count,
-		                                  temp_state_buf.get(), layout.total_state_size);
-	}
+	DeserializeState(layout, inputs[0], input_data, count, temp_state_buf.get());
 
 	ArenaAllocator allocator(Allocator::DefaultAllocator());
 	AggregateInputData combine_input(bind_data.aggr, bind_data.bind_data.get(), allocator,
@@ -927,13 +765,7 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	auto layout = GetLayout(underlying_aggr);
 
 	result.Flatten();
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		SerializeStructFields(layout.type, layout.field, result, count, addresses_ptrs);
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses_ptrs);
-	} else {
-		TemplateDispatch<StorePrimitiveOp>(layout.type.InternalType(), result, count, addresses_ptrs);
-	}
+	SerializeState(layout, result, count, addresses_ptrs);
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -177,7 +177,8 @@ void DeserializeState(const AggregateStateLayout &layout, const Vector &input_ve
 		const auto &struct_entries = StructVector::GetEntries(input_vec);
 		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
 			const auto &child = layout.field.children[field_idx];
-			AggregateStateLayout child_layout(child_types[field_idx].second, layout.total_state_size, child.is_optional);
+			AggregateStateLayout child_layout(child_types[field_idx].second, layout.total_state_size,
+			                                  child.is_optional);
 			DeserializeState(child_layout, struct_entries[field_idx], count, dest_buffer + child.field_offset);
 		}
 	} else if (layout.field.is_optional) {
@@ -196,8 +197,7 @@ void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t co
 		for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
 			const auto &child = layout.field.children[field_idx];
 			AggregateStateLayout child_layout(child_types[field_idx].second, 0, child.is_optional);
-			SerializeState(child_layout, struct_entries[field_idx], count, addresses,
-			               base_offset + child.field_offset);
+			SerializeState(child_layout, struct_entries[field_idx], count, addresses, base_offset + child.field_offset);
 		}
 	} else if (layout.field.is_optional) {
 		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses, base_offset);

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -111,17 +111,14 @@ static AggregateStateLayout GetLayout(const BoundAggregateFunction &aggr) {
 	return aggr.GetStateTypeCallback()(aggr);
 }
 
-// Load rows from input_vec into the packed binary state buffer.
-// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
-// Skips null rows.
+// Load rows from input_vec into the packed binary state buffer. Skips null rows.
 struct LoadOp {
 	template <class T>
-	static void Operation(idx_t root_stride, const Vector &input_vec, const SelectionVector &sel, idx_t count,
-	                      data_ptr_t base_ptr, idx_t field_offset) {
+	static void Operation(idx_t root_stride, const Vector &input_vec, idx_t count, data_ptr_t base_ptr,
+	                      idx_t field_offset) {
 		auto values = input_vec.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			const auto entry = values[row];
+			const auto entry = values[i];
 			if (entry.IsValid()) {
 				Store(entry.GetValue(), base_ptr + i * root_stride + field_offset);
 			}
@@ -130,59 +127,39 @@ struct LoadOp {
 };
 
 // Store rows from the packed binary state buffer into a result vector.
-// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct StoreOp {
 	template <class T>
-	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, const data_ptr_t *sources,
-	                      idx_t field_offset) {
-		auto dst = FlatVector::ScatterWriter<T>(result);
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *sources, idx_t field_offset) {
+		auto dst = FlatVector::Writer<T>(result, count);
 		for (idx_t i = 0; i < count; i++) {
-			dst[sel.get_index(i)] = Load<T>(sources[i] + field_offset);
-		}
-	}
-};
-
-// Copy selected rows from input to result.
-// Used for struct fields (extract child before calling) and primitive states.
-struct CopyOp {
-	template <class T>
-	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
-		auto input_values = input.Values<T>();
-		auto dst = FlatVector::ScatterWriter<T>(result);
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			dst[row] = input_values.GetValueUnsafe(row);
+			dst.WriteValue(Load<T>(sources[i] + field_offset));
 		}
 	}
 };
 
 // Serialize optional<T> state buffers into a result vector, setting NULL for disengaged optionals.
-// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct StorePrimitiveOptionalOp {
 	template <class T>
-	static void Operation(Vector &result, const SelectionVector &sel, idx_t count, const data_ptr_t *addresses) {
-		auto dst = FlatVector::ScatterWriter<T>(result);
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *addresses) {
+		auto dst = FlatVector::Writer<T>(result, count);
 		for (idx_t i = 0; i < count; i++) {
 			const auto opt = Load<optional<T>>(addresses[i]);
 			if (opt.has_value()) {
-				dst[sel.get_index(i)] = *opt;
+				dst.WriteValue(*opt);
 			} else {
-				dst.SetInvalid(sel.get_index(i));
+				dst.WriteNull();
 			}
 		}
 	}
 };
 
 // Deserialize a nullable input vector into optional<T> state buffer slots.
-// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
 struct LoadPrimitiveOptionalOp {
 	template <class T>
-	static void Operation(const Vector &input, const SelectionVector &sel, idx_t count, data_ptr_t base_ptr,
-	                      idx_t aligned_state_size) {
+	static void Operation(const Vector &input, idx_t count, data_ptr_t base_ptr, idx_t aligned_state_size) {
 		auto values = input.Values<T>();
 		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			const auto entry = values[row];
+			const auto entry = values[i];
 			auto &opt = *reinterpret_cast<optional<T> *>(base_ptr + i * aligned_state_size);
 			if (entry.IsValid()) {
 				opt = entry.GetValue();
@@ -193,30 +170,8 @@ struct LoadPrimitiveOptionalOp {
 	}
 };
 
-// Copy a nullable primitive value from selected rows of input to the same rows of result
-struct CopyPrimitiveOptionalOp {
-	template <class T>
-	static void Operation(const Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
-		auto input_values = input.Values<T>();
-		auto dst = FlatVector::ScatterWriter<T>(result);
-		for (idx_t i = 0; i < count; i++) {
-			idx_t row = sel.get_index(i);
-			const auto entry = input_values[row];
-			if (entry.IsValid()) {
-				dst[row] = entry.GetValue();
-			} else {
-				dst.SetInvalid(row);
-			}
-		}
-	}
-};
-
-// Deserialize struct fields from a flattened struct vector into a state buffer.
-// root_stride is the aligned size of the top-level state, used to stride between rows in the buffer.
-// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
 void DeserializeStructFields(const LogicalType &type, const AggregateStateField &field, idx_t root_stride,
-                             const Vector &struct_vec, const SelectionVector &sel, idx_t count,
-                             data_ptr_t dest_buffer) {
+                             const Vector &struct_vec, idx_t count, data_ptr_t dest_buffer) {
 	const auto &child_types = StructType::GetChildTypes(type);
 	const auto &struct_entries = StructVector::GetEntries(struct_vec);
 	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
@@ -226,18 +181,15 @@ void DeserializeStructFields(const LogicalType &type, const AggregateStateField 
 		const auto &child_vec = struct_entries[field_idx];
 
 		if (!child.children.empty()) {
-			DeserializeStructFields(child_type, child, root_stride, child_vec, sel, count,
-			                        dest_buffer + child.field_offset);
+			DeserializeStructFields(child_type, child, root_stride, child_vec, count, dest_buffer + child.field_offset);
 		} else {
-			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, sel, count, dest_buffer, child.field_offset);
+			TemplateDispatch<LoadOp>(physical, root_stride, child_vec, count, dest_buffer, child.field_offset);
 		}
 	}
 }
 
-// Serialize packed binary states into a struct result vector.
-// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
-void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result,
-                           const SelectionVector &sel, idx_t count, const data_ptr_t *addresses_ptrs) {
+void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
+                           const data_ptr_t *addresses_ptrs, idx_t base_offset = 0) {
 	const auto &child_types = StructType::GetChildTypes(type);
 	auto &struct_entries = StructVector::GetEntries(result);
 	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
@@ -247,60 +199,33 @@ void SerializeStructFields(const LogicalType &type, const AggregateStateField &f
 		auto &child_vec = struct_entries[field_idx];
 
 		if (!child.children.empty()) {
-			// Adjust addresses to point to the start of this nested struct field for each row
-			Vector child_addresses(LogicalType::POINTER);
-			auto child_writer = FlatVector::Writer<data_ptr_t>(child_addresses, count);
-			for (idx_t row = 0; row < count; row++) {
-				child_writer.WriteValue(addresses_ptrs[row] + child.field_offset);
-			}
-			auto child_ptrs = FlatVector::GetData<data_ptr_t>(child_addresses);
-			SerializeStructFields(child_type, child, child_vec, sel, count, child_ptrs);
+			SerializeStructFields(child_type, child, child_vec, count, addresses_ptrs,
+			                      base_offset + child.field_offset);
 		} else {
-			TemplateDispatch<StoreOp>(physical, child_vec, sel, count, addresses_ptrs, child.field_offset);
+			TemplateDispatch<StoreOp>(physical, child_vec, count, addresses_ptrs, base_offset + child.field_offset);
 		}
 	}
 }
 
-// sel selects which input rows to read (pass *FlatVector::IncrementalSelectionVector() for sequential).
-void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec, const SelectionVector &sel,
-                      idx_t count, data_ptr_t dest_buffer) {
+void DeserializeState(const AggregateStateLayout &layout, const Vector &input_vec, idx_t count,
+                      data_ptr_t dest_buffer) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, sel, count, dest_buffer);
+		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input_vec, count, dest_buffer);
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, sel, count, dest_buffer,
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input_vec, count, dest_buffer,
 		                                          layout.total_state_size);
 	} else {
-		TemplateDispatch<LoadOp>(layout.type.InternalType(), layout.total_state_size, input_vec, sel, count, dest_buffer,
-		                         0);
+		TemplateDispatch<LoadOp>(layout.type.InternalType(), layout.total_state_size, input_vec, count, dest_buffer, 0);
 	}
 }
 
-// sel selects which result rows to write (pass *FlatVector::IncrementalSelectionVector() for sequential).
-void SerializeState(const AggregateStateLayout &layout, Vector &result, const SelectionVector &sel, idx_t count,
-                    const data_ptr_t *addresses) {
+void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses) {
 	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		SerializeStructFields(layout.type, layout.field, result, sel, count, addresses);
+		SerializeStructFields(layout.type, layout.field, result, count, addresses);
 	} else if (layout.field.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, sel, count, addresses);
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses);
 	} else {
-		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, sel, count, addresses, 0);
-	}
-}
-
-void CopyState(const AggregateStateLayout &layout, const Vector &input, Vector &result, const SelectionVector &sel,
-               idx_t count) {
-	if (layout.type.id() == LogicalTypeId::STRUCT) {
-		const auto &child_types = StructType::GetChildTypes(layout.type);
-		const auto &input_entries = StructVector::GetEntries(input);
-		auto &result_entries = StructVector::GetEntries(result);
-		for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
-			auto physical = child_types[field_idx].second.InternalType();
-			TemplateDispatch<CopyOp>(physical, input_entries[field_idx], result_entries[field_idx], sel, count);
-		}
-	} else if (layout.field.is_optional) {
-		TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input, result, sel, count);
-	} else {
-		TemplateDispatch<CopyOp>(layout.type.InternalType(), input, result, sel, count);
+		TemplateDispatch<StoreOp>(layout.type.InternalType(), result, count, addresses, 0);
 	}
 }
 
@@ -356,23 +281,20 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 
 	auto layout = GetLayout(bind_data.aggr);
 
-	auto state_vec_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses, input.size());
-
-	input.data[0].Flatten();
-
-	for (idx_t i = 0; i < input.size(); i++) {
+	auto count = input.size();
+	auto state_vec_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses, count);
+	for (idx_t i = 0; i < count; i++) {
 		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.total_state_size);
 	}
 
-	DeserializeState(layout, input.data[0], *FlatVector::IncrementalSelectionVector(), input.size(),
-	                 local_state.state_buffer.get());
+	DeserializeState(layout, input.data[0], count, local_state.state_buffer.get());
 
 	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
-	bind_data.aggr.GetStateFinalizeCallback()(local_state.addresses, aggr_input_data, result, input.size(), 0);
+	bind_data.aggr.GetStateFinalizeCallback()(local_state.addresses, aggr_input_data, result, count, 0);
 
-	auto &validity = FlatVector::Validity(input.data[0]);
-	for (idx_t i = 0; i < input.size(); i++) {
-		if (!validity.RowIsValid(i)) {
+	auto validity = input.data[0].Validity();
+	for (idx_t i = 0; i < count; i++) {
+		if (!validity.IsValid(i)) {
 			FlatVector::SetNull(result, i, true);
 		}
 	}
@@ -384,86 +306,49 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	local_state.allocator.Reset();
 
 	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSizeCallback()(bind_data.aggr));
-
 	D_ASSERT(input.data.size() == 2);
 	D_ASSERT(input.data[0].GetType() == result.GetType());
-
-	auto layout = GetLayout(bind_data.aggr);
 
 	if (input.data[0].GetType().InternalType() != input.data[1].GetType().InternalType()) {
 		throw IOException("Aggregate state combine type mismatch, expect %s, got %s",
 		                  input.data[0].GetType().ToString(), input.data[1].GetType().ToString());
 	}
 
-	input.data[0].Flatten();
-	input.data[1].Flatten();
+	auto layout = GetLayout(bind_data.aggr);
+	auto count = input.size();
+
 	result.Flatten();
 
-	auto &validity0 = FlatVector::Validity(input.data[0]);
-	auto &validity1 = FlatVector::Validity(input.data[1]);
+	auto validity0 = input.data[0].Validity();
+	auto validity1 = input.data[1].Validity();
 
-	// Partition rows by NULL using SelectionVector
-	SelectionVector both_null_sel(STANDARD_VECTOR_SIZE);
-	// input1 is null
-	SelectionVector copy_from_0_sel(STANDARD_VECTOR_SIZE);
-	// input0 is null
-	SelectionVector copy_from_1_sel(STANDARD_VECTOR_SIZE);
-	SelectionVector both_valid_sel(STANDARD_VECTOR_SIZE);
+	// Initialize both state buffers and build address vectors for all rows
+	auto state0_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses0, count);
+	auto state1_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses1, count);
+	for (idx_t i = 0; i < count; i++) {
+		auto ptr0 = local_state.state_buffer0.get() + i * layout.total_state_size;
+		auto ptr1 = local_state.state_buffer1.get() + i * layout.total_state_size;
+		bind_data.aggr.GetStateInitCallback()(bind_data.aggr, ptr0);
+		bind_data.aggr.GetStateInitCallback()(bind_data.aggr, ptr1);
+		state0_writer.WriteValue(ptr0);
+		state1_writer.WriteValue(ptr1);
+	}
 
-	idx_t both_null_count = 0, copy_from_0_count = 0, copy_from_1_count = 0, both_valid_count = 0;
+	// Deserialize both inputs — null rows are skipped by LoadOp, keeping the initialized empty state
+	DeserializeState(layout, input.data[0], count, local_state.state_buffer0.get());
+	DeserializeState(layout, input.data[1], count, local_state.state_buffer1.get());
 
-	for (idx_t i = 0; i < input.size(); i++) {
-		const bool is_null0 = !validity0.RowIsValid(i);
-		const bool is_null1 = !validity1.RowIsValid(i);
+	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator,
+	                                   AggregateCombineType::ALLOW_DESTRUCTIVE);
+	bind_data.aggr.GetStateCombineCallback()(local_state.addresses0, local_state.addresses1, aggr_input_data, count);
 
-		if (is_null0 && is_null1) {
-			both_null_sel.set_index(both_null_count++, i);
-		} else if (is_null0) {
-			copy_from_1_sel.set_index(copy_from_1_count++, i);
-		} else if (is_null1) {
-			copy_from_0_sel.set_index(copy_from_0_count++, i);
-		} else {
-			both_valid_sel.set_index(both_valid_count++, i);
+	SerializeState(layout, result, count, FlatVector::GetData<data_ptr_t>(local_state.addresses1));
+
+	// Rows where both inputs were NULL produce no meaningful combined state — mark result as NULL
+	for (idx_t i = 0; i < count; i++) {
+		if (!validity0.IsValid(i) && !validity1.IsValid(i)) {
+			FlatVector::SetNull(result, i, true);
 		}
-	}
-
-	D_ASSERT(both_null_count + copy_from_0_count + copy_from_1_count + both_valid_count == input.size());
-
-	// Handle both-null rows
-	for (idx_t i = 0; i < both_null_count; i++) {
-		FlatVector::SetNull(result, both_null_sel.get_index(i), true);
-	}
-
-	// Handle one-null rows - copy non-null input directly to result
-	if (copy_from_0_count > 0) {
-		CopyState(layout, input.data[0], result, copy_from_0_sel, copy_from_0_count);
-	}
-	if (copy_from_1_count > 0) {
-		CopyState(layout, input.data[1], result, copy_from_1_sel, copy_from_1_count);
-	}
-
-	// Handle both-valid rows - batched load, combine, store
-	if (both_valid_count > 0) {
-		auto state0_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses0, both_valid_count);
-		auto state1_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses1, both_valid_count);
-
-		// Pack state buffer pointers in selection order (not row order)
-		for (idx_t i = 0; i < both_valid_count; i++) {
-			state0_writer.WriteValue(local_state.state_buffer0.get() + i * layout.total_state_size);
-			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.total_state_size);
-		}
-
-		DeserializeState(layout, input.data[0], both_valid_sel, both_valid_count, local_state.state_buffer0.get());
-		DeserializeState(layout, input.data[1], both_valid_sel, both_valid_count, local_state.state_buffer1.get());
-
-		// Single batched combine call
-		AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator,
-		                                   AggregateCombineType::ALLOW_DESTRUCTIVE);
-		bind_data.aggr.GetStateCombineCallback()(local_state.addresses0, local_state.addresses1, aggr_input_data,
-		                                         both_valid_count);
-
-		SerializeState(layout, result, both_valid_sel, both_valid_count,
-		               FlatVector::GetData<data_ptr_t>(local_state.addresses1));
 	}
 }
 
@@ -575,7 +460,7 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 	auto layout = GetLayout(aggr_input_data.function);
 
 	result.Flatten();
-	SerializeState(layout, result, *FlatVector::IncrementalSelectionVector(), count, addresses_ptrs);
+	SerializeState(layout, result, count, addresses_ptrs);
 }
 
 unique_ptr<FunctionData> CombineAggrBind(BindAggregateFunctionInput &input) {
@@ -604,14 +489,10 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 
 	auto layout = GetLayout(underlying_aggr);
 
-	UnifiedVectorFormat sdata;
-	states.ToUnifiedFormat(sdata);
-	auto state_ptrs = UnifiedVectorFormat::GetData<data_ptr_t>(sdata);
-
-	inputs[0].Flatten();
-
 	auto aligned_size = layout.total_state_size;
 	unsafe_unique_array<data_t> temp_state_buf = make_unsafe_uniq_array<data_t>(count * aligned_size);
+
+	auto state_values = states.Values<data_ptr_t>();
 
 	// source_vec holds pointers to the binary states buffer (temp_state_buf) deserialized from the input states
 	Vector source_vec(LogicalType::POINTER);
@@ -626,10 +507,10 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 		auto temp_ptr = temp_state_buf.get() + i * aligned_size;
 		underlying_aggr.GetStateInitCallback()(underlying_aggr, temp_ptr);
 		source_data.WriteValue(temp_ptr);
-		target_data.WriteValue(state_ptrs[sdata.sel->get_index(i)]);
+		target_data.WriteValue(state_values[i].GetValue());
 	}
 
-	DeserializeState(layout, inputs[0], *FlatVector::IncrementalSelectionVector(), count, temp_state_buf.get());
+	DeserializeState(layout, inputs[0], count, temp_state_buf.get());
 
 	ArenaAllocator allocator(Allocator::DefaultAllocator());
 	AggregateInputData combine_input(bind_data.aggr, bind_data.bind_data.get(), allocator,
@@ -655,7 +536,7 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	auto layout = GetLayout(underlying_aggr);
 
 	result.Flatten();
-	SerializeState(layout, result, *FlatVector::IncrementalSelectionVector(), count, addresses_ptrs);
+	SerializeState(layout, result, count, addresses_ptrs);
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -108,27 +108,9 @@ void TemplateDispatch(PhysicalType type, ARGS &&... args) {
 	}
 }
 
-struct AggregateStateLayout {
-	AggregateStateLayout(const LogicalType &type, idx_t state_size)
-	    : state_size(state_size), aligned_state_size(AlignValue(state_size)) {
-		owned_type = type;
-		is_struct = type.InternalType() == PhysicalType::STRUCT;
-		if (is_struct) {
-			child_types = &StructType::GetChildTypes(owned_type);
-		} else {
-			// optional<T> states are larger than the physical primitive T due to the has_value byte + alignment.
-			// Detect this by comparing the actual state_size against what a bare T would occupy.
-			is_optional = state_size > GetTypeIdSize(type.InternalType());
-		}
-	}
-
-	bool is_struct = false;
-	bool is_optional = false;
-	idx_t state_size;
-	idx_t aligned_state_size;
-	LogicalType owned_type;
-	const child_list_t<LogicalType> *child_types = nullptr;
-};
+static AggregateStateLayout GetLayout(const BoundAggregateFunction &aggr) {
+	return aggr.GetStateTypeCallback()(aggr);
+}
 
 /*
  * Load a specific field from the struct aggregate state into the packed binary representation
@@ -189,16 +171,15 @@ struct CopyFromInputFieldOp {
 
 struct LoadFieldForSelectedRowsOp {
 	template <class T>
-	static void Operation(const AggregateStateLayout &layout, const Vector &struct_vec, idx_t field_idx,
-	                      const SelectionVector &sel, idx_t count, const UnifiedVectorFormat &state_data,
-	                      data_ptr_t base_ptr, idx_t field_offset) {
+	static void Operation(idx_t total_state_size, const Vector &struct_vec, idx_t field_idx, const SelectionVector &sel,
+	                      idx_t count, const UnifiedVectorFormat &state_data, data_ptr_t base_ptr, idx_t field_offset) {
 		const auto &child = StructVector::GetEntries(struct_vec)[field_idx];
 		auto child_data = FlatVector::GetData<T>(child);
 
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
 			auto src_idx = state_data.sel->get_index(row);
-			auto dest = base_ptr + i * layout.aligned_state_size + field_offset;
+			auto dest = base_ptr + i * total_state_size + field_offset;
 			*reinterpret_cast<T *>(dest) = child_data[src_idx];
 		}
 	}
@@ -206,14 +187,14 @@ struct LoadFieldForSelectedRowsOp {
 
 struct StoreFieldForSelectedRowsOp {
 	template <class T>
-	static void Operation(const AggregateStateLayout &layout, Vector &result, idx_t field_idx,
-	                      const SelectionVector &sel, idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
+	static void Operation(idx_t total_state_size, Vector &result, idx_t field_idx, const SelectionVector &sel,
+	                      idx_t count, data_ptr_t base_ptr, idx_t field_offset) {
 		auto &child = StructVector::GetEntries(result)[field_idx];
 		auto child_data = FlatVector::ScatterWriter<T>(child);
 
 		for (idx_t i = 0; i < count; i++) {
 			idx_t row = sel.get_index(i);
-			auto src = base_ptr + i * layout.aligned_state_size + field_offset;
+			auto src = base_ptr + i * total_state_size + field_offset;
 			child_data[row] = *reinterpret_cast<T *>(src);
 		}
 	}
@@ -307,8 +288,8 @@ struct StorePrimitiveOptionalOp {
 // Deserialize a nullable flat input vector into optional<T> state buffer slots
 struct LoadPrimitiveOptionalOp {
 	template <class T>
-	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count,
-	                      data_ptr_t base_ptr, idx_t aligned_state_size) {
+	static void Operation(const Vector &input, const UnifiedVectorFormat &input_data, idx_t count, data_ptr_t base_ptr,
+	                      idx_t aligned_state_size) {
 		auto src = FlatVector::GetData<T>(input);
 		for (idx_t i = 0; i < count; i++) {
 			auto src_idx = input_data.sel->get_index(i);
@@ -378,75 +359,54 @@ struct StorePrimitiveOptionalForSelectedRowsOp {
 	}
 };
 
-idx_t GetRecursivePhysicalSize(const LogicalType &type) {
-	if (type.id() != LogicalTypeId::STRUCT) {
-		return GetTypeIdSize(type.InternalType());
-	}
-	idx_t size = 0;
-	for (const auto &child : StructType::GetChildTypes(type)) {
-		size += GetRecursivePhysicalSize(child.second);
-	}
-	return size;
-}
-
 // Deserialize struct fields from a flattened struct vector into a state buffer.
 // Uses LoadFieldOp for tight SIMD-friendly loops.
-// root_stride is the aligned size of the top-level state, used to stride between rows in the buffer (root-state's
-// size must be taken into account)
-void DeserializeStructFields(const AggregateStateLayout &layout, idx_t root_stride, const Vector &struct_vec,
-                             const UnifiedVectorFormat &state_data, idx_t count, data_ptr_t dest_buffer) {
-	idx_t offset_in_state = 0;
-	for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-		auto &field_type = layout.child_types->at(field_idx).second;
-		auto physical = field_type.InternalType();
-		idx_t field_size = GetRecursivePhysicalSize(field_type);
-		idx_t alignment = MinValue<idx_t>(field_size, 8);
-		offset_in_state = AlignValue(offset_in_state, alignment);
+// root_stride is the aligned size of the top-level state, used to stride between rows in the buffer.
+// Child field offsets are pre-computed in AggregateStateField.field_offset (relative to dest_buffer).
+void DeserializeStructFields(const LogicalType &type, const AggregateStateField &field, idx_t root_stride,
+                             const Vector &struct_vec, const UnifiedVectorFormat &state_data, idx_t count,
+                             data_ptr_t dest_buffer) {
+	const auto &child_types = StructType::GetChildTypes(type);
+	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
+		const auto &child = field.children[field_idx];
+		const auto &child_type = child_types[field_idx].second;
+		auto physical = child_type.InternalType();
 
-		if (field_type.id() == LogicalTypeId::STRUCT) {
-			auto child_layout = AggregateStateLayout(field_type, field_size);
+		if (!child.children.empty()) {
 			const auto &struct_entries = StructVector::GetEntries(struct_vec);
-			DeserializeStructFields(child_layout, root_stride, struct_entries[field_idx], state_data, count,
-			                        dest_buffer + offset_in_state);
+			DeserializeStructFields(child_type, child, root_stride, struct_entries[field_idx], state_data, count,
+			                        dest_buffer + child.field_offset);
 		} else {
 			TemplateDispatch<LoadFieldOp>(physical, root_stride, struct_vec, field_idx, state_data, count, dest_buffer,
-			                              offset_in_state);
+			                              child.field_offset);
 		}
-
-		offset_in_state += field_size;
 	}
 }
 
 // Serialize packed binary states into a struct result vector.
-// Uses StoreFieldOp for tight SIMD-friendly loops
-void SerializeStructFields(const AggregateStateLayout &layout, Vector &result, idx_t count,
+// Uses StoreFieldOp for tight SIMD-friendly loops.
+// Child field offsets are pre-computed in AggregateStateField.field_offset (relative to addresses_ptrs[row]).
+void SerializeStructFields(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
                            const data_ptr_t *addresses_ptrs) {
-	idx_t offset_in_state = 0;
-	for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-		auto &field_type = layout.child_types->at(field_idx).second;
-		auto physical = field_type.InternalType();
-		idx_t field_size = GetRecursivePhysicalSize(field_type);
-		idx_t alignment = MinValue<idx_t>(field_size, 8);
-		offset_in_state = AlignValue(offset_in_state, alignment);
+	const auto &child_types = StructType::GetChildTypes(type);
+	for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
+		const auto &child = field.children[field_idx];
+		const auto &child_type = child_types[field_idx].second;
+		auto physical = child_type.InternalType();
 
-		if (field_type.id() == LogicalTypeId::STRUCT) {
-			auto child_layout = AggregateStateLayout(field_type, field_size);
-
-			// we need to write to the buffers with the current offset the child is pointing to in the state
+		if (!child.children.empty()) {
+			// Adjust addresses to point to the start of this nested struct field for each row
 			Vector child_addresses(LogicalType::POINTER);
 			auto child_writer = FlatVector::Writer<data_ptr_t>(child_addresses, count);
 			for (idx_t row = 0; row < count; row++) {
-				child_writer.WriteValue(addresses_ptrs[row] + offset_in_state);
+				child_writer.WriteValue(addresses_ptrs[row] + child.field_offset);
 			}
-
 			auto child_ptrs = FlatVector::GetData<data_ptr_t>(child_addresses);
 			auto &struct_entries = StructVector::GetEntries(result);
-			SerializeStructFields(child_layout, struct_entries[field_idx], count, child_ptrs);
+			SerializeStructFields(child_type, child, struct_entries[field_idx], count, child_ptrs);
 		} else {
-			TemplateDispatch<StoreFieldOp>(physical, result, field_idx, count, addresses_ptrs, offset_in_state);
+			TemplateDispatch<StoreFieldOp>(physical, result, field_idx, count, addresses_ptrs, child.field_offset);
 		}
-
-		offset_in_state += field_size;
 	}
 }
 
@@ -475,20 +435,20 @@ void VerifyStructStateRoundtrip(const AggregateStateLayout &layout, const Vector
 	for (idx_t i = 0; i < valid_count; i++) {
 		addresses_ptrs[i] = state_vec_ptr[valid_sel.get_index(i)];
 	}
-	SerializeStructFields(layout, struct_vec, valid_count, addresses_ptrs.get());
+	SerializeStructFields(layout.type, layout.field, struct_vec, valid_count, addresses_ptrs.get());
 
 	// DeserializeStructFields: struct vector -> packed buffer
-	unsafe_unique_array<data_t> temp_state_buf(make_unsafe_uniq_array<data_t>(valid_count * layout.aligned_state_size));
+	unsafe_unique_array<data_t> temp_state_buf(make_unsafe_uniq_array<data_t>(valid_count * layout.total_state_size));
 	UnifiedVectorFormat struct_format;
 	struct_vec.ToUnifiedFormat(struct_format);
-	DeserializeStructFields(layout, layout.aligned_state_size, struct_vec, struct_format, valid_count,
+	DeserializeStructFields(layout.type, layout.field, layout.total_state_size, struct_vec, struct_format, valid_count,
 	                        temp_state_buf.get());
 
 	// AggregateStateFinalize: packed buffer -> result values
 	Vector addresses_vec(LogicalType::POINTER);
 	auto addresses_finalize = FlatVector::Writer<data_ptr_t>(addresses_vec, valid_count);
 	for (idx_t i = 0; i < valid_count; i++) {
-		addresses_finalize.WriteValue(temp_state_buf.get() + i * layout.aligned_state_size);
+		addresses_finalize.WriteValue(temp_state_buf.get() + i * layout.total_state_size);
 	}
 	Vector result_roundtrip(result.GetType(), valid_count);
 	bind_data.aggr.GetStateFinalizeCallback()(addresses_vec, aggr_input_data, result_roundtrip, valid_count, 0);
@@ -555,7 +515,7 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	D_ASSERT(bind_data.state_size == bind_data.aggr.GetStateSizeCallback()(bind_data.aggr));
 	D_ASSERT(input.data.size() == 1);
 
-	AggregateStateLayout layout(input.data[0].GetType(), bind_data.state_size);
+	auto layout = GetLayout(bind_data.aggr);
 
 	auto state_vec_writer = FlatVector::Writer<data_ptr_t>(local_state.addresses, input.size());
 
@@ -565,19 +525,18 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	input.data[0].ToUnifiedFormat(state_data);
 
 	for (idx_t i = 0; i < input.size(); i++) {
-		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.aligned_state_size);
+		state_vec_writer.WriteValue(local_state.state_buffer.get() + i * layout.total_state_size);
 	}
 
-	if (layout.is_struct) {
-		DeserializeStructFields(layout, layout.aligned_state_size, input.data[0], state_data, input.size(),
-		                        local_state.state_buffer.get());
-	} else if (layout.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[0], state_data,
-		                                           input.size(), local_state.state_buffer.get(),
-		                                           layout.aligned_state_size);
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, input.data[0], state_data,
+		                        input.size(), local_state.state_buffer.get());
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), input.data[0], state_data, input.size(),
+		                                          local_state.state_buffer.get(), layout.total_state_size);
 	} else {
-		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], state_data, input.size(),
-		                                  local_state.state_buffer.get(), layout.aligned_state_size);
+		TemplateDispatch<LoadPrimitiveOp>(layout.type.InternalType(), input.data[0], state_data, input.size(),
+		                                  local_state.state_buffer.get(), layout.total_state_size);
 	}
 
 	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
@@ -591,7 +550,7 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 	}
 
 #ifdef DEBUG
-	if (layout.is_struct) {
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
 		auto state_vec_ptr = FlatVector::GetData<data_ptr_t>(local_state.addresses);
 		VerifyStructStateRoundtrip(layout, input.data[0], input.size(), state_data, state_vec_ptr, result, bind_data,
 		                           aggr_input_data);
@@ -609,7 +568,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	D_ASSERT(input.data.size() == 2);
 	D_ASSERT(input.data[0].GetType() == result.GetType());
 
-	AggregateStateLayout layout(input.data[0].GetType(), bind_data.state_size);
+	auto layout = GetLayout(bind_data.aggr);
 
 	if (input.data[0].GetType().InternalType() != input.data[1].GetType().InternalType()) {
 		throw IOException("Aggregate state combine type mismatch, expect %s, got %s",
@@ -659,45 +618,35 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 	// Handle one-null rows - copy non-null input directly to result
 	// copy_from_0: input1 is null, copy input0
 	if (copy_from_0_count > 0) {
-		if (layout.is_struct) {
-			idx_t offset_in_state = 0;
-			for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-				auto &field_type = layout.child_types->at(field_idx).second;
-				auto physical = field_type.InternalType();
-				idx_t field_size = GetTypeIdSize(physical);
-				idx_t alignment = MinValue<idx_t>(field_size, 8);
-				offset_in_state = AlignValue(offset_in_state, alignment);
+		if (layout.type.id() == LogicalTypeId::STRUCT) {
+			const auto &child_types = StructType::GetChildTypes(layout.type);
+			for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
+				auto physical = child_types[field_idx].second.InternalType();
 				TemplateDispatch<CopyFromInputFieldOp>(physical, input.data[0], result, field_idx, copy_from_0_sel,
 				                                       copy_from_0_count, state0_data);
-				offset_in_state += field_size;
 			}
-		} else if (layout.is_optional) {
-			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[0], result,
-			                                           copy_from_0_sel, copy_from_0_count, state0_data);
+		} else if (layout.field.is_optional) {
+			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input.data[0], result,
+			                                          copy_from_0_sel, copy_from_0_count, state0_data);
 		} else {
-			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[0], result, copy_from_0_sel,
+			TemplateDispatch<CopyPrimitiveOp>(layout.type.InternalType(), input.data[0], result, copy_from_0_sel,
 			                                  copy_from_0_count, state0_data);
 		}
 	}
 	// copy_from_1: input0 is null, copy input1
 	if (copy_from_1_count > 0) {
-		if (layout.is_struct) {
-			idx_t offset_in_state = 0;
-			for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-				auto &field_type = layout.child_types->at(field_idx).second;
-				auto physical = field_type.InternalType();
-				idx_t field_size = GetTypeIdSize(physical);
-				idx_t alignment = MinValue<idx_t>(field_size, 8);
-				offset_in_state = AlignValue(offset_in_state, alignment);
+		if (layout.type.id() == LogicalTypeId::STRUCT) {
+			const auto &child_types = StructType::GetChildTypes(layout.type);
+			for (idx_t field_idx = 0; field_idx < child_types.size(); field_idx++) {
+				auto physical = child_types[field_idx].second.InternalType();
 				TemplateDispatch<CopyFromInputFieldOp>(physical, input.data[1], result, field_idx, copy_from_1_sel,
 				                                       copy_from_1_count, state1_data);
-				offset_in_state += field_size;
 			}
-		} else if (layout.is_optional) {
-			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.owned_type.InternalType(), input.data[1], result,
-			                                           copy_from_1_sel, copy_from_1_count, state1_data);
+		} else if (layout.field.is_optional) {
+			TemplateDispatch<CopyPrimitiveOptionalOp>(layout.type.InternalType(), input.data[1], result,
+			                                          copy_from_1_sel, copy_from_1_count, state1_data);
 		} else {
-			TemplateDispatch<CopyPrimitiveOp>(layout.owned_type.InternalType(), input.data[1], result, copy_from_1_sel,
+			TemplateDispatch<CopyPrimitiveOp>(layout.type.InternalType(), input.data[1], result, copy_from_1_sel,
 			                                  copy_from_1_count, state1_data);
 		}
 	}
@@ -709,42 +658,38 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 
 		// Pack state buffer pointers in selection order (not row order)
 		for (idx_t i = 0; i < both_valid_count; i++) {
-			state0_writer.WriteValue(local_state.state_buffer0.get() + i * layout.aligned_state_size);
-			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.aligned_state_size);
+			state0_writer.WriteValue(local_state.state_buffer0.get() + i * layout.total_state_size);
+			state1_writer.WriteValue(local_state.state_buffer1.get() + i * layout.total_state_size);
 		}
 
-		if (layout.is_struct) {
+		if (layout.type.id() == LogicalTypeId::STRUCT) {
 			// Use tight loops to load both inputs
-			idx_t offset_in_state = 0;
-			for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-				auto &field_type = layout.child_types->at(field_idx).second;
-				auto physical = field_type.InternalType();
-				idx_t field_size = GetTypeIdSize(physical);
-				idx_t alignment = MinValue<idx_t>(field_size, 8);
-				offset_in_state = AlignValue(offset_in_state, alignment);
+			const auto &child_types = StructType::GetChildTypes(layout.type);
+			for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+				const auto &child = layout.field.children[field_idx];
+				auto physical = child_types[field_idx].second.InternalType();
 
-				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout, input.data[0], field_idx, both_valid_sel,
-				                                             both_valid_count, state0_data,
-				                                             local_state.state_buffer0.get(), offset_in_state);
-				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout, input.data[1], field_idx, both_valid_sel,
-				                                             both_valid_count, state1_data,
-				                                             local_state.state_buffer1.get(), offset_in_state);
-				offset_in_state += field_size;
+				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout.total_state_size, input.data[0],
+				                                             field_idx, both_valid_sel, both_valid_count, state0_data,
+				                                             local_state.state_buffer0.get(), child.field_offset);
+				TemplateDispatch<LoadFieldForSelectedRowsOp>(physical, layout.total_state_size, input.data[1],
+				                                             field_idx, both_valid_sel, both_valid_count, state1_data,
+				                                             local_state.state_buffer1.get(), child.field_offset);
 			}
-		} else if (layout.is_optional) {
+		} else if (layout.field.is_optional) {
 			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
-			    layout.owned_type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
-			    local_state.state_buffer0.get(), layout.aligned_state_size);
+			    layout.type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
+			    local_state.state_buffer0.get(), layout.total_state_size);
 			TemplateDispatch<LoadPrimitiveOptionalForSelectedRowsOp>(
-			    layout.owned_type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
-			    local_state.state_buffer1.get(), layout.aligned_state_size);
+			    layout.type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
+			    local_state.state_buffer1.get(), layout.total_state_size);
 		} else {
-			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(
-			    layout.owned_type.InternalType(), input.data[0], both_valid_sel, both_valid_count, state0_data,
-			    local_state.state_buffer0.get(), layout.aligned_state_size);
-			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(
-			    layout.owned_type.InternalType(), input.data[1], both_valid_sel, both_valid_count, state1_data,
-			    local_state.state_buffer1.get(), layout.aligned_state_size);
+			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(layout.type.InternalType(), input.data[0], both_valid_sel,
+			                                                 both_valid_count, state0_data,
+			                                                 local_state.state_buffer0.get(), layout.total_state_size);
+			TemplateDispatch<LoadPrimitiveForSelectedRowsOp>(layout.type.InternalType(), input.data[1], both_valid_sel,
+			                                                 both_valid_count, state1_data,
+			                                                 local_state.state_buffer1.get(), layout.total_state_size);
 		}
 
 		// Single batched combine call
@@ -754,28 +699,24 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 		                                         both_valid_count);
 
 		// Store results
-		if (layout.is_struct) {
-			idx_t offset_in_state = 0;
-			for (idx_t field_idx = 0; field_idx < layout.child_types->size(); field_idx++) {
-				auto &field_type = layout.child_types->at(field_idx).second;
-				auto physical = field_type.InternalType();
-				idx_t field_size = GetTypeIdSize(physical);
-				idx_t alignment = MinValue<idx_t>(field_size, 8);
-				offset_in_state = AlignValue(offset_in_state, alignment);
+		if (layout.type.id() == LogicalTypeId::STRUCT) {
+			const auto &child_types = StructType::GetChildTypes(layout.type);
+			for (idx_t field_idx = 0; field_idx < layout.field.children.size(); field_idx++) {
+				const auto &child = layout.field.children[field_idx];
+				auto physical = child_types[field_idx].second.InternalType();
 
-				TemplateDispatch<StoreFieldForSelectedRowsOp>(physical, layout, result, field_idx, both_valid_sel,
-				                                              both_valid_count, local_state.state_buffer1.get(),
-				                                              offset_in_state);
-				offset_in_state += field_size;
+				TemplateDispatch<StoreFieldForSelectedRowsOp>(physical, layout.total_state_size, result, field_idx,
+				                                              both_valid_sel, both_valid_count,
+				                                              local_state.state_buffer1.get(), child.field_offset);
 			}
-		} else if (layout.is_optional) {
+		} else if (layout.field.is_optional) {
 			TemplateDispatch<StorePrimitiveOptionalForSelectedRowsOp>(
-			    layout.owned_type.InternalType(), result, both_valid_sel, both_valid_count,
-			    local_state.state_buffer1.get(), layout.aligned_state_size);
+			    layout.type.InternalType(), result, both_valid_sel, both_valid_count, local_state.state_buffer1.get(),
+			    layout.total_state_size);
 		} else {
-			TemplateDispatch<StorePrimitiveForSelectedRowsOp>(layout.owned_type.InternalType(), result, both_valid_sel,
+			TemplateDispatch<StorePrimitiveForSelectedRowsOp>(layout.type.InternalType(), result, both_valid_sel,
 			                                                  both_valid_count, local_state.state_buffer1.get(),
-			                                                  layout.aligned_state_size);
+			                                                  layout.total_state_size);
 		}
 	}
 }
@@ -885,17 +826,15 @@ void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data,
 		addresses_ptrs = FlatVector::GetData<data_ptr_t>(state);
 	}
 
-	auto state_size = aggr_input_data.function.GetStateSizeCallback()(aggr_input_data.function);
-
-	AggregateStateLayout layout(result.GetType(), state_size);
+	auto layout = GetLayout(aggr_input_data.function);
 
 	result.Flatten();
-	if (layout.is_struct) {
-		SerializeStructFields(layout, result, count, addresses_ptrs);
-	} else if (layout.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		SerializeStructFields(layout.type, layout.field, result, count, addresses_ptrs);
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses_ptrs);
 	} else {
-		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+		TemplateDispatch<StorePrimitiveOp>(layout.type.InternalType(), result, count, addresses_ptrs);
 	}
 }
 
@@ -922,9 +861,8 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 
 	auto &bind_data = aggr_input_data.bind_data->Cast<ExportAggregateBindData>();
 	auto &underlying_aggr = bind_data.aggr;
-	auto state_size = bind_data.state_size;
 
-	AggregateStateLayout layout(inputs[0].GetType(), state_size);
+	auto layout = GetLayout(underlying_aggr);
 
 	UnifiedVectorFormat sdata;
 	states.ToUnifiedFormat(sdata);
@@ -935,7 +873,7 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 	UnifiedVectorFormat input_data;
 	inputs[0].ToUnifiedFormat(input_data);
 
-	auto aligned_size = layout.aligned_state_size;
+	auto aligned_size = layout.total_state_size;
 	unsafe_unique_array<data_t> temp_state_buf = make_unsafe_uniq_array<data_t>(count * aligned_size);
 
 	// source_vec holds pointers to the binary states buffer (temp_state_buf) deserialized from the input states
@@ -954,14 +892,15 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 		target_data.WriteValue(state_ptrs[sdata.sel->get_index(i)]);
 	}
 
-	if (layout.is_struct) {
-		DeserializeStructFields(layout, layout.aligned_state_size, inputs[0], input_data, count, temp_state_buf.get());
-	} else if (layout.is_optional) {
-		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.owned_type.InternalType(), inputs[0], input_data, count,
-		                                           temp_state_buf.get(), layout.aligned_state_size);
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		DeserializeStructFields(layout.type, layout.field, layout.total_state_size, inputs[0], input_data, count,
+		                        temp_state_buf.get());
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<LoadPrimitiveOptionalOp>(layout.type.InternalType(), inputs[0], input_data, count,
+		                                          temp_state_buf.get(), layout.total_state_size);
 	} else {
-		TemplateDispatch<LoadPrimitiveOp>(layout.owned_type.InternalType(), inputs[0], input_data, count,
-		                                  temp_state_buf.get(), layout.aligned_state_size);
+		TemplateDispatch<LoadPrimitiveOp>(layout.type.InternalType(), inputs[0], input_data, count,
+		                                  temp_state_buf.get(), layout.total_state_size);
 	}
 
 	ArenaAllocator allocator(Allocator::DefaultAllocator());
@@ -975,7 +914,6 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 	D_ASSERT(offset == 0);
 	auto &bind_data = aggr_input_data.bind_data->Cast<ExportAggregateBindData>();
 	auto &underlying_aggr = bind_data.aggr;
-	auto state_size = bind_data.state_size;
 	const data_ptr_t *addresses_ptrs;
 	if (state.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (count != 1) {
@@ -986,15 +924,15 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 		addresses_ptrs = FlatVector::GetData<data_ptr_t>(state);
 	}
 
-	AggregateStateLayout layout(underlying_aggr.GetStateType(), state_size);
+	auto layout = GetLayout(underlying_aggr);
 
 	result.Flatten();
-	if (layout.is_struct) {
-		SerializeStructFields(layout, result, count, addresses_ptrs);
-	} else if (layout.is_optional) {
-		TemplateDispatch<StorePrimitiveOptionalOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+	if (layout.type.id() == LogicalTypeId::STRUCT) {
+		SerializeStructFields(layout.type, layout.field, result, count, addresses_ptrs);
+	} else if (layout.field.is_optional) {
+		TemplateDispatch<StorePrimitiveOptionalOp>(layout.type.InternalType(), result, count, addresses_ptrs);
 	} else {
-		TemplateDispatch<StorePrimitiveOp>(layout.owned_type.InternalType(), result, count, addresses_ptrs);
+		TemplateDispatch<StorePrimitiveOp>(layout.type.InternalType(), result, count, addresses_ptrs);
 	}
 }
 
@@ -1002,7 +940,7 @@ void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vec
 // the state layout (a struct) is aliased to AGGREGATE_STATE, with the function name and signature stored in the
 // extension type info so that the aggregate can be re-bound later (e.g. by FINALIZE/COMBINE)
 LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_function) {
-	LogicalType state_layout = bound_function.GetStateType();
+	LogicalType state_layout = bound_function.GetStateType().type;
 	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	ext_info->properties.emplace("function_name", bound_function.GetName());
@@ -1059,7 +997,7 @@ unique_ptr<FunctionData> ToAggregateStateBind(BindScalarFunctionInput &input) {
 		    "Aggregate function \"%s\" does not have a state type callback defined - cannot convert to its state",
 		    function_name);
 	}
-	auto state_layout = aggr.GetStateType();
+	auto state_layout = aggr.GetStateType().type;
 	bound_function.GetArguments()[0] = state_layout;
 	bound_function.SetReturnType(CreateAggregateStateType(aggr));
 	return std::move(bind_data);

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -574,6 +574,8 @@ public:
 		if constexpr (HasStructStateType<STATE>::value) {
 			result.SetStructStateExport(
 			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(); });
+		} else if constexpr (HasPrimitiveLogicalType<STATE>::value) {
+			result.SetStructStateExport([](const BoundAggregateFunction &) { return PrimitiveToLogicalType<STATE>(); });
 		}
 	}
 
@@ -699,10 +701,7 @@ public:
 
 	LogicalType GetStateType() const {
 		D_ASSERT(callbacks.get_state_type);
-		const auto result = callbacks.get_state_type(*this);
-		// The underlying type of the AggregateState should be a struct
-		D_ASSERT(result.id() == LogicalTypeId::STRUCT);
-		return result;
+		return callbacks.get_state_type(*this);
 	}
 };
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -568,7 +568,8 @@ public:
 	static void WireStructStateType(AggregateFunction &result) {
 		if constexpr (HasStructStateType<STATE>::value) {
 			result.SetStructStateExport([](const BoundAggregateFunction &) {
-				return AggregateStateLayout(STATE::STATE_TYPE::GetLogicalType(STATE::STATE_NAMES), AlignValue<idx_t>(sizeof(STATE)));
+				return AggregateStateLayout(STATE::STATE_TYPE::GetLogicalType(STATE::STATE_NAMES),
+				                            AlignValue<idx_t>(sizeof(STATE)));
 			});
 		} else if constexpr (HasPrimitiveLogicalType<STATE>::value) {
 			result.SetStructStateExport([](const BoundAggregateFunction &) {

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -576,6 +576,10 @@ public:
 			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(); });
 		} else if constexpr (HasPrimitiveLogicalType<STATE>::value) {
 			result.SetStructStateExport([](const BoundAggregateFunction &) { return PrimitiveToLogicalType<STATE>(); });
+		} else if constexpr (HasOptionalPrimitiveType<STATE>::value) {
+			// Export as the inner type; nullopt ↔ SQL NULL is handled by the serialization layer
+			result.SetStructStateExport(
+			    [](const BoundAggregateFunction &) { return PrimitiveToLogicalType<typename STATE::value_type>(); });
 		}
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -126,7 +126,7 @@ typedef void (*aggregate_serialize_t)(Serializer &serializer, const optional_ptr
 typedef unique_ptr<FunctionData> (*aggregate_deserialize_t)(Deserializer &deserializer,
                                                             BoundAggregateFunction &function);
 
-typedef LogicalType (*aggregate_get_state_type_t)(const BoundAggregateFunction &function);
+typedef AggregateStateLayout (*aggregate_get_state_type_t)(const BoundAggregateFunction &function);
 
 struct AggregateFunctionInfo {
 	DUCKDB_API virtual ~AggregateFunctionInfo();
@@ -500,11 +500,6 @@ public:
 		return *this;
 	}
 
-	template <class STATE_TYPE>
-	AggregateFunction &SetStructStateExport() {
-		return SetStructStateExport([](const BoundAggregateFunction &) { return STATE_TYPE::GetLogicalType(); });
-	}
-
 	AggregateFunction &SetClusterCallback(aggregate_cluster_update_t cluster_update) {
 		callbacks.cluster_update = cluster_update;
 		return *this;
@@ -572,14 +567,18 @@ public:
 	template <class STATE>
 	static void WireStructStateType(AggregateFunction &result) {
 		if constexpr (HasStructStateType<STATE>::value) {
-			result.SetStructStateExport(
-			    [](const BoundAggregateFunction &) { return STATE::STATE_TYPE::GetLogicalType(); });
+			result.SetStructStateExport([](const BoundAggregateFunction &) {
+				return AggregateStateLayout(STATE::STATE_TYPE::GetLogicalType(), AlignValue<idx_t>(sizeof(STATE)));
+			});
 		} else if constexpr (HasPrimitiveLogicalType<STATE>::value) {
-			result.SetStructStateExport([](const BoundAggregateFunction &) { return PrimitiveToLogicalType<STATE>(); });
+			result.SetStructStateExport([](const BoundAggregateFunction &) {
+				return AggregateStateLayout(PrimitiveToLogicalType<STATE>(), AlignValue<idx_t>(sizeof(STATE)));
+			});
 		} else if constexpr (HasOptionalPrimitiveType<STATE>::value) {
-			// Export as the inner type; nullopt ↔ SQL NULL is handled by the serialization layer
-			result.SetStructStateExport(
-			    [](const BoundAggregateFunction &) { return PrimitiveToLogicalType<typename STATE::value_type>(); });
+			result.SetStructStateExport([](const BoundAggregateFunction &) {
+				return AggregateStateLayout(PrimitiveToLogicalType<typename STATE::value_type>(),
+				                            AlignValue<idx_t>(sizeof(STATE)), true);
+			});
 		}
 	}
 
@@ -703,7 +702,7 @@ public:
 	DUCKDB_API bool operator==(const BoundAggregateFunction &rhs) const;
 	DUCKDB_API bool operator!=(const BoundAggregateFunction &rhs) const;
 
-	LogicalType GetStateType() const {
+	AggregateStateLayout GetStateType() const {
 		D_ASSERT(callbacks.get_state_type);
 		return callbacks.get_state_type(*this);
 	}

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -18,6 +18,59 @@ struct HasStructStateType : std::false_type {};
 template <class STATE>
 struct HasStructStateType<STATE, std::void_t<typename STATE::STATE_TYPE>> : std::true_type {};
 
+//! Detection trait: true when STATE is itself a C++ primitive type mappable to a LogicalType via PrimitiveToLogicalType
+template <class T>
+struct HasPrimitiveLogicalType : std::false_type {};
+
+template <>
+struct HasPrimitiveLogicalType<bool> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<int8_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<int16_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<int32_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<int64_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<uint8_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<uint16_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<uint32_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<uint64_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<hugeint_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<uhugeint_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<float> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<double> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<date_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<dtime_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<dtime_tz_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<dtime_ns_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_sec_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_ms_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_ns_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_tz_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<timestamp_tz_ns_t> : std::true_type {};
+template <>
+struct HasPrimitiveLogicalType<interval_t> : std::true_type {};
+
 //! Maps a single C++ field type to a LogicalType.
 //! If T itself defines STATE_TYPE, returns its nested struct type; otherwise calls PrimitiveToLogicalType<T>().
 template <class T>

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#include "duckdb/common/type_util.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/type_util.hpp"
 
 namespace duckdb {
 
@@ -105,6 +106,66 @@ struct StructStateType {
 		(children.emplace_back(Names[i++], FieldToLogicalType<Ts>()), ...);
 		return LogicalType::STRUCT(std::move(children));
 	}
+};
+
+//! Per-field layout information within an aggregate state.
+//! field_offset: byte offset of this field relative to the parent struct's base.
+//! is_optional: true when this field is an optional<T> (nullopt maps to SQL NULL).
+//! children: non-empty only when the field is itself a STRUCT; each child's offset is relative to this field's base.
+struct AggregateStateField {
+	idx_t field_offset = 0;
+	bool is_optional = false;
+	vector<AggregateStateField> children;
+
+	static idx_t GetPhysicalSize(const LogicalType &type) {
+		if (type.id() != LogicalTypeId::STRUCT) {
+			return GetTypeIdSize(type.InternalType());
+		}
+		idx_t size = 0;
+		for (const auto &child : StructType::GetChildTypes(type)) {
+			idx_t child_size = GetPhysicalSize(child.second);
+			size = AlignValue(size, MinValue<idx_t>(child_size, 8));
+			size += child_size;
+		}
+		return size;
+	}
+
+	static void PopulateChildren(const LogicalType &type, AggregateStateField &field) {
+		if (type.id() != LogicalTypeId::STRUCT) {
+			return;
+		}
+		D_ASSERT(field.children.empty());
+		idx_t offset = 0;
+		for (auto &[name, child_type] : StructType::GetChildTypes(type)) {
+			idx_t child_size = GetPhysicalSize(child_type);
+			offset = AlignValue(offset, MinValue<idx_t>(child_size, 8));
+			AggregateStateField child_field;
+			child_field.field_offset = offset;
+			PopulateChildren(child_type, child_field);
+			field.children.push_back(std::move(child_field));
+			offset += child_size;
+		}
+	}
+};
+
+//! Top-level description of an aggregate state for export/import purposes.
+//! Returned by the aggregate_get_state_type_t callback registered via SetStructStateExport.
+//!
+//! - Primitive state (e.g. int64_t for count): type=BIGINT, field.children empty, field.is_optional=false
+//! - Optional state (e.g. optional<bool>): type=BOOLEAN, field.is_optional=true, field.children empty
+//! - Struct state: type=STRUCT(...), field.children fully populated in the constructor
+//! total_state_size is the aligned size of the full state (stride between consecutive states in a buffer).
+struct AggregateStateLayout {
+	AggregateStateLayout() = default;
+	AggregateStateLayout(LogicalType type_p, idx_t total_state_size_p, bool is_optional = false)
+	    : type(std::move(type_p)), total_state_size(total_state_size_p) {
+		field.is_optional = is_optional;
+		AggregateStateField::PopulateChildren(type, field);
+	}
+
+	LogicalType type;
+	AggregateStateField field;
+	idx_t total_state_size = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state_layout.hpp
+++ b/src/include/duckdb/function/aggregate_state_layout.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "duckdb/common/type_util.hpp"
+#include "duckdb/common/optional.hpp"
 
 namespace duckdb {
 
@@ -70,6 +71,14 @@ template <>
 struct HasPrimitiveLogicalType<timestamp_tz_ns_t> : std::true_type {};
 template <>
 struct HasPrimitiveLogicalType<interval_t> : std::true_type {};
+
+//! Detection trait: true when STATE is optional<T> where T itself has HasPrimitiveLogicalType.
+//! These states export as PrimitiveToLogicalType<T>(), with nullopt ↔ SQL NULL.
+template <class T>
+struct HasOptionalPrimitiveType : std::false_type {};
+
+template <class T>
+struct HasOptionalPrimitiveType<optional<T>> : HasPrimitiveLogicalType<T> {};
 
 //! Maps a single C++ field type to a LogicalType.
 //! If T itself defines STATE_TYPE, returns its nested struct type; otherwise calls PrimitiveToLogicalType<T>().

--- a/test/sql/aggregate/aggregate_state_export/bool_and_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/bool_and_export_state.test
@@ -1,0 +1,91 @@
+# name: test/sql/aggregate/aggregate_state_export/bool_and_export_state.test
+# description: Test bool_and aggregate state export
+# group: [aggregate_state_export]
+
+# All-true group: state exports as true
+query I
+SELECT bool_and(v) EXPORT_STATE FROM (VALUES (true), (true), (true)) t(v)
+----
+1
+
+# Mixed group: state exports as false
+query I
+SELECT bool_and(v) EXPORT_STATE FROM (VALUES (true), (false), (true)) t(v)
+----
+0
+
+# All-null group: state exports as NULL (no non-null inputs seen)
+query I
+SELECT bool_and(v) EXPORT_STATE FROM (VALUES (NULL::bool)) t(v)
+----
+NULL
+
+# finalize round-trips the state back to a plain boolean
+query I
+SELECT finalize(bool_and(v) EXPORT_STATE) FROM (VALUES (true), (true)) t(v)
+----
+1
+
+query I
+SELECT finalize(bool_and(v) EXPORT_STATE) FROM (VALUES (true), (false)) t(v)
+----
+0
+
+query I
+SELECT finalize(bool_and(v) EXPORT_STATE) FROM (VALUES (NULL::bool)) t(v)
+----
+NULL
+
+# combine_aggr merges two exported states
+query I
+SELECT finalize(combine_aggr(s)) FROM (
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true), (true)) t(v)
+    UNION ALL
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true)) t(v)
+)
+----
+1
+
+query I
+SELECT finalize(combine_aggr(s)) FROM (
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true), (true)) t(v)
+    UNION ALL
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (false)) t(v)
+)
+----
+0
+
+# combining a NULL state (no inputs) with a real state yields the real state
+query I
+SELECT finalize(combine_aggr(s)) FROM (
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (NULL::bool)) t(v)
+    UNION ALL
+    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true)) t(v)
+)
+----
+1
+
+# bool_or mirrors bool_and
+query I
+SELECT bool_or(v) EXPORT_STATE FROM (VALUES (false), (false)) t(v)
+----
+0
+
+query I
+SELECT bool_or(v) EXPORT_STATE FROM (VALUES (false), (true)) t(v)
+----
+1
+
+query I
+SELECT bool_or(v) EXPORT_STATE FROM (VALUES (NULL::bool)) t(v)
+----
+NULL
+
+query I
+SELECT finalize(combine_aggr(s)) FROM (
+    SELECT bool_or(v) EXPORT_STATE AS s FROM (VALUES (false)) t(v)
+    UNION ALL
+    SELECT bool_or(v) EXPORT_STATE AS s FROM (VALUES (true)) t(v)
+)
+----
+1

--- a/test/sql/aggregate/aggregate_state_export/bool_and_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/bool_and_export_state.test
@@ -2,6 +2,16 @@
 # description: Test bool_and aggregate state export
 # group: [aggregate_state_export]
 
+query I
+SELECT bool_and(NULL) EXPORT_STATE
+----
+NULL
+
+query I
+SELECT finalize(bool_and(NULL) EXPORT_STATE)
+----
+NULL
+
 # All-true group: state exports as true
 query I
 SELECT bool_and(v) EXPORT_STATE FROM (VALUES (true), (true), (true)) t(v)
@@ -41,7 +51,7 @@ query I
 SELECT finalize(combine_aggr(s)) FROM (
     SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true), (true)) t(v)
     UNION ALL
-    SELECT bool_and(v) EXPORT_STATE AS s FROM (VALUES (true)) t(v)
+    SELECT bool_and(NULL) EXPORT_STATE AS s
 )
 ----
 1

--- a/test/sql/aggregate/aggregate_state_export/count_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/count_export_state.test
@@ -1,0 +1,21 @@
+# name: test/sql/aggregate/aggregate_state_export/count_export_state.test
+# description: Test count aggregate state
+# group: [aggregate_state_export]
+
+query I
+SELECT COUNT(*) export_state
+----
+1
+
+query I
+SELECT COUNT(*) export_state FROM range(10);
+----
+10
+
+query I
+SELECT finalize(combine_aggr(s)) from (select COUNT(*) export_state AS s FROM range(10) union all select count(*) export_state AS s from range(5));
+----
+15
+
+
+

--- a/test/sql/aggregate/aggregate_state_export/test_aggregate_state_type.test
+++ b/test/sql/aggregate/aggregate_state_export/test_aggregate_state_type.test
@@ -123,17 +123,17 @@ SELECT (avg(42) export_state)::struct(count ubigint, "value" double);
 ----
 {'count': 1, 'value': 42.0}
 
-# Casting count state to struct should work
+# Casting count state to underlying type should work
 query T
-SELECT (count(42) export_state)::struct(count bigint);
+SELECT (count(42) export_state)::bigint;
 ----
-{'count': 1}
+1
 
-# Casting count(*) state to struct should also work
+# Casting count(*) state to underlying type should also work
 query T
-SELECT (count(*) export_state)::struct(count bigint);
+SELECT (count(*) export_state)::bigint;
 ----
-{'count': 1}
+1
 
 # first() now has the new get_state_type callback
 query T
@@ -291,9 +291,9 @@ SELECT finalize(combine(state, state)) FROM t_regr_count;
 
 # Casting regression state to struct should work
 query T
-SELECT (regr_count(1.0, 2.0) export_state)::struct(count ubigint);
+SELECT (regr_count(1.0, 2.0) export_state)::ubigint;
 ----
-{'count': 1}
+1
 
 query T
 SELECT (regr_avgx(1.0, 2.0) export_state)::struct(sum double, count ubigint);

--- a/test/sql/aggregate/aggregate_state_export/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregate_state_export/test_state_export_struct.test
@@ -205,9 +205,9 @@ SELECT g, finalize(slope_state), finalize(count_state) FROM state_regr ORDER BY 
 
 # Regression: struct shape for state export
 query T
-SELECT (regr_count(1, 2) export_state)::struct(count ubigint);
+SELECT (regr_count(1, 2) export_state)::ubigint
 ----
-{'count': 1}
+1
 
 query T
 SELECT (regr_avgx(1.0, 2.0) export_state)::struct(sum double, count ubigint);
@@ -454,16 +454,16 @@ statement error
 SELECT finalize(finalize(avg(d) EXPORT_STATE)) from dummy;
 ----
 
-# Casting to struct should work
+# Casting to type should work
 query T
-SELECT (count(42) export_state)::struct(count bigint);
+SELECT (count(42) export_state)::bigint
 ----
-{'count': 1}
+1
 
 query T
-SELECT (count(*) export_state)::struct(count bigint);
+SELECT (count(*) export_state)::bigint
 ----
-{'count': 1}
+1
 
 query T
 SELECT (sum(42) export_state)::struct(isset boolean, "value" bigint);

--- a/test/sql/aggregate/aggregate_state_export/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregate_state_export/test_state_export_struct.test
@@ -330,11 +330,6 @@ query II nosort res8a
 SELECT g, FINALIZE(bool_and(d > 50) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query T
-SELECT (bool_and(42 > 0) export_state)::struct(empty boolean, val boolean);
-----
-{'empty': false, 'val': true}
-
 query II nosort res8a2
 SELECT g, bool_or(d > 50) FROM dummy GROUP BY g ORDER BY g;
 ----
@@ -342,16 +337,6 @@ SELECT g, bool_or(d > 50) FROM dummy GROUP BY g ORDER BY g;
 query II nosort res8a2
 SELECT g, FINALIZE(bool_or(d > 50) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
-
-query T
-SELECT (bool_or(42 > 0) export_state)::struct(empty boolean, val boolean);
-----
-{'empty': false, 'val': true}
-
-query T
-SELECT (bool_or(42 < 0) export_state)::struct(empty boolean, val boolean);
-----
-{'empty': false, 'val': false}
 
 query III nosort res8b
 SELECT g, bit_and(d), bit_or(d), bit_xor(d) FROM dummy GROUP BY g ORDER BY g;


### PR DESCRIPTION
Previously aggregate states were required to be structs. This PR removes that requirement and allows aggregate states to be scalars. For simple aggregate states, such as `count(*)`, we can just export the state as a primitive type directly instead of having to wrap it in a struct:

```sql
select count(*) export_state;
┌───────────────────────────┐
│ count_star() EXPORT_STATE │
│      aggregate_state      │
├───────────────────────────┤
│                         1 │
└───────────────────────────┘
```

In order to facilitate this, the aggregate state (de)serialization code is refactored to allow for treating of aggregate states in a more dynamic manner. A lot of complexity is also removed.

We also add support for `optional` as an aggregate state, and use that for `bool_and`. This replaces the current pattern of `value + bool is_set`:

```cpp
// old
struct BoolState {
	bool empty;
	bool val;
};

// new
using BoolState = optional<bool>;
```

These can then be exported as an aggregate state of only the value (`bool`) with the state being set to `NULL` when the value is not present.