### PR TITLE
Optimize rollup / cube / grouping sets queries by folding them into CTEs to allow for cascading aggregation

### DIFF
--- a/benchmark/tpch/aggregate/lineitem_rollup.benchmark
+++ b/benchmark/tpch/aggregate/lineitem_rollup.benchmark
@@ -1,0 +1,22 @@
+# name: benchmark/tpch/aggregate/lineitem_rollup.benchmark
+# description: ROLLUP aggregation over lineitem
+# group: [aggregate]
+
+include benchmark/tpch/tpch_load.benchmark.in
+
+name Lineitem Rollup
+group aggregate
+subgroup tpch
+
+run
+SELECT l_returnflag, l_linestatus, SUM(l_quantity) FROM lineitem GROUP BY ROLLUP(l_returnflag, l_linestatus) ORDER BY ALL;
+
+result III sf=1
+A	F	37734107.00
+A	NULL	37734107.00
+N	F	991417.00
+N	O	76633518.00
+N	NULL	77624935.00
+R	F	37719753.00
+R	NULL	37719753.00
+NULL	NULL	153078795.00

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3656,19 +3656,20 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::ROW_NUMBER_REWRITER), "ROW_NUMBER_REWRITER" },
 		{ static_cast<uint32_t>(OptimizerType::PARTITIONED_EXECUTION), "PARTITIONED_EXECUTION" },
 		{ static_cast<uint32_t>(OptimizerType::PARTIAL_AGGREGATE_PUSHDOWN), "PARTIAL_AGGREGATE_PUSHDOWN" },
