### PR TITLE
Fix JSON COPY date/time formatting for nested values

### DIFF
--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -73,6 +73,7 @@ public:
 	                                                optional_ptr<ReplacementScanData> data);
 	static TableFunction GetReadJSONTableFunction(shared_ptr<JSONScanInfo> function_info);
 	static CopyFunction GetJSONCopyFunction();
+	static ScalarFunction GetJSONCopyToJSONFunction();
 	static void RegisterSimpleCastFunctions(ExtensionLoader &loader);
 	static void RegisterJSONCreateCastFunctions(ExtensionLoader &loader);
 	static void RegisterJSONTransformCastFunctions(ExtensionLoader &loader);
@@ -85,7 +86,6 @@ private:
 	static ScalarFunctionSet GetArrayFunction();
 	static ScalarFunctionSet GetObjectFunction();
 	static ScalarFunctionSet GetToJSONFunction();
-	static ScalarFunctionSet GetJSONCopyToJSONFunction();
 	static ScalarFunctionSet GetArrayToJSONFunction();
 	static ScalarFunctionSet GetRowToJSONFunction();
 	static ScalarFunctionSet GetMergePatchFunction();

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -85,6 +85,7 @@ private:
 	static ScalarFunctionSet GetArrayFunction();
 	static ScalarFunctionSet GetObjectFunction();
 	static ScalarFunctionSet GetToJSONFunction();
