### PR TITLE
Cache Arrow schema in the ArrowQueryResult

### DIFF
--- a/src/common/adbc/nanoarrow/schema.cpp
+++ b/src/common/adbc/nanoarrow/schema.cpp
@@ -441,6 +441,13 @@ int ArrowSchemaDeepCopy(struct ArrowSchema *schema, struct ArrowSchema *schema_o
 		return result;
 	}
 
+	// ArrowSchemaInit hard-codes flags to ARROW_FLAG_NULLABLE; preserve the source
+	// flags instead so a deep copy is semantically identical to its source. DuckDB
+	// sets non-default flags (root struct non-nullable, map keys/entries
+	// non-nullable) in ArrowConverter::ToArrowSchema, and the Arrow spec requires
+	// map keys to be non-nullable -- dropping these produces an invalid schema.
+	schema_out->flags = schema->flags;
+
 	result = ArrowSchemaAllocateChildren(schema_out, schema->n_children);
 	if (result != NANOARROW_OK) {
 		schema_out->release(schema_out);

--- a/src/common/arrow/arrow_query_result.cpp
+++ b/src/common/arrow/arrow_query_result.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/nanoarrow/nanoarrow.hpp"
 
 namespace duckdb {
 
@@ -48,6 +49,21 @@ void ArrowQueryResult::SetArrowData(vector<unique_ptr<ArrowArrayWrapper>> arrays
 
 idx_t ArrowQueryResult::BatchSize() const {
 	return batch_size;
+}
+
+void ArrowQueryResult::BuildCachedSchema() {
+	ArrowConverter::ToArrowSchema(&cached_schema.arrow_schema, types, names, client_properties);
+}
+
+void ArrowQueryResult::GetSchema(ArrowSchema &out) const {
+	if (!HasCachedSchema()) {
+		throw InternalException("ArrowQueryResult has no cached schema; it was not produced by an arrow collector");
+	}
+	// nanoarrow's source parameter is non-const but only read from; cached_schema
+	// is `mutable` so this stays a const accessor.
+	if (duckdb_nanoarrow::ArrowSchemaDeepCopy(&cached_schema.arrow_schema, &out) != NANOARROW_OK) {
+		throw InternalException("Failed to deep-copy cached Arrow schema");
+	}
 }
 
 } // namespace duckdb

--- a/src/common/arrow/physical_arrow_batch_collector.cpp
+++ b/src/common/arrow/physical_arrow_batch_collector.cpp
@@ -18,16 +18,21 @@ SinkFinalizeType PhysicalArrowBatchCollector::Finalize(Pipeline &pipeline, Event
 	auto total_tuple_count = gstate.data.Count();
 	if (total_tuple_count == 0) {
 		// Create the result containing a single empty result conversion
-		gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types,
-		                                            context.GetClientProperties(), record_batch_size);
+		auto result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types,
+		                                          context.GetClientProperties(), record_batch_size);
+		result->BuildCachedSchema();
+		gstate.result = std::move(result);
 		return SinkFinalizeType::READY;
 	}
 
 	// Already create the final query result
-	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
-	                                            record_batch_size);
+	auto result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
+	                                          record_batch_size);
+	// Cache the schema while the producing transaction is still active (see duckdb/duckdb-python#475).
+	result->BuildCachedSchema();
+	auto &arrow_result = *result;
+	gstate.result = std::move(result);
 	// Spawn an event that will populate the conversion result
-	auto &arrow_result = gstate.result->Cast<ArrowQueryResult>();
 	auto new_event = make_shared_ptr<ArrowMergeEvent>(arrow_result, gstate.data, pipeline);
 	event.InsertEvent(std::move(new_event));
 

