### PR TITLE
Step 6: Flip the switch and have delim join as CTEs by default

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -487,7 +487,7 @@
         "description": "Rewrite delim joins to materialized CTEs during dependent join flattening",
         "type": "BOOLEAN",
         "default_scope": "local",
-        "default_value": "false"
+        "default_value": "true"
     },
     {
         "name": "deprecated_using_key_syntax",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -776,7 +776,7 @@ struct DelimJoinAsCteSetting {
 	static constexpr const char *Description =
 	    "Rewrite delim joins to materialized CTEs during dependent join flattening";
 	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
+	static constexpr const char *DefaultValue = "true";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
@@ -722,46 +724,59 @@ public:
 				}
 			}
 
-			// Collect all subplan bindings, and figure out which subplan has the most outgoing bindings
-			idx_t max_subplan_idx = 0;
-			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size(); subplan_idx++) {
-				const auto &subplan_bindings = subplan_info.subplans[subplan_idx].canonical_bindings;
-				const auto &max_subplan_bindings = subplan_info.subplans[max_subplan_idx].canonical_bindings;
-				if (subplan_bindings.size() > max_subplan_bindings.size()) {
-					max_subplan_idx = subplan_idx;
-				}
-			}
-
-			// Move the "maximum subplan" to the front
-			std::swap(subplan_info.subplans[0], subplan_info.subplans[max_subplan_idx]);
-
 			// We can bail on a subplan for various reasons (some of which could potentially be fixed)
 			bool bail = false;
 
