### PR TITLE
Add managed async task queue 

### DIFF
--- a/src/common/serializer/CMakeLists.txt
+++ b/src/common/serializer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_common_serializer
   OBJECT
   async_file_writer.cpp
+  async_task_queue.cpp
   async_write_queue.cpp
   binary_serializer.cpp
   binary_deserializer.cpp

--- a/src/common/serializer/CMakeLists.txt
+++ b/src/common/serializer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_common_serializer
   OBJECT
   async_file_writer.cpp
+  async_memory_governor.cpp
   async_task_queue.cpp
   async_write_queue.cpp
   binary_serializer.cpp

--- a/src/common/serializer/async_memory_governor.cpp
+++ b/src/common/serializer/async_memory_governor.cpp
@@ -1,0 +1,91 @@
+#include "duckdb/common/serializer/async_memory_governor.hpp"
+
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/storage/temporary_memory_manager.hpp"
+
+namespace duckdb {
+
+ManagedAsyncMemoryGovernor::ManagedAsyncMemoryGovernor(ClientContext &client_context_p)
+    : client_context(client_context_p) {
+	auto &scheduler = TaskScheduler::GetScheduler(client_context);
+	auto regular_threads = MaxValue<idx_t>(NumericCast<idx_t>(scheduler.NumberOfThreads()), 1);
+	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
+	max_pending_bytes = ManagedAsyncMemoryConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads;
+	min_pending_bytes =
+	    MinValue(max_pending_bytes, ManagedAsyncMemoryConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads);
+	// A reservation is only useful when drain tasks run asynchronously; synchronous draining bounds itself.
+	if (async_threads > 0 && max_pending_bytes > 0) {
+		memory_state = TemporaryMemoryManager::Get(client_context).Register(client_context);
+		memory_state->SetMinimumReservation(min_pending_bytes);
+		memory_state->SetZero();
+	}
+}
+
+bool ManagedAsyncMemoryGovernor::IsActive() const {
+	return memory_state != nullptr;
+}
+
+void ManagedAsyncMemoryGovernor::UpdateReservation(idx_t current_pending_bytes) {
+	if (!memory_state || current_pending_bytes == 0) {
+		return;
+	}
+
+	auto current_reservation = memory_state->GetReservation();
+	while (current_pending_bytes > MinValue(current_reservation, max_pending_bytes)) {
+		idx_t next_request;
+		if (memory_request_bytes > current_reservation) {
+			// TMM did not fully grant the previous request. Keep retrying it on later growth checks.
+			next_request = memory_request_bytes;
+		} else if (memory_request_bytes == 0) {
+			// Grow coarsely and only release on Release().
+			// Repeatedly shrinking here would touch shared TMM state on the registration hot path.
+			next_request = min_pending_bytes;
+		} else if (memory_request_bytes >= max_pending_bytes) {
+			return;
+		} else if (memory_request_bytes > max_pending_bytes / 2) {
+			next_request = max_pending_bytes;
+		} else {
+			next_request = memory_request_bytes * 2;
+		}
+		next_request = MinValue(MaxValue(next_request, min_pending_bytes), max_pending_bytes);
+		if (next_request <= memory_request_bytes) {
+			return;
+		}
+
+		auto previous_reservation = current_reservation;
+		memory_state->SetRemainingSizeAndUpdateReservation(client_context, next_request);
+		memory_request_bytes = next_request;
+		current_reservation = memory_state->GetReservation();
+		if (current_reservation <= previous_reservation) {
+			return;
+		}
+		if (current_reservation < next_request) {
+			return;
+		}
+	}
+}
+
+idx_t ManagedAsyncMemoryGovernor::BackpressureBudget() const {
+	if (!memory_state) {
+		return NumericLimits<idx_t>::Maximum();
+	}
+	auto reservation = MinValue(memory_state->GetReservation(), max_pending_bytes);
+	// If TMM only grants a tiny reservation, do not retain an async backlog. This makes low-memory execution
+	// behave close to synchronous draining, but automatically allows overlap again if the reservation grows later.
+	if (reservation < ManagedAsyncMemoryConfig::MIN_RESERVATION_FOR_BACKLOG) {
+		return 0;
+	}
+	return reservation;
+}
+
+void ManagedAsyncMemoryGovernor::Release() {
+	if (!memory_state || memory_request_bytes == 0) {
+		return;
+	}
+	memory_state->SetZero();
+	memory_request_bytes = 0;
+}
+
+} // namespace duckdb

--- a/src/common/serializer/async_memory_governor.cpp
+++ b/src/common/serializer/async_memory_governor.cpp
@@ -23,6 +23,8 @@ ManagedAsyncMemoryGovernor::ManagedAsyncMemoryGovernor(ClientContext &client_con
 	}
 }
 
