### PR TITLE
Fix flaky `AsyncFileWriter` test

### DIFF
--- a/test/common/test_async_file_writer.cpp
+++ b/test/common/test_async_file_writer.cpp
@@ -544,10 +544,13 @@ static void TestQueuedDrainTaskCoversNewTinyTail(bool local_file, const string &
 	AsyncFileWriter writer(*con->context, fs, path);
 	writer.WriteData(make_uniq<StringAsyncWriteBuffer>(large));
 	writer.WriteData(make_uniq<StringAsyncWriteBuffer>(tail));
-	CHECK(fs.BlockedWrites() == 0);
+	auto blocked_before_release = fs.BlockedWrites();
+	CHECK(blocked_before_release <= 1);
 
 	async_thread_blocker.Release();
-	CHECK(fs.WaitForBlockedWrites(1));
+	if (blocked_before_release == 0) {
+		CHECK(fs.WaitForBlockedWrites(1));
+	}
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	CHECK(fs.BlockedWrites() == 1);
 


### PR DESCRIPTION
Saw another flaky test failure in https://github.com/duckdb/duckdb/pull/23308