-			// Insert the bindings of the subplan with the most bindings into a set
-			column_binding_set_t max_subplan_column_binding_set;
-			for (auto &cb : subplan_info.subplans[0].canonical_bindings) {
-				if (max_subplan_column_binding_set.find(cb) != max_subplan_column_binding_set.end()) {
-					bail = true; // Subplan contains duplicate column bindings, i.e., another nested duplicate subplan
+			column_binding_set_t required_bindings;
+			for (auto &subplan : subplan_info.subplans) {
+				column_binding_set_t subplan_bindings;
+				for (auto &cb : subplan.canonical_bindings) {
+					if (subplan_bindings.find(cb) != subplan_bindings.end()) {
+						bail =
+						    true; // Subplan contains duplicate column bindings, i.e., another nested duplicate subplan
+						break;
+					}
+					subplan_bindings.insert(cb);
+					required_bindings.insert(cb);
+				}
+				if (bail) {
 					break;
 				}
-				max_subplan_column_binding_set.insert(cb);
 			}
 
-			// Check if the maximum subplan fully contains the column bindings of the other subplans
-			for (idx_t subplan_idx = 1; subplan_idx < subplan_info.subplans.size() && !bail; subplan_idx++) {
-				const auto &subplan_bindings = subplan_info.subplans[subplan_idx].canonical_bindings;
-				for (auto &cb : subplan_bindings) {
-					if (max_subplan_column_binding_set.find(cb) == max_subplan_column_binding_set.end()) {
-						bail = true; // Subplan does not fully contain the other subplans
+			idx_t primary_subplan_idx = subplan_info.subplans.size();
+			idx_t primary_subplan_binding_count = 0;
+			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size() && !bail; subplan_idx++) {
+				const auto expanded_bindings =
+				    GetExpandedCanonicalBindings(*subplan_info.subplans[subplan_idx].op.get());
+				bool contains_required_bindings = true;
+				for (auto &cb : required_bindings) {
+					if (std::find(expanded_bindings.begin(), expanded_bindings.end(), cb) == expanded_bindings.end()) {
+						contains_required_bindings = false;
 						break;
 					}
 				}
+				if (!contains_required_bindings) {
+					continue;
+				}
+				auto &subplan = subplan_info.subplans[subplan_idx];
+				if (primary_subplan_idx == subplan_info.subplans.size() ||
+				    subplan.canonical_bindings.size() > primary_subplan_binding_count) {
+					primary_subplan_idx = subplan_idx;
+					primary_subplan_binding_count = subplan.canonical_bindings.size();
+				}
+			}
+			if (primary_subplan_idx == subplan_info.subplans.size()) {
+				bail = true; // None of the subplans can expose every binding required by the duplicate occurrences
 			}
 
 			if (bail) {
 				to_remove.push_back(signature);
+				continue;
 			}
+
+			// Move the primary subplan to the front
+			std::swap(subplan_info.subplans[0], subplan_info.subplans[primary_subplan_idx]);
 		}
 
 		// Only remove them all at the end so the logic above doesn't get affected
@@ -788,17 +803,60 @@ public:
 			// Resolve types to be used for creating the materialized CTE and refs
 			op->ResolveOperatorTypes();
 
-			// Get types and names
 			const auto &primary_subplan = subplan_info.subplans[0];
-			const auto &types = primary_subplan.op.get()->types;
+
+			vector<vector<ColumnBinding>> old_bindings(subplan_info.subplans.size());
+			vector<vector<LogicalType>> old_types(subplan_info.subplans.size());
+			arena_vector<ColumnBinding> required_canonical_bindings(state.allocator);
+			column_binding_set_t required_canonical_binding_set;
+			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size(); subplan_idx++) {
+				auto &subplan = subplan_info.subplans[subplan_idx];
+				old_bindings[subplan_idx] = subplan.op.get()->GetColumnBindings();
+				old_types[subplan_idx] = subplan.op.get()->types;
+				for (auto &cb : subplan.canonical_bindings) {
+					if (required_canonical_binding_set.find(cb) != required_canonical_binding_set.end()) {
+						continue;
+					}
+					required_canonical_binding_set.insert(cb);
+					required_canonical_bindings.push_back(cb);
+				}
+			}
+
+			if (required_canonical_bindings.size() != primary_subplan.canonical_bindings.size()) {
+				// The signature ignores projection maps. If duplicate subplans expose different
+				// subsets of the same work, widen the materialized producer just enough to make
+				// every referenced output available, then project each reader back to its original
+				// schema below.
+				ClearProjectionMaps(*primary_subplan.op.get());
+				primary_subplan.op.get()->ResolveOperatorTypes();
+			}
+
+			const auto materialized_bindings = primary_subplan.op.get()->GetColumnBindings();
+			const auto materialized_canonical_bindings = GetCanonicalBindings(*primary_subplan.op.get());
+			column_binding_map_t<idx_t> materialized_binding_index;
+			for (idx_t i = 0; i < materialized_canonical_bindings.size(); i++) {
+				materialized_binding_index.emplace(materialized_canonical_bindings[i], i);
+			}
+
+			vector<LogicalType> types;
+			vector<ColumnBinding> materialized_output_bindings;
+			types.reserve(required_canonical_bindings.size());
+			materialized_output_bindings.reserve(required_canonical_bindings.size());
+			column_binding_map_t<idx_t> cte_binding_index;
+			for (idx_t i = 0; i < required_canonical_bindings.size(); i++) {
+				auto &cb = required_canonical_bindings[i];
+				const auto entry = materialized_binding_index.find(cb);
+				D_ASSERT(entry != materialized_binding_index.end()); // guaranteed by FilterSubplans
+				const auto materialized_col_idx = entry->second;
+				cte_binding_index.emplace(cb, i);
+				types.push_back(primary_subplan.op.get()->types[materialized_col_idx]);
+				materialized_output_bindings.push_back(materialized_bindings[materialized_col_idx]);
+			}
+
+			// Get names
 			vector<Identifier> col_names;
 			for (idx_t i = 0; i < types.size(); i++) {
 				col_names.emplace_back(StringUtil::Format("%s_col_%llu", cte_name, i + 1));
-			}
-			const auto &primary_subplan_bindings = primary_subplan.canonical_bindings;
-			column_binding_map_t<idx_t> primary_binding_index;
-			for (idx_t i = 0; i < primary_subplan_bindings.size(); i++) {
-				primary_binding_index.emplace(primary_subplan_bindings[i], i);
 			}
 			vector<vector<idx_t>> cte_column_indexes(subplan_info.subplans.size());
 			vector<bool> needs_projection(subplan_info.subplans.size(), false);
@@ -809,11 +867,11 @@ public:
 				needs_projection[subplan_idx] = canonical_bindings.size() != types.size();
 				for (idx_t i = 0; i < canonical_bindings.size(); i++) {
 					const auto &cb = canonical_bindings[i];
-					const auto entry = primary_binding_index.find(cb);
-					D_ASSERT(entry != primary_binding_index.end()); // guaranteed by FilterSubplans
+					const auto entry = cte_binding_index.find(cb);
+					D_ASSERT(entry != cte_binding_index.end()); // guaranteed by FilterSubplans
 					const auto cte_col_idx = entry->second;
 					// Types must match: same canonical binding = same base column = same type
-					D_ASSERT(subplan.op.get()->types[i] == types[cte_col_idx]);
+					D_ASSERT(old_types[subplan_idx][i] == types[cte_col_idx]);
 					cte_column_indexes[subplan_idx].push_back(cte_col_idx);
 					needs_projection[subplan_idx] = needs_projection[subplan_idx] || cte_col_idx != i;
 				}
@@ -829,11 +887,10 @@ public:
 				if (subplan.op.get()->has_estimated_cardinality) {
 					cte_refs.back()->SetEstimatedCardinality(subplan.op.get()->estimated_cardinality);
 				}
-				const auto old_bindings = subplan.op.get()->GetColumnBindings();
 				auto new_bindings = cte_refs.back()->GetColumnBindings();
 				if (needs_projection[subplan_idx]) {
 					// Preserve each subplan's original output order when it differs from the
-					// primary materialized CTE.
+					// materialized CTE.
 					vector<unique_ptr<Expression>> select_list;
 					for (auto cte_col_idx : cte_column_indexes[subplan_idx]) {
 						select_list.emplace_back(make_uniq<BoundColumnRefExpression>(
@@ -847,9 +904,9 @@ public:
 					cte_refs.back() = std::move(proj);
 					new_bindings = cte_refs.back()->GetColumnBindings();
 				}
-				D_ASSERT(old_bindings.size() == new_bindings.size());
-				for (idx_t i = 0; i < old_bindings.size(); i++) {
-					replacer.replacement_bindings.emplace_back(old_bindings[i], new_bindings[i]);
+				D_ASSERT(old_bindings[subplan_idx].size() == new_bindings.size());
+				for (idx_t i = 0; i < old_bindings[subplan_idx].size(); i++) {
+					replacer.replacement_bindings.emplace_back(old_bindings[subplan_idx][i], new_bindings[i]);
 				}
 			}
 
@@ -859,10 +916,9 @@ public:
 			auto materialized_subplan = std::move(primary_subplan.op.get());
 			auto remainder = std::move(lowest_common_ancestor);
 			vector<unique_ptr<Expression>> materialized_select_list;
-			const auto materialized_bindings = materialized_subplan->GetColumnBindings();
-			for (idx_t i = 0; i < materialized_bindings.size(); i++) {
+			for (idx_t i = 0; i < materialized_output_bindings.size(); i++) {
 				materialized_select_list.emplace_back(
-				    make_uniq<BoundColumnRefExpression>(types[i], materialized_bindings[i]));
+				    make_uniq<BoundColumnRefExpression>(types[i], materialized_output_bindings[i]));
 			}
 			auto materialized_projection = make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(),
 			                                                            std::move(materialized_select_list));
@@ -919,21 +975,8 @@ private:
 
 	arena_vector<ColumnBinding> GetCanonicalBindings(LogicalOperator &op) {
 		// Compute the canonical column bindings coming out of this operator for convenience later
-		const auto &table_index_map = state.table_index_map.GetMap();
 		const auto original_bindings = op.GetColumnBindings();
-		arena_vector<ColumnBinding> canonical_bindings(state.allocator);
-		for (idx_t col_idx = 0; col_idx < original_bindings.size(); col_idx++) {
-			auto &cb = original_bindings[col_idx];
-			const auto canonical_table_index = to_canonical_table_index.at(cb.table_index);
-			auto &table_map = table_index_map.at(cb.table_index);
-			if (table_map.Empty<ConversionType::TO_CANONICAL>()) {
-				canonical_bindings.emplace_back(canonical_table_index, cb.column_index);
-			} else {
-				const auto canonical_col_idx = table_map.Get<ConversionType::TO_CANONICAL>(cb.column_index);
-				canonical_bindings.emplace_back(canonical_table_index, canonical_col_idx);
-			}
-		}
-		return canonical_bindings;
+		return GetCanonicalBindings(original_bindings);
 	}
 
 	unique_ptr<LogicalOperator> &LowestCommonAncestor(reference<unique_ptr<LogicalOperator>> a,
@@ -964,6 +1007,86 @@ private:
 		}
 
 		return a.get();
+	}
+
+	vector<ColumnBinding> GetExpandedColumnBindings(LogicalOperator &op) {
+		switch (op.type) {
+		case LogicalOperatorType::LOGICAL_FILTER:
+		case LogicalOperatorType::LOGICAL_ORDER_BY:
+			return GetExpandedColumnBindings(*op.children[0]);
+		case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+		case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+			auto &join = op.Cast<LogicalJoin>();
+			auto left_bindings = GetExpandedColumnBindings(*op.children[0]);
+			if (join.join_type == JoinType::SEMI || join.join_type == JoinType::ANTI) {
+				return left_bindings;
+			}
+			if (join.join_type == JoinType::MARK) {
+				left_bindings.emplace_back(join.mark_index, ProjectionIndex(0));
+				return left_bindings;
+			}
+			auto right_bindings = GetExpandedColumnBindings(*op.children[1]);
+			if (join.join_type == JoinType::RIGHT_SEMI || join.join_type == JoinType::RIGHT_ANTI) {
+				return right_bindings;
+			}
+			left_bindings.insert(left_bindings.end(), right_bindings.begin(), right_bindings.end());
+			return left_bindings;
+		}
+		case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN: {
+			auto left_bindings = GetExpandedColumnBindings(*op.children[0]);
+			auto right_bindings = GetExpandedColumnBindings(*op.children[1]);
+			left_bindings.insert(left_bindings.end(), right_bindings.begin(), right_bindings.end());
+			return left_bindings;
+		}
+		default:
+			return op.GetColumnBindings();
+		}
+	}
+
+	arena_vector<ColumnBinding> GetCanonicalBindings(const vector<ColumnBinding> &original_bindings) {
+		const auto &table_index_map = state.table_index_map.GetMap();
+		arena_vector<ColumnBinding> canonical_bindings(state.allocator);
+		for (auto &cb : original_bindings) {
+			const auto canonical_table_index = to_canonical_table_index.at(cb.table_index);
+			auto &table_map = table_index_map.at(cb.table_index);
+			if (table_map.Empty<ConversionType::TO_CANONICAL>()) {
+				canonical_bindings.emplace_back(canonical_table_index, cb.column_index);
+			} else {
+				const auto canonical_col_idx = table_map.Get<ConversionType::TO_CANONICAL>(cb.column_index);
+				canonical_bindings.emplace_back(canonical_table_index, canonical_col_idx);
+			}
+		}
+		return canonical_bindings;
+	}
+
+	arena_vector<ColumnBinding> GetExpandedCanonicalBindings(LogicalOperator &op) {
+		return GetCanonicalBindings(GetExpandedColumnBindings(op));
+	}
+
+	static void ClearProjectionMaps(LogicalOperator &op) {
+		switch (op.type) {
+		case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+		case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+			auto &join = op.Cast<LogicalJoin>();
+			join.left_projection_map.clear();
+			join.right_projection_map.clear();
+			break;
+		}
+		case LogicalOperatorType::LOGICAL_FILTER:
+			op.Cast<LogicalFilter>().projection_map.clear();
+			break;
+		case LogicalOperatorType::LOGICAL_ORDER_BY:
+			op.Cast<LogicalOrder>().projection_map.clear();
+			break;
+		default:
+			break;
+		}
+		for (auto &child : op.children) {
+			ClearProjectionMaps(*child);
+		}
 	}
 
 	bool ShouldMaterialize(const SubplanInfo &subplan_info) const {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -366,12 +366,16 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			}
 		}
 
