### PR TITLE
fix out-of-bounds read in UTF8ToCodepoint on truncated input

### DIFF
--- a/extension/core_functions/scalar/string/translate.cpp
+++ b/extension/core_functions/scalar/string/translate.cpp
@@ -35,10 +35,10 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 	// Character to be replaced
 	unordered_map<int32_t, int32_t> to_replace;
 	while (i < size_needle && j < size_thread) {
-		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz);
+		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz, size_needle - i);
 		input_needle += sz;
 		i += UnsafeNumericCast<idx_t>(sz);
-		auto codepoint_thread = Utf8Proc::UTF8ToCodepoint(input_thread, sz);
+		auto codepoint_thread = Utf8Proc::UTF8ToCodepoint(input_thread, sz, size_thread - j);
 		input_thread += sz;
 		j += UnsafeNumericCast<idx_t>(sz);
 		// Ignore unicode character that is existed in to_replace
@@ -50,7 +50,7 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 	// Character to be deleted
 	unordered_set<int32_t> to_delete;
 	while (i < size_needle) {
-		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz);
+		auto codepoint_needle = Utf8Proc::UTF8ToCodepoint(input_needle, sz, size_needle - i);
 		input_needle += sz;
 		i += UnsafeNumericCast<idx_t>(sz);
 		// Add unicode character that will be deleted
