### PR TITLE
Fix projection_ids corruption on unsupported-pushdown filter columns

### DIFF
--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -117,8 +117,13 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 					}
 				}
 				if (!column_id_filter.IsValid()) {
-					projection_ids.push_back(filter_idx);
-					column_id_filter = projection_ids.size() - 1;
+					if (projection_ids.empty()) {
+						// empty projection_ids == identity mapping: column position is its index in column_ids
+						column_id_filter = filter_idx.GetIndex();
+					} else {
+						projection_ids.push_back(filter_idx);
+						column_id_filter = projection_ids.size() - 1;
+					}
 				}
 				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter.GetIndex());
 				select_list.push_back(filter_expr.ToExpression(*column));
@@ -131,13 +136,23 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 
 		if (!select_list.empty()) {
 			vector<LogicalType> filter_types;
-			for (auto &c : projection_ids) {
-				auto column_id = column_ids[c].GetPrimaryIndex();
+			// empty projection_ids == identity mapping: the scan emits all column_ids in order
+			auto build_filter_type = [&](idx_t col_index) {
+				auto column_id = column_ids[col_index].GetPrimaryIndex();
 				if (IsVirtualColumn(column_id)) {
 					auto &column = virtual_columns.at(column_id);
 					filter_types.push_back(column.type);
 				} else {
 					filter_types.push_back(op.returned_types[column_id]);
+				}
+			};
+			if (projection_ids.empty()) {
+				for (idx_t i = 0; i < column_ids.size(); i++) {
+					build_filter_type(i);
+				}
+			} else {
+				for (auto &c : projection_ids) {
+					build_filter_type(c);
 				}
 			}
 			filter = Make<PhysicalFilter>(filter_types, std::move(select_list), op.estimated_cardinality);

--- a/test/sql/function/table/CMakeLists.txt
+++ b/test/sql/function/table/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(test_table_function OBJECT table_in_out.cpp
-                  table_bind_replace.cpp)
+                  table_bind_replace.cpp table_filter_pushdown_projection.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_table_function>
     PARENT_SCOPE)

--- a/test/sql/function/table/table_filter_pushdown_projection.cpp
+++ b/test/sql/function/table/table_filter_pushdown_projection.cpp
@@ -1,0 +1,112 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+using namespace duckdb;
+
+// Regression test for projection_ids corruption when a filter is pushed on a column whose type
+// is not supported for pushdown (supports_pushdown_type returns false).
+//
+// The plan generator extracts such filters into a PhysicalFilter on top of the scan. When
+// projection_ids is empty (the identity-mapping convention: all column_ids are output columns),
+// it must not be appended to - doing so silently rewrites "output all columns" into "output only
+// the filter column", dropping the other columns and causing an out-of-bounds access downstream.
+//
+// The table function below follows the projection-pushdown contract correctly: it honors
+// column_ids and sizes its output from projection_ids. Column 1 ("val") reports
+// supports_pushdown_type == false, mimicking a custom type (e.g. INET).
+struct PushdownProjection {
+	struct BindData : public TableFunctionData {};
+	struct GlobalState : public GlobalTableFunctionState {
+		duckdb::vector<column_t> projected_cols;
+		bool done = false;
+	};
+
+	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                             duckdb::vector<LogicalType> &return_types,
+	                                             duckdb::vector<string> &names) {
+		return_types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("id");
+		return_types.emplace_back(LogicalType::VARCHAR);
+		names.emplace_back("val");
+		return make_uniq<BindData>();
+	}
+
+	static duckdb::unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context,
+	                                                               TableFunctionInitInput &input) {
+		auto result = make_uniq<GlobalState>();
+		// Honor the projection-pushdown contract: empty projection_ids == identity mapping.
+		if (input.projection_ids.empty()) {
+			for (auto &col_id : input.column_ids) {
+				result->projected_cols.push_back(col_id);
+			}
+		} else {
+			for (auto &proj_idx : input.projection_ids) {
+				result->projected_cols.push_back(input.column_ids[proj_idx]);
+			}
+		}
+		return std::move(result);
+	}
+
+	static void Function(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+		auto &gstate = data_p.global_state->Cast<GlobalState>();
+		if (gstate.done) {
+			output.SetCardinality(0);
+			return;
+		}
+		for (idx_t out = 0; out < gstate.projected_cols.size(); out++) {
+			if (gstate.projected_cols[out] == 0) {
+				output.SetValue(out, 0, Value::INTEGER(42));
+			} else if (gstate.projected_cols[out] == 1) {
+				output.SetValue(out, 0, Value("hello"));
+			}
+		}
+		output.SetCardinality(1);
+		gstate.done = true;
+	}
+
+	// Column 1 ("val") cannot be pushed down (mimics a custom type such as INET).
+	static bool SupportsPushdownType(const FunctionData &bind_data, idx_t col_idx) {
+		return col_idx != 1;
+	}
+};
+
+TEST_CASE("Filter pushdown on unsupported type with multi-column projection", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	con.BeginTransaction();
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+	TableFunction pd("pushdown_projection", {}, PushdownProjection::Function, PushdownProjection::Bind,
+	                 PushdownProjection::InitGlobal);
+	pd.supports_pushdown_type = PushdownProjection::SupportsPushdownType;
+	pd.projection_pushdown = true;
+	pd.filter_pushdown = true;
+	CreateTableFunctionInfo info(pd);
+	catalog.CreateTableFunction(*con.context, info);
+	con.Commit();
+
+	// Multi-column projection with a single-element IN filter on the unsupported column.
+	auto result = con.Query("SELECT id, val FROM pushdown_projection() WHERE val IN ('hello');");
+	REQUIRE(!result->HasError());
+	REQUIRE(result->ColumnCount() == 2);
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"hello"}));
+
+	// Multi-element IN filter.
+	result = con.Query("SELECT id, val FROM pushdown_projection() WHERE val IN ('hello', 'world');");
+	REQUIRE(!result->HasError());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"hello"}));
+
+	// Equality filter on the unsupported column.
+	result = con.Query("SELECT id, val FROM pushdown_projection() WHERE val = 'hello';");
+	REQUIRE(!result->HasError());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"hello"}));
+
+	// Single-column projection of the unsupported column (also exercised the filter path).
+	result = con.Query("SELECT val FROM pushdown_projection() WHERE val IN ('hello');");
+	REQUIRE(!result->HasError());
+	REQUIRE(CHECK_COLUMN(result, 0, {"hello"}));
+}


### PR DESCRIPTION
I was fixing a similar bug to this in an extension, and Claude told me there was an issue with core DuckDB as well.  This was the result of Claude's analysis and proposed fix.  I hope it's helpful!

---

When a table function sets projection_pushdown = true and provides a supports_pushdown_type callback that returns false for some column, filtering on that column with a multi-column projection crashed with:

  INTERNAL Error: Attempted to access index 1 within vector of size 1

An empty projection_ids is DuckDB's identity-mapping convention (all columns in column_ids are output columns, in order). When PhysicalPlanGenerator extracts a filter on an unsupported-pushdown type into a PhysicalFilter, it unconditionally appended the filter column to projection_ids. If projection_ids was empty, that single push_back silently rewrote the scan's meaning from "all columns" to "only the filter column", so ResolveOperatorTypes produced fewer columns than the surrounding operators expected.

Fix in plan_get.cpp: when the filter column is not already in projection_ids and projection_ids is empty (identity), use the column's index in column_ids directly instead of appending. Also build the PhysicalFilter's filter_types from all of column_ids when projection_ids is empty.

Adds a C++ regression test registering a table function with supports_pushdown_type that verifies =, single-element IN, and multi-element IN filters on an unsupported column with a multi-column projection.