### PR TITLE
Propagate shredded stats through `variant_comparator`

### DIFF
--- a/src/function/scalar/variant/variant_comparator.cpp
+++ b/src/function/scalar/variant/variant_comparator.cpp
@@ -6,10 +6,13 @@
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/bignum.hpp"
 #include "duckdb/common/types/bit.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/variant.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/types/variant_iterator.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
@@ -519,11 +522,114 @@ void VariantComparatorFunction(DataChunk &input, ExpressionState &state, Vector 
 	CreateVariantComparator(input.data[0], input.size(), result);
 }
 
+//===--------------------------------------------------------------------===//
+// Statistics Propagation
+//===--------------------------------------------------------------------===//
+// When the input VARIANT is fully shredded onto a single primitive type, every (non-NULL) value lives
+// in the same comparator "bucket" - all of its sort keys share the type-rank prefix - and the values
+// are bounded by the typed min/max of the shredded column. Because the comparator encoding is
+// order-preserving, encoding the typed min/max with the exact same encoding yields valid min/max sort
+// keys for the BLOB output: min/max are derived by running the real comparator (CreateVariantComparator)
+// over a cast of the bound to VARIANT, so the derived bounds can never diverge from the runtime encoding.
+// A root that resolves to NULL is always a genuine SQL NULL (VARIANT_NULL is reserved for nested values),
+// so its NULL is propagated via validity and never lands in the primitive bucket.
+
+//! Encode a single bound value into its comparator sort key by reusing the exact comparator encoding.
+bool TryEncodeBoundKey(ClientContext &context, const Value &bound, string &result_key) {
+	if (bound.IsNull()) {
+		return false;
+	}
+	Value variant_value;
+	if (!bound.TryCastAs(context, LogicalType::VARIANT(), variant_value, nullptr)) {
+		return false;
+	}
+	if (variant_value.IsNull()) {
+		return false;
+	}
+	Vector input(LogicalType::VARIANT(), 1);
+	input.SetValue(0, variant_value);
+	Vector sort_key(LogicalType::BLOB, 1);
+	CreateVariantComparator(input, 1, sort_key);
+	auto key = sort_key.GetValue(0);
+	if (key.IsNull()) {
+		return false;
+	}
+	result_key = StringValue::Get(key);
+	return true;
+}
+
+//! Extract the lower/upper bound of the (primitive) typed stats as Values - leaves a bound as NULL when
+//! it is not available.
+void GetTypedBounds(const BaseStatistics &typed_stats, Value &min_bound, Value &max_bound) {
+	switch (typed_stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		if (NumericStats::HasMin(typed_stats)) {
+			min_bound = NumericStats::Min(typed_stats);
+		}
+		if (NumericStats::HasMax(typed_stats)) {
+			max_bound = NumericStats::Max(typed_stats);
+		}
+		break;
+	case StatisticsType::STRING_STATS:
+		// only VARCHAR has UTF-8 ordered min/max we can turn into valid lower/upper bounds
+		if (typed_stats.GetType().id() == LogicalTypeId::VARCHAR) {
+			if (StringStats::HasMin(typed_stats)) {
+				min_bound = StringStats::TryGetValidMin(typed_stats);
+			}
+			if (StringStats::HasMax(typed_stats)) {
+				max_bound = StringStats::TryGetValidMax(typed_stats);
+			}
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+unique_ptr<BaseStatistics> VariantComparatorStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &variant_stats = input.child_stats[0];
+	// Keep the (loosest) validity baseline - the BLOB sort key is NULL only when the input variant is a
+	// SQL NULL, but the input validity is not propagated here: this code only narrows the value bounds,
+	// and over-claiming "cannot be NULL" off of incomplete child stats would prune valid rows.
+	auto result = BaseStatistics::CreateUnknown(input.expr.GetReturnType());
+
+	if (variant_stats.GetStatsType() != StatisticsType::VARIANT_STATS || !VariantStats::IsShredded(variant_stats)) {
+		return result.ToUnique();
+	}
+	auto &shredded_stats = VariantStats::GetShreddedStats(variant_stats);
+	if (!VariantShreddedStats::IsFullyShredded(shredded_stats)) {
+		// values can live in the unshredded component with arbitrary type ranks - no bucket
+		return result.ToUnique();
+	}
+	auto &typed_stats = VariantStats::GetTypedStats(shredded_stats);
+	if (typed_stats.GetType().IsNested()) {
+		// only a primitive shredding maps every value into a single comparator bucket
+		return result.ToUnique();
+	}
+
+	Value min_bound, max_bound;
+	GetTypedBounds(typed_stats, min_bound, max_bound);
+
+	string min_key;
+	if (TryEncodeBoundKey(context, min_bound, min_key)) {
+		StringStats::SetMin(result, string_t(min_key.data(), NumericCast<uint32_t>(min_key.size())),
+		                    StringStatsType::TRUNCATED_STATS);
+	}
+	string max_key;
+	if (TryEncodeBoundKey(context, max_bound, max_key)) {
+		StringStats::SetMax(result, string_t(max_key.data(), NumericCast<uint32_t>(max_key.size())),
+		                    StringStatsType::TRUNCATED_STATS);
+	}
+	return result.ToUnique();
+}
+
 } // namespace
 
 ScalarFunction VariantComparatorFun::GetFunction() {
 	auto variant_type = LogicalType::VARIANT();
-	return ScalarFunction("variant_comparator", {variant_type}, LogicalType::BLOB, VariantComparatorFunction);
+	ScalarFunction function("variant_comparator", {variant_type}, LogicalType::BLOB, VariantComparatorFunction);
+	function.SetStatisticsCallback(VariantComparatorStats);
+	return function;
 }
 
 } // namespace duckdb

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -112,6 +112,7 @@
         "test/sql/function/generic/test_stats.test",
         "test/sql/function/timetz/test_date_part.test",
         "test/sql/storage/types/variant/variant_extract_stats.test",
