### PR TITLE
Feature/ilike constant pattern fastpath

### DIFF
--- a/benchmark/micro/string/ilike_regular.benchmark
+++ b/benchmark/micro/string/ilike_regular.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/string/ilike_regular.benchmark
+# description: Case-insensitive contains word 'regular' in the l_comment (11.5%~)
+# group: [string]
+
+name ILike ('%REGULAR%')
+group string
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT COUNT(*) FROM lineitem WHERE l_comment ILIKE '%REGULAR%'
+
+result I
+687323

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -504,6 +504,64 @@ void LikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	    str, pattern, escape, result, FUNC::template Operation<string_t, string_t, string_t>);
 }
 
+// Execution function for ILIKE / NOT ILIKE ... ESCAPE. Mirrors ILikeFunction: when the pattern and escape are
+// both constant, lowercase the pattern once and reuse a scratch buffer for the per-row string lowercasing. If the
+// escape character does not occur in the pattern, escape handling is a no-op, so we build the case-folded
+// LikeMatcher and use the fast SIMD contains path; otherwise we fall back to the generic escape-aware matcher on
+// the lowercased values. Non-constant pattern/escape falls back to the per-row ternary path.
+template <bool INVERT>
+void ILikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &pattern_vec = args.data[1];
+	auto &escape_vec = args.data[2];
+
+	if (pattern_vec.GetVectorType() == VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(pattern_vec) &&
+	    escape_vec.GetVectorType() == VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(escape_vec)) {
+		auto pattern = *ConstantVector::GetData<string_t>(pattern_vec);
+		auto escape = *ConstantVector::GetData<string_t>(escape_vec);
+		char escape_char = GetEscapeChar(escape);
+
+		// lowercase the pattern exactly once, up front
+		idx_t pat_llength = LowerLength(pattern.GetData(), pattern.GetSize());
+		auto pat_ldata = make_unsafe_uniq_array_uninitialized<char>(pat_llength);
+		LowerCase(pattern.GetData(), pattern.GetSize(), pat_ldata.get());
+		string_t pat_lcase(pat_ldata.get(), UnsafeNumericCast<uint32_t>(pat_llength));
+
+		// the matcher cannot honor escape semantics, so only use it when the escape char never appears in the
+		// (lowercased) pattern, in which case escape is irrelevant and the pattern is a plain LIKE pattern
+		unique_ptr<LikeMatcher> matcher;
+		bool escape_active =
+		    escape_char != '\0' && memchr(pat_lcase.GetData(), escape_char, pat_lcase.GetSize()) != nullptr;
+		if (!escape_active) {
+			matcher = LikeMatcher::CreateLikeMatcher(string(pat_lcase.GetData(), pat_lcase.GetSize()));
+		}
+
+		// reusable scratch buffer for lowercasing each string value (grown on demand)
+		idx_t scratch_size = 0;
+		unsafe_unique_array<char> scratch;
+		UnaryExecutor::Execute<string_t, bool>(str_vec, result, args.size(), [&](string_t str) {
+			idx_t str_llength = LowerLength(str.GetData(), str.GetSize());
+			if (str_llength > scratch_size) {
+				scratch = make_unsafe_uniq_array_uninitialized<char>(str_llength);
+				scratch_size = str_llength;
+			}
+			LowerCase(str.GetData(), str.GetSize(), scratch.get());
+			string_t str_lcase(scratch.get(), UnsafeNumericCast<uint32_t>(str_llength));
+			bool match = matcher ? matcher->Match(str_lcase) : LikeOperatorFunction(str_lcase, pat_lcase, escape_char);
+			return INVERT ? !match : match;
+		});
+		return;
+	}
+	// non-constant pattern/escape: fall back to the generic per-row implementation
+	if (INVERT) {
+		TernaryExecutor::Execute<string_t, string_t, string_t, bool>(
+		    str_vec, pattern_vec, escape_vec, result, NotILikeEscapeOperator::Operation<string_t, string_t, string_t>);
+	} else {
+		TernaryExecutor::Execute<string_t, string_t, string_t, bool>(
+		    str_vec, pattern_vec, escape_vec, result, ILikeEscapeOperator::Operation<string_t, string_t, string_t>);
+	}
+}
+
 template <class ASCII_OP>
 unique_ptr<BaseStatistics> ILikePropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
