### PR TITLE
Propagate stats in `structured type -> variant` casts

### DIFF
--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -47,6 +47,11 @@ public:
 	DUCKDB_API static BaseStatistics CreateUnknown(LogicalType type);
 	DUCKDB_API static BaseStatistics CreateEmpty(LogicalType type);
 	DUCKDB_API static BaseStatistics CreateShredded(const LogicalType &shredded_type);
+	//! Propagate statistics through a cast to VARIANT - builds fully-shredded VARIANT statistics describing
+	//! a (possibly nested) non-variant value of `source_type` with statistics `child_stats`.
+	//! Returns nullptr when the type can not be represented as a single consistent shredding.
+	DUCKDB_API static unique_ptr<BaseStatistics> StatisticsPropagateToVariant(const LogicalType &source_type,
+	                                                                          const BaseStatistics &child_stats);
 
 public:
 	//! Stats related to the 'unshredded' column, which holds all data that doesn't fit in the structure of the shredded

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -218,23 +218,6 @@ static unique_ptr<BaseStatistics> StatisticsPropagateVariant(const BaseStatistic
 	return StatisticsPropagator::TryPropagateCast(typed_stats, structured_type, target);
 }
 
-static unique_ptr<BaseStatistics> StatisticsPropagateToVariant(const BaseStatistics &input, const LogicalType &source) {
-	if (source.IsNested() || source.id() == LogicalTypeId::VARIANT) {
-		// only propagate primitive types - the variant stores them in a single shredded bucket
-		return nullptr;
-	}
-	if (source.id() == LogicalTypeId::ENUM) {
-		// an ENUM is not stored as an ENUM in the variant, so its typed stats don't carry over
-		return nullptr;
-	}
-	// the cast stores every value in a single fully-shredded primitive bucket - the input stats are the typed stats
-	auto result = VariantStats::CreateShredded(source);
-	VariantStats::SetShreddedStats(result, input);
-	// the cast preserves NULLs exactly, so the variant validity matches the input validity
-	result.CopyBase(input);
-	return result.ToUnique();
-}
-
 unique_ptr<BaseStatistics> StatisticsPropagator::TryPropagateCast(const BaseStatistics &stats,
                                                                   const LogicalType &source,
                                                                   const LogicalType &target) {
@@ -242,7 +225,8 @@ unique_ptr<BaseStatistics> StatisticsPropagator::TryPropagateCast(const BaseStat
 		return StatisticsPropagateVariant(stats, target);
 	}
 	if (target.id() == LogicalTypeId::VARIANT) {
-		return StatisticsPropagateToVariant(stats, source);
+		// the cast shreds every value into a single bucket - mirror the (possibly nested) source as typed stats
+		return VariantStats::StatisticsPropagateToVariant(source, stats);
 	}
 	if (!CanPropagateCast(source, target)) {
 		return nullptr;

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -218,11 +218,31 @@ static unique_ptr<BaseStatistics> StatisticsPropagateVariant(const BaseStatistic
 	return StatisticsPropagator::TryPropagateCast(typed_stats, structured_type, target);
 }
 
+static unique_ptr<BaseStatistics> StatisticsPropagateToVariant(const BaseStatistics &input, const LogicalType &source) {
+	if (source.IsNested() || source.id() == LogicalTypeId::VARIANT) {
+		// only propagate primitive types - the variant stores them in a single shredded bucket
+		return nullptr;
+	}
+	if (source.id() == LogicalTypeId::ENUM) {
+		// an ENUM is not stored as an ENUM in the variant, so its typed stats don't carry over
+		return nullptr;
+	}
+	// the cast stores every value in a single fully-shredded primitive bucket - the input stats are the typed stats
+	auto result = VariantStats::CreateShredded(source);
+	VariantStats::SetShreddedStats(result, input);
+	// the cast preserves NULLs exactly, so the variant validity matches the input validity
+	result.CopyBase(input);
+	return result.ToUnique();
+}
+
 unique_ptr<BaseStatistics> StatisticsPropagator::TryPropagateCast(const BaseStatistics &stats,
                                                                   const LogicalType &source,
                                                                   const LogicalType &target) {
 	if (source.id() == LogicalTypeId::VARIANT) {
 		return StatisticsPropagateVariant(stats, target);
+	}
+	if (target.id() == LogicalTypeId::VARIANT) {
+		return StatisticsPropagateToVariant(stats, source);
 	}
 	if (!CanPropagateCast(source, target)) {
 		return nullptr;

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/statistics/variant_stats.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/array_stats.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
@@ -447,6 +448,74 @@ static BaseStatistics WrapTypedValue(const BaseStatistics &typed_value,
 		StructStats::GetChildStats(shredded, VariantStats::UNTYPED_VALUE_INDEX).Copy(*untyped_value_index);
 	}
 	return shredded;
+}
+
+//! Recursively build the shredding representation stats for a value of `type` with statistics `input`.
+//! Returns nullptr when the type can not be represented as a single consistent shredding.
+static unique_ptr<BaseStatistics> TryBuildShreddingStats(const LogicalType &type, const BaseStatistics &input) {
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT: {
+		auto &fields = StructType::GetChildTypes(type);
+		if (fields.empty()) {
+			// an empty object has no shredded fields to push down
+			return nullptr;
+		}
+		child_list_t<LogicalType> typed_children;
+		vector<unique_ptr<BaseStatistics>> child_stats;
+		child_stats.reserve(fields.size());
+		for (idx_t i = 0; i < fields.size(); i++) {
+			auto child_result = TryBuildShreddingStats(fields[i].second, StructStats::GetChildStats(input, i));
+			if (!child_result) {
+				return nullptr;
+			}
+			typed_children.emplace_back(fields[i].first, child_result->GetType());
+			child_stats.push_back(std::move(child_result));
+		}
+		auto typed_value = BaseStatistics::CreateEmpty(LogicalType::STRUCT(std::move(typed_children)));
+		for (idx_t i = 0; i < child_stats.size(); i++) {
+			StructStats::SetChildStats(typed_value, i, *child_stats[i]);
+		}
+		typed_value.CopyValidity(input);
+		return WrapTypedValue(typed_value, nullptr).ToUnique();
+	}
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::ARRAY: {
+		const bool is_list = type.id() == LogicalTypeId::LIST;
+		auto &child_type = is_list ? ListType::GetChildType(type) : ArrayType::GetChildType(type);
+		auto &input_child = is_list ? ListStats::GetChildStats(input) : ArrayStats::GetChildStats(input);
+		auto child_result = TryBuildShreddingStats(child_type, input_child);
+		if (!child_result) {
+			return nullptr;
+		}
+		// a variant stores both LISTs and fixed-size ARRAYs as a (variable length) array
+		auto typed_value = BaseStatistics::CreateEmpty(LogicalType::LIST(child_result->GetType()));
+		ListStats::SetChildStats(typed_value, std::move(child_result));
+		typed_value.CopyValidity(input);
+		return WrapTypedValue(typed_value, nullptr).ToUnique();
+	}
+	default:
+		if (type.IsNested() || type.id() == LogicalTypeId::ENUM) {
+			// MAP / UNION / ENUM etc. are not stored in their source representation in the variant
+			return nullptr;
+		}
+		return input.ToUnique();
+	}
+}
+
+unique_ptr<BaseStatistics> VariantStats::StatisticsPropagateToVariant(const LogicalType &source_type,
+                                                                     const BaseStatistics &child_stats) {
+	if (source_type.id() == LogicalTypeId::VARIANT) {
+		return nullptr;
+	}
+	auto shredding = TryBuildShreddingStats(source_type, child_stats);
+	if (!shredding) {
+		return nullptr;
+	}
+	auto result = VariantStats::CreateShredded(shredding->GetType());
+	VariantStats::SetShreddedStats(result, *shredding);
+	// the cast preserves NULLs exactly, so the top-level variant validity matches the input validity
+	result.CopyBase(child_stats);
+	return result.ToUnique();
 }
 
 unique_ptr<BaseStatistics> VariantStats::WrapExtractedFieldAsVariant(const BaseStatistics &base_variant,

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -503,7 +503,7 @@ static unique_ptr<BaseStatistics> TryBuildShreddingStats(const LogicalType &type
 }
 
 unique_ptr<BaseStatistics> VariantStats::StatisticsPropagateToVariant(const LogicalType &source_type,
-                                                                     const BaseStatistics &child_stats) {
+                                                                      const BaseStatistics &child_stats) {
 	if (source_type.id() == LogicalTypeId::VARIANT) {
 		return nullptr;
 	}

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -364,7 +364,7 @@ static Value GetShreddedStatsStruct(const BaseStatistics &stats, bool fully_shre
 		return Value();
 	}
 
-	auto &typed_value = StructStats::GetChildStats(stats, VariantStats::TYPED_VALUE_INDEX);
+	auto &typed_value = VariantStats::GetTypedStats(stats);
 	auto type_id = typed_value.GetType().id();
 	if (type_id == LogicalTypeId::LIST) {
 		// list

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -113,6 +113,7 @@
         "test/sql/function/timetz/test_date_part.test",
         "test/sql/storage/types/variant/variant_extract_stats.test",
         "test/sql/storage/types/variant/variant_comparator_stats.test",
+        "test/sql/types/variant/variant_cast_stats.test",
         "test/sql/alter/alter_type/test_alter_type.test",
         "test/sql/alter/add_col/test_add_col_stats.test",
         "test/sql/copy/return_stats.test",

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -29,6 +29,7 @@
         "test/sql/function/generic/test_stats.test",
         "test/sql/storage/types/variant/variant_extract_stats.test",
         "test/sql/storage/types/variant/variant_comparator_stats.test",
+        "test/sql/types/variant/variant_cast_stats.test",
         "test/sql/alter/alter_type/test_alter_type.test",
         "test/sql/alter/add_col/test_add_col_stats.test",
         "test/sql/copy/parquet/bloom_filters.test",

--- a/test/sql/types/variant/variant_cast_stats.test
+++ b/test/sql/types/variant/variant_cast_stats.test
@@ -1,0 +1,79 @@
+# name: test/sql/types/variant/variant_cast_stats.test
+# description: statistics propagation for casts to VARIANT
+# group: [variant]
+
+# ------------------------------ Cast from a primitive (INTEGER) ------------------------------
+
+statement ok
+CREATE TABLE t AS SELECT range n FROM range(10);
+
+# the cast stores every value in a single fully-shredded bucket - the typed min/max carry over
+query IIIII
+SELECT s.shredding_state, s.fully_shredded.type, s.fully_shredded.stats.min, s.fully_shredded.stats.max,
+       s.fully_shredded.stats.has_null
+FROM (SELECT stats(n::VARIANT) s FROM t LIMIT 1);
+----
+SHREDDED	BIGINT	0	9	false
+
+# ------------------------------ Cast from VARCHAR ------------------------------
+
+statement ok
+CREATE TABLE s AS SELECT 'val_' || range AS v FROM range(10);
+
+query IIIII
+SELECT s.shredding_state, s.fully_shredded.type, s.fully_shredded.stats.min, s.fully_shredded.stats.max,
+       s.fully_shredded.stats.has_null
+FROM (SELECT stats(v::VARIANT) s FROM s LIMIT 1);
+----
+SHREDDED	VARCHAR	val_0	val_9	false
+
+# ------------------------------ NULLs are propagated ------------------------------
+
+statement ok
+CREATE TABLE nn AS SELECT CASE WHEN range % 2 = 0 THEN range END AS c FROM range(10);
+
+# a nullable source propagates NULLs to both the top-level variant and the typed bucket
+query IIII
+SELECT s.shredding_state, s.fully_shredded.type, s.has_null, s.fully_shredded.stats.has_null
+FROM (SELECT stats(c::VARIANT) s FROM nn LIMIT 1);
+----
+SHREDDED	BIGINT	true	true
+
+# a TRY_CAST can always introduce NULLs at the top level, even over a non-nullable source
+query IIII
+SELECT s.shredding_state, s.fully_shredded.type, s.has_null, s.fully_shredded.stats.has_null
+FROM (SELECT stats(TRY_CAST(n AS VARIANT)) s FROM t LIMIT 1);
+----
+SHREDDED	BIGINT	true	false
+
+# ------------------------------ Nested sources are not shredded into a single bucket ------------------------------
+
+statement ok
+CREATE TABLE l AS SELECT [range] AS c FROM range(10);
+
+query I
+SELECT s.shredding_state FROM (SELECT stats([n]::VARIANT) s FROM t LIMIT 1);
+----
+INCONSISTENT
+
+# ------------------------------ The derived bounds are correct (pruning) ------------------------------
+
+statement ok
+CREATE TABLE big AS SELECT range m FROM range(100);
+
+# values inside the range still match
+query I
+SELECT count(*) FROM big WHERE m::VARIANT = 50::BIGINT::VARIANT;
+----
+1
+
+# a value outside the bucket range matches nothing
+query I
+SELECT count(*) FROM big WHERE m::VARIANT = 5000::BIGINT::VARIANT;
+----
+0
+
+query I
+SELECT count(*) FROM big WHERE m::VARIANT > 90::BIGINT::VARIANT;
+----
+9

--- a/test/sql/types/variant/variant_cast_stats.test
+++ b/test/sql/types/variant/variant_cast_stats.test
@@ -46,13 +46,41 @@ FROM (SELECT stats(TRY_CAST(n AS VARIANT)) s FROM t LIMIT 1);
 ----
 SHREDDED	BIGINT	true	false
 
-# ------------------------------ Nested sources are not shredded into a single bucket ------------------------------
+# ------------------------------ Nested sources shred recursively ------------------------------
 
 statement ok
-CREATE TABLE l AS SELECT [range] AS c FROM range(10);
+CREATE TABLE obj AS SELECT {'a': range, 'b': 'x' || range} AS o, [range, range + 100] AS l FROM range(50);
 
+# a STRUCT cast keeps a typed bucket per field
+query III
+SELECT s.shredding_state, s.fully_shredded.a.type, s.fully_shredded.b.type
+FROM (SELECT stats(o::VARIANT) s FROM obj LIMIT 1);
+----
+SHREDDED	BIGINT	VARCHAR
+
+# extracting a field from the casted struct propagates that field's bounds
+query III
+SELECT s.fully_shredded.type, s.fully_shredded.stats.min, s.fully_shredded.stats.max
+FROM (SELECT stats((o::VARIANT).a) s FROM obj LIMIT 1);
+----
+BIGINT	0	49
+
+query III
+SELECT s.fully_shredded.type, s.fully_shredded.stats.min, s.fully_shredded.stats.max
+FROM (SELECT stats((o::VARIANT).b) s FROM obj LIMIT 1);
+----
+VARCHAR	x0	x9
+
+# a LIST cast shreds the element type - extracting an element propagates the child bounds
+query III
+SELECT s.fully_shredded.type, s.fully_shredded.stats.min, s.fully_shredded.stats.max
+FROM (SELECT stats((l::VARIANT)[1]) s FROM obj LIMIT 1);
+----
+BIGINT	0	149
+
+# MAP can not be represented as a single shredding
 query I
-SELECT s.shredding_state FROM (SELECT stats([n]::VARIANT) s FROM t LIMIT 1);
+SELECT s.shredding_state FROM (SELECT stats(MAP {'k': n}::VARIANT) s FROM t LIMIT 1);
 ----
 INCONSISTENT
 
@@ -77,3 +105,14 @@ query I
 SELECT count(*) FROM big WHERE m::VARIANT > 90::BIGINT::VARIANT;
 ----
 9
+
+# pruning through a nested field extract - the filter is provably empty
+query I
+SELECT count(*) FROM obj WHERE (o::VARIANT).a::BIGINT = 9999;
+----
+0
+
+query I
+SELECT count(*) FROM obj WHERE (o::VARIANT).a::BIGINT = 25;
+----
+1


### PR DESCRIPTION
When we cast from a structured type (e.g. `INT`, `INT[]` or `STRUCT(x INT)`) to a variant we know that the variant has a consistent schema. We already take advantage of that in the cast implementation by emitting a shredded vector. This PR extends this by also propagating the statistics of the structured type into the shredded variant stats so that subsequent operations know that the variant is shredded on this specific type. 