### PR TITLE
[Variant] Fix crash for variant_extract on non-object shredded column

### DIFF
--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -110,6 +110,10 @@ static bool TryShreddedExtractRecursive(const Vector &input, const vector<Varian
 		// only by key supported
 		return false;
 	}
+	if (input.GetType().id() != LogicalTypeId::STRUCT) {
+		//! Not shredded on OBJECT, can't extract a key
+		return false;
+	}
 	// first entry is "typed_value"
 	auto &typed_entries = StructVector::GetEntries(input);
 	auto &typed_value = typed_entries[0];

--- a/src/include/duckdb/common/types/variant_visitor.hpp
+++ b/src/include/duckdb/common/types/variant_visitor.hpp
@@ -33,6 +33,7 @@ public:
 	template <typename... Args>
 	static ReturnType Visit(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_idx, Args &&...args) {
 		if (!variant.RowIsValid(row)) {
+			VisitMetadata(VariantLogicalType::VARIANT_NULL, std::forward<Args>(args)...);
 			return Visitor::VisitNull(std::forward<Args>(args)...);
 		}
 

--- a/test/sql/storage/types/variant/variant_shredded_extract_non_object.test
+++ b/test/sql/storage/types/variant/variant_shredded_extract_non_object.test
@@ -1,0 +1,33 @@
+# name: test/sql/storage/types/variant/variant_shredded_extract_non_object.test
+# group: [variant]
+
+load __TEST_DIR__/variant_struct_checkpoint.db readwrite v2.0.0
+
+statement ok
+set variant_minimum_shredding_size = 0;
+
+statement ok
+create table t(
+	col struct(
+		f1 integer,
+		f2 VARIANT
+	)
+);
+
+statement ok
+insert into t select {
+	'f1': 1
+};
+
+restart
+
+statement ok
+checkpoint;
+
+# f2 is shredded on NULL (integer), it's not an OBJECT(a), can't extract
+query I
+select
+	col.f2.a::integer
+from t;
+----
+NULL


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/9335

#### Misc

Also fixes dormant issue where root NULL values weren't counting towards VariantColumnStatsData::total_count in variant shredding analysis.
This change affects all VariantVisitor implementations that define VisitMetadata, as it's now also called for root NULL values.