-		// A materialized CTE returns the RHS/continuation columns. If a parent already registered explicit references
-		// to those columns, use them to prune the continuation instead of forcing all RHS columns to stay live.
-		RemoveUnusedColumns rhs_child_optimizer(*this, everything_referenced && !has_output_references);
-		rhs_child_optimizer.column_references.reserve(column_references.size());
-		for (auto &entry : column_references) {
-			rhs_child_optimizer.column_references.emplace(entry.first, entry.second);
+		// A materialized CTE returns the RHS/continuation columns. If this pass is allowed to prune outputs and a
+		// parent registered explicit references to those columns, use them to prune the continuation. Respect
+		// everything_referenced barriers, e.g. DML operators that rely on a fixed child schema.
+		auto prune_rhs_outputs = !everything_referenced && has_output_references;
+		RemoveUnusedColumns rhs_child_optimizer(*this, !prune_rhs_outputs);
+		if (prune_rhs_outputs) {
+			rhs_child_optimizer.column_references.reserve(column_references.size());
+			for (auto &entry : column_references) {
+				rhs_child_optimizer.column_references.emplace(entry.first, entry.second);
+			}
 		}
 		rhs_child_optimizer.VisitOperator(cte.children[1]);
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -357,7 +357,22 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 		// Gather all scans of this CTE in the query and mark them as expected readers of this CTE
 		GatherCTEScans(cte.table_index, *cte.children[1], cte_map_entry.expected_readers);
 		cte_map_entry.everything_referenced = false;
-		RemoveUnusedColumns rhs_child_optimizer(*this, true);
+		auto output_bindings = cte.GetColumnBindings();
+		bool has_output_references = false;
+		for (auto &binding : output_bindings) {
+			if (column_references.find(binding) != column_references.end()) {
+				has_output_references = true;
+				break;
+			}
+		}
+
+		// A materialized CTE returns the RHS/continuation columns. If a parent already registered explicit references
+		// to those columns, use them to prune the continuation instead of forcing all RHS columns to stay live.
+		RemoveUnusedColumns rhs_child_optimizer(*this, everything_referenced && !has_output_references);
+		rhs_child_optimizer.column_references.reserve(column_references.size());
+		for (auto &entry : column_references) {
+			rhs_child_optimizer.column_references.emplace(entry.first, entry.second);
+		}
 		rhs_child_optimizer.VisitOperator(cte.children[1]);
 
 		unordered_set<ProjectionIndex> referenced_columns_in_rhs;

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -772,23 +772,11 @@ bool GeneratedDedupRefEliminator::CoversAllDedupColumns(const GeneratedDedupRef 
 
 optional_idx GeneratedDedupRefEliminator::FindGeneratedOutputBinding(const Expression &expr,
                                                                      const GeneratedDedupRef &dedup_ref) const {
-	optional_idx result;
-	bool unsupported = false;
-	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
-		if (unsupported || colref.Depth() != 0) {
-			return;
-		}
-		auto binding_idx = FindBindingIndex(dedup_ref.output_bindings, colref.Binding());
-		if (!binding_idx.IsValid()) {
-			return;
-		}
-		if (result.IsValid() && result.GetIndex() != binding_idx.GetIndex()) {
-			unsupported = true;
-			return;
-		}
-		result = binding_idx;
-	});
-	return unsupported ? optional_idx() : result;
+	ColumnBinding binding;
+	if (!GetBoundColumnRefBinding(expr, binding)) {
+		return optional_idx();
+	}
+	return FindBindingIndex(dedup_ref.output_bindings, binding);
 }
 
 bool GeneratedDedupRefEliminator::ExpressionReferencesGeneratedSide(const Expression &expr,
@@ -1782,23 +1770,11 @@ unique_ptr<GeneratedDomainRef> GeneratedDomainJoinEliminator::GetGeneratedDomain
 
 optional_idx GeneratedDomainJoinEliminator::FindOutputBinding(Expression &expr,
                                                               const vector<ColumnBinding> &bindings) const {
-	optional_idx result;
-	bool unsupported = false;
-	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
-		if (unsupported || colref.Depth() != 0) {
-			return;
-		}
-		auto binding_idx = FindBindingIndex(bindings, colref.Binding());
-		if (!binding_idx.IsValid()) {
-			return;
-		}
-		if (result.IsValid() && result.GetIndex() != binding_idx.GetIndex()) {
-			unsupported = true;
-			return;
-		}
-		result = binding_idx;
-	});
-	return unsupported ? optional_idx() : result;
+	ColumnBinding binding;
+	if (!GetBoundColumnRefBinding(expr, binding)) {
+		return optional_idx();
+	}
+	return FindBindingIndex(bindings, binding);
 }
 
 bool GeneratedDomainJoinEliminator::ContainsRecursiveCTERef(LogicalOperator &op) const {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -144,7 +144,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"enable_caching_operators", {false}},
 	    {"enable_optimizer", {false}},
 	    {"parallelize_sequential_sources", {false}},
