### PR TITLE
fix out-of-bounds read in json path ReadKey lookahead

### DIFF
--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -134,14 +134,14 @@ static inline idx_t ReadInteger(const char *ptr, const char *const end, idx_t &i
 static inline JSONKeyReadResult ReadKey(const char *ptr, const char *const end) {
 	D_ASSERT(ptr != end);
 	if (*ptr == '*') { // Wildcard
-		if (*(ptr + 1) == '*') {
+		if (ptr + 1 != end && *(ptr + 1) == '*') {
 			return JSONKeyReadResult::RecWildCard();
 		}
 		return JSONKeyReadResult::WildCard();
 	}
 	bool recursive = false;
 	if (*ptr == '.') {
-		char next = *(ptr + 1);
+		const char next = ptr + 1 == end ? '\0' : *(ptr + 1);
 		if (next == '*') {
 			return JSONKeyReadResult::RecWildCard();
 		}
@@ -150,6 +150,10 @@ static inline JSONKeyReadResult ReadKey(const char *ptr, const char *const end) 
 		}
 		ptr++;
 		recursive = true;
+	}
+	if (ptr == end) {
+		// recursive '.' with no key following it
+		return JSONKeyReadResult::Empty();
 	}
 	bool escaped = false;
 	if (*ptr == '"') {

--- a/test/sql/json/scalar/test_json_path.test
+++ b/test/sql/json/scalar/test_json_path.test
@@ -198,6 +198,24 @@ select json_extract(j, p) from tbl
 ----
 Invalid Input Error
 
+# a non-constant path that is not inlined (> 12 bytes) must not be read past its end
+# while looking ahead in ReadKey (trailing '*' or '.')
+statement error
+with tbl as (
+    select '{"aaaaaaaaaaaa":1}' j, '$.aaaaaaaaaaaa.*' p
+)
+select json_extract(j, p) from tbl
+----
+Invalid Input Error
+
+statement error
+with tbl as (
+    select '{"aaaaaaaaaaaa":1}' j, '$.aaaaaaaaaaaa..' p
+)
+select json_extract(j, p) from tbl
+----
+Invalid Input Error
+
 # wildcards do not work inside of a multi-extract
 statement error
 select json_extract('[{"duck":42},{"goose":43}]', ['$[*].duck', '$[*].goose'])


### PR DESCRIPTION
Two lookahead reads in the JSON path parser (ReadKey) run one byte past the path while only one byte is guaranteed left:
- the `**` wildcard check reads `*(ptr + 1)`, hitting `*end` when `*` ends the path
- the recursive `.` branch reads the same byte, then walks ptr past end

Reachable from a non-constant path arg whose string_t is non-inlined (> 12 bytes, so not null-terminated), e.g. `json_extract(j, '$.aaaaaaaaaaaa.*')`. ASan flags a heap-buffer-overflow read of size 1 in ReadKey. Constant paths come from a null-terminated copy and are unaffected. Bounded both lookaheads against end and reject a trailing recursive `.`.