### PR TITLE
Add support for partial shredded stats emission for parquet variants

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -361,21 +361,30 @@ bool IsVariantNull(const string &str) {
 	return str.size() == 1 && str[0] == '\0';
 }
 
-static bool ConvertUnshreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p) {
+// The conversion is best-effort and non-fatal: when the statistics of a particular (sub)node cannot be
+// converted, that node is left as UNKNOWN stats (which makes it "not fully shredded", so consumers fall
+// back to a full scan for that field) instead of discarding the statistics of the entire variant.
+static void ConvertUnshreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::UINTEGER);
 
 	if (!input_p) {
-		return false;
+		//! No overlay statistics -> conservatively unknown (this node is not "fully shredded")
+		result.Copy(BaseStatistics::CreateUnknown(LogicalType::UINTEGER));
+		return;
 	}
 	auto &input = *input_p;
 	D_ASSERT(input.GetType().id() == LogicalTypeId::BLOB);
 	result.CopyValidity(input);
 
 	if (!result.CanHaveNoNull()) {
-		return true;
+		//! The overlay is entirely NULL -> no overlay values -> fully shredded
+		return;
 	}
 	if (!StringStats::HasMinMax(input)) {
-		return false;
+		//! The overlay may contain values but we can't tell what they are (e.g. the writer dropped min/max for
+		//! a large blob value) -> conservatively unknown so this node is treated as not fully shredded
+		result.Copy(BaseStatistics::CreateUnknown(LogicalType::UINTEGER));
+		return;
 	}
 
 	auto min = StringStats::Min(input);
@@ -386,12 +395,12 @@ static bool ConvertUnshreddedStats(BaseStatistics &result, optional_ptr<BaseStat
 		NumericStats::SetMax<uint32_t>(result, 0);
 		result.SetHasNoNull();
 	}
-	return true;
+	//! else: there are real overlay values -> leave min/max unset, so this node is not fully shredded
 }
 
-static bool ConvertShreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p);
+static void ConvertShreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p);
 
-static bool ConvertShreddedStatsItem(BaseStatistics &result, BaseStatistics &input) {
+static void ConvertShreddedStatsItem(BaseStatistics &result, BaseStatistics &input) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::STRUCT);
 	D_ASSERT(input.GetType().id() == LogicalTypeId::STRUCT);
 
@@ -403,41 +412,37 @@ static bool ConvertShreddedStatsItem(BaseStatistics &result, BaseStatistics &inp
 	auto &value_stats = StructStats::GetChildStats(input, 0);
 	auto &typed_value_input = StructStats::GetChildStats(input, 1);
 
-	if (!ConvertUnshreddedStats(untyped_value_index_stats, value_stats)) {
-		return false;
-	}
-	if (!ConvertShreddedStats(typed_value_result, typed_value_input)) {
-		return false;
-	}
-	return true;
+	ConvertUnshreddedStats(untyped_value_index_stats, value_stats);
+	ConvertShreddedStats(typed_value_result, typed_value_input);
 }
 