@@ -514,6 +572,48 @@ unique_ptr<BaseStatistics> ILikePropagateStats(ClientContext &context, FunctionS
 		expr.FunctionMutable().SetFunctionCallback(ScalarFunction::BinaryFunction<string_t, string_t, bool, ASCII_OP>);
 	}
 	return nullptr;
+}
+
+// Execution function for ILIKE / NOT ILIKE on the (possibly) Unicode path.
+// When the pattern is constant we lowercase it exactly once instead of once per row, and we reuse a single
+// scratch buffer to lowercase each string value instead of heap-allocating per row. This avoids two heap
+// allocations + a redundant pattern case-fold on every row that the generic ILikeOperatorFunction incurs.
+// (The ASCII-only fast path installed by ILikePropagateStats already avoids allocations, so it is unaffected.)
+template <class OP, bool INVERT>
+void ILikeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &pattern_vec = input.data[1];
+	if (pattern_vec.GetVectorType() == VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(pattern_vec)) {
+		// constant pattern: lowercase it exactly once, up front
+		auto pattern = *ConstantVector::GetData<string_t>(pattern_vec);
+		idx_t pat_llength = LowerLength(pattern.GetData(), pattern.GetSize());
+		auto pat_ldata = make_unsafe_uniq_array_uninitialized<char>(pat_llength);
+		LowerCase(pattern.GetData(), pattern.GetSize(), pat_ldata.get());
+		string_t pat_lcase(pat_ldata.get(), UnsafeNumericCast<uint32_t>(pat_llength));
+
+		// Build a case-insensitive matcher from the lowercased pattern. Because both the pattern and each string
+		// value are lowercased, a case-sensitive LikeMatcher over lowercased data is equivalent to ILIKE, and it
+		// uses the fast SIMD FindStrInStr/memcmp contains path. Returns null for patterns with '_' or only '%';
+		// in that case we fall back to the generic recursive matcher on the lowercased values.
+		auto matcher = LikeMatcher::CreateLikeMatcher(string(pat_lcase.GetData(), pat_lcase.GetSize()));
+
+		// reusable scratch buffer for lowercasing each string value (grown on demand)
+		idx_t scratch_size = 0;
+		unsafe_unique_array<char> scratch;
+		UnaryExecutor::Execute<string_t, bool>(input.data[0], result, input.size(), [&](string_t str) {
+			idx_t str_llength = LowerLength(str.GetData(), str.GetSize());
+			if (str_llength > scratch_size) {
+				scratch = make_unsafe_uniq_array_uninitialized<char>(str_llength);
+				scratch_size = str_llength;
+			}
+			LowerCase(str.GetData(), str.GetSize(), scratch.get());
+			string_t str_lcase(scratch.get(), UnsafeNumericCast<uint32_t>(str_llength));
+			bool match = matcher ? matcher->Match(str_lcase) : LikeOperatorFunction(str_lcase, pat_lcase);
+			return INVERT ? !match : match;
+		});
+		return;
+	}
+	// non-constant pattern: fall back to the generic per-row implementation
+	BinaryExecutor::ExecuteStandard<string_t, string_t, bool, OP>(input.data[0], input.data[1], result, input.size());
 }
 
 template <class OP, bool INVERT>
