### PR TITLE
Add dictionary surviving hash join

### DIFF
--- a/benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
+++ b/benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
@@ -1,0 +1,48 @@
+# name: benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
+# description: Pipeline-global dictionary surviving across three chained hash joins into a GROUP BY: a low-cardinality VARCHAR payload stays dict-encoded instead of materialising the full string at each build
+# group: [join]
+
+name Hash Join Dictionary Surviving Build
+group join
+
+# Measures the dict-surviving path: a small build emits a pipeline-global dictionary kept dict-encoded
+# across two large downstream join builds and the GROUP BY, versus materialising the full string per
+# build row. Each probe is larger than its build (3M -> 6M -> 12M rows) so the dictionary-carrying side
+# stays on the build of joins 2 and 3 and the aggregate input is large. Single thread and fixed join
+# order keep the plan deterministic; compressed_materialization is off so the planner does not
+# pre-encode the payload and mask the effect under test.
+init
+SET threads TO 1;
+SET disabled_optimizers TO 'join_order,compressed_materialization';
+
+load
+CREATE TABLE dim AS
+  SELECT 'KEY_' || i AS d_key,
+         'LABEL_' || (i % 5) AS d_label
+  FROM range(25) t(i);
+CREATE TABLE fact1 AS
+  SELECT 'KEY_' || (i % 25) AS f1_dkey,
+         i AS f1_k2
+  FROM range(3000000) t(i);
+CREATE TABLE fact2 AS
+  SELECT (i % 3000000) AS f2_k2,
+         i AS f2_k3
+  FROM range(6000000) t(i);
+CREATE TABLE fact3 AS
+  SELECT (i % 6000000) AS f3_k3
+  FROM range(12000000) t(i);
+
+run
+SELECT d.d_label, COUNT(*) AS cnt
+FROM dim d
+JOIN fact1 f1 ON d.d_key = f1.f1_dkey
+JOIN fact2 f2 ON f1.f1_k2 = f2.f2_k2
+JOIN fact3 f3 ON f2.f2_k3 = f3.f3_k3
+GROUP BY d.d_label;
+
+result II
+LABEL_0	2400000
+LABEL_1	2400000
+LABEL_2	2400000
+LABEL_3	2400000
+LABEL_4	2400000

--- a/benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
+++ b/benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
@@ -1,11 +1,11 @@
 # name: benchmark/micro/join/hashjoin_dictionary_surviving_build.benchmark
-# description: Pipeline-global dictionary surviving across three chained hash joins into a GROUP BY: a low-cardinality VARCHAR payload stays dict-encoded instead of materialising the full string at each build
+# description: Global dictionary surviving across three chained hash joins into a GROUP BY: a low-cardinality VARCHAR payload stays dict-encoded instead of materialising the full string at each build
 # group: [join]
 
 name Hash Join Dictionary Surviving Build
 group join
 
-# Measures the dict-surviving path: a small build emits a pipeline-global dictionary kept dict-encoded
+# Measures the dict-surviving path: a small build emits a global dictionary kept dict-encoded
 # across two large downstream join builds and the GROUP BY, versus materialising the full string per
 # build row. Each probe is larger than its build (3M -> 6M -> 12M rows) so the dictionary-carrying side
 # stays on the build of joins 2 and 3 and the aggregate input is large. Single thread and fixed join

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -188,6 +188,8 @@ void Vector::Reinterpret(const Vector &other) {
 		new_vector.Reinterpret(DictionaryVector::Child(other));
 		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
+		// reinterpret re-mints the entry, so carry the flag across by hand
+		new_entry->pipeline_global = old_dict.GetEntry().pipeline_global;
 		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), old_dict.Capacity(), std::move(new_entry));
 	}
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -188,7 +188,8 @@ void Vector::Reinterpret(const Vector &other) {
 		new_vector.Reinterpret(DictionaryVector::Child(other));
 		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
-		// reinterpret re-mints the entry, so carry the flag across by hand
+		// reinterpret re-mints the entry; the id and global flag are one contract and must survive together
+		new_entry->id = old_dict.GetEntry().id;
 		new_entry->global_dictionary = old_dict.GetEntry().global_dictionary;
 		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), old_dict.Capacity(), std::move(new_entry));
 	}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -189,7 +189,7 @@ void Vector::Reinterpret(const Vector &other) {
 		auto &old_dict = buffer->Cast<DictionaryBuffer>();
 		auto new_entry = make_shared_ptr<DictionaryEntry>(std::move(new_vector));
 		// reinterpret re-mints the entry, so carry the flag across by hand
-		new_entry->pipeline_global = old_dict.GetEntry().pipeline_global;
+		new_entry->global_dictionary = old_dict.GetEntry().global_dictionary;
 		buffer = make_buffer<DictionaryBuffer>(old_dict.GetSelVector(), old_dict.Capacity(), std::move(new_entry));
 	}
 }

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -167,6 +167,13 @@ buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const Log
 	return entry;
 }
 
+buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusablePipelineGlobalDictionary(const LogicalType &type,
+                                                                                     const idx_t &size) {
+	auto entry = CreateReusableDictionary(type, size);
+	entry->pipeline_global = true;
+	return entry;
+}
+
 const Vector &DictionaryVector::GetCachedHashes(const Vector &input) {
 	D_ASSERT(CanCacheHashes(input));
 

--- a/src/common/vector/dictionary_vector.cpp
+++ b/src/common/vector/dictionary_vector.cpp
@@ -167,10 +167,10 @@ buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableDictionary(const Log
 	return entry;
 }
 
-buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusablePipelineGlobalDictionary(const LogicalType &type,
-                                                                                     const idx_t &size) {
+buffer_ptr<DictionaryEntry> DictionaryVector::CreateReusableGlobalDictionary(const LogicalType &type,
+                                                                             const idx_t &size) {
 	auto entry = CreateReusableDictionary(type, size);
-	entry->pipeline_global = true;
+	entry->global_dictionary = true;
 	return entry;
 }
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -165,7 +165,7 @@ void JoinHashTable::Merge(JoinHashTable &other) {
 
 	sink_collection->Combine(*other.sink_collection);
 
-	// Reconcile per-column pinned dictionary entries. For pipeline-global producers every thread pins the
+	// Reconcile per-column pinned dictionary entries. For global dictionary producers every thread pins the
 	// same buffer_ptr, so this is normally a no-op or a "take theirs" adoption.
 	if (dict_registry.size() < other.dict_registry.size()) {
 		dict_registry.resize(other.dict_registry.size(), nullptr);
@@ -479,7 +479,7 @@ uint8_t JoinHashTable::GetDictSurvivingIndexWidth(idx_t build_col_idx, const Vec
 	if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
 		return 0;
 	}
-	if (!DictionaryVector::IsPipelineGlobal(incoming)) {
+	if (!DictionaryVector::IsGlobalDictionary(incoming)) {
 		return 0;
 	}
 	// an empty/invalid dictionary keeps native width
@@ -543,9 +543,9 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 			// Slot was narrowed on the first chunk; no fallback for a non-dict later chunk. Throw, not D_ASSERT:
 			// the Cast<DictionaryBuffer> below is UB in release on a non-dict vector, scattering foreign bytes.
 			if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
-			    DictionaryVector::DictionaryId(incoming).empty() || !DictionaryVector::IsPipelineGlobal(incoming)) {
+			    DictionaryVector::DictionaryId(incoming).empty() || !DictionaryVector::IsGlobalDictionary(incoming)) {
 				throw InternalException("dict-surviving join: narrowed column %llu received a "
-				                        "non-pipeline-global chunk; build pipeline is not single-source",
+				                        "non-global-dictionary chunk; build pipeline is not single-source",
 				                        static_cast<uint64_t>(i));
 			}
 			// Pin the dictionary on the first chunk; enforce id continuity on subsequent chunks
@@ -559,7 +559,7 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 				// producer that grows the child past it fails loudly instead of truncating in the UnsafeNumericCast.
 				D_ASSERT(child_count <= (idx_t(1) << (8 * index_width)));
 				auto owned_entry =
-				    DictionaryVector::CreateReusablePipelineGlobalDictionary(upstream_child.GetType(), child_count);
+				    DictionaryVector::CreateReusableGlobalDictionary(upstream_child.GetType(), child_count);
 				if (child_count > 0) {
 					VectorOperations::Copy(upstream_child, owned_entry->data, child_count, 0, 0);
 				}
@@ -2679,16 +2679,15 @@ void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
 	const auto row_ptrs = FlatVector::GetData<data_ptr_t>(row_pointer_vector);
 
 	// LEFT / OUTER joins fill unmatched probe rows with a constant-NULL vector (NextLeftJoin), so they do not
-	// wrap this entry on every chunk; it is only pipeline-global when every chunk goes through EmitDictVectors.
+	// wrap this entry on every chunk; it is only a global dictionary when every chunk goes through EmitDictVectors.
 	const bool dict_on_every_chunk = join_type != JoinType::LEFT && join_type != JoinType::OUTER;
 
 	// gather RHS output columns into columnar dictionary arrays
 	const auto &sel = *FlatVector::IncrementalSelectionVector();
 	for (idx_t col_idx = 0; col_idx < op.rhs_output_columns.col_types.size(); col_idx++) {
 		const auto &type = op.rhs_output_columns.col_types[col_idx];
-		auto dict_entry = dict_on_every_chunk
-		                      ? DictionaryVector::CreateReusablePipelineGlobalDictionary(type, build_count)
-		                      : DictionaryVector::CreateReusableDictionary(type, build_count);
+		auto dict_entry = dict_on_every_chunk ? DictionaryVector::CreateReusableGlobalDictionary(type, build_count)
+		                                      : DictionaryVector::CreateReusableDictionary(type, build_count);
 		const auto output_col_idx = output_columns[col_idx];
 		collection.Gather(row_pointer_vector, sel, build_count, output_col_idx, dict_entry->data, sel, nullptr);
 		dict_arrays.emplace_back(std::move(dict_entry));

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -83,18 +83,29 @@ JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &o
 	// at least one equality is necessary
 	D_ASSERT(!equality_types.empty());
 
-	// Types for the layout
-	auto layout = make_shared_ptr<TupleDataLayout>();
-	vector<LogicalType> layout_types(condition_types);
-	layout_types.insert(layout_types.end(), build_types.begin(), build_types.end());
-	if (PropagatesBuildSide(join_type)) {
-		// full/right outer joins need an extra bool to keep track of whether or not a tuple has found a matching entry
-		// we place the bool before the NEXT pointer
-		layout_types.emplace_back(LogicalType::BOOLEAN);
+	if (join_type == JoinType::SINGLE) {
+		single_join_error_on_multiple_rows = Settings::Get<ScalarSubqueryErrorOnMultipleRowsSetting>(context);
 	}
-	layout_types.emplace_back(LogicalType::HASH);
-	layout->Initialize(layout_types, TupleDataValidityType::CAN_HAVE_NULL_VALUES);
-	layout_ptr = std::move(layout);
+
+	if (non_equality_predicates.empty() && !residual_predicate &&
+	    (join_type == JoinType::SEMI || join_type == JoinType::ANTI || join_type == JoinType::MARK)) {
+		insert_duplicate_keys = false;
+	}
+
+	InitializePartitionMasks();
+	// Layout-dependent state is published lazily on the first Sink chunk (see FinishInitWithLayout).
+}
+
+void JoinHashTable::FinishInitWithLayout(shared_ptr<TupleDataLayout> published_layout,
+                                         vector<uint8_t> dict_index_width_p) {
+	D_ASSERT(!layout_ptr);
+	layout_ptr = std::move(published_layout);
+	if (dict_index_width_p.empty()) {
+		dict_index_width.assign(build_types.size(), 0);
+	} else {
+		D_ASSERT(dict_index_width_p.size() == build_types.size());
+		dict_index_width = std::move(dict_index_width_p);
+	}
 
 	// Initialize the row matcher that are used for filtering during the probing only if there are non-equality preds
 	if (!non_equality_predicates.empty()) {
@@ -125,16 +136,8 @@ JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &o
 	dead_end = make_unsafe_uniq_array_uninitialized<data_t>(layout_ptr->GetRowWidth());
 	memset(dead_end.get(), 0, layout_ptr->GetRowWidth());
 
-	if (join_type == JoinType::SINGLE) {
-		single_join_error_on_multiple_rows = Settings::Get<ScalarSubqueryErrorOnMultipleRowsSetting>(context);
-	}
-
-	if (non_equality_predicates.empty() && !residual_predicate &&
-	    (join_type == JoinType::SEMI || join_type == JoinType::ANTI || join_type == JoinType::MARK)) {
-		insert_duplicate_keys = false;
-	}
-
-	InitializePartitionMasks();
+	// indexed parallel to build_types / payload columns (not to output_columns)
+	dict_registry.assign(build_types.size(), nullptr);
 }
 
 JoinHashTable::~JoinHashTable() {
@@ -161,6 +164,23 @@ void JoinHashTable::Merge(JoinHashTable &other) {
 	}
 
 	sink_collection->Combine(*other.sink_collection);
+
+	// Reconcile per-column pinned dictionary entries. For pipeline-global producers every thread pins the
+	// same buffer_ptr, so this is normally a no-op or a "take theirs" adoption.
+	if (dict_registry.size() < other.dict_registry.size()) {
+		dict_registry.resize(other.dict_registry.size(), nullptr);
+	}
+	for (idx_t col = 0; col < other.dict_registry.size(); col++) {
+		if (!other.dict_registry[col]) {
+			continue;
+		}
+		if (!dict_registry[col]) {
+			dict_registry[col] = std::move(other.dict_registry[col]);
+		} else {
+			// Both threads pinned the same upstream entry, so ids match by construction; a mismatch is a producer bug.
+			D_ASSERT(dict_registry[col]->id == other.dict_registry[col]->id);
+		}
+	}
 }
 
 static void ApplyBitmaskAndGetSaltBuild(Vector &hashes_v, Vector &salt_v, const idx_t &bitmask) {
@@ -391,6 +411,91 @@ static idx_t FilterNullValues(UnifiedVectorFormat &vdata, const SelectionVector 
 	return result_count;
 }
 
+// A dictionary of D slots uses indices 0..D-1, so D slots fit a W-byte index iff D <= 2^(8*W).
+static constexpr idx_t DICT_INDEX_UINT8_CAPACITY = 256;
+static constexpr idx_t DICT_INDEX_UINT16_CAPACITY = 65536;
+
+//! Narrowest unsigned-integer byte width that can hold any index into a dictionary of dict_size slots
+static uint8_t DictIndexWidth(idx_t dict_size) {
+	if (dict_size <= DICT_INDEX_UINT8_CAPACITY) {
+		return sizeof(uint8_t);
+	}
+	if (dict_size <= DICT_INDEX_UINT16_CAPACITY) {
+		return sizeof(uint16_t);
+	}
+	return sizeof(uint32_t);
+}
+
+//! Materialise a flat width-INDEX_T index vector (allocation owned by `buffers`, view in `vectors`) from the
+//! dict sel. UnsafeNumericCast is safe: the publisher sized the width to the dictionary, so every index fits.
+template <class INDEX_T>
+static void ScatterDictIndices(const SelectionVector &dict_sel, idx_t count, const LogicalType &index_type,
+                               Allocator &allocator, vector<AllocatedData> &buffers, vector<Vector> &vectors) {
+	buffers.emplace_back(allocator.Allocate(count * sizeof(INDEX_T)));
+	vectors.emplace_back(index_type, buffers.back().get(), count);
+	auto idx_data = FlatVector::GetDataMutable<INDEX_T>(vectors.back());
+	for (idx_t r = 0; r < count; r++) {
+		idx_data[r] = UnsafeNumericCast<INDEX_T>(dict_sel.get_index(r));
+	}
+}
+
+//! Load the per-match dict index (width INDEX_T) from each matched row's slot at col_offset into build_sel_vec
+template <class INDEX_T>
+static void LoadDictIndices(const data_ptr_t *ptrs, const SelectionVector &ptr_sel, idx_t count, idx_t col_offset,
+                            SelectionVector &build_sel_vec) {
+	for (idx_t i = 0; i < count; i++) {
+		build_sel_vec.set_index(i, Load<INDEX_T>(ptrs[ptr_sel.get_index(i)] + col_offset));
+	}
+}
+
+bool JoinHashTable::ColumnReferencedByResidual(idx_t build_col_idx) const {
+	if (!residual_info) {
+		return false;
+	}
+	const auto layout_col = condition_types.size() + build_col_idx;
+	for (const auto &kv : residual_info->build_input_to_layout_map) {
+		if (kv.second == layout_col) {
+			return true;
+		}
+	}
+	return false;
+}
+
+uint8_t JoinHashTable::GetDictSurvivingIndexWidth(idx_t build_col_idx, const Vector &incoming) const {
+	const auto &type = build_types[build_col_idx];
+	// Vector::Dictionary rejects nested types
+	switch (type.InternalType()) {
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+	case PhysicalType::ARRAY:
+		return 0;
+	default:
+		break;
+	}
+	// residual predicates read from the row slot directly; a narrowed slot would corrupt them
+	if (ColumnReferencedByResidual(build_col_idx)) {
+		return 0;
+	}
+	if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
+		return 0;
+	}
+	if (!DictionaryVector::IsPipelineGlobal(incoming)) {
+		return 0;
+	}
+	// an empty/invalid dictionary keeps native width
+	const auto dict_size = DictionaryVector::DictionarySize(incoming);
+	if (!dict_size.IsValid()) {
+		return 0;
+	}
+	// only narrow when strictly smaller than the native slot (never regress; e.g. INTEGER over a D<=256 dict)
+	const uint8_t index_width = DictIndexWidth(dict_size.GetIndex());
+	const auto native_bytes = GetTypeIdSize(type.InternalType());
+	if (index_width >= native_bytes) {
+		return 0;
+	}
+	return index_width;
+}
+
 void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChunk &keys, DataChunk &payload) {
 	D_ASSERT(!finalized);
 	D_ASSERT(keys.size() == payload.size());
@@ -427,8 +532,63 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 	}
 	idx_t col_offset = keys.ColumnCount();
 	D_ASSERT(build_types.size() == payload.ColumnCount());
+	// Scratch index vectors for narrowed columns, allocated via the buffer manager so the bytes are accounted.
+	// buffers own the bytes, vectors are flat views; both must outlive the ToUnifiedFormat / AppendUnified below.
+	vector<AllocatedData> dict_idx_buffers;
+	vector<Vector> dict_idx_vectors;
 	for (idx_t i = 0; i < payload.ColumnCount(); i++) {
-		source_chunk.data[col_offset + i].Reference(payload.data[i]);
+		auto &incoming = payload.data[i];
+		const uint8_t index_width = i < dict_index_width.size() ? dict_index_width[i] : 0;
+		if (index_width != 0) {
+			// Slot was narrowed on the first chunk; no fallback for a non-dict later chunk. Throw, not D_ASSERT:
+			// the Cast<DictionaryBuffer> below is UB in release on a non-dict vector, scattering foreign bytes.
+			if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
+			    DictionaryVector::DictionaryId(incoming).empty() || !DictionaryVector::IsPipelineGlobal(incoming)) {
+				throw InternalException("dict-surviving join: narrowed column %llu received a "
+				                        "non-pipeline-global chunk; build pipeline is not single-source",
+				                        static_cast<uint64_t>(i));
+			}
+			// Pin the dictionary on the first chunk; enforce id continuity on subsequent chunks
+			auto entry_ptr = incoming.BufferMutable().Cast<DictionaryBuffer>().GetEntryPtr();
+			if (!dict_registry[i]) {
+				// The upstream child is a zero-copy gather: its long strings point into the producer's row-store
+				// heap, recycled before we gather on probe. Deep-copy into a self-owned entry so it outlives them.
+				const auto &upstream_child = entry_ptr->data;
+				const auto child_count = upstream_child.size();
+				// child_count fits index_width by construction (publisher sized the width to this dict). Assert so a
+				// producer that grows the child past it fails loudly instead of truncating in the UnsafeNumericCast.
+				D_ASSERT(child_count <= (idx_t(1) << (8 * index_width)));
+				auto owned_entry =
+				    DictionaryVector::CreateReusablePipelineGlobalDictionary(upstream_child.GetType(), child_count);
+				if (child_count > 0) {
+					VectorOperations::Copy(upstream_child, owned_entry->data, child_count, 0, 0);
+				}
+				owned_entry->id = entry_ptr->id;
+				dict_registry[i] = std::move(owned_entry);
+			} else {
+				// Subsequent chunks wrap the same entry, so ids match by construction; a mismatch is a producer bug.
+				D_ASSERT(dict_registry[i]->id == entry_ptr->id);
+			}
+			const auto &dict_sel = DictionaryVector::SelVector(incoming);
+			auto &index_allocator = buffer_manager.GetBufferAllocator();
+			switch (index_width) {
+			case sizeof(uint8_t):
+				ScatterDictIndices<uint8_t>(dict_sel, payload.size(), LogicalType::UTINYINT, index_allocator,
+				                            dict_idx_buffers, dict_idx_vectors);
+				break;
+			case sizeof(uint16_t):
+				ScatterDictIndices<uint16_t>(dict_sel, payload.size(), LogicalType::USMALLINT, index_allocator,
+				                             dict_idx_buffers, dict_idx_vectors);
+				break;
+			default:
+				ScatterDictIndices<uint32_t>(dict_sel, payload.size(), LogicalType::UINTEGER, index_allocator,
+				                             dict_idx_buffers, dict_idx_vectors);
+				break;
+			}
+			source_chunk.data[col_offset + i].Reference(dict_idx_vectors.back());
+		} else {
+			source_chunk.data[col_offset + i].Reference(incoming);
+		}
 	}
 	col_offset += payload.ColumnCount();
 	if (PropagatesBuildSide(join_type)) {
@@ -1438,10 +1598,45 @@ void JoinHashTable::GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, 
 		return;
 	}
 	const auto &result_sel = *FlatVector::IncrementalSelectionVector();
+	const auto ptrs = FlatVector::GetData<data_ptr_t>(row_ptrs);
+	const auto &offsets = layout_ptr->GetOffsets();
+	const auto cond_count = condition_types.size();
+
 	for (idx_t col_idx = 0; col_idx < output_columns.size(); col_idx++) {
 		auto &vector = result.data[rhs_col_offset + col_idx];
 		const auto output_col_idx = output_columns[col_idx];
+
+		// Pinned column: re-emit the upstream dictionary. Layout is [conditions, build, (found), hash], so payload
+		// columns sit at layout index >= cond_count; guard the subtraction so it cannot underflow into a spurious idx.
+		if (output_col_idx >= cond_count) {
+			const idx_t payload_idx = output_col_idx - cond_count;
+			if (payload_idx < dict_registry.size() && dict_registry[payload_idx]) {
+				SelectionVector build_sel_vec(count);
+				const auto col_offset = offsets[output_col_idx];
+				// Read the dict index at the width chosen at layout-publication time
+				const uint8_t index_width = payload_idx < dict_index_width.size() ? dict_index_width[payload_idx] : 0;
+				switch (index_width) {
+				case sizeof(uint8_t):
+					LoadDictIndices<uint8_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+					break;
+				case sizeof(uint16_t):
+					LoadDictIndices<uint16_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+					break;
+				default:
+					LoadDictIndices<uint32_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+					break;
+				}
+				vector.Dictionary(dict_registry[payload_idx], build_sel_vec, count);
+				continue;
+			}
+		}
+
 		D_ASSERT(vector.GetType() == layout_ptr->GetTypes()[output_col_idx]);
+		// The native gather writes straight into a flat buffer. A reused output chunk (e.g. across recursive-CTE
+		// iterations) may still hold a DICTIONARY_VECTOR left by a prior dict-emitting iteration; reset it to flat.
+		if (vector.GetVectorType() != VectorType::FLAT_VECTOR) {
+			vector.Initialize();
+		}
 		data_collection->Gather(row_ptrs, ptr_sel, count, output_col_idx, vector, result_sel, nullptr);
 		FlatVector::SetSize(vector, count_t(count));
 	}
@@ -2178,6 +2373,10 @@ static void ResetCorrelatedMarkJoinInfo(JoinHashTable &ht) {
 }
 
 void JoinHashTable::ResetForNewIterationSinglePartition() {
+	if (!layout_ptr) {
+		// layout was never published (no Sink chunk last iteration); the next first chunk will publish
+		return;
+	}
 	data_collection->Reset();
 	// Always use a single partition (radix_bits=0) to avoid per-iteration overhead of resetting
 	// and re-creating many radix partitions when only one thread builds the hash table.
@@ -2208,6 +2407,10 @@ void JoinHashTable::ResetForNewIterationSinglePartition() {
 	aux_next_ptrs.Reset();
 	aux_next_ptrs_data = nullptr;
 	use_dict_emission = false;
+	// Drop pinned upstream dictionary entries; the next iteration's first chunk re-pins
+	for (auto &entry : dict_registry) {
+		entry.reset();
+	}
 }
 
 bool JoinHashTable::PrepareExternalFinalize(const idx_t max_ht_size) {
@@ -2401,6 +2604,13 @@ bool JoinHashTable::CanUseDictionaryEmission(const PhysicalHashJoin &op, bool ex
 	if (external) {
 		return false;
 	}
+	// mutually exclusive with the dict-surviving path: that path narrows the payload slot to a 1/2/4-byte
+	// index, while NEXT_PTR embedding here overwrites a different field and assumes payload bytes are intact.
+	for (const auto &entry : dict_registry) {
+		if (entry) {
+			return false;
+		}
+	}
 	// SINGLE joins need FlatVector::SetNull for unmatched rows; dictionary vectors cannot supply it
 	if (join_type == JoinType::SINGLE) {
 		return false;
@@ -2468,11 +2678,17 @@ void JoinHashTable::BuildDictionaryArrays(const PhysicalHashJoin &op) {
 	(void)collected;
 	const auto row_ptrs = FlatVector::GetData<data_ptr_t>(row_pointer_vector);
 
+	// LEFT / OUTER joins fill unmatched probe rows with a constant-NULL vector (NextLeftJoin), so they do not
+	// wrap this entry on every chunk; it is only pipeline-global when every chunk goes through EmitDictVectors.
+	const bool dict_on_every_chunk = join_type != JoinType::LEFT && join_type != JoinType::OUTER;
+
 	// gather RHS output columns into columnar dictionary arrays
 	const auto &sel = *FlatVector::IncrementalSelectionVector();
 	for (idx_t col_idx = 0; col_idx < op.rhs_output_columns.col_types.size(); col_idx++) {
 		const auto &type = op.rhs_output_columns.col_types[col_idx];
-		auto dict_entry = DictionaryVector::CreateReusableDictionary(type, build_count);
+		auto dict_entry = dict_on_every_chunk
+		                      ? DictionaryVector::CreateReusablePipelineGlobalDictionary(type, build_count)
+		                      : DictionaryVector::CreateReusableDictionary(type, build_count);
 		const auto output_col_idx = output_columns[col_idx];
 		collection.Gather(row_pointer_vector, sel, build_count, output_col_idx, dict_entry->data, sel, nullptr);
 		dict_arrays.emplace_back(std::move(dict_entry));

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -439,12 +439,44 @@ static void ScatterDictIndices(const SelectionVector &dict_sel, idx_t count, con
 	}
 }
 
+//! Dispatch on the chosen index width (1/2/4 B) to the matching templated ScatterDictIndices
+static void ScatterDictIndices(uint8_t index_width, const SelectionVector &dict_sel, idx_t count, Allocator &allocator,
+                               vector<AllocatedData> &buffers, vector<Vector> &vectors) {
+	switch (index_width) {
+	case sizeof(uint8_t):
+		ScatterDictIndices<uint8_t>(dict_sel, count, LogicalType::UTINYINT, allocator, buffers, vectors);
+		break;
+	case sizeof(uint16_t):
+		ScatterDictIndices<uint16_t>(dict_sel, count, LogicalType::USMALLINT, allocator, buffers, vectors);
+		break;
+	default:
+		ScatterDictIndices<uint32_t>(dict_sel, count, LogicalType::UINTEGER, allocator, buffers, vectors);
+		break;
+	}
+}
+
 //! Load the per-match dict index (width INDEX_T) from each matched row's slot at col_offset into build_sel_vec
 template <class INDEX_T>
 static void LoadDictIndices(const data_ptr_t *ptrs, const SelectionVector &ptr_sel, idx_t count, idx_t col_offset,
                             SelectionVector &build_sel_vec) {
 	for (idx_t i = 0; i < count; i++) {
 		build_sel_vec.set_index(i, Load<INDEX_T>(ptrs[ptr_sel.get_index(i)] + col_offset));
+	}
+}
+
+//! Dispatch on the chosen index width (1/2/4 B) to the matching templated LoadDictIndices
+static void LoadDictIndices(uint8_t index_width, const data_ptr_t *ptrs, const SelectionVector &ptr_sel, idx_t count,
+                            idx_t col_offset, SelectionVector &build_sel_vec) {
+	switch (index_width) {
+	case sizeof(uint8_t):
+		LoadDictIndices<uint8_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+		break;
+	case sizeof(uint16_t):
+		LoadDictIndices<uint16_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+		break;
+	default:
+		LoadDictIndices<uint32_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
+		break;
 	}
 }
 
@@ -496,6 +528,36 @@ uint8_t JoinHashTable::GetDictSurvivingIndexWidth(idx_t build_col_idx, const Vec
 	return index_width;
 }
 
+void JoinHashTable::PinDictSurvivingColumn(idx_t build_col_idx, const Vector &incoming, uint8_t index_width) {
+	// Slot was narrowed on the first chunk; there is no fallback for a non-dict later chunk. Throw, not D_ASSERT:
+	// the Cast<DictionaryBuffer> below is UB in release on a non-dict vector, scattering foreign bytes as indices.
+	if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR || DictionaryVector::DictionaryId(incoming).empty() ||
+	    !DictionaryVector::IsGlobalDictionary(incoming)) {
+		throw InternalException("dict-surviving join: narrowed column %llu received a "
+		                        "non-global-dictionary chunk; build pipeline is not single-source",
+		                        static_cast<uint64_t>(build_col_idx));
+	}
+	const auto &entry = incoming.Buffer().Cast<DictionaryBuffer>().GetEntry();
+	if (dict_registry[build_col_idx]) {
+		// Subsequent chunks wrap the same entry, so ids match by construction; a mismatch is a producer bug.
+		D_ASSERT(dict_registry[build_col_idx]->id == entry.id);
+		return;
+	}
+	// The upstream child is a zero-copy gather: its long strings point into the producer's row-store heap, recycled
+	// before we gather on probe. Deep-copy into a self-owned entry so it outlives them.
+	const auto &upstream_child = entry.data;
+	const auto child_count = upstream_child.size();
+	// child_count fits index_width by construction (publisher sized the width to this dict). Assert so a producer
+	// that grows the child past it fails loudly instead of truncating in the UnsafeNumericCast.
+	D_ASSERT(child_count <= (idx_t(1) << (8 * index_width)));
+	auto owned_entry = DictionaryVector::CreateReusableGlobalDictionary(upstream_child.GetType(), child_count);
+	if (child_count > 0) {
+		VectorOperations::Copy(upstream_child, owned_entry->data, child_count, 0, 0);
+	}
+	owned_entry->id = entry.id;
+	dict_registry[build_col_idx] = std::move(owned_entry);
+}
+
 void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChunk &keys, DataChunk &payload) {
 	D_ASSERT(!finalized);
 	D_ASSERT(keys.size() == payload.size());
@@ -539,56 +601,15 @@ void JoinHashTable::Build(PartitionedTupleDataAppendState &append_state, DataChu
 	for (idx_t i = 0; i < payload.ColumnCount(); i++) {
 		auto &incoming = payload.data[i];
 		const uint8_t index_width = i < dict_index_width.size() ? dict_index_width[i] : 0;
-		if (index_width != 0) {
-			// Slot was narrowed on the first chunk; no fallback for a non-dict later chunk. Throw, not D_ASSERT:
-			// the Cast<DictionaryBuffer> below is UB in release on a non-dict vector, scattering foreign bytes.
-			if (incoming.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
-			    DictionaryVector::DictionaryId(incoming).empty() || !DictionaryVector::IsGlobalDictionary(incoming)) {
-				throw InternalException("dict-surviving join: narrowed column %llu received a "
-				                        "non-global-dictionary chunk; build pipeline is not single-source",
-				                        static_cast<uint64_t>(i));
-			}
-			// Pin the dictionary on the first chunk; enforce id continuity on subsequent chunks
-			auto entry_ptr = incoming.BufferMutable().Cast<DictionaryBuffer>().GetEntryPtr();
-			if (!dict_registry[i]) {
-				// The upstream child is a zero-copy gather: its long strings point into the producer's row-store
-				// heap, recycled before we gather on probe. Deep-copy into a self-owned entry so it outlives them.
-				const auto &upstream_child = entry_ptr->data;
-				const auto child_count = upstream_child.size();
-				// child_count fits index_width by construction (publisher sized the width to this dict). Assert so a
-				// producer that grows the child past it fails loudly instead of truncating in the UnsafeNumericCast.
-				D_ASSERT(child_count <= (idx_t(1) << (8 * index_width)));
-				auto owned_entry =
-				    DictionaryVector::CreateReusableGlobalDictionary(upstream_child.GetType(), child_count);
-				if (child_count > 0) {
-					VectorOperations::Copy(upstream_child, owned_entry->data, child_count, 0, 0);
-				}
-				owned_entry->id = entry_ptr->id;
-				dict_registry[i] = std::move(owned_entry);
-			} else {
-				// Subsequent chunks wrap the same entry, so ids match by construction; a mismatch is a producer bug.
-				D_ASSERT(dict_registry[i]->id == entry_ptr->id);
-			}
-			const auto &dict_sel = DictionaryVector::SelVector(incoming);
-			auto &index_allocator = buffer_manager.GetBufferAllocator();
-			switch (index_width) {
-			case sizeof(uint8_t):
-				ScatterDictIndices<uint8_t>(dict_sel, payload.size(), LogicalType::UTINYINT, index_allocator,
-				                            dict_idx_buffers, dict_idx_vectors);
-				break;
-			case sizeof(uint16_t):
-				ScatterDictIndices<uint16_t>(dict_sel, payload.size(), LogicalType::USMALLINT, index_allocator,
-				                             dict_idx_buffers, dict_idx_vectors);
-				break;
-			default:
-				ScatterDictIndices<uint32_t>(dict_sel, payload.size(), LogicalType::UINTEGER, index_allocator,
-				                             dict_idx_buffers, dict_idx_vectors);
-				break;
-			}
-			source_chunk.data[col_offset + i].Reference(dict_idx_vectors.back());
-		} else {
+		if (index_width == 0) {
 			source_chunk.data[col_offset + i].Reference(incoming);
+			continue;
 		}
+		// Narrowed column: pin the dictionary, then scatter its sel indices at the chosen width in place of the value.
+		PinDictSurvivingColumn(i, incoming, index_width);
+		ScatterDictIndices(index_width, DictionaryVector::SelVector(incoming), payload.size(),
+		                   buffer_manager.GetBufferAllocator(), dict_idx_buffers, dict_idx_vectors);
+		source_chunk.data[col_offset + i].Reference(dict_idx_vectors.back());
 	}
 	col_offset += payload.ColumnCount();
 	if (PropagatesBuildSide(join_type)) {
@@ -1615,17 +1636,7 @@ void JoinHashTable::GatherRHS(Vector &row_ptrs, const SelectionVector &ptr_sel, 
 				const auto col_offset = offsets[output_col_idx];
 				// Read the dict index at the width chosen at layout-publication time
 				const uint8_t index_width = payload_idx < dict_index_width.size() ? dict_index_width[payload_idx] : 0;
-				switch (index_width) {
-				case sizeof(uint8_t):
-					LoadDictIndices<uint8_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
-					break;
-				case sizeof(uint16_t):
-					LoadDictIndices<uint16_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
-					break;
-				default:
-					LoadDictIndices<uint32_t>(ptrs, ptr_sel, count, col_offset, build_sel_vec);
-					break;
-				}
+				LoadDictIndices(index_width, ptrs, ptr_sel, count, col_offset, build_sel_vec);
 				vector.Dictionary(dict_registry[payload_idx], build_sel_vec, count);
 				continue;
 			}

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -138,7 +138,7 @@ bool PerfectHashJoinExecutor::BuildPerfectHashTable() {
 	const auto build_size = perfect_join_statistics.build_range + 1;
 	for (const auto &type : join.rhs_output_columns.col_types) {
 		// PHJ keeps each entry alive for the operator's lifetime and wraps it in every emitted chunk
-		perfect_hash_table.emplace_back(DictionaryVector::CreateReusablePipelineGlobalDictionary(type, build_size));
+		perfect_hash_table.emplace_back(DictionaryVector::CreateReusableGlobalDictionary(type, build_size));
 	}
 
 	// and for duplicate_checking

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -137,7 +137,8 @@ bool PerfectHashJoinExecutor::BuildPerfectHashTable() {
 	// First, allocate memory for each build column
 	const auto build_size = perfect_join_statistics.build_range + 1;
 	for (const auto &type : join.rhs_output_columns.col_types) {
-		perfect_hash_table.emplace_back(DictionaryVector::CreateReusableDictionary(type, build_size));
+		// PHJ keeps each entry alive for the operator's lifetime and wraps it in every emitted chunk
+		perfect_hash_table.emplace_back(DictionaryVector::CreateReusablePipelineGlobalDictionary(type, build_size));
 	}
 
 	// and for duplicate_checking

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -135,6 +135,14 @@ OperatorResultType CrossProductExecutor::Execute(const DataChunk &input, DataChu
 	auto &constant_chunk = scan_input_chunk ? scan_chunk : input;
 	auto col_count = constant_chunk.ColumnCount();
 	auto col_offset = scan_input_chunk ? input.ColumnCount() : 0;
+	// SetChildCardinality cannot resize a non-flat vector, and a reused output chunk may still hold a stale
+	// DICTIONARY_VECTOR (e.g. a recursive-CTE dict flush Reset cannot flatten), so reset to flat before resizing.
+	for (auto &v : output.data) {
+		auto vtype = v.GetVectorType();
+		if (vtype != VectorType::FLAT_VECTOR && vtype != VectorType::CONSTANT_VECTOR) {
+			v.Initialize();
+		}
+	}
 	output.SetChildCardinality(constant_chunk.size());
 	for (idx_t i = 0; i < col_count; i++) {
 		output.data[col_offset + i].Reference(constant_chunk.data[i]);

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -574,12 +574,10 @@ static shared_ptr<TupleDataLayout> BuildJoinLayout(const vector<LogicalType> &co
 }
 
 //! Join-level gate: shape-only eligibility checks, mirroring the dict-emission path plus a PHJ exclusion
-static bool CanUseDictSurvivingJoin(const PhysicalHashJoin &op, const JoinHashTable &ht, bool external,
-                                    bool can_use_perfect_hash, bool build_side_multi_source) {
-	// external joins rebuild partitions; pinned upstream entries cannot survive the rebuild
-	if (external) {
-		return false;
-	}
+static bool CanUseDictSurvivingJoin(const PhysicalHashJoin &op, const JoinHashTable &ht, bool can_use_perfect_hash,
+                                    bool build_side_multi_source) {
+	// external is safe here: the dictionary is an in-memory self-owned copy and the index is a plain row-store
+	// column, so a spill/repartition preserves both (unlike the pointer-embedding dict-emission/compressed-probe paths)
 	// a multi-source build can deliver a later chunk flat or as a different dictionary under the
 	// already-narrowed slot, so disqualify the whole join (see BuildSideHasMultipleSources)
 	if (build_side_multi_source) {
@@ -634,7 +632,7 @@ void HashJoinGlobalSinkState::PublishLayoutIfFirst(HashJoinLocalSinkState &lstat
 	const auto &build_types = lstate.hash_table->build_types;
 	layout_gate.dict_index_width.assign(build_types.size(), 0);
 
-	if (CanUseDictSurvivingJoin(op, *lstate.hash_table, external, can_use_perfect_hash, build_side_multi_source)) {
+	if (CanUseDictSurvivingJoin(op, *lstate.hash_table, can_use_perfect_hash, build_side_multi_source)) {
 		// Per-column width decision lives on the JHT (GetDictSurvivingIndexWidth); feed it each arriving vector.
 		for (idx_t col = 0; col < build_types.size(); col++) {
 			if (col >= payload_chunk.ColumnCount()) {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -595,7 +595,7 @@ static bool CanUseDictSurvivingJoin(const PhysicalHashJoin &op, const JoinHashTa
 		return false;
 	}
 	// OUTER fills unmatched-probe rows with CONSTANT_NULL (NextLeftJoin), mixing dict chunks with flat fill chunks;
-	// admitting it would re-emit a falsely pipeline-global dictionary a downstream consumer cannot trust.
+	// admitting it would re-emit a falsely global dictionary a downstream consumer cannot trust.
 	if (ht.join_type == JoinType::OUTER) {
 		return false;
 	}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
+#include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/join_hashtable.hpp"
 #include "duckdb/execution/operator/aggregate/ungrouped_aggregate_state.hpp"
@@ -293,6 +294,36 @@ unique_ptr<JoinFilterGlobalState> JoinFilterPushdownInfo::GetGlobalState(ClientC
 	return result;
 }
 
+//! True iff the build subtree funnels multiple producer pipelines into one sink (UNION ALL, recursive CTE),
+//! breaking the "decide layout once on the first chunk" contract. Conservative: may over-exclude, never misses one.
+static bool BuildSideHasMultipleSources(const PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::UNION || op.type == PhysicalOperatorType::RECURSIVE_CTE ||
+	    op.type == PhysicalOperatorType::RECURSIVE_KEY_CTE) {
+		return true;
+	}
+	for (const auto &child : op.children) {
+		if (BuildSideHasMultipleSources(child.get())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+//! Synchronisation state for the first-chunk publication of the TupleDataLayout: the canonical layout
+//! shared by all per-thread JHTs, plus the per-column decision on whether to narrow the row-store slot.
+struct LayoutGate {
+	mutex publish_mutex;
+	atomic<bool> published {false};
+	shared_ptr<TupleDataLayout> layout_ptr;
+	vector<uint8_t> dict_index_width;
+
+	void Reset() {
+		published.store(false, std::memory_order_release);
+		layout_ptr.reset();
+		dict_index_width.clear();
+	}
+};
+
 class HashJoinGlobalSinkState : public GlobalSinkState {
 public:
 	HashJoinGlobalSinkState(const PhysicalHashJoin &op_p, ClientContext &context_p)
@@ -306,6 +337,10 @@ public:
 		// For perfect hash join
 		perfect_join_executor = make_uniq<PerfectHashJoinExecutor>(op, *hash_table);
 		auto use_perfect_hash = CanUsePerfectHashJoin(op, *perfect_join_executor);
+		can_use_perfect_hash = use_perfect_hash;
+		// A multi-source build side (UNION ALL / recursive CTE) feeds the sink from several producers,
+		// disqualifying dict-surviving. Computed once from the static plan; cannot change at runtime.
+		build_side_multi_source = BuildSideHasMultipleSources(op.children[1].get());
 		// For external hash join
 		external = Settings::Get<DebugForceExternalSetting>(context);
 		// Set probe types
@@ -328,6 +363,11 @@ public:
 
 	void ScheduleFinalize(Pipeline &pipeline, Event &event);
 	void InitializeProbeSpill();
+	//! First-chunk election: build the canonical layout (with per-column slot narrowing) and publish it.
+	//! Idempotent and safe to call concurrently; only the first thread runs the slow path.
+	void PublishLayoutIfFirst(class HashJoinLocalSinkState &lstate, DataChunk &payload_chunk);
+	//! True iff at least one column on the global JHT carries a pinned upstream dictionary entry.
+	bool DictSurvivingActive() const;
 
 	bool SupportsReuse() const override {
 		return true;
@@ -338,6 +378,7 @@ public:
 		hash_table->ResetForNewIterationSinglePartition();
 		perfect_join_executor = make_uniq<PerfectHashJoinExecutor>(op, *hash_table);
 		auto use_perfect_hash = CanUsePerfectHashJoin(op, *perfect_join_executor);
+		can_use_perfect_hash = use_perfect_hash;
 		finalized = false;
 		active_local_states = 0;
 		external = Settings::Get<DebugForceExternalSetting>(context);
@@ -360,6 +401,8 @@ public:
 			}
 			global_filter_state = op.filter_pushdown->GetGlobalState(context, op);
 		}
+		// Keep the published layout across CTE iterations (same upstream operator, same arrival types).
+		// ResetForNewIterationSinglePartition already cleared the row data and dict_registry.
 		GlobalSinkState::Reset(context);
 	}
 
@@ -406,6 +449,15 @@ public:
 	bool skip_filter_pushdown = false;
 	unique_ptr<JoinFilterGlobalState> global_filter_state;
 	bool keep_local_hash_tables = false;
+
+	//! Coordinates first-chunk publication of the TupleDataLayout across parallel sinks.
+	LayoutGate layout_gate;
+	//! True iff this join may use perfect-hash-join at Finalize. PHJ's FullScanHashTable reads payload at native
+	//! width, so it disables dict-surviving slot narrowing.
+	bool can_use_perfect_hash = false;
+	//! True iff the build subtree funnels multiple producer pipelines into this sink (UNION ALL /
+	//! recursive CTE); disables dict-surviving because the first-chunk layout election is unsound there.
+	bool build_side_multi_source = false;
 };
 
 unique_ptr<JoinFilterLocalState> JoinFilterPushdownInfo::GetLocalState(JoinFilterGlobalState &gstate) const {
@@ -430,7 +482,8 @@ public:
 		}
 
 		hash_table = op.InitializeHashTable(context, gstate.hash_table->GetRadixBits());
-		hash_table->GetSinkCollection().InitializeAppendState(append_state);
+		// sink_collection exists only after the layout is published on the first build chunk, so
+		// InitializeAppendState runs lazily inside Sink.
 		keep_hash_table = gstate.keep_local_hash_tables;
 
 		gstate.active_local_states++;
@@ -443,6 +496,8 @@ public:
 public:
 	const PhysicalHashJoin &op;
 	PartitionedTupleDataAppendState append_state;
+	//! True once InitializeAppendState has been called against the published sink_collection
+	bool append_state_initialised = false;
 
 	ExpressionExecutor join_key_executor;
 	DataChunk join_keys;
@@ -463,12 +518,16 @@ public:
 		auto &gstate = gstate_p.Cast<HashJoinGlobalSinkState>();
 		join_keys.Reset();
 		payload_chunk.Reset();
-		if (hash_table) {
+		if (hash_table && append_state_initialised) {
+			// the layout survives the iteration; only the row data is dropped
 			hash_table->ResetForNewIterationSinglePartition();
+			hash_table->GetSinkCollection().ResetAppendState(append_state);
 		} else {
+			// HT was moved into gstate during Combine, or never had a layout published. Rebuild against the global
+			// radix_bits so partition counts stay consistent in PrepareFinalize.
 			hash_table = op.InitializeHashTable(context.client, gstate.hash_table->GetRadixBits());
+			append_state_initialised = false;
 		}
-		hash_table->GetSinkCollection().ResetAppendState(append_state);
 		keep_hash_table = gstate.keep_local_hash_tables;
 		gstate.active_local_states++;
 		if (op.filter_pushdown) {
@@ -478,6 +537,124 @@ public:
 		}
 	}
 };
+
+//! Map a dict-index byte width to its row-store slot type (the width is decided by GetDictSurvivingIndexWidth)
+static LogicalType DictIndexType(uint8_t index_width) {
+	switch (index_width) {
+	case sizeof(uint8_t):
+		return LogicalType::UTINYINT;
+	case sizeof(uint16_t):
+		return LogicalType::USMALLINT;
+	default:
+		return LogicalType::UINTEGER;
+	}
+}
+
+//! Build the row layout [conditions, build payload, (found flag), hash], narrowing a payload column to its
+//! dict-index slot when dict_index_width[col] != 0. Shared by publisher and empty-input fallback to avoid drift.
+static shared_ptr<TupleDataLayout> BuildJoinLayout(const vector<LogicalType> &cond_types,
+                                                   const vector<LogicalType> &build_types, JoinType join_type,
+                                                   const vector<uint8_t> &dict_index_width) {
+	vector<LogicalType> layout_types(cond_types);
+	for (idx_t col = 0; col < build_types.size(); col++) {
+		if (col < dict_index_width.size() && dict_index_width[col] != 0) {
+			layout_types.emplace_back(DictIndexType(dict_index_width[col]));
+		} else {
+			layout_types.emplace_back(build_types[col]);
+		}
+	}
+	if (PropagatesBuildSide(join_type)) {
+		layout_types.emplace_back(LogicalType::BOOLEAN);
+	}
+	layout_types.emplace_back(LogicalType::HASH);
+
+	auto layout = make_shared_ptr<TupleDataLayout>();
+	layout->Initialize(layout_types, TupleDataValidityType::CAN_HAVE_NULL_VALUES);
+	return layout;
+}
+
+//! Join-level gate: shape-only eligibility checks, mirroring the dict-emission path plus a PHJ exclusion
+static bool CanUseDictSurvivingJoin(const PhysicalHashJoin &op, const JoinHashTable &ht, bool external,
+                                    bool can_use_perfect_hash, bool build_side_multi_source) {
+	// external joins rebuild partitions; pinned upstream entries cannot survive the rebuild
+	if (external) {
+		return false;
+	}
+	// a multi-source build can deliver a later chunk flat or as a different dictionary under the
+	// already-narrowed slot, so disqualify the whole join (see BuildSideHasMultipleSources)
+	if (build_side_multi_source) {
+		return false;
+	}
+	// SINGLE joins need FlatVector::SetNull on unmatched rows; dictionary vectors cannot supply it
+	if (ht.join_type == JoinType::SINGLE) {
+		return false;
+	}
+	// LEFT may dispatch into NextUniqueLeftJoin, which gathers payload via ScanStructure::GatherResult and
+	// bypasses GatherRHS' dict branch; the narrowed slot would be read as native type and trip the gather type check.
+	if (ht.join_type == JoinType::LEFT) {
+		return false;
+	}
+	// OUTER fills unmatched-probe rows with CONSTANT_NULL (NextLeftJoin), mixing dict chunks with flat fill chunks;
+	// admitting it would re-emit a falsely pipeline-global dictionary a downstream consumer cannot trust.
+	if (ht.join_type == JoinType::OUTER) {
+		return false;
+	}
+	if (op.rhs_output_columns.col_types.empty()) {
+		return false;
+	}
+	// PHJ's FullScanHashTable reads payload from the row store at native width; a narrowed slot would corrupt it.
+	if (can_use_perfect_hash) {
+		return false;
+	}
+	return true;
+}
+
+bool HashJoinGlobalSinkState::DictSurvivingActive() const {
+	if (!hash_table) {
+		return false;
+	}
+	for (const auto &entry : hash_table->dict_registry) {
+		if (entry) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void HashJoinGlobalSinkState::PublishLayoutIfFirst(HashJoinLocalSinkState &lstate, DataChunk &payload_chunk) {
+	if (layout_gate.published.load(std::memory_order_acquire)) {
+		return;
+	}
+	unique_lock<mutex> guard(layout_gate.publish_mutex);
+	if (layout_gate.published.load(std::memory_order_relaxed)) {
+		return;
+	}
+
+	const auto &cond_types = lstate.hash_table->condition_types;
+	const auto &build_types = lstate.hash_table->build_types;
+	layout_gate.dict_index_width.assign(build_types.size(), 0);
+
+	if (CanUseDictSurvivingJoin(op, *lstate.hash_table, external, can_use_perfect_hash, build_side_multi_source)) {
+		// Per-column width decision lives on the JHT (GetDictSurvivingIndexWidth); feed it each arriving vector.
+		for (idx_t col = 0; col < build_types.size(); col++) {
+			if (col >= payload_chunk.ColumnCount()) {
+				continue;
+			}
+			layout_gate.dict_index_width[col] =
+			    lstate.hash_table->GetDictSurvivingIndexWidth(col, payload_chunk.data[col]);
+		}
+	}
+
+	auto layout = BuildJoinLayout(cond_types, build_types, lstate.hash_table->join_type, layout_gate.dict_index_width);
+	layout_gate.layout_ptr = layout;
+
+	// global HT receives the same layout so Merge/Combine and finalize-time scans operate against it
+	if (hash_table && !hash_table->IsLayoutFinalized()) {
+		hash_table->FinishInitWithLayout(layout, layout_gate.dict_index_width);
+	}
+
+	layout_gate.published.store(true, std::memory_order_release);
+}
 
 static bool ShouldPrepareBloomFilterBuild(const PhysicalHashJoin &op) {
 	if (!op.filter_pushdown || op.filter_pushdown->probe_info.empty()) {
@@ -628,6 +805,16 @@ SinkResultType PhysicalHashJoin::Sink(ExecutionContext &context, DataChunk &chun
 		lstate.payload_chunk.ReferenceColumns(chunk, payload_columns.col_idxs);
 	}
 
+	// first-chunk: publish the canonical layout against the actually-arriving vector types
+	gstate.PublishLayoutIfFirst(lstate, lstate.payload_chunk);
+
+	// lazy per-thread setup against the published layout
+	if (!lstate.append_state_initialised) {
+		lstate.hash_table->FinishInitWithLayout(gstate.layout_gate.layout_ptr, gstate.layout_gate.dict_index_width);
+		lstate.hash_table->GetSinkCollection().InitializeAppendState(lstate.append_state);
+		lstate.append_state_initialised = true;
+	}
+
 	// build the HT
 	lstate.hash_table->Build(lstate.append_state, lstate.join_keys, lstate.payload_chunk);
 
@@ -642,9 +829,16 @@ SinkCombineResultType PhysicalHashJoin::Combine(ExecutionContext &context, Opera
 	auto &gstate = input.global_state.Cast<HashJoinGlobalSinkState>();
 	auto &lstate = input.local_state.Cast<HashJoinLocalSinkState>();
 
-	lstate.hash_table->GetSinkCollection().FlushAppendState(lstate.append_state);
+	// Under deferred layout, a thread that never received a Sink chunk has no sink_collection to flush
+	const bool has_layout = lstate.append_state_initialised;
+	if (has_layout) {
+		lstate.hash_table->GetSinkCollection().FlushAppendState(lstate.append_state);
+	}
 	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
-	if (lstate.keep_hash_table) {
+	if (!has_layout) {
+		// nothing to merge — drop the empty thread-local hash table
+		gstate.active_local_states--;
+	} else if (lstate.keep_hash_table) {
 		gstate.local_hash_tables.push_back(*lstate.hash_table);
 	} else {
 		gstate.owned_local_hash_tables.push_back(std::move(lstate.hash_table));
@@ -736,6 +930,24 @@ static idx_t GetPartitioningSpaceRequirement(ClientContext &context, const vecto
 
 void PhysicalHashJoin::PrepareFinalize(ClientContext &context, GlobalSinkState &global_state) const {
 	auto &gstate = global_state.Cast<HashJoinGlobalSinkState>();
+	// If no Sink chunk ever arrived, the layout was never published. Fall back to a default layout
+	// (all columns at their native width) so finalize-time scans can dereference data_collection.
+	if (!gstate.layout_gate.published.load(std::memory_order_acquire)) {
+		unique_lock<mutex> guard(gstate.layout_gate.publish_mutex);
+		if (!gstate.layout_gate.published.load(std::memory_order_relaxed)) {
+			const auto &cond_types = gstate.hash_table->condition_types;
+			const auto &build_types = gstate.hash_table->build_types;
+			gstate.layout_gate.dict_index_width.assign(build_types.size(), 0);
+			// all-zero dict_index_width => BuildJoinLayout keeps every build column at its native width
+			auto layout = BuildJoinLayout(cond_types, build_types, gstate.hash_table->join_type,
+			                              gstate.layout_gate.dict_index_width);
+			gstate.layout_gate.layout_ptr = layout;
+			if (!gstate.hash_table->IsLayoutFinalized()) {
+				gstate.hash_table->FinishInitWithLayout(layout);
+			}
+			gstate.layout_gate.published.store(true, std::memory_order_release);
+		}
+	}
 	const auto &ht = *gstate.hash_table;
 
 	gstate.total_size =
@@ -1575,6 +1787,11 @@ SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 
 	// check for possible perfect hash table
 	auto use_perfect_hash = sink.perfect_join_executor->CanDoPerfectHashJoin(*this, min, max);
+	// PHJ's FullScanHashTable reads payload at native width; if any slot was narrowed it would crash. Runtime
+	// min/max from filter pushdown can re-enable PHJ here, so re-check after dict-surviving may have narrowed.
+	if (use_perfect_hash && sink.DictSurvivingActive()) {
+		use_perfect_hash = false;
+	}
 	if (use_perfect_hash) {
 		use_perfect_hash = sink.perfect_join_executor->BuildPerfectHashTable();
 	}

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -416,16 +416,16 @@ SelectExecutionMode(const DataChunk &chunk, const OperatorResultType child_resul
 	return CachingPhysicalOperatorExecuteMode::RETURN_CHUNK;
 }
 
-static bool ChunkHasPipelineGlobalDict(const DataChunk &chunk) {
+static bool ChunkHasGlobalDictionary(const DataChunk &chunk) {
 	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
-		if (DictionaryVector::IsPipelineGlobal(chunk.data[col_idx])) {
+		if (DictionaryVector::IsGlobalDictionary(chunk.data[col_idx])) {
 			return true;
 		}
 	}
 	return false;
 }
 
-//! Switch the empty cache to dictionary mode: pin each pipeline-global dict column's upstream entry, allocate its
+//! Switch the empty cache to dictionary mode: pin each global dictionary column's upstream entry, allocate its
 //! sel accumulator, and make its flat cache slot a zero-width placeholder so dict and flat columns stay
 //! row-aligned. A column's dict/flat tag is frozen here; correctness then relies on the producer never falling
 //! back to flat (enforced by the throw in AppendToCache).
@@ -435,7 +435,7 @@ static void SeedDictCache(CachingOperatorState &state, DataChunk &source, Client
 	state.dict_columns.resize(col_count);
 	auto flat_initialize = vector<bool>(col_count, true);
 	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
-		if (!DictionaryVector::IsPipelineGlobal(source.data[col_idx])) {
+		if (!DictionaryVector::IsGlobalDictionary(source.data[col_idx])) {
 			continue;
 		}
 		auto &slot = state.dict_columns[col_idx];
@@ -453,14 +453,14 @@ static void SeedDictCache(CachingOperatorState &state, DataChunk &source, Client
 }
 
 //! Append source into the cache (created lazily). On the first append into an empty cache, detect
-//! pipeline-global dict columns; those concatenate their selection indices instead of flattening.
+//! global dictionary columns; those concatenate their selection indices instead of flattening.
 static void AppendToCache(CachingOperatorState &state, DataChunk &source, ClientContext &client_context) {
 	if (!state.cached_chunk) {
 		state.cached_chunk = make_uniq<DataChunk>();
 		state.cached_chunk->Initialize(Allocator::Get(client_context), source.GetTypes());
 	}
 	auto &cache = *state.cached_chunk;
-	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasPipelineGlobalDict(source)) {
+	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasGlobalDictionary(source)) {
 		SeedDictCache(state, source, client_context);
 	}
 	if (!state.dict_cache_active) {
@@ -476,12 +476,13 @@ static void AppendToCache(CachingOperatorState &state, DataChunk &source, Client
 	for (idx_t col_idx = 0; col_idx < cache.ColumnCount(); col_idx++) {
 		auto &slot = state.dict_columns[col_idx];
 		if (slot.entry) {
-			// dict column: every later chunk must be the same pipeline-global dictionary. Throw (not D_ASSERT)
+			// dict column: every later chunk must be the same global dictionary. Throw (not D_ASSERT)
 			// because the Cast below is UB on a non-dict vector in release, accumulating foreign bytes as indices.
 			auto &source_col = source.data[col_idx];
 			if (source_col.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
-			    DictionaryVector::DictionaryId(source_col).empty() || !DictionaryVector::IsPipelineGlobal(source_col)) {
-				throw InternalException("dict-surviving cache: column %llu received a non-pipeline-global "
+			    DictionaryVector::DictionaryId(source_col).empty() ||
+			    !DictionaryVector::IsGlobalDictionary(source_col)) {
+				throw InternalException("dict-surviving cache: column %llu received a non-global-dictionary "
 				                        "chunk after being seeded for dictionary caching",
 				                        static_cast<uint64_t>(col_idx));
 			}
@@ -503,7 +504,7 @@ static void AppendToCache(CachingOperatorState &state, DataChunk &source, Client
 }
 
 //! After moving the cache into chunk, re-wrap each dict column as a DICTIONARY_VECTOR over the
-//! pinned upstream entry, carrying its id and pipeline_global flag through unchanged.
+//! pinned upstream entry, carrying its id and global_dictionary flag through unchanged.
 static void RewrapDictColumns(CachingOperatorState &state, DataChunk &chunk, idx_t count) {
 	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
 		auto &slot = state.dict_columns[col_idx];

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -614,7 +614,6 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 		}
 	}
 
-
 	return child_result;
 }
 

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/common/vector/dictionary_vector.hpp"
 #include "duckdb/function/table_function.hpp"
 
 #include "duckdb/common/printer.hpp"
@@ -340,10 +341,8 @@ enum class CachingPhysicalOperatorExecuteMode : uint8_t {
 	RETURN_CACHED
 };
 
-static CachingPhysicalOperatorExecuteMode SelectExecutionMode(const DataChunk &chunk,
-                                                              const OperatorResultType child_result,
-                                                              CachingOperatorState &state,
-                                                              ClientContext &client_context) {
+static CachingPhysicalOperatorExecuteMode
+SelectExecutionMode(const DataChunk &chunk, const OperatorResultType child_result, CachingOperatorState &state) {
 	if (state.can_cache_chunk == OperatorCachingMode::NONE) {
 		return CachingPhysicalOperatorExecuteMode::RETURN_CHUNK;
 	}
@@ -378,12 +377,7 @@ static CachingPhysicalOperatorExecuteMode SelectExecutionMode(const DataChunk &c
 		return CachingPhysicalOperatorExecuteMode::RETURN_CHUNK;
 	} else if (chunk.size() <= CachingPhysicalOperator::CACHE_THRESHOLD && !needs_continuation_chunk) {
 		// We have filtered out a significant amount of tuples
-
-		if (!state.cached_chunk) {
-			// Initialize cached_chunk
-			state.cached_chunk = make_uniq<DataChunk>();
-			state.cached_chunk->Initialize(Allocator::Get(client_context), chunk.GetTypes());
-		}
+		// The cache is materialised lazily by AppendToCache on first use
 
 		if (has_space_for_chunk_in_cache) {
 			// We can just append, do and return empty chunk
@@ -422,6 +416,119 @@ static CachingPhysicalOperatorExecuteMode SelectExecutionMode(const DataChunk &c
 	return CachingPhysicalOperatorExecuteMode::RETURN_CHUNK;
 }
 
+static bool ChunkHasPipelineGlobalDict(const DataChunk &chunk) {
+	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+		if (DictionaryVector::IsPipelineGlobal(chunk.data[col_idx])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+//! Switch the empty cache to dictionary mode: pin each pipeline-global dict column's upstream entry, allocate its
+//! sel accumulator, and make its flat cache slot a zero-width placeholder so dict and flat columns stay
+//! row-aligned. A column's dict/flat tag is frozen here; correctness then relies on the producer never falling
+//! back to flat (enforced by the throw in AppendToCache).
+static void SeedDictCache(CachingOperatorState &state, DataChunk &source, ClientContext &client_context) {
+	const idx_t col_count = source.ColumnCount();
+	state.dict_columns.clear();
+	state.dict_columns.resize(col_count);
+	auto flat_initialize = vector<bool>(col_count, true);
+	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
+		if (!DictionaryVector::IsPipelineGlobal(source.data[col_idx])) {
+			continue;
+		}
+		auto &slot = state.dict_columns[col_idx];
+		slot.entry = source.data[col_idx].BufferMutable().Cast<DictionaryBuffer>().GetEntryPtr();
+		slot.accumulated_sel.Initialize(STANDARD_VECTOR_SIZE);
+		flat_initialize[col_idx] = false;
+	}
+	// dict columns become zero-width placeholders in cached_chunk; the dict lives in the accumulator
+	state.cached_chunk->Destroy();
+	state.cached_chunk->Initialize(Allocator::Get(client_context), source.GetTypes(), flat_initialize);
+	// With every column a zero-width placeholder there is no flat vector to derive a cardinality from, so set the
+	// count explicitly before AppendToCache reads cache.size().
+	state.cached_chunk->SetChildCardinality(0);
+	state.dict_cache_active = true;
+}
+
+//! Append source into the cache (created lazily). On the first append into an empty cache, detect
+//! pipeline-global dict columns; those concatenate their selection indices instead of flattening.
+static void AppendToCache(CachingOperatorState &state, DataChunk &source, ClientContext &client_context) {
+	if (!state.cached_chunk) {
+		state.cached_chunk = make_uniq<DataChunk>();
+		state.cached_chunk->Initialize(Allocator::Get(client_context), source.GetTypes());
+	}
+	auto &cache = *state.cached_chunk;
+	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasPipelineGlobalDict(source)) {
+		SeedDictCache(state, source, client_context);
+	}
+	if (!state.dict_cache_active) {
+		// no dict columns: plain flat append
+		cache.Append(source);
+		return;
+	}
+	const idx_t base = cache.size();
+	const idx_t added = source.size();
+	// accumulated_sel is sized STANDARD_VECTOR_SIZE and the caching state machine guarantees base + added stays
+	// within it. Index accumulation has no overrun guard of its own (unlike the flat Append), so assert it.
+	D_ASSERT(base + added <= STANDARD_VECTOR_SIZE);
+	for (idx_t col_idx = 0; col_idx < cache.ColumnCount(); col_idx++) {
+		auto &slot = state.dict_columns[col_idx];
+		if (slot.entry) {
+			// dict column: every later chunk must be the same pipeline-global dictionary. Throw (not D_ASSERT)
+			// because the Cast below is UB on a non-dict vector in release, accumulating foreign bytes as indices.
+			auto &source_col = source.data[col_idx];
+			if (source_col.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
+			    DictionaryVector::DictionaryId(source_col).empty() || !DictionaryVector::IsPipelineGlobal(source_col)) {
+				throw InternalException("dict-surviving cache: column %llu received a non-pipeline-global "
+				                        "chunk after being seeded for dictionary caching",
+				                        static_cast<uint64_t>(col_idx));
+			}
+			// An id mismatch past the encoding check is a producer bug (never user-triggerable), so assert.
+			D_ASSERT(source_col.Buffer().Cast<DictionaryBuffer>().GetEntry().id == slot.entry->id);
+			const auto &source_sel = DictionaryVector::SelVector(source_col);
+			for (idx_t row = 0; row < added; row++) {
+				slot.accumulated_sel.set_index(base + row, source_sel.get_index(row));
+			}
+		} else {
+			// flat column: append per column. The D_ASSERT catches a refactor that routes a dict placeholder here.
+			D_ASSERT(!slot.entry);
+			FlatVector::SetSize(cache.data[col_idx], base);
+			cache.data[col_idx].Append(source.data[col_idx], added, VectorAppendMode::ERROR_ON_NO_SPACE);
+		}
+	}
+	// dict columns are null-buffer placeholders, flat columns already sized; only sets the cardinality
+	cache.SetChildCardinality(base + added);
+}
+
+//! After moving the cache into chunk, re-wrap each dict column as a DICTIONARY_VECTOR over the
+//! pinned upstream entry, carrying its id and pipeline_global flag through unchanged.
+static void RewrapDictColumns(CachingOperatorState &state, DataChunk &chunk, idx_t count) {
+	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+		auto &slot = state.dict_columns[col_idx];
+		if (!slot.entry) {
+			continue;
+		}
+		chunk.data[col_idx].Dictionary(slot.entry, slot.accumulated_sel, count);
+	}
+}
+
+//! Move the cache into chunk (reconstructing dict columns) and re-initialize an empty cache for the next
+//! batch. With no dict columns this is the plain flat flush.
+static void FlushCacheToChunk(CachingOperatorState &state, DataChunk &chunk, ClientContext &client_context) {
+	if (!state.dict_cache_active) {
+		chunk.Move(*state.cached_chunk);
+		state.cached_chunk->Initialize(Allocator::Get(client_context), chunk.GetTypes());
+		return;
+	}
+	const idx_t count = state.cached_chunk->size();
+	chunk.Move(*state.cached_chunk);
+	RewrapDictColumns(state, chunk, count);
+	state.cached_chunk->Initialize(Allocator::Get(client_context), chunk.GetTypes());
+	state.ResetDictCache();
+}
+
 OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
                                                     GlobalOperatorState &gstate, OperatorState &state_p) const {
 	auto &state = state_p.Cast<CachingOperatorState>();
@@ -452,33 +559,32 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 		}
 	}
 
-	const auto execution_mode = SelectExecutionMode(chunk, child_result, state, context.client);
+	const auto execution_mode = SelectExecutionMode(chunk, child_result, state);
 
+	// Appends and flushes MUST route through AppendToCache / FlushCacheToChunk: a raw Append flattens a zero-width
+	// dict placeholder and a raw flush drops the dict. (The continuation case below Moves a fresh chunk in -- a
+	// full replacement, not an append -- so raw dict columns pass through verbatim.)
 	switch (execution_mode) {
 	case CachingPhysicalOperatorExecuteMode::RETURN_CACHED_APPEND_CHUNK: {
 		auto tmp = make_uniq<DataChunk>();
 		tmp->Move(chunk);
-		chunk.Move(*state.cached_chunk);
-		state.cached_chunk->Initialize(Allocator::Get(context.client), chunk.GetTypes());
-		state.cached_chunk->Append(*tmp);
+		FlushCacheToChunk(state, chunk, context.client);
+		AppendToCache(state, *tmp, context.client);
 		break;
 	}
 	case CachingPhysicalOperatorExecuteMode::RETURN_CACHED_PLUS_CHUNK:
-		state.cached_chunk->Append(chunk);
-		chunk.Move(*state.cached_chunk);
-		state.cached_chunk->Initialize(Allocator::Get(context.client), chunk.GetTypes());
+		AppendToCache(state, chunk, context.client);
+		FlushCacheToChunk(state, chunk, context.client);
 		break;
 	case CachingPhysicalOperatorExecuteMode::RETURN_CACHED:
 		D_ASSERT(chunk.size() == 0);
-		chunk.Move(*state.cached_chunk);
-		state.cached_chunk->Initialize(Allocator::Get(context.client), chunk.GetTypes());
+		FlushCacheToChunk(state, chunk, context.client);
 		break;
 	case CachingPhysicalOperatorExecuteMode::RETURN_CACHED_THEN_CHUNK_VIA_CONTINUATION: {
 		// Swap chunk and *state.cached_chunk
 		auto tmp = make_uniq<DataChunk>();
 		tmp->Move(chunk);
-		chunk.Move(*state.cached_chunk);
-		state.cached_chunk->Initialize(Allocator::Get(context.client), chunk.GetTypes());
+		FlushCacheToChunk(state, chunk, context.client);
 		state.cached_chunk->Move(*tmp);
 
 		// Now chunk holds what was in (*state.cached_chunk), and it's returned directly
@@ -488,7 +594,7 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 		return OperatorResultType::HAVE_MORE_OUTPUT;
 	}
 	case CachingPhysicalOperatorExecuteMode::APPEND_CHUNK: {
-		state.cached_chunk->Append(chunk);
+		AppendToCache(state, chunk, context.client);
 		chunk.Reset();
 		break;
 	}
@@ -504,7 +610,13 @@ OperatorFinalizeResultType CachingPhysicalOperator::FinalExecute(ExecutionContex
                                                                  OperatorState &state_p) const {
 	auto &state = state_p.Cast<CachingOperatorState>();
 	if (state.cached_chunk) {
+		const idx_t count = state.cached_chunk->size();
+		const bool dict_cache_active = state.dict_cache_active;
 		chunk.Move(*state.cached_chunk);
+		if (dict_cache_active) {
+			RewrapDictColumns(state, chunk, count);
+			state.ResetDictCache();
+		}
 		state.cached_chunk.reset();
 	}
 	return OperatorFinalizeResultType::FINISHED;

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -603,6 +603,18 @@ OperatorResultType CachingPhysicalOperator::Execute(ExecutionContext &context, D
 		break;
 	}
 
+	// A flushed/reset dict column can leave the reused output chunk holding a DICTIONARY_VECTOR over a null cache
+	// slot that Reset cannot flatten; on an empty result that desyncs the chunk, so flatten stale columns to flat.
+	if (chunk.size() == 0) {
+		for (auto &vector : chunk.data) {
+			const auto vector_type = vector.GetVectorType();
+			if (vector_type != VectorType::FLAT_VECTOR && vector_type != VectorType::CONSTANT_VECTOR) {
+				vector.Initialize();
+			}
+		}
+	}
+
+
 	return child_result;
 }
 

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -425,15 +425,12 @@ static bool ChunkHasGlobalDictionary(const DataChunk &chunk) {
 	return false;
 }
 
-//! Switch the empty cache to dictionary mode: pin each global dictionary column's upstream entry, allocate its
-//! sel accumulator, and make its flat cache slot a zero-width placeholder so dict and flat columns stay
-//! row-aligned. A column's dict/flat tag is frozen here; correctness then relies on the producer never falling
-//! back to flat (enforced by the throw in AppendToCache).
-static void SeedDictCache(CachingOperatorState &state, DataChunk &source, ClientContext &client_context) {
+//! Switch the empty cache to dictionary mode: pin each global dictionary column's upstream entry and allocate its
+//! sel accumulator. Columns keep a real (resettable) cache so a flushed dict column flattens on the next Reset.
+static void SeedDictCache(CachingOperatorState &state, DataChunk &source) {
 	const idx_t col_count = source.ColumnCount();
 	state.dict_columns.clear();
 	state.dict_columns.resize(col_count);
-	auto flat_initialize = vector<bool>(col_count, true);
 	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
 		if (!DictionaryVector::IsGlobalDictionary(source.data[col_idx])) {
 			continue;
@@ -441,14 +438,7 @@ static void SeedDictCache(CachingOperatorState &state, DataChunk &source, Client
 		auto &slot = state.dict_columns[col_idx];
 		slot.entry = source.data[col_idx].BufferMutable().Cast<DictionaryBuffer>().GetEntryPtr();
 		slot.accumulated_sel.Initialize(STANDARD_VECTOR_SIZE);
-		flat_initialize[col_idx] = false;
 	}
-	// dict columns become zero-width placeholders in cached_chunk; the dict lives in the accumulator
-	state.cached_chunk->Destroy();
-	state.cached_chunk->Initialize(Allocator::Get(client_context), source.GetTypes(), flat_initialize);
-	// With every column a zero-width placeholder there is no flat vector to derive a cardinality from, so set the
-	// count explicitly before AppendToCache reads cache.size().
-	state.cached_chunk->SetChildCardinality(0);
 	state.dict_cache_active = true;
 }
 
@@ -461,7 +451,7 @@ static void AppendToCache(CachingOperatorState &state, DataChunk &source, Client
 	}
 	auto &cache = *state.cached_chunk;
 	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasGlobalDictionary(source)) {
-		SeedDictCache(state, source, client_context);
+		SeedDictCache(state, source);
 	}
 	if (!state.dict_cache_active) {
 		// no dict columns: plain flat append
@@ -499,7 +489,7 @@ static void AppendToCache(CachingOperatorState &state, DataChunk &source, Client
 			cache.data[col_idx].Append(source.data[col_idx], added, VectorAppendMode::ERROR_ON_NO_SPACE);
 		}
 	}
-	// dict columns are null-buffer placeholders, flat columns already sized; only sets the cardinality
+	// dict columns are rewrapped on flush, flat columns already sized; this only sets the cardinality
 	cache.SetChildCardinality(base + added);
 }
 

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -23,8 +23,8 @@ public:
 	//! Optional id to uniquely identify re-occurring dictionaries
 	string id;
 	//! True iff the producer wraps this same entry in every output chunk for its lifetime (stable id, no flat
-	//! fall-through). Set only via CreateReusablePipelineGlobalDictionary.
-	bool pipeline_global = false;
+	//! fall-through), making it a global dictionary. Set only via CreateReusableGlobalDictionary.
+	bool global_dictionary = false;
 	//! For caching the hashes of a child buffer (mutable: cache is logically const)
 	mutable mutex cached_hashes_lock;
 	mutable unique_ptr<Vector> cached_hashes;
@@ -155,14 +155,13 @@ struct DictionaryVector {
 	}
 	static buffer_ptr<DictionaryEntry> CreateReusableDictionary(const LogicalType &type, const idx_t &size);
 	//! Mint a reusable dictionary entry whose lifetime spans the entire producing operator instance
-	static buffer_ptr<DictionaryEntry> CreateReusablePipelineGlobalDictionary(const LogicalType &type,
-	                                                                          const idx_t &size);
-	//! True iff vector is a DICTIONARY_VECTOR whose entry is pipeline-global
-	static inline bool IsPipelineGlobal(const Vector &vector) {
+	static buffer_ptr<DictionaryEntry> CreateReusableGlobalDictionary(const LogicalType &type, const idx_t &size);
+	//! True iff vector is a DICTIONARY_VECTOR whose entry is a global dictionary
+	static inline bool IsGlobalDictionary(const Vector &vector) {
 		if (vector.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
 			return false;
 		}
-		return vector.Buffer().Cast<DictionaryBuffer>().GetEntry().pipeline_global;
+		return vector.Buffer().Cast<DictionaryBuffer>().GetEntry().global_dictionary;
 	}
 	static const Vector &GetCachedHashes(const Vector &input);
 };

--- a/src/include/duckdb/common/vector/dictionary_vector.hpp
+++ b/src/include/duckdb/common/vector/dictionary_vector.hpp
@@ -22,6 +22,9 @@ public:
 	Vector data;
 	//! Optional id to uniquely identify re-occurring dictionaries
 	string id;
+	//! True iff the producer wraps this same entry in every output chunk for its lifetime (stable id, no flat
+	//! fall-through). Set only via CreateReusablePipelineGlobalDictionary.
+	bool pipeline_global = false;
 	//! For caching the hashes of a child buffer (mutable: cache is logically const)
 	mutable mutex cached_hashes_lock;
 	mutable unique_ptr<Vector> cached_hashes;
@@ -151,6 +154,16 @@ struct DictionaryVector {
 		return DictionarySize(vector).IsValid() && !DictionaryId(vector).empty() && CanCacheHashes(vector.GetType());
 	}
 	static buffer_ptr<DictionaryEntry> CreateReusableDictionary(const LogicalType &type, const idx_t &size);
+	//! Mint a reusable dictionary entry whose lifetime spans the entire producing operator instance
+	static buffer_ptr<DictionaryEntry> CreateReusablePipelineGlobalDictionary(const LogicalType &type,
+	                                                                          const idx_t &size);
+	//! True iff vector is a DICTIONARY_VECTOR whose entry is pipeline-global
+	static inline bool IsPipelineGlobal(const Vector &vector) {
+		if (vector.GetVectorType() != VectorType::DICTIONARY_VECTOR) {
+			return false;
+		}
+		return vector.Buffer().Cast<DictionaryBuffer>().GetEntry().pipeline_global;
+	}
 	static const Vector &GetCachedHashes(const Vector &input);
 };
 

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -59,6 +59,12 @@ private:
    [POINTER]
    [POINTER]
    The pointers are either NULL
+
+   Two-phase lifecycle: the constructor populates only layout-INDEPENDENT state; all layout-DEPENDENT state
+   (layout_ptr, row matchers, tuple_size/pointer_offset/entry_size, data_collection, sink_collection, dead_end,
+   dict_registry) is published by FinishInitWithLayout on the first build chunk, so slot widths can be chosen from
+   the data's actual runtime encoding. Until then the JHT is unusable except for the null-safe Count() /
+   SizeInBytes() accessors; the layout-dependent accessors assert IsLayoutFinalized().
 */
 class JoinHashTable {
 public:
@@ -226,6 +232,17 @@ public:
 	              optional_ptr<Expression> predicate_ptr = nullptr, const vector<idx_t> &output_in_probe = {});
 	~JoinHashTable();
 
+	//! Initialize layout-dependent state from a layout shared across all per-thread JHTs (deferred ctor body)
+	void FinishInitWithLayout(shared_ptr<TupleDataLayout> published_layout, vector<uint8_t> dict_index_width_p = {});
+	//! True iff FinishInitWithLayout has populated layout-dependent state
+	bool IsLayoutFinalized() const {
+		return layout_ptr.get() != nullptr;
+	}
+
+	//! Per-column index-width decision for the dict-surviving optimisation, consulted by the layout publisher on
+	//! the first build chunk. Returns the narrowed index byte width (1/2/4), or 0 to keep native width.
+	uint8_t GetDictSurvivingIndexWidth(idx_t build_col_idx, const Vector &incoming) const;
+
 	//! Add the given data to the HT
 	void Build(PartitionedTupleDataAppendState &append_state, DataChunk &keys, DataChunk &input);
 	//! Merge another HT into this one
@@ -275,17 +292,21 @@ public:
 	}
 
 	idx_t Count() const {
-		return data_collection->Count();
+		return data_collection ? data_collection->Count() : 0;
 	}
 	idx_t SizeInBytes() const {
-		return data_collection->SizeInBytes();
+		return data_collection ? data_collection->SizeInBytes() : 0;
 	}
 
 	PartitionedTupleData &GetSinkCollection() {
+		// Only valid after FinishInitWithLayout; assert so a premature access fails loudly, not as a null-deref.
+		D_ASSERT(IsLayoutFinalized());
 		return *sink_collection;
 	}
 
 	TupleDataCollection &GetDataCollection() {
+		// Only valid after FinishInitWithLayout (see GetSinkCollection).
+		D_ASSERT(IsLayoutFinalized());
 		return *data_collection;
 	}
 	//! Perform a full scan of a build column, filling the provided addresses vector and result vector.
@@ -370,6 +391,12 @@ public:
 	bool use_dict_emission = false;
 	//! Pre-materialized columnar data, one entry per RHS output column
 	vector<buffer_ptr<DictionaryEntry>> dict_arrays;
+	//! Per build payload column: pinned upstream dict entry. Non-null means the row store carries a narrow dict
+	//! index for this column instead of the native value.
+	vector<buffer_ptr<DictionaryEntry>> dict_registry;
+	//! Per build payload column: byte width of the narrowed dict-index slot (0 = native, else 1/2/4). Parallel to
+	//! build_types; set by FinishInitWithLayout.
+	vector<uint8_t> dict_index_width;
 	//! Saved NEXT_PTR values, indexed by dict index; only allocated when chains_longer_than_one
 	AllocatedData aux_next_ptrs;
 	//! Typed pointer into aux_next_ptrs; set by BuildDictionaryArrays alongside the allocation
@@ -596,6 +623,10 @@ public:
 	void ProbeAndSpill(ScanStructure &scan_structure, DataChunk &probe_keys, TupleDataChunkState &key_state,
 	                   ProbeState &probe_state, DataChunk &probe_chunk, ProbeSpill &probe_spill,
 	                   ProbeSpillLocalAppendState &spill_state, DataChunk &spill_chunk);
+
+private:
+	//! True iff the residual predicate (if any) reads build payload column build_col_idx from its row slot
+	bool ColumnReferencedByResidual(idx_t build_col_idx) const;
 
 private:
 	//! The current number of radix bits used to partition

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -627,6 +627,9 @@ public:
 private:
 	//! True iff the residual predicate (if any) reads build payload column build_col_idx from its row slot
 	bool ColumnReferencedByResidual(idx_t build_col_idx) const;
+	//! Validate the incoming dict chunk and pin a self-owned copy of its dictionary into dict_registry on the first
+	//! chunk; on later chunks assert id continuity. Called per narrowed column from Build.
+	void PinDictSurvivingColumn(idx_t build_col_idx, const Vector &incoming, uint8_t index_width);
 
 private:
 	//! The current number of radix bits used to partition

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -247,7 +247,7 @@ public:
 	}
 };
 
-//! A cached column that arrived as a pipeline-global dictionary: the pinned upstream entry is kept and
+//! A cached column that arrived as a global dictionary: the pinned upstream entry is kept and
 //! per-chunk selection indices concatenated, so the dictionary survives the cache instead of flattening
 struct CachedDictColumn {
 	buffer_ptr<DictionaryEntry> entry;
@@ -285,7 +285,7 @@ public:
 	bool must_return_continuation_chunk = false;
 	OperatorResultType cached_result;
 
-	//! One slot per cached column. Invariant: entry != null iff the column is accumulating a pipeline-global
+	//! One slot per cached column. Invariant: entry != null iff the column is accumulating a global
 	//! dictionary; entry == null iff plain flat caching (the common case)
 	vector<CachedDictColumn> dict_columns;
 	bool dict_cache_active = false;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -26,6 +26,7 @@
 
 namespace duckdb {
 
+class DictionaryEntry;
 class Event;
 class Executor;
 class PhysicalOperator;
@@ -246,6 +247,13 @@ public:
 	}
 };
 
+//! A cached column that arrived as a pipeline-global dictionary: the pinned upstream entry is kept and
+//! per-chunk selection indices concatenated, so the dictionary survives the cache instead of flattening
+struct CachedDictColumn {
+	buffer_ptr<DictionaryEntry> entry;
+	SelectionVector accumulated_sel;
+};
+
 //! Contains state for the CachingPhysicalOperator
 class CachingOperatorState : public OperatorState {
 public:
@@ -261,6 +269,13 @@ public:
 		can_cache_chunk = OperatorCachingMode::NONE;
 		must_return_continuation_chunk = false;
 		cached_result = OperatorResultType::NEED_MORE_INPUT;
+		ResetDictCache();
+	}
+
+	//! Drop the dictionary accumulators, returning the cache to plain flat caching
+	void ResetDictCache() {
+		dict_columns.clear();
+		dict_cache_active = false;
 	}
 
 	unique_ptr<DataChunk> cached_chunk;
@@ -269,6 +284,11 @@ public:
 	OperatorCachingMode can_cache_chunk = OperatorCachingMode::NONE;
 	bool must_return_continuation_chunk = false;
 	OperatorResultType cached_result;
+
+	//! One slot per cached column. Invariant: entry != null iff the column is accumulating a pipeline-global
+	//! dictionary; entry == null iff plain flat caching (the common case)
+	vector<CachedDictColumn> dict_columns;
+	bool dict_cache_active = false;
 };
 
 //! Base class that caches output from child Operator class. Note that Operators inheriting from this class should also

--- a/test/sql/join/hash_join/hash_join_dict_surviving.test
+++ b/test/sql/join/hash_join/hash_join_dict_surviving.test
@@ -1,5 +1,5 @@
 # name: test/sql/join/hash_join/hash_join_dict_surviving.test
-# description: Test the dict-surviving hash join - a pipeline-global build-side DICTIONARY_VECTOR is stored as a narrow row-store index and re-emitted at probe time
+# description: Test the dict-surviving hash join - a global dictionary build-side DICTIONARY_VECTOR is stored as a narrow row-store index and re-emitted at probe time
 # group: [hash_join]
 
 # force multi-threaded build so thread-local dictionaries reconcile through Merge
@@ -376,7 +376,7 @@ NATION_2	400
 NATION_3	400
 NATION_4	400
 
-# storage dict not admitted: a per-row-group DICTIONARY_VECTOR is not pipeline-global
+# storage dict not admitted: a per-row-group DICTIONARY_VECTOR is not a global dictionary
 statement ok
 SET disabled_optimizers='join_order,build_side_probe_side'
 
@@ -416,7 +416,7 @@ PRAGMA force_compression='auto'
 statement ok
 SET disabled_optimizers='join_order'
 
-# small-build dictionary emission produces a pipeline-global dictionary the next join narrows
+# small-build dictionary emission produces a global dictionary the next join narrows
 statement ok
 CREATE TABLE dim AS SELECT 'KEY_' || i AS d_key, 'LABEL_' || (i % 5) AS d_label FROM range(100) t(i)
 

--- a/test/sql/join/hash_join/hash_join_dict_surviving.test
+++ b/test/sql/join/hash_join/hash_join_dict_surviving.test
@@ -1,0 +1,439 @@
+# name: test/sql/join/hash_join/hash_join_dict_surviving.test
+# description: Test the dict-surviving hash join - a pipeline-global build-side DICTIONARY_VECTOR is stored as a narrow row-store index and re-emitted at probe time
+# group: [hash_join]
+
+# force multi-threaded build so thread-local dictionaries reconcile through Merge
+statement ok
+PRAGMA threads=4
+
+statement ok
+PRAGMA verify_parallelism
+
+# keep the written join order so the dictionary lands on the downstream build side
+statement ok
+SET disabled_optimizers='join_order'
+
+# dense nation key picks a perfect hash join that mints the dictionaries; customer's wide key keeps the next join on the regular path
+statement ok
+CREATE TABLE nation AS
+SELECT i AS nk, 'NATION_' || (i % 5) AS n_name, ((i % 5) * 10)::INTEGER AS n_region
+FROM range(25) t(i)
+
+statement ok
+CREATE TABLE customer AS SELECT i * 1000 AS ck, i % 25 AS nk FROM range(2000) t(i)
+
+statement ok
+CREATE TABLE orders AS SELECT i AS ok, (i % 2000) * 1000 AS ck FROM range(8000) t(i)
+
+# VARCHAR payload (16B) over a 25-slot dictionary narrows to a 1-byte index
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	1600
+NATION_1	1600
+NATION_2	1600
+NATION_3	1600
+NATION_4	1600
+
+# INTEGER payload (4B) narrows to a 1-byte index - the slot only ever shrinks
+query II
+SELECT n.n_region, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_region ORDER BY n.n_region
+----
+0	1600
+10	1600
+20	1600
+30	1600
+40	1600
+
+# two narrowed columns (VARCHAR + INTEGER) survive together
+query III
+SELECT n.n_name, n.n_region, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_name, n.n_region ORDER BY n.n_name
+----
+NATION_0	0	1600
+NATION_1	10	1600
+NATION_2	20	1600
+NATION_3	30	1600
+NATION_4	40	1600
+
+# dictionary > 256 slots -> 2-byte index
+statement ok
+CREATE TABLE nation2 AS SELECT i AS nk, 'NAME_' || i AS n_name FROM range(300) t(i)
+
+statement ok
+CREATE TABLE customer2 AS SELECT i * 1000 AS ck, i % 300 AS nk FROM range(2000) t(i)
+
+statement ok
+CREATE TABLE orders2 AS SELECT i AS ok, (i % 2000) * 1000 AS ck FROM range(8000) t(i)
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT u.n_name)
+FROM (
+    SELECT n.n_name FROM nation2 n JOIN customer2 c ON n.nk = c.nk JOIN orders2 o ON o.ck = c.ck
+) u
+----
+8000	300
+
+# dictionary > 65536 slots -> 4-byte index (nation4 is the smaller perfect-hash build side)
+statement ok
+CREATE TABLE nation4 AS SELECT i AS nk, 'NM_' || i AS n_name FROM range(70000) t(i)
+
+statement ok
+CREATE TABLE customer4 AS SELECT i * 1000 AS ck, i % 70000 AS nk FROM range(200000) t(i)
+
+statement ok
+CREATE TABLE orders4 AS SELECT i AS ok, (i % 200000) * 1000 AS ck FROM range(400000) t(i)
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT u.n_name)
+FROM (SELECT n.n_name FROM nation4 n JOIN customer4 c ON n.nk = c.nk JOIN orders4 o ON o.ck = c.ck) u
+----
+400000	70000
+
+# chained: the narrowed dictionary survives two consecutive downstream joins (join_order on so each dict result becomes the next build)
+statement ok
+SET disabled_optimizers=''
+
+statement ok
+CREATE TABLE lineitem AS SELECT i AS lk, (i % 8000) * 1000 AS ok FROM range(30000) t(i)
+
+statement ok
+CREATE TABLE orders_c AS SELECT i * 1000 AS ok, (i % 2000) * 1000 AS ck FROM range(8000) t(i)
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n
+JOIN customer c ON n.nk = c.nk
+JOIN orders_c o ON o.ck = c.ck
+JOIN lineitem l ON l.ok = o.ok
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	6000
+NATION_1	6000
+NATION_2	6000
+NATION_3	6000
+NATION_4	6000
+
+statement ok
+SET disabled_optimizers='join_order'
+
+# tiny build routes dict chunks through the caching operator, which must coalesce them without flattening
+statement ok
+CREATE TABLE customer_tiny AS SELECT i * 100000 AS ck, i % 25 AS nk FROM range(50) t(i)
+
+statement ok
+CREATE TABLE orders_tiny AS SELECT i AS ok, (i % 50) * 100000 AS ck FROM range(200) t(i)
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer_tiny c ON n.nk = c.nk JOIN orders_tiny o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	40
+NATION_1	40
+NATION_2	40
+NATION_3	40
+NATION_4	40
+
+# join types that emit RHS columns through GatherRHS
+
+# SEMI: the dict-carrying side flips to a RIGHT_SEMI build and emits through GatherRHS
+query I
+SELECT COUNT(*)
+FROM (SELECT c.ck, n.n_name FROM nation n JOIN customer c ON n.nk = c.nk) u
+SEMI JOIN orders o ON u.ck = o.ck
+----
+2000
+
+# ANTI: every dict-carrying build row matches, so none survive
+query I
+SELECT COUNT(*)
+FROM (SELECT c.ck, n.n_name FROM nation n JOIN customer c ON n.nk = c.nk) u
+ANTI JOIN orders o ON u.ck = o.ck
+----
+0
+
+# RIGHT: an unmatched build row's dictionary index must still resolve via ScanFullOuter
+statement ok
+CREATE TABLE customer_orphan AS
+SELECT i * 1000 AS ck, i % 25 AS nk FROM range(2000) t(i)
+UNION ALL SELECT 7777777, 0
+
+statement ok
+CREATE TABLE orders_miss AS
+SELECT i AS ok, CASE WHEN i < 800 THEN 999999999 ELSE (i % 2000) * 1000 END AS ck FROM range(8000) t(i)
+
+query II
+SELECT COALESCE(u.n_name, 'NO_BUILD') AS nm, COUNT(*) AS cnt
+FROM orders_miss o
+RIGHT JOIN (SELECT c.ck, n.n_name FROM nation n JOIN customer_orphan c ON n.nk = c.nk) u ON o.ck = u.ck
+GROUP BY nm ORDER BY nm
+----
+NATION_0	1441
+NATION_1	1440
+NATION_2	1440
+NATION_3	1440
+NATION_4	1440
+
+# LEFT excluded: NextUniqueLeftJoin gathers outside GatherRHS; build_side_probe_side off keeps the dict side as build
+statement ok
+SET disabled_optimizers='join_order,build_side_probe_side'
+
+query II
+SELECT COALESCE(u.n_name, 'NO_MATCH') AS nm, COUNT(*) AS cnt
+FROM orders_miss o
+LEFT JOIN (SELECT c.ck, n.n_name FROM nation n JOIN customer c ON n.nk = c.nk) u ON o.ck = u.ck
+GROUP BY nm ORDER BY nm
+----
+NATION_0	1440
+NATION_1	1440
+NATION_2	1440
+NATION_3	1440
+NATION_4	1440
+NO_MATCH	800
+
+statement ok
+SET disabled_optimizers='join_order'
+
+# FULL OUTER excluded: constant-NULL left-fill makes the output stream non-uniform
+query II
+SELECT COALESCE(u.n_name, 'NO_MATCH') AS nm, COUNT(*) AS cnt
+FROM orders_miss o
+FULL OUTER JOIN (SELECT c.ck, n.n_name FROM nation n JOIN customer_orphan c ON n.nk = c.nk) u ON o.ck = u.ck
+GROUP BY nm ORDER BY nm
+----
+NATION_0	1441
+NATION_1	1440
+NATION_2	1440
+NATION_3	1440
+NATION_4	1440
+NO_MATCH	800
+
+# SINGLE excluded: needs FlatVector::SetNull on unmatched rows, which a dictionary cannot supply
+query I
+SELECT COUNT(*) FROM orders o
+WHERE o.ok < 10
+  AND (SELECT n.n_name FROM nation n JOIN customer c ON n.nk = c.nk WHERE c.ck = o.ck) IS NOT NULL
+----
+10
+
+# external excluded: a partition rebuild cannot keep a pinned dictionary alive
+statement ok
+PRAGMA debug_force_external=true
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	1600
+NATION_1	1600
+NATION_2	1600
+NATION_3	1600
+NATION_4	1600
+
+statement ok
+PRAGMA debug_force_external=false
+
+# a column read by a residual predicate keeps native width (the predicate spans both sides to stay a residual)
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk
+JOIN orders o ON o.ck = c.ck AND (o.ok + length(n.n_name)) > 5
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	1600
+NATION_1	1600
+NATION_2	1600
+NATION_3	1600
+NATION_4	1600
+
+# nested-type (LIST) column keeps native width - Vector::Dictionary rejects nested types
+statement ok
+CREATE TABLE nation_list AS SELECT i AS nk, ['NATION_' || (i % 5)] AS n_names FROM range(25) t(i)
+
+query II
+SELECT n.n_names[1] AS nm, COUNT(*) AS cnt
+FROM nation_list n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY nm ORDER BY nm
+----
+NATION_0	1600
+NATION_1	1600
+NATION_2	1600
+NATION_3	1600
+NATION_4	1600
+
+# a 1-byte native column has no narrower index, so it stays native
+statement ok
+CREATE TABLE nation_tiny AS SELECT i AS nk, (i % 5)::TINYINT AS n_t FROM range(25) t(i)
+
+query II
+SELECT n.n_t, COUNT(*) AS cnt
+FROM nation_tiny n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_t ORDER BY n.n_t
+----
+0	1600
+1	1600
+2	1600
+3	1600
+4	1600
+
+# NULL handling
+
+# NULL probe keys never match under equality and are dropped
+statement ok
+CREATE TABLE orders_null_probe AS
+SELECT i AS ok, CASE WHEN i < 100 THEN NULL ELSE (i % 2000) * 1000 END AS ck FROM range(8000) t(i)
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders_null_probe o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	1580
+NATION_1	1580
+NATION_2	1580
+NATION_3	1580
+NATION_4	1580
+
+# NULL build keys are carried but match no probe row
+statement ok
+CREATE TABLE customer_null_key AS
+SELECT CASE WHEN i < 100 THEN NULL ELSE i * 1000 END AS ck, i % 25 AS nk FROM range(2000) t(i)
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation n JOIN customer_null_key c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name
+----
+NATION_0	1520
+NATION_1	1520
+NATION_2	1520
+NATION_3	1520
+NATION_4	1520
+
+# dictionary NULL child slots and a NULL payload value must be preserved 1:1
+statement ok
+CREATE TABLE nation_gap (nk INTEGER, n_name VARCHAR)
+
+statement ok
+INSERT INTO nation_gap VALUES (0, 'A'), (1, 'B'), (2, 'A'), (5, 'C'), (6, NULL)
+
+statement ok
+CREATE TABLE customer_gap AS
+SELECT i * 1000 AS ck, (CASE WHEN i % 7 IN (3, 4) THEN 9 ELSE i % 7 END) AS nk FROM range(2000) t(i)
+
+statement ok
+CREATE TABLE orders_gap AS SELECT i AS ok, (i % 2000) * 1000 AS ck FROM range(8000) t(i)
+
+query II
+SELECT n.n_name, COUNT(*) AS cnt
+FROM nation_gap n JOIN customer_gap c ON n.nk = c.nk JOIN orders_gap o ON o.ck = c.ck
+GROUP BY n.n_name ORDER BY n.n_name NULLS FIRST
+----
+NULL	1140
+A	2288
+B	1144
+C	1140
+
+# empty build: no Sink chunk, so a default-width layout is published at finalize without crashing
+query II
+SELECT u.n_name, COUNT(*) AS cnt
+FROM (SELECT c.ck, n.n_name FROM nation n JOIN customer c ON n.nk = c.nk WHERE 1=0) u
+JOIN orders o ON o.ck = u.ck
+GROUP BY u.n_name ORDER BY u.n_name
+----
+
+# UNION ALL build excluded: multiple producers break the decide-once-on-first-chunk layout contract
+statement ok
+CREATE TABLE other_flat AS SELECT i * 1000 + 500 AS ck, 'FLAT_' || (i % 5) AS n_name FROM range(2000) t(i)
+
+statement ok
+CREATE TABLE probe_mixed AS SELECT i * 500 AS pk FROM range(8000) t(i)
+
+query II
+SELECT u.n_name, COUNT(*) AS cnt
+FROM probe_mixed p JOIN (
+    SELECT c.ck AS ck, n.n_name FROM nation n JOIN customer c ON n.nk = c.nk
+    UNION ALL
+    SELECT o.ck, o.n_name FROM other_flat o
+) u ON p.pk = u.ck
+GROUP BY u.n_name ORDER BY u.n_name
+----
+FLAT_0	400
+FLAT_1	400
+FLAT_2	400
+FLAT_3	400
+FLAT_4	400
+NATION_0	400
+NATION_1	400
+NATION_2	400
+NATION_3	400
+NATION_4	400
+
+# storage dict not admitted: a per-row-group DICTIONARY_VECTOR is not pipeline-global
+statement ok
+SET disabled_optimizers='join_order,build_side_probe_side'
+
+statement ok
+ATTACH '{TEST_DIR}/hash_join_dict_surviving.db' AS sdb
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+statement ok
+CREATE TABLE sdb.dim (k VARCHAR, name VARCHAR)
+
+statement ok
+INSERT INTO sdb.dim SELECT 'K_' || i, 'NAME_' || (i % 5) FROM range(5000) t(i)
+
+statement ok
+CREATE TABLE sdb.fact (id INTEGER, k VARCHAR)
+
+statement ok
+INSERT INTO sdb.fact SELECT i, 'K_' || (i % 5000) FROM range(20000) t(i)
+
+statement ok
+CHECKPOINT sdb
+
+query II
+SELECT d.name, COUNT(*) AS cnt FROM sdb.fact f JOIN sdb.dim d ON f.k = d.k GROUP BY d.name ORDER BY d.name
+----
+NAME_0	4000
+NAME_1	4000
+NAME_2	4000
+NAME_3	4000
+NAME_4	4000
+
+statement ok
+PRAGMA force_compression='auto'
+
+statement ok
+SET disabled_optimizers='join_order'
+
+# small-build dictionary emission produces a pipeline-global dictionary the next join narrows
+statement ok
+CREATE TABLE dim AS SELECT 'KEY_' || i AS d_key, 'LABEL_' || (i % 5) AS d_label FROM range(100) t(i)
+
+statement ok
+CREATE TABLE fact1 AS SELECT 'KEY_' || (i % 100) AS f1_dkey, 'CUST_' || i AS f1_ckey FROM range(262200) t(i)
+
+# fact2 is 2x the dim-fact1 result so the dict-carrying side becomes the build
+statement ok
+CREATE TABLE fact2 AS SELECT 'CUST_' || (i % 262200) AS f2_ckey FROM range(524400) t(i)
+
+query II
+SELECT d.d_label, COUNT(*) AS cnt
+FROM dim d JOIN fact1 f1 ON d.d_key = f1.f1_dkey JOIN fact2 f2 ON f1.f1_ckey = f2.f2_ckey
+GROUP BY d.d_label ORDER BY d.d_label
+----
+LABEL_0	104880
+LABEL_1	104880
+LABEL_2	104880
+LABEL_3	104880
+LABEL_4	104880

--- a/test/sql/join/hash_join/hash_join_dict_surviving.test
+++ b/test/sql/join/hash_join/hash_join_dict_surviving.test
@@ -222,7 +222,8 @@ WHERE o.ok < 10
 ----
 10
 
-# external excluded: a partition rebuild cannot keep a pinned dictionary alive
+# external is supported: the in-memory dictionary and the narrow index column survive the spill/repartition,
+# so results must match the in-memory path
 statement ok
 PRAGMA debug_force_external=true
 
@@ -236,6 +237,47 @@ NATION_1	1600
 NATION_2	1600
 NATION_3	1600
 NATION_4	1600
+
+# the strings themselves must reconstruct correctly after the external rebuild (not just the row counts)
+query II
+SELECT n.n_name, o.ok
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+WHERE o.ok < 5
+ORDER BY o.ok
+----
+NATION_0	0
+NATION_1	1
+NATION_2	2
+NATION_3	3
+NATION_4	4
+
+# carry both a VARCHAR (n_name) and an INTEGER (n_region) global-dictionary payload through the external join
+query III
+SELECT n.n_name, n.n_region, COUNT(*) AS cnt
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+GROUP BY n.n_name, n.n_region ORDER BY n.n_name
+----
+NATION_0	0	1600
+NATION_1	10	1600
+NATION_2	20	1600
+NATION_3	30	1600
+NATION_4	40	1600
+
+# aggregate keyed on the surviving dictionary column (exercises the downstream per-id cache across the boundary)
+query I
+SELECT COUNT(DISTINCT n.n_name)
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+----
+5
+
+# row-level self-consistency across the external rebuild (the GROUP BY above only checks aggregates)
+query II
+SELECT n.n_name, o.ok
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+EXCEPT
+SELECT n.n_name, o.ok
+FROM nation n JOIN customer c ON n.nk = c.nk JOIN orders o ON o.ck = c.ck
+----
 
 statement ok
 PRAGMA debug_force_external=false


### PR DESCRIPTION
# Add Dictionary Surviving Hash Join

## Motivation

DuckDB's hash-join build side is **not dictionary-aware**. As each chunk arrives at the sink, `Scatter` materializes every payload column into the row store at its native physical width. When the column already arrived dictionary-encoded over a small set of distinct values, this throws the encoding away: the same few values are copied into the row store once per build row, and their string heap is re-materialized on top of the upstream child that already holds it. That wastes both **memory** and **CPU**.

## Global Dictionaries

We introduce a new concept: a **global dictionary**. A dictionary is global when an operator builds it once and guarantees that *every* chunk it emits for that column carries the exact same dictionary for the operator's entire lifetime. No chunk is ever emitted in a flat form or with a different dictionary. That guarantee is what makes it safe for a downstream sink to commit to the dictionary after seeing only the **first** chunk, knowing every later chunk will match it.

Two operators already produce such dictionaries:

- **Perfect Hash Join**: `perfect_hash_table[i]` is wrapped by every probe-output chunk for the operator's lifetime.
- **Small-build-side dictionary emission** (#22340): `dict_arrays[col_idx]` is wrapped by every matched-row emission once activated.

Storage-emitted dictionaries do **not** qualify (they rotate per row group and fall back to flat), so they are excluded for now.

## Approach

When a build-side payload column arrives at a hash-join sink as a global dictionary, the sink stores a compact **index** into the dictionary instead of flattening the value:

- On the **first** build chunk, the sink inspects the live vectors, narrows each eligible payload column's row-store slot to the smallest index width that can address its dictionary, and pins a self-owned copy of the dictionary child (the producer's string heap is recycled when its pipeline finishes, so the copy must outlive it).
- During the build, `Scatter` writes the 1/2/4-byte index per row instead of the full value.
- At probe time, `GatherRHS` reads the index and re-emits a `DICTIONARY_VECTOR` over the pinned child, preserving the same `dictionary_id`, so the dictionary survives the join.

**Index width** is chosen per column from the dictionary size `D`: `D ≤ 256 → 1 B` (`UTINYINT`), `D ≤ 65536 → 2 B` (`USMALLINT`), else `4 B` (`UINTEGER`). The eligibility gate is `index_width(D) < native_width`, so a row can only ever shrink, never grow. This also unlocks narrow non-string payloads (a `D ≤ 256` `INTEGER` narrows 4 B → 1 B).

Because the dictionary survives intact, the optimization **chains**: the re-emitted output of a dictionary-surviving join is itself a first-class global producer, so a chain of consecutive joins can carry one dictionary end-to-end under a single id.

## Two supporting changes

Two existing parts of DuckDB had to change for a global dictionary to reach the sink intact.

### 1. Delayed `TupleDataLayout` construction

To store an index instead of a full value, the slot width must be fixed **before the first row is written**, because everything afterward reads from fixed offsets. But the layout is currently built in the `JoinHashTable` **constructor**, from logical types alone, before any chunk exists, so it cannot know a column will arrive dictionary-encoded or how large its dictionary is.

The fix splits `JoinHashTable` initialization into two phases. The constructor now does only the work that does *not* depend on the `TupleDataLayout`; everything that does is moved into a new `FinishInitWithLayout`, which runs once the first chunk has arrived:

1. The first thread to reach `Sink` becomes the **publisher**: it inspects the arriving vectors, picks each payload column's slot width, and builds one canonical `TupleDataLayout`.
2. It stores the layout in a `LayoutGate` (the layout plus an `atomic<bool> published`, double-checked under a mutex). Every other build thread reads the *same* layout rather than building its own.
3. Because every per-thread `JoinHashTable` shares the one published layout, all threads write rows in an identical byte format, so the parallel `Merge` can splice row blocks together without re-encoding.

### 2. Global-Dictionary-aware caching operator

Every `PhysicalHashJoin` is a `CachingPhysicalOperator` (via `PhysicalJoin`), so every hash join's probe output passes through a caching layer that buffers and combines small chunks before reaching the next sink. The cache is built type-blind and flat, so it flattens the dictionary on append, dropping the `buffer_ptr`, the `id`, and the `pipeline_global` flag.

This **breaks the global-dictionary guarantee**: the cache emits a fresh, unrelated dictionary on flush, while the sink has already pinned the original entry from the first chunk, so the sink would scatter indices that point into a *different* child than the one it gathers from.

The fix teaches the caching operator to recognize a global dictionary and preserve it. Each cached column is handled one of two ways:

- **Flat column (common case):** cached exactly as before, behind a single `dict_cache_active` flag, so non-dictionary workloads are byte-for-byte the old path.
- **Global dict column:** the cache keeps a reference to the upstream dictionary and appends each chunk's indices into a running selection vector; on flush it re-emits a `DICTIONARY_VECTOR` over that same dictionary, so `id` and `pipeline_global` are preserved automatically.

This is also cheaper per row than flattening.

## Activation conditions

Checked in two layers; any failure falls through silently to the unchanged path.

**Join-level:** the join must not be external, its type must not be `SINGLE` / `LEFT` / `OUTER`, its build side must not be fed by multiple sources, it must not use Perfect Hash Join at finalize, and its RHS output must be non-empty.

**Per-column:** the column must arrive as a **Global** `DICTIONARY_VECTOR`, be of a non-nested type, not be read by a residual predicate, and have an index width strictly smaller than its native width.

## Benchmarks

Single-threaded, 10 runs per query, comparing this branch against `main`. Peak memory is the buffer-pool high-water mark over the whole query (an `atomic<int64_t>` added to the buffer pool, reset at query start, read at query end); we report the minimum across runs.

### IMDB / Join Order Benchmark

Top queries by peak-memory reduction, with runtime:

| Query | main peak (MB) | branch peak (MB) | peak reduction | main (s) | branch (s) | speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 07c | 4753.88 | 827.53 | 82.6% | 0.435 | 0.185 | **2.35×** |
| 13c | 155.09 | 102.36 | 34.0% | 0.103 | 0.094 | 1.09× |
| 13b | 157.97 | 105.76 | 33.1% | 0.116 | 0.107 | 1.08× |
| 13d | 97.70 | 70.65 | 27.7% | 0.098 | 0.093 | 1.06× |
| 16c | 300.39 | 284.99 | 5.1% | 0.169 | 0.162 | 1.04× |
| 16d | 290.53 | 276.56 | 4.8% | 0.159 | 0.154 | 1.03× |
| 20a | 336.24 | 326.53 | 2.9% | 0.311 | 0.303 | 1.03× |

07c is the flagship: a 12.6k-name dictionary referenced by 1.6M build rows, peak dropping from 4.75 GB to 0.83 GB and the query running 2.35× faster.

### TPC-H

The clearest TPC-H result is **Q21 at SF100**, where `s_name` survives three consecutive joins as a global dictionary.

Peak memory (10 runs, fully deterministic so min = median = mean):

| Metric | main (MB) | branch (MB) | reduction (MB) | reduction % |
| --- | ---: | ---: | ---: | ---: |
| Min | 8248.10 | 7573.60 | 674.50 | 8.18% |

Runtime (10 timed runs, real seconds):

| Metric | main | branch | reduction | speedup |
| --- | ---: | ---: | ---: | ---: |
| Geomean | 11.877 s | 11.578 s | 2.52% | **1.026×** |

### Showcase: avoiding a spill

A large enough reduction flips a spilling join into an in-memory one, and the disk-spill penalty far outweighs any per-row saving.

```sql
SET threads = 1;
SET disabled_optimizers = 'join_order';
SET memory_limit = '600MB';

CREATE TABLE nation AS
  SELECT i AS n_nationkey,
         'NATION_NAME_…_LONG_COUNTRY_NAME_…_'      || (i % 5) AS n_name,
         'NATION_COMMENT_…_SUBSTANTIAL_PADDING_…_' || (i % 7) AS n_comment
  FROM range(25) t(i);
CREATE TABLE customer AS
  SELECT i * 100 AS c_custkey, i % 25 AS c_nationkey FROM range(2000000) t(i);
CREATE TABLE orders AS
  SELECT i AS o_orderkey, (i % 2000000) * 100 AS o_custkey FROM range(6000000) t(i);

SELECT n.n_name, n.n_comment
FROM nation n
JOIN customer c ON n.n_nationkey = c.c_nationkey   -- Perfect Hash Join (dict producer)
JOIN orders   o ON o.o_custkey   = c.c_custkey;     -- dictionary-surviving join fires here
```

The build-side row store goes from **641 MB on `main`** (> the ~600 MB reservation → spills to disk) **to 68 MB on this branch** (fits, stays in memory), a 9.5× reduction that flips the spill decision:

| Metric | main | this branch | reduction | speedup |
| --- | ---: | ---: | ---: | ---: |
| Min | 0.362 s | 0.246 s | 32.1% | **1.47×** |
| Geomean | 0.412 s | 0.266 s | 35.3% | **1.55×** |

---

@lnkuiper, PR is ready to review, Thanks!
