### PR TITLE
Fix client ctx ref cycle

### DIFF
--- a/src/execution/operator/helper/physical_materialized_collector.cpp
+++ b/src/execution/operator/helper/physical_materialized_collector.cpp
@@ -15,7 +15,8 @@ class MaterializedCollectorGlobalState : public GlobalSinkState {
 public:
 	mutex glock;
 	unique_ptr<ColumnDataCollection> collection;
-	shared_ptr<ClientContext> context;
+	//! This is weak to avoid creating a cyclical reference
+	weak_ptr<ClientContext> context;
 };
 
 class MaterializedCollectorLocalState : public LocalSinkState {
@@ -64,12 +65,12 @@ unique_ptr<LocalSinkState> PhysicalMaterializedCollector::GetLocalSinkState(Exec
 
 unique_ptr<QueryResult> PhysicalMaterializedCollector::GetResult(GlobalSinkState &state) const {
 	auto &gstate = state.Cast<MaterializedCollectorGlobalState>();
+	auto cc = gstate.context.lock();
 	if (!gstate.collection) {
-		gstate.collection = CreateCollection(*gstate.context);
+		gstate.collection = CreateCollection(*cc);
 	}
-	auto result =
-	    make_uniq<MaterializedQueryResult>(statement_type, properties, IdentifiersToStrings(names),
-	                                       std::move(gstate.collection), gstate.context->GetClientProperties());
+	auto result = make_uniq<MaterializedQueryResult>(statement_type, properties, IdentifiersToStrings(names),
+	                                                 std::move(gstate.collection), cc->GetClientProperties());
 	return std::move(result);
 }
 


### PR DESCRIPTION
See context in #23344 

The cyclic ref works as follows. A call the `ClientContext::PendingQuery` does the following:

* On the main thread, through `PendingStatementOrPreparedStatement`:
   * set `ClientContext::active_query` (a `unique_ptr<ActiveQueryContext>`) in `BeginQueryInternal`
   * then through `PendingStatementInternal` -> `CreatePreparedStatement` -> `PendingPreparedStatementInternal`:
      * set `active_query->executor = make_uniq<Executor>(*this)`
      * build pipelines with `executor.Initialize(std::move(collector));`
      * then through `Executor::Initialize` -> `InitializeInternal` -> `ScheduleEvents`:
         * create a `make_shared_ptr<PipelineInitializeEvent>` and schedule it
* Then when a worker runs the scheduled `PipelineInitializeEvent`:
   * through `PipelineInitializeTask::ExecuteTask` -> `ResetSink`:
      * gets the sink state through `PhysicalMaterializedCollector::GetGlobalSinkState`, which:
         * creates a `unique_ptr<MaterializedCollectorGlobalState> state`
         * sets a `shared_ptr<ClientContext>` on the state: `state->context = context.shared_from_this();`
         * returns the state
      * then saves the state on `Pipeline`'s `optional_ptr<PhysicalOperator> sink;`

This creates the `shared_ptr` loop, which is essentially:
```
ClientContext → active_query → executor → pipeline ─┐
^───────────────────────────────────────────────────┘
```