### PR TITLE
Initialize `TransactionContext::invalidation_policy` and `auto_rollback`

### DIFF
--- a/src/include/duckdb/transaction/transaction_context.hpp
+++ b/src/include/duckdb/transaction/transaction_context.hpp
@@ -72,8 +72,8 @@ public:
 private:
 	ClientContext &context;
 	bool auto_commit;
-	TransactionInvalidationPolicy invalidation_policy;
-	bool auto_rollback;
+	TransactionInvalidationPolicy invalidation_policy = TransactionInvalidationPolicy::STANDARD_POLICY;
+	bool auto_rollback = false;
 
 	unique_ptr<MetaTransaction> current_transaction;
 


### PR DESCRIPTION
Another Valgrind error.

`auto_commit` is initialized in the constructor, so perhaps `auto_rollback` should be too. On the other hand, I imagine that this fancy new syntax will propagate to all constructor types. Happy to adapt the initialization to the existing style.

I also wonder if we can add deterministic static analysis that detects missing initializers.

Claude writes:

Both members are only written via `SetInvalidationPolicy` / `SetAutoRollback`, which never run for auto-commit connections, yet `ClientContext::ErrorInvalidatesTransaction` reads the policy. Initialize them in-class with the same defaults that `TransactionInfo` uses.
