### PR TITLE
Allow table functions to propagate the query return type

### DIFF
--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -175,6 +175,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	dsdgen_func.named_parameters["catalog"] = LogicalType::VARCHAR;
 	dsdgen_func.named_parameters["schema"] = LogicalType::VARCHAR;
 	dsdgen_func.named_parameters["suffix"] = LogicalType::VARCHAR;
+	dsdgen_func.call_return_type = StatementReturnType::NOTHING;
 
 	loader.RegisterFunction(dsdgen_func);
 

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -185,6 +185,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	dbgen_func.named_parameters["suffix"] = LogicalType::VARCHAR;
 	dbgen_func.named_parameters["children"] = LogicalType::UINTEGER;
 	dbgen_func.named_parameters["step"] = LogicalType::UINTEGER;
+	dbgen_func.call_return_type = StatementReturnType::NOTHING;
 	loader.RegisterFunction(dbgen_func);
 
 	// create the TPCH pragma that allows us to run the query

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -23,6 +23,7 @@
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/common/enums/order_preservation_type.hpp"
+#include "duckdb/common/enums/statement_type.hpp"
 
 namespace duckdb {
 
@@ -509,6 +510,9 @@ public:
 	//! Whether or not the table function supports late materialization
 	bool late_materialization;
 	TableFunctionReturnType return_type;
+	//! The return type used when this function is invoked through a CALL statement
+	//! By default a CALL returns a query result - functions that only have side effects can use NOTHING instead
+	StatementReturnType call_return_type = StatementReturnType::QUERY_RESULT;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
 	//! The order preservation type of the table function

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -3,8 +3,22 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 
 namespace duckdb {
+
+static optional_ptr<LogicalGet> FindTableFunctionGet(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		return op.Cast<LogicalGet>();
+	}
+	for (auto &child : op.children) {
+		auto get = FindTableFunctionGet(*child);
+		if (get) {
+			return get;
+		}
+	}
+	return nullptr;
+}
 
 BoundStatement Binder::Bind(CallStatement &stmt) {
 	SelectStatement select_statement;
@@ -18,6 +32,13 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	auto result = Bind(select_statement);
 	auto &properties = GetStatementProperties();
 	properties.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	// use the return type of the table function (if any) instead of the default query result
+	if (result.plan) {
+		auto get = FindTableFunctionGet(*result.plan);
+		if (get) {
+			properties.return_type = get->function.call_return_type;
+		}
+	}
 	return result;
 }
 


### PR DESCRIPTION
Currently when running a statement like `CALL <function>` we always assume the result is a `QUERY_RESULT` - meaning e.g. this gets rendered as part of a query result in the CLI:

```sql
memory D call dbgen(sf=0);
┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows 
```

This PR extends table functions so that they can specify their return type, e.g. `StatementReturnType::NOTHING`. When invoked through `CALL` we then emit that return type instead of blindly returning `QUERY_RESULT`.

This means that now `dbgen` / `dsdgen` no longer emit output in the CLI. But, more impactfully, this can be used together with e.g. `*_query` functions to ensure table functions that just send queries to remote databases have the "correct" return type.

CC @carlopi 