### PR TITLE
Sort unordered delete return IDs to stabilize test

### DIFF
--- a/test/sql/trigger/trigger_returning.test
+++ b/test/sql/trigger/trigger_returning.test
@@ -199,7 +199,7 @@ statement ok
 CREATE TRIGGER tr_del AFTER DELETE ON del FOR EACH STATEMENT
     INSERT INTO dlog VALUES ('deleted');
 
-query I
+query I rowsort
 DELETE FROM del RETURNING id;
 ----
 10


### PR DESCRIPTION
I saw a [flaky](https://github.com/duckdb/duckdb/actions/runs/28140390316/job/83336925309#step:7:20) test on `Vector Sizes`:

```
retrying failed test test/sql/trigger/trigger_returning.test (attempt 1/2, retry 1/4)
...
================================================================
error: FAIL test/sql/trigger/trigger_returning.test

  > 202  query I
    203  DELETE FROM del RETURNING id;
    204  ----
    205  10
    206  20
    207  30

1. test/sql/trigger/trigger_returning.test:202
================================================================================

Error: Wrong result in query! (test/sql/trigger/trigger_returning.test:202)!
================================================================================
DELETE FROM del RETURNING id;
================================================================================
Mismatch on row 1, column id(index 1)
30 <> 10
================================================================================
Expected result:
================================================================================
10
20
30

================================================================================
Actual result:
================================================================================
30
10
20

recovered: passed on retry 1/2
```

I think the order of the results is not defined, and that could cause this intermittent failure in CI.

I've added `rowsort` to order the results before comparing the deleted IDs in the test.

Note: I only saw this error for a CI build with `STANDARD_VECTOR_SIZE=2` which explains why that test did not fail elsewhere.