### PR TITLE
Quote special object keys in json_each/json_tree fullkey and path

### DIFF
--- a/extension/json/json_functions/json_table_in_out.cpp
+++ b/extension/json/json_functions/json_table_in_out.cpp
@@ -1,5 +1,6 @@
 #include "json_common.hpp"
 #include "json_functions.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table_function.hpp"
 
 namespace duckdb {
@@ -100,6 +101,40 @@ static unique_ptr<GlobalTableFunctionState> JSONTableInOutInitGlobal(ClientConte
 	return std::move(result);
 }
 
+//! Whether an object key can appear unquoted in a JSON path (as in "$.key"). Mirrors SQLite's json_each/json_tree:
+//! only keys consisting of an ASCII letter followed by ASCII alphanumerics/underscores go unquoted
+static bool JSONPathKeyNeedsQuoting(const char *data, const idx_t len) {
+	if (len == 0 || !StringUtil::CharacterIsAlpha(data[0])) {
+		return true;
+	}
+	for (idx_t i = 1; i < len; i++) {
+		if (!StringUtil::CharacterIsAlphaNumeric(data[i]) && data[i] != '_') {
+			return true;
+		}
+	}
+	return false;
+}
+
+//! Appends ".key" to the path, quoting the key (as in "$.\"a.b\"") when needed so that the resulting path
+//! round-trips through JSON path extraction (issue #23148)
+static void AppendObjectPathElement(yyjson_val *vkey, string &path) {
+	const auto data = unsafe_yyjson_get_str(vkey);
+	const auto len = unsafe_yyjson_get_len(vkey);
+	path += '.';
+	if (!JSONPathKeyNeedsQuoting(data, len)) {
+		path.append(data, len);
+		return;
+	}
+	path += '"';
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] == '"' || data[i] == '\\') {
+			path += '\\';
+		}
+		path += data[i];
+	}
+	path += '"';
+}
+
 struct JSONTableInOutRecursionNode {
 	JSONTableInOutRecursionNode(string path_p, yyjson_val *parent_val_p)
 	    : path(std::move(path_p)), parent_val(parent_val_p), child_index(0) {
@@ -127,7 +162,7 @@ struct JSONTableInOutLocalState : LocalTableFunctionState {
 	void AddRecursionNode(yyjson_val *val, optional_ptr<yyjson_val> vkey, const optional_idx arr_index) {
 		string str;
 		if (vkey) {
-			str = "." + string(unsafe_yyjson_get_str(vkey.get()), unsafe_yyjson_get_len(vkey.get()));
+			AppendObjectPathElement(vkey.get(), str);
 		} else if (arr_index.IsValid()) {
 			str = "[" + to_string(arr_index.GetIndex()) + "]";
 		}
@@ -213,8 +248,9 @@ struct JSONTableInOutResult {
 		const auto path_str = lstate.GetPath();
 		if (fullkey.enabled) {
 			if (vkey) { // Object field
-				const auto vkey_str = string(unsafe_yyjson_get_str(vkey.get()), unsafe_yyjson_get_len(vkey.get()));
-				fullkey.data[count] = StringVector::AddString(fullkey.vector, path_str + "." + vkey_str);
+				auto fullkey_str = path_str;
+				AppendObjectPathElement(vkey.get(), fullkey_str);
+				fullkey.data[count] = StringVector::AddString(fullkey.vector, fullkey_str);
 			} else if (arr_el) { // Array element
 				const auto arr_path = "[" + to_string(recursion_nodes.back().child_index) + "]";
 				fullkey.data[count] = StringVector::AddString(fullkey.vector, path_str + arr_path);

--- a/test/sql/json/table/json_table_in_out_fullkey_quoting.test
+++ b/test/sql/json/table/json_table_in_out_fullkey_quoting.test
@@ -1,0 +1,107 @@
+# name: test/sql/json/table/json_table_in_out_fullkey_quoting.test
+# description: Test that json_each/json_tree quote object keys in fullkey/path when needed (issue #23148)
+# group: [table]
+
+require json
+
+# the exact repro from issue #23148: a key containing a '.' must be quoted in fullkey
+query II
+SELECT fullkey, value FROM json_each('{"a.b": 1}')
+----
+$."a.b"	1
+
+# the fullkey must round-trip through json_extract
+query I
+SELECT json_extract('{"a.b": 1}', fullkey) FROM json_each('{"a.b": 1}')
+----
+1
+
+# same for json_tree: fullkey and path of descendants must quote the special key
+query III
+SELECT key, fullkey, path FROM json_tree('{"a.b": {"c": [1, 2]}}')
+----
+NULL	$	$
+a.b	$."a.b"	$
+c	$."a.b".c	$."a.b"
+0	$."a.b".c[0]	$."a.b".c
+1	$."a.b".c[1]	$."a.b".c
+
+# every fullkey in the tree round-trips: extracting it from the original JSON yields the row's value
+query I
+SELECT count(*)
+FROM json_tree('{"a.b": {"c": [1, 2]}}')
+WHERE json_extract('{"a.b": {"c": [1, 2]}}', fullkey) IS DISTINCT FROM value
+----
+0
+
+# quoting rule matches SQLite: unquoted only if the key is an ASCII letter
+# followed by ASCII alphanumerics/underscores
+query II
+SELECT key, fullkey FROM json_each('{"x1": 1, "Ab": 2, "a_b": 3}')
+----
+x1	$.x1
+Ab	$.Ab
+a_b	$.a_b
+
+query II
+SELECT key, fullkey FROM json_each('{"a.b": 1, "a b": 2, "0a": 3, "_x": 4, "*": 5, "a[0]": 6}')
+----
+a.b	$."a.b"
+a b	$."a b"
+0a	$."0a"
+_x	$."_x"
+*	$."*"
+a[0]	$."a[0]"
+
+# quotes and backslashes within keys are escaped inside the quoted key
+query II
+SELECT key, fullkey FROM json_each('{"a\"b": 1}')
+----
+a"b	$."a\"b"
+
+query II
+SELECT key, fullkey FROM json_each('{"a\\b": 1}')
+----
+a\b	$."a\\b"
+
+# non-ASCII keys are quoted
+query II
+SELECT key, fullkey FROM json_each('{"é": 1}')
+----
+é	$."é"
+
+# the empty key is quoted (matches SQLite's fullkey output)
+query II
+SELECT key, fullkey FROM json_each('{"": 1}')
+----
+(empty)	$.""
+
+# all of these round-trip through json_extract
+# (the empty key and the literal '*' key are excluded: our path parser does not yet accept an
+#  empty quoted key, and a quoted '*' is interpreted as a wildcard - both pre-existing limitations)
+query I
+SELECT count(*)
+FROM json_each('{"a.b": 1, "a b": 2, "0a": 3, "_x": 4, "a[0]": 6, "a\"b": 7, "a\\b": 8, "é": 9, "x1": 10}')
+WHERE json_extract('{"a.b": 1, "a b": 2, "0a": 3, "_x": 4, "a[0]": 6, "a\"b": 7, "a\\b": 8, "é": 9, "x1": 10}',
+                   fullkey) IS DISTINCT FROM value
+----
+0
+
+# quoting also applies when starting from a nested path argument
+query II
+SELECT key, fullkey FROM json_each('{"nested": {"a.b": 1}}', '$.nested')
+----
+a.b	$.nested."a.b"
+
+query I
+SELECT json_extract('{"nested": {"a.b": 1}}', fullkey) FROM json_each('{"nested": {"a.b": 1}}', '$.nested')
+----
+1
+
+# recursion through arrays of objects with special keys
+query III
+SELECT key, fullkey, path FROM json_tree('[{"a.b": 42}]')
+----
+NULL	$	$
+0	$[0]	$
+a.b	$[0]."a.b"	$[0]


### PR DESCRIPTION
Fixes #23148.

`json_each`/`json_tree` build the `fullkey` and `path` columns by appending `'.' || key` verbatim, so a key containing path-special characters (like `a.b`) produces `$.a.b`, which misparses on the way back through `json_extract` and returns NULL.

SQLite (whose `json_each`/`json_tree` these functions follow) quotes such keys: a key goes unquoted only when it is an ASCII letter followed by ASCII alphanumerics/underscores; anything else is wrapped in double quotes with `"` and `\` backslash-escaped, e.g. `$."a.b"`. This PR applies the same rule in `AddRow` (the `fullkey` column) and `AddRecursionNode` (the recursion-path prefix, which also feeds the `path` column of descendants), so every emitted fullkey now round-trips through our own path parser, including `a"b`, which SQLite itself emits as `$."a\"b"` but then fails to re-parse, while our quoted-key reader handles it.

Two pre-existing parser limitations are visible in (but not introduced by) this change, noted in the new test: an empty quoted key (`$.""`) is rejected by `ValidatePath` (the old output for an empty key, `$.`, didn't parse either), and a quoted `"*"` is still interpreted as a wildcard, so a literal `*` key can't be addressed. Happy to follow up on either separately.

Added a regression test covering the issue's repro, the `json_tree` fullkey/path table, the SQLite quoting-boundary cases, and `json_extract` round-trips.