### PR TITLE
Add support for pushing collations into lists using `lambda_transform`, and add support for collations to `list_contains / list_position`

### DIFF
--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -628,6 +628,35 @@ static bool RequiresCollationPropagation(const LogicalType &type) {
 	return type.id() == LogicalTypeId::VARCHAR && !type.HasAlias();
 }
 
+//! Recursively extracts the collation of a (possibly nested) type, e.g. the element collation of a LIST(VARCHAR).
+static string ExtractCollationFromType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		return RequiresCollationPropagation(type) ? StringType::GetCollation(type) : string();
+	case LogicalTypeId::LIST:
+		return ExtractCollationFromType(ListType::GetChildType(type));
+	case LogicalTypeId::ARRAY:
+		return ExtractCollationFromType(ArrayType::GetChildType(type));
+	default:
+		return string();
+	}
+}
+
+//! Returns a copy of the type with the collation applied to every (nested) VARCHAR leaf.
+static LogicalType ApplyCollationToType(const LogicalType &type, const LogicalType &collation_type) {
+	switch (type.id()) {
+	case LogicalTypeId::VARCHAR:
+		return RequiresCollationPropagation(type) ? collation_type : type;
+	case LogicalTypeId::LIST:
+		return LogicalType::LIST(ApplyCollationToType(ListType::GetChildType(type), collation_type));
+	case LogicalTypeId::ARRAY:
+		return LogicalType::ARRAY(ApplyCollationToType(ArrayType::GetChildType(type), collation_type),
+		                          ArrayType::GetSize(type));
+	default:
+		return type;
+	}
+}
+
 static string ExtractCollation(const vector<unique_ptr<Expression>> &children) {
 	string collation;
 	for (auto &arg : children) {
@@ -636,6 +665,20 @@ static string ExtractCollation(const vector<unique_ptr<Expression>> &children) {
 			continue;
 		}
 		auto child_collation = StringType::GetCollation(arg->GetReturnType());
+		if (collation.empty()) {
+			collation = child_collation;
+		} else if (!child_collation.empty() && collation != child_collation) {
+			throw BinderException("Cannot combine types with different collation!");
+		}
+	}
+	return collation;
+}
+
+//! Like ExtractCollation, but also considers the collation of nested (LIST/ARRAY) VARCHAR elements.
+static string ExtractNestedCollation(const vector<unique_ptr<Expression>> &children) {
+	string collation;
+	for (auto &arg : children) {
+		auto child_collation = ExtractCollationFromType(arg->GetReturnType());
 		if (collation.empty()) {
 			collation = child_collation;
 		} else if (!child_collation.empty() && collation != child_collation) {
@@ -663,7 +706,7 @@ static void PropagateCollations(ClientContext &, BoundSimpleFunction &bound_func
 
 static void PushCollations(ClientContext &context, BoundSimpleFunction &bound_function,
                            vector<unique_ptr<Expression>> &children, CollationType type) {
-	auto collation = ExtractCollation(children);
+	auto collation = ExtractNestedCollation(children);
 	if (collation.empty()) {
 		// no collation to push
 		return;
@@ -675,12 +718,14 @@ static void PushCollations(ClientContext &context, BoundSimpleFunction &bound_fu
 	}
 	// push collations to the children
 	for (auto &arg : children) {
+		// apply the collation to the (possibly nested) varchar leaves of the argument type
+		auto collated_type = ApplyCollationToType(arg->GetReturnType(), collation_type);
 		if (RequiresCollationPropagation(arg->GetReturnType())) {
 			// if this is a varchar type - propagate the collation
 			arg->SetReturnType(collation_type);
 		}
 		// now push the actual collation handling
-		ExpressionBinder::PushCollation(context, arg, arg->GetReturnType(), type);
+		ExpressionBinder::PushCollation(context, arg, collated_type, type);
 	}
 }
 

--- a/src/function/scalar/list/contains_or_position.cpp
+++ b/src/function/scalar/list/contains_or_position.cpp
@@ -22,14 +22,17 @@ static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector 
 }
 
 ScalarFunction ListContainsFun::GetFunction() {
-	return ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
-	                      LogicalType::BOOLEAN, ListSearchFunction<bool>);
+	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
+	                          LogicalType::BOOLEAN, ListSearchFunction<bool>);
+	fun.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
+	return fun;
 }
 
 ScalarFunction ListPositionFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
 	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	fun.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return fun;
 }
 

--- a/src/include/duckdb/planner/collation_binding.hpp
+++ b/src/include/duckdb/planner/collation_binding.hpp
@@ -16,14 +16,17 @@ struct MapCastInfo;
 struct MapCastNode;
 struct DBConfig;
 
-typedef bool (*try_push_collation_t)(ClientContext &context, unique_ptr<Expression> &source,
-                                     const LogicalType &sql_type, CollationType type);
+//! Returns the (ordered) list of scalar functions that need to be applied to a value of the given type to make it
+//! byte-comparable under its collation. Returns an empty list if no collation needs to be applied.
+typedef vector<string> (*get_collation_functions_t)(ClientContext &context, const LogicalType &sql_type,
+                                                    CollationType type);
 
 struct CollationCallback {
-	explicit CollationCallback(try_push_collation_t try_push_collation_p) : try_push_collation(try_push_collation_p) {
+	explicit CollationCallback(get_collation_functions_t get_collation_functions_p)
+	    : get_collation_functions(get_collation_functions_p) {
 	}
 
-	try_push_collation_t try_push_collation;
+	get_collation_functions_t get_collation_functions;
 };
 
 class CollationBinding {

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_lambda_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/catalog/catalog.hpp"
@@ -10,11 +12,12 @@
 namespace duckdb {
 constexpr const char *CollateCatalogEntry::Name;
 
-bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                          CollationType type) {
+static vector<string> GetVarcharCollationFunctions(ClientContext &context, const LogicalType &sql_type,
+                                                   CollationType type) {
+	vector<string> result;
 	if (sql_type.id() != LogicalTypeId::VARCHAR) {
 		// only VARCHAR columns require collation
-		return false;
+		return result;
 	}
 	// replace default collation with system collation
 	auto str_collation = StringType::GetCollation(sql_type);
@@ -28,7 +31,7 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	// bind the collation
 	if (collation.empty() || collation == "binary" || collation == "c" || collation == "posix") {
 		// no collation or binary collation: skip
-		return false;
+		return result;
 	}
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto splits = StringUtil::Split(StringUtil::Lower(collation), ".");
@@ -55,128 +58,131 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	for (auto &entry : entries) {
 		auto &collation_entry = entry.get();
 		if (!collation_entry.combinable && type == CollationType::COMBINABLE_COLLATIONS) {
-			// not a combinable collation - ignore
-			return false;
+			// not a combinable collation - only apply the (preceding) combinable collations
+			break;
 		}
-		vector<unique_ptr<Expression>> children;
-		children.push_back(std::move(source));
-
-		FunctionBinder function_binder(context);
-		auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
-		source = std::move(function);
+		result.push_back(collation_entry.function.GetName().GetIdentifierName());
 	}
-	return true;
+	return result;
 }
 
-bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                         CollationType) {
+static vector<string> GetTimeTZCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::TIME_TZ) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "timetz_byte_comparable");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("timetz_byte_comparable should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"timetz_byte_comparable"};
 }
 
-bool PushBitStringCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                            CollationType) {
+static vector<string> GetBitStringCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::BIT) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "bitstring_byte_comparable");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("bitstring_byte_comparable should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"bitstring_byte_comparable"};
 }
 
