### PR TITLE
Dont allow scheduling a copy file lifecycle task after drained

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -333,6 +333,8 @@ private:
 private:
 	ClientContext &context;
 	TaskExecutor executor;
+	mutex lifecycle_lock;
+	bool drained = false;
 	idx_t async_threads;
 	idx_t max_pending_tasks;
 	atomic<idx_t> pending_tasks {0};
@@ -402,21 +404,26 @@ private:
 template <class FUNC>
 void CopyFileLifecycleExecutor::Schedule(shared_ptr<CopyFileLifecycleJob> job, CopyFileLifecycleWaitMode mode,
                                          FUNC &&task) {
-	WaitForTaskSlot(mode);
 	auto job_ref = job;
-	++pending_tasks;
-	try {
-		using TaskType = CopyFileLifecycleTask<typename std::decay<FUNC>::type>;
-		executor.ScheduleTask(make_uniq<TaskType>(executor, *this, std::move(job), std::forward<FUNC>(task)));
-	} catch (...) {
-		--pending_tasks;
-		throw;
+	{
+		lock_guard<mutex> guard(lifecycle_lock);
+		if (drained) {
+			throw InternalException("Attempted to schedule a copy file lifecycle task after drained");
+		}
+		WaitForTaskSlot(mode);
+		++pending_tasks;
+		try {
+			using TaskType = CopyFileLifecycleTask<typename std::decay<FUNC>::type>;
+			executor.ScheduleTask(make_uniq<TaskType>(executor, *this, std::move(job), std::forward<FUNC>(task)));
+		} catch (...) {
+			--pending_tasks;
+			throw;
+		}
 	}
 	if (async_threads == 0) {
 		WaitForJob(*job_ref, mode);
 	}
 }
-
 //===--------------------------------------------------------------------===//
 // Copy State Declarations
 //===--------------------------------------------------------------------===//
@@ -1512,6 +1519,10 @@ void CopyFileLifecycleExecutor::WaitForJob(CopyFileLifecycleJob &job, CopyFileLi
 
 void CopyFileLifecycleExecutor::WaitAll(CopyFileLifecycleWaitMode mode) {
 	if (mode == CopyFileLifecycleWaitMode::DRAIN) {
+		{
+			lock_guard<mutex> guard(lifecycle_lock);
+			drained = true;
+		}
 		executor.WorkOnTasks();
 		ThrowError();
 		return;


### PR DESCRIPTION
### Flaky test failure on main

we have a flaky test [failure](https://github.com/duckdb/duckdb/actions/runs/27957665380/job/82730642381#step:9:14) on main:
```
retrying failed test test/sql/copy/parquet/writer/parquet_write_memory_usage.test (attempt 1/2, retry 1/4)
..
error: test batch failed

src/execution/operator/persistent/physical_copy_to_file.cpp:2731:17: runtime error: member access within address 0x7ba3e285b988 which does not point to an object of type 'const CopyFunction'
0x7ba3e285b988: note: object is of type 'duckdb::Function'
 00 00 00 00  90 14 0a 46 a4 7f 00 00  a0 b9 85 e2 a3 7b 00 00  07 00 00 00 00 00 00 00  70 61 72 71
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'duckdb::Function'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/execution/operator/persistent/physical_copy_to_file.cpp:2731:17

recovered: passed on retry 1/2

reproduce:
build/relassert/test/unittest test/sql/copy/parquet/writer/parquet_write_date.test,test/sql/copy/parquet/writer/write_stats_null_count.test,test/sql/copy/parquet/writer/parquet_write_strings.test,test/sql/copy/parquet/writer/parquet_empty_struct.test,test/sql/copy/parquet/writer/write_map.test,test/sql/copy/parquet/writer/parquet_write_field_id.test,test/sql/copy/parquet/writer/parquet_write_string_distinct.test,test/sql/copy/parquet/writer/test_copy_overwrite_parquet.test,test/sql/copy/parquet/writer/parquet_timetz_metadata.test,test/sql/copy/parquet/writer/parquet_write_memory_usage.test
```

Note that the test failure is _recovered_, so the ubsan error happens "sometimes".

### Cause

`CopyFileLifecycleExecutor` had a shutdown race in the async `COPY TO` file lifecycle path.

During terminal teardown, `WaitAll(...)` could start draining lifecycle work while another path still scheduled a new async open/finalize task. Those late tasks capture `CopyToFileGlobalState::op` by reference. If they ran after operator teardown had started, they could access stale `PhysicalCopyToFile` state and UBSan would report type confusion when reading `op.function`.

In practice, this showed up as a flaky `relassert` failure in the Parquet writer tests, with `CopyFunction` access landing on memory that no longer held a live `CopyFunction`.

### Change

The fix makes terminal lifecycle shutdown a real scheduling barrier:

- `CopyFileLifecycleExecutor::Schedule(...)` now checks a `closed` flag under `lifecycle_lock` and rejects scheduling after shutdown begins.
- `CopyFileLifecycleExecutor::WaitAll(CopyFileLifecycleWaitMode::DRAIN)` now sets `closed = true` before draining tasks.
- Non-terminal waits still allow scheduling:
  - `WaitAll(INTERRUPTIBLE)` remains non-closing.
  - existing wait-mode behavior stays intact.

This keeps the newer wait-mode lifecycle executor design, but prevents new async lifecycle tasks from being admitted once teardown starts.