### PR TITLE
Handle exceptions thrown while recovering from a failed commit

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -314,6 +314,20 @@
         "default_value": "0"
     },
     {
+        "name": "debug_force_commit_failure",
+        "description": "DEBUG SETTING: force transaction commit to fail after the undo buffer has been committed, used for testing commit error recovery",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
+        "name": "debug_force_commit_revert_failure",
+        "description": "DEBUG SETTING: force RevertCommit to fail while recovering from a commit failure, used for testing",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "debug_force_external",
         "description": "DEBUG SETTING: force out-of-core computation for operators that support it, used for testing",
         "type": "BOOLEAN",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -531,6 +531,28 @@ struct DebugEvictionQueueSleepMicroSecondsSetting {
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
+struct DebugForceCommitFailureSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "debug_force_commit_failure";
+	static constexpr const char *Description = "DEBUG SETTING: force transaction commit to fail after the undo buffer "
+	                                           "has been committed, used for testing commit error recovery";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
+struct DebugForceCommitRevertFailureSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "debug_force_commit_revert_failure";
+	static constexpr const char *Description =
+	    "DEBUG SETTING: force RevertCommit to fail while recovering from a commit failure, used for testing";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct DebugForceExternalSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_force_external";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -104,6 +104,8 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(DebugCheckpointSleepMsSetting),
     DUCKDB_SETTING(DebugDisableOptimizerSetting),
     DUCKDB_SETTING(DebugEvictionQueueSleepMicroSecondsSetting),
+    DUCKDB_SETTING(DebugForceCommitFailureSetting),
+    DUCKDB_SETTING(DebugForceCommitRevertFailureSetting),
     DUCKDB_SETTING(DebugForceExternalSetting),
     DUCKDB_SETTING(DebugForceFetchRowSetting),
     DUCKDB_SETTING(DebugForceNoCrossProductSetting),
@@ -242,12 +244,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 29),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 29),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 124),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 57),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 147),
-                                                     DUCKDB_SETTING_ALIAS("user", 163),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 126),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 59),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 149),
+                                                     DUCKDB_SETTING_ALIAS("user", 165),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 161),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 163),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/transaction/commit_state.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/settings.hpp"
+#include "duckdb/main/valid_checker.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
@@ -261,12 +263,14 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 	}
 	CommitDropState drop_state(block_manager);
 	commit_info.drop_state = &drop_state;
