### PR TITLE
Fix a fitering bug.

### DIFF
--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -127,8 +127,13 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 					}
 				}
 				if (!found_projection) {
-					projection_ids.push_back(entry.first);
-					column_id_filter = projection_ids.size() - 1;
+					if (projection_ids.empty()) {
+						// Identity mapping: column is already in output at position entry.first
+						column_id_filter = entry.first;
+					} else {
+						projection_ids.push_back(entry.first);
+						column_id_filter = projection_ids.size() - 1;
+					}
 				}
 				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter);
 				select_list.push_back(entry.second->ToExpression(*column));
@@ -141,13 +146,26 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 
 		if (!select_list.empty()) {
 			vector<LogicalType> filter_types;
-			for (auto &c : projection_ids) {
-				auto column_id = column_ids[c].GetPrimaryIndex();
-				if (IsVirtualColumn(column_id)) {
-					auto &column = virtual_columns.at(column_id);
-					filter_types.push_back(column.type);
-				} else {
-					filter_types.push_back(op.returned_types[column_id]);
+			if (projection_ids.empty()) {
+				// Identity mapping: scan outputs all column_ids, filter passes them all through
+				for (auto &col_id : column_ids) {
+					auto primary_id = col_id.GetPrimaryIndex();
+					if (IsVirtualColumn(primary_id)) {
+						auto &column = virtual_columns.at(primary_id);
+						filter_types.push_back(column.type);
+					} else {
+						filter_types.push_back(op.returned_types[primary_id]);
+					}
+				}
+			} else {
+				for (auto &c : projection_ids) {
+					auto column_id = column_ids[c].GetPrimaryIndex();
+					if (IsVirtualColumn(column_id)) {
+						auto &column = virtual_columns.at(column_id);
+						filter_types.push_back(column.type);
+					} else {
+						filter_types.push_back(op.returned_types[column_id]);
+					}
 				}
 			}
 			filter = Make<PhysicalFilter>(filter_types, std::move(select_list), op.estimated_cardinality);

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -558,6 +558,11 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 
+	if (!TypeSupportsConstantFilter(type)) {
+		// type does not support constant filters - do not push down IN
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
 	//! Check if values are consecutive, if yes transform them to >= <= (only for integers)
 	// e.g. if we have x IN (1, 2, 3, 4, 5) we transform this into x >= 1 AND x <= 5
 	vector<Value> in_list;

--- a/test/sql/filter/inet_filter_projection.test
+++ b/test/sql/filter/inet_filter_projection.test
@@ -1,0 +1,55 @@
+# name: test/sql/filter/inet_filter_projection.test
+# description: Regression test for IN+INET PhysicalProjection crash (plan_get.cpp identity-mapping bug)
+# group: [filter]
+
+require inet
+
+statement ok
+CREATE TABLE t_inet AS
+SELECT '1.2.3.4'::inet AS a, 'hello'::varchar AS b
+UNION ALL
+SELECT '5.6.7.8'::inet AS a, 'world'::varchar AS b;
+
+# Multi-column projection + IN on INET — this triggered a crash in plan_get.cpp
+# where empty projection_ids (identity mapping) was not respected.
+query II
+SELECT a, b FROM t_inet WHERE a IN ('1.2.3.4'::inet);
+----
+1.2.3.4	hello
+
+# Three-column projection (exercises the column_ids > 2 path)
+statement ok
+CREATE TABLE t_inet2 AS
+SELECT a, b, 42::int AS c FROM t_inet;
+
+query III
+SELECT a, b, c FROM t_inet2 WHERE a IN ('1.2.3.4'::inet);
+----
+1.2.3.4	hello	42
+
+# Multi-value IN with multi-column projection
+query II
+SELECT a, b FROM t_inet WHERE a IN ('1.2.3.4'::inet, '5.6.7.8'::inet);
+----
+1.2.3.4	hello
+5.6.7.8	world
+
+# Mixed equality + IN on same column
+query II
+SELECT a, b FROM t_inet WHERE a = '1.2.3.4'::inet OR a IN ('5.6.7.8'::inet);
+----
+1.2.3.4	hello
+5.6.7.8	world
+
+# IN on non-INET column (ensures no regression for standard types)
+query II
+SELECT a, b FROM t_inet WHERE b IN ('hello');
+----
+1.2.3.4	hello
+
+# Cleanup
+statement ok
+DROP TABLE t_inet;
+
+statement ok
+DROP TABLE t_inet2;

--- a/test/sql/function/table/CMakeLists.txt
+++ b/test/sql/function/table/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library_unity(test_table_function OBJECT table_in_out.cpp
-                  table_bind_replace.cpp)
+                  table_bind_replace.cpp
+                  table_filter_pushdown_projection.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_table_function>
     PARENT_SCOPE)

--- a/test/sql/function/table/table_filter_pushdown_projection.cpp
+++ b/test/sql/function/table/table_filter_pushdown_projection.cpp
@@ -1,0 +1,85 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+using namespace duckdb;
+
+struct FilterPushdownFn {
+	struct Data : public TableFunctionData {
+		bool done = false;
+	};
+
+	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                             duckdb::vector<LogicalType> &return_types,
+	                                             duckdb::vector<string> &names) {
+		return_types.push_back(LogicalType::INTEGER);
+		names.push_back("id");
+		return_types.push_back(LogicalType::VARCHAR);
+		names.push_back("val");
+		return make_uniq<Data>();
+	}
+
+	static void Function(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+		auto &data = (Data &)*data_p.bind_data;
+		if (!data.done) {
+			for (idx_t c = 0; c < output.ColumnCount(); c++) {
+				auto &type = output.data[c].GetType();
+				if (type == LogicalType::INTEGER) {
+					output.SetValue(c, 0, Value(42));
+				} else {
+					output.SetValue(c, 0, Value("hello"));
+				}
+			}
+			output.SetCardinality(1);
+			data.done = true;
+		}
+	}
+
+	static bool SupportsPushdownType(const FunctionData &bind_data, idx_t col_idx) {
+		return col_idx != 1;
+	}
+
+	static void Register(Connection &con) {
+		con.BeginTransaction();
+		auto &context = *con.context;
+		auto &catalog = Catalog::GetSystemCatalog(context);
+		TableFunction fn("filter_pushdown_test", {}, FilterPushdownFn::Function, FilterPushdownFn::Bind);
+		fn.supports_pushdown_type = FilterPushdownFn::SupportsPushdownType;
+		fn.projection_pushdown = true;
+		CreateTableFunctionInfo info(fn);
+		catalog.CreateTableFunction(context, info);
+		con.Commit();
+	}
+};
+
+TEST_CASE("Multi-column projection with IN on unsupported pushdown type", "[tablefunction][filter]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	FilterPushdownFn::Register(con);
+
+	auto result = con.Query("SELECT id, val FROM filter_pushdown_test() WHERE val IN ('hello');");
+	REQUIRE(result->RowCount() == 1);
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"hello"}));
+}
+
+TEST_CASE("Single-column projection with IN on unsupported pushdown type", "[tablefunction][filter]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	FilterPushdownFn::Register(con);
+
+	auto result = con.Query("SELECT val FROM filter_pushdown_test() WHERE val IN ('hello');");
+	REQUIRE(result->RowCount() == 1);
+	REQUIRE(CHECK_COLUMN(result, 0, {"hello"}));
+}
+
+TEST_CASE("Multi-column projection with = on unsupported pushdown type", "[tablefunction][filter]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	FilterPushdownFn::Register(con);
+
+	auto result = con.Query("SELECT id, val FROM filter_pushdown_test() WHERE val = 'hello';");
+	REQUIRE(result->RowCount() == 1);
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"hello"}));
+}


