### PR TITLE
Propagate lambda bindings into `try` operator

### DIFF
--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -105,6 +105,8 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		D_ASSERT(op.children.size() == 1);
 		//! This binder is used to throw when the child expression is of a type that is not allowed.
 		TryOperatorBinder try_operator_binder(binder, context);
+		//! Propagate any lambda parameter bindings so lambda parameters can be referenced inside TRY(...)
+		try_operator_binder.lambda_bindings = lambda_bindings;
 		try_operator_binder.BindChild(op.children[0], depth, error);
 	} else {
 		for (idx_t i = 0; i < op.children.size(); i++) {

--- a/test/sql/error/test_try_expression.test_slow
+++ b/test/sql/error/test_try_expression.test_slow
@@ -156,3 +156,34 @@ from values (0, null), (1, 1), (1, 1) t(a, b);
 NULL
 1
 1
+
+# --- lambda parameters referenced inside TRY ---
+# Previously failed to bind: "Referenced column x was not found"
+
+query I
+select list_transform([1, 2, 3], lambda x: TRY(x + 1));
+----
+[2, 3, 4]
+
+query I
+select list_transform([1, 2], lambda x: TRY(x));
+----
+[1, 2]
+
+# multiple lambda parameters inside TRY
+query I
+select list_reduce([1, 2, 3, 4], lambda acc, x: TRY(acc + x));
+----
+10
+
+# TRY catches a per-row error referencing the lambda parameter
+query I
+select list_transform([4, 0, 2], lambda x: TRY(10 // x));
+----
+[2, NULL, 5]
+
+# the originally reported query: decimal overflow caught per-element via TRY
+query I
+select list_transform([100.00, 101.21], lambda x: TRY(x = 1234567890123456789012345678901234567.8));
+----
+[NULL, NULL]


### PR DESCRIPTION
This correctly allows lambda parameters to be referenced inside the `try` expression.