### PR TITLE
Refactor Multi-File Scan for ASYNC I/O

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -337,10 +337,6 @@ public:
 	                       LocalTableFunctionState &lstate) override;
 	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
-	//! Parquet resets its own chunk, because of the filter-prefetch
-	bool OwnsChunkReset() const override {
-		return true;
-	}
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -188,13 +188,6 @@ struct ParquetPrefetchMetrics {
 	}
 };
 
-//! Where the scan is in its async execution.
-enum class ParquetScanState : uint8_t {
-	PROCESS,        //! process the current row group into a output chunk
-	RESUME_PAYLOAD, //! resume decoding the payload columns after the filter-column I/O blocked
-	FINISHED        //! the scan is done
-};
-
 struct ParquetReaderScanState {
 public:
 	ColumnReader &GetColumnReader(idx_t i);
@@ -208,7 +201,8 @@ public:
 	vector<unique_ptr<ColumnReader>> column_readers;
 	duckdb_base_std::unique_ptr<duckdb_apache::thrift::protocol::TProtocol> thrift_file_proto;
 
-	ParquetScanState scan_state;
+	//! Set while resuming payload-column decode after the filter-column I/O blocked (vs a fresh row-group pass)
+	bool resuming_payload = false;
 	SelectionVector sel;
 
 	ResizeableBuffer define_buf;
@@ -342,7 +336,6 @@ public:
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, idx_t group_to_read) const;
-	AsyncResult Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
 	idx_t NumRows() const;
 	idx_t NumRowGroups() const;
@@ -416,7 +409,7 @@ private:
 	//! Build the async I/O tasks for the registered read-heads
 	AsyncResult ScheduleRowGroupReads(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
-	AsyncResult Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	AsyncResult Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result);
 	//! Log and finalize the row group's prefetch metrics
 	void FinishRowGroup(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch);
 	//! Process filters

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -411,10 +411,10 @@ private:
 	ParquetPrefetchStrategy ColumnWisePrefetch(ParquetReaderScanState &state, ThriftFileTransport &trans,
 	                                           const duckdb_parquet::RowGroup &group, bool filters_look_unselective,
 	                                           bool log_prefetch) const;
-	//! Prune the current row group and register its read-heads
-	ParquetPrefetchStrategy PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state);
-	//! Turn the read-heads registered by PrepareGroupIO into async I/O tasks (BLOCKED) or HAVE_MORE_OUTPUT.
-	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy);
+	//! Register the read-heads to fetch, and select prefetch strategy
+	ParquetPrefetchStrategy RegisterRowGroupReads(ClientContext &context, ParquetReaderScanState &state);
+	//! Build the async I/O tasks for the registered read-heads
+	AsyncResult ScheduleRowGroupReads(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
 	AsyncResult Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Log and finalize the row group's prefetch metrics

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -190,7 +190,6 @@ struct ParquetPrefetchMetrics {
 
 //! Where the scan is in its async execution.
 enum class ParquetScanState : uint8_t {
-	SCHEDULE,       //! schedule the next row group's I/O
 	PROCESS,        //! process the current row group into a output chunk
 	RESUME_PAYLOAD, //! resume decoding the payload columns after the filter-column I/O blocked
 	FINISHED        //! the scan is done
@@ -201,8 +200,8 @@ public:
 	ColumnReader &GetColumnReader(idx_t i);
 
 public:
-	vector<idx_t> group_idx_list;
-	int64_t current_group;
+	//! The row group index this scan state decodes
+	idx_t group_index;
 	idx_t offset_in_group;
 	idx_t group_offset;
 	shared_ptr<CachingFileHandle> file_handle;
@@ -220,8 +219,6 @@ public:
 	idx_t filter_head_count = 0;
 	//! Surviving row count
 	idx_t filter_count = 0;
-	//! Prefetch strategy chosen for the current row group
-	ParquetPrefetchStrategy group_prefetch_strategy = ParquetPrefetchStrategy::NONE;
 
 	ParquetPrefetchMetrics prefetch_metrics;
 
@@ -344,7 +341,7 @@ public:
 	double GetProgressInFile(ClientContext &context) override;
 
 public:
-	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read) const;
+	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, idx_t group_to_read) const;
 	AsyncResult Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
 	idx_t NumRows() const;
@@ -414,14 +411,14 @@ private:
 	ParquetPrefetchStrategy ColumnWisePrefetch(ParquetReaderScanState &state, ThriftFileTransport &trans,
 	                                           const duckdb_parquet::RowGroup &group, bool filters_look_unselective,
 	                                           bool log_prefetch) const;
-	//! Switch to the next row group, prune it, and register its read-heads (records the chosen prefetch strategy).
-	void PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state);
+	//! Prune the current row group and register its read-heads
+	ParquetPrefetchStrategy PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state);
 	//! Turn the read-heads registered by PrepareGroupIO into async I/O tasks (BLOCKED) or HAVE_MORE_OUTPUT.
-	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state);
-	//! Switch the next row group
-	AsyncResult ScheduleNextGroup(ClientContext &context, ParquetReaderScanState &state);
+	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
-	AsyncResult Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	AsyncResult Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	//! Log and finalize the row group's prefetch metrics
+	void FinishRowGroup(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch);
 	//! Process filters
 	AsyncResult ProcessFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count, uint8_t *define_ptr,
 	                           uint8_t *repeat_ptr, bool log_prefetch);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -220,6 +220,8 @@ public:
 	idx_t filter_head_count = 0;
 	//! Surviving row count
 	idx_t filter_count = 0;
+	//! Prefetch strategy chosen for the current row group
+	ParquetPrefetchStrategy scheduled_strategy = ParquetPrefetchStrategy::NONE;
 
 	ParquetPrefetchMetrics prefetch_metrics;
 
@@ -410,6 +412,10 @@ private:
 	ParquetPrefetchStrategy ColumnWisePrefetch(ParquetReaderScanState &state, ThriftFileTransport &trans,
 	                                           const duckdb_parquet::RowGroup &group, bool filters_look_unselective,
 	                                           bool log_prefetch) const;
+	//! Switch to the next row group, prune it, and register its read-heads (records the chosen prefetch strategy).
+	void PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch);
+	//! Turn the read-heads registered by PrepareGroupIO into async I/O tasks (BLOCKED) or HAVE_MORE_OUTPUT.
+	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state);
 	//! Switch to the next row group and schedule its I/O (prepare column buffers, prefetch the bytes).
 	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -336,6 +336,8 @@ public:
 	                       LocalTableFunctionState &lstate) override;
 	void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
 	                 LocalTableFunctionState &lstate_p) override;
+	AsyncResult ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate,
+	                       LocalTableFunctionState &lstate) override;
 	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
@@ -413,11 +415,11 @@ private:
 	                                           const duckdb_parquet::RowGroup &group, bool filters_look_unselective,
 	                                           bool log_prefetch) const;
 	//! Switch to the next row group, prune it, and register its read-heads (records the chosen prefetch strategy).
-	void PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch);
+	void PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state);
 	//! Turn the read-heads registered by PrepareGroupIO into async I/O tasks (BLOCKED) or HAVE_MORE_OUTPUT.
 	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state);
 	//! Switch to the next row group and schedule its I/O (prepare column buffers, prefetch the bytes).
-	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
+	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
 	AsyncResult Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process filters

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -221,7 +221,7 @@ public:
 	//! Surviving row count
 	idx_t filter_count = 0;
 	//! Prefetch strategy chosen for the current row group
-	ParquetPrefetchStrategy scheduled_strategy = ParquetPrefetchStrategy::NONE;
+	ParquetPrefetchStrategy group_prefetch_strategy = ParquetPrefetchStrategy::NONE;
 
 	ParquetPrefetchMetrics prefetch_metrics;
 
@@ -418,8 +418,8 @@ private:
 	void PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state);
 	//! Turn the read-heads registered by PrepareGroupIO into async I/O tasks (BLOCKED) or HAVE_MORE_OUTPUT.
 	AsyncResult CollectGroupIOTasks(ParquetReaderScanState &state);
