### PR TITLE
[v1.5] Backport scalar-wrapped agg macros in window

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -33,6 +33,7 @@ class QueryNode;
 class ScalarFunctionCatalogEntry;
 class AggregateFunctionCatalogEntry;
 class ScalarMacroCatalogEntry;
+class ScalarMacroFunction;
 class CatalogEntry;
 class SimpleFunction;
 
@@ -218,6 +219,8 @@ protected:
 	virtual BindResult BindUnnest(FunctionExpression &expr, idx_t depth, bool root_expression);
 	virtual BindResult BindMacro(FunctionExpression &expr, ScalarMacroCatalogEntry &macro, idx_t depth,
 	                             unique_ptr<ParsedExpression> &expr_ptr);
+	void FindAggregateExprs(unique_ptr<ParsedExpression> &expr, vector<reference<unique_ptr<ParsedExpression>>> &exprs);
+	void UnfoldWindowMacroExpression(unique_ptr<ParsedExpression> &expr, ScalarMacroFunction &macro_def);
 	void UnfoldMacroExpression(FunctionExpression &function, ScalarMacroCatalogEntry &macro_func,
 	                           unique_ptr<ParsedExpression> &expr, idx_t depth);
 

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
+#include "duckdb/catalog/entry_lookup_info.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/enums/on_entry_not_found.hpp"
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/function/scalar_macro_function.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
@@ -91,6 +94,55 @@ void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr
 	    *expr, [&](unique_ptr<ParsedExpression> &child) { ReplaceMacroParameters(child, lambda_params); });
 }
 
