### PR TITLE
Remove special formatting code for main CMakeLists.txt

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -428,11 +428,7 @@ def format_directory(directory):
 
 files = []
 if format_all:
-    try:
-        os.system(cmake_format_command.replace("${FILE}", "CMakeLists.txt"))
-    except:
-        pass
-
+    files.append('CMakeLists.txt')
     for direct in formatted_directories:
         files += format_directory(direct)
 


### PR DESCRIPTION
There's special formatting code for the main `CMakeLists.txt` which runs old in-place formatting code. This can cause the file to get deleted when the formatting is interrupted. Instead just format using the standard channel.