### PR TITLE
Use std::shared_mutex in StorageLock

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -30,6 +30,7 @@
 #include "duckdb/planner/filter/table_filter_functions.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
+#include "duckdb/transaction/vacuum_lock.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
@@ -130,7 +131,7 @@ public:
 	mutex index_scan_lock;
 	//! Synchronize <ART version, SegmentTree<RowGroup>> when vacuum_rebuild_indexes is enabled (since
 	//! ART indexes are rebuilt during vacuuming with this setting).
-	unique_ptr<StorageLockKey> vacuum_lock;
+	unique_ptr<VacuumLockKey> vacuum_lock;
 
 public:
 	unique_ptr<LocalTableFunctionState> InitLocalState(ExecutionContext &context,
@@ -449,7 +450,7 @@ unique_ptr<GlobalTableFunctionState> DuckTableScanInitGlobal(ClientContext &cont
 
 unique_ptr<GlobalTableFunctionState> DuckIndexScanInitGlobal(ClientContext &context, TableFunctionInitInput &input,
                                                              const TableScanBindData &bind_data, set<row_t> &row_ids,
-                                                             unique_ptr<StorageLockKey> vacuum_lock) {
+                                                             unique_ptr<VacuumLockKey> vacuum_lock) {
 	auto g_state = make_uniq<DuckIndexScanState>(context, input.bind_data.get());
 	g_state->vacuum_lock = std::move(vacuum_lock);
 	g_state->finished_first_phase = row_ids.empty() ? true : false;
@@ -806,7 +807,7 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 	// scanning the index. This prevents the checkpoint from rebuilding the index and swapping
 	// row groups while we hold row IDs from the ART, ensuring we always see a consistent
 	// <ART index, SegmentTree<RowGroup> pairing.
-	unique_ptr<StorageLockKey> vacuum_lock;
+	unique_ptr<VacuumLockKey> vacuum_lock;
 	const auto &attached = storage.GetAttached();
 	if (attached.GetVacuumRebuildIndexThreshold() > 0) {
 		auto &transaction_manager = DuckTransactionManager::Get(storage.GetAttached());

--- a/src/include/duckdb/storage/storage_lock.hpp
+++ b/src/include/duckdb/storage/storage_lock.hpp
@@ -41,11 +41,6 @@ public:
 	unique_ptr<StorageLockKey> GetSharedLock();
 	//! Try to get an exclusive lock - if we cannot get it immediately we return `nullptr`
 	unique_ptr<StorageLockKey> TryGetExclusiveLock();
-	//! This is a special method that only exists for checkpointing
-	//! This method takes a shared lock, and returns an exclusive lock if the parameter is the only active shared lock
-	//! If this method succeeds, we have **both** a shared and exclusive lock active (which normally is not allowed)
-	//! But this behavior is required for checkpointing
-	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock);
 
 private:
 	shared_ptr<StorageLockInternals> internals;

--- a/src/include/duckdb/transaction/checkpoint_lock.hpp
+++ b/src/include/duckdb/transaction/checkpoint_lock.hpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/checkpoint_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+
+namespace duckdb {
+struct CheckpointLockInternals;
+
+enum class CheckpointLockType { SHARED, EXCLUSIVE };
+
+class CheckpointLockCoordinator;
+
+class CheckpointLockKey {
+public:
+	CheckpointLockKey(shared_ptr<CheckpointLockInternals> internals, CheckpointLockType type);
+	~CheckpointLockKey();
+
+	CheckpointLockType GetType() const {
+		return type;
+	}
+
+private:
+	shared_ptr<CheckpointLockInternals> internals;
+	CheckpointLockType type;
+
+	friend struct CheckpointLockInternals;
+	friend class CheckpointLockCoordinator;
+};
+
+//! Coordinates transactions that prevent checkpointing with checkpoint operations.
+class CheckpointLockCoordinator {
+public:
+	CheckpointLockCoordinator();
+	~CheckpointLockCoordinator();
+
+	unique_ptr<CheckpointLockKey> GetSharedLock();
+	unique_ptr<CheckpointLockKey> TryGetExclusiveLock();
+	//! Obtain exclusive ownership if the supplied key is the only active shared key.
+	//! On success, both the shared key and the returned exclusive key remain active.
+	unique_ptr<CheckpointLockKey> TryUpgrade(CheckpointLockKey &lock);
+
+private:
+	shared_ptr<CheckpointLockInternals> internals;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -17,6 +17,7 @@
 
 namespace duckdb {
 class CheckpointLock;
+class CheckpointLockKey;
 class CommitDropState;
 class DuckTableEntry;
 class RowGroupCollection;
@@ -93,7 +94,7 @@ public:
 		return true;
 	}
 
-	unique_ptr<StorageLockKey> TryGetCheckpointLock();
+	unique_ptr<CheckpointLockKey> TryGetCheckpointLock();
 
 	//! Get a shared lock on a table
 	shared_ptr<CheckpointLock> SharedLockTable(DataTableInfo &info);
@@ -109,7 +110,7 @@ private:
 	//! The set of uncommitted appends for the transaction
 	unique_ptr<LocalStorage> storage;
 	//! Lock that prevents checkpoints from starting
-	unique_ptr<StorageLockKey> checkpoint_lock;
+	unique_ptr<CheckpointLockKey> checkpoint_lock;
 	//! Lock that prevents vacuums from starting
 	unique_ptr<StorageLockKey> vacuum_lock;
 	//! Lock for accessing sequence_usage

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -23,8 +23,8 @@ class DuckTableEntry;
 class RowGroupCollection;
 class RowVersionManager;
 class DuckTransactionManager;
-class StorageLockKey;
 class StorageCommitState;
+class VacuumLockKey;
 struct DataTableInfo;
 struct UndoBufferProperties;
 
@@ -112,7 +112,7 @@ private:
 	//! Lock that prevents checkpoints from starting
 	unique_ptr<CheckpointLockKey> checkpoint_lock;
 	//! Lock that prevents vacuums from starting
-	unique_ptr<StorageLockKey> vacuum_lock;
+	unique_ptr<VacuumLockKey> vacuum_lock;
 	//! Lock for accessing sequence_usage
 	mutex sequence_lock;
 	//! Map of all sequences that were used during the transaction and the value they had in this transaction

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/transaction/transaction_manager.hpp"
+#include "duckdb/transaction/checkpoint_lock.hpp"
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/common/queue.hpp"
@@ -68,10 +69,10 @@ public:
 	}
 
 	//! Obtains a shared lock to the checkpoint lock
-	unique_ptr<StorageLockKey> SharedCheckpointLock();
+	unique_ptr<CheckpointLockKey> SharedCheckpointLock();
 	//! Try to obtain an exclusive checkpoint lock
-	unique_ptr<StorageLockKey> TryGetCheckpointLock();
-	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock);
+	unique_ptr<CheckpointLockKey> TryGetCheckpointLock();
+	unique_ptr<CheckpointLockKey> TryUpgradeCheckpointLock(CheckpointLockKey &lock);
 	unique_ptr<StorageLockKey> SharedVacuumLock();
 	unique_ptr<StorageLockKey> TryGetVacuumLock();
 
@@ -102,7 +103,7 @@ private:
 	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction, bool store_transaction) noexcept;
 
 	//! Whether or not we can checkpoint
-	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &checkpoint_lock,
+	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<CheckpointLockKey> &checkpoint_lock,
 	                                 const UndoBufferProperties &properties);
 	//! Get the checkpoint type of an automatic checkpoint
 	CheckpointDecision GetCheckpointType(DuckTransaction &transaction, const UndoBufferProperties &undo_properties);
@@ -130,7 +131,7 @@ private:
 	//! The lock used for transaction operations
 	mutex transaction_lock;
 	//! The checkpoint lock
-	StorageLock checkpoint_lock;
+	CheckpointLockCoordinator checkpoint_lock;
 	//! The vacuum lock - necessary to start vacuum operations
 	StorageLock vacuum_lock;
 	//! Lock necessary to start transactions only - used by FORCE CHECKPOINT to prevent new transactions from starting

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -10,7 +10,7 @@
 
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/transaction/checkpoint_lock.hpp"
-#include "duckdb/storage/storage_lock.hpp"
+#include "duckdb/transaction/vacuum_lock.hpp"
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/common/queue.hpp"
 
@@ -73,8 +73,8 @@ public:
 	//! Try to obtain an exclusive checkpoint lock
 	unique_ptr<CheckpointLockKey> TryGetCheckpointLock();
 	unique_ptr<CheckpointLockKey> TryUpgradeCheckpointLock(CheckpointLockKey &lock);
-	unique_ptr<StorageLockKey> SharedVacuumLock();
-	unique_ptr<StorageLockKey> TryGetVacuumLock();
+	unique_ptr<VacuumLockKey> SharedVacuumLock();
+	unique_ptr<VacuumLockKey> TryGetVacuumLock();
 
 	//! Returns the current version of the catalog (incremented whenever anything changes, not stored between restarts)
 	DUCKDB_API idx_t GetCatalogVersion(Transaction &transaction);
@@ -133,7 +133,7 @@ private:
 	//! The checkpoint lock
 	CheckpointLockCoordinator checkpoint_lock;
 	//! The vacuum lock - necessary to start vacuum operations
-	StorageLock vacuum_lock;
+	VacuumLockCoordinator vacuum_lock;
 	//! Lock necessary to start transactions only - used by FORCE CHECKPOINT to prevent new transactions from starting
 	mutex start_transaction_lock;
 

--- a/src/include/duckdb/transaction/vacuum_lock.hpp
+++ b/src/include/duckdb/transaction/vacuum_lock.hpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/vacuum_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+
+namespace duckdb {
+struct VacuumLockInternals;
+
+enum class VacuumLockType { SHARED, EXCLUSIVE };
+
+class VacuumLockKey {
+public:
+	VacuumLockKey(shared_ptr<VacuumLockInternals> internals, VacuumLockType type);
+	~VacuumLockKey();
+
+	VacuumLockType GetType() const {
+		return type;
+	}
+
+private:
+	shared_ptr<VacuumLockInternals> internals;
+	VacuumLockType type;
+};
+
+//! Coordinates long-lived leases that prevent full vacuum/checkpoint rewrites.
+class VacuumLockCoordinator {
+public:
+	VacuumLockCoordinator();
+	~VacuumLockCoordinator();
+
+	unique_ptr<VacuumLockKey> GetSharedLock();
+	unique_ptr<VacuumLockKey> TryGetExclusiveLock();
+
+private:
+	shared_ptr<VacuumLockInternals> internals;
+};
+
+} // namespace duckdb

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -1,29 +1,44 @@
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/thread_annotation/thread_annotation.hpp"
 
+#include <condition_variable>
 #include <shared_mutex>
 
 namespace duckdb {
 
 struct StorageLockInternals : enable_shared_from_this<StorageLockInternals> {
 public:
-	std::shared_mutex lock;
-
-public:
 	unique_ptr<StorageLockKey> GetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		WaitForExclusiveAccess();
 		lock.lock();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
 	unique_ptr<StorageLockKey> GetSharedLock() {
+		{
+			unique_lock<mutex> guard(gate_lock);
+			gate_condition.wait(guard, [&] { return !writer_active && waiting_writers == 0; });
+			active_readers++;
+		}
 		lock.lock_shared();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::SHARED);
 	}
 
 	unique_ptr<StorageLockKey> TryGetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		{
+			lock_guard<mutex> guard(gate_lock);
+			if (writer_active || waiting_writers != 0 || active_readers != 0) {
+				return nullptr;
+			}
+			writer_active = true;
+		}
 		if (!lock.try_lock()) {
+			lock_guard<mutex> guard(gate_lock);
+			writer_active = false;
+			gate_condition.notify_all();
 			return nullptr;
 		}
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
@@ -31,10 +46,38 @@ public:
 
 	void ReleaseExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 		lock.unlock();
+		lock_guard<mutex> guard(gate_lock);
+		D_ASSERT(writer_active);
+		writer_active = false;
+		gate_condition.notify_all();
 	}
+
 	void ReleaseSharedLock() {
 		lock.unlock_shared();
+		lock_guard<mutex> guard(gate_lock);
+		D_ASSERT(active_readers > 0);
+		active_readers--;
+		if (active_readers == 0) {
+			gate_condition.notify_all();
+		}
 	}
+
+private:
+	void WaitForExclusiveAccess() {
+		unique_lock<mutex> guard(gate_lock);
+		waiting_writers++;
+		gate_condition.wait(guard, [&] { return !writer_active && active_readers == 0; });
+		waiting_writers--;
+		writer_active = true;
+	}
+
+private:
+	std::shared_mutex lock;
+	mutex gate_lock;
+	std::condition_variable gate_condition;
+	idx_t active_readers = 0;
+	idx_t waiting_writers = 0;
+	bool writer_active = false;
 };
 
 StorageLockKey::StorageLockKey(shared_ptr<StorageLockInternals> internals_p, StorageLockType type)

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -1,94 +1,39 @@
 #include "duckdb/storage/storage_lock.hpp"
