### PR TITLE
Re-fix fsync implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,12 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
   set(SUN TRUE)
 endif()
 
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(fdatasync "unistd.h" DUCKDB_HAVE_FDATASYNC)
+if(DUCKDB_HAVE_FDATASYNC)
+  add_definitions(-DDUCKDB_HAVE_FDATASYNC=1)
+endif()
+
 if (OVERRIDE_GIT_DESCRIBE MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+$")
   if (DUCKDB_EXPLICIT_VERSION)
     if (DUCKDB_EXPLICIT_PLATFORM STREQUAL DUCKDB_EXPLICIT_PLATFORM)

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -764,19 +764,19 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 void LocalFileSystem::FileSync(FileHandle &handle) {
 	int fd = handle.Cast<UnixFileHandle>().fd;
 
-#if HAVE_FULLFSYNC
+#ifdef F_FULLFSYNC
 	// On macOS and iOS, fsync() doesn't guarantee durability past power failures. fcntl(F_FULLFSYNC) is required for
 	// that purpose. Some filesystems don't support fcntl(F_FULLFSYNC), and require a fallback to fsync().
 	if (::fcntl(fd, F_FULLFSYNC) == 0) {
 		return;
 	}
-#endif // HAVE_FULLFSYNC
+#endif // F_FULLFSYNC
 
-#if HAVE_FDATASYNC
+#ifdef DUCKDB_HAVE_FDATASYNC
 	bool sync_success = ::fdatasync(fd) == 0;
 #else
 	bool sync_success = ::fsync(fd) == 0;
-#endif // HAVE_FDATASYNC
+#endif // DUCKDB_HAVE_FDATASYNC
 
 	if (sync_success) {
 		return;


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/9664

The issue description is correct, use leveldb's implementation as reference
- `HAVE_FULLFSYNC` is defined [here](https://github.com/google/leveldb/blob/7ee830d02b623e8ffe0b95d59a74db1e58da04c5/CMakeLists.txt#L53) and used [here](https://github.com/google/leveldb/blob/7ee830d02b623e8ffe0b95d59a74db1e58da04c5/util/env_posix.cc#L398)
- `HAVE_FDATASYNC` is defined [here](https://github.com/google/leveldb/blob/7ee830d02b623e8ffe0b95d59a74db1e58da04c5/CMakeLists.txt#L52) and used [here](https://github.com/google/leveldb/blob/7ee830d02b623e8ffe0b95d59a74db1e58da04c5/util/env_posix.cc#L408)