### PR TITLE
Parquet: add expression stats pruning for arithmetic filters

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -398,7 +398,7 @@ private:
 	idx_t GetGroupOffset(ParquetReaderScanState &state);
 	//! Group span is the distance between the min page offset and the max page offset plus the max page compressed size
 	uint64_t GetGroupSpan(ParquetReaderScanState &state);
-	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
+	void PrepareRowGroupBuffer(ClientContext &context, ParquetReaderScanState &state, idx_t out_col_idx);
 	//! Whole-group prefetch strategy.
 	ParquetPrefetchStrategy WholeGroupPrefetch(ParquetReaderScanState &state, ThriftFileTransport &trans,
 	                                           const duckdb_parquet::RowGroup &group, uint64_t total_row_group_span,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1301,8 +1301,8 @@ idx_t ParquetReader::GetGroupOffset(ParquetReaderScanState &state) {
 	return min_offset;
 }
 
-static FilterPropagateResult CheckParquetFloatFilter(ColumnReader &reader, const Statistics &pq_col_stats,
-                                                     const TableFilter &filter) {
+static FilterPropagateResult CheckParquetFloatFilter(ClientContext &context, ColumnReader &reader,
+                                                     const Statistics &pq_col_stats, const TableFilter &filter) {
 	// floating point values can have values in the [min, max] domain AND nan values
 	// check both stats against the filter
 	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "CheckParquetFloatFilter");
@@ -1311,10 +1311,10 @@ static FilterPropagateResult CheckParquetFloatFilter(ColumnReader &reader, const
 	auto nan_value = Value("nan").DefaultCastAs(type);
 	NumericStats::SetMin(nan_stats, nan_value);
 	NumericStats::SetMax(nan_stats, nan_value);
-	auto nan_prune = expr_filter.CheckStatistics(nan_stats);
+	auto nan_prune = expr_filter.CheckStatistics(context, nan_stats);
 
 	auto min_max_stats = ParquetStatisticsUtils::CreateNumericStats(reader.Type(), reader.Schema(), pq_col_stats);
-	auto prune = expr_filter.CheckStatistics(*min_max_stats);
+	auto prune = expr_filter.CheckStatistics(context, *min_max_stats);
 
 	// if EITHER of them cannot be pruned - we cannot prune
 	if (prune == FilterPropagateResult::NO_PRUNING_POSSIBLE ||
@@ -1334,7 +1334,7 @@ ColumnReader &ParquetReaderScanState::GetColumnReader(idx_t i) {
 	return *column_readers[i];
 }
 
-void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t i) {
+void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderScanState &state, idx_t i) {
 	auto &group = GetGroup(state);
 	auto col_idx = MultiFileLocalIndex(i);
 	auto &column_reader = state.GetColumnReader(col_idx);
@@ -1372,12 +1372,12 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t i
 				// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 				// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning
 				// based on nan
-				prune_result = CheckParquetFloatFilter(column_reader,
+				prune_result = CheckParquetFloatFilter(context, column_reader,
 				                                       group.columns[schema_column_index].meta_data.statistics, filter);
 			} else {
 				auto &expr_filter =
 				    ExpressionFilter::GetExpressionFilter(filter, "ParquetReader::PrepareRowGroupBuffer");
-				prune_result = expr_filter.CheckStatistics(*stats);
+				prune_result = expr_filter.CheckStatistics(context, *stats);
 			}
 			// check the bloom filter if present
 			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE && !column_reader.Type().IsNested() &&
@@ -1745,7 +1745,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 	uint64_t to_scan_compressed_bytes = 0;
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto col_idx = MultiFileLocalIndex(i);
-		PrepareRowGroupBuffer(state, col_idx);
+		PrepareRowGroupBuffer(context, state, col_idx);
 		to_scan_compressed_bytes += state.GetColumnReader(i).TotalCompressedSize();
 	}
 

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -8,6 +8,7 @@
       "paths": [
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",
+        "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
         "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -42,6 +42,7 @@
         "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
         "test/sql/copy/parquet/parquet_prefetch_cost_model.test",
         "test/sql/copy/parquet/parquet_prefetch_cost_model_remote.test",
+        "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
         "test/sql/parallelism/async_task_schedule_pool.test"
       ]
     },

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -1,0 +1,129 @@
+# name: test/sql/copy/parquet/parquet_expression_filter_pruning.test
+# description: Test row group pruning with arithmetic expression filters
+# group: [parquet]
+
+require parquet
+
+# 10 row groups of 10240 rows (multiple of vector size -> deterministic boundaries)
+statement ok
+COPY (SELECT range AS a FROM range(102400)) TO '__TEST_DIR__/expr_prune_int.parquet' (ROW_GROUP_SIZE 10240)
+
+statement ok
+COPY (SELECT range::DOUBLE AS d FROM range(102400)) TO '__TEST_DIR__/expr_prune_double.parquet' (ROW_GROUP_SIZE 10240)
+
+statement ok
+COPY (SELECT CASE WHEN range = 95000 THEN 'nan'::DOUBLE ELSE range::DOUBLE END AS d FROM range(102400)) TO '__TEST_DIR__/expr_prune_nan.parquet' (ROW_GROUP_SIZE 10240)
+
+# constants are not divisible by the multiplier, so the optimizer keeps the expression filter
+# instead of folding it into a plain comparison
+
+# a * 4 + 4 > 327681  <=>  a >= 81920  -> last 2 row groups
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 + 4 > 327681
+----
+20480
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	2
+SkipRowGroup	8
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# a * 4 - 4 < 40961  <=>  a <= 10241  -> first 2 row groups
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 - 4 < 40961
+----
+10242
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	2
+SkipRowGroup	8
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# false for the whole file -> optimizer folds to EMPTY_RESULT from file-level stats
+query II
+EXPLAIN SELECT count(*) FROM '__TEST_DIR__/expr_prune_int.parquet' WHERE a * 4 + 4 > 409601
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# d + d < 20479.5  <=>  d < 10239.75  -> first row group (d twice -> not foldable)
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/expr_prune_double.parquet' WHERE d + d < 20479.5e0
+----
+10240
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	1
+SkipRowGroup	9
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# NaN at row 95000 -> its row group has no min/max stats and is never pruned; the others are pruned
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/expr_prune_nan.parquet' WHERE d + d > 184318.5e0
+----
+10240
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	1
+SkipRowGroup	9
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# can_have_nan=true disables stats pruning entirely (NaN compares larger than anything),
+# but the NaN row must still survive the filter
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query III
+SELECT count(*), min(d), max(d) FROM read_parquet('__TEST_DIR__/expr_prune_nan.parquet', can_have_nan=true) WHERE d + d > 184318.5e0
+----
+10240	92160.0	nan
+
+statement ok
+CALL disable_logging()
+
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	10
+
+statement ok
+CALL truncate_duckdb_logs()


### PR DESCRIPTION
Follow-up to #22819, this PR supports arithmetic filters pruning for parquet files in row-group scan. Since it is a little complicated to pass context through page skip path and  currently there is no observability at the page level(no per-page skip metric/counter) so it is not included in this PR.