### PR TITLE
Fix eviction node memleak when external file cache disabled

### DIFF
--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -3,11 +3,13 @@
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
+#include "duckdb/common/enums/destroy_buffer_upon.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/storage/buffer/block_handle.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/external_file_cache/external_file_cache.hpp"
 #include "duckdb/storage/external_file_cache/external_file_cache_util.hpp"
@@ -16,6 +18,16 @@ namespace duckdb {
 
 // Forward declaration.
 class DatabaseInstance;
+
+namespace {
+
+// Allocate an uncached read buffer to make sure it's de-allocated immediately, and its metadata is not stored in the
+// eviction queue.
+BufferHandle AllocateUncachedReadBuffer(BufferManager &buffer_manager, idx_t size) {
+	auto buffer = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, size);
+	buffer.GetBlockHandle()->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::UNPIN);
+	return buffer;
+}
 
 //===----------------------------------------------------------------------===//
 // FetchBlockTask
@@ -109,6 +121,8 @@ private:
 	idx_t block_size;
 	BufferHandle &result_pin;
 };
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // CachingFileSystem
@@ -262,7 +276,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	    Validate() && version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
 
 	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || no_validation_metadata) {
-		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
 		mem_handles.push_back({std::move(buf), 0, nr_bytes});
@@ -327,7 +341,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek()) {
-		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buf.GetDataMutable(), nr_bytes));
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
 		mem_handles.push_back({std::move(buf), 0, nr_bytes});


### PR DESCRIPTION
Related to https://github.com/duckdb/ducklake/issues/1136

@zhming0's using DuckLake for continuous metrics data ingestion. During the process he found memory leak with the following setup and phenomenon. Credit to Zhiming for the repro script!
- Workload: long-running ingestion + merge
- External file cache is disabled
- While container RSS keeps growing until OOM, `duckdb_memory` doesn't report it

I'm able to reproduce the issue on my end, and I found a lot of dead nodes accumulated in eviction queue with `duckdb_eviction_queues`.

The root cause is
- In the current implementation, when external file cache disabled, we always allocate a buffer, read and return it right away
- The default [`DestroyBufferUpon`](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/common/enums/destroy_buffer_upon.hpp) option is `EVICTION`, which means on block destruction it's placed into eviction queue
- Eviction queue is [only visited and evicted](https://github.com/duckdb/duckdb/blob/0361de441a122f11fe07c40ce4531cd58f5eaf7a/src/storage/buffer/buffer_pool.cpp#L396-L401) when buffer manager detects insufficient memory **under its management**
- The situation for us is, the overall memory consumption under buffer manager's track is low, but quite a lot is wasted upon useless eviction nodes

This PR switches the DestroyBufferUpon mode from EVICTION to UNPIN, which destructs memory directly within going through the eviction queue. I've verified eviction queue size shows empty after my change.