-bool PushIntervalCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                           CollationType) {
+static vector<string> GetIntervalCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::INTERVAL) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "normalized_interval");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("normalized_interval should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"normalized_interval"};
 }
 
-bool PushVariantCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                          CollationType) {
+static vector<string> GetVariantCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::VARIANT) {
-		return false;
+		return vector<string>();
 	}
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "variant_comparator");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("variant_comparator should only have a single overload");
-	}
-	auto source_alias = source->GetAlias();
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	function->SetAlias(source_alias);
-	source = std::move(function);
-	return true;
+	return {"variant_comparator"};
 }
 
-// timetz_byte_comparable
 CollationBinding::CollationBinding() {
-	RegisterCollation(CollationCallback(PushVarcharCollation));
-	RegisterCollation(CollationCallback(PushTimeTZCollation));
-	RegisterCollation(CollationCallback(PushBitStringCollation));
-	RegisterCollation(CollationCallback(PushIntervalCollation));
-	RegisterCollation(CollationCallback(PushVariantCollation));
+	RegisterCollation(CollationCallback(GetVarcharCollationFunctions));
+	RegisterCollation(CollationCallback(GetTimeTZCollationFunctions));
+	RegisterCollation(CollationCallback(GetBitStringCollationFunctions));
+	RegisterCollation(CollationCallback(GetIntervalCollationFunctions));
+	RegisterCollation(CollationCallback(GetVariantCollationFunctions));
 }
 
 void CollationBinding::RegisterCollation(CollationCallback callback) {
 	collations.push_back(callback);
 }
 
