### PR TITLE
fix list of struct cast with quoted closing brace

### DIFF
--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -130,23 +130,31 @@ static string_t HandleString(Vector &vec, const char *buf, idx_t start, idx_t en
 	for (idx_t i = 0; i < length; i++) {
 		auto current_char = buf[start + i];
 		if (!escaped) {
-			if (scopes.empty() && current_char == '\\') {
-				if (quoted || (start + i + 1 < end && (buf[start + i + 1] == '\'' || buf[start + i + 1] == '"'))) {
+			if (current_char == '\\') {
+				if (quoted || (scopes.empty() && start + i + 1 < end &&
+				               (buf[start + i + 1] == '\'' || buf[start + i + 1] == '"'))) {
 					//! Start of escape
 					escaped = true;
+					if (!scopes.empty()) {
+						string_data[copied_count++] = current_char;
+					}
 					continue;
 				}
 			}
-			if (scopes.empty() && (current_char == '\'' || current_char == '"')) {
+			if (current_char == '\'' || current_char == '"') {
 				if (quoted && current_char == quote_char) {
 					quoted = false;
-					//! Skip the ending quote
-					continue;
+					if (scopes.empty()) {
+						//! Skip the ending quote
+						continue;
+					}
 				} else if (!quoted) {
 					quoted = true;
 					quote_char = current_char;
-					//! Skip the starting quote
-					continue;
+					if (scopes.empty()) {
+						//! Skip the starting quote
+						continue;
+					}
 				}
 			}
 			if (!quoted && !scopes.empty() && current_char == scopes.top()) {

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -447,6 +447,21 @@ SELECT '[{a: hii}, {a: "{" }]'::STRUCT(a VARCHAR)[] FROM struct_tbl1;
 ----
 [{'a': hii}, {'a': '{'}]
 
+query I
+SELECT '[{''name'':''a}b''}]'::STRUCT(name VARCHAR)[];
+----
+[{'name': 'a}b'}]
+
+query I
+SELECT '[{"name":"a}b"}]'::STRUCT(name VARCHAR)[];
+----
+[{'name': 'a}b'}]
+
+query I
+SELECT CAST(list_value(struct_pack(name := 'a}b')) AS VARCHAR)::STRUCT(name VARCHAR)[];
+----
+[{'name': 'a}b'}]
+
 
 # ---------------------------------------------------
 statement ok


### PR DESCRIPTION
Fixes #23364
This fixes `VARCHAR -> STRUCT(...)[]` casts when a quoted struct field value contains `}`.
The list element splitter was treating `}` inside a quoted field value as the end of the struct, which truncated the element string before it was cast to `STRUCT`. This also broke round-tripping strings produced by DuckDB itself, e.g. `CAST(list_value(struct_pack(...)) AS VARCHAR)` back into `STRUCT(...)[]`.
Tests:
- `build/reldebug/test/unittest test/sql/cast/string_to_list_cast.test`