### PR TITLE
Rework ordered aggregates to use the `list` infrastructure

### DIFF
--- a/benchmark/micro/aggregate/sorted_string_agg.benchmark
+++ b/benchmark/micro/aggregate/sorted_string_agg.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/aggregate/sorted_string_agg.benchmark
+# description: STRING_AGG with ORDER BY over many groups
+# group: [aggregate]
+
+name Sorted String Agg (Grouped)
+group aggregate
+
+load
+CREATE TABLE t AS SELECT range % 100000 AS g, range AS r, 'val' || (range % 97)::VARCHAR AS v FROM range(20000000);
+
+run
+SELECT count(*), max(strlen(s)) FROM (
+	SELECT g, STRING_AGG(v, ',' ORDER BY r DESC) AS s
+	FROM t
+	GROUP BY g
+)
+
+result II
+100000	1179

--- a/benchmark/micro/aggregate/sorted_string_agg_single_group.benchmark
+++ b/benchmark/micro/aggregate/sorted_string_agg_single_group.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/aggregate/sorted_string_agg_single_group.benchmark
+# description: STRING_AGG with ORDER BY over a single large group
+# group: [aggregate]
+
+name Sorted String Agg (Single Group)
+group aggregate
+
+load
+CREATE TABLE t AS SELECT range AS r, 'val' || (range % 97)::VARCHAR AS v FROM range(20000000);
+
+run
+SELECT strlen(STRING_AGG(v, ',' ORDER BY r DESC)) FROM t
+
+result I
+117938139

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -1,69 +1,9 @@
-#include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/list_vector.hpp"
-#include "duckdb/common/types/list_segment.hpp"
+#include "duckdb/function/aggregate/list_aggregate.hpp"
 #include "core_functions/aggregate/nested_functions.hpp"
 
 namespace duckdb {
 
 namespace {
-
-struct ListAggState {
-	LinkedList linked_list;
-
-	//! The state is a linked list of values - exported/imported as the aggregate's LIST return type
-	using STATE_TYPE = StateListType<StateReturnType>;
-};
-
-struct ListFunction {
-	static bool IgnoreNull() {
-		return false;
-	}
-};
-
-void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &state_vector,
-                        idx_t count) {
-	D_ASSERT(input_count == 1);
-	auto &input = inputs[0];
-	RecursiveUnifiedVectorFormat input_data;
-	Vector::RecursiveToUnifiedFormat(input, input_data);
-
-	auto states = state_vector.Values<ListAggState *>();
-
-	ListSegmentFunctions functions;
-	GetSegmentDataFunctions(functions, input.GetType());
-
-	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].GetValue();
-		aggr_input_data.allocator.AlignNext();
-		functions.AppendRow(aggr_input_data.allocator, state.linked_list, input_data, i);
-	}
-}
-
-void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
-	D_ASSERT(aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE);
-
-	auto states = states_vector.Values<ListAggState *>();
-	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
-	for (idx_t i = 0; i < count; i++) {
-		auto &state = *states[i].GetValue();
-		if (state.linked_list.total_capacity == 0) {
-			// NULL, no need to append
-			// this can happen when adding a FILTER to the grouping, e.g.,
-			// LIST(i) FILTER (WHERE i <> 3)
-			continue;
-		}
-
-		if (combined_ptr[i]->linked_list.total_capacity == 0) {
-			combined_ptr[i]->linked_list = state.linked_list;
-			continue;
-		}
-
-		// append the linked list
-		combined_ptr[i]->linked_list.last_segment->next = state.linked_list.first_segment;
-		combined_ptr[i]->linked_list.last_segment = state.linked_list.last_segment;
-		combined_ptr[i]->linked_list.total_capacity += state.linked_list.total_capacity;
-	}
-}
 
 void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
                   idx_t offset) {
@@ -82,43 +22,13 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 	functions.BuildLists(linked_lists, result, offset);
 }
 
-void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
-	//	Can we use destructive combining?
-	if (aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
-		ListAbsorbFunction(states_vector, combined, aggr_input_data, count);
-		return;
-	}
-
-	auto states = states_vector.Values<ListAggState *>();
-	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
-
-	auto child_type = ListType::GetChildType(aggr_input_data.function.GetReturnType());
-	ListSegmentFunctions functions;
-	GetSegmentDataFunctions(functions, child_type);
-
-	for (idx_t i = 0; i < count; i++) {
-		auto &source = *states[i].GetValue();
-		auto &target = *combined_ptr[i];
-
-		const auto entry_count = source.linked_list.total_capacity;
-		Vector input(child_type, entry_count);
-		functions.BuildListVector(source.linked_list, input, 0);
-
-		RecursiveUnifiedVectorFormat input_data;
-		Vector::RecursiveToUnifiedFormat(input, input_data);
-
-		functions.AppendListEntry(aggr_input_data.allocator, target.linked_list, input_data,
-		                          list_entry_t(0, entry_count));
-	}
-}
-
 } // namespace
 
 AggregateFunction ListFun::GetFunction() {
 	auto func = AggregateFunction({LogicalType::TEMPLATE("T")}, LogicalType::LIST(LogicalType::TEMPLATE("T")),
 	                              AggregateFunction::StateSize<ListAggState>,
 	                              AggregateFunction::StateInitialize<ListAggState, ListFunction>, ListUpdateFunction,
-	                              ListCombineFunction, ListFinalize, nullptr, nullptr, nullptr, nullptr);
+	                              ListCombineFunction<ListFunction>, ListFinalize, nullptr, nullptr, nullptr, nullptr);
 	AggregateFunction::WireStructStateType<ListAggState>(func);
 
 	return func;

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -132,10 +132,10 @@ static const bool *GetNullMask(const ListSegment *segment) {
 	return reinterpret_cast<const bool *>(const_data_ptr_cast(segment) + sizeof(ListSegment));
 }
 