-#include "duckdb/common/atomic.hpp"
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/thread_annotation/thread_annotation.hpp"
 
-#include <condition_variable>
+#include <shared_mutex>
 
 namespace duckdb {
 
-// A phase-fair read-write lock: waiters sleep on a condition variable instead of busy-spinning.
-// A registering writer drains the readers ahead of it (no new readers are admitted past it), but a reader only
-// waits for writers registered before it - so neither side can starve the other.
 struct StorageLockInternals : enable_shared_from_this<StorageLockInternals> {
 public:
-	StorageLockInternals() : read_count(0), writer_active(false), writer_tickets(0), writers_done(0) {
-	}
-
-	mutex state_lock;
-	std::condition_variable state_cv;
-	idx_t read_count;
-	bool writer_active;
-	//! Incremented when a writer registers (blocking acquisition) or acquires (try/upgrade)
-	idx_t writer_tickets;
-	//! Incremented when a writer releases
-	idx_t writers_done;
+	std::shared_mutex lock;
 
 public:
 	unique_ptr<StorageLockKey> GetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		unique_lock<mutex> guard(state_lock);
-		writer_tickets++;
-		state_cv.wait(guard, [&]() { return !writer_active && read_count == 0; });
-		writer_active = true;
+		lock.lock();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	unique_ptr<StorageLockKey> GetSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		unique_lock<mutex> guard(state_lock);
-		// wait for the writers registered before us (they drain and run first), but not for later ones
-		auto target = writer_tickets;
-		state_cv.wait(guard, [&]() { return !writer_active && writers_done >= target; });
-		read_count++;
+	unique_ptr<StorageLockKey> GetSharedLock() {
+		lock.lock_shared();
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::SHARED);
 	}
 
 	unique_ptr<StorageLockKey> TryGetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		lock_guard<mutex> guard(state_lock);
-		if (writer_active || read_count != 0) {
+		if (!lock.try_lock()) {
 			return nullptr;
 		}
-		writer_tickets++;
-		writer_active = true;
-		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
-	}
-
-	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		if (lock.GetType() != StorageLockType::SHARED) {
-			throw InternalException("StorageLock::TryUpgradeLock called on an exclusive lock");
-		}
-		lock_guard<mutex> guard(state_lock);
-		if (writer_active || read_count != 1) {
-			// other shared locks (or a writer) are active: failed to upgrade
-			D_ASSERT(read_count != 0);
-			return nullptr;
-		}
-		// we are the only reader: grant the exclusive lock alongside the held shared lock (read_count stays 1)
-		writer_tickets++;
-		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
 	void ReleaseExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		{
-			lock_guard<mutex> guard(state_lock);
-			writer_active = false;
-			writers_done++;
-		}
-		state_cv.notify_all();
+		lock.unlock();
 	}