+ManagedAsyncMemoryGovernor::~ManagedAsyncMemoryGovernor() = default;
+
 bool ManagedAsyncMemoryGovernor::IsActive() const {
 	return memory_state != nullptr;
 }

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -558,6 +558,7 @@ void ManagedAsyncTaskQueue::VerifyDrained() const {
 }
 
 void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &error) noexcept {
+	(void)error;
 	deque<AsyncTaskRequest> tasks;
 	{
 		lock_guard<mutex> guard(lock);
@@ -573,14 +574,7 @@ void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &erro
 	}
 
 	for (auto &request : tasks) {
-		auto request_size = request.Size();
 		request.task.reset();
-		if (request.completion) {
-			try {
-				request.completion(request_size, error);
-			} catch (...) {
-			}
-		}
 	}
 }
 

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -1,0 +1,635 @@
+#include "duckdb/common/serializer/async_task_queue.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+#include <exception>
+
+namespace duckdb {
+
+static ErrorData TaskErrorDataFromExceptionPtr(const std::exception_ptr &error_ptr) {
+	try {
+		std::rethrow_exception(error_ptr);
+	} catch (const std::exception &ex) {
+		return ErrorData(ex);
+	} catch (...) { // LCOV_EXCL_START
+		return ErrorData("Unknown exception during async task");
+	} // LCOV_EXCL_STOP
+}
+
+AsyncTaskRequest::AsyncTaskRequest(unique_ptr<AsyncTask> task_p, idx_t size_p,
+                                   AsyncWriteCompletionCallback completion_p)
+    : task(std::move(task_p)), size(size_p), completion(std::move(completion_p)) {
+}
+
+idx_t AsyncTaskRequest::Size() const {
+	return size;
+}
+
+//===--------------------------------------------------------------------===//
+// AsyncTaskQueue
+//===--------------------------------------------------------------------===//
+class AsyncTaskQueueTaskGuard {
+public:
+	explicit AsyncTaskQueueTaskGuard(AsyncTaskQueue &queue_p) : queue(queue_p) {
+	}
+
+	~AsyncTaskQueueTaskGuard() {
+		Finish();
+	}
+
+	void SetRequestSize(idx_t request_size_p) {
+		D_ASSERT(!finished);
+		request_size = request_size_p;
+	}
+
+	void Finish() {
+		if (!finished) {
+			queue.FinishTask(request_size);
+			finished = true;
+		}
+	}
+
+private:
+	AsyncTaskQueue &queue;
+	idx_t request_size = 0;
+	bool finished = false;
+};
+
+class AsyncTaskQueueTask : public BaseExecutorTask {
+public:
+	AsyncTaskQueueTask(AsyncTaskQueue &queue_p, TaskExecutor &executor) : BaseExecutorTask(executor), queue(queue_p) {
+	}
+
+	~AsyncTaskQueueTask() override {
+		if (!started) {
+			queue.CancelScheduledTask();
+		}
+	}
+
+	void ExecuteTask() override {
+		started = true;
+		queue.DrainRequest();
+	}
+
+private:
+	AsyncTaskQueue &queue;
+	bool started = false;
+};
+
+AsyncTaskQueue::AsyncTaskQueue(ClientContext &client_context_p, idx_t max_active_tasks_p)
+    : client_context(client_context_p) {
+	auto &scheduler = TaskScheduler::GetScheduler(client_context);
+	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
+	max_active_tasks = max_active_tasks_p > 0 ? max_active_tasks_p : MaxValue<idx_t>(async_threads, 1);
+	if (async_threads == 0) {
+		return;
+	}
+	executor = make_uniq<TaskExecutor>(client_context, TaskSchedulerType::ASYNC);
+}
+
+AsyncTaskQueue::~AsyncTaskQueue() {
+	lock_guard<mutex> guard(lock);
+	auto drained = pending_requests.empty() && pending_bytes == 0 && in_flight_bytes == 0 && active_tasks == 0 &&
+	               pending_tasks == 0;
+	D_ASSERT(closed || drained);
+	D_ASSERT(!closed || drained);
+}
+
+bool AsyncTaskQueue::IsAsync() const {
+	return executor != nullptr;
+}
+
+bool AsyncTaskQueue::HasError() {
+	return executor && executor->HasError();
+}
+
+void AsyncTaskQueue::Submit(AsyncTaskRequest request) {
+	if (!request.task) {
+		return;
+	}
+	auto request_size = request.Size();
+	if (executor && executor->HasError()) {
+		ErrorData error;
+		try {
+			executor->ThrowError();
+		} catch (const std::exception &ex) {
+			error = ErrorData(ex);
+		} catch (...) { // LCOV_EXCL_START
+			error = ErrorData("Unknown exception during async task");
+		} // LCOV_EXCL_STOP
+		request.task.reset();
+		CompleteRequest(request, request_size, error);
+		error.Throw();
+	}
+	if (!executor) {
+		VerifyOpen();
+		ExecuteRequest(std::move(request));
+		return;
+	}
+
+	{
+		lock_guard<mutex> guard(lock);
+		VerifyOpen();
+		pending_requests.push_back(std::move(request));
+		pending_bytes += request_size;
+	}
+	ScheduleTasksInternal();
+}
+
+idx_t AsyncTaskQueue::PendingBytes() {
+	lock_guard<mutex> guard(lock);
+	return pending_bytes + in_flight_bytes;
+}
+
+void AsyncTaskQueue::ScheduleTasksInternal() {
+	if (!executor) {
+		return;
+	}
+	idx_t schedule_count = 0;
+	{
+		lock_guard<mutex> guard(lock);
+		VerifyOpen();
+		// One drain task per still-unclaimed pending request, capped at the concurrency limit.
+		while (pending_tasks + schedule_count < pending_requests.size() &&
+		       active_tasks + schedule_count < max_active_tasks) {
+			schedule_count++;
+		}
+		active_tasks += schedule_count;
+		pending_tasks += schedule_count;
+	}
+	for (idx_t task_idx = 0; task_idx < schedule_count; task_idx++) {
+		unique_ptr<AsyncTaskQueueTask> task;
+		try {
+			task = make_uniq<AsyncTaskQueueTask>(*this, *executor);
+		} catch (...) {
+			CancelScheduledTasks(schedule_count - task_idx);
+			throw;
+		}
+		try {
+			executor->ScheduleTask(std::move(task));
+		} catch (...) {
+			// The task destructor releases this task's slot. Release the slots for tasks not yet created.
+			CancelScheduledTasks(schedule_count - task_idx - 1);
+			throw;
+		}
+	}
+}
+
+void AsyncTaskQueue::FinishTask(idx_t task_size) {
+	lock_guard<mutex> guard(lock);
+	D_ASSERT(active_tasks > 0);
+	active_tasks--;
+	D_ASSERT(in_flight_bytes >= task_size);
+	in_flight_bytes -= task_size;
+}
+
+void AsyncTaskQueue::CancelScheduledTask() {
+	CancelScheduledTasks(1);
+}
+
+void AsyncTaskQueue::CancelScheduledTasks(idx_t task_count) {
+	if (task_count == 0) {
+		return;
+	}
+	lock_guard<mutex> guard(lock);
+	D_ASSERT(active_tasks >= task_count);
+	D_ASSERT(pending_tasks >= task_count);
+	active_tasks -= task_count;
+	pending_tasks -= task_count;
+}
+
+void AsyncTaskQueue::DrainRequest() {
+	AsyncTaskQueueTaskGuard guard(*this);
+	AsyncTaskRequest request;
+	bool has_request = false;
+	{
+		lock_guard<mutex> task_guard(lock);
+		D_ASSERT(active_tasks > 0);
+		D_ASSERT(pending_tasks > 0);
+		pending_tasks--;
+		if (!pending_requests.empty()) {
+			request = std::move(pending_requests.front());
+			pending_requests.pop_front();
+			D_ASSERT(pending_bytes >= request.size);
+			pending_bytes -= request.size;
+			in_flight_bytes += request.size;
+			has_request = true;
+		}
+	}
+	if (!has_request) {
+		guard.Finish();
+		return;
+	}
+	guard.SetRequestSize(request.size);
+	ExecuteRequest(std::move(request));
+	guard.Finish();
+	ScheduleTasksInternal();
+}
+
+void AsyncTaskQueue::CompleteRequest(AsyncTaskRequest &request, idx_t size, optional_ptr<const ErrorData> error) {
+	if (request.completion) {
+		// Tasks have no positional offset; pass 0 to reuse the shared completion callback signature.
+		request.completion(0, size, error);
+	}
+}
+
+void AsyncTaskQueue::ExecuteRequest(AsyncTaskRequest request) {
+	auto request_size = request.Size();
+	ErrorData task_error;
+	bool has_error = false;
+	try {
+		request.task->Execute();
+	} catch (const std::exception &ex) {
+		task_error = ErrorData(ex);
+		has_error = true;
+	} catch (...) { // LCOV_EXCL_START
+		task_error = ErrorData("Unknown exception during async task");
+		has_error = true;
+	} // LCOV_EXCL_STOP
+
+	request.task.reset();
+	if (has_error) {
+		CompleteRequest(request, request_size, task_error);
+		task_error.Throw();
+	}
+	CompleteRequest(request, request_size, nullptr);
+}
+
+void AsyncTaskQueue::RethrowTaskError() {
+	if (executor && executor->HasError()) {
+		executor->ThrowError();
+	}
+}
+
+void AsyncTaskQueue::WorkOnPendingTask() {
+	if (!executor) {
+		VerifyOpen();
+		return;
+	}
+	shared_ptr<Task> task;
+	if (!executor->GetTask(task)) {
+		TaskScheduler::YieldThread();
+		return;
+	}
+	auto result = task->Execute(TaskExecutionMode::PROCESS_ALL);
+	D_ASSERT(result != TaskExecutionResult::TASK_BLOCKED);
+	task.reset();
+}
+
+void AsyncTaskQueue::Flush() {
+	bool already_closed;
+	{
+		lock_guard<mutex> guard(lock);
+		already_closed = closed;
+	}
+	if (already_closed) {
+		RethrowTaskError();
+		return;
+	}
+	if (!executor) {
+		RethrowTaskError();
+		return;
+	}
+
+	try {
+		ScheduleTasksInternal();
+		executor->WorkOnTasks();
+	} catch (...) {
+		try {
+			executor->WorkOnTasks();
+		} catch (...) {
+		}
+		throw;
+	}
+	RethrowTaskError();
+}
+
+void AsyncTaskQueue::VerifyDrained() const {
+	if (!pending_requests.empty() || pending_bytes != 0 || in_flight_bytes != 0 || active_tasks != 0 ||
+	    pending_tasks != 0) {
+		throw InternalException("AsyncTaskQueue still owns submitted tasks");
+	}
+}
+
+void AsyncTaskQueue::CancelPendingRequestsAfterFailure(const ErrorData &error) noexcept {
+	deque<AsyncTaskRequest> requests;
+	{
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(active_tasks == 0);
+		D_ASSERT(pending_tasks == 0);
+		D_ASSERT(in_flight_bytes == 0);
+		if (active_tasks != 0 || pending_tasks != 0 || in_flight_bytes != 0) {
+			return;
+		}
+
+		requests = std::move(pending_requests);
+		pending_bytes = 0;
+		closed = true;
+	}
+
+	for (auto &request : requests) {
+		auto request_size = request.Size();
+		request.task.reset();
+		try {
+			CompleteRequest(request, request_size, error);
+		} catch (...) {
+		}
+	}
+}
+
+void AsyncTaskQueue::Close() {
+	bool already_closed;
+	{
+		lock_guard<mutex> guard(lock);
+		already_closed = closed;
+	}
+	if (already_closed) {
+		RethrowTaskError();
+		return;
+	}
+
+	try {
+		Flush();
+	} catch (...) {
+		auto error = std::current_exception();
+		auto error_data = TaskErrorDataFromExceptionPtr(error);
+		CancelPendingRequestsAfterFailure(error_data);
+		std::rethrow_exception(error);
+	}
+
+	lock_guard<mutex> guard(lock);
+	VerifyDrained();
+	closed = true;
+}
+
+void AsyncTaskQueue::VerifyOpen() const {
+	if (closed) {
+		throw InternalException("Cannot use closed AsyncTaskQueue");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// ManagedAsyncTaskQueue
+//===--------------------------------------------------------------------===//
+ManagedAsyncTaskQueue::ManagedAsyncTaskQueue(ClientContext &client_context_p, idx_t max_active_tasks)
+    : client_context(client_context_p), memory_governor(client_context_p) {
+	auto &scheduler = TaskScheduler::GetScheduler(client_context);
+	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
+	max_active_drain_tasks = max_active_tasks > 0 ? max_active_tasks : MaxValue<idx_t>(async_threads, 1);
+	task_queue = make_uniq<AsyncTaskQueue>(client_context, max_active_drain_tasks);
+}
+
+ManagedAsyncTaskQueue::~ManagedAsyncTaskQueue() {
+	lock_guard<mutex> guard(lock);
+	auto drained = pending_requests.empty() && pending_bytes == 0 && submitted_bytes == 0 && submitted_requests == 0;
+	D_ASSERT(closed || drained);
+	D_ASSERT(!closed || drained);
+}
+
+bool ManagedAsyncTaskQueue::IsAsync() const {
+	return task_queue->IsAsync();
+}
+
+bool ManagedAsyncTaskQueue::HasError() {
+	return task_queue->HasError();
+}
+
+void ManagedAsyncTaskQueue::Register(unique_ptr<AsyncTask> task, idx_t byte_size) {
+	if (!task) {
+		return;
+	}
+	RethrowTaskError();
+
+	if (!task_queue->IsAsync()) {
+		VerifyOpen();
+		task_queue->Submit(AsyncTaskRequest(std::move(task), byte_size));
+		return;
+	}
+
+	AsyncTaskRequest request(std::move(task), byte_size);
+	AddCompletionAccounting(request);
+	{
+		lock_guard<mutex> guard(lock);
+		VerifyOpen();
+		pending_requests.push_back(std::move(request));
+		pending_bytes += byte_size;
+	}
+	UpdateMemoryState();
+	SchedulePendingTasks();
+}
+
+void ManagedAsyncTaskQueue::SchedulePendingTasks(SchedulePolicy policy) {
+	if (!task_queue->IsAsync()) {
+		return;
+	}
+	while (true) {
+		AsyncTaskRequest request;
+		if (!TakePendingTaskRequest(request, policy)) {
+			return;
+		}
+		task_queue->Submit(std::move(request));
+	}
+}
+
+void ManagedAsyncTaskQueue::UpdateMemoryState() {
+	if (!memory_governor.IsActive()) {
+		return;
+	}
+	idx_t current_pending_bytes;
+	{
+		lock_guard<mutex> guard(lock);
+		current_pending_bytes = TotalPendingBytes();
+	}
+	memory_governor.UpdateReservation(current_pending_bytes);
+}
+
+idx_t ManagedAsyncTaskQueue::TotalPendingBytes() const {
+	return pending_bytes + submitted_bytes;
+}
+
+bool ManagedAsyncTaskQueue::TakePendingTaskRequest(AsyncTaskRequest &request, SchedulePolicy policy) {
+	lock_guard<mutex> guard(lock);
+	if (pending_requests.empty()) {
+		return false;
+	}
+	// Keep at most max_active_drain_tasks submitted so the low-level queue's backlog stays bounded.
+	if (policy == SchedulePolicy::THRESHOLD && submitted_requests >= max_active_drain_tasks) {
+		return false;
+	}
+
+	auto request_size = pending_requests.front().Size();
+	request = std::move(pending_requests.front());
+	pending_requests.pop_front();
+	D_ASSERT(pending_bytes >= request_size);
+	pending_bytes -= request_size;
+	submitted_bytes += request_size;
+	submitted_requests++;
+	return true;
+}
+
+void ManagedAsyncTaskQueue::AddCompletionAccounting(AsyncTaskRequest &request) {
+	request.completion = [this](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
+		(void)offset;
+		CompleteSubmittedTask(size, error);
+	};
+}
+
+void ManagedAsyncTaskQueue::CompleteSubmittedTask(idx_t size, optional_ptr<const ErrorData> error) {
+	bool refill = false;
+	{
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(submitted_requests > 0);
+		submitted_requests--;
+		D_ASSERT(submitted_bytes >= size);
+		submitted_bytes -= size;
+		refill = !error && !closed && !pending_requests.empty();
+	}
+	if (refill) {
+		SchedulePendingTasks();
+	}
+}
+
+void ManagedAsyncTaskQueue::ApplyBackpressure() {
+	if (!task_queue->IsAsync()) {
+		VerifyOpen();
+		return;
+	}
+	RethrowTaskError();
+	UpdateMemoryState();
+	SchedulePendingTasks();
+	while (true) {
+		idx_t current_pending_bytes;
+		{
+			lock_guard<mutex> guard(lock);
+			current_pending_bytes = TotalPendingBytes();
+		}
+		if (current_pending_bytes <= memory_governor.BackpressureBudget()) {
+			return;
+		}
+		SchedulePendingTasks(SchedulePolicy::FORCE);
+		task_queue->WorkOnPendingTask();
+		RethrowTaskError();
+	}
+}
+
+void ManagedAsyncTaskQueue::WaitAll() {
+	bool already_closed;
+	{
+		lock_guard<mutex> guard(lock);
+		already_closed = closed;
+	}
+	if (already_closed) {
+		RethrowTaskError();
+		return;
+	}
+	if (!task_queue->IsAsync()) {
+		RethrowTaskError();
+		return;
+	}
+
+	try {
+		UpdateMemoryState();
+		while (true) {
+			if (!task_queue->HasError()) {
+				SchedulePendingTasks(SchedulePolicy::FORCE);
+			}
+			task_queue->Flush();
+			lock_guard<mutex> guard(lock);
+			if (pending_requests.empty() && pending_bytes == 0 && submitted_bytes == 0 && submitted_requests == 0) {
+				break;
+			}
+		}
+	} catch (...) {
+		try {
+			task_queue->Flush();
+		} catch (...) {
+		}
+		throw;
+	}
+
+	RethrowTaskError();
+}
+
+void ManagedAsyncTaskQueue::VerifyDrained() const {
+	if (!pending_requests.empty() || pending_bytes != 0 || submitted_bytes != 0 || submitted_requests != 0) {
+		throw InternalException("ManagedAsyncTaskQueue still owns registered tasks");
+	}
+}
+
+void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &error) noexcept {
+	deque<AsyncTaskRequest> tasks;
+	{
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(submitted_requests == 0);
+		D_ASSERT(submitted_bytes == 0);
+		if (submitted_requests != 0 || submitted_bytes != 0) {
+			return;
+		}
+
+		tasks = std::move(pending_requests);
+		pending_bytes = 0;
+		closed = true;
+	}
+
+	for (auto &request : tasks) {
+		auto request_size = request.Size();
+		request.task.reset();
+		if (request.completion) {
+			try {
+				request.completion(0, request_size, error);
+			} catch (...) {
+			}
+		}
+	}
+}
+
+void ManagedAsyncTaskQueue::Close() {
+	bool already_closed;
+	{
+		lock_guard<mutex> guard(lock);
+		already_closed = closed;
+	}
+	if (already_closed) {
+		RethrowTaskError();
+		return;
+	}
+
+	try {
+		WaitAll();
+		task_queue->Close();
+		memory_governor.Release();
+	} catch (...) {
+		auto error = std::current_exception();
+		try {
+			task_queue->Close();
+		} catch (...) {
+		}
+		auto error_data = TaskErrorDataFromExceptionPtr(error);
+		CancelPendingTasksAfterFailure(error_data);
+		try {
+			memory_governor.Release();
+		} catch (...) {
+		}
+		std::rethrow_exception(error);
+	}
+
+	lock_guard<mutex> guard(lock);
+	VerifyDrained();
+	closed = true;
+}
+
+void ManagedAsyncTaskQueue::RethrowTaskError() {
+	task_queue->RethrowTaskError();
+}
+
+void ManagedAsyncTaskQueue::VerifyOpen() const {
+	if (closed) {
+		throw InternalException("Cannot use closed ManagedAsyncTaskQueue");
+	}
+}
+
+} // namespace duckdb

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -409,7 +409,6 @@ void ManagedAsyncTaskQueue::Register(unique_ptr<AsyncTask> task, idx_t byte_size
 	}
 
 	AsyncTaskRequest request(std::move(task), byte_size);
-	AddCompletionAccounting(request);
 	{
 		lock_guard<mutex> guard(lock);
 		VerifyOpen();
@@ -466,6 +465,8 @@ bool ManagedAsyncTaskQueue::TakePendingTaskRequest(AsyncTaskRequest &request, Sc
 	pending_bytes -= request_size;
 	submitted_bytes += request_size;
 	submitted_requests++;
+	// Attach accounting only on submission, so cancelled pending tasks never carry it.
+	AddCompletionAccounting(request);
 	return true;
 }
 
@@ -558,7 +559,6 @@ void ManagedAsyncTaskQueue::VerifyDrained() const {
 }
 
 void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &error) noexcept {
-	(void)error;
 	deque<AsyncTaskRequest> tasks;
 	{
 		lock_guard<mutex> guard(lock);
@@ -573,8 +573,16 @@ void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &erro
 		closed = true;
 	}
 
+	// Pending tasks were never submitted, so they carry no accounting; only a user completion (if any) fires.
 	for (auto &request : tasks) {
+		auto request_size = request.Size();
 		request.task.reset();
+		if (request.completion) {
+			try {
+				request.completion(request_size, error);
+			} catch (...) {
+			}
+		}
 	}
 }
 

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -20,8 +20,7 @@ static ErrorData TaskErrorDataFromExceptionPtr(const std::exception_ptr &error_p
 	} // LCOV_EXCL_STOP
 }
 
