### PR TITLE
CLI: mode .trash should not force result materialization 

### DIFF
--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1722,7 +1722,8 @@ public:
 		return SuccessState::SUCCESS;
 	}
 	bool RequireMaterializedResult() const override {
-		return true;
+		// mode trash discards the result
+		return false;
 	}
 	bool ShouldUsePager(RenderingQueryResult &result, PagerMode global_mode) override {
 		// mode trash never uses the pager


### PR DESCRIPTION
Don't let `.mode trash` pay the full cost of materializing the query result into memory before the renderer throws it all away.

The trash renderer's purpose is to suppress output and forcing materialization even for the simplest stream-able queries undermines its utility in, e.g., benchmarking.

With this change, the following streaming query runs flawlessly again (as it did in 1.4.x):

```sql
ATTACH 'tpch-sf100.db' AS tpch;
USE tpch;
SET memory_limit = '2MB';
SET max_temp_directory_size = '0MB';

.mode trash

-- Streaming filtering+projection
SELECT l_quantity * 10
FROM   lineitem;
```

Without this change, the query fails with OOM on DuckDB 1.5.4 (however, it does work with `.mode line` which also foregoes materialization).