### PR TITLE
Use correct start time when verifying dependencies

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -445,7 +445,7 @@ void CatalogSet::VerifyExistenceOfDependency(transaction_t commit_id, CatalogEnt
 	// Make sure that we don't see any uncommitted changes
 	auto transaction_id = MAX_TRANSACTION_ID;
 	// This will allow us to see all committed changes made before this COMMIT happened
-	auto tx_start_time = commit_id;
+	auto tx_start_time = commit_id + 1;
 	CatalogTransaction commit_transaction(duck_catalog.GetDatabase(), transaction_id, tx_start_time);
 
 	D_ASSERT(entry.type == CatalogType::DEPENDENCY_ENTRY);

--- a/test/sql/catalog/dependencies/drop_recreate_schema_dependency.test
+++ b/test/sql/catalog/dependencies/drop_recreate_schema_dependency.test
@@ -1,0 +1,83 @@
+# name: test/sql/catalog/dependencies/drop_recreate_schema_dependency.test
+# description: A schema and its dependent objects can be dropped and re-created within a single transaction
+# group: [dependencies]
+
+statement ok
+CREATE TABLE documents(id VARCHAR, body VARCHAR);
+
+statement ok
+INSERT INTO documents VALUES ('d1', 'hello world');
+
+# initial build: a schema containing a macro, and a table that depends on that macro - all in one transaction
+statement ok
+BEGIN
+
+statement ok
+DROP SCHEMA IF EXISTS idx CASCADE
+
+statement ok
+CREATE SCHEMA idx
+
+statement ok
+CREATE MACRO idx.tokenize(s) AS string_split(s, ' ')
+
+statement ok
+CREATE TABLE idx.terms AS SELECT unnest(idx.tokenize(body)) AS term FROM documents
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM idx.terms
+----
+2
+
+# overwrite: drop and re-create the same schema + dependent objects in a single transaction.
+# Before the fix the COMMIT below failed with:
+#   Could not commit creation of dependency, subject "idx" was dropped and re-created by another transaction
+statement ok
+BEGIN
+
+statement ok
+DROP SCHEMA IF EXISTS idx CASCADE
+
+statement ok
+CREATE SCHEMA idx
+
+statement ok
+CREATE MACRO idx.tokenize(s) AS string_split(s, ' ')
+
+statement ok
+CREATE TABLE idx.terms AS SELECT unnest(idx.tokenize(body)) AS term FROM documents
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM idx.terms
+----
+2
+
+# re-running the overwrite a second time must keep working
+statement ok
+BEGIN
+
+statement ok
+DROP SCHEMA IF EXISTS idx CASCADE
+
+statement ok
+CREATE SCHEMA idx
+
+statement ok
+CREATE MACRO idx.tokenize(s) AS string_split(s, ' ')
+
+statement ok
+CREATE TABLE idx.terms AS SELECT unnest(idx.tokenize(body)) AS term FROM documents
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM idx.terms
+----
+2


### PR DESCRIPTION
If we use our own commit id, we don't see changes made by ourselves, which means we still see old state. This can cause us to run into incorrect dependency conflict errors (as in the attached test). 