--- a/src/common/arrow/physical_arrow_collector.cpp
+++ b/src/common/arrow/physical_arrow_collector.cpp
@@ -105,21 +105,19 @@ SinkFinalizeType PhysicalArrowCollector::Finalize(Pipeline &pipeline, Event &eve
                                                   OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<ArrowCollectorGlobalState>();
 
-	if (gstate.chunks.empty()) {
-		if (gstate.tuple_count != 0) {
-			throw InternalException(
-			    "PhysicalArrowCollector Finalize contains no chunks, but tuple_count is non-zero (%d)",
-			    gstate.tuple_count);
-		}
-		gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types,
-		                                            context.GetClientProperties(), record_batch_size);
-		return SinkFinalizeType::READY;
+	if (gstate.chunks.empty() && gstate.tuple_count != 0) {
+		throw InternalException("PhysicalArrowCollector Finalize contains no chunks, but tuple_count is non-zero (%d)",
+		                        gstate.tuple_count);
 	}
 
-	gstate.result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
-	                                            record_batch_size);
-	auto &arrow_result = gstate.result->Cast<ArrowQueryResult>();
-	arrow_result.SetArrowData(std::move(gstate.chunks));
+	auto result = make_uniq<ArrowQueryResult>(statement_type, properties, names, types, context.GetClientProperties(),
+	                                          record_batch_size);
+	// Cache the schema while the producing transaction is still active (see duckdb/duckdb-python#475).
+	result->BuildCachedSchema();
+	if (!gstate.chunks.empty()) {
+		result->SetArrowData(std::move(gstate.chunks));
+	}
+	gstate.result = std::move(result);
 
 	return SinkFinalizeType::READY;
 }

--- a/src/include/duckdb/common/arrow/arrow_query_result.hpp
+++ b/src/include/duckdb/common/arrow/arrow_query_result.hpp
@@ -40,12 +40,33 @@ public:
 	void SetArrowData(vector<unique_ptr<ArrowArrayWrapper>> arrays);
 	idx_t BatchSize() const;
 
+	//! True once the Arrow schema has been built and cached (see BuildCachedSchema).
+	bool HasCachedSchema() const {
+		return cached_schema.arrow_schema.release != nullptr;
+	}
+	//! Build this result's Arrow schema (from its own types/names/client
+	//! properties) and cache it. The producing arrow collector calls this during
+	//! Finalize, while the transaction is still active. Building the schema later,
+	//! at fetch time, breaks arrow type extensions whose schema callback does a
+	//! catalog lookup -- e.g. GeoArrow CRS resolution in ArrowGeometry::WriteCRS,
+	//! which asserts an active transaction that no longer exists post-commit.
+	//! See duckdb-python#475 / duckdb-spatial#788.
+	DUCKDB_API void BuildCachedSchema();
+	//! Deep-copy the cached schema into `out` (the caller owns and must release
+	//! it). This is how consumers obtain a materialized result's Arrow schema --
+	//! they must never rebuild it via ArrowConverter::ToArrowSchema post-commit.
+	//! Throws if no schema was cached.
+	DUCKDB_API void GetSchema(ArrowSchema &out) const;
+
 protected:
 	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override;
 
 private:
 	vector<unique_ptr<ArrowArrayWrapper>> arrays;
 	idx_t batch_size;
+	//! Owns its ArrowSchema; released by ~ArrowSchemaWrapper when the result dies.
+	//! `mutable` so GetSchema() can hand nanoarrow a (non-const) pointer to copy.
+	mutable ArrowSchemaWrapper cached_schema;
 };
 
 } // namespace duckdb

--- a/test/arrow/CMakeLists.txt
+++ b/test/arrow/CMakeLists.txt
@@ -1,6 +1,11 @@
 add_library_unity(
-  test_arrow_roundtrip OBJECT arrow_test_helper.cpp arrow_roundtrip.cpp
-  arrow_move_children.cpp arrow_filter_pushdown.cpp)
+  test_arrow_roundtrip
+  OBJECT
+  arrow_test_helper.cpp
+  arrow_roundtrip.cpp
+  arrow_move_children.cpp
+  arrow_filter_pushdown.cpp
+  test_arrow_geometry_crs_schema.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_arrow_roundtrip>
     PARENT_SCOPE)

