### PR TITLE
Add support for state export to ordered aggregates

### DIFF
--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -354,7 +354,7 @@ void ApproxTopKFinalize(Vector &state_vector, AggregateFinalizeInputData &, Vect
 	}
 	// reserve space in the list vector
 	ListVector::Reserve(result, old_len + new_entries);
-	auto list_entries = FlatVector::Writer<list_entry_t>(result, offset + count, offset);
+	auto list_entries = FlatVector::Writer<list_entry_t>(result, count, offset);
 	auto &child_data = ListVector::GetChildMutable(result);
 
 	idx_t current_offset = old_len;

--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -404,7 +404,6 @@ AggregateStateLayout ApproxTopKGetStateType(AggregateLayoutInput &input) {
 template <class OP = HistogramGenericFunctor>
 void ApproxTopKExportState(Vector &state_vector, AggregateFinalizeInputData &aggr_input_data, Vector &result,
                            idx_t count, idx_t offset) {
-	D_ASSERT(offset == 0);
 	auto states = state_vector.Values<ApproxTopKState *>();
 
 	auto &mask = FlatVector::ValidityMutable(result);
@@ -420,23 +419,24 @@ void ApproxTopKExportState(Vector &state_vector, AggregateFinalizeInputData &agg
 	idx_t total_values = ListVector::GetListSize(value_lists);
 	idx_t total_filters = ListVector::GetListSize(filter_lists);
 	for (idx_t i = 0; i < count; i++) {
+		const idx_t row = offset + i;
 		auto state_ptr = states[i].GetValue()->state;
-		value_entries[i].offset = total_values;
-		filter_entries[i].offset = total_filters;
+		value_entries[row].offset = total_values;
+		filter_entries[row].offset = total_filters;
 		if (!state_ptr || state_ptr->values.empty()) {
 			// no values have been added to this state - export NULL (children of a NULL struct must also be NULL)
-			mask.SetInvalid(i);
-			k_validity.SetInvalid(i);
-			value_validity.SetInvalid(i);
-			filter_validity.SetInvalid(i);
-			value_entries[i].length = 0;
-			filter_entries[i].length = 0;
-			k_data[i] = 0;
+			mask.SetInvalid(row);
+			k_validity.SetInvalid(row);
+			value_validity.SetInvalid(row);
+			filter_validity.SetInvalid(row);
+			value_entries[row].length = 0;
+			filter_entries[row].length = 0;
+			k_data[row] = 0;
 			continue;
 		}
-		k_data[i] = state_ptr->k;
-		value_entries[i].length = state_ptr->values.size();
-		filter_entries[i].length = state_ptr->filter.size();
+		k_data[row] = state_ptr->k;
+		value_entries[row].length = state_ptr->values.size();
+		filter_entries[row].length = state_ptr->filter.size();
 		total_values += state_ptr->values.size();
 		total_filters += state_ptr->filter.size();
 	}
@@ -449,13 +449,14 @@ void ApproxTopKExportState(Vector &state_vector, AggregateFinalizeInputData &agg
 	auto count_data = FlatVector::GetDataMutable<uint64_t>(value_fields[1]);
 	auto filter_data = FlatVector::GetDataMutable<uint64_t>(ListVector::GetChildMutable(filter_lists));
 	for (idx_t i = 0; i < count; i++) {
+		const idx_t row = offset + i;
 		auto state_ptr = states[i].GetValue()->state;
 		if (!state_ptr || state_ptr->values.empty()) {
 			continue;
 		}
 		auto &state = *state_ptr;
 		// write the values (in descending count order) - decoding them back to the input type
-		idx_t value_offset = value_entries[i].offset;
+		idx_t value_offset = value_entries[row].offset;
 		for (auto &val_ref : state.values) {
 			auto &val = val_ref.get();
 			OP::template HistogramFinalize<string_t>(val.str_val.str, value_child, value_offset);
@@ -463,15 +464,15 @@ void ApproxTopKExportState(Vector &state_vector, AggregateFinalizeInputData &agg
 			value_offset++;
 		}
 		for (idx_t filter_idx = 0; filter_idx < state.filter.size(); filter_idx++) {
-			filter_data[filter_entries[i].offset + filter_idx] = state.filter[filter_idx];
+			filter_data[filter_entries[row].offset + filter_idx] = state.filter[filter_idx];
 		}
 	}
 	ListVector::SetListSize(value_lists, total_values);
 	ListVector::SetListSize(filter_lists, total_filters);
-	FlatVector::SetSize(fields[0], count);
-	FlatVector::SetSize(value_lists, count);
-	FlatVector::SetSize(filter_lists, count);
-	FlatVector::SetSize(result, count);
+	FlatVector::SetSize(fields[0], offset + count);
+	FlatVector::SetSize(value_lists, offset + count);
+	FlatVector::SetSize(filter_lists, offset + count);
+	FlatVector::SetSize(result, offset + count);
 }
 
 template <class OP = HistogramGenericFunctor>

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -219,9 +219,8 @@ using APPROX_QUANTILE_EXPORT_TYPE =
 
 void ApproxQuantileExportState(Vector &state_vector, AggregateFinalizeInputData &aggr_input_data, Vector &result,
                                idx_t count, idx_t offset) {
-	D_ASSERT(offset == 0);
 	auto states = state_vector.Values<ApproxQuantileState *>();
-	auto writer = FlatVector::Writer<APPROX_QUANTILE_EXPORT_TYPE>(result, count);
+	auto writer = FlatVector::Writer<APPROX_QUANTILE_EXPORT_TYPE>(result, count, offset);
 	for (idx_t i = 0; i < count; i++) {
 		auto &state = *states[i].GetValue();
 		if (!state.h || state.pos == 0) {

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -22,6 +22,42 @@
 namespace duckdb {
 
 namespace {
+
+//! Maps each ORDER BY key to a buffered column, reusing an argument column when the key matches one. Returns the
+//! buffered column types and fills `orders` with the (column, modifiers) per key.
+vector<LogicalType> MapSortedColumns(const vector<unique_ptr<Expression>> &children,
+                                     const vector<BoundOrderByNode> &order_bys,
+                                     vector<SortedAggregateStateOrder> &orders) {
+	vector<LogicalType> column_types;
+	for (const auto &child : children) {
+		column_types.emplace_back(child->GetReturnType());
+	}
+	for (const auto &order : order_bys) {
+		idx_t column = DConstants::INVALID_INDEX;
+		for (idx_t arg = 0; arg < children.size(); ++arg) {
+			if (children[arg]->Equals(*order.expression)) {
+				column = arg;
+				break;
+			}
+		}
+		if (column == DConstants::INVALID_INDEX) {
+			column = column_types.size();
+			column_types.emplace_back(order.expression->GetReturnType());
+		}
+		orders.push_back(SortedAggregateStateOrder {column, order.type, order.null_order});
+	}
+	return column_types;
+}
+
+//! The struct type of a buffered row: the buffered columns named v0, v1, ...
+LogicalType BufferStructType(const vector<LogicalType> &column_types) {
+	child_list_t<LogicalType> children;
+	for (idx_t i = 0; i < column_types.size(); i++) {
+		children.emplace_back("v" + to_string(i), column_types[i]);
+	}
+	return LogicalType::STRUCT(std::move(children));
+}
+
 struct SortedAggregateBindData : public FunctionData {
 	using Expressions = vector<unique_ptr<Expression>>;
 	using BindInfoPtr = unique_ptr<FunctionData>;
@@ -31,34 +67,22 @@ struct SortedAggregateBindData : public FunctionData {
 	                        BindInfoPtr &bind_info, OrderBys &order_bys)
 	    : context(context), function(aggregate), bind_info(std::move(bind_info)),
 	      threshold(Settings::Get<OrderedAggregateThresholdSetting>(context)) {
-		//	Describe the arguments - column 0 in the sort data is the group number, so the args start at 1
-		for (const auto &child : children) {
-			buffered_cols.emplace_back(buffered_cols.size());
-			buffered_types.emplace_back(child->GetReturnType());
-			scan_cols.emplace_back(buffered_cols.size());
-		}
-		scan_types = buffered_types;
-
-		// Determine which buffered column each ORDER BY key sorts on. A key that matches an argument reuses that
-		// argument's column; any other key is appended as its own buffered column (so we are no longer sorted on args).
 		vector<SortedAggregateStateOrder> order_spec;
-		for (idx_t ord_idx = 0; ord_idx < order_bys.size(); ++ord_idx) {
-			auto &order = order_bys[ord_idx];
-			idx_t column = DConstants::INVALID_INDEX;
-			for (idx_t arg_idx = 0; arg_idx < children.size(); ++arg_idx) {
-				if (children[arg_idx]->Equals(*order.expression)) {
-					column = arg_idx;
-					break;
-				}
-			}
-			if (column == DConstants::INVALID_INDEX) {
-				sorted_on_args = false;
-				column = buffered_types.size();
-				buffered_cols.emplace_back(children.size() + ord_idx);
-				buffered_types.emplace_back(order.expression->GetReturnType());
-			}
-			order_spec.push_back(SortedAggregateStateOrder {column, order.type, order.null_order});
+		buffered_types = MapSortedColumns(children, order_bys, order_spec);
+		const idx_t argument_count = children.size();
+		// the arguments are the leading buffered columns (referencing their input slot); appended sort keys follow
+		buffered_cols.resize(buffered_types.size());
+		for (idx_t i = 0; i < argument_count; i++) {
+			buffered_cols[i] = i;
+			scan_cols.emplace_back(i + 1);
+			scan_types.emplace_back(buffered_types[i]);
 		}
+		for (idx_t o = 0; o < order_spec.size(); o++) {
+			if (order_spec[o].column >= argument_count) {
+				buffered_cols[order_spec[o].column] = argument_count + o;
+			}
+		}
+		sorted_on_args = (buffered_types.size() == argument_count);
 		BuildSort(order_spec);
 	}
 
@@ -72,8 +96,8 @@ struct SortedAggregateBindData : public FunctionData {
 	                              expr.ArgOrdersMutable()) {
 	}
 
-	//! Reconstruct from an exported buffer state. The buffer struct (buffered columns), the per-key (column, modifiers)
-	//! and the number of leading argument columns fully describe the layout - no original expressions are needed.
+	//! Reconstruct from an exported buffer state - the buffer struct, the per-key (column, modifiers) and the leading
+	//! argument count fully describe the layout, no original expressions are needed.
 	SortedAggregateBindData(ClientContext &context, const BoundAggregateFunction &inner_function,
 	                        unique_ptr<FunctionData> inner_bind_info, const LogicalType &buffer_struct,
 	                        const vector<SortedAggregateStateOrder> &order_spec, idx_t argument_count)
@@ -83,7 +107,6 @@ struct SortedAggregateBindData : public FunctionData {
 			buffered_cols.emplace_back(buffered_cols.size());
 			buffered_types.emplace_back(child.second);
 		}
-		//	Only scan the argument columns after sorting (column 0 in the sort data is the group number)
 		for (idx_t i = 0; i < argument_count; i++) {
 			scan_cols.emplace_back(i + 1);
 			scan_types.emplace_back(buffered_types[i]);
@@ -92,24 +115,17 @@ struct SortedAggregateBindData : public FunctionData {
 		BuildSort(order_spec);
 	}
 
-	//! Builds the sort layout once the buffered columns and the per-key (column, modifiers) are known: prefixes the
-	//! group number onto the sort, stores the buffered rows as a linked list of structs, and creates the sort.
+	//! Builds the sort once the buffered columns and per-key (column, modifiers) are known: prefixes the group number,
+	//! lays out the buffered struct and creates the sort. Sort keys reference buffered columns, offset by the prefix.
 	void BuildSort(const vector<SortedAggregateStateOrder> &order_spec) {
-		//	The first sort column is the group number, prefixed onto the buffered data
 		sort_types.emplace_back(LogicalType::USMALLINT);
 		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST,
 		                    make_uniq<BoundReferenceExpression>(LogicalType::USMALLINT, 0U));
-
-		//	The buffered rows are stored in a linked list of structs
-		child_list_t<LogicalType> buffered_children;
-		for (idx_t i = 0; i < buffered_types.size(); i++) {
-			buffered_children.emplace_back("v" + to_string(i), buffered_types[i]);
-			sort_types.emplace_back(buffered_types[i]);
+		for (const auto &buffered_type : buffered_types) {
+			sort_types.emplace_back(buffered_type);
 		}
-		buffered_struct_type = LogicalType::STRUCT(std::move(buffered_children));
+		buffered_struct_type = BufferStructType(buffered_types);
 		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
-
-		//	The sort keys reference the buffered columns (offset by 1 for the group-number prefix)
 		for (const auto &entry : order_spec) {
 			orders.emplace_back(entry.order_type, entry.null_order,
 			                    make_uniq<BoundReferenceExpression>(buffered_types[entry.column],
@@ -497,8 +513,7 @@ struct SortedAggregateFunction {
 	}
 };
 
-//! State-type callback for the sorted aggregate wrapper: the exported state is the buffer of values, i.e. a
-//! LIST<buffered_struct>. The field-based export/import path serializes/rebuilds the linked list of buffered rows.
+//! The exported state of a sorted aggregate is its buffer of values: a LIST<buffered_struct>.
 AggregateStateLayout SortedAggregateGetStateType(AggregateLayoutInput &input) {
 	auto &bind_data = input.bind_data->Cast<SortedAggregateBindData>();
 	AggregateStateLayout layout;
@@ -518,7 +533,6 @@ AggregateFunction CreateSortedAggregateWrapper(const Identifier &name, const vec
 	    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize, null_handling, nullptr,
 	    nullptr, nullptr, nullptr, SortedAggregateFunction::WindowBatch);
 	ordered_aggregate.SetInitLocalStateFinalizeCallback(SortedAggregateFinalizeState::Init);
-	// the exported state is the buffer of values (a LIST<buffered_struct>)
 	ordered_aggregate.SetStructStateExport(SortedAggregateGetStateType);
 	return ordered_aggregate;
 }
@@ -527,36 +541,9 @@ AggregateFunction CreateSortedAggregateWrapper(const Identifier &name, const vec
 
 void FunctionBinder::GetSortedAggregateStateLayout(const BoundAggregateExpression &expr, LogicalType &buffer_struct,
                                                    vector<SortedAggregateStateOrder> &orders, idx_t &argument_count) {
-	auto &children = expr.GetChildren();
 	D_ASSERT(expr.GetOrderBys());
-	auto &order_bys = expr.GetOrderBys()->orders;
-
-	// arguments first, then any sort key that does not match an argument (mirrors SortedAggregateBindData)
-	vector<LogicalType> column_types;
-	argument_count = children.size();
-	for (const auto &child : children) {
-		column_types.emplace_back(child->GetReturnType());
-	}
-	for (const auto &order : order_bys) {
-		idx_t column = DConstants::INVALID_INDEX;
-		for (idx_t arg_idx = 0; arg_idx < children.size(); ++arg_idx) {
-			if (children[arg_idx]->Equals(*order.expression)) {
-				column = arg_idx;
-				break;
-			}
-		}
-		if (column == DConstants::INVALID_INDEX) {
-			column = column_types.size();
-			column_types.emplace_back(order.expression->GetReturnType());
-		}
-		orders.push_back(SortedAggregateStateOrder {column, order.type, order.null_order});
-	}
-
-	child_list_t<LogicalType> struct_children;
-	for (idx_t i = 0; i < column_types.size(); i++) {
-		struct_children.emplace_back("v" + to_string(i), column_types[i]);
-	}
-	buffer_struct = LogicalType::STRUCT(std::move(struct_children));
+	argument_count = expr.GetChildren().size();
+	buffer_struct = BufferStructType(MapSortedColumns(expr.GetChildren(), expr.GetOrderBys()->orders, orders));
 }
 
 pair<AggregateFunction, unique_ptr<FunctionData>>
@@ -583,10 +570,8 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 		// not a sorted aggregate: return
 		return;
 	}
-	// the exported state is the buffer of values - the ORDER BY must be preserved verbatim (see the ordered aggregate
-	// export path in aggregate_export.cpp), so the redundant-ORDER-BY simplification is skipped for state export
+	// the exported state buffers the values, so the ORDER BY must be preserved verbatim - skip the simplification
 	const bool state_export = expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT;
-	// Remove unnecessary ORDER BY clauses and return if nothing remains
 	if (!state_export && Settings::Get<EnableOptimizerSetting>(context)) {
 		if (expr.GetOrderBysMutable()->Simplify(groups, grouping_sets)) {
 			expr.GetOrderBysMutable().reset();
@@ -598,28 +583,24 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	auto &order_bys = *expr.GetOrderBysMutable();
 
 	if (state_export) {
-		// the exported AGGREGATE_STATE type (the buffered struct) was fixed at bind time, but the statistics optimizer
-		// may have narrowed the argument/sort-key column types since (e.g. a small-range group column
-		// INTEGER->TINYINT). Cast the buffered columns back to their bind-time logical types so the runtime buffer
-		// matches its declared type. This widening cast preserves sort order, and casting reused arg/sort-key columns
-		// to the same type keeps the arg/sort-key matching intact.
+		// the statistics optimizer may have narrowed the buffered column types since the exported type was fixed at
+		// bind time (e.g. a small-range group column INTEGER->TINYINT) - cast them back so the buffer matches its
+		// declared type. The widening preserves sort order; casting reused columns to the same type keeps matching.
 		LogicalType plan_struct;
 		vector<SortedAggregateStateOrder> order_columns;
 		idx_t argument_count;
 		GetSortedAggregateStateLayout(expr, plan_struct, order_columns, argument_count);
 		auto &logical_fields = StructType::GetChildTypes(ListType::GetChildType(expr.GetReturnType()));
-		for (idx_t i = 0; i < children.size() && i < logical_fields.size(); i++) {
-			if (children[i]->GetReturnType() != logical_fields[i].second) {
-				children[i] =
-				    BoundCastExpression::AddCastToType(context, std::move(children[i]), logical_fields[i].second);
+		auto cast_to = [&](unique_ptr<Expression> &e, const LogicalType &type) {
+			if (e->GetReturnType() != type) {
+				e = BoundCastExpression::AddCastToType(context, std::move(e), type);
 			}
+		};
+		for (idx_t i = 0; i < children.size() && i < logical_fields.size(); i++) {
+			cast_to(children[i], logical_fields[i].second);
 		}
 		for (idx_t o = 0; o < order_bys.orders.size() && o < order_columns.size(); o++) {
-			auto &order_expr = order_bys.orders[o].expression;
-			const auto &logical_type = logical_fields[order_columns[o].column].second;
-			if (order_expr->GetReturnType() != logical_type) {
-				order_expr = BoundCastExpression::AddCastToType(context, std::move(order_expr), logical_type);
-			}
+			cast_to(order_bys.orders[o].expression, logical_fields[order_columns[o].column].second);
 		}
 	}
 
@@ -648,8 +629,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	expr.GetOrderBysMutable().reset();
 
 	if (state_export) {
-		// re-apply the export wiring onto the wrapper: it serializes/combines the buffer of values, and the exported
-		// AGGREGATE_STATE type (with the encoded ORDER BY) was already set on the expression at bind time
+		// wire the export onto the wrapper - the AGGREGATE_STATE return type was already set at bind time
 		ExportAggregateFunction::SetStateExport(expr, expr.GetReturnType());
 	}
 }

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -6,10 +6,13 @@
 #include "duckdb/common/types/list_segment.hpp"
 #include "duckdb/function/aggregate/list_aggregate.hpp"
 #include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/aggregate_state_layout.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/generic_common.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/parallel/thread_context.hpp"
@@ -90,6 +93,41 @@ struct SortedAggregateBindData : public FunctionData {
 	SortedAggregateBindData(ClientContext &context, BoundWindowExpression &expr)
 	    : SortedAggregateBindData(context, expr.GetChildrenMutable(), *expr.AggregateFunction(), expr.BindInfoMutable(),
 	                              expr.ArgOrdersMutable()) {
+	}
+
+	//! Reconstruct from an exported buffer state. The buffer struct (buffered columns), the per-key (column, modifiers)
+	//! and the number of leading argument columns fully describe the layout - no original expressions are needed.
+	SortedAggregateBindData(ClientContext &context, const BoundAggregateFunction &inner_function,
+	                        unique_ptr<FunctionData> inner_bind_info, const LogicalType &buffer_struct,
+	                        const vector<SortedAggregateStateOrder> &order_spec, idx_t argument_count)
+	    : context(context), function(inner_function), bind_info(std::move(inner_bind_info)),
+	      threshold(Settings::Get<OrderedAggregateThresholdSetting>(context)) {
+		const auto &struct_children = StructType::GetChildTypes(buffer_struct);
+		for (idx_t i = 0; i < struct_children.size(); i++) {
+			buffered_cols.emplace_back(i);
+			buffered_types.emplace_back(struct_children[i].second);
+		}
+		//	Only scan the argument columns after sorting
+		for (idx_t i = 0; i < argument_count; i++) {
+			scan_cols.emplace_back(i + 1); // +1 for the group-number prefix
+			scan_types.emplace_back(struct_children[i].second);
+		}
+		//	The first sort column is the group number, prefixed onto the buffered data
+		sort_types.emplace_back(LogicalType::USMALLINT);
+		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST,
+		                    make_uniq<BoundReferenceExpression>(LogicalType::USMALLINT, 0U));
+		for (auto &col_type : buffered_types) {
+			sort_types.emplace_back(col_type);
+		}
+		for (const auto &entry : order_spec) {
+			orders.emplace_back(entry.order_type, entry.null_order,
+			                    make_uniq<BoundReferenceExpression>(struct_children[entry.column].second,
+			                                                        UnsafeNumericCast<idx_t>(entry.column + 1)));
+		}
+		sorted_on_args = (argument_count == struct_children.size());
+		buffered_struct_type = buffer_struct;
+		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
+		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
 	}
 
 	SortedAggregateBindData(const SortedAggregateBindData &other)
@@ -471,7 +509,84 @@ struct SortedAggregateFunction {
 	}
 };
 
+//! State-type callback for the sorted aggregate wrapper: the exported state is the buffer of values, i.e. a
+//! LIST<buffered_struct>. The field-based export/import path serializes/rebuilds the linked list of buffered rows.
+AggregateStateLayout SortedAggregateGetStateType(AggregateLayoutInput &input) {
+	auto &bind_data = input.bind_data->Cast<SortedAggregateBindData>();
+	AggregateStateLayout layout;
+	layout.type = LogicalType::LIST(bind_data.buffered_struct_type);
+	layout.total_state_size = AlignValue<idx_t>(sizeof(SortedAggregateState));
+	layout.field = BuildStateField<StateListType<StateReturnType>>();
+	AggregateStateField::PopulateListFunctions(layout.type, layout.field);
+	return layout;
+}
+
+//! Builds the sorted aggregate wrapper AggregateFunction (shared by the forward export path and the re-bind path).
+AggregateFunction CreateSortedAggregateWrapper(const Identifier &name, const vector<LogicalType> &arguments,
+                                               const LogicalType &return_type, FunctionNullHandling null_handling) {
+	AggregateFunction ordered_aggregate(
+	    name, arguments, return_type, AggregateFunction::StateSize<SortedAggregateState>,
+	    AggregateFunction::StateInitialize<SortedAggregateState, ListFunction>, SortedAggregateFunction::ScatterUpdate,
+	    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize, null_handling, nullptr,
+	    nullptr, nullptr, nullptr, SortedAggregateFunction::WindowBatch);
+	ordered_aggregate.SetInitLocalStateFinalizeCallback(SortedAggregateFinalizeState::Init);
+	// the exported state is the buffer of values (a LIST<buffered_struct>)
+	ordered_aggregate.SetStructStateExport(SortedAggregateGetStateType);
+	return ordered_aggregate;
+}
+
 } // namespace
+
+void FunctionBinder::GetSortedAggregateStateLayout(const BoundAggregateExpression &expr, LogicalType &buffer_struct,
+                                                   vector<SortedAggregateStateOrder> &orders, idx_t &argument_count) {
+	auto &children = expr.GetChildren();
+	D_ASSERT(expr.GetOrderBys());
+	auto &order_bys = expr.GetOrderBys()->orders;
+
+	// arguments first, then any sort key that does not match an argument (mirrors SortedAggregateBindData)
+	vector<LogicalType> column_types;
+	argument_count = children.size();
+	for (const auto &child : children) {
+		column_types.emplace_back(child->GetReturnType());
+	}
+	for (const auto &order : order_bys) {
+		idx_t column = DConstants::INVALID_INDEX;
+		for (idx_t arg_idx = 0; arg_idx < children.size(); ++arg_idx) {
+			if (children[arg_idx]->Equals(*order.expression)) {
+				column = arg_idx;
+				break;
+			}
+		}
+		if (column == DConstants::INVALID_INDEX) {
+			column = column_types.size();
+			column_types.emplace_back(order.expression->GetReturnType());
+		}
+		orders.push_back(SortedAggregateStateOrder {column, order.type, order.null_order});
+	}
+
+	child_list_t<LogicalType> struct_children;
+	for (idx_t i = 0; i < column_types.size(); i++) {
+		struct_children.emplace_back("v" + to_string(i), column_types[i]);
+	}
+	buffer_struct = LogicalType::STRUCT(std::move(struct_children));
+}
+
+pair<AggregateFunction, unique_ptr<FunctionData>>
+FunctionBinder::BindSortedAggregateState(ClientContext &context, const BoundAggregateFunction &inner_function,
+                                         unique_ptr<FunctionData> inner_bind_info, const LogicalType &buffer_struct,
+                                         const vector<SortedAggregateStateOrder> &orders, idx_t argument_count) {
+	const auto null_handling = inner_function.GetProperties().GetNullHandling();
+	auto bind_data = make_uniq<SortedAggregateBindData>(context, inner_function, std::move(inner_bind_info),
+	                                                    buffer_struct, orders, argument_count);
+	// the wrapper consumes the buffered columns (the struct fields)
+	vector<LogicalType> arguments;
+	for (const auto &child : StructType::GetChildTypes(buffer_struct)) {
+		arguments.emplace_back(child.second);
+	}
+	auto result_function = CreateSortedAggregateWrapper(inner_function.GetName(), arguments,
+	                                                    inner_function.GetReturnType(), null_handling);
+	return make_pair(std::move(result_function), std::move(bind_data));
+}
 
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
                                          const vector<unique_ptr<Expression>> &groups,
@@ -480,8 +595,11 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 		// not a sorted aggregate: return
 		return;
 	}
+	// the exported state is the buffer of values - the ORDER BY must be preserved verbatim (see the ordered aggregate
+	// export path in aggregate_export.cpp), so the redundant-ORDER-BY simplification is skipped for state export
+	const bool state_export = expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT;
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
-	if (Settings::Get<EnableOptimizerSetting>(context)) {
+	if (!state_export && Settings::Get<EnableOptimizerSetting>(context)) {
 		if (expr.GetOrderBysMutable()->Simplify(groups, grouping_sets)) {
 			expr.GetOrderBysMutable().reset();
 			return;
@@ -490,6 +608,33 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	auto &bound_function = expr.Function();
 	auto &children = expr.GetChildrenMutable();
 	auto &order_bys = *expr.GetOrderBysMutable();
+
+	if (state_export) {
+		// the exported AGGREGATE_STATE type (the buffered struct) was fixed at bind time, but the statistics optimizer
+		// may have narrowed the argument/sort-key column types since (e.g. a small-range group column
+		// INTEGER->TINYINT). Cast the buffered columns back to their bind-time logical types so the runtime buffer
+		// matches its declared type. This widening cast preserves sort order, and casting reused arg/sort-key columns
+		// to the same type keeps the arg/sort-key matching intact.
+		LogicalType plan_struct;
+		vector<SortedAggregateStateOrder> order_columns;
+		idx_t argument_count;
+		GetSortedAggregateStateLayout(expr, plan_struct, order_columns, argument_count);
+		auto &logical_fields = StructType::GetChildTypes(ListType::GetChildType(expr.GetReturnType()));
+		for (idx_t i = 0; i < children.size() && i < logical_fields.size(); i++) {
+			if (children[i]->GetReturnType() != logical_fields[i].second) {
+				children[i] =
+				    BoundCastExpression::AddCastToType(context, std::move(children[i]), logical_fields[i].second);
+			}
+		}
+		for (idx_t o = 0; o < order_bys.orders.size() && o < order_columns.size(); o++) {
+			auto &order_expr = order_bys.orders[o].expression;
+			const auto &logical_type = logical_fields[order_columns[o].column].second;
+			if (order_expr->GetReturnType() != logical_type) {
+				order_expr = BoundCastExpression::AddCastToType(context, std::move(order_expr), logical_type);
+			}
+		}
+	}
+
 	auto sorted_bind = make_uniq<SortedAggregateBindData>(context, expr);
 
 	if (!sorted_bind->sorted_on_args) {
@@ -506,18 +651,19 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	}
 
 	// Replace the aggregate with the wrapper
-	AggregateFunction ordered_aggregate(bound_function.GetName(), arguments, bound_function.GetReturnType(),
-	                                    AggregateFunction::StateSize<SortedAggregateState>,
-	                                    AggregateFunction::StateInitialize<SortedAggregateState, ListFunction>,
-	                                    SortedAggregateFunction::ScatterUpdate,
-	                                    ListCombineFunction<SortedAggregateFunction>, SortedAggregateFunction::Finalize,
-	                                    bound_function.GetProperties().GetNullHandling(), nullptr, nullptr, nullptr,
-	                                    nullptr, SortedAggregateFunction::WindowBatch);
-	ordered_aggregate.SetInitLocalStateFinalizeCallback(SortedAggregateFinalizeState::Init);
+	auto ordered_aggregate =
+	    CreateSortedAggregateWrapper(bound_function.GetName(), arguments, bound_function.GetReturnType(),
+	                                 bound_function.GetProperties().GetNullHandling());
 
 	expr.FunctionMutable().ReplaceImplementation(ordered_aggregate);
 	expr.BindInfoMutable() = std::move(sorted_bind);
 	expr.GetOrderBysMutable().reset();
+
+	if (state_export) {
+		// re-apply the export wiring onto the wrapper: it serializes/combines the buffer of values, and the exported
+		// AGGREGATE_STATE type (with the encoded ORDER BY) was already set on the expression at bind time
+		ExportAggregateFunction::SetStateExport(expr, expr.GetReturnType());
+	}
 }
 
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr) {

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -31,58 +31,35 @@ struct SortedAggregateBindData : public FunctionData {
 	                        BindInfoPtr &bind_info, OrderBys &order_bys)
 	    : context(context), function(aggregate), bind_info(std::move(bind_info)),
 	      threshold(Settings::Get<OrderedAggregateThresholdSetting>(context)) {
-		//	Describe the arguments.
+		//	Describe the arguments - column 0 in the sort data is the group number, so the args start at 1
 		for (const auto &child : children) {
 			buffered_cols.emplace_back(buffered_cols.size());
 			buffered_types.emplace_back(child->GetReturnType());
-
-			//	Column 0 in the sort data is the group number
 			scan_cols.emplace_back(buffered_cols.size());
 		}
 		scan_types = buffered_types;
 
-		//	The first sort column is the group number. It is prefixed onto the buffered data
-		sort_types.emplace_back(LogicalType::USMALLINT);
-		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST,
-		                    make_uniq<BoundReferenceExpression>(sort_types.back(), 0U));
-
-		// Determine whether we are sorted on all the arguments.
-		// Even if we are not, we want to share inputs for sorting.
+		// Determine which buffered column each ORDER BY key sorts on. A key that matches an argument reuses that
+		// argument's column; any other key is appended as its own buffered column (so we are no longer sorted on args).
+		vector<SortedAggregateStateOrder> order_spec;
 		for (idx_t ord_idx = 0; ord_idx < order_bys.size(); ++ord_idx) {
-			auto order = order_bys[ord_idx].Copy();
-			bool matched = false;
-			const auto &type = order.expression->GetReturnType();
-
+			auto &order = order_bys[ord_idx];
+			idx_t column = DConstants::INVALID_INDEX;
 			for (idx_t arg_idx = 0; arg_idx < children.size(); ++arg_idx) {
-				auto &child = children[arg_idx];
-				if (child->Equals(*order.expression)) {
-					order.expression = make_uniq<BoundReferenceExpression>(type, arg_idx + 1);
-					matched = true;
+				if (children[arg_idx]->Equals(*order.expression)) {
+					column = arg_idx;
 					break;
 				}
 			}
-
-			if (!matched) {
+			if (column == DConstants::INVALID_INDEX) {
 				sorted_on_args = false;
+				column = buffered_types.size();
 				buffered_cols.emplace_back(children.size() + ord_idx);
-				buffered_types.emplace_back(type);
-				order.expression = make_uniq<BoundReferenceExpression>(type, buffered_cols.size());
+				buffered_types.emplace_back(order.expression->GetReturnType());
 			}
-
-			orders.emplace_back(std::move(order));
+			order_spec.push_back(SortedAggregateStateOrder {column, order.type, order.null_order});
 		}
-
-		// The buffered rows are stored in a linked list of structs
-		child_list_t<LogicalType> buffered_children;
-		for (idx_t i = 0; i < buffered_types.size(); i++) {
-			buffered_children.emplace_back("v" + to_string(i), buffered_types[i]);
-			sort_types.emplace_back(buffered_types[i]);
-		}
-		buffered_struct_type = LogicalType::STRUCT(std::move(buffered_children));
-		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
-
-		//	Only scan the argument columns after sorting
-		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
+		BuildSort(order_spec);
 	}
 
 	SortedAggregateBindData(ClientContext &context, BoundAggregateExpression &expr)
@@ -102,31 +79,42 @@ struct SortedAggregateBindData : public FunctionData {
 	                        const vector<SortedAggregateStateOrder> &order_spec, idx_t argument_count)
 	    : context(context), function(inner_function), bind_info(std::move(inner_bind_info)),
 	      threshold(Settings::Get<OrderedAggregateThresholdSetting>(context)) {
-		const auto &struct_children = StructType::GetChildTypes(buffer_struct);
-		for (idx_t i = 0; i < struct_children.size(); i++) {
-			buffered_cols.emplace_back(i);
-			buffered_types.emplace_back(struct_children[i].second);
+		for (auto &child : StructType::GetChildTypes(buffer_struct)) {
+			buffered_cols.emplace_back(buffered_cols.size());
+			buffered_types.emplace_back(child.second);
 		}
-		//	Only scan the argument columns after sorting
+		//	Only scan the argument columns after sorting (column 0 in the sort data is the group number)
 		for (idx_t i = 0; i < argument_count; i++) {
-			scan_cols.emplace_back(i + 1); // +1 for the group-number prefix
-			scan_types.emplace_back(struct_children[i].second);
+			scan_cols.emplace_back(i + 1);
+			scan_types.emplace_back(buffered_types[i]);
 		}
+		sorted_on_args = (argument_count == buffered_types.size());
+		BuildSort(order_spec);
+	}
+
+	//! Builds the sort layout once the buffered columns and the per-key (column, modifiers) are known: prefixes the
+	//! group number onto the sort, stores the buffered rows as a linked list of structs, and creates the sort.
+	void BuildSort(const vector<SortedAggregateStateOrder> &order_spec) {
 		//	The first sort column is the group number, prefixed onto the buffered data
 		sort_types.emplace_back(LogicalType::USMALLINT);
 		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST,
 		                    make_uniq<BoundReferenceExpression>(LogicalType::USMALLINT, 0U));
-		for (auto &col_type : buffered_types) {
-			sort_types.emplace_back(col_type);
+
+		//	The buffered rows are stored in a linked list of structs
+		child_list_t<LogicalType> buffered_children;
+		for (idx_t i = 0; i < buffered_types.size(); i++) {
+			buffered_children.emplace_back("v" + to_string(i), buffered_types[i]);
+			sort_types.emplace_back(buffered_types[i]);
 		}
+		buffered_struct_type = LogicalType::STRUCT(std::move(buffered_children));
+		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
+
+		//	The sort keys reference the buffered columns (offset by 1 for the group-number prefix)
 		for (const auto &entry : order_spec) {
 			orders.emplace_back(entry.order_type, entry.null_order,
-			                    make_uniq<BoundReferenceExpression>(struct_children[entry.column].second,
+			                    make_uniq<BoundReferenceExpression>(buffered_types[entry.column],
 			                                                        UnsafeNumericCast<idx_t>(entry.column + 1)));
 		}
-		sorted_on_args = (argument_count == struct_children.size());
-		buffered_struct_type = buffer_struct;
-		GetSegmentDataFunctions(buffered_funcs, buffered_struct_type);
 		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
 	}
 

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/list_segment.hpp"
 #include "duckdb/common/types/variant_value.hpp"
 #include "duckdb/function/aggregate_state_layout.hpp"
@@ -330,13 +331,28 @@ static void SerializeState(const AggregateStateLayout &layout, Vector &result, i
 	SerializeField(layout.type, layout.field, result, count, addresses, 0, offset);
 }
 
+// Invokes an aggregate's explicit export-state callback. These callbacks only write at offset 0 - when finalizing at a
+// non-zero offset (e.g. one group at a time through the sorted aggregate wrapper) serialize into a temporary vector and
+// copy the result into place, so every export callback works at an offset without each having to support one.
+static void CallExportStateCallback(AggregateFinalizeInputData &aggr_input_data, Vector &states, idx_t count,
+                                    Vector &result, idx_t offset) {
+	auto callback = aggr_input_data.function.GetExportAggregateStateCallback();
+	if (offset == 0) {
+		callback(states, aggr_input_data, result, count, 0);
+		return;
+	}
+	Vector temp(result.GetType(), count);
+	callback(states, aggr_input_data, temp, count, 0);
+	VectorOperations::Copy(temp, result, count, 0, offset);
+}
+
 static void SerializeState(const BoundAggregateFunction &aggr, optional_ptr<FunctionData> bind_data,
                            const AggregateStateLayout &layout, Vector &states, idx_t count, Vector &result,
                            ArenaAllocator &allocator, idx_t offset) {
 	if (aggr.HasExportAggregateStateCallback()) {
 		// the aggregate explicitly serializes its own states
 		AggregateFinalizeInputData aggr_input_data(aggr, bind_data, allocator);
-		aggr.GetExportAggregateStateCallback()(states, aggr_input_data, result, count, offset);
+		CallExportStateCallback(aggr_input_data, states, count, result, offset);
 		return;
 	}
 	const data_ptr_t *addresses;
@@ -620,7 +636,37 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	map<idx_t, Value> constant_parameters;
 	ParseStateParameters(entry->second, argument_types, constant_parameters);
 
-	return BindExportedAggregate(context, function_name, argument_types, constant_parameters);
+	auto inner = BindExportedAggregate(context, function_name, argument_types, constant_parameters);
+
+	auto order_entry = ext_info->properties.find("order_bys");
+	if (order_entry == ext_info->properties.end()) {
+		// a plain (non-ordered) aggregate state
+		return inner;
+	}
+	// an ordered aggregate state: the value is the buffer (LIST<buffered_struct>) and the ORDER BY spec is stored in
+	// the extension info - reconstruct the sorted aggregate wrapper around the (re-bound) inner aggregate so that
+	// finalize sorts the buffered values and runs the inner aggregate, and combine concatenates buffers
+	vector<SortedAggregateStateOrder> orders;
+	for (auto &order_value : ListValue::GetChildren(order_entry->second)) {
+		auto &fields = StructValue::GetChildren(order_value);
+		SortedAggregateStateOrder order;
+		order.column = fields[0].GetValue<uint32_t>();
+		order.order_type = static_cast<OrderType>(fields[1].GetValue<uint8_t>());
+		order.null_order = static_cast<OrderByNullType>(fields[2].GetValue<uint8_t>());
+		orders.push_back(order);
+	}
+	auto arg_count_entry = ext_info->properties.find("argument_count");
+	if (arg_count_entry == ext_info->properties.end()) {
+		throw InternalException("Ordered aggregate state is missing the argument_count property");
+	}
+	const idx_t argument_count = arg_count_entry->second.GetValue<uint32_t>();
+	const auto buffer_struct = ListType::GetChildType(arg_return_type);
+
+	auto reconstructed = FunctionBinder::BindSortedAggregateState(context, inner->aggr, std::move(inner->bind_data),
+	                                                              buffer_struct, orders, argument_count);
+	BoundAggregateFunction wrapper(reconstructed.first);
+	const auto state_size = wrapper.GetStateSizeCallback()(wrapper);
+	return make_uniq<ExportAggregateBindData>(std::move(wrapper), std::move(reconstructed.second), state_size);
 }
 
 unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
@@ -685,6 +731,13 @@ void ExportAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_inp
 		result.Flatten();
 	}
 	SerializeState(layout, result, count, addresses_ptrs, offset);
+}
+
+// Finalize callback for aggregates that serialize their state through an explicit export callback (e.g. approx_top_k).
+// Routes through CallExportStateCallback so the callback keeps working when finalizing at a non-zero offset.
+void ExportAggregateExplicitFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result,
+                                     idx_t count, idx_t offset) {
+	CallExportStateCallback(aggr_input_data, state, count, result, offset);
 }
 
 // the executor invokes this callback with combine_aggr's own bind data (ExportAggregateBindData) - the underlying
@@ -779,18 +832,11 @@ void CombineAggrFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_d
 	               offset);
 }
 
-// constructs the AGGREGATE_STATE type for the given bound aggregate function
-// the state layout (a struct) is aliased to AGGREGATE_STATE, with the function name and signature stored in the
-// extension type info so that the aggregate can be re-bound later (e.g. by FINALIZE/COMBINE)
-LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_function,
-                                     optional_ptr<FunctionData> bind_data) {
-	auto layout = bound_function.GetStateType(bind_data);
-	// deep copy the type before modifying it - SetAlias/SetExtensionInfo modify the (shared) extra type info in
-	// place, and the state layout type can share its type info with e.g. the aggregate's input expressions
-	LogicalType state_layout = layout.type.DeepCopy();
-	state_layout.SetAlias("AGGREGATE_STATE");
-	auto ext_info = make_uniq<ExtensionTypeInfo>();
-	ext_info->properties.emplace("function_name", bound_function.GetName());
+// stores the function name and signature (with any constant parameters) into the extension type info, so that the
+// aggregate can be re-bound later (e.g. by FINALIZE/COMBINE)
+void EncodeStateParameters(ExtensionTypeInfo &ext_info, const BoundAggregateFunction &bound_function,
+                           const AggregateStateLayout &layout) {
+	ext_info.properties.emplace("function_name", bound_function.GetName());
 	auto &original_arguments = bound_function.GetOriginalArguments().empty() ? bound_function.GetArguments()
 	                                                                         : bound_function.GetOriginalArguments();
 	vector<Value> arguments;
@@ -799,7 +845,7 @@ LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_functio
 		for (auto &arg : original_arguments) {
 			arguments.push_back(Value::TYPE(arg));
 		}
-		ext_info->properties.emplace("parameters", Value::LIST(LogicalType::TYPE(), std::move(arguments)));
+		ext_info.properties.emplace("parameters", Value::LIST(LogicalType::TYPE(), std::move(arguments)));
 	} else {
 		// some parameters were bound to a constant (e.g. string_agg's separator) - store the parameters as a list of
 		// (type, value) pairs, where the value holds the constant the parameter must be re-bound with
@@ -815,8 +861,52 @@ LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_functio
 			arguments.push_back(Value::STRUCT(std::move(children)));
 		}
 		auto entry_type = LogicalType::STRUCT({{"type", LogicalType::TYPE()}, {"value", LogicalType::VARIANT()}});
-		ext_info->properties.emplace("parameters", Value::LIST(entry_type, std::move(arguments)));
+		ext_info.properties.emplace("parameters", Value::LIST(entry_type, std::move(arguments)));
 	}
+}
+
+// the STRUCT type of a single ORDER BY entry encoded into an ordered aggregate state's extension info
+LogicalType OrderByEntryType() {
+	return LogicalType::STRUCT(
+	    {{"column", LogicalType::UINTEGER}, {"order", LogicalType::UTINYINT}, {"nulls", LogicalType::UTINYINT}});
+}
+
+// constructs the AGGREGATE_STATE type for the given bound aggregate function
+// the state layout (a struct) is aliased to AGGREGATE_STATE, with the function name and signature stored in the
+// extension type info so that the aggregate can be re-bound later (e.g. by FINALIZE/COMBINE)
+LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_function,
+                                     optional_ptr<FunctionData> bind_data) {
+	auto layout = bound_function.GetStateType(bind_data);
+	// deep copy the type before modifying it - SetAlias/SetExtensionInfo modify the (shared) extra type info in
+	// place, and the state layout type can share its type info with e.g. the aggregate's input expressions
+	LogicalType state_layout = layout.type.DeepCopy();
+	state_layout.SetAlias("AGGREGATE_STATE");
+	auto ext_info = make_uniq<ExtensionTypeInfo>();
+	EncodeStateParameters(*ext_info, bound_function, layout);
+	state_layout.SetExtensionInfo(std::move(ext_info));
+	return state_layout;
+}
+
+// constructs the AGGREGATE_STATE type for an ordered aggregate - the exported state is the buffer of values
+// (a LIST<buffered_struct>), with the inner aggregate's signature and the ORDER BY spec stored in the extension info
+LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_function,
+                                           optional_ptr<FunctionData> inner_bind_data, const LogicalType &buffer_struct,
+                                           const vector<SortedAggregateStateOrder> &orders, idx_t argument_count) {
+	LogicalType state_layout = LogicalType::LIST(buffer_struct);
+	state_layout.SetAlias("AGGREGATE_STATE");
+	auto ext_info = make_uniq<ExtensionTypeInfo>();
+	EncodeStateParameters(*ext_info, inner_function, inner_function.GetStateType(inner_bind_data));
+	// encode the ORDER BY: per key, the buffered column it sorts on and the order/null modifiers
+	vector<Value> order_values;
+	for (auto &order : orders) {
+		child_list_t<Value> children;
+		children.emplace_back("column", Value::UINTEGER(UnsafeNumericCast<uint32_t>(order.column)));
+		children.emplace_back("order", Value::UTINYINT(static_cast<uint8_t>(order.order_type)));
+		children.emplace_back("nulls", Value::UTINYINT(static_cast<uint8_t>(order.null_order)));
+		order_values.push_back(Value::STRUCT(std::move(children)));
+	}
+	ext_info->properties.emplace("order_bys", Value::LIST(OrderByEntryType(), std::move(order_values)));
+	ext_info->properties.emplace("argument_count", Value::UINTEGER(UnsafeNumericCast<uint32_t>(argument_count)));
 	state_layout.SetExtensionInfo(std::move(ext_info));
 	return state_layout;
 }
@@ -860,6 +950,62 @@ void ParseConstantParameters(const Value &constants, idx_t argument_count, map<i
 			continue;
 		}
 		constant_parameters[i] = children[i];
+	}
+}
+
+// parses a single order modifier string (e.g. "DESC NULLS LAST", "ASC", "NULLS FIRST") into its order and null type.
+// the order defaults to ASC and the null order to the SQL default for that order (NULLS LAST for ASC, NULLS FIRST for
+// DESC) when not specified.
+void ParseOrderModifier(const string &modifier, OrderType &order_type, OrderByNullType &null_order) {
+	auto upper = StringUtil::Upper(modifier);
+	order_type = StringUtil::Contains(upper, "DESC") ? OrderType::DESCENDING : OrderType::ASCENDING;
+	if (StringUtil::Contains(upper, "NULLS FIRST")) {
+		null_order = OrderByNullType::NULLS_FIRST;
+	} else if (StringUtil::Contains(upper, "NULLS LAST")) {
+		null_order = OrderByNullType::NULLS_LAST;
+	} else {
+		null_order = order_type == OrderType::DESCENDING ? OrderByNullType::NULLS_FIRST : OrderByNullType::NULLS_LAST;
+	}
+}
+
+// parses the optional fifth argument of to_aggregate_state: the ORDER BY specification of an ordered aggregate, as a
+// list of {column, order} structs, e.g. [{'column': 1, 'order': 'DESC NULLS LAST'}]. 'column' is the buffered struct
+// column the key sorts on, 'order' is the modifier string.
+void ParseOrderBys(const Value &order_value, idx_t column_count, vector<SortedAggregateStateOrder> &orders) {
+	if (order_value.IsNull()) {
+		return;
+	}
+	if (order_value.type().id() != LogicalTypeId::LIST) {
+		throw BinderException(
+		    "to_aggregate_state: the ORDER BY argument must be a list of {column, order} structs, e.g. "
+		    "[{'column': 1, 'order': 'DESC NULLS LAST'}]");
+	}
+	for (auto &entry : ListValue::GetChildren(order_value)) {
+		if (entry.IsNull() || entry.type().id() != LogicalTypeId::STRUCT) {
+			throw BinderException("to_aggregate_state: each ORDER BY entry must be a {column, order} struct");
+		}
+		auto &field_types = StructType::GetChildTypes(entry.type());
+		auto &field_values = StructValue::GetChildren(entry);
+		Value column, order;
+		for (idx_t f = 0; f < field_types.size(); f++) {
+			if (field_types[f].first == "column") {
+				column = field_values[f];
+			} else if (field_types[f].first == "order") {
+				order = field_values[f];
+			}
+		}
+		if (column.IsNull() || order.IsNull()) {
+			throw BinderException("to_aggregate_state: each ORDER BY entry must have a non-NULL 'column' and 'order'");
+		}
+		SortedAggregateStateOrder state_order;
+		state_order.column = column.GetValue<uint32_t>();
+		if (state_order.column >= column_count) {
+			throw BinderException(
+			    "to_aggregate_state: ORDER BY column %llu is out of range (the state has %llu columns)",
+			    (uint64_t)state_order.column, (uint64_t)column_count);
+		}
+		ParseOrderModifier(StringValue::Get(order), state_order.order_type, state_order.null_order);
+		orders.push_back(state_order);
 	}
 }
 
@@ -911,6 +1057,32 @@ unique_ptr<FunctionData> ToAggregateStateBind(BindScalarFunctionInput &input) {
 		    "Aggregate function \"%s\" does not have a state type callback defined - cannot convert to its state",
 		    function_name);
 	}
+
+	if (arguments.size() > 4) {
+		// an ordered aggregate state: the value is the buffer of values (LIST<buffered_struct>) and the fifth argument
+		// describes the ORDER BY keys. The number of buffered argument columns is the inner aggregate's bound arity;
+		// any further buffered columns are appended sort keys.
+		auto &state_type = arguments[0]->GetReturnType();
+		if (state_type.id() != LogicalTypeId::LIST ||
+		    ListType::GetChildType(state_type).id() != LogicalTypeId::STRUCT) {
+			throw BinderException("to_aggregate_state: an ordered aggregate state value must be a LIST of STRUCTs (the "
+			                      "buffer of values), e.g. [{'v0': ...}, ...]");
+		}
+		const auto buffer_struct = ListType::GetChildType(state_type);
+		const idx_t column_count = StructType::GetChildTypes(buffer_struct).size();
+		const idx_t argument_count = aggr.GetArguments().size();
+		vector<SortedAggregateStateOrder> orders;
+		auto order_value = ExpressionExecutor::EvaluateScalar(context, *arguments[4]);
+		ParseOrderBys(order_value, column_count, orders);
+		if (orders.empty()) {
+			throw BinderException("to_aggregate_state: an ordered aggregate state must have at least one ORDER BY key");
+		}
+		bound_function.GetArguments()[0] = LogicalType::LIST(buffer_struct);
+		bound_function.SetReturnType(
+		    CreateSortedAggregateStateType(aggr, bind_data->bind_data.get(), buffer_struct, orders, argument_count));
+		return std::move(bind_data);
+	}
+
 	auto state_layout = aggr.GetStateType(bind_data->bind_data.get()).type;
 	bound_function.GetArguments()[0] = state_layout;
 	bound_function.SetReturnType(CreateAggregateStateType(aggr, bind_data->bind_data.get()));
@@ -926,10 +1098,10 @@ void ToAggregateStateFunction(DataChunk &input, ExpressionState &state, Vector &
 
 void ExportAggregateFunction::SetStateExport(BoundAggregateExpression &aggregate, LogicalType state_layout) {
 	auto &bound_function = aggregate.FunctionMutable();
-	// functions with an explicit export callback use it as the finalize; others use the field-based serialization
-	bound_function.SetStateFinalizeCallback(bound_function.HasExportAggregateStateCallback()
-	                                            ? bound_function.GetExportAggregateStateCallback()
-	                                            : ExportAggregateFinalize);
+	// functions with an explicit export callback use it as the finalize (wrapped so it honors a non-zero offset);
+	// others use the field-based serialization
+	bound_function.SetStateFinalizeCallback(
+	    bound_function.HasExportAggregateStateCallback() ? ExportAggregateExplicitFinalize : ExportAggregateFinalize);
 	// statistics propagation is no longer correct post
 	bound_function.SetStatisticsCallback(nullptr);
 	bound_function.SetReturnType(state_layout);
@@ -958,6 +1130,19 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 	D_ASSERT(bound_function.HasStateSizeCallback());
 	D_ASSERT(bound_function.HasStateFinalizeCallback());
 	D_ASSERT(child_aggregate->Function().GetReturnType().id() != LogicalTypeId::INVALID);
+	if (child_aggregate->GetOrderBys() && !child_aggregate->GetOrderBys()->orders.empty()) {
+		// ordered aggregate: the exported state is the buffer of values (LIST<buffered_struct>) plus the ORDER BY spec.
+		// The sorted aggregate wrapper (built later, at physical planning) serializes/combines that buffer; here we
+		// only fix the exported AGGREGATE_STATE type so it is known to downstream binding (e.g. finalize/combine).
+		LogicalType buffer_struct;
+		vector<SortedAggregateStateOrder> orders;
+		idx_t argument_count;
+		FunctionBinder::GetSortedAggregateStateLayout(*child_aggregate, buffer_struct, orders, argument_count);
+		SetStateExport(*child_aggregate,
+		               CreateSortedAggregateStateType(bound_function, child_aggregate->BindInfo().get(), buffer_struct,
+		                                              orders, argument_count));
+		return child_aggregate;
+	}
 	SetStateExport(*child_aggregate, CreateAggregateStateType(bound_function, child_aggregate->BindInfo().get()));
 	return child_aggregate;
 }
@@ -994,10 +1179,14 @@ ScalarFunction CombineFun::GetFunction() {
 ScalarFunctionSet ToAggregateStateFun::GetFunctions() {
 	ScalarFunctionSet set("to_aggregate_state");
 	vector<LogicalType> arguments {LogicalTypeId::ANY, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::ANY)};
-	for (idx_t constant_params = 0; constant_params < 2; constant_params++) {
-		if (constant_params) {
+	for (idx_t optional_args = 0; optional_args < 3; optional_args++) {
+		if (optional_args == 1) {
 			// optional fourth argument: constant parameter values as a list with one entry per argument (e.g.
 			// [NULL, ','])
+			arguments.emplace_back(LogicalTypeId::ANY);
+		} else if (optional_args == 2) {
+			// optional fifth argument: the ORDER BY of an ordered aggregate, as a list of {column, order} structs
+			// (e.g. [{'column': 1, 'order': 'DESC NULLS LAST'}])
 			arguments.emplace_back(LogicalTypeId::ANY);
 		}
 		ScalarFunction function("to_aggregate_state", arguments, LogicalTypeId::ANY, ToAggregateStateFunction,

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -595,6 +595,9 @@ void ParseStateParameters(const Value &parameters, vector<LogicalType> &argument
 	}
 }
 
+// parses an ORDER BY spec (a list of {column, order} structs) - shared by the re-bind path and to_aggregate_state
+void ParseOrderBys(const Value &order_value, idx_t column_count, vector<SortedAggregateStateOrder> &orders);
+
 unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &context, BoundSimpleFunction &function,
                                                                vector<unique_ptr<Expression>> &arguments) {
 	auto &arg_return_type = arguments[0]->GetReturnType();
@@ -631,21 +634,12 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	// an ordered aggregate state: the value is the buffer (LIST<buffered_struct>) and the ORDER BY spec is stored in
 	// the extension info - reconstruct the sorted aggregate wrapper around the (re-bound) inner aggregate so that
 	// finalize sorts the buffered values and runs the inner aggregate, and combine concatenates buffers
-	vector<SortedAggregateStateOrder> orders;
-	for (auto &order_value : ListValue::GetChildren(order_entry->second)) {
-		auto &fields = StructValue::GetChildren(order_value);
-		SortedAggregateStateOrder order;
-		order.column = fields[0].GetValue<uint32_t>();
-		order.order_type = static_cast<OrderType>(fields[1].GetValue<uint8_t>());
-		order.null_order = static_cast<OrderByNullType>(fields[2].GetValue<uint8_t>());
-		orders.push_back(order);
-	}
-	auto arg_count_entry = ext_info->properties.find("argument_count");
-	if (arg_count_entry == ext_info->properties.end()) {
-		throw InternalException("Ordered aggregate state is missing the argument_count property");
-	}
-	const idx_t argument_count = arg_count_entry->second.GetValue<uint32_t>();
 	const auto buffer_struct = ListType::GetChildType(arg_return_type);
+	const idx_t column_count = StructType::GetChildTypes(buffer_struct).size();
+	vector<SortedAggregateStateOrder> orders;
+	ParseOrderBys(order_entry->second, column_count, orders);
+	// the leading buffered columns are the inner aggregate's bound arguments (after any constant-parameter erasure)
+	const idx_t argument_count = inner->aggr.GetArguments().size();
 
 	auto reconstructed = FunctionBinder::BindSortedAggregateState(context, inner->aggr, std::move(inner->bind_data),
 	                                                              buffer_struct, orders, argument_count);
@@ -843,10 +837,15 @@ void EncodeStateParameters(ExtensionTypeInfo &ext_info, const BoundAggregateFunc
 	}
 }
 
-// the STRUCT type of a single ORDER BY entry encoded into an ordered aggregate state's extension info
+// the STRUCT type of a single ORDER BY entry encoded into an ordered aggregate state's extension info. It matches the
+// shape of to_aggregate_state's ORDER BY argument: the buffered column the key sorts on, and the modifier string.
 LogicalType OrderByEntryType() {
-	return LogicalType::STRUCT(
-	    {{"column", LogicalType::UINTEGER}, {"order", LogicalType::UTINYINT}, {"nulls", LogicalType::UTINYINT}});
+	return LogicalType::STRUCT({{"column", LogicalType::UINTEGER}, {"order", LogicalType::VARCHAR}});
+}
+
+// renders an order modifier (e.g. ASC NULLS LAST) into the string form parsed by OrderModifiers::Parse
+string OrderModifierToString(OrderType order_type, OrderByNullType null_order) {
+	return StringUtil::Format("%s %s", EnumUtil::ToChars(order_type), EnumUtil::ToChars(null_order));
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function
@@ -869,22 +868,22 @@ LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_functio
 // (a LIST<buffered_struct>), with the inner aggregate's signature and the ORDER BY spec stored in the extension info
 LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_function,
                                            optional_ptr<FunctionData> inner_bind_data, const LogicalType &buffer_struct,
-                                           const vector<SortedAggregateStateOrder> &orders, idx_t argument_count) {
+                                           const vector<SortedAggregateStateOrder> &orders) {
 	LogicalType state_layout = LogicalType::LIST(buffer_struct);
 	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, inner_function, inner_function.GetStateType(inner_bind_data));
-	// encode the ORDER BY: per key, the buffered column it sorts on and the order/null modifiers
+	// encode the ORDER BY: per key, the buffered column it sorts on and the modifier string. The number of leading
+	// argument columns is not stored - it is the re-bound inner aggregate's bound arity (see
+	// BindAggregateStateInternal)
 	vector<Value> order_values;
 	for (auto &order : orders) {
 		child_list_t<Value> children;
 		children.emplace_back("column", Value::UINTEGER(UnsafeNumericCast<uint32_t>(order.column)));
-		children.emplace_back("order", Value::UTINYINT(static_cast<uint8_t>(order.order_type)));
-		children.emplace_back("nulls", Value::UTINYINT(static_cast<uint8_t>(order.null_order)));
+		children.emplace_back("order", Value(OrderModifierToString(order.order_type, order.null_order)));
 		order_values.push_back(Value::STRUCT(std::move(children)));
 	}
 	ext_info->properties.emplace("order_bys", Value::LIST(OrderByEntryType(), std::move(order_values)));
-	ext_info->properties.emplace("argument_count", Value::UINTEGER(UnsafeNumericCast<uint32_t>(argument_count)));
 	state_layout.SetExtensionInfo(std::move(ext_info));
 	return state_layout;
 }
@@ -931,24 +930,9 @@ void ParseConstantParameters(const Value &constants, idx_t argument_count, map<i
 	}
 }
 
-// parses a single order modifier string (e.g. "DESC NULLS LAST", "ASC", "NULLS FIRST") into its order and null type.
-// the order defaults to ASC and the null order to the SQL default for that order (NULLS LAST for ASC, NULLS FIRST for
-// DESC) when not specified.
-void ParseOrderModifier(const string &modifier, OrderType &order_type, OrderByNullType &null_order) {
-	auto upper = StringUtil::Upper(modifier);
-	order_type = StringUtil::Contains(upper, "DESC") ? OrderType::DESCENDING : OrderType::ASCENDING;
-	if (StringUtil::Contains(upper, "NULLS FIRST")) {
-		null_order = OrderByNullType::NULLS_FIRST;
-	} else if (StringUtil::Contains(upper, "NULLS LAST")) {
-		null_order = OrderByNullType::NULLS_LAST;
-	} else {
-		null_order = order_type == OrderType::DESCENDING ? OrderByNullType::NULLS_FIRST : OrderByNullType::NULLS_LAST;
-	}
-}
-
 // parses the optional fifth argument of to_aggregate_state: the ORDER BY specification of an ordered aggregate, as a
 // list of {column, order} structs, e.g. [{'column': 1, 'order': 'DESC NULLS LAST'}]. 'column' is the buffered struct
-// column the key sorts on, 'order' is the modifier string.
+// column the key sorts on, 'order' is the modifier string (parsed with the same rules as create_sort_key).
 void ParseOrderBys(const Value &order_value, idx_t column_count, vector<SortedAggregateStateOrder> &orders) {
 	if (order_value.IsNull()) {
 		return;
@@ -982,7 +966,9 @@ void ParseOrderBys(const Value &order_value, idx_t column_count, vector<SortedAg
 			    "to_aggregate_state: ORDER BY column %llu is out of range (the state has %llu columns)",
 			    (uint64_t)state_order.column, (uint64_t)column_count);
 		}
-		ParseOrderModifier(StringValue::Get(order), state_order.order_type, state_order.null_order);
+		auto modifiers = OrderModifiers::Parse(StringValue::Get(order));
+		state_order.order_type = modifiers.order_type;
+		state_order.null_order = modifiers.null_type;
 		orders.push_back(state_order);
 	}
 }
@@ -1048,7 +1034,6 @@ unique_ptr<FunctionData> ToAggregateStateBind(BindScalarFunctionInput &input) {
 		}
 		const auto buffer_struct = ListType::GetChildType(state_type);
 		const idx_t column_count = StructType::GetChildTypes(buffer_struct).size();
-		const idx_t argument_count = aggr.GetArguments().size();
 		vector<SortedAggregateStateOrder> orders;
 		auto order_value = ExpressionExecutor::EvaluateScalar(context, *arguments[4]);
 		ParseOrderBys(order_value, column_count, orders);
@@ -1057,7 +1042,7 @@ unique_ptr<FunctionData> ToAggregateStateBind(BindScalarFunctionInput &input) {
 		}
 		bound_function.GetArguments()[0] = LogicalType::LIST(buffer_struct);
 		bound_function.SetReturnType(
-		    CreateSortedAggregateStateType(aggr, bind_data->bind_data.get(), buffer_struct, orders, argument_count));
+		    CreateSortedAggregateStateType(aggr, bind_data->bind_data.get(), buffer_struct, orders));
 		return std::move(bind_data);
 	}
 
@@ -1114,11 +1099,10 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 		// only fix the exported AGGREGATE_STATE type so it is known to downstream binding (e.g. finalize/combine).
 		LogicalType buffer_struct;
 		vector<SortedAggregateStateOrder> orders;
-		idx_t argument_count;
+		idx_t argument_count; // unused here - the buffered arg count is re-derived from the inner aggregate on re-bind
 		FunctionBinder::GetSortedAggregateStateLayout(*child_aggregate, buffer_struct, orders, argument_count);
-		SetStateExport(*child_aggregate,
-		               CreateSortedAggregateStateType(bound_function, child_aggregate->BindInfo().get(), buffer_struct,
-		                                              orders, argument_count));
+		SetStateExport(*child_aggregate, CreateSortedAggregateStateType(
+		                                     bound_function, child_aggregate->BindInfo().get(), buffer_struct, orders));
 		return child_aggregate;
 	}
 	SetStateExport(*child_aggregate, CreateAggregateStateType(bound_function, child_aggregate->BindInfo().get()));

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -334,8 +334,7 @@ static void SerializeState(const BoundAggregateFunction &aggr, optional_ptr<Func
                            const AggregateStateLayout &layout, Vector &states, idx_t count, Vector &result,
                            ArenaAllocator &allocator, idx_t offset) {
 	if (aggr.HasExportAggregateStateCallback()) {
-		// the aggregate explicitly serializes its own states (the callback writes the count rows at [offset, offset +
-		// count))
+		// the aggregate explicitly serializes its own states, writing the count rows at [offset, offset + count)
 		AggregateFinalizeInputData aggr_input_data(aggr, bind_data, allocator);
 		aggr.GetExportAggregateStateCallback()(states, aggr_input_data, result, count, offset);
 		return;
@@ -631,14 +630,13 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 		// a plain (non-ordered) aggregate state
 		return inner;
 	}
-	// an ordered aggregate state: the value is the buffer (LIST<buffered_struct>) and the ORDER BY spec is stored in
-	// the extension info - reconstruct the sorted aggregate wrapper around the (re-bound) inner aggregate so that
-	// finalize sorts the buffered values and runs the inner aggregate, and combine concatenates buffers
+	// an ordered aggregate state: the value is the buffer (LIST<buffered_struct>) - reconstruct the sorted wrapper
+	// around the inner aggregate so finalize sorts the buffer and combine concatenates buffers
 	const auto buffer_struct = ListType::GetChildType(arg_return_type);
 	const idx_t column_count = StructType::GetChildTypes(buffer_struct).size();
 	vector<SortedAggregateStateOrder> orders;
 	ParseOrderBys(order_entry->second, column_count, orders);
-	// the leading buffered columns are the inner aggregate's bound arguments (after any constant-parameter erasure)
+	// the leading buffered columns are the inner aggregate's bound arguments (post constant-erasure)
 	const idx_t argument_count = inner->aggr.GetArguments().size();
 
 	auto reconstructed = FunctionBinder::BindSortedAggregateState(context, inner->aggr, std::move(inner->bind_data),
@@ -864,8 +862,8 @@ LogicalType CreateAggregateStateType(const BoundAggregateFunction &bound_functio
 	return state_layout;
 }
 
-// constructs the AGGREGATE_STATE type for an ordered aggregate - the exported state is the buffer of values
-// (a LIST<buffered_struct>), with the inner aggregate's signature and the ORDER BY spec stored in the extension info
+// constructs the AGGREGATE_STATE type for an ordered aggregate - the state is the buffer of values
+// (LIST<buffered_struct>), with the inner signature and the ORDER BY spec stored in the extension info
 LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_function,
                                            optional_ptr<FunctionData> inner_bind_data, const LogicalType &buffer_struct,
                                            const vector<SortedAggregateStateOrder> &orders) {
@@ -873,9 +871,7 @@ LogicalType CreateSortedAggregateStateType(const BoundAggregateFunction &inner_f
 	state_layout.SetAlias("AGGREGATE_STATE");
 	auto ext_info = make_uniq<ExtensionTypeInfo>();
 	EncodeStateParameters(*ext_info, inner_function, inner_function.GetStateType(inner_bind_data));
-	// encode the ORDER BY: per key, the buffered column it sorts on and the modifier string. The number of leading
-	// argument columns is not stored - it is the re-bound inner aggregate's bound arity (see
-	// BindAggregateStateInternal)
+	// per key: the buffered column it sorts on and the modifier string (the argument count is re-derived on re-bind)
 	vector<Value> order_values;
 	for (auto &order : orders) {
 		child_list_t<Value> children;
@@ -1023,9 +1019,7 @@ unique_ptr<FunctionData> ToAggregateStateBind(BindScalarFunctionInput &input) {
 	}
 
 	if (arguments.size() > 4) {
-		// an ordered aggregate state: the value is the buffer of values (LIST<buffered_struct>) and the fifth argument
-		// describes the ORDER BY keys. The number of buffered argument columns is the inner aggregate's bound arity;
-		// any further buffered columns are appended sort keys.
+		// an ordered aggregate state: the value is the buffer (LIST<buffered_struct>), the fifth argument the ORDER BY
 		auto &state_type = arguments[0]->GetReturnType();
 		if (state_type.id() != LogicalTypeId::LIST ||
 		    ListType::GetChildType(state_type).id() != LogicalTypeId::STRUCT) {
@@ -1094,12 +1088,11 @@ ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggrega
 	D_ASSERT(bound_function.HasStateFinalizeCallback());
 	D_ASSERT(child_aggregate->Function().GetReturnType().id() != LogicalTypeId::INVALID);
 	if (child_aggregate->GetOrderBys() && !child_aggregate->GetOrderBys()->orders.empty()) {
-		// ordered aggregate: the exported state is the buffer of values (LIST<buffered_struct>) plus the ORDER BY spec.
-		// The sorted aggregate wrapper (built later, at physical planning) serializes/combines that buffer; here we
-		// only fix the exported AGGREGATE_STATE type so it is known to downstream binding (e.g. finalize/combine).
+		// ordered aggregate: export the buffer of values. The sorted wrapper is built later (physical planning); here
+		// we only fix the AGGREGATE_STATE type so downstream binding (finalize/combine) sees it
 		LogicalType buffer_struct;
 		vector<SortedAggregateStateOrder> orders;
-		idx_t argument_count; // unused here - the buffered arg count is re-derived from the inner aggregate on re-bind
+		idx_t argument_count; // re-derived from the inner aggregate on re-bind
 		FunctionBinder::GetSortedAggregateStateLayout(*child_aggregate, buffer_struct, orders, argument_count);
 		SetStateExport(*child_aggregate, CreateSortedAggregateStateType(
 		                                     bound_function, child_aggregate->BindInfo().get(), buffer_struct, orders));

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -132,39 +132,39 @@ struct LoadOp {
 	}
 };
 
-// Store rows from the packed binary state buffer into a result vector.
+// Store rows from the packed binary state buffer into a result vector at [offset, offset + count).
 struct StoreOp {
 	template <class T>
-	static void Operation(Vector &result, idx_t count, const data_ptr_t *sources, idx_t field_offset) {
-		auto dst = FlatVector::Writer<T>(result, count);
+	static void Operation(Vector &result, idx_t count, const data_ptr_t *sources, idx_t field_offset, idx_t offset) {
+		auto dst = FlatVector::Writer<T>(result, count, offset);
 		for (idx_t i = 0; i < count; i++) {
 			dst.WriteValue(Load<T>(sources[i] + field_offset));
 		}
 	}
 };
 
-// Recursively serialize a state field to a result vector.
+// Recursively serialize a state field to a result vector, writing the `count` rows at [offset, offset + count).
 // base: accumulated byte offset from the state slot start to this field's parent base.
 // Each child's field_offset is relative to that parent base.
 static void SerializeField(const LogicalType &type, const AggregateStateField &field, Vector &result, idx_t count,
-                           const data_ptr_t *addresses, idx_t base) {
+                           const data_ptr_t *addresses, idx_t base, idx_t offset) {
 	switch (field.kind) {
 	case AggregateFieldKind::OPTIONAL_VALUE:
 		D_ASSERT(field.children.size() == 1);
 		for (idx_t i = 0; i < count; i++) {
 			if (!Load<bool>(addresses[i] + base + field.field_offset)) {
-				FlatVector::SetNull(result, i, true);
+				FlatVector::SetNull(result, offset + i, true);
 			}
 		}
-		SerializeField(type, field.children[0], result, count, addresses, base);
+		SerializeField(type, field.children[0], result, count, addresses, base, offset);
 		break;
 	case AggregateFieldKind::SORT_KEY:
 		for (idx_t i = 0; i < count; i++) {
-			if (!FlatVector::Validity(result).RowIsValid(i)) {
+			if (!FlatVector::Validity(result).RowIsValid(offset + i)) {
 				continue;
 			}
 			const string_t sort_key = Load<string_t>(addresses[i] + base + field.field_offset);
-			CreateSortKeyHelpers::DecodeSortKey(sort_key, result, i,
+			CreateSortKeyHelpers::DecodeSortKey(sort_key, result, offset + i,
 			                                    OrderModifiers(field.sort_key_order, OrderByNullType::NULLS_LAST));
 		}
 		break;
@@ -174,12 +174,12 @@ static void SerializeField(const LogicalType &type, const AggregateStateField &f
 		const idx_t new_base = base + field.field_offset;
 		for (idx_t field_idx = 0; field_idx < field.children.size(); field_idx++) {
 			SerializeField(child_types[field_idx].second, field.children[field_idx], struct_entries[field_idx], count,
-			               addresses, new_base);
+			               addresses, new_base, offset);
 		}
 		break;
 	}
 	case AggregateFieldKind::PRIMITIVE:
-		TemplateDispatch<StoreOp>(type.InternalType(), result, count, addresses, base + field.field_offset);
+		TemplateDispatch<StoreOp>(type.InternalType(), result, count, addresses, base + field.field_offset, offset);
 		break;
 	case AggregateFieldKind::LIST: {
 		// linked list field: build the result LIST vector from each state's linked list
@@ -194,7 +194,8 @@ static void SerializeField(const LogicalType &type, const AggregateStateField &f
 		const auto &element = field.children[0];
 		if (element.kind != AggregateFieldKind::SORT_KEY) {
 			// elements are stored directly - build the result LIST vector from each state's linked list
-			field.list_functions.BuildLists(linked_lists, result, 0);
+			// (BuildLists appends to the result's child, writing the list entries at [offset, offset + count))
+			field.list_functions.BuildLists(linked_lists, result, offset);
 			break;
 		}
 		// the elements are sort keys: build the physically stored (BLOB) elements into a temporary LIST vector, then
@@ -202,14 +203,15 @@ static void SerializeField(const LogicalType &type, const AggregateStateField &f
 		Vector physical_list(LogicalType::LIST(LogicalType::BLOB), count);
 		field.list_functions.BuildLists(linked_lists, physical_list, 0);
 
-		ListVector::Reserve(result, ListVector::GetListSize(physical_list));
+		// append to the result child, starting after any rows already written at a lower offset
+		idx_t child_offset = ListVector::GetListSize(result);
+		ListVector::Reserve(result, child_offset + ListVector::GetListSize(physical_list));
 		auto &result_child = ListVector::GetChildMutable(result);
 		auto result_entries = FlatVector::GetDataMutable<list_entry_t>(result);
 		const OrderModifiers modifiers(element.sort_key_order, OrderByNullType::NULLS_LAST);
 
-		idx_t child_offset = 0;
 		for (const auto list_entry : physical_list.Values<VectorListType<string_t>>()) {
-			const auto row = list_entry.GetIndex();
+			const auto row = offset + list_entry.GetIndex();
 			if (!list_entry.IsValid()) {
 				// an empty linked list is exported as NULL, matching the finalize semantics of list aggregates
 				FlatVector::SetNull(result, row, true);
@@ -323,18 +325,18 @@ static void DeserializeState(const BoundAggregateFunction &aggr, const Aggregate
 	DeserializeField(layout.type, layout.field, input_vec, count, dest_buffer, layout.total_state_size, 0, allocator);
 }
 
-static void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count,
-                           const data_ptr_t *addresses) {
-	SerializeField(layout.type, layout.field, result, count, addresses, 0);
+static void SerializeState(const AggregateStateLayout &layout, Vector &result, idx_t count, const data_ptr_t *addresses,
+                           idx_t offset) {
+	SerializeField(layout.type, layout.field, result, count, addresses, 0, offset);
 }
 
 static void SerializeState(const BoundAggregateFunction &aggr, optional_ptr<FunctionData> bind_data,
                            const AggregateStateLayout &layout, Vector &states, idx_t count, Vector &result,
-                           ArenaAllocator &allocator) {
+                           ArenaAllocator &allocator, idx_t offset) {
 	if (aggr.HasExportAggregateStateCallback()) {
 		// the aggregate explicitly serializes its own states
 		AggregateFinalizeInputData aggr_input_data(aggr, bind_data, allocator);
-		aggr.GetExportAggregateStateCallback()(states, aggr_input_data, result, count, 0);
+		aggr.GetExportAggregateStateCallback()(states, aggr_input_data, result, count, offset);
 		return;
 	}
 	const data_ptr_t *addresses;
@@ -343,7 +345,7 @@ static void SerializeState(const BoundAggregateFunction &aggr, optional_ptr<Func
 	} else {
 		addresses = FlatVector::GetData<data_ptr_t>(states);
 	}
-	SerializeState(layout, result, count, addresses);
+	SerializeState(layout, result, count, addresses, offset);
 }
 
 // destroys the temporary underlying-aggregate states referenced by `states` (no-op if the aggregate has no
@@ -488,7 +490,7 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 		bind_data.aggr.GetStateCombineCallback()(local_state.addresses0, local_state.addresses1, aggr_input_data,
 		                                         count);
 		SerializeState(bind_data.aggr, bind_data.bind_data.get(), layout, local_state.addresses1, count, result,
-		               local_state.allocator);
+		               local_state.allocator, 0);
 	} catch (...) {
 		destroy_states();
 		throw;
@@ -665,7 +667,6 @@ unique_ptr<FunctionData> BindAggregateState(BindScalarFunctionInput &input) {
 
 void ExportAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result, idx_t count,
                              idx_t offset) {
-	D_ASSERT(offset == 0);
 	const data_ptr_t *addresses_ptrs;
 	if (state.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		if (count != 1) {
@@ -678,8 +679,12 @@ void ExportAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_inp
 
 	auto layout = GetLayout(aggr_input_data.function, aggr_input_data.bind_data);
 
-	result.Flatten();
-	SerializeState(layout, result, count, addresses_ptrs);
+	// only flatten the result the first time it is written - ordered aggregates finalize one group at a time at
+	// increasing offsets, appending into the (already flat) result
+	if (offset == 0) {
+		result.Flatten();
+	}
+	SerializeState(layout, result, count, addresses_ptrs, offset);
 }
 
 // the executor invokes this callback with combine_aggr's own bind data (ExportAggregateBindData) - the underlying
@@ -767,7 +772,8 @@ void CombineAggrFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_d
 	auto layout = GetLayout(underlying_aggr, bind_data.bind_data.get());
 
 	result.Flatten();
-	SerializeState(underlying_aggr, bind_data.bind_data.get(), layout, state, count, result, aggr_input_data.allocator);
+	SerializeState(underlying_aggr, bind_data.bind_data.get(), layout, state, count, result, aggr_input_data.allocator,
+	               0);
 }
 
 // constructs the AGGREGATE_STATE type for the given bound aggregate function

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/list_segment.hpp"
 #include "duckdb/common/types/variant_value.hpp"
 #include "duckdb/function/aggregate_state_layout.hpp"
@@ -331,28 +330,14 @@ static void SerializeState(const AggregateStateLayout &layout, Vector &result, i
 	SerializeField(layout.type, layout.field, result, count, addresses, 0, offset);
 }
 
-// Invokes an aggregate's explicit export-state callback. These callbacks only write at offset 0 - when finalizing at a
-// non-zero offset (e.g. one group at a time through the sorted aggregate wrapper) serialize into a temporary vector and
-// copy the result into place, so every export callback works at an offset without each having to support one.
-static void CallExportStateCallback(AggregateFinalizeInputData &aggr_input_data, Vector &states, idx_t count,
-                                    Vector &result, idx_t offset) {
-	auto callback = aggr_input_data.function.GetExportAggregateStateCallback();
-	if (offset == 0) {
-		callback(states, aggr_input_data, result, count, 0);
-		return;
-	}
-	Vector temp(result.GetType(), count);
-	callback(states, aggr_input_data, temp, count, 0);
-	VectorOperations::Copy(temp, result, count, 0, offset);
-}
-
 static void SerializeState(const BoundAggregateFunction &aggr, optional_ptr<FunctionData> bind_data,
                            const AggregateStateLayout &layout, Vector &states, idx_t count, Vector &result,
                            ArenaAllocator &allocator, idx_t offset) {
 	if (aggr.HasExportAggregateStateCallback()) {
-		// the aggregate explicitly serializes its own states
+		// the aggregate explicitly serializes its own states (the callback writes the count rows at [offset, offset +
+		// count))
 		AggregateFinalizeInputData aggr_input_data(aggr, bind_data, allocator);
-		CallExportStateCallback(aggr_input_data, states, count, result, offset);
+		aggr.GetExportAggregateStateCallback()(states, aggr_input_data, result, count, offset);
 		return;
 	}
 	const data_ptr_t *addresses;
@@ -733,13 +718,6 @@ void ExportAggregateFinalize(Vector &state, AggregateFinalizeInputData &aggr_inp
 	SerializeState(layout, result, count, addresses_ptrs, offset);
 }
 
-// Finalize callback for aggregates that serialize their state through an explicit export callback (e.g. approx_top_k).
-// Routes through CallExportStateCallback so the callback keeps working when finalizing at a non-zero offset.
-void ExportAggregateExplicitFinalize(Vector &state, AggregateFinalizeInputData &aggr_input_data, Vector &result,
-                                     idx_t count, idx_t offset) {
-	CallExportStateCallback(aggr_input_data, state, count, result, offset);
-}
-
 // the executor invokes this callback with combine_aggr's own bind data (ExportAggregateBindData) - the underlying
 // aggregate's combine expects its own bind data, so we forward it here
 void CombineAggrStateCombine(Vector &source, Vector &target, AggregateInputData &aggr_input_data, idx_t count) {
@@ -1098,10 +1076,10 @@ void ToAggregateStateFunction(DataChunk &input, ExpressionState &state, Vector &
 
 void ExportAggregateFunction::SetStateExport(BoundAggregateExpression &aggregate, LogicalType state_layout) {
 	auto &bound_function = aggregate.FunctionMutable();
-	// functions with an explicit export callback use it as the finalize (wrapped so it honors a non-zero offset);
-	// others use the field-based serialization
-	bound_function.SetStateFinalizeCallback(
-	    bound_function.HasExportAggregateStateCallback() ? ExportAggregateExplicitFinalize : ExportAggregateFinalize);
+	// functions with an explicit export callback use it as the finalize; others use the field-based serialization
+	bound_function.SetStateFinalizeCallback(bound_function.HasExportAggregateStateCallback()
+	                                            ? bound_function.GetExportAggregateStateCallback()
+	                                            : ExportAggregateFinalize);
 	// statistics propagation is no longer correct post
 	bound_function.SetStatisticsCallback(nullptr);
 	bound_function.SetReturnType(state_layout);

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -14,10 +14,18 @@
 #include "duckdb/function/window_function.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/enums/order_type.hpp"
 
 namespace duckdb {
 
 class WindowFunctionCatalogEntry;
+
+//! One ORDER BY key of an exported ordered aggregate state: the buffered struct column it sorts on and the modifiers.
+struct SortedAggregateStateOrder {
+	idx_t column;
+	OrderType order_type;
+	OrderByNullType null_order;
+};
 
 //! The FunctionBinder class is responsible for binding functions
 class FunctionBinder {
@@ -138,6 +146,21 @@ public:
 	                                           const vector<unique_ptr<Expression>> &groups,
 	                                           optional_ptr<vector<GroupingSet>> grouping_sets);
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr);
+
+	//! Computes the exported buffer layout of an ordered aggregate: the struct of buffered columns (arguments first,
+	//! then any appended sort keys), the per-key column + modifiers, and the number of leading argument columns.
+	//! Mirrors the matching done by the sorted aggregate bind data so the export type matches the runtime buffer.
+	DUCKDB_API static void GetSortedAggregateStateLayout(const BoundAggregateExpression &expr,
+	                                                     LogicalType &buffer_struct,
+	                                                     vector<SortedAggregateStateOrder> &orders,
+	                                                     idx_t &argument_count);
+	//! Reconstructs a sorted aggregate wrapper from an exported buffer state so finalize/combine operate on the buffer:
+	//! finalize sorts by the keys and runs the (already re-bound) inner aggregate, combine concatenates buffers.
+	//! Returns the wrapper function and its bind data.
+	DUCKDB_API static pair<AggregateFunction, unique_ptr<FunctionData>>
+	BindSortedAggregateState(ClientContext &context, const BoundAggregateFunction &inner_function,
+	                         unique_ptr<FunctionData> inner_bind_info, const LogicalType &buffer_struct,
+	                         const vector<SortedAggregateStateOrder> &orders, idx_t argument_count);
 
 	DUCKDB_API unique_ptr<BoundWindowExpression>
 	BindWindowFunction(const WindowFunction &function, vector<unique_ptr<Expression>> children,

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -182,6 +182,11 @@ public:
 			return false;
 		}
 		auto &expr = expr_p.Cast<BoundAggregateExpression>();
+		// don't rewrite state-export aggregates - list(x ORDER BY x) EXPORT_STATE would become
+		// list_sort(list(x) EXPORT_STATE, ...), which cannot bind list_sort on the AGGREGATE_STATE result
+		if (expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
+			return false;
+		}
 		if (!FunctionMatcher::Match(function, expr.Function().GetName())) {
 			return false;
 		}

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -323,8 +323,7 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		error.Throw();
 	}
 
-	// attach the ORDER BY before binding the state export: an ordered aggregate exports its buffer of values, so its
-	// exported AGGREGATE_STATE type depends on the ORDER BY keys (see ExportAggregateFunction::Bind)
+	// attach the ORDER BY before the state export: an ordered aggregate's exported type depends on the ORDER BY keys
 	aggregate->GetOrderBysMutable() = std::move(order_bys);
 	if (aggr.ExportState()) {
 		aggregate = ExportAggregateFunction::Bind(std::move(aggregate));

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -323,10 +323,12 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		error.Throw();
 	}
 
+	// attach the ORDER BY before binding the state export: an ordered aggregate exports its buffer of values, so its
+	// exported AGGREGATE_STATE type depends on the ORDER BY keys (see ExportAggregateFunction::Bind)
+	aggregate->GetOrderBysMutable() = std::move(order_bys);
 	if (aggr.ExportState()) {
 		aggregate = ExportAggregateFunction::Bind(std::move(aggregate));
 	}
-	aggregate->GetOrderBysMutable() = std::move(order_bys);
 
 	// check for all the aggregates if this aggregate already exists
 	ProjectionIndex aggr_index;

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -79,7 +79,8 @@
         "test/sql/aggregate/aggregate_state_export/first_last_export_state.test",
         "test/sql/aggregate/aggregate_state_export/list_export_state.test",
         "test/sql/aggregate/aggregate_state_export/approx_top_k_export_state.test",
-        "test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test"
+        "test/sql/aggregate/aggregate_state_export/approx_quantile_export_state.test",
+        "test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test"
       ]
     },
     {

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -11,6 +11,7 @@
         "test/optimizer/eager_aggregate_execution_parquet.test",
         "test/optimizer/partial_aggregate_precomputation.test",
         "test/optimizer/test_aggregate_function_rewrite.test",
+        "test/optimizer/ordered_aggregate.test",
         "test/sql/copy/parquet/parquet_glob_cache.test",
         "test/sql/optimizer/expression/test_common_aggregate.test",
         "test/sql/pragma/profiling/test_custom_profiling_row_group_metrics_local_storage.test"

--- a/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
@@ -1,0 +1,144 @@
+# name: test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
+# description: Test EXPORT_STATE for ordered (ORDER BY) aggregates - the sorted aggregate wrapper finalizes one group at a time at increasing offsets
+# group: [aggregate_state_export]
+
+# ordered aggregate finalize is only deterministic single-threaded - with multiple threads the combine order of the
+# thread-local states is arbitrary (relevant for small vector sizes, where even small inputs span many chunks)
+statement ok
+SET threads=1;
+
+# the reported case: list ordered by a different column, grouped (this used to assert offset == 0)
+statement ok
+CREATE TABLE lineitem(l_orderkey BIGINT, l_quantity DECIMAL(15,2), l_shipdate DATE);
+
+statement ok
+INSERT INTO lineitem VALUES (1, 10.0, '1995-01-01'), (2, 5.0, '1995-01-01'), (3, 20.0, '1995-01-02'),
+                            (4, 1.0, '1995-01-02'), (5, 50.0, '1995-01-02');
+
+query II
+SELECT l_shipdate, finalize(list(l_orderkey ORDER BY l_quantity) EXPORT_STATE)
+FROM lineitem GROUP BY l_shipdate ORDER BY l_shipdate;
+----
+1995-01-01	[2, 1]
+1995-01-02	[4, 3, 5]
+
+# ungrouped ordered list export
+query I
+SELECT finalize(list(l_orderkey ORDER BY l_quantity) EXPORT_STATE) FROM lineitem;
+----
+[4, 2, 1, 3, 5]
+
+# ORDER BY the same column as the argument (this path is rewritten to list_sort(list(...)) for non-export aggregates,
+# which must be skipped for EXPORT_STATE)
+query I
+SELECT finalize(list(i ORDER BY i DESC) EXPORT_STATE) FROM (VALUES (1), (3), (2)) t(i);
+----
+[3, 2, 1]
+
+query I
+SELECT finalize(list(i ORDER BY i) EXPORT_STATE) FROM (VALUES (1), (3), (2)) t(i);
+----
+[1, 2, 3]
+
+# the exported state (before finalize) is still the ordered list itself
+query I
+SELECT list(i ORDER BY i DESC) EXPORT_STATE FROM (VALUES (1), (3), (2)) t(i);
+----
+[3, 2, 1]
+
+# NULLS ordering is preserved
+query I
+SELECT finalize(list(i ORDER BY i DESC NULLS LAST) EXPORT_STATE) FROM (VALUES (1), (NULL), (2)) t(i);
+----
+[2, 1, NULL]
+
+query I
+SELECT finalize(list(i ORDER BY i ASC NULLS FIRST) EXPORT_STATE) FROM (VALUES (1), (NULL), (2)) t(i);
+----
+[NULL, 1, 2]
+
+# empty group exports a NULL state
+query I
+SELECT finalize(list(i ORDER BY i) EXPORT_STATE) FROM (SELECT 1 AS i WHERE false) t;
+----
+NULL
+
+# string_agg ordered, grouped
+query II
+SELECT g, finalize(string_agg(v, ',' ORDER BY v) EXPORT_STATE)
+FROM (VALUES (0, 'b'), (0, 'a'), (0, 'c'), (1, 'y'), (1, 'x')) t(g, v) GROUP BY g ORDER BY g;
+----
+0	a,b,c
+1	x,y
+
+# many groups via the regular hash aggregate - ordered export must match the direct ordered aggregate
+statement ok
+CREATE TABLE wide AS SELECT range % 500 AS g, range AS v FROM range(20000);
+
+query I
+SELECT count(*) FROM (
+    SELECT g, list(v ORDER BY v DESC) AS direct FROM wide GROUP BY g
+) d JOIN (
+    SELECT g, finalize(list(v ORDER BY v DESC) EXPORT_STATE) AS exported FROM wide GROUP BY g
+) e USING (g)
+WHERE d.direct IS DISTINCT FROM e.exported;
+----
+0
+
+# many groups via the perfect hash aggregate (small integer keys)
+statement ok
+CREATE TABLE narrow AS SELECT (range % 8)::TINYINT AS g, range AS v FROM range(1000);
+
+query I
+SELECT count(*) FROM (
+    SELECT g, list(v ORDER BY v) AS direct FROM narrow GROUP BY g
+) d JOIN (
+    SELECT g, finalize(list(v ORDER BY v) EXPORT_STATE) AS exported FROM narrow GROUP BY g
+) e USING (g)
+WHERE d.direct IS DISTINCT FROM e.exported;
+----
+0
+
+# large single group - the sorted data spans many vectors
+query II
+SELECT len(l), l[1] FROM (SELECT finalize(list(v ORDER BY v DESC) EXPORT_STATE) l FROM range(5000) t(v));
+----
+5000	4999
+
+# nested types respect the ordering
+query I
+SELECT finalize(list(l ORDER BY k) EXPORT_STATE)
+FROM (VALUES (3, [3]), (1, [1, 2]), (2, NULL)) t(k, l);
+----
+[[1, 2], NULL, [3]]
+
+# we can persist the ordered state and finalize later
+statement ok
+CREATE TABLE ordered_state AS SELECT g, list(v ORDER BY v) EXPORT_STATE l FROM narrow GROUP BY g;
+
+query I
+SELECT count(*) FROM ordered_state os JOIN (
+    SELECT g, list(v ORDER BY v) AS direct FROM narrow GROUP BY g
+) d USING (g)
+WHERE finalize(os.l) IS DISTINCT FROM d.direct;
+----
+0
+
+# combine two ordered exported states (combine concatenates the two states - compare as multisets)
+query I
+SELECT list_sort(finalize(combine(
+    list(i ORDER BY i) EXPORT_STATE,
+    (SELECT list(j ORDER BY j) EXPORT_STATE FROM (VALUES (3), (4)) s(j))
+))) FROM (VALUES (1), (2)) t(i);
+----
+[1, 2, 3, 4]
+
+# combine_aggr across groups of ordered states
+query I
+SELECT list_sort(finalize(combine_aggr(s))) FROM (
+    SELECT list(v ORDER BY v) EXPORT_STATE AS s FROM (VALUES (2), (1)) t(v)
+    UNION ALL
+    SELECT list(v ORDER BY v) EXPORT_STATE AS s FROM (VALUES (4), (3)) t(v)
+) t;
+----
+[1, 2, 3, 4]

--- a/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
@@ -182,6 +182,36 @@ FROM (VALUES (3, [3]), (1, [1, 2]), (2, NULL)) t(k, l);
 ----
 [[1, 2], NULL, [3]]
 
+# the buffered argument is itself a nested type - the buffer struct holds the LIST value alongside the sort key
+query I
+SELECT list(l ORDER BY k) EXPORT_STATE FROM (VALUES ([3, 3], 3), ([1], 1), ([2], 2)) t(l, k);
+----
+[{'v0': [3, 3], 'v1': 3}, {'v0': [1], 'v1': 1}, {'v0': [2], 'v1': 2}]
+
+# ordering by a nested (LIST) sort key
+query I
+SELECT finalize(list(x ORDER BY k) EXPORT_STATE) FROM (VALUES (1, [2]), (2, [1]), (3, [1, 5])) t(x, k);
+----
+[2, 3, 1]
+
+# ordering by a STRUCT, with a STRUCT argument, combined across partitions
+query I
+SELECT finalize(combine(
+    (SELECT list(s ORDER BY s) EXPORT_STATE FROM (VALUES ({'a': 1, 'b': 'x'}), ({'a': 3, 'b': 'z'})) t(s)),
+    (SELECT list(s ORDER BY s) EXPORT_STATE FROM (VALUES ({'a': 2, 'b': 'y'}), ({'a': 4, 'b': 'w'})) t(s))
+));
+----
+[{'a': 1, 'b': x}, {'a': 2, 'b': y}, {'a': 3, 'b': z}, {'a': 4, 'b': w}]
+
+# nested types round-trip through to_aggregate_state
+query I
+SELECT finalize(to_aggregate_state(
+    [{'v0': [3, 3], 'v1': 3}, {'v0': [1], 'v1': 1}, {'v0': [2], 'v1': 2}],
+    'list', ['INTEGER[]'], [NULL], [{'column': 1, 'order': 'ASC NULLS LAST'}]
+));
+----
+[[1], [2], [3, 3]]
+
 # we can persist the ordered state and finalize later
 statement ok
 CREATE TABLE ordered_state AS SELECT g, list(v ORDER BY v) EXPORT_STATE l FROM narrow GROUP BY g;

--- a/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
@@ -246,7 +246,7 @@ query I
 SELECT finalize(to_aggregate_state(
     [{'v0': 'b', 'v1': 2}, {'v0': 'a', 'v1': 1}, {'v0': 'c', 'v1': 3}],
     'string_agg', ['VARCHAR', 'VARCHAR'], [NULL, ' '],
-    [{'column': 1, 'order': 'ASC'}]
+    [{'column': 1, 'order': 'ASC NULLS LAST'}]
 ));
 ----
 a b c
@@ -265,7 +265,7 @@ c|b|a
 query I
 SELECT finalize(to_aggregate_state(
     (SELECT list(x ORDER BY y) EXPORT_STATE FROM (VALUES (10, 1), (30, 3), (20, 2)) t(x, y))::STRUCT(v0 INTEGER, v1 INTEGER)[],
-    'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}]
+    'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC NULLS LAST'}]
 ));
 ----
 [10, 20, 30]
@@ -273,14 +273,14 @@ SELECT finalize(to_aggregate_state(
 # combine of two hand-built ordered states merges the orderings
 query I
 SELECT finalize(combine(
-    to_aggregate_state([{'v0': 1, 'v1': 10}, {'v0': 2, 'v1': 30}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}]),
-    to_aggregate_state([{'v0': 3, 'v1': 20}, {'v0': 4, 'v1': 40}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}])
+    to_aggregate_state([{'v0': 1, 'v1': 10}, {'v0': 2, 'v1': 30}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC NULLS LAST'}]),
+    to_aggregate_state([{'v0': 3, 'v1': 20}, {'v0': 4, 'v1': 40}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC NULLS LAST'}])
 ));
 ----
 [1, 3, 2, 4]
 
 # the ORDER BY argument must reference a valid column
 statement error
-SELECT to_aggregate_state([{'v0': 1, 'v1': 10}], 'list', ['INTEGER'], [NULL], [{'column': 5, 'order': 'ASC'}]);
+SELECT to_aggregate_state([{'v0': 1, 'v1': 10}], 'list', ['INTEGER'], [NULL], [{'column': 5, 'order': 'ASC NULLS LAST'}]);
 ----
 <REGEX>:.*out of range.*

--- a/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/ordered_aggregate_export_state.test
@@ -2,10 +2,9 @@
 # description: Test EXPORT_STATE for ordered (ORDER BY) aggregates - the sorted aggregate wrapper finalizes one group at a time at increasing offsets
 # group: [aggregate_state_export]
 
-# ordered aggregate finalize is only deterministic single-threaded - with multiple threads the combine order of the
-# thread-local states is arbitrary (relevant for small vector sizes, where even small inputs span many chunks)
-statement ok
-SET threads=1;
+# Unlike a plain list(x), an ordered list(x ORDER BY y) is deterministic regardless of the thread count: the sorted
+# aggregate buffers every row of a group and sorts them at finalize, so the combine order of the thread-local states
+# does not affect the result. Every case below orders on a total order (distinct sort keys) so there are no ties.
 
 # the reported case: list ordered by a different column, grouped (this used to assert offset == 0)
 statement ok
@@ -40,11 +39,18 @@ SELECT finalize(list(i ORDER BY i) EXPORT_STATE) FROM (VALUES (1), (3), (2)) t(i
 ----
 [1, 2, 3]
 
-# the exported state (before finalize) is still the ordered list itself
+# the exported state is the buffer of values (with the sort key), kept in insertion order - it is sorted at finalize.
+# here the sort key equals the argument, so the buffer reuses a single column v0
 query I
 SELECT list(i ORDER BY i DESC) EXPORT_STATE FROM (VALUES (1), (3), (2)) t(i);
 ----
-[3, 2, 1]
+[{'v0': 1}, {'v0': 3}, {'v0': 2}]
+
+# the sort key is buffered alongside the argument when it is a different expression (here v0 = i, v1 = the sort key)
+query I
+SELECT list(i ORDER BY i % 2, i) EXPORT_STATE FROM (VALUES (1), (3), (2)) t(i);
+----
+[{'v0': 1, 'v1': 1}, {'v0': 3, 'v1': 1}, {'v0': 2, 'v1': 0}]
 
 # NULLS ordering is preserved
 query I
@@ -63,6 +69,27 @@ SELECT finalize(list(i ORDER BY i) EXPORT_STATE) FROM (SELECT 1 AS i WHERE false
 ----
 NULL
 
+# ordering by the (small-range) group column: the statistics optimizer narrows grp's type after the exported state
+# type is fixed - the buffered sort key must be cast back to its declared type (regression: this crashed with a
+# vector type mismatch). grp is buffered as INTEGER even though it fits in TINYINT
+statement ok
+CREATE TABLE grp_ints(grp INTEGER, i INTEGER);
+
+statement ok
+INSERT INTO grp_ints VALUES (1, 10), (2, 15), (1, 30), (2, 20);
+
+query II
+SELECT grp, first(i ORDER BY grp, i DESC) EXPORT_STATE FROM grp_ints GROUP BY grp ORDER BY grp;
+----
+1	[{'v0': 10, 'v1': 1}, {'v0': 30, 'v1': 1}]
+2	[{'v0': 15, 'v1': 2}, {'v0': 20, 'v1': 2}]
+
+query II
+SELECT grp, finalize(first(i ORDER BY grp, i DESC) EXPORT_STATE) FROM grp_ints GROUP BY grp ORDER BY grp;
+----
+1	30
+2	20
+
 # string_agg ordered, grouped
 query II
 SELECT g, finalize(string_agg(v, ',' ORDER BY v) EXPORT_STATE)
@@ -70,6 +97,49 @@ FROM (VALUES (0, 'b'), (0, 'a'), (0, 'c'), (1, 'y'), (1, 'x')) t(g, v) GROUP BY 
 ----
 0	a,b,c
 1	x,y
+
+# other order-dependent aggregates with a struct/optional state (first/last/any_value) ordered + grouped
+query IIII
+SELECT g, finalize(first(v ORDER BY v) EXPORT_STATE), finalize(last(v ORDER BY v) EXPORT_STATE),
+       finalize(any_value(v ORDER BY v DESC) EXPORT_STATE)
+FROM (VALUES (0, 30), (0, 10), (0, 20), (1, 5), (1, 9)) t(g, v) GROUP BY g ORDER BY g;
+----
+0	10	30	30
+1	5	9	9
+
+# arg_max ordered + grouped
+query II
+SELECT g, finalize(arg_max(v, v ORDER BY v) EXPORT_STATE)
+FROM (VALUES (0, 30), (0, 10), (0, 20), (1, 5), (1, 9)) t(g, v) GROUP BY g ORDER BY g;
+----
+0	30
+1	9
+
+# aggregates with an explicit export callback (approx_top_k / approx_quantile) keep their ORDER BY (they are
+# order-dependent by default), so they are finalized one group at a time through the sorted wrapper - the export
+# callback must honor the non-zero offset. Compare exported+finalized against the direct ordered aggregate.
+statement ok
+CREATE TABLE approx_t AS SELECT (range % 8)::TINYINT AS g, range AS v FROM range(4000);
+
+query I
+SELECT count(*) FROM (
+    SELECT g, list_sort(approx_top_k(v, 5 ORDER BY v)) AS direct FROM approx_t GROUP BY g
+) d JOIN (
+    SELECT g, list_sort(finalize(approx_top_k(v, 5 ORDER BY v) EXPORT_STATE)) AS exported FROM approx_t GROUP BY g
+) e USING (g)
+WHERE d.direct IS DISTINCT FROM e.exported;
+----
+0
+
+query I
+SELECT count(*) FROM (
+    SELECT g, approx_quantile(v, 0.5 ORDER BY v) AS direct FROM approx_t GROUP BY g
+) d JOIN (
+    SELECT g, finalize(approx_quantile(v, 0.5 ORDER BY v) EXPORT_STATE) AS exported FROM approx_t GROUP BY g
+) e USING (g)
+WHERE d.direct IS DISTINCT FROM e.exported;
+----
+0
 
 # many groups via the regular hash aggregate - ordered export must match the direct ordered aggregate
 statement ok
@@ -124,21 +194,93 @@ WHERE finalize(os.l) IS DISTINCT FROM d.direct;
 ----
 0
 
-# combine two ordered exported states (combine concatenates the two states - compare as multisets)
+# combine of two separately-exported ordered states must MERGE the orderings (not just concatenate the two states):
+# the values are interleaved by the sort key across both partitions. Splitting by x is irrelevant to ORDER BY y.
 query I
-SELECT list_sort(finalize(combine(
-    list(i ORDER BY i) EXPORT_STATE,
-    (SELECT list(j ORDER BY j) EXPORT_STATE FROM (VALUES (3), (4)) s(j))
-))) FROM (VALUES (1), (2)) t(i);
+SELECT finalize(combine(
+    (SELECT list(x ORDER BY y) EXPORT_STATE FROM (VALUES (1, 10), (2, 30)) t(x, y)),
+    (SELECT list(x ORDER BY y) EXPORT_STATE FROM (VALUES (3, 20), (4, 40)) t(x, y))
+));
 ----
-[1, 2, 3, 4]
+[1, 3, 2, 4]
 
-# combine_aggr across groups of ordered states
+# string_agg combine_aggr - the reported case: the result is globally ordered by the sort key regardless of how the
+# input was partitioned across the two states (this used to ignore the ORDER BY and just concatenate)
 query I
-SELECT list_sort(finalize(combine_aggr(s))) FROM (
+SELECT finalize(combine_aggr(state)) FROM (
+    SELECT string_agg(v, ' ' ORDER BY i) EXPORT_STATE AS state FROM (VALUES ('c', 2), ('d', 2)) t(v, i)
+    UNION ALL
+    SELECT string_agg(v, ' ' ORDER BY i) EXPORT_STATE AS state FROM (VALUES ('a', 1), ('b', 1)) t(v, i)
+);
+----
+a b c d
+
+# combine of two ordered states equals the direct ordered aggregate over the union, across many random partitions
+statement ok
+CREATE TABLE parts AS SELECT (range * 2654435761) % 1000 AS x, ((range * 40503) % 97) AS y, range % 2 AS part
+FROM range(4000);
+
+query I
+SELECT count(*) FROM (
+    SELECT finalize(combine(a.s, b.s)) AS combined FROM
+        (SELECT list(x ORDER BY y, x) EXPORT_STATE AS s FROM parts WHERE part = 0) a,
+        (SELECT list(x ORDER BY y, x) EXPORT_STATE AS s FROM parts WHERE part = 1) b
+) c, (SELECT list(x ORDER BY y, x) AS direct FROM parts) d
+WHERE c.combined IS DISTINCT FROM d.direct;
+----
+0
+
+# combine_aggr across groups of ordered states, order preserved
+query I
+SELECT finalize(combine_aggr(s)) FROM (
     SELECT list(v ORDER BY v) EXPORT_STATE AS s FROM (VALUES (2), (1)) t(v)
     UNION ALL
     SELECT list(v ORDER BY v) EXPORT_STATE AS s FROM (VALUES (4), (3)) t(v)
 ) t;
 ----
 [1, 2, 3, 4]
+
+# to_aggregate_state reconstructs an ordered aggregate state from a hand-built buffer of values: the 5th argument is
+# the ORDER BY spec as a list of {column, order} structs (column = the buffered struct column the key sorts on)
+query I
+SELECT finalize(to_aggregate_state(
+    [{'v0': 'b', 'v1': 2}, {'v0': 'a', 'v1': 1}, {'v0': 'c', 'v1': 3}],
+    'string_agg', ['VARCHAR', 'VARCHAR'], [NULL, ' '],
+    [{'column': 1, 'order': 'ASC'}]
+));
+----
+a b c
+
+# the modifier string controls order and null placement; the constant separator is supplied as the 4th argument
+query I
+SELECT finalize(to_aggregate_state(
+    [{'v0': 'b', 'v1': 2}, {'v0': 'a', 'v1': 1}, {'v0': 'c', 'v1': 3}],
+    'string_agg', ['VARCHAR', 'VARCHAR'], [NULL, '|'],
+    [{'column': 1, 'order': 'DESC NULLS LAST'}]
+));
+----
+c|b|a
+
+# a state exported from an ordered aggregate round-trips back through to_aggregate_state
+query I
+SELECT finalize(to_aggregate_state(
+    (SELECT list(x ORDER BY y) EXPORT_STATE FROM (VALUES (10, 1), (30, 3), (20, 2)) t(x, y))::STRUCT(v0 INTEGER, v1 INTEGER)[],
+    'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}]
+));
+----
+[10, 20, 30]
+
+# combine of two hand-built ordered states merges the orderings
+query I
+SELECT finalize(combine(
+    to_aggregate_state([{'v0': 1, 'v1': 10}, {'v0': 2, 'v1': 30}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}]),
+    to_aggregate_state([{'v0': 3, 'v1': 20}, {'v0': 4, 'v1': 40}], 'list', ['INTEGER'], [NULL], [{'column': 1, 'order': 'ASC'}])
+));
+----
+[1, 3, 2, 4]
+
+# the ORDER BY argument must reference a valid column
+statement error
+SELECT to_aggregate_state([{'v0': 1, 'v1': 10}], 'list', ['INTEGER'], [NULL], [{'column': 5, 'order': 'ASC'}]);
+----
+<REGEX>:.*out of range.*

--- a/test/sql/aggregate/aggregates/approx_top_k.test
+++ b/test/sql/aggregate/aggregates/approx_top_k.test
@@ -55,3 +55,22 @@ statement error
 select approx_top_k(i, NULL) from range(5) t(i)
 ----
 NULL
+
+# ordered approx_top_k with grouping - the sorted aggregate wrapper finalizes one group at a time at increasing
+# offsets, so ApproxTopKFinalize must honor a non-zero offset (regression: it used to crash on the second group)
+statement ok
+CREATE TABLE ordered_groups AS SELECT (i % 8)::TINYINT AS g, i AS v FROM range(4000) t(i);
+
+query I
+SELECT count(*) FROM (
+    SELECT g, list_sort(approx_top_k(v, 5 ORDER BY v)) AS ordered,
+              list_sort(approx_top_k(v, 5)) AS unordered
+    FROM ordered_groups GROUP BY g
+) WHERE ordered IS DISTINCT FROM unordered;
+----
+0
+
+query I
+SELECT g FROM (SELECT g, approx_top_k(v, 3 ORDER BY v DESC) k FROM ordered_groups GROUP BY g)
+WHERE len(k) <> 3;
+----


### PR DESCRIPTION
This PR adds support for state export to ordered aggregates. Now that they follow the list infrastructure (https://github.com/duckdb/duckdb/pull/23231) this is relatively straightforward as we can already export/import their intermediate state using the generic state export/import code. 

The aggregate state is a `list` of structs, where the struct holds all columns required by the aggregate and the order by. For example:

```sql
-- required columns are "l_comment", "l_orderkey"
select string_agg(l_comment order by l_orderkey) export_state from lineitem group by l_shipdate limit 5;
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                      string_agg(l_comment ORDER BY l_orderkey) EXPORT_STATE                                      │
│                                                         aggregate_state                                                          │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [{'v0': usual instructions. slyly fi, 'v1': 5601}]                                                                               │
│ [{'v0': ' carefully. i', 'v1': 5409}]                                                                                            │
│ [{'v0': ' carefully aroun', 'v1': 4800}]                                                                                         │
│ [{'v0': 'play. special, regular pint', 'v1': 3712}]                                                                              │
│ [{'v0': 'kages. blithe, c', 'v1': 1248}, {'v0': carefully final instr, 'v1': 3271}, {'v0': furiously furiously eve, 'v1': 5382}] │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

The main challenge then lies in the (re)-binding of the ordered aggregates. Effectively this expands the function signature that is held in the aggregate state with an `ORDER BY` clause:

```cpp
ext_info->properties.emplace("order_bys", Value::LIST(OrderByEntryType(), std::move(order_values)));
```

For `to_aggregate_state`, we get an extra parameter to define these order terms, with the columns referenced by offset:

```sql
select finalize(to_aggregate_state([{'v0': 'world', 'v1': 2}, {'v0': 'hello', 'v1': 1}], 'string_agg', ['VARCHAR'], [NULL], [{'column': 1, 'order': 'ASC NULLS LAST'}])) as result;
┌─────────────┐
│   result    │
│   varchar   │
├─────────────┤
│ hello,world │
└─────────────┘
```

When a column is used both as an argument to the aggregate function, and as a condition in the `ORDER BY` clause, it is contained only once in the list. For example:

```sql
select string_agg(l_comment order by l_comment) export_state from lineitem group by l_shipdate limit 3;
┌───────────────────────────────────────────────────────┐
│ string_agg(l_comment ORDER BY l_comment) EXPORT_STATE │
│                    aggregate_state                    │
├───────────────────────────────────────────────────────┤
│ [{'v0': usual instructions. slyly fi}]                │
│ [{'v0': ' carefully. i'}]                             │
│ [{'v0': ' carefully aroun'}]                          │
└───────────────────────────────────────────────────────┘
```

Similarly we can then define the `ORDER BY` term to just refer to the first column. The column will then be both part of the aggregate and part of the `ORDER BY` clause:

```sql
select finalize(to_aggregate_state([{'v0': 'world'}, {'v0': 'hello'}], 'string_agg', ['VARCHAR'], [NULL], [{'column': 0, 'order': 'ASC NULLS LAST'}])) as result;
┌─────────────┐
│   result    │
│   varchar   │
├─────────────┤
│ hello,world │
└─────────────┘
```
