### PR TITLE
[Dev] Fix variant shredding analysis logic discrepancy with shredded writing

### DIFF
--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -29,7 +29,7 @@ public:
 
 	idx_t total_count = 0;
 	//! indices into the top-level 'columns' vector where the stats for the field/element live
-	case_insensitive_map_t<idx_t> field_stats;
+	map<string, idx_t> field_stats;
 	idx_t element_stats = DConstants::INVALID_INDEX;
 };
 

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -29,7 +29,7 @@ public:
 
 	idx_t total_count = 0;
 	//! indices into the top-level 'columns' vector where the stats for the field/element live
-	map<string, idx_t> field_stats;
+	unordered_map<string, idx_t> field_stats;
 	idx_t element_stats = DConstants::INVALID_INDEX;
 };
 

--- a/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+++ b/test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
@@ -1,0 +1,50 @@
+# name: test/sql/storage/types/variant/variant_case_sensitive_fields_shredded.test
+# group: [variant]
+
+load __TEST_DIR__/variant_checkpoint_issue.db readwrite v1.5.3
+
+statement ok
+set variant_minimum_shredding_size = 0;
+
+statement ok
+create or replace table test_structs(
+    id int,
+    s VARIANT
+);
+
+statement ok
+insert into test_structs
+values
+	(1, {
+		'name': {
+			'v': 'row 1',
+			'id': 1
+		},
+		'nested_struct': {
+			'a': 42,
+			'b': true
+		}
+	}),
+	(2, null),
+	(3, {
+		'name': {
+			'v': 'row 3',
+			'id': 3
+		},
+		'nested_struct': {
+			'a': 84,
+			'b': null
+		}
+	}),
+	(4, {
+		'name': null,
+		'nested_struct': {
+			'A': null,
+			'b': false
+		}
+	});
+
+restart
+
+statement ok
+checkpoint;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/9069

During analysis fields were being treated as case-insensitive, but during writing we correctly differentiate the two.
This discrepancy could cause us to hit an internal exception