-static bool ConvertShreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p) {
+static void ConvertShreddedStats(BaseStatistics &result, optional_ptr<BaseStatistics> input_p) {
 	if (!input_p) {
-		return false;
+		//! No statistics for this shredded subtree -> leave it unknown (conservative)
+		result.Copy(BaseStatistics::CreateUnknown(result.GetType()));
+		return;
 	}
 	auto &input = *input_p;
 	result.CopyValidity(input);
 
 	auto type_id = result.GetType().id();
 	if (type_id == LogicalTypeId::LIST) {
-		auto &child_result = ListStats::GetChildStats(result);
-		auto &child_input = ListStats::GetChildStats(input);
-		return ConvertShreddedStatsItem(child_result, child_input);
+		ConvertShreddedStatsItem(ListStats::GetChildStats(result), ListStats::GetChildStats(input));
+		return;
 	}
 	if (type_id == LogicalTypeId::STRUCT) {
 		auto field_count = StructType::GetChildCount(result.GetType());
 		for (idx_t i = 0; i < field_count; i++) {
-			auto &result_field = StructStats::GetChildStats(result, i);
-			auto &input_field = StructStats::GetChildStats(input, i);
-			if (!ConvertShreddedStatsItem(result_field, input_field)) {
-				return false;
-			}
+			ConvertShreddedStatsItem(StructStats::GetChildStats(result, i), StructStats::GetChildStats(input, i));
 		}
-		return true;
+		return;
 	}
-	result.Copy(input);
-	return true;
+	//! Primitive leaf - copy the parquet stats if the types line up, otherwise leave it unknown
+	if (result.GetType() == input.GetType()) {
+		result.Copy(input);
+	} else {
+		result.Copy(BaseStatistics::CreateUnknown(result.GetType()));
+	}
 }
 
 bool StringStatsAreValid(const string &stats, bool is_varchar, StringStatsType stats_type) {
@@ -629,17 +634,13 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 		auto &value = schema.children[1];
 		D_ASSERT(value.name == "value");
 		auto value_stats = ParquetStatisticsUtils::TransformColumnStatistics(value, columns, can_have_nan);
-		if (!ConvertUnshreddedStats(untyped_value_index_stats, value_stats.get())) {
-			//! Couldn't convert the stats, or there are no stats
-			return nullptr;
-		}
+		//! Best-effort: nodes whose stats can't be converted are left UNKNOWN (not fully shredded) rather
+		//! than discarding the statistics for the entire variant column
+		ConvertUnshreddedStats(untyped_value_index_stats, value_stats.get());
 
 		auto parquet_typed_value_stats =
 		    ParquetStatisticsUtils::TransformColumnStatistics(typed_value, columns, can_have_nan);
-		if (!ConvertShreddedStats(typed_value_stats, parquet_typed_value_stats.get())) {
-			//! Couldn't convert the stats, or there are no stats
-			return nullptr;
-		}
+		ConvertShreddedStats(typed_value_stats, parquet_typed_value_stats.get());
 		//! Set validity to UNKNOWN
 		variant_stats.SetHasNoNull();
 		variant_stats.SetHasNull();

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -121,6 +121,7 @@
         "test/sql/copy/parquet/parquet_stats.test",
         "test/sql/copy/parquet/writer/parquet_write_decimals.test",
         "test/sql/copy/parquet/shredded_variant_stats.test",
+        "test/parquet/variant/variant_partial_stats.test",
         "test/sql/copy/parquet/corrupt_stats.test",
         "test/sql/copy/parquet/parquet_row_number.test",
         "test/sql/copy/parquet/parquet_string_stats.test",

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -2,6 +2,7 @@
   "description": "Run with SET debug_disable_optimizer=true;.",
   "on_init": "SET debug_disable_optimizer=true;",
   "skip_compiled": "true",
+  "inherit_skip_tests": "test/configs/stats_dependent_tests.json",
   "skip_tests": [
     {
       "reason": "Zone map pruning requires filter pushdown from optimizer.",
@@ -93,42 +94,6 @@
       "reason": "Tests extension optimizer.",
       "paths": [
         "test/extension/test_extensible_filter.test"
-      ]
-    },
-    {
-      "reason": "Statistics are not set without optimizers.",
-      "paths": [
-        "test/optimizer/statistics/statistics_numeric.test",
-        "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
-        "test/fuzzer/duckfuzz/bitstring_agg_uhugeint.test",
-        "test/parquet/parquet_stats_function.test",
-        "test/parquet/issue_22144.test",
-        "test/sql/types/struct/struct_stats.test",
-        "test/sql/types/list/list_stats.test",
-        "test/sql/types/nested/array/array_statistics.test",
-        "test/sql/vacuum/test_analyze.test",
-        "test/sql/function/date/date_part_stats.test",
-        "test/sql/function/date/test_date_trunc.test",
-        "test/sql/function/time/test_extract_stats.test",
-        "test/sql/function/generic/test_stats.test",
-        "test/sql/function/timetz/test_date_part.test",
-        "test/sql/storage/types/variant/variant_extract_stats.test",
-        "test/sql/storage/types/variant/variant_comparator_stats.test",
-        "test/sql/types/variant/variant_cast_stats.test",
-        "test/sql/alter/alter_type/test_alter_type.test",
-        "test/sql/alter/add_col/test_add_col_stats.test",
-        "test/sql/copy/return_stats.test",
-        "test/sql/copy/parquet/parquet_stats.test",
-        "test/sql/copy/parquet/writer/parquet_write_decimals.test",
-        "test/sql/copy/parquet/shredded_variant_stats.test",
-        "test/parquet/variant/variant_partial_stats.test",
-        "test/sql/copy/parquet/corrupt_stats.test",
-        "test/sql/copy/parquet/parquet_row_number.test",
-        "test/sql/copy/parquet/parquet_string_stats.test",
-        "test/sql/storage/extended_string_stats.test",
-        "test/sql/storage/min_string_length_too_large.test_slow",
-        "test/sql/storage/total_string_length_repeated_insert.test",
-        "test/sql/types/geo/geometry_from_wkb_stats.test"
       ]
     },
     {

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -34,7 +34,18 @@
         "test/sql/storage/min_string_length_too_large.test_slow",
         "test/sql/storage/total_string_length_repeated_insert.test",
         "test/sql/types/geo/geometry_from_wkb_stats.test",
-        "test/parquet/variant/variant_stats_propagation.test"
+        "test/parquet/variant/variant_stats_propagation.test",
+        "test/sql/types/geo/geometry_stats.test",
+        "test/sql/types/geo/geometry_compatability.test",
+        "test/sql/function/numeric/test_random.test",
+        "test/sql/copy/parquet/bloom_filters.test",
+        "test/sql/copy/parquet/parquet_filename_filter.test",
+        "test/sql/copy/parquet/union_by_name_hive_partitioning.test",
+        "test/sql/copy/parquet/parquet_hive.test",
+        "test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test",
+        "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
+        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
+        "test/sql/types/geo/geometry_vertex_extract.test"
       ]
     }
     ]

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -1,0 +1,40 @@
+{
+  "skip_tests": [
+    {
+      "reason": "Statistics are not set without optimizers.",
+      "paths": [
+        "test/optimizer/statistics/statistics_numeric.test",
+        "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
+        "test/fuzzer/duckfuzz/bitstring_agg_uhugeint.test",
+        "test/parquet/parquet_stats_function.test",
+        "test/parquet/issue_22144.test",
+        "test/sql/types/struct/struct_stats.test",
+        "test/sql/types/list/list_stats.test",
+        "test/sql/types/nested/array/array_statistics.test",
+        "test/sql/vacuum/test_analyze.test",
+        "test/sql/function/date/date_part_stats.test",
+        "test/sql/function/date/test_date_trunc.test",
+        "test/sql/function/time/test_extract_stats.test",
+        "test/sql/function/generic/test_stats.test",
+        "test/sql/function/timetz/test_date_part.test",
+        "test/sql/storage/types/variant/variant_extract_stats.test",
+        "test/sql/storage/types/variant/variant_comparator_stats.test",
+        "test/sql/types/variant/variant_cast_stats.test",
+        "test/sql/alter/alter_type/test_alter_type.test",
+        "test/sql/alter/add_col/test_add_col_stats.test",
+        "test/sql/copy/return_stats.test",
+        "test/sql/copy/parquet/parquet_stats.test",
+        "test/sql/copy/parquet/writer/parquet_write_decimals.test",
+        "test/sql/copy/parquet/shredded_variant_stats.test",
+        "test/parquet/variant/variant_partial_stats.test",
+        "test/sql/copy/parquet/corrupt_stats.test",
+        "test/sql/copy/parquet/parquet_row_number.test",
+        "test/sql/copy/parquet/parquet_string_stats.test",
+        "test/sql/storage/extended_string_stats.test",
+        "test/sql/storage/min_string_length_too_large.test_slow",
+        "test/sql/storage/total_string_length_repeated_insert.test",
+        "test/sql/types/geo/geometry_from_wkb_stats.test"
+      ]
+    }
+    ]
+}

--- a/test/configs/stats_dependent_tests.json
+++ b/test/configs/stats_dependent_tests.json
@@ -33,7 +33,8 @@
         "test/sql/storage/extended_string_stats.test",
         "test/sql/storage/min_string_length_too_large.test_slow",
         "test/sql/storage/total_string_length_repeated_insert.test",
-        "test/sql/types/geo/geometry_from_wkb_stats.test"
+        "test/sql/types/geo/geometry_from_wkb_stats.test",
+        "test/parquet/variant/variant_stats_propagation.test"
       ]
     }
     ]

