### PR TITLE
Add explicit `-dark-mode` and `-light-mode` options to the CLI, and improve terminal background color detection

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -472,27 +472,47 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 	}
 
 	bool success = false;
-	if (write(ofd, "\x1b]11;?\007", 7) == 7) {
-		// Read the response: until \a or until we fill up our buffer
+	// We send the OSC 11 query to request the background color, followed by a DA1 ("Primary Device Attributes")
+	// Terminals answer queries in order, and virtually every terminal responds to DA1 - but not every
+	// terminal responds to OSC 11. When we receive the DA1 response without a preceding OSC 11 response, we know
+	// the terminal does not support OSC 11 - instead of blocking on a response that will never come.
+	if (write(ofd, "\x1b]11;?\007\x1b[c", 10) == 10) {
+		// Read the response: until the DA1 response ("\x1b[?<params>c")
 		string buf;
 		char read_buf[1];
+		bool found_da1 = false;
+		idx_t da1_start = 0;
 		while (true) {
-			// check if we have data to read
+			// wait up until 5s
+			if (!HasMoreData(ifd, 5000000)) {
+				// we didn't get data for 5s...
+				fprintf(stderr, "Timeout trying to read terminal background color (> 5s elapsed).\n");
+				fprintf(
+				    stderr,
+				    "Disable terminal background color detection by using duckdb -dark-mode or duckdb -light-mode.\n");
+				fprintf(stderr, "This likely means duckdb does not correctly support your CLI.\n");
+				fprintf(stderr, "Please file an issue.\n");
+				break;
+			}
 			if (read(ifd, read_buf, 1) != 1) {
 				break;
 			}
 			char c = read_buf[0];
-			if (c == '\a') {
-				break;
-			}
-			if (!buf.empty() && buf.back() == '\x1b' && c == '\\') {
-				buf.pop_back();
-				break;
-			}
 			buf += c;
+			if (!found_da1) {
+				if (buf.size() >= 3 && buf.compare(buf.size() - 3, 3, "\x1b[?") == 0) {
+					// found the start of the DA1 response
+					found_da1 = true;
+					da1_start = buf.size() - 3;
+				}
+			} else if (c == 'c') {
+				// the DA1 response is complete - stop reading
+				break;
+			}
 		}
-
-		success = ParseTerminalColor(color, buf.c_str(), buf.size());
+		// the OSC 11 response (if any) is everything before the DA1 response
+		idx_t response_size = found_da1 ? da1_start : buf.size();
+		success = ParseTerminalColor(color, buf.c_str(), response_size);
 	}
 	DisableRawModeInternal(ifd);
 	if (ifd != STDIN_FILENO) {

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -113,6 +113,14 @@ MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) 
 	return MetadataResult::SUCCESS;
 }
 
+template <HighlightMode mode>
+MetadataResult SetColorScheme(ShellState &state, const vector<string> &args) {
+	state.highlight_mode = mode;
+	ShellHighlight highlight(state);
+	highlight.ToggleMode(mode);
+	return MetadataResult::SUCCESS;
+}
+
 MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
 	state.readStdin = false;
 	auto &file = args[1];
@@ -161,6 +169,8 @@ static const CommandLineOption command_line_options[] = {
     {"cmd", 1, "COMMAND", nullptr, RunCommand<false>, "run \"COMMAND\" before reading stdin"},
     {"csv", 0, "", nullptr, ToggleCSVMode, "set output mode to 'csv'"},
     {"c", 1, "COMMAND", EnableBatch, RunCommand<true>, "run \"COMMAND\" and exit"},
+    {"dark-mode", 0, "", SetColorScheme<HighlightMode::DARK_MODE>, SetColorScheme<HighlightMode::DARK_MODE>,
+     "use dark mode colors"},
     {"echo", 0, "", nullptr, EnableEcho, "print commands before execution"},
     {"f", 1, "FILENAME", EnableBatch, ProcessFile, "read/process named file and exit"},
     {"init", 1, "FILENAME", SetInitFile, nullptr, "read/process named file"},
@@ -171,6 +181,8 @@ static const CommandLineOption command_line_options[] = {
     {"interactive", 0, "", nullptr, DisableBatch, "force interactive I/O"},
     {"json", 0, "", nullptr, ToggleOutputMode<RenderMode::JSON>, "set output mode to 'json'"},
     {"jsonlines", 0, "", nullptr, ToggleOutputMode<RenderMode::JSONLINES>, "set output mode to 'jsonlines'"},
+    {"light-mode", 0, "", SetColorScheme<HighlightMode::LIGHT_MODE>, SetColorScheme<HighlightMode::LIGHT_MODE>,
+     "use light mode colors"},
     {"line", 0, "", nullptr, ToggleOutputMode<RenderMode::LINE>, "set output mode to 'line'"},
     {"list", 0, "", nullptr, ToggleOutputMode<RenderMode::LIST>, "set output mode to 'list'"},
     {"markdown", 0, "", nullptr, ToggleOutputMode<RenderMode::MARKDOWN>, "set output mode to 'markdown'"},


### PR DESCRIPTION
Follow-up fix to https://github.com/duckdb/duckdb/pull/22838

The 1s time-out silently appeared to make the terminal background detection not interfere with certain shells (that would silently ignore the request - followed by us aborting). Removing that timeout now means those shells get stuck permanently.

This PR fixes up the terminal background detection by sending two requests: the OSC 11 query to get the background color, followed by a DA1 request to get the primary device attributes. The DA1 request is much more broadly supported by many more terminals. If a terminal silently ignores the OSC 11 query, it will likely still respond to the DA1 request. As a result, if we see the DA1 response only, we know that the terminal doesn't support the OSC11 response and we can immediately return without having to wait on a time-out.

Because this is all pretty fragile, we also add a fail-safe where we have a 5 second timeout on terminal background detection now. If that time-out expires, we print the following message:

```
Timeout trying to read terminal background color (> 5s elapsed).
Disable terminal background color detection by using duckdb -dark-mode or duckdb -light-mode.
This likely means duckdb does not correctly support your CLI.
Please file an issue.
```

We now also allow users to explicitly choose the mode using `duckdb -dark-mode` or `duckdb -light-mode` - which fully side-steps the terminal background color detection and can be used as a (temporary) work-around for any further unsupported terminals / CLIs.