### PR TITLE
Fix selection vector use in Arrow extension callbacks

### DIFF
--- a/src/common/arrow/appender/append_data.cpp
+++ b/src/common/arrow/appender/append_data.cpp
@@ -26,4 +26,18 @@ void ArrowAppendData::AppendValidity(UnifiedVectorFormat &format, idx_t from, id
 	}
 }
 
+void ArrowAppendData::AppendChild(Vector &input, idx_t from, idx_t to, idx_t input_size) {
+	if (extension_data && extension_data->duckdb_to_arrow) {
+		// Convert the DuckDB-typed input into the extension's internal Arrow type before
+		// handing it to the (internal-typed) child appender. Size the internal vector to the
+		// actual input_size: container children can exceed STANDARD_VECTOR_SIZE (e.g. a 2048-row
+		// LIST whose elements average two entries), and duckdb_to_arrow writes input_size values.
+		Vector internal(extension_data->GetInternalType(), MaxValue<idx_t>(input_size, STANDARD_VECTOR_SIZE));
+		extension_data->duckdb_to_arrow(*options.client_context, input, internal, input_size);
+		append_vector(*this, internal, from, to, input_size);
+	} else {
+		append_vector(*this, input, from, to, input_size);
+	}
+}
+
 } // namespace duckdb

--- a/src/common/arrow/appender/fixed_size_list_data.cpp
+++ b/src/common/arrow/appender/fixed_size_list_data.cpp
@@ -23,7 +23,7 @@ void ArrowFixedSizeListData::Append(ArrowAppendData &append_data, Vector &input,
 	auto array_size = ArrayType::GetSize(input.GetType());
 	auto &child_vector = ArrayVector::GetEntry(input);
 	auto &child_data = *append_data.child_data[0];
-	child_data.append_vector(child_data, child_vector, from * array_size, to * array_size, size * array_size);
+	child_data.AppendChild(child_vector, from * array_size, to * array_size, size * array_size);
 	append_data.row_count += size;
 }
 

--- a/src/common/arrow/appender/struct_data.cpp
+++ b/src/common/arrow/appender/struct_data.cpp
@@ -24,7 +24,7 @@ void ArrowStructData::Append(ArrowAppendData &append_data, Vector &input, idx_t 
 	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
 		auto &child = children[child_idx];
 		auto &child_data = *append_data.child_data[child_idx];
-		child_data.append_vector(child_data, *child, from, to, size);
+		child_data.AppendChild(*child, from, to, input_size);
 	}
 	append_data.row_count += size;
 }

--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -49,7 +49,7 @@ void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t f
 	for (idx_t child_idx = 0; child_idx < child_vectors.size(); child_idx++) {
 		auto &child_buffer = append_data.child_data[child_idx];
 		auto &child = child_vectors[child_idx];
-		child_buffer->append_vector(*child_buffer, child, 0, size, size);
+		child_buffer->AppendChild(child, 0, size, size);
 	}
 	append_data.row_count += size;
 }

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/arrow/appender/append_data.hpp"
 #include "duckdb/common/arrow/appender/list.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -19,14 +20,13 @@ ArrowAppender::ArrowAppender(vector<LogicalType> types_p, const idx_t initial_ca
                              unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast)
     : types(std::move(types_p)), options(options) {
 	for (idx_t i = 0; i < types.size(); i++) {
-		unique_ptr<ArrowAppendData> entry;
-		bool bitshift_boolean = types[i].id() == LogicalTypeId::BOOLEAN && !options.arrow_lossless_conversion;
-		if (extension_type_cast.find(i) != extension_type_cast.end() && !bitshift_boolean) {
-			entry = InitializeChild(types[i], initial_capacity, options, extension_type_cast[i]);
-		} else {
-			entry = InitializeChild(types[i], initial_capacity, options);
-		}
-		root_data.push_back(std::move(entry));
+		// Pass any explicit per-column extension override through to InitializeChild; when none
+		// is supplied it auto-resolves the extension (and applies the bitshift_boolean gate) so
+		// children of nested types pick up the same extension SetArrowFormat uses for the schema.
+		auto extension_it = extension_type_cast.find(i);
+		shared_ptr<ArrowTypeExtensionData> extension =
+		    extension_it != extension_type_cast.end() ? extension_it->second : nullptr;
+		root_data.push_back(InitializeChild(types[i], initial_capacity, options, extension));
 	}
 }
 