--- a/test/configs/verify_serializer.json
+++ b/test/configs/verify_serializer.json
@@ -2,53 +2,12 @@
   "description": "Run with SET debug_verify_serializer=true to test logical plan serialization",
   "on_init": "SET debug_verify_serializer=true",
   "skip_compiled": "true",
+  "inherit_skip_tests": "test/configs/stats_dependent_tests.json",
   "skip_tests": [
     {
       "reason": "Extension optimizer pass breaks logical plan serialization",
       "paths": [
         "test/extension/test_extensible_filter.test"
-      ]
-    },
-    {
-      "reason": "Stats aren't preserved for serialization",
-      "paths": [
-        "test/optimizer/statistics/statistics_numeric.test",
-        "test/fuzzer/pedro/vacuum_table_with_generated_column.test",
-        "test/parquet/parquet_stats_function.test",
-        "test/parquet/variant/variant_stats_propagation.test",
-        "test/sql/types/geo/geometry_stats.test",
-        "test/sql/types/geo/geometry_compatability.test",
-        "test/sql/types/struct/struct_stats.test",
-        "test/sql/types/list/list_stats.test",
-        "test/sql/types/nested/array/array_statistics.test",
-        "test/sql/vacuum/test_analyze.test",
-        "test/sql/function/date/date_part_stats.test",
-        "test/sql/function/date/test_date_trunc.test",
-        "test/sql/function/time/test_extract_stats.test",
-        "test/sql/function/numeric/test_random.test",
-        "test/sql/function/generic/test_stats.test",
-        "test/sql/storage/types/variant/variant_extract_stats.test",
-        "test/sql/storage/types/variant/variant_comparator_stats.test",
-        "test/sql/types/variant/variant_cast_stats.test",
-        "test/sql/alter/alter_type/test_alter_type.test",
-        "test/sql/alter/add_col/test_add_col_stats.test",
-        "test/sql/copy/parquet/bloom_filters.test",
-        "test/sql/copy/parquet/parquet_filename_filter.test",
-        "test/sql/copy/parquet/union_by_name_hive_partitioning.test",
-        "test/sql/copy/parquet/parquet_hive.test",
-        "test/sql/copy/parquet/writer/parquet_write_decimals.test",
-        "test/sql/copy/parquet/shredded_variant_stats.test",
-        "test/sql/copy/parquet/corrupt_stats.test",
-        "test/sql/copy/parquet/parquet_row_number.test",
-        "test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test",
-        "test/sql/copy/parquet/parquet_prefetch_metrics_multifile.test",
-        "test/sql/copy/parquet/parquet_prefetch_strategy_option.test",
-        "test/sql/copy/parquet/parquet_string_stats.test",
-        "test/sql/storage/extended_string_stats.test",
-        "test/sql/storage/min_string_length_too_large.test_slow",
-        "test/sql/storage/total_string_length_repeated_insert.test",
-        "test/sql/types/geo/geometry_vertex_extract.test",
-        "test/sql/types/geo/geometry_from_wkb_stats.test"
       ]
     }
   ]

