### PR TITLE
Add `vertex_extract` function to get coordinates out of point-geometries

### DIFF
--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -268,6 +268,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_SCALAR_FUNCTION_SET(VariantKeysFun),
 	DUCKDB_SCALAR_FUNCTION(VariantNormalizeFun),
 	DUCKDB_SCALAR_FUNCTION(VariantTypeofFun),
+	DUCKDB_SCALAR_FUNCTION(VertexExtractFun),
 	DUCKDB_SCALAR_FUNCTION_SET(WriteLogFun),
 	DUCKDB_SCALAR_FUNCTION(ConcatOperatorFun),
 	DUCKDB_SCALAR_FUNCTION(LikeFun),

--- a/src/function/scalar/geometry/functions.json
+++ b/src/function/scalar/geometry/functions.json
@@ -45,6 +45,15 @@
     "name": "st_setcrs",
     "parameters": "geom,crs",
     "description": "Sets the Coordinate Reference System (CRS) identifier of the geometry",
+    "categories": ["geometry"],
+    "type": "scalar_function"
+  },
+  {
+    "name": "vertex_extract",
+    "parameters": "geom,ordinate",
+    "description": "Extracts the specified ordinate (X, Y, Z, M) from a point geometry",
+    "example": "vertex_extract('POINT(1 2 3)', 'Z')",
+    "categories": ["geometry"],
     "type": "scalar_function"
   }
 ]