@@ -38,14 +38,7 @@ void ArrowAppender::Append(DataChunk &input, const idx_t from, const idx_t to, c
 	D_ASSERT(types == input.GetTypes());
 	D_ASSERT(to >= from);
 	for (idx_t i = 0; i < input.ColumnCount(); i++) {
-		if (root_data[i]->extension_data && root_data[i]->extension_data->duckdb_to_arrow) {
-			Vector input_data(root_data[i]->extension_data->GetInternalType());
-			root_data[i]->extension_data->duckdb_to_arrow(*options.client_context, input.data[i], input_data,
-			                                              input_size);
-			root_data[i]->append_vector(*root_data[i], input_data, from, to, input_size);
-		} else {
-			root_data[i]->append_vector(*root_data[i], input.data[i], from, to, input_size);
-		}
+		root_data[i]->AppendChild(input.data[i], from, to, input_size);
 	}
 	row_count += to - from;
 }
@@ -315,12 +308,28 @@ unique_ptr<ArrowAppendData> ArrowAppender::InitializeChild(const LogicalType &ty
                                                            ClientProperties &options,
                                                            const shared_ptr<ArrowTypeExtensionData> &extension_type) {
 	auto result = make_uniq<ArrowAppendData>(options);
+
+	// Resolve the effective extension. An explicit override (from the top-level appender) wins.
+	// Otherwise auto-resolve from DBConfig so nested children use the same extension SetArrowFormat
+	// declares in the schema. BOOLEAN stays plain bit-packed when arrow_lossless_conversion is off
+	// (the bitshift_boolean gate), applied here so it holds at every nesting level.
+	shared_ptr<ArrowTypeExtensionData> effective_extension = extension_type;
+	const bool bitshift_boolean = type.id() == LogicalTypeId::BOOLEAN && !options.arrow_lossless_conversion;
+	if (bitshift_boolean) {
+		effective_extension = nullptr;
+	} else if (!effective_extension && options.client_context) {
+		const auto &db_config = DBConfig::GetConfig(*options.client_context);
+		if (db_config.HasArrowExtension(type)) {
+			effective_extension = db_config.GetArrowExtension(type).GetTypeExtension();
+		}
+	}
+
 	LogicalType array_type = type;
-	if (extension_type) {
-		array_type = extension_type->GetInternalType();
+	if (effective_extension) {
+		array_type = effective_extension->GetInternalType();
 	}
 	InitializeFunctionPointers(*result, array_type);
-	result->extension_data = extension_type;
+	result->extension_data = effective_extension;
 
 	const auto byte_count = (capacity + 7) / 8;
 	result->GetValidityBuffer().reserve(byte_count);

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -351,6 +351,9 @@ struct ArrowBignum {
 
 struct ArrowBool8 {
 	static void ArrowToDuck(ClientContext &context, Vector &source, Vector &result, idx_t count) {
+		// The caller (ColumnArrowToDuckDB) always builds a flat storage vector for the
+		// extension's internal type, so reading it flat is safe.
+		D_ASSERT(source.GetVectorType() == VectorType::FLAT_VECTOR);
 		auto source_ptr = reinterpret_cast<int8_t *>(FlatVector::GetData(source));
 		auto result_ptr = reinterpret_cast<bool *>(FlatVector::GetData(result));
 		for (idx_t i = 0; i < count; i++) {
@@ -358,14 +361,20 @@ struct ArrowBool8 {
 		}
 	}
 	static void DuckToArrow(ClientContext &context, Vector &source, Vector &result, idx_t count) {
+		// The source may be dictionary/constant/sliced (container appenders hand us such
+		// children), so resolve every row through the selection vector. The result is flat,
+		// so its validity is keyed by the logical row index.
 		UnifiedVectorFormat format;
 		source.ToUnifiedFormat(count, format);
-		FlatVector::SetValidity(result, format.validity);
-		auto source_ptr = reinterpret_cast<bool *>(format.data);
-		auto result_ptr = reinterpret_cast<int8_t *>(FlatVector::GetData(result));
+		auto source_ptr = UnifiedVectorFormat::GetData<bool>(format);
+		auto result_ptr = FlatVector::GetData<int8_t>(result);
+		auto &result_validity = FlatVector::Validity(result);
 		for (idx_t i = 0; i < count; i++) {
-			if (format.validity.RowIsValid(i)) {
-				result_ptr[i] = static_cast<int8_t>(source_ptr[i]);
+			auto source_idx = format.sel->get_index(i);
+			if (format.validity.RowIsValid(source_idx)) {
+				result_ptr[i] = static_cast<int8_t>(source_ptr[source_idx]);
+			} else {
+				result_validity.SetInvalid(i);
 			}
 		}
 	}

--- a/src/include/duckdb/common/arrow/appender/append_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/append_data.hpp
@@ -93,6 +93,13 @@ public:
 	}
 	void AppendValidity(UnifiedVectorFormat &format, idx_t from, idx_t to);
 
+	//! Append a (child) vector, routing it through the Arrow extension's duckdb_to_arrow
+	//! conversion first when one is set. Container appenders must call this instead of
+	//! append_vector so nested extension types (e.g. arrow.bool8 BOOLEAN) get the same
+	//! conversion the top-level appender applies, keeping the data layout in sync with
+	//! the schema declared by SetArrowFormat.
+	void AppendChild(Vector &input, idx_t from, idx_t to, idx_t input_size);
+
 public:
 	idx_t row_count = 0;
 	idx_t null_count = 0;

--- a/src/include/duckdb/common/arrow/appender/list_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_data.hpp
@@ -37,7 +37,7 @@ public:
 		auto child_size = child_indices.size();
 		Vector child_copy(child.GetType());
 		child_copy.Slice(child, child_sel, child_size);
-		append_data.child_data[0]->append_vector(*append_data.child_data[0], child_copy, 0, child_size, child_size);
+		append_data.child_data[0]->AppendChild(child_copy, 0, child_size, child_size);
 		append_data.row_count += size;
 	}
 

--- a/src/include/duckdb/common/arrow/appender/list_view_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_view_data.hpp
@@ -39,7 +39,7 @@ public:
 		auto child_size = child_indices.size();
 		Vector child_copy(child.GetType());
 		child_copy.Slice(child, child_sel, child_size);
-		append_data.child_data[0]->append_vector(*append_data.child_data[0], child_copy, 0, child_size, child_size);
+		append_data.child_data[0]->AppendChild(child_copy, 0, child_size, child_size);
 		append_data.row_count += size;
 	}
 

--- a/src/include/duckdb/common/arrow/appender/map_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/map_data.hpp
@@ -56,8 +56,8 @@ public:
 		key_vector_copy.Slice(key_vector, child_sel, list_size);
 		Vector value_vector_copy(value_vector.GetType());
 		value_vector_copy.Slice(value_vector, child_sel, list_size);
-		key_data.append_vector(key_data, key_vector_copy, 0, list_size, list_size);
-		value_data.append_vector(value_data, value_vector_copy, 0, list_size, list_size);
+		key_data.AppendChild(key_vector_copy, 0, list_size, list_size);
+		value_data.AppendChild(value_vector_copy, 0, list_size, list_size);
 
 		append_data.row_count += size;
 		struct_data.row_count += size;

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -206,6 +206,43 @@ TEST_CASE("Test Arrow UNION type roundtrip", "[arrow]") {
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT * FROM union_tbl3", false));
 	REQUIRE(ArrowTestHelper::RunArrowComparison(con, "SELECT * FROM union_tbl3", true));
 }
+
+// Regression for duckdb#22444: under arrow_lossless_conversion a BOOLEAN child of a
+// nested type is declared as arrow.bool8 (byte-packed) in the schema, so its data must
+// be byte-packed too. Nested BOOLEAN children used to be written bit-packed, so every
+// row past the first read back wrong.
+TEST_CASE("Test Arrow nested BOOLEAN roundtrip", "[arrow]") {
+	// BOOLEAN inside each container type.
+	TestArrowRoundtrip("SELECT {'b': (i % 2 = 0)}::STRUCT(b BOOLEAN) AS s FROM range(64) tbl(i)", false, true);
+	TestArrowRoundtrip("SELECT [(i % 2 = 0), (i % 3 = 0)]::BOOLEAN[] AS l FROM range(64) tbl(i)", false, true);
+	TestArrowRoundtrip("SELECT [(i % 2 = 0), true, (i % 3 = 0)]::BOOLEAN[3] AS a FROM range(64) tbl(i)", false, true);
+	TestArrowRoundtrip("SELECT MAP {'x': (i % 2 = 0), 'y': (i % 3 = 0)} AS m FROM range(64) tbl(i)", false, true);
+	TestArrowRoundtrip("SELECT union_value(b := (i % 2 = 0))::UNION(i INT, b BOOLEAN) AS u FROM range(64) tbl(i)",
+	                   false, true);
+
+	// BOOLEAN as a MAP key: keys used to collapse to one byte value, crashing ingest with
+	// a duplicate-key error.
+	TestArrowRoundtrip("SELECT MAP {true: i, false: i + 1} AS m FROM range(64) tbl(i)", false, true);
+
+	// Two levels of nesting.
+	TestArrowRoundtrip("SELECT [{'b': (i % 2 = 0)}]::STRUCT(b BOOLEAN)[] AS l FROM range(64) tbl(i)", false, true);
+}
+
+// A constant BOOLEAN child reaches the arrow.bool8 conversion with a non-identity
+// selection (every row maps to the single value); it must still expand to that value
+// for every row.
+TEST_CASE("Test Arrow constant BOOLEAN child roundtrip", "[arrow]") {
+	TestArrowRoundtrip("SELECT {'c': true, 'v': (i % 2 = 0)}::STRUCT(c BOOLEAN, v BOOLEAN) AS s FROM range(64) tbl(i)",
+	                   false, true);
+	TestArrowRoundtrip("SELECT [true, true]::BOOLEAN[] AS l FROM range(64) tbl(i)", false, true);
+}
+
+// A LIST(BOOLEAN) whose total child element count per chunk exceeds STANDARD_VECTOR_SIZE:
+// guards the converted vector being sized to the actual child count rather than 2048.
+TEST_CASE("Test Arrow large LIST(BOOLEAN) roundtrip", "[arrow]") {
+	TestArrowRoundtrip("SELECT [(i % 2 = 0), (i % 3 = 0), (i % 5 = 0)]::BOOLEAN[] AS l FROM range(10000) tbl(i)", false,
+	                   true);
+}
 TEST_CASE("Test Arrow Extension Types", "[arrow][.]") {
 	// UUID
 	TestArrowRoundtrip("SELECT '2d89ebe6-1e13-47e5-803a-b81c87660b66'::UUID str FROM range(5) tbl(i)", false, true);


### PR DESCRIPTION
Replaces #22445 / fixes #22444

If arrow extensions are used and nested types contain values that should use the extension, we currently do not correctly resolve the extension for those children. E.g. nested BOOLEAN children were written bit-packed even if the Arrow schema declared them as arrow.bool8 (byte-packed) when using `arrow_lossless_conversion`.

In this PR, `InitializeChild` auto-resolves the Arrow extension for child types. `ArrowAppendData::AppendChild` runs the `duckdb_to_arrow` conversion, and all container appenders route through it. The difference with #22445 is that instead of flattening input vectors before the callback, we fixed `ArrowBool8::DuckToArrow` to use the selection vector. This makes sure that e.g. constant vectors are not needlessly expanded. On `ArrowToDuck` I've added a `D_ASSERT` as documentation for the input vector always being flat (which it always should be). The converted vector is also sized to the actual child count to avoid an OOB write on large lists.