-AsyncTaskRequest::AsyncTaskRequest(unique_ptr<AsyncTask> task_p, idx_t size_p,
-                                   AsyncWriteCompletionCallback completion_p)
+AsyncTaskRequest::AsyncTaskRequest(unique_ptr<AsyncTask> task_p, idx_t size_p, AsyncTaskCompletionCallback completion_p)
     : task(std::move(task_p)), size(size_p), completion(std::move(completion_p)) {
 }
 
@@ -232,8 +231,7 @@ void AsyncTaskQueue::DrainRequest() {
 
 void AsyncTaskQueue::CompleteRequest(AsyncTaskRequest &request, idx_t size, optional_ptr<const ErrorData> error) {
 	if (request.completion) {
-		// Tasks have no positional offset; pass 0 to reuse the shared completion callback signature.
-		request.completion(0, size, error);
+		request.completion(size, error);
 	}
 }
 
@@ -472,8 +470,7 @@ bool ManagedAsyncTaskQueue::TakePendingTaskRequest(AsyncTaskRequest &request, Sc
 }
 
 void ManagedAsyncTaskQueue::AddCompletionAccounting(AsyncTaskRequest &request) {
-	request.completion = [this](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
-		(void)offset;
+	request.completion = [this](idx_t size, optional_ptr<const ErrorData> error) {
 		CompleteSubmittedTask(size, error);
 	};
 }
@@ -580,7 +577,7 @@ void ManagedAsyncTaskQueue::CancelPendingTasksAfterFailure(const ErrorData &erro
 		request.task.reset();
 		if (request.completion) {
 			try {
-				request.completion(0, request_size, error);
+				request.completion(request_size, error);
 			} catch (...) {
 			}
 		}

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
-#include "duckdb/storage/temporary_memory_manager.hpp"
 
 #include <cstring>
 #include <exception>
@@ -23,86 +22,6 @@ static ErrorData ErrorDataFromExceptionPtr(const std::exception_ptr &error_ptr) 
 	} catch (...) { // LCOV_EXCL_START
 		return ErrorData("Unknown exception during async write");
 	} // LCOV_EXCL_STOP
-}
-
-ManagedAsyncMemoryGovernor::ManagedAsyncMemoryGovernor(ClientContext &client_context_p)
-    : client_context(client_context_p) {
-	auto &scheduler = TaskScheduler::GetScheduler(client_context);
-	auto regular_threads = MaxValue<idx_t>(NumericCast<idx_t>(scheduler.NumberOfThreads()), 1);
-	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
-	max_pending_bytes = AsyncWriteConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads;
-	min_pending_bytes = MinValue(max_pending_bytes, AsyncWriteConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads);
-	// A reservation is only useful when drain tasks run asynchronously; synchronous draining bounds itself.
-	if (async_threads > 0 && max_pending_bytes > 0) {
-		memory_state = TemporaryMemoryManager::Get(client_context).Register(client_context);
-		memory_state->SetMinimumReservation(min_pending_bytes);
-		memory_state->SetZero();
-	}
-}
-
-bool ManagedAsyncMemoryGovernor::IsActive() const {
-	return memory_state != nullptr;
-}
-
-void ManagedAsyncMemoryGovernor::UpdateReservation(idx_t current_pending_bytes) {
-	if (!memory_state || current_pending_bytes == 0) {
-		return;
-	}
-
-	auto current_reservation = memory_state->GetReservation();
-	while (current_pending_bytes > MinValue(current_reservation, max_pending_bytes)) {
-		idx_t next_request;
-		if (memory_request_bytes > current_reservation) {
-			// TMM did not fully grant the previous request. Keep retrying it on later growth checks.
-			next_request = memory_request_bytes;
-		} else if (memory_request_bytes == 0) {
-			// Grow coarsely and only release on Release().
-			// Repeatedly shrinking here would touch shared TMM state on the registration hot path.
-			next_request = min_pending_bytes;
-		} else if (memory_request_bytes >= max_pending_bytes) {
-			return;
-		} else if (memory_request_bytes > max_pending_bytes / 2) {
-			next_request = max_pending_bytes;
-		} else {
-			next_request = memory_request_bytes * 2;
-		}
-		next_request = MinValue(MaxValue(next_request, min_pending_bytes), max_pending_bytes);
-		if (next_request <= memory_request_bytes) {
-			return;
-		}
-
-		auto previous_reservation = current_reservation;
-		memory_state->SetRemainingSizeAndUpdateReservation(client_context, next_request);
-		memory_request_bytes = next_request;
-		current_reservation = memory_state->GetReservation();
-		if (current_reservation <= previous_reservation) {
-			return;
-		}
-		if (current_reservation < next_request) {
-			return;
-		}
-	}
-}
-
-idx_t ManagedAsyncMemoryGovernor::BackpressureBudget() const {
-	if (!memory_state) {
-		return NumericLimits<idx_t>::Maximum();
-	}
-	auto reservation = MinValue(memory_state->GetReservation(), max_pending_bytes);
-	// If TMM only grants a tiny reservation, do not retain an async backlog. This makes low-memory execution
-	// behave close to synchronous draining, but automatically allows overlap again if the reservation grows later.
-	if (reservation < AsyncWriteConfig::REMOTE_COALESCE_THRESHOLD) {
-		return 0;
-	}
-	return reservation;
-}
-
-void ManagedAsyncMemoryGovernor::Release() {
-	if (!memory_state || memory_request_bytes == 0) {
-		return;
-	}
-	memory_state->SetZero();
-	memory_request_bytes = 0;
 }
 
 AsyncWriteRequest::AsyncWriteRequest(unique_ptr<AsyncWritePayload> payload_p, idx_t offset_p,

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -486,9 +486,8 @@ void AsyncWriteQueue::VerifyOpen() const {
 	}
 }
 
-ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p,
-                                                   AsyncWriteCompletionCallback pending_completion_p)
-    : request(std::move(request_p)), size(request.Size()), pending_completion(std::move(pending_completion_p)) {
+ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p)
+    : request(std::move(request_p)), size(request.Size()) {
 }
 
 idx_t ManagedAsyncWriteQueue::PendingWrite::Size() const {
@@ -580,7 +579,6 @@ void ManagedAsyncWriteQueue::RegisterWriteInternal(AsyncWriteRequest request, id
 		return;
 	}
 
-	auto pending_completion = AddCompletionAccounting(request);
 	{
 		lock_guard<mutex> guard(lock);
 		VerifyOpen();
@@ -588,7 +586,7 @@ void ManagedAsyncWriteQueue::RegisterWriteInternal(AsyncWriteRequest request, id
 			D_ASSERT(external_pending_bytes >= accounted_external_bytes);
 			external_pending_bytes -= accounted_external_bytes;
 		}
-		pending_writes.emplace_back(std::move(request), std::move(pending_completion));
+		pending_writes.emplace_back(std::move(request));
 		pending_bytes += request_size;
 	}
 	UpdateMemoryState();
@@ -678,10 +676,12 @@ bool ManagedAsyncWriteQueue::TakePendingWriteRequest(AsyncWriteRequest &request,
 	pending_bytes -= request_size;
 	submitted_bytes += request_size;
 	submitted_requests++;
+	// Attach accounting only on submission, so cancelled pending writes never carry it.
+	AddCompletionAccounting(request);
 	return true;
 }
 
-AsyncWriteCompletionCallback ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request) {
+void ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request) {
 	auto user_completion = request.completion;
 	request.completion = [this, user_completion](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
 		CompleteSubmittedWrite(offset, size, error);
@@ -689,7 +689,6 @@ AsyncWriteCompletionCallback ManagedAsyncWriteQueue::AddCompletionAccounting(Asy
 			user_completion(offset, size, error);
 		}
 	};
-	return user_completion;
 }
 
 void ManagedAsyncWriteQueue::CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
