### PR TITLE
[SqllogicTester] Add `--stdin` option to read statements from stdin

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -200,6 +200,12 @@ jobs:
         run: |
           python -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
+      - name: Unittest Stdin Tests
+        shell: bash
+        if: ${{ !inputs.skip_tests }}
+        run: |
+          python -m pytest tools/sqllogic/tests --unittest-binary build/release/test/unittest
+
       - name: Examples
         shell: bash
         if: ${{ !inputs.skip_tests }}

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -32,6 +32,7 @@
 namespace duckdb {
 
 void RegisterSqllogictests();
+void RegisterSqllogictestStdin();
 bool SummarizeFailures();
 
 void DeleteDatabase(string path);

--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -6,18 +6,24 @@
 namespace duckdb {
 
 bool SQLLogicParser::OpenFile(const string &path) {
-	this->file_name = path;
-
-	std::ifstream infile(file_name);
-	if (infile.bad() || infile.fail()) {
+	auto infile = make_uniq<std::ifstream>(path);
+	if (infile->bad() || infile->fail()) {
 		return false;
 	}
+	owned_stream = std::move(infile);
+	return OpenStream(*owned_stream, path);
+}
 
-	string line;
-	while (std::getline(infile, line)) {
-		lines.push_back(StringUtil::Replace(line, "\r", ""));
-	}
-	return !infile.bad();
+bool SQLLogicParser::OpenStream(std::istream &input, const string &source_name) {
+	file_name = source_name;
+	stream = &input;
+	stream_finished = false;
+	current_line = 0;
+	line_start = 0;
+	lines.clear();
+	seen_statement = false;
+	current_include.reset();
+	return !stream->bad() && !stream->fail();
 }
 
 void SQLLogicParser::IncludeFile(const string &file_name) {
@@ -33,14 +39,49 @@ bool SQLLogicParser::EmptyOrComment(const string &line) {
 	return line.empty() || StringUtil::StartsWith(line, "#");
 }
 
+bool SQLLogicParser::HasLine(idx_t line_idx) {
+	if (line_idx < line_start) {
+		return false;
+	}
+	while (!stream_finished && line_idx >= line_start + lines.size()) {
+		if (!stream || !stream->good()) {
+			stream_finished = true;
+			break;
+		}
+		string line;
+		if (!std::getline(*stream, line)) {
+			stream_finished = true;
+			break;
+		}
+		lines.push_back(StringUtil::Replace(line, "\r", ""));
+	}
+	return line_idx >= line_start && line_idx < line_start + lines.size();
+}
+
+string &SQLLogicParser::GetLine(idx_t line_idx) {
+	if (!HasLine(line_idx)) {
+		Fail("Unexpected end of file");
+	}
+	return lines[line_idx - line_start];
+}
+
+void SQLLogicParser::PruneLines() {
+	if (current_line <= line_start || lines.empty()) {
+		return;
+	}
+	auto prune_count = MinValue<idx_t>(current_line - line_start, lines.size());
+	lines.erase(lines.begin(), lines.begin() + prune_count);
+	line_start += prune_count;
+}
+
 bool SQLLogicParser::NextLineEmptyOrComment() {
 	if (current_include) {
 		return current_include->NextLineEmptyOrComment();
 	}
-	if (current_line + 1 >= lines.size()) {
+	if (!HasLine(current_line + 1)) {
 		return true;
 	} else {
-		return EmptyOrComment(lines[current_line + 1]);
+		return EmptyOrComment(GetLine(current_line + 1));
 	}
 }
 
@@ -56,17 +97,18 @@ bool SQLLogicParser::NextStatement() {
 	if (seen_statement) {
 		// skip the current statement
 		// but only if we have already seen a statement in the file
-		while (current_line < lines.size() && !EmptyOrComment(lines[current_line])) {
+		while (HasLine(current_line) && !EmptyOrComment(GetLine(current_line))) {
 			current_line++;
 		}
 	}
 	seen_statement = true;
 	// now look for the first non-empty line
-	while (current_line < lines.size() && EmptyOrComment(lines[current_line])) {
+	while (HasLine(current_line) && EmptyOrComment(GetLine(current_line))) {
 		current_line++;
 	}
+	PruneLines();
 	// return whether or not we reached the end of the file
-	return current_line < lines.size();
+	return HasLine(current_line);
 }
 
 void SQLLogicParser::NextLine() {
@@ -84,14 +126,14 @@ string SQLLogicParser::ExtractStatement() {
 	string statement;
 
 	bool first_line = true;
-	while (current_line < lines.size() && !EmptyOrComment(lines[current_line])) {
-		if (lines[current_line] == "----") {
+	while (HasLine(current_line) && !EmptyOrComment(GetLine(current_line))) {
+		if (GetLine(current_line) == "----") {
 			break;
 		}
 		if (!first_line) {
 			statement += "\n";
 		}
-		statement += lines[current_line];
+		statement += GetLine(current_line);
 		first_line = false;
 
 		current_line++;
@@ -106,12 +148,12 @@ vector<string> SQLLogicParser::ExtractExpectedResult() {
 	}
 	vector<string> result;
 	// skip the result line (----) if we are still reading that
-	if (current_line < lines.size() && lines[current_line] == "----") {
+	if (HasLine(current_line) && GetLine(current_line) == "----") {
 		current_line++;
 	}
 	// read the expected result until we encounter a new line
-	while (current_line < lines.size() && !lines[current_line].empty()) {
-		result.push_back(lines[current_line]);
+	while (HasLine(current_line) && !GetLine(current_line).empty()) {
+		result.push_back(GetLine(current_line));
 		current_line++;
 	}
 	return result;
@@ -125,7 +167,7 @@ string SQLLogicParser::ExtractExpectedError(ExpectedResult expected_result, bool
 	    expected_result == ExpectedResult::RESULT_ERROR || expected_result == ExpectedResult::RESULT_UNKNOWN;
 
 	// check if there is an expected error at all
-	if (current_line >= lines.size() || lines[current_line] != "----") {
+	if (!HasLine(current_line) || GetLine(current_line) != "----") {
 		if (expect_error_message && !original_sqlite_test) {
 			Fail("Failed to parse statement: statement error and maybe needs to have an expected error message");
 		}
@@ -138,8 +180,8 @@ string SQLLogicParser::ExtractExpectedError(ExpectedResult expected_result, bool
 	current_line++;
 	string error;
 	vector<string> error_lines;
-	while (current_line < lines.size() && !lines[current_line].empty()) {
-		error_lines.push_back(lines[current_line]);
+	while (HasLine(current_line) && !GetLine(current_line).empty()) {
+		error_lines.push_back(GetLine(current_line));
 		current_line++;
 	}
 	error = StringUtil::Join(error_lines, "\n");
@@ -157,13 +199,13 @@ SQLLogicToken SQLLogicParser::Tokenize() {
 		return current_include->Tokenize();
 	}
 	SQLLogicToken result;
-	if (current_line >= lines.size()) {
+	if (!HasLine(current_line)) {
 		result.type = SQLLogicTokenType::SQLLOGIC_INVALID;
 		return result;
 	}
 
 	vector<string> argument_list;
-	auto &line = lines[current_line];
+	auto &line = GetLine(current_line);
 	idx_t last_pos = 0;
 	for (idx_t i = 0; i < line.size(); i++) {
 		if (StringUtil::CharacterIsSpace(line[i])) {

--- a/test/sqlite/sqllogic_parser.hpp
+++ b/test/sqlite/sqllogic_parser.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/exception_format_value.hpp"
 #include "sqllogic_command.hpp"
+#include <istream>
 
 namespace duckdb {
 
@@ -53,8 +54,6 @@ public:
 class SQLLogicParser {
 public:
 	string file_name;
-	//! The lines of the current text file
-	vector<string> lines;
 	//! The current line number
 	idx_t current_line = 0;
 	//! Whether or not the input should be printed to stdout as it is executed
@@ -74,6 +73,7 @@ public:
 
 	//! Opens the file, returns whether or not reading was successful
 	bool OpenFile(const string &path);
+	bool OpenStream(std::istream &input, const string &source_name);
 
 	void IncludeFile(const string &file_name);
 
@@ -105,6 +105,9 @@ public:
 	}
 
 private:
+	bool HasLine(idx_t line_idx);
+	string &GetLine(idx_t line_idx);
+	void PruneLines();
 	SQLLogicTokenType CommandToToken(const string &token);
 
 	void FailRecursive(const string &msg, vector<ExceptionFormatValue> &values);
@@ -114,6 +117,13 @@ private:
 		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
 		FailRecursive(msg, values, params...);
 	}
+
+private:
+	unique_ptr<std::istream> owned_stream;
+	optional_ptr<std::istream> stream;
+	vector<string> lines;
+	idx_t line_start = 0;
+	bool stream_finished = false;
 };
 
 } // namespace duckdb

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -688,6 +688,24 @@ void SQLLogicTestRunner::ConfigureDefaultInMemoryTemporaryDirectory(const string
 }
 
 void SQLLogicTestRunner::ExecuteFile(string script) {
+	SQLLogicParser parser;
+	bool success = parser.OpenFile(script);
+	if (!success) {
+		FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
+	}
+	ExecuteInternal(parser, script);
+}
+
+void SQLLogicTestRunner::ExecuteStream(std::istream &input, const string &source_name) {
+	SQLLogicParser parser;
+	bool success = parser.OpenStream(input, source_name);
+	if (!success) {
+		FAIL("Could not read sqllogictest stream '" + source_name + "'");
+	}
+	ExecuteInternal(parser, source_name);
+}
+
+void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &script) {
 	auto &test_config = TestConfiguration::Get();
 	if (test_config.ShouldSkipTest(script)) {
 		SkipTest("config skip_tests");
@@ -695,7 +713,6 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 	}
 
 	file_name = script;
-	SQLLogicParser parser;
 	idx_t skip_level = 0;
 	bool test_expr_executed = false;
 	bool file_tags_expr_seen = false;
@@ -726,12 +743,6 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 
 	// initialize the database with the default dbpath
 	LoadDatabase(dbpath, true);
-
-	// open the file and parse it
-	bool success = parser.OpenFile(script);
-	if (!success) {
-		FAIL("Could not find test script '" + script + "'. Perhaps run `make sqlite`. ");
-	}
 
 	if (StringUtil::EndsWith(script, ".test_slow")) {
 		file_tags.emplace_back("slow");

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "sqllogic_command.hpp"
 #include "test_config.hpp"
+#include <istream>
 
 namespace duckdb {
 
@@ -89,6 +90,7 @@ public:
 
 public:
 	void ExecuteFile(string script);
+	void ExecuteStream(std::istream &input, const string &source_name);
 	virtual void LoadDatabase(string dbpath, bool load_extensions);
 
 	string ReplaceKeywords(string input);
@@ -111,6 +113,7 @@ public:
 	Value GetVariableReplacement(const string &token_name, string &variable_name);
 
 private:
+	void ExecuteInternal(SQLLogicParser &parser, const string &script);
 	RequireResult CheckRequire(SQLLogicParser &parser, const vector<string> &params);
 	void ConfigureDefaultInMemoryTemporaryDirectory(const string &script);
 	static void AddSkipReason(const string &reason);

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -8,6 +8,7 @@
 #include "test_config.hpp"
 
 #include <functional>
+#include <iostream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -41,11 +42,8 @@ static void register_sqllogic_test_case(void (*test_fun)(), const string &path, 
 	REGISTER_TEST_CASE(test_fun, normalized_path, tags);
 }
 
-template <bool AUTO_SWITCH_TEST_DIR = false>
-static void testRunner() {
-	// this is an ugly hack that uses the test case name to pass the script file
-	// name if someone has a better idea...
-	const auto name = Catch::getResultCapture().getCurrentTestName();
+template <bool AUTO_SWITCH_TEST_DIR>
+static void RunSQLLogicTest(const string &name, optional_ptr<std::istream> input) {
 	const auto test_dir_path = TestDirectoryPath(); // can vary between tests, and does IO
 	auto &test_config = TestConfiguration::Get();
 
@@ -73,7 +71,7 @@ static void testRunner() {
 	// We assume the test working dir for extensions to be one dir above the test/sql. Note that this is very hacky.
 	// however for now it suffices: we use it to run tests from out-of-tree extensions that are based on the extension
 	// template which adheres to this convention.
-	if (AUTO_SWITCH_TEST_DIR) {
+	if (!input && AUTO_SWITCH_TEST_DIR) {
 		prev_directory = TestGetCurrentDirectory();
 
 		std::size_t found = name.rfind("/test/sql");
@@ -96,12 +94,16 @@ static void testRunner() {
 
 	ErrorData error;
 	try {
-		runner.ExecuteFile(name);
+		if (input) {
+			runner.ExecuteStream(*input, name);
+		} else {
+			runner.ExecuteFile(name);
+		}
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
 	}
 
-	if (AUTO_SWITCH_TEST_DIR) {
+	if (!input && AUTO_SWITCH_TEST_DIR) {
 		test_config.ChangeWorkingDirectory(prev_directory);
 	}
 
@@ -130,6 +132,18 @@ static void testRunner() {
 	if (error.HasError()) {
 		FAIL(error.Message());
 	}
+}
+
+template <bool AUTO_SWITCH_TEST_DIR = false>
+static void testRunner() {
+	// this is an ugly hack that uses the test case name to pass the script file
+	// name if someone has a better idea...
+	const auto name = Catch::getResultCapture().getCurrentTestName();
+	RunSQLLogicTest<AUTO_SWITCH_TEST_DIR>(name, nullptr);
+}
+
+static void testRunnerFromStdin() {
+	RunSQLLogicTest<false>("<stdin>", &std::cin);
 }
 
 static string ParseGroupFromPath(string file) {
@@ -228,5 +242,9 @@ void RegisterSqllogictests() {
 			}
 		});
 	}
+}
+
+void RegisterSqllogictestStdin() {
+	register_sqllogic_test_case(testRunnerFromStdin, "<stdin>", "[sqlitelogic][stdin]");
 }
 } // namespace duckdb

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -18,6 +18,7 @@ int main(int argc_in, char *argv[]) {
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
 	bool keep_home = false;
+	bool use_stdin = false;
 
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
@@ -39,6 +40,8 @@ int main(int argc_in, char *argv[]) {
 			AddRequire(string(argv[++i]));
 		} else if (argument == "--keep-home") {
 			keep_home = true;
+		} else if (argument == "--stdin") {
+			use_stdin = true;
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {
@@ -79,10 +82,14 @@ int main(int argc_in, char *argv[]) {
 #endif
 	}
 
-	if (test_config.GetSkipCompiledTests()) {
+	if (use_stdin || test_config.GetSkipCompiledTests()) {
 		Catch::getMutableRegistryHub().clearTests();
 	}
-	RegisterSqllogictests();
+	if (use_stdin) {
+		RegisterSqllogictestStdin();
+	} else {
+		RegisterSqllogictests();
+	}
 	int result = Catch::Session().run(new_argc, new_argv.get());
 
 	std::string failures_summary = FailureSummary::GetFailureSummary();

--- a/tools/sqllogic/tests/conftest.py
+++ b/tools/sqllogic/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--unittest-binary",
+        action="store",
+        default=None,
+        help="Provide the unittest binary to use for the tests",
+    )
+
+
+@pytest.fixture()
+def unittest_binary(request):
+    custom_arg = request.config.getoption("--unittest-binary")
+    if not custom_arg:
+        raise ValueError(
+            "Please provide a unittest binary path to the tester, using '--unittest-binary <path_to_unittest>'"
+        )
+    return custom_arg

--- a/tools/sqllogic/tests/test_unittest_stdin.py
+++ b/tools/sqllogic/tests/test_unittest_stdin.py
@@ -1,0 +1,34 @@
+import subprocess
+
+
+def test_unittest_stdin_separate_writes(unittest_binary):
+    proc = subprocess.Popen(
+        [unittest_binary, "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        proc.stdin.write("statement ok\nCREATE TABLE t(i INTEGER);\n\n")
+        proc.stdin.flush()
+
+        proc.stdin.write("statement ok\nINSERT INTO t VALUES (42);\n\n")
+        proc.stdin.write("query I\nSELECT i FROM t\n----\n42")
+        proc.stdin.close()
+
+        stdout = proc.stdout.read()
+        print(stdout)
+        assert 'All tests passed' in stdout
+        stderr = proc.stderr.read()
+        print(stderr)
+        proc.wait()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    assert proc.returncode == 0, stderr
+    assert "All tests passed" in stdout
+    assert "<stdin>" in stdout


### PR DESCRIPTION
In the new `--stdin` mode, the unittester reads statements from stdin, instead of from files on disk, and it performs eager execution for every statement it encounters, rather than gather all statements first.

As can be seen in `tools/sqllogic/tests/test_unittest_stdin.py` this allows us to use the tester with more granularity, opening the possibility to perform other work (such as modifying shared tables in an Iceberg REST Catalog) between statements.