### PR TITLE
Make list aggregate append work on batches of rows instead of per rows and implement cluster update function

### DIFF
--- a/benchmark/micro/aggregate/list_aggregate_grouped.benchmark
+++ b/benchmark/micro/aggregate/list_aggregate_grouped.benchmark
@@ -1,0 +1,22 @@
+# name: benchmark/micro/aggregate/list_aggregate_grouped.benchmark
+# description: Grouped list() aggregate with few groups (clustered grouped hash-table path)
+# group: [aggregate]
+
+name List Aggregate (Grouped)
+group aggregate
+
+load
+CREATE TABLE integers AS SELECT i, i % 8 AS g FROM range(0, 10000000) tbl(i);
+
+run
+SELECT g, len(list(i)) FROM integers GROUP BY g ORDER BY g
+
+result II
+0	1250000
+1	1250000
+2	1250000
+3	1250000
+4	1250000
+5	1250000
+6	1250000
+7	1250000

--- a/benchmark/micro/aggregate/list_aggregate_ungrouped.benchmark
+++ b/benchmark/micro/aggregate/list_aggregate_ungrouped.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/aggregate/list_aggregate_ungrouped.benchmark
+# description: Ungrouped list() aggregate over many rows (clustered single-run batch append)
+# group: [aggregate]
+
+name List Aggregate (Ungrouped)
+group aggregate
+
+load
+CREATE TABLE integers AS SELECT i FROM range(0, 10000000) tbl(i);
+
+run
+SELECT len(list(i)) FROM integers
+
+result I
+10000000

--- a/benchmark/micro/aggregate/list_aggregate_ungrouped_varchar.benchmark
+++ b/benchmark/micro/aggregate/list_aggregate_ungrouped_varchar.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/aggregate/list_aggregate_ungrouped_varchar.benchmark
+# description: Ungrouped list() aggregate over many VARCHAR rows (clustered single-run batch append)
+# group: [aggregate]
+
+name List Aggregate VARCHAR (Ungrouped)
+group aggregate
+
+load
+CREATE TABLE strings AS SELECT 'string_' || (i % 1000)::VARCHAR AS s FROM range(0, 10000000) tbl(i);
+
+run
+SELECT len(list(s)) FROM strings
+
+result I
+10000000

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -28,7 +28,8 @@ AggregateFunction ListFun::GetFunction() {
 	auto func = AggregateFunction({LogicalType::TEMPLATE("T")}, LogicalType::LIST(LogicalType::TEMPLATE("T")),
 	                              AggregateFunction::StateSize<ListAggState>,
 	                              AggregateFunction::StateInitialize<ListAggState, ListFunction>, ListUpdateFunction<>,
-	                              ListCombineFunction<ListFunction>, ListFinalize, nullptr, nullptr, nullptr, nullptr);
+	                              ListCombineFunction<ListFunction>, ListFinalize, ListClusterUpdate<>, nullptr,
+	                              nullptr, nullptr);
 	AggregateFunction::WireStructStateType<ListAggState>(func);
 
 	return func;

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -248,102 +248,117 @@ static ListSegment *GetSegment(const ListSegmentFunctions &functions, ArenaAlloc
 //===--------------------------------------------------------------------===//
 template <class T>
 static void WriteDataToPrimitiveSegment(const ListSegmentFunctions &, ArenaAllocator &, ListSegment *segment,
-                                        RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
-
-	// write null validity
+                                        RecursiveUnifiedVectorFormat &input_data, idx_t offset, idx_t count) {
 	auto null_mask = GetNullMask(segment);
-	auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
-	null_mask[segment->count] = !valid;
+	auto segment_data = GetPrimitiveData<T>(segment);
+	auto input_data_ptr = UnifiedVectorFormat::GetData<T>(input_data.unified);
 
-	// write value
-	if (valid) {
-		auto segment_data = GetPrimitiveData<T>(segment);
-		auto input_data_ptr = UnifiedVectorFormat::GetData<T>(input_data.unified);
-		Store<T>(input_data_ptr[sel_entry_idx], data_ptr_cast(segment_data + segment->count));
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_entry_idx = input_data.unified.sel->get_index(offset + i);
+		auto target_idx = segment->count + i;
+
+		// write null validity
+		auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
+		null_mask[target_idx] = !valid;
+
+		// write value
+		if (valid) {
+			Store<T>(input_data_ptr[sel_entry_idx], data_ptr_cast(segment_data + target_idx));
+		}
 	}
 }
 
 static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
-                                      ListSegment *segment, RecursiveUnifiedVectorFormat &input_data,
-                                      idx_t &entry_idx) {
-	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
-
-	// write null validity
+                                      ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t offset,
+                                      idx_t count) {
 	auto null_mask = GetNullMask(segment);
-	auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
-	null_mask[segment->count] = !valid;
-
-	// set the length of this string
 	auto str_length_data = GetListLengthData(segment);
+	auto input_strings = UnifiedVectorFormat::GetData<string_t>(input_data.unified);
 
-	// we can reconstruct the offset from the length
-	if (!valid) {
-		Store<uint64_t>(0, data_ptr_cast(str_length_data + segment->count));
-		return;
-	}
-	auto &str_entry = UnifiedVectorFormat::GetData<string_t>(input_data.unified)[sel_entry_idx];
-	auto str_data = str_entry.GetData();
-	idx_t str_size = str_entry.GetSize();
-	Store<uint64_t>(str_size, data_ptr_cast(str_length_data + segment->count));
-
-	// write the characters to the linked list of child segments
+	// load the linked list of child segments once, and store it back after writing all strings
 	auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
-	idx_t current_offset = 0;
-	while (current_offset < str_size) {
-		auto child_segment = GetSegment(functions.child_functions.back(), allocator, child_segments);
-		auto data = GetStringData(child_segment);
-		idx_t copy_count = MinValue<idx_t>(str_size - current_offset, child_segment->capacity - child_segment->count);
-		memcpy(data + child_segment->count, str_data + current_offset, copy_count);
-		current_offset += copy_count;
-		child_segment->count += copy_count;
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_entry_idx = input_data.unified.sel->get_index(offset + i);
+		auto target_idx = segment->count + i;
+
+		// write null validity
+		auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
+		null_mask[target_idx] = !valid;
+
+		// we can reconstruct the offset from the length
+		if (!valid) {
+			Store<uint64_t>(0, data_ptr_cast(str_length_data + target_idx));
+			continue;
+		}
+
+		// set the length of this string
+		auto &str_entry = input_strings[sel_entry_idx];
+		auto str_data = str_entry.GetData();
+		idx_t str_size = str_entry.GetSize();
+		Store<uint64_t>(str_size, data_ptr_cast(str_length_data + target_idx));
+
+		// write the characters to the linked list of child segments
+		idx_t current_offset = 0;
+		while (current_offset < str_size) {
+			auto child_segment = GetSegment(functions.child_functions.back(), allocator, child_segments);
+			auto data = GetStringData(child_segment);
+			idx_t copy_count =
+			    MinValue<idx_t>(str_size - current_offset, child_segment->capacity - child_segment->count);
+			memcpy(data + child_segment->count, str_data + current_offset, copy_count);
+			current_offset += copy_count;
+			child_segment->count += copy_count;
+		}
+		child_segments.total_capacity += str_size;
 	}
-	child_segments.total_capacity += str_size;
 	// store the updated linked list
 	Store<LinkedList>(child_segments, data_ptr_cast(GetListChildData(segment)));
 }
 
 static void WriteDataToListSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
