### PR TITLE
Clean async tasks after schedule

### DIFF
--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -44,11 +44,11 @@ public:
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	//! Schedule held async_tasks into the Executor, eventually unblocking InterruptState
-	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! needs to be called with non-empty async_tasks and from BLOCKED state, will empty the async_tasks and transform
 	//! into INVALID
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
 	//! Execute tasks synchronously at callsite
-	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! needs to be called with non-empty async_tasks and from BLOCKED state, will empty the async_tasks and transform
 	//! into HAVE_MORE_OUTPUT
 	void ExecuteTasksSynchronously();
 

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -128,6 +128,9 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 		auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state, completion);
 		TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task), pool_type);
 	}
+
+	async_tasks.clear();
+	result_type = AsyncResultType::INVALID;
 }
 
 void AsyncResult::ExecuteTasksSynchronously() {


### PR DESCRIPTION
Implementation doesn't confirm its documentation https://github.com/duckdb/duckdb/blob/ababb622f71f2ed49ff891fe3332bcd2679980a7/src/include/duckdb/parallel/async_result.hpp#L46-L49

Current implementation leaves vector there but all tasks inside are default.

I have ran CI on my fork: https://github.com/dentiny/duckdb/pull/112, failure unrelated