+	static ScalarFunctionSet GetJSONCopyToJSONFunction();
 	static ScalarFunctionSet GetArrayToJSONFunction();
 	static ScalarFunctionSet GetRowToJSONFunction();
 	static ScalarFunctionSet GetMergePatchFunction();

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -14,6 +14,8 @@
 namespace duckdb {
 
 class TableRef;
+class Expression;
+class ClientContext;
 struct ReplacementScanData;
 class CastFunctionSet;
 struct CastParameters;
@@ -74,6 +76,9 @@ public:
 	static TableFunction GetReadJSONTableFunction(shared_ptr<JSONScanInfo> function_info);
 	static CopyFunction GetJSONCopyFunction();
 	static ScalarFunction GetJSONCopyToJSONFunction();
+	static unique_ptr<Expression> CreateJSONCopyToJSONExpression(ClientContext &context, unique_ptr<Expression> payload,
+	                                                             unique_ptr<Expression> date_format,
+	                                                             unique_ptr<Expression> timestamp_format);
 	static void RegisterSimpleCastFunctions(ExtensionLoader &loader);
 	static void RegisterJSONCreateCastFunctions(ExtensionLoader &loader);
 	static void RegisterJSONTransformCastFunctions(ExtensionLoader &loader);

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -23,6 +23,7 @@ static const DefaultMacro JSON_MACROS[] = {
     {DEFAULT_SCHEMA, "json_copy_strftime_if_date", "(x, format) AS x, (x DATE, format) AS strftime(x, format);"},
     {DEFAULT_SCHEMA, "json_copy_strftime_if_timestamp",
      "(x, format) AS x, (x TIMESTAMP, format) AS strftime(x, format), "
+     "(x TIMESTAMP_NS, format) AS strftime(x, format), "
      "(x TIMESTAMPTZ, format) AS strftime(x, format), "
      "(x TIMESTAMPTZ_NS, format) AS strftime(x, format);"},
     {nullptr, nullptr, nullptr}};

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -22,7 +22,9 @@ static const DefaultMacro JSON_MACROS[] = {
     {DEFAULT_SCHEMA, "json", "(x) AS json_extract(x, '$')"},
     {DEFAULT_SCHEMA, "json_copy_strftime_if_date", "(x, format) AS x, (x DATE, format) AS strftime(x, format);"},
     {DEFAULT_SCHEMA, "json_copy_strftime_if_timestamp",
-     "(x, format) AS x, (x TIMESTAMP, format) AS strftime(x, format), (x TIMESTAMPTZ, format) AS strftime(x, format);"},
+     "(x, format) AS x, (x TIMESTAMP, format) AS strftime(x, format), "
+     "(x TIMESTAMPTZ, format) AS strftime(x, format), "
+     "(x TIMESTAMPTZ_NS, format) AS strftime(x, format);"},
     {nullptr, nullptr, nullptr}};
 
 static void LoadInternal(ExtensionLoader &loader) {

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -162,6 +162,7 @@ vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
 	functions.push_back(GetArrayFunction());
 	functions.push_back(GetObjectFunction());
 	AddAliases({"to_json", "json_quote"}, GetToJSONFunction(), functions);
+	functions.push_back(ScalarFunctionSet(GetJSONCopyToJSONFunction()));
 	functions.push_back(GetArrayToJSONFunction());
 	functions.push_back(GetRowToJSONFunction());
 	functions.push_back(GetMergePatchFunction());

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -162,7 +162,6 @@ vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
 	functions.push_back(GetArrayFunction());
 	functions.push_back(GetObjectFunction());
 	AddAliases({"to_json", "json_quote"}, GetToJSONFunction(), functions);
-	functions.push_back(GetJSONCopyToJSONFunction());
 	functions.push_back(GetArrayToJSONFunction());
 	functions.push_back(GetRowToJSONFunction());
 	functions.push_back(GetMergePatchFunction());

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -162,6 +162,7 @@ vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
 	functions.push_back(GetArrayFunction());
 	functions.push_back(GetObjectFunction());
 	AddAliases({"to_json", "json_quote"}, GetToJSONFunction(), functions);
+	functions.push_back(GetJSONCopyToJSONFunction());
 	functions.push_back(GetArrayToJSONFunction());
 	functions.push_back(GetRowToJSONFunction());
 	functions.push_back(GetMergePatchFunction());

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -7,7 +7,12 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/common/helper.hpp"
 #include "json_functions.hpp"
 #include "json_scan.hpp"
@@ -83,11 +88,52 @@ static unique_ptr<ParsedExpression> JSONCopyPartitionColumnExpression(const stri
 	return result;
 }
 
-static unique_ptr<ParsedExpression> JSONCopyFormatConstant(const string &format) {
+static unique_ptr<Expression> JSONCopyBoundFormatConstant(const string &format) {
 	if (format.empty()) {
-		return make_uniq<ConstantExpression>(Value(LogicalType::VARCHAR));
+		return make_uniq<BoundConstantExpression>(Value(LogicalType::VARCHAR));
 	}
-	return make_uniq<ConstantExpression>(Value(format));
+	return make_uniq<BoundConstantExpression>(Value(format));
+}
+
+static void BindJSONCopyToJSONFunction(Binder &binder, BoundStatement &bound, const string &date_format,
+                                       const string &timestamp_format) {
+	if (date_format.empty() && timestamp_format.empty()) {
+		return;
+	}
+	if (!bound.plan || bound.plan->type != LogicalOperatorType::LOGICAL_COPY_TO_FILE) {
+		throw InternalException("Expected JSON COPY rewrite to bind to a LogicalCopyToFile");
+	}
+	auto &copy = bound.plan->Cast<LogicalCopyToFile>();
+	if (copy.children.empty() || copy.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		throw InternalException("Expected JSON COPY rewrite to bind a top-level projection");
+	}
+	auto &projection = copy.children[0]->Cast<LogicalProjection>();
+	if (projection.expressions.empty()) {
+		throw InternalException("Expected JSON COPY rewrite projection to contain a JSON payload expression");
+	}
+
+	auto to_json = std::move(projection.expressions[0]);
+	if (to_json->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		throw InternalException("Expected JSON COPY payload expression to be a bound function");
+	}
+	auto &to_json_function = to_json->Cast<BoundFunctionExpression>();
+	if (to_json_function.Function().GetName() != "to_json" || to_json_function.GetChildren().size() != 1) {
+		throw InternalException("Expected JSON COPY payload expression to be to_json with one argument");
+	}
+
+	auto alias = to_json->GetAlias();
+	auto &to_json_children = to_json_function.GetChildrenMutable();
+	vector<unique_ptr<Expression>> json_copy_to_json_args;
+	json_copy_to_json_args.push_back(std::move(to_json_children[0]));
+	json_copy_to_json_args.push_back(JSONCopyBoundFormatConstant(date_format));
+	json_copy_to_json_args.push_back(JSONCopyBoundFormatConstant(timestamp_format));
+
+	FunctionBinder function_binder(binder);
+	auto replacement = function_binder.BindScalarFunction(JSONFunctions::GetJSONCopyToJSONFunction(),
+	                                                      std::move(json_copy_to_json_args), false, &binder);
+	replacement->SetAlias(std::move(alias));
+	projection.expressions[0] = std::move(replacement);
+	projection.ResolveOperatorTypes();
 }
 
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
@@ -203,13 +249,7 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 
 	vector<unique_ptr<ParsedExpression>> to_json_args;
 	to_json_args.push_back(std::move(struct_pack));
-	if (!date_format.empty() || !timestamp_format.empty()) {
-		to_json_args.push_back(JSONCopyFormatConstant(date_format));
-		to_json_args.push_back(JSONCopyFormatConstant(timestamp_format));
-		select_node.select_list.push_back(make_uniq<FunctionExpression>("json_copy_to_json", std::move(to_json_args)));
-	} else {
-		select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
-	}
+	select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
 
 	// Keep the partition columns as separate columns so the COPY writer can partition on them. The writer routes rows
 	// into the right files based on these columns but does not write them to disk (WRITE_PARTITION_COLUMNS is handled
@@ -227,7 +267,9 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	copy_info.options["delimiter"] = {"\n"};
 	copy_info.options["header"] = {{0}};
 
-	return binder.Bind(stmt);
+	auto result = binder.Bind(stmt);
+	BindJSONCopyToJSONFunction(binder, result, date_format, timestamp_format);
+	return result;
 }
 
 CopyFunction JSONFunctions::GetJSONCopyFunction() {

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -12,7 +12,6 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
-#include "duckdb/function/function_binder.hpp"
 #include "duckdb/common/helper.hpp"
 #include "json_functions.hpp"
 #include "json_scan.hpp"
@@ -123,14 +122,9 @@ static void BindJSONCopyToJSONFunction(Binder &binder, BoundStatement &bound, co
 
 	auto alias = to_json->GetAlias();
 	auto &to_json_children = to_json_function.GetChildrenMutable();
-	vector<unique_ptr<Expression>> json_copy_to_json_args;
-	json_copy_to_json_args.push_back(std::move(to_json_children[0]));
-	json_copy_to_json_args.push_back(JSONCopyBoundFormatConstant(date_format));
-	json_copy_to_json_args.push_back(JSONCopyBoundFormatConstant(timestamp_format));
-
-	FunctionBinder function_binder(binder);
-	auto replacement = function_binder.BindScalarFunction(JSONFunctions::GetJSONCopyToJSONFunction(),
-	                                                      std::move(json_copy_to_json_args), false, &binder);
+	auto replacement = JSONFunctions::CreateJSONCopyToJSONExpression(binder.context, std::move(to_json_children[0]),
+	                                                                 JSONCopyBoundFormatConstant(date_format),
+	                                                                 JSONCopyBoundFormatConstant(timestamp_format));
 	replacement->SetAlias(std::move(alias));
 	projection.expressions[0] = std::move(replacement);
 	projection.ResolveOperatorTypes();

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -61,21 +61,33 @@ static bool GetJSONCopyBoolean(Binder &binder, const string &loption, const vect
 	return values.back().CastAs(binder.context, LogicalType::BOOLEAN).GetValue<bool>();
 }
 
-static unique_ptr<SubqueryRef> PushJSONFormatProjection(unique_ptr<SubqueryRef> source_ref,
-                                                        const Identifier &function_name, const string &format) {
-	auto format_node = make_uniq<SelectNode>();
-	format_node->from_table = std::move(source_ref);
-
-	auto columns_star = make_uniq<StarExpression>();
-	columns_star->IsColumnsMutable() = true;
+static unique_ptr<ParsedExpression> JSONCopyFormatExpression(unique_ptr<ParsedExpression> expr,
+                                                             const Identifier &function_name, const string &format) {
 	vector<unique_ptr<ParsedExpression>> args;
-	args.push_back(std::move(columns_star));
+	args.push_back(std::move(expr));
 	args.push_back(make_uniq<ConstantExpression>(Value(format)));
-	format_node->select_list.push_back(make_uniq<FunctionExpression>(function_name, std::move(args)));
+	return make_uniq<FunctionExpression>(function_name, std::move(args));
+}
 
-	auto format_stmt = make_uniq<SelectStatement>();
-	format_stmt->node = std::move(format_node);
-	return make_uniq<SubqueryRef>(std::move(format_stmt));
+static unique_ptr<ParsedExpression> JSONCopyPartitionColumnExpression(const string &partition_column,
+                                                                      const string &date_format,
+                                                                      const string &timestamp_format) {
+	unique_ptr<ParsedExpression> result = make_uniq<ColumnRefExpression>(Identifier(partition_column));
+	if (!date_format.empty()) {
+		result = JSONCopyFormatExpression(std::move(result), "json_copy_strftime_if_date", date_format);
+	}
+	if (!timestamp_format.empty()) {
+		result = JSONCopyFormatExpression(std::move(result), "json_copy_strftime_if_timestamp", timestamp_format);
+	}
+	result->SetAlias(Identifier(partition_column));
+	return result;
+}
+
+static unique_ptr<ParsedExpression> JSONCopyFormatConstant(const string &format) {
+	if (format.empty()) {
+		return make_uniq<ConstantExpression>(Value(LogicalType::VARCHAR));
+	}
+	return make_uniq<ConstantExpression>(Value(format));
 }
 
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
@@ -168,13 +180,6 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	inner_select_stmt->node = std::move(copy_info.select_statement);
 
 	auto source_ref = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
-	if (!date_format.empty()) {
-		source_ref = PushJSONFormatProjection(std::move(source_ref), "json_copy_strftime_if_date", date_format);
-	}
-	if (!timestamp_format.empty()) {
-		source_ref =
-		    PushJSONFormatProjection(std::move(source_ref), "json_copy_strftime_if_timestamp", timestamp_format);
-	}
 
 	// Build outer: SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source_ref>
 	copy_info.select_statement = make_uniq_base<QueryNode, SelectNode>();
@@ -198,13 +203,20 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 
 	vector<unique_ptr<ParsedExpression>> to_json_args;
 	to_json_args.push_back(std::move(struct_pack));
-	select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
+	if (!date_format.empty() || !timestamp_format.empty()) {
+		to_json_args.push_back(JSONCopyFormatConstant(date_format));
+		to_json_args.push_back(JSONCopyFormatConstant(timestamp_format));
+		select_node.select_list.push_back(make_uniq<FunctionExpression>("json_copy_to_json", std::move(to_json_args)));
+	} else {
+		select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
+	}
 
 	// Keep the partition columns as separate columns so the COPY writer can partition on them. The writer routes rows
 	// into the right files based on these columns but does not write them to disk (WRITE_PARTITION_COLUMNS is handled
 	// above by keeping the columns inside the JSON object instead).
 	for (const auto &partition_column : partition_columns) {
-		select_node.select_list.push_back(make_uniq<ColumnRefExpression>(Identifier(partition_column)));
+		select_node.select_list.push_back(
+		    JSONCopyPartitionColumnExpression(partition_column, date_format, timestamp_format));
 	}
 
 	// Now we can just use the CSV writer

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -9,7 +9,9 @@
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
@@ -18,6 +20,8 @@
 #include "json_functions.hpp"
 
 namespace duckdb {
+
+static constexpr const char *JSON_COPY_TO_JSON_INTERNAL_NAME = "__internal_json_copy_to_json";
 
 struct StructNames {
 	void Insert(const string &name) {
@@ -315,6 +319,13 @@ static bool BindJSONCopyFormat(ClientContext &context, Expression &argument, con
 	return true;
 }
 
+static void ParseJSONCopyFormatString(const string &format_string, const string &name, StrfTimeFormat &format) {
+	auto error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+	if (!error.empty()) {
+		throw InvalidInputException("Failed to parse %s format specifier %s: %s", name, format_string, error);
+	}
+}
+
 static unique_ptr<Expression> BindJSONCopyTimestampTZFormatter(ClientContext &context, const string &format_string,
                                                                const LogicalType &type) {
 	vector<unique_ptr<Expression>> children;
@@ -331,31 +342,17 @@ static unique_ptr<Expression> BindJSONCopyTimestampTZFormatter(ClientContext &co
 	return result;
 }
 
-static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &input) {
-	auto &context = input.GetClientContext();
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
-	if (arguments.size() != 3) {
-		throw BinderException("json_copy_to_json() takes exactly three arguments");
-	}
-	if (arguments[0]->HasParameter()) {
-		throw ParameterNotResolvedException();
-	}
-
-	StructNames const_struct_names;
-	auto &bound_arguments = bound_function.GetArguments();
-	bound_arguments.clear();
-	bound_arguments.push_back(GetJSONType(const_struct_names, arguments[0]->GetReturnType()));
-	bound_arguments.push_back(LogicalType::VARCHAR);
-	bound_arguments.push_back(LogicalType::VARCHAR);
-
+static unique_ptr<JSONCopyToJSONFunctionData>
+CreateJSONCopyToJSONFunctionData(ClientContext &context, StructNames const_struct_names, bool has_date_format,
+                                 string date_format_string, bool has_timestamp_format, string timestamp_format_string) {
 	StrfTimeFormat date_format;
 	StrfTimeFormat timestamp_format;
-	string date_format_string;
-	string timestamp_format_string;
-	auto has_date_format = BindJSONCopyFormat(context, *arguments[1], "date", date_format_string, date_format);
-	auto has_timestamp_format =
-	    BindJSONCopyFormat(context, *arguments[2], "timestamp", timestamp_format_string, timestamp_format);
+	if (has_date_format) {
+		ParseJSONCopyFormatString(date_format_string, "date", date_format);
+	}
+	if (has_timestamp_format) {
+		ParseJSONCopyFormatString(timestamp_format_string, "timestamp", timestamp_format);
+	}
 
 	unique_ptr<Expression> timestamptz_format_expression;
 	unique_ptr<Expression> timestamptz_ns_format_expression;
@@ -370,6 +367,26 @@ static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &inpu
 	    std::move(const_struct_names), has_date_format, std::move(date_format_string), std::move(date_format),
 	    has_timestamp_format, std::move(timestamp_format_string), std::move(timestamp_format),
 	    std::move(timestamptz_format_expression), std::move(timestamptz_ns_format_expression));
+}
+
+static unique_ptr<JSONCopyToJSONFunctionData> CreateJSONCopyToJSONFunctionData(ClientContext &context,
+                                                                               StructNames const_struct_names,
+                                                                               Expression &date_argument,
+                                                                               Expression &timestamp_argument) {
+	StrfTimeFormat date_format;
+	StrfTimeFormat timestamp_format;
+	string date_format_string;
+	string timestamp_format_string;
+	auto has_date_format = BindJSONCopyFormat(context, date_argument, "date", date_format_string, date_format);
+	auto has_timestamp_format =
+	    BindJSONCopyFormat(context, timestamp_argument, "timestamp", timestamp_format_string, timestamp_format);
+	return CreateJSONCopyToJSONFunctionData(context, std::move(const_struct_names), has_date_format,
+	                                        std::move(date_format_string), has_timestamp_format,
+	                                        std::move(timestamp_format_string));
+}
+
+static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &) {
+	throw BinderException("%s is for internal use only", JSON_COPY_TO_JSON_INTERNAL_NAME);
 }
 
 template <class INPUT_TYPE, class RESULT_TYPE>
@@ -1017,12 +1034,65 @@ static void JSONCopyToJSONFunction(DataChunk &args, ExpressionState &state, Vect
 	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc, options);
 }
 
-static void JSONCopyToJSONSerialize(Serializer &, optional_ptr<FunctionData>, const BoundScalarFunction &) {
-	throw NotImplementedException("json_copy_to_json is only serializable as part of JSON COPY planning");
+static void JSONCopyToJSONSerialize(Serializer &serializer, optional_ptr<FunctionData> bind_data,
+                                    const BoundScalarFunction &) {
+	if (!bind_data) {
+		throw InternalException("%s is missing bind data during serialization", JSON_COPY_TO_JSON_INTERNAL_NAME);
+	}
+	auto &data = bind_data->Cast<JSONCopyToJSONFunctionData>();
+	serializer.WriteProperty(100, "has_date_format", data.has_date_format);
+	serializer.WriteProperty(101, "date_format", data.date_format_string);
+	serializer.WriteProperty(102, "has_timestamp_format", data.has_timestamp_format);
+	serializer.WriteProperty(103, "timestamp_format", data.timestamp_format_string);
 }
 
-static unique_ptr<FunctionData> JSONCopyToJSONDeserialize(Deserializer &, BoundScalarFunction &) {
-	throw NotImplementedException("json_copy_to_json is only deserializable as part of JSON COPY planning");
+static unique_ptr<FunctionData> JSONCopyToJSONDeserialize(Deserializer &deserializer, BoundScalarFunction &function) {
+	auto has_date_format = deserializer.ReadProperty<bool>(100, "has_date_format");
+	auto date_format_string = deserializer.ReadProperty<string>(101, "date_format");
+	auto has_timestamp_format = deserializer.ReadProperty<bool>(102, "has_timestamp_format");
+	auto timestamp_format_string = deserializer.ReadProperty<string>(103, "timestamp_format");
+
+	auto &arguments = function.GetArguments();
+	if (arguments.size() != 3) {
+		throw InternalException("%s must have exactly three arguments during deserialization",
+		                        JSON_COPY_TO_JSON_INTERNAL_NAME);
+	}
+
+	StructNames const_struct_names;
+	GetJSONType(const_struct_names, arguments[0]);
+
+	auto &context = deserializer.Get<ClientContext &>();
+	return CreateJSONCopyToJSONFunctionData(context, std::move(const_struct_names), has_date_format,
+	                                        std::move(date_format_string), has_timestamp_format,
+	                                        std::move(timestamp_format_string));
+}
+
+unique_ptr<Expression> JSONFunctions::CreateJSONCopyToJSONExpression(ClientContext &context,
+                                                                     unique_ptr<Expression> payload,
+                                                                     unique_ptr<Expression> date_format,
+                                                                     unique_ptr<Expression> timestamp_format) {
+	StructNames const_struct_names;
+	auto json_type = GetJSONType(const_struct_names, payload->GetReturnType());
+	auto bind_data =
+	    CreateJSONCopyToJSONFunctionData(context, std::move(const_struct_names), *date_format, *timestamp_format);
+
+	payload = BoundCastExpression::AddCastToType(context, std::move(payload), json_type);
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(payload));
+	children.push_back(std::move(date_format));
+	children.push_back(std::move(timestamp_format));
+
+	auto function = GetJSONCopyToJSONFunction();
+	BoundScalarFunction bound_function(function);
+	auto &arguments = bound_function.GetArguments();
+	arguments.clear();
+	arguments.push_back(std::move(json_type));
+	arguments.push_back(LogicalType::VARCHAR);
+	arguments.push_back(LogicalType::VARCHAR);
+	bound_function.SetReturnType(LogicalType::JSON());
+
+	return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(children), std::move(bind_data));
 }
 
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
@@ -1049,7 +1119,7 @@ ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
 }
 
 ScalarFunction JSONFunctions::GetJSONCopyToJSONFunction() {
-	ScalarFunction fun("json_copy_to_json", {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	ScalarFunction fun(JSON_COPY_TO_JSON_INTERNAL_NAME, {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), JSONCopyToJSONFunction, JSONCopyToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -693,7 +693,7 @@ static void CreateValuesDate(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector
 		return;
 	}
 	Vector string_vector(LogicalType::VARCHAR, count);
-	options.date_format->ConvertDateVector(value_v, string_vector);
+	options.date_format.get_mutable()->ConvertDateVector(value_v, string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
 
@@ -704,7 +704,7 @@ static void CreateValuesTimestamp(yyjson_mut_doc *doc, yyjson_mut_val *vals[], V
 		return;
 	}
 	Vector string_vector(LogicalType::VARCHAR, count);
-	options.timestamp_format->ConvertTimestampVector(value_v, string_vector);
+	options.timestamp_format.get_mutable()->ConvertTimestampVector(value_v, string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
 
@@ -724,7 +724,7 @@ static void CreateValuesTimestampTZ(yyjson_mut_doc *doc, yyjson_mut_val *vals[],
 	input.CheckCardinality(count);
 
 	Vector string_vector(LogicalType::VARCHAR, count);
-	ExpressionExecutor executor(*options.context, *options.timestamptz_format_expression);
+	ExpressionExecutor executor(*options.context.get_mutable(), *options.timestamptz_format_expression);
 	executor.ExecuteExpression(input, string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -12,6 +12,8 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "json_common.hpp"
 #include "json_functions.hpp"
 
@@ -115,11 +117,12 @@ public:
 		result.date_format = has_date_format ? optional_ptr<StrfTimeFormat>(&date_format) : nullptr;
 		result.timestamp_format = has_timestamp_format ? optional_ptr<StrfTimeFormat>(&timestamp_format) : nullptr;
 		result.context = context;
-		result.timestamptz_format_expression =
-		    timestamptz_format_expression ? optional_ptr<const Expression>(timestamptz_format_expression.get()) : nullptr;
-		result.timestamptz_ns_format_expression = timestamptz_ns_format_expression
-		                                               ? optional_ptr<const Expression>(timestamptz_ns_format_expression.get())
-		                                               : nullptr;
+		result.timestamptz_format_expression = timestamptz_format_expression
+		                                           ? optional_ptr<const Expression>(timestamptz_format_expression.get())
+		                                           : nullptr;
+		result.timestamptz_ns_format_expression =
+		    timestamptz_ns_format_expression ? optional_ptr<const Expression>(timestamptz_ns_format_expression.get())
+		                                     : nullptr;
 		return result;
 	}
 
@@ -350,8 +353,7 @@ static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &inpu
 	StrfTimeFormat timestamp_format;
 	string date_format_string;
 	string timestamp_format_string;
-	auto has_date_format =
-	    BindJSONCopyFormat(context, *arguments[1], "date", date_format_string, date_format);
+	auto has_date_format = BindJSONCopyFormat(context, *arguments[1], "date", date_format_string, date_format);
 	auto has_timestamp_format =
 	    BindJSONCopyFormat(context, *arguments[2], "timestamp", timestamp_format_string, timestamp_format);
 
@@ -506,8 +508,8 @@ static void CreateRawValues(yyjson_mut_doc *doc, yyjson_mut_val *vals[], const V
 	}
 }
 
-static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[],
-                               Vector &value_v, idx_t count, const JSONCopyFormatOptions &options) {
+static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
+                               idx_t count, const JSONCopyFormatOptions &options) {
 	// Structs become values, therefore we initialize vals to JSON values
 	for (idx_t i = 0; i < count; i++) {
 		vals[i] = yyjson_mut_obj(doc);
@@ -950,8 +952,7 @@ static void ArrayFunction(DataChunk &args, ExpressionState &state, Vector &resul
 }
 
 static void ToJSONFunctionInternal(const StructNames &names, Vector &input, const idx_t count, Vector &result,
-                                   yyjson_alc *alc,
-                                   const JSONCopyFormatOptions &options = JSONCopyFormatOptions()) {
+                                   yyjson_alc *alc, const JSONCopyFormatOptions &options = JSONCopyFormatOptions()) {
 	// Initialize array for values
 	auto doc = JSONCommon::CreateDocument(alc);
 	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
@@ -997,6 +998,14 @@ static void JSONCopyToJSONFunction(DataChunk &args, ExpressionState &state, Vect
 	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc, options);
 }
 
+static void JSONCopyToJSONSerialize(Serializer &, optional_ptr<FunctionData>, const BoundScalarFunction &) {
+	throw NotImplementedException("json_copy_to_json is only serializable as part of JSON COPY planning");
+}
+
+static unique_ptr<FunctionData> JSONCopyToJSONDeserialize(Deserializer &, BoundScalarFunction &) {
+	throw NotImplementedException("json_copy_to_json is only deserializable as part of JSON COPY planning");
+}
+
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
 	ScalarFunction fun("json_object", {}, LogicalType::JSON(), ObjectFunction, JSONObjectBind, nullptr,
 	                   JSONFunctionLocalState::Init);
@@ -1020,12 +1029,14 @@ ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
 	return ScalarFunctionSet(fun);
 }
 
-ScalarFunctionSet JSONFunctions::GetJSONCopyToJSONFunction() {
+ScalarFunction JSONFunctions::GetJSONCopyToJSONFunction() {
 	ScalarFunction fun("json_copy_to_json", {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), JSONCopyToJSONFunction, JSONCopyToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	return ScalarFunctionSet(fun);
+	fun.SetSerializeCallback(JSONCopyToJSONSerialize);
+	fun.SetDeserializeCallback(JSONCopyToJSONDeserialize);
+	return fun;
 }
 
 ScalarFunctionSet JSONFunctions::GetArrayToJSONFunction() {

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -76,6 +76,7 @@ struct JSONCopyFormatOptions {
 	optional_ptr<StrfTimeFormat> timestamp_format;
 	optional_ptr<ClientContext> context;
 	optional_ptr<const Expression> timestamptz_format_expression;
+	optional_ptr<const Expression> timestamptz_ns_format_expression;
 };
 
 struct JSONCopyToJSONFunctionData : public FunctionData {
@@ -83,19 +84,22 @@ public:
 	JSONCopyToJSONFunctionData(StructNames const_struct_names_p, bool has_date_format_p, string date_format_string_p,
 	                           StrfTimeFormat date_format_p, bool has_timestamp_format_p,
 	                           string timestamp_format_string_p, StrfTimeFormat timestamp_format_p,
-	                           unique_ptr<Expression> timestamptz_format_expression_p)
+	                           unique_ptr<Expression> timestamptz_format_expression_p,
+	                           unique_ptr<Expression> timestamptz_ns_format_expression_p)
 	    : const_struct_names(std::move(const_struct_names_p)), has_date_format(has_date_format_p),
 	      date_format_string(std::move(date_format_string_p)), date_format(std::move(date_format_p)),
 	      has_timestamp_format(has_timestamp_format_p), timestamp_format_string(std::move(timestamp_format_string_p)),
 	      timestamp_format(std::move(timestamp_format_p)),
-	      timestamptz_format_expression(std::move(timestamptz_format_expression_p)) {
+	      timestamptz_format_expression(std::move(timestamptz_format_expression_p)),
+	      timestamptz_ns_format_expression(std::move(timestamptz_ns_format_expression_p)) {
 	}
 
 	unique_ptr<FunctionData> Copy() const override {
 		return make_uniq<JSONCopyToJSONFunctionData>(
 		    const_struct_names.Copy(), has_date_format, date_format_string, date_format, has_timestamp_format,
 		    timestamp_format_string, timestamp_format,
-		    timestamptz_format_expression ? timestamptz_format_expression->Copy() : nullptr);
+		    timestamptz_format_expression ? timestamptz_format_expression->Copy() : nullptr,
+		    timestamptz_ns_format_expression ? timestamptz_ns_format_expression->Copy() : nullptr);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
@@ -113,6 +117,9 @@ public:
 		result.context = context;
 		result.timestamptz_format_expression =
 		    timestamptz_format_expression ? optional_ptr<const Expression>(timestamptz_format_expression.get()) : nullptr;
+		result.timestamptz_ns_format_expression = timestamptz_ns_format_expression
+		                                               ? optional_ptr<const Expression>(timestamptz_ns_format_expression.get())
+		                                               : nullptr;
 		return result;
 	}
 
@@ -125,6 +132,7 @@ public:
 	string timestamp_format_string;
 	StrfTimeFormat timestamp_format;
 	unique_ptr<Expression> timestamptz_format_expression;
+	unique_ptr<Expression> timestamptz_ns_format_expression;
 };
 
 static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalType &type) {
@@ -304,9 +312,10 @@ static bool BindJSONCopyFormat(ClientContext &context, Expression &argument, con
 	return true;
 }
 
-static unique_ptr<Expression> BindJSONCopyTimestampTZFormatter(ClientContext &context, const string &format_string) {
+static unique_ptr<Expression> BindJSONCopyTimestampTZFormatter(ClientContext &context, const string &format_string,
+                                                               const LogicalType &type) {
 	vector<unique_ptr<Expression>> children;
-	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType::TIMESTAMP_TZ, 0));
+	children.push_back(make_uniq<BoundReferenceExpression>(type, 0));
 	children.push_back(make_uniq<BoundConstantExpression>(Value(format_string)));
 
 	FunctionBinder function_binder(context);
@@ -347,14 +356,18 @@ static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &inpu
 	    BindJSONCopyFormat(context, *arguments[2], "timestamp", timestamp_format_string, timestamp_format);
 
 	unique_ptr<Expression> timestamptz_format_expression;
+	unique_ptr<Expression> timestamptz_ns_format_expression;
 	if (has_timestamp_format) {
-		timestamptz_format_expression = BindJSONCopyTimestampTZFormatter(context, timestamp_format_string);
+		timestamptz_format_expression =
+		    BindJSONCopyTimestampTZFormatter(context, timestamp_format_string, LogicalType::TIMESTAMP_TZ);
+		timestamptz_ns_format_expression =
+		    BindJSONCopyTimestampTZFormatter(context, timestamp_format_string, LogicalType::TIMESTAMP_TZ_NS);
 	}
 
 	return make_uniq<JSONCopyToJSONFunctionData>(
 	    std::move(const_struct_names), has_date_format, std::move(date_format_string), std::move(date_format),
 	    has_timestamp_format, std::move(timestamp_format_string), std::move(timestamp_format),
-	    std::move(timestamptz_format_expression));
+	    std::move(timestamptz_format_expression), std::move(timestamptz_ns_format_expression));
 }
 
 template <class INPUT_TYPE, class RESULT_TYPE>
@@ -731,7 +744,10 @@ static void CreateValuesTimestampTZ(yyjson_mut_doc *doc, yyjson_mut_val *vals[],
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);
 		return;
 	}
-	if (!options.context || !options.timestamptz_format_expression) {
+	auto format_expression = value_v.GetType().id() == LogicalTypeId::TIMESTAMP_TZ_NS
+	                             ? options.timestamptz_ns_format_expression
+	                             : options.timestamptz_format_expression;
+	if (!options.context || !format_expression) {
 		throw InternalException("Missing bound TIMESTAMPTZ formatter for JSON COPY");
 	}
 
@@ -741,7 +757,7 @@ static void CreateValuesTimestampTZ(yyjson_mut_doc *doc, yyjson_mut_val *vals[],
 	input.CheckCardinality(count);
 
 	Vector string_vector(LogicalType::VARCHAR, count);
-	ExpressionExecutor executor(*options.context.get_mutable(), *options.timestamptz_format_expression);
+	ExpressionExecutor executor(*options.context.get_mutable(), *format_expression);
 	executor.ExecuteExpression(input, string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
@@ -822,6 +838,7 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 		CreateValuesTimestampNS(doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ_NS:
 		CreateValuesTimestampTZ(doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::BIT:
@@ -832,7 +849,6 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_NS:
 	case LogicalTypeId::TIME_TZ:
-	case LogicalTypeId::TIMESTAMP_TZ_NS:
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::GEOMETRY: {
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -703,8 +703,25 @@ static void CreateValuesTimestamp(yyjson_mut_doc *doc, yyjson_mut_val *vals[], V
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);
 		return;
 	}
+	if (value_v.GetType().id() != LogicalTypeId::TIMESTAMP) {
+		Vector timestamp_vector(LogicalType::TIMESTAMP, count);
+		VectorOperations::DefaultCast(value_v, timestamp_vector, count);
+		CreateValuesTimestamp(doc, vals, timestamp_vector, count, options);
+		return;
+	}
 	Vector string_vector(LogicalType::VARCHAR, count);
 	options.timestamp_format.get_mutable()->ConvertTimestampVector(value_v, string_vector);
+	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
+static void CreateValuesTimestampNS(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                    const JSONCopyFormatOptions &options) {
+	if (!options.timestamp_format) {
+		CreateValuesFromDefaultCast(doc, vals, value_v, count);
+		return;
+	}
+	Vector string_vector(LogicalType::VARCHAR, count);
+	options.timestamp_format.get_mutable()->ConvertTimestampNSVector(value_v, string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
 
@@ -797,7 +814,12 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 		CreateValuesDate(doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_SEC:
 		CreateValuesTimestamp(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		CreateValuesTimestampNS(doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::TIMESTAMP_TZ:
 		CreateValuesTimestampTZ(doc, vals, value_v, count, options);
@@ -811,9 +833,6 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 	case LogicalTypeId::TIME_NS:
 	case LogicalTypeId::TIME_TZ:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
-	case LogicalTypeId::TIMESTAMP_NS:
-	case LogicalTypeId::TIMESTAMP_MS:
-	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::GEOMETRY: {
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -194,7 +194,7 @@ static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalTyp
 		return LogicalType::STRUCT(child_types);
 	}
 	case LogicalTypeId::MAP: {
-		return LogicalType::MAP(LogicalType::VARCHAR, GetJSONType(const_struct_names, MapType::ValueType(type)));
+		return LogicalType::MAP(MapType::KeyType(type), GetJSONType(const_struct_names, MapType::ValueType(type)));
 	}
 	case LogicalTypeId::UNION: {
 		child_list_t<LogicalType> member_types;
@@ -535,15 +535,16 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 	}
 }
 
+static void CreateValuesMapKeys(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                const JSONCopyFormatOptions &options);
+
 static void CreateValuesMap(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
                             idx_t count, const JSONCopyFormatOptions &options) {
 	// Create nested keys
 	auto &map_key_v = MapVector::GetKeys(value_v);
 	auto map_key_count = ListVector::GetListSize(value_v);
-	Vector map_keys_string(LogicalType::VARCHAR, map_key_count);
-	VectorOperations::DefaultCast(map_key_v, map_keys_string, map_key_count);
 	auto nested_keys = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, map_key_count);
-	TemplatedCreateValues<string_t, string_t>(doc, nested_keys, map_keys_string, map_key_count);
+	CreateValuesMapKeys(doc, nested_keys, map_key_v, map_key_count, options);
 	// Create nested values
 	auto &map_val_v = MapVector::GetValues(value_v);
 	auto map_val_count = ListVector::GetListSize(value_v);
@@ -701,67 +702,85 @@ static void CreateValuesFromDefaultCast(yyjson_mut_doc *doc, yyjson_mut_val *val
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
 
-static void CreateValuesDate(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
-                             const JSONCopyFormatOptions &options) {
-	if (!options.date_format) {
+template <class FILL>
+static void CreateValuesFormatted(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                  bool has_format, FILL &&fill_strings) {
+	if (!has_format) {
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);
 		return;
 	}
 	Vector string_vector(LogicalType::VARCHAR, count);
-	options.date_format.get_mutable()->ConvertDateVector(value_v, string_vector);
+	fill_strings(string_vector);
 	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
+static void CreateValuesDate(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                             const JSONCopyFormatOptions &options) {
+	CreateValuesFormatted(doc, vals, value_v, count, bool(options.date_format), [&](Vector &string_vector) {
+		options.date_format.get_mutable()->ConvertDateVector(value_v, string_vector);
+	});
 }
 
 static void CreateValuesTimestamp(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
                                   const JSONCopyFormatOptions &options) {
-	if (!options.timestamp_format) {
-		CreateValuesFromDefaultCast(doc, vals, value_v, count);
-		return;
-	}
-	if (value_v.GetType().id() != LogicalTypeId::TIMESTAMP) {
+	if (options.timestamp_format && value_v.GetType().id() != LogicalTypeId::TIMESTAMP) {
 		Vector timestamp_vector(LogicalType::TIMESTAMP, count);
 		VectorOperations::DefaultCast(value_v, timestamp_vector, count);
 		CreateValuesTimestamp(doc, vals, timestamp_vector, count, options);
 		return;
 	}
-	Vector string_vector(LogicalType::VARCHAR, count);
-	options.timestamp_format.get_mutable()->ConvertTimestampVector(value_v, string_vector);
-	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+	CreateValuesFormatted(doc, vals, value_v, count, bool(options.timestamp_format), [&](Vector &string_vector) {
+		options.timestamp_format.get_mutable()->ConvertTimestampVector(value_v, string_vector);
+	});
 }
 
 static void CreateValuesTimestampNS(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
                                     const JSONCopyFormatOptions &options) {
-	if (!options.timestamp_format) {
-		CreateValuesFromDefaultCast(doc, vals, value_v, count);
-		return;
-	}
-	Vector string_vector(LogicalType::VARCHAR, count);
-	options.timestamp_format.get_mutable()->ConvertTimestampNSVector(value_v, string_vector);
-	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+	CreateValuesFormatted(doc, vals, value_v, count, bool(options.timestamp_format), [&](Vector &string_vector) {
+		options.timestamp_format.get_mutable()->ConvertTimestampNSVector(value_v, string_vector);
+	});
 }
 
 static void CreateValuesTimestampTZ(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
                                     const JSONCopyFormatOptions &options) {
-	if (!options.timestamp_format) {
+	CreateValuesFormatted(doc, vals, value_v, count, bool(options.timestamp_format), [&](Vector &string_vector) {
+		auto format_expression = value_v.GetType().id() == LogicalTypeId::TIMESTAMP_TZ_NS
+		                             ? options.timestamptz_ns_format_expression
+		                             : options.timestamptz_format_expression;
+		if (!options.context || !format_expression) {
+			throw InternalException("Missing bound TIMESTAMPTZ formatter for JSON COPY");
+		}
+		DataChunk input;
+		input.InitializeEmpty({value_v.GetType()});
+		input.data[0].Reference(value_v);
+		input.CheckCardinality(count);
+		ExpressionExecutor executor(*options.context.get_mutable(), *format_expression);
+		executor.ExecuteExpression(input, string_vector);
+	});
+}
+
+static void CreateValuesMapKeys(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                const JSONCopyFormatOptions &options) {
+	switch (value_v.GetType().id()) {
+	case LogicalTypeId::DATE:
+		CreateValuesDate(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+		CreateValuesTimestamp(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		CreateValuesTimestampNS(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ_NS:
+		CreateValuesTimestampTZ(doc, vals, value_v, count, options);
+		break;
+	default:
 		CreateValuesFromDefaultCast(doc, vals, value_v, count);
-		return;
+		break;
 	}
-	auto format_expression = value_v.GetType().id() == LogicalTypeId::TIMESTAMP_TZ_NS
-	                             ? options.timestamptz_ns_format_expression
-	                             : options.timestamptz_format_expression;
-	if (!options.context || !format_expression) {
-		throw InternalException("Missing bound TIMESTAMPTZ formatter for JSON COPY");
-	}
-
-	DataChunk input;
-	input.InitializeEmpty({value_v.GetType()});
-	input.data[0].Reference(value_v);
-	input.CheckCardinality(count);
-
-	Vector string_vector(LogicalType::VARCHAR, count);
-	ExpressionExecutor executor(*options.context.get_mutable(), *format_expression);
-	executor.ExecuteExpression(input, string_vector);
-	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
 }
 
 static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -4,8 +4,13 @@
 #include "duckdb/common/vector/map_vector.hpp"
 #include "duckdb/common/vector/union_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/strftime_format.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "json_common.hpp"
 #include "json_functions.hpp"
@@ -33,6 +38,18 @@ struct StructNames {
 		return result;
 	}
 
+	bool Equals(const StructNames &other) const {
+		if (values.size() != other.values.size()) {
+			return false;
+		}
+		for (const auto &kv : values) {
+			if (other.values.find(kv.first) == other.values.end()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 private:
 	unordered_map<string, unique_ptr<Vector>> values;
 };
@@ -52,6 +69,62 @@ public:
 public:
 	// Const struct name vectors live here so they don't have to be re-initialized for every DataChunk
 	StructNames const_struct_names;
+};
+
+struct JSONCopyFormatOptions {
+	optional_ptr<StrfTimeFormat> date_format;
+	optional_ptr<StrfTimeFormat> timestamp_format;
+	optional_ptr<ClientContext> context;
+	optional_ptr<const Expression> timestamptz_format_expression;
+};
+
+struct JSONCopyToJSONFunctionData : public FunctionData {
+public:
+	JSONCopyToJSONFunctionData(StructNames const_struct_names_p, bool has_date_format_p, string date_format_string_p,
+	                           StrfTimeFormat date_format_p, bool has_timestamp_format_p,
+	                           string timestamp_format_string_p, StrfTimeFormat timestamp_format_p,
+	                           unique_ptr<Expression> timestamptz_format_expression_p)
+	    : const_struct_names(std::move(const_struct_names_p)), has_date_format(has_date_format_p),
+	      date_format_string(std::move(date_format_string_p)), date_format(std::move(date_format_p)),
+	      has_timestamp_format(has_timestamp_format_p), timestamp_format_string(std::move(timestamp_format_string_p)),
+	      timestamp_format(std::move(timestamp_format_p)),
+	      timestamptz_format_expression(std::move(timestamptz_format_expression_p)) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<JSONCopyToJSONFunctionData>(
+		    const_struct_names.Copy(), has_date_format, date_format_string, date_format, has_timestamp_format,
+		    timestamp_format_string, timestamp_format,
+		    timestamptz_format_expression ? timestamptz_format_expression->Copy() : nullptr);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<JSONCopyToJSONFunctionData>();
+		return has_date_format == other.has_date_format && has_timestamp_format == other.has_timestamp_format &&
+		       date_format_string == other.date_format_string &&
+		       timestamp_format_string == other.timestamp_format_string &&
+		       const_struct_names.Equals(other.const_struct_names);
+	}
+
+	JSONCopyFormatOptions GetFormatOptions(ClientContext &context) {
+		JSONCopyFormatOptions result;
+		result.date_format = has_date_format ? optional_ptr<StrfTimeFormat>(&date_format) : nullptr;
+		result.timestamp_format = has_timestamp_format ? optional_ptr<StrfTimeFormat>(&timestamp_format) : nullptr;
+		result.context = context;
+		result.timestamptz_format_expression =
+		    timestamptz_format_expression ? optional_ptr<const Expression>(timestamptz_format_expression.get()) : nullptr;
+		return result;
+	}
+
+public:
+	StructNames const_struct_names;
+	bool has_date_format;
+	string date_format_string;
+	StrfTimeFormat date_format;
+	bool has_timestamp_format;
+	string timestamp_format_string;
+	StrfTimeFormat timestamp_format;
+	unique_ptr<Expression> timestamptz_format_expression;
 };
 
 static LogicalType GetJSONType(StructNames &const_struct_names, const LogicalType &type) {
@@ -208,6 +281,82 @@ static unique_ptr<FunctionData> RowToJSONBind(BindScalarFunctionInput &input) {
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
 
+static bool BindJSONCopyFormat(ClientContext &context, Expression &argument, const string &name, string &format_string,
+                               StrfTimeFormat &format) {
+	if (argument.HasParameter()) {
+		throw ParameterNotResolvedException();
+	}
+	if (!argument.IsFoldable()) {
+		throw InvalidInputException(argument, "json_copy_to_json %s format must be a constant", name);
+	}
+	auto value = ExpressionExecutor::EvaluateScalar(context, argument);
+	if (value.IsNull()) {
+		return false;
+	}
+	if (value.type().id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("json_copy_to_json %s format must be VARCHAR or NULL", name);
+	}
+	format_string = StringValue::Get(value);
+	auto error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+	if (!error.empty()) {
+		throw InvalidInputException(argument, "Failed to parse format specifier %s: %s", format_string, error);
+	}
+	return true;
+}
+
+static unique_ptr<Expression> BindJSONCopyTimestampTZFormatter(ClientContext &context, const string &format_string) {
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType::TIMESTAMP_TZ, 0));
+	children.push_back(make_uniq<BoundConstantExpression>(Value(format_string)));
+
+	FunctionBinder function_binder(context);
+	ErrorData error;
+	auto result =
+	    function_binder.BindScalarFunction(Identifier::DefaultSchema(), "strftime", std::move(children), error);
+	if (!result) {
+		error.Throw();
+	}
+	return result;
+}
+
+static unique_ptr<FunctionData> JSONCopyToJSONBind(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+	if (arguments.size() != 3) {
+		throw BinderException("json_copy_to_json() takes exactly three arguments");
+	}
+	if (arguments[0]->HasParameter()) {
+		throw ParameterNotResolvedException();
+	}
+
+	StructNames const_struct_names;
+	auto &bound_arguments = bound_function.GetArguments();
+	bound_arguments.clear();
+	bound_arguments.push_back(GetJSONType(const_struct_names, arguments[0]->GetReturnType()));
+	bound_arguments.push_back(LogicalType::VARCHAR);
+	bound_arguments.push_back(LogicalType::VARCHAR);
+
+	StrfTimeFormat date_format;
+	StrfTimeFormat timestamp_format;
+	string date_format_string;
+	string timestamp_format_string;
+	auto has_date_format =
+	    BindJSONCopyFormat(context, *arguments[1], "date", date_format_string, date_format);
+	auto has_timestamp_format =
+	    BindJSONCopyFormat(context, *arguments[2], "timestamp", timestamp_format_string, timestamp_format);
+
+	unique_ptr<Expression> timestamptz_format_expression;
+	if (has_timestamp_format) {
+		timestamptz_format_expression = BindJSONCopyTimestampTZFormatter(context, timestamp_format_string);
+	}
+
+	return make_uniq<JSONCopyToJSONFunctionData>(
+	    std::move(const_struct_names), has_date_format, std::move(date_format_string), std::move(date_format),
+	    has_timestamp_format, std::move(timestamp_format_string), std::move(timestamp_format),
+	    std::move(timestamptz_format_expression));
+}
+
 template <class INPUT_TYPE, class RESULT_TYPE>
 struct CreateJSONValue {
 	static inline RESULT_TYPE Operation(const INPUT_TYPE &input) {
@@ -280,7 +429,7 @@ inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const string
 
 // Forward declaration so we can recurse for nested types
 static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                         idx_t count);
+                         idx_t count, const JSONCopyFormatOptions &options = JSONCopyFormatOptions());
 
 static void AddKeyValuePairs(yyjson_mut_doc *doc, yyjson_mut_val *objs[], const Vector &key_v, yyjson_mut_val *vals[],
                              idx_t count) {
@@ -296,8 +445,9 @@ static void AddKeyValuePairs(yyjson_mut_doc *doc, yyjson_mut_val *objs[], const 
 }
 
 static void CreateKeyValuePairs(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *objs[],
-                                yyjson_mut_val *vals[], const Vector &key_v, Vector &value_v, idx_t count) {
-	CreateValues(names, doc, vals, value_v, count);
+                                yyjson_mut_val *vals[], const Vector &key_v, Vector &value_v, idx_t count,
+                                const JSONCopyFormatOptions &options = JSONCopyFormatOptions()) {
+	CreateValues(names, doc, vals, value_v, count, options);
 	AddKeyValuePairs(doc, objs, key_v, vals, count);
 }
 
@@ -343,8 +493,8 @@ static void CreateRawValues(yyjson_mut_doc *doc, yyjson_mut_val *vals[], const V
 	}
 }
 
-static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                               idx_t count) {
+static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[],
+                               Vector &value_v, idx_t count, const JSONCopyFormatOptions &options) {
 	// Structs become values, therefore we initialize vals to JSON values
 	for (idx_t i = 0; i < count; i++) {
 		vals[i] = yyjson_mut_obj(doc);
@@ -357,7 +507,7 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 	for (idx_t entry_i = 0; entry_i < entries.size(); entry_i++) {
 		auto &struct_key_v = names.Get(StructType::GetChildName(value_v.GetType(), entry_i).GetIdentifierName(), count);
 		auto &struct_val_v = entries[entry_i];
-		CreateKeyValuePairs(names, doc, vals, nested_vals, struct_key_v, struct_val_v, count);
+		CreateKeyValuePairs(names, doc, vals, nested_vals, struct_key_v, struct_val_v, count, options);
 	}
 	// Whole struct can be NULL
 	UnifiedVectorFormat struct_data;
@@ -371,7 +521,7 @@ static void CreateValuesStruct(const StructNames &names, yyjson_mut_doc *doc, yy
 }
 
 static void CreateValuesMap(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                            idx_t count) {
+                            idx_t count, const JSONCopyFormatOptions &options) {
 	// Create nested keys
 	auto &map_key_v = MapVector::GetKeys(value_v);
 	auto map_key_count = ListVector::GetListSize(value_v);
@@ -383,7 +533,7 @@ static void CreateValuesMap(const StructNames &names, yyjson_mut_doc *doc, yyjso
 	auto &map_val_v = MapVector::GetValues(value_v);
 	auto map_val_count = ListVector::GetListSize(value_v);
 	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, map_val_count);
-	CreateValues(names, doc, nested_vals, map_val_v, map_val_count);
+	CreateValues(names, doc, nested_vals, map_val_v, map_val_count, options);
 	// Add the key/value pairs to the values
 	UnifiedVectorFormat map_data;
 	value_v.ToUnifiedFormat(map_data);
@@ -407,7 +557,7 @@ static void CreateValuesMap(const StructNames &names, yyjson_mut_doc *doc, yyjso
 }
 
 static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                              idx_t count) {
+                              idx_t count, const JSONCopyFormatOptions &options) {
 	// Structs become values, therefore we initialize vals to JSON values
 	UnifiedVectorFormat value_data;
 	value_v.ToUnifiedFormat(value_data);
@@ -443,7 +593,7 @@ static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyj
 		// This implementation is not optimal since we convert the entire member vector,
 		// and then skip the rows not matching the tag afterwards.
 
-		CreateValues(names, doc, nested_vals, member_val_v, count);
+		CreateValues(names, doc, nested_vals, member_val_v, count, options);
 
 		// This is a inlined copy of AddKeyValuePairs but we also skip null tags
 		// and the rows where the member is not matching the tag
@@ -476,13 +626,13 @@ static void CreateValuesUnion(const StructNames &names, yyjson_mut_doc *doc, yyj
 }
 
 static void CreateValuesList(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                             idx_t count) {
+                             idx_t count, const JSONCopyFormatOptions &options) {
 	// Initialize array for the nested values
 	auto &child_v = ListVector::GetChildMutable(value_v);
 	auto child_count = ListVector::GetListSize(value_v);
 	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, child_count);
 	// Fill nested_vals with list values
-	CreateValues(names, doc, nested_vals, child_v, child_count);
+	CreateValues(names, doc, nested_vals, child_v, child_count, options);
 	// Now we add the values to the appropriate JSON arrays
 	UnifiedVectorFormat list_data;
 	value_v.ToUnifiedFormat(list_data);
@@ -502,7 +652,7 @@ static void CreateValuesList(const StructNames &names, yyjson_mut_doc *doc, yyjs
 }
 
 static void CreateValuesArray(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                              idx_t count) {
+                              idx_t count, const JSONCopyFormatOptions &options) {
 	value_v.Flatten();
 
 	// Initialize array for the nested values
@@ -512,7 +662,7 @@ static void CreateValuesArray(const StructNames &names, yyjson_mut_doc *doc, yyj
 
 	auto nested_vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, child_count);
 	// Fill nested_vals with list values
-	CreateValues(names, doc, nested_vals, child_v, child_count);
+	CreateValues(names, doc, nested_vals, child_v, child_count, options);
 	// Now we add the values to the appropriate JSON arrays
 	UnifiedVectorFormat list_data;
 	value_v.ToUnifiedFormat(list_data);
@@ -530,8 +680,57 @@ static void CreateValuesArray(const StructNames &names, yyjson_mut_doc *doc, yyj
 	}
 }
 
+static void CreateValuesFromDefaultCast(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count) {
+	Vector string_vector(LogicalTypeId::VARCHAR, count);
+	VectorOperations::DefaultCast(value_v, string_vector, count);
+	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
+static void CreateValuesDate(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                             const JSONCopyFormatOptions &options) {
+	if (!options.date_format) {
+		CreateValuesFromDefaultCast(doc, vals, value_v, count);
+		return;
+	}
+	Vector string_vector(LogicalType::VARCHAR, count);
+	options.date_format->ConvertDateVector(value_v, string_vector);
+	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
+static void CreateValuesTimestamp(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                  const JSONCopyFormatOptions &options) {
+	if (!options.timestamp_format) {
+		CreateValuesFromDefaultCast(doc, vals, value_v, count);
+		return;
+	}
+	Vector string_vector(LogicalType::VARCHAR, count);
+	options.timestamp_format->ConvertTimestampVector(value_v, string_vector);
+	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
+static void CreateValuesTimestampTZ(yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v, idx_t count,
+                                    const JSONCopyFormatOptions &options) {
+	if (!options.timestamp_format) {
+		CreateValuesFromDefaultCast(doc, vals, value_v, count);
+		return;
+	}
+	if (!options.context || !options.timestamptz_format_expression) {
+		throw InternalException("Missing bound TIMESTAMPTZ formatter for JSON COPY");
+	}
+
+	DataChunk input;
+	input.InitializeEmpty({value_v.GetType()});
+	input.data[0].Reference(value_v);
+	input.CheckCardinality(count);
+
+	Vector string_vector(LogicalType::VARCHAR, count);
+	ExpressionExecutor executor(*options.context, *options.timestamptz_format_expression);
+	executor.ExecuteExpression(input, string_vector);
+	TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+}
+
 static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
-                         idx_t count) {
+                         idx_t count, const JSONCopyFormatOptions &options) {
 	const auto &type = value_v.GetType();
 	switch (type.id()) {
 	case LogicalTypeId::SQLNULL:
@@ -580,40 +779,44 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 		TemplatedCreateValues<string_t, string_t>(doc, vals, value_v, count);
 		break;
 	case LogicalTypeId::STRUCT:
-		CreateValuesStruct(names, doc, vals, value_v, count);
+		CreateValuesStruct(names, doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::MAP:
-		CreateValuesMap(names, doc, vals, value_v, count);
+		CreateValuesMap(names, doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::LIST:
-		CreateValuesList(names, doc, vals, value_v, count);
+		CreateValuesList(names, doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::UNION:
-		CreateValuesUnion(names, doc, vals, value_v, count);
+		CreateValuesUnion(names, doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::ARRAY:
-		CreateValuesArray(names, doc, vals, value_v, count);
+		CreateValuesArray(names, doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::DATE:
+		CreateValuesDate(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		CreateValuesTimestamp(doc, vals, value_v, count, options);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		CreateValuesTimestampTZ(doc, vals, value_v, count, options);
 		break;
 	case LogicalTypeId::BIT:
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::LEGACY_AGGREGATE_STATE:
 	case LogicalTypeId::ENUM:
-	case LogicalTypeId::DATE:
 	case LogicalTypeId::INTERVAL:
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIME_NS:
 	case LogicalTypeId::TIME_TZ:
-	case LogicalTypeId::TIMESTAMP:
-	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIMESTAMP_TZ_NS:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::GEOMETRY: {
-		Vector string_vector(LogicalTypeId::VARCHAR, count);
-		VectorOperations::DefaultCast(value_v, string_vector, count);
-		TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
+		CreateValuesFromDefaultCast(doc, vals, value_v, count);
 		break;
 	}
 	case LogicalTypeId::BIGNUM: {
@@ -712,11 +915,12 @@ static void ArrayFunction(DataChunk &args, ExpressionState &state, Vector &resul
 }
 
 static void ToJSONFunctionInternal(const StructNames &names, Vector &input, const idx_t count, Vector &result,
-                                   yyjson_alc *alc) {
+                                   yyjson_alc *alc,
+                                   const JSONCopyFormatOptions &options = JSONCopyFormatOptions()) {
 	// Initialize array for values
 	auto doc = JSONCommon::CreateDocument(alc);
 	auto vals = JSONCommon::AllocateArray<yyjson_mut_val *>(doc, count);
-	CreateValues(names, doc, vals, input, count);
+	CreateValues(names, doc, vals, input, count, options);
 
 	// Write JSON values to string
 	auto objects = FlatVector::GetDataMutable<string_t>(result);
@@ -748,6 +952,16 @@ static void ToJSONFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc);
 }
 
+static void JSONCopyToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &info = func_expr.BindInfo()->Cast<JSONCopyToJSONFunctionData>();
+	auto &lstate = JSONFunctionLocalState::ResetAndGet(state);
+	auto alc = lstate.json_allocator->GetYYAlc();
+	auto options = info.GetFormatOptions(state.GetContext());
+
+	ToJSONFunctionInternal(info.const_struct_names, args.data[0], args.size(), result, alc, options);
+}
+
 ScalarFunctionSet JSONFunctions::GetObjectFunction() {
 	ScalarFunction fun("json_object", {}, LogicalType::JSON(), ObjectFunction, JSONObjectBind, nullptr,
 	                   JSONFunctionLocalState::Init);
@@ -768,6 +982,14 @@ ScalarFunctionSet JSONFunctions::GetToJSONFunction() {
 	ScalarFunction fun("to_json", {}, LogicalType::JSON(), ToJSONFunction, ToJSONBind, nullptr,
 	                   JSONFunctionLocalState::Init);
 	fun.SetVarArgs(LogicalType::ANY);
+	return ScalarFunctionSet(fun);
+}
+
+ScalarFunctionSet JSONFunctions::GetJSONCopyToJSONFunction() {
+	ScalarFunction fun("json_copy_to_json", {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::JSON(), JSONCopyToJSONFunction, JSONCopyToJSONBind, nullptr,
+	                   JSONFunctionLocalState::Init);
+	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return ScalarFunctionSet(fun);
 }
 

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -55,6 +55,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"@>", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"^", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"^@", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"__internal_json_copy_to_json", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"abs", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"acos", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"acosh", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -395,7 +395,6 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"json_contains", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_copy_strftime_if_date", "json", CatalogType::MACRO_ENTRY},
     {"json_copy_strftime_if_timestamp", "json", CatalogType::MACRO_ENTRY},
-    {"json_copy_to_json", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_deep_merge", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_deserialize_sql", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_each", "json", CatalogType::TABLE_FUNCTION_ENTRY},

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -395,6 +395,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"json_contains", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_copy_strftime_if_date", "json", CatalogType::MACRO_ENTRY},
     {"json_copy_strftime_if_timestamp", "json", CatalogType::MACRO_ENTRY},
+    {"json_copy_to_json", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_deep_merge", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_deserialize_sql", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_each", "json", CatalogType::TABLE_FUNCTION_ENTRY},

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -23,6 +23,12 @@
       "paths": [
         "test/sql/secrets/secret_autoloading_errors.test"
       ]
+    },
+    {
+      "reason": "COPY TO local paths requires LocalFileSystem during binding/planning",
+      "paths": [
+        "test/sql/json/test_json_copy_serialize_plan.test"
+      ]
     }
   ]
 }

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -248,6 +248,98 @@ select ts from '{TEMP_DIR}/my_file.json';
 ----
 2026-01-01 +00
 
+# issue #23152: COPY JSON dateformat/timestampformat should apply inside nested JSON values
+statement ok
+COPY (
+    SELECT
+        DATE '2026-01-02' AS d,
+        {'d': DATE '2026-01-02'} AS payload,
+        [DATE '2026-01-02'] AS date_list
+) TO '{TEMP_DIR}/nested_dateformat.json' (FORMAT JSON, dateformat '%d/%m/%Y');
+
+query III
+SELECT
+    json_extract_string(json, '$.d') AS top_level,
+    json_extract_string(json, '$.payload.d') AS nested_struct,
+    json_extract_string(json, '$.date_list[0]') AS nested_list
+FROM read_json_objects('{TEMP_DIR}/nested_dateformat.json');
+----
+02/01/2026	02/01/2026	02/01/2026
+
+statement ok
+COPY (
+    SELECT
+        TIMESTAMP '2026-01-02 03:04:05' AS ts,
+        {'ts': TIMESTAMP '2026-01-02 03:04:05'} AS payload,
+        TIMESTAMPTZ '2026-01-02 03:04:05+00' AS tstz,
+        {'tstz': TIMESTAMPTZ '2026-01-02 03:04:05+00'} AS payload_tz
+) TO '{TEMP_DIR}/nested_timestampformat.json' (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M');
+
+query II
+SELECT
+    json_extract_string(json, '$.ts') AS top_level_ts,
+    json_extract_string(json, '$.payload.ts') AS nested_ts
+FROM read_json_objects('{TEMP_DIR}/nested_timestampformat.json');
+----
+2026/01/02 03:04	2026/01/02 03:04
+
+query II
+WITH copied AS (
+    SELECT json FROM read_json_objects('{TEMP_DIR}/nested_timestampformat.json')
+),
+expected AS (
+    SELECT strftime(TIMESTAMPTZ '2026-01-02 03:04:05+00', '%Y/%m/%d %H:%M') AS formatted
+)
+SELECT
+    json_extract_string(json, '$.tstz') = formatted AS top_level_tstz_matches,
+    json_extract_string(json, '$.payload_tz.tstz') = formatted AS nested_tstz_matches
+FROM copied, expected;
+----
+true	true
+
+statement ok
+COPY (
+    SELECT
+        TIMESTAMP_NS '2026-01-02 03:04:05.123456789' AS ts_ns,
+        TIMESTAMP_MS '2026-01-02 03:04:05.123' AS ts_ms,
+        TIMESTAMP_S '2026-01-02 03:04:05' AS ts_s,
+        TIME '03:04:05' AS t
+) TO '{TEMP_DIR}/timestampformat_unchanged_types.json' (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M');
+
+query IIII
+SELECT
+    json_extract_string(json, '$.ts_ns') AS ts_ns,
+    json_extract_string(json, '$.ts_ms') AS ts_ms,
+    json_extract_string(json, '$.ts_s') AS ts_s,
+    json_extract_string(json, '$.t') AS t
+FROM read_json_objects('{TEMP_DIR}/timestampformat_unchanged_types.json');
+----
+2026-01-02 03:04:05.123456789	2026-01-02 03:04:05.123	2026-01-02 03:04:05	03:04:05
+
+statement ok
+COPY (
+    SELECT DATE '2026-01-02' AS d, {'d': DATE '2026-01-02'} AS payload, 42 AS v
+) TO '{TEMP_DIR}/nested_dateformat_partition'
+  (FORMAT JSON, PARTITION_BY (d), WRITE_PARTITION_COLUMNS, dateformat '%d/%m/%Y');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/nested_dateformat_partition/*/*.json') ORDER BY filename;
+----
+{TEMP_DIR}/nested_dateformat_partition/d=02%2F01%2F2026/data_0.json	{"d":"02/01/2026","payload":{"d":"02/01/2026"},"v":42}
+
+statement ok
+COPY (
+    SELECT DATE '2026-01-02' AS d, {'d': DATE '2026-01-02'} AS payload, 42 AS v
+) TO '{TEMP_DIR}/nested_dateformat_partition_excluded'
+  (FORMAT JSON, PARTITION_BY (d), dateformat '%d/%m/%Y');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/nested_dateformat_partition_excluded/*/*.json') ORDER BY filename;
+----
+{TEMP_DIR}/nested_dateformat_partition_excluded/d=02%2F01%2F2026/data_0.json	{"payload":{"d":"02/01/2026"},"v":42}
+
 # invalid timestampformat must produce a clear error
 statement ok
 CREATE TABLE t (ts TIMESTAMP[])

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -318,6 +318,24 @@ FROM read_json_objects('{TEMP_DIR}/timestampformat_timestamp_variants.json');
 
 statement ok
 COPY (
+    SELECT
+        '2026-01-02 03:04:05.123456789+00'::TIMESTAMPTZ_NS AS tstz_ns,
+        {'tstz_ns': '2026-01-02 03:04:05.123456789+00'::TIMESTAMPTZ_NS} AS payload_tz_ns,
+        ['2026-01-02 03:04:05.123456789+00'::TIMESTAMPTZ_NS] AS tstz_ns_list
+) TO '{TEMP_DIR}/timestampformat_timestamptz_ns.json'
+  (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query III
+SELECT
+    json_extract_string(json, '$.tstz_ns') AS top_level_tstz_ns,
+    json_extract_string(json, '$.payload_tz_ns.tstz_ns') AS nested_tstz_ns,
+    json_extract_string(json, '$.tstz_ns_list[0]') AS list_tstz_ns
+FROM read_json_objects('{TEMP_DIR}/timestampformat_timestamptz_ns.json');
+----
+2026/01/02 03:04:05.123456789	2026/01/02 03:04:05.123456789	2026/01/02 03:04:05.123456789
+
+statement ok
+COPY (
     SELECT DATE '2026-01-02' AS d, {'d': DATE '2026-01-02'} AS payload, 42 AS v
 ) TO '{TEMP_DIR}/nested_dateformat_partition'
   (FORMAT JSON, PARTITION_BY (d), WRITE_PARTITION_COLUMNS, dateformat '%d/%m/%Y');
@@ -339,6 +357,18 @@ SELECT filename, trim(content, chr(10))
 FROM read_text('{TEMP_DIR}/nested_dateformat_partition_excluded/*/*.json') ORDER BY filename;
 ----
 {TEMP_DIR}/nested_dateformat_partition_excluded/d=02%2F01%2F2026/data_0.json	{"payload":{"d":"02/01/2026"},"v":42}
+
+statement ok
+COPY (
+    SELECT '2026-01-02 03:04:05.123456789+00'::TIMESTAMPTZ_NS AS ts, 42 AS v
+) TO '{TEMP_DIR}/timestamptz_ns_partition'
+  (FORMAT JSON, PARTITION_BY (ts), WRITE_PARTITION_COLUMNS, timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/timestamptz_ns_partition/*/*.json') ORDER BY filename;
+----
+{TEMP_DIR}/timestamptz_ns_partition/ts=2026%2F01%2F02%2003%3A04%3A05.123456789/data_0.json	{"ts":"2026/01/02 03:04:05.123456789","v":42}
 
 # invalid timestampformat must produce a clear error
 statement ok

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -304,7 +304,7 @@ COPY (
         TIMESTAMP_MS '2026-01-02 03:04:05.123' AS ts_ms,
         TIMESTAMP_S '2026-01-02 03:04:05' AS ts_s,
         TIME '03:04:05' AS t
-) TO '{TEMP_DIR}/timestampformat_unchanged_types.json' (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M');
+) TO '{TEMP_DIR}/timestampformat_timestamp_variants.json' (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M');
 
 query IIII
 SELECT
@@ -312,9 +312,9 @@ SELECT
     json_extract_string(json, '$.ts_ms') AS ts_ms,
     json_extract_string(json, '$.ts_s') AS ts_s,
     json_extract_string(json, '$.t') AS t
-FROM read_json_objects('{TEMP_DIR}/timestampformat_unchanged_types.json');
+FROM read_json_objects('{TEMP_DIR}/timestampformat_timestamp_variants.json');
 ----
-2026-01-02 03:04:05.123456789	2026-01-02 03:04:05.123	2026-01-02 03:04:05	03:04:05
+2026/01/02 03:04	2026/01/02 03:04	2026/01/02 03:04	03:04:05
 
 statement ok
 COPY (

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -370,6 +370,18 @@ FROM read_text('{TEMP_DIR}/timestamptz_ns_partition/*/*.json') ORDER BY filename
 ----
 {TEMP_DIR}/timestamptz_ns_partition/ts=2026%2F01%2F02%2003%3A04%3A05.123456789/data_0.json	{"ts":"2026/01/02 03:04:05.123456789","v":42}
 
+statement ok
+COPY (
+    SELECT TIMESTAMP_NS '2026-01-02 03:04:05.123456789' AS ts, 42 AS v
+) TO '{TEMP_DIR}/timestamp_ns_partition'
+  (FORMAT JSON, PARTITION_BY (ts), WRITE_PARTITION_COLUMNS, timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query II
+SELECT filename, trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/timestamp_ns_partition/*/*.json') ORDER BY filename;
+----
+{TEMP_DIR}/timestamp_ns_partition/ts=2026%2F01%2F02%2003%3A04%3A05.123456789/data_0.json	{"ts":"2026/01/02 03:04:05.123456789","v":42}
+
 # invalid timestampformat must produce a clear error
 statement ok
 CREATE TABLE t (ts TIMESTAMP[])

--- a/test/sql/json/table/read_json_dates.test
+++ b/test/sql/json/table/read_json_dates.test
@@ -336,6 +336,28 @@ FROM read_json_objects('{TEMP_DIR}/timestampformat_timestamptz_ns.json');
 
 statement ok
 COPY (
+    SELECT map([DATE '2026-01-02'], [DATE '2026-01-03']) AS m
+) TO '{TEMP_DIR}/map_key_dateformat.json' (FORMAT JSON, dateformat '%d/%m/%Y');
+
+query I
+SELECT trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/map_key_dateformat.json');
+----
+{"m":{"02/01/2026":"03/01/2026"}}
+
+statement ok
+COPY (
+    SELECT map([TIMESTAMP_NS '2026-01-02 03:04:05.123456789'], [1]) AS m
+) TO '{TEMP_DIR}/map_key_timestamp_ns_format.json' (FORMAT JSON, timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query I
+SELECT trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/map_key_timestamp_ns_format.json');
+----
+{"m":{"2026/01/02 03:04:05.123456789":1}}
+
+statement ok
+COPY (
     SELECT DATE '2026-01-02' AS d, {'d': DATE '2026-01-02'} AS payload, 42 AS v
 ) TO '{TEMP_DIR}/nested_dateformat_partition'
   (FORMAT JSON, PARTITION_BY (d), WRITE_PARTITION_COLUMNS, dateformat '%d/%m/%Y');

--- a/test/sql/json/test_json_copy_serialize_plan.test
+++ b/test/sql/json/test_json_copy_serialize_plan.test
@@ -1,0 +1,38 @@
+# name: test/sql/json/test_json_copy_serialize_plan.test
+# group: [json]
+
+require json
+
+query I
+SELECT json_extract_string(
+    json_serialize_plan('COPY (SELECT DATE ''2026-01-02'' AS d) TO ''{TEMP_DIR}/serialize_copy_date'' (FORMAT JSON, dateformat ''%d/%m/%Y'')'),
+    '$.error'
+);
+----
+false
+
+query I
+SELECT json_extract_string(
+    json_serialize_plan('COPY (SELECT ''2026-01-02 03:04:05.123456789+00''::TIMESTAMPTZ_NS AS ts) TO ''{TEMP_DIR}/serialize_copy_tstz_ns'' (FORMAT JSON, timestampformat ''%Y/%m/%d %H:%M:%S.%n'')'),
+    '$.error'
+);
+----
+false
+
+statement ok
+SET debug_verify_serializer=true;
+
+statement ok
+COPY (
+    SELECT {'d': DATE '2026-01-02', 'ts': TIMESTAMP_NS '2026-01-02 03:04:05.123456789'} AS payload
+) TO '{TEMP_DIR}/serialize_copy_nested_payload.json'
+  (FORMAT JSON, dateformat '%d/%m/%Y', timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query I
+SELECT trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/serialize_copy_nested_payload.json')
+----
+{"payload":{"d":"02/01/2026","ts":"2026/01/02 03:04:05.123456789"}}
+
+statement ok
+SET debug_verify_serializer=false;

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -49,37 +49,3 @@ true
 
 statement ok
 select json_serialize_plan('select blob ''\\x00''');
-
-query I
-SELECT json_extract_string(
-    json_serialize_plan('COPY (SELECT DATE ''2026-01-02'' AS d) TO ''{TEMP_DIR}/serialize_copy_date'' (FORMAT JSON, dateformat ''%d/%m/%Y'')'),
-    '$.error'
-);
-----
-false
-
-query I
-SELECT json_extract_string(
-    json_serialize_plan('COPY (SELECT ''2026-01-02 03:04:05.123456789+00''::TIMESTAMPTZ_NS AS ts) TO ''{TEMP_DIR}/serialize_copy_tstz_ns'' (FORMAT JSON, timestampformat ''%Y/%m/%d %H:%M:%S.%n'')'),
-    '$.error'
-);
-----
-false
-
-statement ok
-SET debug_verify_serializer=true;
-
-statement ok
-COPY (
-    SELECT {'d': DATE '2026-01-02', 'ts': TIMESTAMP_NS '2026-01-02 03:04:05.123456789'} AS payload
-) TO '{TEMP_DIR}/serialize_copy_nested_payload.json'
-  (FORMAT JSON, dateformat '%d/%m/%Y', timestampformat '%Y/%m/%d %H:%M:%S.%n');
-
-query I
-SELECT trim(content, chr(10))
-FROM read_text('{TEMP_DIR}/serialize_copy_nested_payload.json')
-----
-{"payload":{"d":"02/01/2026","ts":"2026/01/02 03:04:05.123456789"}}
-
-statement ok
-SET debug_verify_serializer=false;

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -3,6 +3,16 @@
 
 require json
 
+statement error
+SELECT json_copy_to_json({'d': DATE '2026-01-02'}, '%d/%m/%Y', NULL);
+----
+<REGEX>:Catalog Error:.*json_copy_to_json.*
+
+statement error
+SELECT __internal_json_copy_to_json({'d': DATE '2026-01-02'}, '%d/%m/%Y', NULL);
+----
+<REGEX>:Binder Error:.*internal use only.*
+
 statement ok
 CREATE TABLE tbl1 (i int);
 
@@ -39,3 +49,37 @@ true
 
 statement ok
 select json_serialize_plan('select blob ''\\x00''');
+
+query I
+SELECT json_extract_string(
+    json_serialize_plan('COPY (SELECT DATE ''2026-01-02'' AS d) TO ''{TEMP_DIR}/serialize_copy_date'' (FORMAT JSON, dateformat ''%d/%m/%Y'')'),
+    '$.error'
+);
+----
+false
+
+query I
+SELECT json_extract_string(
+    json_serialize_plan('COPY (SELECT ''2026-01-02 03:04:05.123456789+00''::TIMESTAMPTZ_NS AS ts) TO ''{TEMP_DIR}/serialize_copy_tstz_ns'' (FORMAT JSON, timestampformat ''%Y/%m/%d %H:%M:%S.%n'')'),
+    '$.error'
+);
+----
+false
+
+statement ok
+SET debug_verify_serializer=true;
+
+statement ok
+COPY (
+    SELECT {'d': DATE '2026-01-02', 'ts': TIMESTAMP_NS '2026-01-02 03:04:05.123456789'} AS payload
+) TO '{TEMP_DIR}/serialize_copy_nested_payload.json'
+  (FORMAT JSON, dateformat '%d/%m/%Y', timestampformat '%Y/%m/%d %H:%M:%S.%n');
+
+query I
+SELECT trim(content, chr(10))
+FROM read_text('{TEMP_DIR}/serialize_copy_nested_payload.json')
+----
+{"payload":{"d":"02/01/2026","ts":"2026/01/02 03:04:05.123456789"}}
+
+statement ok
+SET debug_verify_serializer=false;


### PR DESCRIPTION
Fixes #23152

This updates JSON COPY formatting so `dateformat` and `timestampformat` are applied by the recursive JSON serializer, including nested `STRUCT` and `LIST` values.

Partition path formatting remains handled by the existing COPY projection macros, so partition directory values keep the current behavior.

Validation:
- `DUCKDB_EXTENSIONS='json;icu' make reldebug`
- `build/reldebug/test/unittest test/sql/json/table/read_json_dates.test`