-	    {"initial_column_segment_size", {4096}}};
+	    {"initial_column_segment_size", {4096}},
+	    {"delim_join_as_cte", {true}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		switch (type.id()) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -145,7 +145,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"enable_optimizer", {false}},
 	    {"parallelize_sequential_sources", {false}},
 	    {"initial_column_segment_size", {4096}},
-	    {"delim_join_as_cte", {true}}};
+	    {"delim_join_as_cte", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		switch (type.id()) {

--- a/test/optimizer/common_subplan.test_slow
+++ b/test/optimizer/common_subplan.test_slow
@@ -466,3 +466,56 @@ ORDER BY
     value DESC;
 ----
 logical_opt	<REGEX>:.*CTE.*
+
+statement ok
+RESET disabled_optimizers
+
+# TPCH Q2 with delimiter joins rewritten to CTEs should still expose the
+# repeated supplier/nation/region subtree to common subplan elimination.
+query II
+explain
+SELECT
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+FROM
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+WHERE
+    p_partkey = ps_partkey
+    AND s_suppkey = ps_suppkey
+    AND p_size = 15
+    AND p_type LIKE '%BRASS'
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND ps_supplycost = (
+        SELECT
+            min(ps_supplycost)
+        FROM
+            partsupp,
+            supplier,
+            nation,
+            region
+        WHERE
+            p_partkey = ps_partkey
+            AND s_suppkey = ps_suppkey
+            AND s_nationkey = n_nationkey
+            AND n_regionkey = r_regionkey
+            AND r_name = 'EUROPE')
+ORDER BY
+    s_acctbal DESC,
+    n_name,
+    s_name,
+    p_partkey
+LIMIT 100;
+----
+logical_opt	<REGEX>:.*__common_subplan_.*__duckdb_delim_.*

--- a/test/optimizer/deliminator.test
+++ b/test/optimizer/deliminator.test
@@ -31,6 +31,12 @@ explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHER
 ----
 logical_opt	<REGEX>:.*Groups: p_partkey.*COMPARISON_JOIN.*(l_partkey = p_partkey|p_partkey = l_partkey).*(DELIM_GET|CTE_SCAN).*
 
+# Q 17: the generated delimiter CTE should not preserve unused columns from the lineitem input
+query II
+explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);
+----
+logical_opt	<!REGEX>:.*l_orderkey.*
+
 # Q 17: if we remove the filters """ p_brand = 'Brand#23' AND p_container = 'MED BOX' """ we can remove the whole DELIM join
 query II
 explain SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND l_quantity < (SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);

--- a/test/sql/function/list/aggregates/minmax_nested.test
+++ b/test/sql/function/list/aggregates/minmax_nested.test
@@ -198,14 +198,14 @@ statement ok
 INSERT INTO float_values VALUES ('0'), ('-3.4e38'), ('3.4e38'), ('nan'), ('inf'), ('-inf')
 
 query II
-SELECT f, (SELECT MIN({'v': x}) FROM (VALUES (f)) t(x)) FROM float_values;
+SELECT f, (SELECT MIN({'v': x}) FROM (VALUES (f)) t(x)) FROM float_values ORDER BY ALL;
 ----
-0.0	{'v': 0.0}
--3.4e+38	{'v': -3.4e+38}
-3.4e+38	{'v': 3.4e+38}
-nan	{'v': nan}
-inf	{'v': inf}
 -inf	{'v': -inf}
+-3.4e+38	{'v': -3.4e+38}
+0.0	{'v': 0.0}
+3.4e+38	{'v': 3.4e+38}
+inf	{'v': inf}
+nan	{'v': nan}
 
 statement ok
 CREATE TABLE double_values(d DOUBLE);
@@ -214,11 +214,11 @@ statement ok
 INSERT INTO double_values VALUES ('0'), ('-1e308'), ('1e308'), ('nan'), ('inf'), ('-inf')
 
 query II
-SELECT d, (SELECT MIN({'v': x}) FROM (VALUES (d)) t(x)) FROM double_values;
+SELECT d, (SELECT MIN({'v': x}) FROM (VALUES (d)) t(x)) FROM double_values ORDER BY ALL;
 ----
-0.0	{'v': 0.0}
--1e+308	{'v': -1e+308}
-1e+308	{'v': 1e+308}
-nan	{'v': nan}
-inf	{'v': inf}
 -inf	{'v': -inf}
+-1e+308	{'v': -1e+308}
+0.0	{'v': 0.0}
+1e+308	{'v': 1e+308}
+inf	{'v': inf}
+nan	{'v': nan}

--- a/test/sql/function/list/lambdas/arrow/filter_deprecated.test
+++ b/test/sql/function/list/lambdas/arrow/filter_deprecated.test
@@ -171,28 +171,28 @@ ORDER BY ct.n
 3
 
 query I
-SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)) FROM corr_test
+SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [2, hello, wie gehts]
 NULL
