### PR TITLE
Copy table_filters to LHS scan in late materialization

### DIFF
--- a/src/optimizer/late_materialization_helper.cpp
+++ b/src/optimizer/late_materialization_helper.cpp
@@ -1,9 +1,10 @@
 #include "duckdb/optimizer/late_materialization_helper.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
 
 namespace duckdb {
 
 unique_ptr<LogicalGet> LateMaterializationHelper::CreateLHSGet(const LogicalGet &rhs, Binder &binder) {
-	// we need to construct a new scan of the same table
 	auto table_index = binder.GenerateTableIndex();
 	auto new_get = make_uniq<LogicalGet>(table_index, rhs.function, rhs.bind_data->Copy(), rhs.returned_types,
 	                                     rhs.names, rhs.virtual_columns);
@@ -13,6 +14,18 @@ unique_ptr<LogicalGet> LateMaterializationHelper::CreateLHSGet(const LogicalGet 
 	new_get->named_parameters = rhs.named_parameters;
 	new_get->input_table_types = rhs.input_table_types;
 	new_get->input_table_names = rhs.input_table_names;
+	auto &column_ids = rhs.GetColumnIds();
+	for (auto &filter_entry : rhs.table_filters) {
+		auto &expr_filter = filter_entry.Filter().Cast<ExpressionFilter>();
+		if (ExpressionFilter::ContainsInternalFunction(*expr_filter.expr, DynamicFilterScalarFun::NAME)) {
+			continue;
+		}
+		auto col_idx = column_ids[filter_entry.GetIndex()].GetPrimaryIndex();
+		auto &col_type = rhs.returned_types[col_idx];
+		auto optional_expr = CreateOptionalFilterExpression(expr_filter.expr->Copy(), col_type);
+		new_get->table_filters.PushFilter(filter_entry.GetIndex(),
+		                                  make_uniq<ExpressionFilter>(std::move(optional_expr)));
+	}
 	return new_get;
 }
 

--- a/test/sql/optimizer/late_materialization_table_filters.test
+++ b/test/sql/optimizer/late_materialization_table_filters.test
@@ -1,0 +1,223 @@
+# name: test/sql/optimizer/late_materialization_table_filters.test
+# description: Test that late materialization copies table_filters to LHS scan
+# group: [optimizer]
+
+statement ok
+CREATE TABLE lm_test (
+    id INTEGER,
+    grp INTEGER,
+    ts TIMESTAMP,
+    payload1 VARCHAR,
+    payload2 VARCHAR,
+    payload3 VARCHAR,
+    payload4 VARCHAR,
+    payload5 VARCHAR
+);
+
+# Insert 100K rows, 100 groups, interleaved to spread rowids
+statement ok
+INSERT INTO lm_test
+SELECT
+    i AS id,
+    (i % 100) + 1 AS grp,
+    TIMESTAMP '2024-01-01' + INTERVAL (i * 60) SECOND AS ts,
+    md5(i::VARCHAR || 'p1') AS payload1,
+    md5(i::VARCHAR || 'p2') AS payload2,
+    md5(i::VARCHAR || 'p3') AS payload3,
+    md5(i::VARCHAR || 'p4') AS payload4,
+    md5(i::VARCHAR || 'p5') AS payload5
+FROM generate_series(1, 100000) t(i);
+
+statement ok
+CHECKPOINT;
+
+# Verify data distribution
+query I
+SELECT count(*) FROM lm_test WHERE grp = 1
+----
+1000
+
+# Enable late materialization
+statement ok
+SET late_materialization_max_rows = 100;
+
+# Core correctness test: results must be the same with and without late materialization
+query I
+SELECT count(*) FROM (
+    SELECT id, grp, ts, payload1, payload2, payload3, payload4, payload5
+    FROM lm_test
+    WHERE grp = 1
+      AND ts >= TIMESTAMP '2024-01-01'
+      AND ts < TIMESTAMP '2024-07-01'
+    ORDER BY ts
+    LIMIT 20
+) sub
+----
+20
+
+# Verify the query plan shows filters on LHS TABLE_SCAN
+query II
+EXPLAIN
+SELECT id, grp, ts, payload1, payload2, payload3, payload4, payload5
+FROM lm_test
+WHERE grp = 1
+  AND ts >= TIMESTAMP '2024-01-01'
+  AND ts < TIMESTAMP '2024-07-01'
+ORDER BY ts
+LIMIT 20;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*SEMI.*
+
+# Verify result correctness: grp=1 when i%100=0, so i=100,200,300...
+query III
+SELECT id, grp, ts
+FROM lm_test
+WHERE grp = 1
+  AND ts >= TIMESTAMP '2024-01-01'
+  AND ts < TIMESTAMP '2024-07-01'
+ORDER BY ts
+LIMIT 3
+----
+100	1	2024-01-01 01:40:00
+200	1	2024-01-01 03:20:00
+300	1	2024-01-01 05:00:00
+
+# Compare with no late materialization - results must be identical
+statement ok
+SET late_materialization_max_rows = 0;
+
+query III
+SELECT id, grp, ts
+FROM lm_test
+WHERE grp = 1
+  AND ts >= TIMESTAMP '2024-01-01'
+  AND ts < TIMESTAMP '2024-07-01'
+ORDER BY ts
+LIMIT 3
+----
+100	1	2024-01-01 01:40:00
+200	1	2024-01-01 03:20:00
+300	1	2024-01-01 05:00:00
+
+# Verify payload columns are also correct
+statement ok
+SET late_materialization_max_rows = 100;
+
+query I
+SELECT payload1 = md5(id::VARCHAR || 'p1')
+FROM lm_test
+WHERE grp = 1
+  AND ts >= TIMESTAMP '2024-01-01'
+  AND ts < TIMESTAMP '2024-07-01'
+ORDER BY ts
+LIMIT 1
+----
+true
+
+# ─────────────────────────────────────────────────────────────
+# Test: ORDER BY + LIMIT without WHERE (dynamic filter must NOT be copied to LHS)
+# The TOP_N optimizer pushes a dynamic boundary filter into the RHS scan.
+# If this filter were copied to the LHS, it would use a stale boundary
+# and incorrectly filter out rows.
+# ─────────────────────────────────────────────────────────────
+
+statement ok
+SET late_materialization_max_rows = 100;
+
+query II
+EXPLAIN SELECT id, grp, ts, payload1, payload2, payload3, payload4, payload5
+FROM lm_test ORDER BY ts LIMIT 3;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*SEMI.*
+
+query III
+SELECT id, grp, ts
+FROM lm_test ORDER BY ts LIMIT 3
+----
+1	2	2024-01-01 00:01:00
+2	3	2024-01-01 00:02:00
+3	4	2024-01-01 00:03:00
+
+# ─────────────────────────────────────────────────────────────
+# Test: WHERE on a different column than ORDER BY
+# The WHERE filter (grp = 1) should be copied to the LHS as an optional
+# filter for zone-map pruning. The dynamic filter on ts must NOT be copied.
+# ─────────────────────────────────────────────────────────────
+
+query II
+EXPLAIN SELECT id, grp, ts, payload1
+FROM lm_test WHERE grp = 1 ORDER BY ts LIMIT 3;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*SEMI.*SEQ_SCAN.*optional.*grp.*
+
+query III
+SELECT id, grp, ts
+FROM lm_test WHERE grp = 1 ORDER BY ts LIMIT 3
+----
+100	1	2024-01-01 01:40:00
+200	1	2024-01-01 03:20:00
+300	1	2024-01-01 05:00:00
+
+# ─────────────────────────────────────────────────────────────
+# Test: WHERE on the same column as ORDER BY
+# When WHERE and TOP_N dynamic filter are on the same column, they are
+# ANDed together. The entire column filter is skipped on the LHS because
+# it contains a dynamic filter. This loses zone-map pruning for the
+# WHERE condition on that column, but guarantees correctness.
+# ─────────────────────────────────────────────────────────────
+
+query III
+SELECT id, grp, ts
+FROM lm_test WHERE ts >= TIMESTAMP '2024-03-01' ORDER BY ts LIMIT 3
+----
+86400	1	2024-03-01 00:00:00
+86401	2	2024-03-01 00:01:00
+86402	3	2024-03-01 00:02:00
+
+statement ok
+SET late_materialization_max_rows = 0;
+
+query III
+SELECT id, grp, ts
+FROM lm_test WHERE ts >= TIMESTAMP '2024-03-01' ORDER BY ts LIMIT 3
+----
+86400	1	2024-03-01 00:00:00
+86401	2	2024-03-01 00:01:00
+86402	3	2024-03-01 00:02:00
+
+# ─────────────────────────────────────────────────────────────
+# Test: WHERE on both same and different columns from ORDER BY
+# grp filter should be copied to LHS; ts filter should be skipped
+# (because it is ANDed with the dynamic filter on ts).
+# ─────────────────────────────────────────────────────────────
+
+statement ok
+SET late_materialization_max_rows = 100;
+
+query II
+EXPLAIN SELECT id, grp, ts, payload1
+FROM lm_test WHERE grp = 1 AND ts >= TIMESTAMP '2024-03-01' ORDER BY ts LIMIT 3;
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*SEMI.*SEQ_SCAN.*optional.*grp.*
+
+query III
+SELECT id, grp, ts
+FROM lm_test WHERE grp = 1 AND ts >= TIMESTAMP '2024-03-01' ORDER BY ts LIMIT 3
+----
+86400	1	2024-03-01 00:00:00
+86500	1	2024-03-01 01:40:00
+86600	1	2024-03-01 03:20:00
+
+statement ok
+SET late_materialization_max_rows = 0;
+
+query III
+SELECT id, grp, ts
+FROM lm_test WHERE grp = 1 AND ts >= TIMESTAMP '2024-03-01' ORDER BY ts LIMIT 3
+----
+86400	1	2024-03-01 00:00:00
+86500	1	2024-03-01 01:40:00
+86600	1	2024-03-01 03:20:00
+
+statement ok
+DROP TABLE lm_test;


### PR DESCRIPTION
Problems：
========
  `LateMaterializationHelper::CreateLHSGet` does not copy `table_filters` from the RHS scan to the LHS scan. This causes the LHS  (which reads all payload columns) to rely solely on bloom filter + rowid range dynamic filters pushed down from the HASH_JOIN.  When the target rows are a small fraction of the table and their rowids are interleaved with other groups, the LHS candidate set is far larger than necessary, leading to:

  1. Massive bloom filter false positives (candidate rows × FPR)
  2. Expensive reads of wide payload columns for rows that will be discarded by the SEMI JOIN
  3. Late materialization becoming **slower** than no late materialization (negative performance)

Solution：
=======
  Copy `table_filters` to the LHS `LogicalGet` in `CreateLHSGet`:

Test：
====
### LIMIT 50 (median of 5 runs)

| Scenario | Time (ms) | vs Baseline |
|----------|-----------|-------------|
| No late materialization (baseline) | **78** | — |
| Late mat WITHOUT table_filters copy (before fix) | **95** | **1.22× slower (negative!)** |
| Late mat WITH table_filters copy (after fix) | **48** | **1.6× faster** |

### EXPLAIN ANALYZE diff

**Before (LHS TABLE_SCAN — no filters):**

```
TABLE_SCAN wide_table
  Type: Sequential Scan
  Projections: operator_id, ts, id, col1..col20
  (no Filters)                          ← only dynamic rowid/BF filters
  50 rows, 0.05s
```

**After (LHS TABLE_SCAN — has filters):**

```
TABLE_SCAN wide_table
  Type: Sequential Scan
  Projections: operator_id, ts, id, col1..col20
  Filters: (operator_id = 1)            ← table_filters copied from RHS
           (ts < '2024-04-01')
           optional: Dynamic Filter (ts)
  50 rows, 0.01s
```