### PR TITLE
Add support for RECORDS option for COPY FROM

### DIFF
--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -256,6 +256,25 @@ bool JSONMultiFileInfo::ParseCopyOption(ClientContext &context, const string &ke
 		}
 		return true;
 	}
+	if (loption == "records") {
+		JSONCheckSingleParameter(key, values);
+		auto &val = values.back();
+		if (val.type().id() == LogicalTypeId::BOOLEAN) {
+			options.record_type = BooleanValue::Get(val) ? JSONRecordType::RECORDS : JSONRecordType::VALUES;
+		} else {
+			auto arg = StringUtil::Lower(StringValue::Get(val));
+			if (arg == "auto") {
+				options.record_type = JSONRecordType::AUTO_DETECT;
+			} else if (arg == "true") {
+				options.record_type = JSONRecordType::RECORDS;
+			} else if (arg == "false") {
+				options.record_type = JSONRecordType::VALUES;
+			} else {
+				throw BinderException("COPY (FORMAT JSON) \"records\" parameter must be one of ['auto', 'true', 'false'].");
+			}
+		}
+		return true;
+	}
 	return false;
 }
 
@@ -364,6 +383,9 @@ void JSONMultiFileInfo::FinalizeCopyBind(ClientContext &context, BaseFileReaderO
 	auto &options = reader_options.options;
 	options.name_list = expected_names;
 	options.sql_type_list = expected_types;
+	if (options.record_type == JSONRecordType::VALUES && expected_types.size() != 1) {
+		throw BinderException("COPY (FORMAT JSON) with \"records\" set to 'false' requires a single column.");
+	}
 	if (options.auto_detect && options.format != JSONFormat::ARRAY) {
 		options.format = JSONFormat::AUTO_DETECT;
 	}

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -270,7 +270,8 @@ bool JSONMultiFileInfo::ParseCopyOption(ClientContext &context, const string &ke
 			} else if (arg == "false") {
 				options.record_type = JSONRecordType::VALUES;
 			} else {
-				throw BinderException("COPY (FORMAT JSON) \"records\" parameter must be one of ['auto', 'true', 'false'].");
+				throw BinderException(
+				    "COPY (FORMAT JSON) \"records\" parameter must be one of ['auto', 'true', 'false'].");
 			}
 		}
 		return true;

--- a/test/sql/json/copy_json_records_option.test
+++ b/test/sql/json/copy_json_records_option.test
@@ -10,7 +10,7 @@ COPY (SELECT 1 AS a, 'hello' AS b UNION ALL SELECT 2, 'world') TO '{TEST_DIR}/re
 
 # Setup: write a JSON array of bare scalars using the CSV trick ([0,1,2])
 statement ok
-COPY (SELECT list(range) FROM range(3)) TO '{TEST_DIR}/values.json' (FORMAT CSV, QUOTE '', HEADER 0);
+COPY (SELECT '[0,1,2]') TO '{TEST_DIR}/values.json' (FORMAT CSV, QUOTE '', HEADER 0);
 
 # RECORDS 'true' — read newline-delimited JSON objects into a multi-column table
 statement ok