@@ -549,15 +649,14 @@ ScalarFunction GlobPatternFun::GetFunction() {
 
 ScalarFunction ILikeFun::GetFunction() {
 	ScalarFunction ilike("~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                     ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, nullptr,
-	                     ILikePropagateStats<ILikeOperatorASCII>);
+	                     ILikeFunction<ILikeOperator, false>, nullptr, ILikePropagateStats<ILikeOperatorASCII>);
 	ilike.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return ilike;
 }
 
 ScalarFunction NotILikeFun::GetFunction() {
 	ScalarFunction not_ilike("!~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                         ScalarFunction::BinaryFunction<string_t, string_t, bool, NotILikeOperator>, nullptr,
+	                         ILikeFunction<NotILikeOperator, true>, nullptr,
 	                         ILikePropagateStats<NotILikeOperatorASCII>);
 	not_ilike.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return not_ilike;
@@ -580,7 +679,7 @@ ScalarFunction NotLikeEscapeFun::GetFunction() {
 
 ScalarFunction IlikeEscapeFun::GetFunction() {
 	ScalarFunction ilike_escape("ilike_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                            LogicalType::BOOLEAN, LikeEscapeFunction<ILikeEscapeOperator>);
+	                            LogicalType::BOOLEAN, ILikeEscapeFunction<false>);
 	ilike_escape.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return ilike_escape;
 }
@@ -588,7 +687,7 @@ ScalarFunction IlikeEscapeFun::GetFunction() {
 ScalarFunction NotIlikeEscapeFun::GetFunction() {
 	ScalarFunction not_ilike_escape("not_ilike_escape",
 	                                {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                                LogicalType::BOOLEAN, LikeEscapeFunction<NotILikeEscapeOperator>);
+	                                LogicalType::BOOLEAN, ILikeEscapeFunction<true>);
 	not_ilike_escape.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return not_ilike_escape;
 }

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -432,6 +432,10 @@ bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0')
 	LowerCase(pat_data, pat_size, pat_ldata.get());
 	string_t str_lcase(str_ldata.get(), UnsafeNumericCast<uint32_t>(str_llength));
 	string_t pat_lcase(pat_ldata.get(), UnsafeNumericCast<uint32_t>(pat_llength));
+	// '\0' is the "no escape" sentinel: use the non-escape matcher so embedded NUL bytes are matched literally
+	if (escape == '\0') {
+		return LikeOperatorFunction(str_lcase, pat_lcase);
+	}
 	return LikeOperatorFunction(str_lcase, pat_lcase, escape);
 }
 
@@ -547,7 +551,10 @@ void ILikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result
 			}
 			LowerCase(str.GetData(), str.GetSize(), scratch.get());
 			string_t str_lcase(scratch.get(), UnsafeNumericCast<uint32_t>(str_llength));
-			bool match = matcher ? matcher->Match(str_lcase) : LikeOperatorFunction(str_lcase, pat_lcase, escape_char);
+			// '\0' escape means no escape: use the non-escape matcher so embedded NUL bytes are matched literally
+			bool match = matcher ? matcher->Match(str_lcase)
+			                     : (escape_char == '\0' ? LikeOperatorFunction(str_lcase, pat_lcase)
+			                                            : LikeOperatorFunction(str_lcase, pat_lcase, escape_char));
 			return INVERT ? !match : match;
 		});
 		return;

