### PR TITLE
Hopefully fix timeouts on `v1.5-variegata`

### DIFF
--- a/test/configs/enable_verification_for_debug.json
+++ b/test/configs/enable_verification_for_debug.json
@@ -281,7 +281,7 @@
         "test/sql/join/full_outer/full_outer_join_union.test",
         "test/sql/join/full_outer/test_full_outer_join_issue_4252.test",
         "test/sql/join/iejoin/iejoin_issue_7278.test",
-        "test/sql/join/iejoin/iejoin_projection_maps.test",
+        "test/sql/join/iejoin/iejoin_projection_maps.test_slow",
         "test/sql/join/iejoin/predicate_expressions.test",
         "test/sql/join/iejoin/test_iejoin.test",
         "test/sql/join/inner/join_cache.test",

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -179,7 +179,7 @@
     {
       "reason": "Too many columns (20k) exceeds CSV field size limit in compatibility test script.",
       "paths": [
-        "test/sql/join/test_hash_join_many_columns.test"
+        "test/sql/join/test_hash_join_many_columns.test_slow"
       ]
     }
   ]

--- a/test/sql/join/iejoin/iejoin_projection_maps.test_slow
+++ b/test/sql/join/iejoin/iejoin_projection_maps.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/join/iejoin/iejoin_projection_maps.test
+# name: test/sql/join/iejoin/iejoin_projection_maps.test_slow
 # description: Test IEJoin projection mapping
 # group: [iejoin]
 

--- a/test/sql/join/test_hash_join_many_columns.test_slow
+++ b/test/sql/join/test_hash_join_many_columns.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/join/test_hash_join_many_columns.test
+# name: test/sql/join/test_hash_join_many_columns.test_slow
 # description: Divide by 0 in GetPartitioningSpaceRequirement, inlined by PhysicalHashJoin::PrepareFinalize when running a query with 20k columns (PR #21271)
 # group: [join]
 


### PR DESCRIPTION
One batch was on the edge for a long time, just got pushed over. I've renamed the two slowest tests to `.test_slow`