### PR TITLE
Add invoke scalar function

### DIFF
--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -147,6 +147,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_WINDOW_FUNCTION(FirstValueFun),
 	DUCKDB_SCALAR_FUNCTION(GetVariableFun),
 	DUCKDB_SCALAR_FUNCTION(IlikeEscapeFun),
+	DUCKDB_SCALAR_FUNCTION(InvokeFun),
 	DUCKDB_WINDOW_FUNCTION(LagFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(LastFun),
 	DUCKDB_WINDOW_FUNCTION(LastValueFun),

--- a/src/function/scalar/generic/CMakeLists.txt
+++ b/src/function/scalar/generic/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_func_generic_main OBJECT constant_or_null.cpp
-                  error.cpp getvariable.cpp)
+                  error.cpp getvariable.cpp invoke.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_generic_main>

--- a/src/function/scalar/generic/functions.json
+++ b/src/function/scalar/generic/functions.json
@@ -27,5 +27,12 @@
         "description": "Constructs a binary-comparable sort key based on a set of input parameters and sort qualifiers",
         "example": "create_sort_key('A', 'DESC')",
         "type": "scalar_function"
+    },
+    {
+        "name": "invoke",
+        "parameters": "lambda, arg1, arg2, ...",
+        "description": "Invokes a lambda function with the given arguments",
+        "example": "invoke(x -> x + 1, 5)",
+        "type": "scalar_function"
     }
 ]

