### PR TITLE
[Variant] Implement `SetVectorType` for `ShreddedVectorBuffer`

### DIFF
--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -36,7 +36,7 @@ string ShreddedVectorBuffer::ToString(const LogicalType &type, idx_t count) cons
 }
 
 void ShreddedVectorBuffer::SetVectorType(VectorType new_vector_type) {
-	shredded_data->SetVectorType(new_vector_type);
+	throw InternalException("ShreddedVectorBuffer::SetVectorType is not implemented and shouldn't be reached");
 }
 
 Value ShreddedVectorBuffer::GetValue(const LogicalType &type, idx_t index) const {

--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -35,6 +35,10 @@ string ShreddedVectorBuffer::ToString(const LogicalType &type, idx_t count) cons
 	return "Shredded: " + shredded.ToString() + ", Unshredded: " + unshredded.ToString();
 }
 
+void ShreddedVectorBuffer::SetVectorType(VectorType new_vector_type) {
+	shredded_data->SetVectorType(new_vector_type);
+}
+
 Value ShreddedVectorBuffer::GetValue(const LogicalType &type, idx_t index) const {
 	// FIXME: this is extremely inefficient
 	auto &shredded = StructVector::GetEntries(*shredded_data)[1];

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -124,14 +124,6 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 			ConstantVector::SetNull(target_vector, count_t(count));
 		}
 	}
-
-	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		FlatVector::SetSize(result, count);
-		ConstantVector::SetNull(result, ConstantVector::IsNull(source));
-		return all_converted;
-	}
-
 	FlatVector::CopyValidity(result, source, count);
 	FlatVector::SetSize(result, count);
 	result.Verify();

--- a/src/include/duckdb/common/vector/shredded_vector.hpp
+++ b/src/include/duckdb/common/vector/shredded_vector.hpp
@@ -30,6 +30,7 @@ public:
 	idx_t GetAllocationSize() const override;
 	string ToString(const LogicalType &type, idx_t count) const override;
 	Value GetValue(const LogicalType &type, idx_t index) const override;
+	void SetVectorType(VectorType new_vector_type) override;
 
 protected:
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,

--- a/test/sql/storage/types/variant/struct_of_variant.test
+++ b/test/sql/storage/types/variant/struct_of_variant.test
@@ -26,6 +26,9 @@ INSERT INTO variant_list SELECT {
 } from range(1000) t(i)
 
 statement ok
+INSERT INTO variant_list VALUES(row(3000, 'test', 'hello world', 42));
+
+statement ok
 checkpoint;
 
 restart
@@ -35,7 +38,7 @@ select
 	col.f2.a::INTEGER,
 	col.f2.b::VARCHAR,
 	col.f4
-from variant_list limit 10
+from variant_list order by col.f1 limit 10
 ----
 0	val0	true
 1	val1	false


### PR DESCRIPTION
This PR fixes #23274

The newly introduced `ShreddedVectorBuffer` didn't implement `SetVectorType`, which gets hit for example when `VectorType::CONSTANT` is set on the Vector when all arguments are constant. (such as a INSERT with a single value)