### PR TITLE
fix: raise error on invalid `regexp_replace` replacement strings

### DIFF
--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -198,15 +198,16 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, replaces, result, [&](string_t input, string_t replace) {
+			    auto replace_piece = CreateStringPiece(replace);
 			    std::string rewrite_error;
-			    if (!lstate.constant_pattern.CheckRewriteString(CreateStringPiece(replace), &rewrite_error)) {
+			    if (!lstate.constant_pattern.CheckRewriteString(replace_piece, &rewrite_error)) {
 				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
 			    }
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
+				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, replace_piece);
 			    } else {
-				    RE2::Replace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
+				    RE2::Replace(&sstring, lstate.constant_pattern, replace_piece);
 			    }
 			    return heap.AddString(sstring);
 		    });
@@ -217,16 +218,16 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 			    if (!re.ok()) {
 				    throw InvalidInputException(re.error());
 			    }
+			    auto replace_piece = CreateStringPiece(replace);
 			    std::string rewrite_error;
-			    if (!re.CheckRewriteString(CreateStringPiece(replace), &rewrite_error)) {
+			    if (!re.CheckRewriteString(replace_piece, &rewrite_error)) {
 				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
 			    }
-
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
-				    RE2::GlobalReplace(&sstring, re, CreateStringPiece(replace));
+				    RE2::GlobalReplace(&sstring, re, replace_piece);
 			    } else {
-				    RE2::Replace(&sstring, re, CreateStringPiece(replace));
+				    RE2::Replace(&sstring, re, replace_piece);
 			    }
 			    return heap.AddString(sstring);
 		    });

