### PR TITLE
DRAFT: Trusted custom extension repositories (per-origin signing keys)

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -53,6 +53,13 @@
         ]
     },
     {
+        "name": "allow_custom_extension_repositories",
+        "description": "Allow verifying extensions against per-origin custom repository signing keys",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "allow_extensions_metadata_mismatch",
         "description": "Allow to load extensions with not compatible metadata",
         "type": "BOOLEAN",

--- a/src/execution/operator/helper/physical_load.cpp
+++ b/src/execution/operator/helper/physical_load.cpp
@@ -8,11 +8,18 @@ namespace duckdb {
 
 static void InstallFromRepository(ClientContext &context, const LoadInfo &info) {
 	ExtensionRepository repository;
+	bool custom_repository = false;
 	if (!info.repository.empty() && info.repo_is_alias) {
 		auto repository_url = ExtensionRepository::TryGetRepositoryUrl(info.repository);
-		// This has been checked during bind, so it should not fail here
 		if (repository_url.empty()) {
-			throw InternalException("The repository alias failed to resolve");
+			// Not a built-in alias: resolve a registered extension_repository secret named like the alias.
+			// Only this named form authorizes trusting the repository's pinned signing key.
+			repository_url = ExtensionHelper::TryGetRepositoryUrlFromSecret(context, info.repository);
+			if (repository_url.empty()) {
+				// This has been checked during bind, so it should not fail here
+				throw InternalException("The repository alias failed to resolve");
+			}
+			custom_repository = true;
 		}
 		repository = ExtensionRepository(info.repository, repository_url);
 	} else if (!info.repository.empty()) {
@@ -24,6 +31,7 @@ static void InstallFromRepository(ClientContext &context, const LoadInfo &info) 
 	options.throw_on_origin_mismatch = true;
 	options.version = info.version;
 	options.repository = repository;
+	options.custom_repository = custom_repository;
 
 	ExtensionHelper::InstallExtension(context, info.filename, options);
 }

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library_unity(
   duckdb_databases.cpp
   duckdb_dependencies.cpp
   duckdb_extensions.cpp
+  duckdb_extension_repositories.cpp
+  duckdb_register_extension_repo.cpp
   duckdb_external_file_cache.cpp
   duckdb_functions.cpp
   duckdb_keywords.cpp

--- a/src/function/table/system/duckdb_extension_repositories.cpp
+++ b/src/function/table/system/duckdb_extension_repositories.cpp
@@ -1,0 +1,91 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/common/identifier.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/extension/extension_repository_discovery.hpp"
+
+namespace duckdb {
+
+struct DuckDBExtensionRepositoriesData : public GlobalTableFunctionState {
+	DuckDBExtensionRepositoriesData() : offset(0) {
+	}
+	idx_t offset;
+	duckdb::vector<SecretEntry> secrets;
+};
+
+static unique_ptr<FunctionData> DuckDBExtensionRepositoriesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                vector<LogicalType> &return_types,
+                                                                vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("url");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("key_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("key_fingerprint");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("valid_to");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> DuckDBExtensionRepositoriesInit(ClientContext &context,
+                                                                            TableFunctionInitInput &input) {
+	return make_uniq<DuckDBExtensionRepositoriesData>();
+}
+
+static Value GetSecretVarchar(const KeyValueSecret &secret, const string &key) {
+	Value result;
+	if (secret.TryGetValue(Identifier(key), result) && !result.IsNull()) {
+		return Value(result.ToString());
+	}
+	return Value(LogicalType::VARCHAR);
+}
+
+static void DuckDBExtensionRepositoriesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DuckDBExtensionRepositoriesData>();
+
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	if (data.secrets.empty()) {
+		data.secrets = secret_manager.AllSecrets(transaction);
+	}
+
+	idx_t count = 0;
+	while (data.offset < data.secrets.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.secrets[data.offset];
+		data.offset++;
+		if (!entry.secret || entry.secret->GetType() != "extension_repository") {
+			continue;
+		}
+		auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*entry.secret);
+
+		auto signing_key = GetSecretVarchar(kv_secret, "signing_key");
+		Value fingerprint(LogicalType::VARCHAR);
+		if (!signing_key.IsNull()) {
+			fingerprint = Value(ExtensionRepositoryDiscovery::KeyFingerprint(signing_key.ToString()));
+		}
+
+		output.data[0].Append(Value(entry.secret->GetName()));
+		output.data[1].Append(GetSecretVarchar(kv_secret, "url"));
+		output.data[2].Append(GetSecretVarchar(kv_secret, "key_id"));
+		output.data[3].Append(fingerprint);
+		output.data[4].Append(GetSecretVarchar(kv_secret, "valid_to"));
+		count++;
+	}
+}
+
+void DuckDBExtensionRepositoriesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_extension_repositories", {}, DuckDBExtensionRepositoriesFunction,
+	                              DuckDBExtensionRepositoriesBind, DuckDBExtensionRepositoriesInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system/duckdb_register_extension_repo.cpp
+++ b/src/function/table/system/duckdb_register_extension_repo.cpp
@@ -122,14 +122,12 @@ static void RegisterExtensionRepoFunction(ClientContext &context, TableFunctionI
 	auto &secret_manager = SecretManager::Get(context);
 	secret_manager.CreateSecret(context, secret_input);
 
-	// 4. Report the pinned key(s) (the explicit TOFU moment)
-	for (auto &sk : discovery.signing_keys) {
-		output.data[0].Append(Value(bind_data.repo_name));
-		output.data[1].Append(Value(base_url));
-		output.data[2].Append(sk.kid.empty() ? Value(LogicalType::VARCHAR) : Value(sk.kid));
-		output.data[3].Append(Value(ExtensionRepositoryDiscovery::KeyFingerprint(sk.public_key)));
-		output.data[4].Append(sk.valid_to.empty() ? Value(LogicalType::VARCHAR) : Value(sk.valid_to));
-	}
+	// 4. Report the pinned key (the explicit TOFU moment). Only the primary key is pinned for now.
+	output.data[0].Append(Value(bind_data.repo_name));
+	output.data[1].Append(Value(base_url));
+	output.data[2].Append(primary_key.kid.empty() ? Value(LogicalType::VARCHAR) : Value(primary_key.kid));
+	output.data[3].Append(Value(ExtensionRepositoryDiscovery::KeyFingerprint(primary_key.public_key)));
+	output.data[4].Append(primary_key.valid_to.empty() ? Value(LogicalType::VARCHAR) : Value(primary_key.valid_to));
 }
 
 void DuckDBRegisterExtensionRepoFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/table/system/duckdb_register_extension_repo.cpp
+++ b/src/function/table/system/duckdb_register_extension_repo.cpp
@@ -12,18 +12,19 @@
 namespace duckdb {
 
 struct RegisterExtensionRepoBindData : public FunctionData {
-	RegisterExtensionRepoBindData(string repo_name_p, string repo_url_p)
-	    : repo_name(std::move(repo_name_p)), repo_url(std::move(repo_url_p)) {
+	RegisterExtensionRepoBindData(string repo_name_p, string repo_url_p, bool persist_p)
+	    : repo_name(std::move(repo_name_p)), repo_url(std::move(repo_url_p)), persist(persist_p) {
 	}
 	string repo_name;
 	string repo_url;
+	bool persist;
 
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<RegisterExtensionRepoBindData>(repo_name, repo_url);
+		return make_uniq<RegisterExtensionRepoBindData>(repo_name, repo_url, persist);
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<RegisterExtensionRepoBindData>();
-		return repo_name == other.repo_name && repo_url == other.repo_url;
+		return repo_name == other.repo_name && repo_url == other.repo_url && persist == other.persist;
 	}
 };
 
@@ -41,6 +42,12 @@ static unique_ptr<FunctionData> RegisterExtensionRepoBind(ClientContext &context
 	auto repo_name = input.inputs[0].GetValue<string>();
 	auto repo_url = input.inputs[1].GetValue<string>();
 
+	bool persist = false;
+	auto persist_entry = input.named_parameters.find("persist");
+	if (persist_entry != input.named_parameters.end() && !persist_entry->second.IsNull()) {
+		persist = BooleanValue::Get(persist_entry->second);
+	}
+
 	names.emplace_back("name");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("url");
@@ -52,7 +59,7 @@ static unique_ptr<FunctionData> RegisterExtensionRepoBind(ClientContext &context
 	names.emplace_back("valid_to");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
-	return make_uniq<RegisterExtensionRepoBindData>(std::move(repo_name), std::move(repo_url));
+	return make_uniq<RegisterExtensionRepoBindData>(std::move(repo_name), std::move(repo_url), persist);
 }
 
 static unique_ptr<GlobalTableFunctionState> RegisterExtensionRepoInit(ClientContext &context,
@@ -110,7 +117,7 @@ static void RegisterExtensionRepoFunction(ClientContext &context, TableFunctionI
 		secret_input.options["url_template"] = Value(discovery.url_template);
 	}
 	secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
-	secret_input.persist_type = SecretPersistType::DEFAULT;
+	secret_input.persist_type = bind_data.persist ? SecretPersistType::PERSISTENT : SecretPersistType::DEFAULT;
 
 	auto &secret_manager = SecretManager::Get(context);
 	secret_manager.CreateSecret(context, secret_input);
@@ -126,8 +133,10 @@ static void RegisterExtensionRepoFunction(ClientContext &context, TableFunctionI
 }
 
 void DuckDBRegisterExtensionRepoFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_register_extension_repo", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                              RegisterExtensionRepoFunction, RegisterExtensionRepoBind, RegisterExtensionRepoInit));
+	TableFunction fun("duckdb_register_extension_repo", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                  RegisterExtensionRepoFunction, RegisterExtensionRepoBind, RegisterExtensionRepoInit);
+	fun.named_parameters["persist"] = LogicalType::BOOLEAN;
+	set.AddFunction(fun);
 }
 
 } // namespace duckdb

--- a/src/function/table/system/duckdb_register_extension_repo.cpp
+++ b/src/function/table/system/duckdb_register_extension_repo.cpp
@@ -1,0 +1,133 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/common/identifier.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_repository_discovery.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/settings.hpp"
+
+namespace duckdb {
+
+struct RegisterExtensionRepoBindData : public FunctionData {
+	RegisterExtensionRepoBindData(string repo_name_p, string repo_url_p)
+	    : repo_name(std::move(repo_name_p)), repo_url(std::move(repo_url_p)) {
+	}
+	string repo_name;
+	string repo_url;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<RegisterExtensionRepoBindData>(repo_name, repo_url);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<RegisterExtensionRepoBindData>();
+		return repo_name == other.repo_name && repo_url == other.repo_url;
+	}
+};
+
+struct RegisterExtensionRepoState : public GlobalTableFunctionState {
+	RegisterExtensionRepoState() : executed(false) {
+	}
+	bool executed;
+};
+
+static unique_ptr<FunctionData> RegisterExtensionRepoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                          vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+		throw InvalidInputException("duckdb_register_extension_repo: name and url must not be NULL");
+	}
+	auto repo_name = input.inputs[0].GetValue<string>();
+	auto repo_url = input.inputs[1].GetValue<string>();
+
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("url");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("key_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("key_fingerprint");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("valid_to");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return make_uniq<RegisterExtensionRepoBindData>(std::move(repo_name), std::move(repo_url));
+}
+
+static unique_ptr<GlobalTableFunctionState> RegisterExtensionRepoInit(ClientContext &context,
+                                                                      TableFunctionInitInput &input) {
+	return make_uniq<RegisterExtensionRepoState>();
+}
+
+static void RegisterExtensionRepoFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = data_p.global_state->Cast<RegisterExtensionRepoState>();
+	if (state.executed) {
+		return;
+	}
+	state.executed = true;
+	auto &bind_data = data_p.bind_data->Cast<RegisterExtensionRepoBindData>();
+
+	if (!Settings::Get<AllowCustomExtensionRepositoriesSetting>(context)) {
+		throw InvalidInputException(
+		    "duckdb_register_extension_repo requires SET allow_custom_extension_repositories=true");
+	}
+
+	// 1. Resolve and fetch the discovery document
+	auto discovery_url = ExtensionRepositoryDiscovery::NormalizeDiscoveryUrl(bind_data.repo_url);
+	auto discovery = ExtensionRepositoryDiscovery::FetchAndParse(context, discovery_url);
+
+	// 2. Determine the canonical repository base url
+	string base_url;
+	if (!discovery.url.empty()) {
+		base_url = discovery.url;
+	} else if (StringUtil::EndsWith(StringUtil::Lower(bind_data.repo_url), ".json")) {
+		throw InvalidInputException("Discovery document '%s' must advertise a 'url' (repository base) when registering "
+		                            "via a discovery (.json) url",
+		                            discovery_url);
+	} else {
+		base_url = bind_data.repo_url;
+	}
+
+	// 3. Pin the first advertised signing key (MVP: single key)
+	auto &primary_key = discovery.signing_keys[0];
+
+	CreateSecretInput secret_input;
+	secret_input.type = "extension_repository";
+	secret_input.provider = "config";
+	secret_input.name = Identifier(bind_data.repo_name);
+	secret_input.scope = {base_url};
+	secret_input.options["url"] = Value(base_url);
+	secret_input.options["signing_key"] = Value(primary_key.public_key);
+	if (!primary_key.kid.empty()) {
+		secret_input.options["key_id"] = Value(primary_key.kid);
+	}
+	if (!primary_key.valid_to.empty()) {
+		secret_input.options["valid_to"] = Value(primary_key.valid_to);
+	}
+	secret_input.options["discovery_url"] = Value(discovery_url);
+	if (!discovery.url_template.empty()) {
+		secret_input.options["url_template"] = Value(discovery.url_template);
+	}
+	secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	secret_input.persist_type = SecretPersistType::DEFAULT;
+
+	auto &secret_manager = SecretManager::Get(context);
+	secret_manager.CreateSecret(context, secret_input);
+
+	// 4. Report the pinned key(s) (the explicit TOFU moment)
+	for (auto &sk : discovery.signing_keys) {
+		output.data[0].Append(Value(bind_data.repo_name));
+		output.data[1].Append(Value(base_url));
+		output.data[2].Append(sk.kid.empty() ? Value(LogicalType::VARCHAR) : Value(sk.kid));
+		output.data[3].Append(Value(ExtensionRepositoryDiscovery::KeyFingerprint(sk.public_key)));
+		output.data[4].Append(sk.valid_to.empty() ? Value(LogicalType::VARCHAR) : Value(sk.valid_to));
+	}
+}
+
+void DuckDBRegisterExtensionRepoFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_register_extension_repo", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                              RegisterExtensionRepoFunction, RegisterExtensionRepoBind, RegisterExtensionRepoInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -33,6 +33,8 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);
 	DuckDBExtensionsFun::RegisterFunction(*this);
+	DuckDBExtensionRepositoriesFun::RegisterFunction(*this);
+	DuckDBRegisterExtensionRepoFun::RegisterFunction(*this);
 	DuckDBMemoryFun::RegisterFunction(*this);
 	DuckDBEvictionQueuesFun::RegisterFunction(*this);
 	DuckDBExternalFileCacheFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -87,6 +87,14 @@ struct DuckDBExtensionsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBExtensionRepositoriesFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct DuckDBRegisterExtensionRepoFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBPreparedStatementsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/extension/extension_repository_discovery.hpp
+++ b/src/include/duckdb/main/extension/extension_repository_discovery.hpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/extension/extension_repository_discovery.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+class ClientContext;
+
+//! A single signing key advertised by a repository discovery document
+struct ExtensionRepositorySigningKey {
+	string kid;
+	string algorithm;
+	string public_key; // PEM
+	string valid_to;   // ISO date, optional
+};
+
+//! Parsed `.well-known/duckdb-extensions.json` discovery document
+struct ExtensionRepositoryDiscovery {
+	static constexpr const char *WELL_KNOWN_PATH = "/.well-known/duckdb-extensions.json";
+
+	int64_t schema_version = 0;
+	string repository;   //! advertised repository name (optional)
+	string url;          //! advertised canonical base url (optional)
+	string url_template; //! advertised install-path layout (optional)
+	vector<ExtensionRepositorySigningKey> signing_keys;
+
+	//! Normalize a user-provided url into the discovery-document url:
+	//! ends with `.json` -> used as-is; otherwise `<url>/.well-known/duckdb-extensions.json`.
+	static string NormalizeDiscoveryUrl(const string &url);
+	//! Compute the SHA256 fingerprint (hex) of a PEM public key
+	static string KeyFingerprint(const string &public_key);
+	//! Parse a discovery document from JSON content
+	static ExtensionRepositoryDiscovery Parse(const string &json_content, const string &source);
+	//! Fetch (via the FileSystem, honoring access secrets/protocols) and parse the discovery document
+	static ExtensionRepositoryDiscovery FetchAndParse(ClientContext &context, const string &discovery_url);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -159,6 +159,9 @@ public:
 	static vector<string> GetRepositoryKeys(DatabaseInstance &db, const string &repository_url);
 	//! Resolve a registered extension_repository secret by name to its repository url, or "" if none.
 	static string TryGetRepositoryUrlFromSecret(ClientContext &context, const string &secret_name);
+	//! Look up the install-path url_template advertised by a registered extension_repository secret for the
+	//! origin (relative to the repository base url). Returns "" if none.
+	static string GetRepositoryUrlTemplate(DatabaseInstance &db, const string &repository_url);
 	static ParsedExtensionMetaData ParseExtensionMetaData(const char *metadata) noexcept;
 	static ParsedExtensionMetaData ParseExtensionMetaData(FileHandle &handle);
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -91,6 +91,9 @@ struct ExtensionInstallOptions {
 	bool use_etags = false;
 	//! Throw an error when installing an extension with a different origin than the one that is installed
 	bool throw_on_origin_mismatch = false;
+	//! The repository was resolved from a registered 'extension_repository' secret (named form). Only then
+	//! may the repository's pinned signing key be trusted at install-time verification.
+	bool custom_repository = false;
 };
 
 class ExtensionHelper {
@@ -133,15 +136,29 @@ public:
 	static vector<string> GetExtensionDirectoryPath(ClientContext &context);
 	static vector<string> GetExtensionDirectoryPath(DatabaseInstance &db, FileSystem &fs);
 
-	// Check signature of an Extension stored as FileHandle
-	static bool CheckExtensionSignature(FileHandle &handle, ParsedExtensionMetaData &parsed_metadata,
+	// Check signature of an Extension stored as FileHandle. repository_url scopes the per-origin custom
+	// signing keys to try (empty = core/community keys only).
+	static bool CheckExtensionSignature(DatabaseInstance &db, FileHandle &handle,
+	                                    ParsedExtensionMetaData &parsed_metadata, const string &repository_url,
 	                                    const bool allow_community_extensions);
 	// Check signature of an Extension, represented by a buffer and total_buffer_length, and a signature to be added
-	static bool CheckExtensionBufferSignature(const char *buffer, idx_t buffer_length, const string &signature,
+	static bool CheckExtensionBufferSignature(DatabaseInstance &db, const char *buffer, idx_t buffer_length,
+	                                          const string &signature, const string &repository_url,
 	                                          const bool allow_community_extensions);
 	// Check signature of an Extension, represented by a buffer and total_buffer_length
-	static bool CheckExtensionBufferSignature(const char *buffer, idx_t total_buffer_length,
-	                                          const bool allow_community_extensions);
+	static bool CheckExtensionBufferSignature(DatabaseInstance &db, const char *buffer, idx_t total_buffer_length,
+	                                          const string &repository_url, const bool allow_community_extensions);
+
+	//! Resolve the full set of public keys to verify an extension from the given origin: core (+ community)
+	//! keys always, plus the pinned per-origin keys when the feature is enabled and a matching
+	//! extension_repository secret exists. For empty/core/community origins this equals GetPublicKeys().
+	static vector<string> GetVerificationKeys(DatabaseInstance &db, const string &repository_url,
+	                                          bool allow_community_extensions);
+	//! Look up the pinned signing key(s) for a repository origin in the extension_repository secrets.
+	//! Returns empty if none match. Works without a ClientContext (uses a system transaction).
+	static vector<string> GetRepositoryKeys(DatabaseInstance &db, const string &repository_url);
+	//! Resolve a registered extension_repository secret by name to its repository url, or "" if none.
+	static string TryGetRepositoryUrlFromSecret(ClientContext &context, const string &secret_name);
 	static ParsedExtensionMetaData ParseExtensionMetaData(const char *metadata) noexcept;
 	static ParsedExtensionMetaData ParseExtensionMetaData(FileHandle &handle);
 

--- a/src/include/duckdb/main/secret/default_secrets.hpp
+++ b/src/include/duckdb/main/secret/default_secrets.hpp
@@ -33,4 +33,19 @@ protected:
 	static unique_ptr<BaseSecret> CreateHTTPSecretFromEnv(ClientContext &context, CreateSecretInput &input);
 };
 
+//! The 'extension_repository' secret pins the trust anchor (signing key) for a self-hosted extension
+//! repository. The signing key is a public key, so nothing here is sensitive/redacted.
+struct CreateExtensionRepositorySecretFunctions {
+public:
+	//! Get the extension_repository secret type
+	static vector<SecretType> GetDefaultSecretTypes();
+	//! Get the extension_repository secret functions
+	static vector<CreateSecretFunction> GetDefaultSecretFunctions();
+
+protected:
+	//! extension_repository secret CONFIG provider
+	static unique_ptr<BaseSecret> CreateExtensionRepositorySecretFromConfig(ClientContext &context,
+	                                                                        CreateSecretInput &input);
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -171,6 +171,17 @@ struct AllowCommunityExtensionsSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct AllowCustomExtensionRepositoriesSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "allow_custom_extension_repositories";
+	static constexpr const char *Description =
+	    "Allow verifying extensions against per-origin custom repository signing keys";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct AllowExtensionsMetadataMismatchSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_extensions_metadata_mismatch";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -72,6 +72,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AllocatorBulkDeallocationFlushThresholdSetting),
     DUCKDB_SETTING_CALLBACK(AllocatorFlushThresholdSetting),
     DUCKDB_SETTING_CALLBACK(AllowCommunityExtensionsSetting),
+    DUCKDB_SETTING(AllowCustomExtensionRepositoriesSetting),
     DUCKDB_SETTING(AllowExtensionsMetadataMismatchSetting),
     DUCKDB_SETTING_CALLBACK(AllowParserOverrideExtensionSetting),
     DUCKDB_GLOBAL(AllowPersistentSecretsSetting),
@@ -244,14 +245,14 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 29),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 29),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 127),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 60),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 150),
-                                                     DUCKDB_SETTING_ALIAS("user", 167),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 165),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
+                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 61),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
+                                                     DUCKDB_SETTING_ALIAS("user", 168),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 166),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/extension/CMakeLists.txt
+++ b/src/main/extension/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(
   duckdb_main_extension OBJECT
   extension_alias.cpp extension_helper.cpp extension_install.cpp
-  extension_load.cpp extension_loader.cpp)
+  extension_load.cpp extension_loader.cpp extension_repository_discovery.cpp)
 
 # Escape ; in the string to ensure this is treated as a plain string instead of
 # a list

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -911,6 +911,29 @@ vector<string> ExtensionHelper::GetVerificationKeys(DatabaseInstance &db, const 
 	return keys;
 }
 
