### PR TITLE
Fix #23405: Pass args.size() to UnaryExecutor in JSON extraction to respect selection vectors

### DIFF
--- a/extension/json/include/json_executors.hpp
+++ b/extension/json/include/json_executors.hpp
@@ -29,7 +29,7 @@ public:
 		auto alc = lstate.json_allocator->GetYYAlc();
 
 		const auto &inputs = args.data[0];
-		UnaryExecutor::Execute<string_t, T>(inputs, result, [&](string_t input) -> optional<T> {
+		UnaryExecutor::Execute<string_t, T>(inputs, result, args.size(), [&](string_t input) -> optional<T> {
 			auto doc = JSONCommon::ReadDocument(input, JSONCommon::READ_FLAG, alc);
 			return fun(doc->root, alc, result);
 		});
@@ -50,7 +50,7 @@ public:
 			const char *ptr = info.ptr;
 			const idx_t &len = info.len;
 			if (info.path_type == JSONCommon::JSONPathType::REGULAR) {
-				UnaryExecutor::Execute<string_t, T>(inputs, result, [&](string_t input) -> optional<T> {
+				UnaryExecutor::Execute<string_t, T>(inputs, result, args.size(), [&](string_t input) -> optional<T> {
 					auto doc = JSONCommon::ReadDocument(input, JSONCommon::READ_FLAG, alc);
 					auto val = JSONCommon::GetUnsafe(doc->root, ptr, len);
 					if (SET_NULL_IF_NOT_FOUND && !val) {
@@ -62,7 +62,7 @@ public:
 			} else {
 				D_ASSERT(info.path_type == JSONCommon::JSONPathType::WILDCARD);
 				vector<yyjson_val *> vals;
-				UnaryExecutor::Execute<string_t, list_entry_t>(inputs, result, [&](string_t input) {
+				UnaryExecutor::Execute<string_t, list_entry_t>(inputs, result, args.size(), [&](string_t input) {
 					vals.clear();
 
 					auto doc = JSONCommon::ReadDocument(input, JSONCommon::READ_FLAG, alc);


### PR DESCRIPTION
->PR Description
Problem: 
When evaluating `WHERE` clauses, the JSON extraction operators (like `->>`) were ignoring the active selection vectors generated by preceding filter conditions. Because `args.size()` was omitted, `UnaryExecutor` defaulted to eagerly parsing the entire chunk. This caused a `Conversion Error` to be thrown when the chunk contained invalid JSON strings that were supposed to be filtered out by earlier conditions.

Solution: 
Passed `args.size()` into the three `UnaryExecutor::Execute` calls inside `json_executors.hpp` (for both standard and wildcard binary execution paths). This ensures the executor correctly references the selection vector and only parses valid, unfiltered rows.

Closes #23405