### PR TITLE
[v1.5] Lock append operation when ongoing index creation

### DIFF
--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -49,9 +49,7 @@ public:
 
 unique_ptr<GlobalSinkState> PhysicalCreateIndex::GetGlobalSinkState(ClientContext &context) const {
 	auto gstate = make_uniq<CreateIndexGlobalSinkState>();
-	if (!alter_table_info) {
-		gstate->append_guard = table.GetStorage().LockAppendsForCreateIndex();
-	}
+	gstate->append_guard = table.GetStorage().LockAppendsForCreateIndex();
 
 	IndexBuildInitGlobalStateInput global_state_input {bind_data.get(),     context,    table, *info,
 	                                                   unbound_expressions, storage_ids};

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -43,14 +43,14 @@ PhysicalCreateIndex::PhysicalCreateIndex(PhysicalPlan &physical_plan, LogicalOpe
 //---------------------------------------------------------------------------------------------------------------------
 class CreateIndexGlobalSinkState : public GlobalSinkState {
 public:
-	unique_lock<mutex> append_lock;
+	DataTable::IndexBuildAppendGuard append_guard;
 	unique_ptr<IndexBuildGlobalState> gstate;
 };
 
 unique_ptr<GlobalSinkState> PhysicalCreateIndex::GetGlobalSinkState(ClientContext &context) const {
 	auto gstate = make_uniq<CreateIndexGlobalSinkState>();
 	if (!alter_table_info) {
-		gstate->append_lock = table.GetStorage().LockAppendsForCreateIndex();
+		gstate->append_guard = table.GetStorage().LockAppendsForCreateIndex();
 	}
 
 	IndexBuildInitGlobalStateInput global_state_input {bind_data.get(),     context,    table, *info,
@@ -153,9 +153,6 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 				throw CatalogException("Index with name \"%s\" already exists!", info->index_name);
 			}
 			// IF NOT EXISTS on existing index. We are done.
-			if (gstate.append_lock.owns_lock()) {
-				gstate.append_lock.unlock();
-			}
 			return SinkFinalizeType::READY;
 		}
 
@@ -179,9 +176,6 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));
-	if (gstate.append_lock.owns_lock()) {
-		gstate.append_lock.unlock();
-	}
 
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -43,11 +43,13 @@ PhysicalCreateIndex::PhysicalCreateIndex(PhysicalPlan &physical_plan, LogicalOpe
 //---------------------------------------------------------------------------------------------------------------------
 class CreateIndexGlobalSinkState : public GlobalSinkState {
 public:
+	unique_lock<mutex> append_lock;
 	unique_ptr<IndexBuildGlobalState> gstate;
 };
 
 unique_ptr<GlobalSinkState> PhysicalCreateIndex::GetGlobalSinkState(ClientContext &context) const {
 	auto gstate = make_uniq<CreateIndexGlobalSinkState>();
+	gstate->append_lock = table.GetStorage().LockAppendsForCreateIndex();
 
 	IndexBuildInitGlobalStateInput global_state_input {bind_data.get(),     context,    table, *info,
 	                                                   unbound_expressions, storage_ids};
@@ -149,6 +151,7 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 				throw CatalogException("Index with name \"%s\" already exists!", info->index_name);
 			}
 			// IF NOT EXISTS on existing index. We are done.
+			gstate.append_lock.unlock();
 			return SinkFinalizeType::READY;
 		}
 
@@ -172,6 +175,7 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));
+	gstate.append_lock.unlock();
 
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -49,7 +49,9 @@ public:
 
 unique_ptr<GlobalSinkState> PhysicalCreateIndex::GetGlobalSinkState(ClientContext &context) const {
 	auto gstate = make_uniq<CreateIndexGlobalSinkState>();
-	gstate->append_lock = table.GetStorage().LockAppendsForCreateIndex();
+	if (!alter_table_info) {
+		gstate->append_lock = table.GetStorage().LockAppendsForCreateIndex();
+	}
 
 	IndexBuildInitGlobalStateInput global_state_input {bind_data.get(),     context,    table, *info,
 	                                                   unbound_expressions, storage_ids};
@@ -151,7 +153,9 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 				throw CatalogException("Index with name \"%s\" already exists!", info->index_name);
 			}
 			// IF NOT EXISTS on existing index. We are done.
-			gstate.append_lock.unlock();
+			if (gstate.append_lock.owns_lock()) {
+				gstate.append_lock.unlock();
+			}
 			return SinkFinalizeType::READY;
 		}
 
@@ -175,7 +179,9 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 
 	// Add the index to the storage.
 	storage.AddIndex(std::move(bound_index));
-	gstate.append_lock.unlock();
+	if (gstate.append_lock.owns_lock()) {
+		gstate.append_lock.unlock();
+	}
 
 	return SinkFinalizeType::READY;
 }

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -23,6 +23,8 @@
 #include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
 class BoundForeignKeyConstraint;
