### PR TITLE
Step 5: Make Mark to Semi join conversion more stable

### DIFF
--- a/src/include/duckdb/planner/subquery/delim_join_cte_rewriter.hpp
+++ b/src/include/duckdb/planner/subquery/delim_join_cte_rewriter.hpp
@@ -23,9 +23,9 @@ private:
 
 	void Rewrite(unique_ptr<LogicalOperator> &plan);
 	void RewriteDelimJoinsToCTEs(unique_ptr<LogicalOperator> &plan, LogicalOperator &rewrite_root,
-	                             bool null_rejecting_filter_above = false);
+	                             bool null_rejecting_filter_above = false, bool preserve_evidence_side = false);
 	void MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator> &plan, LogicalOperator &rewrite_root,
-	                               bool null_rejecting_filter_above);
+	                               bool null_rejecting_filter_above, bool preserve_evidence_side);
 
 private:
 	Binder &binder;

--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -24,6 +24,7 @@ namespace duckdb {
 struct JoinFilterBuildSideHeuristics {
 	static constexpr idx_t MIN_FILTER_TARGET_CARDINALITY = 1000000;
 	static constexpr idx_t MAX_BUILD_TO_TARGET_RATIO = 64;
+	static constexpr idx_t SEMI_JOIN_FILTER_TARGET_RATIO = 3;
 };
 
 static void GetRowidBindings(LogicalOperator &op, vector<ColumnBinding> &bindings) {
@@ -152,6 +153,19 @@ static double DynamicFilterBuildBonus(LogicalComparisonJoin &join, const idx_t p
 	return static_cast<double>(max_target_cardinality) / static_cast<double>(MaxValue<idx_t>(build_cardinality, 1));
 }
 
+static idx_t MaxDynamicFilterTargetCardinality(LogicalComparisonJoin &join, const idx_t probe_idx) {
+	idx_t max_target_cardinality = 0;
+	for (auto &cond : join.conditions) {
+		if (!cond.IsComparison() || cond.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
+			continue;
+		}
+		auto &probe_expr = probe_idx == 0 ? cond.GetLHS() : cond.GetRHS();
+		max_target_cardinality =
+		    MaxValue(max_target_cardinality, MaxDynamicFilterTargetCardinality(*join.children[probe_idx], probe_expr));
+	}
+	return max_target_cardinality;
+}
+
 BuildSize BuildProbeSideOptimizer::GetBuildSizes(const LogicalOperator &op, const idx_t lhs_cardinality,
                                                  const idx_t rhs_cardinality) {
 	BuildSize ret;
@@ -248,6 +262,16 @@ bool BuildProbeSideOptimizer::TryFlipJoinChildren(LogicalOperator &op) const {
 		if (HasInverseJoinType(join.join_type) &&
 		    JoinFilterPushdownUtil::JoinTypeIsSupported(InverseJoinType(join.join_type))) {
 			left_side_build_cost /= DynamicFilterBuildBonus(join, 1, 0, lhs_cardinality);
+		}
+		if (join.join_type == JoinType::SEMI && JoinFilterPushdownOptimizer::IsFiltering(join.children[0])) {
+			// SEMI joins often have a filtered domain on the LHS and a larger RHS with residual filters. If flipping
+			// lets that domain generate a runtime filter for a much larger RHS scan, prefer the domain build side.
+			auto right_filter_target = MaxDynamicFilterTargetCardinality(join, 1);
+			if (right_filter_target >= JoinFilterBuildSideHeuristics::MIN_FILTER_TARGET_CARDINALITY &&
+			    right_filter_target / JoinFilterBuildSideHeuristics::SEMI_JOIN_FILTER_TARGET_RATIO > lhs_cardinality &&
+			    right_filter_target / JoinFilterBuildSideHeuristics::SEMI_JOIN_FILTER_TARGET_RATIO > rhs_cardinality) {
+				swap = true;
+			}
 		}
 	}
 

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -1,10 +1,146 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
 using Filter = FilterPushdown::Filter;
+
+static bool FilterNullRejectsExpression(const Expression &filter, const Expression &expr) {
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		for (auto &child : conjunction.GetChildren()) {
+			if (FilterNullRejectsExpression(*child, expr)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (filter.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+		auto &conjunction = filter.Cast<BoundConjunctionExpression>();
+		if (conjunction.GetChildren().empty()) {
+			return false;
+		}
+		for (auto &child : conjunction.GetChildren()) {
+			if (!FilterNullRejectsExpression(*child, expr)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	if (filter.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		auto &op = filter.Cast<BoundOperatorExpression>();
+		return !op.GetChildren().empty() && Expression::Equals(*op.GetChildren()[0], expr);
+	}
+	if (!BoundComparisonExpression::IsComparison(filter)) {
+		return false;
+	}
+	if (filter.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
+	    filter.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		return false;
+	}
+	auto &comparison = filter.Cast<BoundFunctionExpression>();
+	return Expression::Equals(BoundComparisonExpression::Left(comparison), expr) ||
+	       Expression::Equals(BoundComparisonExpression::Right(comparison), expr);
+}
+
+static bool GetColumnRefBinding(const Expression &expr, ColumnBinding &binding) {
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &colref = expr.Cast<BoundColumnRefExpression>();
+	if (colref.Depth() != 0) {
+		return false;
+	}
+	binding = colref.Binding();
+	return true;
+}
+
+static bool ExpressionIsNotNull(ClientContext &context, LogicalOperator &op, const Expression &expr) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		auto &projection = op.Cast<LogicalProjection>();
+		if (projection.children.size() != 1) {
+			return false;
+		}
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto projection_bindings = projection.GetColumnBindings();
+		for (idx_t idx = 0; idx < projection_bindings.size(); idx++) {
+			if (projection_bindings[idx] == binding) {
+				return ExpressionIsNotNull(context, *projection.children[0], *projection.expressions[idx]);
+			}
+		}
+		return false;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = op.Cast<LogicalFilter>();
+		for (auto &filter_expr : filter.expressions) {
+			if (FilterNullRejectsExpression(*filter_expr, expr)) {
+				return true;
+			}
+		}
+		return filter.children.size() == 1 && ExpressionIsNotNull(context, *filter.children[0], expr);
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		ColumnBinding binding;
+		if (!GetColumnRefBinding(expr, binding)) {
+			return false;
+		}
+		auto &get = op.Cast<LogicalGet>();
+		if (binding.table_index != get.table_index) {
+			return false;
+		}
+		if (get.table_filters.HasFilter(binding.column_index)) {
+			auto column_expr = make_uniq<BoundColumnRefExpression>(expr.GetReturnType(), binding);
+			auto filter_expr = get.table_filters.GetFilterByColumnIndex(binding.column_index).ToExpression(*column_expr);
+			if (FilterNullRejectsExpression(*filter_expr, expr)) {
+				return true;
+			}
+		}
+		auto table = get.GetTable();
+		if (!table) {
+			return false;
+		}
+		auto &column_index = get.GetColumnIndex(binding);
+		if (!column_index.HasPrimaryIndex() || column_index.HasChildren() ||
+		    column_index.GetPrimaryIndex() == DConstants::INVALID_INDEX) {
+			return false;
+		}
+		auto stats = table->GetStatistics(context, column_index.GetPrimaryIndex());
+		return stats && !stats->CanHaveNull();
+	}
+	default:
+		return false;
+	}
+}
+
+static void SimplifyNullSafeSemiJoinConditions(ClientContext &context, LogicalComparisonJoin &join) {
+	D_ASSERT(join.join_type == JoinType::SEMI);
+	for (auto &cond : join.conditions) {
+		if (!cond.IsComparison() || cond.GetComparisonType() != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			continue;
+		}
+		// Once a MARK join is reduced to SEMI, a null-safe equality is equivalent to regular equality if either
+		// join key is known not to be NULL. Regular equality unlocks the existing runtime-filter infrastructure.
+		if (!ExpressionIsNotNull(context, *join.children[0], cond.GetLHS()) &&
+		    !ExpressionIsNotNull(context, *join.children[1], cond.GetRHS())) {
+			continue;
+		}
+		cond = JoinCondition(cond.LeftReference()->Copy(), cond.RightReference()->Copy(), ExpressionType::COMPARE_EQUAL);
+	}
+}
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalOperator> op,
                                                              unordered_set<TableIndex> &left_bindings,
@@ -82,6 +218,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 	}
 	op->children[0] = left_pushdown.Rewrite(std::move(op->children[0]));
 	op->children[1] = right_pushdown.Rewrite(std::move(op->children[1]));
+	if (join.join_type == JoinType::SEMI) {
+		SimplifyNullSafeSemiJoinConditions(GetContext(), comp_join);
+	}
 	return PushFinalFilters(std::move(op));
 }
 

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -104,7 +104,8 @@ static bool ExpressionIsNotNull(ClientContext &context, LogicalOperator &op, con
 		}
 		if (get.table_filters.HasFilter(binding.column_index)) {
 			auto column_expr = make_uniq<BoundColumnRefExpression>(expr.GetReturnType(), binding);
-			auto filter_expr = get.table_filters.GetFilterByColumnIndex(binding.column_index).ToExpression(*column_expr);
+			auto filter_expr =
+			    get.table_filters.GetFilterByColumnIndex(binding.column_index).ToExpression(*column_expr);
 			if (FilterNullRejectsExpression(*filter_expr, expr)) {
 				return true;
 			}
@@ -138,7 +139,8 @@ static void SimplifyNullSafeSemiJoinConditions(ClientContext &context, LogicalCo
 		    !ExpressionIsNotNull(context, *join.children[1], cond.GetRHS())) {
 			continue;
 		}
-		cond = JoinCondition(cond.LeftReference()->Copy(), cond.RightReference()->Copy(), ExpressionType::COMPARE_EQUAL);
+		cond =
+		    JoinCondition(cond.LeftReference()->Copy(), cond.RightReference()->Copy(), ExpressionType::COMPARE_EQUAL);
 	}
 }
 

--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -36,6 +36,16 @@ static optional_idx FindBindingIndex(const vector<ColumnBinding> &bindings, cons
 	return NumericCast<idx_t>(entry - bindings.begin());
 }
 
+static idx_t CountUniqueBindings(const vector<ColumnBinding> &bindings) {
+	vector<ColumnBinding> unique_bindings;
+	for (auto &binding : bindings) {
+		if (!FindBindingIndex(unique_bindings, binding).IsValid()) {
+			unique_bindings.push_back(binding);
+		}
+	}
+	return unique_bindings.size();
+}
+
 static idx_t CountCTERefs(LogicalOperator &op, TableIndex cte_index) {
 	idx_t result = 0;
 	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF && op.Cast<LogicalCTERef>().cte_index == cte_index) {
@@ -454,10 +464,12 @@ bool UnnestRewriter::RewriteInlineCTEDedupCandidate(unique_ptr<LogicalOperator> 
 	for (idx_t binding_idx = 0; binding_idx < dedup_bindings.size(); binding_idx++) {
 		domain_ref_replacer.replacement_bindings.emplace_back(dedup_bindings[binding_idx], delim_columns[binding_idx]);
 	}
-	LogicalOperatorVisitor::EnumerateExpressions(
-	    topmost_op, [&](unique_ptr<Expression> *expr) { domain_ref_replacer.VisitExpression(expr); });
+	domain_ref_replacer.VisitOperator(topmost_op);
 	overwritten_tbl_idx = dedup_bindings[0].table_index;
-	distinct_unnest_count = dedup_bindings.size();
+	// Inline CTE dedup inputs can contain repeated source columns, e.g. table-in-out UNNEST can project an input
+	// column and carry it again as a delimiter column. The RHS projection path only has the unique delimiter
+	// columns at its tail.
+	distinct_unnest_count = CountUniqueBindings(delim_columns);
 
 	unnest.children[0] = std::move(domain_cte.children[0]);
 	if (path_to_unnest.empty()) {
@@ -720,31 +732,21 @@ void UnnestRewriter::UpdateRHSBindings(unique_ptr<LogicalOperator> &plan, unique
 	// update all bindings coming from the LHS to RHS bindings
 	D_ASSERT(topmost_op.children[0]->type == LogicalOperatorType::LOGICAL_PROJECTION);
 	auto &top_proj = topmost_op.children[0]->Cast<LogicalProjection>();
+	vector<ColumnBinding> source_lhs_bindings;
+	source_lhs_bindings.reserve(lhs_bindings.size());
 	for (idx_t i = 0; i < lhs_bindings.size(); i++) {
-		ReplaceBinding replace_binding(lhs_bindings[i].binding,
-		                               ColumnBinding(top_proj.table_index, ProjectionIndex(i)));
-		updater.replace_bindings.push_back(replace_binding);
+		source_lhs_bindings.push_back(lhs_bindings[i].binding);
 	}
-
-	// temporarily remove the BOUND_UNNESTs and the child of the LOGICAL_UNNEST from the plan
-	D_ASSERT(curr_op.get()->type == LogicalOperatorType::LOGICAL_UNNEST);
-	auto &unnest = curr_op.get()->Cast<LogicalUnnest>();
-	vector<unique_ptr<Expression>> temp_bound_unnests;
-	for (auto &temp_bound_unnest : unnest.expressions) {
-		temp_bound_unnests.push_back(std::move(temp_bound_unnest));
+	// References above the RHS projection path should point at the LHS columns exposed by the top projection.
+	// Expressions inside the path itself still need to bind against their child; those are repaired below as each
+	// projection gets the LHS columns prepended.
+	ColumnBindingReplacer lhs_replacer;
+	lhs_replacer.stop_operator = topmost_op.children[0];
+	for (idx_t i = 0; i < lhs_bindings.size(); i++) {
+		lhs_replacer.replacement_bindings.emplace_back(
+		    lhs_bindings[i].binding, ColumnBinding(top_proj.table_index, ProjectionIndex(i)), lhs_bindings[i].type);
 	}
-	D_ASSERT(unnest.children.size() == 1);
-	auto temp_unnest_child = std::move(unnest.children[0]);
-	unnest.expressions.clear();
-	unnest.children.clear();
-	// update the bindings of the plan
-	updater.VisitOperator(*plan);
-	updater.replace_bindings.clear();
-	// add the children again
-	for (auto &temp_bound_unnest : temp_bound_unnests) {
-		unnest.expressions.push_back(std::move(temp_bound_unnest));
-	}
-	unnest.children.push_back(std::move(temp_unnest_child));
+	lhs_replacer.VisitOperator(*plan);
 
 	// add the LHS expressions to each LOGICAL_PROJECTION
 	for (idx_t i = path_to_unnest.size(); i > 0; i--) {
@@ -754,6 +756,18 @@ void UnnestRewriter::UpdateRHSBindings(unique_ptr<LogicalOperator> &plan, unique
 		// temporarily store the existing expressions
 		auto existing_expressions = std::move(proj.expressions);
 		proj.expressions.clear();
+
+		ColumnBindingReplacer child_lhs_replacer;
+		for (idx_t expr_idx = 0; expr_idx < lhs_bindings.size(); expr_idx++) {
+			if (source_lhs_bindings[expr_idx] == lhs_bindings[expr_idx].binding) {
+				continue;
+			}
+			child_lhs_replacer.replacement_bindings.emplace_back(
+			    source_lhs_bindings[expr_idx], lhs_bindings[expr_idx].binding, lhs_bindings[expr_idx].type);
+		}
+		for (auto &expr : existing_expressions) {
+			child_lhs_replacer.VisitExpression(&expr);
+		}
 
 		// add the new expressions
 		for (idx_t expr_idx = 0; expr_idx < lhs_bindings.size(); expr_idx++) {

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -446,17 +446,18 @@ struct GeneratedDedupRef {
 	bool has_projection = false;
 };
 
-static bool IsEqualityJoinCondition(const JoinCondition &cond) {
-	if (!cond.IsComparison()) {
-		return false;
-	}
-	switch (cond.GetComparisonType()) {
+static bool IsEqualityComparison(ExpressionType comparison_type) {
+	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
 		return true;
 	default:
 		return false;
 	}
+}
+
+static bool IsEqualityJoinCondition(const JoinCondition &cond) {
+	return cond.IsComparison() && IsEqualityComparison(cond.GetComparisonType());
 }
 
 static bool FindAndReplaceBindings(vector<ColumnBinding> &traced_bindings,
@@ -529,7 +530,7 @@ static void ReplaceExpressionBindings(unique_ptr<Expression> &expr, const vector
 	replacer.VisitExpression(&expr);
 }
 
-static bool GetBoundColumnRefBinding(Expression &expr, ColumnBinding &binding) {
+static bool GetBoundColumnRefBinding(const Expression &expr, ColumnBinding &binding) {
 	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 		return false;
 	}
@@ -612,14 +613,14 @@ public:
 private:
 	unique_ptr<GeneratedDedupRef> GetGeneratedDedupRef(LogicalOperator &op, bool collect_filters = false,
 	                                                   bool allow_projection = false) const;
-	bool ExpressionReferencesGeneratedDedupRef(Expression &expr, const GeneratedDedupRef &dedup_ref) const;
+	bool ExpressionReferencesGeneratedDedupRef(const Expression &expr, const GeneratedDedupRef &dedup_ref) const;
 	bool AddReplacement(vector<ReplacementBinding> &replacements, ColumnBinding old_binding,
 	                    ColumnBinding new_binding) const;
 	bool AddReplacement(vector<ReplacementBinding> &replacements, ColumnBinding old_binding, ColumnBinding new_binding,
 	                    const LogicalType &new_type) const;
 	bool CoversAllDedupColumns(const GeneratedDedupRef &dedup_ref, const vector<ColumnBinding> &bindings) const;
-	optional_idx FindGeneratedOutputBinding(Expression &expr, const GeneratedDedupRef &dedup_ref) const;
-	bool ExpressionReferencesGeneratedSide(Expression &expr, const GeneratedDedupRef &dedup_ref) const;
+	optional_idx FindGeneratedOutputBinding(const Expression &expr, const GeneratedDedupRef &dedup_ref) const;
+	bool ExpressionReferencesGeneratedSide(const Expression &expr, const GeneratedDedupRef &dedup_ref) const;
 	bool FilterIsGeneratedDedupCrossProduct(LogicalOperator &op) const;
 	void FindJoinsWithGeneratedDedupRefs(unique_ptr<LogicalOperator> &op, vector<JoinWithGeneratedDedupRef> &joins,
 	                                     idx_t depth = 0, bool under_aggregate = false,
@@ -628,6 +629,7 @@ private:
 	bool RemoveInequalityJoinConditions(LogicalOperator &target_op, const vector<JoinCondition> &join_conditions,
 	                                    idx_t dedup_idx);
 	bool PreserveJoinAsSemi(unique_ptr<LogicalOperator> &join);
+	bool PreserveFilterCrossProductAsSemi(unique_ptr<LogicalOperator> &filter_op);
 	bool RemoveJoin(unique_ptr<LogicalOperator> &join);
 	bool RemoveFilterCrossProduct(unique_ptr<LogicalOperator> &filter_op);
 
@@ -708,7 +710,7 @@ unique_ptr<GeneratedDedupRef> GeneratedDedupRefEliminator::GetGeneratedDedupRef(
 	return nullptr;
 }
 
-bool GeneratedDedupRefEliminator::ExpressionReferencesGeneratedDedupRef(Expression &expr,
+bool GeneratedDedupRefEliminator::ExpressionReferencesGeneratedDedupRef(const Expression &expr,
                                                                         const GeneratedDedupRef &dedup_ref) const {
 	bool found = false;
 	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
@@ -768,7 +770,7 @@ bool GeneratedDedupRefEliminator::CoversAllDedupColumns(const GeneratedDedupRef 
 	return true;
 }
 
-optional_idx GeneratedDedupRefEliminator::FindGeneratedOutputBinding(Expression &expr,
+optional_idx GeneratedDedupRefEliminator::FindGeneratedOutputBinding(const Expression &expr,
                                                                      const GeneratedDedupRef &dedup_ref) const {
 	optional_idx result;
 	bool unsupported = false;
@@ -789,7 +791,7 @@ optional_idx GeneratedDedupRefEliminator::FindGeneratedOutputBinding(Expression 
 	return unsupported ? optional_idx() : result;
 }
 
-bool GeneratedDedupRefEliminator::ExpressionReferencesGeneratedSide(Expression &expr,
+bool GeneratedDedupRefEliminator::ExpressionReferencesGeneratedSide(const Expression &expr,
                                                                     const GeneratedDedupRef &dedup_ref) const {
 	if (ExpressionReferencesGeneratedDedupRef(expr, dedup_ref)) {
 		return true;
@@ -1079,6 +1081,122 @@ bool GeneratedDedupRefEliminator::PreserveJoinAsSemi(unique_ptr<LogicalOperator>
 	return true;
 }
 
+bool GeneratedDedupRefEliminator::PreserveFilterCrossProductAsSemi(unique_ptr<LogicalOperator> &filter_op) {
+	auto &filter = filter_op->Cast<LogicalFilter>();
+	if (filter.HasProjectionMap() || filter.children.size() != 1 ||
+	    filter.children[0]->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		return false;
+	}
+	auto &cross_product = *filter.children[0];
+	if (cross_product.children.size() != 2) {
+		return false;
+	}
+
+	const idx_t dedup_idx = GetGeneratedDedupRef(*cross_product.children[0], false, true) ? 0 : 1;
+	auto dedup_ref = GetGeneratedDedupRef(*cross_product.children[dedup_idx], false, true);
+	if (!dedup_ref) {
+		return false;
+	}
+
+	filter.SplitPredicates();
+	vector<bool> consumed(filter.expressions.size(), false);
+	vector<ColumnBinding> covered_dedup_bindings;
+	covered_dedup_bindings.reserve(dedup_ref->output_bindings.size());
+	vector<ColumnBinding> base_replacement_bindings;
+	vector<unique_ptr<Expression>> base_replacement_expressions;
+	vector<JoinCondition> semi_conditions;
+	ColumnBindingReplacer replacer;
+	auto &replacement_bindings = replacer.replacement_bindings;
+
+	for (idx_t expr_idx = 0; expr_idx < filter.expressions.size(); expr_idx++) {
+		auto &expr = *filter.expressions[expr_idx];
+		if (!BoundComparisonExpression::IsComparison(expr) || !IsEqualityComparison(expr.GetExpressionType())) {
+			continue;
+		}
+		auto &comparison = expr.Cast<BoundFunctionExpression>();
+		auto &lhs = BoundComparisonExpression::Left(comparison);
+		auto &rhs = BoundComparisonExpression::Right(comparison);
+
+		auto lhs_generated_idx = FindGeneratedOutputBinding(lhs, *dedup_ref);
+		auto rhs_generated_idx = FindGeneratedOutputBinding(rhs, *dedup_ref);
+		if (lhs_generated_idx.IsValid() == rhs_generated_idx.IsValid()) {
+			continue;
+		}
+
+		auto generated_idx = lhs_generated_idx.IsValid() ? lhs_generated_idx.GetIndex() : rhs_generated_idx.GetIndex();
+		auto &generated_binding = dedup_ref->output_bindings[generated_idx];
+		auto &generated_expression = *dedup_ref->output_expressions[generated_idx];
+		auto &other_side = lhs_generated_idx.IsValid() ? rhs : lhs;
+
+		ColumnBinding other_binding;
+		if (!GetBoundColumnRefBinding(other_side, other_binding)) {
+			return false;
+		}
+		if (!AddReplacement(replacement_bindings, generated_binding, other_binding,
+		                    generated_expression.GetReturnType())) {
+			return false;
+		}
+
+		ColumnBinding base_binding;
+		if (GetBoundColumnRefBinding(generated_expression, base_binding) &&
+		    base_binding.table_index == dedup_ref->cte_ref->table_index) {
+			if (!AddReplacement(replacement_bindings, base_binding, other_binding)) {
+				return false;
+			}
+			covered_dedup_bindings.emplace_back(base_binding);
+			base_replacement_bindings.push_back(base_binding);
+			base_replacement_expressions.push_back(other_side.Copy());
+		}
+
+		auto generated_expr = lhs_generated_idx.IsValid() ? lhs.Copy() : rhs.Copy();
+		auto other_expr = lhs_generated_idx.IsValid() ? rhs.Copy() : lhs.Copy();
+		auto comparison_type =
+		    lhs_generated_idx.IsValid() ? FlipComparisonExpression(expr.GetExpressionType()) : expr.GetExpressionType();
+		semi_conditions.emplace_back(std::move(other_expr), std::move(generated_expr), comparison_type);
+		consumed[expr_idx] = true;
+	}
+
+	if (semi_conditions.empty() || !CoversAllDedupColumns(*dedup_ref, covered_dedup_bindings)) {
+		return false;
+	}
+	for (idx_t expr_idx = 0; expr_idx < filter.expressions.size(); expr_idx++) {
+		if (!consumed[expr_idx] && ExpressionReferencesGeneratedSide(*filter.expressions[expr_idx], *dedup_ref)) {
+			return false;
+		}
+	}
+
+	vector<unique_ptr<Expression>> generated_output_replacements;
+	generated_output_replacements.reserve(dedup_ref->output_expressions.size());
+	for (auto &expr : dedup_ref->output_expressions) {
+		auto rewritten_expr = expr->Copy();
+		ReplaceExpressionBindings(rewritten_expr, base_replacement_bindings, base_replacement_expressions);
+		if (ExpressionReferencesGeneratedSide(*rewritten_expr, *dedup_ref)) {
+			return false;
+		}
+		generated_output_replacements.push_back(std::move(rewritten_expr));
+	}
+
+	auto semi_join = make_uniq<LogicalComparisonJoin>(JoinType::SEMI);
+	semi_join->conditions = std::move(semi_conditions);
+	semi_join->children.push_back(std::move(cross_product.children[1 - dedup_idx]));
+	semi_join->children.push_back(std::move(cross_product.children[dedup_idx]));
+	semi_join->ResolveOperatorTypes();
+
+	unique_ptr<LogicalOperator> replacement_op = std::move(semi_join);
+	for (idx_t expr_idx = 0; expr_idx < filter.expressions.size(); expr_idx++) {
+		if (consumed[expr_idx]) {
+			continue;
+		}
+		AddFilterToOperator(replacement_op, std::move(filter.expressions[expr_idx]));
+	}
+
+	filter_op = std::move(replacement_op);
+	replacer.stop_operator = filter_op.get();
+	replacer.VisitOperator(rewrite_root);
+	ReplaceOperatorBindings(rewrite_root, dedup_ref->output_bindings, generated_output_replacements, filter_op.get());
+	return true;
+}
+
 bool GeneratedDedupRefEliminator::RemoveJoin(unique_ptr<LogicalOperator> &join) {
 	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
 	if (comparison_join.join_type != JoinType::INNER && comparison_join.join_type != JoinType::SEMI) {
@@ -1347,7 +1465,9 @@ idx_t GeneratedDedupRefEliminator::Remove() {
 		if (preserve_selected_domain && (join.under_aggregate || join.under_evidence_side)) {
 			// This join is a semijoin reduction for a grouped RHS or an existence-check evidence side. Removing it is
 			// valid, but can turn a selective correlated subquery into a global aggregate or full evidence scan.
-			if (!join.filter_cross_product) {
+			if (join.filter_cross_product) {
+				PreserveFilterCrossProductAsSemi(join.join.get());
+			} else {
 				PreserveJoinAsSemi(join.join.get());
 			}
 			continue;

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -241,6 +241,30 @@ static bool FilterNullRejectsDelimJoinRHS(LogicalFilter &filter, LogicalComparis
 	return false;
 }
 
+static bool ExpressionIsMarkerRef(Expression &expr, TableIndex mark_index) {
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &colref = expr.Cast<BoundColumnRefExpression>();
+	return colref.Depth() == 0 && colref.Binding().table_index == mark_index;
+}
+
+static bool FilterNegatesDelimJoinMarker(LogicalFilter &filter, LogicalComparisonJoin &delim_join) {
+	if (filter.HasProjectionMap() || delim_join.join_type != JoinType::MARK) {
+		return false;
+	}
+	for (auto &expr : filter.expressions) {
+		if (expr->GetExpressionType() != ExpressionType::OPERATOR_NOT) {
+			continue;
+		}
+		auto &op = expr->Cast<BoundOperatorExpression>();
+		if (!op.GetChildren().empty() && ExpressionIsMarkerRef(*op.GetChildren()[0], delim_join.mark_index)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static bool PushEligibleFilterExpressionsIntoDelimJoinInputs(unique_ptr<LogicalOperator> &plan) {
 	auto &filter = plan->Cast<LogicalFilter>();
 	if (filter.HasProjectionMap()) {
@@ -350,17 +374,68 @@ static bool HasSelection(const LogicalOperator &op) {
 	return false;
 }
 
+static bool IsEvidenceSide(LogicalOperator &op, idx_t child_idx) {
+	if (op.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return false;
+	}
+	auto &join = op.Cast<LogicalComparisonJoin>();
+	switch (join.join_type) {
+	case JoinType::MARK:
+	case JoinType::ANTI:
+		return child_idx == 1;
+	case JoinType::RIGHT_ANTI:
+		return child_idx == 0;
+	default:
+		return false;
+	}
+}
+
+static bool HasEvidenceSide(JoinType join_type) {
+	switch (join_type) {
+	case JoinType::MARK:
+	case JoinType::ANTI:
+	case JoinType::RIGHT_ANTI:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool ContainsSubqueryJoin(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		switch (join.join_type) {
+		case JoinType::MARK:
+		case JoinType::SEMI:
+		case JoinType::ANTI:
+		case JoinType::RIGHT_SEMI:
+		case JoinType::RIGHT_ANTI:
+		case JoinType::SINGLE:
+			return true;
+		default:
+			break;
+		}
+	}
+	for (auto &child : op.children) {
+		if (ContainsSubqueryJoin(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 struct JoinWithGeneratedDedupRef {
 	JoinWithGeneratedDedupRef(unique_ptr<LogicalOperator> &join_p, idx_t depth_p, bool filter_cross_product_p = false,
-	                          bool under_aggregate_p = false)
+	                          bool under_aggregate_p = false, bool under_evidence_side_p = false)
 	    : join(join_p), depth(depth_p), filter_cross_product(filter_cross_product_p),
-	      under_aggregate(under_aggregate_p) {
+	      under_aggregate(under_aggregate_p), under_evidence_side(under_evidence_side_p) {
 	}
 
 	reference<unique_ptr<LogicalOperator>> join;
 	idx_t depth;
 	bool filter_cross_product;
 	bool under_aggregate;
+	bool under_evidence_side;
 };
 
 struct GeneratedDedupRef {
@@ -530,7 +605,7 @@ static void ReplaceOperatorBindings(LogicalOperator &op, const vector<ColumnBind
 class GeneratedDedupRefEliminator {
 public:
 	GeneratedDedupRefEliminator(LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index, idx_t dedup_ref_count,
-	                            LogicalOperator &rewrite_root);
+	                            LogicalOperator &rewrite_root, bool preserve_evidence_side);
 
 	idx_t Remove();
 
@@ -547,7 +622,8 @@ private:
 	bool ExpressionReferencesGeneratedSide(Expression &expr, const GeneratedDedupRef &dedup_ref) const;
 	bool FilterIsGeneratedDedupCrossProduct(LogicalOperator &op) const;
 	void FindJoinsWithGeneratedDedupRefs(unique_ptr<LogicalOperator> &op, vector<JoinWithGeneratedDedupRef> &joins,
-	                                     idx_t depth = 0, bool under_aggregate = false) const;
+	                                     idx_t depth = 0, bool under_aggregate = false,
+	                                     bool under_evidence_side = false) const;
 	idx_t CountGeneratedDedupRefs(LogicalOperator &op) const;
 	bool RemoveInequalityJoinConditions(LogicalOperator &target_op, const vector<JoinCondition> &join_conditions,
 	                                    idx_t dedup_idx);
@@ -560,12 +636,14 @@ private:
 	TableIndex dedup_cte_index;
 	idx_t dedup_ref_count;
 	LogicalOperator &rewrite_root;
+	bool preserve_evidence_side;
 };
 
 GeneratedDedupRefEliminator::GeneratedDedupRefEliminator(LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index,
-                                                         idx_t dedup_ref_count, LogicalOperator &rewrite_root)
+                                                         idx_t dedup_ref_count, LogicalOperator &rewrite_root,
+                                                         bool preserve_evidence_side)
     : delim_join(delim_join), dedup_cte_index(dedup_cte_index), dedup_ref_count(dedup_ref_count),
-      rewrite_root(rewrite_root) {
+      rewrite_root(rewrite_root), preserve_evidence_side(preserve_evidence_side) {
 }
 
 unique_ptr<GeneratedDedupRef> GeneratedDedupRefEliminator::GetGeneratedDedupRef(LogicalOperator &op,
@@ -742,25 +820,27 @@ bool GeneratedDedupRefEliminator::FilterIsGeneratedDedupCrossProduct(LogicalOper
 }
 
 void GeneratedDedupRefEliminator::FindJoinsWithGeneratedDedupRefs(unique_ptr<LogicalOperator> &op,
-                                                                  vector<JoinWithGeneratedDedupRef> &joins,
-                                                                  idx_t depth, bool under_aggregate) const {
+                                                                  vector<JoinWithGeneratedDedupRef> &joins, idx_t depth,
+                                                                  bool under_aggregate,
+                                                                  bool under_evidence_side) const {
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		if (!op->children.empty()) {
-			FindJoinsWithGeneratedDedupRefs(op->children[0], joins, depth + 1, under_aggregate);
+			FindJoinsWithGeneratedDedupRefs(op->children[0], joins, depth + 1, under_aggregate, under_evidence_side);
 		}
 		return;
 	}
 
 	auto child_under_aggregate = under_aggregate || op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY;
-	for (auto &child : op->children) {
-		FindJoinsWithGeneratedDedupRefs(child, joins, depth + 1, child_under_aggregate);
+	for (idx_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
+		FindJoinsWithGeneratedDedupRefs(op->children[child_idx], joins, depth + 1, child_under_aggregate,
+		                                under_evidence_side);
 	}
 
 	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
 	    (GetGeneratedDedupRef(*op->children[0], false, true) || GetGeneratedDedupRef(*op->children[1], false, true))) {
-		joins.emplace_back(op, depth, false, under_aggregate);
+		joins.emplace_back(op, depth, false, under_aggregate, under_evidence_side);
 	} else if (FilterIsGeneratedDedupCrossProduct(*op)) {
-		joins.emplace_back(op, depth, true, under_aggregate);
+		joins.emplace_back(op, depth, true, under_aggregate, under_evidence_side);
 	}
 }
 
@@ -965,8 +1045,8 @@ bool GeneratedDedupRefEliminator::PreserveJoinAsSemi(unique_ptr<LogicalOperator>
 
 		auto generated_expr = lhs_generated_idx.IsValid() ? cond.GetLHS().Copy() : cond.GetRHS().Copy();
 		auto other_expr = lhs_generated_idx.IsValid() ? cond.GetRHS().Copy() : cond.GetLHS().Copy();
-		auto comparison_type = lhs_generated_idx.IsValid() ? FlipComparisonExpression(cond.GetComparisonType())
-		                                                   : cond.GetComparisonType();
+		auto comparison_type =
+		    lhs_generated_idx.IsValid() ? FlipComparisonExpression(cond.GetComparisonType()) : cond.GetComparisonType();
 		semi_conditions.emplace_back(std::move(other_expr), std::move(generated_expr), comparison_type);
 	}
 	if (!CoversAllDedupColumns(*dedup_ref, covered_dedup_bindings)) {
@@ -1249,7 +1329,11 @@ bool GeneratedDedupRefEliminator::RemoveFilterCrossProduct(unique_ptr<LogicalOpe
 
 idx_t GeneratedDedupRefEliminator::Remove() {
 	vector<JoinWithGeneratedDedupRef> joins;
-	FindJoinsWithGeneratedDedupRefs(delim_join.children[1], joins);
+	auto preserve_selected_domain = HasSelection(*delim_join.children[0]);
+	auto selected_evidence_side = preserve_selected_domain && preserve_evidence_side &&
+	                              HasEvidenceSide(delim_join.join_type) &&
+	                              !ContainsSubqueryJoin(*delim_join.children[0]);
+	FindJoinsWithGeneratedDedupRefs(delim_join.children[1], joins, 0, false, selected_evidence_side);
 	if (joins.empty()) {
 		return dedup_ref_count;
 	}
@@ -1259,11 +1343,10 @@ idx_t GeneratedDedupRefEliminator::Remove() {
 		          return lhs.depth > rhs.depth;
 	          });
 
-	auto preserve_selected_domain = HasSelection(*delim_join.children[0]);
 	for (auto &join : joins) {
-		if (preserve_selected_domain && join.under_aggregate) {
-			// This join is a semijoin reduction for the grouped RHS. Removing it is valid, but can turn a
-			// selective correlated aggregate into a global aggregate over the inner relation.
+		if (preserve_selected_domain && (join.under_aggregate || join.under_evidence_side)) {
+			// This join is a semijoin reduction for a grouped RHS or an existence-check evidence side. Removing it is
+			// valid, but can turn a selective correlated subquery into a global aggregate or full evidence scan.
 			if (!join.filter_cross_product) {
 				PreserveJoinAsSemi(join.join.get());
 			}
@@ -1298,7 +1381,8 @@ public:
 private:
 	void CollectCTEs(LogicalOperator &op);
 	optional_ptr<LogicalCTE> FindCTE(TableIndex cte_index) const;
-	bool TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate = false);
+	bool TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate = false, bool under_evidence_side = false,
+	                    bool negated_marker_filter_above = false);
 
 	unique_ptr<GeneratedDedupRef> GetGeneratedDedupRef(LogicalOperator &op, bool collect_filters = false,
 	                                                   bool allow_projection = false) const;
@@ -1314,8 +1398,8 @@ private:
 
 	bool AddReplacement(vector<ReplacementBinding> &replacements, ColumnBinding old_binding,
 	                    ColumnBinding new_binding) const;
-	bool RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate);
-	bool RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate);
+	bool RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate, bool under_evidence_side);
+	bool RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate, bool under_evidence_side);
 
 private:
 	unique_ptr<LogicalOperator> &rewrite_root;
@@ -1628,7 +1712,8 @@ bool GeneratedDomainJoinEliminator::AddReplacement(vector<ReplacementBinding> &r
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate) {
+bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate,
+                                                             bool under_evidence_side) {
 	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
 	if (comparison_join.join_type != JoinType::INNER &&
 	    (comparison_join.join_type != JoinType::SEMI || !GetGeneratedDedupRef(*join->children[1], false, true))) {
@@ -1648,9 +1733,9 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalO
 	if (!dedup_ref) {
 		return false;
 	}
-	if (under_aggregate && GeneratedDedupRefHasSelection(*dedup_ref)) {
-		// The first CTE rewrite can preserve selected domains below aggregates as regular joins. Do not
-		// substitute that selected generated CTE away in the cleanup pass.
+	if ((under_aggregate || under_evidence_side) && GeneratedDedupRefHasSelection(*dedup_ref)) {
+		// The first CTE rewrite can preserve selected domains below aggregates or existence checks as regular joins.
+		// Do not substitute that selected generated CTE away in the cleanup pass.
 		return false;
 	}
 
@@ -1747,7 +1832,8 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalO
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate) {
+bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate,
+                                                              bool under_evidence_side) {
 	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
 	if (comparison_join.join_type != JoinType::INNER) {
 		return false;
@@ -1775,8 +1861,9 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<Logical
 	if (!generated_ref || !domain_ref) {
 		return false;
 	}
-	if (under_aggregate && (domain_ref->has_selection || !domain_ref->filters.empty())) {
-		// Same invariant as above: selected domains below aggregates are part of the physical reduction.
+	if ((under_aggregate || under_evidence_side) && (domain_ref->has_selection || !domain_ref->filters.empty())) {
+		// Same invariant as above: selected domains below aggregates or existence checks are part of the physical
+		// reduction.
 		return false;
 	}
 
@@ -1863,17 +1950,40 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<Logical
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate) {
+bool GeneratedDomainJoinEliminator::TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate,
+                                                   bool under_evidence_side, bool negated_marker_filter_above) {
 	auto child_under_aggregate = under_aggregate || op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY;
-	for (auto &child : op->children) {
-		if (TryRewriteOnce(child, child_under_aggregate)) {
+	for (idx_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
+		auto &child = op->children[child_idx];
+		auto child_under_evidence_side = under_evidence_side;
+		if (negated_marker_filter_above && IsEvidenceSide(*op, child_idx)) {
+			child_under_evidence_side = true;
+		} else if (!under_evidence_side && op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+			auto &join = op->Cast<LogicalComparisonJoin>();
+			if ((join.join_type == JoinType::ANTI || join.join_type == JoinType::RIGHT_ANTI) &&
+			    IsEvidenceSide(*op, child_idx)) {
+				child_under_evidence_side = true;
+			}
+		}
+
+		bool child_negated_marker_filter_above = false;
+		if (op->type == LogicalOperatorType::LOGICAL_FILTER && child_idx == 0 &&
+		    child->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+			auto &filter = op->Cast<LogicalFilter>();
+			auto &join = child->Cast<LogicalComparisonJoin>();
+			child_negated_marker_filter_above = FilterNegatesDelimJoinMarker(filter, join);
+		}
+
+		if (TryRewriteOnce(child, child_under_aggregate, child_under_evidence_side,
+		                   child_negated_marker_filter_above)) {
 			return true;
 		}
 	}
 	if (op->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
 		return false;
 	}
-	return RemoveGeneratedDomainJoin(op, under_aggregate) || RemoveGeneratedDedupJoin(op, under_aggregate);
+	return RemoveGeneratedDomainJoin(op, under_aggregate, under_evidence_side) ||
+	       RemoveGeneratedDedupJoin(op, under_aggregate, under_evidence_side);
 }
 
 bool GeneratedDomainJoinEliminator::Rewrite() {
@@ -1954,7 +2064,7 @@ DelimJoinCTERewriter::DelimJoinCTERewriter(Binder &binder) : binder(binder) {
 }
 
 void DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator> &plan, LogicalOperator &rewrite_root,
-                                                     bool null_rejecting_filter_above) {
+                                                     bool null_rejecting_filter_above, bool preserve_evidence_side) {
 	auto &join = plan->Cast<LogicalComparisonJoin>();
 	if (join.delim_flipped) {
 		throw InternalException("Flatten dependent joins - flipped delim join CTE rewrite not supported");
@@ -1967,7 +2077,8 @@ void DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator>
 	if (cte_deliminator_enabled) {
 		auto cte_deliminator_timer =
 		    QueryProfiler::Get(binder.context).StartTimerInternal(CTE_DELIMINATOR_PROFILER_KEY);
-		GeneratedDedupRefEliminator eliminator(join, dedup_cte_index, dedup_ref_count, rewrite_root);
+		GeneratedDedupRefEliminator eliminator(join, dedup_cte_index, dedup_ref_count, rewrite_root,
+		                                       preserve_evidence_side);
 		dedup_ref_count = eliminator.Remove();
 		if (SingleJoinRHSIsDeduplicated(join)) {
 			join.join_type = null_rejecting_filter_above ? JoinType::INNER : JoinType::LEFT;
@@ -2089,21 +2200,23 @@ void DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator>
 }
 
 void DelimJoinCTERewriter::RewriteDelimJoinsToCTEs(unique_ptr<LogicalOperator> &plan, LogicalOperator &rewrite_root,
-                                                   bool null_rejecting_filter_above) {
+                                                   bool null_rejecting_filter_above, bool preserve_evidence_side) {
 	for (auto &child : plan->children) {
 		auto old_child_bindings = child->GetColumnBindings();
 		bool child_null_rejecting_filter_above = false;
+		bool child_preserve_evidence_side = false;
 		if (plan->type == LogicalOperatorType::LOGICAL_FILTER &&
 		    child->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 			auto &filter = plan->Cast<LogicalFilter>();
 			auto &delim_join = child->Cast<LogicalComparisonJoin>();
 			child_null_rejecting_filter_above = FilterNullRejectsDelimJoinRHS(filter, delim_join);
+			child_preserve_evidence_side = FilterNegatesDelimJoinMarker(filter, delim_join);
 		}
-		RewriteDelimJoinsToCTEs(child, rewrite_root, child_null_rejecting_filter_above);
+		RewriteDelimJoinsToCTEs(child, rewrite_root, child_null_rejecting_filter_above, child_preserve_evidence_side);
 		RewriteChangedChildBindings(*plan, *child, old_child_bindings);
 	}
 	if (plan->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		MaterializeDelimJoinAsCTE(plan, rewrite_root, null_rejecting_filter_above);
+		MaterializeDelimJoinAsCTE(plan, rewrite_root, null_rejecting_filter_above, preserve_evidence_side);
 	}
 }
 

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -351,13 +351,16 @@ static bool HasSelection(const LogicalOperator &op) {
 }
 
 struct JoinWithGeneratedDedupRef {
-	JoinWithGeneratedDedupRef(unique_ptr<LogicalOperator> &join_p, idx_t depth_p, bool filter_cross_product_p = false)
-	    : join(join_p), depth(depth_p), filter_cross_product(filter_cross_product_p) {
+	JoinWithGeneratedDedupRef(unique_ptr<LogicalOperator> &join_p, idx_t depth_p, bool filter_cross_product_p = false,
+	                          bool under_aggregate_p = false)
+	    : join(join_p), depth(depth_p), filter_cross_product(filter_cross_product_p),
+	      under_aggregate(under_aggregate_p) {
 	}
 
 	reference<unique_ptr<LogicalOperator>> join;
 	idx_t depth;
 	bool filter_cross_product;
+	bool under_aggregate;
 };
 
 struct GeneratedDedupRef {
@@ -410,6 +413,20 @@ public:
 		D_ASSERT(bindings.size() == expressions.size());
 	}
 
+	ExpressionBindingReplacer(const vector<ColumnBinding> &bindings, const vector<unique_ptr<Expression>> &expressions,
+	                          optional_ptr<LogicalOperator> stop_operator)
+	    : bindings(bindings), expressions(expressions), stop_operator(stop_operator) {
+		D_ASSERT(bindings.size() == expressions.size());
+	}
+
+	void VisitOperator(LogicalOperator &op) override {
+		if (stop_operator && stop_operator.get() == &op) {
+			return;
+		}
+		VisitOperatorChildren(op);
+		VisitOperatorExpressions(op);
+	}
+
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override {
 		if (expr.Depth() != 0) {
 			return nullptr;
@@ -425,6 +442,7 @@ public:
 private:
 	const vector<ColumnBinding> &bindings;
 	const vector<unique_ptr<Expression>> &expressions;
+	optional_ptr<LogicalOperator> stop_operator;
 };
 
 static void ReplaceExpressionBindings(unique_ptr<Expression> &expr, const vector<ColumnBinding> &bindings,
@@ -499,6 +517,16 @@ static void ReplaceOperatorBindings(LogicalOperator &op, const vector<ColumnBind
 	replacer.VisitOperator(op);
 }
 
+static void ReplaceOperatorBindings(LogicalOperator &op, const vector<ColumnBinding> &bindings,
+                                    const vector<unique_ptr<Expression>> &expressions,
+                                    optional_ptr<LogicalOperator> stop_operator) {
+	if (bindings.empty()) {
+		return;
+	}
+	ExpressionBindingReplacer replacer(bindings, expressions, stop_operator);
+	replacer.VisitOperator(op);
+}
+
 class GeneratedDedupRefEliminator {
 public:
 	GeneratedDedupRefEliminator(LogicalComparisonJoin &delim_join, TableIndex dedup_cte_index, idx_t dedup_ref_count,
@@ -519,10 +547,11 @@ private:
 	bool ExpressionReferencesGeneratedSide(Expression &expr, const GeneratedDedupRef &dedup_ref) const;
 	bool FilterIsGeneratedDedupCrossProduct(LogicalOperator &op) const;
 	void FindJoinsWithGeneratedDedupRefs(unique_ptr<LogicalOperator> &op, vector<JoinWithGeneratedDedupRef> &joins,
-	                                     idx_t depth = 0) const;
+	                                     idx_t depth = 0, bool under_aggregate = false) const;
 	idx_t CountGeneratedDedupRefs(LogicalOperator &op) const;
 	bool RemoveInequalityJoinConditions(LogicalOperator &target_op, const vector<JoinCondition> &join_conditions,
 	                                    idx_t dedup_idx);
+	bool PreserveJoinAsSemi(unique_ptr<LogicalOperator> &join);
 	bool RemoveJoin(unique_ptr<LogicalOperator> &join);
 	bool RemoveFilterCrossProduct(unique_ptr<LogicalOperator> &filter_op);
 
@@ -714,23 +743,24 @@ bool GeneratedDedupRefEliminator::FilterIsGeneratedDedupCrossProduct(LogicalOper
 
 void GeneratedDedupRefEliminator::FindJoinsWithGeneratedDedupRefs(unique_ptr<LogicalOperator> &op,
                                                                   vector<JoinWithGeneratedDedupRef> &joins,
-                                                                  idx_t depth) const {
+                                                                  idx_t depth, bool under_aggregate) const {
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		if (!op->children.empty()) {
-			FindJoinsWithGeneratedDedupRefs(op->children[0], joins, depth + 1);
+			FindJoinsWithGeneratedDedupRefs(op->children[0], joins, depth + 1, under_aggregate);
 		}
 		return;
 	}
 
+	auto child_under_aggregate = under_aggregate || op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY;
 	for (auto &child : op->children) {
-		FindJoinsWithGeneratedDedupRefs(child, joins, depth + 1);
+		FindJoinsWithGeneratedDedupRefs(child, joins, depth + 1, child_under_aggregate);
 	}
 
 	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
 	    (GetGeneratedDedupRef(*op->children[0], false, true) || GetGeneratedDedupRef(*op->children[1], false, true))) {
-		joins.emplace_back(op, depth);
+		joins.emplace_back(op, depth, false, under_aggregate);
 	} else if (FilterIsGeneratedDedupCrossProduct(*op)) {
-		joins.emplace_back(op, depth, true);
+		joins.emplace_back(op, depth, true, under_aggregate);
 	}
 }
 
@@ -863,6 +893,110 @@ bool GeneratedDedupRefEliminator::RemoveInequalityJoinConditions(LogicalOperator
 	}
 
 	return found_all;
+}
+
+bool GeneratedDedupRefEliminator::PreserveJoinAsSemi(unique_ptr<LogicalOperator> &join) {
+	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
+	if (comparison_join.join_type != JoinType::INNER && comparison_join.join_type != JoinType::SEMI) {
+		return false;
+	}
+	if (comparison_join.HasProjectionMap()) {
+		return false;
+	}
+
+	auto left_is_generated = GetGeneratedDedupRef(*join->children[0], false, true) != nullptr;
+	auto right_is_generated = GetGeneratedDedupRef(*join->children[1], false, true) != nullptr;
+	if (left_is_generated == right_is_generated) {
+		return false;
+	}
+	const idx_t dedup_idx = left_is_generated ? 0 : 1;
+	if (comparison_join.join_type == JoinType::SEMI && dedup_idx == 0) {
+		return false;
+	}
+
+	auto dedup_ref = GetGeneratedDedupRef(*join->children[dedup_idx], false, true);
+	if (!dedup_ref) {
+		return false;
+	}
+
+	ColumnBindingReplacer replacer;
+	auto &replacement_bindings = replacer.replacement_bindings;
+	vector<ColumnBinding> covered_dedup_bindings;
+	covered_dedup_bindings.reserve(comparison_join.conditions.size());
+	vector<ColumnBinding> base_replacement_bindings;
+	vector<unique_ptr<Expression>> base_replacement_expressions;
+	vector<JoinCondition> semi_conditions;
+	semi_conditions.reserve(comparison_join.conditions.size());
+
+	for (auto &cond : comparison_join.conditions) {
+		if (!cond.IsComparison() || !IsEqualityJoinCondition(cond)) {
+			return false;
+		}
+
+		auto lhs_generated_idx = FindGeneratedOutputBinding(cond.GetLHS(), *dedup_ref);
+		auto rhs_generated_idx = FindGeneratedOutputBinding(cond.GetRHS(), *dedup_ref);
+		if (lhs_generated_idx.IsValid() == rhs_generated_idx.IsValid()) {
+			return false;
+		}
+		auto generated_idx = lhs_generated_idx.IsValid() ? lhs_generated_idx.GetIndex() : rhs_generated_idx.GetIndex();
+		auto &generated_binding = dedup_ref->output_bindings[generated_idx];
+		auto &generated_expression = *dedup_ref->output_expressions[generated_idx];
+		auto &other_side = lhs_generated_idx.IsValid() ? cond.GetRHS() : cond.GetLHS();
+
+		ColumnBinding other_binding;
+		if (!GetBoundColumnRefBinding(other_side, other_binding)) {
+			return false;
+		}
+		if (!AddReplacement(replacement_bindings, generated_binding, other_binding,
+		                    generated_expression.GetReturnType())) {
+			return false;
+		}
+
+		ColumnBinding base_binding;
+		if (GetBoundColumnRefBinding(generated_expression, base_binding) &&
+		    base_binding.table_index == dedup_ref->cte_ref->table_index) {
+			if (!AddReplacement(replacement_bindings, base_binding, other_binding)) {
+				return false;
+			}
+			covered_dedup_bindings.emplace_back(base_binding);
+			base_replacement_bindings.push_back(base_binding);
+			base_replacement_expressions.push_back(other_side.Copy());
+		}
+
+		auto generated_expr = lhs_generated_idx.IsValid() ? cond.GetLHS().Copy() : cond.GetRHS().Copy();
+		auto other_expr = lhs_generated_idx.IsValid() ? cond.GetRHS().Copy() : cond.GetLHS().Copy();
+		auto comparison_type = lhs_generated_idx.IsValid() ? FlipComparisonExpression(cond.GetComparisonType())
+		                                                   : cond.GetComparisonType();
+		semi_conditions.emplace_back(std::move(other_expr), std::move(generated_expr), comparison_type);
+	}
+	if (!CoversAllDedupColumns(*dedup_ref, covered_dedup_bindings)) {
+		return false;
+	}
+
+	vector<unique_ptr<Expression>> generated_output_replacements;
+	generated_output_replacements.reserve(dedup_ref->output_expressions.size());
+	for (auto &expr : dedup_ref->output_expressions) {
+		auto rewritten_expr = expr->Copy();
+		ReplaceExpressionBindings(rewritten_expr, base_replacement_bindings, base_replacement_expressions);
+		if (ExpressionReferencesGeneratedSide(*rewritten_expr, *dedup_ref)) {
+			return false;
+		}
+		generated_output_replacements.push_back(std::move(rewritten_expr));
+	}
+
+	if (dedup_idx == 0) {
+		std::swap(comparison_join.children[0], comparison_join.children[1]);
+	}
+	comparison_join.join_type = JoinType::SEMI;
+	comparison_join.conditions = std::move(semi_conditions);
+	comparison_join.left_projection_map.clear();
+	comparison_join.right_projection_map.clear();
+	comparison_join.ResolveOperatorTypes();
+
+	replacer.stop_operator = join.get();
+	replacer.VisitOperator(rewrite_root);
+	ReplaceOperatorBindings(rewrite_root, dedup_ref->output_bindings, generated_output_replacements, join.get());
+	return true;
 }
 
 bool GeneratedDedupRefEliminator::RemoveJoin(unique_ptr<LogicalOperator> &join) {
@@ -1125,11 +1259,16 @@ idx_t GeneratedDedupRefEliminator::Remove() {
 		          return lhs.depth > rhs.depth;
 	          });
 
-	if (!joins.empty() && HasSelection(*delim_join.children[0])) {
-		joins.erase(joins.begin());
-	}
-
+	auto preserve_selected_domain = HasSelection(*delim_join.children[0]);
 	for (auto &join : joins) {
+		if (preserve_selected_domain && join.under_aggregate) {
+			// This join is a semijoin reduction for the grouped RHS. Removing it is valid, but can turn a
+			// selective correlated aggregate into a global aggregate over the inner relation.
+			if (!join.filter_cross_product) {
+				PreserveJoinAsSemi(join.join.get());
+			}
+			continue;
+		}
 		if (join.filter_cross_product) {
 			RemoveFilterCrossProduct(join.join.get());
 		} else {
@@ -1146,6 +1285,7 @@ struct GeneratedDomainRef {
 	vector<ColumnBinding> output_bindings;
 	vector<unique_ptr<Expression>> output_expressions;
 	vector<unique_ptr<Expression>> filters;
+	bool has_selection = false;
 };
 
 class GeneratedDomainJoinEliminator {
@@ -1158,21 +1298,24 @@ public:
 private:
 	void CollectCTEs(LogicalOperator &op);
 	optional_ptr<LogicalCTE> FindCTE(TableIndex cte_index) const;
-	bool TryRewriteOnce(unique_ptr<LogicalOperator> &op);
+	bool TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate = false);
 
 	unique_ptr<GeneratedDedupRef> GetGeneratedDedupRef(LogicalOperator &op, bool collect_filters = false,
 	                                                   bool allow_projection = false) const;
 	unique_ptr<GeneratedDomainRef> GetGeneratedDomainDefinition(LogicalOperator &op) const;
 	unique_ptr<GeneratedDomainRef> GetGeneratedDomainRef(LogicalOperator &op, bool collect_filters = false,
 	                                                     bool allow_projection = false) const;
+	bool CTEHasSelection(TableIndex cte_index, vector<TableIndex> &seen_ctes) const;
+	bool OperatorHasSelection(LogicalOperator &op, vector<TableIndex> &seen_ctes) const;
+	bool GeneratedDedupRefHasSelection(const GeneratedDedupRef &dedup_ref) const;
 
 	optional_idx FindOutputBinding(Expression &expr, const vector<ColumnBinding> &bindings) const;
 	bool ContainsRecursiveCTERef(LogicalOperator &op) const;
 
 	bool AddReplacement(vector<ReplacementBinding> &replacements, ColumnBinding old_binding,
 	                    ColumnBinding new_binding) const;
-	bool RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join);
-	bool RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join);
+	bool RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate);
+	bool RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate);
 
 private:
 	unique_ptr<LogicalOperator> &rewrite_root;
@@ -1202,6 +1345,41 @@ optional_ptr<LogicalCTE> GeneratedDomainJoinEliminator::FindCTE(TableIndex cte_i
 		}
 	}
 	return nullptr;
+}
+
+bool GeneratedDomainJoinEliminator::CTEHasSelection(TableIndex cte_index, vector<TableIndex> &seen_ctes) const {
+	if (std::find(seen_ctes.begin(), seen_ctes.end(), cte_index) != seen_ctes.end()) {
+		return false;
+	}
+	seen_ctes.push_back(cte_index);
+	auto cte = FindCTE(cte_index);
+	if (!cte || cte->children.empty()) {
+		return false;
+	}
+	return OperatorHasSelection(*cte->children[0], seen_ctes);
+}
+
+bool GeneratedDomainJoinEliminator::OperatorHasSelection(LogicalOperator &op, vector<TableIndex> &seen_ctes) const {
+	if (HasSelection(op)) {
+		return true;
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		return CTEHasSelection(op.Cast<LogicalCTERef>().cte_index, seen_ctes);
+	}
+	for (auto &child : op.children) {
+		if (OperatorHasSelection(*child, seen_ctes)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool GeneratedDomainJoinEliminator::GeneratedDedupRefHasSelection(const GeneratedDedupRef &dedup_ref) const {
+	if (!dedup_ref.cte_ref) {
+		return false;
+	}
+	vector<TableIndex> seen_ctes;
+	return CTEHasSelection(dedup_ref.cte_ref->cte_index, seen_ctes);
 }
 
 unique_ptr<GeneratedDedupRef> GeneratedDomainJoinEliminator::GetGeneratedDedupRef(LogicalOperator &op,
@@ -1351,6 +1529,8 @@ unique_ptr<GeneratedDomainRef> GeneratedDomainJoinEliminator::GetGeneratedDomain
 
 		result->cte_ref = cteref;
 		result->output_bindings = cteref.GetColumnBindings();
+		vector<TableIndex> seen_ctes;
+		result->has_selection = CTEHasSelection(cteref.cte_index, seen_ctes);
 		return result;
 	}
 	if (op.type == LogicalOperatorType::LOGICAL_FILTER) {
@@ -1448,7 +1628,7 @@ bool GeneratedDomainJoinEliminator::AddReplacement(vector<ReplacementBinding> &r
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join) {
+bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate) {
 	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
 	if (comparison_join.join_type != JoinType::INNER &&
 	    (comparison_join.join_type != JoinType::SEMI || !GetGeneratedDedupRef(*join->children[1], false, true))) {
@@ -1466,6 +1646,11 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalO
 	}
 	auto dedup_ref = GetGeneratedDedupRef(*join->children[dedup_idx], true, true);
 	if (!dedup_ref) {
+		return false;
+	}
+	if (under_aggregate && GeneratedDedupRefHasSelection(*dedup_ref)) {
+		// The first CTE rewrite can preserve selected domains below aggregates as regular joins. Do not
+		// substitute that selected generated CTE away in the cleanup pass.
 		return false;
 	}
 
@@ -1562,7 +1747,7 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDedupJoin(unique_ptr<LogicalO
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join) {
+bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<LogicalOperator> &join, bool under_aggregate) {
 	auto &comparison_join = join->Cast<LogicalComparisonJoin>();
 	if (comparison_join.join_type != JoinType::INNER) {
 		return false;
@@ -1588,6 +1773,10 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<Logical
 	auto generated_ref = GetGeneratedDedupRef(*join->children[generated_idx], true, true);
 	auto domain_ref = GetGeneratedDomainRef(*join->children[domain_idx], true, true);
 	if (!generated_ref || !domain_ref) {
+		return false;
+	}
+	if (under_aggregate && (domain_ref->has_selection || !domain_ref->filters.empty())) {
+		// Same invariant as above: selected domains below aggregates are part of the physical reduction.
 		return false;
 	}
 
@@ -1674,16 +1863,17 @@ bool GeneratedDomainJoinEliminator::RemoveGeneratedDomainJoin(unique_ptr<Logical
 	return true;
 }
 
-bool GeneratedDomainJoinEliminator::TryRewriteOnce(unique_ptr<LogicalOperator> &op) {
+bool GeneratedDomainJoinEliminator::TryRewriteOnce(unique_ptr<LogicalOperator> &op, bool under_aggregate) {
+	auto child_under_aggregate = under_aggregate || op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY;
 	for (auto &child : op->children) {
-		if (TryRewriteOnce(child)) {
+		if (TryRewriteOnce(child, child_under_aggregate)) {
 			return true;
 		}
 	}
 	if (op->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
 		return false;
 	}
-	return RemoveGeneratedDomainJoin(op) || RemoveGeneratedDedupJoin(op);
+	return RemoveGeneratedDomainJoin(op, under_aggregate) || RemoveGeneratedDedupJoin(op, under_aggregate);
 }
 
 bool GeneratedDomainJoinEliminator::Rewrite() {
@@ -1771,11 +1961,6 @@ void DelimJoinCTERewriter::MaterializeDelimJoinAsCTE(unique_ptr<LogicalOperator>
 	}
 
 	plan->type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
-	if (join.join_type == JoinType::MARK) {
-		// Match the LOGICAL_DELIM_JOIN filter-pushdown semantics: the mark column can still be required above
-		// this join, so pushing NOT(mark) into the join must not drop it by rewriting to ANTI.
-		join.convert_mark_to_semi = false;
-	}
 
 	auto dedup_cte_index = binder.GenerateTableIndex();
 	auto dedup_ref_count = RewriteDelimScanReferences(plan->children[1], dedup_cte_index);

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -25,6 +25,12 @@ explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHER
 ----
 logical_opt	<!REGEX>:.*SINGLE.*
 
+# Q 17: the selected delimiter domain should still restrict the inner aggregate input
+query II
+explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);
+----
+logical_opt	<REGEX>:.*Groups: p_partkey.*COMPARISON_JOIN.*l_partkey = p_partkey.*(DELIM_GET|CTE_SCAN).*
+
 # Q 17: if we remove the filters """ p_brand = 'Brand#23' AND p_container = 'MED BOX' """ we can remove the whole DELIM join
 query II
 explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND l_quantity < (SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);
@@ -181,3 +187,13 @@ NULL	0
 1	1
 2	1
 3	0
+
+# CTE delimiter rewrite: marker-only EXISTS joins can be converted to a RIGHT_SEMI join if the RHS key is
+# null-rejected and the filtered LHS can act as a runtime-filter build side.
+statement ok
+SET delim_join_as_cte=true;
+
+query II
+EXPLAIN SELECT x FROM range(1000000) o(x) WHERE x < 10000 AND EXISTS (SELECT 1 FROM range(10000000) l(y) WHERE y = x AND y > 0);
+----
+logical_opt	<REGEX>:.*Join Type: RIGHT_SEMI.*x = x.*

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -29,7 +29,7 @@ logical_opt	<!REGEX>:.*SINGLE.*
 query II
 explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);
 ----
-logical_opt	<REGEX>:.*Groups: p_partkey.*COMPARISON_JOIN.*l_partkey = p_partkey.*(DELIM_GET|CTE_SCAN).*
+logical_opt	<REGEX>:.*Groups: p_partkey.*COMPARISON_JOIN.*(l_partkey = p_partkey|p_partkey = l_partkey).*(DELIM_GET|CTE_SCAN).*
 
 # Q 17: if we remove the filters """ p_brand = 'Brand#23' AND p_container = 'MED BOX' """ we can remove the whole DELIM join
 query II
@@ -202,7 +202,7 @@ logical_opt	<REGEX>:.*Join Type: RIGHT_SEMI.*x = x.*
 query II
 EXPLAIN SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM (SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17') AND c_acctbal > (SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17')) AND NOT EXISTS (SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;
 ----
-logical_opt	<REGEX>:.*__duckdb_delim.*Join Type: MARK.*Join Type: INNER.*o_custkey = c_custkey.*
+logical_opt	<REGEX>:.*__duckdb_delim.*Join Type: MARK.*Join Type: (SEMI|RIGHT_SEMI).*o_custkey = c_custkey.*
 
 # Q 21: nested EXISTS/NOT EXISTS domains should still fully decorrelate
 query II

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -197,3 +197,15 @@ query II
 EXPLAIN SELECT x FROM range(1000000) o(x) WHERE x < 10000 AND EXISTS (SELECT 1 FROM range(10000000) l(y) WHERE y = x AND y > 0);
 ----
 logical_opt	<REGEX>:.*Join Type: RIGHT_SEMI.*x = x.*
+
+# Q 22: the selected delimiter domain should still restrict the NOT EXISTS evidence side
+query II
+EXPLAIN SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM (SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17') AND c_acctbal > (SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN ('13', '31', '23', '29', '30', '18', '17')) AND NOT EXISTS (SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;
+----
+logical_opt	<REGEX>:.*__duckdb_delim.*Join Type: MARK.*Join Type: INNER.*o_custkey = c_custkey.*
+
+# Q 21: nested EXISTS/NOT EXISTS domains should still fully decorrelate
+query II
+EXPLAIN SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = 'SAUDI ARABIA' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100;
+----
+logical_opt	<!REGEX>:.*Join Type: MARK.*


### PR DESCRIPTION
In this PR, I try to make the full decorrelation cases more stable and robust, while allowing more cases. There were a few areas in the optimizer that prevented the system from finding good join types and/or join orders which can regress performance:

- For correlated mark joins, `convert_mark_to_semi` was statically set to false. However, this was more of a guardrail to prevent the system from establishing semi-optimal join orders, because we were missing some heuristics in the `build_probe_side` optimizer for semi joins. This has been added now.
- Decorrelated plans contain many `... IS NOT DISTINCT ...` predicates. Problem is, this can prevent adding dynamic filters. `pushdown_mark_join` now tries to reduce them to regular equality predicates, if the join has been rewritten to a semi join.
- The `delim_cte_rewriter` technically did the right thing for full decorrelation cases. However, it is not always desireable to fully decorrelate plans, instead of stopping early. This is a bit hard to decide without cost/cardinality information (maybe we should change that at some point). Therefore, it is a bit conservative when full decorrelation is used. Still, we allow it for more cases now (e. g. TPC-H Q21).

For TPC-H Q21, this PR improves performance by about 30-40%, for Q4 by about 25%, while avoiding to regress Q22 and Q17.