### PR TITLE
Fix *COLUMNS() false rejection when operator wraps function result

### DIFF
--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -75,21 +75,34 @@ static void ReplaceInOperator(unique_ptr<ParsedExpression> &expr, expression_lis
                               optional_ptr<duckdb_re2::RE2> regex) {
 	auto &operator_expr = expr->Cast<OperatorExpression>();
 
-	vector<ExpressionType> allowed_types({
-	    ExpressionType::OPERATOR_COALESCE,
-	    ExpressionType::COMPARE_IN,
-	    ExpressionType::COMPARE_NOT_IN,
-	});
-	bool allowed = false;
-	for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
-		auto &type = allowed_types[i];
-		if (operator_expr.GetExpressionType() == type) {
-			allowed = true;
+	// Only enforce the allowlist when *COLUMNS() is a direct child of this operator.
+	// Operators that appear as ancestors of a function containing *COLUMNS() (e.g.
+	// COALESCE(*COLUMNS(*)) IS NOT NULL) must not be rejected — the expansion happens
+	// inside the function, not inside this operator.
+	bool has_unpacked_child = false;
+	for (auto &child : operator_expr.GetChildren()) {
+		if (StarExpression::IsColumnsUnpacked(*child)) {
+			has_unpacked_child = true;
+			break;
 		}
 	}
-	if (!allowed) {
-		throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
-		                      EnumUtil::ToString(operator_expr.GetExpressionType()));
+	if (has_unpacked_child) {
+		vector<ExpressionType> allowed_types({
+		    ExpressionType::OPERATOR_COALESCE,
+		    ExpressionType::COMPARE_IN,
+		    ExpressionType::COMPARE_NOT_IN,
+		});
+		bool allowed = false;
+		for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
+			auto &type = allowed_types[i];
+			if (operator_expr.GetExpressionType() == type) {
+				allowed = true;
+			}
+		}
+		if (!allowed) {
+			throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
+			                      EnumUtil::ToString(operator_expr.GetExpressionType()));
+		}
 	}
 
 	// Replace children

--- a/test/sql/parser/test_columns_unpacked_outer_operators.test
+++ b/test/sql/parser/test_columns_unpacked_outer_operators.test
@@ -1,0 +1,48 @@
+# name: test/sql/parser/test_columns_unpacked_outer_operators.test
+# description: Test *COLUMNS() when operators wrap the result of a function containing *COLUMNS()
+# group: [parser]
+
+statement ok
+CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, NULL, 3), (NULL, NULL, NULL);
+
+# COALESCE(*COLUMNS(*)) IS NOT NULL — operator wraps function result, not *COLUMNS() directly
+query I
+SELECT COALESCE(*COLUMNS(*)) IS NOT NULL FROM t;
+----
+true
+false
+
+# COALESCE(*COLUMNS(*)) IS NULL
+query I
+SELECT COALESCE(*COLUMNS(*)) IS NULL FROM t;
+----
+false
+true
+
+# Nested in CASE WHEN
+query I
+SELECT CASE WHEN COALESCE(*COLUMNS(*)) IS NOT NULL THEN 'has value' ELSE 'all null' END FROM t;
+----
+has value
+all null
+
+# Used in WHERE clause
+query III
+SELECT * FROM t WHERE COALESCE(*COLUMNS(*)) IS NOT NULL;
+----
+1	NULL	3
+
+# Direct *COLUMNS(*) IS NOT NULL is still correctly rejected (arity is undefined after expansion)
+statement error
+SELECT *COLUMNS(*) IS NOT NULL FROM t;
+----
+Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
+
+# Direct *COLUMNS(*) IS NULL is still correctly rejected
+statement error
+SELECT *COLUMNS(*) IS NULL FROM t;
+----
+Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NULL' operator


### PR DESCRIPTION
## Context

Follow-up to #17617. While tracing the root cause of that issue, I found the allowlist in `ReplaceInOperator` blocks operators in two distinct situations. The lambda body case is fixed in the PR for #17617. This PR addresses the second case — operators that appear as **ancestors** of a function containing `*COLUMNS()`.

See #23365 for the discussion with @Tishj before this is marked ready for review.

## Problem

```sql
CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER);
INSERT INTO t VALUES (1, NULL, 3), (NULL, NULL, NULL);

-- Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
SELECT COALESCE(*COLUMNS(*)) IS NOT NULL FROM t;

-- Works — manually expanded equivalent
SELECT COALESCE(a, b, c) IS NOT NULL FROM t;
```

## Root Cause

`ReplaceUnpackedStarExpression` walks the tree via `EnumerateChildren` and calls `ReplaceInOperator` on every operator — including operators that are merely ancestors of a function containing `*COLUMNS()`, not direct wrappers of it. The allowlist check fired unconditionally, throwing for any operator not in `{COALESCE, IN, NOT_IN}`.

**Expression tree:**
```
IS NOT NULL                        [OPERATOR] → allowlist fires here, throws ✗
└── COALESCE                       [FUNCTION] → *COLUMNS() expanded correctly here
    └── *COLUMNS(*)                [OPERATOR_UNPACK]
```

## Fix

Guard the allowlist so it only fires when `*COLUMNS()` is a **direct child** of the operator — i.e. when this operator is the actual expansion site and expansion would change its arity.

**After fix:**
```
IS NOT NULL                        [OPERATOR] → no direct *COLUMNS() child, skip allowlist ✓
└── COALESCE                       [FUNCTION] → *COLUMNS() expanded correctly here ✓
    └── *COLUMNS(*)                [OPERATOR_UNPACK]
```

Direct `*COLUMNS(*) IS NOT NULL` remains an error — `*COLUMNS()` IS a direct child there, the guard fires, and IS NOT NULL is not in the allowlist.

## Tests

Added `test/sql/parser/test_columns_unpacked_outer_operators.test` covering:
- `COALESCE(*COLUMNS(*)) IS NOT NULL`
- `COALESCE(*COLUMNS(*)) IS NULL`
- Nested in `CASE WHEN`
- Used in `WHERE` clause
- Direct `*COLUMNS(*) IS NOT NULL` still correctly errors

Fixes #23365