--- a/src/function/scalar/geometry/functions.json
+++ b/src/function/scalar/geometry/functions.json
@@ -50,8 +50,8 @@
   },
   {
     "name": "vertex_extract",
-    "parameters": "geom,ordinate",
-    "description": "Extracts the specified ordinate (X, Y, Z, M) from a point geometry",
+    "parameters": "geom,coordinate",
+    "description": "Extracts the specified coordinate (X, Y, Z, M) from a point geometry",
     "example": "vertex_extract('POINT(1 2 3)', 'Z')",
     "categories": ["geometry"],
     "type": "scalar_function"

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -150,4 +150,172 @@ ScalarFunction StSetcrsFun::GetFunction() {
 	return geom_func;
 }
 
+namespace {
+
+struct VertexExtractBindData final : public FunctionData {
+	explicit VertexExtractBindData(idx_t vertex_index) : vertex_index(vertex_index) {
+	}
+
+	idx_t vertex_index;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<VertexExtractBindData>(vertex_index);
+	}
+
+	auto Equals(const FunctionData &other) const -> bool override {
+		auto &other_bind = other.Cast<VertexExtractBindData>();
+		return vertex_index == other_bind.vertex_index;
+	}
+};
+
+} // namespace
+
+static auto VertexExtractBind(BindScalarFunctionInput &input) -> unique_ptr<FunctionData> {
+	auto &arguments = input.GetArguments();
+
+	if (arguments[1]->GetReturnType().id() != LogicalTypeId::VARCHAR) {
+		return nullptr;
+	}
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("vertex_extract: vertex argument must be constant!");
+	}
+	if (arguments[1]->HasParameter()) {
+		throw ParameterNotResolvedException();
+	}
+	const auto vertex_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[1]);
+	if (vertex_val.IsNull()) {
+		throw BinderException("vertex_extract: vertex argument cannot be NULL!");
+	}
+	const auto vertex_str = StringUtil::Lower(StringValue::Get(vertex_val));
+	if (vertex_str == "x") {
+		return make_uniq<VertexExtractBindData>(static_cast<idx_t>(0));
+	}
+	if (vertex_str == "y") {
+		return make_uniq<VertexExtractBindData>(static_cast<idx_t>(1));
+	}
+	if (vertex_str == "z") {
+		return make_uniq<VertexExtractBindData>(static_cast<idx_t>(2));
+	}
+	if (vertex_str == "m") {
+		return make_uniq<VertexExtractBindData>(static_cast<idx_t>(3));
+	}
+	throw BinderException("vertex_extract: invalid vertex argument '%s', expected one of 'x', 'y', 'z', or 'm'",
+	                      vertex_str);
+}
+
+static auto VertexExtractStats(ClientContext &context, FunctionStatisticsInput &input) -> unique_ptr<BaseStatistics> {
+	const auto &child_stats = input.child_stats;
+	const auto &bind_data = input.bind_data->Cast<VertexExtractBindData>();
+
+	const auto &extent = GeometryStats::GetExtent(child_stats[0]);
+	const auto &types = GeometryStats::GetTypes(child_stats[0]);
+	const auto &flags = GeometryStats::GetFlags(child_stats[0]);
+
+	auto new_stats = NumericStats::CreateUnknown(LogicalType::DOUBLE);
+
+	if (!types.Has(GeometryType::POINT) || !flags.HasNonEmptyGeometry()) {
+		// No non-empty points present, so vertex extraction will always return NULL
+		*input.expr_ptr = make_uniq<BoundConstantExpression>(Value(LogicalType::DOUBLE));
+		new_stats.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+		new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		return new_stats.ToUnique();
+	}
+
+	new_stats.CopyValidity(child_stats[0]);
+
+	if (bind_data.vertex_index == 0 && extent.HasXY()) { // X
+		NumericStats::SetMin(new_stats, extent.x_min);
+		NumericStats::SetMax(new_stats, extent.x_max);
+		return new_stats.ToUnique();
+	}
+	if (bind_data.vertex_index == 1 && extent.HasXY()) { // Y
+		NumericStats::SetMin(new_stats, extent.y_min);
+		NumericStats::SetMax(new_stats, extent.y_max);
+		return new_stats.ToUnique();
+	}
+	if (bind_data.vertex_index == 2 && extent.HasZ()) { // Z
+		NumericStats::SetMin(new_stats, extent.z_min);
+		NumericStats::SetMax(new_stats, extent.z_max);
+		return new_stats.ToUnique();
+	}
+	if (bind_data.vertex_index == 3 && extent.HasM()) { // M
+		NumericStats::SetMin(new_stats, extent.m_min);
+		NumericStats::SetMax(new_stats, extent.m_max);
+		return new_stats.ToUnique();
+	}
+
+	return nullptr;
+}
+
+static auto VertexExtractFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	const auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &bind_data = func_expr.BindInfo()->Cast<VertexExtractBindData>();
+
+	BinaryExecutor::Execute<string_t, string_t, double>(
+	    input.data[0], input.data[1], result, [&](const string_t &geom_str, const string_t &) {
+		    const auto data = const_data_ptr_cast(geom_str.GetData());
+		    const auto size = geom_str.GetSize();
+		    const auto meta = Load<uint32_t>(data + sizeof(uint8_t));
+
+		    const auto type_id = (meta & 0x0000FFFF) % 1000;
+		    const auto flag_id = (meta & 0x0000FFFF) / 1000;
+		    const auto has_z = ((flag_id & 0x01) != 0);
+		    const auto has_m = ((flag_id & 0x02) != 0);
+
+		    if (type_id != 1) {
+			    return optional<double>();
+		    }
+
+		    auto value = std::numeric_limits<double>::quiet_NaN();
+
+		    if (bind_data.vertex_index == 0) { // X
+			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t);
+			    if (size < offset + sizeof(double)) {
+				    return optional<double>();
+			    }
+			    value = Load<double>(data + offset);
+		    } else if (bind_data.vertex_index == 1) { // Y
+			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(double);
+			    if (size < offset + sizeof(double)) {
+				    return optional<double>();
+			    }
+			    value = Load<double>(data + offset);
+		    } else if (bind_data.vertex_index == 2) { // Z
+			    if (!has_z) {
+				    return optional<double>();
+			    }
+			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + 2 * sizeof(double);
+			    if (size < offset + sizeof(double)) {
+				    return optional<double>();
+			    }
+			    value = Load<double>(data + offset);
+		    } else if (bind_data.vertex_index == 3) { // M
+			    if (!has_m) {
+				    return optional<double>();
+			    }
+			    const auto offset = sizeof(uint8_t) + sizeof(uint32_t) + (2 + has_z) * sizeof(double);
+			    if (size < offset + sizeof(double)) {
+				    return optional<double>();
+			    }
+			    value = Load<double>(data + offset);
+		    }
+
+		    if (std::isnan(value)) {
+			    return optional<double>();
+		    }
+
+		    return optional<double>(value);
+	    });
+}
+
+ScalarFunction VertexExtractFun::GetFunction() {
+	auto fun = ScalarFunction({}, LogicalTypeId::DOUBLE, VertexExtractFunction, VertexExtractBind, VertexExtractStats);
+	fun.GetSignature()
+	    .AddParameter("geom", LogicalType::GEOMETRY())
+	    .AddParameter("ordinate", LogicalTypeId::VARCHAR)
+	    .SetReturnType(LogicalType::DOUBLE);
+
+	return fun;
+}
+
 } // namespace duckdb

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -173,14 +173,11 @@ struct VertexExtractBindData final : public FunctionData {
 static auto VertexExtractBind(BindScalarFunctionInput &input) -> unique_ptr<FunctionData> {
 	auto &arguments = input.GetArguments();
 
-	if (arguments[1]->GetReturnType().id() != LogicalTypeId::VARCHAR) {
-		return nullptr;
+	if (arguments[1]->HasParameter()) {
+		throw ParameterNotResolvedException();
 	}
 	if (!arguments[1]->IsFoldable()) {
 		throw BinderException("vertex_extract: vertex argument must be constant!");
-	}
-	if (arguments[1]->HasParameter()) {
-		throw ParameterNotResolvedException();
 	}
 	const auto vertex_val = ExpressionExecutor::EvaluateScalar(input.GetClientContext(), *arguments[1]);
 	if (vertex_val.IsNull()) {

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -223,6 +223,44 @@ static auto VertexExtractStats(ClientContext &context, FunctionStatisticsInput &
 
 	new_stats.CopyValidity(child_stats[0]);
 
+	if (!types.HasOnly(GeometryType::POINT)) {
+		// If there are non-point geometries, we cannot guarantee that all rows will yield a valid value
+		new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+
+	// If there are empty geometries, we cannot guarantee that all rows will yield a valid value
+	if (flags.HasEmptyGeometry()) {
+		new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+
+	if (bind_data.vertex_index == 2) {
+		// Z is absent on XY and XYM points
+		if (types.Has(VertexType::XY) || types.Has(VertexType::XYM)) {
+			new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		if (!types.Has(VertexType::XYZ) && !types.Has(VertexType::XYZM)) {
+			// If there are no vertex types with Z, we can guarantee that all rows will yield NULL
+			*input.expr_ptr = make_uniq<BoundConstantExpression>(Value(LogicalType::DOUBLE));
+			new_stats.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+			new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			return new_stats.ToUnique();
+		}
+	}
+
+	if (bind_data.vertex_index == 3) {
+		// M is absent on XY and XYZ points
+		if (types.Has(VertexType::XY) || types.Has(VertexType::XYZ)) {
+			new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		}
+		if (!types.Has(VertexType::XYM) && !types.Has(VertexType::XYZM)) {
+			// If there are no vertex types with M, we can guarantee that all rows will yield NULL
+			*input.expr_ptr = make_uniq<BoundConstantExpression>(Value(LogicalType::DOUBLE));
+			new_stats.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+			new_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			return new_stats.ToUnique();
+		}
+	}
+
 	if (bind_data.vertex_index == 0 && extent.HasXY()) { // X
 		NumericStats::SetMin(new_stats, extent.x_min);
 		NumericStats::SetMax(new_stats, extent.x_max);
@@ -251,70 +289,70 @@ static auto VertexExtractFunction(DataChunk &input, ExpressionState &state, Vect
 	const auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	const auto &bind_data = func_expr.BindInfo()->Cast<VertexExtractBindData>();
 
-	BinaryExecutor::Execute<string_t, string_t, double>(
-	    input.data[0], input.data[1], result, [&](const string_t &geom_str, const string_t &) {
-		    const auto data = const_data_ptr_cast(geom_str.GetData());
-		    const auto size = geom_str.GetSize();
-		    const auto meta = Load<uint32_t>(data + sizeof(uint8_t));
+	UnaryExecutor::Execute<string_t, double>(input.data[0], result, [&](const string_t &geom_str) {
+		const auto data = const_data_ptr_cast(geom_str.GetData());
+		const auto size = geom_str.GetSize();
+		const auto meta = Load<uint32_t>(data + sizeof(uint8_t));
 
-		    const auto type_id = (meta & 0x0000FFFF) % 1000;
-		    const auto flag_id = (meta & 0x0000FFFF) / 1000;
-		    const auto has_z = ((flag_id & 0x01) != 0);
-		    const auto has_m = ((flag_id & 0x02) != 0);
+		const auto type_id = (meta & 0x0000FFFF) % 1000;
+		const auto flag_id = (meta & 0x0000FFFF) / 1000;
+		const auto has_z = ((flag_id & 0x01) != 0);
+		const auto has_m = ((flag_id & 0x02) != 0);
 
-		    if (type_id != 1) {
-			    return optional<double>();
-		    }
+		if (type_id != 1) {
+			return optional<double>();
+		}
 
-		    auto value = std::numeric_limits<double>::quiet_NaN();
+		auto value = std::numeric_limits<double>::quiet_NaN();
 
-		    if (bind_data.vertex_index == 0) { // X
-			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t);
-			    if (size < offset + sizeof(double)) {
-				    return optional<double>();
-			    }
-			    value = Load<double>(data + offset);
-		    } else if (bind_data.vertex_index == 1) { // Y
-			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(double);
-			    if (size < offset + sizeof(double)) {
-				    return optional<double>();
-			    }
-			    value = Load<double>(data + offset);
-		    } else if (bind_data.vertex_index == 2) { // Z
-			    if (!has_z) {
-				    return optional<double>();
-			    }
-			    constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + 2 * sizeof(double);
-			    if (size < offset + sizeof(double)) {
-				    return optional<double>();
-			    }
-			    value = Load<double>(data + offset);
-		    } else if (bind_data.vertex_index == 3) { // M
-			    if (!has_m) {
-				    return optional<double>();
-			    }
-			    const auto offset = sizeof(uint8_t) + sizeof(uint32_t) + (2 + has_z) * sizeof(double);
-			    if (size < offset + sizeof(double)) {
-				    return optional<double>();
-			    }
-			    value = Load<double>(data + offset);
-		    }
+		if (bind_data.vertex_index == 0) { // X
+			constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t);
+			if (size < offset + sizeof(double)) {
+				return optional<double>();
+			}
+			value = Load<double>(data + offset);
+		} else if (bind_data.vertex_index == 1) { // Y
+			constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + sizeof(double);
+			if (size < offset + sizeof(double)) {
+				return optional<double>();
+			}
+			value = Load<double>(data + offset);
+		} else if (bind_data.vertex_index == 2) { // Z
+			if (!has_z) {
+				return optional<double>();
+			}
+			constexpr auto offset = sizeof(uint8_t) + sizeof(uint32_t) + 2 * sizeof(double);
+			if (size < offset + sizeof(double)) {
+				return optional<double>();
+			}
+			value = Load<double>(data + offset);
+		} else if (bind_data.vertex_index == 3) { // M
+			if (!has_m) {
+				return optional<double>();
+			}
+			const auto offset = sizeof(uint8_t) + sizeof(uint32_t) + (2 + has_z) * sizeof(double);
+			if (size < offset + sizeof(double)) {
+				return optional<double>();
+			}
+			value = Load<double>(data + offset);
+		}
 
-		    if (std::isnan(value)) {
-			    return optional<double>();
-		    }
+		if (std::isnan(value)) {
+			return optional<double>();
+		}
 
-		    return optional<double>(value);
-	    });
+		return optional<double>(value);
+	});
 }
 
 ScalarFunction VertexExtractFun::GetFunction() {
 	auto fun = ScalarFunction({}, LogicalTypeId::DOUBLE, VertexExtractFunction, VertexExtractBind, VertexExtractStats);
 	fun.GetSignature()
 	    .AddParameter("geom", LogicalType::GEOMETRY())
-	    .AddParameter("ordinate", LogicalTypeId::VARCHAR)
+	    .AddParameter("coordinate", LogicalTypeId::VARCHAR)
 	    .SetReturnType(LogicalType::DOUBLE);
 
+	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }
 

--- a/src/include/duckdb/function/scalar/geometry_functions.hpp
+++ b/src/include/duckdb/function/scalar/geometry_functions.hpp
@@ -88,7 +88,17 @@ struct StSetcrsFun {
 	static constexpr const char *Parameters = "geom,crs";
 	static constexpr const char *Description = "Sets the Coordinate Reference System (CRS) identifier of the geometry";
 	static constexpr const char *Example = "";
-	static constexpr const char *Categories = "";
+	static constexpr const char *Categories = "geometry";
+
+	static ScalarFunction GetFunction();
+};
+
+struct VertexExtractFun {
+	static constexpr const char *Name = "vertex_extract";
+	static constexpr const char *Parameters = "geom,ordinate";
+	static constexpr const char *Description = "Extracts the specified ordinate (X, Y, Z, M) from a point geometry";
+	static constexpr const char *Example = "vertex_extract('POINT(1 2 3)', 'Z')";
+	static constexpr const char *Categories = "geometry";
 
 	static ScalarFunction GetFunction();
 };

--- a/src/include/duckdb/function/scalar/geometry_functions.hpp
+++ b/src/include/duckdb/function/scalar/geometry_functions.hpp
@@ -95,8 +95,8 @@ struct StSetcrsFun {
 
 struct VertexExtractFun {
 	static constexpr const char *Name = "vertex_extract";
-	static constexpr const char *Parameters = "geom,ordinate";
-	static constexpr const char *Description = "Extracts the specified ordinate (X, Y, Z, M) from a point geometry";
+	static constexpr const char *Parameters = "geom,coordinate";
+	static constexpr const char *Description = "Extracts the specified coordinate (X, Y, Z, M) from a point geometry";
 	static constexpr const char *Example = "vertex_extract('POINT(1 2 3)', 'Z')";
 	static constexpr const char *Categories = "geometry";
 

--- a/src/include/duckdb/storage/statistics/geometry_stats.hpp
+++ b/src/include/duckdb/storage/statistics/geometry_stats.hpp
@@ -75,6 +75,23 @@ public:
 		}
 	}
 
+	bool Has(GeometryType geom_type) const {
+		const auto geom_idx = static_cast<uint8_t>(geom_type);
+		D_ASSERT(geom_idx < PART_TYPES);
+		for (idx_t i = 0; i < VERT_TYPES; i++) {
+			if (sets[i] & (1 << geom_idx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool Has(VertexType vert_type) const {
+		const auto vert_idx = static_cast<uint8_t>(vert_type);
+		D_ASSERT(vert_idx < VERT_TYPES);
+		return sets[vert_idx] != 0;
+	}
+
 	//! Check if only the given geometry and vertex type is present
 	//! (all others are absent)
 	bool HasOnly(GeometryType geom_type, VertexType vert_type) const {

--- a/src/include/duckdb/storage/statistics/geometry_stats.hpp
+++ b/src/include/duckdb/storage/statistics/geometry_stats.hpp
@@ -115,6 +115,46 @@ public:
 		return true;
 	}
 
+	//! Check if only the given geometry type is present (with any vertex type),
+	//! and that at least one such geometry is present.
+	bool HasOnly(GeometryType geom_type) const {
+		const auto geom_idx = static_cast<uint8_t>(geom_type);
+		D_ASSERT(geom_idx < PART_TYPES);
+		bool found = false;
+		for (uint8_t v_idx = 0; v_idx < VERT_TYPES; v_idx++) {
+			for (uint8_t g_idx = 1; g_idx < PART_TYPES; g_idx++) {
+				if (!(sets[v_idx] & (1 << g_idx))) {
+					continue;
+				}
+				if (g_idx != geom_idx) {
+					return false;
+				}
+				found = true;
+			}
+		}
+		return found;
+	}
+
+	//! Check if only the given vertex type is present (with any geometry type),
+	//! and that at least one such geometry is present.
+	bool HasOnly(VertexType vert_type) const {
+		const auto vert_idx = static_cast<uint8_t>(vert_type);
+		D_ASSERT(vert_idx < VERT_TYPES);
+		bool found = false;
+		for (uint8_t v_idx = 0; v_idx < VERT_TYPES; v_idx++) {
+			for (uint8_t g_idx = 1; g_idx < PART_TYPES; g_idx++) {
+				if (!(sets[v_idx] & (1 << g_idx))) {
+					continue;
+				}
+				if (v_idx != vert_idx) {
+					return false;
+				}
+				found = true;
+			}
+		}
+		return found;
+	}
+
 	bool HasSingleType() const {
 		idx_t type_count = 0;
 		for (uint8_t v_idx = 0; v_idx < VERT_TYPES; v_idx++) {

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -176,10 +176,11 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		const auto &extract_expr_type = extract_exp->GetReturnType();
 		if (extract_expr_type.id() != LogicalTypeId::STRUCT && extract_expr_type.id() != LogicalTypeId::UNION &&
 		    extract_expr_type.id() != LogicalTypeId::MAP && extract_expr_type.id() != LogicalTypeId::SQLNULL &&
-		    !extract_expr_type.IsJSONType() && extract_expr_type.id() != LogicalTypeId::VARIANT) {
-			return BindResult(StringUtil::Format(
-			    "Cannot extract field %s from expression \"%s\" because it is not a struct, union, map, or json",
-			    name_exp->ToString(), extract_exp->ToString()));
+		    !extract_expr_type.IsJSONType() && extract_expr_type.id() != LogicalTypeId::VARIANT &&
+		    extract_expr_type.id() != LogicalTypeId::GEOMETRY) {
+			return BindResult(StringUtil::Format("Cannot extract field %s from expression \"%s\" because it is not a "
+			                                     "struct, union, map, json or geometry",
+			                                     name_exp->ToString(), extract_exp->ToString()));
 		}
 		if (extract_expr_type.id() == LogicalTypeId::UNION) {
 			function_name = "union_extract";
@@ -206,6 +207,8 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 					const_exp.SetReturnType(LogicalType::VARCHAR);
 				}
 			}
+		} else if (extract_expr_type.id() == LogicalTypeId::GEOMETRY) {
+			function_name = "vertex_extract";
 		} else {
 			function_name = "struct_extract";
 		}

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -36,6 +36,7 @@
         "test/sql/window/test_window_constant_allocator.test",
         "test/parquet/variant/variant_stats_propagation.test",
         "test/sql/types/geo/geometry_compatability.test",
+        "test/sql/types/geo/geometry_vertex_extract.test",
         "test/sql/copy/parquet/parquet_glob_cache.test",
         "test/optimizer/joins/fkpk_composite_key_ce.test",
         "test/sql/cast/signed_cast_repro.test"

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -56,6 +56,7 @@
         "test/sql/storage/types/variant/update.test",
         "test/sql/types/geo/geometry_crs.test",
         "test/sql/types/geo/geometry_stats.test",
+        "test/sql/types/geo/geometry_vertex_extract.test",
         "test/sql/sample/can_sample_from_ingested_files.test"
       ]
     },

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -110,6 +110,7 @@
         "test/sql/types/geo/geometry_crs.test",
         "test/sql/types/geo/geometry_crs_projjson.test",
         "test/sql/types/geo/geometry_crs_wkt2.test",
+        "test/sql/types/geo/geometry_vertex_extract.test",
         "test/geoparquet/disabled.test",
         "test/geoparquet/geoarrow.test",
         "test/geoparquet/mixed.test",

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -44,7 +44,8 @@
         "test/sql/copy/parquet/parquet_string_stats.test",
         "test/sql/storage/extended_string_stats.test",
         "test/sql/storage/min_string_length_too_large.test_slow",
-        "test/sql/storage/total_string_length_repeated_insert.test"
+        "test/sql/storage/total_string_length_repeated_insert.test",
+        "test/sql/types/geo/geometry_vertex_extract.test"
       ]
     }
   ]

--- a/test/sql/types/geo/geometry_vertex_extract.test
+++ b/test/sql/types/geo/geometry_vertex_extract.test
@@ -1,0 +1,3 @@
+# name: test/sql/types/geo/geometry_vertex_extract.test
+# group: [geo]
+

--- a/test/sql/types/geo/geometry_vertex_extract.test
+++ b/test/sql/types/geo/geometry_vertex_extract.test
@@ -1,3 +1,266 @@
 # name: test/sql/types/geo/geometry_vertex_extract.test
 # group: [geo]
 
+# ------------------------------------------------------------------------------
+# Basic extraction via the vertex_extract function
+# ------------------------------------------------------------------------------
+
+query I
+SELECT vertex_extract('POINT(1 2)'::GEOMETRY, 'x');
+----
+1
+
+query I
+SELECT vertex_extract('POINT(1 2)'::GEOMETRY, 'y');
+----
+2
+
+# The ordinate argument is case-insensitive
+query II
+SELECT vertex_extract('POINT(1 2)'::GEOMETRY, 'X'), vertex_extract('POINT(1 2)'::GEOMETRY, 'Y');
+----
+1	2
+
+# ------------------------------------------------------------------------------
+# The .x / .y / .z / .m dot syntax
+# ------------------------------------------------------------------------------
+
+query II
+SELECT ('POINT(1 2)'::GEOMETRY).x, ('POINT(1 2)'::GEOMETRY).y
+----
+1	2
+
+# Fractional and negative coordinates round-trip exactly
+query II
+SELECT ('POINT(-1.5 2.25)'::GEOMETRY).x, ('POINT(-1.5 2.25)'::GEOMETRY).y
+----
+-1.5	2.25
+
+# ------------------------------------------------------------------------------
+# Z / M ordinates on the various vertex types
+# ------------------------------------------------------------------------------
+
+# POINT Z carries x, y, z (no m)
+query IIII
+SELECT ('POINT Z (1 2 3)'::GEOMETRY).x, ('POINT Z (1 2 3)'::GEOMETRY).y,
+       ('POINT Z (1 2 3)'::GEOMETRY).z, ('POINT Z (1 2 3)'::GEOMETRY).m
+----
+1	2	3	NULL
+
+# POINT M carries x, y, m (no z) - m must not be read from the z slot
+query IIII
+SELECT ('POINT M (1 2 4)'::GEOMETRY).x, ('POINT M (1 2 4)'::GEOMETRY).y,
+       ('POINT M (1 2 4)'::GEOMETRY).z, ('POINT M (1 2 4)'::GEOMETRY).m
+----
+1	2	NULL	4
+
+# POINT ZM carries all four ordinates
+query IIII
+SELECT ('POINT ZM (1 2 3 4)'::GEOMETRY).x, ('POINT ZM (1 2 3 4)'::GEOMETRY).y,
+       ('POINT ZM (1 2 3 4)'::GEOMETRY).z, ('POINT ZM (1 2 3 4)'::GEOMETRY).m
+----
+1	2	3	4
+
+# Requesting z or m from a plain 2D point yields NULL (the ordinate is absent)
+query II
+SELECT ('POINT(1 2)'::GEOMETRY).z, ('POINT(1 2)'::GEOMETRY).m
+----
+NULL	NULL
+
+# ------------------------------------------------------------------------------
+# Non-point geometries always return NULL (vertex extraction is point-only)
+# ------------------------------------------------------------------------------
+
+query I
+SELECT ('LINESTRING(0 0, 1 1)'::GEOMETRY).x
+----
+NULL
+
+query I
+SELECT ('POLYGON((0 0, 1 0, 1 1, 0 0))'::GEOMETRY).x
+----
+NULL
+
+query I
+SELECT ('MULTIPOINT(1 2, 3 4)'::GEOMETRY).x
+----
+NULL
+
+query I
+SELECT ('GEOMETRYCOLLECTION(POINT(1 2))'::GEOMETRY).x
+----
+NULL
+
+# ------------------------------------------------------------------------------
+# Empty points and NULL geometries return NULL
+# ------------------------------------------------------------------------------
+
+# An empty point has no vertices - every ordinate is NULL
+query IIII
+SELECT ('POINT EMPTY'::GEOMETRY).x, ('POINT EMPTY'::GEOMETRY).y,
+       ('POINT EMPTY'::GEOMETRY).z, ('POINT EMPTY'::GEOMETRY).m
+----
+NULL	NULL	NULL	NULL
+
+query I
+SELECT (NULL::GEOMETRY).x
+----
+NULL
+
+# ------------------------------------------------------------------------------
+# Per-row extraction over a column of mixed geometries
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE geometries(id INTEGER, geom GEOMETRY);
+
+statement ok
+INSERT INTO geometries VALUES
+    (1, 'POINT(1 2)'),
+    (2, 'POINT Z (3 4 5)'),
+    (3, 'POINT M (6 7 8)'),
+    (4, 'POINT ZM (9 10 11 12)'),
+    (5, 'POINT EMPTY'),
+    (6, 'LINESTRING(0 0, 1 1)'),
+    (7, NULL);
+
+query IIIII
+SELECT id, geom.x, geom.y, geom.z, geom.m FROM geometries ORDER BY id;
+----
+1	1	2	NULL	NULL
+2	3	4	5	NULL
+3	6	7	NULL	8
+4	9	10	11	12
+5	NULL	NULL	NULL	NULL
+6	NULL	NULL	NULL	NULL
+7	NULL	NULL	NULL	NULL
+
+# ------------------------------------------------------------------------------
+# Error handling
+# ------------------------------------------------------------------------------
+
+# An unknown ordinate name is rejected at bind time
+statement error
+SELECT vertex_extract('POINT(1 2)'::GEOMETRY, 'w');
+----
+<REGEX>:Binder Error:.*invalid vertex argument.*
+
+# A NULL ordinate is rejected at bind time (special null handling lets the bind run)
+statement error
+SELECT vertex_extract('POINT(1 2)'::GEOMETRY, NULL::VARCHAR);
+----
+<REGEX>:Binder Error:.*cannot be NULL.*
+
+# The ordinate must be a constant, not a per-row value
+statement error
+SELECT geom.x, vertex_extract(geom, ord) FROM (SELECT 'POINT(1 2)'::GEOMETRY AS geom, 'x' AS ord);
+----
+<REGEX>:Binder Error:.*must be constant.*
+
+# ------------------------------------------------------------------------------
+# Statistics propagation
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE pts(geom GEOMETRY);
+
+statement ok
+INSERT INTO pts VALUES ('POINT(1 2)'), ('POINT(5 8)'), ('POINT(-3 4)');
+
+# X / Y stats are derived from the geometry extent (min/max bounding box)
+query I
+SELECT stats(geom.x) FROM pts LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 5.0, 'min': -3.0}
+
+query I
+SELECT stats(geom.y) FROM pts LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 8.0, 'min': 2.0}
+
+# Z is absent from every point, so extraction always yields NULL: the stats
+# recognise this and report "always NULL" (folded to a constant).
+query I
+SELECT stats(geom.z) FROM pts LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+statement ok
+CREATE TABLE pts_zm(geom GEOMETRY);
+
+statement ok
+INSERT INTO pts_zm VALUES ('POINT ZM (1 2 3 4)'), ('POINT ZM (5 6 7 8)');
+
+# Z / M stats are derived from the extent when those ordinates are present
+query I
+SELECT stats(geom.z) FROM pts_zm LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 7.0, 'min': 3.0}
+
+query I
+SELECT stats(geom.m) FROM pts_zm LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 8.0, 'min': 4.0}
+
+# When the requested ordinate is absent from some (but not all) points, the
+# result can contain NULLs that the input column did not - so the stats must
+# report has_null even though the geometry column has no NULL rows.
+statement ok
+CREATE TABLE pts_mixed_dim(geom GEOMETRY);
+
+statement ok
+INSERT INTO pts_mixed_dim VALUES ('POINT(1 2)'), ('POINT M (3 4 9)');
+
+query I
+SELECT stats(geom.m) FROM pts_mixed_dim LIMIT 1;
+----
+{'has_no_null': true, 'has_null': true, 'max': 9.0, 'min': 9.0}
+
+# Likewise, mixing point and non-point geometries makes extraction nullable
+statement ok
+CREATE TABLE pts_and_lines(geom GEOMETRY);
+
+statement ok
+INSERT INTO pts_and_lines VALUES ('POINT(1 2)'), ('LINESTRING(0 0, 10 10)');
+
+query I
+SELECT stats(geom.x) FROM pts_and_lines LIMIT 1;
+----
+{'has_no_null': true, 'has_null': true, 'max': 10.0, 'min': 0.0}
+
+# A column of only non-empty 2D points keeps the no-NULL guarantee for x / y
+statement ok
+CREATE TABLE pts_2d_only(geom GEOMETRY);
+
+statement ok
+INSERT INTO pts_2d_only VALUES ('POINT(1 2)'), ('POINT(5 8)');
+
+query I
+SELECT stats(geom.x) FROM pts_2d_only LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 5.0, 'min': 1.0}
+
+# When the column can contain no non-empty points, extraction is folded to a
+# constant NULL: the stats reflect "always NULL".
+statement ok
+CREATE TABLE lines_only(geom GEOMETRY);
+
+statement ok
+INSERT INTO lines_only VALUES ('LINESTRING(0 0, 1 1)'), ('LINESTRING(2 2, 3 3)');
+
+query I
+SELECT stats(geom.x) FROM lines_only LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+# The same folding applies when the column contains only empty points
+statement ok
+CREATE TABLE empty_pts(geom GEOMETRY);
+
+statement ok
+INSERT INTO empty_pts VALUES ('POINT EMPTY'), ('POINT EMPTY');
+
+query I
+SELECT stats(geom.x) FROM empty_pts LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}


### PR DESCRIPTION
This PR adds a `vertex_extract` function, with shorthand `.x / .y / .z / .m` syntax sugar to extract the x/y/z/m coordinate out of `POINT` geometries. Any other geometry sub-kind will return null.

While this doesn't sound very complicated on its own, this function is heavily optimized to perform stats-propagation, meaning that relatively common range expressions like `select ... where geom.x > 2 AND geom.x < 10` can now push down stats pruning into storage. We also propagate null-flags depending on what geometry sub-types are present in the stats, and can even short-circuit and return a constant null if we know at bind time that there are no non-empty point geometries with the requested coordinate axis present.

In the future I also want to add a `part_extract` function to extract nested geometry parts for non-point geometries by index, e.g. `('LINESTRING(0 0, 1 1, 2 2)'::GEOMETRY)[2] -> 'POINT(1 1)'`. Maybe even support slicing too (e.g. `[1...n]` returns a sub-line string).