### PR TITLE
Add Pull app config to sync fork branches with upstream

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,46 @@
+# Configuration for the "Pull" GitHub App, which keeps this fork in sync with
+# the upstream duckdb/duckdb repository.
+#
+# Pointers:
+#   - App / install / manage:  https://pull.git.ci/
+#   - Source:                  https://github.com/wei/pull
+#   - Configuration reference: https://github.com/wei/pull/blob/master/docs/CONFIGURATIONS.md
+#   - Trigger a manual sync:   https://pull.git.ci/process/krlmlr/duckdb
+#
+# Notes:
+#   - This file must live on the fork's default branch for Pull to read it.
+#   - `upstream` is written as `owner:branch` (here always duckdb:<branch>).
+#   - `mergeMethod` values: none | merge | squash | rebase | hardreset.
+#       hardreset -> force the fork branch to match upstream exactly (1:1 mirror).
+#   - hardreset discards any fork-local commits on the branch; do not place
+#     fork-only changes on branches synced with hardreset.
+
+version: "1"
+
+rules:
+  - base: v1.1-eatoni
+    upstream: duckdb:v1.1-eatoni
+    mergeMethod: hardreset
+
+  - base: v1.2-histrionicus
+    upstream: duckdb:v1.2-histrionicus
+    mergeMethod: hardreset
+
+  - base: v1.3-ossivalis
+    upstream: duckdb:v1.3-ossivalis
+    mergeMethod: hardreset
+
+  - base: v1.4-andium
+    upstream: duckdb:v1.4-andium
+    mergeMethod: hardreset
+
+  - base: v1.5-variegata
+    upstream: duckdb:v1.5-variegata
+    mergeMethod: hardreset
+
+  - base: main
+    upstream: duckdb:main
+    mergeMethod: hardreset
+
+label: ":arrow_heart_down: pull"
+conflictLabel: "merge-conflict"

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,19 +1,11 @@
-# Configuration for the "Pull" GitHub App, which keeps this fork in sync with
+# Default configuration for the "Pull" GitHub App, which keeps this fork in sync with
 # the upstream duckdb/duckdb repository.
 #
 # Pointers:
 #   - App / install / manage:  https://pull.git.ci/
 #   - Source:                  https://github.com/wei/pull
 #   - Configuration reference: https://github.com/wei/pull/blob/master/docs/CONFIGURATIONS.md
-#   - Trigger a manual sync:   https://pull.git.ci/process/krlmlr/duckdb
-#
-# Notes:
-#   - This file must live on the fork's default branch for Pull to read it.
-#   - `upstream` is written as `owner:branch` (here always duckdb:<branch>).
-#   - `mergeMethod` values: none | merge | squash | rebase | hardreset.
-#       hardreset -> force the fork branch to match upstream exactly (1:1 mirror).
-#   - hardreset discards any fork-local commits on the branch; do not place
-#     fork-only changes on branches synced with hardreset.
+#   - Trigger a manual sync:   https://pull.git.ci/process/<your-user>/duckdb
 
 version: "1"
 
@@ -41,6 +33,3 @@ rules:
   - base: main
     upstream: duckdb:main
     mergeMethod: hardreset
-
-label: ":arrow_heart_down: pull"
-conflictLabel: "merge-conflict"


### PR DESCRIPTION
This is a small file that helps users of the "pull" Probot app to keep their forks fully in sync with upstream. Just a convenience, nothing mission-critical.

https://pull.git.ci/

Initial commit by Claude, tweaked and reviewed.

Adds a bit of maintenance burden with each new branch. Where would we document that?