@@ -73,6 +75,21 @@ public:
 	AttachedDatabase &db;
 
 public:
+	//! RAII guard returned by LockAppendsForCreateIndex.
+	struct IndexBuildAppendGuard {
+		DataTable *table = nullptr;
+
+		IndexBuildAppendGuard() = default;
+		explicit IndexBuildAppendGuard(DataTable &tbl);
+		~IndexBuildAppendGuard();
+		IndexBuildAppendGuard(const IndexBuildAppendGuard &) = delete;
+		IndexBuildAppendGuard &operator=(const IndexBuildAppendGuard &) = delete;
+		IndexBuildAppendGuard(IndexBuildAppendGuard &&other) noexcept : table(other.table) {
+			other.table = nullptr;
+		}
+		IndexBuildAppendGuard &operator=(IndexBuildAppendGuard &&other) noexcept;
+	};
+
 	AttachedDatabase &GetAttached();
 	TableIOManager &GetTableIOManager();
 
@@ -164,9 +181,10 @@ public:
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
 	//! Fetches an append lock
-	void AppendLock(DuckTransaction &transaction, TableAppendState &state);
-	//! Lock appends while creating an index over the table
-	unique_lock<mutex> LockAppendsForCreateIndex();
+	void AppendLock(DuckTransaction &transaction, TableAppendState &state) DUCKDB_EXCLUDES(append_lock);
+
+	//! Block appends while creating a standalone index over the table.
+	IndexBuildAppendGuard LockAppendsForCreateIndex() DUCKDB_EXCLUDES(append_lock);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
 	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
 	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
@@ -328,7 +346,11 @@ private:
 	//! The set of physical columns stored by this DataTable
 	vector<ColumnDefinition> column_definitions;
 	//! Lock for appending entries to the table
-	mutex append_lock;
+	annotated_mutex append_lock;
+	//! Notifies when an index build completes
+	std::condition_variable append_blocker_cv;
+	//! Indicates whether a standalone index creation is scanning this table
+	bool index_build_in_progress DUCKDB_GUARDED_BY(append_lock) = false;
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
 	//! The version of the data table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/enums/column_segment_info_scan_type.hpp"
 #include "duckdb/common/enums/index_constraint_type.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
@@ -181,10 +180,10 @@ public:
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
 	//! Fetches an append lock
-	void AppendLock(DuckTransaction &transaction, TableAppendState &state) DUCKDB_EXCLUDES(append_lock);
+	void AppendLock(DuckTransaction &transaction, TableAppendState &state);
 
 	//! Block appends while creating a standalone index over the table.
-	IndexBuildAppendGuard LockAppendsForCreateIndex() DUCKDB_EXCLUDES(append_lock);
+	IndexBuildAppendGuard LockAppendsForCreateIndex();
 	//! Begin appending structs to this table, obtaining necessary locks, etc
 	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
 	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
@@ -346,11 +345,11 @@ private:
 	//! The set of physical columns stored by this DataTable
 	vector<ColumnDefinition> column_definitions;
 	//! Lock for appending entries to the table
-	annotated_mutex append_lock;
+	mutex append_lock;
 	//! Notifies when all index builds complete
 	std::condition_variable append_blocker_cv;
 	//! The number of active index builds on the table
-	idx_t active_index_builds DUCKDB_GUARDED_BY(append_lock) = 0;
+	idx_t active_index_builds = 0;
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
 	//! The version of the data table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -347,10 +347,10 @@ private:
 	vector<ColumnDefinition> column_definitions;
 	//! Lock for appending entries to the table
 	annotated_mutex append_lock;
-	//! Notifies when an index build completes
+	//! Notifies when all index builds complete
 	std::condition_variable append_blocker_cv;
-	//! Indicates whether a standalone index creation is scanning this table
-	bool index_build_in_progress DUCKDB_GUARDED_BY(append_lock) = false;
+	//! The number of active index builds on the table
+	idx_t active_index_builds DUCKDB_GUARDED_BY(append_lock) = 0;
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
 	//! The version of the data table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include "duckdb/common/enums/column_segment_info_scan_type.hpp"
 #include "duckdb/common/enums/index_constraint_type.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/storage/index.hpp"
@@ -163,6 +165,8 @@ public:
 
 	//! Fetches an append lock
 	void AppendLock(DuckTransaction &transaction, TableAppendState &state);
