### PR TITLE
fix out-of-bounds read in string to struct cast

### DIFF
--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -460,6 +460,9 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 	auto end_char = buf[pos] == '{' ? '}' : ')';
 	pos++;
 	SkipWhitespace(input_state);
+	if (pos == len) {
+		return false;
+	}
 	if (buf[pos] == end_char) {
 		pos++;
 		SkipWhitespace(input_state);

--- a/test/sql/cast/string_to_struct_cast.test
+++ b/test/sql/cast/string_to_struct_cast.test
@@ -376,6 +376,18 @@ SELECT CAST('{[{]}}' AS STRUCT(a VARCHAR[]));
 ----
 can't be cast to the destination type STRUCT(a VARCHAR[])
 
+# only an opening brace/paren followed by whitespace must not read past the buffer
+# (use a long, non-inlined string so the over-read lands on the heap)
+statement error
+SELECT CAST('{               ' AS STRUCT(a INTEGER));
+----
+can't be cast to the destination type STRUCT(a INTEGER)
+
+statement error
+SELECT CAST('(               ' AS STRUCT(a INTEGER));
+----
+can't be cast to the destination type STRUCT(a INTEGER)
+
 
 
 #               Test WHERE clause


### PR DESCRIPTION
**Out-of-bounds read in SplitStruct**
After consuming the opening `{`/`(` and skipping whitespace, the empty-struct check reads `buf[pos]` without testing `pos` against `len`, so a non-inlined string that is just the opening character followed by spaces reads one byte past the buffer. The list and map splitters already guard this spot (`pos < len` / `pos == len`); matched the struct path to them.

ASan on `CAST('{               ' AS STRUCT(a INTEGER))` before the fix:
```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
    #0 ... duckdb::VectorStringToStruct::SplitStruct(...) vector_cast_helpers.cpp:462
```