### PR TITLE
In variant_extract correctly traverse child stats during stats propagation

### DIFF
--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -786,6 +786,7 @@ unique_ptr<BaseStatistics> VariantStats::PushdownExtract(const BaseStatistics &s
 		if (!index_iter.get().HasChildren()) {
 			break;
 		}
+		index_iter = index_iter.get().GetChildIndex(0);
 	}
 	auto &shredded_child_stats = *res;
 

--- a/test/sql/storage/types/variant/variant_extract_stats.test
+++ b/test/sql/storage/types/variant/variant_extract_stats.test
@@ -188,3 +188,41 @@ query I
 select stats(col.c).shredding_state from tbl order by rowid offset 2 limit 1;
 ----
 INCONSISTENT
+
+# ------------------------------ Nested OBJECT paths (depth >= 2) ------------------------------
+
+statement ok
+delete from tbl;
+
+statement ok
+SET force_variant_shredding = 'STRUCT(a STRUCT(b VARCHAR, c VARCHAR))';
+
+statement ok
+insert into tbl select {'a': {'b': 'hello', 'c': 'world'}} from range(5)
+
+statement ok
+checkpoint
+
+restart
+
+# A depth-2 path through nested shredded OBJECTs propagates stats
+query II
+select s.fully_shredded.stats.min, s.fully_shredded.stats.max from (select stats(col.a.b) s from tbl limit 1);
+----
+hello	hello
+
+query II
+select s.fully_shredded.stats.min, s.fully_shredded.stats.max from (select stats(col.a.c) s from tbl limit 1);
+----
+world	world
+
+query I
+select stats(col.a.b).shredding_state from tbl limit 1;
+----
+SHREDDED
+
+# The intermediate OBJECT is fully shredded too
+query I
+select stats(col.a).shredding_state from tbl limit 1;
+----
+SHREDDED


### PR DESCRIPTION
Otherwise all stats more than 2 levels deep get incorrectly labeled as inconsistent.