+//! Binds the scalar function with the given name (looked up from the system catalog) around "source".
+static unique_ptr<Expression> ApplyCollationFunction(ClientContext &context, const string &function_name,
+                                                     unique_ptr<Expression> source) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &function_entry =
+	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), Identifier(function_name));
+	auto source_alias = source->GetAlias();
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
+
+	FunctionBinder function_binder(context);
+	ErrorData error;
+	auto function = function_binder.BindScalarFunction(function_entry, std::move(children), error);
+	if (!function) {
+		error.Throw();
+	}
+	function->SetAlias(source_alias);
+	return function;
+}
+
+//! Pushes a collation into a LIST/ARRAY type by wrapping the source in a list_transform that applies the collation to
+//! every element via a lambda. Returns false if the elements do not require collation, or if list_transform is not
+//! available (i.e. the core_functions extension is not loaded).
+static bool PushNestedCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &child_type,
+                                CollationType type, const CollationBinding &binding) {
+	// build a lambda body that applies the collation to the lambda parameter (a reference to the child element)
+	unique_ptr<Expression> lambda_body = make_uniq<BoundReferenceExpression>(child_type, idx_t(0));
+	if (!binding.PushCollation(context, lambda_body, child_type, type)) {
+		// the child type does not require collation - nothing to push
+		return false;
+	}
+
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto list_transform = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(),
+	                                                                   "list_transform", OnEntryNotFound::RETURN_NULL);
+	if (!list_transform) {
+		// list_transform is not available - cannot push the collation into the list
+		return false;
+	}
+
+	auto bound_lambda =
+	    make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(lambda_body), 1);
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
+	children.push_back(std::move(bound_lambda));
+
+	FunctionBinder function_binder(context);
+	ErrorData error;
+	auto function = function_binder.BindScalarFunction(*list_transform, std::move(children), error);
+	if (!function) {
+		error.Throw();
+	}
+	// the lambda expression is consumed by the bind - remove it from the children
+	auto &bound_function = function->Cast<BoundFunctionExpression>();
+	bound_function.GetChildrenMutable().erase_at(1);
+	source = std::move(function);
+	return true;
+}
+
 bool CollationBinding::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
                                      const LogicalType &sql_type, CollationType type) const {
+	if (sql_type.id() == LogicalTypeId::LIST) {
+		return PushNestedCollation(context, source, ListType::GetChildType(sql_type), type, *this);
+	}
+	if (sql_type.id() == LogicalTypeId::ARRAY) {
+		return PushNestedCollation(context, source, ArrayType::GetChildType(sql_type), type, *this);
+	}
 	for (auto &collation : collations) {
-		if (collation.try_push_collation(context, source, sql_type, type)) {
-			// successfully pushed a collation
-			return true;
+		auto functions = collation.get_collation_functions(context, sql_type, type);
+		if (functions.empty()) {
+			continue;
 		}
+		// successfully retrieved the collation functions - apply them to the source expression
+		for (auto &function_name : functions) {
+			source = ApplyCollationFunction(context, function_name, std::move(source));
+		}
+		return true;
 	}
 	return false;
 }

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_lambda_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/catalog/catalog.hpp"
@@ -10,11 +12,11 @@
 namespace duckdb {
 constexpr const char *CollateCatalogEntry::Name;
 
-bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                          CollationType type) {
+static vector<string> GetVarcharCollationFunctions(ClientContext &context, const LogicalType &sql_type, CollationType type) {
+	vector<string> result;
 	if (sql_type.id() != LogicalTypeId::VARCHAR) {
 		// only VARCHAR columns require collation
-		return false;
+		return result;
 	}
 	// replace default collation with system collation
 	auto str_collation = StringType::GetCollation(sql_type);
@@ -28,7 +30,7 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	// bind the collation
 	if (collation.empty() || collation == "binary" || collation == "c" || collation == "posix") {
 		// no collation or binary collation: skip
-		return false;
+		return result;
 	}
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto splits = StringUtil::Split(StringUtil::Lower(collation), ".");
@@ -55,128 +57,131 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	for (auto &entry : entries) {
 		auto &collation_entry = entry.get();
 		if (!collation_entry.combinable && type == CollationType::COMBINABLE_COLLATIONS) {
-			// not a combinable collation - ignore
-			return false;
+			// not a combinable collation - only apply the (preceding) combinable collations
+			break;
 		}
-		vector<unique_ptr<Expression>> children;
-		children.push_back(std::move(source));
-
-		FunctionBinder function_binder(context);
-		auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
-		source = std::move(function);
+		result.push_back(collation_entry.function.GetName().GetIdentifierName());
 	}
-	return true;
+	return result;
 }
 
-bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                         CollationType) {
+static vector<string> GetTimeTZCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::TIME_TZ) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "timetz_byte_comparable");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("timetz_byte_comparable should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"timetz_byte_comparable"};
 }
 
