### PR TITLE
Add `init_local_state_finalize` callback to aggregate functions which allows them to create a `FunctionLocalState` that is persisted across `Finalize` calls, and use this to speed up ordered aggregates

### DIFF
--- a/.github/patches/extensions/delta/0009-pin-brotli-decompressor.patch
+++ b/.github/patches/extensions/delta/0009-pin-brotli-decompressor.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ff33ba9..57fe9c5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -153,6 +153,12 @@ ExternalProject_Add(
+   # header in ./src/include/delta_kernel_ffi.hpp should be also bumped, applying
+   # the fix
+   GIT_TAG v0.19.0
++  # Pin brotli-decompressor to a version that uses the same alloc-no-stdlib
++  # (2.0.4) as brotli 8.0.3. brotli-decompressor 5.0.2 bumped to alloc-no-stdlib
++  # 3.0.0, which conflicts with brotli 8.0.3 and breaks the build with
++  # `StandardAlloc: alloc::Allocator<u8> is not satisfied`.
++  PATCH_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS} ${RUST_ENV_VARS}
++                cargo update -p brotli-decompressor --precise 5.0.0
+   # Prints the env variables passed to the cargo build to the terminal, useful
+   # in debugging because passing them through CMake is an error-prone mess
+   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS}

--- a/.github/patches/extensions/spatial/0020-aggregate-finalize-input-data.patch
+++ b/.github/patches/extensions/spatial/0020-aggregate-finalize-input-data.patch
@@ -1,0 +1,35 @@
+diff --git a/src/spatial/modules/geos/geos_module.cpp b/src/spatial/modules/geos/geos_module.cpp
+index dd74e23..4a248ad 100644
+--- a/src/spatial/modules/geos/geos_module.cpp
++++ b/src/spatial/modules/geos/geos_module.cpp
+@@ -2625,7 +2625,7 @@ struct ST_Union_Agg {
+ 		}
+ 	}
+ 
+-	static void Finalize(Vector &state_vec, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
++	static void Finalize(Vector &state_vec, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
+ 	                     idx_t offset) {
+ 
+ 		UnifiedVectorFormat state_format;
+@@ -2815,7 +2815,7 @@ struct GEOSCoverageAggFunction {
+ 	}
+ 
+ 	template <class OP>
+-	static void Finalize(Vector &state_vec, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
++	static void Finalize(Vector &state_vec, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
+ 	                     idx_t offset) {
+ 
+ 		UnifiedVectorFormat state_format;
+diff --git a/src/spatial/modules/mvt/mvt_module.cpp b/src/spatial/modules/mvt/mvt_module.cpp
+index 93f63fc..53ce70f 100644
+--- a/src/spatial/modules/mvt/mvt_module.cpp
++++ b/src/spatial/modules/mvt/mvt_module.cpp
+@@ -1178,7 +1178,7 @@ struct ST_AsMVT {
+ 	//------------------------------------------------------------------------------------------------------------------
+ 	// Finalize
+ 	//------------------------------------------------------------------------------------------------------------------
+-	static void Finalize(Vector &state_vec, AggregateInputData &aggr, Vector &result, idx_t count, idx_t offset) {
++	static void Finalize(Vector &state_vec, AggregateFinalizeInputData &aggr, Vector &result, idx_t count, idx_t offset) {
+ 		const auto &bdata = aggr.bind_data->Cast<BindData>();
+ 
+ 		UnifiedVectorFormat state_format;

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -335,7 +335,7 @@ void ApproxTopKUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t inp
 }
 
 template <class OP = HistogramGenericFunctor>
-void ApproxTopKFinalize(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+void ApproxTopKFinalize(Vector &state_vector, AggregateFinalizeInputData &, Vector &result, idx_t count, idx_t offset) {
 	auto states = state_vector.Values<ApproxTopKState *>();
 
 	auto old_len = ListVector::GetListSize(result);

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -441,6 +441,7 @@ struct ScalarDiscreteQuantile {
 		                      QuantileSortKeyUpdate, ListCombineFunction<OP>,
 		                      AggregateFunction::StateVoidFinalize<STATE, OP>, nullptr, nullptr,
 		                      AggregateFunction::StateDestroy<STATE, OP>);
+		fun.SetInitLocalStateFinalizeCallback(FlattenedQuantileValues<string_t>::Init);
 		return fun;
 	}
 };
@@ -468,6 +469,7 @@ struct ListDiscreteQuantile {
 		                      QuantileSortKeyUpdate, ListCombineFunction<OP>,
 		                      AggregateFunction::StateFinalize<STATE, list_entry_t, OP>, nullptr, nullptr,
 		                      AggregateFunction::StateDestroy<STATE, OP>);
+		fun.SetInitLocalStateFinalizeCallback(FlattenedQuantileValues<string_t>::Init);
 		return fun;
 	}
 };

--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -271,7 +271,7 @@ void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector
 }
 
 template <class OP, class T>
-void HistogramBinFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count,
+void HistogramBinFinalizeFunction(Vector &state_vector, AggregateFinalizeInputData &, Vector &result, idx_t count,
                                   idx_t offset) {
 	auto states = state_vector.Values<HistogramBinState<T> *>();
 

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -84,7 +84,8 @@ void HistogramUpdateFunction(Vector inputs[], AggregateInputData &aggr_input, id
 }
 
 template <class OP, class T, class MAP_TYPE>
-void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+void HistogramFinalizeFunction(Vector &state_vector, AggregateFinalizeInputData &, Vector &result, idx_t count,
+                               idx_t offset) {
 	using HIST_STATE = HistogramAggState<T, typename MAP_TYPE::MAP_TYPE>;
 
 	auto states = state_vector.Values<HIST_STATE *>();

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 namespace {
 
-void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+void ListFinalize(Vector &states_vector, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
                   idx_t offset) {
 	auto states = states_vector.Values<ListAggState *>();
 

--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -18,24 +18,26 @@ namespace duckdb {
 
 //! Flattens the values of a linked list into a contiguous array for interpolation.
 //! The flattened values are mutable - the interpolators partially sort them in place.
-//! The flattened chunk is cached in the finalize data's local state, so that it is allocated (at most) once per
-//! result chunk instead of once per finalized group.
+//! The flattened chunk lives in the finalize's local state, so that it is allocated (at most) once per
+//! finalize call instead of once per finalized group - callers that keep the local state alive re-use it
+//! across finalize calls.
 template <class INPUT_TYPE>
 struct FlattenedQuantileValues : FunctionLocalState {
-	FlattenedQuantileValues(const LogicalType &type, idx_t capacity_p) : capacity(capacity_p) {
-		chunk.Initialize(Allocator::DefaultAllocator(), {type}, capacity_p);
+	FlattenedQuantileValues() : capacity(0) {
 	}
 
-	//! Flatten the values of the given linked list into the chunk cached in the finalize data
+	static unique_ptr<FunctionLocalState> Init(const BoundAggregateFunction &, optional_ptr<FunctionData>) {
+		return make_uniq<FlattenedQuantileValues>();
+	}
+
+	//! Flatten the values of the given linked list into the chunk cached in the finalize local state
 	static FlattenedQuantileValues &Flatten(AggregateFinalizeData &finalize_data, const LinkedList &linked_list) {
 		const auto type = PrimitiveToLogicalType<INPUT_TYPE>();
 		const auto required_capacity = MaxValue<idx_t>(linked_list.total_capacity, 1);
-		if (!finalize_data.local_state) {
-			finalize_data.local_state = make_uniq<FlattenedQuantileValues>(type, NextPowerOfTwo(required_capacity));
-		}
-		auto &values = finalize_data.local_state->Cast<FlattenedQuantileValues>();
+		D_ASSERT(finalize_data.input.local_state);
+		auto &values = finalize_data.input.local_state->Cast<FlattenedQuantileValues>();
 		if (values.capacity < required_capacity) {
-			// grow the cached chunk
+			// (re-)allocate the cached chunk
 			values.capacity = NextPowerOfTwo(required_capacity);
 			values.chunk.Destroy();
 			values.chunk.Initialize(Allocator::DefaultAllocator(), {type}, values.capacity);
@@ -125,12 +127,14 @@ struct QuantileOperation {
 //! Quantiles ignore NULL values, so they are filtered out while appending.
 template <class STATE, class RESULT_TYPE, class OP>
 AggregateFunction QuantileBufferingAggregate(const LogicalType &input_type, const LogicalType &result_type) {
-	return AggregateFunction({input_type}, result_type, AggregateFunction::StateSize<STATE>,
-	                         AggregateFunction::StateInitialize<STATE, OP, AggregateDestructorType::LEGACY>,
-	                         ListUpdateFunction<true>, ListCombineFunction<OP>,
-	                         AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>,
-	                         FunctionNullHandling::DEFAULT_NULL_HANDLING, AggregateFunction::NoClusterUpdate(),
-	                         AggregateFunction::NoBind(), AggregateFunction::StateDestroy<STATE, OP>);
+	AggregateFunction fun({input_type}, result_type, AggregateFunction::StateSize<STATE>,
+	                      AggregateFunction::StateInitialize<STATE, OP, AggregateDestructorType::LEGACY>,
+	                      ListUpdateFunction<true>, ListCombineFunction<OP>,
+	                      AggregateFunction::StateFinalize<STATE, RESULT_TYPE, OP>,
+	                      FunctionNullHandling::DEFAULT_NULL_HANDLING, AggregateFunction::NoClusterUpdate(),
+	                      AggregateFunction::NoBind(), AggregateFunction::StateDestroy<STATE, OP>);
+	fun.SetInitLocalStateFinalizeCallback(FlattenedQuantileValues<typename STATE::InputType>::Init);
+	return fun;
 }
 
 template <class T>

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -218,7 +218,7 @@ void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &res
 	auto &aggr = info.aggr_expr->Cast<BoundAggregateExpression>();
 	auto &allocator = ExecuteFunctionState::GetFunctionState(state)->Cast<ListAggregatesLocalState>().arena_allocator;
 	allocator.Reset();
-	AggregateInputData aggr_input_data(aggr, allocator);
+	AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 
 	D_ASSERT(aggr.Function().HasStateUpdateCallback());
 

--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -161,11 +161,23 @@ void RowOperations::FinalizeStates(RowOperationsState &state, TupleDataLayout &l
 	VectorOperations::AddInPlace(addresses_copy, UnsafeNumericCast<int64_t>(layout.GetAggrOffset()));
 
 	auto &aggregates = layout.GetAggregates();
+	// initialize the finalize local states once - they are re-used across all finalize calls of this state
+	if (state.local_states.size() < aggregates.size()) {
+		state.local_states.resize(aggregates.size());
+		for (idx_t i = 0; i < aggregates.size(); i++) {
+			auto &callbacks = aggregates[i].function.GetCallbacks();
+			if (callbacks.HasInitLocalStateFinalizeCallback()) {
+				AggregateInputData aggr_input_data(aggregates[i], state.allocator);
+				state.local_states[i] =
+				    callbacks.GetInitLocalStateFinalizeCallback()(aggr_input_data.function, aggr_input_data.bind_data);
+			}
+		}
+	}
 	for (idx_t i = 0; i < aggregates.size(); i++) {
 		auto &target = result.data[aggr_idx + i];
 		auto &aggr = aggregates[i];
-		AggregateInputData aggr_input_data(aggr, state.allocator);
-		aggr.function.GetStateFinalizeCallback()(addresses_copy, aggr_input_data, target, result.size(), 0);
+		AggregateFinalizeInputData finalize_input_data(aggr, state.allocator, state.local_states[i].get());
+		aggr.function.GetStateFinalizeCallback()(addresses_copy, finalize_input_data, target, result.size(), 0);
 		FlatVector::SetSize(target, count_t(result.size()));
 
 		// Move to the next aggregate state

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -289,7 +289,8 @@ void StreamingWindowState::AggregateState::Execute(ExecutionContext &context, Da
 	}
 
 	// Update the state and finalize it one row at a time.
-	AggregateInputData aggr_input_data(*wexpr.AggregateFunction(), wexpr.BindInfo().get(), aggr_state.arena_allocator);
+	AggregateFinalizeInputData aggr_input_data(*wexpr.AggregateFunction(), wexpr.BindInfo().get(),
+	                                           aggr_state.arena_allocator);
 	for (idx_t i = 0; i < count; ++i) {
 		sel.set_index(0, i);
 		for (const auto struct_idx : structs) {

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -683,7 +683,7 @@ void GlobalUngroupedAggregateState::Finalize(DataChunk &result, idx_t column_off
 	for (idx_t aggr_idx = 0; aggr_idx < state.functions.size(); aggr_idx++) {
 		auto &func = state.functions[aggr_idx];
 		Vector state_vector(Value::POINTER(CastPointerToValue(state.aggregate_data[aggr_idx].get())), count_t(1));
-		AggregateInputData aggr_input_data(func, state.bind_data[aggr_idx].get(), allocator);
+		AggregateFinalizeInputData aggr_input_data(func, state.bind_data[aggr_idx].get(), allocator);
 		func.GetStateFinalizeCallback()(state_vector, aggr_input_data, result.data[column_offset + aggr_idx], 1, 0);
 		FlatVector::SetSize(result.data[column_offset + aggr_idx], count_t(1));
 	}

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -27,7 +27,7 @@ PhysicalPivot::PhysicalPivot(PhysicalPlan &physical_plan, vector<LogicalType> ty
 		aggr.Function().GetStateInitCallback()(aggr.Function(), state.get());
 		Vector state_vector(Value::POINTER(CastPointerToValue(state.get())), count_t(1));
 		Vector result_vector(aggr_expr->GetReturnType());
-		AggregateInputData aggr_input_data(aggr, physical_plan.ArenaRef());
+		AggregateFinalizeInputData aggr_input_data(aggr, physical_plan.ArenaRef());
 		aggr.Function().GetStateFinalizeCallback()(state_vector, aggr_input_data, result_vector, 1, 0);
 		empty_aggregates.push_back(result_vector.GetValue(0));
 	}

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -1076,7 +1076,7 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 				    aggr.Function().GetStateSizeCallback()(aggr.Function()));
 				aggr.Function().GetStateInitCallback()(aggr.Function(), aggr_state.get());
 
-				AggregateInputData aggr_input_data(aggr, allocator);
+				AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 				Vector state_vector(Value::POINTER(CastPointerToValue(aggr_state.get())), count_t(1));
 				auto &agg_result = chunk.data[null_groups.size() + i];
 				aggr.Function().GetStateFinalizeCallback()(state_vector, aggr_input_data, agg_result, 1, 0);

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -167,6 +167,52 @@ struct SortedAggregateBindData : public FunctionData {
 //! The sorted aggregate buffers its input rows in a linked list of structs, sharing the "list" callbacks
 struct SortedAggregateState : ListAggState {};
 
+//! Caches the chunks, contexts and inner aggregate state used while finalizing the groups of a sorted aggregate.
+//! When the caller provides a local state slot (e.g. the hash table scan), this state survives across finalize
+//! calls instead of being re-instantiated for every result chunk.
+struct SortedAggregateFinalizeState : FunctionLocalState {
+	explicit SortedAggregateFinalizeState(const SortedAggregateBindData &order_bind)
+	    : thread(order_bind.context), context(order_bind.context, thread, nullptr),
+	      agg_state(order_bind.function.GetCallbacks().GetStateSizeCallback()(order_bind.function)),
+	      agg_state_vec(Value::POINTER(CastPointerToValue(agg_state.data())), count_t(1)) {
+		auto &buffer_allocator = BufferManager::GetBufferManager(order_bind.context).GetBufferAllocator();
+		rows.Initialize(buffer_allocator, {order_bind.buffered_struct_type});
+		scanned.Initialize(buffer_allocator, order_bind.scan_types);
+		sliced.Initialize(buffer_allocator, order_bind.scan_types);
+		prefixed.Initialize(buffer_allocator, order_bind.sort_types);
+
+		//	The local state of the inner aggregate's finalize is kept alive across finalize calls as well
+		const auto &callbacks = order_bind.function.GetCallbacks();
+		if (callbacks.HasInitLocalStateFinalizeCallback()) {
+			inner_local_state =
+			    callbacks.GetInitLocalStateFinalizeCallback()(order_bind.function, order_bind.bind_info.get());
+		}
+	}
+
+	static unique_ptr<FunctionLocalState> Init(const BoundAggregateFunction &, optional_ptr<FunctionData> bind_data) {
+		return make_uniq<SortedAggregateFinalizeState>(bind_data->Cast<SortedAggregateBindData>());
+	}
+
+	//! The execution context for the sort operator
+	ThreadContext thread;
+	ExecutionContext context;
+	InterruptState interrupt;
+	//! The buffered rows of (possibly many) groups, accumulated before they are sunk into the sort
+	DataChunk rows;
+	//! The chunk for scanning the sorted data
+	DataChunk scanned;
+	//! The scanned data sliced to the rows of a single group
+	DataChunk sliced;
+	//! The sink chunk holding the buffered rows prefixed with the group number
+	DataChunk prefixed;
+	//! The state of the inner aggregate
+	vector<data_t> agg_state;
+	//! A vector pointing to the inner aggregate state
+	Vector agg_state_vec;
+	//! The local state used by the inner aggregate's finalize (may be null)
+	unique_ptr<FunctionLocalState> inner_local_state;
+};
+
 struct SortedAggregateFunction {
 	static LogicalType GetElementType(AggregateInputData &aggr_input_data) {
 		return aggr_input_data.bind_data->Cast<SortedAggregateBindData>().buffered_struct_type;
@@ -177,7 +223,7 @@ struct SortedAggregateFunction {
 		if (!count) {
 			return;
 		}
-		//	Pack the buffered columns into a single struct vector for the list update
+		// Pack the buffered columns into a single struct vector and append the rows through the list update
 		const auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
 		Vector packed(order_bind.buffered_struct_type, count);
 		auto &entries = StructVector::GetEntries(packed);
@@ -204,51 +250,89 @@ struct SortedAggregateFunction {
 		}
 	}
 
-	//! Sinks all buffered rows of the state into the sort, prefixed with the group number
-	static void SinkState(const SortedAggregateBindData &order_bind, SortedAggregateState &state, idx_t group_number,
-	                      ExecutionContext &context, OperatorSinkInput &sink, DataChunk &prefixed) {
-		auto &sort = *order_bind.sort;
-		ListSegmentScanState scan_state;
-		order_bind.buffered_funcs.InitializeScan(state.linked_list, scan_state);
-		for (;;) {
-			Vector rows(order_bind.buffered_struct_type, STANDARD_VECTOR_SIZE);
-			const auto chunk_count = order_bind.buffered_funcs.Scan(scan_state, rows);
-			if (!chunk_count) {
-				break;
+	//! Sinks the rows accumulated in the rows chunk into the sort, prefixed with their group numbers
+	static void FlushAccumulated(const SortedAggregateBindData &order_bind, idx_t &accumulated,
+	                             SortedAggregateFinalizeState &finalize_state, ExecutionContext &context,
+	                             OperatorSinkInput &sink) {
+		if (!accumulated) {
+			return;
+		}
+		auto &prefixed = finalize_state.prefixed;
+		FlatVector::SetSize(prefixed.data[0], count_t(accumulated));
+		auto &entries = StructVector::GetEntries(finalize_state.rows.data[0]);
+		for (column_t col_idx = 0; col_idx < entries.size(); ++col_idx) {
+			prefixed.data[col_idx + 1].Reference(entries[col_idx]);
+			FlatVector::SetSize(prefixed.data[col_idx + 1], count_t(accumulated));
+		}
+		order_bind.sort->Sink(context, prefixed, sink);
+		finalize_state.rows.Reset();
+		accumulated = 0;
+	}
+
+	//! Buffers the rows of the state into the cached rows chunk, prefixed with the group number, flushing into
+	//! the sort whenever the chunk fills up - this batches many small groups into a single sink call
+	static void SinkState(const SortedAggregateBindData &order_bind, SortedAggregateState &state,
+	                      const idx_t group_number, idx_t &accumulated, SortedAggregateFinalizeState &finalize_state,
+	                      ExecutionContext &context, OperatorSinkInput &sink) {
+		const auto group_count = state.linked_list.total_capacity;
+		if (!group_count) {
+			return;
+		}
+		auto &rows = finalize_state.rows.data[0];
+		auto group_numbers = FlatVector::GetDataMutable<uint16_t>(finalize_state.prefixed.data[0]);
+		if (group_count <= STANDARD_VECTOR_SIZE) {
+			//	The group fits in the rows chunk - flush first if there is not enough space left
+			if (accumulated + group_count > STANDARD_VECTOR_SIZE) {
+				FlushAccumulated(order_bind, accumulated, finalize_state, context, sink);
 			}
-			auto &entries = StructVector::GetEntries(rows);
-			prefixed.Reset();
-			prefixed.data[0].Reference(Value::USMALLINT(UnsafeNumericCast<uint16_t>(group_number)), count_t(1));
-			FlatVector::SetSize(prefixed.data[0], count_t(chunk_count));
-			for (column_t col_idx = 0; col_idx < entries.size(); ++col_idx) {
-				prefixed.data[col_idx + 1].Reference(entries[col_idx]);
-				FlatVector::SetSize(prefixed.data[col_idx + 1], count_t(chunk_count));
+			//	Append the group's rows to the accumulated rows
+			order_bind.buffered_funcs.BuildListVector(state.linked_list, rows, accumulated);
+			for (idx_t i = 0; i < group_count; ++i) {
+				group_numbers[accumulated + i] = UnsafeNumericCast<uint16_t>(group_number);
 			}
-			sort.Sink(context, prefixed, sink);
+			accumulated += group_count;
+		} else {
+			//	The group does not fit in a single chunk - flush, then stream it chunk at a time
+			FlushAccumulated(order_bind, accumulated, finalize_state, context, sink);
+			ListSegmentScanState scan_state;
+			order_bind.buffered_funcs.InitializeScan(state.linked_list, scan_state);
+			for (;;) {
+				const auto chunk_count = order_bind.buffered_funcs.Scan(scan_state, rows);
+				if (!chunk_count) {
+					break;
+				}
+				for (idx_t i = 0; i < chunk_count; ++i) {
+					group_numbers[i] = UnsafeNumericCast<uint16_t>(group_number);
+				}
+				accumulated = chunk_count;
+				FlushAccumulated(order_bind, accumulated, finalize_state, context, sink);
+			}
 		}
 		//	Release the state - the rows are freed with the arena allocator
 		state.linked_list = LinkedList();
 	}
 
-	static void Finalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+	static void Finalize(Vector &states, AggregateFinalizeInputData &finalize_input_data, Vector &result, idx_t count,
 	                     const idx_t offset) {
-		auto &order_bind = aggr_input_data.bind_data->Cast<SortedAggregateBindData>();
+		auto &order_bind = finalize_input_data.bind_data->Cast<SortedAggregateBindData>();
 		auto &client = order_bind.context;
 
-		auto &buffer_allocator = BufferManager::GetBufferManager(client).GetBufferAllocator();
-		DataChunk scanned;
-		scanned.Initialize(buffer_allocator, order_bind.scan_types);
-		DataChunk sliced;
-		sliced.Initialize(buffer_allocator, order_bind.scan_types);
-
-		//	 Reusable inner state
-		auto &aggr = order_bind.function;
-		vector<data_t> agg_state(aggr.GetCallbacks().GetStateSizeCallback()(aggr));
-		Vector agg_state_vec(Value::POINTER(CastPointerToValue(agg_state.data())), count_t(1));
+		//	The local state holds the chunks and contexts - callers can keep it alive across finalize calls
+		//	so they do not have to be re-instantiated for every finalize call
+		D_ASSERT(finalize_input_data.local_state);
+		auto &finalize_state = finalize_input_data.local_state->Cast<SortedAggregateFinalizeState>();
+		auto &scanned = finalize_state.scanned;
+		auto &sliced = finalize_state.sliced;
+		auto &agg_state = finalize_state.agg_state;
+		auto &agg_state_vec = finalize_state.agg_state_vec;
+		auto &context = finalize_state.context;
+		auto &interrupt = finalize_state.interrupt;
 
 		// State variables
+		auto &aggr = order_bind.function;
 		auto bind_info = order_bind.bind_info.get();
-		AggregateInputData aggr_bind_info(aggr, bind_info, aggr_input_data.allocator);
+		AggregateFinalizeInputData aggr_bind_info(aggr, bind_info, finalize_input_data.allocator,
+		                                          finalize_state.inner_local_state.get());
 
 		// Inner aggregate APIs
 		auto initialize = aggr.GetCallbacks().GetStateInitCallback();
@@ -264,30 +348,31 @@ struct SortedAggregateFunction {
 			state_unprocessed[i] = sdata[i].GetValueUnsafe()->linked_list.total_capacity;
 		}
 
-		ThreadContext thread(client);
-		ExecutionContext context(client, thread, nullptr);
-		InterruptState interrupt;
 		auto &sort = order_bind.sort;
 		auto global_sink = sort->GetGlobalSinkState(client);
 		auto local_sink = sort->GetLocalSinkState(context);
 
-		DataChunk prefixed;
-		prefixed.Initialize(buffer_allocator, order_bind.sort_types);
-
 		//	Go through the states accumulating values to sort until we hit the sort threshold
 		idx_t unsorted_count = 0;
 		idx_t sorted = 0;
+		idx_t accumulated = 0;
 		for (idx_t finalized = 0; finalized < count;) {
 			if (unsorted_count < order_bind.threshold) {
 				auto state = sdata[finalized].GetValueUnsafe();
 				OperatorSinkInput sink {*global_sink, *local_sink, interrupt};
-				SinkState(order_bind, *state, finalized, context, sink, prefixed);
+				SinkState(order_bind, *state, finalized, accumulated, finalize_state, context, sink);
 				unsorted_count += state_unprocessed[finalized];
 
 				// Go to the next aggregate unless this is the last one
 				if (++finalized < count) {
 					continue;
 				}
+			}
+
+			//	Sink any remaining accumulated rows before sorting
+			{
+				OperatorSinkInput sink {*global_sink, *local_sink, interrupt};
+				FlushAccumulated(order_bind, accumulated, finalize_state, context, sink);
 			}
 
 			//	If they were all empty (filtering) flush them
@@ -428,6 +513,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	                                    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize,
 	                                    bound_function.GetProperties().GetNullHandling(), nullptr, nullptr, nullptr,
 	                                    nullptr, SortedAggregateFunction::WindowBatch);
+	ordered_aggregate.SetInitLocalStateFinalizeCallback(SortedAggregateFinalizeState::Init);
 
 	expr.FunctionMutable().ReplaceImplementation(ordered_aggregate);
 	expr.BindInfoMutable() = std::move(sorted_bind);
@@ -482,6 +568,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	    aggregate.GetProperties().GetNullHandling(), nullptr, nullptr, nullptr, nullptr,
 	    SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetWindowCallback(SortedAggregateFunction::Window);
+	ordered_aggregate.SetInitLocalStateFinalizeCallback(SortedAggregateFinalizeState::Init);
 
 	aggregate.ReplaceImplementation(ordered_aggregate);
 	expr.BindInfoMutable() = std::move(sorted_bind);

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -17,6 +17,39 @@ AggregateInputData::AggregateInputData(const AggregateObject &aggr, ArenaAllocat
                          allocator_p, combine_type_p) {
 }
 
+AggregateFinalizeInputData::AggregateFinalizeInputData(const BoundAggregateFunction &function_p,
+                                                       optional_ptr<FunctionData> bind_data_p,
+                                                       ArenaAllocator &allocator_p,
+                                                       optional_ptr<FunctionLocalState> local_state_p)
+    : AggregateInputData(function_p, bind_data_p, allocator_p), local_state(local_state_p) {
+	InitializeLocalState();
+}
+
+AggregateFinalizeInputData::AggregateFinalizeInputData(const BoundAggregateExpression &expr,
+                                                       ArenaAllocator &allocator_p,
+                                                       optional_ptr<FunctionLocalState> local_state_p)
+    : AggregateInputData(expr, allocator_p), local_state(local_state_p) {
+	InitializeLocalState();
+}
+
+AggregateFinalizeInputData::AggregateFinalizeInputData(const AggregateObject &aggr, ArenaAllocator &allocator_p,
+                                                       optional_ptr<FunctionLocalState> local_state_p)
+    : AggregateInputData(aggr, allocator_p), local_state(local_state_p) {
+	InitializeLocalState();
+}
+
+void AggregateFinalizeInputData::InitializeLocalState() {
+	if (local_state) {
+		// the caller passed in an externally-owned local state
+		return;
+	}
+	auto &callbacks = function.GetCallbacks();
+	if (callbacks.HasInitLocalStateFinalizeCallback()) {
+		owned_state = callbacks.GetInitLocalStateFinalizeCallback()(function, bind_data);
+		local_state = owned_state.get();
+	}
+}
+
 bool AggregateFunctionProperties::operator==(const AggregateFunctionProperties &rhs) const {
 	return FunctionProperties::operator==(rhs) && order_dependent == rhs.order_dependent &&
 	       distinct_dependent == rhs.distinct_dependent;
@@ -27,7 +60,8 @@ bool AggregateFunctionProperties::operator!=(const AggregateFunctionProperties &
 
 bool AggregateFunctionCallbacks::operator==(const AggregateFunctionCallbacks &rhs) const {
 	return state_size == rhs.state_size && initialize == rhs.initialize && update == rhs.update &&
-	       combine == rhs.combine && finalize == rhs.finalize && cluster_update == rhs.cluster_update &&
+	       combine == rhs.combine && finalize == rhs.finalize &&
+	       init_local_state_finalize == rhs.init_local_state_finalize && cluster_update == rhs.cluster_update &&
 	       window == rhs.window && window_init == rhs.window_init && window_batch == rhs.window_batch &&
 	       bind == rhs.bind && destructor == rhs.destructor && statistics == rhs.statistics &&
 	       serialize == rhs.serialize && deserialize == rhs.deserialize && get_state_type == rhs.get_state_type;

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -336,7 +336,7 @@ void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &
 
 	DeserializeState(layout, input.data[0], count, local_state.state_buffer.get(), local_state.allocator);
 
-	AggregateInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
+	AggregateFinalizeInputData aggr_input_data(bind_data.aggr, bind_data.bind_data.get(), local_state.allocator);
 	bind_data.aggr.GetStateFinalizeCallback()(local_state.addresses, aggr_input_data, result, count, 0);
 
 	auto validity = input.data[0].Validity();
@@ -491,7 +491,7 @@ unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
 	return std::move(bind_data);
 }
 
-void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+void ExportAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
                              idx_t offset) {
 	D_ASSERT(offset == 0);
 	const data_ptr_t *addresses_ptrs;
@@ -573,7 +573,7 @@ void CombineAggrUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx
 	underlying_aggr.GetStateCombineCallback()(source_vec, target_vec, combine_input, count);
 }
 
-void CombineAggrFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+void CombineAggrFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
                          idx_t offset) {
 	D_ASSERT(offset == 0);
 	auto &bind_data = aggr_input_data.bind_data->Cast<ExportAggregateBindData>();

--- a/src/function/window/window_aggregate_states.cpp
+++ b/src/function/window/window_aggregate_states.cpp
@@ -31,7 +31,7 @@ void WindowAggregateStates::Combine(WindowAggregateStates &target) {
 }
 
 void WindowAggregateStates::Finalize(Vector &result) {
-	AggregateInputData aggr_input_data(aggr, allocator);
+	AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 	aggr.function.GetStateFinalizeCallback()(*statef, aggr_input_data, result, GetCount(), 0);
 }
 

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -351,7 +351,7 @@ void WindowNaiveLocalState::Evaluate(ExecutionContext &context, const WindowAggr
 	FlushStates(gsink);
 
 	//	Finalise the result aggregates and write to the result
-	AggregateInputData aggr_input_data(aggr, allocator);
+	AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 	aggr.function.GetStateFinalizeCallback()(statef, aggr_input_data, result, count, 0);
 
 	//	Destruct the result aggregates

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -281,7 +281,7 @@ void WindowSegmentTreePart::WindowSegmentValue(const WindowSegmentTreeGlobalStat
 }
 void WindowSegmentTreePart::Finalize(Vector &result, idx_t count) {
 	//	Finalise the result aggregates and write to result if write_result is set
-	AggregateInputData aggr_input_data(aggr, allocator);
+	AggregateFinalizeInputData aggr_input_data(aggr, allocator);
 	aggr.function.GetStateFinalizeCallback()(statef, aggr_input_data, result, count, 0);
 
 	//	Destruct the result aggregates

--- a/src/include/duckdb/common/row_operations/row_operations.hpp
+++ b/src/include/duckdb/common/row_operations/row_operations.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/function.hpp"
 
 namespace duckdb {
 
@@ -32,6 +33,8 @@ struct RowOperationsState {
 
 	ArenaAllocator &allocator;
 	unique_ptr<Vector> addresses; // Re-usable vector for row_aggregate.cpp
+	//! Per-aggregate slots in which the aggregates can cache state across finalize calls
+	vector<unique_ptr<FunctionLocalState>> local_states;
 };
 
 // RowOperations contains a set of operations that operate on data using a TupleDataLayout

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -787,7 +787,7 @@ public:
 	}
 
 	template <class STATE_TYPE, class RESULT_TYPE, class OP>
-	static void Finalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+	static void Finalize(Vector &states, AggregateFinalizeInputData &finalize_input_data, Vector &result, idx_t count,
 	                     idx_t offset) {
 		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -795,7 +795,7 @@ public:
 
 			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
 			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
-			AggregateFinalizeData finalize_data(result, aggr_input_data, count);
+			AggregateFinalizeData finalize_data(result, finalize_input_data, count);
 			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(**sdata, *rdata, finalize_data);
 		} else {
 			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
@@ -803,7 +803,7 @@ public:
 
 			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
 			auto rdata = FlatVector::GetDataMutable<RESULT_TYPE>(result);
-			AggregateFinalizeData finalize_data(result, aggr_input_data, count);
+			AggregateFinalizeData finalize_data(result, finalize_input_data, count);
 			for (idx_t i = 0; i < count; i++) {
 				finalize_data.result_idx = i + offset;
 				OP::template Finalize<RESULT_TYPE, STATE_TYPE>(*sdata[i], rdata[finalize_data.result_idx],
@@ -813,21 +813,21 @@ public:
 	}
 
 	template <class STATE_TYPE, class OP>
-	static void VoidFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
-	                         idx_t offset) {
+	static void VoidFinalize(Vector &states, AggregateFinalizeInputData &finalize_input_data, Vector &result,
+	                         idx_t count, idx_t offset) {
 		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			FlatVector::SetSize(result, count);
 
 			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
-			AggregateFinalizeData finalize_data(result, aggr_input_data, count);
+			AggregateFinalizeData finalize_data(result, finalize_input_data, count);
 			OP::template Finalize<STATE_TYPE>(**sdata, finalize_data);
 		} else {
 			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
 			result.SetVectorType(VectorType::FLAT_VECTOR);
 
 			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
-			AggregateFinalizeData finalize_data(result, aggr_input_data);
+			AggregateFinalizeData finalize_data(result, finalize_input_data);
 			for (idx_t i = 0; i < count; i++) {
 				finalize_data.result_idx = i + offset;
 				OP::template Finalize<STATE_TYPE>(*sdata[i], finalize_data);

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -442,7 +442,7 @@ struct MinMaxNOperation {
 	}
 
 	template <class STATE>
-	static void Finalize(Vector &state_vector, AggregateInputData &input_data, Vector &result, idx_t count,
+	static void Finalize(Vector &state_vector, AggregateFinalizeInputData &input_data, Vector &result, idx_t count,
 	                     idx_t offset) {
 		// We only expect bind data from arg_max, otherwise nulls last is the default
 		const bool nulls_last =

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -87,8 +87,13 @@ typedef void (*aggregate_update_t)(Vector inputs[], AggregateInputData &aggr_inp
 //! The type used for combining hashed aggregate states
 typedef void (*aggregate_combine_t)(Vector &state, Vector &combined, AggregateInputData &aggr_input_data, idx_t count);
 //! The type used for finalizing hashed aggregate function payloads
-typedef void (*aggregate_finalize_t)(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
-                                     idx_t offset);
+typedef void (*aggregate_finalize_t)(Vector &state, AggregateFinalizeInputData &finalize_input_data, Vector &result,
+                                     idx_t count, idx_t offset);
+//! Initializes the local state used by the finalize of the aggregate (optional).
+//! The local state can be used to cache expensive intermediates between finalized groups - callers can keep the
+//! local state alive to re-use it across multiple finalize calls (see AggregateFinalizeInputData).
+typedef unique_ptr<FunctionLocalState> (*aggregate_init_local_state_finalize_t)(const BoundAggregateFunction &function,
+                                                                                optional_ptr<FunctionData> bind_data);
 //! The type used for propagating statistics in aggregate functions (optional)
 typedef unique_ptr<BaseStatistics> (*aggregate_statistics_t)(ClientContext &context, BoundAggregateExpression &expr,
                                                              AggregateStatisticsInput &input);
@@ -185,6 +190,10 @@ public:
 	aggregate_finalize_t GetStateFinalizeCallback() const { return finalize; }
 	bool HasStateFinalizeCallback() const { return finalize != nullptr; }
 
+	void SetInitLocalStateFinalizeCallback(aggregate_init_local_state_finalize_t callback) { init_local_state_finalize = callback; }
+	aggregate_init_local_state_finalize_t GetInitLocalStateFinalizeCallback() const { return init_local_state_finalize; }
+	bool HasInitLocalStateFinalizeCallback() const { return init_local_state_finalize != nullptr; }
+
 	bool HasWindowCallback() const { return window != nullptr; }
 	aggregate_window_t GetWindowCallback() const { return window; }
 	void SetWindowCallback(aggregate_window_t callback) { window = callback; }
@@ -220,6 +229,8 @@ public:
 	aggregate_combine_t combine = nullptr;
 	//! The hashed aggregate finalization function (may be null, if window is set)
 	aggregate_finalize_t finalize = nullptr;
+	//! Initializes the local state used by the finalize (may be null)
+	aggregate_init_local_state_finalize_t init_local_state_finalize = nullptr;
 	//! The clustered aggregate update function (may be null)
 	aggregate_cluster_update_t cluster_update = nullptr;
 	//! The windowed aggregate custom function (may be null)
@@ -335,6 +346,10 @@ public: // Callbacks
 	auto HasStateFinalizeCallback() const -> bool { return callbacks.finalize != nullptr; }
 	auto GetStateFinalizeCallback() const -> aggregate_finalize_t { return callbacks.finalize; }
 	auto SetStateFinalizeCallback(aggregate_finalize_t callback) -> void { callbacks.finalize = callback; }
+
+	auto HasInitLocalStateFinalizeCallback() const -> bool { return callbacks.init_local_state_finalize != nullptr; }
+	auto GetInitLocalStateFinalizeCallback() const -> aggregate_init_local_state_finalize_t { return callbacks.init_local_state_finalize; }
+	auto SetInitLocalStateFinalizeCallback(aggregate_init_local_state_finalize_t callback) -> void { callbacks.init_local_state_finalize = callback; }
 
 	auto HasWindowCallback() const -> bool { return callbacks.window != nullptr; }
 	auto GetWindowCallback() const -> aggregate_window_t { return callbacks.window; }
@@ -668,15 +683,15 @@ public:
 	}
 
 	template <class STATE, class RESULT_TYPE, class OP>
-	static void StateFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
-	                          idx_t offset) {
-		AggregateExecutor::Finalize<STATE, RESULT_TYPE, OP>(states, aggr_input_data, result, count, offset);
+	static void StateFinalize(Vector &states, AggregateFinalizeInputData &finalize_input_data, Vector &result,
+	                          idx_t count, idx_t offset) {
+		AggregateExecutor::Finalize<STATE, RESULT_TYPE, OP>(states, finalize_input_data, result, count, offset);
 	}
 
 	template <class STATE, class OP>
-	static void StateVoidFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
-	                              idx_t offset) {
-		AggregateExecutor::VoidFinalize<STATE, OP>(states, aggr_input_data, result, count, offset);
+	static void StateVoidFinalize(Vector &states, AggregateFinalizeInputData &finalize_input_data, Vector &result,
+	                              idx_t count, idx_t offset) {
+		AggregateExecutor::VoidFinalize<STATE, OP>(states, finalize_input_data, result, count, offset);
 	}
 
 	template <class STATE, class OP>

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -50,6 +50,31 @@ struct AggregateInputData {
 	optional_ptr<const ClusteredAggr> clustered;
 };
 
+//! The input data provided to the finalize callback of an aggregate function.
+//! If the function defines an "init_local_state_finalize" callback, the local state is initialized on construction.
+//! Callers can instead pass in an externally-owned local state - this way the local state can be kept alive and
+//! re-used across multiple finalize calls (e.g. for the duration of a hash table scan).
+struct AggregateFinalizeInputData : public AggregateInputData {
+	DUCKDB_API AggregateFinalizeInputData(const BoundAggregateFunction &function_p,
+	                                      optional_ptr<FunctionData> bind_data_p, ArenaAllocator &allocator_p,
+	                                      optional_ptr<FunctionLocalState> local_state_p = nullptr);
+	DUCKDB_API AggregateFinalizeInputData(const BoundAggregateExpression &expr, ArenaAllocator &allocator_p,
+	                                      optional_ptr<FunctionLocalState> local_state_p = nullptr);
+	DUCKDB_API AggregateFinalizeInputData(const AggregateObject &aggr, ArenaAllocator &allocator_p,
+	                                      optional_ptr<FunctionLocalState> local_state_p = nullptr);
+
+	//! The local state of the finalize (set if the function defines an "init_local_state_finalize" callback)
+	optional_ptr<FunctionLocalState> local_state;
+
+private:
+	//! Initializes the local state when the caller did not pass in an external one
+	void InitializeLocalState();
+
+private:
+	//! The local state owned by this input data - used when the caller does not pass in an external local state
+	unique_ptr<FunctionLocalState> owned_state;
+};
+
 struct AggregateUnaryInput {
 	AggregateUnaryInput(AggregateInputData &input_p, const ValidityMask &input_mask_p)
 	    : input(input_p), input_mask(input_mask_p), input_idx(0) {
@@ -77,15 +102,14 @@ struct AggregateBinaryInput {
 };
 
 struct AggregateFinalizeData {
-	AggregateFinalizeData(Vector &result_p, AggregateInputData &input_p, idx_t result_count_p = 1)
+	AggregateFinalizeData(Vector &result_p, AggregateFinalizeInputData &input_p, idx_t result_count_p = 1)
 	    : result(result_p), input(input_p), result_idx(0), result_count(result_count_p) {
 	}
 
 	Vector &result;
-	AggregateInputData &input;
+	AggregateFinalizeInputData &input;
 	idx_t result_idx;
 	idx_t result_count;
-	unique_ptr<FunctionLocalState> local_state;
 
 	inline void ReturnNull() {
 		switch (result.GetVectorType()) {

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -122,7 +122,7 @@ void CAPIAggregateCombine(Vector &state, Vector &combined, AggregateInputData &a
 	}
 }
 
-void CAPIAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+void CAPIAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
                            idx_t offset) {
 	state.Flatten();
 	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();


### PR DESCRIPTION
Ordered aggregates need a lot of dynamically allocated state during `Finalize`. Currently this is re-allocated for every vector. However, this allocation can become a significant bottleneck when there are only a few rows per aggregate, dominating the actual execution time for the sort + aggregation phase. 

As an example, the `Many Groups` benchmark in https://github.com/duckdb/duckdb/pull/23231:

```sql
-- Many Groups
-- 1.5M groups, ~4 rows each group
select string_agg(l_comment order by l_linenumber) from lineitem group by l_orderkey;
```

This takes 0.7s on TPC-H SF1 after the `list` rework, but the majority of time is spent on (re)-allocation of intermediate structs.

This PR adds the `init_local_state_finalize` callback that can be used to cache intermediate structures during the `finalize`, and rewires the ordered aggregates to use this infrastructure. This greatly speeds up ordered aggregates with small groups. For the above benchmark, these are the new timings:

| Version | Timing (s) |
|---------|------------|
| v1.5    | 2.5s       |
| main    | 0.75s      |
| new     | 0.2s       |

i.e. small ordered aggregates are now >10x faster than in v1.5 as a combined result of using the linked lists together with the intermediate state caching. 