### PR TITLE
fix integer overflow when sizing the DELTA_BYTE_ARRAY length buffer

### DIFF
--- a/extension/parquet/decoder/delta_byte_array_decoder.cpp
+++ b/extension/parquet/decoder/delta_byte_array_decoder.cpp
@@ -6,7 +6,9 @@
 
 #include "column_reader.hpp"
 #include "parquet_reader.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "parquet_column_schema.hpp"
@@ -26,7 +28,12 @@ void DeltaByteArrayDecoder::ReadDbpData(Allocator &allocator, ResizeableBuffer &
 	auto decoder = make_uniq<DbpDecoder>(buffer.ptr, buffer.len);
 	value_count = decoder->TotalValues();
 	result_buffer.reset();
-	result_buffer.resize(allocator, sizeof(uint32_t) * value_count);
+	// value_count is read from the file, so the buffer size can overflow on a corrupt input
+	idx_t result_size;
+	if (!TryMultiplyOperator::Operation<idx_t, idx_t, idx_t>(value_count, sizeof(uint32_t), result_size)) {
+		throw InvalidInputException("DELTA_BYTE_ARRAY value count is too large - corrupt file?");
+	}
+	result_buffer.resize(allocator, result_size);
 	decoder->GetBatch<uint32_t>(result_buffer.ptr, value_count);
 	decoder->Finalize();
 	buffer.inc(buffer.len - decoder->BufferPtr().len);


### PR DESCRIPTION
**Integer overflow when sizing the DELTA_BYTE_ARRAY length buffer**

`DeltaByteArrayDecoder::ReadDbpData` allocates with `sizeof(uint32_t) * value_count`, where `value_count` is the DELTA_BINARY_PACKED total value count read from the file with no upper bound, so a count at or above 2^62 wraps the 64-bit multiply down to a few bytes and the following `GetBatch` writes `value_count` entries past the allocation. ASan reports a heap-buffer-overflow write in `DbpDecoder::GetBatchInternal` when reading a crafted parquet file with a DELTA_BYTE_ARRAY column. Switched to a checked multiply so the bad count is rejected before allocating; the sibling decoders size from the batch-bounded `valid_count`, so this is the only affected spot.