### PR TITLE
Fix VARIANT shredding, avoid including empty object keys

### DIFF
--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -427,6 +427,10 @@ bool VariantShreddingStats::GetShreddedTypeInternal(const VariantColumnStatsData
 		child_list_t<LogicalType> child_types;
 		for (auto &entry : column.field_stats) {
 			auto &child_column = GetColumnStats(entry.second);
+			if (entry.first.empty()) {
+				//! Do not include empty field names in the shredded type!
+				continue;
+			}
 			LogicalType child_type;
 			if (GetShreddedTypeInternal(child_column, child_type, total_value_count)) {
 				child_types.emplace_back(entry.first, child_type);
@@ -770,7 +774,18 @@ void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t co
 	for (idx_t i = 0; i < count; i++) {
 		auto input_val = input.GetValue(i);
 		auto roundtripped_val = roundtrip_result.GetValue(i);
-		if (!ValueOperations::NotDistinctFrom(input_val, roundtripped_val)) {
+
+		Vector input_vec(input_val, count_t(1));
+		Vector roundtripped_vec(roundtripped_val, count_t(1));
+
+		Vector normalized_input(LogicalType::VARIANT(), count_t(1));
+		Vector normalized_roundtrip(LogicalType::VARIANT(), count_t(1));
+		VariantNormalizer::Normalize(input_vec, normalized_input);
+		VariantNormalizer::Normalize(roundtripped_vec, normalized_roundtrip);
+
+		auto normalized_input_value = normalized_input.GetValue(0);
+		auto normalized_roundtrip_value = normalized_roundtrip.GetValue(0);
+		if (!ValueOperations::NotDistinctFrom(normalized_input_value, normalized_roundtrip_value)) {
 			throw InternalException("Shredding roundtrip verification failed for row: %d, expected: %s, actual: %s", i,
 			                        input_val.ToString(), roundtripped_val.ToString());
 		}

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -775,13 +775,13 @@ void VariantColumnData::ShredVariantData(Vector &input, Vector &output, idx_t co
 		auto input_val = input.GetValue(i);
 		auto roundtripped_val = roundtrip_result.GetValue(i);
 
-		Vector input_vec(input_val, count_t(1));
-		Vector roundtripped_vec(roundtripped_val, count_t(1));
+		Vector input_vec(input_val);
+		Vector roundtripped_vec(roundtripped_val);
 
-		Vector normalized_input(LogicalType::VARIANT(), count_t(1));
-		Vector normalized_roundtrip(LogicalType::VARIANT(), count_t(1));
-		VariantNormalizer::Normalize(input_vec, normalized_input);
-		VariantNormalizer::Normalize(roundtripped_vec, normalized_roundtrip);
+		Vector normalized_input(LogicalType::VARIANT(), 1);
+		Vector normalized_roundtrip(LogicalType::VARIANT(), 1);
+		VariantNormalizer::Normalize(input_vec, normalized_input, 1);
+		VariantNormalizer::Normalize(roundtripped_vec, normalized_roundtrip, 1);
 
 		auto normalized_input_value = normalized_input.GetValue(0);
 		auto normalized_roundtrip_value = normalized_roundtrip.GetValue(0);

--- a/test/sql/storage/types/variant/variant_shredding_empty_keys.test
+++ b/test/sql/storage/types/variant/variant_shredding_empty_keys.test
@@ -1,0 +1,38 @@
+# name: test/sql/storage/types/variant/variant_shredding_empty_keys.test
+# group: [variant]
+
+require json
+
+load {TEST_DIR}/repro_eka.db readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size=0;
+
+statement ok
+create table succeeds as SELECT '{"": 1, "x": {"y": "t"}}'::JSON::VARIANT;
+
+statement ok
+checkpoint;
+
+restart
+
+statement ok
+select * from succeeds;
+
+statement ok
+create table fails as SELECT '{"x": "hello", "": "world"}'::JSON::VARIANT AS j;
+
+restart
+
+statement ok
+CHECKPOINT
+
+query I
+select * from fails;
+----
+(world, hello)
+
+query I
+select * from succeeds;
+----
+(1, {'y': t})


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/9647

Because we don't support unnamed structs in the storage layer, we have to avoid empty keys in the shredding.
This also exposed another problem with our roundtrip verification.
If structs are partially shredded (both unshredded and shredded value), these have to be merged and the result is unpredictable.
To fix this, we add normalize to it.

As mentioned in a comment below, due to DuckDB STRUCTs being either named (no empty field names) or unnamed (unnamed tuple), partially named structs (1 or more fields are "") aren't possible and the other named fields will have their names stripped.