### PR TITLE
Add missing import / fix non-unity builds

### DIFF
--- a/third_party/concurrentqueue/lightweightsemaphore.h
+++ b/third_party/concurrentqueue/lightweightsemaphore.h
@@ -7,6 +7,7 @@
 
 #include <cstddef> // For std::size_t
 #include <atomic>
+#include <cassert>
 #include <type_traits> // For std::make_signed<T>
 
 // VS2012 doesn't support deleted functions.


### PR DESCRIPTION
This missing import causes non unity builds to fail.