### PR DESCRIPTION
I ran into this while working on the DuckDB Zeek extension.  I used AI to try to make a reproducer that didn't depend on the Zeek extension, and it kept telling me a C++ example like this was best.  I also used AI on the fix.  I hope this MR is helpful:

# DuckDB Bug Report: IN on unsupported filter types corrupts projection_ids

## Symptom

When a table function sets `projection_pushdown = true` AND has
`supports_pushdown_type` that returns `false` for some column type,
queries with `IN` filters on that column using **multi-column projections**
produce wrong results or crash.

Single-column projections and `=` filters on the same column work fine.

## SQL Reproducer

No built-in DuckDB function sets `supports_pushdown_type` (only Arrow and
custom extensions do). A self-contained C++ reproducer is provided below,
or the `inet` community extension can be used with any extension that
provides a table function with `supports_pushdown_type`, like the `zeek` 
extension.

## C++ Reproducer

Compile and run against any DuckDB:

```cpp
#include "duckdb.hpp"
#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
#include <iostream>
using namespace duckdb;

struct Fn {
	struct D : public TableFunctionData { bool done = false; };
	static unique_ptr<FunctionData> Bind(ClientContext &, TableFunctionBindInput &,
	                                     vector<LogicalType> &ret, vector<string> &n) {
		ret.push_back(LogicalType::INTEGER); n.push_back("id");
		ret.push_back(LogicalType::VARCHAR); n.push_back("val");
		return make_uniq<D>();
	}
	static void F(ClientContext &, TableFunctionInput &d, DataChunk &o) {
		auto &data = (D &)*d.bind_data;
		if (!data.done) {
			o.SetValue(0, 0, Value(42));
			o.SetValue(1, 0, Value("hello"));
			o.SetCardinality(1);
			data.done = true;
		}
	}
	static bool S(const FunctionData &, idx_t c) { return c != 1; }
};

int main() {
	DuckDB db(nullptr);
	Connection con(db);
	con.BeginTransaction();
	auto &ctx = *con.context;
	auto &cat = Catalog::GetSystemCatalog(ctx);
	TableFunction fn("pd_test", {}, Fn::F, Fn::Bind);
	fn.supports_pushdown_type = Fn::S;
	fn.projection_pushdown = true;
	auto info = CreateTableFunctionInfo(fn);
	cat.CreateTableFunction(ctx, info);
	con.Commit();
	auto r = con.Query("SELECT id, val FROM pd_test() WHERE val IN ('hello');");
	if (r->HasError()) { std::cerr << "CRASH: " << r->GetError() << "\n"; return 1; }
	r->Print();
	return 0;
}
```