--- a/test/parquet/variant/variant_blob_roundtrip.test
+++ b/test/parquet/variant/variant_blob_roundtrip.test
@@ -5,7 +5,7 @@
 require parquet
 
 statement ok
-COPY (SELECT '\x00\x01ABC'::BLOB::VARIANT AS v) TO '__TEST_DIR__/variant_blob.parquet' (FORMAT PARQUET);
+COPY (SELECT '\x00\x01ABC'::BLOB::VARIANT AS v) TO '{TEST_DIR}/variant_blob.parquet' (FORMAT PARQUET);
 
 query IIII
 SELECT
@@ -13,6 +13,6 @@ SELECT
     v::VARCHAR AS reread_text,
     hex(v::BLOB) AS reread_blob_hex,
     v = '\x00\x01ABC'::BLOB::VARIANT AS roundtrips
-FROM read_parquet('__TEST_DIR__/variant_blob.parquet');
+FROM read_parquet('{TEST_DIR}/variant_blob.parquet');
 ----
 BLOB	\x00\x01ABC	0001414243	true

--- a/test/parquet/variant/variant_partial_stats.test
+++ b/test/parquet/variant/variant_partial_stats.test
@@ -1,0 +1,45 @@
+# name: test/parquet/variant/variant_partial_stats.test
+# description: An unconvertible nested overlay leaves that node's stats unknown instead of marking the
+#              whole variant column's statistics INCONSISTENT
+# group: [variant]
+
+require parquet
+
+# A heterogeneous list of objects: auto-shredding produces a deeply-nested overlay column whose parquet
+# statistics cannot be converted (a value column with data but no min/max, across row groups). Before the
+# fix this discarded the statistics of the *entire* variant column (shredding_state = INCONSISTENT). Now
+# only that node is left unknown and the rest of the column keeps usable shredded statistics.
+statement ok
+COPY (SELECT [CASE WHEN i % 4 = 0 THEN {'v': {'like': 'x'}} ELSE {'other': i::INTEGER} END]::VARIANT AS j
+      FROM range(5000) t(i))
+TO '{TEST_DIR}/variant_partial_stats.parquet' (ROW_GROUP_SIZE 2048)
+
+# the column is SHREDDED (not INCONSISTENT), so shredded statistics are still produced
+query I
+SELECT DISTINCT stats(j).shredding_state::VARCHAR FROM '{TEST_DIR}/variant_partial_stats.parquet'
+----
+SHREDDED
+
+# the convertible 'other' field keeps usable min/max statistics
+query II
+SELECT stats(j).fully_shredded.child_stats.other.stats.min::INTEGER,
+       stats(j).fully_shredded.child_stats.other.stats.max::INTEGER
+FROM '{TEST_DIR}/variant_partial_stats.parquet' LIMIT 1
+----
+1	4999
+
+# the data still reads back correctly (the un-prunable overlay node does not corrupt results)
+query II
+SELECT count(*), count(*) FILTER (WHERE j::VARCHAR LIKE '%like%')
+FROM '{TEST_DIR}/variant_partial_stats.parquet'
+----
+5000	1250
+
+# a filter on the shredded field prunes correctly: an out-of-range predicate returns no rows, and an
+# in-range predicate returns the matching rows (pruning must never drop a matching row)
+query II
+SELECT
+  (SELECT count(*) FROM '{TEST_DIR}/variant_partial_stats.parquet' WHERE j::VARCHAR LIKE '%999999%'),
+  (SELECT count(*) FROM '{TEST_DIR}/variant_partial_stats.parquet' WHERE j::VARCHAR LIKE '%''other'': 4999%')
+----
+0	1

--- a/test/parquet/variant/variant_partial_stats.test
+++ b/test/parquet/variant/variant_partial_stats.test
@@ -1,7 +1,8 @@
 # name: test/parquet/variant/variant_partial_stats.test
 # description: An unconvertible nested overlay leaves that node's stats unknown instead of marking the
-#              whole variant column's statistics INCONSISTENT
 # group: [variant]
+
+#              whole variant column's statistics INCONSISTENT
 
 require parquet
 


### PR DESCRIPTION
Currently when we have partially shredded variant stats in Parquet these are always emitted as inconsistent - this PR changes this so that the correct stats are emitted.