-                                   ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
-
-	// write null validity
+                                   ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t offset,
+                                   idx_t count) {
 	auto null_mask = GetNullMask(segment);
-	auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
-	null_mask[segment->count] = !valid;
-
-	// set the length of this list
 	auto list_length_data = GetListLengthData(segment);
-	uint64_t list_length = 0;
+	auto input_lists = UnifiedVectorFormat::GetData<list_entry_t>(input_data.unified);
 
-	if (valid) {
-		// get list entry information
-		const auto &list_entry = UnifiedVectorFormat::GetData<list_entry_t>(input_data.unified)[sel_entry_idx];
-		list_length = list_entry.length;
+	D_ASSERT(functions.child_functions.size() == 1);
+	// load the linked list of child segments once, and store it back after writing all lists
+	auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_entry_idx = input_data.unified.sel->get_index(offset + i);
+		auto target_idx = segment->count + i;
 
-		// loop over the child vector entries and recurse on them
-		auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
-		D_ASSERT(functions.child_functions.size() == 1);
-		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
-			auto source_idx_child = list_entry.offset + child_idx;
-			functions.child_functions[0].AppendRow(allocator, child_segments, input_data.children.back(),
-			                                       source_idx_child);
+		// write null validity
+		auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
+		null_mask[target_idx] = !valid;
+
+		// set the length of this list
+		uint64_t list_length = 0;
+		if (valid) {
+			// get list entry information
+			const auto &list_entry = input_lists[sel_entry_idx];
+			list_length = list_entry.length;
+
+			// recurse on the child vector entries of this list
+			functions.child_functions[0].AppendRows(allocator, child_segments, input_data.children.back(),
+			                                        list_entry.offset, list_entry.length);
 		}
-		// store the updated linked list
-		Store<LinkedList>(child_segments, data_ptr_cast(GetListChildData(segment)));
+		Store<uint64_t>(list_length, data_ptr_cast(list_length_data + target_idx));
 	}
-
-	Store<uint64_t>(list_length, data_ptr_cast(list_length_data + segment->count));
+	// store the updated linked list
+	Store<LinkedList>(child_segments, data_ptr_cast(GetListChildData(segment)));
 }
 
 static void WriteDataToStructSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
