### PR TITLE
Fix in remote pushdown optimizer for query macro 

### DIFF
--- a/src/optimizer/remote_pushdown_optimizer.cpp
+++ b/src/optimizer/remote_pushdown_optimizer.cpp
@@ -607,6 +607,17 @@ CatalogPushdownResult RemotePushdownOptimizer::RewriteTableFunctionOnly(TableFun
 	if (!catalog_name.empty()) {
 		auto catalog = Catalog::GetCatalogEntry(binder.context, catalog_name);
 		if (catalog && catalog->Supports(RemoteCapability::EXECUTE_QUERY_NODE) && catalog->SupportsPushdown(ref)) {
+			// special case for query
+			if (func_expr.FunctionName() == "query") {
+				const auto &lookup_schema = schema_name.empty() ? Identifier(DEFAULT_SCHEMA) : schema_name;
+				EntryLookupInfo macro_lookup(CatalogType::TABLE_FUNCTION_ENTRY, func_expr.FunctionName());
+				auto entry = Catalog::GetEntry(binder.context, catalog_name, lookup_schema, macro_lookup,
+				                               OnEntryNotFound::RETURN_NULL);
+				if (entry && entry->type == CatalogType::TABLE_MACRO_ENTRY) {
+					TrackLocalTable(ref);
+					return CatalogPushdownResult::Unknown();
+				}
+			}
 			// "catalog" is remote and we can pushdown this function
 			return CatalogPushdownResult::RemoteReference(*catalog);
 		}


### PR DESCRIPTION
In quack there exists a `query()` macro, which should be used like `<quack_catalog>.query()`. This works fine for single statement inputs, but fails for multiple statements. 

Currently, the `RemotePushdownOptimizer` intercepts `<quack_catalog>.query()` and serializes it back as a SQL string _before_ the binder gets a chance to expand the query macro into `quack_query_by_name()`. This leads to a CI failure in quack, because of an `Invalid Input Error: Expected a single SELECT statement` error. 

This PR should fix this by special casing the `query()` function in the remote pushdown optimizer. 

fixes https://github.com/duckdblabs/duckdb-internal/issues/9657



