### PR TITLE
Pass `ParserOptions` in default macro generation

### DIFF
--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
 #include "duckdb/catalog/default/default_functions.hpp"
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 
@@ -63,9 +64,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	copy_fun.SetName("jsonl");
 	loader.RegisterFunction(copy_fun);
 
-	// JSON macro's
+	// Pass the database's ParserCache so the parser matcher is reused, not rebuilt per macro.
+	ParserOptions parser_options;
+	parser_options.parser_cache = &loader.GetDatabaseInstance().GetParserCache();
 	for (idx_t index = 0; JSON_MACROS[index].name != nullptr; index++) {
-		auto info = DefaultFunctionGenerator::CreateInternalMacroInfo(JSON_MACROS[index]);
+		auto info = DefaultFunctionGenerator::CreateInternalMacroInfo(JSON_MACROS[index], parser_options);
 		loader.RegisterFunction(*info);
 	}
 }

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 
@@ -222,11 +224,16 @@ static const DefaultMacro internal_macros[] = {
     {nullptr, nullptr, nullptr}};
 
 unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalMacroInfo(const DefaultMacro &default_macro) {
+	return CreateInternalMacroInfo(default_macro, ParserOptions());
+}
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalMacroInfo(const DefaultMacro &default_macro,
+                                                                              ParserOptions options) {
 	auto bind_info = make_uniq<CreateMacroInfo>(CatalogType::MACRO_ENTRY);
 	// Build a full CREATE MACRO statement and let the parser handle parameters, types, and defaults.
 	// macro_definition may contain multiple comma-separated overloads, e.g. "(x) AS x, (x, y) AS x+y".
 	auto sql = StringUtil::Format("CREATE MACRO __dummy__%s", default_macro.macro_definition);
-	Parser parser;
+	Parser parser(options);
 	parser.ParseQuery(sql);
 	D_ASSERT(parser.statements.size() == 1);
 	D_ASSERT(parser.statements[0]->type == StatementType::CREATE_STATEMENT);
@@ -254,12 +261,13 @@ static bool DefaultFunctionMatches(const DefaultMacro &macro, const Identifier &
 	return macro.schema == schema && macro.name == name;
 }
 
-static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const Identifier &input_schema, const Identifier &input_name) {
+static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const Identifier &input_schema, const Identifier &input_name,
+                                                         ParserOptions options) {
 	auto &schema = input_schema;
 	auto &name = input_name;
 	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {
 		if (DefaultFunctionMatches(internal_macros[index], schema, name)) {
-			return DefaultFunctionGenerator::CreateInternalMacroInfo(internal_macros[index]);
+			return DefaultFunctionGenerator::CreateInternalMacroInfo(internal_macros[index], options);
 		}
 	}
 	return nullptr;
@@ -271,7 +279,9 @@ DefaultFunctionGenerator::DefaultFunctionGenerator(Catalog &catalog, SchemaCatal
 
 unique_ptr<CatalogEntry> DefaultFunctionGenerator::CreateDefaultEntry(ClientContext &context,
                                                                       const Identifier &entry_name) {
-	auto info = GetDefaultFunction(schema.name, entry_name);
+	ParserOptions options;
+	options.parser_cache = &context.db->GetParserCache();
+	auto info = GetDefaultFunction(schema.name, entry_name, options);
 	if (info) {
 		return make_uniq_base<CatalogEntry, ScalarMacroCatalogEntry>(catalog, schema, info->Cast<CreateMacroInfo>());
 	}

--- a/src/catalog/default/default_table_functions.cpp
+++ b/src/catalog/default/default_table_functions.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/function/table_macro_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 
@@ -118,7 +120,12 @@ DefaultTableFunctionGenerator::CreateInternalTableMacroInfo(const DefaultTableMa
 
 unique_ptr<CreateMacroInfo>
 DefaultTableFunctionGenerator::CreateTableMacroInfo(const DefaultTableMacro &default_macro) {
-	Parser parser;
+	return CreateTableMacroInfo(default_macro, ParserOptions());
+}
+
+unique_ptr<CreateMacroInfo> DefaultTableFunctionGenerator::CreateTableMacroInfo(const DefaultTableMacro &default_macro,
+                                                                                ParserOptions options) {
+	Parser parser(options);
 	parser.ParseQuery(default_macro.macro);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
 		throw InternalException("Expected a single select statement in CreateTableMacroInfo internal");
@@ -130,10 +137,10 @@ DefaultTableFunctionGenerator::CreateTableMacroInfo(const DefaultTableMacro &def
 }
 
 static unique_ptr<CreateFunctionInfo> GetDefaultTableFunction(const Identifier &input_schema,
-                                                              const Identifier &input_name) {
+                                                              const Identifier &input_name, ParserOptions options) {
 	for (idx_t index = 0; internal_table_macros[index].name != nullptr; index++) {
 		if (internal_table_macros[index].schema == input_schema && internal_table_macros[index].name == input_name) {
-			return DefaultTableFunctionGenerator::CreateTableMacroInfo(internal_table_macros[index]);
+			return DefaultTableFunctionGenerator::CreateTableMacroInfo(internal_table_macros[index], options);
 		}
 	}
 	return nullptr;
@@ -141,7 +148,9 @@ static unique_ptr<CreateFunctionInfo> GetDefaultTableFunction(const Identifier &
 
 unique_ptr<CatalogEntry> DefaultTableFunctionGenerator::CreateDefaultEntry(ClientContext &context,
                                                                            const Identifier &entry_name) {
-	auto info = GetDefaultTableFunction(schema.name, entry_name);
+	ParserOptions options;
+	options.parser_cache = &context.db->GetParserCache();
+	auto info = GetDefaultTableFunction(schema.name, entry_name, options);
 	if (info) {
 		return make_uniq_base<CatalogEntry, TableMacroCatalogEntry>(catalog, schema, info->Cast<CreateMacroInfo>());
 	}

--- a/src/include/duckdb/catalog/default/default_functions.hpp
+++ b/src/include/duckdb/catalog/default/default_functions.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/default/default_generator.hpp"
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
+#include "duckdb/parser/parser_options.hpp"
 
 namespace duckdb {
 class SchemaCatalogEntry;
@@ -27,6 +28,9 @@ public:
 	SchemaCatalogEntry &schema;
 
 	DUCKDB_API static unique_ptr<CreateMacroInfo> CreateInternalMacroInfo(const DefaultMacro &default_macro);
+	//! Overload taking ParserOptions, so the caller's ParserCache is reused instead of rebuilt per macro.
+	DUCKDB_API static unique_ptr<CreateMacroInfo> CreateInternalMacroInfo(const DefaultMacro &default_macro,
+	                                                                      ParserOptions options);
 
 public:
 	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const Identifier &entry_name) override;

--- a/src/include/duckdb/catalog/default/default_table_functions.hpp
+++ b/src/include/duckdb/catalog/default/default_table_functions.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/default/default_generator.hpp"
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
+#include "duckdb/parser/parser_options.hpp"
 
 namespace duckdb {
 class SchemaCatalogEntry;
@@ -38,6 +39,9 @@ public:
 	vector<Identifier> GetDefaultEntries() override;
 
 	static unique_ptr<CreateMacroInfo> CreateTableMacroInfo(const DefaultTableMacro &default_macro);
+	//! Overload taking ParserOptions, so the caller's ParserCache is reused instead of rebuilt per macro.
+	static unique_ptr<CreateMacroInfo> CreateTableMacroInfo(const DefaultTableMacro &default_macro,
+	                                                        ParserOptions options);
 
 private:
 	static unique_ptr<CreateMacroInfo> CreateInternalTableMacroInfo(const DefaultTableMacro &default_macro,

--- a/test/sql/settings/integer_division_setting.test
+++ b/test/sql/settings/integer_division_setting.test
@@ -37,3 +37,11 @@ query I
 SELECT 1//2
 ----
 0
+
+statement ok
+SET integer_division=true
+
+query I
+SELECT weighted_avg(v, w) FROM (VALUES (1, 1), (2, 2)) t(v, w)
+----
+1.6666666666666667


### PR DESCRIPTION
This avoids rebuilding a fresh `ParserCache` on every default macro instantiation, which happens on database instantiation with the JSON extension preloaded.

Adds a `ParserOptions` overload for both default macro generators, in addition to the existing ones.

--------------------

Hey! I'm currently building https://github.com/nicholasjng/ducky to explore how much performance I can get for ML workloads in Python from duckDB's C API paired with nanobind's zero-copy-via-DLPack array construction. 

By benchmarking against duckDB's own Python bindings, I noticed I'm significantly slower on connection creation compared to the last released `duckdb-python`. Profiling then lead me to repeated parser cache creation on JSON extension import.

This change reduces the time spent in a `ducky.connect()` call from ~11ms to ~6ms  as measured on my Apple M1 Pro.

The reason I'm hitting this is because I statically link `json` into my Python bindings module, since I haven't been able to figure out yet how to lazy-load duckDB extensions via the C API. From a quick survey of the other builtin extensions, it seems like JSON is the only one building the macros on load.