-static uint16_t GetCapacityForNewSegment(uint16_t capacity) {
+static uint16_t GetCapacityForNewSegment(const ListSegmentFunctions &functions, uint16_t capacity) {
 	auto next_power_of_two = idx_t(capacity) * 2;
-	if (next_power_of_two >= NumericLimits<uint16_t>::Maximum()) {
-		return capacity;
+	if (next_power_of_two >= functions.maximum_capacity) {
+		return functions.maximum_capacity;
 	}
 	return uint16_t(next_power_of_two);
 }
@@ -226,7 +226,7 @@ static ListSegment *GetSegment(const ListSegmentFunctions &functions, ArenaAlloc
 		linked_list.last_segment = segment;
 	} else if (linked_list.last_segment->capacity == linked_list.last_segment->count) {
 		// the last segment of the linked list is full, create a new one and append it
-		auto capacity = GetCapacityForNewSegment(linked_list.last_segment->capacity);
+		auto capacity = GetCapacityForNewSegment(functions, linked_list.last_segment->capacity);
 		segment = functions.create_segment(functions, allocator, capacity);
 		linked_list.last_segment->next = segment;
 		linked_list.last_segment = segment;
@@ -443,10 +443,20 @@ static void ReadDataFromVarcharSegment(const ListSegmentFunctions &, const ListS
 		// read the string
 		auto &result_str = aggr_vector_data[total_count + i];
 		auto str_length = Load<uint64_t>(const_data_ptr_cast(str_length_data + i));
-		// allocate an empty string for the given size
+		if (current_segment && child_offset + str_length <= current_segment->capacity) {
+			// reference the string directly - the segment data outlives the result vector
+			result_str =
+			    string_t(GetStringData(current_segment) + child_offset, UnsafeNumericCast<uint32_t>(str_length));
+			child_offset += str_length;
+			if (child_offset == current_segment->capacity) {
+				current_segment = current_segment->next;
+				child_offset = 0;
+			}
+			continue;
+		}
+		// the string spans multiple child segments - copy over the data
 		result_str = StringVector::EmptyString(result, str_length);
 		auto result_data = result_str.GetDataWriteable();
-		// copy over the data
 		idx_t current_offset = 0;
 		while (current_offset < str_length) {
 			if (!current_segment) {
@@ -553,6 +563,23 @@ static void ReadDataFromArraySegment(const ListSegmentFunctions &functions, cons
 	// recurse into the linked list of child values
 	D_ASSERT(functions.child_functions.size() == 1);
 	functions.child_functions[0].BuildListVector(linked_child_list, child_vector, child_size);
+}
+
+void ListSegmentFunctions::InitializeScan(const LinkedList &linked_list, ListSegmentScanState &state) const {
+	state.segment = linked_list.first_segment;
+}
+
+idx_t ListSegmentFunctions::Scan(ListSegmentScanState &state, Vector &result) const {
+	idx_t scan_count = 0;
+	while (state.segment && scan_count + state.segment->count <= STANDARD_VECTOR_SIZE) {
+		read_data(*this, state.segment, result, scan_count);
+		scan_count += state.segment->count;
+		state.segment = state.segment->next;
+	}
+	if (!scan_count && state.segment) {
+		throw InternalException("Cannot scan a list segment that is larger than a vector");
+	}
+	return scan_count;
 }
 
 void ListSegmentFunctions::BuildListVector(const LinkedList &linked_list, Vector &result, idx_t total_count) const {
@@ -676,6 +703,7 @@ void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType 
 		child_function.write_data = nullptr;
 		child_function.read_data = nullptr;
 		child_function.initial_capacity = 16;
+		child_function.maximum_capacity = uint16_t(ListSegmentFunctions::DATA_SEGMENT_MAXIMUM_CAPACITY);
 		functions.child_functions.push_back(child_function);
 		break;
 	}

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -443,6 +443,11 @@ static void ReadDataFromVarcharSegment(const ListSegmentFunctions &, const ListS
 		// read the string
 		auto &result_str = aggr_vector_data[total_count + i];
 		auto str_length = Load<uint64_t>(const_data_ptr_cast(str_length_data + i));
+		if (child_offset + str_length <= current_segment->capacity) {
+			result_str = string_t(GetStringData(current_segment) + child_offset, NumericCast<uint32_t>(str_length));
+			child_offset += str_length;
+			continue;
+		}
 		// allocate an empty string for the given size
 		result_str = StringVector::EmptyString(result, str_length);
 		auto result_data = result_str.GetDataWriteable();

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -50,6 +50,10 @@ static char *GetStringData(ListSegment *segment) {
 	return reinterpret_cast<char *>(data_ptr_cast(segment) + sizeof(ListSegment));
 }
 
+static const char *GetStringData(const ListSegment *segment) {
+	return reinterpret_cast<const char *>(const_data_ptr_cast(segment) + sizeof(ListSegment));
+}
+
 //===--------------------------------------------------------------------===//
 // Lists
 //===--------------------------------------------------------------------===//
@@ -132,10 +136,10 @@ static const bool *GetNullMask(const ListSegment *segment) {
 	return reinterpret_cast<const bool *>(const_data_ptr_cast(segment) + sizeof(ListSegment));
 }
 
-static uint16_t GetCapacityForNewSegment(const ListSegmentFunctions &functions, uint16_t capacity) {
+static uint16_t GetCapacityForNewSegment(uint16_t capacity) {
 	auto next_power_of_two = idx_t(capacity) * 2;
-	if (next_power_of_two >= functions.maximum_capacity) {
-		return functions.maximum_capacity;
+	if (next_power_of_two >= NumericLimits<uint16_t>::Maximum()) {
+		return capacity;
 	}
 	return uint16_t(next_power_of_two);
 }
@@ -226,7 +230,7 @@ static ListSegment *GetSegment(const ListSegmentFunctions &functions, ArenaAlloc
 		linked_list.last_segment = segment;
 	} else if (linked_list.last_segment->capacity == linked_list.last_segment->count) {
 		// the last segment of the linked list is full, create a new one and append it
-		auto capacity = GetCapacityForNewSegment(functions, linked_list.last_segment->capacity);
+		auto capacity = GetCapacityForNewSegment(linked_list.last_segment->capacity);
 		segment = functions.create_segment(functions, allocator, capacity);
 		linked_list.last_segment->next = segment;
 		linked_list.last_segment = segment;
@@ -396,199 +400,279 @@ void ListSegmentFunctions::AppendListEntry(ArenaAllocator &allocator, LinkedList
 }
 
 //===--------------------------------------------------------------------===//
-// Read
+// Scan
 //===--------------------------------------------------------------------===//
+//! Move the scan state to the next segment of the linked list (clearing any child scan states)
+static void MoveToNextSegment(ListSegmentScanState &state) {
+	state.segment = state.segment->next;
+	state.offset = 0;
+	state.children.clear();
+}
+
 template <class T>
-static void ReadDataFromPrimitiveSegment(const ListSegmentFunctions &, const ListSegment *segment, Vector &result,
-                                         idx_t &total_count) {
+static idx_t ScanPrimitiveData(const ListSegmentFunctions &, ListSegmentScanState &state, idx_t count, Vector &result,
+                               idx_t result_offset) {
 	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
-
-	// set NULLs
-	auto null_mask = GetNullMask(segment);
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (null_mask[i]) {
-			aggr_vector_validity.SetInvalid(total_count + i);
-		}
-	}
-
 	auto aggr_vector_data = FlatVector::GetDataMutable<T>(result);
 
-	// load values
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (aggr_vector_validity.RowIsValid(total_count + i)) {
-			auto data = GetPrimitiveData<T>(segment);
-			aggr_vector_data[total_count + i] = Load<T>(const_data_ptr_cast(data + i));
+	idx_t total_read = 0;
+	while (total_read < count && state.segment) {
+		auto segment = state.segment;
+		auto read_count = MinValue<idx_t>(count - total_read, segment->count - state.offset);
+		auto null_mask = GetNullMask(segment);
+		auto data = GetPrimitiveData<T>(segment);
+		for (idx_t i = 0; i < read_count; i++) {
+			auto source_idx = state.offset + i;
+			auto target_idx = result_offset + total_read + i;
+			if (null_mask[source_idx]) {
+				aggr_vector_validity.SetInvalid(target_idx);
+			} else {
+				aggr_vector_data[target_idx] = Load<T>(const_data_ptr_cast(data + source_idx));
+			}
+		}
+		total_read += read_count;
+		state.offset += read_count;
+		if (state.offset == segment->count) {
+			MoveToNextSegment(state);
 		}
 	}
+	return total_read;
 }
 
-static void ReadDataFromVarcharSegment(const ListSegmentFunctions &, const ListSegment *segment, Vector &result,
-                                       idx_t &total_count) {
+static idx_t ScanVarcharData(const ListSegmentFunctions &, ListSegmentScanState &state, idx_t count, Vector &result,
+                             idx_t result_offset) {
 	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
-
-	// use length and (reconstructed) offset to get the correct substrings
 	auto aggr_vector_data = FlatVector::GetDataMutable<string_t>(result);
-	auto str_length_data = GetListLengthData(segment);
 
-	auto null_mask = GetNullMask(segment);
-	auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetListChildData(segment)));
-	auto current_segment = linked_child_list.first_segment;
-	idx_t child_offset = 0;
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (null_mask[i]) {
-			// set to null
-			aggr_vector_validity.SetInvalid(total_count + i);
-			continue;
+	idx_t total_read = 0;
+	while (total_read < count && state.segment) {
+		auto segment = state.segment;
+		if (state.children.empty()) {
+			// entering this segment - point the child state at the start of the segment's character data
+			auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetListChildData(segment)));
+			state.children.emplace_back();
+			state.children.back().segment = linked_child_list.first_segment;
 		}
-		// read the string
-		auto &result_str = aggr_vector_data[total_count + i];
-		auto str_length = Load<uint64_t>(const_data_ptr_cast(str_length_data + i));
-		if (current_segment && child_offset + str_length <= current_segment->capacity) {
-			// the string fits in the current segment - reference it directly instead of copying
-			result_str = string_t(GetStringData(current_segment) + child_offset, NumericCast<uint32_t>(str_length));
-			child_offset += str_length;
-			if (child_offset == current_segment->capacity) {
-				current_segment = current_segment->next;
-				child_offset = 0;
+		auto &child_state = state.children.back();
+		auto read_count = MinValue<idx_t>(count - total_read, segment->count - state.offset);
+		auto null_mask = GetNullMask(segment);
+		auto str_length_data = GetListLengthData(segment);
+		for (idx_t i = 0; i < read_count; i++) {
+			auto source_idx = state.offset + i;
+			auto target_idx = result_offset + total_read + i;
+			if (null_mask[source_idx]) {
+				// set to null
+				aggr_vector_validity.SetInvalid(target_idx);
+				continue;
 			}
-			continue;
-		}
-		// allocate an empty string for the given size
-		result_str = StringVector::EmptyString(result, str_length);
-		auto result_data = result_str.GetDataWriteable();
-		idx_t current_offset = 0;
-		while (current_offset < str_length) {
-			if (!current_segment) {
-				throw InternalException("Insufficient data to read string");
+			// read the string
+			auto &result_str = aggr_vector_data[target_idx];
+			auto str_length = Load<uint64_t>(const_data_ptr_cast(str_length_data + source_idx));
+			if (child_state.segment && child_state.offset + str_length <= child_state.segment->capacity) {
+				// the string fits in the current segment - reference it directly instead of copying
+				result_str = string_t(GetStringData(child_state.segment) + child_state.offset,
+				                      NumericCast<uint32_t>(str_length));
+				child_state.offset += str_length;
+				if (child_state.offset == child_state.segment->capacity) {
+					child_state.segment = child_state.segment->next;
+					child_state.offset = 0;
+				}
+				continue;
 			}
-			auto child_data = GetStringData(current_segment);
-			idx_t max_copy = MinValue<idx_t>(str_length - current_offset, current_segment->capacity - child_offset);
-			memcpy(result_data + current_offset, child_data + child_offset, max_copy);
-			current_offset += max_copy;
-			child_offset += max_copy;
-			if (child_offset >= current_segment->capacity) {
-				D_ASSERT(child_offset == current_segment->capacity);
-				current_segment = current_segment->next;
-				child_offset = 0;
+			// allocate an empty string for the given size
+			result_str = StringVector::EmptyString(result, str_length);
+			auto result_data = result_str.GetDataWriteable();
+			idx_t current_offset = 0;
+			while (current_offset < str_length) {
+				if (!child_state.segment) {
+					throw InternalException("Insufficient data to read string");
+				}
+				auto child_data = GetStringData(child_state.segment);
+				idx_t max_copy =
+				    MinValue<idx_t>(str_length - current_offset, child_state.segment->capacity - child_state.offset);
+				memcpy(result_data + current_offset, child_data + child_state.offset, max_copy);
+				current_offset += max_copy;
+				child_state.offset += max_copy;
+				if (child_state.offset >= child_state.segment->capacity) {
+					D_ASSERT(child_state.offset == child_state.segment->capacity);
+					child_state.segment = child_state.segment->next;
+					child_state.offset = 0;
+				}
 			}
-		}
 
-		// finalize the str
-		result_str.Finalize();
+			// finalize the str
+			result_str.Finalize();
+		}
+		total_read += read_count;
+		state.offset += read_count;
+		if (state.offset == segment->count) {
+			MoveToNextSegment(state);
+		}
 	}
+	return total_read;
 }
 
-static void ReadDataFromListSegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
-                                    idx_t &total_count) {
+static idx_t ScanListData(const ListSegmentFunctions &functions, ListSegmentScanState &state, idx_t count,
+                          Vector &result, idx_t result_offset) {
 	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
-
-	// set NULLs
-	auto null_mask = GetNullMask(segment);
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (null_mask[i]) {
-			aggr_vector_validity.SetInvalid(total_count + i);
-		}
-	}
-
 	auto list_vector_data = FlatVector::GetDataMutable<list_entry_t>(result);
 
-	// get the starting offset
-	idx_t offset = 0;
-	if (total_count != 0) {
-		offset = list_vector_data[total_count - 1].offset + list_vector_data[total_count - 1].length;
-	}
-	idx_t starting_offset = offset;
-
-	// set length and offsets
-	auto list_length_data = GetListLengthData(segment);
-	for (idx_t i = 0; i < segment->count; i++) {
-		auto list_length = Load<uint64_t>(const_data_ptr_cast(list_length_data + i));
-		list_vector_data[total_count + i].length = list_length;
-		list_vector_data[total_count + i].offset = offset;
-		offset += list_length;
-	}
-
-	auto &child_vector = ListVector::GetChildMutable(result);
-	auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetListChildData(segment)));
-	ListVector::Reserve(result, offset);
-
-	// recurse into the linked list of child values
 	D_ASSERT(functions.child_functions.size() == 1);
-	functions.child_functions[0].BuildListVector(linked_child_list, child_vector, starting_offset);
-	ListVector::SetListSize(result, offset);
-}
+	auto &child_function = functions.child_functions[0];
 
-static void ReadDataFromStructSegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
-                                      idx_t &total_count) {
-	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
+	idx_t total_read = 0;
+	while (total_read < count && state.segment) {
+		auto segment = state.segment;
+		if (state.children.empty()) {
+			// entering this segment - point the child state at the start of the segment's child values
+			auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetListChildData(segment)));
+			state.children.emplace_back();
+			state.children.back().segment = linked_child_list.first_segment;
+		}
+		auto &child_state = state.children.back();
+		auto read_count = MinValue<idx_t>(count - total_read, segment->count - state.offset);
+		auto null_mask = GetNullMask(segment);
+		auto list_length_data = GetListLengthData(segment);
 
-	// set NULLs
-	auto null_mask = GetNullMask(segment);
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (null_mask[i]) {
-			aggr_vector_validity.SetInvalid(total_count + i);
+		// get the starting offset in the result child vector
+		auto current_result_offset = result_offset + total_read;
+		idx_t offset = 0;
+		if (current_result_offset != 0) {
+			offset =
+			    list_vector_data[current_result_offset - 1].offset + list_vector_data[current_result_offset - 1].length;
+		}
+		idx_t starting_offset = offset;
+
+		// set length and offsets
+		for (idx_t i = 0; i < read_count; i++) {
+			auto source_idx = state.offset + i;
+			auto target_idx = current_result_offset + i;
+			if (null_mask[source_idx]) {
+				aggr_vector_validity.SetInvalid(target_idx);
+			}
+			auto list_length = Load<uint64_t>(const_data_ptr_cast(list_length_data + source_idx));
+			list_vector_data[target_idx].length = list_length;
+			list_vector_data[target_idx].offset = offset;
+			offset += list_length;
+		}
+
+		ListVector::Reserve(result, offset);
+		auto &child_vector = ListVector::GetChildMutable(result);
+
+		// recurse into the linked list of child values
+		auto child_read = child_function.scan_data(child_function, child_state, offset - starting_offset, child_vector,
+		                                           starting_offset);
+		if (child_read != offset - starting_offset) {
+			throw InternalException("Insufficient data in linked list to read list entries");
+		}
+		ListVector::SetListSize(result, offset);
+
+		total_read += read_count;
+		state.offset += read_count;
+		if (state.offset == segment->count) {
+			MoveToNextSegment(state);
 		}
 	}
+	return total_read;
+}
 
+static idx_t ScanStructData(const ListSegmentFunctions &functions, ListSegmentScanState &state, idx_t count,
+                            Vector &result, idx_t result_offset) {
+	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
 	auto &children = StructVector::GetEntries(result);
-
-	// recurse into the child segments of each child of the struct
 	D_ASSERT(children.size() == functions.child_functions.size());
-	auto struct_children = GetStructData(segment);
-	for (idx_t child_count = 0; child_count < children.size(); child_count++) {
-		auto struct_children_segment = Load<ListSegment *>(const_data_ptr_cast(struct_children + child_count));
-		auto &child_function = functions.child_functions[child_count];
-		child_function.read_data(child_function, struct_children_segment, children[child_count], total_count);
-	}
-}
 
-static void ReadDataFromArraySegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
-                                     idx_t &total_count) {
-	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
+	idx_t total_read = 0;
+	while (total_read < count && state.segment) {
+		auto segment = state.segment;
+		if (state.children.empty()) {
+			// entering this segment - point the child states at the segment's child segments
+			auto struct_children = GetStructData(segment);
+			state.children.resize(children.size());
+			for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+				state.children[child_idx].segment =
+				    Load<ListSegment *>(const_data_ptr_cast(struct_children + child_idx));
+			}
+		}
+		auto read_count = MinValue<idx_t>(count - total_read, segment->count - state.offset);
+		auto null_mask = GetNullMask(segment);
+		for (idx_t i = 0; i < read_count; i++) {
+			if (null_mask[state.offset + i]) {
+				aggr_vector_validity.SetInvalid(result_offset + total_read + i);
+			}
+		}
 
-	// set NULLs
-	auto null_mask = GetNullMask(segment);
-	for (idx_t i = 0; i < segment->count; i++) {
-		if (null_mask[i]) {
-			aggr_vector_validity.SetInvalid(total_count + i);
+		// recurse into the child segments of each child of the struct
+		// the child segments are aligned with the parent segment, so they advance in lockstep
+		for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+			auto &child_function = functions.child_functions[child_idx];
+			child_function.scan_data(child_function, state.children[child_idx], read_count, children[child_idx],
+			                         result_offset + total_read);
+		}
+
+		total_read += read_count;
+		state.offset += read_count;
+		if (state.offset == segment->count) {
+			MoveToNextSegment(state);
 		}
 	}
+	return total_read;
+}
 
+static idx_t ScanArrayData(const ListSegmentFunctions &functions, ListSegmentScanState &state, idx_t count,
+                           Vector &result, idx_t result_offset) {
+	auto &aggr_vector_validity = FlatVector::ValidityMutable(result);
 	auto &child_vector = ArrayVector::GetChildMutable(result);
-	auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetArrayChildData(segment)));
 	auto array_size = ArrayType::GetSize(result.GetType());
-	auto child_size = array_size * total_count;
 
-	// recurse into the linked list of child values
 	D_ASSERT(functions.child_functions.size() == 1);
-	functions.child_functions[0].BuildListVector(linked_child_list, child_vector, child_size);
+	auto &child_function = functions.child_functions[0];
+
+	idx_t total_read = 0;
+	while (total_read < count && state.segment) {
+		auto segment = state.segment;
+		if (state.children.empty()) {
+			// entering this segment - point the child state at the start of the segment's child values
+			auto linked_child_list = Load<LinkedList>(const_data_ptr_cast(GetArrayChildData(segment)));
+			state.children.emplace_back();
+			state.children.back().segment = linked_child_list.first_segment;
+		}
+		auto &child_state = state.children.back();
+		auto read_count = MinValue<idx_t>(count - total_read, segment->count - state.offset);
+		auto null_mask = GetNullMask(segment);
+		for (idx_t i = 0; i < read_count; i++) {
+			if (null_mask[state.offset + i]) {
+				aggr_vector_validity.SetInvalid(result_offset + total_read + i);
+			}
+		}
+
+		// recurse into the linked list of child values
+		child_function.scan_data(child_function, child_state, read_count * array_size, child_vector,
+		                         (result_offset + total_read) * array_size);
+
+		total_read += read_count;
+		state.offset += read_count;
+		if (state.offset == segment->count) {
+			MoveToNextSegment(state);
+		}
+	}
+	return total_read;
 }
 
 void ListSegmentFunctions::InitializeScan(const LinkedList &linked_list, ListSegmentScanState &state) const {
 	state.segment = linked_list.first_segment;
+	state.offset = 0;
+	state.children.clear();
 }
 
 idx_t ListSegmentFunctions::Scan(ListSegmentScanState &state, Vector &result) const {
-	idx_t scan_count = 0;
-	while (state.segment && scan_count + state.segment->count <= STANDARD_VECTOR_SIZE) {
-		read_data(*this, state.segment, result, scan_count);
-		scan_count += state.segment->count;
-		state.segment = state.segment->next;
-	}
-	if (!scan_count && state.segment) {
-		throw InternalException("Cannot scan a list segment that is larger than a vector");
-	}
-	return scan_count;
+	return scan_data(*this, state, STANDARD_VECTOR_SIZE, result, 0);
 }
 
 void ListSegmentFunctions::BuildListVector(const LinkedList &linked_list, Vector &result, idx_t total_count) const {
-	auto &read_data_from_segment = *this;
-	auto segment = linked_list.first_segment;
-	while (segment) {
-		read_data_from_segment.read_data(read_data_from_segment, segment, result, total_count);
-		total_count += segment->count;
-		segment = segment->next;
-	}
+	ListSegmentScanState state;
+	InitializeScan(linked_list, state);
+	scan_data(*this, state, NumericLimits<idx_t>::Maximum(), result, total_count);
 }
 
 void ListSegmentFunctions::BuildLists(const vector<LinkedList> &linked_lists, Vector &result, idx_t offset) const {
@@ -636,7 +720,7 @@ template <class T>
 void SegmentPrimitiveFunction(ListSegmentFunctions &functions) {
 	functions.create_segment = CreatePrimitiveSegment<T>;
 	functions.write_data = WriteDataToPrimitiveSegment<T>;
-	functions.read_data = ReadDataFromPrimitiveSegment<T>;
+	functions.scan_data = ScanPrimitiveData<T>;
 }
 
 void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType &type) {
@@ -695,21 +779,20 @@ void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType 
 	case PhysicalType::VARCHAR: {
 		functions.create_segment = CreateListSegment;
 		functions.write_data = WriteDataToVarcharSegment;
-		functions.read_data = ReadDataFromVarcharSegment;
+		functions.scan_data = ScanVarcharData;
 
 		ListSegmentFunctions child_function;
 		child_function.create_segment = CreateVarcharDataSegment;
 		child_function.write_data = nullptr;
-		child_function.read_data = nullptr;
+		child_function.scan_data = nullptr;
 		child_function.initial_capacity = 16;
-		child_function.maximum_capacity = uint16_t(ListSegmentFunctions::DATA_SEGMENT_MAXIMUM_CAPACITY);
 		functions.child_functions.push_back(child_function);
 		break;
 	}
 	case PhysicalType::LIST: {
 		functions.create_segment = CreateListSegment;
 		functions.write_data = WriteDataToListSegment;
-		functions.read_data = ReadDataFromListSegment;
+		functions.scan_data = ScanListData;
 
 		// recurse
 		functions.child_functions.emplace_back();
@@ -719,7 +802,7 @@ void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType 
 	case PhysicalType::STRUCT: {
 		functions.create_segment = CreateStructSegment;
 		functions.write_data = WriteDataToStructSegment;
-		functions.read_data = ReadDataFromStructSegment;
+		functions.scan_data = ScanStructData;
 
 		// recurse
 		auto child_types = StructType::GetChildTypes(type);
@@ -732,7 +815,7 @@ void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType 
 	case PhysicalType::ARRAY: {
 		functions.create_segment = CreateArraySegment;
 		functions.write_data = WriteDataToArraySegment;
-		functions.read_data = ReadDataFromArraySegment;
+		functions.scan_data = ScanArrayData;
 
 		// recurse
 		functions.child_functions.emplace_back();

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -2,8 +2,9 @@
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/sorting/sort.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/common/types/list_segment.hpp"
+#include "duckdb/function/aggregate/list_aggregate.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
@@ -68,13 +69,14 @@ struct SortedAggregateBindData : public FunctionData {
 			orders.emplace_back(std::move(order));
 		}
 
-		// Look up all the linked list functions we need
-		for (auto &type : buffered_types) {
-			ListSegmentFunctions funcs;
-			GetSegmentDataFunctions(funcs, type);
-			buffered_funcs.emplace_back(std::move(funcs));
-			sort_types.emplace_back(type);
+		// The buffered rows are stored in a linked list of structs
+		child_list_t<LogicalType> buffered_children;
+		for (idx_t i = 0; i < buffered_types.size(); i++) {
+			buffered_children.emplace_back("v" + to_string(i), buffered_types[i]);
+			sort_types.emplace_back(buffered_types[i]);
 		}
+		buffered_struct_type = LogicalType::STRUCT(std::move(buffered_children));
+		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
 
 		//	Only scan the argument columns after sorting
 		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
@@ -93,7 +95,8 @@ struct SortedAggregateBindData : public FunctionData {
 	SortedAggregateBindData(const SortedAggregateBindData &other)
 	    : context(other.context), function(other.function), sort_types(other.sort_types), scan_cols(other.scan_cols),
 	      scan_types(other.scan_types), buffered_cols(other.buffered_cols), buffered_types(other.buffered_types),
-	      buffered_funcs(other.buffered_funcs), sorted_on_args(other.sorted_on_args), threshold(other.threshold) {
+	      buffered_struct_type(other.buffered_struct_type), buffered_funcs(other.buffered_funcs),
+	      sorted_on_args(other.sorted_on_args), threshold(other.threshold) {
 		if (other.bind_info) {
 			bind_info = other.bind_info->Copy();
 		}
@@ -150,8 +153,10 @@ struct SortedAggregateBindData : public FunctionData {
 	vector<column_t> buffered_cols;
 	//! The schema of the buffered data
 	vector<LogicalType> buffered_types;
-	//! The linked list functions for the buffered data
-	vector<ListSegmentFunctions> buffered_funcs;
+	//! The struct type holding one buffered row
+	LogicalType buffered_struct_type;
+	//! The linked list functions for the buffered rows
+	ListSegmentFunctions buffered_funcs;
 	//! Can we just use the inputs for sorting?
 	bool sorted_on_args = true;
 
@@ -159,291 +164,14 @@ struct SortedAggregateBindData : public FunctionData {
 	const idx_t threshold;
 };
 
-struct SortedAggregateState {
-	// Linked list equivalent of DataChunk
-	using LinkedLists = vector<LinkedList>;
-	using LinkedChunkFunctions = vector<ListSegmentFunctions>;
-
-	//! Capacities of the various levels of buffering
-	static const idx_t CHUNK_CAPACITY = STANDARD_VECTOR_SIZE;
-	static const idx_t LIST_CAPACITY = MinValue<idx_t>(16, CHUNK_CAPACITY);
-
-	SortedAggregateState() : count(0), nsel(0), offset(0) {
-	}
-
-	static inline void InitializeLinkedList(LinkedLists &linked, const vector<LogicalType> &types) {
-		if (linked.empty() && !types.empty()) {
-			linked.resize(types.size(), LinkedList());
-		}
-	}
-
-	inline void InitializeLinkedLists(const SortedAggregateBindData &order_bind) {
-		InitializeLinkedList(input_linked, order_bind.buffered_types);
-	}
-
-	static inline void InitializeChunk(Allocator &allocator, unique_ptr<DataChunk> &chunk,
-	                                   const vector<LogicalType> &types) {
-		if (!chunk && !types.empty()) {
-			chunk = make_uniq<DataChunk>();
-			chunk->Initialize(allocator, types);
-		}
-	}
-
-	void InitializeChunks(const SortedAggregateBindData &order_bind) {
-		// Lazy instantiation of the buffer chunks
-		auto &allocator = BufferManager::GetBufferManager(order_bind.context).GetBufferAllocator();
-		InitializeChunk(allocator, input_chunk, order_bind.buffered_types);
-	}
-
-	static inline void FlushLinkedList(const LinkedChunkFunctions &funcs, LinkedLists &linked, DataChunk &chunk) {
-		idx_t total_count = 0;
-		for (column_t i = 0; i < linked.size(); ++i) {
-			funcs[i].BuildListVector(linked[i], chunk.data[i], total_count);
-			FlatVector::SetSize(chunk.data[i], count_t(linked[i].total_capacity));
-		}
-	}
-
-	void FlushLinkedLists(const SortedAggregateBindData &order_bind) {
-		InitializeChunks(order_bind);
-		FlushLinkedList(order_bind.buffered_funcs, input_linked, *input_chunk);
-	}
-
-	void InitializeCollections(const SortedAggregateBindData &order_bind) {
-		input_collection = make_uniq<ColumnDataCollection>(order_bind.context, order_bind.buffered_types);
-		input_append = make_uniq<ColumnDataAppendState>();
-		input_collection->InitializeAppend(*input_append);
-	}
-
-	void FlushChunks(const SortedAggregateBindData &order_bind) {
-		D_ASSERT(input_chunk);
-		input_collection->Append(*input_append, *input_chunk);
-		input_chunk->Reset();
-	}
-
-	void Resize(const SortedAggregateBindData &order_bind, idx_t n) {
-		count = n;
-
-		//	Establish the current buffering
-		if (count <= LIST_CAPACITY) {
-			InitializeLinkedLists(order_bind);
-		}
-
-		if (count > LIST_CAPACITY && !input_chunk && !input_collection) {
-			FlushLinkedLists(order_bind);
-		}
-
-		if (count > CHUNK_CAPACITY && !input_collection) {
-			InitializeCollections(order_bind);
-			FlushChunks(order_bind);
-		}
-	}
-
-	static void LinkedAppend(const LinkedChunkFunctions &functions, ArenaAllocator &allocator, DataChunk &input,
-	                         LinkedLists &linked, SelectionVector &sel, idx_t nsel) {
-		for (column_t c = 0; c < input.ColumnCount(); ++c) {
-			auto &func = functions[c];
-			auto &linked_list = linked[c];
-			RecursiveUnifiedVectorFormat input_data;
-			Vector::RecursiveToUnifiedFormat(input.data[c], input_data);
-			for (idx_t i = 0; i < nsel; ++i) {
-				idx_t sidx = sel.get_index(i);
-				func.AppendRow(allocator, linked_list, input_data, sidx);
-			}
-		}
-	}
-
-	static void LinkedAbsorb(LinkedLists &source, LinkedLists &target) {
-		D_ASSERT(source.size() == target.size());
-		for (column_t i = 0; i < source.size(); ++i) {
-			auto &src = source[i];
-			if (!src.total_capacity) {
-				break;
-			}
-
-			auto &tgt = target[i];
-			if (!tgt.total_capacity) {
-				tgt = src;
-			} else {
-				// append the linked list
-				tgt.last_segment->next = src.first_segment;
-				tgt.last_segment = src.last_segment;
-				tgt.total_capacity += src.total_capacity;
-			}
-		}
-	}
-
-	void Update(const AggregateInputData &aggr_input_data, DataChunk &input) {
-		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
-		Resize(order_bind, count + input.size());
-
-		sel.Initialize(nullptr);
-		nsel = input.size();
-
-		if (input_collection) {
-			//	Using collections
-			input_collection->Append(*input_append, input);
-		} else if (input_chunk) {
-			//	Still using data chunks
-			input_chunk->Append(input);
-		} else {
-			//	Still using linked lists
-			LinkedAppend(order_bind.buffered_funcs, aggr_input_data.allocator, input, input_linked, sel, nsel);
-		}
-
-		nsel = 0;
-		offset = 0;
-	}
-
-	void UpdateSlice(const AggregateInputData &aggr_input_data, DataChunk &input) {
-		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
-		Resize(order_bind, count + nsel);
-
-		if (input_collection) {
-			//	Using collections
-			D_ASSERT(input_chunk);
-			input_chunk->Slice(input, sel, nsel);
-			FlushChunks(order_bind);
-		} else if (input_chunk) {
-			//	Still using data chunks
-			input_chunk->Append(input, sel, nsel, VectorAppendMode::ALLOW_RESIZE);
-		} else {
-			//	Still using linked lists
-			LinkedAppend(order_bind.buffered_funcs, aggr_input_data.allocator, input, input_linked, sel, nsel);
-		}
-
-		nsel = 0;
-		offset = 0;
-	}
-
-	void Swap(SortedAggregateState &other) {
-		std::swap(count, other.count);
-
-		std::swap(input_collection, other.input_collection);
-		std::swap(input_append, other.input_append);
-
-		std::swap(input_chunk, other.input_chunk);
-
-		std::swap(input_linked, other.input_linked);
-	}
-
-	void Absorb(const SortedAggregateBindData &order_bind, SortedAggregateState &other) {
-		if (!other.count) {
-			return;
-		} else if (!count) {
-			Swap(other);
-			return;
-		}
-
-		//	Change to a state large enough for all the data
-		Resize(order_bind, count + other.count);
-
-		//	3x3 matrix.
-		//	We can simplify the logic a bit because the target is already set for the final capacity
-		if (!input_chunk) {
-			//	If the combined count is still linked lists,
-			//	then just move the pointers.
-			//	Note that this assumes ArenaAllocator is shared and the memory will not vanish under us.
-			LinkedAbsorb(other.input_linked, input_linked);
-
-			other.Reset();
-			return;
-		}
-
-		if (!other.input_chunk) {
-			other.FlushLinkedLists(order_bind);
-		}
-
-		if (!input_collection) {
-			//	Still using chunks, which means the source is using chunks or lists
-			D_ASSERT(input_chunk);
-			D_ASSERT(other.input_chunk);
-			input_chunk->Append(*other.input_chunk);
-		} else {
-			// Using collections, so source could be using anything.
-			if (other.input_collection) {
-				input_collection->Combine(*other.input_collection);
-			} else {
-				input_collection->Append(*other.input_chunk);
-			}
-		}
-
-		//	Free all memory as we have absorbed it.
-		other.Reset();
-	}
-
-	void PrefixSortBuffer(DataChunk &prefixed) {
-		for (column_t col_idx = 0; col_idx < input_chunk->ColumnCount(); ++col_idx) {
-			prefixed.data[col_idx + 1].Reference(input_chunk->data[col_idx]);
-		}
-		// data[0] was referenced as a constant with count=1 - resize to match
-		FlatVector::SetSize(prefixed.data[0], count_t(input_chunk->size()));
-	}
-
-	void Finalize(const SortedAggregateBindData &order_bind, DataChunk &prefixed, ExecutionContext &context,
-	              OperatorSinkInput &sink) {
-		auto &sort = *order_bind.sort;
-		if (input_collection) {
-			ColumnDataScanState sort_state;
-			input_collection->InitializeScan(sort_state);
-			for (input_chunk->Reset(); input_collection->Scan(sort_state, *input_chunk); input_chunk->Reset()) {
-				PrefixSortBuffer(prefixed);
-				sort.Sink(context, prefixed, sink);
-			}
-		} else {
-			//	Force chunks so we can sort
-			if (!input_chunk) {
-				FlushLinkedLists(order_bind);
-			}
-
-			PrefixSortBuffer(prefixed);
-			sort.Sink(context, prefixed, sink);
-		}
-
-		Reset();
-	}
-
-	void Reset() {
-		//	Release all memory
-		input_collection.reset();
-		input_chunk.reset();
-		input_linked.clear();
-
-		count = 0;
-	}
-
-	idx_t count;
-
-	unique_ptr<ColumnDataCollection> input_collection;
-	unique_ptr<ColumnDataAppendState> input_append;
-	unique_ptr<DataChunk> input_chunk;
-	LinkedLists input_linked;
-
-	// Selection for scattering
-	SelectionVector sel;
-	idx_t nsel;
-	idx_t offset;
-};
+//! The sorted aggregate buffers its input rows in a linked list of structs - it shares the state and the
+//! update/combine callbacks of the "list" aggregate function, only the finalize differs.
+struct SortedAggregateState : ListAggState {};
 
 struct SortedAggregateFunction {
-	template <typename STATE>
-	static void Initialize(STATE &state) {
-		new (&state) STATE();
-	}
-
-	template <typename STATE>
-	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
-		state.~STATE();
-	}
-
-	static void ProjectInputs(Vector inputs[], const SortedAggregateBindData &order_bind, idx_t input_count,
-	                          idx_t count, DataChunk &buffered) {
-		//	Only reference the buffered columns
-		buffered.InitializeEmpty(order_bind.buffered_types);
-		const auto &buffered_cols = order_bind.buffered_cols;
-		for (idx_t b = 0; b < buffered_cols.size(); ++b) {
-			D_ASSERT(buffered_cols[b] < input_count);
-			buffered.data[b].Reference(inputs[buffered_cols[b]]);
-		}
+	//! The values stored in the linked list are the buffered input rows packed into a struct
+	static LogicalType GetElementType(AggregateInputData &aggr_input_data) {
+		return aggr_input_data.bind_data->Cast<SortedAggregateBindData>().buffered_struct_type;
 	}
 
 	static void ScatterUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
@@ -451,57 +179,17 @@ struct SortedAggregateFunction {
 		if (!count) {
 			return;
 		}
-
-		// Append the arguments to the two sub-collections
+		//	Pack the buffered columns into a single struct vector and append the rows through the list update
 		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
-		DataChunk arg_inputs;
-		ProjectInputs(inputs, order_bind, input_count, count, arg_inputs);
-
-		// We have to scatter the chunks one at a time
-		// so build a selection vector for each one.
-		UnifiedVectorFormat svdata;
-		states.ToUnifiedFormat(svdata);
-
-		// Size the selection vector for each state.
-		auto sdata = UnifiedVectorFormat::GetData<SortedAggregateState *>(svdata);
-		for (idx_t i = 0; i < count; ++i) {
-			auto sidx = svdata.sel->get_index(i);
-			auto order_state = sdata[sidx];
-			order_state->nsel++;
+		Vector packed(order_bind.buffered_struct_type, count);
+		auto &entries = StructVector::GetEntries(packed);
+		const auto &buffered_cols = order_bind.buffered_cols;
+		for (idx_t b = 0; b < buffered_cols.size(); ++b) {
+			D_ASSERT(buffered_cols[b] < input_count);
+			entries[b].Reference(inputs[buffered_cols[b]]);
 		}
-
-		// Build the selection vector for each state.
-		vector<sel_t> sel_data(count);
-		idx_t start = 0;
-		for (idx_t i = 0; i < count; ++i) {
-			auto sidx = svdata.sel->get_index(i);
-			auto order_state = sdata[sidx];
-			if (!order_state->offset) {
-				//	First one
-				order_state->offset = start;
-				order_state->sel.Initialize(sel_data.data() + order_state->offset, count - order_state->offset);
-				start += order_state->nsel;
-			}
-			sel_data[order_state->offset++] = UnsafeNumericCast<sel_t>(i);
-		}
-
-		// Append nonempty slices to the arguments
-		for (idx_t i = 0; i < count; ++i) {
-			auto sidx = svdata.sel->get_index(i);
-			auto order_state = sdata[sidx];
-			if (!order_state->nsel) {
-				continue;
-			}
-
-			order_state->UpdateSlice(aggr_input_data, arg_inputs);
-		}
-	}
-
-	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
-		auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
-		auto &other = const_cast<STATE &>(source); // NOLINT: absorb explicitly allows destruction
-		target.Absorb(order_bind, other);
+		FlatVector::SetSize(packed, count_t(count));
+		ListUpdateFunction(&packed, aggr_input_data, 1, states, count);
 	}
 
 	static void Window(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition,
@@ -516,6 +204,33 @@ struct SortedAggregateFunction {
 		for (idx_t rid = 0; rid < count; ++rid) {
 			Window(aggr_input_data, partition, g_state, l_state, subframes_per_row[rid], result, rid);
 		}
+	}
+
+	//! Sinks all buffered rows of the state into the sort, prefixed with the group number
+	static void SinkState(const SortedAggregateBindData &order_bind, SortedAggregateState &state, idx_t group_number,
+	                      ExecutionContext &context, OperatorSinkInput &sink, DataChunk &prefixed) {
+		auto &sort = *order_bind.sort;
+		const auto total_count = state.linked_list.total_capacity;
+		if (!total_count) {
+			return;
+		}
+		//	Build the buffered rows from the linked list
+		Vector rows(order_bind.buffered_struct_type, total_count);
+		order_bind.buffered_funcs.BuildListVector(state.linked_list, rows, 0);
+		auto &entries = StructVector::GetEntries(rows);
+		//	Sink the rows in vector-sized chunks
+		for (idx_t pos = 0; pos < total_count; pos += STANDARD_VECTOR_SIZE) {
+			const auto chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, total_count - pos);
+			prefixed.Reset();
+			prefixed.data[0].Reference(Value::USMALLINT(UnsafeNumericCast<uint16_t>(group_number)), count_t(1));
+			FlatVector::SetSize(prefixed.data[0], count_t(chunk_count));
+			for (column_t col_idx = 0; col_idx < entries.size(); ++col_idx) {
+				prefixed.data[col_idx + 1].Slice(entries[col_idx], pos, pos + chunk_count);
+			}
+			sort.Sink(context, prefixed, sink);
+		}
+		//	Release the state (the arena-allocated rows are freed with the allocator)
+		state.linked_list = LinkedList();
 	}
 
 	static void Finalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
@@ -549,7 +264,7 @@ struct SortedAggregateFunction {
 
 		vector<idx_t> state_unprocessed(count, 0);
 		for (idx_t i = 0; i < count; ++i) {
-			state_unprocessed[i] = sdata[i].GetValueUnsafe()->count;
+			state_unprocessed[i] = sdata[i].GetValueUnsafe()->linked_list.total_capacity;
 		}
 
 		ThreadContext thread(client);
@@ -568,10 +283,8 @@ struct SortedAggregateFunction {
 		for (idx_t finalized = 0; finalized < count;) {
 			if (unsorted_count < order_bind.threshold) {
 				auto state = sdata[finalized].GetValueUnsafe();
-				prefixed.Reset();
-				prefixed.data[0].Reference(Value::USMALLINT(UnsafeNumericCast<uint16_t>(finalized)), count_t(1));
 				OperatorSinkInput sink {*global_sink, *local_sink, interrupt};
-				state->Finalize(order_bind, prefixed, context, sink);
+				SinkState(order_bind, *state, finalized, context, sink, prefixed);
 				unsorted_count += state_unprocessed[finalized];
 
 				// Go to the next aggregate unless this is the last one
@@ -711,16 +424,13 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	}
 
 	// Replace the aggregate with the wrapper
-	AggregateFunction ordered_aggregate(
-	    bound_function.GetName(), arguments, bound_function.GetReturnType(),
-	    AggregateFunction::StateSize<SortedAggregateState>,
-	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction,
-	                                       AggregateDestructorType::LEGACY>,
-	    SortedAggregateFunction::ScatterUpdate,
-	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
-	    SortedAggregateFunction::Finalize, bound_function.GetProperties().GetNullHandling(), nullptr, nullptr,
-	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
-	    SortedAggregateFunction::WindowBatch);
+	AggregateFunction ordered_aggregate(bound_function.GetName(), arguments, bound_function.GetReturnType(),
+	                                    AggregateFunction::StateSize<SortedAggregateState>,
+	                                    AggregateFunction::StateInitialize<SortedAggregateState, ListFunction>,
+	                                    SortedAggregateFunction::ScatterUpdate,
+	                                    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize,
+	                                    bound_function.GetProperties().GetNullHandling(), nullptr, nullptr, nullptr,
+	                                    nullptr, SortedAggregateFunction::WindowBatch);
 
 	expr.FunctionMutable().ReplaceImplementation(ordered_aggregate);
 	expr.BindInfoMutable() = std::move(sorted_bind);
@@ -770,12 +480,9 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	// Replace the aggregate with the wrapper
 	AggregateFunction ordered_aggregate(
 	    aggregate.GetName(), arguments, aggregate.GetReturnType(), AggregateFunction::StateSize<SortedAggregateState>,
-	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction,
-	                                       AggregateDestructorType::LEGACY>,
-	    SortedAggregateFunction::ScatterUpdate,
-	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
-	    SortedAggregateFunction::Finalize, aggregate.GetProperties().GetNullHandling(), nullptr, nullptr,
-	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>, nullptr,
+	    AggregateFunction::StateInitialize<SortedAggregateState, ListFunction>, SortedAggregateFunction::ScatterUpdate,
+	    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize,
+	    aggregate.GetProperties().GetNullHandling(), nullptr, nullptr, nullptr, nullptr,
 	    SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);
 

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -164,12 +164,10 @@ struct SortedAggregateBindData : public FunctionData {
 	const idx_t threshold;
 };
 
-//! The sorted aggregate buffers its input rows in a linked list of structs - it shares the state and the
-//! update/combine callbacks of the "list" aggregate function, only the finalize differs.
+//! The sorted aggregate buffers its input rows in a linked list of structs, sharing the "list" callbacks
 struct SortedAggregateState : ListAggState {};
 
 struct SortedAggregateFunction {
-	//! The values stored in the linked list are the buffered input rows packed into a struct
 	static LogicalType GetElementType(AggregateInputData &aggr_input_data) {
 		return aggr_input_data.bind_data->Cast<SortedAggregateBindData>().buffered_struct_type;
 	}
@@ -179,7 +177,7 @@ struct SortedAggregateFunction {
 		if (!count) {
 			return;
 		}
-		//	Pack the buffered columns into a single struct vector and append the rows through the list update
+		//	Pack the buffered columns into a single struct vector for the list update
 		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
 		Vector packed(order_bind.buffered_struct_type, count);
 		auto &entries = StructVector::GetEntries(packed);
@@ -210,26 +208,25 @@ struct SortedAggregateFunction {
 	static void SinkState(const SortedAggregateBindData &order_bind, SortedAggregateState &state, idx_t group_number,
 	                      ExecutionContext &context, OperatorSinkInput &sink, DataChunk &prefixed) {
 		auto &sort = *order_bind.sort;
-		const auto total_count = state.linked_list.total_capacity;
-		if (!total_count) {
-			return;
-		}
-		//	Build the buffered rows from the linked list
-		Vector rows(order_bind.buffered_struct_type, total_count);
-		order_bind.buffered_funcs.BuildListVector(state.linked_list, rows, 0);
-		auto &entries = StructVector::GetEntries(rows);
-		//	Sink the rows in vector-sized chunks
-		for (idx_t pos = 0; pos < total_count; pos += STANDARD_VECTOR_SIZE) {
-			const auto chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, total_count - pos);
+		ListSegmentScanState scan_state;
+		order_bind.buffered_funcs.InitializeScan(state.linked_list, scan_state);
+		for (;;) {
+			Vector rows(order_bind.buffered_struct_type, STANDARD_VECTOR_SIZE);
+			const auto chunk_count = order_bind.buffered_funcs.Scan(scan_state, rows);
+			if (!chunk_count) {
+				break;
+			}
+			auto &entries = StructVector::GetEntries(rows);
 			prefixed.Reset();
 			prefixed.data[0].Reference(Value::USMALLINT(UnsafeNumericCast<uint16_t>(group_number)), count_t(1));
 			FlatVector::SetSize(prefixed.data[0], count_t(chunk_count));
 			for (column_t col_idx = 0; col_idx < entries.size(); ++col_idx) {
-				prefixed.data[col_idx + 1].Slice(entries[col_idx], pos, pos + chunk_count);
+				prefixed.data[col_idx + 1].Reference(entries[col_idx]);
+				FlatVector::SetSize(prefixed.data[col_idx + 1], count_t(chunk_count));
 			}
 			sort.Sink(context, prefixed, sink);
 		}
-		//	Release the state (the arena-allocated rows are freed with the allocator)
+		//	Release the state - the rows are freed with the arena allocator
 		state.linked_list = LinkedList();
 	}
 

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -179,7 +179,7 @@ struct SortedAggregateFunction {
 		if (!count) {
 			return;
 		}
-		//	Pack the buffered columns into a single struct vector and append the rows through the list update
+		// Pack the buffered columns into a single struct vector and append the rows through the list update
 		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
 		Vector packed(order_bind.buffered_struct_type, count);
 		auto &entries = StructVector::GetEntries(packed);

--- a/src/include/duckdb/common/types/list_segment.hpp
+++ b/src/include/duckdb/common/types/list_segment.hpp
@@ -32,6 +32,10 @@ struct LinkedList {
 	ListSegment *last_segment;
 };
 
+struct ListSegmentScanState {
+	const ListSegment *segment = nullptr;
+};
+
 // forward declarations
 struct ListSegmentFunctions;
 typedef ListSegment *(*create_segment_t)(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
@@ -47,6 +51,10 @@ struct ListSegmentFunctions {
 	write_data_to_segment_t write_data;
 	read_data_from_segment_t read_data;
 	uint16_t initial_capacity = ListSegment::INITIAL_CAPACITY;
+	//! Row segments are capped at STANDARD_VECTOR_SIZE so that any segment can be scanned into a single vector
+	uint16_t maximum_capacity = uint16_t(MinValue<idx_t>(STANDARD_VECTOR_SIZE, DATA_SEGMENT_MAXIMUM_CAPACITY));
+
+	static constexpr idx_t DATA_SEGMENT_MAXIMUM_CAPACITY = 32768;
 
 	vector<ListSegmentFunctions> child_functions;
 
@@ -56,6 +64,12 @@ struct ListSegmentFunctions {
 	void AppendListEntry(ArenaAllocator &allocator, LinkedList &linked_list, RecursiveUnifiedVectorFormat &child_data,
 	                     const list_entry_t &list_entry) const;
 	void BuildListVector(const LinkedList &linked_list, Vector &result, idx_t total_count) const;
+
+	void InitializeScan(const LinkedList &linked_list, ListSegmentScanState &state) const;
+	//! Scans up to STANDARD_VECTOR_SIZE rows into the (freshly initialized) result vector,
+	//! returning the number of rows scanned - 0 when the scan is exhausted
+	idx_t Scan(ListSegmentScanState &state, Vector &result) const;
+
 	//! Build a LIST result vector from a set of linked lists - one per row, written at rows [offset, offset + count).
 	//! Rows with an empty linked list (total_capacity == 0) are set to NULL.
 	void BuildLists(const vector<LinkedList> &linked_lists, Vector &result, idx_t offset) const;

--- a/src/include/duckdb/common/types/list_segment.hpp
+++ b/src/include/duckdb/common/types/list_segment.hpp
@@ -33,7 +33,13 @@ struct LinkedList {
 };
 
 struct ListSegmentScanState {
+	//! The current segment
 	const ListSegment *segment = nullptr;
+	//! The offset of the next row to be scanned within the current segment
+	idx_t offset = 0;
+	//! The scan states for the children of the current segment (if any)
+	//! These are (re-)initialized by the scan whenever it moves to a new segment
+	vector<ListSegmentScanState> children;
 };
 
 // forward declarations
@@ -43,18 +49,16 @@ typedef ListSegment *(*create_segment_t)(const ListSegmentFunctions &functions, 
 typedef void (*write_data_to_segment_t)(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
                                         ListSegment *segment, RecursiveUnifiedVectorFormat &input_data,
                                         idx_t &entry_idx);
-typedef void (*read_data_from_segment_t)(const ListSegmentFunctions &functions, const ListSegment *segment,
-                                         Vector &result, idx_t &total_count);
+//! Scans up to "count" rows from the state's current position into the result vector at result_offset,
+//! advancing the state - returns the number of rows scanned (less than "count" only if the scan is exhausted)
+typedef idx_t (*scan_data_t)(const ListSegmentFunctions &functions, ListSegmentScanState &state, idx_t count,
+                             Vector &result, idx_t result_offset);
 
 struct ListSegmentFunctions {
 	create_segment_t create_segment;
 	write_data_to_segment_t write_data;
-	read_data_from_segment_t read_data;
+	scan_data_t scan_data;
 	uint16_t initial_capacity = ListSegment::INITIAL_CAPACITY;
-	//! Row segments are capped at STANDARD_VECTOR_SIZE so that any segment can be scanned into a single vector
-	uint16_t maximum_capacity = uint16_t(MinValue<idx_t>(STANDARD_VECTOR_SIZE, DATA_SEGMENT_MAXIMUM_CAPACITY));
-
-	static constexpr idx_t DATA_SEGMENT_MAXIMUM_CAPACITY = 32768;
 
 	vector<ListSegmentFunctions> child_functions;
 

--- a/src/include/duckdb/function/aggregate/list_aggregate.hpp
+++ b/src/include/duckdb/function/aggregate/list_aggregate.hpp
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/aggregate/list_aggregate.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/list_segment.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+
+namespace duckdb {
+
+//! The state of the "list" aggregate function - aggregates that buffer their input rows in a linked list
+//! (e.g. sorted aggregates) share this state and its callbacks, differing only in their finalize.
+struct ListAggState {
+	LinkedList linked_list;
+
+	//! The state is a linked list of values - exported/imported as the aggregate's LIST return type
+	using STATE_TYPE = StateListType<StateReturnType>;
+};
+
+struct ListFunction {
+	static bool IgnoreNull() {
+		return false;
+	}
+
+	//! The type of the values stored in the linked list - for "list" this is the child of the LIST return type
+	static LogicalType GetElementType(AggregateInputData &aggr_input_data) {
+		return ListType::GetChildType(aggr_input_data.function.GetReturnType());
+	}
+};
+
+//! Appends the i-th input row to the i-th state's linked list
+inline void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
+                               Vector &state_vector, idx_t count) {
+	D_ASSERT(input_count == 1);
+	auto &input = inputs[0];
+	RecursiveUnifiedVectorFormat input_data;
+	Vector::RecursiveToUnifiedFormat(input, input_data);
+
+	auto states = state_vector.Values<ListAggState *>();
+
+	ListSegmentFunctions functions;
+	GetSegmentDataFunctions(functions, input.GetType());
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i].GetValue();
+		aggr_input_data.allocator.AlignNext();
+		functions.AppendRow(aggr_input_data.allocator, state.linked_list, input_data, i);
+	}
+}
+
+//! Absorbs the source states into the combined states by linking the lists together
+inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data,
+                               idx_t count) {
+	D_ASSERT(aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE);
+
+	auto states = states_vector.Values<ListAggState *>();
+	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i].GetValue();
+		if (state.linked_list.total_capacity == 0) {
+			// NULL, no need to append
+			// this can happen when adding a FILTER to the grouping, e.g.,
+			// LIST(i) FILTER (WHERE i <> 3)
+			continue;
+		}
+
+		if (combined_ptr[i]->linked_list.total_capacity == 0) {
+			combined_ptr[i]->linked_list = state.linked_list;
+			continue;
+		}
+
+		// append the linked list
+		combined_ptr[i]->linked_list.last_segment->next = state.linked_list.first_segment;
+		combined_ptr[i]->linked_list.last_segment = state.linked_list.last_segment;
+		combined_ptr[i]->linked_list.total_capacity += state.linked_list.total_capacity;
+	}
+}
+
+//! Combines the source states into the combined states - absorbing when allowed, copying the values otherwise.
+//! OP provides GetElementType(aggr_input_data), returning the type of the values stored in the linked list.
+template <class OP>
+void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
+	//	Can we use destructive combining?
+	if (aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
+		ListAbsorbFunction(states_vector, combined, aggr_input_data, count);
+		return;
+	}
+
+	auto states = states_vector.Values<ListAggState *>();
+	auto combined_ptr = FlatVector::GetDataMutable<ListAggState *>(combined);
+
+	auto element_type = OP::GetElementType(aggr_input_data);
+	ListSegmentFunctions functions;
+	GetSegmentDataFunctions(functions, element_type);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &source = *states[i].GetValue();
+		auto &target = *combined_ptr[i];
+
+		const auto entry_count = source.linked_list.total_capacity;
+		Vector input(element_type, entry_count);
+		functions.BuildListVector(source.linked_list, input, 0);
+
+		RecursiveUnifiedVectorFormat input_data;
+		Vector::RecursiveToUnifiedFormat(input, input_data);
+
+		functions.AppendListEntry(aggr_input_data.allocator, target.linked_list, input_data,
+		                          list_entry_t(0, entry_count));
+	}
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/aggregate/list_aggregate.hpp
+++ b/src/include/duckdb/function/aggregate/list_aggregate.hpp
@@ -14,12 +14,10 @@
 
 namespace duckdb {
 
-//! The state of the "list" aggregate function - aggregates that buffer their input rows in a linked list
-//! (e.g. sorted aggregates) share this state and its callbacks, differing only in their finalize.
+//! The state of the "list" aggregate - shared by aggregates that buffer their input in a linked list
 struct ListAggState {
 	LinkedList linked_list;
 
-	//! The state is a linked list of values - exported/imported as the aggregate's LIST return type
 	using STATE_TYPE = StateListType<StateReturnType>;
 };
 
@@ -28,7 +26,6 @@ struct ListFunction {
 		return false;
 	}
 
-	//! The type of the values stored in the linked list - for "list" this is the child of the LIST return type
 	static LogicalType GetElementType(AggregateInputData &aggr_input_data) {
 		return ListType::GetChildType(aggr_input_data.function.GetReturnType());
 	}
@@ -54,7 +51,6 @@ inline void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_d
 	}
 }
 
-//! Absorbs the source states into the combined states by linking the lists together
 inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data,
                                idx_t count) {
 	D_ASSERT(aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE);
@@ -82,8 +78,7 @@ inline void ListAbsorbFunction(Vector &states_vector, Vector &combined, Aggregat
 	}
 }
 
-//! Combines the source states into the combined states - absorbing when allowed, copying the values otherwise.
-//! OP provides GetElementType(aggr_input_data), returning the type of the values stored in the linked list.
+//! OP provides GetElementType(aggr_input_data), returning the type of the values stored in the linked list
 template <class OP>
 void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
 	//	Can we use destructive combining?


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/23228

Ordered aggregates effectively just gather all inputs, then in the finalize step do a sort and a re-aggregation. Gathering all inputs has been implemented [efficiently by the `LIST` aggregate](https://github.com/duckdb/duckdb/pull/8309).  In addition, we now support that structure (`LinkedList`) explicitly for [aggregate state export](https://github.com/duckdb/duckdb/pull/23199).

As such, both for performance as well as code re-usability reasons, it would be nice if ordered aggregates could just re-use the existing infrastructure of the `LIST` aggregate. That also means that aggregate state export for these aggregates becomes significantly more straightforward (in a follow-up PR), as well as any potential disk spilling as that can then be shared between the sorted aggregates and the `LIST` aggregate.

This PR does exactly that - and refactors the sorted aggregates to effectively just run the same code as `LIST`. All required data is gathered in a single struct vector which is then pushed into the `list` aggregate, i.e. if we have an aggregate like so:

```sql
select string_agg(l_comment order by l_linenumber) from lineitem group by l_orderkey;
```

We would ~more or less run:

```sql
SELECT LIST({'l_comment': l_comment, 'l_linenumber': l_linenumber}) FROM lineitem GROUP BY l_orderkey;
```

But in the finalize step, instead of emitting the list, we scan the list and perform the ordered aggregation.

In particular with many small groups this has substantial performance benefits, primarily because `LIST` has been optimized for exactly this case:

```sql
-- Many Groups
-- 1.5M groups, ~4 rows each group
select string_agg(l_comment order by l_linenumber) from lineitem group by l_orderkey;
```

| Version | Timing (s) |
|---------|------------|
| v1.5    | 2.5s       |
| New     | 0.75s      |


For enormous large aggregates there is a slight performance penalty for this approach, likely because the `ColumnDataCollection`-per-value is better optimized for large scans / appends than the linked list.


```sql
-- Few Groups
-- 4 groups, 1.5M rows per group
select max(strlen(strings)) from (select string_agg(l_comment order by l_orderkey) strings from lineitem group by l_returnflag);
```

| Version | Timing (s) |
|---------|------------|
| v1.5    | 0.28s      |
| New     | 0.33s      |

However, despite the small performance penalty in this scenario, the benefits / added simplicity of unifying this code and the performance boost in the many small groups seems like it is still very worthwhile to make this change. 

CC @hawkfish 