### PR TITLE
Clean-up VariantIterator API and unify it with vector iterator infrastructure

### DIFF
--- a/src/common/types/variant/variant_iterator.cpp
+++ b/src/common/types/variant/variant_iterator.cpp
@@ -58,9 +58,9 @@ bool ShreddedIsValid(const ShreddedVariantIterator &node, idx_t index) {
 } // namespace
 
 //===--------------------------------------------------------------------===//
-// VariantIteratorState
+// VariantIterator
 //===--------------------------------------------------------------------===//
-VariantIteratorState::VariantIteratorState(const Vector &variant)
+VariantIterator::VariantIterator(const Vector &variant)
     //! The unshredded ("core") source is the variant itself, or the unshredded component of a shredded vector
     : unshredded(variant.GetVectorType() == VectorType::SHREDDED_VECTOR ? ShreddedVector::GetUnshreddedVector(variant)
                                                                         : variant) {
@@ -155,27 +155,27 @@ uint32_t UnshreddedVariantIterator::GetValuesIndex(idx_t row, idx_t child_index)
 //===--------------------------------------------------------------------===//
 // Root / row validity
 //===--------------------------------------------------------------------===//
-VariantIterator VariantIteratorState::Root(idx_t row) const {
+VariantNode VariantIterator::Root(idx_t row) const {
 	if (is_shredded) {
 		//! The shredded component's top-level validity is the authoritative row validity (a SQL-NULL row
 		//! has the whole shredded struct set to NULL). This must be checked separately because
 		//! ResolveShredded only inspects the typed_value / untyped_value_index of a wrapper, never the
 		//! wrapper's own struct validity.
 		if (!ShreddedIsValid(shredded_format, row)) {
-			return VariantIterator::MakeNull(*this);
+			return VariantNode::MakeNull(*this);
 		}
-		auto root = VariantIterator::ResolveShredded(*this, shredded_format, row, row);
+		auto root = VariantNode::ResolveShredded(*this, shredded_format, row, row);
 		//! a root value is never "missing" - treat any such case as a SQL NULL
-		return root.IsMissing() ? VariantIterator::MakeNull(*this) : root;
+		return root.IsMissing() ? VariantNode::MakeNull(*this) : root;
 	}
 	if (!unshredded.RowIsValid(row)) {
-		return VariantIterator::MakeNull(*this);
+		return VariantNode::MakeNull(*this);
 	}
 	//! The unshredded root value lives at values[0]
-	return VariantIterator::MakeUnshredded(*this, row, 0);
+	return VariantNode::MakeUnshredded(*this, row, 0);
 }
 
-bool VariantIteratorState::RowIsValid(idx_t row) const {
+bool VariantIterator::RowIsValid(idx_t row) const {
 	//! A VARIANT is never NULL at the root via a VARIANT_NULL value (that is reserved for nested values) -
 	//! a root that resolves to NULL is a genuine SQL NULL. This matches the semantics of unshredding,
 	//! where a shredded value whose typed leaf is NULL (with no unshredded leftover) becomes a SQL NULL.
@@ -183,24 +183,24 @@ bool VariantIteratorState::RowIsValid(idx_t row) const {
 }
 
 //===--------------------------------------------------------------------===//
-// VariantIterator - factory helpers
+// VariantNode - factory helpers
 //===--------------------------------------------------------------------===//
-VariantIterator VariantIterator::MakeNull(const VariantIteratorState &state) {
-	VariantIterator result;
+VariantNode VariantNode::MakeNull(const VariantIterator &state) {
+	VariantNode result;
 	result.state = &state;
 	result.kind = Kind::NULL_VALUE;
 	return result;
 }
 
-VariantIterator VariantIterator::MakeMissing(const VariantIteratorState &state) {
-	VariantIterator result;
+VariantNode VariantNode::MakeMissing(const VariantIterator &state) {
+	VariantNode result;
 	result.state = &state;
 	result.kind = Kind::MISSING;
 	return result;
 }
 
-VariantIterator VariantIterator::MakeUnshredded(const VariantIteratorState &state, idx_t row, uint32_t value_index) {
-	VariantIterator result;
+VariantNode VariantNode::MakeUnshredded(const VariantIterator &state, idx_t row, uint32_t value_index) {
+	VariantNode result;
 	result.state = &state;
 	result.kind = Kind::UNSHREDDED;
 	result.row = row;
@@ -208,9 +208,9 @@ VariantIterator VariantIterator::MakeUnshredded(const VariantIteratorState &stat
 	return result;
 }
 
-VariantIterator VariantIterator::MakeShredded(const VariantIteratorState &state, const ShreddedVariantIterator &content,
-                                              idx_t index, idx_t row, uint32_t overlay_value_index) {
-	VariantIterator result;
+VariantNode VariantNode::MakeShredded(const VariantIterator &state, const ShreddedVariantIterator &content, idx_t index,
+                                      idx_t row, uint32_t overlay_value_index) {
+	VariantNode result;
 	result.state = &state;
 	result.kind = Kind::SHREDDED;
 	result.row = row;
@@ -223,8 +223,8 @@ VariantIterator VariantIterator::MakeShredded(const VariantIteratorState &state,
 //===--------------------------------------------------------------------===//
 // Shredded resolution
 //===--------------------------------------------------------------------===//
-VariantIterator VariantIterator::ResolveShredded(const VariantIteratorState &state, const ShreddedVariantIterator &node,
-                                                 idx_t index, idx_t row) {
+VariantNode VariantNode::ResolveShredded(const VariantIterator &state, const ShreddedVariantIterator &node, idx_t index,
+                                         idx_t row) {
 	if (node.logical_type.id() != LogicalTypeId::STRUCT) {
 		//! A flattened (fully-consistent) primitive - a NULL here represents a VARIANT_NULL value
 		if (!ShreddedIsValid(node, index)) {
@@ -348,12 +348,11 @@ static VariantLogicalType ShreddedTypeId(const ShreddedVariantIterator &content,
 	case LogicalTypeId::GEOMETRY:
 		return VariantLogicalType::GEOMETRY;
 	default:
-		throw NotImplementedException("Shredded VARIANT type '%s' is not supported by VariantIterator",
-		                              type.ToString());
+		throw NotImplementedException("Shredded VARIANT type '%s' is not supported by VariantNode", type.ToString());
 	}
 }
 
-VariantLogicalType VariantIterator::GetTypeId() const {
+VariantLogicalType VariantNode::GetTypeId() const {
 	switch (kind) {
 	case Kind::NULL_VALUE:
 		return VariantLogicalType::VARIANT_NULL;
@@ -362,14 +361,14 @@ VariantLogicalType VariantIterator::GetTypeId() const {
 	case Kind::SHREDDED:
 		return ShreddedTypeId(*shredded_format, shredded_index);
 	default:
-		throw InternalException("VariantIterator::GetTypeId called on a MISSING value");
+		throw InternalException("VariantNode::GetTypeId called on a MISSING value");
 	}
 }
 
 //===--------------------------------------------------------------------===//
 // Primitive accessors
 //===--------------------------------------------------------------------===//
-const_data_ptr_t VariantIterator::GetDataPointer() const {
+const_data_ptr_t VariantNode::GetDataPointer() const {
 	if (kind == Kind::UNSHREDDED) {
 		auto &blob = state->unshredded.GetBlob(row);
 		return const_data_ptr_cast(blob.GetData()) + state->unshredded.GetByteOffset(row, value_index);
@@ -380,7 +379,7 @@ const_data_ptr_t VariantIterator::GetDataPointer() const {
 	return content.unified.data + content.unified.sel->get_index(shredded_index) * type_size;
 }
 
-string_t VariantIterator::GetString() const {
+string_t VariantNode::GetString() const {
 	if (kind == Kind::UNSHREDDED) {
 		return DecodeStringData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, value_index));
 	}
@@ -389,7 +388,7 @@ string_t VariantIterator::GetString() const {
 	return content.unified.GetData<string_t>()[content.unified.sel->get_index(shredded_index)];
 }
 
-VariantDecimalData VariantIterator::GetDecimal() const {
+VariantDecimalData VariantNode::GetDecimal() const {
 	if (kind == Kind::UNSHREDDED) {
 		return DecodeDecimalData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, value_index));
 	}
@@ -406,19 +405,19 @@ VariantDecimalData VariantIterator::GetDecimal() const {
 //===--------------------------------------------------------------------===//
 // Nested accessors
 //===--------------------------------------------------------------------===//
-VariantObjectIterator VariantIterator::GetObjectChildren(VariantIterationOrder order) const {
+VariantObjectIterator VariantNode::GetObjectChildren(VariantIterationOrder order) const {
 	return VariantObjectIterator(*this, order);
 }
 
-VariantArrayIterator VariantIterator::GetArrayChildren() const {
+VariantArrayIterator VariantNode::GetArrayChildren() const {
 	return VariantArrayIterator(*this);
 }
 
 //===--------------------------------------------------------------------===//
 // VariantArrayIterator
 //===--------------------------------------------------------------------===//
-VariantArrayIterator::VariantArrayIterator(const VariantIterator &array)
-    : state(array.state), row(array.row), shredded(array.kind == VariantIterator::Kind::SHREDDED) {
+VariantArrayIterator::VariantArrayIterator(const VariantNode &array)
+    : state(array.state), row(array.row), shredded(array.kind == VariantNode::Kind::SHREDDED) {
 	if (!shredded) {
 		auto nested =
 		    DecodeNestedData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, array.value_index));
@@ -435,18 +434,18 @@ VariantArrayIterator::VariantArrayIterator(const VariantIterator &array)
 	element_node = content.children[0];
 }
 
-VariantIterator VariantArrayIterator::operator[](idx_t i) const {
+VariantNode VariantArrayIterator::operator[](idx_t i) const {
 	if (shredded) {
-		return VariantIterator::ResolveShredded(*state, *element_node, base + i, row);
+		return VariantNode::ResolveShredded(*state, *element_node, base + i, row);
 	}
-	return VariantIterator::MakeUnshredded(*state, row, state->unshredded.GetValuesIndex(row, base + i));
+	return VariantNode::MakeUnshredded(*state, row, state->unshredded.GetValuesIndex(row, base + i));
 }
 
 //===--------------------------------------------------------------------===//
 // VariantObjectIterator
 //===--------------------------------------------------------------------===//
-VariantObjectIterator::VariantObjectIterator(const VariantIterator &object, VariantIterationOrder order)
-    : state(object.state), row(object.row), order(order), shredded(object.kind == VariantIterator::Kind::SHREDDED) {
+VariantObjectIterator::VariantObjectIterator(const VariantNode &object, VariantIterationOrder order)
+    : state(object.state), row(object.row), order(order), shredded(object.kind == VariantNode::Kind::SHREDDED) {
 	if (!shredded) {
 		auto nested =
 		    DecodeNestedData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, object.value_index));
@@ -490,21 +489,21 @@ VariantObjectEntry VariantObjectIterator::RawEntry(idx_t raw_pos) const {
 		auto key_idx = state->unshredded.GetKeysIndex(row, child_idx);
 		auto value_idx = state->unshredded.GetValuesIndex(row, child_idx);
 		return VariantObjectEntry {state->unshredded.GetKey(row, key_idx),
-		                           VariantIterator::MakeUnshredded(*state, row, value_idx)};
+		                           VariantNode::MakeUnshredded(*state, row, value_idx)};
 	}
 	if (raw_pos < typed_field_count) {
 		//! A shredded (typed) field - struct fields preserve the (logical) index of the parent
 		auto &name = StructType::GetChildTypes(content->logical_type)[raw_pos].first;
 		return VariantObjectEntry {
 		    string_t(name.c_str(), NumericCast<uint32_t>(name.size())),
-		    VariantIterator::ResolveShredded(*state, content->children[raw_pos], shredded_index, row)};
+		    VariantNode::ResolveShredded(*state, content->children[raw_pos], shredded_index, row)};
 	}
 	//! A leftover field from the overlay (unshredded) object
 	auto child_idx = overlay_base + (raw_pos - typed_field_count);
 	auto key_idx = state->unshredded.GetKeysIndex(row, child_idx);
 	auto value_idx = state->unshredded.GetValuesIndex(row, child_idx);
 	return VariantObjectEntry {state->unshredded.GetKey(row, key_idx),
-	                           VariantIterator::MakeUnshredded(*state, row, value_idx)};
+	                           VariantNode::MakeUnshredded(*state, row, value_idx)};
 }
 
 void VariantObjectIterator::Iterator::Load() {

--- a/src/common/types/variant/variant_iterator.cpp
+++ b/src/common/types/variant/variant_iterator.cpp
@@ -417,10 +417,10 @@ VariantArrayIterator VariantNode::GetArrayChildren() const {
 // VariantArrayIterator
 //===--------------------------------------------------------------------===//
 VariantArrayIterator::VariantArrayIterator(const VariantNode &array)
-    : state(array.state), row(array.row), shredded(array.kind == VariantNode::Kind::SHREDDED) {
+    : state(*array.state), row(array.row), shredded(array.kind == VariantNode::Kind::SHREDDED) {
 	if (!shredded) {
-		auto nested =
-		    DecodeNestedData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, array.value_index));
+		auto &unshredded = state.get().unshredded;
+		auto nested = DecodeNestedData(unshredded.GetBlob(row), unshredded.GetByteOffset(row, array.value_index));
 		base = nested.children_idx;
 		length = nested.child_count;
 		return;
@@ -435,20 +435,21 @@ VariantArrayIterator::VariantArrayIterator(const VariantNode &array)
 }
 
 VariantNode VariantArrayIterator::operator[](idx_t i) const {
+	auto &state_ref = state.get();
 	if (shredded) {
-		return VariantNode::ResolveShredded(*state, *element_node, base + i, row);
+		return VariantNode::ResolveShredded(state_ref, *element_node, base + i, row);
 	}
-	return VariantNode::MakeUnshredded(*state, row, state->unshredded.GetValuesIndex(row, base + i));
+	return VariantNode::MakeUnshredded(state_ref, row, state_ref.unshredded.GetValuesIndex(row, base + i));
 }
 
 //===--------------------------------------------------------------------===//
 // VariantObjectIterator
 //===--------------------------------------------------------------------===//
 VariantObjectIterator::VariantObjectIterator(const VariantNode &object, VariantIterationOrder order)
-    : state(object.state), row(object.row), order(order), shredded(object.kind == VariantNode::Kind::SHREDDED) {
+    : state(*object.state), row(object.row), order(order), shredded(object.kind == VariantNode::Kind::SHREDDED) {
+	auto &unshredded = state.get().unshredded;
 	if (!shredded) {
-		auto nested =
-		    DecodeNestedData(state->unshredded.GetBlob(row), state->unshredded.GetByteOffset(row, object.value_index));
+		auto nested = DecodeNestedData(unshredded.GetBlob(row), unshredded.GetByteOffset(row, object.value_index));
 		base = nested.children_idx;
 		raw_count = nested.child_count;
 	} else {
@@ -459,8 +460,7 @@ VariantObjectIterator::VariantObjectIterator(const VariantNode &object, VariantI
 		raw_count = typed_field_count;
 		if (object.overlay_value_index != 0) {
 			auto overlay_value_index = object.overlay_value_index - 1;
-			auto nested = DecodeNestedData(state->unshredded.GetBlob(row),
-			                               state->unshredded.GetByteOffset(row, overlay_value_index));
+			auto nested = DecodeNestedData(unshredded.GetBlob(row), unshredded.GetByteOffset(row, overlay_value_index));
 			overlay_base = nested.children_idx;
 			raw_count += nested.child_count;
 		}
@@ -484,26 +484,27 @@ VariantObjectIterator::VariantObjectIterator(const VariantNode &object, VariantI
 }
 
 VariantObjectEntry VariantObjectIterator::RawEntry(idx_t raw_pos) const {
+	auto &state_ref = state.get();
+	auto &unshredded = state_ref.unshredded;
 	if (!shredded) {
 		auto child_idx = base + raw_pos;
-		auto key_idx = state->unshredded.GetKeysIndex(row, child_idx);
-		auto value_idx = state->unshredded.GetValuesIndex(row, child_idx);
-		return VariantObjectEntry {state->unshredded.GetKey(row, key_idx),
-		                           VariantNode::MakeUnshredded(*state, row, value_idx)};
+		auto key_idx = unshredded.GetKeysIndex(row, child_idx);
+		auto value_idx = unshredded.GetValuesIndex(row, child_idx);
+		return VariantObjectEntry {unshredded.GetKey(row, key_idx),
+		                           VariantNode::MakeUnshredded(state_ref, row, value_idx)};
 	}
 	if (raw_pos < typed_field_count) {
 		//! A shredded (typed) field - struct fields preserve the (logical) index of the parent
 		auto &name = StructType::GetChildTypes(content->logical_type)[raw_pos].first;
 		return VariantObjectEntry {
 		    string_t(name.c_str(), NumericCast<uint32_t>(name.size())),
-		    VariantNode::ResolveShredded(*state, content->children[raw_pos], shredded_index, row)};
+		    VariantNode::ResolveShredded(state_ref, content->children[raw_pos], shredded_index, row)};
 	}
 	//! A leftover field from the overlay (unshredded) object
 	auto child_idx = overlay_base + (raw_pos - typed_field_count);
-	auto key_idx = state->unshredded.GetKeysIndex(row, child_idx);
-	auto value_idx = state->unshredded.GetValuesIndex(row, child_idx);
-	return VariantObjectEntry {state->unshredded.GetKey(row, key_idx),
-	                           VariantNode::MakeUnshredded(*state, row, value_idx)};
+	auto key_idx = unshredded.GetKeysIndex(row, child_idx);
+	auto value_idx = unshredded.GetValuesIndex(row, child_idx);
+	return VariantObjectEntry {unshredded.GetKey(row, key_idx), VariantNode::MakeUnshredded(state_ref, row, value_idx)};
 }
 
 void VariantObjectIterator::Iterator::Load() {

--- a/src/function/scalar/variant/variant_comparator.cpp
+++ b/src/function/scalar/variant/variant_comparator.cpp
@@ -257,7 +257,7 @@ VariantNumberKey IntegerNumberKey(T value) {
 }
 
 //! Compute the number key for any value in the NUMBER rank (integer, decimal or bignum)
-VariantNumberKey VariantGetNumberKey(VariantLogicalType type_id, const VariantIterator &it) {
+VariantNumberKey VariantGetNumberKey(VariantLogicalType type_id, const VariantNode &it) {
 	switch (type_id) {
 	case VariantLogicalType::DECIMAL: {
 		auto decimal_data = it.GetDecimal();
@@ -360,7 +360,7 @@ void VariantEncodeString(SINK &sink, const string_t &str, bool is_varchar) {
 }
 
 template <class SINK>
-void EncodeVariantValue(const VariantIterator &it, SINK &sink) {
+void EncodeVariantValue(const VariantNode &it, SINK &sink) {
 	auto type_id = it.GetTypeId();
 	// write the type rank - this guarantees values are ordered by type first
 	sink.Write(GetVariantTypeRank(type_id));
@@ -484,7 +484,7 @@ void EncodeVariantValue(const VariantIterator &it, SINK &sink) {
 //! encode the *logical* value of the variant - this encoding is intentionally not reversible (e.g.
 //! all integer widths fold together). NULLs are propagated into the result validity.
 void CreateVariantComparator(const Vector &input, idx_t count, Vector &result) {
-	VariantIteratorState variant(input);
+	auto variant = input.Values<VectorVariantType>();
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto writer = FlatVector::Writer<string_t>(result, count);
@@ -492,7 +492,7 @@ void CreateVariantComparator(const Vector &input, idx_t count, Vector &result) {
 	//! reused growable buffer - the key is encoded once and then copied into the result vector
 	string buffer;
 	for (idx_t r = 0; r < count; r++) {
-		auto root = variant.Root(r);
+		auto root = variant.GetValue(r);
 		// a VARIANT is only NULL at the root via a genuine SQL NULL (never a VARIANT_NULL value)
 		if (root.IsNull()) {
 			// propagate NULL so that NULL = NULL stays NULL and ORDER BY ... NULLS FIRST/LAST is honored

--- a/src/function/scalar/variant/variant_comparator.cpp
+++ b/src/function/scalar/variant/variant_comparator.cpp
@@ -492,7 +492,7 @@ void CreateVariantComparator(const Vector &input, idx_t count, Vector &result) {
 	//! reused growable buffer - the key is encoded once and then copied into the result vector
 	string buffer;
 	for (idx_t r = 0; r < count; r++) {
-		auto root = variant.GetValue(r);
+		auto root = variant[r];
 		// a VARIANT is only NULL at the root via a genuine SQL NULL (never a VARIANT_NULL value)
 		if (root.IsNull()) {
 			// propagate NULL so that NULL = NULL stays NULL and ORDER BY ... NULLS FIRST/LAST is honored

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -38,6 +38,9 @@ struct VectorStructType;
 template <class T>
 struct VectorListType;
 
+//! Marker type selecting the VARIANT specialization of VectorIterator (see variant_iterator.hpp)
+struct VectorVariantType;
+
 template <class T, typename... ARGS>
 buffer_ptr<T> make_buffer(ARGS &&...args) { // NOLINT: mimic std casing
 	return make_shared_ptr<T>(std::forward<ARGS>(args)...);

--- a/src/include/duckdb/common/types/variant_iterator.hpp
+++ b/src/include/duckdb/common/types/variant_iterator.hpp
@@ -183,7 +183,8 @@ private:
 	static VariantNode MakeMissing(const VariantIterator &state);
 
 private:
-	const VariantIterator *state;
+	//! The owning iterator this value lives in (null only for a default-constructed cursor)
+	optional_ptr<const VariantIterator> state;
 	Kind kind;
 
 	//! The row this value belongs to (used for the unshredded component / overlay lookups)
@@ -244,7 +245,8 @@ public:
 	}
 
 private:
-	const VariantIterator *state;
+	//! The owning iterator this array's elements live in (always non-null for a real ARRAY node)
+	reference<const VariantIterator> state;
 	idx_t row;
 	idx_t length;
 	bool shredded;
@@ -316,7 +318,8 @@ private:
 	}
 
 private:
-	const VariantIterator *state;
+	//! The owning iterator this object's values live in (always non-null for a real OBJECT node)
+	reference<const VariantIterator> state;
 	idx_t row;
 	VariantIterationOrder order;
 	bool shredded;
@@ -340,7 +343,7 @@ private:
 };
 
 //! Specialization of VectorIterator for VectorVariantType.
-//! Iterates over a VARIANT vector, handing out a VariantNode cursor per row via GetValue(row).
+//! Iterates over a VARIANT vector, handing out a VariantNode cursor per row via operator[].
 //! The cursors point back into the owned VariantIterator, so this iterator must outlive them.
 template <>
 class VectorIterator<VectorVariantType> {
@@ -350,15 +353,12 @@ public:
 
 public:
 	//! Returns a cursor pointing at the root VARIANT value of the given row
-	VariantNode GetValue(idx_t row) const {
+	VariantNode operator[](idx_t row) const {
 		return state.Root(row);
 	}
 	//! Whether the row is a valid (non-NULL) variant
 	bool RowIsValid(idx_t row) const {
 		return state.RowIsValid(row);
-	}
-	VariantNode operator[](idx_t row) const {
-		return state.Root(row);
 	}
 	idx_t size() const {
 		return count;
@@ -369,7 +369,7 @@ public:
 		Iterator(const VectorIterator &parent, idx_t index) : parent(parent), index(index) {
 		}
 		VariantNode operator*() const {
-			return parent.GetValue(index);
+			return parent[index];
 		}
 		Iterator &operator++() { // NOLINT: match stl API
 			++index;

--- a/src/include/duckdb/common/types/variant_iterator.hpp
+++ b/src/include/duckdb/common/types/variant_iterator.hpp
@@ -31,7 +31,8 @@ enum class VariantIterationOrder {
 //===--------------------------------------------------------------------===//
 // VariantIterator
 //===--------------------------------------------------------------------===//
-// VariantIterator iterates over the logical values of a VARIANT vector *without* unshredding it.
+// VariantIterator iterates over the logical values of a VARIANT vector *without* unshredding it,
+// handing out a VariantNode cursor per row (each cursor points at a single logical value/node).
 //
 // A VARIANT vector is either stored in its canonical "unshredded" layout:
 //     STRUCT(
@@ -95,19 +96,19 @@ public:
 	LogicalType logical_type;
 };
 
-class VariantIterator;
+class VariantNode;
 
 //! Shared state required to iterate a single VARIANT vector. Owns the vector iterators / flattened
-//! vectors that the individual VariantIterator cursors point into - so it must outlive any cursor.
-class VariantIteratorState {
+//! vectors that the individual VariantNode cursors point into - so it must outlive any cursor.
+class VariantIterator {
 public:
-	explicit VariantIteratorState(const Vector &variant);
+	explicit VariantIterator(const Vector &variant);
 
 public:
 	//! Whether the row is a (SQL) NULL variant
 	bool RowIsValid(idx_t row) const;
 	//! Returns a cursor pointing at the root value of the given row
-	VariantIterator Root(idx_t row) const;
+	VariantNode Root(idx_t row) const;
 
 private:
 	//! The "core": the unshredded component reader (plain vector iterators)
@@ -118,7 +119,7 @@ private:
 	//! The shredded component - the (recursive) view of the root of the shredded tree
 	ShreddedVariantIterator shredded_format;
 
-	friend class VariantIterator;
+	friend class VariantNode;
 	friend class VariantArrayIterator;
 	friend class VariantObjectIterator;
 };
@@ -127,7 +128,7 @@ class VariantArrayIterator;
 class VariantObjectIterator;
 
 //! A lightweight cursor pointing at a single logical VARIANT value.
-class VariantIterator {
+class VariantNode {
 public:
 	enum class Kind {
 		NULL_VALUE, //! a (SQL/variant) NULL value
@@ -137,7 +138,7 @@ public:
 	};
 
 public:
-	VariantIterator() : state(nullptr), kind(Kind::NULL_VALUE) {
+	VariantNode() : state(nullptr), kind(Kind::NULL_VALUE) {
 	}
 
 public:
@@ -172,17 +173,17 @@ public:
 private:
 	//! Resolve the shredded node (a "STRUCT(typed_value, [untyped_value_index])" wrapper, or a
 	//! flattened primitive) at the given index into a concrete cursor
-	static VariantIterator ResolveShredded(const VariantIteratorState &state, const ShreddedVariantIterator &node,
-	                                       idx_t index, idx_t row);
+	static VariantNode ResolveShredded(const VariantIterator &state, const ShreddedVariantIterator &node, idx_t index,
+	                                   idx_t row);
 
-	static VariantIterator MakeUnshredded(const VariantIteratorState &state, idx_t row, uint32_t value_index);
-	static VariantIterator MakeShredded(const VariantIteratorState &state, const ShreddedVariantIterator &content,
-	                                    idx_t index, idx_t row, uint32_t overlay_value_index);
-	static VariantIterator MakeNull(const VariantIteratorState &state);
-	static VariantIterator MakeMissing(const VariantIteratorState &state);
+	static VariantNode MakeUnshredded(const VariantIterator &state, idx_t row, uint32_t value_index);
+	static VariantNode MakeShredded(const VariantIterator &state, const ShreddedVariantIterator &content, idx_t index,
+	                                idx_t row, uint32_t overlay_value_index);
+	static VariantNode MakeNull(const VariantIterator &state);
+	static VariantNode MakeMissing(const VariantIterator &state);
 
 private:
-	const VariantIteratorState *state;
+	const VariantIterator *state;
 	Kind kind;
 
 	//! The row this value belongs to (used for the unshredded component / overlay lookups)
@@ -199,28 +200,28 @@ private:
 	//! (0 means there is no leftover object to merge)
 	uint32_t overlay_value_index = 0;
 
-	friend class VariantIteratorState;
+	friend class VariantIterator;
 	friend class VariantArrayIterator;
 	friend class VariantObjectIterator;
 };
 
-//! Lazily iterates the element values of an ARRAY VariantIterator. Random-access: no child cursor is
+//! Lazily iterates the element values of an ARRAY VariantNode. Random-access: no child cursor is
 //! materialized until it is dereferenced.
 class VariantArrayIterator {
 public:
-	explicit VariantArrayIterator(const VariantIterator &array);
+	explicit VariantArrayIterator(const VariantNode &array);
 
 public:
 	idx_t size() const {
 		return length;
 	}
-	VariantIterator operator[](idx_t i) const;
+	VariantNode operator[](idx_t i) const;
 
 	class Iterator {
 	public:
 		Iterator(const VariantArrayIterator &parent, idx_t pos) : parent(parent), pos(pos) {
 		}
-		VariantIterator operator*() const {
+		VariantNode operator*() const {
 			return parent[pos];
 		}
 		Iterator &operator++() { // NOLINT: match stl API
@@ -243,7 +244,7 @@ public:
 	}
 
 private:
-	const VariantIteratorState *state;
+	const VariantIterator *state;
 	idx_t row;
 	idx_t length;
 	bool shredded;
@@ -256,16 +257,16 @@ private:
 //! A single (key, value) entry of an OBJECT
 struct VariantObjectEntry {
 	string_t key;
-	VariantIterator value;
+	VariantNode value;
 };
 
-//! Iterates the (key, value) children of an OBJECT VariantIterator, merging the shredded (typed)
+//! Iterates the (key, value) children of an OBJECT VariantNode, merging the shredded (typed)
 //! fields with the leftover unshredded fields. There are two backing modes:
 //!   - INTERNAL order: lazy forward iteration over the raw entries (skipping missing fields)
 //!   - LEXICOGRAPHIC order: iterates the materialized + sorted 'ordered_entries'
 class VariantObjectIterator {
 public:
-	VariantObjectIterator(const VariantIterator &object, VariantIterationOrder order);
+	VariantObjectIterator(const VariantNode &object, VariantIterationOrder order);
 
 public:
 	//! Forward iterator over the object entries. All modes are position-based, so the only difference is
@@ -315,7 +316,7 @@ private:
 	}
 
 private:
-	const VariantIteratorState *state;
+	const VariantIterator *state;
 	idx_t row;
 	VariantIterationOrder order;
 	bool shredded;
@@ -336,6 +337,62 @@ private:
 	vector<VariantObjectEntry> ordered_entries;
 
 	friend class Iterator;
+};
+
+//! Specialization of VectorIterator for VectorVariantType.
+//! Iterates over a VARIANT vector, handing out a VariantNode cursor per row via GetValue(row).
+//! The cursors point back into the owned VariantIterator, so this iterator must outlive them.
+template <>
+class VectorIterator<VectorVariantType> {
+public:
+	explicit VectorIterator(const Vector &vector) : state(vector), count(vector.size()) {
+	}
+
+public:
+	//! Returns a cursor pointing at the root VARIANT value of the given row
+	VariantNode GetValue(idx_t row) const {
+		return state.Root(row);
+	}
+	//! Whether the row is a valid (non-NULL) variant
+	bool RowIsValid(idx_t row) const {
+		return state.RowIsValid(row);
+	}
+	VariantNode operator[](idx_t row) const {
+		return state.Root(row);
+	}
+	idx_t size() const {
+		return count;
+	}
+
+	class Iterator {
+	public:
+		Iterator(const VectorIterator &parent, idx_t index) : parent(parent), index(index) {
+		}
+		VariantNode operator*() const {
+			return parent.GetValue(index);
+		}
+		Iterator &operator++() { // NOLINT: match stl API
+			++index;
+			return *this;
+		}
+		bool operator!=(const Iterator &other) const {
+			return index != other.index;
+		}
+
+	private:
+		const VectorIterator &parent;
+		idx_t index;
+	};
+	Iterator begin() const { // NOLINT: match stl API
+		return Iterator(*this, 0);
+	}
+	Iterator end() const { // NOLINT: match stl API
+		return Iterator(*this, count);
+	}
+
+private:
+	VariantIterator state;
+	idx_t count;
 };
 
 } // namespace duckdb

--- a/test/sql/storage/types/variant/variant_comparator_shredded.test
+++ b/test/sql/storage/types/variant/variant_comparator_shredded.test
@@ -5,7 +5,7 @@
 load {TEST_DIR}/variant_comparator_shredded.db readwrite v1.5.0
 
 # always shred, and force a partial object shredding so that the leftover fields (c/d/e/g) and the
-# NULL/array rows end up in the unshredded component - exercising the merge in VariantIterator
+# NULL/array rows end up in the unshredded component - exercising the merge in VariantNode
 statement ok
 SET variant_minimum_shredding_size = 0;
 


### PR DESCRIPTION
Instead of having a separate iterator for variants, we can now do this:

```cpp
auto variant_values = input.Values<VectorVariantType>();

for (idx_t r = 0; r < count; r++) {
    auto entry = variant_values[r];
    if (entry.IsNull()) {
        // top level variant is NULL
    }
    auto val = entry.GetValue(); // get the variant value
}
```

Also, for clarity, renamed:

* `VariantIteratorState -> VariantIterator` - this represents the iterator over the variant vector that holds the unified vector formats, etc - created once per vector
* `VariantIterator -> VariantNode` - this is a single node within the variant (e.g. an integer, an object, etc)

CC @Tishj 