@@ -801,9 +800,10 @@ void ManagedAsyncWriteQueue::CancelPendingWritesAfterFailure(const ErrorData &er
 		auto request_size = pending.Size();
 		auto &request = pending.request;
 		request.payload.reset();
-		if (pending.pending_completion) {
+		// Pending writes were never submitted, so request.completion is still the raw user callback (if any).
+		if (request.completion) {
 			try {
-				pending.pending_completion(request.offset, request_size, error);
+				request.completion(request.offset, request_size, error);
 			} catch (...) {
 			}
 		}

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -486,8 +486,9 @@ void AsyncWriteQueue::VerifyOpen() const {
 	}
 }
 
-ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p)
-    : request(std::move(request_p)), size(request.Size()) {
+ManagedAsyncWriteQueue::PendingWrite::PendingWrite(AsyncWriteRequest request_p,
+                                                   AsyncWriteCompletionCallback pending_completion_p)
+    : request(std::move(request_p)), size(request.Size()), pending_completion(std::move(pending_completion_p)) {
 }
 
 idx_t ManagedAsyncWriteQueue::PendingWrite::Size() const {
@@ -579,7 +580,7 @@ void ManagedAsyncWriteQueue::RegisterWriteInternal(AsyncWriteRequest request, id
 		return;
 	}
 
-	AddCompletionAccounting(request);
+	auto pending_completion = AddCompletionAccounting(request);
 	{
 		lock_guard<mutex> guard(lock);
 		VerifyOpen();
@@ -587,7 +588,7 @@ void ManagedAsyncWriteQueue::RegisterWriteInternal(AsyncWriteRequest request, id
 			D_ASSERT(external_pending_bytes >= accounted_external_bytes);
 			external_pending_bytes -= accounted_external_bytes;
 		}
-		pending_writes.emplace_back(std::move(request));
+		pending_writes.emplace_back(std::move(request), std::move(pending_completion));
 		pending_bytes += request_size;
 	}
 	UpdateMemoryState();
@@ -680,7 +681,7 @@ bool ManagedAsyncWriteQueue::TakePendingWriteRequest(AsyncWriteRequest &request,
 	return true;
 }
 
-void ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request) {
+AsyncWriteCompletionCallback ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request) {
 	auto user_completion = request.completion;
 	request.completion = [this, user_completion](idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
 		CompleteSubmittedWrite(offset, size, error);
@@ -688,6 +689,7 @@ void ManagedAsyncWriteQueue::AddCompletionAccounting(AsyncWriteRequest &request)
 			user_completion(offset, size, error);
 		}
 	};
+	return user_completion;
 }
 
 void ManagedAsyncWriteQueue::CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error) {
@@ -799,9 +801,9 @@ void ManagedAsyncWriteQueue::CancelPendingWritesAfterFailure(const ErrorData &er
 		auto request_size = pending.Size();
 		auto &request = pending.request;
 		request.payload.reset();
-		if (request.completion) {
+		if (pending.pending_completion) {
 			try {
-				request.completion(request.offset, request_size, error);
+				pending.pending_completion(request.offset, request_size, error);
 			} catch (...) {
 			}
 		}

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -25,6 +25,86 @@ static ErrorData ErrorDataFromExceptionPtr(const std::exception_ptr &error_ptr) 
 	} // LCOV_EXCL_STOP
 }
 
+ManagedAsyncMemoryGovernor::ManagedAsyncMemoryGovernor(ClientContext &client_context_p)
+    : client_context(client_context_p) {
+	auto &scheduler = TaskScheduler::GetScheduler(client_context);
+	auto regular_threads = MaxValue<idx_t>(NumericCast<idx_t>(scheduler.NumberOfThreads()), 1);
+	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
+	max_pending_bytes = AsyncWriteConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads;
+	min_pending_bytes = MinValue(max_pending_bytes, AsyncWriteConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads);
+	// A reservation is only useful when drain tasks run asynchronously; synchronous draining bounds itself.
+	if (async_threads > 0 && max_pending_bytes > 0) {
+		memory_state = TemporaryMemoryManager::Get(client_context).Register(client_context);
+		memory_state->SetMinimumReservation(min_pending_bytes);
+		memory_state->SetZero();
+	}
+}
+
+bool ManagedAsyncMemoryGovernor::IsActive() const {
+	return memory_state != nullptr;
+}
+
+void ManagedAsyncMemoryGovernor::UpdateReservation(idx_t current_pending_bytes) {
+	if (!memory_state || current_pending_bytes == 0) {
+		return;
+	}
+
+	auto current_reservation = memory_state->GetReservation();
+	while (current_pending_bytes > MinValue(current_reservation, max_pending_bytes)) {
+		idx_t next_request;
+		if (memory_request_bytes > current_reservation) {
+			// TMM did not fully grant the previous request. Keep retrying it on later growth checks.
+			next_request = memory_request_bytes;
+		} else if (memory_request_bytes == 0) {
+			// Grow coarsely and only release on Release().
+			// Repeatedly shrinking here would touch shared TMM state on the registration hot path.
+			next_request = min_pending_bytes;
+		} else if (memory_request_bytes >= max_pending_bytes) {
+			return;
+		} else if (memory_request_bytes > max_pending_bytes / 2) {
+			next_request = max_pending_bytes;
+		} else {
+			next_request = memory_request_bytes * 2;
+		}
+		next_request = MinValue(MaxValue(next_request, min_pending_bytes), max_pending_bytes);
+		if (next_request <= memory_request_bytes) {
+			return;
+		}
+
+		auto previous_reservation = current_reservation;
+		memory_state->SetRemainingSizeAndUpdateReservation(client_context, next_request);
+		memory_request_bytes = next_request;
+		current_reservation = memory_state->GetReservation();
+		if (current_reservation <= previous_reservation) {
+			return;
+		}
+		if (current_reservation < next_request) {
+			return;
+		}
+	}
+}
+
+idx_t ManagedAsyncMemoryGovernor::BackpressureBudget() const {
+	if (!memory_state) {
+		return NumericLimits<idx_t>::Maximum();
+	}
+	auto reservation = MinValue(memory_state->GetReservation(), max_pending_bytes);
+	// If TMM only grants a tiny reservation, do not retain an async backlog. This makes low-memory execution
+	// behave close to synchronous draining, but automatically allows overlap again if the reservation grows later.
+	if (reservation < AsyncWriteConfig::REMOTE_COALESCE_THRESHOLD) {
+		return 0;
+	}
+	return reservation;
+}
+
+void ManagedAsyncMemoryGovernor::Release() {
+	if (!memory_state || memory_request_bytes == 0) {
+		return;
+	}
+	memory_state->SetZero();
+	memory_request_bytes = 0;
+}
+
 AsyncWriteRequest::AsyncWriteRequest(unique_ptr<AsyncWritePayload> payload_p, idx_t offset_p,
                                      AsyncWriteCompletionCallback completion_p)
     : payload(std::move(payload_p)), offset(offset_p), completion(std::move(completion_p)) {
@@ -496,21 +576,13 @@ idx_t ManagedAsyncWriteQueue::PendingWrite::Size() const {
 }
 
 ManagedAsyncWriteQueue::ManagedAsyncWriteQueue(ClientContext &client_context_p, AsyncWriteTarget &target_p)
-    : client_context(client_context_p), target(target_p) {
+    : client_context(client_context_p), target(target_p), memory_governor(client_context_p) {
 	auto &scheduler = TaskScheduler::GetScheduler(client_context);
-	auto regular_threads = MaxValue<idx_t>(NumericCast<idx_t>(scheduler.NumberOfThreads()), 1);
 	auto async_threads = NumericCast<idx_t>(scheduler.NumberOfAsyncThreads());
 	max_active_drain_tasks = MaxValue<idx_t>(async_threads, 1);
-	max_pending_bytes = AsyncWriteConfig::MAX_PENDING_BYTES_PER_THREAD * regular_threads;
-	min_pending_bytes = MinValue(max_pending_bytes, AsyncWriteConfig::MIN_PENDING_BYTES_PER_THREAD * regular_threads);
 
 	AsyncWriteTarget &async_target = *this;
 	write_queue = make_uniq<AsyncWriteQueue>(client_context, async_target);
-	if (write_queue->IsAsync() && max_pending_bytes > 0) {
-		memory_state = TemporaryMemoryManager::Get(client_context).Register(client_context);
-		memory_state->SetMinimumReservation(min_pending_bytes);
-		memory_state->SetZero();
-	}
 }
 
 ManagedAsyncWriteQueue::~ManagedAsyncWriteQueue() {
@@ -629,7 +701,7 @@ void ManagedAsyncWriteQueue::SchedulePendingWritesInternal(SchedulePolicy policy
 
 void ManagedAsyncWriteQueue::UpdateMemoryState(MemoryUpdateMode mode) {
 	(void)mode;
-	if (!memory_state) {
+	if (!memory_governor.IsActive()) {
 		return;
 	}
 
@@ -638,56 +710,11 @@ void ManagedAsyncWriteQueue::UpdateMemoryState(MemoryUpdateMode mode) {
 		lock_guard<mutex> guard(lock);
 		current_pending_bytes = TotalPendingBytes();
 	}
-	if (current_pending_bytes == 0) {
-		return;
-	}
-
-	auto current_reservation = memory_state->GetReservation();
-	while (current_pending_bytes > MinValue(current_reservation, max_pending_bytes)) {
-		idx_t next_request;
-		if (memory_request_bytes > current_reservation) {
-			// TMM did not fully grant the previous request. Keep retrying it on later growth checks.
-			next_request = memory_request_bytes;
-		} else if (memory_request_bytes == 0) {
-			// Grow coarsely and only release on Close().
-			// Repeatedly shrinking here would touch shared TMM state on the write-registration hot path.
-			next_request = min_pending_bytes;
-		} else if (memory_request_bytes >= max_pending_bytes) {
-			return;
-		} else if (memory_request_bytes > max_pending_bytes / 2) {
-			next_request = max_pending_bytes;
-		} else {
-			next_request = memory_request_bytes * 2;
-		}
-		next_request = MinValue(MaxValue(next_request, min_pending_bytes), max_pending_bytes);
-		if (next_request <= memory_request_bytes) {
-			return;
-		}
-
-		auto previous_reservation = current_reservation;
-		memory_state->SetRemainingSizeAndUpdateReservation(client_context, next_request);
-		memory_request_bytes = next_request;
-		current_reservation = memory_state->GetReservation();
-		if (current_reservation <= previous_reservation) {
-			return;
-		}
-		if (current_reservation < next_request) {
-			return;
-		}
-	}
+	memory_governor.UpdateReservation(current_pending_bytes);
 }
 
 idx_t ManagedAsyncWriteQueue::BackpressureBudget() {
-	if (!memory_state) {
-		return NumericLimits<idx_t>::Maximum();
-	}
-	auto reservation = MinValue(memory_state->GetReservation(), max_pending_bytes);
-	// If TMM only grants a tiny reservation, do not retain an async backlog. This makes low-memory execution
-	// behave close to synchronous writes, but automatically allows overlap again if the reservation grows later.
-	if (reservation < AsyncWriteConfig::REMOTE_COALESCE_THRESHOLD) {
-		return 0;
-	}
-	return reservation;
+	return memory_governor.BackpressureBudget();
 }
 
 idx_t ManagedAsyncWriteQueue::DrainTaskByteBudget() const {
@@ -898,11 +925,7 @@ void ManagedAsyncWriteQueue::Close() {
 }
 
 void ManagedAsyncWriteQueue::ReleaseMemoryReservation() {
-	if (!memory_state || memory_request_bytes == 0) {
-		return;
-	}
-	memory_state->SetZero();
-	memory_request_bytes = 0;
+	memory_governor.Release();
 }
 
 void ManagedAsyncWriteQueue::RethrowTaskError() {

--- a/src/include/duckdb/common/serializer/async_memory_governor.hpp
+++ b/src/include/duckdb/common/serializer/async_memory_governor.hpp
@@ -31,6 +31,7 @@ struct ManagedAsyncMemoryConfig {
 class ManagedAsyncMemoryGovernor {
 public:
 	explicit ManagedAsyncMemoryGovernor(ClientContext &client_context);
+	~ManagedAsyncMemoryGovernor();
 
 	ManagedAsyncMemoryGovernor(const ManagedAsyncMemoryGovernor &) = delete;
 	ManagedAsyncMemoryGovernor &operator=(const ManagedAsyncMemoryGovernor &) = delete;

--- a/src/include/duckdb/common/serializer/async_memory_governor.hpp
+++ b/src/include/duckdb/common/serializer/async_memory_governor.hpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/serializer/async_memory_governor.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class TemporaryMemoryState;
+
+//! Memory policy shared by the managed async queues.
+struct ManagedAsyncMemoryConfig {
+	//! Maximum queued async bytes retained per regular execution thread.
+	static constexpr idx_t MAX_PENDING_BYTES_PER_THREAD = 64ULL * 1024ULL * 1024ULL;
+	//! Minimum async reservation requested per regular execution thread.
+	static constexpr idx_t MIN_PENDING_BYTES_PER_THREAD = 8ULL * 1024ULL * 1024ULL;
+	//! Below this reservation, do not retain an async backlog (behave close to synchronous draining).
+	static constexpr idx_t MIN_RESERVATION_FOR_BACKLOG = 8ULL * 1024ULL * 1024ULL;
+};
+
+//! Shared TemporaryMemoryManager reservation governor for the managed async queues.
+//! Encapsulates the coarse-growth reservation heuristic and backpressure budget so each queue bounds its
+//! queued and in-flight backlog through the same memory logic.
+class ManagedAsyncMemoryGovernor {
+public:
+	explicit ManagedAsyncMemoryGovernor(ClientContext &client_context);
+
+	ManagedAsyncMemoryGovernor(const ManagedAsyncMemoryGovernor &) = delete;
+	ManagedAsyncMemoryGovernor &operator=(const ManagedAsyncMemoryGovernor &) = delete;
+
+	//! Whether a TemporaryMemoryState reservation is tracking this queue's backlog.
+	bool IsActive() const;
+	//! Grow the reservation coarsely until it covers current_pending_bytes; released only on Release().
+	void UpdateReservation(idx_t current_pending_bytes);
+	//! Current async backlog budget after applying the fixed cap, or 0 when memory is too tight to retain a backlog.
+	idx_t BackpressureBudget() const;
+	//! Release the reservation; further UpdateReservation calls may grow it again.
+	void Release();
+
+private:
+	ClientContext &client_context;
+	//! Temporary memory reservation state used to limit queued async data. Absent when draining synchronously.
+	unique_ptr<TemporaryMemoryState> memory_state;
+	//! Last remaining-size request sent to TemporaryMemoryManager. Grows monotonically until Release().
+	idx_t memory_request_bytes = 0;
+	//! Minimum TemporaryMemoryManager reservation while work is outstanding.
+	idx_t min_pending_bytes = 0;
+	//! Hard cap over the TemporaryMemoryState reservation.
+	idx_t max_pending_bytes = 0;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/serializer/async_task_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_task_queue.hpp
@@ -1,0 +1,203 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/serializer/async_task_queue.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/deque.hpp"
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/serializer/async_write_queue.hpp"
+#include "duckdb/parallel/async_result.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class TaskExecutor;
+
+//! One unit of generic async work, tagged with a byte size used for memory accounting.
+class AsyncTaskRequest {
+public:
+	AsyncTaskRequest() = default;
+	AsyncTaskRequest(unique_ptr<AsyncTask> task, idx_t size, AsyncWriteCompletionCallback completion = nullptr);
+
+	//! The byte size reported for this task (used to bound queued/in-flight memory).
+	idx_t Size() const;
+
+	unique_ptr<AsyncTask> task;
+	idx_t size = 0;
+	AsyncWriteCompletionCallback completion;
+};
+
+//! Minimal generic async task scheduler.
+//! Each drain task executes exactly one request, so up to max_active_tasks requests run concurrently.
+//! Memory policy lives in the ManagedAsyncTaskQueue wrapper; this is the bare scheduling/draining layer.
+class AsyncTaskQueue {
+	friend class AsyncTaskQueueTask;
+	friend class AsyncTaskQueueTaskGuard;
+
+public:
+	DUCKDB_API explicit AsyncTaskQueue(ClientContext &client_context, idx_t max_active_tasks = 0);
+	DUCKDB_API ~AsyncTaskQueue();
+
+	AsyncTaskQueue(const AsyncTaskQueue &) = delete;
+	AsyncTaskQueue &operator=(const AsyncTaskQueue &) = delete;
+
+public:
+	//! Return whether tasks are drained by async scheduler tasks. If false, Submit runs the task synchronously.
+	DUCKDB_API bool IsAsync() const;
+	//! Return whether the async task executor has captured an error.
+	DUCKDB_API bool HasError();
+	//! Submit one owned task to the configured sync/async path.
+	DUCKDB_API void Submit(AsyncTaskRequest request);
+	//! Return queued/in-flight bytes whose tasks have not completed yet.
+	DUCKDB_API idx_t PendingBytes();
+	//! Execute one queued task owned by this queue, or yield if the tasks are already running.
+	DUCKDB_API void WorkOnPendingTask();
+	//! Wait until all submitted tasks have completed.
+	DUCKDB_API void Flush();
+	//! Wait for all tasks and close the queue.
+	DUCKDB_API void Close();
+	//! Surface an error thrown by an async drain task.
+	DUCKDB_API void RethrowTaskError();
+
+private:
+	//! Schedule one drain task per still-unclaimed pending request, up to max_active_tasks.
+	void ScheduleTasksInternal();
+	//! Release one scheduled/running task slot and its in-flight byte accounting.
+	void FinishTask(idx_t task_size);
+	//! Release a task slot for a scheduled task that never started because another task failed.
+	void CancelScheduledTask();
+	//! Release multiple reserved task slots that were never scheduled.
+	void CancelScheduledTasks(idx_t task_count);
+
+	//! Async task entry point that drains exactly one pending request.
+	void DrainRequest();
+	//! Run one task and invoke its completion callback.
+	void ExecuteRequest(AsyncTaskRequest request);
+	//! Invoke a completion callback outside the queue lock.
+	void CompleteRequest(AsyncTaskRequest &request, idx_t size, optional_ptr<const ErrorData> error);
+	//! Throw if a mutating API is used after Close().
+	void VerifyOpen() const;
+	//! Throw if the queue still owns registered or scheduled work.
+	void VerifyDrained() const;
+	//! Fail and discard queued tasks after an async failure once all scheduled tasks have stopped.
+	void CancelPendingRequestsAfterFailure(const ErrorData &error) noexcept;
+
+private:
+	ClientContext &client_context;
+	//! Maximum scheduled/running tasks for this queue (the upload concurrency K).
+	idx_t max_active_tasks = 1;
+
+	//! Protects state shared between the submitting thread and async tasks.
+	mutex lock;
+	//! Tasks waiting for an async drain task.
+	deque<AsyncTaskRequest> pending_requests;
+	//! Bytes queued in pending_requests that have not been claimed by a task yet.
+	idx_t pending_bytes = 0;
+	//! Bytes owned by running tasks that have not completed yet.
+	idx_t in_flight_bytes = 0;
+	//! Scheduled or running tasks for this queue.
+	idx_t active_tasks = 0;
+	//! Scheduled tasks that have not yet claimed a request.
+	idx_t pending_tasks = 0;
+	//! Set after Close() has drained the queue. Further submissions are rejected.
+	bool closed = false;
+
+	//! Async task executor. If absent, tasks are executed synchronously on submission.
+	//! Keep this after task-accounting fields so queued task destructors can still release slots.
+	unique_ptr<TaskExecutor> executor;
+};
+
+//! Generic, memory-managed, multi-producer async task queue.
+//! Tasks are drained on the ASYNC TaskScheduler pool; queued+in-flight bytes are bounded by a shared
+//! TemporaryMemoryManager reservation. Falls back to synchronous execution when async_threads == 0.
+//!
+//! Semantics:
+//! - Multi-producer: Register is safe to call concurrently from many threads (it takes the internal lock).
+//! - Concurrency K: up to max_active_tasks (default async_threads) tasks run concurrently; one unit per drain
+//!   task, so independent tasks overlap. No coalescing of units.
+//! - Sync fallback: if async_threads == 0, Register executes the task inline on the caller.
+//! - Error model: the first task exception is captured by the underlying TaskExecutor; subsequent scheduling
+//!   stops; WaitAll/Close/RethrowTaskError rethrow it. Partial completion is possible on error.
+//! - Lifetime: call WaitAll then Close in the consumer's finalize step; the destructor asserts drained/closed.
+class ManagedAsyncTaskQueue {
+public:
+	//! max_active_tasks == 0 -> use TaskScheduler::NumberOfAsyncThreads() (the upload concurrency K).
+	DUCKDB_API explicit ManagedAsyncTaskQueue(ClientContext &client_context, idx_t max_active_tasks = 0);
+	DUCKDB_API ~ManagedAsyncTaskQueue();
+
+	ManagedAsyncTaskQueue(const ManagedAsyncTaskQueue &) = delete;
+	ManagedAsyncTaskQueue &operator=(const ManagedAsyncTaskQueue &) = delete;
+
+public:
+	//! Whether tasks are drained asynchronously (false => Register runs the task synchronously).
+	DUCKDB_API bool IsAsync() const;
+	//! Return whether the async task executor has captured an error.
+	DUCKDB_API bool HasError();
+	//! Hand off one unit of work. byte_size feeds the memory accounting (use the serialized payload size).
+	//! The task's Execute() runs on an ASYNC-pool thread (or synchronously if !IsAsync()); it MUST throw on
+	//! failure (the first error is captured, scheduling stops, and it is rethrown from WaitAll/Close).
+	DUCKDB_API void Register(unique_ptr<AsyncTask> task, idx_t byte_size);
+	//! Block the calling (producer) thread, helping drain, until queued+in-flight bytes fall under the budget.
+	DUCKDB_API void ApplyBackpressure();
+	//! Drain everything; after WaitAll returns (no error) all registered tasks have completed.
+	DUCKDB_API void WaitAll();
+	//! WaitAll + release the memory reservation + reject further Register calls.
+	DUCKDB_API void Close();
+	//! Surface an error thrown by an async drain task.
+	DUCKDB_API void RethrowTaskError();
+
+private:
+	//! Whether scheduling should respect the in-flight window, or force all pending tasks to drain.
+	enum class SchedulePolicy : uint8_t { THRESHOLD, FORCE };
+
+private:
+	//! Submit pending tasks to the low-level queue, bounded by the in-flight window unless forced.
+	void SchedulePendingTasks(SchedulePolicy policy = SchedulePolicy::THRESHOLD);
+	//! Grow the shared reservation coarsely to cover the current backlog.
+	void UpdateMemoryState();
+	//! Return queued + submitted bytes that have not completed yet. Caller must hold lock.
+	idx_t TotalPendingBytes() const;
+	//! Move one pending task into a submission to the low-level queue.
+	bool TakePendingTaskRequest(AsyncTaskRequest &request, SchedulePolicy policy);
+	//! Wrap a request with submitted-byte accounting that runs when the task completes.
+	void AddCompletionAccounting(AsyncTaskRequest &request);
+	//! Release byte accounting for one submitted task and refill the in-flight window.
+	void CompleteSubmittedTask(idx_t size, optional_ptr<const ErrorData> error);
+	//! Throw if a mutating API is used after Close().
+	void VerifyOpen() const;
+	//! Throw if the queue still owns registered or submitted work.
+	void VerifyDrained() const;
+	//! Fail and discard queued tasks after an async failure once all submitted tasks have stopped.
+	void CancelPendingTasksAfterFailure(const ErrorData &error) noexcept;
+
+private:
+	ClientContext &client_context;
+	//! Low-level one-unit-per-task scheduler.
+	unique_ptr<AsyncTaskQueue> task_queue;
+	//! Shared TemporaryMemoryManager reservation governor bounding queued async task data.
+	ManagedAsyncMemoryGovernor memory_governor;
+	//! Maximum number of submitted/running tasks for this queue (the in-flight window).
+	idx_t max_active_drain_tasks = 1;
+
+	//! Protects state shared between registering threads and async completion callbacks.
+	mutex lock;
+	//! Tasks queued for submission to the low-level queue.
+	deque<AsyncTaskRequest> pending_requests;
+	//! Bytes queued in pending_requests that have not been submitted yet.
+	idx_t pending_bytes = 0;
+	//! Bytes submitted to the low-level queue that have not completed yet.
+	idx_t submitted_bytes = 0;
+	//! Submitted tasks that have not completed yet.
+	idx_t submitted_requests = 0;
+	//! Set after Close() has drained the queue. Further registration is rejected.
+	bool closed = false;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/serializer/async_task_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_task_queue.hpp
@@ -12,26 +12,31 @@
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/serializer/async_write_queue.hpp"
+#include "duckdb/common/serializer/async_memory_governor.hpp"
 #include "duckdb/parallel/async_result.hpp"
+
+#include <functional>
 
 namespace duckdb {
 
 class ClientContext;
 class TaskExecutor;
 
+//! Completion callback for one generic async task. The error is set when the task failed.
+using AsyncTaskCompletionCallback = std::function<void(idx_t size, optional_ptr<const ErrorData> error)>;
+
 //! One unit of generic async work, tagged with a byte size used for memory accounting.
 class AsyncTaskRequest {
 public:
 	AsyncTaskRequest() = default;
-	AsyncTaskRequest(unique_ptr<AsyncTask> task, idx_t size, AsyncWriteCompletionCallback completion = nullptr);
+	AsyncTaskRequest(unique_ptr<AsyncTask> task, idx_t size, AsyncTaskCompletionCallback completion = nullptr);
 
 	//! The byte size reported for this task (used to bound queued/in-flight memory).
 	idx_t Size() const;
 
 	unique_ptr<AsyncTask> task;
 	idx_t size = 0;
-	AsyncWriteCompletionCallback completion;
+	AsyncTaskCompletionCallback completion;
 };
 
 //! Minimal generic async task scheduler.
@@ -91,7 +96,7 @@ private:
 
 private:
 	ClientContext &client_context;
-	//! Maximum scheduled/running tasks for this queue (the upload concurrency K).
+	//! Maximum scheduled/running tasks for this queue.
 	idx_t max_active_tasks = 1;
 
 	//! Protects state shared between the submitting thread and async tasks.
@@ -115,20 +120,19 @@ private:
 };
 
 //! Generic, memory-managed, multi-producer async task queue.
-//! Tasks are drained on the ASYNC TaskScheduler pool; queued+in-flight bytes are bounded by a shared
+//! Tasks are drained on the ASYNC TaskScheduler pool; queued and in-flight bytes are bounded by a shared
 //! TemporaryMemoryManager reservation. Falls back to synchronous execution when async_threads == 0.
 //!
-//! Semantics:
-//! - Multi-producer: Register is safe to call concurrently from many threads (it takes the internal lock).
-//! - Concurrency K: up to max_active_tasks (default async_threads) tasks run concurrently; one unit per drain
-//!   task, so independent tasks overlap. No coalescing of units.
-//! - Sync fallback: if async_threads == 0, Register executes the task inline on the caller.
-//! - Error model: the first task exception is captured by the underlying TaskExecutor; subsequent scheduling
-//!   stops; WaitAll/Close/RethrowTaskError rethrow it. Partial completion is possible on error.
-//! - Lifetime: call WaitAll then Close in the consumer's finalize step; the destructor asserts drained/closed.
+//! Contract:
+//! - Register is safe to call concurrently from multiple threads.
+//! - Up to max_active_tasks tasks run concurrently; each drain task executes one task.
+//! - With async_threads == 0, Register executes the task inline on the caller.
+//! - The first task error is captured, further scheduling stops, and it is rethrown from WaitAll/Close.
+//!   Partial completion is possible on error.
+//! - Call WaitAll then Close in the consumer's finalize step; the destructor asserts the queue is drained.
 class ManagedAsyncTaskQueue {
 public:
-	//! max_active_tasks == 0 -> use TaskScheduler::NumberOfAsyncThreads() (the upload concurrency K).
+	//! max_active_tasks == 0 -> use TaskScheduler::NumberOfAsyncThreads().
 	DUCKDB_API explicit ManagedAsyncTaskQueue(ClientContext &client_context, idx_t max_active_tasks = 0);
 	DUCKDB_API ~ManagedAsyncTaskQueue();
 

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -40,6 +40,37 @@ struct AsyncWriteConfig {
 	static constexpr idx_t DRAIN_TASK_BYTE_BUDGET = 16ULL * 1024ULL * 1024ULL;
 };
 
+//! Shared TemporaryMemoryManager reservation governor for the managed async queues.
+//! Encapsulates the coarse-growth reservation heuristic and backpressure budget so the positional write
+//! queue and the generic task queue bound their queued/in-flight backlog through identical memory logic.
+class ManagedAsyncMemoryGovernor {
+public:
+	explicit ManagedAsyncMemoryGovernor(ClientContext &client_context);
+
+	ManagedAsyncMemoryGovernor(const ManagedAsyncMemoryGovernor &) = delete;
+	ManagedAsyncMemoryGovernor &operator=(const ManagedAsyncMemoryGovernor &) = delete;
+
+	//! Whether a TemporaryMemoryState reservation is tracking this queue's backlog.
+	bool IsActive() const;
+	//! Grow the reservation coarsely until it covers current_pending_bytes; released only on Release().
+	void UpdateReservation(idx_t current_pending_bytes);
+	//! Current async backlog budget after applying the fixed cap, or 0 when memory is too tight to retain a backlog.
+	idx_t BackpressureBudget() const;
+	//! Release the reservation; further UpdateReservation calls may grow it again.
+	void Release();
+
+private:
+	ClientContext &client_context;
+	//! Temporary memory reservation state used to limit queued async data. Absent when draining synchronously.
+	unique_ptr<TemporaryMemoryState> memory_state;
+	//! Last remaining-size request sent to TemporaryMemoryManager. Grows monotonically until Release().
+	idx_t memory_request_bytes = 0;
+	//! Minimum TemporaryMemoryManager reservation while work is outstanding.
+	idx_t min_pending_bytes = 0;
+	//! Hard cap over the TemporaryMemoryState reservation.
+	idx_t max_pending_bytes = 0;
+};
+
 //! Owned payload that can be handed to an async write queue.
 class AsyncWritePayload {
 public:
@@ -299,16 +330,10 @@ private:
 
 	//! Low-level positional request scheduler.
 	unique_ptr<AsyncWriteQueue> write_queue;
-	//! Temporary memory reservation state used to limit queued async write data.
-	unique_ptr<TemporaryMemoryState> memory_state;
-	//! Last remaining-size request sent to TemporaryMemoryManager. Grows monotonically until close.
-	idx_t memory_request_bytes = 0;
+	//! Shared TemporaryMemoryManager reservation governor bounding queued async write data.
+	ManagedAsyncMemoryGovernor memory_governor;
 	//! Maximum number of submitted/running drain requests for this queue.
 	idx_t max_active_drain_tasks = 1;
-	//! Minimum TemporaryMemoryManager reservation while writes are outstanding.
-	idx_t min_pending_bytes = 0;
-	//! Hard cap over the TemporaryMemoryState reservation.
-	idx_t max_pending_bytes = 0;
 	//! Maximum bytes one managed async request should submit before yielding scheduler capacity.
 	idx_t drain_task_byte_budget = AsyncWriteConfig::DRAIN_TASK_BYTE_BUDGET;
 

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -241,13 +241,12 @@ public:
 
 private:
 	struct PendingWrite {
-		PendingWrite(AsyncWriteRequest request, AsyncWriteCompletionCallback pending_completion);
+		explicit PendingWrite(AsyncWriteRequest request);
 
 		idx_t Size() const;
 
 		AsyncWriteRequest request;
 		idx_t size;
-		AsyncWriteCompletionCallback pending_completion;
 	};
 
 private:
@@ -276,7 +275,7 @@ private:
 	//! Move one pending positional write into a physical async request.
 	bool TakePendingWriteRequest(AsyncWriteRequest &request, SchedulePolicy policy);
 	//! Wrap a request callback so submitted-byte accounting is released before user callbacks run.
-	AsyncWriteCompletionCallback AddCompletionAccounting(AsyncWriteRequest &request);
+	void AddCompletionAccounting(AsyncWriteRequest &request);
 	//! Release byte accounting for one submitted physical request.
 	void CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error);
 

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -241,12 +241,13 @@ public:
 
 private:
 	struct PendingWrite {
-		explicit PendingWrite(AsyncWriteRequest request);
+		PendingWrite(AsyncWriteRequest request, AsyncWriteCompletionCallback pending_completion);
 
 		idx_t Size() const;
 
 		AsyncWriteRequest request;
 		idx_t size;
+		AsyncWriteCompletionCallback pending_completion;
 	};
 
 private:
@@ -275,7 +276,7 @@ private:
 	//! Move one pending positional write into a physical async request.
 	bool TakePendingWriteRequest(AsyncWriteRequest &request, SchedulePolicy policy);
 	//! Wrap a request callback so submitted-byte accounting is released before user callbacks run.
-	void AddCompletionAccounting(AsyncWriteRequest &request);
+	AsyncWriteCompletionCallback AddCompletionAccounting(AsyncWriteRequest &request);
 	//! Release byte accounting for one submitted physical request.
 	void CompleteSubmittedWrite(idx_t offset, idx_t size, optional_ptr<const ErrorData> error);
 

--- a/src/include/duckdb/common/serializer/async_write_queue.hpp
+++ b/src/include/duckdb/common/serializer/async_write_queue.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/serializer/async_memory_governor.hpp"
 
 #include <functional>
 
@@ -20,7 +21,6 @@ namespace duckdb {
 
 class ClientContext;
 class TaskExecutor;
-class TemporaryMemoryState;
 
 //! Compile-time policy used by the async write layers.
 struct AsyncWriteConfig {
@@ -32,43 +32,8 @@ struct AsyncWriteConfig {
 	static constexpr idx_t LOCAL_COALESCE_THRESHOLD = 4096;
 	//! Remote file systems benefit from fewer round trips, so coalesce contiguous small buffers more aggressively.
 	static constexpr idx_t REMOTE_COALESCE_THRESHOLD = 8ULL * 1024ULL * 1024ULL;
-	//! Maximum queued async bytes retained per regular execution thread.
-	static constexpr idx_t MAX_PENDING_BYTES_PER_THREAD = 64ULL * 1024ULL * 1024ULL;
-	//! Minimum async write reservation requested per regular execution thread.
-	static constexpr idx_t MIN_PENDING_BYTES_PER_THREAD = 8ULL * 1024ULL * 1024ULL;
 	//! Maximum bytes a single managed stream request should submit before yielding scheduler capacity.
 	static constexpr idx_t DRAIN_TASK_BYTE_BUDGET = 16ULL * 1024ULL * 1024ULL;
-};
-
-//! Shared TemporaryMemoryManager reservation governor for the managed async queues.
-//! Encapsulates the coarse-growth reservation heuristic and backpressure budget so the positional write
-//! queue and the generic task queue bound their queued/in-flight backlog through identical memory logic.
-class ManagedAsyncMemoryGovernor {
-public:
-	explicit ManagedAsyncMemoryGovernor(ClientContext &client_context);
-
-	ManagedAsyncMemoryGovernor(const ManagedAsyncMemoryGovernor &) = delete;
-	ManagedAsyncMemoryGovernor &operator=(const ManagedAsyncMemoryGovernor &) = delete;
-
-	//! Whether a TemporaryMemoryState reservation is tracking this queue's backlog.
-	bool IsActive() const;
-	//! Grow the reservation coarsely until it covers current_pending_bytes; released only on Release().
-	void UpdateReservation(idx_t current_pending_bytes);
-	//! Current async backlog budget after applying the fixed cap, or 0 when memory is too tight to retain a backlog.
-	idx_t BackpressureBudget() const;
-	//! Release the reservation; further UpdateReservation calls may grow it again.
-	void Release();
-
-private:
-	ClientContext &client_context;
-	//! Temporary memory reservation state used to limit queued async data. Absent when draining synchronously.
-	unique_ptr<TemporaryMemoryState> memory_state;
-	//! Last remaining-size request sent to TemporaryMemoryManager. Grows monotonically until Release().
-	idx_t memory_request_bytes = 0;
-	//! Minimum TemporaryMemoryManager reservation while work is outstanding.
-	idx_t min_pending_bytes = 0;
-	//! Hard cap over the TemporaryMemoryState reservation.
-	idx_t max_pending_bytes = 0;
 };
 
 //! Owned payload that can be handed to an async write queue.

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   caching_test_utils.cpp
   test_async_file_writer.cpp
+  test_managed_async_task_queue.cpp
   test_cast.cpp
   test_checked_integer.cpp
   test_checksum.cpp

--- a/test/common/test_managed_async_task_queue.cpp
+++ b/test/common/test_managed_async_task_queue.cpp
@@ -1,0 +1,236 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/serializer/async_task_queue.hpp"
+#include "test_helpers.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <thread>
+
+using namespace duckdb;
+
+namespace {
+
+//! Task that increments a shared counter once when executed.
+class CountingTask : public AsyncTask {
+public:
+	explicit CountingTask(std::atomic<idx_t> &counter_p) : counter(counter_p) {
+	}
+
+	void Execute() override {
+		counter++;
+	}
+
+private:
+	std::atomic<idx_t> &counter;
+};
+
+//! Task that always throws when executed.
+class ThrowingTask : public AsyncTask {
+public:
+	void Execute() override {
+		throw IOException("Injected async task failure");
+	}
+};
+
+//! Coordinates how many tasks are running concurrently, blocking each task until released.
+class ConcurrencyLatch {
+public:
+	void Enter() {
+		unique_lock<mutex> guard(lock);
+		active++;
+		max_active = MaxValue(max_active, active);
+		entered++;
+		cv.notify_all();
+		cv.wait(guard, [&]() { return released; });
+		active--;
+	}
+
+	bool WaitForEntered(idx_t count) {
+		unique_lock<mutex> guard(lock);
+		return cv.wait_for(guard, std::chrono::seconds(5), [&]() { return entered >= count; });
+	}
+
+	void Release() {
+		{
+			lock_guard<mutex> guard(lock);
+			released = true;
+		}
+		cv.notify_all();
+	}
+
+	idx_t MaxActive() {
+		lock_guard<mutex> guard(lock);
+		return max_active;
+	}
+
+private:
+	mutex lock;
+	std::condition_variable cv;
+	idx_t active = 0;
+	idx_t max_active = 0;
+	idx_t entered = 0;
+	bool released = false;
+};
+
+//! Task that blocks on a ConcurrencyLatch until released.
+class LatchTask : public AsyncTask {
+public:
+	explicit LatchTask(ConcurrencyLatch &latch_p) : latch(latch_p) {
+	}
+
+	void Execute() override {
+		latch.Enter();
+	}
+
+private:
+	ConcurrencyLatch &latch;
+};
+
+unique_ptr<Connection> TaskQueueConnectionWithAsyncThreads(DuckDB &db, idx_t async_threads = 1) {
+	auto con = make_uniq<Connection>(db);
+	REQUIRE_NO_FAIL(con->Query("SET async_threads=" + to_string(async_threads)));
+	return con;
+}
+
+unique_ptr<Connection> TaskQueueConnectionWithoutAsyncThreads(DuckDB &db) {
+	auto con = make_uniq<Connection>(db);
+	REQUIRE_NO_FAIL(con->Query("SET async_threads=0"));
+	return con;
+}
+
+} // namespace
+
+TEST_CASE("ManagedAsyncTaskQueue runs all registered tasks", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 4);
+	ManagedAsyncTaskQueue queue(*con->context);
+	REQUIRE(queue.IsAsync());
+
+	std::atomic<idx_t> counter(0);
+	const idx_t task_count = 50;
+	for (idx_t i = 0; i < task_count; i++) {
+		queue.Register(make_uniq<CountingTask>(counter), 16);
+	}
+	queue.WaitAll();
+	REQUIRE(counter.load() == task_count);
+	queue.Close();
+}
+
+TEST_CASE("ManagedAsyncTaskQueue runs tasks concurrently", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 4);
+	ManagedAsyncTaskQueue queue(*con->context);
+
+	ConcurrencyLatch latch;
+	for (idx_t i = 0; i < 4; i++) {
+		queue.Register(make_uniq<LatchTask>(latch), 16);
+	}
+	REQUIRE(latch.WaitForEntered(2));
+	latch.Release();
+	queue.Close();
+
+	REQUIRE(latch.MaxActive() >= 2);
+}
+
+TEST_CASE("ManagedAsyncTaskQueue honors max_active_tasks concurrency cap", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 4);
+	ManagedAsyncTaskQueue queue(*con->context, 1);
+
+	ConcurrencyLatch latch;
+	for (idx_t i = 0; i < 3; i++) {
+		queue.Register(make_uniq<LatchTask>(latch), 16);
+	}
+	REQUIRE(latch.WaitForEntered(1));
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	REQUIRE(latch.MaxActive() == 1);
+	latch.Release();
+	queue.Close();
+
+	REQUIRE(latch.MaxActive() == 1);
+}
+
+TEST_CASE("ManagedAsyncTaskQueue runs synchronously without async threads", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithoutAsyncThreads(db);
+	ManagedAsyncTaskQueue queue(*con->context);
+	REQUIRE(!queue.IsAsync());
+
+	std::atomic<idx_t> counter(0);
+	queue.Register(make_uniq<CountingTask>(counter), 16);
+	// Without async threads the task runs inline before Register returns.
+	REQUIRE(counter.load() == 1);
+	queue.Register(make_uniq<CountingTask>(counter), 16);
+	REQUIRE(counter.load() == 2);
+
+	queue.WaitAll();
+	queue.Close();
+	REQUIRE(counter.load() == 2);
+}
+
+TEST_CASE("ManagedAsyncTaskQueue rethrows asynchronous task errors", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 2);
+	ManagedAsyncTaskQueue queue(*con->context);
+
+	queue.Register(make_uniq<ThrowingTask>(), 16);
+	try {
+		queue.Close();
+		FAIL("Expected async task failure");
+	} catch (const Exception &ex) {
+		string error = ex.what();
+		REQUIRE(error.find("Injected async task failure") != string::npos);
+	}
+}
+
+TEST_CASE("ManagedAsyncTaskQueue rethrows synchronous task errors", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithoutAsyncThreads(db);
+	ManagedAsyncTaskQueue queue(*con->context);
+
+	try {
+		queue.Register(make_uniq<ThrowingTask>(), 16);
+		FAIL("Expected synchronous task failure");
+	} catch (const Exception &ex) {
+		string error = ex.what();
+		REQUIRE(error.find("Injected async task failure") != string::npos);
+	}
+	queue.Close();
+}
+
+TEST_CASE("ManagedAsyncTaskQueue applies backpressure without deadlock", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 2);
+	ManagedAsyncTaskQueue queue(*con->context);
+
+	std::atomic<idx_t> counter(0);
+	const idx_t task_count = 20;
+	for (idx_t i = 0; i < task_count; i++) {
+		queue.Register(make_uniq<CountingTask>(counter), 1ULL << 20);
+		queue.ApplyBackpressure();
+	}
+	queue.WaitAll();
+	REQUIRE(counter.load() == task_count);
+	queue.Close();
+}
+
+TEST_CASE("ManagedAsyncTaskQueue close drains without explicit WaitAll and is idempotent", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 2);
+	ManagedAsyncTaskQueue queue(*con->context);
+
+	std::atomic<idx_t> counter(0);
+	const idx_t task_count = 10;
+	for (idx_t i = 0; i < task_count; i++) {
+		queue.Register(make_uniq<CountingTask>(counter), 16);
+	}
+	queue.Close();
+	REQUIRE(counter.load() == task_count);
+
+	// Double close and post-close error checks must not throw.
+	queue.Close();
+	queue.RethrowTaskError();
+}

--- a/test/common/test_managed_async_task_queue.cpp
+++ b/test/common/test_managed_async_task_queue.cpp
@@ -89,6 +89,21 @@ private:
 	ConcurrencyLatch &latch;
 };
 
+//! Task that blocks on a ConcurrencyLatch and then throws.
+class LatchThrowingTask : public AsyncTask {
+public:
+	explicit LatchThrowingTask(ConcurrencyLatch &latch_p) : latch(latch_p) {
+	}
+
+	void Execute() override {
+		latch.Enter();
+		throw IOException("Injected async task failure");
+	}
+
+private:
+	ConcurrencyLatch &latch;
+};
+
 unique_ptr<Connection> TaskQueueConnectionWithAsyncThreads(DuckDB &db, idx_t async_threads = 1) {
 	auto con = make_uniq<Connection>(db);
 	REQUIRE_NO_FAIL(con->Query("SET async_threads=" + to_string(async_threads)));
@@ -233,4 +248,28 @@ TEST_CASE("ManagedAsyncTaskQueue close drains without explicit WaitAll and is id
 	// Double close and post-close error checks must not throw.
 	queue.Close();
 	queue.RethrowTaskError();
+}
+
+TEST_CASE("ManagedAsyncTaskQueue closes after failure with pending tasks", "[async_task_queue]") {
+	DuckDB db(nullptr);
+	auto con = TaskQueueConnectionWithAsyncThreads(db, 1);
+	ManagedAsyncTaskQueue queue(*con->context, 1);
+
+	std::atomic<idx_t> counter(0);
+	ConcurrencyLatch latch;
+	queue.Register(make_uniq<LatchThrowingTask>(latch), 16);
+	queue.Register(make_uniq<CountingTask>(counter), 16);
+	REQUIRE(latch.WaitForEntered(1));
+	latch.Release();
+	while (!queue.HasError()) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
+
+	try {
+		queue.Close();
+		FAIL("Expected async task failure");
+	} catch (const Exception &ex) {
+		string error = ex.what();
+		REQUIRE(error.find("Injected async task failure") != string::npos);
+	}
 }


### PR DESCRIPTION
The existing infrastructure around `AsyncWriteQueue` / `ManagedAsyncWriteQueue` was designed with the parquet writer in mind (writing bytes to a file at an offset). This PR pulls the reusable components out of it and reuses it in a generic, memory-managed task queue for arbitrary `AsyncTask`s. This is particularly interesting for quack: regular execution threads can serialize a batch and hand it off as a task, and dedicated async-pool threads do the blocking work (an HTTP POST, say) while the regular threads keep crunching.

## Parts

- `AsyncTaskQueue`: the bare scheduling/draining layer. One unit per drain task, so up to K tasks run concurrently and independent tasks actually overlap (no coalescing, that only makes sense for contiguous writes). Multi-producer, with the same error capture/rethrow behavior as the write path.
- `ManagedAsyncTaskQueue`: the public wrapper. Register(task, byte_size), ApplyBackpressure(), WaitAll(), Close(), and memory-bounded draining via a TemporaryMemoryManager reservation.
- `ManagedAsyncMemoryGovernor`: the one shared bit. The coarse-growth reservation heuristic plus the backpressure budget, now lives in one place and is used by both the write queue and the task queue.

## Alternative ideas

I did not follow the template approach on purpose because I thought it would add complexity. However, there is an argument to be made that, even if this approach is more involved, it can create a single reference for a `ManagedAsyncQueueBase`. This is initially what I had in mind but turned down due to complexity. Happy to try it out if you think is best.

cc: @lnkuiper 