-[]
 
 query I
-SELECT (SELECT list_filter(l, elem -> length(elem) >= n)) FROM corr_test
+SELECT (SELECT list_filter(l, elem -> length(elem) >= n)) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [hello, wie gehts]
 NULL
-[]
 
 query I
-SELECT (SELECT (SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)))) FROM corr_test
+SELECT (SELECT (SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)))) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [2, hello, wie gehts]
 NULL
-[]
 
 # positional references in lambda functions
 query I

--- a/test/sql/function/list/lambdas/arrow/filter_deprecated.test
+++ b/test/sql/function/list/lambdas/arrow/filter_deprecated.test
@@ -174,8 +174,8 @@ query I
 SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)) FROM corr_test ORDER BY ALL
 ----
 []
-[a, 11, 23]
 [2, hello, wie gehts]
+[a, 11, 23]
 NULL
 
 query I
@@ -190,8 +190,8 @@ query I
 SELECT (SELECT (SELECT (SELECT list_filter(l, elem -> length(elem) >= 1)))) FROM corr_test ORDER BY ALL
 ----
 []
-[a, 11, 23]
 [2, hello, wie gehts]
+[a, 11, 23]
 NULL
 
 # positional references in lambda functions

--- a/test/sql/function/list/lambdas/arrow/transform_deprecated.test
+++ b/test/sql/function/list/lambdas/arrow/transform_deprecated.test
@@ -234,28 +234,28 @@ ORDER BY ct.n
 3
 
 query I