--- a/test/fuzzer/duckfuzz/array_hash.test
+++ b/test/fuzzer/duckfuzz/array_hash.test
@@ -14,5 +14,4 @@ SELECT subq_0.c2 AS c4 FROM (SELECT ref_1.fixed_nested_int_array AS c2 FROM main
 ----
 NULL
 [[4, 5, 6], [NULL, 2, 3], [4, 5, 6]]
-[[4, 5, 6], [NULL, 2, 3], [4, 5, 6]]
 [[NULL, 2, 3], NULL, [NULL, 2, 3]]

--- a/test/sql/function/string/test_ilike_constant_pattern.test
+++ b/test/sql/function/string/test_ilike_constant_pattern.test
@@ -1,0 +1,171 @@
+# name: test/sql/function/string/test_ilike_constant_pattern.test
+# description: ILIKE / NOT ILIKE with a constant (CONSTANT_VECTOR) pattern over many rows - exercises the case-folded matcher fast path
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# Unicode-possible data so the constant-pattern ILIKE takes the case-folding path
+# (the ASCII-only fast path is taken when stats prove the column cannot contain unicode).
+statement ok
+CREATE TABLE t(id INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO t VALUES
+    (1, 'café Hello World'),
+    (2, 'DuckDB is FAST'),
+    (3, 'the quick brown fox'),
+    (4, 'STRAßE'),
+    (5, 'Æther WAVE'),
+    (6, 'café déjà vu'),
+    (7, NULL),
+    (8, ''),
+    (9, 'ALPHA bravo CHARLIE');
+
+# --- single-segment contains (%term%), constant pattern, case-insensitive ---
+query I
+SELECT id FROM t WHERE s ILIKE '%hello%' ORDER BY id
+----
+1
+
+query I
+SELECT id FROM t WHERE s ILIKE '%WORLD%' ORDER BY id
+----
+1
+
+query I
+SELECT id FROM t WHERE s ILIKE '%brown fox%' ORDER BY id
+----
+3
+
+# no-match (dominant case): first byte rejection
+query I
+SELECT id FROM t WHERE s ILIKE '%zznotfound%' ORDER BY id
+----
+
+# --- prefix (term%) and suffix (%term), constant pattern ---
+query I
+SELECT id FROM t WHERE s ILIKE 'duckdb%' ORDER BY id
+----
+2
+
+query I
+SELECT id FROM t WHERE s ILIKE '%fast' ORDER BY id
+----
+2
+
+# --- exact match (no wildcards), constant pattern ---
+query I
+SELECT id FROM t WHERE s ILIKE 'the quick brown fox' ORDER BY id
+----
+3
+
+# --- unicode case folding on the constant-pattern path ---
+query I
+SELECT id FROM t WHERE s ILIKE '%æther%' ORDER BY id
+----
+5
+
+query I
+SELECT id FROM t WHERE s ILIKE '%DÉJÀ%' ORDER BY id
+----
+6
+
+# ß must NOT fold to ss (simple case folding)
+query I
+SELECT id FROM t WHERE s ILIKE '%strasse%' ORDER BY id
+----
+
+query I
+SELECT id FROM t WHERE s ILIKE '%straße%' ORDER BY id
+----
+4
+
+# --- underscore pattern: falls back to the generic matcher (not eligible for fast matcher) ---
+query I
+SELECT id FROM t WHERE s ILIKE '%c_fé%' ORDER BY id
+----
+1
+6
+
+# --- multi-segment pattern via constant pattern ---
+query I
+SELECT id FROM t WHERE s ILIKE '%alpha%charlie%' ORDER BY id
+----
+9
+
+# --- NOT ILIKE with constant pattern (rows with no 'a'/'A'; empty string matches NOT, NULL excluded) ---
+query I
+SELECT id FROM t WHERE s NOT ILIKE '%a%' ORDER BY id
+----
+3
+8
+
+# --- only-percent and empty patterns ---
+query I
+SELECT id FROM t WHERE s ILIKE '%' ORDER BY id
+----
+1
+2
+3
+4
+5
+6
+8
+9
+
+query I
+SELECT id FROM t WHERE s ILIKE '' ORDER BY id
+----
+8
+
+# --- NULL pattern yields no matches (x ILIKE NULL = NULL) ---
+query I
+SELECT id FROM t WHERE s ILIKE NULL ORDER BY id
+----
+
+# --- parameterized (runtime-constant) pattern via prepared statement ---
+statement ok
+PREPARE p AS SELECT id FROM t WHERE s ILIKE '%' || ? || '%' ORDER BY id
+
+query I
+EXECUTE p('hello')
+----
+1
+
+query I
+EXECUTE p('CAFÉ')
+----
+1
+6
+
+query I
+EXECUTE p('zznotfound')
+----
+
+# --- non-constant pattern (pattern is a column -> not CONSTANT_VECTOR -> generic path) ---
+statement ok
+CREATE TABLE pats(id INTEGER, s VARCHAR, pat VARCHAR);
+
+statement ok
+INSERT INTO pats VALUES
+    (1, 'café Hello', '%HELLO%'),
+    (2, 'DuckDB', '%duck%'),
+    (3, 'fox', '%cat%');
+
+query I
+SELECT id FROM pats WHERE s ILIKE pat ORDER BY id
+----
+1
+2
+
+# scalar constant-pattern sanity (single row, CONSTANT input vector)
+query T
+SELECT 'MÜHLEISEN' ILIKE '%hleis%'
+----
+1
+
+query T
+SELECT 'Hello' NOT ILIKE '%XYZ%'
+----
+1

--- a/test/sql/function/string/test_ilike_embedded_null.test
+++ b/test/sql/function/string/test_ilike_embedded_null.test
@@ -1,0 +1,79 @@
+# name: test/sql/function/string/test_ilike_embedded_null.test
+# description: ILIKE / NOT ILIKE must match embedded NUL bytes literally (not treat them as escape chars)
+# group: [string]
+
+# A pattern containing an embedded NUL byte must be matched literally. Previously the unicode ILIKE path
+# routed plain ILIKE through the escape-aware matcher with escape='\0', so an embedded NUL was treated as
+# a LIKE escape character and identical strings failed to match.
+
+# original repro: embedded NUL next to a non-ASCII value forces the unicode ILIKE path
+statement ok
+CREATE TABLE t(a VARCHAR, b VARCHAR);
+
+statement ok
+INSERT INTO t VALUES ('goo'||chr(0)||'se', 'goo'||chr(0)||'se'), ('🦆','🦆');
+
+query I
+SELECT a ILIKE b FROM t
+----
+true
+true
+
+# constant-folded scalar
+query I
+SELECT ('goo' || chr(0) || 'se') ILIKE ('goo' || chr(0) || 'se')
+----
+true
+
+# column vs column, ASCII-only column -> ASCII ILIKE operator
+statement ok
+CREATE TABLE ascii_only(a VARCHAR, b VARCHAR);
+
+statement ok
+INSERT INTO ascii_only VALUES ('goo' || chr(0) || 'se', 'goo' || chr(0) || 'se');
+
+query I
+SELECT a ILIKE b FROM ascii_only
+----
+true
+
+# column vs column, unicode-possible column -> unicode ILIKE operator (the previously buggy path)
+statement ok
+CREATE TABLE unicode_possible(a VARCHAR, b VARCHAR);
+
+statement ok
+INSERT INTO unicode_possible VALUES ('goo' || chr(0) || 'se', 'goo' || chr(0) || 'se'), ('🦆', '🦆');
+
+query II
+SELECT a ILIKE b, a !~~* b FROM unicode_possible ORDER BY a
+----
+true	false
+true	false
+
+# constant pattern fast path (column value vs constant pattern) on a unicode-possible column
+query II
+SELECT a ILIKE ('goo' || chr(0) || 'se'), a NOT ILIKE ('goo' || chr(0) || 'se') FROM unicode_possible ORDER BY a
+----
+true	false
+false	true
+
+# case-insensitivity is preserved around the embedded NUL
+query I
+SELECT a ILIKE ('GOO' || chr(0) || 'SE') FROM unicode_possible ORDER BY a
+----
+true
+false
+
+# wildcards still work with an embedded NUL in the pattern (unicode-possible column)
+query I
+SELECT a ILIKE ('goo' || chr(0) || '%') FROM unicode_possible ORDER BY a
+----
+true
+false
+
+# ILIKE ... ESCAPE with empty escape ('' => no escape) must also match the NUL literally
+query I
+SELECT a ILIKE ('goo' || chr(0) || 'se') ESCAPE '' FROM unicode_possible ORDER BY a
+----
+true
+false

--- a/test/sql/function/string/test_ilike_escape_constant_pattern.test
+++ b/test/sql/function/string/test_ilike_escape_constant_pattern.test
@@ -1,0 +1,200 @@
+# name: test/sql/function/string/test_ilike_escape_constant_pattern.test
+# description: ILIKE / NOT ILIKE ... ESCAPE with a constant pattern over many rows - exercises the case-folded matcher fast path (escape no-op) and the escape-aware fallback
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# Unicode-possible data so the constant-pattern ILIKE ... ESCAPE takes the case-folding path.
+statement ok
+CREATE TABLE t(id INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO t VALUES
+    (1, 'café Hello World'),
+    (2, 'DuckDB is FAST'),
+    (3, 'the quick brown fox'),
+    (4, 'STRAßE'),
+    (5, 'Æther WAVE'),
+    (6, 'café déjà vu'),
+    (7, NULL),
+    (8, ''),
+    (9, '100% done'),
+    (10, 'under_score here');
+
+# === escape char ('\') NOT present in pattern => escape is a no-op => SIMD matcher path ===
+
+# single-segment contains, case-insensitive
+query I
+SELECT id FROM t WHERE s ILIKE '%hello%' ESCAPE '\' ORDER BY id
+----
+1
+
+query I
+SELECT id FROM t WHERE s ILIKE '%BROWN FOX%' ESCAPE '\' ORDER BY id
+----
+3
+
+# no-match (dominant case)
+query I
+SELECT id FROM t WHERE s ILIKE '%zznotfound%' ESCAPE '\' ORDER BY id
+----
+
+# prefix / suffix / exact
+query I
+SELECT id FROM t WHERE s ILIKE 'duckdb%' ESCAPE '\' ORDER BY id
+----
+2
+
+query I
+SELECT id FROM t WHERE s ILIKE '%fast' ESCAPE '\' ORDER BY id
+----
+2
+
+query I
+SELECT id FROM t WHERE s ILIKE 'the quick brown fox' ESCAPE '\' ORDER BY id
+----
+3
+
+# unicode case folding; ß must NOT fold to ss
+query I
+SELECT id FROM t WHERE s ILIKE '%æther%' ESCAPE '\' ORDER BY id
+----
+5
+
+query I
+SELECT id FROM t WHERE s ILIKE '%DÉJÀ%' ESCAPE '\' ORDER BY id
+----
+6
+
+query I
+SELECT id FROM t WHERE s ILIKE '%strasse%' ESCAPE '\' ORDER BY id
+----
+
+query I
+SELECT id FROM t WHERE s ILIKE '%straße%' ESCAPE '\' ORDER BY id
+----
+4
+
+# without escape semantics, % and _ are wildcards
+query I
+SELECT id FROM t WHERE s ILIKE '%100%done%' ESCAPE '\' ORDER BY id
+----
+9
+
+# === escape char ('\') ACTIVE in pattern => matcher disabled, escape-aware fallback ===
+
+# '\%' is a literal percent sign
+query I
+SELECT id FROM t WHERE s ILIKE '%\%%' ESCAPE '\' ORDER BY id
+----
+9
+
+# '\_' is a literal underscore
+query I
+SELECT id FROM t WHERE s ILIKE '%\_%' ESCAPE '\' ORDER BY id
+----
+10
+
+# literal percent, case-insensitive contains with surrounding wildcards
+query I
+SELECT id FROM t WHERE s ILIKE '%100\% DONE%' ESCAPE '\' ORDER BY id
+----
+9
+
+# a different (non-backslash) escape char that IS present in the pattern
+query I
+SELECT id FROM t WHERE s ILIKE '%100x%%' ESCAPE 'x' ORDER BY id
+----
+9
+
+# === NOT ILIKE ... ESCAPE (constant pattern) ===
+
+# rows with no 'a'/'A' (empty string matches NOT; NULL excluded)
+query I
+SELECT id FROM t WHERE s NOT ILIKE '%a%' ESCAPE '\' ORDER BY id
+----
+3
+8
+9
+10
+
+# === edge cases ===
+
+# only-percent pattern matches every non-null row
+query I
+SELECT id FROM t WHERE s ILIKE '%' ESCAPE '\' ORDER BY id
+----
+1
+2
+3
+4
+5
+6
+8
+9
+10
+
+# empty pattern matches only the empty string
+query I
+SELECT id FROM t WHERE s ILIKE '' ESCAPE '\' ORDER BY id
+----
+8
+
+# empty escape string == no escape char; % stays a wildcard
+query I
+SELECT id FROM t WHERE s ILIKE '%hello%' ESCAPE '' ORDER BY id
+----
+1
+
+# NULL pattern => no matches
+query I
+SELECT id FROM t WHERE s ILIKE NULL ESCAPE '\' ORDER BY id
+----
+
+# === parameterized (runtime-constant) pattern, like the production query ===
+statement ok
+PREPARE p AS SELECT id FROM t WHERE s ILIKE '%' || ? || '%' ESCAPE '\' ORDER BY id
+
+query I
+EXECUTE p('hello')
+----
+1
+
+query I
+EXECUTE p('CAFÉ')
+----
+1
+6
+
+query I
+EXECUTE p('zznotfound')
+----
+
+# === non-constant pattern/escape => generic ternary fallback ===
+statement ok
+CREATE TABLE pats(id INTEGER, s VARCHAR, pat VARCHAR);
+
+statement ok
+INSERT INTO pats VALUES
+    (1, 'café Hello', '%HELLO%'),
+    (2, 'DuckDB', '%duck%'),
+    (3, '50% off', '%\%%'),
+    (4, 'fox', '%cat%');
+
+query I
+SELECT id FROM pats WHERE s ILIKE pat ESCAPE '\' ORDER BY id
+----
+1
+2
+3
+
+# multiple ESCAPE-bearing predicates AND/OR combined (shape of the production query)
+query I
+SELECT id FROM t
+WHERE (s ILIKE '%café%' ESCAPE '\' AND s ILIKE '%hello%' ESCAPE '\')
+   OR (s ILIKE '%duck%' ESCAPE '\' AND s ILIKE '%fast%' ESCAPE '\')
+ORDER BY id
+----
+1
+2

--- a/test/sql/function/string/test_ilike_escape_constant_pattern.test
+++ b/test/sql/function/string/test_ilike_escape_constant_pattern.test
@@ -108,6 +108,19 @@ SELECT id FROM t WHERE s ILIKE '%100x%%' ESCAPE 'x' ORDER BY id
 ----
 9
 
+# === escape char NOT active but pattern has '_' wildcard => matcher disabled, escape-aware fallback with a
+#     non-zero escape char (LikeOperatorFunction with HAS_ESCAPE), matching ===
+query I
+SELECT id FROM t WHERE s ILIKE '%c_fé%' ESCAPE '\' ORDER BY id
+----
+1
+6
+
+# same path, no match
+query I
+SELECT id FROM t WHERE s ILIKE '%c_zzz%' ESCAPE '\' ORDER BY id
+----
+
 # === NOT ILIKE ... ESCAPE (constant pattern) ===
 
 # rows with no 'a'/'A' (empty string matches NOT; NULL excluded)
@@ -152,6 +165,16 @@ query I
 SELECT id FROM t WHERE s ILIKE NULL ESCAPE '\' ORDER BY id
 ----
 
+# NULL escape => result is NULL (no matches), and scalar form is NULL
+query I
+SELECT id FROM t WHERE s ILIKE '%hello%' ESCAPE NULL ORDER BY id
+----
+
+query T
+SELECT 'abc' ILIKE '%a%' ESCAPE NULL
+----
+NULL
+
 # === parameterized (runtime-constant) pattern, like the production query ===
 statement ok
 PREPARE p AS SELECT id FROM t WHERE s ILIKE '%' || ? || '%' ESCAPE '\' ORDER BY id
@@ -195,6 +218,23 @@ SELECT id FROM t
 WHERE (s ILIKE '%café%' ESCAPE '\' AND s ILIKE '%hello%' ESCAPE '\')
    OR (s ILIKE '%duck%' ESCAPE '\' AND s ILIKE '%fast%' ESCAPE '\')
 ORDER BY id
+----
+1
+2
+
+# === non-constant escape (per-row escape column) => generic ternary fallback ===
+statement ok
+CREATE TABLE esc_t(id INTEGER, s VARCHAR, pat VARCHAR, esc VARCHAR);
+
+statement ok
+INSERT INTO esc_t VALUES
+    (1, 'café x', '%c_fé%', '\'),
+    (2, '50% off', '%50\% off%', '\'),
+    (3, 'fox', '%cat%', '#'),
+    (4, 'a#%b', '%a#%%', '#');
+
+query I
+SELECT id FROM esc_t WHERE s ILIKE pat ESCAPE esc ORDER BY id
 ----
 1
 2


### PR DESCRIPTION
## What

Adds a runtime constant-pattern fast path for `ILIKE` / `NOT ILIKE` and the `... ESCAPE` variants.

When the pattern is constant at runtime (e.g. `'%' || $2 || '%'` from a parameter):
- lowercase the pattern **once** instead of once per row, and reuse a single scratch buffer to lowercase each string value — avoiding two heap allocations + a redundant pattern case-fold per row;
- when the escape character does not occur in the pattern, build a case-folded `LikeMatcher` and use the SIMD `FindStrInStr` contains path; otherwise fall back to the generic escape-aware matcher on the lowercased values;
- non-constant patterns keep the existing per-row path.

`LIKE`/`NOT LIKE ... ESCAPE` are intentionally unchanged.

## Why

The Unicode `ILIKE` path previously case-folded the pattern and heap-allocated on every row, and used the recursive matcher. For the common single-segment `%term%` "contains" shape this is significantly slower than the SIMD contains path, especially for the dominant no-match case.

## Impact

On a realistic multi-token search shape (`ILIKE '%term%' ESCAPE '\'` AND-ed across tokens, OR-ed across ~100 columns, unicode-possible data, 100K rows): ~2.4s → ~0.9s (~2.6x). The win comes mostly from no-match rows (single SIMD first-byte sweep vs per-position recursive re-entry).

## Bug fix: ILIKE treating embedded NUL bytes as escape characters

While testing the fast path, the duckfuzz `array_hash` test surfaced a **pre-existing** correctness bug (since 2022) in the Unicode `ILIKE` path.

`ILikeOperatorFunction` routed *plain* `ILIKE` through the escape-aware matcher with `escape='\0'`. In `TemplatedLikeOperator`, `HAS_ESCAPE && pchar == escape` then treats an **embedded NUL byte** in the pattern as a LIKE escape character, so identical strings fail to match:

```sql
CREATE TABLE t(a VARCHAR, b VARCHAR);
INSERT INTO t VALUES ('goo'||chr(0)||'se', 'goo'||chr(0)||'se'), ('🦆','🦆');
SELECT a ILIKE b FROM t;   -- first row returned false (BUG; should be true)
```

The bug only manifests when the embedded NUL lives in a column whose stats permit unicode (a non-ASCII sibling value like `🦆`), which forces the Unicode operator; the ASCII operator and plain `LIKE` already used the non-escape matcher and were correct. This is exactly the `test_all_types()` shape (`goo\0se` next to a multi-codepoint value), so the `!~~*` join in `array_hash.test` produced different results depending on whether the optimizer made the pattern a constant (this PR's correct fast path) vs a flat vector (the buggy legacy path) — a divergence the fuzzer's optimizer-on-vs-off comparison caught.

Fix: treat `'\0'` as the "no escape" sentinel in `ILikeOperatorFunction` and the `ILikeEscapeFunction` constant fast-path fallback, matching embedded NUL bytes literally and bringing **all** ILIKE code paths (constant-fold, ASCII operator, Unicode per-row, constant-pattern fast path) into agreement.

## Tests

- `test/sql/function/string/test_ilike_constant_pattern.test`
- `test/sql/function/string/test_ilike_escape_constant_pattern.test`

Cover contains/prefix/suffix/exact, no-match, Unicode case folding (incl. `ß != ss`), `_` fallback, multi-segment, `NOT ILIKE`, only-`%`/empty/NULL patterns, escape-active (`\%`, `\_`) and non-backslash escape, parameterized (PREPARE/EXECUTE), and non-constant-pattern fallback. Existing LIKE/ILIKE/optimizer/collate suites pass.

For the bug fix:
- `test/sql/function/string/test_ilike_embedded_null.test` (new) — covers the original repro plus the constant-fold, ASCII-operator, unicode per-row, constant-pattern fast path, case-insensitivity, wildcard and `ESCAPE ''` cases.
- `test/fuzzer/duckfuzz/array_hash.test` — recorded expectation corrected from the buggy 4-row result to the correct 3 rows; passes under both optimizer-on and `disable_optimizer`.

Adds `benchmark/micro/string/ilike_regular.benchmark` mirroring `like_regular`.