+        "test/sql/storage/types/variant/variant_comparator_stats.test",
         "test/sql/alter/alter_type/test_alter_type.test",
         "test/sql/alter/add_col/test_add_col_stats.test",
         "test/sql/copy/return_stats.test",

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -28,6 +28,7 @@
         "test/sql/function/numeric/test_random.test",
         "test/sql/function/generic/test_stats.test",
         "test/sql/storage/types/variant/variant_extract_stats.test",
+        "test/sql/storage/types/variant/variant_comparator_stats.test",
         "test/sql/alter/alter_type/test_alter_type.test",
         "test/sql/alter/add_col/test_add_col_stats.test",
         "test/sql/copy/parquet/bloom_filters.test",

--- a/test/sql/storage/types/variant/variant_comparator_stats.test
+++ b/test/sql/storage/types/variant/variant_comparator_stats.test
@@ -1,0 +1,170 @@
+# name: test/sql/storage/types/variant/variant_comparator_stats.test
+# description: statistics propagation for variant_comparator over (fully) shredded variants
+# group: [variant]
+
+require noforcestorage
+
+load {TEST_DIR}/variant_comparator_stats.db readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+# ------------------------------ Fully shredded on a primitive (INTEGER) ------------------------------
+
+statement ok
+SET force_variant_shredding = 'INTEGER';
+
+statement ok
+CREATE TABLE ints(col VARIANT);
+
+statement ok
+INSERT INTO ints SELECT (i + 1)::INTEGER FROM range(100) t(i);
+
+statement ok
+CHECKPOINT;
+
+# reopen so the variant column is scanned from storage as a shredded vector
+restart
+
+# the comparator stats push the bucket (type-rank prefix) and the typed min/max, so the BLOB min/max
+# are exactly the comparator sort keys of the typed extremes (1 and 100)
+query II
+SELECT
+	s.min::VARCHAR = variant_comparator(1::INTEGER::VARIANT)::VARCHAR,
+	s.max::VARCHAR = variant_comparator(100::INTEGER::VARIANT)::VARCHAR
+FROM (SELECT stats(variant_comparator(col)) s FROM ints LIMIT 1);
+----
+true	true
+
+# the derived bounds must be correct - filtering against them returns the right rows
+query I
+SELECT count(*) FROM ints WHERE col > 50::INTEGER::VARIANT;
+----
+50
+
+query I
+SELECT count(*) FROM ints WHERE col <= 10::INTEGER::VARIANT;
+----
+10
+
+# a value outside the bucket range matches nothing
+query I
+SELECT count(*) FROM ints WHERE col = 1000::INTEGER::VARIANT;
+----
+0
+
+# ------------------------------ Fully shredded on VARCHAR ------------------------------
+
+statement ok
+SET force_variant_shredding = 'VARCHAR';
+
+statement ok
+CREATE TABLE strs(col VARIANT);
+
+statement ok
+INSERT INTO strs VALUES ('apple'::VARIANT), ('mango'::VARIANT), ('cherry'::VARIANT);
+
+statement ok
+CHECKPOINT;
+
+restart
+
+# the bucket + bounds are derived (the exact max can be a rounded-up valid upper bound when the typed
+# string stats are stored truncated - so we assert the bounds exist and filter correctly instead)
+query II
+SELECT s.min IS NOT NULL, s.max IS NOT NULL
+FROM (SELECT stats(variant_comparator(col)) s FROM strs LIMIT 1);
+----
+true	true
+
+query I
+SELECT count(*) FROM strs WHERE col > 'cherry'::VARIANT;
+----
+1
+
+query I
+SELECT count(*) FROM strs WHERE col >= 'apple'::VARIANT;
+----
+3
+
+query I
+SELECT count(*) FROM strs WHERE col > 'zzzzz'::VARIANT;
+----
+0
+
+# ------------------------------ Nullable column, still fully shredded ------------------------------
+
+statement ok
+SET force_variant_shredding = 'INTEGER';
+
+statement ok
+CREATE TABLE nullable_ints(col VARIANT);
+
+statement ok
+INSERT INTO nullable_ints SELECT (i + 1)::INTEGER FROM range(10) t(i);
+
+statement ok
+INSERT INTO nullable_ints VALUES (NULL::VARIANT);
+
+statement ok
+CHECKPOINT;
+
+restart
+
+# SQL-NULL rows are handled by validity and never widen the primitive bucket
+query II
+SELECT
+	s.min::VARCHAR = variant_comparator(1::INTEGER::VARIANT)::VARCHAR,
+	s.max::VARCHAR = variant_comparator(10::INTEGER::VARIANT)::VARCHAR
+FROM (SELECT stats(variant_comparator(col)) s FROM nullable_ints LIMIT 1);
+----
+true	true
+
+# ------------------------------ Not fully shredded -> no bounds ------------------------------
+
+statement ok
+SET force_variant_shredding = 'INTEGER';
+
+statement ok
+CREATE TABLE mixed(col VARIANT);
+
+statement ok
+INSERT INTO mixed SELECT (i + 1)::INTEGER FROM range(10) t(i);
+
+# a non-integer value spills into the unshredded component - the column is no longer fully shredded
+statement ok
+INSERT INTO mixed VALUES ('hello'::VARIANT);
+
+statement ok
+CHECKPOINT;
+
+restart
+
+query II
+SELECT s.min IS NULL, s.max IS NULL
+FROM (SELECT stats(variant_comparator(col)) s FROM mixed LIMIT 1);
+----
+true	true
+
+# ------------------------------ Shredded on a nested type -> no primitive bucket ------------------------------
+
+statement ok
+SET force_variant_shredding = 'STRUCT(a INTEGER)';
+
+statement ok
+CREATE TABLE objs(col VARIANT);
+
+statement ok
+INSERT INTO objs SELECT {'a': (i + 1)::INTEGER} FROM range(10) t(i);
+
+statement ok
+CHECKPOINT;
+
+restart
+
+# only a primitive shredding maps every value into a single comparator bucket
+query I
+SELECT s.min IS NULL
+FROM (SELECT stats(variant_comparator(col)) s FROM objs LIMIT 1);
+----
+true


### PR DESCRIPTION
When we push `variant_comparator` over a shredded variant, we can propagate its stats by computing `variant_comparator` over the min/max of the shredded stats as `variant_comparator` is composable, i.e. for primitive types:

```
MIN(variant_comparator(X)) = variant_comparator(MIN(X))
```

This PR makes use of this by implementing stats propagation for `variant_comparator`. This then allows more pruning of comparisons involving variants (as they always have `variant_comparator` pushed as part of the collation rule). 