### PR TITLE
Allow slicing of shredded vectors, and fix issue with shredded vectors being fed into `StructVector::GetEntries`

### DIFF
--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -59,6 +59,20 @@ Value ShreddedVectorBuffer::GetValue(const LogicalType &type, idx_t index) const
 	return result_vec.GetValue(0);
 }
 
+buffer_ptr<VectorBuffer> ShreddedVectorBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {
+	// propagate the slice into the shredded data and emit a new shredded vector
+	auto count = count_t(end - offset);
+	Vector sliced(*shredded_data, offset, end);
+	return make_buffer<ShreddedVectorBuffer>(sliced, count);
+}
+
+buffer_ptr<VectorBuffer> ShreddedVectorBuffer::SliceInternal(const LogicalType &type, const SelectionVector &sel,
+                                                             idx_t count) {
+	// propagate the slice into the shredded data and emit a new shredded vector
+	Vector sliced(*shredded_data, sel, count);
+	return make_buffer<ShreddedVectorBuffer>(sliced, count_t(count));
+}
+
 buffer_ptr<VectorBuffer> ShreddedVectorBuffer::FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,
                                                                     idx_t count) const {
 	Vector *source = shredded_data.get();

--- a/src/common/vector/struct_vector.cpp
+++ b/src/common/vector/struct_vector.cpp
@@ -293,6 +293,10 @@ vector<Vector> &StructVector::GetEntries(Vector &vector) {
 	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		throw InternalException("Struct vectors cannot be dictionary vectors");
 	}
+	if (vector.GetVectorType() != VectorType::FLAT_VECTOR && vector.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		// non-flat representation (e.g. a shredded variant) - flatten so we can access the struct entries
+		vector.Flatten();
+	}
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
 	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
 	D_ASSERT(vector.GetBufferRef());

--- a/src/include/duckdb/common/vector/shredded_vector.hpp
+++ b/src/include/duckdb/common/vector/shredded_vector.hpp
@@ -33,6 +33,8 @@ public:
 	void SetVectorType(VectorType new_vector_type) override;
 
 protected:
+	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, idx_t offset, idx_t end) override;
+	buffer_ptr<VectorBuffer> SliceInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) override;
 	buffer_ptr<VectorBuffer> FlattenSliceInternal(const LogicalType &type, const SelectionVector &sel,
 	                                              idx_t count) const override;
 	void VerifyInternal(const LogicalType &type, const SelectionVector &sel, idx_t count) const override;

--- a/test/sql/storage/types/variant/variant_shredded_slice.test
+++ b/test/sql/storage/types/variant/variant_shredded_slice.test
@@ -1,0 +1,39 @@
+# name: test/sql/storage/types/variant/variant_shredded_slice.test
+# description: Slicing a shredded variant vector and consuming it (hash/aggregate)
+# group: [variant]
+
+require json
+
+load {TEST_DIR}/variant_shredded_slice.db readwrite v1.5.0
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+create table bluesky (col VARIANT)
+
+statement ok
+insert into bluesky from read_ndjson_objects('{DATA_DIR}/json/bluesky.json.gz')
+
+statement ok
+checkpoint
+
+# count(DISTINCT) hashes a shredded variant - the distinct aggregate slices the shredded vector
+query I
+SELECT count(DISTINCT col.did) FROM bluesky;
+----
+10
+
+# jsonbench q02: filter slices the shredded vector, then it is grouped/hashed
+query TII
+SELECT col.commit.collection AS event, count() AS count, count(DISTINCT col.did) AS users
+FROM bluesky
+WHERE (col.kind = 'commit') AND (col.commit.operation = 'create')
+GROUP BY event
+ORDER BY count DESC, event
+----
+app.bsky.feed.like	3	3
+app.bsky.feed.post	3	3
+app.bsky.graph.follow	3	3
+app.bsky.feed.repost	1	1

--- a/test/sql/storage/types/variant/variant_shredded_slice.test
+++ b/test/sql/storage/types/variant/variant_shredded_slice.test
@@ -2,8 +2,6 @@
 # description: Slicing a shredded variant vector and consuming it (hash/aggregate)
 # group: [variant]
 
-require json
-
 load {TEST_DIR}/variant_shredded_slice.db readwrite v1.5.0
 
 # Always shred
@@ -11,29 +9,33 @@ statement ok
 SET variant_minimum_shredding_size = 0;
 
 statement ok
-create table bluesky (col VARIANT)
+create table bluesky (j VARIANT)
 
+# heterogeneous schemas -> the variant column is only partially shredded
 statement ok
-insert into bluesky from read_ndjson_objects('{DATA_DIR}/json/bluesky.json.gz')
+insert into bluesky select
+  case when i%3=0
+       then {'kind':'commit','did':'c'|| (i%4),'commit':{'collection':'coll'|| (i%2),'operation':'create'}}::VARIANT
+       else {'kind':'identity','did':'d'|| (i%5)}::VARIANT
+  end
+from range(4096) t(i)
 
 statement ok
 checkpoint
 
-# count(DISTINCT) hashes a shredded variant - the distinct aggregate slices the shredded vector
-query I
-SELECT count(DISTINCT col.did) FROM bluesky;
+# count(DISTINCT) hashes a shredded variant - the distinct aggregate slices/hashes the shredded vector
+query II
+SELECT count(DISTINCT j.did), count(*) FROM bluesky;
 ----
-10
+9	4096
 
-# jsonbench q02: filter slices the shredded vector, then it is grouped/hashed
+# jsonbench q02 style: the filter slices the shredded vector, then it is grouped/hashed
 query TII
-SELECT col.commit.collection AS event, count() AS count, count(DISTINCT col.did) AS users
+SELECT j.commit.collection AS event, count() AS count, count(DISTINCT j.did) AS users
 FROM bluesky
-WHERE (col.kind = 'commit') AND (col.commit.operation = 'create')
+WHERE (j.kind = 'commit') AND (j.commit.operation = 'create')
 GROUP BY event
 ORDER BY count DESC, event
 ----
-app.bsky.feed.like	3	3
-app.bsky.feed.post	3	3
-app.bsky.graph.follow	3	3
-app.bsky.feed.repost	1	1
+coll0	683	2
+coll1	683	2


### PR DESCRIPTION
Currently slicing a shredded vector forces unshredding - this PR makes it so that we just slice the underlying shredded / unshredded vectors instead.

In addition we fix an issue with shredded vectors where we would call `StructVector::GetEntries` on them which would result in accessing the wrong vector buffer.