### PR TITLE
Replace slow 'dd bs=1' calls and verify extensions concurrently

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -274,7 +274,9 @@ jobs:
 
           rm -rf /tmp/repository_signed_validation
           make upload-extensions EXTENSION_REPOSITORY_PATH=/tmp/repository_generation
-          ./scripts/verify-extension-signing.sh /tmp/repository_signed_validation "$public_key_file"
+          make verify-extension-signing \
+            SIGNED_EXTENSIONS_DIR=/tmp/repository_signed_validation \
+            EXTENSION_SIGNING_PUBLIC_KEY_FILE="$public_key_file"
 
       - name: Deploy extensions
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -421,10 +421,16 @@ clean:
 
 EXTENSION_REPOSITORY_PATH ?= build/release/repository
 EXTENSION_BUCKET ?= duckdb-core-extensions
+SIGNED_EXTENSIONS_DIR ?= $(EXTENSION_REPOSITORY_PATH)
+EXTENSION_SIGNING_PUBLIC_KEY_FILE ?=
 
 .PHONY: upload-extensions
 upload-extensions:
 	CI_CPU_COUNT="$(CI_CPU_COUNT)" ./scripts/extension-upload-repository.sh "$(EXTENSION_REPOSITORY_PATH)" "$(EXTENSION_BUCKET)"
+
+.PHONY: verify-extension-signing
+verify-extension-signing:
+	CI_CPU_COUNT="$(CI_CPU_COUNT)" ./scripts/verify-extension-signing.sh "$(SIGNED_EXTENSIONS_DIR)" "$(EXTENSION_SIGNING_PUBLIC_KEY_FILE)"
 
 define cmake_build
 	mkdir -p ./$(1) && \

