### PR TITLE
Add setting `force_update_to_del_and_insert ` which forces updates to always be converted to delete and inserts

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/extra_type_info.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parser/constraints/list.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
@@ -307,7 +308,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	// we thus need all the columns to be available, hence we check if the update touches any index columns
 	// If the returning keyword is used, we need access to the whole row in case the user requests it.
 	// Therefore switch the update to a delete and insert.
-	update.update_is_del_and_insert = false;
+	update.update_is_del_and_insert = Settings::Get<ForceUpdateToDelAndInsertSetting>(context);
 	TableStorageInfo table_storage_info = GetStorageInfo(context);
 	for (auto index : table_storage_info.index_info) {
 		for (auto &column : update.columns) {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -775,6 +775,13 @@
         "custom_implementation": true
     },
     {
+        "name": "force_update_to_del_and_insert",
+        "description": "DEBUG SETTING: forces all updates to use the delete + insert code path instead of in-place updates",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "force_variant_shredding",
         "description": "Forces the VARIANT shredding that happens at checkpoint to use the provided schema for the shredding.",
         "type": "VARCHAR",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1158,6 +1158,17 @@ struct ForceMbedtlsUnsafeSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ForceUpdateToDelAndInsertSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "force_update_to_del_and_insert";
+	static constexpr const char *Description =
+	    "DEBUG SETTING: forces all updates to use the delete + insert code path instead of in-place updates";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct ForceVariantShredding {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "force_variant_shredding";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -162,6 +162,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ForceColumnMetadataReuseSetting),
     DUCKDB_SETTING_CALLBACK(ForceCompressionSetting),
     DUCKDB_GLOBAL(ForceMbedtlsUnsafeSetting),
+    DUCKDB_SETTING(ForceUpdateToDelAndInsertSetting),
     DUCKDB_GLOBAL(ForceVariantShredding),
     DUCKDB_SETTING(GeometryMinimumShreddingSize),
     DUCKDB_SETTING_CALLBACK(HomeDirectorySetting),
@@ -238,12 +239,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 28),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 28),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 120),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 121),
                                                      DUCKDB_SETTING_ALIAS("null_order", 55),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 143),
-                                                     DUCKDB_SETTING_ALIAS("user", 159),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 144),
+                                                     DUCKDB_SETTING_ALIAS("user", 160),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 27),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 157),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 158),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/test/sql/update/force_update_to_del_and_insert.test
+++ b/test/sql/update/force_update_to_del_and_insert.test
@@ -1,0 +1,53 @@
+# name: test/sql/update/force_update_to_del_and_insert.test
+# description: Test the force_update_to_del_and_insert setting
+# group: [update]
+
+# default value is false
+query I
+SELECT current_setting('force_update_to_del_and_insert')
+----
+false
+
+statement ok
+CREATE TABLE t(i INTEGER, j INTEGER, k INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300);
+
+statement ok
+SET force_update_to_del_and_insert=true;
+
+query I
+SELECT current_setting('force_update_to_del_and_insert')
+----
+true
+
+# the update still produces correct results when forced to del + insert
+statement ok
+UPDATE t SET j=j+1 WHERE i>1;
+
+query III
+SELECT * FROM t ORDER BY i
+----
+1	10	100
+2	21	200
+3	31	300
+
+# resetting the setting brings back in-place updates
+statement ok
+RESET force_update_to_del_and_insert;
+
+query I
+SELECT current_setting('force_update_to_del_and_insert')
+----
+false
+
+statement ok
+UPDATE t SET k=k+1;
+
+query III
+SELECT * FROM t ORDER BY i
+----
+1	10	101
+2	21	201
+3	31	301


### PR DESCRIPTION
Currently we try to use update deltas (stored in `UpdateSegment`) when binding updates, which use more efficient update deltas to store updates. As a fallback, we convert updates into deletes and inserts, in particular when columns are of complex nested types (which our update deltas don't yet support) or when the columns we are updating are indexed on. 

This PR adds the `force_update_to_del_and_insert` setting which, when set to true, forces all updates to go through the `delete + insert` code-path. Usage:

```sql
SET force_update_to_del_and_insert=true;
UPDATE <tbl> ...; -- runs as delete + insert
```

The performance impact of this setting depends on the size of the updates relative to the size of the table. The update deltas excel when we are only updating a one or a few columns of a wide table. The delete + insert code-path has to rewrite entire rows.

Here's an example of the worst case of this behavior:

```sql
.timer on
update lineitem set l_orderkey=l_orderkey+100;
-- 0.033s (with update deltas)
SET force_update_to_del_and_insert=true;
update lineitem set l_orderkey=l_orderkey+100;
-- 0.98s (without update deltas)
```

The delete + insert code-path effectively rewrites the entire table in this scenario, where the update deltas only rewrites one of the columns.

This is a worst case, however. When only updating smaller subsets of the table this setting is significantly less impactful w.r.t. updates.