-	void ReleaseSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		bool notify;
-		{
-			lock_guard<mutex> guard(state_lock);
-			read_count--;
-			notify = read_count == 0;
-		}
-		if (notify) {
-			// last reader left - wake a waiting writer
-			state_cv.notify_all();
-		}
+	void ReleaseSharedLock() {
+		lock.unlock_shared();
 	}
 };
 
@@ -120,10 +65,6 @@ unique_ptr<StorageLockKey> StorageLock::TryGetExclusiveLock() {
 
 unique_ptr<StorageLockKey> StorageLock::GetSharedLock() {
 	return internals->GetSharedLock();
-}
-
-unique_ptr<StorageLockKey> StorageLock::TryUpgradeCheckpointLock(StorageLockKey &lock) {
-	return internals->TryUpgradeCheckpointLock(lock);
 }
 
 } // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -735,7 +735,7 @@ void SingleFileStorageManager::CreateCheckpoint(QueryContext context, Checkpoint
 	if (read_only || !load_complete) {
 		return;
 	}
-	unique_ptr<StorageLockKey> vacuum_lock;
+	unique_ptr<VacuumLockKey> vacuum_lock;
 	if (options.type != CheckpointType::CONCURRENT_CHECKPOINT) {
 		auto &transaction_manager = GetAttached().GetTransactionManager().Cast<DuckTransactionManager>();
 		vacuum_lock = transaction_manager.TryGetVacuumLock();

--- a/src/transaction/CMakeLists.txt
+++ b/src/transaction/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   duckdb_transaction
   OBJECT
+  checkpoint_lock.cpp
   duck_transaction_manager.cpp
   duck_transaction.cpp
   meta_transaction.cpp

--- a/src/transaction/CMakeLists.txt
+++ b/src/transaction/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_transaction
   OBJECT
   checkpoint_lock.cpp
+  vacuum_lock.cpp
   duck_transaction_manager.cpp
   duck_transaction.cpp
   meta_transaction.cpp

--- a/src/transaction/checkpoint_lock.cpp
+++ b/src/transaction/checkpoint_lock.cpp
@@ -1,0 +1,93 @@
+#include "duckdb/transaction/checkpoint_lock.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/mutex.hpp"
+
+#include <condition_variable>
+
+namespace duckdb {
+
+struct CheckpointLockInternals : enable_shared_from_this<CheckpointLockInternals> {
+public:
+	unique_ptr<CheckpointLockKey> GetSharedLock() {
+		unique_lock<mutex> guard(lock);
+		condition.wait(guard, [&] { return !exclusive; });
+		shared_count++;
+		return make_uniq<CheckpointLockKey>(shared_from_this(), CheckpointLockType::SHARED);
+	}
+
+	unique_ptr<CheckpointLockKey> TryGetExclusiveLock() {
+		lock_guard<mutex> guard(lock);
+		if (exclusive || shared_count != 0) {
+			return nullptr;
+		}
+		exclusive = true;
+		return make_uniq<CheckpointLockKey>(shared_from_this(), CheckpointLockType::EXCLUSIVE);
+	}
+
+	unique_ptr<CheckpointLockKey> TryUpgrade(CheckpointLockKey &key) {
+		if (key.type != CheckpointLockType::SHARED || key.internals.get() != this) {
+			throw InternalException("CheckpointLockCoordinator::TryUpgrade called with an invalid shared lock");
+		}
+		lock_guard<mutex> guard(lock);
+		if (exclusive || shared_count != 1) {
+			return nullptr;
+		}
+		exclusive = true;
+		return make_uniq<CheckpointLockKey>(shared_from_this(), CheckpointLockType::EXCLUSIVE);
+	}
+
+	void ReleaseSharedLock() {
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(shared_count > 0);
+		shared_count--;
+	}
+
+	void ReleaseExclusiveLock() {
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(exclusive);
+		exclusive = false;
+		condition.notify_all();
+	}
+
+private:
+	mutex lock;
+	std::condition_variable condition;
+	idx_t shared_count = 0;
+	bool exclusive = false;
+};
+
+CheckpointLockKey::CheckpointLockKey(shared_ptr<CheckpointLockInternals> internals_p, CheckpointLockType type_p)
+    : internals(std::move(internals_p)), type(type_p) {
+}
+
+CheckpointLockKey::~CheckpointLockKey() {
+	if (type == CheckpointLockType::EXCLUSIVE) {
+		internals->ReleaseExclusiveLock();
+	} else {
+		D_ASSERT(type == CheckpointLockType::SHARED);
+		internals->ReleaseSharedLock();
+	}
+}
+
+CheckpointLockCoordinator::CheckpointLockCoordinator() : internals(make_shared_ptr<CheckpointLockInternals>()) {
+}
+
+CheckpointLockCoordinator::~CheckpointLockCoordinator() {
+}
+
+unique_ptr<CheckpointLockKey> CheckpointLockCoordinator::GetSharedLock() {
+	return internals->GetSharedLock();
+}
+
+unique_ptr<CheckpointLockKey> CheckpointLockCoordinator::TryGetExclusiveLock() {
+	return internals->TryGetExclusiveLock();
+}
+
+unique_ptr<CheckpointLockKey> CheckpointLockCoordinator::TryUpgrade(CheckpointLockKey &lock) {
+	return internals->TryUpgrade(lock);
+}
+
+} // namespace duckdb

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -21,7 +21,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/attached_database.hpp"
-#include "duckdb/storage/storage_lock.hpp"
+#include "duckdb/transaction/checkpoint_lock.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 
@@ -351,7 +351,7 @@ void DuckTransaction::SetModifications(DatabaseModificationType type) {
 	}
 }
 
