### PR TITLE
check for interrupt state in ExecuteTaskInternal

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -738,7 +738,8 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	bool invalidate_transaction = true;
 	try {
 		// Surface a pending interrupt even when this thread runs no task that reaches InterruptCheck.
-		if (!dry_run && interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
+		// IsInterrupted() rather than InterruptCheck(): we must not enforce query_deadline here.
+		if (!dry_run && IsInterrupted()) {
 			throw InterruptException();
 		}
 		auto query_result = active_query->executor->ExecuteTask(dry_run);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -737,6 +737,10 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	D_ASSERT(active_query->IsOpenResult(result));
 	bool invalidate_transaction = true;
 	try {
+		// Surface a pending interrupt even when this thread runs no task that reaches InterruptCheck.
+		if (!dry_run && interrupt_state.load(std::memory_order_relaxed) == ClientInterruptState::INTERRUPTED) {
+			throw InterruptException();
+		}
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
 		if (active_query->progress_bar) {
 			auto is_finished = PendingQueryResult::IsResultReady(query_result);

--- a/test/api/test_pending_query.cpp
+++ b/test/api/test_pending_query.cpp
@@ -223,6 +223,39 @@ TEST_CASE("PROBE cancel a streaming producer parked on a full buffer", "[api][.]
 	}
 }
 
+TEST_CASE("Interrupt is observed by PendingQueryResult::ExecuteTask", "[api]") {
+	DuckDB db;
+	Connection con(db);
+
+	// Single thread + tiny streaming buffer make the parked-collector RESULT_READY state reachable fast.
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+	REQUIRE_NO_FAIL(con.Query("SET streaming_buffer_size='16KB'"));
+
+	auto pending = con.PendingQuery("SELECT * FROM range(10000000)", true);
+	REQUIRE(!pending->HasError());
+
+	PendingExecutionResult state = PendingExecutionResult::RESULT_NOT_READY;
+	for (idx_t i = 0; i < 1000000; i++) {
+		state = pending->ExecuteTask();
+		if (state == PendingExecutionResult::RESULT_READY || state == PendingExecutionResult::EXECUTION_ERROR) {
+			break;
+		}
+	}
+	REQUIRE(state == PendingExecutionResult::RESULT_READY);
+
+	con.Interrupt();
+
+	// Without the fix the parked collector keeps reporting RESULT_READY and the interrupt is never seen.
+	bool saw_error = false;
+	for (idx_t j = 0; j < 1000; j++) {
+		if (pending->ExecuteTask() == PendingExecutionResult::EXECUTION_ERROR) {
+			saw_error = true;
+			break;
+		}
+	}
+	REQUIRE(saw_error);
+}
+
 static void parallel_pending_query(Connection *conn, bool *correct, size_t threadnr) {
 	correct[threadnr] = true;
 	for (size_t i = 0; i < 100; i++) {


### PR DESCRIPTION
`PendingQueryResult::ExecuteTask` would only see that it was interrupted if there was a task available for execution. Which wouldn't happen if e.g. a streaming result has a full buffer. ExecuteTask would just keep returning RESULT_READY as long as nothing consumes the result.

the fix here is to check for the interrupt state top level, in ExecuteTask directly (same as in `SimpleBufferedData::ExecuteTaskInternal`)