+string ExtensionHelper::GetRepositoryUrlTemplate(DatabaseInstance &db, const string &repository_url) {
+	if (repository_url.empty()) {
+		return "";
+	}
+	auto &secret_manager = SecretManager::Get(db);
+	auto transaction = CatalogTransaction::GetSystemTransaction(db);
+	SecretMatch match;
+	try {
+		match = secret_manager.LookupSecret(transaction, repository_url, "extension_repository");
+	} catch (...) {
+		return "";
+	}
+	if (!match.HasMatch()) {
+		return "";
+	}
+	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(match.GetSecret());
+	Value url_template;
+	if (kv_secret.TryGetValue("url_template", url_template) && !url_template.IsNull()) {
+		return url_template.ToString();
+	}
+	return "";
+}
+
 string ExtensionHelper::TryGetRepositoryUrlFromSecret(ClientContext &context, const string &secret_name) {
 	auto &secret_manager = SecretManager::Get(context);
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -871,10 +871,11 @@ const vector<string> ExtensionHelper::GetPublicKeys(bool allow_community_extensi
 	return keys;
 }
 
-vector<string> ExtensionHelper::GetRepositoryKeys(DatabaseInstance &db, const string &repository_url) {
-	vector<string> keys;
+// Look up the extension_repository secret matching an origin (by scope) and read a single field.
+static bool TryGetRepositorySecretValue(DatabaseInstance &db, const string &repository_url, const char *field,
+                                        Value &result) {
 	if (repository_url.empty()) {
-		return keys;
+		return false;
 	}
 	auto &secret_manager = SecretManager::Get(db);
 	auto transaction = CatalogTransaction::GetSystemTransaction(db);
@@ -882,14 +883,22 @@ vector<string> ExtensionHelper::GetRepositoryKeys(DatabaseInstance &db, const st
 	try {
 		match = secret_manager.LookupSecret(transaction, repository_url, "extension_repository");
 	} catch (...) {
-		return keys;
+		return false;
 	}
 	if (!match.HasMatch()) {
-		return keys;
+		return false;
 	}
-	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(match.GetSecret());
+	auto kv_secret = dynamic_cast<const KeyValueSecret *>(&match.GetSecret());
+	if (!kv_secret) {
+		return false;
+	}
+	return kv_secret->TryGetValue(field, result) && !result.IsNull();
+}
+
+vector<string> ExtensionHelper::GetRepositoryKeys(DatabaseInstance &db, const string &repository_url) {
+	vector<string> keys;
 	Value signing_key;
-	if (kv_secret.TryGetValue("signing_key", signing_key) && !signing_key.IsNull()) {
+	if (TryGetRepositorySecretValue(db, repository_url, "signing_key", signing_key)) {
 		keys.push_back(signing_key.ToString());
 	}
 	return keys;
@@ -912,23 +921,8 @@ vector<string> ExtensionHelper::GetVerificationKeys(DatabaseInstance &db, const 
 }
 
 string ExtensionHelper::GetRepositoryUrlTemplate(DatabaseInstance &db, const string &repository_url) {
-	if (repository_url.empty()) {
-		return "";
-	}
-	auto &secret_manager = SecretManager::Get(db);
-	auto transaction = CatalogTransaction::GetSystemTransaction(db);
-	SecretMatch match;
-	try {
-		match = secret_manager.LookupSecret(transaction, repository_url, "extension_repository");
-	} catch (...) {
-		return "";
-	}
-	if (!match.HasMatch()) {
-		return "";
-	}
-	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(match.GetSecret());
 	Value url_template;
-	if (kv_secret.TryGetValue("url_template", url_template) && !url_template.IsNull()) {
+	if (TryGetRepositorySecretValue(db, repository_url, "url_template", url_template)) {
 		return url_template.ToString();
 	}
 	return "";
@@ -946,9 +940,12 @@ string ExtensionHelper::TryGetRepositoryUrlFromSecret(ClientContext &context, co
 	if (!entry || !entry->secret || entry->secret->GetType() != "extension_repository") {
 		return "";
 	}
-	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*entry->secret);
+	auto kv_secret = dynamic_cast<const KeyValueSecret *>(entry->secret.get());
+	if (!kv_secret) {
+		return "";
+	}
 	Value url_value;
-	if (kv_secret.TryGetValue("url", url_value) && !url_value.IsNull()) {
+	if (kv_secret->TryGetValue("url", url_value) && !url_value.IsNull()) {
 		return url_value.ToString();
 	}
 	return "";

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -13,6 +13,9 @@
 #include "duckdb/main/extension.hpp"
 #include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/catalog/catalog_transaction.hpp"
 
 // Note that c++ preprocessor doesn't have a nice way to clean this up so we need to set the defines we use to false
 // explicitly when they are undefined
@@ -320,6 +323,9 @@ static ExtensionUpdateResult UpdateExtensionInternal(ClientContext &context, Dat
 	options.repository = repository_from_info;
 	options.force_install = true;
 	options.use_etags = true;
+	// Re-trust the repository's pinned key on update if one is registered for this origin (the binary already
+	// passed a trusted install). Empty for core/community origins, so they keep verifying against core keys.
+	options.custom_repository = !ExtensionHelper::GetRepositoryKeys(db, extension_install_info->repository_url).empty();
 
 	unique_ptr<ExtensionInstallInfo> install_result;
 	try {
@@ -863,6 +869,66 @@ const vector<string> ExtensionHelper::GetPublicKeys(bool allow_community_extensi
 		}
 	}
 	return keys;
+}
+
+vector<string> ExtensionHelper::GetRepositoryKeys(DatabaseInstance &db, const string &repository_url) {
+	vector<string> keys;
+	if (repository_url.empty()) {
+		return keys;
+	}
+	auto &secret_manager = SecretManager::Get(db);
+	auto transaction = CatalogTransaction::GetSystemTransaction(db);
+	SecretMatch match;
+	try {
+		match = secret_manager.LookupSecret(transaction, repository_url, "extension_repository");
+	} catch (...) {
+		return keys;
+	}
+	if (!match.HasMatch()) {
+		return keys;
+	}
+	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(match.GetSecret());
+	Value signing_key;
+	if (kv_secret.TryGetValue("signing_key", signing_key) && !signing_key.IsNull()) {
+		keys.push_back(signing_key.ToString());
+	}
+	return keys;
+}
+
+vector<string> ExtensionHelper::GetVerificationKeys(DatabaseInstance &db, const string &repository_url,
+                                                    bool allow_community_extensions) {
+	auto keys = GetPublicKeys(allow_community_extensions);
+	// Empty origin, feature disabled, or a built-in repository: only core (+ community) keys, as before.
+	if (repository_url.empty() || !Settings::Get<AllowCustomExtensionRepositoriesSetting>(db)) {
+		return keys;
+	}
+	if (!ExtensionRepository::TryConvertUrlToKnownRepository(repository_url).empty()) {
+		return keys;
+	}
+	for (auto &key : GetRepositoryKeys(db, repository_url)) {
+		keys.push_back(key);
+	}
+	return keys;
+}
+
+string ExtensionHelper::TryGetRepositoryUrlFromSecret(ClientContext &context, const string &secret_name) {
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	unique_ptr<SecretEntry> entry;
+	try {
+		entry = secret_manager.GetSecretByName(transaction, secret_name);
+	} catch (...) {
+		return "";
+	}
+	if (!entry || !entry->secret || entry->secret->GetType() != "extension_repository") {
+		return "";
+	}
+	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*entry->secret);
+	Value url_value;
+	if (kv_secret.TryGetValue("url", url_value) && !url_value.IsNull()) {
+		return url_value.ToString();
+	}
+	return "";
 }
 
 } // namespace duckdb

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -220,11 +220,16 @@ static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, con
 	return in_buffer;
 }
 
-static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs, const string &path, void *data,
-                                     idx_t data_size, DBConfig &config) {
+static void WriteExtensionFileToDisk(DatabaseInstance &db, QueryContext &query_context, FileSystem &fs,
+                                     const string &path, void *data, idx_t data_size,
+                                     const string &trusted_repository_url) {
+	auto &config = db.config;
 	if (!Settings::Get<AllowUnsignedExtensionsSetting>(config)) {
+		// trusted_repository_url is non-empty only for named custom repositories; it scopes the per-origin
+		// signing key to additionally trust. Literal-URL/built-in installs pass "" and stay strict.
 		const bool signature_valid = ExtensionHelper::CheckExtensionBufferSignature(
-		    static_cast<char *>(data), data_size, Settings::Get<AllowCommunityExtensionsSetting>(config));
+		    db, static_cast<char *>(data), data_size, trusted_repository_url,
+		    Settings::Get<AllowCommunityExtensionsSetting>(config));
 		if (!signature_valid) {
 			throw IOException("Attempting to install an extension file that doesn't have a valid signature, see "
 			                  "https://duckdb.org/docs/current/operations_manual/securing_duckdb/securing_extensions");
@@ -297,9 +302,9 @@ static void CheckExtensionMetadataOnInstall(DatabaseInstance &db, void *in_buffe
 //   1. Crash after extension removal: extension is now uninstalled, metadata file still present
 //   2. Crash after metadata removal: extension is now uninstalled, extension dir is clean
 //   3. Crash after extension move: extension is now uninstalled, new metadata file present
-static void WriteExtensionFiles(QueryContext &query_context, FileSystem &fs, const string &temp_path,
-                                const string &local_extension_path, void *in_buffer, idx_t file_size,
-                                ExtensionInstallInfo &info, DBConfig &config) {
+static void WriteExtensionFiles(DatabaseInstance &db, QueryContext &query_context, FileSystem &fs,
+                                const string &temp_path, const string &local_extension_path, void *in_buffer,
+                                idx_t file_size, ExtensionInstallInfo &info, const string &trusted_repository_url) {
 	// temp_path ends with '.duckdb_extension'
 	if (!StringUtil::EndsWith(temp_path, ".duckdb_extension")) {
 		throw InternalException("Extension install temp_path of '%s' is not valid, should end in '.duckdb_extension'",
@@ -314,7 +319,7 @@ static void WriteExtensionFiles(QueryContext &query_context, FileSystem &fs, con
 	}
 
 	// Write extension to tmp file
-	WriteExtensionFileToDisk(query_context, fs, temp_path, in_buffer, file_size, config);
+	WriteExtensionFileToDisk(db, query_context, fs, temp_path, in_buffer, file_size, trusted_repository_url);
 	// When this exit, signature has already being checked (if enabled by config)
 
 	// Write metadata to tmp file
@@ -398,8 +403,11 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance 
 	}
 
 	QueryContext query_context(context);
-	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, extension_decompressed,
-	                    extension_decompressed_size, info, db.config);
+	// Only a named custom repository (resolved from an extension_repository secret) may have its pinned key
+	// trusted at install time; literal-URL and built-in installs stay strict (empty origin).
+	string trusted_repository_url = options.custom_repository ? info.repository_url : string();
+	WriteExtensionFiles(db, query_context, fs, temp_path, local_extension_path, extension_decompressed,
+	                    extension_decompressed_size, info, trusted_repository_url);
 
 	return make_uniq<ExtensionInstallInfo>(info);
 }
@@ -500,8 +508,9 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 
 	QueryContext query_context(context);
 	auto fs = FileSystem::CreateLocal();
-	WriteExtensionFiles(query_context, *fs, temp_path, local_extension_path, extension_data, extension_size, info,
-	                    db.config);
+	string trusted_repository_url = options.custom_repository ? info.repository_url : string();
+	WriteExtensionFiles(db, query_context, *fs, temp_path, local_extension_path, extension_data, extension_size, info,
+	                    trusted_repository_url);
 
 	return make_uniq<ExtensionInstallInfo>(info);
 }
@@ -515,8 +524,10 @@ static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &
 	string url_template = ExtensionHelper::ExtensionUrlTemplate(db, *options.repository, options.version);
 	string generated_url = ExtensionHelper::ExtensionFinalizeUrlTemplate(url_template, extension_name);
 
-	// Special handling for http repository: avoid using regular filesystem (note: the filesystem is not used here)
-	if (HTTPUtil::IsHTTPProtocol(options.repository->path)) {
+	// Special handling for the built-in http repositories: avoid using regular filesystem (no httpfs dependency).
+	// Named custom repositories (resolved from an extension_repository secret) instead go through the FileSystem
+	// for every protocol, so access secrets (s3/http/azure) are resolved by scope automatically.
+	if (HTTPUtil::IsHTTPProtocol(options.repository->path) && !options.custom_repository) {
 		if (db.ExtensionIsLoaded("httpfs")) {
 			HTTPUtil::BumpToSecureProtocol(generated_url);
 		}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -521,7 +521,15 @@ static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &
                                                               const string &local_extension_path,
                                                               ExtensionInstallOptions &options,
                                                               optional_ptr<ClientContext> context) {
-	string url_template = ExtensionHelper::ExtensionUrlTemplate(db, *options.repository, options.version);
+	// A named custom repository may advertise its own install-path layout (url_template), relative to the
+	// repository base url; otherwise use DuckDB's default layout.
+	string custom_template;
+	if (options.custom_repository) {
+		custom_template = ExtensionHelper::GetRepositoryUrlTemplate(db, options.repository->path);
+	}
+	string url_template = custom_template.empty()
+	                          ? ExtensionHelper::ExtensionUrlTemplate(db, *options.repository, options.version)
+	                          : options.repository->path + custom_template;
 	string generated_url = ExtensionHelper::ExtensionFinalizeUrlTemplate(url_template, extension_name);
 
 	// Special handling for the built-in http repositories: avoid using regular filesystem (no httpfs dependency).

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -347,9 +347,8 @@ ParsedExtensionMetaData ExtensionHelper::ParseExtensionMetaData(FileHandle &hand
 	return ParseExtensionMetaData(metadata_segment.data());
 }
 
-static bool CheckKnownSignatures(const string &two_level_hash, const string &signature,
-                                 const bool allow_community_extensions) {
-	for (auto &key : ExtensionHelper::GetPublicKeys(allow_community_extensions)) {
+static bool CheckKnownSignatures(const string &two_level_hash, const string &signature, const vector<string> &keys) {
+	for (auto &key : keys) {
 		if (duckdb_mbedtls::MbedTlsWrapper::IsValidSha256Signature(key, signature, two_level_hash)) {
 			return true;
 		}
@@ -358,7 +357,8 @@ static bool CheckKnownSignatures(const string &two_level_hash, const string &sig
 	return false;
 }
 
-bool ExtensionHelper::CheckExtensionSignature(FileHandle &handle, ParsedExtensionMetaData &parsed_metadata,
+bool ExtensionHelper::CheckExtensionSignature(DatabaseInstance &db, FileHandle &handle,
+                                              ParsedExtensionMetaData &parsed_metadata, const string &repository_url,
                                               const bool allow_community_extensions) {
 	auto signature_offset = handle.GetFileSize() - ParsedExtensionMetaData::SIGNATURE_SIZE;
 
@@ -373,10 +373,12 @@ bool ExtensionHelper::CheckExtensionSignature(FileHandle &handle, ParsedExtensio
 	// TODO maybe we should do a stream read / hash update here
 	handle.Read((void *)parsed_metadata.signature.data(), parsed_metadata.signature.size(), signature_offset);
 
-	return CheckKnownSignatures(resulting_hash, parsed_metadata.signature, allow_community_extensions);
+	auto keys = GetVerificationKeys(db, repository_url, allow_community_extensions);
+	return CheckKnownSignatures(resulting_hash, parsed_metadata.signature, keys);
 }
 
-bool ExtensionHelper::CheckExtensionBufferSignature(const char *buffer, idx_t buffer_length, const string &signature,
+bool ExtensionHelper::CheckExtensionBufferSignature(DatabaseInstance &db, const char *buffer, idx_t buffer_length,
+                                                    const string &signature, const string &repository_url,
                                                     const bool allow_community_extensions) {
 	vector<string> hash_chunks;
 	vector<idx_t> splits;
@@ -386,15 +388,18 @@ bool ExtensionHelper::CheckExtensionBufferSignature(const char *buffer, idx_t bu
 
 	const string resulting_hash = ComputeFinalHash(hash_chunks);
 
-	return CheckKnownSignatures(resulting_hash, signature, allow_community_extensions);
+	auto keys = GetVerificationKeys(db, repository_url, allow_community_extensions);
+	return CheckKnownSignatures(resulting_hash, signature, keys);
 }
 
-bool ExtensionHelper::CheckExtensionBufferSignature(const char *buffer, idx_t total_buffer_length,
+bool ExtensionHelper::CheckExtensionBufferSignature(DatabaseInstance &db, const char *buffer, idx_t total_buffer_length,
+                                                    const string &repository_url,
                                                     const bool allow_community_extensions) {
 	auto signature_offset = total_buffer_length - ParsedExtensionMetaData::SIGNATURE_SIZE;
 	string signature = std::string(buffer + signature_offset, ParsedExtensionMetaData::SIGNATURE_SIZE);
 
-	return CheckExtensionBufferSignature(buffer, signature_offset, signature, allow_community_extensions);
+	return CheckExtensionBufferSignature(db, buffer, signature_offset, signature, repository_url,
+	                                     allow_community_extensions);
 }
 
 bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,
@@ -517,11 +522,22 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		metadata_mismatch_error = StringUtil::Format("Failed to load '%s', %s", extension, metadata_mismatch_error);
 	}
 
+	// Read the install origin from the .info sidecar before verifying, so the signature can be checked
+	// against the repository's pinned signing key (in addition to the core/community keys).
+	string repository_url;
+	if (!direct_load) {
+		auto info_file_name = filename + ".info";
+		auto origin_info =
+		    ExtensionInstallInfo::TryReadInfoFile(fs, info_file_name, StringUtil::Lower(fs.ExtractBaseName(filename)));
+		repository_url = origin_info->repository_url;
+	}
+
 	if (!Settings::Get<AllowUnsignedExtensionsSetting>(db)) {
 		bool signature_valid;
 		if (parsed_metadata.AppearsValid()) {
 			bool allow_community_extensions = Settings::Get<AllowCommunityExtensionsSetting>(db);
-			signature_valid = CheckExtensionSignature(*handle, parsed_metadata, allow_community_extensions);
+			signature_valid =
+			    CheckExtensionSignature(db, *handle, parsed_metadata, repository_url, allow_community_extensions);
 		} else {
 			signature_valid = false;
 		}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -522,14 +522,14 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		metadata_mismatch_error = StringUtil::Format("Failed to load '%s', %s", extension, metadata_mismatch_error);
 	}
 
-	// Read the install origin from the .info sidecar before verifying, so the signature can be checked
-	// against the repository's pinned signing key (in addition to the core/community keys).
+	// Read the .info sidecar once, before verifying, so the signature can be checked against the
+	// repository's pinned signing key (in addition to the core/community keys).
 	string repository_url;
 	if (!direct_load) {
 		auto info_file_name = filename + ".info";
-		auto origin_info =
+		result.install_info =
 		    ExtensionInstallInfo::TryReadInfoFile(fs, info_file_name, StringUtil::Lower(fs.ExtractBaseName(filename)));
-		repository_url = origin_info->repository_url;
+		repository_url = result.install_info->repository_url;
 	}
 
 	if (!Settings::Get<AllowUnsignedExtensionsSetting>(db)) {
@@ -595,10 +595,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 	result.abi_type = parsed_metadata.abi_type;
 
 	if (!direct_load) {
-		auto info_file_name = filename + ".info";
-
-		result.install_info = ExtensionInstallInfo::TryReadInfoFile(fs, info_file_name, lowercase_extension_name);
-
+		// result.install_info was already read above (before signature verification)
 		if (result.install_info->mode == ExtensionInstallMode::UNKNOWN) {
 			// The info file was missing, we just set the version, since we have it from the parsed footer
 			result.install_info->version = parsed_metadata.extension_version;

--- a/src/main/extension/extension_repository_discovery.cpp
+++ b/src/main/extension/extension_repository_discovery.cpp
@@ -1,0 +1,154 @@
+#include "duckdb/main/extension/extension_repository_discovery.hpp"
+
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_helper.hpp"
+
+#include "mbedtls_wrapper.hpp"
+#include "yyjson.hpp"
+
+using namespace duckdb_yyjson; // NOLINT
+
+namespace duckdb {
+
+string ExtensionRepositoryDiscovery::NormalizeDiscoveryUrl(const string &url) {
+	if (StringUtil::EndsWith(StringUtil::Lower(url), ".json")) {
+		return url;
+	}
+	string base = url;
+	while (!base.empty() && base.back() == '/') {
+		base.pop_back();
+	}
+	return base + WELL_KNOWN_PATH;
+}
+
+string ExtensionRepositoryDiscovery::KeyFingerprint(const string &public_key) {
+	auto hash = duckdb_mbedtls::MbedTlsWrapper::ComputeSha256Hash(public_key);
+	static const char *HEX = "0123456789abcdef";
+	string hex;
+	hex.reserve(hash.size() * 2);
+	for (auto c : hash) {
+		auto byte = static_cast<uint8_t>(c);
+		hex += HEX[byte >> 4];
+		hex += HEX[byte & 0x0F];
+	}
+	return "SHA256:" + hex;
+}
+
+ExtensionRepositoryDiscovery ExtensionRepositoryDiscovery::Parse(const string &json_content, const string &source) {
+	ExtensionRepositoryDiscovery result;
+
+	yyjson_doc *doc = yyjson_read(json_content.c_str(), json_content.size(), 0);
+	if (!doc) {
+		throw IOException("Failed to parse extension repository discovery document at '%s': invalid JSON", source);
+	}
+
+	try {
+		yyjson_val *root = yyjson_doc_get_root(doc);
+		if (!root || !yyjson_is_obj(root)) {
+			throw IOException("Extension repository discovery document at '%s' is not a JSON object", source);
+		}
+
+		auto schema = yyjson_obj_get(root, "schema_version");
+		if (schema && yyjson_is_int(schema)) {
+			result.schema_version = yyjson_get_sint(schema);
+		}
+		auto repository = yyjson_obj_get(root, "repository");
+		if (repository && yyjson_is_str(repository)) {
+			result.repository = yyjson_get_str(repository);
+		}
+		auto url = yyjson_obj_get(root, "url");
+		if (url && yyjson_is_str(url)) {
+			result.url = yyjson_get_str(url);
+		}
+		auto url_template = yyjson_obj_get(root, "url_template");
+		if (url_template && yyjson_is_str(url_template)) {
+			result.url_template = yyjson_get_str(url_template);
+		}
+
+		auto signing_keys = yyjson_obj_get(root, "signing_keys");
+		if (signing_keys && yyjson_is_arr(signing_keys)) {
+			size_t idx, max;
+			yyjson_val *key;
+			yyjson_arr_foreach(signing_keys, idx, max, key) {
+				if (!yyjson_is_obj(key)) {
+					continue;
+				}
+				ExtensionRepositorySigningKey sk;
+				auto public_key = yyjson_obj_get(key, "public_key");
+				if (public_key && yyjson_is_str(public_key)) {
+					sk.public_key = yyjson_get_str(public_key);
+				}
+				auto kid = yyjson_obj_get(key, "kid");
+				if (kid && yyjson_is_str(kid)) {
+					sk.kid = yyjson_get_str(kid);
+				}
+				auto algorithm = yyjson_obj_get(key, "algorithm");
+				if (algorithm && yyjson_is_str(algorithm)) {
+					sk.algorithm = yyjson_get_str(algorithm);
+				}
+				auto valid_to = yyjson_obj_get(key, "valid_to");
+				if (valid_to && yyjson_is_str(valid_to)) {
+					sk.valid_to = yyjson_get_str(valid_to);
+				}
+				if (!sk.public_key.empty()) {
+					result.signing_keys.push_back(std::move(sk));
+				}
+			}
+		}
+	} catch (...) {
+		yyjson_doc_free(doc);
+		throw;
+	}
+	yyjson_doc_free(doc);
+
+	if (result.signing_keys.empty()) {
+		throw IOException("Extension repository discovery document at '%s' contains no usable signing_keys", source);
+	}
+	return result;
+}
+
+ExtensionRepositoryDiscovery ExtensionRepositoryDiscovery::FetchAndParse(ClientContext &context,
+                                                                         const string &discovery_url) {
+	auto &fs = FileSystem::GetFileSystem(context);
+
+	// For remote discovery urls (https/s3/...), make sure the handling extension (httpfs) is available.
+	string required_extension;
+	if (FileSystem::IsRemoteFile(discovery_url, required_extension)) {
+		if (!required_extension.empty() &&
+		    !DatabaseInstance::GetDatabase(context).ExtensionIsLoaded(required_extension)) {
+			ExtensionHelper::AutoLoadExtension(context, required_extension);
+		}
+	}
+
+	unique_ptr<FileHandle> handle;
+	try {
+		handle = fs.OpenFile(discovery_url, FileFlags::FILE_FLAGS_READ);
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		throw IOException("Failed to open extension repository discovery document at '%s': %s", discovery_url,
+		                  error.RawMessage());
+	}
+
+	auto file_size = handle->GetFileSize();
+	if (file_size <= 0) {
+		throw IOException("Extension repository discovery document at '%s' is empty", discovery_url);
+	}
+	static constexpr int64_t MAX_DISCOVERY_SIZE = 1 << 20; // 1 MiB
+	if (file_size > MAX_DISCOVERY_SIZE) {
+		throw IOException("Extension repository discovery document at '%s' is too large (%lld bytes)", discovery_url,
+		                  file_size);
+	}
+
+	string content;
+	content.resize(NumericCast<idx_t>(file_size));
+	handle->Read(const_cast<char *>(content.data()), NumericCast<idx_t>(file_size), 0);
+
+	return Parse(content, discovery_url);
+}
+
+} // namespace duckdb

--- a/src/main/extension/extension_repository_discovery.cpp
+++ b/src/main/extension/extension_repository_discovery.cpp
@@ -28,15 +28,10 @@ string ExtensionRepositoryDiscovery::NormalizeDiscoveryUrl(const string &url) {
 
 string ExtensionRepositoryDiscovery::KeyFingerprint(const string &public_key) {
 	auto hash = duckdb_mbedtls::MbedTlsWrapper::ComputeSha256Hash(public_key);
-	static const char *HEX = "0123456789abcdef";
-	string hex;
-	hex.reserve(hash.size() * 2);
-	for (auto c : hash) {
-		auto byte = static_cast<uint8_t>(c);
-		hex += HEX[byte >> 4];
-		hex += HEX[byte & 0x0F];
-	}
-	return "SHA256:" + hex;
+	char hex[duckdb_mbedtls::MbedTlsWrapper::SHA256_HASH_LENGTH_TEXT];
+	duckdb_mbedtls::MbedTlsWrapper::ToBase16(hash.data(), hex,
+	                                         duckdb_mbedtls::MbedTlsWrapper::SHA256_HASH_LENGTH_BYTES);
+	return "SHA256:" + string(hex, duckdb_mbedtls::MbedTlsWrapper::SHA256_HASH_LENGTH_TEXT);
 }
 
 ExtensionRepositoryDiscovery ExtensionRepositoryDiscovery::Parse(const string &json_content, const string &source) {
@@ -146,7 +141,7 @@ ExtensionRepositoryDiscovery ExtensionRepositoryDiscovery::FetchAndParse(ClientC
 
 	string content;
 	content.resize(NumericCast<idx_t>(file_size));
-	handle->Read(const_cast<char *>(content.data()), NumericCast<idx_t>(file_size), 0);
+	handle->Read(content.data(), NumericCast<idx_t>(file_size), 0);
 
 	return Parse(content, discovery_url);
 }

--- a/src/main/secret/default_secrets.cpp
+++ b/src/main/secret/default_secrets.cpp
@@ -112,4 +112,62 @@ unique_ptr<BaseSecret> CreateHTTPSecretFunctions::CreateHTTPSecretFromConfig(Cli
 	return std::move(secret);
 }
 
+vector<SecretType> CreateExtensionRepositorySecretFunctions::GetDefaultSecretTypes() {
+	vector<SecretType> result;
+
+	// extension_repository secret: pins a self-hosted repository's public signing key
+	SecretType secret_type;
+	secret_type.name = "extension_repository";
+	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	secret_type.default_provider = "config";
+	result.push_back(std::move(secret_type));
+
+	return result;
+}
+
+vector<CreateSecretFunction> CreateExtensionRepositorySecretFunctions::GetDefaultSecretFunctions() {
+	vector<CreateSecretFunction> result;
+
+	CreateSecretFunction fun;
+	fun.secret_type = "extension_repository";
+	fun.provider = "config";
+	fun.function = CreateExtensionRepositorySecretFromConfig;
+
+	fun.named_parameters["url"] = LogicalType::VARCHAR;
+	fun.named_parameters["signing_key"] = LogicalType::VARCHAR;
+	fun.named_parameters["key_id"] = LogicalType::VARCHAR;
+	fun.named_parameters["valid_to"] = LogicalType::VARCHAR;
+	fun.named_parameters["discovery_url"] = LogicalType::VARCHAR;
+	fun.named_parameters["url_template"] = LogicalType::VARCHAR;
+	result.push_back(std::move(fun));
+
+	return result;
+}
+
+unique_ptr<BaseSecret>
+CreateExtensionRepositorySecretFunctions::CreateExtensionRepositorySecretFromConfig(ClientContext &context,
+                                                                                    CreateSecretInput &input) {
+	auto scope = input.scope;
+	if (scope.empty()) {
+		// Default the scope to the repository url, so a load-time LookupSecret(url) matches by prefix
+		auto url_entry = input.options.find("url");
+		if (url_entry != input.options.end()) {
+			scope.push_back(url_entry->second.ToString());
+		} else {
+			scope.push_back("");
+		}
+	}
+
+	auto secret = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+	secret->TrySetValue("url", input);
+	secret->TrySetValue("signing_key", input);
+	secret->TrySetValue("key_id", input);
+	secret->TrySetValue("valid_to", input);
+	secret->TrySetValue("discovery_url", input);
+	secret->TrySetValue("url_template", input);
+
+	// The signing key is a public key - nothing to redact here.
+	return std::move(secret);
+}
+
 } // namespace duckdb

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -65,9 +65,15 @@ void SecretManager::Initialize(DatabaseInstance &db) {
 	for (auto &type : CreateHTTPSecretFunctions::GetDefaultSecretTypes()) {
 		RegisterSecretTypeInternal(type);
 	}
+	for (auto &type : CreateExtensionRepositorySecretFunctions::GetDefaultSecretTypes()) {
+		RegisterSecretTypeInternal(type);
+	}
 
 	// Register default functions
 	for (auto &function : CreateHTTPSecretFunctions::GetDefaultSecretFunctions()) {
+		RegisterSecretFunctionInternal(function, OnCreateConflict::ERROR_ON_CONFLICT);
+	}
+	for (auto &function : CreateExtensionRepositorySecretFunctions::GetDefaultSecretFunctions()) {
 		RegisterSecretFunctionInternal(function, OnCreateConflict::ERROR_ON_CONFLICT);
 	}
 }

--- a/src/planner/binder/statement/bind_load.cpp
+++ b/src/planner/binder/statement/bind_load.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
 #include "duckdb/main/extension_install_info.hpp"
+#include "duckdb/main/extension_helper.hpp"
 #include <algorithm>
 
 namespace duckdb {
@@ -11,9 +12,13 @@ BoundStatement Binder::Bind(LoadStatement &stmt) {
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};
 
-	// Ensure the repository exists if it's an alias
+	// Ensure the repository exists if it's an alias - either a built-in alias or a registered
+	// extension_repository secret with that name.
 	if (!stmt.info->repository.empty() && stmt.info->repo_is_alias) {
 		auto repository_url = ExtensionRepository::TryGetRepositoryUrl(stmt.info->repository);
+		if (repository_url.empty()) {
+			repository_url = ExtensionHelper::TryGetRepositoryUrlFromSecret(context, stmt.info->repository);
+		}
 		if (repository_url.empty()) {
 			throw BinderException("'%s' is not a known repository name. Are you trying to query from a repository by "
 			                      "path? Use single quotes: `FROM '%s'`",

--- a/test/sql/extensions/custom_extension_repo.test
+++ b/test/sql/extensions/custom_extension_repo.test
@@ -1,0 +1,42 @@
+# name: test/sql/extensions/custom_extension_repo.test
+# description: Trusted custom extension repositories - secret type, gate and named-repo resolution
+# group: [extensions]
+
+# the opt-in gate exists and defaults to false
+query T
+SELECT current_setting('allow_custom_extension_repositories')
+----
+false
+
+statement ok
+SET allow_custom_extension_repositories=true
+
+# the extension_repository secret type is registered and creatable (signing key is public, not redacted)
+statement ok
+CREATE SECRET custom_repo (
+    TYPE extension_repository,
+    URL '/tmp/duckdb_nonexistent_repo',
+    SIGNING_KEY 'dummy-public-key',
+    KEY_ID 'custom-2026'
+)
+
+query I
+SELECT count(*) FROM duckdb_secrets() WHERE name='custom_repo' AND type='extension_repository'
+----
+1
+
+# an unknown repository name (no matching secret) still fails at bind, as before
+statement error
+INSTALL no_such_extension FROM totally_unknown_repo
+----
+not a known repository name
+
+# the named form resolves the secret's url: bind passes and install proceeds, then fails on the
+# missing local repo file. This proves `INSTALL x FROM <secret_name>` resolution (E3).
+statement error
+INSTALL no_such_extension FROM custom_repo
+----
+no access to the file
+
+statement ok
+DROP SECRET custom_repo

--- a/test/sql/extensions/custom_extension_repo_phase2.test
+++ b/test/sql/extensions/custom_extension_repo_phase2.test
@@ -1,0 +1,55 @@
+# name: test/sql/extensions/custom_extension_repo_phase2.test
+# description: Phase 2 - duckdb_extension_repositories() listing and duckdb_register_extension_repo() guards
+# group: [extensions]
+
+statement ok
+SET allow_custom_extension_repositories=true
+
+# no extension repositories registered yet
+query I
+SELECT count(*) FROM duckdb_extension_repositories()
+----
+0
+
+statement ok
+CREATE SECRET myrepo (
+    TYPE extension_repository,
+    URL 'https://ext.example.com',
+    SIGNING_KEY 'dummy-public-key',
+    KEY_ID 'k1',
+    VALID_TO '2027-01-01'
+)
+
+# listed with its fields
+query IIII
+SELECT name, url, key_id, valid_to FROM duckdb_extension_repositories()
+----
+myrepo	https://ext.example.com	k1	2027-01-01
+
+# the fingerprint is a SHA256 hex of the signing key ("SHA256:" + 64 hex chars)
+query I
+SELECT key_fingerprint LIKE 'SHA256:%' AND length(key_fingerprint) = 71 FROM duckdb_extension_repositories() WHERE name='myrepo'
+----
+true
+
+# register requires the opt-in gate
+statement ok
+SET allow_custom_extension_repositories=false
+
+statement error
+CALL duckdb_register_extension_repo('r', 'https://ext.example.com')
+----
+requires SET allow_custom_extension_repositories=true
+
+statement ok
+SET allow_custom_extension_repositories=true
+
+# registering against a non-existent local discovery document fails while fetching it
+# (proves the function resolves + tries to read the .well-known document)
+statement error
+CALL duckdb_register_extension_repo('r2', '/tmp/duckdb_no_such_repo_xyz')
+----
+discovery document
+
+statement ok
+DROP SECRET myrepo


### PR DESCRIPTION
# Problem

Today there are two trust levels for extensions: DuckDB's own keys only (core/community, hard-compiled), or the global `allow_unsigned_extensions` kill-switch that disables verification for everything. There's no middle ground for private / self-hosted / air-gapped extensions — you have to turn signing off entirely.

# What this adds

An opt-in third tier: verify an extension against a **specific registered repository's** public signing key. DuckDB's keys stay the root of trust; a vendor key only *adds* trust **for its own origin**.

- Gate `allow_custom_extension_repositories` (GLOBAL, default `false`) — with it off, behavior is byte-for-byte unchanged.
- Core secret type `extension_repository` (url / signing_key / key_id / valid_to / discovery_url / url_template), registered alongside `http`/`s3`.
- Trust is granted **only via the named form** `INSTALL x FROM <secret_name>`; the literal form `INSTALL x FROM '<url>'` stays strict (DuckDB keys only).
- Signature verified at install and at load (origin from `.info`), and on `FORCE INSTALL` / `UPDATE EXTENSIONS`.
- Named custom-repo downloads go through `FileSystem` (any protocol: local/s3/https/…); access secrets resolve by scope; built-in repos keep their existing path.
- Discovery via `/.well-known/duckdb-extensions.json` (FileSystem + yyjson); functions `duckdb_register_extension_repo(name, url [, persist => true])` and `duckdb_extension_repositories()`; optional `url_template` for non-default repo layouts.

# SQL surface (examples)

```sql
SET allow_custom_extension_repositories = true;
CALL duckdb_register_extension_repo('mycorp', 'https://ext.mycorp.com');  -- discovery + pin key
INSTALL mssql FROM mycorp;   -- verified against mycorp's pinned key
LOAD mssql;
SELECT * FROM duckdb_extension_repositories();

-- or manually, without discovery:
CREATE SECRET mycorp (
    TYPE extension_repository,
    URL 'https://ext.mycorp.com',
    SIGNING_KEY '-----BEGIN PUBLIC KEY----- … -----END PUBLIC KEY-----'
);
```

# Backward compatibility

Feature is off by default; with the gate unset, behavior is identical to today.
The `.info` format is unchanged (reuses the existing `repository_url` field).
Core/community keys are untouched.

# Changes by area

- setting (`settings.json`); core secret type (`default_secrets.*`,`secret_manager.cpp`)
- `ExtensionHelper`: `GetVerificationKeys` / `GetRepositoryKeys` / `GetRepositoryUrlTemplate` /`TryGetRepositoryUrlFromSecret`; `CheckExtension*Signature` gained `(db, repository_url)`
- install/load wiring (`extension_install.cpp`, `extension_load.cpp`); named resolution (`bind_load.cpp`, `physical_load.cpp`)
- discovery (`extension_repository_discovery.*`); table functions (`duckdb_register_extension_repo.cpp`, `duckdb_extension_repositories.cpp`)

# Tests

- `test/sql/extensions/custom_extension_repo.test` — secret type, gate, named resolution, strict unknown-repo.
- `test/sql/extensions/custom_extension_repo_phase2.test` — discovery / listing / register guards.
- No regressions across `test/sql/extensions/*`, `test/sql/secrets/*`, `test/sql/table_function/*`, `test/sql/settings/*`.
- Manual e2e: an extension signed with a **non-core** test key (`test/mbedtls`) installs/loads only via the named repo with gate+secret; fails with the gate off, with no matching secret, on the literal form, and on a wrong key; `FORCE INSTALL` / `UPDATE EXTENSIONS` re-verify.

# Known limitations / open for discussion

- `register` pins the first discovery key (multi-key rotation later); `valid_to` not yet enforced; `${VERSION}` placeholder not supported in `url_template`; TOFU pinning over plain HTTP is not refused (trust is anchored in the pinned key, not the transport).
- The literal form is intentionally strict; custom trust is only via a named secret.
