### PR TITLE
Infer geometry type based on WKB string stats

### DIFF
--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -54,8 +54,28 @@ static auto FromWKBStats(ClientContext &context, FunctionStatisticsInput &input)
 		// Unsupported or invalid geometry type, we can't say anything about the types
 		return result.ToUnique();
 	}
+
+	// Z/M may also be signalled through the Extended-WKB high bits (matching Geometry::FromBinary)
+	const auto has_z = ((flag_id & 0x01) != 0) || ((meta & 0x80000000) != 0);
+	const auto has_m = ((flag_id & 0x02) != 0) || ((meta & 0x40000000) != 0);
+
 	const auto geom_type = static_cast<GeometryType>(type_id);
-	const auto vert_type = static_cast<VertexType>(flag_id);
+	const auto vert_type = static_cast<VertexType>((has_z ? 1 : 0) | (has_m ? 2 : 0));
+
+	// The single inferred type implies a minimum body length: a POINT serializes all of its ordinates inline
+	// (even when empty, encoded as NaNs); every other type serializes at least a 4-byte element count. If the
+	// shortest row (the exact minimum over all rows) can't hold that, the column has a truncated blob, so bail.
+	const idx_t vert_dims = 2 + (has_z ? 1 : 0) + (has_m ? 1 : 0);
+	const auto min_valid_size = geom_type == GeometryType::POINT ? WKB_HEADER_SIZE + vert_dims * sizeof(double)
+	                                                             : WKB_HEADER_SIZE + sizeof(uint32_t);
+
+	const auto min_len = StringStats::MinStringLength(child_stats);
+	if (!min_len.IsValid() || min_len.GetIndex() < min_valid_size) {
+		// Only bounds the byte envelope, not that a declared element count matches the body.
+		// In general, we cant guarantee that the WKB is valid without parsing every row.
+		// But we're generally OK with optimizing assuming valid input - anything else is essentially UB.
+		return result.ToUnique();
+	}
 
 	// All rows share this single geometry type. The extent and emptiness can't be inferred
 	// from the truncated string stats, so those remain unknown.

--- a/src/function/scalar/geometry/geometry_functions.cpp
+++ b/src/function/scalar/geometry/geometry_functions.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/storage/statistics/geometry_stats.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 
 namespace duckdb {
 
@@ -11,8 +13,62 @@ static void FromWKBFunction(DataChunk &input, ExpressionState &state, Vector &re
 	Geometry::FromBinary(input.data[0], result, input.size(), true);
 }
 
+static auto FromWKBStats(ClientContext &context, FunctionStatisticsInput &input) -> unique_ptr<BaseStatistics> {
+	const auto &child_stats = input.child_stats[0];
+
+	// Start from fully unknown geometry stats and copy over the validity (null-ness) of the input.
+	auto result = GeometryStats::CreateUnknown(input.expr.GetReturnType());
+	result.CopyValidity(child_stats);
+
+	if (!StringStats::HasMinMax(child_stats)) {
+		// No min/max available, we can't say anything about the types
+		return result.ToUnique();
+	}
+
+	// The lexicographically smallest and largest WKB blobs. Any prefix shared by both is shared by every row,
+	// so if the first 5 bytes (byte order + type meta) match, all rows have the exact same geometry type and ZM flags.
+	const auto min_blob = StringStats::Min(child_stats);
+	const auto max_blob = StringStats::Max(child_stats);
+
+	constexpr idx_t WKB_HEADER_SIZE = sizeof(uint8_t) + sizeof(uint32_t);
+	if (min_blob.size() < WKB_HEADER_SIZE || max_blob.size() < WKB_HEADER_SIZE) {
+		return result.ToUnique();
+	}
+	if (memcmp(min_blob.data(), max_blob.data(), WKB_HEADER_SIZE) != 0) {
+		// The headers differ, so multiple geometry types may be present
+		return result.ToUnique();
+	}
+
+	// Now parse the 5-byte WKB header (byte order + type meta) into a geometry/vertex type.
+	const auto header = const_data_ptr_cast(min_blob.data());
+	const auto le = Load<uint8_t>(header);
+
+	auto meta = Load<uint32_t>(header + sizeof(uint8_t));
+	if (!le) {
+		meta = BSwap(meta);
+	}
+
+	const auto type_id = (meta & 0x0000FFFF) % 1000;
+	const auto flag_id = (meta & 0x0000FFFF) / 1000;
+	if (type_id < 1 || type_id > 7 || flag_id > 3) {
+		// Unsupported or invalid geometry type, we can't say anything about the types
+		return result.ToUnique();
+	}
+	const auto geom_type = static_cast<GeometryType>(type_id);
+	const auto vert_type = static_cast<VertexType>(flag_id);
+
+	// All rows share this single geometry type. The extent and emptiness can't be inferred
+	// from the truncated string stats, so those remain unknown.
+	auto &types = GeometryStats::GetTypes(result);
+	types = GeometryTypeSet::Empty();
+	types.Add(geom_type, vert_type);
+
+	return result.ToUnique();
+}
+
 ScalarFunction StGeomfromwkbFun::GetFunction() {
 	ScalarFunction function({LogicalType::BLOB}, LogicalType::GEOMETRY(), FromWKBFunction);
+	function.SetStatisticsCallback(FromWKBStats);
 	return function;
 }
 

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -126,7 +126,8 @@
         "test/sql/copy/parquet/parquet_string_stats.test",
         "test/sql/storage/extended_string_stats.test",
         "test/sql/storage/min_string_length_too_large.test_slow",
-        "test/sql/storage/total_string_length_repeated_insert.test"
+        "test/sql/storage/total_string_length_repeated_insert.test",
+        "test/sql/types/geo/geometry_from_wkb_stats.test"
       ]
     },
     {

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -57,8 +57,9 @@
         "test/sql/types/geo/geometry_crs.test",
         "test/sql/types/geo/geometry_stats.test",
         "test/sql/types/geo/geometry_vertex_extract.test",
-        "test/sql/sample/can_sample_from_ingested_files.test",
-        "test/sql/types/geo/geometry_shred_more.test"
+        "test/sql/types/geo/geometry_shred_more.test",
+        "test/sql/types/geo/geometry_from_wkb_stats.test",
+        "test/sql/sample/can_sample_from_ingested_files.test"
       ]
     },
     {

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -47,7 +47,8 @@
         "test/sql/storage/extended_string_stats.test",
         "test/sql/storage/min_string_length_too_large.test_slow",
         "test/sql/storage/total_string_length_repeated_insert.test",
-        "test/sql/types/geo/geometry_vertex_extract.test"
+        "test/sql/types/geo/geometry_vertex_extract.test",
+        "test/sql/types/geo/geometry_from_wkb_stats.test"
       ]
     }
   ]

