### PR TITLE
WIP: Allow VARIANT type in list_filter/list_transform lambda and UNNEST binding

### DIFF
--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -242,6 +242,8 @@ LogicalType LambdaFunctions::DetermineListChildType(const LogicalType &child_typ
 			return ArrayType::GetChildType(child_type);
 		} else if (child_type.id() == LogicalTypeId::LIST) {
 			return ListType::GetChildType(child_type);
+		} else if (child_type.id() == LogicalTypeId::VARIANT) {
+			return LogicalType::VARIANT();
 		}
 		throw InternalException("The first argument must be a list or array type");
 	}
@@ -369,8 +371,10 @@ unique_ptr<FunctionData> LambdaFunctions::ListLambdaPrepareBind(vector<unique_pt
 		throw ParameterNotResolvedException();
 	}
 
-	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
-	D_ASSERT(arguments[0]->GetReturnType().id() == LogicalTypeId::LIST);
+	if (arguments[0]->GetReturnType().id() != LogicalTypeId::VARIANT) {
+		arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
+		D_ASSERT(arguments[0]->GetReturnType().id() == LogicalTypeId::LIST);
+	}
 	return nullptr;
 }
 

--- a/src/function/table/unnest.cpp
+++ b/src/function/table/unnest.cpp
@@ -45,11 +45,14 @@ struct UnnestLocalState : public LocalTableFunctionState {
 static unique_ptr<FunctionData> UnnestBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 	if (input.input_table_types.size() != 1 || (input.input_table_types[0].id() != LogicalTypeId::LIST &&
-	                                            input.input_table_types[0].id() != LogicalTypeId::ARRAY)) {
+	                                            input.input_table_types[0].id() != LogicalTypeId::ARRAY &&
+	                                            input.input_table_types[0].id() != LogicalTypeId::VARIANT)) {
 		throw BinderException("UNNEST requires a single list or array as input");
 	}
 	auto &input_type = input.input_table_types[0];
-	if (input_type.id() == LogicalTypeId::LIST) {
+	if (input_type.id() == LogicalTypeId::VARIANT) {
+		return_types.push_back(LogicalType::VARIANT());
+	} else if (input_type.id() == LogicalTypeId::LIST) {
 		return_types.push_back(ListType::GetChildType(input_type));
 	} else {
 		return_types.push_back(ArrayType::GetChildType(input_type));
@@ -76,7 +79,13 @@ static unique_ptr<GlobalTableFunctionState> UnnestInit(ClientContext &context, T
 		child = BoundCastExpression::AddArrayCastToList(context, std::move(child));
 	}
 
-	auto bound_unnest = make_uniq<BoundUnnestExpression>(ListType::GetChildType(child->GetReturnType()));
+	LogicalType child_type;
+	if (child->GetReturnType().id() == LogicalTypeId::VARIANT) {
+		child_type = LogicalType::VARIANT();
+	} else {
+		child_type = ListType::GetChildType(child->GetReturnType());
+	}
+	auto bound_unnest = make_uniq<BoundUnnestExpression>(child_type);
 	bound_unnest->ChildMutable() = std::move(child);
 	result->select_list.push_back(std::move(bound_unnest));
 	return std::move(result);

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -415,7 +415,8 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 		if (list_child->GetReturnType().id() != LogicalTypeId::LIST &&
 		    list_child->GetReturnType().id() != LogicalTypeId::ARRAY &&
 		    list_child->GetReturnType().id() != LogicalTypeId::SQLNULL &&
-		    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN) {
+		    list_child->GetReturnType().id() != LogicalTypeId::UNKNOWN &&
+		    list_child->GetReturnType().id() != LogicalTypeId::VARIANT) {
 			return BindResult("Invalid LIST argument during lambda function binding!");
 		}
 	}

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -154,6 +154,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	case LogicalTypeId::LIST:
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::SQLNULL:
+	case LogicalTypeId::VARIANT:
 		break;
 	default:
 		return BindResult(BinderException(function, "UNNEST() can only be applied to lists, structs and NULL, not %s",
@@ -165,6 +166,8 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 
 	auto unnest_expr = std::move(child);
 	if (child_type.id() == LogicalTypeId::SQLNULL) {
+		list_unnests = 1;
+	} else if (child_type.id() == LogicalTypeId::VARIANT) {
 		list_unnests = 1;
 	} else {
 		// perform all LIST/ARRAY unnests
@@ -198,6 +201,8 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 			return_type = ListType::GetChildType(return_type);
 		} else if (return_type.id() == LogicalTypeId::ARRAY) {
 			return_type = ArrayType::GetChildType(return_type);
+		} else if (return_type.id() == LogicalTypeId::VARIANT) {
+			return_type = LogicalType::VARIANT();
 		}
 
 		if (unnest_expr->GetReturnType().id() == LogicalTypeId::ARRAY) {


### PR DESCRIPTION
## Summary

Fixes #23433 — `VARIANT` sub-field access (via `variant_extract`) always returns `VARIANT` at bind time, causing `list_filter`, `list_transform`, and `UNNEST` to reject the input.

This PR adds `VARIANT` to the binder-level type allowlists in the four locations that gate these operations:

- `bind_function_expression.cpp`: Lambda binding allowlist
- `lambda_functions.cpp`: `DetermineListChildType` + skip array-to-list cast for VARIANT in `ListLambdaPrepareBind`
- `unnest.cpp`: `UnnestBind` and `UnnestInit`
- `bind_unnest_expression.cpp`: UNNEST expression binder switch

When VARIANT is the input, child elements are typed as VARIANT (since the concrete type is unknown at bind time).

## Status: WIP

This resolves the **binder-level rejections** but execution still fails with `Invalid PhysicalType for GetTypeIdSize` because the execution engine cannot allocate vectors for VARIANT-typed list children. Full support requires runtime VARIANT-to-concrete-type resolution in the list/unnest execution paths.

Opening as draft to get feedback on the approach before tackling the execution layer.

## Reproduction

```sql
CREATE TABLE t (data VARIANT);
INSERT INTO t VALUES ('{"items": [{"category": "electronics", "label": "A1"}, {"category": "furniture", "label": "B2"}]}'::JSON::VARIANT);

-- All three fail on v1.5.3, pass binder with this PR
SELECT list_filter(data.items, x -> x.category::VARCHAR = 'electronics') FROM t;
SELECT list_transform(data.items, x -> x.label::VARCHAR) FROM t;
SELECT u.category::VARCHAR FROM t, UNNEST(data.items) AS u;
```