### PR TITLE
Dispatch Rust nightly build

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -113,3 +113,14 @@ jobs:
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/release.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "pypi-index": "prod" }}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+
+  notify-rust-nightly:
+    name: Dispatch Rust nightly build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call /dispatch
+        if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}
+        run: |
+          export URL=https://api.github.com/repos/duckdb/duckdb-rs/actions/workflows/nightly.yaml/dispatches
+          export DATA='{"ref": "main", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}" }}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
For periodic integration testing.

Rust job: https://github.com/duckdb/duckdb-rs/pull/791

To do: figure out if the PAT can trigger duckdb-rs workflows.

refs duckdblabs/duckdb-internal#7516