### PR TITLE
fix out-of-bounds read in substring with negative offset

### DIFF
--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -139,7 +139,7 @@ string_t SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_
 				}
 			}
 		}
-		while (!IsCharacter(input_data[start_pos])) {
+		while (start_pos < input_size && !IsCharacter(input_data[start_pos])) {
 			start_pos++;
 		}
 		while (end_pos < input_size && !IsCharacter(input_data[end_pos])) {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library_unity(
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp
+  test_substring_oob.cpp
   test_temporary_memory_manager.cpp
   test_value_to_sql_string.cpp)
 

--- a/test/common/test_substring_oob.cpp
+++ b/test/common/test_substring_oob.cpp
@@ -1,0 +1,23 @@
+#include "catch.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
+
+#include <cstring>
+
+using namespace duckdb;
+
+// substring() scans byte-by-byte to find unicode character boundaries. On a
+// negative offset the backward scan can leave start_pos at 0 when the input has
+// no character boundary; the loop that skips continuation bytes then walks past
+// the end of the buffer. A heap-backed (> 12 byte) string of continuation bytes
+// reproduces the out-of-bounds read.
+TEST_CASE("substring negative offset on non-utf8 input stays in bounds", "[substring]") {
+	Vector result(LogicalType::VARCHAR);
+
+	auto buffer = make_unsafe_uniq_array<char>(20);
+	memset(buffer.get(), '\x80', 20);
+	string_t input(buffer.get(), 20);
+
+	auto out = SubstringUnicode(result, input, -1, 5);
+	REQUIRE(out.GetSize() == 0);
+}


### PR DESCRIPTION
**out-of-bounds read in substring with a negative offset**

on the backward scan, when the input has no utf-8 character boundary (for example bytes that are all continuation bytes), `start_pos` never gets set and the loop that skips continuation bytes walks past the end of the buffer. the `end_pos` loop directly below already bounds itself with `< input_size`, so applied the same bound to `start_pos`.