### PR TITLE
Disable arrow_scan dup in window_self_join opt

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -341,6 +341,7 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	arrow.filter_prune = true;
 	arrow.supports_pushdown_type = ArrowPushdownType;
 	arrow.parallelism = TableFunctionParallelism::SEQUENTIAL;
+	arrow.supports_multiple_scans = false;
 	set.AddFunction(arrow);
 
 	TableFunction arrow_dumb("arrow_scan_dumb", {LogicalType::POINTER, LogicalType::POINTER, LogicalType::POINTER},
@@ -351,6 +352,7 @@ void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	arrow_dumb.filter_pushdown = false;
 	arrow_dumb.filter_prune = false;
 	arrow_dumb.parallelism = TableFunctionParallelism::SEQUENTIAL;
+	arrow_dumb.supports_multiple_scans = false;
 	set.AddFunction(arrow_dumb);
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -76,7 +76,8 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       deserialize == rhs.deserialize && verify_serialization == rhs.verify_serialization &&
 	       projection_pushdown == rhs.projection_pushdown && filter_pushdown == rhs.filter_pushdown &&
 	       filter_prune == rhs.filter_prune && sampling_pushdown == rhs.sampling_pushdown &&
-	       late_materialization == rhs.late_materialization && return_type == rhs.return_type &&
+	       late_materialization == rhs.late_materialization &&
+	       supports_multiple_scans == rhs.supports_multiple_scans && return_type == rhs.return_type &&
 	       global_initialization == rhs.global_initialization;
 }
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -508,6 +508,8 @@ public:
 	bool sampling_pushdown;
 	//! Whether or not the table function supports late materialization
 	bool late_materialization;
+	//! Whether the scan can be re-executed
+	bool supports_multiple_scans = true;
 	TableFunctionReturnType return_type;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;

--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/planner/logical_operator_deep_copy.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
 
@@ -116,6 +117,9 @@ bool WindowSelfJoinOptimizer::CanOptimize(const BoundWindowExpression &w_expr,
 }
 
 bool WindowSelfJoinOptimizer::CanOptimize(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET && !op.Cast<LogicalGet>().function.supports_multiple_scans) {
+		return false;
+	}
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET:
 	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:


### PR DESCRIPTION
This fixes an issue that began with 1.5.0 where very simple queries that reference an arrow_scan table only once but which involve window functions start to fail due to the window_self_join opt.

Fixes: [duckdb-java issue #713](https://github.com/duckdb/duckdb-java/issues/713)

Somewhat related: [duckdb-python issue #70](https://github.com/duckdb/duckdb-python/issues/70)

New here so I apologize if the new field on table_function is presumptuous. There may well be a better solution.

Conspicuously missing is a similar fix for the cte_inlining optimization, which also duplicates upstream-subtrees that could contain non-duplicable table functions like arrow_scan.

Alternative solution: `read_csv` throws `NotImplementedException` when it's serialized, which just so happens to disable these same sorts of optimizations. Could do the same thing for arrow_scan. Feels hacky but it sidesteps the need for a new prop that everybody needs to respect explicitly.