-SELECT (SELECT list_transform(l, elem -> elem + 1)) FROM corr_test
+SELECT (SELECT list_transform(l, elem -> elem + 1)) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 3, 5, 5]
 NULL
-[]
 
 query I
-SELECT (SELECT list_transform(l, elem -> elem + n)) FROM corr_test
+SELECT (SELECT list_transform(l, elem -> elem + n)) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 5, 7, 7]
 NULL
-[]
 
 query I
-SELECT (SELECT (SELECT (SELECT list_transform(l, elem -> elem + 1)))) FROM corr_test
+SELECT (SELECT (SELECT (SELECT list_transform(l, elem -> elem + 1)))) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 3, 5, 5]
 NULL
-[]
 
 # positional references in lambda functions
 query I

--- a/test/sql/function/list/lambdas/filter.test
+++ b/test/sql/function/list/lambdas/filter.test
@@ -175,28 +175,28 @@ ORDER BY ct.n
 3
 
 query I
-SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)) FROM corr_test
+SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [2, hello, wie gehts]
 NULL
-[]
 
 query I
-SELECT (SELECT list_filter(l, lambda elem: length(elem) >= n)) FROM corr_test
+SELECT (SELECT list_filter(l, lambda elem: length(elem) >= n)) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [hello, wie gehts]
 NULL
