### PR TITLE
Zero the inlined buffer in string_t's length-only constructor

### DIFF
--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -40,12 +40,6 @@ public:
 	string_t() = default;
 	explicit string_t(uint32_t len) {
 		value.inlined.length = len;
-		// Zero the inlined buffer. Callers (e.g. StringVector::EmptyString) hand
-		// the resulting string_t to write paths that fill `len` bytes and then
-		// call Finalize(); the unfilled trailing bytes need to be defined so
-		// that copies of the string_t (e.g. through a constant VARIANT BLOB
-		// flowing into StringStats::Update during constant folding) do not
-		// propagate indeterminate bytes.
 		memset(value.inlined.inlined, 0, INLINE_BYTES);
 	}
 	string_t(const char *data, uint32_t len) {

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -40,6 +40,13 @@ public:
 	string_t() = default;
 	explicit string_t(uint32_t len) {
 		value.inlined.length = len;
+		// Zero the inlined buffer. Callers (e.g. StringVector::EmptyString) hand
+		// the resulting string_t to write paths that fill `len` bytes and then
+		// call Finalize(); the unfilled trailing bytes need to be defined so
+		// that copies of the string_t (e.g. through a constant VARIANT BLOB
+		// flowing into StringStats::Update during constant folding) do not
+		// propagate indeterminate bytes.
+		memset(value.inlined.inlined, 0, INLINE_BYTES);
 	}
 	string_t(const char *data, uint32_t len) {
 		value.inlined.length = len;


### PR DESCRIPTION
This is an error that surfaced when checking the R package with valgrind. The fix looks consistent with the more specific constructor just below the change, I'm not sure about the implications.

Claude writes:

StringVector::EmptyString hands out a string_t whose inlined buffer stays indeterminate until the caller writes len bytes and Finalize() zeroes the tail. The 16-byte value is bitwise-copied before that happens, so valgrind tracks the indeterminate bytes into StringValueComparison. Zero the buffer up front, matching what the (const char *, uint32_t) constructor and Finalize() already do.
