### PR TITLE
Rework `quantile` to use `list` infrastructure

### DIFF
--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -174,7 +174,7 @@ template <typename MEDIAN_TYPE>
 struct MedianAbsoluteDeviationOperation : QuantileOperation {
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		if (state.v.empty()) {
+		if (state.v.total_capacity == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
@@ -183,11 +183,12 @@ struct MedianAbsoluteDeviationOperation : QuantileOperation {
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
 		const auto &q = bind_data.quantiles[0];
-		QuantileInterpolator<false> interp(q, state.v.size(), false);
-		const auto med = interp.template Operation<INPUT_TYPE, MEDIAN_TYPE>(state.v.data(), finalize_data.result);
+		auto &flattened = FlattenedQuantileValues<INPUT_TYPE>::Flatten(finalize_data, state.v);
+		QuantileInterpolator<false> interp(q, state.v.total_capacity, false);
+		const auto med = interp.template Operation<INPUT_TYPE, MEDIAN_TYPE>(flattened.Data(), finalize_data.result);
 
 		MadAccessor<INPUT_TYPE, T, MEDIAN_TYPE> accessor(med);
-		target = interp.template Operation<INPUT_TYPE, T>(state.v.data(), finalize_data.result, accessor);
+		target = interp.template Operation<INPUT_TYPE, T>(flattened.Data(), finalize_data.result, accessor);
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -159,15 +159,16 @@ template <bool DISCRETE, class TYPE_OP = QuantileStandardType>
 struct QuantileScalarOperation : public QuantileOperation {
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		if (state.v.empty()) {
+		if (state.v.total_capacity == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
 		D_ASSERT(finalize_data.input.bind_data);
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		QuantileInterpolator<DISCRETE> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
-		target = interp.template Operation<typename STATE::InputType, T>(state.v.data(), finalize_data.result);
+		auto &flattened = FlattenedQuantileValues<typename STATE::InputType>::Flatten(finalize_data, state.v);
+		QuantileInterpolator<DISCRETE> interp(bind_data.quantiles[0], state.v.total_capacity, bind_data.desc);
+		target = interp.template Operation<typename STATE::InputType, T>(flattened.Data(), finalize_data.result);
 	}
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
@@ -234,15 +235,16 @@ struct QuantileScalarFallback : QuantileOperation {
 
 	template <class STATE>
 	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
-		if (state.v.empty()) {
+		if (state.v.total_capacity == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
 		D_ASSERT(finalize_data.input.bind_data);
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		QuantileInterpolator<true> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
-		auto interpolation_result = interp.InterpolateInternal<string_t>(state.v.data());
+		auto &flattened = FlattenedQuantileValues<string_t>::Flatten(finalize_data, state.v);
+		QuantileInterpolator<true> interp(bind_data.quantiles[0], state.v.total_capacity, bind_data.desc);
+		auto interpolation_result = interp.InterpolateInternal<string_t>(flattened.Data());
 		CreateSortKeyHelpers::DecodeSortKey(interpolation_result, finalize_data.result, finalize_data.result_idx,
 		                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 	}
@@ -255,7 +257,7 @@ template <class CHILD_TYPE, bool DISCRETE>
 struct QuantileListOperation : QuantileOperation {
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		if (state.v.empty()) {
+		if (state.v.total_capacity == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
@@ -268,7 +270,8 @@ struct QuantileListOperation : QuantileOperation {
 		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 		auto rdata = FlatVector::GetDataMutable<CHILD_TYPE>(result);
 
-		auto v_t = state.v.data();
+		auto &flattened = FlattenedQuantileValues<typename STATE::InputType>::Flatten(finalize_data, state.v);
+		auto v_t = flattened.Data();
 		D_ASSERT(v_t);
 
 		auto &entry = target;
@@ -276,7 +279,7 @@ struct QuantileListOperation : QuantileOperation {
 		idx_t lower = 0;
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			QuantileInterpolator<DISCRETE> interp(quantile, state.v.size(), bind_data.desc);
+			QuantileInterpolator<DISCRETE> interp(quantile, state.v.total_capacity, bind_data.desc);
 			interp.begin = lower;
 			rdata[ridx + q] = interp.template Operation<typename STATE::InputType, CHILD_TYPE>(v_t, result);
 			lower = interp.FRN;
@@ -342,7 +345,7 @@ struct QuantileListFallback : QuantileOperation {
 
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		if (state.v.empty()) {
+		if (state.v.total_capacity == 0) {
 			finalize_data.ReturnNull();
 			return;
 		}
@@ -354,16 +357,16 @@ struct QuantileListFallback : QuantileOperation {
 		auto ridx = ListVector::GetListSize(finalize_data.result);
 		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 
-		D_ASSERT(state.v.data());
+		auto &flattened = FlattenedQuantileValues<string_t>::Flatten(finalize_data, state.v);
 
 		auto &entry = target;
 		entry.offset = ridx;
 		idx_t lower = 0;
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			QuantileInterpolator<true> interp(quantile, state.v.size(), bind_data.desc);
+			QuantileInterpolator<true> interp(quantile, state.v.total_capacity, bind_data.desc);
 			interp.begin = lower;
-			auto interpolation_result = interp.InterpolateInternal<string_t>(state.v.data());
+			auto interpolation_result = interp.InterpolateInternal<string_t>(flattened.Data());
 			CreateSortKeyHelpers::DecodeSortKey(interpolation_result, result, ridx + q,
 			                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 			lower = interp.FRN;

--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -9,9 +9,54 @@
 #pragma once
 
 #include "core_functions/aggregate/quantile_sort_tree.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/list_segment.hpp"
 #include "SkipList.h"
 
 namespace duckdb {
+
+//! Flattens the values of a linked list into a contiguous array for interpolation.
+//! The flattened values are mutable - the interpolators partially sort them in place.
+//! The flattened chunk is cached in the finalize data's local state, so that it is allocated (at most) once per
+//! result chunk instead of once per finalized group.
+template <class INPUT_TYPE>
+struct FlattenedQuantileValues : FunctionLocalState {
+	FlattenedQuantileValues(const LogicalType &type, idx_t capacity_p) : capacity(capacity_p) {
+		chunk.Initialize(Allocator::DefaultAllocator(), {type}, capacity_p);
+	}
+
+	//! Flatten the values of the given linked list into the chunk cached in the finalize data
+	static FlattenedQuantileValues &Flatten(AggregateFinalizeData &finalize_data, const LinkedList &linked_list) {
+		const auto type = PrimitiveToLogicalType<INPUT_TYPE>();
+		const auto required_capacity = MaxValue<idx_t>(linked_list.total_capacity, 1);
+		if (!finalize_data.local_state) {
+			finalize_data.local_state = make_uniq<FlattenedQuantileValues>(type, NextPowerOfTwo(required_capacity));
+		}
+		auto &values = finalize_data.local_state->Cast<FlattenedQuantileValues>();
+		if (values.capacity < required_capacity) {
+			// grow the cached chunk
+			values.capacity = NextPowerOfTwo(required_capacity);
+			values.chunk.Destroy();
+			values.chunk.Initialize(Allocator::DefaultAllocator(), {type}, values.capacity);
+		} else {
+			// re-use the allocated chunk - resetting clears the string heap of the previously flattened state
+			values.chunk.Reset();
+		}
+		ListSegmentFunctions functions;
+		GetSegmentDataFunctions(functions, type);
+		functions.BuildListVector(linked_list, values.chunk.data[0], 0);
+		return values;
+	}
+
+	INPUT_TYPE *Data() {
+		return FlatVector::GetDataMutable<INPUT_TYPE>(chunk.data[0]);
+	}
+
+	//! The flattened values (a single-column chunk) - strings are materialized into the chunk's string heap
+	DataChunk chunk;
+	//! The allocated capacity of the chunk
+	idx_t capacity;
+};
 
 struct QuantileOperation {
 	template <class STATE>
@@ -33,11 +78,23 @@ struct QuantileOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-		if (source.v.empty()) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
+		if (source.v.total_capacity == 0) {
 			return;
 		}
-		target.v.insert(target.v.end(), source.v.begin(), source.v.end());
+		if (input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
+			// append the source linked list to the target
+			if (target.v.total_capacity == 0) {
+				target.v = source.v;
+			} else {
+				target.v.last_segment->next = source.v.first_segment;
+				target.v.last_segment = source.v.last_segment;
+				target.v.total_capacity += source.v.total_capacity;
+			}
+			return;
+		}
+		// we cannot absorb the source - copy the values by traversing the linked list
+		ListSegmentCopy<typename STATE::InputType>(input_data.allocator, source.v, target.v);
 	}
 
 	template <class STATE>
@@ -266,15 +323,15 @@ struct QuantileState {
 	using InputType = INPUT_TYPE;
 	using CursorType = QuantileCursor<INPUT_TYPE>;
 
-	// Regular aggregation
-	vector<INPUT_TYPE> v;
+	//! Regular aggregation: the values are accumulated in a linked list
+	LinkedList v;
 
-	// Window Quantile State
+	// Window Quantile State (only used for window execution)
 	unique_ptr<WindowQuantileState<INPUT_TYPE>> window_state;
 	unique_ptr<CursorType> window_cursor;
 
 	void AddElement(INPUT_TYPE element, AggregateInputData &aggr_input) {
-		v.emplace_back(TYPE_OP::Operation(element, aggr_input));
+		ListSegmentAppendValue<INPUT_TYPE>(aggr_input.allocator, v, element);
 	}
 
 	bool HasTree() const {

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -395,6 +395,141 @@ void ListSegmentFunctions::AppendListEntry(ArenaAllocator &allocator, LinkedList
 	}
 }
 
+template <class T>
+void ListSegmentAppendValue(ArenaAllocator &allocator, LinkedList &linked_list, const T &value) {
+	ListSegmentFunctions functions;
+	functions.create_segment = CreatePrimitiveSegment<T>;
+	allocator.AlignNext();
+	auto segment = GetSegment(functions, allocator, linked_list);
+	GetNullMask(segment)[segment->count] = false;
+	Store<T>(value, data_ptr_cast(GetPrimitiveData<T>(segment) + segment->count));
+	segment->count++;
+	linked_list.total_capacity++;
+}
+
+template <>
+void ListSegmentAppendValue(ArenaAllocator &allocator, LinkedList &linked_list, const string_t &value) {
+	ListSegmentFunctions functions;
+	functions.create_segment = CreateListSegment;
+	allocator.AlignNext();
+	auto segment = GetSegment(functions, allocator, linked_list);
+	GetNullMask(segment)[segment->count] = false;
+
+	// set the length of this string
+	const idx_t str_size = value.GetSize();
+	auto str_length_data = GetListLengthData(segment);
+	Store<uint64_t>(str_size, data_ptr_cast(str_length_data + segment->count));
+
+	// write the characters to the linked list of child segments
+	ListSegmentFunctions child_function;
+	child_function.create_segment = CreateVarcharDataSegment;
+	child_function.initial_capacity = 16;
+
+	auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
+	auto str_data = value.GetData();
+	idx_t current_offset = 0;
+	while (current_offset < str_size) {
+		auto child_segment = GetSegment(child_function, allocator, child_segments);
+		auto data = GetStringData(child_segment);
+		idx_t copy_count = MinValue<idx_t>(str_size - current_offset, child_segment->capacity - child_segment->count);
+		memcpy(data + child_segment->count, str_data + current_offset, copy_count);
+		current_offset += copy_count;
+		child_segment->count += copy_count;
+	}
+	child_segments.total_capacity += str_size;
+	// store the updated linked list
+	Store<LinkedList>(child_segments, data_ptr_cast(GetListChildData(segment)));
+
+	segment->count++;
+	linked_list.total_capacity++;
+}
+
+template <class T>
+void ListSegmentCopy(ArenaAllocator &allocator, const LinkedList &source, LinkedList &target) {
+	for (auto segment = source.first_segment; segment; segment = segment->next) {
+		auto null_mask = GetNullMask(segment);
+		auto data = GetPrimitiveData<T>(segment);
+		for (idx_t i = 0; i < segment->count; i++) {
+			D_ASSERT(!null_mask[i]);
+			(void)null_mask;
+			ListSegmentAppendValue<T>(allocator, target, Load<T>(data_ptr_cast(data + i)));
+		}
+	}
+}
+
+template <>
+void ListSegmentCopy<string_t>(ArenaAllocator &allocator, const LinkedList &source, LinkedList &target) {
+	vector<char> buffer;
+	for (auto segment = source.first_segment; segment; segment = segment->next) {
+		auto null_mask = GetNullMask(segment);
+		auto str_length_data = GetListLengthData(segment);
+		auto child_list = Load<LinkedList>(const_data_ptr_cast(GetListChildData(segment)));
+		auto child_segment = child_list.first_segment;
+		idx_t child_offset = 0;
+		for (idx_t i = 0; i < segment->count; i++) {
+			D_ASSERT(!null_mask[i]);
+			(void)null_mask;
+			// re-assemble the string from the child segments
+			const auto str_length = Load<uint64_t>(const_data_ptr_cast(str_length_data + i));
+			buffer.resize(MaxValue<idx_t>(str_length, 1));
+			idx_t current_offset = 0;
+			while (current_offset < str_length) {
+				if (!child_segment) {
+					throw InternalException("Insufficient data to read string");
+				}
+				auto child_data = GetStringData(child_segment);
+				idx_t copy_count = MinValue<idx_t>(str_length - current_offset, child_segment->capacity - child_offset);
+				memcpy(buffer.data() + current_offset, child_data + child_offset, copy_count);
+				current_offset += copy_count;
+				child_offset += copy_count;
+				if (child_offset >= child_segment->capacity) {
+					D_ASSERT(child_offset == child_segment->capacity);
+					child_segment = child_segment->next;
+					child_offset = 0;
+				}
+			}
+			ListSegmentAppendValue<string_t>(allocator, target,
+			                                 string_t(buffer.data(), UnsafeNumericCast<uint32_t>(str_length)));
+		}
+	}
+}
+
+template void ListSegmentCopy<bool>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<int8_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<int16_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<int32_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<int64_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<uint8_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<uint16_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<uint32_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<uint64_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<hugeint_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<uhugeint_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<float>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<double>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<interval_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<date_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<dtime_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+template void ListSegmentCopy<timestamp_t>(ArenaAllocator &, const LinkedList &, LinkedList &);
+
+template void ListSegmentAppendValue<bool>(ArenaAllocator &, LinkedList &, const bool &);
+template void ListSegmentAppendValue<int8_t>(ArenaAllocator &, LinkedList &, const int8_t &);
+template void ListSegmentAppendValue<int16_t>(ArenaAllocator &, LinkedList &, const int16_t &);
+template void ListSegmentAppendValue<int32_t>(ArenaAllocator &, LinkedList &, const int32_t &);
+template void ListSegmentAppendValue<int64_t>(ArenaAllocator &, LinkedList &, const int64_t &);
+template void ListSegmentAppendValue<uint8_t>(ArenaAllocator &, LinkedList &, const uint8_t &);
+template void ListSegmentAppendValue<uint16_t>(ArenaAllocator &, LinkedList &, const uint16_t &);
+template void ListSegmentAppendValue<uint32_t>(ArenaAllocator &, LinkedList &, const uint32_t &);
+template void ListSegmentAppendValue<uint64_t>(ArenaAllocator &, LinkedList &, const uint64_t &);
+template void ListSegmentAppendValue<hugeint_t>(ArenaAllocator &, LinkedList &, const hugeint_t &);
+template void ListSegmentAppendValue<uhugeint_t>(ArenaAllocator &, LinkedList &, const uhugeint_t &);
+template void ListSegmentAppendValue<float>(ArenaAllocator &, LinkedList &, const float &);
+template void ListSegmentAppendValue<double>(ArenaAllocator &, LinkedList &, const double &);
+template void ListSegmentAppendValue<interval_t>(ArenaAllocator &, LinkedList &, const interval_t &);
+template void ListSegmentAppendValue<date_t>(ArenaAllocator &, LinkedList &, const date_t &);
+template void ListSegmentAppendValue<dtime_t>(ArenaAllocator &, LinkedList &, const dtime_t &);
+template void ListSegmentAppendValue<timestamp_t>(ArenaAllocator &, LinkedList &, const timestamp_t &);
+
 //===--------------------------------------------------------------------===//
 // Read
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/types/list_segment.hpp
+++ b/src/include/duckdb/common/types/list_segment.hpp
@@ -62,4 +62,23 @@ struct ListSegmentFunctions {
 };
 
 void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType &type);
+
+//! Append a single non-NULL value to a linked list using the standard list segment layout.
+//! Values appended this way are interchangeable with values appended through ListSegmentFunctions::AppendRow.
+template <class T>
+void ListSegmentAppendValue(ArenaAllocator &allocator, LinkedList &linked_list, const T &value);
+
+//! Strings copy their characters into the child segments of the linked list.
+template <>
+void ListSegmentAppendValue(ArenaAllocator &allocator, LinkedList &linked_list, const string_t &value);
+
+//! Append all (non-NULL) values of the source linked list to the target linked list by traversing its segments.
+//! The values must have been appended through ListSegmentAppendValue / the standard list segment layout.
+template <class T>
+void ListSegmentCopy(ArenaAllocator &allocator, const LinkedList &source, LinkedList &target);
+
+//! Strings re-assemble their characters from the child segments of the source linked list.
+template <>
+void ListSegmentCopy<string_t>(ArenaAllocator &allocator, const LinkedList &source, LinkedList &target);
+
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -85,8 +85,6 @@ struct AggregateFinalizeData {
 	AggregateInputData &input;
 	idx_t result_idx;
 	idx_t result_count;
-	//! Local state that finalize callbacks can use to cache allocations across the states finalized into the same
-	//! result chunk - initialized lazily by the finalize callback itself
 	unique_ptr<FunctionLocalState> local_state;
 
 	inline void ReturnNull() {

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -85,6 +85,9 @@ struct AggregateFinalizeData {
 	AggregateInputData &input;
 	idx_t result_idx;
 	idx_t result_count;
+	//! Local state that finalize callbacks can use to cache allocations across the states finalized into the same
+	//! result chunk - initialized lazily by the finalize callback itself
+	unique_ptr<FunctionLocalState> local_state;
 
 	inline void ReturnNull() {
 		switch (result.GetVectorType()) {

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -96,6 +96,21 @@ struct TableFunctionData : public FunctionData {
 	DUCKDB_API bool Equals(const FunctionData &other) const override;
 };
 
+struct FunctionLocalState {
+	DUCKDB_API virtual ~FunctionLocalState();
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
 struct FunctionParameters {
 	vector<Value> values;
 	named_parameter_map_t named_parameters;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -20,21 +20,6 @@
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 
 namespace duckdb {
-struct FunctionLocalState {
-	DUCKDB_API virtual ~FunctionLocalState();
-
-	template <class TARGET>
-	TARGET &Cast() {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<TARGET &>(*this);
-	}
-	template <class TARGET>
-	const TARGET &Cast() const {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-
 struct ScalarFunctionInfo {
 	DUCKDB_API virtual ~ScalarFunctionInfo();
 


### PR DESCRIPTION

This PR reworks the `quantile` family of aggregates to use the `list` infrastructure. Previously these held a `vector<T>`:

```cpp
template<class INPUT_TYPE>
struct QuantileState {
    vector<INPUT_TYPE> v;
};
```

This is now changed to a `LinkedList`:

```cpp
template<class INPUT_TYPE>
struct QuantileState {
    LinkedList v;
};
```

The reason for this change is two-fold:

* `LinkedList` uses the arena allocator, so all memory consumption is tracked and done in bulk, versus the individual untracked allocations of a `vector`
* `LinkedList` can be exported in aggregate states automatically (as per https://github.com/duckdb/duckdb/pull/23199) - so using `LinkedList` as a primitive greatly simplifies that component (*note:* we don't actually implement aggregate state export yet because the bind data cannot be handled yet - I have a follow-up ready to do so)

When we actually resolve the quantile, we flatten the linked list into a `Vector` using `FlattenedQuantileValues` and then do the interpolation on that vector. That is because in order to compute a quantile we still really need a flat array of values as we're doing random mutable access to obtain the quantiles. 

### Performance

Performance is interesting. Consider the followign queries on TPC-H SF10:

```sql
-- Few Groups
-- 3 groups, ~20M rows per group
select quantile(l_orderkey, 0.5) from lineitem group by l_returnflag;

-- Many Groups
-- 15M groups, ~4 rows per group
select avg(q) from (select quantile(l_linenumber, 0.5) q from lineitem group by l_orderkey);
```

On my Macbook it is roughly equivalent:

| Version | Many Groups | Few Groups |
|---------|------------|-------------|
| v1.5    | 0.4s       | 0.2s        |
| New     | 0.39s      | 0.19s       |

However, on my MacMini, the new version is drastically better in the many groups case:

| Version | Many Groups | Few Groups |
|---------|-------------|------------|
| v1.5    | 6.0s        | 0.27s      |
| New     | 0.7s        | 0.24s      |

My guess is this is allocator related, and the arena allocated data performs more consistently as we're not doing many tiny allocations anymore. 