### PR TITLE
Simplify subquery planning for provably single-row subqueries

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -24,6 +24,19 @@
 
 namespace duckdb {
 
+static bool PlanReturnsExactlyOneRow(const LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggr = op.Cast<LogicalAggregate>();
+		return aggr.groups.empty() && aggr.grouping_sets.empty() && aggr.grouping_functions.empty();
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return op.children.size() == 1 && PlanReturnsExactlyOneRow(*op.children[0]);
+	default:
+		return false;
+	}
+}
+
 static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubqueryExpression &expr,
                                                        unique_ptr<LogicalOperator> &root,
                                                        unique_ptr<LogicalOperator> plan) {
@@ -79,6 +92,11 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		// figure out the table index of the bound table of the entry which we want to return
 		auto bindings = plan->GetColumnBindings();
 		D_ASSERT(bindings.size() == 1);
+		if (PlanReturnsExactlyOneRow(*plan)) {
+			auto result = make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(), bindings[0]);
+			root = LogicalCrossProduct::Create(std::move(root), std::move(plan));
+			return std::move(result);
+		}
 		auto table_idx = bindings[0].table_index;
 
 		bool error_on_multiple_rows = Settings::Get<ScalarSubqueryErrorOnMultipleRowsSetting>(binder.context);

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -105,7 +105,7 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 		// figure out the table index of the bound table of the entry which we want to return
 		auto bindings = plan->GetColumnBindings();
 		D_ASSERT(bindings.size() == 1);
-		if (PlanReturnsExactlyOneRow(*plan)) {
+		if (expr.GetReturnType().id() != LogicalTypeId::SQLNULL && PlanReturnsExactlyOneRow(*plan)) {
 			auto result = make_uniq<BoundColumnRefExpression>(expr.GetName(), expr.GetReturnType(), bindings[0]);
 			root = LogicalCrossProduct::Create(std::move(root), std::move(plan));
 			return std::move(result);

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -30,6 +30,19 @@ static bool PlanReturnsExactlyOneRow(const LogicalOperator &op) {
 		auto &aggr = op.Cast<LogicalAggregate>();
 		return aggr.groups.empty() && aggr.grouping_sets.empty() && aggr.grouping_functions.empty();
 	}
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+		return true;
+	case LogicalOperatorType::LOGICAL_LIMIT: {
+		auto &limit = op.Cast<LogicalLimit>();
+		if (limit.limit_val.Type() != LimitNodeType::CONSTANT_VALUE || limit.limit_val.GetConstantValue() != 1) {
+			return false;
+		}
+		if (limit.offset_val.Type() != LimitNodeType::UNSET &&
+		    (limit.offset_val.Type() != LimitNodeType::CONSTANT_VALUE || limit.offset_val.GetConstantValue() != 0)) {
+			return false;
+		}
+		return op.children.size() == 1 && PlanReturnsExactlyOneRow(*op.children[0]);
+	}
 	case LogicalOperatorType::LOGICAL_PROJECTION:
 		return op.children.size() == 1 && PlanReturnsExactlyOneRow(*op.children[0]);
 	default:

--- a/test/sql/subquery/scalar/test_scalar_subquery.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery.test
@@ -33,6 +33,29 @@ SELECT (SELECT 42)
 ----
 42
 
+statement ok
+PRAGMA explain_output='optimized_only'
+
+query II
+EXPLAIN SELECT (SELECT 42)
+----
+logical_opt	<!REGEX>:.*AGGREGATE.*
+
+query II
+EXPLAIN SELECT (SELECT 42 LIMIT 1)
+----
+logical_opt	<!REGEX>:.*AGGREGATE.*
+
+query I
+SELECT (SELECT 42 WHERE false LIMIT 1)
+----
+NULL
+
+query II
+EXPLAIN SELECT (SELECT 42 WHERE false LIMIT 1)
+----
+logical_opt	<REGEX>:.*AGGREGATE.*
+
 # nested subquery
 query I
 SELECT (SELECT (SELECT 42))

--- a/test/sql/subquery/scalar/test_scalar_subquery.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery.test
@@ -46,6 +46,11 @@ EXPLAIN SELECT (SELECT 42 LIMIT 1)
 ----
 logical_opt	<!REGEX>:.*AGGREGATE.*
 
+query II
+EXPLAIN SELECT (SELECT NULL)
+----
+logical_opt	<REGEX>:.*AGGREGATE.*
+
 query I
 SELECT (SELECT 42 WHERE false LIMIT 1)
 ----


### PR DESCRIPTION
Bypasses the more complicated logic (which has side-effects through the `error` function).

Cherry-picked from https://github.com/duckdb/duckdb/pull/22712