-                                     ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
-
+                                     ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t offset,
+                                     idx_t count) {
 	// write null validity
 	auto null_mask = GetNullMask(segment);
-	auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
-	null_mask[segment->count] = !valid;
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_entry_idx = input_data.unified.sel->get_index(offset + i);
+		auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
+		null_mask[segment->count + i] = !valid;
+	}
 
 	// write value
 	D_ASSERT(input_data.children.size() == functions.child_functions.size());
@@ -353,50 +368,58 @@ static void WriteDataToStructSegment(const ListSegmentFunctions &functions, Aren
 	for (idx_t i = 0; i < input_data.children.size(); i++) {
 		auto child_list_segment = Load<ListSegment *>(data_ptr_cast(child_list + i));
 		auto &child_function = functions.child_functions[i];
-		child_function.write_data(child_function, allocator, child_list_segment, input_data.children[i], entry_idx);
-		child_list_segment->count++;
+		child_function.write_data(child_function, allocator, child_list_segment, input_data.children[i], offset, count);
+		child_list_segment->count += count;
 	}
 }
 
 static void WriteDataToArraySegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
-                                    ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
-
-	// write null validity
+                                    ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t offset,
+                                    idx_t count) {
 	auto null_mask = GetNullMask(segment);
-	auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
-	null_mask[segment->count] = !valid;
-
-	// Arrays require there to be values in the child even when the entry is NULL.
 	auto array_size = ArrayType::GetSize(input_data.logical_type);
-	auto array_offset = sel_entry_idx * array_size;
 
-	auto child_segments = Load<LinkedList>(data_ptr_cast(GetArrayChildData(segment)));
 	D_ASSERT(functions.child_functions.size() == 1);
-	for (idx_t elem_idx = array_offset; elem_idx < array_offset + array_size; elem_idx++) {
-		functions.child_functions[0].AppendRow(allocator, child_segments, input_data.children.back(), elem_idx);
+	// load the linked list of child segments once, and store it back after writing all arrays
+	auto child_segments = Load<LinkedList>(data_ptr_cast(GetArrayChildData(segment)));
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_entry_idx = input_data.unified.sel->get_index(offset + i);
+
+		// write null validity
+		auto valid = input_data.unified.validity.RowIsValid(sel_entry_idx);
+		null_mask[segment->count + i] = !valid;
+
+		// Arrays require there to be values in the child even when the entry is NULL.
+		auto array_offset = sel_entry_idx * array_size;
+		functions.child_functions[0].AppendRows(allocator, child_segments, input_data.children.back(), array_offset,
+		                                        array_size);
 	}
 	// store the updated linked list
 	Store<LinkedList>(child_segments, data_ptr_cast(GetArrayChildData(segment)));
 }
 
