### PR TITLE
Add dictionary-aware cache operator

### DIFF
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -416,23 +416,28 @@ SelectExecutionMode(const DataChunk &chunk, const OperatorResultType child_resul
 	return CachingPhysicalOperatorExecuteMode::RETURN_CHUNK;
 }
 
-static bool ChunkHasGlobalDictionary(const DataChunk &chunk) {
+//! Empty-id dicts (e.g. slice-of-flat) mint a fresh entry per slice, so their sels must not be accumulated.
+static inline bool IsAccumulableDictionary(const Vector &vector) {
+	return vector.GetVectorType() == VectorType::DICTIONARY_VECTOR && !DictionaryVector::DictionaryId(vector).empty();
+}
+
+static bool ChunkHasAccumulableDictionary(const DataChunk &chunk) {
 	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
-		if (DictionaryVector::IsGlobalDictionary(chunk.data[col_idx])) {
+		if (IsAccumulableDictionary(chunk.data[col_idx])) {
 			return true;
 		}
 	}
 	return false;
 }
 
-//! Switch the empty cache to dictionary mode: pin each global dictionary column's upstream entry and allocate its
-//! sel accumulator. Columns keep a real (resettable) cache so a flushed dict column flattens on the next Reset.
+//! Switch the empty cache to dictionary mode: pin each accumulable dictionary column's upstream entry and allocate
+//! its sel accumulator. Columns keep a real (resettable) cache so a flushed dict column flattens on the next Reset.
 static void SeedDictCache(CachingOperatorState &state, DataChunk &source) {
 	const idx_t col_count = source.ColumnCount();
 	state.dict_columns.clear();
 	state.dict_columns.resize(col_count);
 	for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
-		if (!DictionaryVector::IsGlobalDictionary(source.data[col_idx])) {
+		if (!IsAccumulableDictionary(source.data[col_idx])) {
 			continue;
 		}
 		auto &slot = state.dict_columns[col_idx];
@@ -442,15 +447,28 @@ static void SeedDictCache(CachingOperatorState &state, DataChunk &source) {
 	state.dict_cache_active = true;
 }
 
+//! On identity change, demote just this column to flat (materializing the rows so far) instead of flushing the
+//! whole cache, so sibling columns keep accumulating and the chunk still coalesces.
+static void FlattenDictColumn(CachingOperatorState &state, DataChunk &cache, idx_t col_idx, idx_t base) {
+	auto &slot = state.dict_columns[col_idx];
+	D_ASSERT(slot.entry);
+	FlatVector::SetSize(cache.data[col_idx], 0);
+	if (base > 0) {
+		// materialize into the cache's own slot so the possibly-shared upstream child is never flattened in place
+		cache.data[col_idx].Append(slot.entry->data, slot.accumulated_sel, base, VectorAppendMode::ERROR_ON_NO_SPACE);
+	}
+	slot.entry = nullptr;
+}
+
 //! Append source into the cache (created lazily). On the first append into an empty cache, detect
-//! global dictionary columns; those concatenate their selection indices instead of flattening.
+//! accumulable dictionary columns; those concatenate their selection indices instead of flattening.
 static void AppendToCache(CachingOperatorState &state, DataChunk &source, ClientContext &client_context) {
 	if (!state.cached_chunk) {
 		state.cached_chunk = make_uniq<DataChunk>();
 		state.cached_chunk->Initialize(Allocator::Get(client_context), source.GetTypes());
 	}
 	auto &cache = *state.cached_chunk;
-	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasGlobalDictionary(source)) {
+	if (cache.size() == 0 && !state.dict_cache_active && ChunkHasAccumulableDictionary(source)) {
 		SeedDictCache(state, source);
 	}
 	if (!state.dict_cache_active) {
@@ -466,28 +484,31 @@ static void AppendToCache(CachingOperatorState &state, DataChunk &source, Client
 	for (idx_t col_idx = 0; col_idx < cache.ColumnCount(); col_idx++) {
 		auto &slot = state.dict_columns[col_idx];
 		if (slot.entry) {
-			// dict column: every later chunk must be the same global dictionary. Throw (not D_ASSERT)
-			// because the Cast below is UB on a non-dict vector in release, accumulating foreign bytes as indices.
 			auto &source_col = source.data[col_idx];
-			if (source_col.GetVectorType() != VectorType::DICTIONARY_VECTOR ||
-			    DictionaryVector::DictionaryId(source_col).empty() ||
-			    !DictionaryVector::IsGlobalDictionary(source_col)) {
-				throw InternalException("dict-surviving cache: column %llu received a non-global-dictionary "
-				                        "chunk after being seeded for dictionary caching",
+			// Compare the pinned entry by pointer: cheaper than the string id and exact, since pinning keeps the
+			// address stable (no ABA). The type check must come first to guard the Cast against a flat vector.
+			const bool same_dict = source_col.GetVectorType() == VectorType::DICTIONARY_VECTOR &&
+			                       &source_col.Buffer().Cast<DictionaryBuffer>().GetEntry() == slot.entry.get();
+			if (same_dict) {
+				const auto &source_sel = DictionaryVector::SelVector(source_col);
+				for (idx_t row = 0; row < added; row++) {
+					slot.accumulated_sel.set_index(base + row, source_sel.get_index(row));
+				}
+				continue;
+			}
+			// A global dictionary wraps the same entry for the producer's lifetime, so a change is a producer bug
+			// that would desync the downstream sink layout -> fail loudly. A non-global dict rotating is normal.
+			if (slot.entry->global_dictionary) {
+				throw InternalException("dict-surviving cache: global dictionary column %llu changed identity "
+				                        "after being seeded for dictionary caching",
 				                        static_cast<uint64_t>(col_idx));
 			}
-			// An id mismatch past the encoding check is a producer bug (never user-triggerable), so assert.
-			D_ASSERT(source_col.Buffer().Cast<DictionaryBuffer>().GetEntry().id == slot.entry->id);
-			const auto &source_sel = DictionaryVector::SelVector(source_col);
-			for (idx_t row = 0; row < added; row++) {
-				slot.accumulated_sel.set_index(base + row, source_sel.get_index(row));
-			}
-		} else {
-			// flat column: append per column. The D_ASSERT catches a refactor that routes a dict placeholder here.
-			D_ASSERT(!slot.entry);
-			FlatVector::SetSize(cache.data[col_idx], base);
-			cache.data[col_idx].Append(source.data[col_idx], added, VectorAppendMode::ERROR_ON_NO_SPACE);
+			FlattenDictColumn(state, cache, col_idx, base);
 		}
+		// reached by originally-flat and just-demoted columns
+		D_ASSERT(!slot.entry);
+		FlatVector::SetSize(cache.data[col_idx], base);
+		cache.data[col_idx].Append(source.data[col_idx], added, VectorAppendMode::ERROR_ON_NO_SPACE);
 	}
 	// dict columns are rewrapped on flush, flat columns already sized; this only sets the cardinality
 	cache.SetChildCardinality(base + added);

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -247,8 +247,7 @@ public:
 	}
 };
 
-//! A cached column that arrived as a global dictionary: the pinned upstream entry is kept and
-//! per-chunk selection indices concatenated, so the dictionary survives the cache instead of flattening
+//! Accumulator that lets a dictionary column survive the cache: pinned entry + concatenated per-chunk sels
 struct CachedDictColumn {
 	buffer_ptr<DictionaryEntry> entry;
 	SelectionVector accumulated_sel;
@@ -285,8 +284,8 @@ public:
 	bool must_return_continuation_chunk = false;
 	OperatorResultType cached_result;
 
-	//! One slot per cached column. Invariant: entry != null iff the column is accumulating a global
-	//! dictionary; entry == null iff plain flat caching (the common case)
+	//! One slot per cached column. Invariant: entry != null iff the column is accumulating a dictionary
+	//! (pinned by entry pointer identity); entry == null iff plain flat caching (the common case)
 	vector<CachedDictColumn> dict_columns;
 	bool dict_cache_active = false;
 };

--- a/test/sql/filter/filter_cache_dictionary.test
+++ b/test/sql/filter/filter_cache_dictionary.test
@@ -1,0 +1,93 @@
+# name: test/sql/filter/filter_cache_dictionary.test
+# description: Caching operator coalesces dictionary-compressed columns through a selective filter
+# group: [filter]
+
+# persistent + dict compression so the VARCHAR reaches the filter as a dictionary vector with a stable id
+load {TEST_DIR}/filter_cache_dictionary.db
+
+# single-threaded so one filter operator state spans the whole scan and sees the segment boundaries
+statement ok
+PRAGMA threads=1
+
+statement ok
+PRAGMA force_compression='dictionary'
+
+# no pushdown so a real filter operator remains, feeding the dictionary column into its cache
+statement ok
+SET disabled_optimizers='filter_pushdown,compressed_materialization'
+
+statement ok
+CREATE TABLE t (id INTEGER, s VARCHAR)
+
+# 1000 distinct values span several dictionary segments, so the dictionary id rotates at the boundaries
+statement ok
+INSERT INTO t SELECT i, 'val_' || (i % 1000) FROM range(300000) tbl(i)
+
+statement ok
+CHECKPOINT
+
+# guard: force_compression yields Dictionary (the shape the dict path needs) on formats that support it, or
+# Uncompressed on the latest format (no plain Dictionary, uses DICT_FSST); anything else means the setup broke
+query T
+SELECT DISTINCT compression FROM pragma_storage_info('t')
+WHERE segment_type ILIKE 'VARCHAR' AND compression NOT IN ('Dictionary', 'Uncompressed')
+----
+
+# selective filter shrinks chunks below the cache threshold; the dictionary accumulates as a selection vector
+query T
+SELECT s FROM t WHERE id % 64 = 0 ORDER BY id LIMIT 6
+----
+val_0
+val_64
+val_128
+val_192
+val_256
+val_320
+
+query I
+SELECT count(*) FROM t WHERE id % 64 = 0
+----
+4688
+
+# the id rotates across segment boundaries: the column flattens on the change but keeps coalescing correctly
+query TI
+SELECT s, count(*) FROM t WHERE id % 100 = 7 GROUP BY s ORDER BY s LIMIT 5
+----
+val_107	300
+val_207	300
+val_307	300
+val_407	300
+val_507	300
+
+query II
+SELECT count(*), count(DISTINCT s) FROM t WHERE id % 100 = 7
+----
+3000	10
+
+# a flat column (id) next to a dictionary column (s) is untouched by the dictionary tracking
+query IT
+SELECT id, s FROM t WHERE id % 100 = 7 ORDER BY id LIMIT 5
+----
+7	val_7
+107	val_107
+207	val_207
+307	val_307
+407	val_407
+
+# every filtered row survives the flatten/coalesce exactly once: no duplication or loss
+query I
+SELECT count(*) FROM (
+    SELECT id, s FROM t WHERE id % 100 = 7
+    EXCEPT
+    SELECT id, s FROM t WHERE id % 100 = 7
+)
+----
+0
+
+query II
+SELECT count(*), sum(id) FROM t WHERE id % 100 = 7
+----
+3000	449871000
+
+statement ok
+SET disabled_optimizers=''


### PR DESCRIPTION
# Add dictionary-aware cache operator

Follow-up to #23360, implementing [[Mark's suggestion](https://github.com/duckdb/duckdb/pull/23360#discussion_r3436616932)](https://github.com/duckdb/duckdb/pull/23360#discussion_r3436616932): instead of keying the cache's dictionary accumulation on the `global_dictionary` flag, accumulate **any** dictionary with a stable id, and flatten only if the id changes (which never happens for global dictionaries).

## Motivation

#23360 only carried a dictionary through the cache when it was **global**. But many runtime dictionaries already carry a stable, non-empty `DictionaryEntry::id`; the only thing special about a global one is its lifetime contract, not its id. So storage (`DictionaryCompressionStorage`, `DictFSST`), Parquet, and expression-emitted dictionaries all have stable ids and were simply flattened on the way into the cache. This PR accumulates them too.

## Benefits

The cache no longer materializes these dictionary columns into flat values. Instead of copying the full value for every row of every small chunk, it just appends the selection indices and re-wraps the dictionary on flush, so the distinct values stay in the shared child and are never re-materialized. This saves both CPU and memory.

## Approach

The cache stops reading the `global_dictionary` flag for admission. It now admits any `DICTIONARY_VECTOR` with a non-empty id, and keys per-chunk identity on **entry-pointer equality**. Per seeded column:

- **same dictionary** → concatenate selection indices into `accumulated_sel` (steady state, identical to the prior global path).
- **dictionary changed, non-global** → **flatten that one column in place** into its existing flat cache slot and ride flat for the rest of the fill; it re-seeds on the next fill.
- **dictionary changed, global** → **throw** (a global dict rotating is a producer bug, and the sink depends on it not happening).

---

@Mytherin @lnkuiper, this is the follow-up to your suggestion on #23360. Ready for review, thanks!