### PR TITLE
parquet: initialize `ParquetReader::rows_read`

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -160,7 +160,7 @@ public:
 	unique_ptr<ParquetColumnSchema> root_schema;
 	shared_ptr<EncryptionUtil> encryption_util;
 	//! How many rows have been read from this file
-	atomic<idx_t> rows_read;
+	atomic<idx_t> rows_read {0};
 
 public:
 	string GetReaderType() const override {


### PR DESCRIPTION
Another Valgrind warning that went away after this change.

Question similar to #23203: do we support/use this new syntax, or should all initialization happen (perhaps redundantly) in the specific constructors?

Claude writes:

The `OpenFileInfo` constructor of `ParquetReader` does not list `rows_read` in its initializer list, leaving the atomic counter with uninitialized storage. Valgrind flags the read in `GetProgressInFile`, from where the taint propagates into the pipeline progress machinery.