-unique_ptr<StorageLockKey> DuckTransaction::TryGetCheckpointLock() {
+unique_ptr<CheckpointLockKey> DuckTransaction::TryGetCheckpointLock() {
 	if (!checkpoint_lock) {
 		return GetTransactionManager().TryGetCheckpointLock();
 	} else {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -264,11 +264,11 @@ unique_ptr<CheckpointLockKey> DuckTransactionManager::TryGetCheckpointLock() {
 	return checkpoint_lock.TryGetExclusiveLock();
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::SharedVacuumLock() {
+unique_ptr<VacuumLockKey> DuckTransactionManager::SharedVacuumLock() {
 	return vacuum_lock.GetSharedLock();
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::TryGetVacuumLock() {
+unique_ptr<VacuumLockKey> DuckTransactionManager::TryGetVacuumLock() {
 	return vacuum_lock.TryGetExclusiveLock();
 }
 

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -130,7 +130,7 @@ bool DuckTransactionManager::HasOtherTransactions(DuckTransaction &transaction) 
 }
 
 DuckTransactionManager::CheckpointDecision
-DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &lock,
+DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<CheckpointLockKey> &lock,
                                       const UndoBufferProperties &undo_properties) {
 	if (db.IsSystem()) {
 		return CheckpointDecision("system transaction");
@@ -222,7 +222,7 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 		}
 	}
 
-	unique_ptr<StorageLockKey> lock;
+	unique_ptr<CheckpointLockKey> lock;
 	if (!force) {
 		// not a force checkpoint
 		// try to get the checkpoint lock
@@ -252,15 +252,15 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 	storage_manager.CreateCheckpoint(context, options);
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::SharedCheckpointLock() {
+unique_ptr<CheckpointLockKey> DuckTransactionManager::SharedCheckpointLock() {
 	return checkpoint_lock.GetSharedLock();
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::TryUpgradeCheckpointLock(StorageLockKey &lock) {
-	return checkpoint_lock.TryUpgradeCheckpointLock(lock);
+unique_ptr<CheckpointLockKey> DuckTransactionManager::TryUpgradeCheckpointLock(CheckpointLockKey &lock) {
+	return checkpoint_lock.TryUpgrade(lock);
 }
 
-unique_ptr<StorageLockKey> DuckTransactionManager::TryGetCheckpointLock() {
+unique_ptr<CheckpointLockKey> DuckTransactionManager::TryGetCheckpointLock() {
 	return checkpoint_lock.TryGetExclusiveLock();
 }
 
@@ -308,7 +308,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	}
 
 	// check if we can checkpoint
-	unique_ptr<StorageLockKey> lock;
+	unique_ptr<CheckpointLockKey> lock;
 	auto undo_properties = transaction.GetUndoProperties();
 	auto checkpoint_decision = CanCheckpoint(transaction, lock, undo_properties);
 	ErrorData error;
@@ -445,7 +445,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	// now perform a checkpoint if (1) we are able to checkpoint, and (2) the WAL has reached sufficient size to
 	// checkpoint
 	if (checkpoint_decision.can_checkpoint) {
-		if (!lock || lock->GetType() != StorageLockType::EXCLUSIVE) {
+		if (!lock || lock->GetType() != CheckpointLockType::EXCLUSIVE) {
 			throw InternalException("Checkpointing requires an exclusive lock to be held");
 		}
 		// we can unlock the transaction lock while checkpointing

--- a/src/transaction/vacuum_lock.cpp
+++ b/src/transaction/vacuum_lock.cpp
@@ -1,0 +1,79 @@
+#include "duckdb/transaction/vacuum_lock.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/mutex.hpp"
+
+#include <condition_variable>
+
+namespace duckdb {
+
+struct VacuumLockInternals : enable_shared_from_this<VacuumLockInternals> {
+public:
+	unique_ptr<VacuumLockKey> GetSharedLock() {
+		unique_lock<mutex> guard(lock);
+		condition.wait(guard, [&] { return !exclusive; });
+		shared_count++;
+		return make_uniq<VacuumLockKey>(shared_from_this(), VacuumLockType::SHARED);
+	}
+
+	unique_ptr<VacuumLockKey> TryGetExclusiveLock() {
+		lock_guard<mutex> guard(lock);
+		if (exclusive || shared_count != 0) {
+			return nullptr;
+		}
+		exclusive = true;
+		return make_uniq<VacuumLockKey>(shared_from_this(), VacuumLockType::EXCLUSIVE);
+	}
+
+	void ReleaseSharedLock() {
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(shared_count > 0);
+		shared_count--;
+		if (shared_count == 0) {
+			condition.notify_all();
+		}
+	}
+
+	void ReleaseExclusiveLock() {
+		lock_guard<mutex> guard(lock);
+		D_ASSERT(exclusive);
+		exclusive = false;
+		condition.notify_all();
+	}
+
+private:
+	mutex lock;
+	std::condition_variable condition;
+	idx_t shared_count = 0;
+	bool exclusive = false;
+};
+
+VacuumLockKey::VacuumLockKey(shared_ptr<VacuumLockInternals> internals_p, VacuumLockType type_p)
+    : internals(std::move(internals_p)), type(type_p) {
+}
+
+VacuumLockKey::~VacuumLockKey() {
+	if (type == VacuumLockType::EXCLUSIVE) {
+		internals->ReleaseExclusiveLock();
+	} else {
+		D_ASSERT(type == VacuumLockType::SHARED);
+		internals->ReleaseSharedLock();
+	}
+}
+
+VacuumLockCoordinator::VacuumLockCoordinator() : internals(make_shared_ptr<VacuumLockInternals>()) {
+}
+
+VacuumLockCoordinator::~VacuumLockCoordinator() {
+}
+
+unique_ptr<VacuumLockKey> VacuumLockCoordinator::GetSharedLock() {
+	return internals->GetSharedLock();
+}
+
+unique_ptr<VacuumLockKey> VacuumLockCoordinator::TryGetExclusiveLock() {
+	return internals->TryGetExclusiveLock();
+}
+
+} // namespace duckdb

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library_unity(
   test_allocator_debug_info.cpp
   test_buffer_pool_reservation.cpp
   test_storage_fuzz.cpp
+  test_storage_lock.cpp
   test_strftime.cpp
   test_string_util.cpp
   test_substring_oob.cpp

--- a/test/common/test_storage_lock.cpp
+++ b/test/common/test_storage_lock.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/transaction/checkpoint_lock.hpp"
+#include "duckdb/transaction/vacuum_lock.hpp"
 
 #include <atomic>
 #include <thread>
@@ -91,4 +92,24 @@ TEST_CASE("StorageLock blocks later readers behind a waiting writer", "[storage]
 	}
 	REQUIRE(reader_acquired);
 	reader.join();
+}
+
+TEST_CASE("VacuumLockCoordinator coordinates shared and exclusive leases", "[storage]") {
+	VacuumLockCoordinator lock;
+	auto first_shared_lock = lock.GetSharedLock();
+	auto second_shared_lock = lock.GetSharedLock();
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	first_shared_lock.reset();
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	second_shared_lock.reset();
+	auto exclusive_lock = lock.TryGetExclusiveLock();
+	REQUIRE(exclusive_lock);
+	REQUIRE(exclusive_lock->GetType() == VacuumLockType::EXCLUSIVE);
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	exclusive_lock.reset();
+	auto third_shared_lock = lock.GetSharedLock();
+	REQUIRE(third_shared_lock);
 }

--- a/test/common/test_storage_lock.cpp
+++ b/test/common/test_storage_lock.cpp
@@ -2,6 +2,9 @@
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/transaction/checkpoint_lock.hpp"
 
+#include <atomic>
+#include <thread>
+
 using namespace duckdb;
 
 TEST_CASE("StorageLock allows shared ownership and excludes writers", "[storage]") {
@@ -39,4 +42,53 @@ TEST_CASE("CheckpointLockCoordinator promotes the final shared lease", "[storage
 
 	first_shared_lock.reset();
 	REQUIRE(lock.TryGetExclusiveLock());
+}
+
+TEST_CASE("StorageLock blocks later readers behind a waiting writer", "[storage]") {
+	StorageLock lock;
+	auto shared_lock = lock.GetSharedLock();
+
+	std::atomic<bool> writer_waiting = false;
+	std::atomic<bool> writer_acquired = false;
+	std::atomic<bool> reader_acquired = false;
+	std::atomic<bool> release_writer = false;
+
+	std::thread writer([&] {
+		writer_waiting = true;
+		auto exclusive_lock = lock.GetExclusiveLock();
+		writer_acquired = true;
+		while (!release_writer) {
+		}
+	});
+
+	while (!writer_waiting) {
+	}
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	std::thread reader([&] {
+		auto later_shared_lock = lock.GetSharedLock();
+		reader_acquired = true;
+	});
+
+	for (idx_t i = 0; i < 1000 && !writer_acquired; i++) {
+		REQUIRE(!reader_acquired);
+		std::this_thread::yield();
+	}
+
+	shared_lock.reset();
+
+	for (idx_t i = 0; i < 1000 && !writer_acquired; i++) {
+		std::this_thread::yield();
+	}
+	REQUIRE(writer_acquired);
+	REQUIRE(!reader_acquired);
+
+	release_writer = true;
+	writer.join();
+
+	for (idx_t i = 0; i < 1000 && !reader_acquired; i++) {
+		std::this_thread::yield();
+	}
+	REQUIRE(reader_acquired);
+	reader.join();
 }

--- a/test/common/test_storage_lock.cpp
+++ b/test/common/test_storage_lock.cpp
@@ -1,0 +1,42 @@
+#include "catch.hpp"
+#include "duckdb/storage/storage_lock.hpp"
+#include "duckdb/transaction/checkpoint_lock.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("StorageLock allows shared ownership and excludes writers", "[storage]") {
+	StorageLock lock;
+	auto shared_lock = lock.GetSharedLock();
+	auto second_shared_lock = lock.GetSharedLock();
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	shared_lock.reset();
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	second_shared_lock.reset();
+	auto exclusive_lock = lock.TryGetExclusiveLock();
+	REQUIRE(exclusive_lock);
+	REQUIRE(!lock.TryGetExclusiveLock());
+}
+
+TEST_CASE("CheckpointLockCoordinator promotes the final shared lease", "[storage]") {
+	CheckpointLockCoordinator lock;
+	auto first_shared_lock = lock.GetSharedLock();
+	auto second_shared_lock = lock.GetSharedLock();
+
+	REQUIRE(!lock.TryUpgrade(*first_shared_lock));
+	REQUIRE(first_shared_lock);
+
+	second_shared_lock.reset();
+	auto exclusive_lock = lock.TryUpgrade(*first_shared_lock);
+	REQUIRE(exclusive_lock);
+	REQUIRE(first_shared_lock);
+	REQUIRE(exclusive_lock->GetType() == CheckpointLockType::EXCLUSIVE);
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	exclusive_lock.reset();
+	REQUIRE(!lock.TryGetExclusiveLock());
+
+	first_shared_lock.reset();
+	REQUIRE(lock.TryGetExclusiveLock());
+}

--- a/test/sql/pragma/profiling/test_autocheckpoint_latency.test
+++ b/test/sql/pragma/profiling/test_autocheckpoint_latency.test
@@ -87,5 +87,29 @@ FROM '{TEST_DIR}/acp_after.json';
 ----
 true	true	true	true
 
+# Force WAL skipping for an auto-checkpoint with a sufficiently large transaction.
+statement ok
+SET auto_checkpoint_skip_wal_threshold=0;
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/acp_skip_wal.json';
+
+statement ok
+INSERT INTO acp_db.tbl SELECT range::INTEGER FROM range(100000);
+
+statement ok
+PRAGMA disable_profiling;
+
+query II
+SELECT
+    CASE WHEN storage.checkpoint_latency > 0 THEN 'true' ELSE 'false' END,
+    CASE WHEN json_extract(to_json(storage), '$.write_to_wal_latency') IS NULL THEN 'true' ELSE 'false' END
+FROM '{TEST_DIR}/acp_skip_wal.json';
+----
+true	true
+
 statement ok
 DETACH acp_db;

--- a/test/sql/pragma/profiling/test_autocheckpoint_latency.test
+++ b/test/sql/pragma/profiling/test_autocheckpoint_latency.test
@@ -89,6 +89,9 @@ true	true	true	true
 
 # Force WAL skipping for an auto-checkpoint with a sufficiently large transaction.
 statement ok
+SET wal_autocheckpoint='1KB';
+
+statement ok
 SET auto_checkpoint_skip_wal_threshold=0;
 
 statement ok
@@ -98,7 +101,7 @@ statement ok
 PRAGMA profiling_output = '{TEST_DIR}/acp_skip_wal.json';
 
 statement ok
-INSERT INTO acp_db.tbl SELECT range::INTEGER FROM range(100000);
+INSERT INTO acp_db.tbl SELECT range::INTEGER FROM range(1000000);
 
 statement ok
 PRAGMA disable_profiling;


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/8928

With this PR, we use `std::shared_mutex` in `StorageLock` while preserving the existing checkpoint locking semantics. We still need a bit of scaffolding around `std::shared_mutex` to preserve the existing writer-prioritization, i.e., no new shared locks can be acquired when an exclusive lock was requested. Moreover, this introduces `CheckpointLock`, which encapsulates the logic to upgrade a shared lock to an exclusive lock if it is the only existing shared lock.