### PR TITLE
Transform type literals into unbound logical types

### DIFF
--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2505,12 +2505,10 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformTypeLiteral(PEGTran
 		throw ParserException("Cannot convert to type %s, requires exactly one type modifier",
 		                      EnumUtil::ToString(type.id()));
 	}
-	if (type == LogicalTypeId::UNBOUND || type.InternalType() == PhysicalType::INVALID) {
-		type = LogicalType::UNBOUND(make_uniq<TypeExpression>(colid, vector<unique_ptr<ParsedExpression>>()));
-	}
 	auto string_literal = list_pr.Child<StringLiteralParseResult>(1).result;
 	auto child = make_uniq<ConstantExpression>(Value(string_literal));
-	auto result = make_uniq<CastExpression>(type, std::move(child));
+	auto unbound_type = LogicalType::UNBOUND(make_uniq<TypeExpression>(colid, vector<unique_ptr<ParsedExpression>>()));
+	auto result = make_uniq<CastExpression>(unbound_type, std::move(child));
 	return std::move(result);
 }
 

--- a/test/configs/verify_statement_to_string.json
+++ b/test/configs/verify_statement_to_string.json
@@ -25,7 +25,8 @@
         "test/sql/types/hugeint/test_hugeint_conversion.test",
         "test/sql/types/uhugeint/test_uhugeint_conversion.test",
         "test/sql/types/decimal/large_decimal_constants.test",
-        "test/sql/cast/cast_error_location.test"
+        "test/sql/cast/cast_error_location.test",
+        "test/sql/types/nested/map/map_error.test"
       ]
     },
     {

--- a/test/sql/types/decimal/test_decimal_from_string.test
+++ b/test/sql/types/decimal/test_decimal_from_string.test
@@ -52,6 +52,11 @@ select cast('9.99' as decimal(1,0));
 Conversion Error: Could not convert string
 
 statement error
+select decimal 'a';
+----
+Conversion Error: Could not convert string
+
+statement error
 select map { 1: decimal 'b' };
 ----
 Conversion Error: Could not convert string

--- a/test/sql/types/enum/standalone_enum.test
+++ b/test/sql/types/enum/standalone_enum.test
@@ -21,6 +21,11 @@ SELECT 'hello'::ENUM;
 ENUM type requires at least one argument
 
 statement error
+SELECT ENUM 'a';
+----
+ENUM type requires at least one argument
+
+statement error
 SELECT 'hello'::ENUM(42);
 ----
 ENUM type requires a set of VARCHAR arguments

--- a/test/sql/types/nested/map/map_error.test
+++ b/test/sql/types/nested/map/map_error.test
@@ -22,6 +22,11 @@ SELECT MAP(NULL)
 ----
 Binder Error: No function matches the given name and argument types 'map("NULL")'
 
+statement error
+SELECT MAP 'a'
+----
+Binder Error: MAP type requires exactly two type modifiers: key type and value type
+
 statement ok
 CREATE TABLE tbl (a INTEGER[], b TEXT[])
 

--- a/test/sql/types/variant/variant_casts.test
+++ b/test/sql/types/variant/variant_casts.test
@@ -7,6 +7,11 @@ statement ok
 CREATE TABLE struct AS SELECT {'a': 42, 'b': 84} s
 
 query I
+select variant 'a'
+----
+a
+
+query I
 select s::VARIANT FROM struct
 ----
 {'a': 42, 'b': 84}


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/9538

Fix typed string literals to always bind their target type through the normal unbound type path instead of eagerly materializing partial LogicalTypes in the PEG parser. This avoids internal assertions for incomplete parameterized or special types such as MAP, DECIMAL, and ENUM, and restores the correct binder/conversion errors or successful casts.