### PR TITLE
Fix *COLUMNS() false rejection when operators appear in lambda bodies

### DIFF
--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -117,6 +117,11 @@ void Binder::ReplaceUnpackedStarExpression(unique_ptr<ParsedExpression> &expr, e
 		ReplaceInOperator(expr, star_list, star, regex);
 		break;
 	}
+	case ExpressionClass::LAMBDA: {
+		// *COLUMNS(*) expansion applies to the arguments of the outer function, not to
+		// lambda body expressions. Lambda parameters are bound per-element at runtime.
+		return;
+	}
 	default: {
 		break;
 	}

--- a/test/sql/parser/test_columns_unpacked.test
+++ b/test/sql/parser/test_columns_unpacked.test
@@ -282,3 +282,40 @@ select
 from (select 21 a, 42 b, 1337 c)
 ----
 Column "d" was selected but was not found in the FROM clause
+
+# *COLUMNS(*) with lambda expressions (issue #17617)
+# Lambda bodies should be skipped during *COLUMNS(*) expansion
+
+statement ok
+CREATE TABLE lambda_test (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO lambda_test VALUES (1, NULL, 3), (NULL, NULL, NULL);
+
+# list_filter with IS NOT NULL in lambda body
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL) FROM lambda_test;
+----
+[1, 3]
+[]
+
+# list_filter with IS NULL in lambda body
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: x IS NULL) FROM lambda_test;
+----
+[NULL]
+[NULL, NULL, NULL]
+
+# list_filter with NOT in lambda body (was also broken before fix)
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: NOT (x = 1)) FROM lambda_test;
+----
+[3]
+[]
+
+# list_filter with multiple conditions in lambda body
+query I
+SELECT list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL AND x > 1) FROM lambda_test;
+----
+[3]
+[]


### PR DESCRIPTION
## Problem

`*COLUMNS()` could not be used in functions whose lambda argument contained
operators like `IS NOT NULL`, `IS NULL`, or `NOT`, even though those operators
had nothing to do with the `*COLUMNS()` expansion.

**Reproduction:**
```sql
-- Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
SELECT list_filter([*COLUMNS(*)], lambda x: x IS NOT NULL) FROM t;

-- Original report (#17617):
SELECT list_filter([*columns(getvariable('my_patt'))], lambda x: lower(x) != 'empty' AND x IS NOT NULL) FROM t;
```

## Root Cause

`ReplaceUnpackedStarExpression` walks the expression tree via `EnumerateChildren`
and calls `ReplaceInOperator` on every operator encountered — including operators
inside lambda bodies that contain no `*COLUMNS()` child at all. The allowlist
check in `ReplaceInOperator` fired unconditionally, throwing a `BinderException`
for any operator not in the list.

**Before fix:**
```
list_filter                        [FUNCTION]
├── [*COLUMNS(*)]                  [OPERATOR] → expanded correctly ✓
└── lambda x: x IS NOT NULL        [LAMBDA]
    └── x IS NOT NULL              [OPERATOR_IS_NOT_NULL]
        └── x                      [COLUMN_REF]
                                   ↑
                          EnumerateChildren recurses here
                          ReplaceInOperator fires on IS_NOT_NULL
                          IS_NOT_NULL not in allowlist → THROWS ✗
```

**After fix:**
```
list_filter                        [FUNCTION]
├── [*COLUMNS(*)]                  [OPERATOR] → expanded correctly ✓
└── lambda x: x IS NOT NULL        [LAMBDA] → return early ✓
    └── x IS NOT NULL              [OPERATOR_IS_NOT_NULL]
        └── x                      [COLUMN_REF]
                                   ↑
                                never visited
```

## Fix

Stop the tree walk at `ExpressionClass::LAMBDA`. Lambda expressions represent a
distinct evaluation scope: `*COLUMNS()` is a bind-time column expansion while
lambda parameters are per-element runtime bindings. There is no valid `*COLUMNS()`
expansion site inside a lambda body.

## Tests

Extended `test/sql/parser/test_columns_unpacked.test` with cases covering:
- `lambda x: x IS NOT NULL`
- `lambda x: x IS NULL`
- `lambda x: NOT (x = 1)`
- `lambda x: x IS NOT NULL AND x > 1` (compound — the original issue pattern)

Fixes #17617
