### PR TITLE
fix: skip deduplication for volatile aggregates and window expressions

### DIFF
--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -112,15 +112,17 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
 				continue;
 			}
 
-			// CSE Elimination: Search for a previous match
+			// CSE Elimination: Search for a previous match (volatile expressions must not be deduplicated)
 			bool cse = false;
-			for (idx_t i = 0; i < matching.size(); ++i) {
-				const auto match_idx = matching[i];
-				auto &match_expr = op.expressions[match_idx]->Cast<BoundWindowExpression>();
-				if (wexpr.Equals(match_expr)) {
-					projection_map[input_width + expr_idx] = output_pos + i;
-					cse = true;
-					break;
+			if (!wexpr.IsVolatile()) {
+				for (idx_t i = 0; i < matching.size(); ++i) {
+					const auto match_idx = matching[i];
+					auto &match_expr = op.expressions[match_idx]->Cast<BoundWindowExpression>();
+					if (wexpr.Equals(match_expr)) {
+						projection_map[input_width + expr_idx] = output_pos + i;
+						cse = true;
+						break;
+					}
 				}
 			}
 			if (cse) {

--- a/src/optimizer/common_aggregate_optimizer.cpp
+++ b/src/optimizer/common_aggregate_optimizer.cpp
@@ -50,6 +50,15 @@ void CommonAggregateOptimizer::ExtractCommonAggregates(LogicalAggregate &aggr) {
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
 		ProjectionIndex original_index(i + total_erased);
 		ProjectionIndex new_index(i);
+		// volatile aggregates must not be deduplicated: each call is independent
+		if (aggr.expressions[i]->IsVolatile()) {
+			if (new_index != original_index) {
+				ColumnBinding original_binding(aggr.aggregate_index, original_index);
+				ColumnBinding new_binding(aggr.aggregate_index, new_index);
+				aggregate_map[original_binding] = new_binding;
+			}
+			continue;
+		}
 		auto entry = aggregate_remap.find(*aggr.expressions[i]);
 		if (entry == aggregate_remap.end()) {
 			// aggregate does not exist yet: add it to the map

--- a/test/sql/window/test_volatile_independence.test
+++ b/test/sql/window/test_volatile_independence.test
@@ -8,11 +8,23 @@ require vector_size 2048
 set seed 0.8675309
 
 query II
-SELECT 
-	list(random()) OVER (ORDER BY id), 
-	max(random()) OVER (ORDER BY id) 
+SELECT
+	list(random()) OVER (ORDER BY id),
+	max(random()) OVER (ORDER BY id)
 FROM range(3) t(id);
 ----
 [0.5232026142836782]	0.985522684201432
 [0.5232026142836782, 0.47754610640283557]	0.985522684201432
 [0.5232026142836782, 0.47754610640283557, 0.6947716273694302]	0.985522684201432
+
+# Identical volatile window expressions must not be CSE'd (issue #23367)
+# any_value(uuid()) called twice should produce two independent UUIDs per partition
+query I
+SELECT count(*) FROM (
+	SELECT
+		any_value(uuid()::varchar) OVER (PARTITION BY g) AS id_a,
+		any_value(uuid()::varchar) OVER (PARTITION BY g) AS id_b
+	FROM (VALUES (1),(1),(2),(2)) t(g)
+) WHERE id_a = id_b;
+----
+0


### PR DESCRIPTION
Fixes #23367

## Root cause

Two code paths deduplicated structurally identical expressions without
checking whether they contain volatile functions (uuid(), random(),
gen_random_uuid()).

The actual execution path for the reported query is:

1. WindowSelfJoinOptimizer converts two identical
   `any_value(uuid()) OVER (PARTITION BY g)` window expressions
   into two identical aggregates inside a LogicalAggregate node.
2. CommonAggregateOptimizer::ExtractCommonAggregates then sees two
   structurally equal aggregates and erases one, remapping both output
   columns to the same result — causing id_a = id_b on every row.

## Changes

**src/optimizer/common_aggregate_optimizer.cpp** (primary fix)
ExtractCommonAggregates now skips volatile aggregates: they are never
added to the deduplication map and never erased. Index remapping due
to prior erasures is still applied correctly.

**src/execution/physical_plan/plan_window.cpp** (defensive fix)
Physical window CSE also skips volatile window expressions, covering
the ORDER BY path that does not go through WindowSelfJoinOptimizer.

## Tests

Added test to test/sql/window/test_volatile_independence.test:
- Two identical `any_value(uuid()::varchar) OVER (PARTITION BY g)`
  expressions must produce independent UUIDs per partition.
- Verified: count of rows where id_a = id_b is now 0.