### PR TITLE
Support AFTER DELETE FOR EACH ROW triggers with OLD.col references

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -478,11 +478,15 @@ private:
 	                                                TableCatalogEntry &table, TriggerEventType event_type);
 	BoundStatement ExpandRowTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
 	                                 const TableCatalogEntry &table,
-	                                 const vector<const_reference<TriggerCatalogEntry>> &triggers);
-	//! Registers NEW as a generic binding so child binders resolve NEW.col at depth=1. The returned binder is
-	//! pushed onto GetActiveBinders(). the caller must keep it alive until the matching pop_back().
-	unique_ptr<ExpressionBinder> SetupNewRowScope(TableIndex table_index, const vector<Identifier> &col_names,
-	                                              const vector<LogicalType> &col_types);
+	                                 const vector<const_reference<TriggerCatalogEntry>> &triggers,
+	                                 TriggerEventType event_type);
+	//! Registers a row scope binding (named "new" for INSERT, "old" for DELETE) so child binders resolve
+	//! NEW.col / OLD.col at depth=1. The returned binder is pushed onto GetActiveBinders().
+	//! The caller must keep it alive until the matching pop_back().
+	unique_ptr<ExpressionBinder> SetupRowScope(TableIndex table_index, const vector<Identifier> &col_names,
+	                                           const vector<LogicalType> &col_types, const string &scope_name);
+	//! Returns the correlated-column scope name for a given event type ("new" for INSERT, "old" for DELETE).
+	static string RowScopeName(TriggerEventType event_type);
 	BoundStatement BindNode(UpdateQueryNode &node);
 	BoundStatement BindNode(DeleteQueryNode &node);
 	BoundStatement BindNode(MergeQueryNode &node);

--- a/src/planner/binder/query_node/bind_trigger_expansion.cpp
+++ b/src/planner/binder/query_node/bind_trigger_expansion.cpp
@@ -457,14 +457,23 @@ unique_ptr<BoundStatement> Binder::TryExpandRowTriggers(QueryNode &node,
 		throw NotImplementedException("RETURNING is not yet supported on tables with FOR EACH ROW triggers");
 	}
 	expanded_tables.insert(table);
-	auto bound = ExpandRowTriggers(node, returning_list, table, triggers);
+	auto bound = ExpandRowTriggers(node, returning_list, table, triggers, event_type);
 	expanded_tables.erase(table);
 	return make_uniq<BoundStatement>(std::move(bound));
 }
 