-void ListSegmentFunctions::AppendRow(ArenaAllocator &allocator, LinkedList &linked_list,
-                                     RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) const {
+void ListSegmentFunctions::AppendRows(ArenaAllocator &allocator, LinkedList &linked_list,
+                                      RecursiveUnifiedVectorFormat &input_data, idx_t offset, idx_t count) const {
 	auto &write_data_to_segment = *this;
-	auto segment = GetSegment(write_data_to_segment, allocator, linked_list);
-	write_data_to_segment.write_data(write_data_to_segment, allocator, segment, input_data, entry_idx);
+	idx_t appended = 0;
+	while (appended < count) {
+		// write into the last segment, filling it up to its capacity before moving to a new one
+		auto segment = GetSegment(write_data_to_segment, allocator, linked_list);
+		auto append_count = MinValue<idx_t>(count - appended, segment->capacity - segment->count);
+		write_data_to_segment.write_data(write_data_to_segment, allocator, segment, input_data, offset + appended,
+		                                 append_count);
 
-	linked_list.total_capacity++;
-	segment->count++;
+		segment->count = NumericCast<uint16_t>(segment->count + append_count);
+		linked_list.total_capacity += append_count;
+		appended += append_count;
+	}
 }
 
 void ListSegmentFunctions::AppendListEntry(ArenaAllocator &allocator, LinkedList &linked_list,
                                            RecursiveUnifiedVectorFormat &child_data,
                                            const list_entry_t &list_entry) const {
-	for (idx_t child_idx = list_entry.offset; child_idx < list_entry.offset + list_entry.length; child_idx++) {
-		allocator.AlignNext();
-		AppendRow(allocator, linked_list, child_data, child_idx);
-	}
+	allocator.AlignNext();
+	AppendRows(allocator, linked_list, child_data, list_entry.offset, list_entry.length);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/types/list_segment.hpp
+++ b/src/include/duckdb/common/types/list_segment.hpp
@@ -47,8 +47,8 @@ struct ListSegmentFunctions;
 typedef ListSegment *(*create_segment_t)(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
                                          uint16_t capacity);
 typedef void (*write_data_to_segment_t)(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
-                                        ListSegment *segment, RecursiveUnifiedVectorFormat &input_data,
-                                        idx_t &entry_idx);
+                                        ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t offset,
+                                        idx_t count);
 //! Scans up to "count" rows from the state's current position into the result vector at result_offset,
 //! advancing the state - returns the number of rows scanned (less than "count" only if the scan is exhausted)
 typedef idx_t (*scan_data_t)(const ListSegmentFunctions &functions, ListSegmentScanState &state, idx_t count,
@@ -62,8 +62,9 @@ struct ListSegmentFunctions {
 
 	vector<ListSegmentFunctions> child_functions;
 
-	void AppendRow(ArenaAllocator &allocator, LinkedList &linked_list, RecursiveUnifiedVectorFormat &input_data,
-	               idx_t &entry_idx) const;
+	//! Append "count" rows of input_data (starting at "offset") to the linked list
+	void AppendRows(ArenaAllocator &allocator, LinkedList &linked_list, RecursiveUnifiedVectorFormat &input_data,
+	                idx_t offset, idx_t count) const;
 	//! Append all rows of the given list entry (indexing into child_data) to the linked list
 	void AppendListEntry(ArenaAllocator &allocator, LinkedList &linked_list, RecursiveUnifiedVectorFormat &child_data,
 	                     const list_entry_t &list_entry) const;

--- a/src/include/duckdb/function/aggregate/list_aggregate.hpp
+++ b/src/include/duckdb/function/aggregate/list_aggregate.hpp
@@ -55,7 +55,47 @@ inline void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_d
 		}
 		auto &state = *states[i].GetValue();
 		aggr_input_data.allocator.AlignNext();
-		functions.AppendRow(aggr_input_data.allocator, state.linked_list, input_data, i);
+		functions.AppendRows(aggr_input_data.allocator, state.linked_list, input_data, i, 1);
+	}
+}
+
+//! Clustered variant of ListUpdateFunction - appends the rows of each run to that run's state.
+//! Contiguous runs are appended in a single batch; scattered runs are appended row by row.
+template <bool IGNORE_NULLS = false>
+inline void ListClusterUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
+                              const ClusteredAggr &clustered, idx_t count) {
+	D_ASSERT(input_count == 1);
+	auto &input = inputs[0];
+	RecursiveUnifiedVectorFormat input_data;
+	Vector::RecursiveToUnifiedFormat(input, input_data);
+
+	ListSegmentFunctions functions;
+	GetSegmentDataFunctions(functions, input.GetType());
+
+	for (idx_t run_idx = 0; run_idx < clustered.n_group_runs; run_idx++) {
+		auto &run = clustered.group_runs[run_idx];
+		auto &state = *reinterpret_cast<ListAggState *>(run.state);
+		auto run_sel = run.sel;
+
+		if (!IGNORE_NULLS && !run_sel) {
+			// contiguous run covering [0, run.count) without NULL filtering - append in a single batch
+			aggr_input_data.allocator.AlignNext();
+			functions.AppendRows(aggr_input_data.allocator, state.linked_list, input_data, 0, run.count);
+			continue;
+		}
+
+		// scattered run and/or NULL filtering - append the rows one by one
+		for (idx_t k = 0; k < run.count; k++) {
+			idx_t entry_idx = run_sel ? run_sel[k] : k;
+			if (IGNORE_NULLS) {
+				const auto idx = input_data.unified.sel->get_index(entry_idx);
+				if (!input_data.unified.validity.RowIsValid(idx)) {
+					continue;
+				}
+			}
+			aggr_input_data.allocator.AlignNext();
+			functions.AppendRows(aggr_input_data.allocator, state.linked_list, input_data, entry_idx, 1);
+		}
 	}
 }
 


### PR DESCRIPTION
This improves performance of the attached ungrouped `list` benchmark by ~40%:

```sql
SELECT len(list(i)) FROM integers
```