+	//! Lock appends while creating an index over the table
+	unique_lock<mutex> LockAppendsForCreateIndex();
 	//! Begin appending structs to this table, obtaining necessary locks, etc
 	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
 	//! Append a chunk to the table using the AppendState obtained from InitializeAppend

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1143,12 +1143,18 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Co
 }
 
 void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state) {
-	state.append_lock = unique_lock<mutex>(append_lock);
+	annotated_unique_lock<annotated_mutex> lock(append_lock);
+	// Wait if a standalone CREATE INDEX scan is in progress over this table.
+	// Once the scan finishes the guard destructor clears the flag and notifies.
+	// The predicate is always called while append_lock is held (condition_variable
+	// contract), so DUCKDB_REQUIRES silences the GUARDED_BY warning.
+	append_blocker_cv.wait(lock, [this]() DUCKDB_REQUIRES(append_lock) { return !index_build_in_progress; });
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
 		                           "a different transaction",
 		                           GetTableName(), TableModification());
 	}
+	state.append_lock = std::move(lock);
 	state.table_lock = transaction.SharedLockTable(*info);
 	state.row_start = NumericCast<row_t>(row_groups->GetTotalRows());
 	state.current_row = state.row_start;
@@ -1162,14 +1168,33 @@ void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state
 	}
 }
 
-unique_lock<mutex> DataTable::LockAppendsForCreateIndex() {
-	unique_lock<mutex> lock(append_lock);
-	if (!IsMainTable()) {
+DataTable::IndexBuildAppendGuard::IndexBuildAppendGuard(DataTable &tbl) : table(&tbl) {
+	const annotated_lock_guard<annotated_mutex> lock(tbl.append_lock);
+	if (!tbl.IsMainTable()) {
+		table = nullptr; // nothing to unblock in the destructor
 		throw TransactionException("Transaction conflict: attempting to add an index to table \"%s\" but it has been "
 		                           "%s by a different transaction",
-		                           GetTableName(), TableModification());
+		                           tbl.GetTableName(), tbl.TableModification());
 	}
-	return lock;
+	tbl.index_build_in_progress = true;
+}
+
+DataTable::IndexBuildAppendGuard &DataTable::IndexBuildAppendGuard::operator=(IndexBuildAppendGuard &&other) noexcept {
+	std::swap(table, other.table);
+	return *this;
+}
+
+DataTable::IndexBuildAppendGuard DataTable::LockAppendsForCreateIndex() {
+	return IndexBuildAppendGuard {*this};
+}
+
+DataTable::IndexBuildAppendGuard::~IndexBuildAppendGuard() {
+	if (!table) {
+		return;
+	}
+	const annotated_lock_guard<annotated_mutex> lk(table->append_lock);
+	table->index_build_in_progress = false;
+	table->append_blocker_cv.notify_all();
 }
 
 bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1162,6 +1162,16 @@ void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state
 	}
 }
 
