### PR TITLE
Add parser extension preprocess hook

### DIFF
--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -60,7 +60,7 @@ struct ParserExtensionInfo {
 enum class ParserExtensionResultType : uint8_t { PARSE_SUCCESSFUL, DISPLAY_ORIGINAL_ERROR, DISPLAY_EXTENSION_ERROR };
 
 //! The ParserExtensionParseData holds the result of a successful parse step
-//! It will be passed along to the subsequent plan function
+//! It will be passed along to the subsequent preprocess or plan function
 struct ParserExtensionParseData {
 	virtual ~ParserExtensionParseData() {
 	}
@@ -125,6 +125,12 @@ typedef ParserExtensionPlanResult (*plan_function_t)(ParserExtensionInfo *info, 
                                                      unique_ptr<ParserExtensionParseData> parse_data);
 
 //===--------------------------------------------------------------------===//
+// Preprocess
+//===--------------------------------------------------------------------===//
+typedef vector<unique_ptr<SQLStatement>> (*preprocess_function_t)(ParserExtensionInfo *info, ClientContext &context,
+                                                                  unique_ptr<ParserExtensionParseData> parse_data);
+
+//===--------------------------------------------------------------------===//
 // Parser override
 //===--------------------------------------------------------------------===//
 struct ParserOverrideResult {
@@ -156,6 +162,12 @@ public:
 	//! The plan function of the parser extension
 	//! Takes as input the result of the parse_function, and outputs various properties of the resulting plan
 	plan_function_t plan_function = nullptr;
+
+	//! The preprocess function of the parser extension
+	//! Takes as input the result of the parse_function, and replaces the ExtensionStatement with one or more
+	//! already-preprocessed statements. This is a one-shot rewrite: the returned vector must be non-empty, and must not
+	//! contain NULL statements, transaction statements, pragma statements, multi statements, or extension statements.
+	preprocess_function_t preprocess_function = nullptr;
 
 	//! Override the current parser with a new parser and return a vector of SQL statements
 	parser_override_function_t parser_override = nullptr;

--- a/src/include/duckdb/planner/statement_preprocessor.hpp
+++ b/src/include/duckdb/planner/statement_preprocessor.hpp
@@ -19,12 +19,15 @@ class ClientContext;
 class ClientContextLock;
 class SQLStatement;
 struct PragmaInfo;
+
 //! Preprocesses parsed statements: expands pragmas, unpacks multi-statements, and wraps in transactions
 class StatementPreprocessor {
 public:
 	explicit StatementPreprocessor(ClientContext &context);
+
 	void Preprocess(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,
 	                CurrentTransactionState transaction_context_state);
+
 	void PreprocessInternal(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,
 	                        CurrentTransactionState transaction_context_state);
 
@@ -35,5 +38,8 @@ private:
 	//! Handles a pragma statement, determines whether the statement needs reparsing, if it does, it returns the
 	//! statement(s) to replace the current one. Otherwise, it just returns back the original statement in a vector.
 	vector<unique_ptr<SQLStatement>> TryReparsePragma(unique_ptr<SQLStatement> statement) const;
+
+	//! Handles an extension statement, replacing it with generated statements if the extension preprocesses itself.
+	vector<unique_ptr<SQLStatement>> TryPreprocessExtension(unique_ptr<SQLStatement> statement) const;
 };
 } // namespace duckdb

--- a/src/planner/statement_preprocessor.cpp
+++ b/src/planner/statement_preprocessor.cpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/pragma_function_catalog_entry.hpp"
+#include "duckdb/parser/statement/extension_statement.hpp"
 #include "duckdb/parser/statement/multi_statement.hpp"
 #include "duckdb/parser/parsed_data/bound_pragma_info.hpp"
 #include "duckdb/function/function.hpp"
@@ -19,7 +20,6 @@
 #include "duckdb/common/enums/current_transaction_state.hpp"
 
 namespace duckdb {
-
 enum class PreprocessingTransactionHandling : uint8_t {
 	// Not in a transaction and should wrap in an implicit BEGIN/COMMIT
 	WRAP_IN_TRANSACTION,
@@ -104,6 +104,26 @@ void UnpackMultiStatement(MultiStatement &multi_statement, const CurrentTransact
 	AddStatements(multi_statement.statements, handling, new_statements);
 }
 
+static void VerifyPreprocessedStatements(const vector<unique_ptr<SQLStatement>> &statements, const string &source) {
+	for (auto &statement : statements) {
+		if (!statement) {
+			throw InvalidInputException("%s cannot contain NULL statements", source);
+		}
+		if (statement->type == StatementType::TRANSACTION_STATEMENT) {
+			throw InvalidInputException("%s cannot generate transaction statements", source);
+		}
+		if (statement->type == StatementType::PRAGMA_STATEMENT) {
+			throw InvalidInputException("%s cannot generate pragma statements", source);
+		}
+		if (statement->type == StatementType::MULTI_STATEMENT) {
+			throw InvalidInputException("%s cannot generate multi statements", source);
+		}
+		if (statement->type == StatementType::EXTENSION_STATEMENT) {
+			throw InvalidInputException("%s cannot generate extension statements", source);
+		}
+	}
+}
+
 vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryReparsePragma(unique_ptr<SQLStatement> statement) const {
 	// Try reparsing
 	const auto info = statement->Cast<PragmaStatement>().info->Copy();
@@ -123,12 +143,37 @@ vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryReparsePragma(unique_
 	return res;
 }
 
+vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryPreprocessExtension(unique_ptr<SQLStatement> statement) const {
+	auto &extension_statement = statement->Cast<ExtensionStatement>();
+	if (!extension_statement.extension.preprocess_function) {
+		vector<unique_ptr<SQLStatement>> result;
+		result.push_back(std::move(statement));
+		return result;
+	}
+
+	auto query = extension_statement.query;
+	auto result = extension_statement.extension.preprocess_function(extension_statement.extension.parser_info.get(),
+	                                                                context, std::move(extension_statement.parse_data));
+	if (result.empty()) {
+		throw InvalidInputException("Parser extension preprocess functions must generate at least one statement");
+	}
+	VerifyPreprocessedStatements(result, "Parser extension preprocess functions");
+	for (auto &replacement_statement : result) {
+		if (replacement_statement->query.empty()) {
+			replacement_statement->query = query;
+		}
+	}
+	return result;
+}
+
 void StatementPreprocessor::Preprocess(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,
                                        CurrentTransactionState transaction_context_state) {
 	// Quick check: do we need preprocessing at all?
 	bool needs_preprocessing = false;
 	for (auto &stmt : statements) {
-		if (stmt->type == StatementType::PRAGMA_STATEMENT || stmt->type == StatementType::MULTI_STATEMENT) {
+		if (stmt->type == StatementType::PRAGMA_STATEMENT || stmt->type == StatementType::MULTI_STATEMENT ||
+		    (stmt->type == StatementType::EXTENSION_STATEMENT &&
+		     stmt->Cast<ExtensionStatement>().extension.preprocess_function)) {
 			needs_preprocessing = true;
 			break;
 		}
@@ -162,6 +207,17 @@ void StatementPreprocessor::PreprocessInternal(ClientContextLock &lock, vector<u
 		case StatementType::MULTI_STATEMENT: {
 			auto &multi_statement = statements[i]->Cast<MultiStatement>();
 			UnpackMultiStatement(multi_statement, full_transaction_state, new_statements);
+			break;
+		}
+		case StatementType::EXTENSION_STATEMENT: {
+			auto &extension_statement = statements[i]->Cast<ExtensionStatement>();
+			if (!extension_statement.extension.preprocess_function) {
+				new_statements.push_back(std::move(statements[i]));
+				break;
+			}
+			auto replacement_statements = TryPreprocessExtension(std::move(statements[i]));
+			const auto handling = GetTransactionHandling(replacement_statements, full_transaction_state);
+			AddStatements(replacement_statements, handling, new_statements);
 			break;
 		}
 		case StatementType::TRANSACTION_STATEMENT: {

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -31,6 +31,8 @@
 #include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/multi_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/tableref/emptytableref.hpp"
@@ -354,6 +356,32 @@ struct QuackExtensionData : public ParserExtensionParseData {
 	}
 };
 
+enum class ContextPreprocessMode : uint8_t {
+	SUCCESS,
+	MULTI,
+	PRAGMA,
+	TRANSACTION,
+	EMPTY,
+	RECURSE,
+	FAIL,
+	NULL_STATEMENT
+};
+
+struct ContextPreprocessData : public ParserExtensionParseData {
+	explicit ContextPreprocessData(ContextPreprocessMode mode) : mode(mode) {
+	}
+
+	ContextPreprocessMode mode;
+
+	duckdb::unique_ptr<ParserExtensionParseData> Copy() const override {
+		return make_uniq<ContextPreprocessData>(mode);
+	}
+
+	string ToString() const override {
+		return "CONTEXT PREPROCESS";
+	}
+};
+
 class QuackExtension : public ParserExtension {
 public:
 	QuackExtension() {
@@ -427,6 +455,101 @@ public:
 			return ParserOverrideResult();
 		}
 		return ParserOverrideResult(std::move(statements));
+	}
+};
+
+class ContextPreprocessExtension : public ParserExtension {
+public:
+	ContextPreprocessExtension() {
+		parse_function = ParseFunction;
+		preprocess_function = PreprocessFunction;
+	}
+
+	static ParserExtensionParseResult ParseFunction(ParserExtensionInfo *info, const vector<SimpleToken> &tokens) {
+		ContextPreprocessMode mode;
+		if (!ParseMode(tokens, mode)) {
+			return ParserExtensionParseResult();
+		}
+		auto result = ParserExtensionParseResult(make_uniq<ContextPreprocessData>(mode));
+		result.consumed_tokens = 4;
+		return result;
+	}
+
+	static bool ParseMode(const vector<SimpleToken> &tokens, ContextPreprocessMode &mode) {
+		if (tokens.size() < 4 || !StringUtil::CIEquals(tokens[0].text, "context") ||
+		    !StringUtil::CIEquals(tokens[1].text, "preprocess")) {
+			return false;
+		}
+		const auto next_type = tokens[3].type;
+		if (next_type != TokenType::TERMINATOR && next_type != TokenType::END_OF_INPUT &&
+		    next_type != TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			return false;
+		}
+		if (StringUtil::CIEquals(tokens[2].text, "success")) {
+			mode = ContextPreprocessMode::SUCCESS;
+		} else if (StringUtil::CIEquals(tokens[2].text, "multi")) {
+			mode = ContextPreprocessMode::MULTI;
+		} else if (StringUtil::CIEquals(tokens[2].text, "pragma")) {
+			mode = ContextPreprocessMode::PRAGMA;
+		} else if (StringUtil::CIEquals(tokens[2].text, "transaction")) {
+			mode = ContextPreprocessMode::TRANSACTION;
+		} else if (StringUtil::CIEquals(tokens[2].text, "empty")) {
+			mode = ContextPreprocessMode::EMPTY;
+		} else if (StringUtil::CIEquals(tokens[2].text, "recurse")) {
+			mode = ContextPreprocessMode::RECURSE;
+		} else if (StringUtil::CIEquals(tokens[2].text, "fail")) {
+			mode = ContextPreprocessMode::FAIL;
+		} else if (StringUtil::CIEquals(tokens[2].text, "null")) {
+			mode = ContextPreprocessMode::NULL_STATEMENT;
+		} else {
+			return false;
+		}
+		return true;
+	}
+
+	static vector<unique_ptr<SQLStatement>> ParseStatements(ClientContext &context, const string &query) {
+		Parser parser(context.GetParserOptions());
+		parser.ParseQuery(query);
+		return std::move(parser.statements);
+	}
+
+	static vector<unique_ptr<SQLStatement>> CreateMultiStatement(ClientContext &context) {
+		auto parsed = ParseStatements(context, "SELECT 1; SELECT 2");
+		auto multi_statement = make_uniq<MultiStatement>();
+		multi_statement->statements = std::move(parsed);
+		vector<unique_ptr<SQLStatement>> result;
+		result.push_back(std::move(multi_statement));
+		return result;
+	}
+
+	static vector<unique_ptr<SQLStatement>>
+	PreprocessFunction(ParserExtensionInfo *info, ClientContext &context,
+	                   duckdb::unique_ptr<ParserExtensionParseData> parse_data) {
+		auto &preprocess_data = dynamic_cast<ContextPreprocessData &>(*parse_data);
+		switch (preprocess_data.mode) {
+		case ContextPreprocessMode::SUCCESS:
+			return ParseStatements(context, "SELECT 1");
+		case ContextPreprocessMode::MULTI:
+			return CreateMultiStatement(context);
+		case ContextPreprocessMode::PRAGMA:
+			return ParseStatements(context, "PRAGMA version");
+		case ContextPreprocessMode::TRANSACTION:
+			return ParseStatements(context, "BEGIN TRANSACTION");
+		case ContextPreprocessMode::EMPTY:
+			return vector<unique_ptr<SQLStatement>>();
+		case ContextPreprocessMode::RECURSE:
+			return ParseStatements(context, "CONTEXT PREPROCESS RECURSE");
+		case ContextPreprocessMode::FAIL:
+			return ParseStatements(context, "CREATE TABLE context_preprocess_rollback AS SELECT 1 AS i; "
+			                                "SELECT * FROM context_preprocess_missing");
+		case ContextPreprocessMode::NULL_STATEMENT: {
+			vector<unique_ptr<SQLStatement>> result;
+			result.push_back(nullptr);
+			return result;
+		}
+		default:
+			throw InternalException("Unsupported context preprocess mode");
+		}
 	}
 };
 
@@ -1201,6 +1324,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 	// add a parser extension
 	auto &config = DBConfig::GetConfig(db);
 	ParserExtension::Register(config, QuackExtension());
+	ParserExtension::Register(config, ContextPreprocessExtension());
 	ExtensionCallback::Register(config, make_shared_ptr<QuackLoadExtension>());
 
 	// add a planner extension that adds an extra column to queries

--- a/test/extension/loadable_parser_preprocess.test
+++ b/test/extension/loadable_parser_preprocess.test
@@ -1,0 +1,53 @@
+# name: test/extension/loadable_parser_preprocess.test
+# description: Try preprocessing a parser extension statement with client context
+# group: [extension]
+
+require skip_reload
+
+statement ok
+LOAD '{BUILD_DIRECTORY}/test/extension/loadable_extension_demo.duckdb_extension';
+
+query I
+CONTEXT PREPROCESS SUCCESS
+----
+1
+
+statement error
+CONTEXT PREPROCESS MULTI
+----
+Invalid Input Error: Parser extension preprocess functions cannot generate multi statements
+
+statement error
+CONTEXT PREPROCESS PRAGMA
+----
+Invalid Input Error: Parser extension preprocess functions cannot generate pragma statements
+
+statement error
+CONTEXT PREPROCESS TRANSACTION
+----
+Invalid Input Error: Parser extension preprocess functions cannot generate transaction statements
+
+statement error
+CONTEXT PREPROCESS EMPTY
+----
+Invalid Input Error: Parser extension preprocess functions must generate at least one statement
+
+statement error
+CONTEXT PREPROCESS NULL
+----
+Invalid Input Error: Parser extension preprocess functions cannot contain NULL statements
+
+statement error
+CONTEXT PREPROCESS RECURSE
+----
+Invalid Input Error: Parser extension preprocess functions cannot generate extension statements
+
+statement error
+CONTEXT PREPROCESS FAIL
+----
+Catalog Error: Table with name context_preprocess_missing does not exist!
+
+statement error
+SELECT * FROM context_preprocess_rollback;
+----
+Catalog Error: Table with name context_preprocess_rollback does not exist!


### PR DESCRIPTION
## Summary

Addresses https://github.com/duckdb/duckdb/discussions/23088.

This PR adds an optional parser extension preprocess hook that lets a parser extension replace its parsed `ExtensionStatement` with one or more regular DuckDB statements before planning.

The preprocess hook is intentionally one-shot. Returned statements must be ordinary executable statements: the preprocessor rejects empty results, `NULL` statements, transaction statements, pragma statements, multi statements, and nested extension statements.

## Changes

- Add `preprocess_function_t` and `ParserExtension::preprocess_function` to the parser extension API.
- Invoke the preprocess hook from `StatementPreprocessor` for top-level extension statements.
- Preserve transaction wrapping behavior when preprocessing expands to multiple statements.
- Document the extension-facing restrictions in `parser_extension.hpp`.
- Add sqllogictest coverage through `loadable_extension_demo` for:
  - successful preprocessing
  - rejected empty/null outputs
  - rejected transaction/pragma/multi/extension statements
  - rollback behavior when a generated statement fails