### PR TITLE
Add VARCHAR overload to octet_length (#23099)

### DIFF
--- a/src/function/scalar/string/functions.json
+++ b/src/function/scalar/string/functions.json
@@ -182,6 +182,12 @@
         "name": "octet_length",
         "variants": [
             {
+                "parameters": [{"name": "string", "type": "VARCHAR"}],
+                "description": "Number of bytes in `string`.",
+                "example": "octet_length('abc')",
+                "categories": ["string"]
+            },
+            {
                 "parameters": [
                     {"name": "blob", "type": "BLOB"}
                 ],

--- a/src/function/scalar/string/length.cpp
+++ b/src/function/scalar/string/length.cpp
@@ -254,8 +254,9 @@ ScalarFunctionSet BitLengthFun::GetFunctions() {
 }
 
 ScalarFunctionSet OctetLengthFun::GetFunctions() {
-	// length for BLOB type
 	ScalarFunctionSet octet_length("octet_length");
+	octet_length.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                                        ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>));
 	octet_length.AddFunction(ScalarFunction({LogicalType::BLOB}, LogicalType::BIGINT,
 	                                        ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>));
 	octet_length.AddFunction(ScalarFunction({LogicalType::BIT}, LogicalType::BIGINT,

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -211,10 +211,10 @@ struct BitLengthFun {
 
 struct OctetLengthFun {
 	static constexpr const char *Name = "octet_length";
-	static constexpr const char *Parameters = "blob::BLOB\001bitstring::BIT";
-	static constexpr const char *Description = "Number of bytes in `blob`.\001Returns the number of bytes in the `bitstring`.";
-	static constexpr const char *Example = "octet_length('\\xAA\\xBB'::BLOB)\001octet_length('1101011'::BITSTRING)";
-	static constexpr const char *Categories = "blob\001bitstring";
+	static constexpr const char *Parameters = "string::VARCHAR\001blob::BLOB\001bitstring::BIT";
+	static constexpr const char *Description = "Number of bytes in `string`.\001Number of bytes in `blob`.\001Returns the number of bytes in the `bitstring`.";
+	static constexpr const char *Example = "octet_length('abc')\001octet_length('\\xAA\\xBB'::BLOB)\001octet_length('1101011'::BITSTRING)";
+	static constexpr const char *Categories = "string\001blob\001bitstring";
 
 	static ScalarFunctionSet GetFunctions();
 };

--- a/test/sql/function/string/test_octet_length.test
+++ b/test/sql/function/string/test_octet_length.test
@@ -1,0 +1,74 @@
+# name: test/sql/function/string/test_octet_length.test
+# description: OCTET_LENGTH test
+# group: [string]
+
+# test on scalars: empty, 1-byte ASCII, 2/3/4-byte UTF-8
+query IIIII
+select OCTET_LENGTH(''), OCTET_LENGTH('$'), OCTET_LENGTH('¢'), OCTET_LENGTH('€'), OCTET_LENGTH('𐍈')
+----
+0	1	2	3	4
+
+# NULL handling: typed NULL for each registered overload returns NULL
+query III
+select OCTET_LENGTH(NULL::VARCHAR), OCTET_LENGTH(NULL::BLOB), OCTET_LENGTH(NULL::BIT)
+----
+NULL	NULL	NULL
+
+# mixed ASCII + multi-byte
+query I
+select OCTET_LENGTH('café')
+----
+5
+
+# test on tables
+statement ok
+CREATE TABLE strings(a STRING, b STRING)
+
+statement ok
+INSERT INTO strings VALUES ('', 'Zero'), ('$', NULL), ('¢','Two'), ('€', NULL), ('𐍈','Four')
+
+query I
+select OCTET_LENGTH(a) FROM strings
+----
+0
+1
+2
+3
+4
+
+query I
+select OCTET_LENGTH(b) FROM strings
+----
+4
+NULL
+3
+NULL
+4
+
+query I
+select OCTET_LENGTH(a) FROM strings WHERE b IS NOT NULL
+----
+0
+2
+4
+
+# regression: existing BLOB overload still works
+query I
+select OCTET_LENGTH('hello'::BLOB)
+----
+5
+
+# regression: existing BIT overload still works
+query I
+select OCTET_LENGTH('1101011'::BITSTRING)
+----
+1
+
+# test incorrect usage
+statement error
+select OCTET_LENGTH()
+----
+
+statement error
+select OCTET_LENGTH(1, 2)
+----


### PR DESCRIPTION
Fixes #23099.

`octet_length` was only registered for `BLOB` and `BIT`, so calling it on a `VARCHAR` failed:

D SELECT octet_length('hello');
Binder Error: No function matches the given name and argument types 'octet_length(STRING_LITERAL)'.

This adds the missing `VARCHAR` overload, mirroring `bit_length` (which already has `VARCHAR + BIT`). The new overload reuses `StrLenOperator` - the same operator already used by `octet_length(BLOB)` - since both return `string_t::GetSize()`.
