### PR TITLE
fix: allow DETACH inside a transaction without invalidating it

### DIFF
--- a/src/execution/operator/schema/physical_detach.cpp
+++ b/src/execution/operator/schema/physical_detach.cpp
@@ -1,12 +1,6 @@
 #include "duckdb/execution/operator/schema/physical_detach.hpp"
 #include "duckdb/parser/parsed_data/detach_info.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/database_manager.hpp"
-#include "duckdb/main/attached_database.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/storage/storage_extension.hpp"
-#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -16,20 +10,6 @@ namespace duckdb {
 SourceResultType PhysicalDetach::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
 	auto &db_manager = DatabaseManager::Get(context.client);
-
-	// Reject detach if the current transaction already has outstanding work on the database.
-	{
-		auto attached_db = db_manager.GetDatabase(info->name);
-		if (attached_db) {
-			auto &meta_transaction = MetaTransaction::Get(context.client);
-			if (meta_transaction.TryGetTransaction(*attached_db)) {
-				throw TransactionException(
-				    "Cannot detach database \"%s\" because the current transaction has outstanding "
-				    "work on it - commit or rollback first",
-				    info->name);
-			}
-		}
-	}
 
 	db_manager.DetachDatabase(context.client, info->name, info->if_not_found);
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -276,6 +277,9 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const Identifier &n
 		}
 		return;
 	}
+
+	auto &meta_transaction = MetaTransaction::Get(context);
+	meta_transaction.DetachDatabase(*attached_db);
 
 	attached_db->OnDetach(context);
 

--- a/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
+++ b/test/fuzzer/duckfuzz/duckdb_fuzzer_4430.test
@@ -5,22 +5,23 @@
 statement ok
 ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
 
-# Write case: forbid DETACH after a write to db1 in the same transaction
+# Write case: DETACH after a write to db1 in the same transaction
 statement ok
 BEGIN
 
 statement ok
 CREATE TABLE db1.tbl(i INTEGER)
 
-statement error
+statement ok
 DETACH db1
-----
-Cannot detach database "db1"
 
 statement ok
 ROLLBACK
 
-# Read case: forbid DETACH after a read from db1 in the same transaction
+# Read case: DETACH after a read from db1 in the same transaction
+statement ok
+ATTACH '{TEST_DIR}/duckdb_fuzzer_4430.db' AS db1
+
 statement ok
 CREATE TABLE db1.tbl(i INTEGER)
 
@@ -31,10 +32,8 @@ query I
 SELECT * FROM db1.tbl
 ----
 
-statement error
+statement ok
 DETACH db1
-----
-Cannot detach database "db1"
 
 statement ok
 ROLLBACK

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -60,7 +60,7 @@ DETACH attach_transaction
 ----
 database not found
 
-# DETACH is forbidden while the current transaction has outstanding work on the database
+# DETACH inside a transaction succeeds; the DETACH itself is not rolled back
 statement ok
 BEGIN TRANSACTION
 
@@ -70,10 +70,8 @@ ATTACH '{TEST_DIR}/attach_transaction.db'
 statement ok
 INSERT INTO attach_transaction.integers VALUES (84)
 
-statement error
+statement ok
 DETACH attach_transaction
-----
-Cannot detach database "attach_transaction"
 
 statement ok
 ROLLBACK
@@ -87,7 +85,7 @@ SELECT * FROM attach_transaction.integers
 ----
 42
 
-# the supported workflow is to COMMIT first, then DETACH
+# the supported workflows
 statement ok
 BEGIN TRANSACTION
 
@@ -109,3 +107,27 @@ SELECT * FROM attach_transaction.integers ORDER BY 1
 ----
 42
 84
+
+# DETACH inside a transaction, then COMMIT: data persists
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO attach_transaction.integers VALUES (168)
+
+statement ok
+DETACH attach_transaction
+
+statement ok
+COMMIT
+
+# verify data was committed
+statement ok
+ATTACH '{TEST_DIR}/attach_transaction.db'
+
+query I
+SELECT * FROM attach_transaction.integers ORDER BY 1
+----
+42
+84
+168


### PR DESCRIPTION
Fixes #23374

Previously DETACH threw a TransactionException when the current transaction had outstanding work on the database (e.g. after ATTACH + INSERT). This error invalidated the entire transaction, causing a subsequent COMMIT to silently convert to ROLLBACK.

The outstanding-work check was added in commit 7146d836a1 which also removed the MetaTransaction::DetachDatabase() cleanup call from DatabaseManager::DetachDatabase.

**Changes:**
1. Removes the outstanding-work check from PhysicalDetach
2. Restores MetaTransaction::DetachDatabase() in DatabaseManager::DetachDatabase to clean up used_databases
3. Updates tests to expect DETACH to succeed within transactions
4. Adds a new test case for ATTACH -> work -> DETACH -> COMMIT