### PR TITLE
Deprecate Implicit Table-Function Identifier String Conversion

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -71,6 +71,7 @@
 #include "duckdb/common/enums/storage_block_prefetch.hpp"
 #include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb/common/enums/subquery_type.hpp"
+#include "duckdb/common/enums/table_function_identifier_conversion.hpp"
 #include "duckdb/common/enums/tableref_type.hpp"
 #include "duckdb/common/enums/task_scheduler_type.hpp"
 #include "duckdb/common/enums/thread_pin_mode.hpp"
@@ -5530,6 +5531,25 @@ const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value) {
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
 	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 12, "TableFilterType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetTableFunctionIdentifierConversionValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(TableFunctionIdentifierConversion::DEFAULT), "DEFAULT" },
+		{ static_cast<uint32_t>(TableFunctionIdentifierConversion::ENABLE_IMPLICIT_STRING), "ENABLE_IMPLICIT_STRING" },
+		{ static_cast<uint32_t>(TableFunctionIdentifierConversion::DISABLE_IMPLICIT_STRING), "DISABLE_IMPLICIT_STRING" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionIdentifierConversion>(TableFunctionIdentifierConversion value) {
+	return StringUtil::EnumToString(GetTableFunctionIdentifierConversionValues(), 3, "TableFunctionIdentifierConversion", static_cast<uint32_t>(value));
+}
+
+template<>
+TableFunctionIdentifierConversion EnumUtil::FromString<TableFunctionIdentifierConversion>(const char *value) {
+	return static_cast<TableFunctionIdentifierConversion>(StringUtil::StringToEnum(GetTableFunctionIdentifierConversionValues(), 3, "TableFunctionIdentifierConversion", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTableFunctionParallelismValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1271,6 +1271,13 @@
         "custom_implementation": true
     },
     {
+        "name": "table_function_identifier_conversion",
+        "description": "Configures the use of deprecated implicit conversion of unbound identifiers to strings in table function arguments.",
+        "type": "ENUM<TableFunctionIdentifierConversion>",
+        "default_scope": "local",
+        "default_value": "DEFAULT"
+    },
+    {
         "name": "temp_directory",
         "description": "Set the directory to which to write temp files",
         "type": "VARCHAR",

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -492,6 +492,8 @@ enum class TableColumnType : uint8_t;
 
 enum class TableFilterType : uint8_t;
 
+enum class TableFunctionIdentifierConversion : uint8_t;
+
 enum class TableFunctionParallelism : uint8_t;
 
 enum class TablePartitionInfo : uint8_t;
@@ -1250,6 +1252,9 @@ const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value);
 
 template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionIdentifierConversion>(TableFunctionIdentifierConversion value);
 
 template<>
 const char* EnumUtil::ToChars<TableFunctionParallelism>(TableFunctionParallelism value);
@@ -2043,6 +2048,9 @@ TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
+
+template<>
+TableFunctionIdentifierConversion EnumUtil::FromString<TableFunctionIdentifierConversion>(const char *value);
 
 template<>
 TableFunctionParallelism EnumUtil::FromString<TableFunctionParallelism>(const char *value);

--- a/src/include/duckdb/common/enums/table_function_identifier_conversion.hpp
+++ b/src/include/duckdb/common/enums/table_function_identifier_conversion.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/table_function_identifier_conversion.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class TableFunctionIdentifierConversion : uint8_t {
+	DEFAULT = 0,
+	ENABLE_IMPLICIT_STRING = 1,
+	DISABLE_IMPLICIT_STRING = 2
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1870,6 +1870,18 @@ struct StreamingBufferSizeSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct TableFunctionIdentifierConversionSetting {
+	using RETURN_TYPE = TableFunctionIdentifierConversion;
+	static constexpr const char *Name = "table_function_identifier_conversion";
+	static constexpr const char *Description = "Configures the use of deprecated implicit conversion of unbound "
+	                                           "identifiers to strings in table function arguments.";
+	static constexpr const char *InputType = "VARCHAR";
+	static constexpr const char *DefaultValue = "DEFAULT";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct TempDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "temp_directory";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -227,6 +227,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(StorageBlockPrefetchSetting),
     DUCKDB_GLOBAL(StorageCompatibilityVersionSetting),
     DUCKDB_LOCAL(StreamingBufferSizeSetting),
+    DUCKDB_SETTING_CALLBACK(TableFunctionIdentifierConversionSetting),
     DUCKDB_GLOBAL(TempDirectorySetting),
     DUCKDB_SETTING_CALLBACK(TempFileEncryptionSetting),
     DUCKDB_GLOBAL(ThreadsSetting),
@@ -247,9 +248,9 @@ static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("confi
                                                      DUCKDB_SETTING_ALIAS("memory_limit", 126),
                                                      DUCKDB_SETTING_ALIAS("null_order", 59),
                                                      DUCKDB_SETTING_ALIAS("profile_output", 149),
-                                                     DUCKDB_SETTING_ALIAS("user", 165),
+                                                     DUCKDB_SETTING_ALIAS("user", 166),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 163),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 164),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -217,6 +217,13 @@ void StorageBlockPrefetchSetting::OnSet(SettingCallbackInfo &info, Value &parame
 }
 
 //===----------------------------------------------------------------------===//
+// Table Function Identifier Conversion
+//===----------------------------------------------------------------------===//
+void TableFunctionIdentifierConversionSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {
+	EnumUtil::FromString<TableFunctionIdentifierConversion>(StringValue::Get(parameter));
+}
+
+//===----------------------------------------------------------------------===//
 // Validate External File Cache
 //===----------------------------------------------------------------------===//
 void ValidateExternalFileCacheSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -1,4 +1,8 @@
 #include "duckdb/planner/expression_binder/table_function_binder.hpp"
+#include "duckdb/common/enums/table_function_identifier_conversion.hpp"
+#include "duckdb/common/sql_identifier.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/table_binding.hpp"
@@ -72,6 +76,21 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		                      result_name);
 	}
 
+	auto setting = Settings::Get<TableFunctionIdentifierConversionSetting>(context);
+	auto implicit_conversion_disabled = setting == TableFunctionIdentifierConversion::DISABLE_IMPLICIT_STRING;
+	auto warn_implicit_conversion = setting == TableFunctionIdentifierConversion::DEFAULT;
+	const auto msg =
+	    StringUtil::Format("Deprecated implicit conversion of unbound identifiers to strings in table function "
+	                       "arguments detected. Please use a string literal instead, e.g. %s.\n"
+	                       "Use SET table_function_identifier_conversion='ENABLE_IMPLICIT_STRING' to revert to the "
+	                       "deprecated behavior.",
+	                       SQLString::ToString(result_name));
+	if (implicit_conversion_disabled) {
+		throw BinderException(query_location, msg);
+	}
+	if (warn_implicit_conversion) {
+		DUCKDB_LOG_WARNING(context, msg);
+	}
 	return BindResult(make_uniq<BoundConstantExpression>(Value(result_name)));
 }
 

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/enums/allow_parser_override.hpp"
 #include "duckdb/common/enums/deprecated_using_key_syntax.hpp"
 #include "duckdb/common/enums/dialect_compatibility_mode.hpp"
+#include "duckdb/common/enums/table_function_identifier_conversion.hpp"
 #include "test_helpers.hpp"
 
 #include <iostream>
@@ -68,6 +69,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"autoinstall_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"lambda_syntax", {EnumUtil::ToString(LambdaSyntax::DISABLE_SINGLE_ARROW)}},
 	    {"deprecated_using_key_syntax", {EnumUtil::ToString(DeprecatedUsingKeySyntax::UNION_AS_UNION_ALL)}},
+	    {"table_function_identifier_conversion",
+	     {EnumUtil::ToString(TableFunctionIdentifierConversion::DISABLE_IMPLICIT_STRING)}},
 	    {"dialect_compatibility_mode", {EnumUtil::ToString(DialectCompatibilityMode::SPARK)}},
 	    {"allow_parser_override_extension", {EnumUtil::ToString(AllowParserOverride::FALLBACK_OVERRIDE)}},
 	    {"profiling_coverage", {EnumUtil::ToString(ProfilingCoverage::ALL)}},

--- a/test/sql/table_function/warn_deprecated_identifier_conversion.test
+++ b/test/sql/table_function/warn_deprecated_identifier_conversion.test
@@ -1,0 +1,69 @@
+# name: test/sql/table_function/warn_deprecated_identifier_conversion.test
+# description: Test warnings for deprecated implicit identifier-to-string conversion in table functions
+# group: [table_function]
+
+statement ok
+CALL enable_logging(level='warning');
+
+# Default behavior still converts the identifier to a string, but warns.
+query I
+SELECT count(*) FROM glob(no_such_file.csv);
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_logs
+WHERE log_level = 'WARNING'
+  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
+----
+1
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Explicit string literals should not warn.
+query I
+SELECT count(*) FROM glob('no_such_file.csv');
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_logs
+WHERE log_level = 'WARNING'
+  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
+----
+0
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Explicitly enabling the deprecated behavior should not warn.
+statement ok
+SET table_function_identifier_conversion='ENABLE_IMPLICIT_STRING';
+
+query I
+SELECT count(*) FROM glob(no_such_file.csv);
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_logs
+WHERE log_level = 'WARNING'
+  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
+----
+0
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Disabling the deprecated behavior rejects implicit conversion.
+statement ok
+SET table_function_identifier_conversion='DISABLE_IMPLICIT_STRING';
+
+statement error
+SELECT count(*) FROM glob(no_such_file.csv);
+----
+Deprecated implicit conversion of unbound identifiers to strings in table function arguments detected
+
+statement ok
+RESET table_function_identifier_conversion;

--- a/test/sql/table_function/warn_deprecated_identifier_conversion.test
+++ b/test/sql/table_function/warn_deprecated_identifier_conversion.test
@@ -1,41 +1,18 @@
 # name: test/sql/table_function/warn_deprecated_identifier_conversion.test
-# description: Test warnings for deprecated implicit identifier-to-string conversion in table functions
+# description: Test deprecated implicit identifier-to-string conversion setting in table functions
 # group: [table_function]
 
-statement ok
-CALL enable_logging(level='warning');
-
-# Default behavior still converts the identifier to a string, but warns.
+# Default behavior still converts the identifier to a string.
 query I
 SELECT count(*) FROM glob(no_such_file.csv);
 ----
 0
 
-query I
-SELECT count(*) FROM duckdb_logs
-WHERE log_level = 'WARNING'
-  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
-----
-1
-
-statement ok
-CALL truncate_duckdb_logs();
-
-# Explicit string literals should not warn.
+# Explicit string literals should continue to work.
 query I
 SELECT count(*) FROM glob('no_such_file.csv');
 ----
 0
-
-query I
-SELECT count(*) FROM duckdb_logs
-WHERE log_level = 'WARNING'
-  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
-----
-0
-
-statement ok
-CALL truncate_duckdb_logs();
 
 # Explicitly enabling the deprecated behavior should not warn.
 statement ok
@@ -45,16 +22,6 @@ query I
 SELECT count(*) FROM glob(no_such_file.csv);
 ----
 0
-
-query I
-SELECT count(*) FROM duckdb_logs
-WHERE log_level = 'WARNING'
-  AND starts_with(message, 'Deprecated implicit conversion of unbound identifiers to strings');
-----
-0
-
-statement ok
-CALL truncate_duckdb_logs();
 
 # Disabling the deprecated behavior rejects implicit conversion.
 statement ok


### PR DESCRIPTION
This PR starts deprecation of automatic column identifier conversion in table function parameters:
```sql
select * from read_csv(lineitem.csv) limit 10;
```

There are three settings now for `table_function_identifier_conversion`:
- `DEFAULT`: warn and keep implicit conversion
- `ENABLE_IMPLICIT_STRING`: keep implicit conversion silently
- `DISABLE_IMPLICIT_STRING`: reject implicit conversion with a binder error

We will keep it on `DEFAULT` for 2.0. Switch it to `DISABLE_IMPLICIT_STRING` with 2.1. And potentially remove the configuration option with 2.2.

fix: https://github.com/duckdblabs/duckdb-internal/issues/9302