--- a/scripts/verify-extension-signing.sh
+++ b/scripts/verify-extension-signing.sh
@@ -31,6 +31,7 @@ if [ ! -f "$public_key_file" ]; then
 fi
 
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/duckdb-extension-verify.XXXXXX")
+file_list="$work_dir/signed_extensions.list"
 
 cleanup() {
 	rm -rf "$work_dir"
@@ -38,36 +39,66 @@ cleanup() {
 
 trap cleanup EXIT
 
-verified_count=0
+find "$signed_extensions_dir" -type f \( -name '*.duckdb_extension' -o -name '*.duckdb_extension.wasm' \) -print0 | sort -z > "$file_list"
 
-while IFS= read -r -d '' signed_extension; do
-	relative_path="${signed_extension#"$signed_extensions_dir"/}"
-	unsigned_extension="$work_dir/${relative_path}.unsigned"
-	signature_file="$work_dir/${relative_path}.signature"
-	hash_file="$work_dir/${relative_path}.hash"
-
-	mkdir -p "$(dirname "$unsigned_extension")"
-	file_size=$(get_file_size "$signed_extension")
-	if [ "$file_size" -lt "$signature_size" ]; then
-		echo "Signed extension '$signed_extension' is smaller than the signature footer"
-		exit 1
-	fi
-
-	unsigned_size=$((file_size - signature_size))
-	dd if="$signed_extension" of="$unsigned_extension" bs=1 count="$unsigned_size" status=none
-	dd if="$signed_extension" of="$signature_file" bs=1 skip="$unsigned_size" count="$signature_size" status=none
-
-	"$script_dir/compute-extension-hash.sh" "$unsigned_extension" > "$hash_file"
-	openssl pkeyutl -verify -pubin -inkey "$public_key_file" -sigfile "$signature_file" -in "$hash_file" \
-		-pkeyopt digest:sha256 >/dev/null
-
-	echo "Verified signature: $relative_path"
-	verified_count=$((verified_count + 1))
-done < <(find "$signed_extensions_dir" -type f \( -name '*.duckdb_extension' -o -name '*.duckdb_extension.wasm' \) -print0 | sort -z)
+verified_count=$(tr -cd '\0' < "$file_list" | wc -c | tr -d '[:space:]')
 
 if [ "$verified_count" -eq 0 ]; then
 	echo "No signed extensions found under '$signed_extensions_dir'"
 	exit 1
 fi
+
+cat "$file_list" | xargs -0 -n 1 -P "${CI_CPU_COUNT:-1}" bash -c '
+	set -euo pipefail
+
+	script_dir="$1"
+	signed_extensions_dir="$2"
+	public_key_file="$3"
+	signature_size="$4"
+	work_dir="$5"
+	signed_extension="$6"
+
+	get_file_size() {
+		if stat -c%s "$1" >/dev/null 2>&1; then
+			stat -c%s "$1"
+		else
+			stat -f%z "$1"
+		fi
+	}
+
+	relative_path="${signed_extension#"$signed_extensions_dir"/}"
+	job_dir=$(mktemp -d "$work_dir/job.XXXXXX") || exit 1
+	log_file=$(mktemp "$work_dir/log.XXXXXX") || exit 1
+	trap '\''rm -rf "$job_dir" "$log_file"'\'' EXIT
+
+	unsigned_extension="$job_dir/extension.unsigned"
+	signature_file="$job_dir/extension.signature"
+	hash_file="$job_dir/extension.hash"
+
+	if ! {
+		file_size=$(get_file_size "$signed_extension")
+		if [ "$file_size" -lt "$signature_size" ]; then
+			echo "Signed extension '\''$signed_extension'\'' is smaller than the signature footer"
+			exit 1
+		fi
+
+		unsigned_size=$((file_size - signature_size))
+		head -c "$unsigned_size" "$signed_extension" > "$unsigned_extension"
+		tail -c "$signature_size" "$signed_extension" > "$signature_file"
+
+		"$script_dir/compute-extension-hash.sh" "$unsigned_extension" > "$hash_file"
+		openssl pkeyutl -verify -pubin -inkey "$public_key_file" -sigfile "$signature_file" -in "$hash_file" \
+			-pkeyopt digest:sha256 >/dev/null
+
+		echo "Verified signature: $relative_path"
+	} >"$log_file" 2>&1; then
+		cat "$log_file"
+		exit 1
+	fi
+
+	cat "$log_file"
+	rm -rf "$job_dir" "$log_file"
+	trap - EXIT
+' bash "$script_dir" "$signed_extensions_dir" "$public_key_file" "$signature_size" "$work_dir"
 
 echo "Verified $verified_count signed extensions"


### PR DESCRIPTION
### Verify step of "Deploy Extensions" takes ~8-30 min

We added a step to verify extension signatures for PRs. That step made the full CI pipeline much slower: it added ~8-30 min to the critical path.

Signing all 29 extensions took a few seconds:
```
11:48:28 CI_CPU_COUNT="16" ./scripts/extension-upload-repository.sh "/tmp/repository_generation" "duckdb-core-extensions"
11:48:28 Deploying extensions from '/tmp/repository_generation' to bucket 'duckdb-core-extensions'.. (DRY RUN)
11:48:28 Uploading 29 extension files
11:48:28 Processing extension: demo_capi
11:48:28 Processing extension: inet
11:48:28 Processing extension: excel
...
11:48:31 Processing extension: spatial
11:48:34 Processing extension: encodings
```

But verifying the 29 extension signatures took ~29 min:
```
11:48:50 Verified signature: 096d6dfc76/linux_amd64/autocomplete.duckdb_extension
11:49:12 Verified signature: 096d6dfc76/linux_amd64/avro.duckdb_extension
11:49:48 Verified signature: 096d6dfc76/linux_amd64/aws.duckdb_extension
...
12:16:18 Verified signature: 096d6dfc76/linux_amd64/unity_catalog.duckdb_extension
12:17:12 Verified signature: 096d6dfc76/linux_amd64/vss.duckdb_extension
12:17:28 Verified signature: 096d6dfc76/linux_amd64/waddle.duckdb_extension
12:17:28 Verified 29 signed extensions
```

### What is slow?

The verify script uses `dd bs=1` (aka 1-byte copies) and that's extremely slow. The `dd bs=1` call takes on my laptop:
```
9.1 MB extension -> 18s.
108 MB extension -> 132s.
```

For context: `bs` is the block size used by `dd` for reading/writing, and 1 byte is (unsurprisingly) very slow.

And we could verify the signatures concurrently (similar to how we sign the extensions concurrently).

### Conclusion

After these changes, signature verification [went](https://github.com/duckdb/duckdb/actions/runs/27952555317/job/82716338853#step:8:28) from 30 min to 6 sec.