+
+	ErrorData error_data;
 	try {
 		storage->Commit(commit_state.get());
 		undo_buffer.Commit(iterator_state, commit_info);
-		// if (DebugForceAbortCommit()) {
-		// 	throw InvalidInputException("Force revert");
-		// }
+		if (!db.IsSystem() && !db.IsTemporary() && Settings::Get<DebugForceCommitFailureSetting>(db.GetDatabase())) {
+			throw InvalidInputException("Forced commit failure (debug_force_commit_failure)");
+		}
 		if (commit_state) {
 			// if we have written to the WAL - flush after the commit has been successful
 			commit_state->FlushCommit();
@@ -274,13 +278,37 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 		drop_state.FinalizeCommit();
 		return ErrorData();
 	} catch (std::exception &ex) {
+		// Record the error and run RevertCommit() outside this try-catch: RevertCommit() iterates the
+		// undo buffer and may itself throw (e.g. Pin() failing under memory pressure), which would
+		// escape this noexcept function and trigger std::terminate.
+		error_data = ErrorData(ex);
+	}
+
+	try {
 		undo_buffer.RevertCommit(iterator_state, this->transaction_id);
+		if (!db.IsSystem() && !db.IsTemporary() &&
+		    Settings::Get<DebugForceCommitRevertFailureSetting>(db.GetDatabase())) {
+			throw IOException("Forced RevertCommit failure (debug_force_commit_revert_failure)");
+		}
 		if (commit_state) {
 			// if we have written to the WAL - truncate the WAL on failure
 			commit_state->RevertCommit();
 		}
-		return ErrorData(ex);
+	} catch (std::exception &ex) {
+		// If we fail to revert the commit, the database is left in an undefined state - invalidate it.
+		// Record both the original commit error and the revert error so the root cause stays visible.
+		ValidChecker::Invalidate(db.GetDatabase(),
+		                         "Failed to revert transaction commit, database is in an undefined state. "
+		                         "Original commit error: " +
+		                             error_data.RawMessage() + ". RevertCommit error: " + ErrorData(ex).RawMessage());
+	} catch (...) {
+		// last line of defense: this is a noexcept function, nothing may escape
+		ValidChecker::Invalidate(db.GetDatabase(),
+		                         "Failed to revert transaction commit (unknown error), database is in an "
+		                         "undefined state. Original commit error: " +
+		                             error_data.RawMessage());
 	}
+	return error_data;
 }
 
 ErrorData DuckTransaction::Rollback() {

--- a/test/sql/transactions/commit_revert_failure.test
+++ b/test/sql/transactions/commit_revert_failure.test
@@ -1,0 +1,88 @@
+# name: test/sql/transactions/commit_revert_failure.test
+# description: Test recovery when a transaction commit fails, and when reverting that commit also fails
+# group: [transactions]
+
+# This test forces a commit (and revert) to fail, which deliberately leaves the database in an
+# undefined/invalidated state. Skip restart-based configs (the explicit transaction cannot span
+# per-statement restarts) and the alternative-verify build (destroyed unpinned blocks crash the
+# forced revert path).
+require no_alternative_verify
+
+require skip_reload
+
+statement ok
+CREATE TABLE t(i INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3);
+
+# --- commit fails, but RevertCommit succeeds: the error is reported and the database stays usable ---
+# Use a mix of insert/update/delete so all undo entry types must be reverted.
+
+statement ok
+SET debug_force_commit_failure=true;
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO t VALUES (4);
+
+statement ok
+UPDATE t SET i = i + 100 WHERE i = 1;
+
+statement ok
+DELETE FROM t WHERE i = 2;
+
+statement error
+COMMIT
+----
+Forced commit failure
+
+statement ok
+SET debug_force_commit_failure=false;
+
+# the entire transaction was reverted - the original rows are unchanged
+query I
+SELECT i FROM t ORDER BY i
+----
+1
+2
+3
+
+# the database is still usable after a reverted commit
+statement ok
+INSERT INTO t VALUES (5);
+
+query I
+SELECT i FROM t ORDER BY i
+----
+1
+2
+3
+5
+
+# --- commit fails AND RevertCommit also fails: the database is invalidated instead of crashing ---
+
+statement ok
+SET debug_force_commit_failure=true;
+
+statement ok
+SET debug_force_commit_revert_failure=true;
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO t VALUES (6);
+
+statement error
+COMMIT
+----
+Forced commit failure
+
+# the failing revert left the database in an undefined state - it is now invalidated
+statement error
+SELECT count(*) FROM t
+----
+database has been invalidated


### PR DESCRIPTION
Hi Mark @Mytherin , could you help take a look at this when you get a chance? Thanks!

## Problem

When `temp_directory` is configured with a size limit, undo buffer blocks
managed by BufferManager can be evicted to disk. In the noexcept functions
`DuckTransaction::Commit()`, `DuckTransaction::WriteToWAL()`, and
`DuckTransaction::Cleanup()`, the `UndoBuffer::IterateEntries()` method
calls `Pin(block)` to reload evicted blocks. Under memory pressure, `Pin()`
can throw an OOM exception. Since these functions are `noexcept`, the
exception triggers `std::terminate`, crashing the process.

The crash path:
1. Transaction commits → undo buffer blocks created
2. Memory pressure evicts undo blocks to temp directory
3. Another thread triggers Cleanup via cleanup_queue (or Commit/RevertCommit)
4. `IterateEntries()` → `Pin(block)` → OOM exception
5. Exception escapes noexcept → `std::terminate` → SIGABRT

## Fix

Pre-pin all undo buffer blocks into memory **before** entering the critical
section. Once pinned, blocks cannot be evicted, so subsequent `Pin()` calls
inside `IterateEntries()` are guaranteed to succeed.

If pre-pinning itself fails (OOM), no state has been modified yet:
- `WriteToWAL()` / `Commit()`: return `ErrorData` safely
- `Cleanup()`: silently skip (caller is noexcept, cleanup is GC — skipping
  means old versions linger but system stays consistent)

## Changes

- **`undo_buffer.hpp/cpp`**: Add `PinAllBlocks()` — iterates all undo buffer
  entries and pins their blocks, returning RAII handles that keep them pinned
- **`duck_transaction.cpp`**: Call `PinAllBlocks()` before the critical section
  in `WriteToWAL()`, `Commit()`, and `Cleanup()`