### PR TITLE
Preserve original chunk cardinality in TryProbeConstant

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1306,6 +1306,8 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
 	// constant vectors carry no dictionary id, so there is no cross-chunk cache - resolve the
 	// single distinct key with one hash-table lookup per chunk
 	D_ASSERT(probe_state.dict_state);
+	// Reference shares the constant vector buffer, so shrinking unique_values would otherwise leak back into keys.
+	const idx_t row_count = keys.size();
 	auto &dict_state = *probe_state.dict_state;
 	auto &unique_values = dict_state.unique_values;
 	if (unique_values.ColumnCount() == 0) {
@@ -1315,6 +1317,7 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
 	unique_values.data[0].Reference(constant_col);
 	unique_values.SetChildCardinality(1);
 	unique_values.Flatten();
+	keys.SetChildCardinality(row_count);
 
 	TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1306,18 +1306,16 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
 	// constant vectors carry no dictionary id, so there is no cross-chunk cache - resolve the
 	// single distinct key with one hash-table lookup per chunk
 	D_ASSERT(probe_state.dict_state);
-	// Reference shares the constant vector buffer, so shrinking unique_values would otherwise leak back into keys.
-	const idx_t row_count = keys.size();
 	auto &dict_state = *probe_state.dict_state;
 	auto &unique_values = dict_state.unique_values;
 	if (unique_values.ColumnCount() == 0) {
 		unique_values.InitializeEmpty(vector<LogicalType> {equality_types[0]});
 		TupleDataCollection::InitializeChunkState(dict_state.unique_key_state, {equality_types[0]});
 	}
-	unique_values.data[0].Reference(constant_col);
-	unique_values.SetChildCardinality(1);
+	SelectionVector sel(1);
+	sel.set_index(0, 0);
+	unique_values.data[0].Slice(constant_col, sel, 1);
 	unique_values.Flatten();
-	keys.SetChildCardinality(row_count);
 
 	TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
 

--- a/test/sql/vector_types/list_vector_types.test
+++ b/test/sql/vector_types/list_vector_types.test
@@ -1,4 +1,4 @@
-# name: test/sql/vector_types/list_vector_types.test_slow
+# name: test/sql/vector_types/list_vector_types.test
 # description: Vector Types test: lists
 # group: [vector_types]
 


### PR DESCRIPTION
We have a release assertion [failure](https://github.com/duckdb/duckdb/actions/runs/28068284128/job/83099639866#step:9:31) on main:
```
error: FAIL test/sql/vector_types/list_vector_types.test_slow

ABORT THROWN BY INTERNAL EXCEPTION: Assertion triggered in 
  file "/home/runner/work/duckdb/duckdb/src/execution/join_hashtable.cpp" on line 1413:
  keys.size() == probe_data.size()
```

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/9641

Reproduced locally:
```
error: FAIL test/sql/vector_types/list_vector_types.test

  > 52  query I nosort self_join
    53  SELECT * FROM test_vector_types(NULL::INT[], all_flat={all_flat}) t(val) JOIN test_vector_types(NULL::INT[], all_flat={all_flat}) t2(val) USING (val)

INTERNAL Error: Assertion triggered in 
  file "/Users/sander/dev/duckdb/duckdb/src/execution/join_hashtable.cpp" on line 1413: 
  keys.size() == probe_data.size()
Stack Trace:
0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 288
1        duckdb::InternalException::InternalException<char const*&, int&, char const*&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*&, int&, char const*&) + 396
2        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 480
3        duckdb::JoinHashTable::ScanStructure::Next(duckdb::DataChunk&, duckdb::DataChunk&, duckdb::DataChunk&) + 264
4        duckdb::PhysicalHashJoin::ExecuteInternal(duckdb::ExecutionContext&, duckdb::DataChunk&, duckdb::DataChunk&, duckdb::GlobalOperatorState&, duckdb::OperatorState&) const + 1504
5        duckdb::CachingPhysicalOperator::Execute(duckdb::ExecutionContext&, duckdb::DataChunk&, duckdb::DataChunk&, duckdb::GlobalOperatorState&, duckdb::OperatorState&) const + 704
6        duckdb::PipelineExecutor::Execute(duckdb::DataChunk&, duckdb::DataChunk&, unsigned long long) + 1652
7        duckdb::PipelineExecutor::ExecutePushInternal(duckdb::DataChunk&, duckdb::ExecutionBudget&, unsigned long long) + 400
8        duckdb::PipelineExecutor::Execute(unsigned long long) + 1284
9        duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode) + 688
10       duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 724
11       duckdb::Executor::ExecuteTask(bool) + 820
12       duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult&, bool) + 528
13       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 340
14       duckdb::ClientContext::Query(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::QueryParameters) + 1720
15       duckdb::Command::ExecuteQuery(duckdb::ExecuteContext&, std::__1::reference_wrapper<duckdb::Connection>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, unsigned long long) const + 352
16       duckdb::Query::ExecuteInternal(duckdb::ExecuteContext&) const + 904
17       duckdb::Command::Execute(duckdb::ExecuteContext&) const + 688
18       duckdb::LoopCommand::ExecuteInternal(duckdb::ExecuteContext&) const + 3240
19       duckdb::Command::Execute(duckdb::ExecuteContext&) const + 496
20       duckdb::SQLLogicTestRunner::EndLoop() + 556
21       duckdb::SQLLogicTestRunner::ExecuteInternal(duckdb::SQLLogicParser&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 14904
22       duckdb::SQLLogicTestRunner::ExecuteFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) + 1000
23       void RunSQLLogicTest<false>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, duckdb::optional_ptr<std::__1::basic_istream<char, std::__1::char_traits<char>>, true>) + 4320
24       void testRunner<false>() + 248
30       main + 2992
31       start + 6992

reproduce:
build/relassert/test/unittest --test-config test/configs/release_assertions.json test/sql/vector_types/list_vector_types.test
```

The bug was that:
1. `unique_values.data[0].Reference(constant_col)` aliases the source constant buffer,
2. `SetChildCardinality(1)` shrinks that shared buffer
3. `Flatten()` detaches it.

### Solution 1: Create a new SelectionVector and use Slice()

This avoids keeping track of and re-setting the cardinality later:

```diff
diff --git a/src/execution/join_hashtable.cpp b/src/execution/join_hashtable.cpp
index b0217e24f5..d8b761ad81 100644
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1312,8 +1312,9 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
                unique_values.InitializeEmpty(vector<LogicalType> {equality_types[0]});
                TupleDataCollection::InitializeChunkState(dict_state.unique_key_state, {equality_types[0]});
        }
-       unique_values.data[0].Reference(constant_col);
-       unique_values.SetChildCardinality(1);
+       SelectionVector sel(1);
+       sel.set_index(0, 0);
+       unique_values.data[0].Slice(constant_col, sel, 1);
        unique_values.Flatten();
 
        TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
```

### Solution 2: Preserve original chunk cardinality in `TryProbeConstant`

This was the original solution I used:

```diff
diff --git a/src/execution/join_hashtable.cpp b/src/execution/join_hashtable.cpp
index b0217e24f5..df47338e71 100644
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1306,6 +1306,8 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
        // constant vectors carry no dictionary id, so there is no cross-chunk cache - resolve the
        // single distinct key with one hash-table lookup per chunk
        D_ASSERT(probe_state.dict_state);
+       // Reference shares the constant vector buffer, so shrinking unique_values would otherwise leak back into keys.
+       const idx_t row_count = keys.size();
        auto &dict_state = *probe_state.dict_state;
        auto &unique_values = dict_state.unique_values;
        if (unique_values.ColumnCount() == 0) {
@@ -1315,6 +1317,7 @@ bool JoinHashTable::TryProbeConstant(ScanStructure &scan_structure, DataChunk &k
        unique_values.data[0].Reference(constant_col);
        unique_values.SetChildCardinality(1);
        unique_values.Flatten();
+       keys.SetChildCardinality(row_count);
 
        TupleDataCollection::ToUnifiedFormat(dict_state.unique_key_state, unique_values);
```

but that seems to increase complexity compared to creating a new vector.
