### PR TITLE
Out-of-line `SelectionData` destructor to silence g++-16 `-Warray-bounds`

### DIFF
--- a/src/common/types/selection_vector.cpp
+++ b/src/common/types/selection_vector.cpp
@@ -16,6 +16,8 @@ SelectionData::SelectionData(idx_t count) {
 #endif
 }
 
+SelectionData::~SelectionData() = default;
+
 // LCOV_EXCL_START
 string SelectionVector::ToString(idx_t count) const {
 	string result = "Selection Vector (" + to_string(count) + ") [";

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -19,6 +19,11 @@ class VectorBuffer;
 
 struct SelectionData {
 	DUCKDB_API explicit SelectionData(idx_t count);
+	// Out-of-line destructor: prevents GCC IPA-ICF from folding
+	// _Sp_counted_ptr_inplace<SelectionData>::_M_dispose with the
+	// corresponding instantiation for TemplatedValidityData, which produces
+	// a spurious -Warray-bounds with g++ >= 14.
+	DUCKDB_API ~SelectionData();
 
 	AllocatedData owned_data;
 };


### PR DESCRIPTION
From what I remember, the underlying issue is fairly old, and we shouldn't hold our breath. I understand very little about what's happening here, but can confirm that this change silences the warning (that is checked by CRAN).

Claude writes:

GCC 14+ emits a spurious array-bounds warning when IPA-ICF folds the `shared_ptr` dispose specialization of `SelectionData` with the structurally similar one of `TemplatedValidityData`. A user-declared out-of-line (defaulted) destructor keeps the disposal sequence non-inline at the call site and avoids the false positive; behaviour is unchanged.
