### PR TITLE
Skip caching when no version metadata available

### DIFF
--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -257,8 +257,11 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return FileBufferHandleGroup();
 	}
 
-	// Uncached files are read directly into one contiguous buffer, skipping the per block syscalls and copies
-	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path)) {
+	// Only cache when file metadata is available.
+	const bool no_validation_metadata =
+	    Validate() && version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+
+	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || no_validation_metadata) {
 		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -43,4 +43,24 @@ string SimpleTrackingFileSystem::GetVersionTag(FileHandle &handle) {
 	return StringUtil::Format("%lld:%lld", GetFileSize(handle), GetLastModifiedTime(handle).value);
 }
 
+string NoValidationMetadataFileSystem::GetName() const {
+	return "NoValidationMetadataFileSystem";
+}
+
+bool NoValidationMetadataFileSystem::CanHandleFile(const string &path) {
+	return StringUtil::StartsWith(path, TestDirectoryPath());
+}
+
+bool NoValidationMetadataFileSystem::CanSeek() {
+	return true;
+}
+
+string NoValidationMetadataFileSystem::GetVersionTag(FileHandle &handle) {
+	return "";
+}
+
+timestamp_t NoValidationMetadataFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	return timestamp_t(0);
+}
+
 } // namespace duckdb

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -33,6 +33,17 @@ public:
 	string GetVersionTag(FileHandle &handle) override;
 };
 
+//! A file system that returns no ETag and timestamp_t(0) for Last-Modified, simulating servers that do not
+//! provide cache-validation headers.
+class NoValidationMetadataFileSystem : public LocalFileSystem {
+public:
+	string GetName() const override;
+	bool CanHandleFile(const string &path) override;
+	bool CanSeek() override;
+	string GetVersionTag(FileHandle &handle) override;
+	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+};
+
 //! In-memory DuckDB with the external file cache forced to also cache local files (off by default), so the external
 //! file cache tests can exercise the cache machinery on local temp files.
 DuckDB MakeCacheLocalFilesDB();

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -17,11 +17,19 @@ namespace {
 
 using EFCTestFileGuard = CachingTestFileGuard;
 using EFCTrackingFileSystem = SimpleTrackingFileSystem;
+using EFCNoMetadataFileSystem = NoValidationMetadataFileSystem;
 
 OpenFileInfo MakeTestOpenFileInfo(const string &path) {
 	OpenFileInfo info(path);
 	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+	return info;
+}
+
+OpenFileInfo MakeValidatingOpenFileInfo(const string &path) {
+	OpenFileInfo info(path);
+	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(true);
 	return info;
 }
 
@@ -449,6 +457,38 @@ TEST_CASE("Failed CachingFileHandle construction leaves evictable cached file en
 	auto &object_cache = db_instance.GetObjectCache();
 	EvictObjectCache(object_cache);
 	REQUIRE(cache.GetCachedFileCount() == 0);
+}
+
+TEST_CASE("No-metadata file is not cached and always returns fresh content", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	auto no_meta_fs = make_uniq<EFCNoMetadataFileSystem>();
+
+	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(BLOCK_SIZE, 'A');
+	const string content_b(BLOCK_SIZE, 'B');
+	EFCTestFileGuard test_file("test_efc_no_metadata.bin", content_a);
+
+	CachingFileSystem cfs(*no_meta_fs, db_instance);
+
+	// First read: data is fetched from source. No blocks should be stored in the cache.
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 0);
+
+	// Overwrite the file with different content.
+	WriteTestContent(test_file.GetPath(), content_b);
+
+	// Second read: validate that we return new content.
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_b);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 0);
 }
 
 } // namespace duckdb

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -468,25 +468,27 @@ TEST_CASE("No-metadata file is not cached and always returns fresh content", "[e
 
 	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
 	const string content_a(BLOCK_SIZE, 'A');
-	const string content_b(BLOCK_SIZE, 'B');
+	const string content_b(BLOCK_SIZE * 2, 'B');
 	EFCTestFileGuard test_file("test_efc_no_metadata.bin", content_a);
 
 	CachingFileSystem cfs(*no_meta_fs, db_instance);
 
-	// First read: data is fetched from source. No blocks should be stored in the cache.
+	// First read: data is fetched from source.  No blocks should be stored in the cache.
 	{
 		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(handle->GetFileSize() == content_a.size());
 		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
 	}
 	REQUIRE(CountCachedBlocks(cache) == 0);
 
-	// Overwrite the file with different content.
+	// Overwrite the file with larger content.
 	WriteTestContent(test_file.GetPath(), content_b);
 
-	// Second read: validate that we return new content.
+	// Second read: file size and content must reflect the new version, not the cached one.
 	{
 		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
-		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_b);
+		REQUIRE(handle->GetFileSize() == content_b.size());
+		REQUIRE(ReadFull(*handle, content_b.size()) == content_b);
 	}
 	REQUIRE(CountCachedBlocks(cache) == 0);
 }


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/23255

The current problem is: when there's no version information available for the requested file (neither last modification timestamp nor etag), file blocks are still cached in external file cache, but we have no way to validate its freshness so it's prune to stale read.

There're two ways I could think of
- Do not cache files without version information (implemented in this PR)
- Cache all files, whether version info available, but requires extra setting on read (for example, [disable external file cache validation](https://github.com/duckdb/duckdb/blob/e884eef8ddaa9434dc33715b1aaa7fec29f8eb4b/src/include/duckdb/main/settings.hpp#L1964)) to explicitly skip validation

I prefer (1) because 
- etag should be generally available for remote storage like S3/GCS, so practically speaking it shouldn't affect perf
- it doesn't require users to do extra setup and prioritize correctness