### PR TITLE
Fix crash when storage path is not set

### DIFF
--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -99,8 +99,8 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 		// Already-active file storage keeps its existing path; only guard a fresh switch.
 		if (current_storage != LogConfig::FILE_STORAGE_NAME) {
 			auto path_entry = result->storage_config.find("path");
-			bool has_usable_path = path_entry != result->storage_config.end() &&
-			                       !path_entry->second.IsNull() && !path_entry->second.ToString().empty();
+			bool has_usable_path = path_entry != result->storage_config.end() && !path_entry->second.IsNull() &&
+			                       !path_entry->second.ToString().empty();
 			if (!has_usable_path) {
 				throw InvalidInputException(
 				    "Cannot enable 'file' log storage without a valid path. Provide one via storage_path, "

--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -91,6 +91,24 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 		}
 	}
 
+	// File logging requires a path. Reject switching to file storage without one before mutating any
+	// state, so the active storage is preserved instead of becoming a path-less storage that throws
+	// on every later flush (end-of-query and shutdown included).
+	if (StringUtil::Lower(result->config.storage) == LogConfig::FILE_STORAGE_NAME) {
+		auto current_storage = StringUtil::Lower(context.db->GetLogManager().GetConfig().storage);
+		// Already-active file storage keeps its existing path; only guard a fresh switch.
+		if (current_storage != LogConfig::FILE_STORAGE_NAME) {
+			auto path_entry = result->storage_config.find("path");
+			bool has_usable_path = path_entry != result->storage_config.end() &&
+			                       !path_entry->second.IsNull() && !path_entry->second.ToString().empty();
+			if (!has_usable_path) {
+				throw InvalidInputException(
+				    "Cannot enable 'file' log storage without a valid path. Provide one via storage_path, "
+				    "e.g. CALL enable_logging(storage='file', storage_path='mylog.csv');");
+			}
+		}
+	}
+
 	// Process positional params
 	if (!input.inputs.empty()) {
 		if (input.inputs[0].type() == LogicalType::VARCHAR) {

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -157,6 +157,15 @@ void LogManager::SetDisabledLogTypes(optional_ptr<unordered_set<string>> disable
 
 void LogManager::SetLogStorage(DatabaseInstance &db, const string &storage_name) {
 	unique_lock<mutex> lck(lock);
+	// 'SET logging_storage' cannot supply the path that file storage requires, so reject the switch
+	// here (active storage preserved) and point users at enable_logging instead of installing a
+	// path-less storage that throws on every later flush.
+	auto storage_name_to_lower = StringUtil::Lower(storage_name);
+	if (storage_name_to_lower == LogConfig::FILE_STORAGE_NAME && config.storage != storage_name_to_lower) {
+		throw InvalidConfigurationException(
+		    "Cannot select 'file' log storage via 'SET logging_storage' because it requires a path. "
+		    "Use CALL enable_logging(storage='file', storage_path='...') instead.");
+	}
 	SetLogStorageInternal(db, storage_name);
 }
 

--- a/test/sql/logging/enable_logging_file_no_path.test
+++ b/test/sql/logging/enable_logging_file_no_path.test
@@ -1,0 +1,115 @@
+# name: test/sql/logging/enable_logging_file_no_path.test
+# description: Regression test for issue 9144 - selecting file log storage without a usable path
+#             must fail cleanly instead of poisoning the log storage and aborting with an
+#             uncaught exception on the end-of-query / shutdown flush.
+# group: [logging]
+
+require noforcestorage
+
+# Normalize to in-memory storage
+statement ok
+CALL enable_logging(storage='memory')
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+# --- Exact issue 9144 sequence ---
+
+# 1) file storage without a path must fail cleanly (no crash on the following flush / on exit)
+statement error
+CALL enable_logging('QueryLog', storage=file);
+----
+Cannot enable 'file' log storage without a valid path
+
+# The failed call must not have switched the active storage...
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+# 2) ...and it must not have poisoned the storage: the same call WITH a path now succeeds.
+#    Before the fix this also failed with "path wasn't set", and DuckDB aborted on exit.
+statement ok
+CALL enable_logging('QueryLog', storage=file, storage_path='__TEST_DIR__/issue9144.csv')
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+file
+
+# A normal query, whose end-of-query log flush previously threw, must succeed
+statement ok
+SELECT 42
+
+# Re-enabling already-active file storage without repeating the path keeps working
+statement ok
+CALL enable_logging()
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+file
+
+statement ok
+CALL disable_logging()
+
+statement ok
+CALL enable_logging(storage='memory')
+
+# --- Other unusable paths must fail the same way, leaving storage untouched ---
+
+# Empty-string path
+statement error
+CALL enable_logging(storage='file', storage_path='');
+----
+Cannot enable 'file' log storage without a valid path
+
+# NULL path
+statement error
+CALL enable_logging(storage='file', storage_path=NULL);
+----
+Cannot enable 'file' log storage without a valid path
+
+# Inferred file storage via storage_config={path:...} with an empty path
+statement error
+CALL enable_logging(storage_config:={path:''});
+----
+Cannot enable 'file' log storage without a valid path
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+statement ok
+SELECT 42
+
+# --- SET logging_storage='file' cannot supply a path: clean error, storage unchanged ---
+statement error
+SET logging_storage='file';
+----
+Cannot select 'file' log storage
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+# Case-insensitive: an upper-cased value must be caught too (must not bypass the guard)
+statement error
+SET logging_storage='FILE';
+----
+Cannot select 'file' log storage
+
+query I
+SELECT value FROM duckdb_settings() WHERE name = 'logging_storage';
+----
+memory
+
+statement ok
+SELECT 42
+
+statement ok
+CALL disable_logging()

--- a/test/sql/logging/enable_logging_file_no_path.test
+++ b/test/sql/logging/enable_logging_file_no_path.test
@@ -1,7 +1,5 @@
 # name: test/sql/logging/enable_logging_file_no_path.test
-# description: Regression test for issue 9144 - selecting file log storage without a usable path
-#             must fail cleanly instead of poisoning the log storage and aborting with an
-#             uncaught exception on the end-of-query / shutdown flush.
+# description: Selecting file log storage without a usable path must fail cleanly instead of poisoning the log storage
 # group: [logging]
 
 require noforcestorage


### PR DESCRIPTION
I think this is a bit of a design problem again, where an issue is only really caught when calling `logger->Flush()`. Also more in general `logger->Flush()` should not interrupt an exit process, which it now does because the exception is not properly handled.. but that could be the scope of another PR.

This PR simply focuses on:
- Adding a guard against `set logging_storage=file` if there is no storage_path (which by default there cannot be since there is not setting for storage_path!!! We will refactor this in main).
- Adding a check when `call enable_logging` to ensure there is a `storage_path` provided if the `storage=file`.