### PR TITLE
Add request body length to http logs

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -146,6 +146,8 @@ struct BaseRequest {
 	bool have_request_timing = false;
 	timestamp_t request_start;
 	timestamp_t request_end;
+	//! Request body size in bytes (the Content-Length we send). Only set for PUT/POST.
+	idx_t request_body_length = 0;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -182,6 +184,7 @@ struct PutRequestInfo : public BaseRequest {
 	               idx_t buffer_in_len, const string &content_type)
 	    : BaseRequest(RequestType::PUT_REQUEST, path, headers, params), buffer_in(buffer_in),
 	      buffer_in_len(buffer_in_len), content_type(content_type) {
+		request_body_length = buffer_in_len;
 	}
 
 	const_data_ptr_t buffer_in;
@@ -206,6 +209,7 @@ struct PostRequestInfo : public BaseRequest {
 	                idx_t buffer_in_len)
 	    : BaseRequest(RequestType::POST_REQUEST, path, headers, params), buffer_in(buffer_in),
 	      buffer_in_len(buffer_in_len) {
+		request_body_length = buffer_in_len;
 	}
 
 	const_data_ptr_t buffer_in;

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -61,6 +61,7 @@ LogicalType HTTPLogType::GetLogType() {
 	    {"url", LogicalType::VARCHAR},
 	    {"start_time", LogicalType::TIMESTAMP_TZ},
 	    {"duration_ms", LogicalType::BIGINT},
+	    {"request_body_length", LogicalType::UBIGINT},
 	    {"headers", LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
 	};
 	auto request_type = LogicalType::STRUCT(request_child_list);
@@ -96,7 +97,8 @@ string HTTPLogType::ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPR
 	    {"start_time", request.have_request_timing ? Value::TIMESTAMP(request.request_start) : Value()},
 	    {"duration_ms", request.have_request_timing ? Value::BIGINT(Timestamp::GetEpochMs(request.request_end) -
 	                                                                Timestamp::GetEpochMs(request.request_start))
-	                                                : Value()}};
+	                                                : Value()},
+	    {"request_body_length", request.request_body_length ? Value::UBIGINT(request.request_body_length) : Value()}};
 	auto request_value = Value::STRUCT(request_child_list);
 	Value response_value;
 	if (response) {

--- a/test/sql/logging/http_log_timing.test
+++ b/test/sql/logging/http_log_timing.test
@@ -17,16 +17,17 @@ FROM "http://localhost:2338/test.csv"
 ----
 
 # Confirm that our request timing returns something reasonable
-query  III
+query  IIII
 SELECT 
 	request.type, 
 	request.duration_ms >= 0,
-	request.duration_ms <= 1000 * 1000
+	request.duration_ms <= 1000 * 1000,
+	request.request_body_length
 FROM 
 	duckdb_logs_parsed('HTTP')
 WHERE 
 	request.type='HEAD'
 ----
-HEAD	true	true
-HEAD	true	true
-HEAD	true	true
+HEAD	true	true	NULL
+HEAD	true	true	NULL
+HEAD	true	true	NULL


### PR DESCRIPTION
While debugging S3 upload PUT timeouts, I found the HTTP log gives us each request's start/end time and duration, but not how many bytes the request body carried. Without that I can't tell how far an upload got before it stalled, or compute its throughput (bytes / duration), which would be useful to tell a dead connection apart from a slow but progressing one.