### PR TITLE
Correctly get typed value stats for fully shredded variants

### DIFF
--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -362,7 +362,7 @@ static string ToStringInternal(const BaseStatistics &stats) {
 	string result;
 	result = StringUtil::Format("fully_shredded: %s", VariantShreddedStats::IsFullyShredded(stats) ? "true" : "false");
 
-	auto &typed_value = StructStats::GetChildStats(stats, VariantStats::TYPED_VALUE_INDEX);
+	auto &typed_value = VariantStats::GetTypedStats(stats);
 	auto type_id = typed_value.GetType().id();
 	if (type_id == LogicalTypeId::LIST) {
 		result += ", child: ";

--- a/test/sql/storage/types/variant/tpch_sf1.test_slow
+++ b/test/sql/storage/types/variant/tpch_sf1.test_slow
@@ -25,6 +25,9 @@ checkpoint;
 
 restart
 
+statement ok
+SELECT stats(lineitem.l_orderkey)::VARCHAR FROM lineitem_variant LIMIT 1
+
 # --- Create views ----
 
 statement ok


### PR DESCRIPTION
Fixes an issue where `stats` could otherwise throw an internal exception