### PR TITLE
fix(optimizer): deduplicate identical window expressions in window_se…

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -193,9 +193,22 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 			groups.push_back(std::move(part_copy));
 		}
 
-		for (auto &expr : window.expressions) {
-			auto &w_expr = expr->Cast<BoundWindowExpression>();
-			aggregates.emplace_back(TranslateAggregate(w_expr));
+		// Build deduplicated aggregates: multiple identical window expressions map to the same aggregate output.
+		vector<idx_t> agg_index_for_window(window.expressions.size());
+		for (idx_t i = 0; i < window.expressions.size(); ++i) {
+			auto &w_expr = window.expressions[i]->Cast<BoundWindowExpression>();
+			bool found = false;
+			for (idx_t j = 0; j < i; ++j) {
+				if (w_expr.Equals(*window.expressions[j])) {
+					agg_index_for_window[i] = agg_index_for_window[j];
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				agg_index_for_window[i] = aggregates.size();
+				aggregates.emplace_back(TranslateAggregate(w_expr));
+			}
 		}
 
 		// args: group_index, aggregate_index, ...
@@ -224,12 +237,11 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		join->children.push_back(std::move(agg_op));
 		join->ResolveOperatorTypes();
 
-		// Replace aggregate bindings
-		// Old window column: (window.window_index, x)
-		// New constant column: (aggregate_index, x)
+		// Replace window column bindings with the deduplicated aggregate output bindings.
+		// Old: (window.window_index, i)  →  New: (aggregate_index, agg_index_for_window[i])
 		for (idx_t column_index = 0; column_index < window.expressions.size(); ++column_index) {
 			ColumnBinding old_binding(window.window_index, ProjectionIndex(column_index));
-			ColumnBinding new_binding(aggregate_index, ProjectionIndex(column_index));
+			ColumnBinding new_binding(aggregate_index, ProjectionIndex(agg_index_for_window[column_index]));
 			replacer.replacement_bindings.emplace_back(old_binding, new_binding);
 		}
 

--- a/test/sql/optimizer/test_window_self_join.test
+++ b/test/sql/optimizer/test_window_self_join.test
@@ -265,3 +265,16 @@ FROM (
 ) AS b;
 ----
 1	10.0
+
+# Regression test: duplicate window-over-aggregate expressions (issue #23383)
+# Using the same window expression standalone AND inside arithmetic must not crash.
+query III rowsort
+SELECT
+    name,
+    MAX(SUM(n)) OVER (PARTITION BY name) AS w1,
+    SUM(n) / MAX(SUM(n)) OVER (PARTITION BY name) AS w2
+FROM (VALUES ('a',1),('a',2),('b',3)) t(name, n)
+GROUP BY name;
+----
+a	3	1.0
+b	3	1.0


### PR DESCRIPTION
…lf_join

Fixes #23383 — an INTERNAL Error: Failed to bind column reference crash triggered when the same window-over-aggregate expression appears more than once in a query's SELECT list (e.g. standalone and inside arithmetic).

Root cause:

The binder pushes one entry into node.windows per occurrence of a window expression, without deduplication. A query like:


SELECT
  MAX(SUM(n)) OVER (PARTITION BY name) AS w1,
  SUM(n) / MAX(SUM(n)) OVER (PARTITION BY name) AS w2
FROM ... GROUP BY name;
produces a LogicalWindow with two identical expressions at slots (window_index, 0) and (window_index, 1).

The window_self_join optimizer previously created one aggregate expression per window expression (including duplicates), yielding two identical aggregate outputs (aggregate_index, 0) and (aggregate_index, 1), and registered a replacement binding for each. A subsequent optimizer (column_lifetime) correctly identified (aggregate_index, 1) as a redundant duplicate and pruned it via the join's right_projection_map. The expressions that had been rewritten to reference (aggregate_index, 1) then had no matching column at ColumnBindingResolver time, producing the internal error.

Fix:

In OptimizeInternal (src/optimizer/window_self_join.cpp), before building the new LogicalAggregate's expression list, deduplicate window expressions using BoundWindowExpression::Equals. Duplicate expressions reuse the earlier aggregate's output index rather than creating a new one. The replacement bindings are updated accordingly, so all references to the same logical window result are collapsed to a single aggregate output column — nothing spurious is created, nothing gets incorrectly pruned.

Test:

Added a regression test to test/sql/optimizer/test_window_self_join.test covering the exact pattern from the issue report.