--- a/src/function/scalar/string/regexp.cpp
+++ b/src/function/scalar/string/regexp.cpp
@@ -198,6 +198,10 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<RegexLocalState>();
 		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    strings, replaces, result, [&](string_t input, string_t replace) {
+			    std::string rewrite_error;
+			    if (!lstate.constant_pattern.CheckRewriteString(CreateStringPiece(replace), &rewrite_error)) {
+				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
+			    }
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
 				    RE2::GlobalReplace(&sstring, lstate.constant_pattern, CreateStringPiece(replace));
@@ -213,6 +217,11 @@ static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector
 			    if (!re.ok()) {
 				    throw InvalidInputException(re.error());
 			    }
+			    std::string rewrite_error;
+			    if (!re.CheckRewriteString(CreateStringPiece(replace), &rewrite_error)) {
+				    throw InvalidInputException("Invalid replacement string for regexp_replace: %s", rewrite_error);
+			    }
+
 			    std::string sstring = input.GetString();
 			    if (info.global_replace) {
 				    RE2::GlobalReplace(&sstring, re, CreateStringPiece(replace));

--- a/test/sql/function/string/regex_replace.test
+++ b/test/sql/function/string/regex_replace.test
@@ -189,3 +189,54 @@ query T
 SELECT regexp_replace('héllo-café/rest', '^([^/]+)/.*$', '\1');
 ----
 héllo-café
+
+# Invalid replacement strings should raise an error (issue #23370).
+# Previously these silently produced wrong output instead of erroring.
+
+# (A) out-of-range backreference, global: was returning input unchanged
+statement error
+SELECT regexp_replace('abcabc', '(b)', '\3Y', 'g');
+----
+Invalid replacement string for regexp_replace
+
+# (B) invalid escape sequence in replacement, global: was returning partial output
+statement error
+SELECT regexp_replace('abcabc', 'b', E'X\\xY', 'g');
+----
+Invalid replacement string for regexp_replace
+
+# (C) trailing backslash in replacement, global: was returning partial output
+statement error
+SELECT regexp_replace('abcabc', 'b', E'X\\', 'g');
+----
+Invalid replacement string for regexp_replace
+
+# (D) out-of-range backreference, non-global: was returning input unchanged
+statement error
+SELECT regexp_replace('abc', '(b)', '\3Y');
+----
+Invalid replacement string for regexp_replace
+
+# Non-constant pattern path: out-of-range backreference should also raise an error
+statement ok
+CREATE TABLE t_repl_invalid(s VARCHAR, pat VARCHAR, repl VARCHAR);
+
+statement ok
+INSERT INTO t_repl_invalid VALUES ('abcabc', '(b)', '\3Y');
+
+statement error
+SELECT regexp_replace(s, pat, repl) FROM t_repl_invalid;
+----
+Invalid replacement string for regexp_replace
+
+# Non-constant pattern path: invalid escape should also raise an error
+statement ok
+DELETE FROM t_repl_invalid;
+
+statement ok
+INSERT INTO t_repl_invalid VALUES ('abcabc', 'b', E'X\\xY');
+
+statement error
+SELECT regexp_replace(s, pat, repl) FROM t_repl_invalid;
+----
+Invalid replacement string for regexp_replace


### PR DESCRIPTION
# Fix: Raise error on invalid `regexp_replace` replacement strings

Closes #23370

## Problem
`regexp_replace` passed replacement strings directly to `RE2::GlobalReplace` / `RE2::Replace`
without any validation. Malformed replacements silently produced wrong output instead of
raising an error, and the behavior was inconsistent across different malformed forms:

| Malformed replacement | Old behavior |
|---|---|
| Out-of-range backref (`\3` with 1 group) | Input returned unchanged |
| Invalid escape (`\xY`) | Partial / corrupted output |
| Trailing backslash (`\`) | Partial / corrupted output |

## Changes

### `src/function/scalar/string/regexp.cpp` 

Added a call to `RE2::CheckRewriteString()` before performing the replacement inside
`RegexReplaceFunction`. The function has two separate execution paths and the check is
added to both:
- Constant-pattern path
- Non-constant-pattern path

Follows the same pattern as #16380 which added validation for malformed pattern strings.

### `test/sql/function/string/regex_replace.test`
Six new `statement error` cases added, covering all malformed forms from the issue report
across both execution paths:

| # | Query | Path | Malformed form | Old behavior |
|---|---|---|---|---|
| A | `regexp_replace('abcabc', '(b)', '\3Y', 'g')` | constant pattern | out-of-range backref, global | input unchanged |
| B | `regexp_replace('abcabc', 'b', E'X\\xY', 'g')` | constant pattern | invalid escape, global | partial output |
| C | `regexp_replace('abcabc', 'b', E'X\\', 'g')` | constant pattern | trailing backslash, global | partial output |
| D | `regexp_replace('abc', '(b)', '\3Y')` | constant pattern | out-of-range backref, non-global | input unchanged |
| E | table query — pattern `(b)`, replacement `\3Y` | **non-constant pattern** | out-of-range backref | silent wrong output |
| F | table query — pattern `b`, replacement `E'X\\xY'` | **non-constant pattern** | invalid escape | silent wrong output |

## Verification
running on original sample queries demonstrated in the issue-
```
./build/release/duckdb -c "SELECT regexp_replace('abcabc', '(b)', '\3Y', 'g');"
Invalid Input Error:
Invalid replacement string for regexp_replace: Rewrite schema requests 3 matches, but the regexp only has 1 parenthesized subexpressions.

./build/release/duckdb -c "SELECT regexp_replace('abcabc', 'b', 'X\xY', 'g');"
Invalid Input Error:
Invalid replacement string for regexp_replace: Rewrite schema error: '\' must be followed by a digit or '\'.

./build/release/duckdb -c "SELECT regexp_replace('abcabc', 'b', 'X\', 'g');"
Invalid Input Error:
Invalid replacement string for regexp_replace: Rewrite schema error: '\' not allowed at end.

./build/release/duckdb -c "SELECT regexp_replace('abc', '(b)', '\3Y');"
Invalid Input Error:
Invalid replacement string for regexp_replace: Rewrite schema requests 3 matches, but the regexp only has 1 parenthesized subexpressions.
```