--- a/test/sql/json/copy_json_records_option.test
+++ b/test/sql/json/copy_json_records_option.test
@@ -1,0 +1,115 @@
+# name: test/sql/json/copy_json_records_option.test
+# description: Test RECORDS option in COPY (FORMAT JSON)
+# group: [json]
+
+require json
+
+# Setup: write a newline-delimited JSON objects file
+statement ok
+COPY (SELECT 1 AS a, 'hello' AS b UNION ALL SELECT 2, 'world') TO '{TEST_DIR}/records.json' (FORMAT JSON);
+
+# Setup: write a JSON array of bare scalars using the CSV trick ([0,1,2])
+statement ok
+COPY (SELECT list(range) FROM range(3)) TO '{TEST_DIR}/values.json' (FORMAT CSV, QUOTE '', HEADER 0);
+
+# RECORDS 'true' — read newline-delimited JSON objects into a multi-column table
+statement ok
+CREATE TABLE tbl_records (a INTEGER, b VARCHAR);
+
+statement ok
+COPY tbl_records FROM '{TEST_DIR}/records.json' (FORMAT JSON, RECORDS 'true');
+
+query IT
+SELECT * FROM tbl_records ORDER BY a;
+----
+1	hello
+2	world
+
+# RECORDS TRUE (unquoted boolean) must also work
+statement ok
+CREATE TABLE tbl_records2 (a INTEGER, b VARCHAR);
+
+statement ok
+COPY tbl_records2 FROM '{TEST_DIR}/records.json' (FORMAT JSON, RECORDS TRUE);
+
+query IT
+SELECT * FROM tbl_records2 ORDER BY a;
+----
+1	hello
+2	world
+
+# RECORDS 'true' with mixed types (INTEGER, VARCHAR, BOOLEAN, DOUBLE)
+statement ok
+COPY (
+    SELECT 10 AS id, 'alice' AS name, true AS active, 1.5 AS score
+    UNION ALL
+    SELECT 20, 'bob', false, 2.7
+) TO '{TEST_DIR}/mixed.json' (FORMAT JSON);
+
+statement ok
+CREATE TABLE tbl_mixed (id INTEGER, name VARCHAR, active BOOLEAN, score DOUBLE);
+
+statement ok
+COPY tbl_mixed FROM '{TEST_DIR}/mixed.json' (FORMAT JSON, RECORDS 'true');
+
+query ITTR
+SELECT * FROM tbl_mixed ORDER BY id;
+----
+10	alice	true	1.5
+20	bob	false	2.7
+
+# RECORDS 'true' with array format (array of objects)
+statement ok
+COPY (
+    SELECT 1 AS x, 'a' AS y
+    UNION ALL
+    SELECT 2, 'b'
+) TO '{TEST_DIR}/array_of_objects.json' (FORMAT JSON, ARRAY TRUE);
+
+statement ok
+CREATE TABLE tbl_array_records (x INTEGER, y VARCHAR);
+
+statement ok
+COPY tbl_array_records FROM '{TEST_DIR}/array_of_objects.json' (FORMAT JSON, ARRAY TRUE, RECORDS 'true');
+
+query IT
+SELECT * FROM tbl_array_records ORDER BY x;
+----
+1	a
+2	b
+
+# RECORDS 'false' (quoted string) — each element maps to a single column
+statement ok
+CREATE TABLE tbl_values (v INTEGER);
+
+statement ok
+COPY tbl_values FROM '{TEST_DIR}/values.json' (FORMAT JSON, ARRAY TRUE, RECORDS 'false');
+
+# RECORDS FALSE (unquoted boolean) must also work
+statement ok
+CREATE TABLE tbl_values2 (v INTEGER);
+
+statement ok
+COPY tbl_values2 FROM '{TEST_DIR}/values.json' (FORMAT JSON, ARRAY TRUE, RECORDS FALSE);
+
+query I
+SELECT * FROM tbl_values ORDER BY v;
+----
+0
+1
+2
+
+# RECORDS 'false' with a multi-column target table must produce a clear error
+statement ok
+CREATE TABLE tbl_multi (a INTEGER, b VARCHAR);
+
+statement error
+COPY tbl_multi FROM '{TEST_DIR}/values.json' (FORMAT JSON, RECORDS 'false');
+----
+<REGEX>:Binder Error.*records.*false.*single column.*
+
+# Invalid RECORDS value must produce a clear error
+statement error
+COPY tbl_values FROM '{TEST_DIR}/values.json' (FORMAT JSON, RECORDS 'maybe');
+----
+<REGEX>:Binder Error.*records.*auto.*true.*false.*


### PR DESCRIPTION
Fixes #23118

The error message thrown when using `COPY FROM` without `RECORDS FALSE` suggests manually specifying the `format` or `records` option.

The expected query is:

```sql id="q7m4ra"
COPY t FROM '/tmp/test.json' (FORMAT JSON, ARRAY TRUE, RECORDS FALSE);
```

However, this currently fails with:

```text id="3p9vke"
Not implemented Error:
Unsupported option for COPY FROM: records
```

### Root cause

`ParseCopyOption` (the `COPY FROM` path) does not handle the `records` option. Additionally, `InitializeOptions` hard-codes `record_type = RECORDS` (JSON object mode) with no way to override it from `COPY`.

The JSON execution path already supports scalar (`VALUES`) mode correctly via `record_type`; the option simply was not exposed through the `COPY` path.

### Solution

1. Add a `records` case in `ParseCopyOption` so `COPY FROM` can configure `record_type`, similar to `read_json`.
2. Add type handling for both:

   * `RECORDS FALSE` (BOOLEAN literal)
   * `RECORDS 'false'` (VARCHAR)

   since `COPY` option values are not automatically cast like table function parameters.
3. Add early validation in `FinalizeCopyBind` for the multi-column + `VALUES` combination, matching the existing validation already enforced by `BindReader` on the `read_json` path.

### Tests

```bash id="1ywx8h"
build/reldebug/test/unittest test/sql/json/copy_json_records_option.test
```