### PR TITLE
[MultiFileReader] Prevent NULL MAP keys because of (likely missing) default value

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -342,6 +342,18 @@ MapColumnMapComponent(ClientContext &context,
 	return child_map;
 }
 
+static bool IsInvalidMapKeyDefault(const ColumnMapResult &mapping) {
+	if (!mapping.default_value) {
+		return false;
+	}
+	auto &expr = *mapping.default_value;
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return false;
+	}
+	auto &constant_expr = expr.Cast<BoundConstantExpression>();
+	return constant_expr.value.IsNull();
+}
+
 ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefinition &global_column,
                              const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
                              const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
@@ -382,6 +394,11 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 
 		auto map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, i,
 		                                        global_component, local_key_value);
+		if (name == "key" && IsInvalidMapKeyDefault(map_result)) {
+			throw InvalidInputException(
+			    "'key' of MAP did not map to a value and the registered DEFAULT is NULL, which is not allowed");
+		}
+
 		if (map_result.column_index) {
 			child_indexes.push_back(std::move(*map_result.column_index));
 			mapping->child_mapping.insert(make_pair(i, std::move(map_result.mapping)));


### PR DESCRIPTION
This PR is related to https://github.com/duckdb/duckdb-iceberg/issues/903

The parquet file in question is missing field-ids for the `key` and `value` parts of the MAP, which result in getting substituted with NULL in the MultiFileReader, which then isn't caught when producing the final chunk.

We should likely also check the correctness of the produced chunk in `MultiFileReader::FinalizeChunk`
Though I imagine that's up to the reader implementation to verify, no?
That a MAP key is non-null