-	//! Switch to the next row group and schedule its I/O (prepare column buffers, prefetch the bytes).
-	AsyncResult Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result);
+	//! Switch the next row group
+	AsyncResult ScheduleNextGroup(ClientContext &context, ParquetReaderScanState &state);
 	//! Process up to STANDARD_VECTOR_SIZE rows of the current row group into result.
 	AsyncResult Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch);
 	//! Process filters

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -337,6 +337,10 @@ public:
 	                       LocalTableFunctionState &lstate) override;
 	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	//! Parquet resets its own chunk, because of the filter-prefetch
+	bool OwnsChunkReset() const override {
+		return true;
+	}
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -795,10 +795,8 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 		}
 	}
 #endif
-	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
-	local_state.scan_state.op = gstate.op;
-	return Scan(context, local_state.scan_state, chunk);
+	return Process(context, local_state.scan_state, chunk);
 }
 
 unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::Copy() {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -770,8 +770,18 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 
 void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                 LocalTableFunctionState &lstate_p) {
+	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
+	lstate.scan_state.op = gstate.op;
 	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
+	// prune the row group and register its read-heads off-lock; ScheduleIO collects the I/O under the parallel lock
+	PrepareGroupIO(context, lstate.scan_state);
+}
+
+AsyncResult ParquetReader::ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                      LocalTableFunctionState &lstate_p) {
+	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
+	return CollectGroupIOTasks(lstate.scan_state);
 }
 
 void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -776,9 +776,8 @@ void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState
 AsyncResult ParquetReader::ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                       LocalTableFunctionState &lstate_p) {
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
-	// prune the row group + register its read-heads, then collect the async I/O tasks - all off-lock
-	auto strategy = PrepareGroupIO(context, lstate.scan_state);
-	return CollectGroupIOTasks(lstate.scan_state, strategy);
+	auto strategy = RegisterRowGroupReads(context, lstate.scan_state);
+	return ScheduleRowGroupReads(lstate.scan_state, strategy);
 }
 
 void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -84,20 +84,17 @@ private:
 };
 
 struct ParquetReadGlobalState : public GlobalTableFunctionState {
-	explicit ParquetReadGlobalState(optional_ptr<const PhysicalOperator> op_p)
-	    : row_group_index(0), batch_index(0), op(op_p) {
+	explicit ParquetReadGlobalState(optional_ptr<const PhysicalOperator> op_p) : row_group_index(0), op(op_p) {
 	}
 	//! Index of row group within file currently up for scanning
 	idx_t row_group_index;
-	//! Batch index of the next row group to be scanned
-	idx_t batch_index;
 	//! (Optional) pointer to physical operator performing the scan
 	optional_ptr<const PhysicalOperator> op;
 };
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
 	ParquetReaderScanState scan_state;
-	vector<idx_t> group_indexes;
+	idx_t group_index;
 };
 
 static void ParseFileRowNumberOption(MultiFileReaderBindData &bind_data, ParquetOptions &options,
@@ -763,7 +760,7 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 		return false;
 	}
 	// The current reader has rowgroups left to be scanned
-	lstate.group_indexes = {gstate.row_group_index};
+	lstate.group_index = gstate.row_group_index;
 	gstate.row_group_index++;
 	return true;
 }
@@ -773,15 +770,15 @@ void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
 	lstate.scan_state.op = gstate.op;
-	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
-	// prune the row group and register its read-heads off-lock; ScheduleIO collects the I/O under the parallel lock
-	PrepareGroupIO(context, lstate.scan_state);
+	InitializeScan(context, lstate.scan_state, lstate.group_index);
 }
 
 AsyncResult ParquetReader::ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                       LocalTableFunctionState &lstate_p) {
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
-	return CollectGroupIOTasks(lstate.scan_state);
+	// prune the row group + register its read-heads, then collect the async I/O tasks - all off-lock
+	auto strategy = PrepareGroupIO(context, lstate.scan_state);
+	return CollectGroupIOTasks(lstate.scan_state, strategy);
 }
 
 void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1720,7 +1720,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		return SourceResultType::FINISHED;
 	case ParquetScanState::SCHEDULE:
 		result.Reset();
-		return Schedule(context, state, result);
+		return ScheduleNextGroup(context, state);
 	case ParquetScanState::PROCESS:
 		result.Reset();
 		return Process(state, result, log_prefetch);
@@ -1736,7 +1736,7 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
 	state.current_group++;
 	state.offset_in_group = 0;
-	state.scheduled_strategy = ParquetPrefetchStrategy::NONE;
+	state.group_prefetch_strategy = ParquetPrefetchStrategy::NONE;
 
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	trans.ClearPrefetch();
@@ -1819,26 +1819,24 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 					strategy = ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 				}
 			}
-			state.scheduled_strategy = strategy;
+			state.group_prefetch_strategy = strategy;
 			if (log_prefetch) {
 				state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();
 			}
 		}
 	}
-
-	// a skipped row group has no rows to decode, so we loop back to schedule the next one
-	state.scan_state = row_group_skipped ? ParquetScanState::SCHEDULE : ParquetScanState::PROCESS;
+	state.scan_state = ParquetScanState::PROCESS;
 }
 
 AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
-	if (state.scheduled_strategy == ParquetPrefetchStrategy::NONE) {
+	if (state.group_prefetch_strategy == ParquetPrefetchStrategy::NONE) {
 		// nothing to prefetch (prefetch disabled, row group skipped, or broken-offset fallback)
 		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	auto read_head_count = trans.GetReadHeads().size();
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	switch (state.scheduled_strategy) {
+	switch (state.group_prefetch_strategy) {
 	case ParquetPrefetchStrategy::PREFETCH_FILTERS:
 		// schedule only the filter columns' I/O, they are last in our list
 		io_tasks = CollectIOTasks(trans, state.file_handle, read_head_count - state.filter_head_count, read_head_count);
@@ -1857,12 +1855,11 @@ AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+AsyncResult ParquetReader::ScheduleNextGroup(ClientContext &context, ParquetReaderScanState &state) {
 	PrepareGroupIO(context, state);
 	if (state.scan_state == ParquetScanState::FINISHED) {
 		return SourceResultType::FINISHED;
 	}
-	result.Reset();
 	return CollectGroupIOTasks(state);
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1950,7 +1950,6 @@ AsyncResult ParquetReader::ProcessFilters(ParquetReaderScanState &state, DataChu
 }
 
 AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
-	// a fresh pass evaluates filters; the resume path (resuming_payload) decodes only the payload columns
 	const bool log_prefetch =
 	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
 	const idx_t group_num_rows = GetGroup(state).num_rows;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1720,7 +1720,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 		return SourceResultType::FINISHED;
 	case ParquetScanState::SCHEDULE:
 		result.Reset();
-		return Schedule(context, state, result, log_prefetch);
+		return Schedule(context, state, result);
 	case ParquetScanState::PROCESS:
 		result.Reset();
 		return Process(state, result, log_prefetch);
@@ -1731,7 +1731,9 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 	}
 }
 
-void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch) {
+void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state) {
+	const bool log_prefetch =
+	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
 	state.current_group++;
 	state.offset_in_group = 0;
 	state.scheduled_strategy = ParquetPrefetchStrategy::NONE;
@@ -1855,9 +1857,8 @@ AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
-                                    bool log_prefetch) {
-	PrepareGroupIO(context, state, log_prefetch);
+AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+	PrepareGroupIO(context, state);
 	if (state.scan_state == ParquetScanState::FINISHED) {
 		return SourceResultType::FINISHED;
 	}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1731,10 +1731,10 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 	}
 }
 
-AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
-                                    bool log_prefetch) {
+void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch) {
 	state.current_group++;
 	state.offset_in_group = 0;
+	state.scheduled_strategy = ParquetPrefetchStrategy::NONE;
 
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	trans.ClearPrefetch();
@@ -1751,7 +1751,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 
 	if ((idx_t)state.current_group == state.group_idx_list.size()) {
 		state.scan_state = ParquetScanState::FINISHED;
-		return SourceResultType::FINISHED;
+		return;
 	}
 
 	// TODO: only need this if we have a deletion vector?
@@ -1777,8 +1777,7 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 		           {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
 	}
 
-	vector<unique_ptr<AsyncTask>> io_tasks;
-	if (state.prefetch_mode && state.offset_in_group != (idx_t)group.num_rows) {
+	if (state.prefetch_mode && !row_group_skipped) {
 		uint64_t total_row_group_span = GetGroupSpan(state);
 
 		double scan_percentage = (double)(to_scan_compressed_bytes) / static_cast<double>(total_row_group_span);
@@ -1818,33 +1817,52 @@ AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanSta
 					strategy = ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 				}
 			}
-			auto read_head_count = trans.GetReadHeads().size();
-			switch (strategy) {
-			case ParquetPrefetchStrategy::PREFETCH_FILTERS:
-				// schedule only the filter columns' I/O, they are last in our list
-				io_tasks = CollectIOTasks(trans, state.file_handle, read_head_count - state.filter_head_count,
-				                          read_head_count);
-				break;
-			case ParquetPrefetchStrategy::WHOLE_GROUP:
-			case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
-				// schedule the I/O for all columns up front
-				io_tasks = CollectIOTasks(trans, state.file_handle, 0, read_head_count);
-				break;
-			default:
-				throw InternalException("Unexpected parquet prefetch strategy when scheduling I/O");
-			}
+			state.scheduled_strategy = strategy;
 			if (log_prefetch) {
 				state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();
 			}
 		}
 	}
