### PR TITLE
Show transport errors in HTTP log

### DIFF
--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -102,7 +102,7 @@ string HTTPLogType::ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPR
 	if (response) {
 		child_list_t<Value> response_child_list = {
 		    {"status", Value(EnumUtil::ToString(response->status))},
-		    {"reason", Value(response->reason)},
+		    {"reason", Value(response->reason.empty() ? response->GetRequestError() : response->reason)},
 		    {"headers", CreateHTTPHeadersValue(response->headers)},
 		};
 		response_value = Value::STRUCT(response_child_list);

--- a/test/sql/logging/http_log_timing.test
+++ b/test/sql/logging/http_log_timing.test
@@ -30,3 +30,14 @@ WHERE
 HEAD	true	true
 HEAD	true	true
 HEAD	true	true
+
+query II
+SELECT DISTINCT
+	response.status,
+	response.reason IS NOT NULL
+FROM
+	duckdb_logs_parsed('HTTP')
+WHERE
+	request.type='HEAD'
+----
+INVALID	true


### PR DESCRIPTION
When an HTTP request fails at the transport level (connection timeout, connection refused etc.) the request is logged as `'response': {'status': INVALID, 'reason': '', 'headers': {}}` which is not very informative. This PR adds the error message in the `reason`.