### PR TITLE
Cleanup: remove stale branch

### DIFF
--- a/src/storage/metadata/metadata_reader.cpp
+++ b/src/storage/metadata/metadata_reader.cpp
@@ -36,7 +36,7 @@ void MetadataReader::ReadData(QueryContext context, data_ptr_t buffer, idx_t rea
 			memcpy(buffer, Ptr(), to_read);
 			read_size -= to_read;
 			buffer += to_read;
-			offset += read_size;
+			offset += to_read;
 		}
 		// then move to the next block
 		ReadNextBlock(context);


### PR DESCRIPTION
In MetadataReader::ReadData, the offset was being advanced by read_size instead of to_read. 

After , read_size is the remaining bytes to read, not the bytes just copied. offset += read_size could skip past the actual data position.

Fixed by advancing offset by to_read instead.