### PR TITLE
add integer path overloads for json_type and json_exists

### DIFF
--- a/extension/json/json_functions/json_exists.cpp
+++ b/extension/json/json_functions/json_exists.cpp
@@ -15,6 +15,8 @@ static void ManyExistsFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 static void GetExistsFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
+	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::BOOLEAN, BinaryExistsFunction,
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BinaryExistsFunction,
 	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -21,6 +21,8 @@ static void ManyTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 static void GetTypeFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type}, LogicalType::VARCHAR, UnaryTypeFunction, nullptr, nullptr,
 	                               JSONFunctionLocalState::Init));
+	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::VARCHAR, BinaryTypeFunction,
+	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, BinaryTypeFunction,
 	                               JSONReadFunctionData::Bind, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},

--- a/test/sql/json/scalar/test_json_exists.test
+++ b/test/sql/json/scalar/test_json_exists.test
@@ -10,6 +10,16 @@ SELECT json_exists('{"duck": null}', '$.duck')
 true
 
 query I
+SELECT json_exists('[1, 2, 3]'::JSON, 0)
+----
+true
+
+query I
+SELECT json_exists('[1, 2, 3]'::JSON, 3)
+----
+false
+
+query I
 with path AS (
     SELECT '$.duck' p
 )

--- a/test/sql/json/scalar/test_json_type.test
+++ b/test/sql/json/scalar/test_json_type.test
@@ -32,6 +32,11 @@ select json_type('NaN')
 DOUBLE
 
 query T
+select json_type('[10, 20, 30]'::JSON, 0)
+----
+UBIGINT
+
+query T
 select json_type('null')
 ----
 NULL


### PR DESCRIPTION
Fixes #23115
Adds missing integer path overloads for `json_type` and `json_exists`, matching the existing integer path support in `json_extract`, `json_extract_string`, and `json_value`.
This fixes binder errors for calls such as:
```sql
SELECT json_type('[10,20,30]'::JSON, 0);
SELECT json_exists('[1,2,3]'::JSON, 0);
Tests:
- build/reldebug/test/unittest test/sql/json/scalar/test_json_type.test
- build/reldebug/test/unittest test/sql/json/scalar/test_json_exists.test