-bool PushBitStringCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                            CollationType) {
+static vector<string> GetBitStringCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::BIT) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "bitstring_byte_comparable");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("bitstring_byte_comparable should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"bitstring_byte_comparable"};
 }
 
-bool PushIntervalCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                           CollationType) {
+static vector<string> GetIntervalCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::INTERVAL) {
-		return false;
+		return vector<string>();
 	}
-
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "normalized_interval");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("normalized_interval should only have a single overload");
-	}
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	source = std::move(function);
-	return true;
+	return {"normalized_interval"};
 }
 
-bool PushVariantCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-                          CollationType) {
+static vector<string> GetVariantCollationFunctions(ClientContext &, const LogicalType &sql_type, CollationType) {
 	if (sql_type.id() != LogicalTypeId::VARIANT) {
-		return false;
+		return vector<string>();
 	}
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &function_entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "variant_comparator");
-	if (function_entry.functions.Size() != 1) {
-		throw InternalException("variant_comparator should only have a single overload");
-	}
-	auto source_alias = source->GetAlias();
-	const auto &scalar_function = function_entry.functions.GetFunctionByOffset(0);
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
-	function->SetAlias(source_alias);
-	source = std::move(function);
-	return true;
+	return {"variant_comparator"};
 }
 
-// timetz_byte_comparable
 CollationBinding::CollationBinding() {
-	RegisterCollation(CollationCallback(PushVarcharCollation));
-	RegisterCollation(CollationCallback(PushTimeTZCollation));
-	RegisterCollation(CollationCallback(PushBitStringCollation));
-	RegisterCollation(CollationCallback(PushIntervalCollation));
-	RegisterCollation(CollationCallback(PushVariantCollation));
+	RegisterCollation(CollationCallback(GetVarcharCollationFunctions));
+	RegisterCollation(CollationCallback(GetTimeTZCollationFunctions));
+	RegisterCollation(CollationCallback(GetBitStringCollationFunctions));
+	RegisterCollation(CollationCallback(GetIntervalCollationFunctions));
+	RegisterCollation(CollationCallback(GetVariantCollationFunctions));
 }
 
 void CollationBinding::RegisterCollation(CollationCallback callback) {
 	collations.push_back(callback);
 }
 
