### PR TITLE
Initialize all `BaseStatistics` members and zero `stats_union`

### DIFF
--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -12,7 +12,8 @@
 
 namespace duckdb {
 
-BaseStatistics::BaseStatistics() : type(LogicalType::INVALID) {
+BaseStatistics::BaseStatistics() : type(LogicalType::INVALID), has_null(false), has_no_null(false), distinct_count(0) {
+	memset(&stats_union, 0, sizeof(stats_union));
 }
 
 BaseStatistics::BaseStatistics(LogicalType type) {
@@ -20,7 +21,10 @@ BaseStatistics::BaseStatistics(LogicalType type) {
 }
 
 void BaseStatistics::Construct(BaseStatistics &stats, LogicalType type) {
+	stats.has_null = false;
+	stats.has_no_null = false;
 	stats.distinct_count = 0;
+	memset(&stats.stats_union, 0, sizeof(stats.stats_union));
 	stats.type = std::move(type);
 	switch (GetStatsType(stats.type)) {
 	case StatisticsType::LIST_STATS:


### PR DESCRIPTION
I've seen Valgrind complaining when the move constructor touches fields which are not initialized by default constructors. I can't tell whether this problem is "harmless by design" or whether we should really initialize and rely on the compiler optimizing it out where it matters.

Claude writes:

The default constructor and `Construct()` left `has_null`, `has_no_null` and `stats_union` (including its padding bytes) indeterminate; copies made during statistics propagation in the optimizer can read those bytes before `CreateEmpty`/`CreateUnknown` overwrite them, which valgrind flags in `StringValueComparison`. The new values match `InitializeEmpty()`, so behaviour is unchanged.