--- a/test/arrow/test_arrow_geometry_crs_schema.cpp
+++ b/test/arrow/test_arrow_geometry_crs_schema.cpp
@@ -1,0 +1,107 @@
+#include "catch.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/arrow_query_result.hpp"
+#include "duckdb/common/arrow/physical_arrow_collector.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/client_context.hpp"
+
+#include <cstring>
+#include <string>
+
+using namespace duckdb;
+
+// Regression test for duckdb-python#475 / duckdb-spatial#788.
+//
+// Converting a GEOMETRY column that carries a CRS to an Arrow schema invokes the
+// internal geoarrow.wkb arrow extension: ArrowGeometry::PopulateSchema ->
+// WriteCRS -> CoordinateReferenceSystem::TryConvert, which does a catalog lookup
+// (Catalog::GetEntry -> GetCatalogTransaction) and therefore requires an active
+// transaction. When an Arrow result is consumed *after* the producing
+// (auto-commit) transaction has closed, rebuilding the schema asserts with
+// "TransactionContext::ActiveTransaction called without active transaction".
+//
+// The fix: PhysicalArrowCollector / PhysicalArrowBatchCollector build the schema
+// during Finalize -- while the producing transaction is still active -- and
+// cache it on the ArrowQueryResult, so consumers never rebuild it post-commit.
+
+// Scan an Arrow C Data Interface metadata blob for a key or value substring.
+static bool MetadataContains(const char *metadata, const std::string &needle) {
+	if (!metadata) {
+		return false;
+	}
+	int32_t n_entries;
+	std::memcpy(&n_entries, metadata, sizeof(int32_t));
+	const char *ptr = metadata + sizeof(int32_t);
+	for (int32_t i = 0; i < n_entries; i++) {
+		int32_t key_len;
+		std::memcpy(&key_len, ptr, sizeof(int32_t));
+		ptr += sizeof(int32_t);
+		std::string key(ptr, static_cast<size_t>(key_len));
+		ptr += key_len;
+		int32_t val_len;
+		std::memcpy(&val_len, ptr, sizeof(int32_t));
+		ptr += sizeof(int32_t);
+		std::string val(ptr, static_cast<size_t>(val_len));
+		ptr += val_len;
+		if (key.find(needle) != std::string::npos || val.find(needle) != std::string::npos) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void ForceArrowCollector(Connection &con) {
+	auto &config = ClientConfig::GetConfig(*con.context);
+	config.get_result_collector = [](ClientContext &context, PreparedStatementData &data) {
+		return PhysicalArrowCollector::Create(context, data, STANDARD_VECTOR_SIZE);
+	};
+}
+
+TEST_CASE("Arrow schema for GEOMETRY with CRS survives transaction commit (#475)", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	ForceArrowCollector(con);
+
+	// 'OGC:CRS84' is an authority-code CRS, so serializing it forces the catalog
+	// lookup in CoordinateReferenceSystem::TryConvert.
+	// Use ClientContext::Query (not Connection::Query, which materializes) so the
+	// get_result_collector override produces an ArrowQueryResult.
+	auto result = con.context->Query("SELECT 'POINT(0 1)'::GEOMETRY('OGC:CRS84') AS g", false);
+	REQUIRE(result);
+	REQUIRE(!result->HasError());
+	REQUIRE(result->type == QueryResultType::ARROW_RESULT);
+	auto &arrow = result->Cast<ArrowQueryResult>();
+
+	// The producing transaction has auto-committed. Rebuilding the schema now --
+	// the way consumers used to before the fix -- reaches the CRS catalog lookup
+	// with no active transaction and throws. This is the #475 failure mode.
+	SECTION("rebuilding the schema post-commit reproduces the failure") {
+		REQUIRE_THROWS([&]() {
+			ArrowSchema rebuilt;
+			rebuilt.release = nullptr;
+			ArrowConverter::ToArrowSchema(&rebuilt, arrow.types, arrow.names, arrow.client_properties);
+			if (rebuilt.release) {
+				rebuilt.release(&rebuilt);
+			}
+		}());
+	}
+
+	// The fix: the collector cached the schema while the producing transaction
+	// was still active. GetSchema() hands consumers an independent, owned copy
+	// without a transaction -- this is the accessor consumers must use instead of
+	// rebuilding via ToArrowSchema. The copy carries the geoarrow.wkb extension
+	// metadata that only the in-transaction build could produce.
+	SECTION("the collector caches the schema built under the producing transaction") {
+		REQUIRE(arrow.HasCachedSchema());
+		ArrowSchema copied;
+		copied.release = nullptr;
+		arrow.GetSchema(copied);
+		REQUIRE(copied.release != nullptr);
+		REQUIRE(copied.n_children == 1);
+		REQUIRE(copied.children[0] != nullptr);
+		REQUIRE(MetadataContains(copied.children[0]->metadata, "geoarrow.wkb"));
+		copied.release(&copied);
+	}
+}

--- a/test/arrow/test_arrow_geometry_crs_schema.cpp
+++ b/test/arrow/test_arrow_geometry_crs_schema.cpp
@@ -109,3 +109,51 @@ TEST_CASE("Arrow schema for GEOMETRY with CRS survives transaction commit (#475)
 		copied.release(&copied);
 	}
 }
+
+// Regression test for the flag-preservation half of the cached-schema fix.
+//
+// GetSchema() hands consumers a deep copy of the cached schema. ArrowSchemaDeepCopy
+// initializes every node as ARROW_FLAG_NULLABLE; if it does not also copy the
+// source flags, the copy silently diverges from the schema DuckDB built. For a MAP
+// column this is not cosmetic: ArrowConverter::ToArrowSchema marks the root struct,
+// the map 'entries' field, and the map 'key' field as non-nullable (flags == 0),
+// and the Arrow spec *requires* map keys to be non-nullable. A copy that flips them
+// back to nullable is an invalid Arrow schema.
+TEST_CASE("Cached Arrow schema preserves non-nullable flags for MAP (#475)", "[arrow]") {
+	DuckDB db;
+	Connection con(db);
+	ForceArrowCollector(con);
+
+	auto result = con.context->Query("SELECT MAP {'a': 1, 'b': 2} AS m", false);
+	REQUIRE(result);
+	REQUIRE(!result->HasError());
+	REQUIRE(result->type == QueryResultType::ARROW_RESULT);
+	auto &arrow = result->Cast<ArrowQueryResult>();
+	REQUIRE(arrow.HasCachedSchema());
+
+	ArrowSchema copied;
+	copied.release = nullptr;
+	arrow.GetSchema(copied);
+	REQUIRE(copied.release != nullptr);
+
+	// Root struct is non-nullable.
+	REQUIRE((copied.flags & ARROW_FLAG_NULLABLE) == 0);
+
+	// child[0] is the map column itself (format "+m"), which is nullable.
+	REQUIRE(copied.n_children == 1);
+	auto &map = *copied.children[0];
+	REQUIRE(std::string(map.format) == "+m");
+	REQUIRE(map.n_children == 1);
+
+	// The map's single child is the non-nullable 'entries' struct (format "+s").
+	auto &entries = *map.children[0];
+	REQUIRE(std::string(entries.format) == "+s");
+	REQUIRE((entries.flags & ARROW_FLAG_NULLABLE) == 0);
+
+	// 'entries' has key (non-nullable) and value children.
+	REQUIRE(entries.n_children == 2);
+	auto &key = *entries.children[0];
+	REQUIRE((key.flags & ARROW_FLAG_NULLABLE) == 0);
+
+	copied.release(&copied);
+}

--- a/test/arrow/test_arrow_geometry_crs_schema.cpp
+++ b/test/arrow/test_arrow_geometry_crs_schema.cpp
@@ -78,6 +78,9 @@ TEST_CASE("Arrow schema for GEOMETRY with CRS survives transaction commit (#475)
 	// the way consumers used to before the fix -- reaches the CRS catalog lookup
 	// with no active transaction and throws. This is the #475 failure mode.
 	SECTION("rebuilding the schema post-commit reproduces the failure") {
+#ifndef DUCKDB_CRASH_ON_ASSERT
+		// Skipped under CRASH_ON_ASSERT: the InternalException this provokes aborts
+		// instead of throwing.
 		REQUIRE_THROWS([&]() {
 			ArrowSchema rebuilt;
 			rebuilt.release = nullptr;
@@ -86,6 +89,7 @@ TEST_CASE("Arrow schema for GEOMETRY with CRS survives transaction commit (#475)
 				rebuilt.release(&rebuilt);
 			}
 		}());
+#endif
 	}
 
 	// The fix: the collector cached the schema while the producing transaction


### PR DESCRIPTION
Fixes the duckdb core part of duckdb/duckdb-python#475 / duckdb/duckdb-spatial#788

This adds caching of the arrow schema to `ArrowQueryResult` so that consumers do not need to rely on an open transaction when consuming an arrow stream or table. Right now there are a number of scenarios where consumers can run into `InternalException`s, e.g. when a schema is constructed that needs catalog access outside of a transaction.