-		{ static_cast<uint32_t>(OptimizerType::REMOTE_PUSHDOWN), "REMOTE_PUSHDOWN" }
+		{ static_cast<uint32_t>(OptimizerType::REMOTE_PUSHDOWN), "REMOTE_PUSHDOWN" },
+		{ static_cast<uint32_t>(OptimizerType::GROUPING_SETS), "GROUPING_SETS" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
-	return StringUtil::EnumToString(GetOptimizerTypeValues(), 40, "OptimizerType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetOptimizerTypeValues(), 41, "OptimizerType", static_cast<uint32_t>(value));
 }
 
 template<>
 OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
-	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 40, "OptimizerType", value));
+	return static_cast<OptimizerType>(StringUtil::StringToEnum(GetOptimizerTypeValues(), 41, "OptimizerType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetOrderByColumnTypeValues() {

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -52,6 +52,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"partitioned_execution", OptimizerType::PARTITIONED_EXECUTION},
     {"partial_aggregate_pushdown", OptimizerType::PARTIAL_AGGREGATE_PUSHDOWN},
     {"remote_pushdown", OptimizerType::REMOTE_PUSHDOWN},
+    {"grouping_sets", OptimizerType::GROUPING_SETS},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -54,6 +54,7 @@ enum class OptimizerType : uint32_t {
 	PARTITIONED_EXECUTION = 37,
 	PARTIAL_AGGREGATE_PUSHDOWN = 38,
 	REMOTE_PUSHDOWN = 39,
+	GROUPING_SETS = 40,
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
+++ b/src/include/duckdb/optimizer/grouping_sets_optimizer.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/grouping_sets_optimizer.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/column_binding_map.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+
+namespace duckdb {
+class Optimizer;
+
+//! The GroupingSetsOptimizer rewrites aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a
+//! cascade of aggregations connected through materialized CTEs. The finest grouping set is computed over the base
+//! data with the aggregate states exported, after which coarser grouping sets are computed by combining the states
+//! of a finer grouping set - instead of re-scanning and re-aggregating the base data for every grouping set.
+class GroupingSetsOptimizer : public LogicalOperatorVisitor {
+public:
+	explicit GroupingSetsOptimizer(Optimizer &optimizer);
+
+	void VisitOperator(unique_ptr<LogicalOperator> &op) override;
+
+private:
+	bool TryRewriteGroupingSets(unique_ptr<LogicalOperator> &op);
+	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
+
+private:
+	Optimizer &optimizer;
+	column_binding_map_t<ColumnBinding> replacement_map;
+};
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library_unity(
   filter_combiner.cpp
   filter_pullup.cpp
   filter_pushdown.cpp
+  grouping_sets_optimizer.cpp
   in_clause_rewriter.cpp
   join_filter_pushdown_optimizer.cpp
   late_materialization.cpp

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -120,22 +120,10 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 	const idx_t group_count = aggr.groups.size();
 	const idx_t aggregate_count = aggr.expressions.size();
 
-	// bind the aggregates of the finest level: the original aggregates, with their state exported
-	vector<unique_ptr<Expression>> export_aggregates;
-	vector<LogicalType> state_types;
-	for (auto &expr : aggr.expressions) {
-		auto aggregate_copy = unique_ptr_cast<Expression, BoundAggregateExpression>(expr->Copy());
-		auto export_aggregate = ExportAggregateFunction::Bind(std::move(aggregate_copy));
-		if (!export_aggregate->GetReturnType().IsAggregateState()) {
-			return false;
-		}
-		state_types.push_back(export_aggregate->GetReturnType());
-		export_aggregates.push_back(std::move(export_aggregate));
-	}
-
 	// build the per-level aggregates
 	auto combine_function = CombineAggrFun::GetFunction();
 	FunctionBinder function_binder(optimizer.context);
+	vector<LogicalType> state_types;
 	for (idx_t level_idx = 0; level_idx < levels.size(); level_idx++) {
 		auto &level = levels[level_idx];
 		auto &grouping_set = aggr.grouping_sets[level.grouping_set_idx];
@@ -148,7 +136,16 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 			for (auto &group_idx : grouping_set) {
 				level_groups.push_back(aggr.groups[group_idx]->Copy());
 			}
-			level_aggregates = std::move(export_aggregates);
+			// bind the aggregates
+			for (auto &expr : aggr.expressions) {
+				auto aggregate_copy = unique_ptr_cast<Expression, BoundAggregateExpression>(expr->Copy());
+				auto export_aggregate = ExportAggregateFunction::Bind(std::move(aggregate_copy));
+				if (!export_aggregate->GetReturnType().IsAggregateState()) {
+					return false;
+				}
+				state_types.push_back(export_aggregate->GetReturnType());
+				level_aggregates.push_back(std::move(export_aggregate));
+			}
 		} else {
 			// coarser levels combine the aggregate states of their source level
 			auto &source = levels[level.source_level.GetIndex()];

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -1,0 +1,329 @@
+#include "duckdb/optimizer/grouping_sets_optimizer.hpp"
+
+#include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/aggregate/distributive_functions.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/generic_common.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
+#include "duckdb/planner/operator/logical_materialized_cte.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+
+namespace duckdb {
+
+GroupingSetsOptimizer::GroupingSetsOptimizer(Optimizer &optimizer_p) : optimizer(optimizer_p) {
+}
+
+namespace {
+
+//! A single grouping set in the cascade, in the order in which it is computed
+struct GroupingSetLevel {
+	explicit GroupingSetLevel(idx_t grouping_set_idx) : grouping_set_idx(grouping_set_idx) {
+	}
+
+	//! The index of the grouping set (within LogicalAggregate::grouping_sets) computed by this level
+	idx_t grouping_set_idx;
+	//! The level this level aggregates over (invalid for the finest level, which aggregates the base data)
+	optional_idx source_level;
+	//! Whether this level is the source of another level (and must be materialized as a CTE)
+	bool materialized = false;
+	//! The table index of the materialized CTE (only set if materialized)
+	TableIndex cte_index;
+	//! The output types of this level: the group columns (in ascending group order), then the aggregate states
+	vector<LogicalType> output_types;
+	//! The output names of this level
+	vector<Identifier> output_names;
+	//! The position of each group within the level output
+	map<ProjectionIndex, idx_t> group_positions;
+	//! The aggregate computing this level
+	unique_ptr<LogicalAggregate> aggregate;
+};
+
+} // namespace
+
+static bool CanRewriteAggregate(const BoundAggregateExpression &aggregate) {
+	if (aggregate.IsDistinct() || aggregate.GetOrderBys()) {
+		// DISTINCT / ORDER BY aggregates cannot be computed by combining states of a finer aggregation
+		return false;
+	}
+	if (aggregate.StateExportMode() != AggregateStateExportMode::NONE) {
+		// the aggregate already exports its state
+		return false;
+	}
+	// mirror the requirements of ExportAggregateFunction::Bind so that binding the export cannot fail
+	auto &function = aggregate.Function();
+	if (!function.HasStateCombineCallback() || function.HasStateDestructorCallback() ||
+	    !function.HasStateSizeCallback() || !function.HasStateFinalizeCallback() ||
+	    !function.HasGetStateTypeCallback()) {
+		return false;
+	}
+	return true;
+}
+
+//! Order the grouping sets so that each set can be computed by re-aggregating an already-computed superset
+static bool FindCascade(const vector<GroupingSet> &grouping_sets, vector<GroupingSetLevel> &levels) {
+	// order the grouping sets by size (descending) - supersets must be computed before their subsets
+	for (idx_t set_idx = 0; set_idx < grouping_sets.size(); set_idx++) {
+		levels.emplace_back(set_idx);
+	}
+	std::stable_sort(levels.begin(), levels.end(), [&](const GroupingSetLevel &a, const GroupingSetLevel &b) {
+		return grouping_sets[a.grouping_set_idx].size() > grouping_sets[b.grouping_set_idx].size();
+	});
+	// each level is computed from the smallest already-computed level that is a superset of it
+	// for ROLLUP this forms a chain, for CUBE a lattice rooted in the complete grouping set
+	for (idx_t level_idx = 1; level_idx < levels.size(); level_idx++) {
+		auto &grouping_set = grouping_sets[levels[level_idx].grouping_set_idx];
+		for (idx_t source_idx = level_idx; source_idx > 0; source_idx--) {
+			auto &source_set = grouping_sets[levels[source_idx - 1].grouping_set_idx];
+			if (std::includes(source_set.begin(), source_set.end(), grouping_set.begin(), grouping_set.end())) {
+				levels[level_idx].source_level = source_idx - 1;
+				levels[source_idx - 1].materialized = true;
+				break;
+			}
+		}
+		if (!levels[level_idx].source_level.IsValid()) {
+			// no computed superset to compute this grouping set from - we cannot cascade
+			return false;
+		}
+	}
+	return true;
+}
+
+bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &op) {
+	if (op->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY || op->children.size() != 1) {
+		return false;
+	}
+	auto &aggr = op->Cast<LogicalAggregate>();
+	if (aggr.grouping_sets.size() < 2 || aggr.expressions.empty()) {
+		// the rewrite is only beneficial when multiple grouping sets are computed
+		return false;
+	}
+	for (auto &expr : aggr.expressions) {
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			return false;
+		}
+		if (!CanRewriteAggregate(expr->Cast<BoundAggregateExpression>())) {
+			return false;
+		}
+	}
+	vector<GroupingSetLevel> levels;
+	if (!FindCascade(aggr.grouping_sets, levels)) {
+		return false;
+	}
+
+	const idx_t group_count = aggr.groups.size();
+	const idx_t aggregate_count = aggr.expressions.size();
+
+	// bind the aggregates of the finest level: the original aggregates, with their state exported
+	vector<unique_ptr<Expression>> export_aggregates;
+	vector<LogicalType> state_types;
+	for (auto &expr : aggr.expressions) {
+		auto aggregate_copy = unique_ptr_cast<Expression, BoundAggregateExpression>(expr->Copy());
+		auto export_aggregate = ExportAggregateFunction::Bind(std::move(aggregate_copy));
+		if (!export_aggregate->GetReturnType().IsAggregateState()) {
+			return false;
+		}
+		state_types.push_back(export_aggregate->GetReturnType());
+		export_aggregates.push_back(std::move(export_aggregate));
+	}
+
+	// build the per-level aggregates
+	auto combine_function = CombineAggrFun::GetFunction();
+	FunctionBinder function_binder(optimizer.context);
+	for (idx_t level_idx = 0; level_idx < levels.size(); level_idx++) {
+		auto &level = levels[level_idx];
+		auto &grouping_set = aggr.grouping_sets[level.grouping_set_idx];
+
+		vector<unique_ptr<Expression>> level_groups;
+		vector<unique_ptr<Expression>> level_aggregates;
+		unique_ptr<LogicalOperator> level_child;
+		if (level_idx == 0) {
+			// the finest level aggregates the base data and exports the aggregate states
+			for (auto &group_idx : grouping_set) {
+				level_groups.push_back(aggr.groups[group_idx]->Copy());
+			}
+			level_aggregates = std::move(export_aggregates);
+		} else {
+			// coarser levels combine the aggregate states of their source level
+			auto &source = levels[level.source_level.GetIndex()];
+			auto &source_set = aggr.grouping_sets[source.grouping_set_idx];
+			const auto cte_ref_index = optimizer.binder.GenerateTableIndex();
+			level_child =
+			    make_uniq<LogicalCTERef>(cte_ref_index, source.cte_index, source.output_types, source.output_names);
+
+			for (auto &group_idx : grouping_set) {
+				const auto group_pos = source.group_positions[group_idx];
+				level_groups.push_back(make_uniq<BoundColumnRefExpression>(
+				    source.output_types[group_pos], ColumnBinding(cte_ref_index, ProjectionIndex(group_pos))));
+			}
+			for (idx_t aggr_idx = 0; aggr_idx < aggregate_count; aggr_idx++) {
+				const auto state_pos = source_set.size() + aggr_idx;
+				vector<unique_ptr<Expression>> arguments;
+				arguments.push_back(make_uniq<BoundColumnRefExpression>(
+				    state_types[aggr_idx], ColumnBinding(cte_ref_index, ProjectionIndex(state_pos))));
+				auto combine_aggregate = function_binder.BindAggregateFunction(combine_function, std::move(arguments));
+				if (combine_aggregate->GetReturnType() != state_types[aggr_idx]) {
+					return false;
+				}
+				level_aggregates.push_back(std::move(combine_aggregate));
+			}
+		}
+
+		// fill in the output layout of this level: the group columns, followed by the aggregate states
+		for (auto &group_idx : grouping_set) {
+			level.group_positions[group_idx] = level.output_types.size();
+			level.output_types.push_back(aggr.groups[group_idx]->GetReturnType());
+			level.output_names.push_back(Identifier(StringUtil::Format("group_%llu", group_idx.GetIndex())));
+		}
+		for (idx_t aggr_idx = 0; aggr_idx < aggregate_count; aggr_idx++) {
+			level.output_types.push_back(state_types[aggr_idx]);
+			level.output_names.push_back(Identifier(StringUtil::Format("state_%llu", aggr_idx)));
+		}
+
+		level.aggregate = make_uniq<LogicalAggregate>(
+		    optimizer.binder.GenerateTableIndex(), optimizer.binder.GenerateTableIndex(), std::move(level_aggregates));
+		level.aggregate->groups = std::move(level_groups);
+		if (aggr.has_estimated_cardinality) {
+			level.aggregate->SetEstimatedCardinality(aggr.estimated_cardinality);
+		}
+		if (level_child) {
+			level.aggregate->children.push_back(std::move(level_child));
+		}
+		if (level.materialized) {
+			level.cte_index = optimizer.binder.GenerateTableIndex();
+		}
+	}
+
+	// build the union branches - one branch per grouping set, in their original order
+	vector<unique_ptr<LogicalOperator>> branches(levels.size());
+	for (auto &level : levels) {
+		auto &grouping_set = aggr.grouping_sets[level.grouping_set_idx];
+
+		// the branch reads from a reference to the CTE if the level is materialized,
+		// otherwise the level aggregate is inlined into the branch directly
+		unique_ptr<LogicalOperator> branch_child;
+		TableIndex cte_ref_index;
+		if (level.materialized) {
+			cte_ref_index = optimizer.binder.GenerateTableIndex();
+			branch_child =
+			    make_uniq<LogicalCTERef>(cte_ref_index, level.cte_index, level.output_types, level.output_names);
+		} else {
+			branch_child = std::move(level.aggregate);
+		}
+		auto GetBranchBinding = [&](idx_t output_pos) {
+			if (level.materialized) {
+				return ColumnBinding(cte_ref_index, ProjectionIndex(output_pos));
+			}
+			auto &branch_aggr = branch_child->Cast<LogicalAggregate>();
+			if (output_pos < grouping_set.size()) {
+				return ColumnBinding(branch_aggr.group_index, ProjectionIndex(output_pos));
+			}
+			return ColumnBinding(branch_aggr.aggregate_index, ProjectionIndex(output_pos - grouping_set.size()));
+		};
+
+		vector<unique_ptr<Expression>> proj_exprs;
+		for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+			auto &group_type = aggr.groups[group_idx]->GetReturnType();
+			auto entry = level.group_positions.find(ProjectionIndex(group_idx));
+			if (entry != level.group_positions.end()) {
+				proj_exprs.push_back(make_uniq<BoundColumnRefExpression>(group_type, GetBranchBinding(entry->second)));
+			} else {
+				// this group is not part of the grouping set: emit NULL
+				proj_exprs.push_back(make_uniq<BoundConstantExpression>(Value(group_type)));
+			}
+		}
+		for (idx_t aggr_idx = 0; aggr_idx < aggregate_count; aggr_idx++) {
+			auto state_ref = make_uniq<BoundColumnRefExpression>(state_types[aggr_idx],
+			                                                     GetBranchBinding(grouping_set.size() + aggr_idx));
+			auto finalize_expr = optimizer.BindScalarFunction("finalize", std::move(state_ref));
+			if (finalize_expr->GetReturnType() != aggr.expressions[aggr_idx]->GetReturnType()) {
+				return false;
+			}
+			proj_exprs.push_back(std::move(finalize_expr));
+		}
+		// GROUPING() function calls are constant within a grouping set (see RadixPartitionedHashTable)
+		for (auto &grouping_function : aggr.grouping_functions) {
+			int64_t grouping_value = 0;
+			for (idx_t i = 0; i < grouping_function.size(); i++) {
+				if (grouping_set.find(grouping_function[i]) == grouping_set.end()) {
+					// we do not group on this column in this grouping set
+					grouping_value += 1LL << (grouping_function.size() - (i + 1));
+				}
+			}
+			proj_exprs.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(grouping_value)));
+		}
+
+		auto branch = make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(), std::move(proj_exprs));
+		branch->children.push_back(std::move(branch_child));
+		branches[level.grouping_set_idx] = std::move(branch);
+	}
+
+	// from here on the rewrite can no longer fail - we can start modifying the original plan
+	// attach the base input to the finest level
+	levels[0].aggregate->children.push_back(std::move(aggr.children[0]));
+
+	// union the branches together
+	const idx_t column_count = group_count + aggregate_count + aggr.grouping_functions.size();
+	const auto union_index = optimizer.binder.GenerateTableIndex();
+	unique_ptr<LogicalOperator> result = make_uniq<LogicalSetOperation>(union_index, column_count, std::move(branches),
+	                                                                    LogicalOperatorType::LOGICAL_UNION, true);
+	if (aggr.has_estimated_cardinality) {
+		result->SetEstimatedCardinality(aggr.estimated_cardinality);
+	}
+
+	// wrap the result in the materialized CTEs, finest level outermost so that coarser levels can reference it
+	for (idx_t level_idx = levels.size(); level_idx > 0; level_idx--) {
+		auto &level = levels[level_idx - 1];
+		if (!level.materialized) {
+			continue;
+		}
+		auto cte_name = Identifier(StringUtil::Format("__grouping_sets_cte_%llu", level.cte_index.index));
+		auto cte = make_uniq<LogicalMaterializedCTE>(std::move(cte_name), level.cte_index, level.output_types.size(),
+		                                             std::move(level.aggregate), std::move(result),
+		                                             CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
+		if (aggr.has_estimated_cardinality) {
+			cte->SetEstimatedCardinality(aggr.estimated_cardinality);
+		}
+		result = std::move(cte);
+	}
+
+	// replace the bindings of the original aggregate with the union output
+	for (idx_t group_idx = 0; group_idx < group_count; group_idx++) {
+		replacement_map[ColumnBinding(aggr.group_index, ProjectionIndex(group_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_idx));
+	}
+	for (idx_t aggr_idx = 0; aggr_idx < aggregate_count; aggr_idx++) {
+		replacement_map[ColumnBinding(aggr.aggregate_index, ProjectionIndex(aggr_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_count + aggr_idx));
+	}
+	for (idx_t grouping_idx = 0; grouping_idx < aggr.grouping_functions.size(); grouping_idx++) {
+		replacement_map[ColumnBinding(aggr.groupings_index, ProjectionIndex(grouping_idx))] =
+		    ColumnBinding(union_index, ProjectionIndex(group_count + aggregate_count + grouping_idx));
+	}
+
+	result->ResolveOperatorTypes();
+	op = std::move(result);
+	return true;
+}
+
+void GroupingSetsOptimizer::VisitOperator(unique_ptr<LogicalOperator> &op) {
+	LogicalOperatorVisitor::VisitOperator(op);
+	TryRewriteGroupingSets(op);
+}
+
+unique_ptr<Expression> GroupingSetsOptimizer::VisitReplace(BoundColumnRefExpression &expr,
+                                                           unique_ptr<Expression> *expr_ptr) {
+	auto entry = replacement_map.find(expr.Binding());
+	if (entry != replacement_map.end()) {
+		expr.BindingMutable() = entry->second;
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -237,6 +237,12 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = deliminator.Optimize(std::move(plan));
 	});
 
+	// rewrite aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a cascade of aggregations
+	RunOptimizer(OptimizerType::GROUPING_SETS, [&]() {
+		GroupingSetsOptimizer grouping_sets_optimizer(*this);
+		grouping_sets_optimizer.VisitOperator(plan);
+	});
+
 	// try to inline CTEs instead of materialization
 	RunOptimizer(OptimizerType::CTE_INLINING, [&]() {
 		CTEInlining cte_inlining(*this);
@@ -302,12 +308,6 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::DUPLICATE_GROUPS, [&]() {
 		RemoveDuplicateGroups remove(*this);
 		remove.VisitOperator(*plan);
-	});
-
-	// rewrite aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a cascade of aggregations
-	RunOptimizer(OptimizerType::GROUPING_SETS, [&]() {
-		GroupingSetsOptimizer grouping_sets_optimizer(*this);
-		grouping_sets_optimizer.VisitOperator(plan);
 	});
 
 	// then we extract common subexpressions inside the different operators

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/optimizer/expression_heuristics.hpp"
 #include "duckdb/optimizer/filter_pullup.hpp"
 #include "duckdb/optimizer/filter_pushdown.hpp"
+#include "duckdb/optimizer/grouping_sets_optimizer.hpp"
 #include "duckdb/optimizer/in_clause_rewriter.hpp"
 #include "duckdb/optimizer/join_elimination.hpp"
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
@@ -301,6 +302,12 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::DUPLICATE_GROUPS, [&]() {
 		RemoveDuplicateGroups remove(*this);
 		remove.VisitOperator(*plan);
+	});
+
+	// rewrite aggregates over multiple grouping sets (ROLLUP/CUBE/GROUPING SETS) into a cascade of aggregations
+	RunOptimizer(OptimizerType::GROUPING_SETS, [&]() {
+		GroupingSetsOptimizer grouping_sets_optimizer(*this);
+		grouping_sets_optimizer.VisitOperator(plan);
 	});
 
 	// then we extract common subexpressions inside the different operators

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -62,6 +62,11 @@ static bool IsSupportedAggregate(const BoundAggregateExpression &expr) {
 	if (expr.IsDistinct() || expr.GetFilter() || expr.GetOrderBys()) {
 		return false;
 	}
+	if (expr.StateExportMode() != AggregateStateExportMode::NONE) {
+		// the aggregate already exports its state - we cannot push it down again (and finalizing the
+		// re-exported state would not round-trip back to the original return type)
+		return false;
+	}
 	if (expr.GetChildren().size() != 1) {
 		return false;
 	}

--- a/test/optimizer/grouping_sets_optimizer.test
+++ b/test/optimizer/grouping_sets_optimizer.test
@@ -1,0 +1,250 @@
+# name: test/optimizer/grouping_sets_optimizer.test
+# description: Test the GroupingSetsOptimizer - cascading ROLLUP/CUBE/GROUPING SETS aggregations
+# group: [optimizer]
+
+statement ok
+CREATE TABLE sales (region VARCHAR, product VARCHAR, amount INTEGER);
+
+statement ok
+INSERT INTO sales VALUES
+	('eu', 'fish', 1),
+	('eu', 'bread', 2),
+	('us', 'fish', 3),
+	('us', NULL, 4),
+	(NULL, 'bread', 5),
+	('eu', 'fish', 10),
+	('us', 'bread', NULL);
+
+# the optimizer should kick in for a ROLLUP - verify the plan contains a materialized CTE
+query II
+EXPLAIN SELECT region, product, SUM(amount) FROM sales GROUP BY ROLLUP(region, product);
+----
+physical_plan	<REGEX>:.*CTE.*
+
+# .. but not when it is disabled
+statement ok
+SET disabled_optimizers='grouping_sets';
+
+query II
+EXPLAIN SELECT region, product, SUM(amount) FROM sales GROUP BY ROLLUP(region, product);
+----
+physical_plan	<!REGEX>:.*CTE.*
+
+statement ok
+SET disabled_optimizers='';
+
+# ROLLUP with various aggregates
+query IIIIII
+SELECT region, product, SUM(amount), COUNT(*), COUNT(amount), MIN(amount) FROM sales GROUP BY ROLLUP(region, product) ORDER BY ALL;
+----
+eu	bread	2	1	1	2
+eu	fish	11	2	2	1
+eu	NULL	13	3	3	1
+us	bread	NULL	1	0	NULL
+us	fish	3	1	1	3
+us	NULL	4	1	1	4
+us	NULL	7	3	2	3
+NULL	bread	5	1	1	5
+NULL	NULL	5	1	1	5
+NULL	NULL	25	7	6	1
+
+# CUBE
+query IIII
+SELECT region, product, SUM(amount), COUNT(*) FROM sales GROUP BY CUBE(region, product) ORDER BY ALL;
+----
+eu	bread	2	1
+eu	fish	11	2
+eu	NULL	13	3
+us	bread	NULL	1
+us	fish	3	1
+us	NULL	4	1
+us	NULL	7	3
+NULL	bread	5	1
+NULL	bread	7	3
+NULL	fish	14	3
+NULL	NULL	4	1
+NULL	NULL	5	1
+NULL	NULL	25	7
+
+# explicit GROUPING SETS, including a duplicate set
+query IIII
+SELECT region, product, SUM(amount), COUNT(*) FROM sales GROUP BY GROUPING SETS ((region, product), (region), (region), ()) ORDER BY ALL;
+----
+eu	bread	2	1
+eu	fish	11	2
+eu	NULL	13	3
+eu	NULL	13	3
+us	bread	NULL	1
+us	fish	3	1
+us	NULL	4	1
+us	NULL	7	3
+us	NULL	7	3
+NULL	bread	5	1
+NULL	NULL	5	1
+NULL	NULL	5	1
+NULL	NULL	25	7
+
+# GROUPING functions are constant within each grouping set
+query IIIIII
+SELECT region, product, GROUPING(region), GROUPING(product), GROUPING(region, product), SUM(amount) FROM sales GROUP BY ROLLUP(region, product) ORDER BY ALL;
+----
+eu	bread	0	0	0	2
+eu	fish	0	0	0	11
+eu	NULL	0	1	1	13
+us	bread	0	0	0	NULL
+us	fish	0	0	0	3
+us	NULL	0	0	0	4
+us	NULL	0	1	1	7
+NULL	bread	0	0	0	5
+NULL	NULL	0	1	1	5
+NULL	NULL	1	1	3	25
+
+# aggregates with a FILTER clause - the filter is only applied at the finest level
+query III
+SELECT region, product, SUM(amount) FILTER (region = 'eu') FROM sales GROUP BY ROLLUP(region, product) ORDER BY ALL;
+----
+eu	bread	2
+eu	fish	11
+eu	NULL	13
+us	bread	NULL
+us	fish	NULL
+us	NULL	NULL
+us	NULL	NULL
+NULL	bread	NULL
+NULL	NULL	13
+NULL	NULL	NULL
+
+# expressions as groups
+query III
+SELECT UPPER(region), product || '!', SUM(amount) FROM sales GROUP BY ROLLUP(UPPER(region), product || '!') ORDER BY ALL;
+----
+EU	bread!	2
+EU	fish!	11
+EU	NULL	13
+US	bread!	NULL
+US	fish!	3
+US	NULL	4
+US	NULL	7
+NULL	bread!	5
+NULL	NULL	5
+NULL	NULL	25
+
+# HAVING on top of a ROLLUP
+query III
+SELECT region, product, SUM(amount) FROM sales GROUP BY ROLLUP(region, product) HAVING SUM(amount) > 5 ORDER BY ALL;
+----
+eu	fish	11
+eu	NULL	13
+us	NULL	7
+NULL	NULL	25
+
+# rollup over an empty table - only the empty grouping set produces a row
+statement ok
+CREATE TABLE empty_sales (region VARCHAR, product VARCHAR, amount INTEGER);
+
+query IIII
+SELECT region, product, SUM(amount), COUNT(*) FROM empty_sales GROUP BY ROLLUP(region, product) ORDER BY ALL;
+----
+NULL	NULL	NULL	0
+
+# DISTINCT aggregates cannot be cascaded - but still produce correct results through the regular path
+query III
+SELECT region, product, COUNT(DISTINCT amount) FROM sales GROUP BY ROLLUP(region, product) ORDER BY ALL;
+----
+eu	bread	1
+eu	fish	2
+eu	NULL	3
+us	bread	0
+us	fish	1
+us	NULL	1
+us	NULL	2
+NULL	bread	1
+NULL	NULL	1
+NULL	NULL	6
+
+# grouping sets without a common superset cannot be cascaded - regular path
+query III
+SELECT region, product, SUM(amount) FROM sales GROUP BY GROUPING SETS ((region), (product)) ORDER BY ALL;
+----
+eu	NULL	13
+us	NULL	7
+NULL	bread	7
+NULL	fish	14
+NULL	NULL	4
+NULL	NULL	5
+
+# ROLLUP with more payload types
+statement ok
+CREATE TABLE measurements (grp INTEGER, subgrp INTEGER, d DECIMAL(18,3), s VARCHAR, f DOUBLE);
+
+statement ok
+INSERT INTO measurements SELECT i % 3, i % 7, i * 0.001, 'str_' || i, i * 0.5 FROM range(1000) t(i);
+
+query IIIIIII
+SELECT grp, subgrp, SUM(d), MIN(s), MAX(s), SUM(f), COUNT(*) FROM measurements GROUP BY ROLLUP(grp, subgrp) ORDER BY ALL;
+----
+0	0	23.688	str_0	str_987	11844.0	48
+0	1	23.406	str_120	str_99	11703.0	47
+0	2	24.120	str_114	str_996	12060.0	48
+0	3	23.832	str_108	str_990	11916.0	48
+0	4	23.547	str_102	str_984	11773.5	47
+0	5	24.264	str_117	str_999	12132.0	48
+0	6	23.976	str_111	str_993	11988.0	48
+0	NULL	166.833	str_0	str_999	83416.5	334
+1	0	24.024	str_112	str_994	12012.0	48
+1	1	23.736	str_1	str_988	11868.0	48
+1	2	23.453	str_100	str_982	11726.5	47
+1	3	24.168	str_10	str_997	12084.0	48
+1	4	23.880	str_109	str_991	11940.0	48
+1	5	23.594	str_103	str_985	11797.0	47
+1	6	23.312	str_118	str_979	11656.0	47
+1	NULL	166.167	str_1	str_997	83083.5	333
+2	0	23.359	str_119	str_980	11679.5	47
+2	1	24.072	str_113	str_995	12036.0	48
+2	2	23.784	str_107	str_989	11892.0	48
+2	3	23.500	str_101	str_983	11750.0	47
+2	4	24.216	str_11	str_998	12108.0	48
+2	5	23.928	str_110	str_992	11964.0	48
+2	6	23.641	str_104	str_986	11820.5	47
+2	NULL	166.500	str_101	str_998	83250.0	333
+NULL	NULL	499.500	str_0	str_999	249750.0	1000
+
+# three-level rollup
+query IIII
+SELECT grp, subgrp, grp + subgrp, COUNT(*) FROM measurements GROUP BY ROLLUP(grp, subgrp, grp + subgrp) ORDER BY ALL LIMIT 15;
+----
+0	0	0	48
+0	0	NULL	48
+0	1	1	47
+0	1	NULL	47
+0	2	2	48
+0	2	NULL	48
+0	3	3	48
+0	3	NULL	48
+0	4	4	47
+0	4	NULL	47
+0	5	5	48
+0	5	NULL	48
+0	6	6	48
+0	6	NULL	48
+0	NULL	NULL	334
+
+# cube over three columns
+query IIII
+SELECT grp, subgrp, grp % 2, COUNT(*) FROM measurements GROUP BY CUBE(grp, subgrp, grp % 2) ORDER BY ALL LIMIT 15;
+----
+0	0	0	48
+0	0	NULL	48
+0	1	0	47
+0	1	NULL	47
+0	2	0	48
+0	2	NULL	48
+0	3	0	48
+0	3	NULL	48
+0	4	0	47
+0	4	NULL	47
+0	5	0	48
+0	5	NULL	48
+0	6	0	48
+0	6	NULL	48
+0	NULL	0	334

--- a/test/sql/optimizer/test_fd_derived_groups.test
+++ b/test/sql/optimizer/test_fd_derived_groups.test
@@ -113,9 +113,12 @@ EXPLAIN (FORMAT JSON) SELECT x, (x - random()) * 2, count(*) FROM t GROUP BY x, 
 ----
 logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
 
-# ROLLUP: positional groups must not collapse.
+# Multiple grouping sets: positional groups must not collapse, because the position of groups
+# matters semantically in the grouping sets. (ROLLUP/CUBE that the grouping_sets optimizer can
+# fold into a cascade are expanded into single-set aggregates before this optimizer runs, so we
+# use a non-cascadable grouping set here to exercise the multi-grouping-set guard directly.)
 query II
-EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY ROLLUP(x, x-1);
+EXPLAIN (FORMAT JSON) SELECT x, x-1, count(*) FROM t GROUP BY GROUPING SETS ((x), (x-1));
 ----
 logical_opt	<REGEX>:.*"Groups":\s*\[\s*"[^"]*"\s*,\s*".*
 


### PR DESCRIPTION
ROLLUP / CUBE / Grouping sets are currently implemented by just using multiple hash tables. However, they can be often implemented using a cascading aggregation. Instead of using one hash table per grouping set, we can compute the "widest" hash table first, and then use that hash table as input for the second aggregation, etc.

For example, if we have a query like so:

```sql
SELECT l_returnflag, l_linestatus, SUM(l_quantity)
FROM lineitem
GROUP BY CUBE(l_returnflag, l_linestatus)
ORDER BY ALL;
```

We are really computing four grouping sets:

```
l_returnflag, l_linestatus
l_returnflag
l_linestatus
(empty) // i.e. ungrouped
```

By doing a cascading grouping we can save a lot of time - the first hash table `l_returnflag, l_linestatus` only has four rows. So instead of pushing every single row of `lineitem` into four different hash tables, we can push it into a single hash table, and re-aggregate over that hash table.

Using materialized CTEs and aggregate states, we have all of the parts necessary to enable this. The above query can effectively be rewritten into:

```sql
with 
	group_by_returnflag_linestatus as (
		select l_returnflag, l_linestatus, sum(l_quantity) export_state l_quantity_state from lineitem group by l_returnflag, l_linestatus
	),
	group_by_returnflag as (
		select l_returnflag, NULL AS l_linestatus, combine_aggr(l_quantity_state) l_quantity_state from group_by_returnflag_linestatus group by l_returnflag		
	),
	group_by_linestatus as (
		select NULL AS l_returnflag, l_linestatus, combine_aggr(l_quantity_state) l_quantity_state from group_by_returnflag_linestatus group by l_linestatus		
	),
	ungrouped as (
		select NULL AS l_returnflag, NULL AS l_linestatus, combine_aggr(l_quantity_state) l_quantity_state from group_by_returnflag
	)
SELECT l_returnflag, l_linestatus, finalize(l_quantity_state) AS l_quantity_sum FROM group_by_returnflag_linestatus
UNION ALL
SELECT l_returnflag, l_linestatus, finalize(l_quantity_state) AS l_quantity_sum FROM group_by_returnflag
UNION ALL
SELECT l_returnflag, l_linestatus, finalize(l_quantity_state) AS l_quantity_sum FROM group_by_linestatus
UNION ALL
SELECT l_returnflag, l_linestatus, finalize(l_quantity_state) AS l_quantity_sum FROM ungrouped;
```

Effectively we compute the first aggregation and export the aggregate state - and then "cascade" over the result of that aggregation. The result can then be obtained by finalizing the aggregate states that have been collected. 

In the above example, we get roughly a ~2x speed-up with `CUBE` (TPC-H SF100):

| Version | Timing (s) |
|---------|------------|
| v1.5    | 0.8s       |
| New     | 0.4s       |


CC @kryonix 