```
# Unpatched:
$ c++ -std=c++17 repro.cpp -L/path/to/duckdb/lib -lduckdb -o repro && ./repro
CRASH: Invalid Input Error: Failed to cast value: Could not convert string 'hello' to INT32

# Patched:
$ ./repro
42	hello
```

## Root Cause

**File:** `src/execution/physical_plan/plan_get.cpp`, lines 129-132

In DuckDB, an empty `projection_ids` vector is the identity mapping convention:
all columns in `column_ids` are output columns (see `LogicalGet::ResolveTypes()`,
line 168). When `plan_get.cpp` extracts unsupported table filters and converts
them to `PhysicalFilter` nodes, the code unconditionally pushes to
`projection_ids`:

```cpp
if (!found_projection) {
    projection_ids.push_back(entry.first);     // BUG: breaks identity mapping
    column_id_filter = projection_ids.size() - 1;
}
```

When `projection_ids` is empty (identity), this changes the semantics from
"all columns" to "only the filter column". `op.ResolveOperatorTypes()` then
recalculates `op.types` from the corrupted `projection_ids`, silently dropping
all non-filter columns from the scan output. The downstream operators disagree
on column count, causing out-of-bounds access.

### Contributing factor: `filter_combiner.cpp`

The `=` operator's pushdown path checks `TypeSupportsConstantFilter(type)` and
returns `NO_PUSHDOWN` for unsupported types. But `TryPushdownInFilter` only
checks this for the single-element shortcut; the multi-element path
unconditionally creates an `InFilter`, even for unsupported types. This
inconsistency pushes `IN` filters as table filters, triggering the bug. `=`
filters remain as expressions and avoid it.

## Fix

### Fix 1: `plan_get.cpp`

```cpp
if (!found_projection) {
    if (projection_ids.empty()) {
        column_id_filter = entry.first;
    } else {
        projection_ids.push_back(entry.first);
        column_id_filter = projection_ids.size() - 1;
    }
}
```

Also fix `filter_types` construction for `PhysicalFilter`:

```cpp
if (projection_ids.empty()) {
    for (auto &col_id : column_ids) {
        // all columns in identity mapping
        ...
    }
} else {
    for (auto &c : projection_ids) {
        // existing logic
    }
}
```

### Fix 2: `filter_combiner.cpp`

```cpp
if (!TypeSupportsConstantFilter(type)) {
    return FilterPushdownResult::NO_PUSHDOWN;
}
```

## Affected Files

| File | Change |
|------|--------|
| `src/execution/physical_plan/plan_get.cpp` | Fix `projection_ids` identity mapping and `filter_types` construction |
| `src/optimizer/filter_combiner.cpp` | Add `TypeSupportsConstantFilter` guard to multi-element `IN` path |
| `test/sql/function/table/table_filter_pushdown_projection.cpp` | C++ test registering a table function with `supports_pushdown_type`, verifying multi-column `IN` filter works |
| `test/sql/function/table/CMakeLists.txt` | Added new test file to build |
| `test/sql/filter/inet_filter_projection.test` | SQL regression test using `require inet` |