-[]
 
 query I
-SELECT (SELECT (SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)))) FROM corr_test
+SELECT (SELECT (SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)))) FROM corr_test ORDER BY ALL
 ----
+[]
 [a, 11, 23]
 [2, hello, wie gehts]
 NULL
-[]
 
 # positional references in lambda functions
 query I

--- a/test/sql/function/list/lambdas/filter.test
+++ b/test/sql/function/list/lambdas/filter.test
@@ -178,8 +178,8 @@ query I
 SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)) FROM corr_test ORDER BY ALL
 ----
 []
-[a, 11, 23]
 [2, hello, wie gehts]
+[a, 11, 23]
 NULL
 
 query I
@@ -194,8 +194,8 @@ query I
 SELECT (SELECT (SELECT (SELECT list_filter(l, lambda elem: length(elem) >= 1)))) FROM corr_test ORDER BY ALL
 ----
 []
-[a, 11, 23]
 [2, hello, wie gehts]
+[a, 11, 23]
 NULL
 
 # positional references in lambda functions

--- a/test/sql/function/list/lambdas/transform.test
+++ b/test/sql/function/list/lambdas/transform.test
@@ -240,28 +240,28 @@ ORDER BY ct.n
 3
 
 query I
-SELECT (SELECT list_transform(l, lambda elem: elem + 1)) FROM corr_test
+SELECT (SELECT list_transform(l, lambda elem: elem + 1)) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 3, 5, 5]
 NULL
-[]
 
 query I