--- a/test/sql/types/geo/geometry_from_wkb_stats.test
+++ b/test/sql/types/geo/geometry_from_wkb_stats.test
@@ -1,0 +1,104 @@
+# name: test/sql/types/geo/geometry_from_wkb_stats.test
+# description: Statistics propagation through ST_GeomFromWKB
+# group: [geo]
+
+# stats() output is not preserved across serialization, so disable alternative verification
+require no_alternative_verify
+
+# ST_GeomFromWKB infers the geometry type and ZM flags of its result from the min/max string statistics of the input
+# WKB blobs: if the 5-byte WKB header (byte order + type code) is shared by the lexicographic min and max blob, then
+# every row has that exact geometry type.
+# We can't observe the propagated type set directly via stats(), but it drives
+# the folding done by vertex_extract,which IS observable: vertex_extract only yields non-NULL for non-empty points.
+
+# A single non-point geometry type is detected, so vertex extraction folds to a constant NULL ("always NULL" stats).
+statement ok
+CREATE TABLE lines_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO lines_wkb SELECT ST_AsWKB(g)
+FROM (VALUES ('LINESTRING(0 0, 1 1)'::GEOMETRY), ('LINESTRING(2 2, 3 3)'::GEOMETRY)) t(g);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM lines_wkb LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+statement ok
+CREATE TABLE poly_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO poly_wkb SELECT ST_AsWKB('POLYGON((0 0, 1 0, 1 1, 0 0))'::GEOMETRY);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM poly_wkb LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+
+# A single point type is detected, so vertex extraction is NOT folded away (a point can produce a valid ordinate).
+statement ok
+CREATE TABLE pts_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO pts_wkb SELECT ST_AsWKB(g)
+FROM (VALUES ('POINT(1 2)'::GEOMETRY), ('POINT(5 8)'::GEOMETRY)) t(g);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM pts_wkb LIMIT 1;
+----
+{'has_no_null': true, 'has_null': true}
+
+# The ZM flags in the header are detected too: a column of plain XY points has no Z ordinate, so 'z' folds to NULL
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'z')) FROM pts_wkb LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+# ... whereas a column of POINT Z carries a Z ordinate, so 'z' is not folded.
+statement ok
+CREATE TABLE pts_z_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO pts_z_wkb SELECT ST_AsWKB(g)
+FROM (VALUES ('POINT Z (1 2 3)'::GEOMETRY), ('POINT Z (5 8 9)'::GEOMETRY)) t(g);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'z')) FROM pts_z_wkb LIMIT 1;
+----
+{'has_no_null': true, 'has_null': true}
+
+# When several geometry types are present the headers of the min/max blob differ, so the type set falls back to unknown
+# and nothing can be folded, even though a non-point type is in the mix.
+
+statement ok
+CREATE TABLE mixed_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO mixed_wkb SELECT ST_AsWKB(g)
+FROM (VALUES ('POINT(1 2)'::GEOMETRY), ('LINESTRING(0 0, 1 1)'::GEOMETRY)) t(g);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM mixed_wkb LIMIT 1;
+----
+{'has_no_null': true, 'has_null': true}
+
+# Big-endian WKB (byte order 0x00) is handled too
+statement ok
+CREATE TABLE be_lines_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO be_lines_wkb VALUES
+  ('\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3F\xF0\x00\x00\x00\x00\x00\x00\x3F\xF0\x00\x00\x00\x00\x00\x00'::BLOB);
+
+# Verify the blob really is a valid big-endian LINESTRING
+query I
+SELECT ST_AsText(ST_GeomFromWKB(wkb)) FROM be_lines_wkb;
+----
+LINESTRING (0 0, 1 1)
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM be_lines_wkb LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}

