### PR TITLE
Avoid unnecessary call to ToUnifiedFormat in ColumnSegment filter

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -849,9 +849,7 @@ void ColumnReader::DirectFilter(ColumnReaderInput &input, Vector &result, const 
 void ColumnReader::ApplyFilter(Vector &v, const TableFilter &filter, TableFilterState &filter_state, idx_t scan_count,
                                SelectionVector &sel, idx_t &approved_tuple_count) {
 	FlatVector::SetSize(v, count_t(scan_count));
-	UnifiedVectorFormat vdata;
-	v.ToUnifiedFormat(vdata);
-	ColumnSegment::FilterSelection(sel, v, vdata, filter, filter_state, scan_count, approved_tuple_count);
+	ColumnSegment::FilterSelection(sel, v, filter_state, scan_count, approved_tuple_count);
 }
 
 void ColumnReader::Skip(idx_t num_values) {

--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -58,12 +58,9 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 		filter_result = make_unsafe_uniq_array<bool>(duckdb_dictionary_size);
 
 		// apply the filter
-		UnifiedVectorFormat vdata;
-		dictionary_data.ToUnifiedFormat(vdata);
 		SelectionVector dict_sel;
 		filter_count = duckdb_dictionary_size;
-		ColumnSegment::FilterSelection(dict_sel, dictionary_data, vdata, *filter, *filter_state, duckdb_dictionary_size,
-		                               filter_count);
+		ColumnSegment::FilterSelection(dict_sel, dictionary_data, *filter_state, duckdb_dictionary_size, filter_count);
 
 		// now set all matching tuples to true
 		for (idx_t i = 0; i < filter_count; i++) {

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -71,8 +71,10 @@ public:
 	//! Fetch a value of the specific row id and append it to the result
 	void FetchRow(ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx);
 
-	static idx_t FilterSelection(SelectionVector &sel, Vector &vector, UnifiedVectorFormat &vdata,
-	                             const TableFilter &filter, TableFilterState &filter_state, idx_t scan_count,
+	[[deprecated("UnifiedVectorFormat parameter is ignored")]] static idx_t
+	FilterSelection(SelectionVector &sel, Vector &vector, UnifiedVectorFormat &vdata, const TableFilter &filter,
+	                TableFilterState &filter_state, idx_t scan_count, idx_t &approved_tuple_count);
+	static idx_t FilterSelection(SelectionVector &sel, Vector &vector, TableFilterState &filter_state, idx_t scan_count,
 	                             idx_t &approved_tuple_count);
 
 	//! Skip a scan forward to the row_index specified in the scan state

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -190,12 +190,9 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 
 			// apply the filter
 			auto &dict_data = scan_state.dictionary->data;
-			UnifiedVectorFormat vdata;
-			dict_data.ToUnifiedFormat(vdata);
 			SelectionVector dict_sel;
 			idx_t filter_count = scan_state.dict_count;
-			ColumnSegment::FilterSelection(dict_sel, dict_data, vdata, filter, filter_state, scan_state.dict_count,
-			                               filter_count);
+			ColumnSegment::FilterSelection(dict_sel, dict_data, filter_state, scan_state.dict_count, filter_count);
 
 			// now set all matching tuples to true
 			for (idx_t i = 0; i < filter_count; i++) {
@@ -225,10 +222,7 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 	}
 	// fallback: scan + filter
 	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
-
-	UnifiedVectorFormat vdata;
-	result.ToUnifiedFormat(vdata);
-	ColumnSegment::FilterSelection(sel, result, vdata, filter, filter_state, vector_count, sel_count);
+	ColumnSegment::FilterSelection(sel, result, filter_state, vector_count, sel_count);
 }
 
 } // namespace dict_fsst

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -448,12 +448,9 @@ void RLEFilter(ColumnSegment &segment, ColumnScanState &state, idx_t vector_coun
 		// execute the filter over all runs at once
 		Vector run_vector(result.GetType(), data_ptr_cast(data_pointer), total_run_count);
 
-		UnifiedVectorFormat run_format;
-		run_vector.ToUnifiedFormat(run_format);
-
 		SelectionVector run_matches;
 		scan_state.matching_run_count = total_run_count;
-		ColumnSegment::FilterSelection(run_matches, run_vector, run_format, filter, filter_state, total_run_count,
+		ColumnSegment::FilterSelection(run_matches, run_vector, filter_state, total_run_count,
 		                               scan_state.matching_run_count);
 
 		// for any runs that pass the filter - set the matches to true

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -377,9 +377,7 @@ void ColumnData::Filter(TransactionData transaction, idx_t vector_index, ColumnS
 	idx_t scan_count = Scan(transaction, vector_index, state, result);
 	FlatVector::SetSize(result, count_t(scan_count));
 
-	UnifiedVectorFormat vdata;
-	result.ToUnifiedFormat(vdata);
-	ColumnSegment::FilterSelection(sel, result, vdata, filter, filter_state, scan_count, s_count);
+	ColumnSegment::FilterSelection(sel, result, filter_state, scan_count, s_count);
 }
 
 void ColumnData::Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -475,6 +475,11 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
                                      const TableFilter &filter, TableFilterState &filter_state, idx_t scan_count,
                                      idx_t &approved_tuple_count) {
 	(void)vdata;
+	return FilterSelection(sel, vector, filter_state, scan_count, approved_tuple_count);
+}
+
+idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, TableFilterState &filter_state,
+                                     idx_t scan_count, idx_t &approved_tuple_count) {
 	auto &state = filter_state.Cast<ExpressionFilterState>();
 	return ExecuteExpressionFilterSelection(sel, vector, state, scan_count, approved_tuple_count);
 }

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -95,9 +95,7 @@ void RowIdColumnData::Filter(TransactionData transaction, idx_t vector_index, Co
 	}
 
 	// Now apply the filter
-	UnifiedVectorFormat vdata;
-	result.ToUnifiedFormat(vdata);
-	ColumnSegment::FilterSelection(sel, result, vdata, filter, filter_state, count, count);
+	ColumnSegment::FilterSelection(sel, result, filter_state, count, count);
 }
 
 void RowIdColumnData::Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,


### PR DESCRIPTION
Now that `ColumnSegment::FilterSelection` is just running an expression on the vector, there's no reason to pass in this `UnifiedVectorFormat` anymore. While `ToUnifiedFormat` is usually cheap, it forces e.g. unshredding of variants, so doing so unnecessarily should be avoided as it prevents certain optimizations.