-	result.Reset();
+
 	// a skipped row group has no rows to decode, so we loop back to schedule the next one
 	state.scan_state = row_group_skipped ? ParquetScanState::SCHEDULE : ParquetScanState::PROCESS;
+}
+
+AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
+	if (state.scheduled_strategy == ParquetPrefetchStrategy::NONE) {
+		// nothing to prefetch (prefetch disabled, row group skipped, or broken-offset fallback)
+		return SourceResultType::HAVE_MORE_OUTPUT;
+	}
+	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
+	auto read_head_count = trans.GetReadHeads().size();
+	vector<unique_ptr<AsyncTask>> io_tasks;
+	switch (state.scheduled_strategy) {
+	case ParquetPrefetchStrategy::PREFETCH_FILTERS:
+		// schedule only the filter columns' I/O, they are last in our list
+		io_tasks = CollectIOTasks(trans, state.file_handle, read_head_count - state.filter_head_count, read_head_count);
+		break;
+	case ParquetPrefetchStrategy::WHOLE_GROUP:
+	case ParquetPrefetchStrategy::COLUMN_WISE_EAGER:
+		// schedule the I/O for all columns up front
+		io_tasks = CollectIOTasks(trans, state.file_handle, 0, read_head_count);
+		break;
+	default:
+		throw InternalException("Unexpected parquet prefetch strategy when scheduling I/O");
+	}
 	if (!io_tasks.empty()) {
 		return AsyncResult(std::move(io_tasks), TaskSchedulerType::ASYNC);
 	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
+}
+
+AsyncResult ParquetReader::Schedule(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
+                                    bool log_prefetch) {
+	PrepareGroupIO(context, state, log_prefetch);
+	if (state.scan_state == ParquetScanState::FINISHED) {
+		return SourceResultType::FINISHED;
+	}
+	result.Reset();
+	return CollectGroupIOTasks(state);
 }
 
 idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1253,9 +1253,8 @@ static idx_t GetRowGroupOffset(const ParquetReader &reader, idx_t group_idx) {
 
 const ParquetRowGroup &ParquetReader::GetGroup(ParquetReaderScanState &state) {
 	auto file_meta_data = GetFileMetadata();
-	D_ASSERT(state.current_group >= 0 && (idx_t)state.current_group < state.group_idx_list.size());
-	D_ASSERT(state.group_idx_list[state.current_group] < file_meta_data->row_groups.size());
-	return file_meta_data->row_groups[state.group_idx_list[state.current_group]];
+	D_ASSERT(state.group_index < file_meta_data->row_groups.size());
+	return file_meta_data->row_groups[state.group_index];
 }
 
 uint64_t ParquetReader::GetGroupCompressedSize(ParquetReaderScanState &state) {
@@ -1365,7 +1364,7 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 	}
 
 	if (filters) {
-		auto stats = column_reader.Stats(state.group_idx_list[state.current_group], group.columns);
+		auto stats = column_reader.Stats(state.group_index, group.columns);
 		// filters contain output chunk index, not file col idx!
 		auto filter_entry = filters->TryGetFilterByColumnIndex(col_idx);
 		if (stats && filter_entry) {
@@ -1414,7 +1413,7 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 		}
 	}
 
-	column_reader.InitializeRead(state.group_idx_list[state.current_group], group.columns, *state.thrift_file_proto);
+	column_reader.InitializeRead(state.group_index, group.columns, *state.thrift_file_proto);
 }
 
 idx_t ParquetReader::NumRows() const {
@@ -1445,13 +1444,11 @@ ParquetScanFilter::ParquetScanFilter(ClientContext &context, ProjectionIndex fil
 ParquetScanFilter::~ParquetScanFilter() {
 }
 
-void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanState &state,
-                                   vector<idx_t> groups_to_read) const {
-	state.current_group = -1;
-	state.scan_state = ParquetScanState::SCHEDULE;
+void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanState &state, idx_t group_to_read) const {
+	state.scan_state = ParquetScanState::PROCESS;
 	state.offset_in_group = 0;
 	state.filter_count = 0;
-	state.group_idx_list = std::move(groups_to_read);
+	state.group_index = group_to_read;
 	state.sel.Initialize(STANDARD_VECTOR_SIZE);
 	if (!state.file_handle || state.file_handle->GetPath() != file_handle->GetPath()) {
 		auto flags = FileFlags::FILE_FLAGS_READ;
@@ -1718,25 +1715,21 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 	case ParquetScanState::FINISHED:
 		result.Reset();
 		return SourceResultType::FINISHED;
-	case ParquetScanState::SCHEDULE:
-		result.Reset();
-		return ScheduleNextGroup(context, state);
 	case ParquetScanState::PROCESS:
 		result.Reset();
-		return Process(state, result, log_prefetch);
+		return Process(context, state, result, log_prefetch);
 	case ParquetScanState::RESUME_PAYLOAD:
-		return Process(state, result, log_prefetch);
+		return Process(context, state, result, log_prefetch);
 	default:
 		throw InternalException("Unexpected ParquetScanState");
 	}
 }
 
-void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state) {
+ParquetPrefetchStrategy ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state) {
 	const bool log_prefetch =
 	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
-	state.current_group++;
 	state.offset_in_group = 0;
-	state.group_prefetch_strategy = ParquetPrefetchStrategy::NONE;
+	ParquetPrefetchStrategy strategy = ParquetPrefetchStrategy::NONE;
 
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	trans.ClearPrefetch();
@@ -1746,18 +1739,8 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 		trans.SetAcceptedColumnGap(DetermineAcceptedColumnGap(context, state));
 	}
 
-	if (log_prefetch && state.prefetch_metrics.filter_ran && state.current_group > 0) {
-		LogRowGroupPrefetch(context, file.path, state.group_idx_list[state.current_group - 1], state);
-	}
-	state.prefetch_metrics.FinalizeRowGroupSelectivity();
-
-	if ((idx_t)state.current_group == state.group_idx_list.size()) {
-		state.scan_state = ParquetScanState::FINISHED;
-		return;
-	}
-
 	// TODO: only need this if we have a deletion vector?
