### PR TITLE
[Dev][Parquet][VARIANT] Fix problem with re-use of cached transform data for differently shredded files

### DIFF
--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -63,10 +63,13 @@ public:
 
 public:
 	ColumnDataCollection &ApplyTransform(ColumnDataCollection &input);
+	bool MatchesTypes(const vector<LogicalType> &other_types) const;
 
 private:
 	//! The buffer to store the transformed chunks of a rowgroup
 	ColumnDataCollection buffer;
+	//! The types used to bind the expressions and initialize the buffer
+	vector<LogicalType> types;
 	//! The expression(s) to apply to the input chunk
 	vector<unique_ptr<Expression>> expressions;
 	//! The expression executor used to transform the input chunk

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -355,9 +355,13 @@ public:
 
 ParquetWriteTransformData::ParquetWriteTransformData(ClientContext &context, vector<LogicalType> types,
                                                      vector<unique_ptr<Expression>> expressions_p)
-    : buffer(context, types, ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR), expressions(std::move(expressions_p)),
-      executor(context, expressions) {
-	chunk.Initialize(buffer.GetAllocator(), types);
+    : buffer(context, types, ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR), types(std::move(types)),
+      expressions(std::move(expressions_p)), executor(context, expressions) {
+	chunk.Initialize(buffer.GetAllocator(), this->types);
+}
+
+bool ParquetWriteTransformData::MatchesTypes(const vector<LogicalType> &other_types) const {
+	return types == other_types;
 }
 
 //! TODO: this doesnt work.. the ParquetWriteTransformData is shared with all threads, the method is stateful, but has
@@ -488,22 +492,28 @@ void ParquetWriter::AnalyzeSchema(ColumnDataCollection &buffer, vector<unique_pt
 }
 
 void ParquetWriter::InitializePreprocessing(unique_ptr<ParquetWriteTransformData> &transform_data) {
-	if (transform_data) {
-		return;
-	}
-
 	vector<LogicalType> transformed_types;
-	vector<unique_ptr<Expression>> transform_expressions;
 	for (idx_t col_idx = 0; col_idx < column_writers.size(); col_idx++) {
 		auto &column_writer = *column_writers[col_idx];
 		auto &original_type = sql_types[col_idx];
-		auto expr = make_uniq<BoundReferenceExpression>(original_type, col_idx);
 		if (!column_writer.HasTransform()) {
 			transformed_types.push_back(original_type);
-			transform_expressions.push_back(std::move(expr));
 			continue;
 		}
 		transformed_types.push_back(column_writer.TransformedType());
+	}
+	if (transform_data && transform_data->MatchesTypes(transformed_types)) {
+		return;
+	}
+
+	vector<unique_ptr<Expression>> transform_expressions;
+	for (idx_t col_idx = 0; col_idx < column_writers.size(); col_idx++) {
+		auto &column_writer = *column_writers[col_idx];
+		auto expr = make_uniq<BoundReferenceExpression>(sql_types[col_idx], col_idx);
+		if (!column_writer.HasTransform()) {
+			transform_expressions.push_back(std::move(expr));
+			continue;
+		}
 		transform_expressions.push_back(column_writer.TransformExpression(std::move(expr)));
 	}
 	transform_data = make_uniq<ParquetWriteTransformData>(context, transformed_types, std::move(transform_expressions));

--- a/test/sql/storage/types/variant/variant_parquet_shredding_bug.test
+++ b/test/sql/storage/types/variant/variant_parquet_shredding_bug.test
@@ -1,0 +1,24 @@
+# name: test/sql/storage/types/variant/variant_parquet_shredding_bug.test
+# group: [variant]
+
+require json
+
+require parquet
+
+load {TEST_DIR}/repro_eka.db readwrite v1.5.0
+
+statement ok
+set threads=1;
+
+statement ok
+CREATE TABLE t AS
+  SELECT ('{"id":"' || md5(i::VARCHAR) || md5((i+9)::VARCHAR) || '","x":' || CASE WHEN i < 150000 THEN '"a string"' ELSE '[1,2,3]' END || '}')::JSON::VARIANT AS v
+FROM range(300000) tbl(i) ORDER BY i;
+
+statement ok
+COPY (from t) TO '__TEST_DIR__/variant.parquet' (file_size_bytes '2mb')
+
+query I
+SELECT count(*) FROM read_parquet('__TEST_DIR__/variant.parquet')
+----
+300000


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/9666

The accompanying test would fail because one file is shredded on `INTEGER[]` while the other is shredded on `VARCHAR`.
In `InitializePreprocessing` for the second file we would see that `transform_data` was already initialized and return, making the method a no-op.

Later causing an assertion failure because the input data we create with the `transform_data` would have a shape that doesn't match the `ColumnWriter` created for the `VARIANT` of that file.

We now store the types used to initialize `transform_data` and compare them in `InitializePreprocessing`. If they do not match the current file’s transformed types, we invalidate the cached `transform_data` and recreate it with the correct types.