### PR TITLE
Trim the system heap in the allocator flush path on jemalloc builds

### DIFF
--- a/src/common/allocator/allocator.cpp
+++ b/src/common/allocator/allocator.cpp
@@ -10,6 +10,10 @@
 
 #include <cstdint>
 
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
+
 #ifdef DUCKDB_DEBUG_ALLOCATION
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/pair.hpp"
@@ -173,6 +177,28 @@ shared_ptr<Allocator> &Allocator::DefaultAllocatorReference() {
 
 Allocator &Allocator::DefaultAllocator() {
 	return *DefaultAllocatorReference();
+}
+
+void Allocator::MallocTrim(idx_t pad) {
+#ifdef __GLIBC__
+	static constexpr int64_t TRIM_INTERVAL_MS = 100;
+	static atomic<int64_t> LAST_TRIM_TIMESTAMP_MS {0};
+
+	int64_t last_trim_timestamp_ms = LAST_TRIM_TIMESTAMP_MS.load();
+	auto current_ts = Timestamp::GetCurrentTimestamp();
+	auto current_timestamp_ms = Cast::Operation<timestamp_t, timestamp_ms_t>(current_ts).value;
+
+	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {
+		return; // We trimmed less than TRIM_INTERVAL_MS ago
+	}
+	if (!LAST_TRIM_TIMESTAMP_MS.compare_exchange_strong(last_trim_timestamp_ms, current_timestamp_ms,
+	                                                    std::memory_order_acquire, std::memory_order_relaxed)) {
+		return; // Another thread has updated LAST_TRIM_TIMESTAMP_MS since we loaded it
+	}
+
+	// We successfully updated LAST_TRIM_TIMESTAMP_MS, we can trim
+	malloc_trim(pad);
+#endif
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/allocator/allocator_jemalloc.cpp
+++ b/src/common/allocator/allocator_jemalloc.cpp
@@ -79,6 +79,11 @@ bool Allocator::SupportsFlush() {
 }
 
 void Allocator::ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count) {
+	// jemalloc only manages allocation done through the Allocator interface.
+	// Any allocations done directly through "malloc" or "operator new" still
+	// go to the system allocator. So we also trim the system heap here.
+	MallocTrim(thread_count * threshold);
+
 	if (!allocator_background_threads) {
 		// We flush after exceeding the threshold
 		if (GetJemallocCTL<uint64_t>("thread.peak.read") <= threshold) {
@@ -115,6 +120,9 @@ void Allocator::FlushAll() {
 
 	// Reset the peak after resetting
 	SetJemallocCTL("thread.peak.reset");
+
+	// Also return the system heap (see ThreadFlush) to the OS
+	MallocTrim(0);
 }
 
 void Allocator::SetBackgroundThreads(bool enable) {

--- a/src/common/allocator/allocator_standard.cpp
+++ b/src/common/allocator/allocator_standard.cpp
@@ -3,15 +3,8 @@
 #ifndef DUCKDB_ENABLE_JEMALLOC
 
 #include "duckdb/common/assert.hpp"
-#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/operator/cast_operators.hpp"
-#include "duckdb/common/types/timestamp.hpp"
-
-#ifdef __GLIBC__
-#include <malloc.h>
-#endif
 
 #ifdef DUCKDB_DEBUG_ALLOCATION
 #include "duckdb/common/mutex.hpp"
@@ -49,28 +42,6 @@ bool Allocator::SupportsFlush() {
 	return true;
 #else
 	return false;
-#endif
-}
-
-static void MallocTrim(idx_t pad) {
-#ifdef __GLIBC__
-	static constexpr int64_t TRIM_INTERVAL_MS = 100;
-	static atomic<int64_t> LAST_TRIM_TIMESTAMP_MS {0};
-
-	int64_t last_trim_timestamp_ms = LAST_TRIM_TIMESTAMP_MS.load();
-	auto current_ts = Timestamp::GetCurrentTimestamp();
-	auto current_timestamp_ms = Cast::Operation<timestamp_t, timestamp_ms_t>(current_ts).value;
-
-	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {
-		return; // We trimmed less than TRIM_INTERVAL_MS ago
-	}
-	if (!LAST_TRIM_TIMESTAMP_MS.compare_exchange_strong(last_trim_timestamp_ms, current_timestamp_ms,
-	                                                    std::memory_order_acquire, std::memory_order_relaxed)) {
-		return; // Another thread has updated LAST_TRIM_TIMESTAMP_MS since we loaded it
-	}
-
-	// We successfully updated LAST_TRIM_TIMESTAMP_MS, we can trim
-	malloc_trim(pad);
 #endif
 }
 

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -133,6 +133,10 @@ public:
 	static void SetBackgroundThreads(bool enable);
 
 private:
+	//! Returns free memory in the system heap (glibc) to the OS via malloc_trim, rate-limited to once
+	//! per 100ms. No-op on non-glibc platforms. Shared by the flush paths of both allocator backends.
+	static void MallocTrim(idx_t pad);
+
 	allocate_function_ptr_t allocate_function;
 	free_function_ptr_t free_function;
 	reallocate_function_ptr_t reallocate_function;


### PR DESCRIPTION
When DuckDB is built with jemalloc, only DuckDB's own `Allocator` allocations go through jemalloc. Everything else in the process that allocates via `operator new` or `malloc` directly (e.g. `make_uniq`/ `make_shared`/`std::vector`/`string`/`unordered_map`) goes to the system allocator, because `OVERRIDE_NEW_DELETE` defaults to off. glibc does not return that freed memory to the OS on its own, and jemalloc's arena purging does not cover it.

Until DuckDB v1.5.2 `Allocator::ThreadFlush` called `malloc_trim()` on every flush (rate-limited to once per 100ms), even when jemalloc was enabled. That call would hand that freed system-heap memory back to the OS. When the allocator was split into per-backend source files for v1.5.3, the `malloc_trim()` call survived only in `allocator_standard.cpp` and was dropped from the jemalloc path. As a result, on a jemalloc build the system heap was never trimmed in v1.5.3: resident memory would ratchet up to the high-water-mark of concurrent activity and it would never be released, even after the work that allocated it had finished.

This moves the rate-limited MallocTrim helper into the shared `allocator.cpp` as `Allocator::MallocTrim` so there is a single definition that is called from both Allocator implementations.