+unique_lock<mutex> DataTable::LockAppendsForCreateIndex() {
+	unique_lock<mutex> lock(append_lock);
+	if (!IsMainTable()) {
+		throw TransactionException("Transaction conflict: attempting to add an index to table \"%s\" but it has been "
+		                           "%s by a different transaction",
+		                           GetTableName(), TableModification());
+	}
+	return lock;
+}
+
 bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id) {
 	if (checkpoint_id == MAX_TRANSACTION_ID) {
 		// no active checkpoint

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1143,8 +1143,8 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Co
 }
 
 void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state) {
-	annotated_unique_lock<annotated_mutex> lock(append_lock);
-	append_blocker_cv.wait(lock, [this]() DUCKDB_REQUIRES(append_lock) { return active_index_builds == 0; });
+	unique_lock<mutex> lock(append_lock);
+	append_blocker_cv.wait(lock, [this]() { return active_index_builds == 0; });
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
 		                           "a different transaction",
@@ -1165,7 +1165,7 @@ void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state
 }
 
 DataTable::IndexBuildAppendGuard::IndexBuildAppendGuard(DataTable &tbl) : table(&tbl) {
-	const annotated_lock_guard<annotated_mutex> lock(tbl.append_lock);
+	const lock_guard<mutex> lock(tbl.append_lock);
 	if (!tbl.IsMainTable()) {
 		table = nullptr; // nothing to unblock in the destructor
 		throw TransactionException("Transaction conflict: attempting to add an index to table \"%s\" but it has been "
@@ -1188,7 +1188,7 @@ DataTable::IndexBuildAppendGuard::~IndexBuildAppendGuard() {
 	if (!table) {
 		return;
 	}
-	const annotated_lock_guard<annotated_mutex> lk(table->append_lock);
+	const lock_guard<mutex> lk(table->append_lock);
 	D_ASSERT(table->active_index_builds > 0);
 	if (--table->active_index_builds == 0) {
 		table->append_blocker_cv.notify_all();

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1144,11 +1144,7 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Co
 
 void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state) {
 	annotated_unique_lock<annotated_mutex> lock(append_lock);
-	// Wait if a standalone CREATE INDEX scan is in progress over this table.
-	// Once the scan finishes the guard destructor clears the flag and notifies.
-	// The predicate is always called while append_lock is held (condition_variable
-	// contract), so DUCKDB_REQUIRES silences the GUARDED_BY warning.
-	append_blocker_cv.wait(lock, [this]() DUCKDB_REQUIRES(append_lock) { return !index_build_in_progress; });
+	append_blocker_cv.wait(lock, [this]() DUCKDB_REQUIRES(append_lock) { return active_index_builds == 0; });
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
 		                           "a different transaction",
@@ -1176,7 +1172,7 @@ DataTable::IndexBuildAppendGuard::IndexBuildAppendGuard(DataTable &tbl) : table(
 		                           "%s by a different transaction",
 		                           tbl.GetTableName(), tbl.TableModification());
 	}
-	tbl.index_build_in_progress = true;
+	tbl.active_index_builds++;
 }
 
 DataTable::IndexBuildAppendGuard &DataTable::IndexBuildAppendGuard::operator=(IndexBuildAppendGuard &&other) noexcept {
@@ -1193,8 +1189,10 @@ DataTable::IndexBuildAppendGuard::~IndexBuildAppendGuard() {
 		return;
 	}
 	const annotated_lock_guard<annotated_mutex> lk(table->append_lock);
-	table->index_build_in_progress = false;
-	table->append_blocker_cv.notify_all();
+	D_ASSERT(table->active_index_builds > 0);
+	if (--table->active_index_builds == 0) {
+		table->append_blocker_cv.notify_all();
+	}
 }
 
 bool DataTableInfo::AppendRequiresNewRowGroup(RowGroupCollection &collection, transaction_t checkpoint_id) {

--- a/test/fuzzer/pedro/index_on_altered_table.test
+++ b/test/fuzzer/pedro/index_on_altered_table.test
@@ -16,7 +16,7 @@ ALTER TABLE t4 ADD c1 BLOB;
 statement error
 CREATE INDEX i3 ON t4 (c3);
 ----
-<REGEX>:TransactionContext Error.*cannot add.*index.*table.*altered.*
+<REGEX>:.*TransactionContext Error.*attempting to add an index.*
 
 statement ok con1
 COMMIT;

--- a/test/sql/alter/add_pk/test_add_same_pk_simultaneously.test
+++ b/test/sql/alter/add_pk/test_add_same_pk_simultaneously.test
@@ -22,7 +22,7 @@ BEGIN TRANSACTION
 statement error tran2
 ALTER TABLE test ADD PRIMARY KEY (j)
 ----
-<REGEX>:TransactionContext Error.*cannot add an index to a table that has been altered.*
+<REGEX>:.*TransactionContext Error.*attempting to add an index.*
 
 statement ok tran3
 BEGIN TRANSACTION

--- a/test/sql/alter/alter_type/test_alter_type_transactions.test
+++ b/test/sql/alter/alter_type/test_alter_type_transactions.test
@@ -143,4 +143,4 @@ ALTER TABLE test ALTER j TYPE VARCHAR
 statement error con1
 CREATE INDEX i_index ON test(j)
 ----
-<REGEX>:.*TransactionContext Error: Transaction conflict.*altered or dropped.*
+<REGEX>:.*TransactionContext Error: Transaction conflict.*attempting to add an index.*

--- a/test/sql/alter/drop_col/test_drop_col_transactions.test
+++ b/test/sql/alter/drop_col/test_drop_col_transactions.test
@@ -141,4 +141,4 @@ ALTER TABLE test DROP COLUMN j
 statement error con1
 CREATE INDEX i_index ON test(j)
 ----
-<REGEX>:.*TransactionContext Error: Transaction conflict: cannot add an index.*
+<REGEX>:.*TransactionContext Error: Transaction conflict.*attempting to add an index.*


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/9642
Closes https://github.com/duckdblabs/duckdb-internal/issues/9673

`test/sql/parallelism/interquery/concurrent_writes_during_index_creation.test_slow` SQL test fails intermittently because rows committed during the index build window can be present in the table but absent from the finalized index, since in the current implementation, the new index is not registered in table storage until finalization.

There're a few possible ways to handle:
- Detect conflict at finalization and throw retriable exception
- Use a staged append to buffer rows during index creation
- (this PR) Acquire a lock on index creation, so no rows will be appended at the same time

(3) is selected because
- It's the simplest and most straightforward solution to implement
- We don't it to be the common case that append and index creation to happen at the same time
- (hopefully not) if we do have perf issue reported, it's easy to revert/change/fix

We already have test case to repro the issue, it's just not stable and deterministic. I ran the tests for a couple of times and it didn't repro any more. 

I have ran CI on my own fork: https://github.com/dentiny/duckdb/pull/108, CI failure unrelated