### PR TITLE
Optimize StringUtil::Replace

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -548,13 +548,36 @@ string StringUtil::Replace(string source, const string &from, const string &to) 
 	if (from.empty()) {
 		throw InternalException("Invalid argument to StringUtil::Replace - empty FROM");
 	}
+	if (source.empty() || from == to) {
+		return source;
+	}
+
+	const auto from_length = from.length();
+	const auto to_length = to.length();
+
+	idx_t match_count = 0;
 	idx_t start_pos = 0;
 	while ((start_pos = source.find(from, start_pos)) != string::npos) {
-		source.replace(start_pos, from.length(), to);
-		start_pos += to.length(); // In case 'to' contains 'from', like
-		                          // replacing 'x' with 'yx'
+		match_count++;
+		start_pos += from_length;
 	}
-	return source;
+	if (match_count == 0) {
+		return source;
+	}
+
+	string result;
+	result.reserve(source.length() - match_count * from_length + match_count * to_length);
+
+	idx_t last_pos = 0;
+	start_pos = 0;
+	while ((start_pos = source.find(from, start_pos)) != string::npos) {
+		result.append(source, last_pos, start_pos - last_pos);
+		result += to;
+		start_pos += from_length;
+		last_pos = start_pos;
+	}
+	result.append(source, last_pos, string::npos);
+	return result;
 }
 
 vector<string> StringUtil::TopNStrings(vector<pair<string, double>> scores, idx_t n, double threshold) {

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -145,6 +145,15 @@ TEST_CASE("Test join vector items", "[string_util]") {
 	}
 }
 
+TEST_CASE("Test replace strings", "[string_util]") {
+	REQUIRE(StringUtil::Replace("abcabc", "ab", "x") == "xcxc");
+	REQUIRE(StringUtil::Replace("aaaa", "aa", "b") == "bb");
+	REQUIRE(StringUtil::Replace("xx", "x", "yx") == "yxyx");
+	REQUIRE(StringUtil::Replace("aaa{SNAPSHOT_ID}bbb{SNAPSHOT_ID}", "{SNAPSHOT_ID}", "1") == "aaa1bbb1");
+	REQUIRE(StringUtil::Replace("", "x", "y") == "");
+	REQUIRE_THROWS(StringUtil::Replace("abc", "", "x"));
+}
+
 TEST_CASE("Test SplitWithParentheses", "[string_util]") {
 	SECTION("Standard split") {
 		REQUIRE(StringUtil::SplitWithParentheses("") == duckdb::vector<string> {});


### PR DESCRIPTION
Optimize StringUtil::Replace to avoid repeated in-place string replacement. The previous implementation called std::string::replace once per match, which can repeatedly move the remaining tail of large strings. This can become very expensive when replacing many occurrences in a large generated string. This was observed at the final step of ducklake commit, where the metadata query has many instances of `{SNAPSHOT_ID}`.

This change first counts matches, reserves the final result size, and then builds the output with append operations. The behavior is preserved, including cases where the replacement text contains the search text. A small regression test was added for the relevant edge cases.