### PR TITLE
Enable parser tools (bison) for musl main extensions

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -176,7 +176,7 @@ jobs:
             exclude_archs: ${{ needs.load-extension-configs.outputs.main_extensions_exclude_archs }}
             opt_in_archs: ${{ needs.load-extension-configs.outputs.main_extensions_opt_in_archs }}
             extension_config: ${{ needs.load-extension-configs.outputs.main_extensions_config }}
-            extra_toolchains: unixodbc
+            extra_toolchains: unixodbc;parser_tools
           - name: Rust-based Extensions
             artifact_prefix: rust-based-extensions
             exclude_archs: ${{ needs.load-extension-configs.outputs.rust_based_extensions_exclude_archs }}


### PR DESCRIPTION
### Bison is missing for musl main extensions

Main extensions are [failing](https://github.com/duckdb/duckdb/actions/runs/27823760584/job/82347917658#step:27:914) for musl (amd64/arm64) because `bison` is not missing:
```
Installing 49/51 libpq[core,lz4,openssl,zlib]:x64-linux-release@18.3...
Building libpq[core,lz4,openssl,zlib]:x64-linux-release@18.3...
/vcpkg/triplets/community/x64-linux-release.cmake: info: loaded community triplet from here. Community triplets are not built in the curated registry and are thus less likely to succeed.
/duckdb_build_dir/build/extension_configuration/_deps/postgres_scanner_extension_fc-src//./vcpkg_ports/libpq: info: installing overlay port from here
Downloading postgresql-18.3.tar.bz2, trying https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.bz2
Successfully downloaded postgresql-18.3.tar.bz2
-- Extracting source /vcpkg/downloads/postgresql-18.3.tar.bz2
...
-- Applying patch windows/getopt.patch
-- Using source at /vcpkg/buildtrees/libpq/src/tgresql-18-c53e6ad68a.clean
-- Getting CMake variables for x64-linux-release
-- Loading CMake variables from /vcpkg/buildtrees/libpq/cmake-get-vars_C_CXX-x64-linux-release.cmake.log
CMake Error at scripts/cmake/vcpkg_find_acquire_program.cmake:179 (message):
  Could not find bison.  Please install it via your package manager:

      sudo apt-get install bison
Call Stack (most recent call first):
  /duckdb_build_dir/build/extension_configuration/_deps/postgres_scanner_extension_fc-src/vcpkg_ports/libpq/portfile.cmake:44 (vcpkg_find_acquire_program)
  scripts/ports.cmake:206 (include)

error: building libpq:x64-linux-release failed with: BUILD_FAILED
```

### Dependencies and packages

The extension `postgres_scanner` [depends](https://github.com/duckdb/duckdb/actions/runs/27823760584/job/82347917658#step:27:132) on `libpq`.

The build of `libpq` succeeds in non-musl jobs, but those CI jobs don't explicitly install `bison` using `extra_toolchain: parser_tools`.

I suspect that alpine installs fewer implicit dependencies and therefore the missing bison error only shows up on both musl CI jobs. Thus, I think that installing `parser_tools` also for non-musl seems useful to avoid this implicit dependency.

Edit: as expected, i see that bison is already (implicitly) installed for linux amd64 (non-musl):
```
#25 [22/28] RUN case ";unixodbc;parser_tools;" in   *;parser_tools;*)    yum install -y bison flex   ;; esac
#25 0.595 Last metadata expiration check: 13:05:20 ago on Sun 21 Jun 2026 10:28:21 PM UTC.
#25 0.956 Package bison-3.0.4-10.el8.x86_64 is already installed.
#25 0.957 Package flex-2.6.1-9.el8.x86_64 is already installed.
#25 0.985 Dependencies resolved.
#25 0.986 Nothing to do.
#25 0.986 Complete!
#25 DONE 1.0s
```

Fixes https://github.com/duckdblabs/ci-tracker/issues/67.