--- a/src/function/scalar/generic/invoke.cpp
+++ b/src/function/scalar/generic/invoke.cpp
@@ -1,0 +1,144 @@
+#include "duckdb/function/scalar/generic_functions.hpp"
+#include "duckdb/function/lambda_functions.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/planner/expression/bound_lambda_expression.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct LambdaInvokeData final : public LambdaFunctionData {
+	unique_ptr<Expression> lambda_expr;
+
+	explicit LambdaInvokeData(unique_ptr<Expression> lambda_expr_p) : lambda_expr(std::move(lambda_expr_p)) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto lambda_expr_copy = lambda_expr ? lambda_expr->Copy() : nullptr;
+		return make_uniq<LambdaInvokeData>(std::move(lambda_expr_copy));
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<LambdaInvokeData>();
+		return Expression::Equals(lambda_expr, other.lambda_expr);
+	}
+
+	//! Serializes a lambda function's bind data
+	static void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+	                      const BoundScalarFunction &function) {
+		auto &bind_data = bind_data_p->Cast<LambdaInvokeData>();
+		serializer.WritePropertyWithDefault(101, "lambda_expr", bind_data.lambda_expr, unique_ptr<Expression>());
+	}
+
+	//! Deserializes a lambda function's bind data
+	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &) {
+		auto lambda_expr = deserializer.ReadPropertyWithExplicitDefault<unique_ptr<Expression>>(
+		    101, "lambda_expr", unique_ptr<Expression>());
+		return make_uniq<LambdaInvokeData>(std::move(lambda_expr));
+	}
+
+	optional_ptr<const Expression> GetLambdaExpression() const override {
+		if (!lambda_expr) {
+			return nullptr;
+		}
+		auto &bound_lambda_expr = lambda_expr->Cast<BoundLambdaExpression>();
+		return bound_lambda_expr.LambdaExpr().get();
+	}
+};
+
+struct LambdaInvokeState final : public FunctionLocalState {
+	unique_ptr<ExpressionExecutor> executor;
+	DataChunk input_chunk;
+	idx_t parameter_count;
+
+	LambdaInvokeState(unique_ptr<ExpressionExecutor> executor_p, const vector<LogicalType> &input_types,
+	                  const idx_t parameter_count_p)
+	    : executor(std::move(executor_p)), parameter_count(parameter_count_p) {
+		input_chunk.InitializeEmpty(input_types);
+	}
+
+	static unique_ptr<FunctionLocalState> Init(ExpressionState &state, const BoundFunctionExpression &expr,
+	                                           FunctionData *bind_data) {
+		auto &bdata = bind_data->Cast<LambdaInvokeData>();
+		if (!bdata.lambda_expr) {
+			throw InternalException("Invoke function is missing its bound lambda expression");
+		}
+		auto &bound_lambda_expr = bdata.lambda_expr->Cast<BoundLambdaExpression>();
+		const auto parameter_count = bound_lambda_expr.ParameterCount();
+		D_ASSERT(parameter_count <= expr.GetChildren().size());
+
+		vector<LogicalType> input_types;
+		input_types.reserve(expr.GetChildren().size());
+		for (idx_t i = 0; i < parameter_count; i++) {
+			input_types.push_back(expr.GetChildren()[parameter_count - i - 1]->GetReturnType());
+		}
+		for (idx_t i = parameter_count; i < expr.GetChildren().size(); i++) {
+			input_types.push_back(expr.GetChildren()[i]->GetReturnType());
+		}
+
+		auto executor = make_uniq<ExpressionExecutor>(state.GetContext(), *bound_lambda_expr.LambdaExpr());
+		return make_uniq<LambdaInvokeState>(std::move(executor), input_types, parameter_count);
+	}
+};
+
+void LambdaInvokeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LambdaInvokeState>();
+	for (idx_t i = 0; i < lstate.parameter_count; i++) {
+		lstate.input_chunk.data[i].Reference(args.data[lstate.parameter_count - i - 1]);
+	}
+	for (idx_t i = lstate.parameter_count; i < args.ColumnCount(); i++) {
+		lstate.input_chunk.data[i].Reference(args.data[i]);
+	}
+	lstate.input_chunk.SetChildCardinality(args.size());
+	lstate.executor->ExecuteExpression(lstate.input_chunk, result);
+}
+
+unique_ptr<FunctionData> LambdaInvokeBind(BindScalarFunctionInput &input) {
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+	// the list column and the bound lambda expression
+	if (arguments[0]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {
+		throw BinderException("Invalid lambda expression passed to 'invoke' function.");
+	}
+
+	auto &bound_lambda_expr = arguments[0]->Cast<BoundLambdaExpression>();
+	if (bound_lambda_expr.ParameterCount() != arguments.size() - 1) {
+		throw BinderException("The number of lambda parameters does not match the number of arguments passed to the "
+		                      "'invoke' function, expected %d, got %d.",
+		                      bound_lambda_expr.ParameterCount(), arguments.size() - 1);
+	}
+
+	bound_function.SetReturnType(bound_lambda_expr.LambdaExpr()->GetReturnType());
+
+	return make_uniq<LambdaInvokeData>(bound_lambda_expr.Copy());
+}
+
+LogicalType LambdaInvokeBindParameters(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                       const idx_t parameter_idx, optional_ptr<BindLambdaContext> bind_lambda_context) {
+	// The first parameter is always the lambda
+	auto child_idx = parameter_idx + 1;
+	if (child_idx >= function_child_types.size()) {
+		throw BinderException("The number of lambda parameters does not match the number of arguments passed to the "
+		                      "'invoke' function, expected at least %d, got %d.",
+		                      parameter_idx + 1, function_child_types.size() - 1);
+	}
+	return function_child_types[child_idx];
+}
+
+} // namespace
+
+ScalarFunction InvokeFun::GetFunction() {
+	ScalarFunction fun("invoke", {LogicalType::LAMBDA, LogicalType::ANY}, LogicalType::ANY, LambdaInvokeFunction);
+	fun.SetBindCallback(LambdaInvokeBind);
+	fun.SetVarArgs(LogicalType::ANY);
+	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	fun.SetBindLambdaCallback(LambdaInvokeBindParameters);
+	fun.SetInitStateCallback(LambdaInvokeState::Init);
+	fun.SetSerializeCallback(LambdaInvokeData::Serialize);
+	fun.SetDeserializeCallback(LambdaInvokeData::Deserialize);
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/lambda_functions.hpp
+++ b/src/include/duckdb/function/lambda_functions.hpp
@@ -18,7 +18,11 @@
 
 namespace duckdb {
 
-struct ListLambdaBindData final : public FunctionData {
+struct LambdaFunctionData : public FunctionData {
+	DUCKDB_API virtual optional_ptr<const Expression> GetLambdaExpression() const = 0;
+};
+
+struct ListLambdaBindData final : public LambdaFunctionData {
 public:
 	ListLambdaBindData(const LogicalType &return_type, unique_ptr<Expression> lambda_expr, const bool has_index = false,
 	                   const bool has_initial = false)
@@ -50,6 +54,10 @@ public:
 	                      const BoundScalarFunction &function);
 	//! Deserializes a lambda function's bind data
 	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &);
+
+	optional_ptr<const Expression> GetLambdaExpression() const override {
+		return lambda_expr.get();
+	}
 };
 
 class LambdaFunctions {

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -55,4 +55,14 @@ struct CreateSortKeyFun {
 	static ScalarFunction GetFunction();
 };
 
+struct InvokeFun {
+	static constexpr const char *Name = "invoke";
+	static constexpr const char *Parameters = "lambda,arg1,arg2,...";
+	static constexpr const char *Description = "Invokes a lambda function with the given arguments";
+	static constexpr const char *Example = "invoke(x -> x + 1, 5)";
+	static constexpr const char *Categories = "";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -378,14 +378,15 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 
 	auto &args = function.GetArgumentsMutable();
 
-	// the first child is the list, the second child is the lambda expression
-	// constexpr idx_t list_ix = 0;
-	constexpr idx_t list_idx = 0;
-	constexpr idx_t lambda_expr_idx = 1;
-	D_ASSERT(args[lambda_expr_idx].GetExpression().GetExpressionClass() == ExpressionClass::LAMBDA);
+	// list lambda functions use the existing (list, lambda) shape; invoke is the only lambda
+	// function that accepts the lambda expression as the first argument.
+	const idx_t lambda_expr_idx = func.name == "invoke" ? 0 : 1;
+	if (args.size() <= lambda_expr_idx ||
+	    args[lambda_expr_idx].GetExpression().GetExpressionClass() != ExpressionClass::LAMBDA) {
+		return BindResult("This scalar function requires a lambda expression!");
+	}
 
 	vector<LogicalType> function_child_types;
-	// bind the list
 	ErrorData error;
 
 	for (idx_t i = 0; i < function.GetArguments().size(); i++) {
@@ -408,13 +409,15 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 		function_child_types.push_back(child->GetReturnType());
 	}
 
-	// get the logical type of the children of the list
-	auto &list_child = BoundExpression::GetExpression(*args[list_idx].GetExpressionMutable());
-	if (list_child->GetReturnType().id() != LogicalTypeId::LIST &&
-	    list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
-	    list_child->GetReturnType().id() != LogicalTypeId::SQLNULL &&
-	    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN) {
-		return BindResult("Invalid LIST argument during lambda function binding!");
+	if (lambda_expr_idx == 1) {
+		// get the logical type of the children of the list
+		auto &list_child = BoundExpression::GetExpression(*args[0].GetExpressionMutable());
+		if (list_child->GetReturnType().id() != LogicalTypeId::LIST &&
+		    list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
+		    list_child->GetReturnType().id() != LogicalTypeId::SQLNULL &&
+		    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN) {
+			return BindResult("Invalid LIST argument during lambda function binding!");
+		}
 	}
 
 	// bind the lambda parameter

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -39,12 +39,10 @@ bool BoundFunctionExpression::IsFoldable() const {
 	if (function.HasBindLambdaCallback()) {
 		// This is a lambda function
 		D_ASSERT(bind_info);
-		auto &lambda_bind_data = bind_info->Cast<ListLambdaBindData>();
-		if (lambda_bind_data.lambda_expr) {
-			auto &expr = *lambda_bind_data.lambda_expr;
-			if (expr.IsVolatile()) {
-				return false;
-			}
+		auto &lambda_bind_data = bind_info->Cast<LambdaFunctionData>();
+		auto lambda_expr = lambda_bind_data.GetLambdaExpression();
+		if (lambda_expr && lambda_expr->IsVolatile()) {
+			return false;
 		}
 	}
 	return function.GetStability() == FunctionStability::VOLATILE ? false : Expression::IsFoldable();

--- a/test/sql/function/generic/invoke.test
+++ b/test/sql/function/generic/invoke.test
@@ -1,0 +1,145 @@
+# name: test/sql/function/generic/invoke.test
+# group: [generic]
+
+# Basic lambda invoke
+query I
+select invoke(lambda x: x * x, 2) as square_of_x
+----
+4
+
+# Multiple bindings using nested invoke
+query I
+select invoke(lambda a: invoke(lambda b: a + b, 4), 3) as sum_ab
+----
+7
+
+# Multiple arguments
+query I
+select invoke(lambda x, y: x * y + y, 3, 4) as result
+----
+16
+
+query I
+select invoke(lambda x, y, z: x + y + z, 1, 2, 3) as result
+----
+6
+
+query I
+select invoke(lambda x, y, z: x * 100 + y * 10 + z, 1, 2, 3) as result
+----
+123
+
+query I
+select invoke(lambda x, y, z, w: x * y + z * w, 1, 2, 3, 4) as result
+----
+14
+
+# Nested invoke expressions
+query I
+select invoke(lambda x: invoke(lambda y: y + 5, x + 3), 2) as result
+----
+10
+
+query I
+select invoke(lambda x: invoke(lambda y: y + x + 5, 3), 2) as result
+----
+10
+
+# Nested multiple lambda invoke with multiple arguments
+query I
+select invoke(lambda a: invoke(lambda b, c: a + b + c, 4, 5), 3) as result
+----
+12
+
+# Also the other way around
+query I
+select invoke(lambda a, b: invoke(lambda c: a + b + c, 5), 3, 4) as result
+----
+12
+
+query I
+select invoke(lambda a, b: invoke(lambda c: a * 100 + b * 10 + c, 3), 1, 2) as result
+----
+123
+
+# Lambda invoke with row constructor
+query II
+SELECT unnest(invoke(lambda x: invoke(lambda y: row(x, y), 3), 2));
+----
+2	3
+
+# Lambda invoke with different types
+query I
+SELECT invoke(lambda name: invoke(lambda age: name || age, 30), 'Alice, ');
+----
+Alice, 30
+
+# Lambda invoke with nested lambda
+query I
+SELECT invoke(lambda x: list_transform([1,2,3], LAMBDA y: y + x), 1);
+----
+[2, 3, 4]
+
+query I
+SELECT invoke(lambda x: list_transform([10, 20], lambda y, i: x + y + i), 100);
+----
+[111, 122]
+
+# Lambda invoke with NULL
+query I
+select invoke(lambda x: x IS NULL, NULL);
+----
+true
+
+# Naming is correct
+query I
+select invoke(lambda x: alias(x), 1);
+----
+x
+
+# Lambda invoke in non-SELECT context
+query I rowsort
+SELECT * FROM range(0, 10) as r(i) WHERE invoke(lambda x: x, i % 2 == 0) ORDER BY ALL;
+----
+0
+2
+4
+6
+8
+
+# Stored invoke expressions should preserve lambda reference ordering across restarts.
+load {TEST_DIR}/invoke_storage.db
+
+statement ok
+CREATE TABLE invoke_order_tbl AS SELECT 1 a, 2 b, 3 c
+
+statement ok
+CREATE VIEW invoke_order_view AS SELECT invoke(lambda x, y, z: x * 100 + y * 10 + z, a, b, c) AS result FROM invoke_order_tbl
+
+query I
+SELECT result FROM invoke_order_view
+----
+123
+
+restart
+
+query I
+SELECT result FROM invoke_order_view
+----
+123
+
+# Errors
+statement error
+SELECT invoke(lambda x: x + x, 2, 4, 6);
+----
+Binder Error: The number of lambda parameters does not match the number of arguments passed to the 'invoke' function, expected 1, got 3.
+
+statement error
+SELECT invoke(lambda x, y: x + y, 2);
+----
+Binder Error: The number of lambda parameters does not match the number of arguments passed to the 'invoke' function, expected at least 2, got 1.
+
+statement error
+SELECT invoke(NULL, 1);
+----
+Binder Error: Invalid lambda expression passed to 'invoke' function.


### PR DESCRIPTION
Split out from #23024

This PR reintroduces the generic `invoke(lambda, args...)` scalar function as a standalone change. The simple CASE rewrite is intentionally left out and can be revisited separately after `invoke` lands.

Changes:
- add `invoke` registration and implementation
- support lambda-first scalar binding for `invoke` while keeping existing list lambda functions in their current `(list, lambda)` shape
- generalize lambda bind data access used by foldability checks
- add sqllogictest coverage for nested invokes, multiple arguments, captures, NULL handling, non-SELECT use, restart persistence, and binder errors