### PR TITLE
Consistent ordering for gen files in package_build

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -476,6 +476,7 @@ def build_package(
                     # directly use the source files
                     new_source_files += [os.path.join(folder_name, file) for file in current_files]
             if unity_files:
+                unity_files.sort()
                 unity_base = dirname.replace(os.path.sep, '_')
                 unity_name = f'ub_{unity_base}.cpp'
                 new_source_files.append(generate_unity_build(unity_files, unity_name, linenumbers))


### PR DESCRIPTION
The `package_build.py` script is used by some of the language clients to create a unity-enabled builds of the DuckDB core and selected extensions.

It appeared that after one of the recent updated the ICU extension has started being sensitive to the file inclusion order in the generated `ub_extension_icu_third_party_icu_i18n.cpp` file, with failured like this one:

```
In file included from /duckdb/src/duckdb/ub_extension_icu_third_party_icu_i18n.cpp:11:
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/listformatter.cpp:216:8: warning: ‘icu_78::ListFormatInternal’ has a field ‘icu_78::LocalPointer<icu_78::{anonymous}::PatternHandler> icu_78::ListFormatInternal::patternHandler’ whose type has internal linkage [-Wsubobject-linkage]
  216 | struct ListFormatInternal : public UMemory {
      |        ^~~~~~~~~~~~~~~~~~
In file included from /duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmt.cpp:32,
                 from /duckdb/src/duckdb/ub_extension_icu_third_party_icu_i18n.cpp:99:
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmtimpl.h:38:27: error: expected identifier before ‘(’ token
   38 | #define COMMA             ((char16_t)0x002C)
      |                           ^
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:44:5: note: in expansion of macro ‘COMMA’
   44 |     COMMA,
      |     ^~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmtimpl.h:38:27: error: expected ‘}’ before ‘(’ token
   38 | #define COMMA             ((char16_t)0x002C)
      |                           ^
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:44:5: note: in expansion of macro ‘COMMA’
   44 |     COMMA,
      |     ^~~~~
In file included from /duckdb/src/duckdb/extension/icu/third_party/icu/i18n/scientificnumberformatter.cpp:19,
                 from /duckdb/src/duckdb/ub_extension_icu_third_party_icu_i18n.cpp:117:
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:28:10: note: to match this ‘{’
   28 | enum Key {
      |          ^
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmtimpl.h:38:29: error: expected unqualified-id before ‘char16_t’
   38 | #define COMMA             ((char16_t)0x002C)
      |                             ^~~~~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:44:5: note: in expansion of macro ‘COMMA’
   44 |     COMMA,
      |     ^~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmtimpl.h:38:29: error: expected ‘)’ before ‘char16_t’
   38 | #define COMMA             ((char16_t)0x002C)
      |                            ~^~~~~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:44:5: note: in expansion of macro ‘COMMA’
   44 |     COMMA,
      |     ^~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/i18n/selfmtimpl.h:38:29: error: expected ‘)’ before ‘char16_t’
   38 | #define COMMA             ((char16_t)0x002C)
      |                           ~ ^~~~~~~~
/duckdb/src/duckdb/extension/icu/third_party/icu/common/static_unicode_sets.h:44:5: note: in expansion of macro ‘COMMA’
   44 |     COMMA,
      |     ^~~~~
```

This PR adds the sorting of the included files in unity builds.