-SELECT (SELECT list_transform(l, lambda elem: elem + n)) FROM corr_test
+SELECT (SELECT list_transform(l, lambda elem: elem + n)) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 5, 7, 7]
 NULL
-[]
 
 query I
-SELECT (SELECT (SELECT (SELECT list_transform(l, lambda elem: elem + 1)))) FROM corr_test
+SELECT (SELECT (SELECT (SELECT list_transform(l, lambda elem: elem + 1)))) FROM corr_test ORDER BY ALL
 ----
+[]
 [3, 2, 2]
 [NULL, 3, 5, 5]
 NULL
-[]
 
 # positional references in lambda functions
 query I

--- a/test/sql/subquery/scalar/array_order_subquery.test
+++ b/test/sql/subquery/scalar/array_order_subquery.test
@@ -18,20 +18,20 @@ select
 
 # correlated
 query I
-select array(select unnest(l) AS i order by i desc nulls last) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l);
+select array(select unnest(l) AS i order by i desc nulls last) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l) ORDER BY ALL;
 ----
+[]
 [4, 3, 2, 1, NULL]
 [8, 7, 6, 5, NULL]
-[]
 [12, 11, 10]
 
 query I
-select array(select unnest(l) AS i order by i desc nulls first) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l);
+select array(select unnest(l) AS i order by i desc nulls first) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l) ORDER BY ALL;
 ----
-[NULL, 4, 3, 2, 1]
-[NULL, 8, 7, 6, 5]
 []
 [12, 11, 10]
+[NULL, 4, 3, 2, 1]
+[NULL, 8, 7, 6, 5]
 
 # row id
 query I

--- a/test/sql/subquery/scalar/test_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_correlated_subquery.test
@@ -190,7 +190,7 @@ NULL	NULL
 3	42
 
 query II
-SELECT i, (SELECT CASE WHEN sum(i) > 1 THEN 0 ELSE 1 END FROM integers WHERE i=i1.i) FROM integers i1;
+SELECT i, (SELECT CASE WHEN sum(i) > 1 THEN 0 ELSE 1 END FROM integers WHERE i=i1.i) FROM integers i1 ORDER BY ALL;
 ----
 1	1
 2	0

--- a/test/sql/subquery/scalar/test_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_correlated_subquery.test
@@ -192,7 +192,7 @@ NULL	NULL
 query II
 SELECT i, (SELECT CASE WHEN sum(i) > 1 THEN 0 ELSE 1 END FROM integers WHERE i=i1.i) FROM integers i1 ORDER BY ALL;
 ----
+NULL	1
 1	1
 2	0
 3	0
-NULL	1

--- a/test/sql/subquery/scalar/test_many_correlated_columns.test
+++ b/test/sql/subquery/scalar/test_many_correlated_columns.test
@@ -50,14 +50,14 @@ SELECT a, a>=ANY(SELECT test2.a+c-b FROM test2 WHERE c>=b AND str=str2) FROM tes
 
 # string comparison
 query TT
-SELECT str, str=ANY(SELECT str2 FROM test2) FROM test
+SELECT str, str=ANY(SELECT str2 FROM test2) FROM test ORDER BY ALL
 ----
 a	1
 b	1
 c	0
 
 query TT
-SELECT str, str=ANY(SELECT str2 FROM test2 WHERE test.a<>test2.a) FROM test
+SELECT str, str=ANY(SELECT str2 FROM test2 WHERE test.a<>test2.a) FROM test ORDER BY ALL
 ----
 a	0
 b	1

--- a/test/sql/types/list/unnest_table_function.test
+++ b/test/sql/types/list/unnest_table_function.test
@@ -141,11 +141,12 @@ SELECT list_sort(array(
 	SELECT list_contains(b, ax)
 	FROM UNNEST(a) ta(ax)
 )) ab_intersect
-FROM tbl;
+FROM tbl
+ORDER BY ALL;
 ----
+[false, false]
 [false, true, true]
 [true, true]
-[false, false]
 
 query IIII
 SELECT k, a, b,


### PR DESCRIPTION
This was supposed to be a "one line" PR. Of course, it was not that easy 😉 CI showed a few remaining issues with regressions and a few underspecified test cases. So this PR:

- Flips the flag to now have DELIM joins expressed as CTEs by default.
- Fixes the CSE optimizer to recognize more identical plan shapes even with different column projections.
- Fixes CTE column pruning (again..) to fix regressions with parquet-based TPC-H.