+// Find aggregate expression children
+void ExpressionBinder::FindAggregateExprs(unique_ptr<ParsedExpression> &expr,
+                                          vector<reference<unique_ptr<ParsedExpression>>> &exprs) {
+	if (expr->GetExpressionType() == ExpressionType::FUNCTION) {
+		auto &fn_expr = expr->Cast<FunctionExpression>();
+
+		// Look up the function in the catalog, check to see if it is actually an aggregate function
+		EntryLookupInfo fn_entry(CatalogType::AGGREGATE_FUNCTION_ENTRY, fn_expr.function_name);
+		auto entry = GetCatalogEntry(fn_expr.catalog, fn_expr.schema, fn_entry, OnEntryNotFound::RETURN_NULL);
+
+		if (entry && entry->type == CatalogType::AGGREGATE_FUNCTION_ENTRY) {
+			exprs.push_back(expr);
+			return;
+		}
+	}
+
+	ParsedExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<ParsedExpression> &child_expr) { FindAggregateExprs(child_expr, exprs); });
+}
+
+void ExpressionBinder::UnfoldWindowMacroExpression(unique_ptr<ParsedExpression> &expr, ScalarMacroFunction &macro_def) {
+	auto macro_copy = macro_def.expression->Copy();
+	vector<reference<unique_ptr<ParsedExpression>>> aggregate_exprs;
+	FindAggregateExprs(macro_copy, aggregate_exprs);
+
+	// Only allowed if the macro body has a single aggregate expression
+	if (aggregate_exprs.size() != 1) {
+		throw BinderException("Window function macro bodies must contain exactly one aggregate function");
+	}
+
+	// The window spec is pushed down to the aggregate function target within the macro body
+	unique_ptr<ParsedExpression> &agg_expr_ref = aggregate_exprs[0];
+	auto &agg_fn_expr = agg_expr_ref->Cast<FunctionExpression>();
+
+	// Transfer the macro function attributes
+	auto &window_expr = expr->Cast<WindowExpression>();
+	window_expr.catalog = agg_fn_expr.catalog;
+	window_expr.schema = agg_fn_expr.schema;
+	window_expr.function_name = agg_fn_expr.function_name;
+	window_expr.children = std::move(agg_fn_expr.children);
+	window_expr.distinct = agg_fn_expr.distinct;
+	window_expr.filter_expr = std::move(agg_fn_expr.filter);
+	// TODO: transfer order_bys when window functions support them
+
+	// Replace the aggregate expression with the new window expression
+	agg_expr_ref = std::move(expr);
+	expr = std::move(macro_copy);
+}
+
 void ExpressionBinder::UnfoldMacroExpression(FunctionExpression &function, ScalarMacroCatalogEntry &macro_func,
                                              unique_ptr<ParsedExpression> &expr, idx_t depth) {
 	// validate the arguments and separate positional and default arguments
@@ -111,21 +163,7 @@ void ExpressionBinder::UnfoldMacroExpression(FunctionExpression &function, Scala
 	// replace current expression with stored macro expression
 	// special case: If this is a window function, then we need to return a window expression
 	if (expr->GetExpressionClass() == ExpressionClass::WINDOW) {
-		//	Only allowed if the expression is a function
-		if (macro_def.expression->GetExpressionType() != ExpressionType::FUNCTION) {
-			throw BinderException("Window function macros must be functions");
-		}
-		auto macro_copy = macro_def.expression->Copy();
-		auto &macro_expr = macro_copy->Cast<FunctionExpression>();
-		// Transfer the macro function attributes
-		auto &window_expr = expr->Cast<WindowExpression>();
-		window_expr.catalog = macro_expr.catalog;
-		window_expr.schema = macro_expr.schema;
-		window_expr.function_name = macro_expr.function_name;
-		window_expr.children = std::move(macro_expr.children);
-		window_expr.distinct = macro_expr.distinct;
-		window_expr.filter_expr = std::move(macro_expr.filter);
-		// TODO: transfer order_bys when window functions support them
+		UnfoldWindowMacroExpression(expr, macro_def);
 	} else {
 		expr = macro_def.expression->Copy();
 	}

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -136,7 +136,11 @@ void ExpressionBinder::UnfoldWindowMacroExpression(unique_ptr<ParsedExpression> 
 	window_expr.children = std::move(agg_fn_expr.children);
 	window_expr.distinct = agg_fn_expr.distinct;
 	window_expr.filter_expr = std::move(agg_fn_expr.filter);
-	// TODO: transfer order_bys when window functions support them
+	// Transfer argument ORDER BYs to the window's argument ordering
+	if (agg_fn_expr.order_bys) {
+		auto clone = agg_fn_expr.order_bys->Copy();
+		window_expr.arg_orders = std::move(clone->Cast<OrderModifier>().orders);
+	}
 
 	// Replace the aggregate expression with the new window expression
 	agg_expr_ref = std::move(expr);

--- a/test/sql/catalog/function/test_window_macro.test
+++ b/test/sql/catalog/function/test_window_macro.test
@@ -29,7 +29,7 @@ statement error
 select my_func(range) OVER () 
 from range(2);
 ----
-mod is not an aggregate function
+Window function macro bodies must contain exactly one aggregate function
 
 # Windowed non-aggregate expression macro
 statement ok
@@ -43,7 +43,7 @@ statement error
 select my_case(range) OVER () 
 from range(2);
 ----
-Window function macros must be functions
+Window function macro bodies must contain exactly one aggregate function
 
 statement error
 CREATE MACRO my_lag(x) AS LAG(x);

--- a/test/sql/json/test_json_group_window_macro.test
+++ b/test/sql/json/test_json_group_window_macro.test
@@ -1,0 +1,23 @@
+# name: test/sql/json/test_json_group_window_macro.test
+# description: Windowed usage of json_group_object / json_group_array macros
+# group: [json]
+
+require json
+
+statement ok
+CREATE TABLE t(g INT, k VARCHAR, v INT);
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 10), (1, 'b', 20), (2, 'c', 30);
+
+query T
+SELECT DISTINCT json_group_object(k, v) OVER (PARTITION BY g) FROM t ORDER BY 1;
+----
+{"a":10,"b":20}
+{"c":30}
+
+query T
+SELECT DISTINCT json_group_array(v) OVER (PARTITION BY g) FROM t ORDER BY 1;
+----
+[10,20]
+[30]

--- a/test/sql/window/test_window_aggregate_macro.test
+++ b/test/sql/window/test_window_aggregate_macro.test
@@ -1,0 +1,30 @@
+# name: test/sql/window/test_window_aggregate_macro.test
+# description: Test acceptable macro use for window aggregates
+# group: [window]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE MACRO tinyint_min(a) as cast(min(a) as tinyint);
+
+statement ok
+CREATE MACRO max_plus_one(a) as 1 + max(a);
+
+statement ok
+create or replace table test as (
+    select unnest(range(1000)) as x
+);
+
+# Standard scalar usage
+query II
+SELECT tinyint_min(x), max_plus_one(x) FROM test;
+----
+0	1000
+
+
+# Whole-table window (same result as above)
+query II
+SELECT DISTINCT tinyint_min(x) OVER (), max_plus_one(x) OVER () FROM test;
+----
+0	1000

--- a/test/sql/window/test_window_aggregate_macro.test
+++ b/test/sql/window/test_window_aggregate_macro.test
@@ -28,3 +28,17 @@ query II
 SELECT DISTINCT tinyint_min(x) OVER (), max_plus_one(x) OVER () FROM test;
 ----
 0	1000
+
+# Argument ORDER BYs transfer to the window's argument ordering
+statement ok
+CREATE MACRO csv_desc(a) as '<' || string_agg(a, ',' ORDER BY a DESC) || '>';
+
+query I
+SELECT csv_desc(x) FROM (VALUES (1), (2), (3)) t(x);
+----
+<3,2,1>
+
+query I
+SELECT DISTINCT csv_desc(x) OVER () FROM (VALUES (1), (2), (3)) t(x);
+----
+<3,2,1>


### PR DESCRIPTION
Backports #23050 to v1.5-variegata. 

Does not include bigger changes from #21963.