@@ -61,7 +61,7 @@ static string_t TranslateScalarFunction(const string_t &haystack, const string_t
 
 	char c[5] = {'\0', '\0', '\0', '\0', '\0'};
 	for (i = 0; i < size_haystack; i += UnsafeNumericCast<idx_t>(sz)) {
-		auto codepoint_haystack = Utf8Proc::UTF8ToCodepoint(input_haystack, sz);
+		auto codepoint_haystack = Utf8Proc::UTF8ToCodepoint(input_haystack, sz, size_haystack - i);
 		if (to_replace.count(codepoint_haystack) != 0) {
 			Utf8Proc::CodepointToUtf8(to_replace[codepoint_haystack], c_sz, c);
 			result.insert(result.end(), c, c + c_sz);

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -39,7 +39,7 @@ static idx_t GetResultLength(const char *input_data, idx_t input_length) {
 
 		// UTF-8.
 		int sz = 0;
-		auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz);
+		auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz, input_length - i);
 		auto converted = IS_UPPER ? Utf8Proc::CodepointToUpper(codepoint) : Utf8Proc::CodepointToLower(codepoint);
 		auto new_sz = Utf8Proc::CodepointLength(converted);
 		output_length += UnsafeNumericCast<idx_t>(new_sz);
@@ -55,7 +55,7 @@ static void CaseConvert(const char *input_data, idx_t input_length, char *result
 		if (input_data[i] & 0x80) {
 			// non-ascii character
 			int sz = 0, new_sz = 0;
-			auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz);
+			auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz, input_length - i);
 			auto converted_codepoint =
 			    IS_UPPER ? Utf8Proc::CodepointToUpper(codepoint) : Utf8Proc::CodepointToLower(codepoint);
 			auto success = Utf8Proc::CodepointToUtf8(converted_codepoint, new_sz, result_data);

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library_unity(
   test_strftime.cpp
   test_string_util.cpp
   test_substring_oob.cpp
+  test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
   test_value_to_sql_string.cpp)
 

--- a/test/common/test_utf8_codepoint_oob.cpp
+++ b/test/common/test_utf8_codepoint_oob.cpp
@@ -1,0 +1,30 @@
+#include "catch.hpp"
+#include "duckdb/common/helper.hpp"
+#include "utf8proc_wrapper.hpp"
+
+#include <cstring>
+
+using namespace duckdb;
+
+// Utf8Proc::UTF8ToCodepoint reads the continuation bytes implied by the lead
+// byte. When a heap-backed (> 12 byte, not null-terminated) string ends in a
+// truncated multi-byte sequence the decoder used to read past the end of the
+// buffer. This path is reached by upper/lower/translate and by the grapheme
+// iterator (reverse, length, ...) on non-utf8 input, which can be produced
+// through the C API / appender as those do not validate UTF-8.
+TEST_CASE("UTF8ToCodepoint stays in bounds on a truncated trailing sequence", "[utf8]") {
+	auto buffer = make_unsafe_uniq_array<char>(13);
+	memset(buffer.get(), 'a', 13);
+
+	// 2-, 3- and 4-byte lead bytes with no continuation bytes following
+	for (auto lead : {'\xc2', '\xe0', '\xf0'}) {
+		buffer.get()[12] = lead;
+
+		int sz = 0;
+		// only one byte is available, the decoder must not read the missing bytes
+		REQUIRE_THROWS(Utf8Proc::UTF8ToCodepoint(buffer.get() + 12, sz, 1));
+
+		// grapheme iteration (reverse, length, ...) decodes the final byte
+		REQUIRE_THROWS(Utf8Proc::GraphemeCount(buffer.get(), 13));
+	}
+}

--- a/third_party/utf8proc/include/utf8proc_wrapper.hpp
+++ b/third_party/utf8proc/include/utf8proc_wrapper.hpp
@@ -55,7 +55,8 @@ public:
 	//! Returns the codepoint length in bytes when encoded in UTF8
 	static int CodepointLength(int cp);
 	//! Transform a UTF8 string to a codepoint; returns the codepoint and writes the length of the codepoint (in UTF8) to sz
-	static int32_t UTF8ToCodepoint(const char *c, int &sz);
+	//! "available" caps how many bytes may be read from "c" so a truncated trailing sequence is rejected rather than read past the end
+	static int32_t UTF8ToCodepoint(const char *c, int &sz, size_t available = 4);
 	//! Returns the render width of a single character in a string
 	static size_t RenderWidth(const char *s, size_t len, size_t pos);
 	static size_t RenderWidth(const std::string &str);

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -203,14 +203,14 @@ std::string Utf8Proc::RemoveInvalid(const char *s, size_t len) {
 
 size_t Utf8Proc::NextGraphemeCluster(const char *s, size_t len, size_t cpos) {
 	int sz;
-	auto prev_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz);
+	auto prev_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz, len - cpos);
 	utf8proc_int32_t state = 0;
 	while (true) {
 		cpos += sz;
 		if (cpos >= len) {
 			return cpos;
 		}
-		auto next_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz);
+		auto next_codepoint = Utf8Proc::UTF8ToCodepoint(s + cpos, sz, len - cpos);
 		if (utf8proc_grapheme_break_stateful(prev_codepoint, next_codepoint, &state)) {
 			// found a grapheme break here
 			return cpos;
@@ -358,7 +358,7 @@ int Utf8Proc::CodepointLength(int cp) {
 	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength, likely due to invalid UTF-8");
 }
 
-int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
+int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz, size_t available) {
 	// from http://www.zedwood.com/article/cpp-utf8-char-to-codepoint
 	auto u = reinterpret_cast<const unsigned char *>(u_input);
 	unsigned char u0 = u[0];
@@ -366,25 +366,37 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 		sz = 1;
 		return u0;
 	}
+	// work out the sequence length from the lead byte and make sure the continuation bytes are present before
+	// reading them, otherwise a truncated trailing sequence reads past the end of the buffer
+	size_t needed;
+	if (u0 >= 240 && u0 <= 247) {
+		needed = 4;
+	} else if (u0 >= 224 && u0 <= 239) {
+		needed = 3;
+	} else if (u0 >= 192 && u0 <= 223) {
+		needed = 2;
+	} else {
+		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+	}
+	if (available < needed) {
+		throw InternalException("incomplete UTF-8 sequence detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+	}
 	unsigned char u1 = u[1];
-	if (u0 >= 192 && u0 <= 223) {
+	if (needed == 2) {
 		sz = 2;
 		return (u0 - 192) * 64 + (u1 - 128);
 	}
-	if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
+	if (u0 == 0xed && (u1 & 0xa0) == 0xa0) {
 		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
 	unsigned char u2 = u[2];
-	if (u0 >= 224 && u0 <= 239) {
+	if (needed == 3) {
 		sz = 3;
 		return (u0 - 224) * 4096 + (u1 - 128) * 64 + (u2 - 128);
 	}
 	unsigned char u3 = u[3];
-	if (u0 >= 240 && u0 <= 247) {
-		sz = 4;
-		return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
-	}
-	throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
+	sz = 4;
+	return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
 }
 
 size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {


### PR DESCRIPTION
Utf8Proc::UTF8ToCodepoint reads the continuation bytes implied by the lead byte without checking how many are left:
- a heap-backed string_t (> 12 bytes, not null-terminated) ending in a truncated 2/3/4-byte sequence reads past the buffer end
- such non-utf8 values reach string functions through the C API / appender, which skip utf8 validation
- hit by upper/lower, translate, and reverse/length via the grapheme iterator

The decoder now takes the bytes available and rejects an incomplete trailing sequence before reading it; callers with null-terminated buffers keep the default. test/common/test_utf8_codepoint_oob.cpp fails under ASan before the change.
