### PR TITLE
Fix deadlock in `TemporaryMemoryManager`

### DIFF
--- a/src/storage/temporary_memory_manager.cpp
+++ b/src/storage/temporary_memory_manager.cpp
@@ -188,26 +188,28 @@ static idx_t ComputeInitialReservation(const TemporaryMemoryState &temporary_mem
 static void ComputeDerivatives(const vector<reference<const TemporaryMemoryState>> &states, const vector<idx_t> &res,
                                vector<double> &der, const idx_t n) {
 	// Cost function takes "throughput" (reservation / size) of each operator as its principal input
-	double prod_siz = 1;
-	double prod_res = 1;
+	double log_throughput_prod = 0;
 	double mat_cost = 0;
 	for (idx_t i = 0; i < n; i++) {
 		auto &state = states[i].get();
 		const auto resd = static_cast<double>(res[i]);
 		const auto sizd = static_cast<double>(MaxValue<idx_t>(state.GetRemainingSize(), 1));
 		const auto pend = static_cast<double>(state.GetMaterializationPenalty());
-		prod_res *= resd;
-		prod_siz *= sizd;
-		mat_cost += pend * (1 - resd / sizd); // Materialization cost: sum of (1 - throughput)
+		D_ASSERT(resd > 0);
+		D_ASSERT(resd <= sizd);
+		const auto throughput = resd / sizd;
+		log_throughput_prod += std::log(throughput);
+		mat_cost += pend * (1 - throughput); // Materialization cost: sum of (1 - throughput)
 	}
-	const double nd = static_cast<double>(n);                    // n as double for convenience
-	const double tp_mult = 1 - pow(prod_res / prod_siz, 1 / nd); // Throughput multiplier: 1 - geomean throughputs
+	const double nd = static_cast<double>(n); // n as double for convenience
+	const double throughput_geomean = std::exp(log_throughput_prod / nd);
+	const double tp_mult = 1 - throughput_geomean; // Throughput multiplier: 1 - geomean throughputs
 
 	// Cost function: materialization cost * (1 - throughput multiplier), but we don't actually need to compute it
 	// here. We need to compute the derivative with respect to every reservation, stored in "der"
 	// Just use https://www.derivative-calculator.net with this (n = 3) to see what's going on
 	// (3 - (a_1/s_1)-(a_2/s_2)-(a_3/s_3))*(1-((a_1/s_1)*(a_2/s_2)*(a_3/s_3))^(1/3))
-	const double intermediate = -(pow(prod_res, 1 / nd) * mat_cost) / (nd * pow(prod_siz, 1 / nd));
+	const double intermediate = -(throughput_geomean * mat_cost) / nd;
 	for (idx_t i = 0; i < n; i++) {
 		auto &state = states[i].get();
 		const auto resd = static_cast<double>(res[i]);
@@ -251,22 +253,26 @@ idx_t TemporaryMemoryManager::ComputeReservation(const TemporaryMemoryState &tem
 	// Distribute memory in OPTIMIZATION_ITERATIONS
 	idx_t remaining_memory = free_memory;
 	const idx_t optimization_iterations = OPTIMIZATION_ITERATIONS_MULTIPLIER * n;
-	for (idx_t opt_idx = 0; opt_idx < optimization_iterations; opt_idx++) {
-		D_ASSERT(remaining_memory != 0);
+	for (idx_t opt_idx = 0; opt_idx < optimization_iterations && remaining_memory > 0; opt_idx++) {
 		ComputeDerivatives(states, res, der, n);
 
 		// Find the index of the state with the lowest derivative
 		idx_t min_idx = 0;
 		double min_der = NumericLimits<double>::Maximum();
+		bool found_candidate = false;
 		for (i = 0; i < n; i++) {
 			auto &state = states[i].get();
 			if (res[i] >= state.GetRemainingSize()) {
 				continue; // We can't increase the reservation of "maxed" states, so we skip these
 			}
-			if (der[i] < min_der) {
+			if (!found_candidate || der[i] < min_der) {
 				min_idx = i;
 				min_der = der[i];
+				found_candidate = true;
 			}
+		}
+		if (!found_candidate) {
+			break;
 		}
 		auto &min_state = states[min_idx].get();
 
@@ -289,7 +295,6 @@ idx_t TemporaryMemoryManager::ComputeReservation(const TemporaryMemoryState &tem
 			opt_idx--;
 		}
 	}
-	D_ASSERT(remaining_memory == 0);
 
 	// We computed how the memory should be assigned to the states,
 	// but we did not yet take into account the upper bound of MAXIMUM_FREE_MEMORY_RATIO * free_memory.

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp
+  test_temporary_memory_manager.cpp
   test_value_to_sql_string.cpp)
 
 set(ALL_OBJECT_FILES

--- a/test/common/test_temporary_memory_manager.cpp
+++ b/test/common/test_temporary_memory_manager.cpp
@@ -1,0 +1,44 @@
+#include "catch.hpp"
+
+#include "duckdb/main/database.hpp"
+#include "duckdb/storage/buffer/buffer_pool.hpp"
+#include "duckdb/storage/temporary_memory_manager.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("TemporaryMemoryManager handles many active states", "[storage][temporary_memory_manager]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
+
+	constexpr idx_t memory_limit = 1024ULL * 1024ULL * 1024ULL;
+	constexpr idx_t state_count = 80;
+	constexpr idx_t initial_reservation = 10ULL * 1024ULL * 1024ULL;
+	constexpr idx_t remaining_size = 1024ULL * 1024ULL * 1024ULL;
+
+	buffer_pool.SetLimit(memory_limit, "temporary memory manager test");
+
+	auto &manager = TemporaryMemoryManager::Get(context);
+	duckdb::vector<duckdb::unique_ptr<TemporaryMemoryState>> states;
+	states.reserve(state_count);
+	for (idx_t i = 0; i < state_count; i++) {
+		auto state = manager.Register(context);
+		state->SetMinimumReservation(initial_reservation);
+		state->SetRemainingSize(remaining_size);
+		states.push_back(std::move(state));
+	}
+
+	REQUIRE_NO_FAIL(con.Query("SET debug_force_external=true"));
+	for (auto &state : states) {
+		state->UpdateReservation(context);
+		REQUIRE(state->GetReservation() == initial_reservation);
+	}
+
+	REQUIRE_NO_FAIL(con.Query("SET debug_force_external=false"));
+	states.back()->UpdateReservation(context);
+
+	REQUIRE(states.back()->GetReservation() >= initial_reservation);
+	REQUIRE(states.back()->GetReservation() <= remaining_size);
+}


### PR DESCRIPTION
Fixes #23219

Some `NaN` values were being created which caused the loop to never end. This PR uses `log` to avoid `NaN` values from being created and adds a guard to make sure the loop is always exited if somehow a `NaN` value manages to slip through.