-unique_ptr<ExpressionBinder> Binder::SetupNewRowScope(TableIndex table_index, const vector<Identifier> &col_names,
-                                                      const vector<LogicalType> &col_types) {
-	bind_context.AddGenericBinding(table_index, "new", col_names, col_types);
+string Binder::RowScopeName(TriggerEventType event_type) {
+	switch (event_type) {
+	case TriggerEventType::DELETE_EVENT:
+		return "old";
+	default:
+		return "new";
+	}
+}
+
+unique_ptr<ExpressionBinder> Binder::SetupRowScope(TableIndex table_index, const vector<Identifier> &col_names,
+                                                   const vector<LogicalType> &col_types, const string &scope_name) {
+	bind_context.AddGenericBinding(table_index, Identifier(scope_name), col_names, col_types);
 	auto scope_binder = make_uniq<ExpressionBinder>(*this, context);
 	GetActiveBinders().push_back(*scope_binder);
 	return scope_binder;
@@ -472,7 +481,8 @@ unique_ptr<ExpressionBinder> Binder::SetupNewRowScope(TableIndex table_index, co
 
 BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<ParsedExpression>> &returning_list,
                                          const TableCatalogEntry &table,
-                                         const vector<const_reference<TriggerCatalogEntry>> &triggers) {
+                                         const vector<const_reference<TriggerCatalogEntry>> &triggers,
+                                         TriggerEventType event_type) {
 	D_ASSERT(!triggers.empty());
 	D_ASSERT(returning_list.empty());
 	returning_list.push_back(make_uniq<StarExpression>());
@@ -496,7 +506,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 	auto &base_mat_cte = bound.plan->Cast<LogicalMaterializedCTE>();
 	auto cte_table_idx = base_mat_cte.table_index;
 
-	// proj_idx is the binding source for NEW.col refs in trigger bodies.
+	// proj_idx is the binding source for NEW.col (INSERT) / OLD.col (DELETE) refs in trigger bodies.
 	vector<Identifier> col_names;
 	vector<LogicalType> col_types;
 	for (auto &col : table.GetColumns().Physical()) {
@@ -508,7 +518,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 	auto cte_ref = make_uniq<LogicalCTERef>(cte_ref_idx, cte_table_idx, col_types, col_names, false);
 	cte_ref->ResolveOperatorTypes();
 
-	auto proj_idx = GenerateTableIndex(); // the table_index for NEW bindings
+	auto proj_idx = GenerateTableIndex(); // the table_index for NEW/OLD bindings
 	vector<unique_ptr<Expression>> proj_exprs;
 	for (idx_t i = 0; i < col_types.size(); i++) {
 		proj_exprs.push_back(make_uniq<BoundColumnRefExpression>(col_names[i], col_types[i],
@@ -518,7 +528,8 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 	new_rows_proj->children.push_back(std::move(cte_ref));
 	new_rows_proj->ResolveOperatorTypes();
 
-	auto new_scope_binder = SetupNewRowScope(proj_idx, col_names, col_types);
+	auto row_scope_name = RowScopeName(event_type);
+	auto new_scope_binder = SetupRowScope(proj_idx, col_names, col_types, row_scope_name);
 
 	unique_ptr<LogicalOperator> trigger_plan = std::move(new_rows_proj);
 	for (idx_t i = 0; i < triggers.size(); i++) {
@@ -530,7 +541,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 
 		CorrelatedColumns corr_cols = std::move(child_binder->correlated_columns);
 		if (corr_cols.empty()) {
-			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW "
+			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW or OLD "
 			                      "column in the trigger body (use FOR EACH STATEMENT if row data is not needed)",
 			                      trigger.name, table.name);
 		}
@@ -554,7 +565,7 @@ BoundStatement Binder::ExpandRowTriggers(QueryNode &node, vector<unique_ptr<Pars
 		logi_trig->ResolveOperatorTypes();
 		trigger_plan = std::move(logi_trig);
 	}
-	// remove new_scope_binder
+	// remove row_scope_binder
 	GetActiveBinders().pop_back();
 
 	Identifier trigger_cte_name(string(TRIGGER_BODY_CTE_PREFIX) + "row_" + uuid_suffix);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -531,8 +531,8 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 		throw NotImplementedException("BEFORE FOR EACH ROW triggers are not yet supported");
 	}
 	if (create_trigger_info.for_each == TriggerForEach::ROW &&
-	    create_trigger_info.event_type != TriggerEventType::INSERT_EVENT) {
-		throw NotImplementedException("UPDATE and DELETE FOR EACH ROW triggers are not yet supported");
+	    create_trigger_info.event_type == TriggerEventType::UPDATE_EVENT) {
+		throw NotImplementedException("UPDATE FOR EACH ROW triggers are not yet supported");
 	}
 	if ((!create_trigger_info.referencing_new_table.empty() || !create_trigger_info.referencing_old_table.empty()) &&
 	    create_trigger_info.timing != TriggerTiming::AFTER) {
@@ -586,8 +586,8 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 			body_copy->cte_map.map[alias] = MakeTriggerValidationCTE(table);
 		}
 	}
-	// For FOR EACH ROW: register NEW as a generic binding so BindCorrelatedColumns can resolve NEW.col column
-	// references.
+	// For FOR EACH ROW: register NEW (INSERT) or OLD (DELETE) as a generic binding so BindCorrelatedColumns can
+	// resolve NEW.col / OLD.col references.
 	unique_ptr<ExpressionBinder> row_scope_binder;
 	if (create_trigger_info.for_each == TriggerForEach::ROW) {
 		if (table.HasGeneratedColumns()) {
@@ -604,14 +604,15 @@ SchemaCatalogEntry &Binder::BindCreateTriggerInfo(CreateTriggerInfo &create_trig
 			col_types.push_back(col.GetType());
 		}
 		auto new_idx = validation_binder->GenerateTableIndex();
-		row_scope_binder = validation_binder->SetupNewRowScope(new_idx, col_names, col_types);
+		auto scope_name = Binder::RowScopeName(create_trigger_info.event_type);
+		row_scope_binder = validation_binder->SetupRowScope(new_idx, col_names, col_types, scope_name);
 	}
 	if (row_scope_binder) {
 		auto body_binder = Binder::CreateBinder(context, validation_binder.get());
 		auto bound_body = body_binder->Bind(*body_copy);
 		validation_binder->GetActiveBinders().pop_back();
 		if (body_binder->correlated_columns.empty()) {
-			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW "
+			throw BinderException("FOR EACH ROW trigger \"%s\" on table \"%s\" must reference at least one NEW or OLD "
 			                      "column in the trigger body (use FOR EACH STATEMENT if row data is not needed)",
 			                      create_trigger_info.trigger_name, table.name);
 		}

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -33,6 +33,9 @@ BoundStatement Binder::BindNode(DeleteQueryNode &node) {
 	if (auto expanded = TryExpandTriggers(node, table, TriggerEventType::DELETE_EVENT)) {
 		return std::move(*expanded);
 	}
+	if (auto expanded = TryExpandRowTriggers(node, node.returning_list, table, TriggerEventType::DELETE_EVENT)) {
+		return std::move(*expanded);
+	}
 
 	if (!table.temporary) {
 		// delete from persistent table: not read only!

--- a/test/sql/merge/trigger_merge_into.test
+++ b/test/sql/merge/trigger_merge_into.test
@@ -238,4 +238,4 @@ MERGE INTO row_target_2
     USING (SELECT 1 AS id) AS s ON (row_target_2.id = s.id)
     WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id);
 ----
-<REGEX>:Binder Error: FOR EACH ROW trigger "trg_row_merge" on table "row_target" must reference at least one NEW column.*
+<REGEX>:Binder Error: FOR EACH ROW trigger "trg_row_merge" on table "row_target" must reference at least one NEW or OLD column.*

--- a/test/sql/trigger/trigger_after_delete.test
+++ b/test/sql/trigger/trigger_after_delete.test
@@ -44,12 +44,28 @@ SELECT COUNT(*) FROM audit;
 ----
 3
 
-# FOR EACH ROW is only supported for AFTER INSERT - blocked at CREATE TRIGGER time
-statement error
-CREATE TRIGGER trg_row AFTER DELETE ON target FOR EACH ROW
-    INSERT INTO audit VALUES ('row');
+# FOR EACH ROW DELETE fires once per deleted row, OLD.col carries the deleted value
+statement ok
+CREATE TABLE row_target (id INTEGER);
+
+statement ok
+CREATE TABLE row_audit (deleted_id INTEGER);
+
+statement ok
+CREATE TRIGGER trg_row AFTER DELETE ON row_target FOR EACH ROW
+    INSERT INTO row_audit VALUES (OLD.id);
+
+statement ok
+INSERT INTO row_target VALUES (10), (20), (30);
+
+statement ok
+DELETE FROM row_target WHERE id IN (10, 20);
+
+query I
+SELECT deleted_id FROM row_audit ORDER BY deleted_id;
 ----
-Not implemented Error: UPDATE and DELETE FOR EACH ROW triggers are not yet supported
+10
+20
 
 # Trigger body failure rolls back the entire statement
 statement ok

--- a/test/sql/trigger/trigger_after_update.test
+++ b/test/sql/trigger/trigger_after_update.test
@@ -49,7 +49,7 @@ statement error
 CREATE TRIGGER trg_row AFTER UPDATE ON target FOR EACH ROW
     INSERT INTO audit VALUES ('row');
 ----
-Not implemented Error: UPDATE and DELETE FOR EACH ROW triggers are not yet supported
+Not implemented Error: UPDATE FOR EACH ROW triggers are not yet supported
 
 # Trigger body failure rolls back the entire statement
 statement ok

--- a/test/sql/trigger/trigger_for_each_row.test
+++ b/test/sql/trigger/trigger_for_each_row.test
@@ -108,7 +108,7 @@ statement error
 CREATE TRIGGER trg_noref AFTER INSERT ON t2 FOR EACH ROW
     INSERT INTO audit2 VALUES ('row');
 ----
-Binder Error: FOR EACH ROW trigger "trg_noref" on table "t2" must reference at least one NEW column
+Binder Error: FOR EACH ROW trigger "trg_noref" on table "t2" must reference at least one NEW or OLD column
 
 # Insert from SELECT fires per row
 statement ok
@@ -288,17 +288,54 @@ statement error
 CREATE TRIGGER trg_upd_ev AFTER UPDATE ON t_upd_ev FOR EACH ROW
     INSERT INTO t_upd_ev VALUES (NEW.id);
 ----
-Not implemented Error: UPDATE and DELETE FOR EACH ROW triggers are not yet supported
+Not implemented Error: UPDATE FOR EACH ROW triggers are not yet supported
 
-# FOR EACH ROW DELETE is not yet supported
+# FOR EACH ROW DELETE: fires once per deleted row using OLD.col
 statement ok
-CREATE TABLE t_del_ev (id INTEGER);
+CREATE TABLE t_del_ev (id INTEGER, v INTEGER);
+
+statement ok
+CREATE TABLE t_del_ev_audit (old_id INTEGER, old_v INTEGER);
+
+statement ok
+CREATE TRIGGER trg_del_ev AFTER DELETE ON t_del_ev FOR EACH ROW
+    INSERT INTO t_del_ev_audit VALUES (OLD.id, OLD.v);
+
+statement ok
+INSERT INTO t_del_ev VALUES (1, 10), (2, 20), (3, 30);
+
+statement ok
+DELETE FROM t_del_ev WHERE id <= 2;
+
+query II
+SELECT old_id, old_v FROM t_del_ev_audit ORDER BY old_id;
+----
+1	10
+2	20
+
+# Deleting all rows triggers once per row
+statement ok
+DELETE FROM t_del_ev;
+
+query II
+SELECT old_id, old_v FROM t_del_ev_audit ORDER BY old_id;
+----
+1	10
+2	20
+3	30
+
+# FOR EACH ROW DELETE body must reference at least one OLD column
+statement ok
+CREATE TABLE t_del_noref (id INTEGER);
+
+statement ok
+CREATE TABLE t_del_noref_audit (msg VARCHAR);
 
 statement error
-CREATE TRIGGER trg_del_ev AFTER DELETE ON t_del_ev FOR EACH ROW
-    INSERT INTO t_del_ev VALUES (1);
+CREATE TRIGGER trg_del_noref AFTER DELETE ON t_del_noref FOR EACH ROW
+    INSERT INTO t_del_noref_audit VALUES ('deleted');
 ----
-Not implemented Error: UPDATE and DELETE FOR EACH ROW triggers are not yet supported
+Binder Error: FOR EACH ROW trigger "trg_del_noref" on table "t_del_noref" must reference at least one NEW or OLD column
 
 # FOR EACH ROW + REFERENCING is rejected
 statement ok
@@ -604,3 +641,273 @@ query I
 SELECT id FROM replace_log ORDER BY id;
 ----
 1
+
+# ============================================================
+# AFTER DELETE FOR EACH ROW
+# ============================================================
+
+# Basic: fires once per deleted row, OLD carries all column values
+statement ok
+CREATE TABLE del_t (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE del_audit (row_id INTEGER, row_val VARCHAR);
+
+statement ok
+CREATE TRIGGER del_trg_basic AFTER DELETE ON del_t FOR EACH ROW
+    INSERT INTO del_audit VALUES (OLD.id, OLD.val);
+
+statement ok
+INSERT INTO del_t VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+DELETE FROM del_t WHERE id = 2;
+
+query II
+SELECT row_id, row_val FROM del_audit ORDER BY row_id;
+----
+2	b
+
+# Multi-row delete: fires once per deleted row
+statement ok
+DELETE FROM del_t;
+
+query II
+SELECT row_id, row_val FROM del_audit ORDER BY row_id;
+----
+1	a
+2	b
+3	c
+
+# Zero-row delete: trigger does not fire
+statement ok
+DELETE FROM del_t WHERE id = 999;
+
+query I
+SELECT COUNT(*) FROM del_audit;
+----
+3
+
+# Duplicate OLD values: trigger must still fire once per deleted row (not deduplicated)
+statement ok
+CREATE TABLE del_dup (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE del_dup_audit (row_id INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_dup AFTER DELETE ON del_dup FOR EACH ROW
+    INSERT INTO del_dup_audit VALUES (OLD.id);
+
+statement ok
+INSERT INTO del_dup VALUES (5, 'a'), (5, 'b'), (5, 'c'), (5, 'd');
+
+statement ok
+DELETE FROM del_dup;
+
+query I
+SELECT COUNT(*) FROM del_dup_audit;
+----
+4
+
+query II
+SELECT row_id, COUNT(*) FROM del_dup_audit GROUP BY row_id;
+----
+5	4
+
+# Fully identical rows: still fires once per deleted row
+statement ok
+CREATE TABLE del_dup_all (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE del_dup_all_audit (row_id INTEGER, row_val VARCHAR);
+
+statement ok
+CREATE TRIGGER del_trg_dup_all AFTER DELETE ON del_dup_all FOR EACH ROW
+    INSERT INTO del_dup_all_audit VALUES (OLD.id, OLD.val);
+
+statement ok
+INSERT INTO del_dup_all VALUES (1, 'same'), (1, 'same'), (1, 'same');
+
+statement ok
+DELETE FROM del_dup_all;
+
+query I
+SELECT COUNT(*) FROM del_dup_all_audit;
+----
+3
+
+# Constraint failure on base table: trigger must NOT fire
+statement ok
+CREATE TABLE del_fk (id INTEGER PRIMARY KEY);
+
+statement ok
+CREATE TABLE del_fk_audit (fired_id INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_fk AFTER DELETE ON del_fk FOR EACH ROW
+    INSERT INTO del_fk_audit VALUES (OLD.id);
+
+statement ok
+INSERT INTO del_fk VALUES (1);
+
+# Delete a non-existent row: no error, no trigger fire
+statement ok
+DELETE FROM del_fk WHERE id = 999;
+
+query I
+SELECT COUNT(*) FROM del_fk_audit;
+----
+0
+
+# DELETE trigger body using OLD in a correlated WHERE (delete from another table)
+statement ok
+CREATE TABLE del_src (id INTEGER);
+
+statement ok
+CREATE TABLE del_ref (id INTEGER);
+
+statement ok
+INSERT INTO del_src VALUES (10), (20), (30);
+INSERT INTO del_ref VALUES (10), (20), (30), (40);
+
+statement ok
+CREATE TRIGGER del_trg_corr AFTER DELETE ON del_src FOR EACH ROW
+    DELETE FROM del_ref WHERE id = OLD.id;
+
+statement ok
+DELETE FROM del_src WHERE id IN (10, 30);
+
+query I
+SELECT id FROM del_ref ORDER BY id;
+----
+20
+40
+
+# Multiple FOR EACH ROW DELETE triggers each fire once per deleted row
+statement ok
+CREATE TABLE del_multi (id INTEGER);
+
+statement ok
+CREATE TABLE del_multi_audit (n INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_m1 AFTER DELETE ON del_multi FOR EACH ROW
+    INSERT INTO del_multi_audit VALUES (OLD.id * 10);
+
+statement ok
+CREATE TRIGGER del_trg_m2 AFTER DELETE ON del_multi FOR EACH ROW
+    INSERT INTO del_multi_audit VALUES (OLD.id * 100);
+
+statement ok
+INSERT INTO del_multi VALUES (1), (2);
+
+statement ok
+DELETE FROM del_multi;
+
+query I
+SELECT COUNT(*) FROM del_multi_audit;
+----
+4
+
+query I
+SELECT SUM(n) FROM del_multi_audit;
+----
+330
+
+# DELETE trigger body with SELECT (using OLD in SELECT list)
+statement ok
+CREATE TABLE del_sel (id INTEGER);
+
+statement ok
+CREATE TABLE del_sel_audit (id INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_sel AFTER DELETE ON del_sel FOR EACH ROW
+    INSERT INTO del_sel_audit SELECT OLD.id;
+
+statement ok
+INSERT INTO del_sel VALUES (1), (2);
+
+statement ok
+DELETE FROM del_sel;
+
+query I
+SELECT COUNT(*) FROM del_sel_audit;
+----
+2
+
+# RETURNING is not supported alongside FOR EACH ROW DELETE trigger
+statement ok
+CREATE TABLE del_ret (id INTEGER);
+
+statement ok
+CREATE TABLE del_ret_log (id INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_ret AFTER DELETE ON del_ret FOR EACH ROW
+    INSERT INTO del_ret_log VALUES (OLD.id);
+
+statement ok
+INSERT INTO del_ret VALUES (1);
+
+statement error
+DELETE FROM del_ret WHERE id = 1 RETURNING id;
+----
+Not implemented Error: RETURNING is not yet supported on tables with FOR EACH ROW triggers
+
+# Self-referential FOR EACH ROW DELETE trigger is rejected
+statement ok
+CREATE TABLE del_self (id INTEGER);
+
+statement error
+CREATE TRIGGER del_trg_self AFTER DELETE ON del_self FOR EACH ROW
+    DELETE FROM del_self WHERE id = OLD.id + 1;
+----
+Not implemented Error: Recursive trigger chains are not yet supported
+
+# Cascade: DELETE trigger body writing to a table that itself has a FOR EACH ROW trigger is rejected
+statement ok
+CREATE TABLE del_casc_a (id INTEGER);
+
+statement ok
+CREATE TABLE del_casc_b (id INTEGER);
+
+statement ok
+CREATE TABLE del_casc_c (id INTEGER);
+
+statement ok
+CREATE TRIGGER del_trg_casc_b AFTER DELETE ON del_casc_b FOR EACH ROW
+    INSERT INTO del_casc_c VALUES (OLD.id);
+
+statement error
+CREATE TRIGGER del_trg_casc_a AFTER DELETE ON del_casc_a FOR EACH ROW
+    DELETE FROM del_casc_b WHERE id = OLD.id;
+----
+writes to a table that has its own FOR EACH ROW trigger (cascading row triggers are not yet supported)
+
+# Replacing a STATEMENT DELETE trigger with a same-name ROW trigger is allowed
+statement ok
+CREATE TABLE del_replace_t (id INTEGER);
+
+statement ok
+CREATE TABLE del_replace_log (id INTEGER);
+
+statement ok
+CREATE TRIGGER del_replace_trg AFTER DELETE ON del_replace_t FOR EACH STATEMENT
+    INSERT INTO del_replace_log VALUES (0);
+
+statement ok
+CREATE OR REPLACE TRIGGER del_replace_trg AFTER DELETE ON del_replace_t FOR EACH ROW
+    INSERT INTO del_replace_log VALUES (OLD.id);
+
+statement ok
+INSERT INTO del_replace_t VALUES (7);
+
+statement ok
+DELETE FROM del_replace_t;
+
+query I
+SELECT id FROM del_replace_log ORDER BY id;
+----
+7


### PR DESCRIPTION
## Summary

- Extends the `FOR EACH ROW` trigger machinery from PR #23284 (AFTER INSERT) to `AFTER DELETE`
- Trigger body fires once per deleted row; `OLD.col` references resolve as correlated columns against the deleted-row set, using the same `LogicalTrigger` / `LogicalDependentJoin` decorrelation pipeline
- All existing infrastructure (`ExpandRowTriggers`, `TryExpandRowTriggers`, `RewriteTriggersToDependent`) was already event-agnostic — the change is small and targeted

## Changes

- `RowScopeName(TriggerEventType)` — maps event type to binding qualifier (`"new"` for INSERT, `"old"` for DELETE)
- `SetupNewRowScope` renamed to `SetupRowScope`, takes scope name as parameter
- `ExpandRowTriggers` now accepts `TriggerEventType` to pick the correct scope name
- `bind_delete.cpp` — calls `TryExpandRowTriggers` for `DELETE_EVENT`
- `bind_create.cpp` — narrows rejection gate from `!= INSERT` to `== UPDATE` only; DELETE is now allowed

## Tests

Comprehensive `AFTER DELETE FOR EACH ROW` coverage added to `trigger_for_each_row.test`, mirroring the INSERT suite:
- Basic single-row and multi-row delete with `OLD.col`
- Zero-row delete (trigger does not fire)
- Duplicate and fully-identical deleted rows (no deduplication — fires once per physical row)
- Correlated `WHERE id = OLD.id` in trigger body
- Multiple DELETE triggers on the same table
- Body using `SELECT OLD.id`
- `RETURNING` rejected on tables with row triggers
- Self-referential trigger rejected
- Cascade rejected at `CREATE TRIGGER` time
- `CREATE OR REPLACE` STATEMENT → ROW replacement