--- a/test/sql/types/geo/geometry_from_wkb_stats.test
+++ b/test/sql/types/geo/geometry_from_wkb_stats.test
@@ -102,3 +102,86 @@ query I
 SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM be_lines_wkb LIMIT 1;
 ----
 {'has_no_null': false, 'has_null': true}
+
+
+# A structurally valid but truncated (bodyless) LINESTRING header is too short to be a valid geometry
+statement ok
+CREATE TABLE bad_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO bad_wkb VALUES ('\x01\x02\x00\x00\x00'::BLOB);
+
+statement error
+SELECT vertex_extract(ST_GeomFromWKB(wkb), 'x') FROM bad_wkb;
+----
+Unexpected end of binary data at position 5
+
+# A valid empty LINESTRING is exactly 9 bytes (header + zero count)
+statement ok
+CREATE TABLE empty_ls_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO empty_ls_wkb VALUES ('\x01\x02\x00\x00\x00\x00\x00\x00\x00'::BLOB);
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'x')) FROM empty_ls_wkb LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}
+
+# The truncation check uses the true min length over every row, not the lexicographic min's prefix length.
+# Here the truncated 6-byte blob sorts AFTER the valid one, so it is not the min blob - yet min_string_length
+# still reflects it, no type is inferred, and the parse error is not folded away.
+statement ok
+CREATE TABLE interior_trunc_wkb(wkb BLOB);
+
+statement ok
+INSERT INTO interior_trunc_wkb SELECT ST_AsWKB('LINESTRING(0 0, 1 1)'::GEOMETRY);
+
+statement ok
+INSERT INTO interior_trunc_wkb VALUES ('\x01\x02\x00\x00\x00\x05'::BLOB);
+
+statement error
+SELECT vertex_extract(ST_GeomFromWKB(wkb), 'x') FROM interior_trunc_wkb;
+----
+Unexpected end of binary data at position 5
+
+# Extended-WKB (EWKB) signals Z/M via the meta high bits (0x80000000 / 0x40000000) rather than the ISO /1000 scheme.
+statement ok
+CREATE TABLE ewkb_point_z(wkb BLOB);
+
+statement ok
+INSERT INTO ewkb_point_z VALUES
+  ('\x01\x01\x00\x00\x80\x00\x00\x00\x00\x00\x00\xF0\x3F\x00\x00\x00\x00\x00\x00\x00\x40\x00\x00\x00\x00\x00\x00\x08\x40'::BLOB);
+
+query I
+SELECT ST_AsText(ST_GeomFromWKB(wkb)) FROM ewkb_point_z;
+----
+POINT Z (1 2 3)
+
+query I
+SELECT vertex_extract(ST_GeomFromWKB(wkb), 'z') FROM ewkb_point_z;
+----
+3.0
+
+# The same for the EWKB M high bit (0x40000000): 'm' is carried (not folded) while 'z' is absent (folded to NULL).
+statement ok
+CREATE TABLE ewkb_point_m(wkb BLOB);
+
+statement ok
+INSERT INTO ewkb_point_m VALUES
+  ('\x01\x01\x00\x00\x40\x00\x00\x00\x00\x00\x00\xF0\x3F\x00\x00\x00\x00\x00\x00\x00\x40\x00\x00\x00\x00\x00\x00\x10\x40'::BLOB);
+
+query I
+SELECT ST_AsText(ST_GeomFromWKB(wkb)) FROM ewkb_point_m;
+----
+POINT M (1 2 4)
+
+query I
+SELECT vertex_extract(ST_GeomFromWKB(wkb), 'm') FROM ewkb_point_m;
+----
+4.0
+
+query I
+SELECT stats(vertex_extract(ST_GeomFromWKB(wkb), 'z')) FROM ewkb_point_m LIMIT 1;
+----
+{'has_no_null': false, 'has_null': true}


### PR DESCRIPTION
When calling `ST_GeomFromWKB()` we can determine if a column contains only a single geometry type by looking at the 5 byte prefix of min/max string statistics. This is pretty common, and detecting it may allow us to perform further optimizations downstream.