+//! Binds the scalar function with the given name (looked up from the system catalog) around "source".
+static unique_ptr<Expression> ApplyCollationFunction(ClientContext &context, const string &function_name,
+                                                     unique_ptr<Expression> source) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &function_entry =
+	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), Identifier(function_name));
+	auto source_alias = source->GetAlias();
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
+
+	FunctionBinder function_binder(context);
+	ErrorData error;
+	auto function = function_binder.BindScalarFunction(function_entry, std::move(children), error);
+	if (!function) {
+		error.Throw();
+	}
+	function->SetAlias(source_alias);
+	return function;
+}
+
+//! Pushes a collation into a LIST/ARRAY type by wrapping the source in a list_transform that applies the collation to
+//! every element via a lambda. Returns false if the elements do not require collation, or if list_transform is not
+//! available (i.e. the core_functions extension is not loaded).
+static bool PushNestedCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &child_type,
+                                CollationType type, const CollationBinding &binding) {
+	// build a lambda body that applies the collation to the lambda parameter (a reference to the child element)
+	unique_ptr<Expression> lambda_body = make_uniq<BoundReferenceExpression>(child_type, idx_t(0));
+	if (!binding.PushCollation(context, lambda_body, child_type, type)) {
+		// the child type does not require collation - nothing to push
+		return false;
+	}
+
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto list_transform = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    context, Identifier::DefaultSchema(), "list_transform", OnEntryNotFound::RETURN_NULL);
+	if (!list_transform) {
+		// list_transform is not available - cannot push the collation into the list
+		return false;
+	}
+
+	auto bound_lambda =
+	    make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(lambda_body), 1);
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
+	children.push_back(std::move(bound_lambda));
+
+	FunctionBinder function_binder(context);
+	ErrorData error;
+	auto function = function_binder.BindScalarFunction(*list_transform, std::move(children), error);
+	if (!function) {
+		error.Throw();
+	}
+	// the lambda expression is consumed by the bind - remove it from the children
+	auto &bound_function = function->Cast<BoundFunctionExpression>();
+	bound_function.GetChildrenMutable().erase_at(1);
+	source = std::move(function);
+	return true;
+}
+
 bool CollationBinding::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
                                      const LogicalType &sql_type, CollationType type) const {
+	if (sql_type.id() == LogicalTypeId::LIST) {
+		return PushNestedCollation(context, source, ListType::GetChildType(sql_type), type, *this);
+	}
+	if (sql_type.id() == LogicalTypeId::ARRAY) {
+		return PushNestedCollation(context, source, ArrayType::GetChildType(sql_type), type, *this);
+	}
 	for (auto &collation : collations) {
-		if (collation.try_push_collation(context, source, sql_type, type)) {
-			// successfully pushed a collation
-			return true;
+		auto functions = collation.get_collation_functions(context, sql_type, type);
+		if (functions.empty()) {
+			continue;
 		}
+		// successfully retrieved the collation functions - apply them to the source expression
+		for (auto &function_name : functions) {
+			source = ApplyCollationFunction(context, function_name, std::move(source));
+		}
+		return true;
 	}
 	return false;
 }

--- a/test/sql/collate/test_collate_list_contains.test
+++ b/test/sql/collate/test_collate_list_contains.test
@@ -1,0 +1,108 @@
+# name: test/sql/collate/test_collate_list_contains.test
+# description: Test that list_contains/list_position correctly push collations
+# group: [collate]
+
+# list_contains pushes the collation of the target onto the list elements
+query I
+SELECT list_contains(['hello', 'world'], 'HELLO' COLLATE NOCASE)
+----
+true
+
+query I
+SELECT list_contains(['hello', 'world'], 'XYZ' COLLATE NOCASE)
+----
+false
+
+# list_position returns the (1-based) position under the collation
+query I
+SELECT list_position(['hello', 'world'], 'WORLD' COLLATE NOCASE)
+----
+2
+
+query I
+SELECT list_position(['hello', 'world'], 'XYZ' COLLATE NOCASE)
+----
+NULL
+
+# contains() routes to the list overload and pushes collations too
+query I
+SELECT contains(['hello', 'world'], 'World' COLLATE NOCASE)
+----
+true
+
+# without a collation the comparison remains case-sensitive (binary)
+query I
+SELECT list_contains(['hello', 'world'], 'HELLO')
+----
+false
+
+query I
+SELECT list_contains(['hello', 'world'], 'hello')
+----
+true
+
+# combined collations
+query I
+SELECT list_contains(['héllo', 'world'], 'HELLO' COLLATE NOACCENT.NOCASE)
+----
+true
+
+# NULLs in the list
+query I
+SELECT list_position([NULL, 'BB'], 'bb' COLLATE NOCASE)
+----
+2
+
+query I
+SELECT list_contains([NULL, 'BB'], 'bb' COLLATE NOCASE)
+----
+true
+
+# empty list
+query I
+SELECT list_contains([]::VARCHAR[], 'x' COLLATE NOCASE)
+----
+false
+
+# NULL list / NULL target
+query I
+SELECT list_contains(NULL::VARCHAR[], 'x' COLLATE NOCASE)
+----
+NULL
+
+statement ok
+CREATE TABLE null_needle(n VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO null_needle VALUES (NULL);
+
+query I
+SELECT list_position(['a', 'b'], n) FROM null_needle
+----
+NULL
+
+# collation pushed from a NOCASE column onto the list elements
+statement ok
+CREATE TABLE t(id INTEGER, l VARCHAR[], needle VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO t VALUES (1, ['Apple', 'Banana'], 'banana'), (2, ['Cherry', 'date'], 'DATE'), (3, ['Egg'], 'fig');
+
+query III
+SELECT id, list_contains(l, needle), list_position(l, needle) FROM t ORDER BY id
+----
+1	true	2
+2	true	2
+3	false	NULL
+
+# the list column itself can carry a NOCASE collation (via a NOCASE column)
+query II
+SELECT list_contains([needle], 'BANANA'), list_position([needle], 'BANANA') FROM t WHERE id = 1
+----
+true	1
+
+# non-varchar lists are unaffected
+query I
+SELECT list_contains([1, 2, 3], 2)
+----
+true


### PR DESCRIPTION
Currently collations are only handled at the top-level, and not inside nested types. This results in some weird / inconsistent behavior, for example:

```sql
-- old inconsistent behavior
select 'hello' collate nocase IN ('HELLO') AS in_result;
┌───────────┐
│ in_result │
│  boolean  │
├───────────┤
│ true      │
└───────────┘
select 'hello' collate nocase IN ['HELLO'] AS list_result;
┌─────────────┐
│ list_result │
│   boolean   │
├─────────────┤
│ false       │
└─────────────┘
```

This PR partially addresses this by adding support to pushing collations into lists, and by pushing collations into `list_contains`.  The way we achieve this is by taking the collation functions, and applying them to each element in the list using a lambda (`lambda_transform`). This means collations are now correctly applied at various stages also inside lists, e.g.:

```sql
select ['hello' COLLATE NOCASE] = ['HELLO'] AS comp_result;
┌─────────────┐
│ comp_result │
│   boolean   │
├─────────────┤
│ true        │
└─────────────┘
select 'hello' collate nocase IN ['HELLO'] AS list_result;
┌─────────────┐
│ list_result │
│   boolean   │
├─────────────┤
│ true        │
└─────────────┘
```