-	state.group_offset = GetRowGroupOffset(*this, state.group_idx_list[state.current_group]);
+	state.group_offset = GetRowGroupOffset(*this, state.group_index);
 
 	uint64_t to_scan_compressed_bytes = 0;
 	for (idx_t i = 0; i < column_ids.size(); i++) {
@@ -1776,7 +1759,7 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 	if (state.op) {
 		DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader",
 		           row_group_skipped ? "SkipRowGroup" : "ReadRowGroup",
-		           {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
+		           {{"file", file.path}, {"row_group_id", to_string(state.group_index)}});
 	}
 
 	if (state.prefetch_mode && !row_group_skipped) {
@@ -1797,7 +1780,6 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 		}
 		if (state.prefetch_mode) {
 			// whole group and column wise prefetch fetch eagerly, filter prefetch fetches lazily
-			ParquetPrefetchStrategy strategy = ParquetPrefetchStrategy::NONE;
 			if (parquet_options.prefetch_strategy == ParquetPrefetchStrategyOption::WHOLE_GROUP) {
 				strategy = WholeGroupPrefetch(state, trans, group, total_row_group_span, log_prefetch);
 			} else {
@@ -1819,24 +1801,24 @@ void ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanStat
 					strategy = ColumnWisePrefetch(state, trans, group, filters_look_unselective, log_prefetch);
 				}
 			}
-			state.group_prefetch_strategy = strategy;
 			if (log_prefetch) {
 				state.prefetch_metrics.logger.accepted_column_gap = trans.GetAcceptedColumnGap();
 			}
 		}
 	}
 	state.scan_state = ParquetScanState::PROCESS;
+	return strategy;
 }
 
-AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
-	if (state.group_prefetch_strategy == ParquetPrefetchStrategy::NONE) {
+AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy) {
+	if (strategy == ParquetPrefetchStrategy::NONE) {
 		// nothing to prefetch (prefetch disabled, row group skipped, or broken-offset fallback)
 		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());
 	auto read_head_count = trans.GetReadHeads().size();
 	vector<unique_ptr<AsyncTask>> io_tasks;
-	switch (state.group_prefetch_strategy) {
+	switch (strategy) {
 	case ParquetPrefetchStrategy::PREFETCH_FILTERS:
 		// schedule only the filter columns' I/O, they are last in our list
 		io_tasks = CollectIOTasks(trans, state.file_handle, read_head_count - state.filter_head_count, read_head_count);
@@ -1855,12 +1837,11 @@ AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state) {
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-AsyncResult ParquetReader::ScheduleNextGroup(ClientContext &context, ParquetReaderScanState &state) {
-	PrepareGroupIO(context, state);
-	if (state.scan_state == ParquetScanState::FINISHED) {
-		return SourceResultType::FINISHED;
+void ParquetReader::FinishRowGroup(ClientContext &context, ParquetReaderScanState &state, bool log_prefetch) {
+	if (log_prefetch && state.prefetch_metrics.filter_ran) {
+		LogRowGroupPrefetch(context, file.path, state.group_index, state);
 	}
-	return CollectGroupIOTasks(state);
+	state.prefetch_metrics.FinalizeRowGroupSelectivity();
 }
 
 idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count,
@@ -1986,7 +1967,8 @@ AsyncResult ParquetReader::ProcessFilters(ParquetReaderScanState &state, DataChu
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-AsyncResult ParquetReader::Process(ParquetReaderScanState &state, DataChunk &result, bool log_prefetch) {
+AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
+                                   bool log_prefetch) {
 	const idx_t group_num_rows = GetGroup(state).num_rows;
 	auto scan_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, group_num_rows - state.offset_in_group);
 	if (state.scan_state == ParquetScanState::PROCESS) {
@@ -1994,8 +1976,9 @@ AsyncResult ParquetReader::Process(ParquetReaderScanState &state, DataChunk &res
 	}
 
 	if (scan_count == 0) {
+		// the row group is fully consumed
+		FinishRowGroup(context, state, log_prefetch);
 		state.scan_state = ParquetScanState::FINISHED;
-		// end of last group, we are done
 		return SourceResultType::FINISHED;
 	}
 
@@ -2035,8 +2018,7 @@ AsyncResult ParquetReader::Process(ParquetReaderScanState &state, DataChunk &res
 	result.SetChildCardinality(result.size());
 	rows_read += scan_count;
 	state.offset_in_group += scan_count;
-	// once the group is fully consumed we schedule the next one, otherwise we keep processing this group
-	state.scan_state = state.offset_in_group >= group_num_rows ? ParquetScanState::SCHEDULE : ParquetScanState::PROCESS;
+	state.scan_state = ParquetScanState::PROCESS;
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1713,12 +1713,10 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 
 	switch (state.scan_state) {
 	case ParquetScanState::FINISHED:
-		result.Reset();
 		return SourceResultType::FINISHED;
 	case ParquetScanState::PROCESS:
-		result.Reset();
-		return Process(context, state, result, log_prefetch);
 	case ParquetScanState::RESUME_PAYLOAD:
+		// the multifile loop owns the chunk reset; it preserves the chunk across a RESUME_PAYLOAD block
 		return Process(context, state, result, log_prefetch);
 	default:
 		throw InternalException("Unexpected ParquetScanState");

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1725,7 +1725,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 	}
 }
 
-ParquetPrefetchStrategy ParquetReader::PrepareGroupIO(ClientContext &context, ParquetReaderScanState &state) {
+ParquetPrefetchStrategy ParquetReader::RegisterRowGroupReads(ClientContext &context, ParquetReaderScanState &state) {
 	const bool log_prefetch =
 	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
 	state.offset_in_group = 0;
@@ -1810,9 +1810,9 @@ ParquetPrefetchStrategy ParquetReader::PrepareGroupIO(ClientContext &context, Pa
 	return strategy;
 }
 
-AsyncResult ParquetReader::CollectGroupIOTasks(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy) {
+AsyncResult ParquetReader::ScheduleRowGroupReads(ParquetReaderScanState &state, ParquetPrefetchStrategy strategy) {
 	if (strategy == ParquetPrefetchStrategy::NONE) {
-		// nothing to prefetch (prefetch disabled, row group skipped, or broken-offset fallback)
+		// nothing to prefetch
 		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 	auto &trans = reinterpret_cast<ThriftFileTransport &>(*state.thrift_file_proto->getTransport());

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1445,7 +1445,7 @@ ParquetScanFilter::~ParquetScanFilter() {
 }
 
 void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanState &state, idx_t group_to_read) const {
-	state.scan_state = ParquetScanState::PROCESS;
+	state.resuming_payload = false;
 	state.offset_in_group = 0;
 	state.filter_count = 0;
 	state.group_index = group_to_read;
@@ -1707,22 +1707,6 @@ ParquetPrefetchStrategy ParquetReader::ColumnWisePrefetch(ParquetReaderScanState
 	return strategy;
 }
 
-AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
-	const bool log_prefetch =
-	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
-
-	switch (state.scan_state) {
-	case ParquetScanState::FINISHED:
-		return SourceResultType::FINISHED;
-	case ParquetScanState::PROCESS:
-	case ParquetScanState::RESUME_PAYLOAD:
-		// the multifile loop owns the chunk reset; it preserves the chunk across a RESUME_PAYLOAD block
-		return Process(context, state, result, log_prefetch);
-	default:
-		throw InternalException("Unexpected ParquetScanState");
-	}
-}
-
 ParquetPrefetchStrategy ParquetReader::RegisterRowGroupReads(ClientContext &context, ParquetReaderScanState &state) {
 	const bool log_prefetch =
 	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
@@ -1804,7 +1788,7 @@ ParquetPrefetchStrategy ParquetReader::RegisterRowGroupReads(ClientContext &cont
 			}
 		}
 	}
-	state.scan_state = ParquetScanState::PROCESS;
+	state.resuming_payload = false;
 	return strategy;
 }
 
@@ -1945,13 +1929,13 @@ vector<unique_ptr<AsyncTask>> ParquetReader::ScheduleRemainingColumns(ParquetRea
 		// no payload to do
 		return {};
 	}
-	state.scan_state = ParquetScanState::RESUME_PAYLOAD;
+	state.resuming_payload = true;
 	return io_tasks;
 }
 
 AsyncResult ParquetReader::ProcessFilters(ParquetReaderScanState &state, DataChunk &result, idx_t scan_count,
                                           uint8_t *define_ptr, uint8_t *repeat_ptr, bool log_prefetch) {
-	if (state.scan_state == ParquetScanState::PROCESS) {
+	if (!state.resuming_payload) {
 		state.filter_count = EvaluateFilters(state, result, scan_count, define_ptr, repeat_ptr, log_prefetch);
 		auto io_tasks = ScheduleRemainingColumns(state, result, scan_count);
 		if (!io_tasks.empty()) {
@@ -1965,18 +1949,19 @@ AsyncResult ParquetReader::ProcessFilters(ParquetReaderScanState &state, DataChu
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
-                                   bool log_prefetch) {
+AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+	// a fresh pass evaluates filters; the resume path (resuming_payload) decodes only the payload columns
+	const bool log_prefetch =
+	    Logger::Get(context).ShouldLog(ParquetPrefetchLogType::NAME, ParquetPrefetchLogType::LEVEL);
 	const idx_t group_num_rows = GetGroup(state).num_rows;
 	auto scan_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, group_num_rows - state.offset_in_group);
-	if (state.scan_state == ParquetScanState::PROCESS) {
+	if (!state.resuming_payload) {
 		result.SetChildCardinality(scan_count);
 	}
 
 	if (scan_count == 0) {
 		// the row group is fully consumed
 		FinishRowGroup(context, state, log_prefetch);
-		state.scan_state = ParquetScanState::FINISHED;
 		return SourceResultType::FINISHED;
 	}
 
@@ -2016,7 +2001,7 @@ AsyncResult ParquetReader::Process(ClientContext &context, ParquetReaderScanStat
 	result.SetChildCardinality(result.size());
 	rows_read += scan_count;
 	state.offset_in_group += scan_count;
-	state.scan_state = ParquetScanState::PROCESS;
+	state.resuming_payload = false;
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -91,6 +91,7 @@
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
+#include "duckdb/common/multi_file/multi_file_states.hpp"
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
@@ -3498,6 +3499,24 @@ const char* EnumUtil::ToChars<MultiFileFileState>(MultiFileFileState value) {
 template<>
 MultiFileFileState EnumUtil::FromString<MultiFileFileState>(const char *value) {
 	return static_cast<MultiFileFileState>(StringUtil::StringToEnum(GetMultiFileFileStateValues(), 5, "MultiFileFileState", value));
+}
+
+const StringUtil::EnumStringLiteral *GetMultiFileScanPhaseValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(MultiFileScanPhase::SCHEDULE), "SCHEDULE" },
+		{ static_cast<uint32_t>(MultiFileScanPhase::DECODE), "DECODE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<MultiFileScanPhase>(MultiFileScanPhase value) {
+	return StringUtil::EnumToString(GetMultiFileScanPhaseValues(), 2, "MultiFileScanPhase", static_cast<uint32_t>(value));
+}
+
+template<>
+MultiFileScanPhase EnumUtil::FromString<MultiFileScanPhase>(const char *value) {
+	return static_cast<MultiFileScanPhase>(StringUtil::StringToEnum(GetMultiFileScanPhaseValues(), 2, "MultiFileScanPhase", value));
 }
 
 const StringUtil::EnumStringLiteral *GetNTypeValues() {

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/parallel/async_result.hpp"
 
 namespace duckdb {
 
@@ -12,6 +13,10 @@ shared_ptr<BaseUnionData> BaseFileReader::GetUnionData(idx_t file_idx) {
 }
 
 void BaseFileReader::PrepareScan(ClientContext &, GlobalTableFunctionState &, LocalTableFunctionState &) {
+}
+
+AsyncResult BaseFileReader::ScheduleIO(ClientContext &, GlobalTableFunctionState &, LocalTableFunctionState &) {
+	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 void BaseFileReader::PrepareReader(ClientContext &context, GlobalTableFunctionState &) {

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -308,7 +308,6 @@ bool DuckDBReader::TryInitializeScan(ClientContext &context, GlobalTableFunction
 
 AsyncResult DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                LocalTableFunctionState &lstate_p, DataChunk &chunk) {
-	chunk.Reset();
 	auto &lstate = lstate_p.Cast<DuckDBReadLocalState>();
 	TableFunctionInput input(bind_data.get(), lstate.local_state, global_state);
 

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -322,6 +322,8 @@ enum class MultiFileColumnMappingMode : uint8_t;
 
 enum class MultiFileFileState : uint8_t;
 
+enum class MultiFileScanPhase : uint8_t;
+
 enum class NType : uint8_t;
 
 enum class NewLineIdentifier : uint8_t;
@@ -997,6 +999,9 @@ const char* EnumUtil::ToChars<MultiFileColumnMappingMode>(MultiFileColumnMapping
 
 template<>
 const char* EnumUtil::ToChars<MultiFileFileState>(MultiFileFileState value);
+
+template<>
+const char* EnumUtil::ToChars<MultiFileScanPhase>(MultiFileScanPhase value);
 
 template<>
 const char* EnumUtil::ToChars<NType>(NType value);
@@ -1793,6 +1798,9 @@ MultiFileColumnMappingMode EnumUtil::FromString<MultiFileColumnMappingMode>(cons
 
 template<>
 MultiFileFileState EnumUtil::FromString<MultiFileFileState>(const char *value);
+
+template<>
+MultiFileScanPhase EnumUtil::FromString<MultiFileScanPhase>(const char *value);
 
 template<>
 NType EnumUtil::FromString<NType>(const char *value);

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -101,6 +101,10 @@ public:
 	//! Scan a chunk
 	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+	//! Whether the reader resets its own scan chunk.
+	virtual bool OwnsChunkReset() const {
+		return false;
+	}
 	//! Finish scanning a given file
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -95,7 +95,11 @@ public:
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Prepare a scan - called after TryInitializeScan succeeds - this is done without any lock held
 	virtual void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
-	//! Scan a chunk from the read state
+	//! Schedule (the I/O for the unit prepared by PrepareScan. We return BLOCKED for the async I/O tasks
+	//!  or HAVE_MORE_OUTPUT when there is nothing to prefetch.
+	DUCKDB_API virtual AsyncResult ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                          LocalTableFunctionState &lstate);
+	//! Scan a chunk from the read state - decodes the I/O scheduled by ScheduleIO, done without any lock held
 	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -101,10 +101,6 @@ public:
 	//! Scan a chunk
 	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
-	//! Whether the reader resets its own scan chunk.
-	virtual bool OwnsChunkReset() const {
-		return false;
-	}
 	//! Finish scanning a given file
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -95,11 +95,10 @@ public:
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Prepare a scan - called after TryInitializeScan succeeds - this is done without any lock held
 	virtual void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
-	//! Schedule (the I/O for the unit prepared by PrepareScan. We return BLOCKED for the async I/O tasks
-	//!  or HAVE_MORE_OUTPUT when there is nothing to prefetch.
+	//! Function to schedule IO tasks, if Reader supports that
 	DUCKDB_API virtual AsyncResult ScheduleIO(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                          LocalTableFunctionState &lstate);
-	//! Scan a chunk from the read state - decodes the I/O scheduled by ScheduleIO, done without any lock held
+	//! Scan a chunk
 	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -480,11 +480,8 @@ public:
 					if (old_file_index != scan_data.file_index) {
 						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
 					}
-					// schedule I/O while holding the parallel lock, so each unit is scheduled once (This is important
-					// for read-ahead)
-					parallel_lock.lock();
-					scan_data.scheduled_io =
-					    scan_data.reader->ScheduleIO(context, *gstate.global_state, *scan_data.local_state);
+					// the claimed batch's I/O is prefetched by the SCHEDULE phase of MultiFileScan before it decodes
+					scan_data.phase = MultiFileScanPhase::SCHEDULE;
 					return true;
 				} else {
 					// Set state to the next file
@@ -534,10 +531,7 @@ public:
 		if (!TryInitializeNextBatch(context.client, bind_data, *result, gstate)) {
 			return nullptr;
 		}
-		// fixme: I'm not sure about this yet
-		if (result->scheduled_io.GetResultType() == AsyncResultType::BLOCKED) {
-			result->scheduled_io.ExecuteTasksSynchronously();
-		}
+		// the first batch starts in the SCHEDULE phase; its I/O is prefetched on the first MultiFileScan call
 		return std::move(result);
 	}
 
@@ -695,6 +689,76 @@ public:
 		}
 	}
 
+	//! Emit the current output to the caller, or signal the loop to continue when there is nothing to emit yet.
+	//! Returns true if MultiFileScan should return, false if it should continue its loop.
+	static bool YieldOutput(TableFunctionInput &data_p, DataChunk &output) {
+		if (output.size() == 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
+			return false;
+		}
+		data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+		return true;
+	}
+
+	//! SCHEDULE phase: prefetch the claimed batch's I/O, then transition to DECODE.
+	//! Returns true if MultiFileScan should return to its caller, false if it should continue its loop.
+	static bool Schedule(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
+	                     MultiFileGlobalState &gstate) {
+		auto scheduled = data.reader->ScheduleIO(context, *gstate.global_state, *data.local_state);
+		// move to DECODE before surfacing a block, so the resume decodes instead of re-scheduling
+		data.phase = MultiFileScanPhase::DECODE;
+		if (scheduled.GetResultType() == AsyncResultType::BLOCKED) {
+			return HandleBlocked(data_p, data, scheduled, /*preserve_chunk=*/false);
+		}
+		return false;
+	}
+
+	static bool Decode(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
+	                   MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
+		auto &scan_chunk = data.scan_chunk;
+		if (data.scan_blocked) {
+			data.scan_blocked = false;
+		} else {
+			scan_chunk.Reset();
+		}
+
+		auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
+
+		if (res.GetResultType() == AsyncResultType::BLOCKED) {
+			// blocked mid-decode: resume into the same scan_chunk once the I/O completes
+			return HandleBlocked(data_p, data, res, /*preserve_chunk=*/true);
+		}
+
+		output.SetChildCardinality(scan_chunk.size());
+
+		if (scan_chunk.size() > 0) {
+			data.rows_scanned += scan_chunk.size();
+			bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.reader, *data.reader_data, scan_chunk,
+			                                           output, data.executor, gstate.multi_file_reader_state);
+			output.SetChildCardinality(output.size());
+		}
+		if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
+			// More chunks left on this batch, lets keep going
+			return YieldOutput(data_p, output);
+		}
+
+		if (res.GetResultType() != AsyncResultType::FINISHED) {
+			throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
+			                        EnumUtil::ToChars(res.GetResultType()));
+		}
+
+		// We are done with this batch
+		if (!TryInitializeNextBatch(context, bind_data, data, gstate)) {
+			if (output.size() > 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
+				gstate.finished = true;
+				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
+			} else {
+				data_p.async_result = SourceResultType::FINISHED;
+			}
+			return true;
+		}
+		return YieldOutput(data_p, output);
+	}
+
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		if (!data_p.local_state) {
 			data_p.async_result = SourceResultType::FINISHED;
@@ -710,67 +774,20 @@ public:
 		}
 
 		do {
-			auto &scan_chunk = data.scan_chunk;
-			if (data.scan_blocked) {
-				data.scan_blocked = false;
-			} else {
-				scan_chunk.Reset();
-			}
-
-			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
-
-			if (res.GetResultType() == AsyncResultType::BLOCKED) {
-				// this is a block mid-decode we need resume into the same scan_chunk once the I/O completes
-				if (HandleBlocked(data_p, data, res, true)) {
+			switch (data.phase) {
+			case MultiFileScanPhase::SCHEDULE:
+				if (Schedule(context, data_p, data, gstate)) {
 					return;
 				}
-				continue;
-			}
-
-			output.SetChildCardinality(scan_chunk.size());
-
-			if (scan_chunk.size() > 0) {
-				data.rows_scanned += scan_chunk.size();
-				bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.reader, *data.reader_data,
-				                                           scan_chunk, output, data.executor,
-				                                           gstate.multi_file_reader_state);
-				output.SetChildCardinality(output.size());
-			}
-			if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
-				// Loop back to the same block
-				if (output.size() == 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
-					continue;
+				break;
+			case MultiFileScanPhase::DECODE:
+				if (Decode(context, data_p, data, gstate, bind_data, output)) {
+					return;
 				}
-				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
-				return;
+				break;
+			default:
+				throw InternalException("Unexpected MultiFileScanPhase in MultiFileScan");
 			}
-
-			if (res.GetResultType() != AsyncResultType::FINISHED) {
-				throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
-				                        EnumUtil::ToChars(res.GetResultType()));
-			}
-
-			if (!TryInitializeNextBatch(context, bind_data, data, gstate)) {
-				if (output.size() > 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
-					gstate.finished = true;
-					data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
-				} else {
-					data_p.async_result = SourceResultType::FINISHED;
-				}
-			} else {
-				if (data.scheduled_io.GetResultType() == AsyncResultType::BLOCKED) {
-					// prefetch the new batch's I/O before decoding it
-					if (HandleBlocked(data_p, data, data.scheduled_io, false)) {
-						return;
-					}
-					continue;
-				}
-				if (output.size() == 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
-					continue;
-				}
-				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
-			}
-			return;
 		} while (true);
 	}
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -480,6 +480,11 @@ public:
 					if (old_file_index != scan_data.file_index) {
 						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
 					}
+					// schedule I/O while holding the parallel lock, so each unit is scheduled once (This is important
+					// for read-ahead)
+					parallel_lock.lock();
+					scan_data.scheduled_io =
+					    scan_data.reader->ScheduleIO(context, *gstate.global_state, *scan_data.local_state);
 					return true;
 				} else {
 					// Set state to the next file
@@ -528,6 +533,10 @@ public:
 
 		if (!TryInitializeNextBatch(context.client, bind_data, *result, gstate)) {
 			return nullptr;
+		}
+		// fixme: I'm not sure about this yet
+		if (result->scheduled_io.GetResultType() == AsyncResultType::BLOCKED) {
+			result->scheduled_io.ExecuteTasksSynchronously();
 		}
 		return std::move(result);
 	}
@@ -663,9 +672,13 @@ public:
 	}
 
 
-	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res) {
+	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res,
+	                          bool preserve_chunk) {
 		D_ASSERT(res.GetResultType() == AsyncResultType::BLOCKED);
-		data.scan_blocked = true;
+		if (preserve_chunk) {
+			// We need to preserve the chunk if the blocks happens mid-decode (e.g., parquet filter prefetching)
+			data.scan_blocked = true;
+		}
 		switch (data_p.results_execution_mode) {
 		case AsyncResultsExecutionMode::TASK_EXECUTOR:
 			data_p.async_result = std::move(res);
@@ -707,7 +720,8 @@ public:
 			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
 			if (res.GetResultType() == AsyncResultType::BLOCKED) {
-				if (HandleBlocked(data_p, data, res)) {
+				// this is a block mid-decode we need resume into the same scan_chunk once the I/O completes
+				if (HandleBlocked(data_p, data, res, true)) {
 					return;
 				}
 				continue;
@@ -744,6 +758,13 @@ public:
 					data_p.async_result = SourceResultType::FINISHED;
 				}
 			} else {
+				if (data.scheduled_io.GetResultType() == AsyncResultType::BLOCKED) {
+					// prefetch the new batch's I/O before decoding it
+					if (HandleBlocked(data_p, data, data.scheduled_io, false)) {
+						return;
+					}
+					continue;
+				}
 				if (output.size() == 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
 					continue;
 				}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -667,10 +667,10 @@ public:
 
 
 	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res,
-	                          bool preserve_chunk) {
+	                                bool preserve_chunk) {
 		D_ASSERT(res.GetResultType() == AsyncResultType::BLOCKED);
 		if (preserve_chunk) {
-			// We need to preserve the chunk if the blocks happens mid-decode (e.g., parquet filter prefetching)
+			// We need to preserve the chunk if the block happens mid-decode (e.g., parquet filter prefetching)
 			data.scan_blocked = true;
 		}
 		switch (data_p.results_execution_mode) {
@@ -690,8 +690,7 @@ public:
 	}
 
 	//! Emit the current output to the caller, or signal the loop to continue when there is nothing to emit yet.
-	//! Returns true if MultiFileScan should return, false if it should continue its loop.
-	static bool YieldOutput(TableFunctionInput &data_p, DataChunk &output) {
+	static bool EmitOutput(TableFunctionInput &data_p, DataChunk &output) {
 		if (output.size() == 0 && data_p.results_execution_mode == AsyncResultsExecutionMode::SYNCHRONOUS) {
 			return false;
 		}
@@ -700,9 +699,8 @@ public:
 	}
 
 	//! SCHEDULE phase: prefetch the claimed batch's I/O, then transition to DECODE.
-	//! Returns true if MultiFileScan should return to its caller, false if it should continue its loop.
-	static bool Schedule(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
-	                     MultiFileGlobalState &gstate) {
+	static bool SchedulePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
+	                                MultiFileGlobalState &gstate) {
 		auto scheduled = data.reader->ScheduleIO(context, *gstate.global_state, *data.local_state);
 		// move to DECODE before surfacing a block, so the resume decodes instead of re-scheduling
 		data.phase = MultiFileScanPhase::DECODE;
@@ -712,8 +710,9 @@ public:
 		return false;
 	}
 
-	static bool Decode(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
-	                   MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
+	//! DECODE phase: pull one chunk from the current reader; claim the next batch once this one is exhausted.
+	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
+	                              MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
 		auto &scan_chunk = data.scan_chunk;
 		if (data.scan_blocked) {
 			data.scan_blocked = false;
@@ -738,7 +737,7 @@ public:
 		}
 		if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
 			// More chunks left on this batch, lets keep going
-			return YieldOutput(data_p, output);
+			return EmitOutput(data_p, output);
 		}
 
 		if (res.GetResultType() != AsyncResultType::FINISHED) {
@@ -756,7 +755,7 @@ public:
 			}
 			return true;
 		}
-		return YieldOutput(data_p, output);
+		return EmitOutput(data_p, output);
 	}
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -776,12 +775,12 @@ public:
 		do {
 			switch (data.phase) {
 			case MultiFileScanPhase::SCHEDULE:
-				if (Schedule(context, data_p, data, gstate)) {
+				if (SchedulePhase(context, data_p, data, gstate)) {
 					return;
 				}
 				break;
 			case MultiFileScanPhase::DECODE:
-				if (Decode(context, data_p, data, gstate, bind_data, output)) {
+				if (DecodePhase(context, data_p, data, gstate, bind_data, output)) {
 					return;
 				}
 				break;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -704,11 +704,13 @@ public:
 	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
 		auto &scan_chunk = data.scan_chunk;
-		if (!data.reader->OwnsChunkReset()) {
+		if (!data.resuming_blocked_scan) {
 			scan_chunk.Reset();
 		}
 		auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
+		// a BLOCKED scan leaves partial data in the chunk (e.g. filter columns) that the resume must keep
+		data.resuming_blocked_scan = res.GetResultType() == AsyncResultType::BLOCKED;
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
 			return HandleBlocked(data_p, res);
 		}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -664,17 +664,14 @@ public:
 		return partition_data;
 	}
 
-
-	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res,
-	                                bool preserve_chunk) {
+	static bool HandleBlocked(TableFunctionInput &data_p, AsyncResult &res) {
 		D_ASSERT(res.GetResultType() == AsyncResultType::BLOCKED);
-		data.preserve_chunk = preserve_chunk;
 		switch (data_p.results_execution_mode) {
 		case AsyncResultsExecutionMode::TASK_EXECUTOR:
 			data_p.async_result = std::move(res);
 			return true;
 		case AsyncResultsExecutionMode::SYNCHRONOUS:
-			// run the I/O syncronously, then loop again to resume
+			// run the I/O synchronously, then loop again to resume
 			res.ExecuteTasksSynchronously();
 			if (res.GetResultType() != AsyncResultType::HAVE_MORE_OUTPUT) {
 				throw InternalException("Unexpected behaviour from ExecuteTasksSynchronously");
@@ -695,30 +692,25 @@ public:
 	}
 
 	static bool SchedulePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
-	                                MultiFileGlobalState &gstate) {
+	                          MultiFileGlobalState &gstate) {
 		auto scheduled = data.reader->ScheduleIO(context, *gstate.global_state, *data.local_state);
 		data.phase = MultiFileScanPhase::DECODE;
 		if (scheduled.GetResultType() == AsyncResultType::BLOCKED) {
-			return HandleBlocked(data_p, data, scheduled, false);
+			return HandleBlocked(data_p, scheduled);
 		}
 		return false;
 	}
 
 	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
-	                              MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
+	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
 		auto &scan_chunk = data.scan_chunk;
-		if (data.preserve_chunk) {
-			// We need to preserve the chunk if the block happens mid-decode (e.g., parquet filter prefetching)
-			data.preserve_chunk = false;
-		} else {
+		if (!data.reader->OwnsChunkReset()) {
 			scan_chunk.Reset();
 		}
-
 		auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
-			// blocked mid-decode: resume into the same scan_chunk once the I/O completes
-			return HandleBlocked(data_p, data, res, true);
+			return HandleBlocked(data_p, res);
 		}
 
 		output.SetChildCardinality(scan_chunk.size());

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -480,7 +480,7 @@ public:
 					if (old_file_index != scan_data.file_index) {
 						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
 					}
-					// the claimed batch's I/O is prefetched by the SCHEDULE phase of MultiFileScan before it decodes
+					// Initializing a batch is always a schedule phase
 					scan_data.phase = MultiFileScanPhase::SCHEDULE;
 					return true;
 				} else {
@@ -531,7 +531,6 @@ public:
 		if (!TryInitializeNextBatch(context.client, bind_data, *result, gstate)) {
 			return nullptr;
 		}
-		// the first batch starts in the SCHEDULE phase; its I/O is prefetched on the first MultiFileScan call
 		return std::move(result);
 	}
 
@@ -669,16 +668,13 @@ public:
 	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res,
 	                                bool preserve_chunk) {
 		D_ASSERT(res.GetResultType() == AsyncResultType::BLOCKED);
-		if (preserve_chunk) {
-			// We need to preserve the chunk if the block happens mid-decode (e.g., parquet filter prefetching)
-			data.scan_blocked = true;
-		}
+		data.preserve_chunk = preserve_chunk;
 		switch (data_p.results_execution_mode) {
 		case AsyncResultsExecutionMode::TASK_EXECUTOR:
 			data_p.async_result = std::move(res);
 			return true;
 		case AsyncResultsExecutionMode::SYNCHRONOUS:
-			// run the I/O inline, then loop again to resume
+			// run the I/O syncronously, then loop again to resume
 			res.ExecuteTasksSynchronously();
 			if (res.GetResultType() != AsyncResultType::HAVE_MORE_OUTPUT) {
 				throw InternalException("Unexpected behaviour from ExecuteTasksSynchronously");
@@ -698,24 +694,22 @@ public:
 		return true;
 	}
 
-	//! SCHEDULE phase: prefetch the claimed batch's I/O, then transition to DECODE.
 	static bool SchedulePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                                MultiFileGlobalState &gstate) {
 		auto scheduled = data.reader->ScheduleIO(context, *gstate.global_state, *data.local_state);
-		// move to DECODE before surfacing a block, so the resume decodes instead of re-scheduling
 		data.phase = MultiFileScanPhase::DECODE;
 		if (scheduled.GetResultType() == AsyncResultType::BLOCKED) {
-			return HandleBlocked(data_p, data, scheduled, /*preserve_chunk=*/false);
+			return HandleBlocked(data_p, data, scheduled, false);
 		}
 		return false;
 	}
 
-	//! DECODE phase: pull one chunk from the current reader; claim the next batch once this one is exhausted.
 	static bool DecodePhase(ClientContext &context, TableFunctionInput &data_p, MultiFileLocalState &data,
 	                              MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
 		auto &scan_chunk = data.scan_chunk;
-		if (data.scan_blocked) {
-			data.scan_blocked = false;
+		if (data.preserve_chunk) {
+			// We need to preserve the chunk if the block happens mid-decode (e.g., parquet filter prefetching)
+			data.preserve_chunk = false;
 		} else {
 			scan_chunk.Reset();
 		}
@@ -724,7 +718,7 @@ public:
 
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
 			// blocked mid-decode: resume into the same scan_chunk once the I/O completes
-			return HandleBlocked(data_p, data, res, /*preserve_chunk=*/true);
+			return HandleBlocked(data_p, data, res, true);
 		}
 
 		output.SetChildCardinality(scan_chunk.size());

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -705,11 +705,12 @@ public:
 	                        MultiFileGlobalState &gstate, MultiFileBindData &bind_data, DataChunk &output) {
 		auto &scan_chunk = data.scan_chunk;
 		if (!data.resuming_blocked_scan) {
+			// A BLOCKED scan leaves partial data in the chunk (e.g. filter prefetch from parquet) that the resume must
+			// keep. Hence, we only reset if we are not resuming from a blocked scan.
 			scan_chunk.Reset();
 		}
 		auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
-		// a BLOCKED scan leaves partial data in the chunk (e.g. filter columns) that the resume must keep
 		data.resuming_blocked_scan = res.GetResultType() == AsyncResultType::BLOCKED;
 		if (res.GetResultType() == AsyncResultType::BLOCKED) {
 			return HandleBlocked(data_p, res);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -662,6 +662,26 @@ public:
 		return partition_data;
 	}
 
+
+	static bool HandleBlocked(TableFunctionInput &data_p, MultiFileLocalState &data, AsyncResult &res) {
+		D_ASSERT(res.GetResultType() == AsyncResultType::BLOCKED);
+		data.scan_blocked = true;
+		switch (data_p.results_execution_mode) {
+		case AsyncResultsExecutionMode::TASK_EXECUTOR:
+			data_p.async_result = std::move(res);
+			return true;
+		case AsyncResultsExecutionMode::SYNCHRONOUS:
+			// run the I/O inline, then loop again to resume
+			res.ExecuteTasksSynchronously();
+			if (res.GetResultType() != AsyncResultType::HAVE_MORE_OUTPUT) {
+				throw InternalException("Unexpected behaviour from ExecuteTasksSynchronously");
+			}
+			return false;
+		default:
+			throw InternalException("Unexpected AsyncResultsExecutionMode in MultiFileScan");
+		}
+	}
+
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		if (!data_p.local_state) {
 			data_p.async_result = SourceResultType::FINISHED;
@@ -687,19 +707,10 @@ public:
 			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
 			if (res.GetResultType() == AsyncResultType::BLOCKED) {
-				data.scan_blocked = true;
-				switch (data_p.results_execution_mode) {
-				case AsyncResultsExecutionMode::TASK_EXECUTOR:
-					data_p.async_result = std::move(res);
+				if (HandleBlocked(data_p, data, res)) {
 					return;
-				case AsyncResultsExecutionMode::SYNCHRONOUS:
-					res.ExecuteTasksSynchronously();
-					if (res.GetResultType() != AsyncResultType::HAVE_MORE_OUTPUT) {
-						throw InternalException("Unexpected behaviour from ExecuteTasksSynchronously");
-					}
-					// no completed output yet, loop again to resume the Scan
-					continue;
 				}
+				continue;
 			}
 
 			output.SetChildCardinality(scan_chunk.size());

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -184,7 +184,7 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 	}
 };
 
-//! Phase of the per-thread multi-file scan: schedule the claimed batch's I/O, then decode it
+//! Phase of the per-thread multi-file scan: we are either scheduling or decoding
 enum class MultiFileScanPhase : uint8_t { SCHEDULE, DECODE };
 
 struct MultiFileLocalState : public LocalTableFunctionState {
@@ -201,9 +201,9 @@ public:
 	unique_ptr<LocalTableFunctionState> local_state;
 	//! The chunk written to by the reader, handed to FinalizeChunk to transform to the global schema
 	DataChunk scan_chunk;
-	//! Whether the last Scan call returned BLOCKED
-	bool scan_blocked = false;
-	//! Whether the current batch still needs its I/O scheduled (SCHEDULE) or is ready to decode (DECODE)
+	//! Whether we preserve the chunk, or we reset it after finishing a process task
+	bool preserve_chunk = false;
+	//! Whether the current batch still needs its I/O scheduled or is ready to decode
 	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/parallel/async_result.hpp"
 
 namespace duckdb {
 struct MultiFileReaderInterface;
@@ -185,6 +184,9 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 	}
 };
 
+//! Phase of the per-thread multi-file scan: schedule the claimed batch's I/O, then decode it
+enum class MultiFileScanPhase : uint8_t { SCHEDULE, DECODE };
+
 struct MultiFileLocalState : public LocalTableFunctionState {
 public:
 	explicit MultiFileLocalState(ClientContext &context) : executor(context) {
@@ -201,8 +203,8 @@ public:
 	DataChunk scan_chunk;
 	//! Whether the last Scan call returned BLOCKED
 	bool scan_blocked = false;
-	//! The I/O scheduled for the current batch by ScheduleIO
-	AsyncResult scheduled_io;
+	//! Whether the current batch still needs its I/O scheduled (SCHEDULE) or is ready to decode (DECODE)
+	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;
 	//! Number of rows scanned by this thread (for profiling)

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -201,6 +201,8 @@ public:
 	unique_ptr<LocalTableFunctionState> local_state;
 	//! The chunk written to by the reader, handed to FinalizeChunk to transform to the global schema
 	DataChunk scan_chunk;
+	//! Set when the previous Scan() returned BLOCKED, so the next Scan() preserves the partial chunk
+	bool resuming_blocked_scan = false;
 	//! Whether the current batch still needs its I/O scheduled or is ready to decode
 	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -201,8 +201,6 @@ public:
 	unique_ptr<LocalTableFunctionState> local_state;
 	//! The chunk written to by the reader, handed to FinalizeChunk to transform to the global schema
 	DataChunk scan_chunk;
-	//! Whether we preserve the chunk, or we reset it after finishing a process task
-	bool preserve_chunk = false;
 	//! Whether the current batch still needs its I/O scheduled or is ready to decode
 	MultiFileScanPhase phase = MultiFileScanPhase::SCHEDULE;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/parallel/async_result.hpp"
 
 namespace duckdb {
 struct MultiFileReaderInterface;
@@ -200,6 +201,8 @@ public:
 	DataChunk scan_chunk;
 	//! Whether the last Scan call returned BLOCKED
 	bool scan_blocked = false;
+	//! The I/O scheduled for the current batch by ScheduleIO
+	AsyncResult scheduled_io;
 	//! The executor to transform scan_chunk into the final result with FinalizeChunk
 	ExpressionExecutor executor;
 	//! Number of rows scanned by this thread (for profiling)


### PR DESCRIPTION
This PR refactors the multi-file scan to split scheduling from decoding, it also introduces one new virtual function: `BaseFileReader::ScheduleIO`, that readers can override if they do support ASYNC I/O scheduling. 
